### PR TITLE
feat(windows): chart narration UI Automation semantics and template narrator (#2707)

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/accessibility/NarrationSemantics.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/accessibility/NarrationSemantics.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.accessibility
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+
+// =============================================================================
+// Narration → Compose Desktop semantics / UI Automation mapping
+// =============================================================================
+//
+// Bridges the deterministic narration contract (com.finance.desktop.narration)
+// to Compose semantics so Windows Narrator and UI Automation can speak chart
+// summaries. This complements the lower-level helpers in `NarratorSupport.kt`
+// (labels, headings, roles) with the live-region announcer and the keyboard
+// "request / replay narration" path required by issue #2707.
+
+/**
+ * Holds the current narration announcement and re-emits it for replay.
+ *
+ * Narrator/UI Automation only re-announces a polite live region when its text
+ * actually changes. To support an explicit "replay" command for the same
+ * narration, [announce] toggles an invisible zero-width marker (U+200B) so the
+ * string differs each call without changing what is spoken.
+ */
+@Stable
+class NarrationAnnouncer {
+
+    /** The text currently exposed to the live region. */
+    var announcement: String by mutableStateOf("")
+        private set
+
+    private var nonce = 0
+
+    /** Sets (or re-emits) the announcement, forcing Narrator to speak it again. */
+    fun announce(text: String) {
+        nonce += 1
+        announcement = if (nonce % 2 == 0) text else text + ZERO_WIDTH_SPACE
+    }
+
+    private companion object {
+        const val ZERO_WIDTH_SPACE = "\u200B"
+    }
+}
+
+/** Remembers a [NarrationAnnouncer] across recompositions. */
+@Composable
+fun rememberNarrationAnnouncer(): NarrationAnnouncer = remember { NarrationAnnouncer() }
+
+/**
+ * Marks the composable as a polite live region whose announced value is [text].
+ *
+ * Place on a small, otherwise-empty node fed by a [NarrationAnnouncer] so chart
+ * summaries are spoken on update and on explicit replay without the user having
+ * to navigate to the element.
+ */
+fun Modifier.narrationLiveRegion(text: String): Modifier =
+    this.semantics {
+        liveRegion = LiveRegionMode.Polite
+        contentDescription = text
+    }
+
+/**
+ * Routes the narration "request / replay" shortcut (<kbd>Alt+R</kbd>) to
+ * [onReplay] when the host element (e.g. a focused chart panel) has focus.
+ *
+ * Alt is used (rather than a bare letter) so the shortcut does not collide with
+ * Narrator scan-mode quick-navigation keys. Returns `true` to consume the event
+ * only when the shortcut matches.
+ */
+fun Modifier.narrationReplayShortcut(onReplay: () -> Unit): Modifier =
+    this.onPreviewKeyEvent { event ->
+        if (event.type == KeyEventType.KeyDown && event.isAltPressed && event.key == Key.R) {
+            onReplay()
+            true
+        } else {
+            false
+        }
+    }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/components/ChartNarration.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/components/ChartNarration.kt
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.components
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.accessibility.narrationLiveRegion
+import com.finance.desktop.accessibility.narrationReplayShortcut
+import com.finance.desktop.accessibility.narratorMerged
+import com.finance.desktop.accessibility.rememberNarrationAnnouncer
+import com.finance.desktop.narration.Narration
+import com.finance.desktop.narration.screenReaderText
+import com.finance.desktop.theme.FinanceDesktopTheme
+
+// =============================================================================
+// NarratedChart — chart surface scaffold with Narrator/UIA semantics
+// =============================================================================
+//
+// Wraps a Canvas chart so it is exposed to Narrator and UI Automation as a
+// single labelled summary node (from the deterministic [Narration]) plus:
+//   * a polite live region that re-announces on data change and on replay,
+//   * a keyboard "request / replay narration" path (Alt+R) on the focused panel,
+//   * a "View as table" toggle that swaps the pixel chart for a focusable table
+//     (the keyboard/Narrator path to per-point detail, WCAG 1.1.1).
+//
+// See `docs/windows/ultrawide-portfolio-cockpit-layout.md` §7 and the validation
+// checklist `docs/windows/chart-narration-validation-checklist.md`.
+
+/**
+ * Renders [chart], exposing [narration] as a merged summary node, with a live
+ * region, an Alt+R replay shortcut, and a "View as table" toggle that swaps in
+ * [table].
+ *
+ * @param narration deterministic narration for this chart surface.
+ * @param panelTestTag stable UI Automation test tag, e.g. "cockpit.panel.performance".
+ * @param table the focusable data-table alternative (per-point detail).
+ * @param chart the visual Canvas chart.
+ */
+@Composable
+fun NarratedChart(
+    narration: Narration,
+    panelTestTag: String,
+    modifier: Modifier = Modifier,
+    table: @Composable () -> Unit,
+    chart: @Composable () -> Unit,
+) {
+    var showTable by remember { mutableStateOf(false) }
+    val announcer = rememberNarrationAnnouncer()
+    val summary = narration.screenReaderText()
+
+    // Announce when the narration changes (e.g. range chip / data refresh).
+    LaunchedEffect(summary) { announcer.announce(summary) }
+
+    Column(
+        modifier = modifier
+            .focusable()
+            .narrationReplayShortcut { announcer.announce(summary) }
+            .semantics { testTag = panelTestTag },
+    ) {
+        if (showTable) {
+            table()
+        } else {
+            Box(modifier = Modifier.narratorMerged(summary)) {
+                chart()
+            }
+        }
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            ViewAsTableToggle(showTable = showTable, onToggle = { showTable = !showTable })
+            Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+            Text(
+                text = "Alt+R replays narration",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.semantics {
+                    contentDescription = "Press Alt plus R to replay the chart narration"
+                },
+            )
+        }
+
+        // Visually minimal polite live region driven by the announcer.
+        Box(
+            modifier = Modifier
+                .size(1.dp)
+                .narrationLiveRegion(announcer.announcement),
+        )
+    }
+}
+
+/**
+ * Toggle button that swaps a chart between its visual and data-table forms.
+ *
+ * Exposes a [Role.Button] name plus a [stateDescription] of "chart" / "table"
+ * for UI Automation (WCAG 4.1.2), matching the cockpit layout spec §7.3.
+ */
+@Composable
+fun ViewAsTableToggle(
+    showTable: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val label = if (showTable) "View as chart" else "View as table"
+    val state = if (showTable) "table" else "chart"
+    TextButton(
+        onClick = onToggle,
+        modifier = modifier.semantics {
+            role = Role.Button
+            stateDescription = state
+            contentDescription = label
+        },
+    ) {
+        Text(label, style = MaterialTheme.typography.labelMedium)
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/narration/ChartNarrator.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/narration/ChartNarrator.kt
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.narration
+
+import com.finance.desktop.narration.NarrationText.formatWholeDollars
+import com.finance.desktop.narration.NarrationText.oneDecimal
+import com.finance.desktop.narration.NarrationText.percentInt
+import com.finance.desktop.narration.NarrationText.roundDollars
+import com.finance.desktop.narration.NarrationText.spellWholeDollars
+import kotlin.math.abs
+
+// =============================================================================
+// ChartNarrator — deterministic narration for Canvas chart surfaces
+// =============================================================================
+//
+// Canvas charts have no intrinsic accessibility tree, so each chart is exposed
+// to Narrator / UI Automation as a single labelled summary node plus an optional
+// data-table alternative (see `docs/windows/ultrawide-portfolio-cockpit-layout.md`
+// §7). This narrator turns a chart's already-computed series into the same
+// [Narration] contract the snapshot generator emits, so the Compose semantics
+// mapping, live region, keyboard replay, and "view as table" affordance work
+// uniformly for any chart.
+//
+// Conventions mirror the narration contract (design §5.2): money is spelled into
+// words for screen-reader text, percentages keep digits and speak "percent", and
+// every value also has a visible glyph form. All output is pure and unit-tested.
+
+/** A single value point of a performance/line/area chart (value in dollars). */
+data class ChartValuePoint(
+    val label: String,
+    val value: Double,
+)
+
+/** A single category slice of an allocation/donut chart (fraction in 0..1). */
+data class ChartCategorySlice(
+    val label: String,
+    val fraction: Double,
+)
+
+object ChartNarrator {
+
+    private const val SCHEMA_VERSION = 1
+
+    private val RULE_HIGH = Confidence(ConfidenceLevel.HIGH, 1.0, ConfidenceBasis.RULE)
+    private val TEMPLATE_PROVENANCE = Provenance(generator = GeneratorKind.TEMPLATE, deterministic = true)
+
+    /**
+     * Narrates a performance/value series for the selected range.
+     *
+     * @param rangeText human-readable range for visible prose, e.g. "1 month".
+     * @param rangeSpoken spoken range for screen-reader text, e.g. "one month".
+     * @param points the value series in chronological order (dollars).
+     * @param seriesLabel panel label, default "Performance".
+     */
+    fun narratePerformance(
+        rangeText: String,
+        rangeSpoken: String,
+        points: List<ChartValuePoint>,
+        seriesLabel: String = "Performance",
+        locale: String = "en-US",
+    ): Narration {
+        if (points.isEmpty()) {
+            return emptyNarration(
+                id = "performance.summary",
+                visible = "$seriesLabel, $rangeText. No performance data yet.",
+                spoken = "$seriesLabel, $rangeSpoken. No performance data yet.",
+                sourceRef = "performanceData",
+                locale = locale,
+            )
+        }
+
+        val first = points.first().value
+        val last = points.last().value
+        val firstDollars = roundDollars(first)
+        val lastDollars = roundDollars(last)
+        val signedPct = if (first != 0.0) (last - first) / first * 100.0 else 0.0
+        val absPct = abs(signedPct)
+
+        val minPoint = points.minByOrNull { it.value } ?: points.first()
+        val maxPoint = points.maxByOrNull { it.value } ?: points.last()
+        val minDollars = roundDollars(minPoint.value)
+        val maxDollars = roundDollars(maxPoint.value)
+
+        val direction =
+            when {
+                last > first -> TrendDirection.UP
+                last < first -> TrendDirection.DOWN
+                else -> TrendDirection.FLAT
+            }
+
+        val headlineText: String
+        val headlineSpoken: String
+        if (direction == TrendDirection.FLAT) {
+            headlineText =
+                "$seriesLabel, $rangeText. Portfolio held about steady at " +
+                    "${formatWholeDollars(lastDollars)}."
+            headlineSpoken =
+                "$seriesLabel, $rangeSpoken. Portfolio held about steady at " +
+                    "${spellWholeDollars(lastDollars)}."
+        } else {
+            val verb = if (direction == TrendDirection.UP) "rose" else "declined"
+            val dirWord = if (direction == TrendDirection.UP) "up" else "down"
+            headlineText =
+                "$seriesLabel, $rangeText. Portfolio $verb from " +
+                    "${formatWholeDollars(firstDollars)} to ${formatWholeDollars(lastDollars)}, " +
+                    "$dirWord ${oneDecimal(absPct)}%."
+            headlineSpoken =
+                "$seriesLabel, $rangeSpoken. Portfolio $verb from " +
+                    "${spellWholeDollars(firstDollars)} to ${spellWholeDollars(lastDollars)}, " +
+                    "$dirWord ${oneDecimal(absPct)} percent."
+        }
+
+        val headline =
+            NarrationSegment(
+                id = "performance.summary",
+                kind = SegmentKind.SUMMARY,
+                text = headlineText,
+                confidence = RULE_HIGH,
+                a11y =
+                    A11yMetadata(
+                        screenReaderText = headlineSpoken,
+                        ariaLive = AriaLive.POLITE,
+                        role = A11yRole.STATUS,
+                        headingLevel = HEADING_LEVEL,
+                    ),
+                sourceRefs = listOf("performanceData"),
+            )
+
+        val rangeSegment =
+            NarrationSegment(
+                id = "performance.range",
+                kind = SegmentKind.INSIGHT,
+                text =
+                    "Range: low ${formatWholeDollars(minDollars)} at ${minPoint.label}, " +
+                        "high ${formatWholeDollars(maxDollars)} at ${maxPoint.label}.",
+                confidence = RULE_HIGH,
+                a11y =
+                    A11yMetadata(
+                        screenReaderText =
+                            "Range: low ${spellWholeDollars(minDollars)} at ${minPoint.label}, " +
+                                "high ${spellWholeDollars(maxDollars)} at ${maxPoint.label}.",
+                        ariaLive = AriaLive.POLITE,
+                        role = A11yRole.NOTE,
+                        headingLevel = null,
+                    ),
+                sourceRefs = listOf("performanceData"),
+            )
+
+        return Narration(
+            mode = NarrationMode.CONCISE,
+            schemaVersion = SCHEMA_VERSION,
+            locale = locale,
+            headline = headline,
+            segments = listOf(rangeSegment),
+            provenance = TEMPLATE_PROVENANCE,
+        )
+    }
+
+    /**
+     * Narrates an allocation/donut chart as a single labelled summary node. Each
+     * legend row keeps its own per-slice description in the UI; this is the
+     * merged summary Narrator reads once instead of every colored swatch.
+     */
+    fun narrateAllocation(
+        slices: List<ChartCategorySlice>,
+        locale: String = "en-US",
+    ): Narration {
+        if (slices.isEmpty()) {
+            return emptyNarration(
+                id = "allocation.summary",
+                visible = "Asset allocation: no holdings yet.",
+                spoken = "Asset allocation: no holdings yet.",
+                sourceRef = "allocationData",
+                locale = locale,
+            )
+        }
+
+        val visible =
+            "Asset allocation: " +
+                slices.joinToString(", ") { "${it.label} ${percentInt(it.fraction)}%" } + "."
+        val spoken =
+            "Asset allocation: " +
+                slices.joinToString(", ") { "${it.label} ${percentInt(it.fraction)} percent" } + "."
+
+        val headline =
+            NarrationSegment(
+                id = "allocation.summary",
+                kind = SegmentKind.SUMMARY,
+                text = visible,
+                confidence = RULE_HIGH,
+                a11y =
+                    A11yMetadata(
+                        screenReaderText = spoken,
+                        ariaLive = AriaLive.POLITE,
+                        role = A11yRole.STATUS,
+                        headingLevel = HEADING_LEVEL,
+                    ),
+                sourceRefs = listOf("allocationData"),
+            )
+
+        return Narration(
+            mode = NarrationMode.CONCISE,
+            schemaVersion = SCHEMA_VERSION,
+            locale = locale,
+            headline = headline,
+            segments = emptyList(),
+            provenance = TEMPLATE_PROVENANCE,
+        )
+    }
+
+    private fun emptyNarration(
+        id: String,
+        visible: String,
+        spoken: String,
+        sourceRef: String,
+        locale: String,
+    ): Narration =
+        Narration(
+            mode = NarrationMode.CONCISE,
+            schemaVersion = SCHEMA_VERSION,
+            locale = locale,
+            headline =
+                NarrationSegment(
+                    id = id,
+                    kind = SegmentKind.SUMMARY,
+                    text = visible,
+                    confidence = RULE_HIGH,
+                    a11y =
+                        A11yMetadata(
+                            screenReaderText = spoken,
+                            ariaLive = AriaLive.POLITE,
+                            role = A11yRole.STATUS,
+                            headingLevel = HEADING_LEVEL,
+                        ),
+                    sourceRefs = listOf(sourceRef),
+                ),
+            segments = emptyList(),
+            provenance = TEMPLATE_PROVENANCE,
+        )
+
+    private const val HEADING_LEVEL = 2
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/narration/NarrationContract.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/narration/NarrationContract.kt
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.narration
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// =============================================================================
+// Narration Contract — deterministic, on-device, screen-reader-first
+// =============================================================================
+//
+// This file implements the narration contract specified in
+// `docs/windows/ml-narration-pipeline-design.md` (§5). It is the stable
+// interface between an already-computed financial state and the plain-language,
+// Narrator-friendly summaries surfaced on the Windows desktop client.
+//
+// IMPORTANT: this is the DETERMINISTIC TEMPLATE layer only. There is no model,
+// no network, and no I/O on this path — narration is pure code over a derived
+// snapshot. The optional ML enhancement (ONNX/DirectML) and on-hardware Narrator
+// validation are tracked as follow-ups in the design doc (§11) and the
+// validation checklist (`docs/windows/chart-narration-validation-checklist.md`).
+//
+// The design places the contract in shared `commonMain` (owned by
+// @kmp-engineer). Until that lands, this Windows-local copy keeps the Windows
+// chart-narration slice (#2707) unblocked while mirroring the documented shapes
+// so the eventual shared types can drop in.
+
+/** Output verbosity. Both modes derive from the same snapshot + generator. */
+@Serializable
+enum class NarrationMode {
+    @SerialName("concise")
+    CONCISE,
+
+    @SerialName("detailed")
+    DETAILED,
+}
+
+/** The kind of fact a [NarrationSegment] conveys (drives ordering and role). */
+@Serializable
+enum class SegmentKind {
+    @SerialName("summary")
+    SUMMARY,
+
+    @SerialName("trend")
+    TREND,
+
+    @SerialName("budget")
+    BUDGET,
+
+    @SerialName("bill")
+    BILL,
+
+    @SerialName("goal")
+    GOAL,
+
+    @SerialName("insight")
+    INSIGHT,
+
+    @SerialName("uncertainty")
+    UNCERTAINTY,
+}
+
+/**
+ * UI Automation live-region politeness. Routine financial state is [POLITE];
+ * [ASSERTIVE] is reserved for time-critical, user-initiated results only and is
+ * never used for passive state (see design §5.2).
+ */
+@Serializable
+enum class AriaLive {
+    @SerialName("off")
+    OFF,
+
+    @SerialName("polite")
+    POLITE,
+
+    @SerialName("assertive")
+    ASSERTIVE,
+}
+
+/** Accessibility role announced by Narrator / exposed to UI Automation. */
+@Serializable
+enum class A11yRole {
+    @SerialName("status")
+    STATUS,
+
+    @SerialName("heading")
+    HEADING,
+
+    @SerialName("note")
+    NOTE,
+}
+
+/** Confidence band for a claim. Every segment carries one. */
+@Serializable
+enum class ConfidenceLevel {
+    @SerialName("high")
+    HIGH,
+
+    @SerialName("medium")
+    MEDIUM,
+
+    @SerialName("low")
+    LOW,
+}
+
+/** What a [Confidence] is grounded in (sample size, model score, recency, …). */
+@Serializable
+enum class ConfidenceBasis {
+    @SerialName("sample_size")
+    SAMPLE_SIZE,
+
+    @SerialName("model_score")
+    MODEL_SCORE,
+
+    @SerialName("recency")
+    RECENCY,
+
+    @SerialName("rule")
+    RULE,
+
+    @SerialName("blended")
+    BLENDED,
+}
+
+/** Direction of a [Trend] over its window. */
+@Serializable
+enum class TrendDirection {
+    @SerialName("up")
+    UP,
+
+    @SerialName("down")
+    DOWN,
+
+    @SerialName("flat")
+    FLAT,
+}
+
+/** Lifecycle status of an upcoming bill. */
+@Serializable
+enum class BillStatus {
+    @SerialName("scheduled")
+    SCHEDULED,
+
+    @SerialName("due")
+    DUE,
+
+    @SerialName("past_due")
+    PAST_DUE,
+}
+
+/** Budget cadence. */
+@Serializable
+enum class BudgetPeriod {
+    @SerialName("monthly")
+    MONTHLY,
+
+    @SerialName("weekly")
+    WEEKLY,
+
+    @SerialName("biweekly")
+    BIWEEKLY,
+
+    @SerialName("yearly")
+    YEARLY,
+}
+
+/** Which generator produced the narration. */
+@Serializable
+enum class GeneratorKind {
+    @SerialName("template")
+    TEMPLATE,
+
+    @SerialName("ml_assisted")
+    ML_ASSISTED,
+}
+
+/** Money is always integer cents plus an ISO 4217 code — never floating point. */
+@Serializable
+data class NarrationMoney(
+    val cents: Long,
+    val currency: String,
+)
+
+/** A stated confidence band with a basis. */
+@Serializable
+data class Confidence(
+    val level: ConfidenceLevel,
+    val score: Double,
+    val basis: ConfidenceBasis,
+)
+
+/** A pre-computed directional change over a window. */
+@Serializable
+data class Trend(
+    val direction: TrendDirection,
+    val changeCents: Long,
+    val changePct: Double,
+    val periodDays: Int,
+    val confidence: Confidence,
+)
+
+/** A pre-computed budget position. */
+@Serializable
+data class BudgetState(
+    val categoryName: String,
+    val plannedCents: Long,
+    val spentCents: Long,
+    val period: BudgetPeriod,
+    val isRollover: Boolean,
+    val percentUsed: Double,
+    val confidence: Confidence,
+)
+
+/** An upcoming bill. */
+@Serializable
+data class BillState(
+    val name: String,
+    val amountCents: Long,
+    val dueDateIso: String,
+    val status: BillStatus,
+)
+
+/** A savings goal position. */
+@Serializable
+data class GoalState(
+    val name: String,
+    val targetCents: Long,
+    val currentCents: Long,
+    val percentComplete: Double,
+    val monthsToTarget: Int? = null,
+    val confidence: Confidence,
+)
+
+/** A pre-ranked insight (rendered when material). */
+@Serializable
+data class InsightInput(
+    val id: String,
+    val kind: String,
+    val salience: Double,
+    val payload: Map<String, String> = emptyMap(),
+)
+
+/** A notable, pre-classified delta (never a raw transaction). */
+@Serializable
+data class Signal(
+    val id: String,
+    val kind: String,
+    val observedCents: Long,
+    val expectedLowCents: Long,
+    val expectedHighCents: Long,
+    val confidence: Confidence,
+)
+
+/**
+ * Input to the narrator: a derived, already-computed projection of financial
+ * state. The narrator performs no financial math — it consumes engine outputs.
+ */
+@Serializable
+data class FinancialStateSnapshot(
+    val schemaVersion: Int,
+    val asOf: String,
+    val locale: String,
+    val currency: String,
+    val netWorth: NarrationMoney,
+    val cashOnHand: NarrationMoney,
+    val safeToSpend: NarrationMoney? = null,
+    val netWorthTrend: Trend,
+    val budgets: List<BudgetState> = emptyList(),
+    val upcomingBills: List<BillState> = emptyList(),
+    val goals: List<GoalState> = emptyList(),
+    val insights: List<InsightInput> = emptyList(),
+    val signals: List<Signal> = emptyList(),
+)
+
+/** Narrator / UI Automation metadata attached to a [NarrationSegment]. */
+@Serializable
+data class A11yMetadata(
+    val screenReaderText: String,
+    val ariaLive: AriaLive = AriaLive.POLITE,
+    val role: A11yRole,
+    val headingLevel: Int? = null,
+)
+
+/** One unit of narration: visible prose plus its accessibility projection. */
+@Serializable
+data class NarrationSegment(
+    val id: String,
+    val kind: SegmentKind,
+    val text: String,
+    val confidence: Confidence,
+    val a11y: A11yMetadata,
+    val sourceRefs: List<String> = emptyList(),
+)
+
+/** How the narration was produced (template vs. ML-assisted). */
+@Serializable
+data class Provenance(
+    val generator: GeneratorKind = GeneratorKind.TEMPLATE,
+    val deterministic: Boolean = true,
+    val modelId: String? = null,
+    val modelVersion: String? = null,
+    val runtime: String? = null,
+)
+
+/** A complete narration: exactly one [headline] plus ordered [segments]. */
+@Serializable
+data class Narration(
+    val mode: NarrationMode,
+    val schemaVersion: Int,
+    val locale: String,
+    val headline: NarrationSegment,
+    val segments: List<NarrationSegment> = emptyList(),
+    val provenance: Provenance = Provenance(),
+)
+
+/**
+ * Joins the [headline] and all [segments] screen-reader text into a single
+ * announcement string — the text a Narrator/UI Automation summary node speaks.
+ */
+fun Narration.screenReaderText(): String =
+    buildString {
+        append(headline.a11y.screenReaderText)
+        segments.forEach { segment ->
+            append(' ')
+            append(segment.a11y.screenReaderText)
+        }
+    }.trim()
+
+/** Joins the visible prose of the [headline] and all [segments]. */
+fun Narration.plainText(): String =
+    buildString {
+        append(headline.text)
+        segments.forEach { segment ->
+            append(' ')
+            append(segment.text)
+        }
+    }.trim()

--- a/apps/windows/src/main/kotlin/com/finance/desktop/narration/NarrationText.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/narration/NarrationText.kt
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.narration
+
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
+
+// =============================================================================
+// Narration text utilities — deterministic, locale-aware (en-US first)
+// =============================================================================
+//
+// Pure formatting helpers shared by every narrator (the snapshot
+// [TemplateNarrationGenerator] and the [ChartNarrator]). Two conventions, drawn
+// from the narration contract (design §5.2) and the cockpit layout doc (§7.2):
+//
+//   * Money is fully spelled into words for screen-reader text
+//     ("$1,240.50" -> "one thousand two hundred forty dollars and fifty cents").
+//   * Percentages keep their digits and speak the symbol ("46%" -> "46 percent",
+//     "5.0%" -> "5.0 percent"), matching the contract's "3.4 percent" example.
+//   * Plain integer counts (days, months) and ordinal days are spelled
+//     ("21 days" -> "twenty-one days", "June 25" -> "June twenty-fifth").
+//
+// Everything here is side-effect free and unit-tested so narration is verifiable
+// with no model present at runtime.
+
+internal object NarrationText {
+
+    private val ONES =
+        arrayOf(
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+            "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen",
+            "seventeen", "eighteen", "nineteen",
+        )
+
+    private val TENS =
+        arrayOf("", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety")
+
+    private val MONTHS =
+        arrayOf(
+            "January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December",
+        )
+
+    private val ORDINALS =
+        mapOf(
+            1 to "first", 2 to "second", 3 to "third", 4 to "fourth", 5 to "fifth",
+            6 to "sixth", 7 to "seventh", 8 to "eighth", 9 to "ninth", 10 to "tenth",
+            11 to "eleventh", 12 to "twelfth", 13 to "thirteenth", 14 to "fourteenth",
+            15 to "fifteenth", 16 to "sixteenth", 17 to "seventeenth", 18 to "eighteenth",
+            19 to "nineteenth", 20 to "twentieth", 30 to "thirtieth",
+        )
+
+    /**
+     * Banned, alarmist / shaming vocabulary derived from the Content Language
+     * Guidelines (design §3, §5.4). Narration must never contain these. The
+     * golden tests fail the build if any generated text includes one.
+     */
+    val BANNED_TERMS: List<String> =
+        listOf(
+            "overspent", "overspend", "over budget", "in the red", "danger",
+            "behind", "deficit", "failed", "failure", "overdue", "delinquent",
+            "warning", "panic", "shame", "ashamed", "disaster", "broke",
+        )
+
+    /** Returns the first banned term found in [text] (case-insensitive), or null. */
+    fun firstBannedTerm(text: String): String? {
+        val lower = text.lowercase(Locale.US)
+        return BANNED_TERMS.firstOrNull { lower.contains(it) }
+    }
+
+    /** Capitalizes the first character (used when prose starts a new sentence). */
+    fun capitalizeFirst(value: String): String =
+        if (value.isEmpty()) value else value[0].uppercaseChar() + value.substring(1)
+
+    private fun spellBelowThousand(value: Int): String {
+        require(value in 0..999) { "spellBelowThousand out of range: $value" }
+        return when {
+            value == 0 -> ""
+            value < 20 -> ONES[value]
+            value < 100 -> TENS[value / 10] + if (value % 10 != 0) "-${ONES[value % 10]}" else ""
+            else ->
+                ONES[value / 100] + " hundred" +
+                    if (value % 100 != 0) " ${spellBelowThousand(value % 100)}" else ""
+        }
+    }
+
+    /** Spells a non-negative whole number into lowercase English words. */
+    fun spellInt(value: Long): String =
+        when {
+            value < 0L -> "negative ${spellInt(-value)}"
+            value == 0L -> "zero"
+            else -> {
+                var remaining = value
+                val billions = (remaining / 1_000_000_000L).toInt(); remaining %= 1_000_000_000L
+                val millions = (remaining / 1_000_000L).toInt(); remaining %= 1_000_000L
+                val thousands = (remaining / 1_000L).toInt(); remaining %= 1_000L
+                val rest = remaining.toInt()
+                val parts = mutableListOf<String>()
+                if (billions > 0) parts.add("${spellBelowThousand(billions)} billion")
+                if (millions > 0) parts.add("${spellBelowThousand(millions)} million")
+                if (thousands > 0) parts.add("${spellBelowThousand(thousands)} thousand")
+                if (rest > 0) parts.add(spellBelowThousand(rest))
+                parts.joinToString(" ")
+            }
+        }
+
+    /** Spells an ordinal day of month (1..31) into words: 25 -> "twenty-fifth". */
+    fun ordinalDay(day: Int): String {
+        require(day in 1..31) { "ordinalDay out of range: $day" }
+        ORDINALS[day]?.let { return it }
+        val tens = (day / 10) * 10
+        val ones = day % 10
+        return spellInt(tens.toLong()) + "-" + ORDINALS.getValue(ones)
+    }
+
+    /** Inserts thousands separators: 124050 -> "124,050". */
+    fun groupThousands(value: Long): String {
+        val negative = value < 0
+        val digits = abs(value).toString()
+        val sb = StringBuilder()
+        val rem = digits.length % 3
+        for (i in digits.indices) {
+            if (i != 0 && (i - rem) % 3 == 0) sb.append(',')
+            sb.append(digits[i])
+        }
+        return (if (negative) "-" else "") + sb.toString()
+    }
+
+    // -- Money --------------------------------------------------------------
+
+    /** Visible currency glyph form of integer cents: 124050 -> "$1,240.50". */
+    fun formatCents(cents: Long): String {
+        val negative = cents < 0
+        val absCents = abs(cents)
+        val dollars = absCents / 100
+        val frac = absCents % 100
+        val body = "$${groupThousands(dollars)}.${frac.toString().padStart(2, '0')}"
+        return if (negative) "-$body" else body
+    }
+
+    /** Spelled form of integer cents: 124050 -> "one thousand … forty dollars and fifty cents". */
+    fun spellCents(cents: Long): String {
+        val prefix = if (cents < 0) "negative " else ""
+        val absCents = abs(cents)
+        val dollars = absCents / 100
+        val frac = absCents % 100
+        val dollarWords = "${spellInt(dollars)} dollar${if (dollars == 1L) "" else "s"}"
+        return if (frac == 0L) {
+            prefix + dollarWords
+        } else {
+            "$prefix$dollarWords and ${spellInt(frac)} cent${if (frac == 1L) "" else "s"}"
+        }
+    }
+
+    /** Visible whole-dollar glyph form: 35000 -> "$35,000". */
+    fun formatWholeDollars(dollars: Long): String {
+        val negative = dollars < 0
+        val body = "$${groupThousands(abs(dollars))}"
+        return if (negative) "-$body" else body
+    }
+
+    /** Spelled whole-dollar form: 35000 -> "thirty-five thousand dollars". */
+    fun spellWholeDollars(dollars: Long): String {
+        val prefix = if (dollars < 0) "negative " else ""
+        val absDollars = abs(dollars)
+        return "$prefix${spellInt(absDollars)} dollar${if (absDollars == 1L) "" else "s"}"
+    }
+
+    // -- Percent ------------------------------------------------------------
+
+    /** Integer percent from a 0..1 fraction: 0.56 -> 56. */
+    fun percentInt(fraction: Double): Int = (fraction * 100.0).roundToInt()
+
+    /** One-decimal value, locale-stable: 5.0 -> "5.0", 21.249 -> "21.2". */
+    fun oneDecimal(value: Double): String = String.format(Locale.US, "%.1f", value)
+
+    // -- Dates --------------------------------------------------------------
+
+    /** Visible "Month D" from an ISO date "YYYY-MM-DD": "2026-06-25" -> "June 25". */
+    fun monthDayVisible(iso: String): String {
+        val (month, day) = parseMonthDay(iso)
+        return "${MONTHS[month - 1]} $day"
+    }
+
+    /** Spoken "Month Dth" from an ISO date: "2026-06-25" -> "June twenty-fifth". */
+    fun monthDayOrdinal(iso: String): String {
+        val (month, day) = parseMonthDay(iso)
+        return "${MONTHS[month - 1]} ${ordinalDay(day)}"
+    }
+
+    private fun parseMonthDay(iso: String): Pair<Int, Int> {
+        val datePart = iso.substringBefore('T')
+        val pieces = datePart.split('-')
+        val month = pieces.getOrNull(1)?.toIntOrNull() ?: 1
+        val day = pieces.getOrNull(2)?.toIntOrNull() ?: 1
+        return month to day
+    }
+
+    /** Rounds a Float/Double dollar amount to whole dollars (charts use Floats). */
+    fun roundDollars(value: Double): Long = value.roundToLong()
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/narration/TemplateNarrationGenerator.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/narration/TemplateNarrationGenerator.kt
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.narration
+
+import com.finance.desktop.narration.NarrationText.capitalizeFirst
+import com.finance.desktop.narration.NarrationText.formatCents
+import com.finance.desktop.narration.NarrationText.formatWholeDollars
+import com.finance.desktop.narration.NarrationText.monthDayOrdinal
+import com.finance.desktop.narration.NarrationText.monthDayVisible
+import com.finance.desktop.narration.NarrationText.percentInt
+import com.finance.desktop.narration.NarrationText.spellCents
+import com.finance.desktop.narration.NarrationText.spellInt
+import com.finance.desktop.narration.NarrationText.spellWholeDollars
+
+// =============================================================================
+// TemplateNarrationGenerator — the deterministic, golden-tested narrator
+// =============================================================================
+//
+// Implements the template layer from `docs/windows/ml-narration-pipeline-design.md`
+// (§4 stage 2, §5, §9). Given an already-computed [FinancialStateSnapshot], it
+// produces a [Narration] in either [NarrationMode] with no model, no network,
+// and no I/O — so the output is fully reproducible and golden-tested in CI.
+//
+// Tone is non-alarmist (design §3, §5.4): budgets are "fully used" not
+// "overspent"; low-confidence claims are hedged ("early signal") and never
+// asserted as fact. Uncertainty is always surfaced: in detailed mode a
+// low-confidence source produces an explicit `uncertainty` segment.
+//
+// Selection / ordering (reproduces the §9 worked example):
+//   headline  = the most time-relevant bill + cash on hand (a "summary").
+//   material  = budgets needing attention, then the net-worth trend, then goals.
+//   concise   = headline + the top two material segments (hedging stays inline).
+//   detailed  = headline + all material segments + one appended `uncertainty`
+//               segment when any included source is low confidence.
+class TemplateNarrationGenerator {
+
+    /** Generates a [Narration] for the [snapshot] in the requested [mode]. */
+    fun generate(
+        snapshot: FinancialStateSnapshot,
+        mode: NarrationMode,
+    ): Narration {
+        val headline = buildHeadline(snapshot)
+        val material = buildMaterialSegments(snapshot)
+
+        val segments =
+            when (mode) {
+                NarrationMode.CONCISE -> material.take(CONCISE_SEGMENT_LIMIT)
+                NarrationMode.DETAILED -> material + buildUncertaintySegments(snapshot, material)
+            }
+
+        return Narration(
+            mode = mode,
+            schemaVersion = snapshot.schemaVersion,
+            locale = snapshot.locale,
+            headline = headline,
+            segments = segments,
+            provenance = TEMPLATE_PROVENANCE,
+        )
+    }
+
+    // -- Headline -----------------------------------------------------------
+
+    private fun buildHeadline(snapshot: FinancialStateSnapshot): NarrationSegment {
+        val bill = mostUrgentBill(snapshot.upcomingBills)
+        return if (bill != null) {
+            billAndCashHeadline(bill, snapshot.cashOnHand)
+        } else {
+            netWorthHeadline(snapshot)
+        }
+    }
+
+    private fun mostUrgentBill(bills: List<BillState>): BillState? =
+        bills.minWithOrNull(
+            compareBy<BillState> { statusPriority(it.status) }.thenBy { it.dueDateIso },
+        )
+
+    private fun statusPriority(status: BillStatus): Int =
+        when (status) {
+            BillStatus.PAST_DUE -> 0
+            BillStatus.DUE -> 1
+            BillStatus.SCHEDULED -> 2
+        }
+
+    private fun billAndCashHeadline(
+        bill: BillState,
+        cash: NarrationMoney,
+    ): NarrationSegment {
+        val text =
+            "Your ${bill.name} bill of ${formatCents(bill.amountCents)} is due " +
+                "${monthDayVisible(bill.dueDateIso)}, and you have " +
+                "${formatCents(cash.cents)} on hand."
+        val screenReader =
+            "Your ${bill.name} bill of ${spellCents(bill.amountCents)} is due " +
+                "${monthDayOrdinal(bill.dueDateIso)}, and you have " +
+                "${spellCents(cash.cents)} on hand."
+        return NarrationSegment(
+            id = "summary",
+            kind = SegmentKind.SUMMARY,
+            text = text,
+            confidence = RULE_HIGH,
+            a11y =
+                A11yMetadata(
+                    screenReaderText = screenReader,
+                    ariaLive = AriaLive.POLITE,
+                    role = A11yRole.STATUS,
+                    headingLevel = HEADLINE_HEADING_LEVEL,
+                ),
+            sourceRefs = listOf("bill.${bill.name.lowercase()}", "cashOnHand"),
+        )
+    }
+
+    private fun netWorthHeadline(snapshot: FinancialStateSnapshot): NarrationSegment {
+        val netWorthDollars = snapshot.netWorth.cents / CENTS_PER_DOLLAR
+        val text =
+            "Your net worth is ${formatWholeDollars(netWorthDollars)}, with " +
+                "${formatCents(snapshot.cashOnHand.cents)} on hand."
+        val screenReader =
+            "Your net worth is ${spellWholeDollars(netWorthDollars)}, with " +
+                "${spellCents(snapshot.cashOnHand.cents)} on hand."
+        return NarrationSegment(
+            id = "summary",
+            kind = SegmentKind.SUMMARY,
+            text = text,
+            confidence = RULE_HIGH,
+            a11y =
+                A11yMetadata(
+                    screenReaderText = screenReader,
+                    ariaLive = AriaLive.POLITE,
+                    role = A11yRole.STATUS,
+                    headingLevel = HEADLINE_HEADING_LEVEL,
+                ),
+            sourceRefs = listOf("netWorth", "cashOnHand"),
+        )
+    }
+
+    // -- Material segments --------------------------------------------------
+
+    private fun buildMaterialSegments(snapshot: FinancialStateSnapshot): List<NarrationSegment> {
+        val segments = mutableListOf<NarrationSegment>()
+        snapshot.budgets
+            .filter { it.percentUsed >= BUDGET_ATTENTION_THRESHOLD }
+            .sortedByDescending { it.percentUsed }
+            .forEach { segments.add(budgetSegment(it)) }
+        segments.add(trendSegment(snapshot.netWorthTrend))
+        snapshot.goals.forEach { segments.add(goalSegment(it)) }
+        return segments
+    }
+
+    private fun budgetSegment(budget: BudgetState): NarrationSegment {
+        val stateWord =
+            when {
+                budget.percentUsed >= 1.0 -> "fully used"
+                budget.percentUsed >= NEARLY_USED_THRESHOLD -> "nearly used"
+                else -> "${percentInt(budget.percentUsed)} percent used"
+            }
+        val text =
+            "Your ${budget.categoryName} plan is $stateWord — " +
+                "${formatCents(budget.spentCents)} of the " +
+                "${formatCents(budget.plannedCents)} you planned. " +
+                "Want to adjust the plan or move funds?"
+        val screenReader =
+            "Your ${budget.categoryName} plan is $stateWord. " +
+                "${capitalizeFirst(spellCents(budget.spentCents))} of the " +
+                "${spellCents(budget.plannedCents)} you planned. " +
+                "Want to adjust the plan or move funds?"
+        return NarrationSegment(
+            id = "budget.${budget.categoryName.lowercase()}",
+            kind = SegmentKind.BUDGET,
+            text = text,
+            confidence = budget.confidence,
+            a11y =
+                A11yMetadata(
+                    screenReaderText = screenReader,
+                    ariaLive = AriaLive.POLITE,
+                    role = A11yRole.NOTE,
+                    headingLevel = null,
+                ),
+            sourceRefs = listOf("budget.${budget.categoryName.lowercase()}"),
+        )
+    }
+
+    private fun trendSegment(trend: Trend): NarrationSegment {
+        val magnitude = magnitudeWord(trend.changePct)
+        val direction = directionWord(trend.direction)
+        val days = trend.periodDays
+        val (text, screenReader) =
+            when (trend.confidence.level) {
+                ConfidenceLevel.LOW -> {
+                    val body =
+                        "your net worth looks $magnitude $direction over the last"
+                    val tail = " This may change as more history builds."
+                    val visible =
+                        "Early signal: $body $days days.$tail"
+                    val spoken =
+                        "Early signal. ${capitalizeFirst(body)} ${spellInt(days.toLong())} days.$tail"
+                    visible to spoken
+                }
+                ConfidenceLevel.MEDIUM -> {
+                    val visible =
+                        "Based on recent activity, your net worth looks $magnitude $direction " +
+                            "over the last $days days."
+                    val spoken =
+                        "Based on recent activity, your net worth looks $magnitude $direction " +
+                            "over the last ${spellInt(days.toLong())} days."
+                    visible to spoken
+                }
+                ConfidenceLevel.HIGH -> {
+                    val visible =
+                        "Your net worth is $magnitude $direction over the last $days days."
+                    val spoken =
+                        "Your net worth is $magnitude $direction over the last " +
+                            "${spellInt(days.toLong())} days."
+                    visible to spoken
+                }
+            }
+        return NarrationSegment(
+            id = "trend",
+            kind = SegmentKind.TREND,
+            text = text,
+            confidence = trend.confidence,
+            a11y =
+                A11yMetadata(
+                    screenReaderText = screenReader,
+                    ariaLive = AriaLive.POLITE,
+                    role = A11yRole.NOTE,
+                    headingLevel = null,
+                ),
+            sourceRefs = listOf("netWorthTrend"),
+        )
+    }
+
+    private fun goalSegment(goal: GoalState): NarrationSegment {
+        val savedDollars = goal.currentCents / CENTS_PER_DOLLAR
+        val pct = percentInt(goal.percentComplete)
+        val months = goal.monthsToTarget
+        val pace =
+            if (months != null) {
+                " — $pct% there, on track for about $months months at your recent pace."
+            } else {
+                " — $pct% there so far."
+            }
+        val spokenPace =
+            if (months != null) {
+                "$pct percent there, on track for about " +
+                    "${spellInt(months.toLong())} months at your recent pace."
+            } else {
+                "$pct percent there so far."
+            }
+        val text = "You've saved ${formatWholeDollars(savedDollars)} toward your ${goal.name}$pace"
+        val screenReader =
+            "You've saved ${spellWholeDollars(savedDollars)} toward your ${goal.name}. $spokenPace"
+        return NarrationSegment(
+            id = "goal.${goal.name.lowercase().replace(' ', '.')}",
+            kind = SegmentKind.GOAL,
+            text = text,
+            confidence = goal.confidence,
+            a11y =
+                A11yMetadata(
+                    screenReaderText = screenReader,
+                    ariaLive = AriaLive.POLITE,
+                    role = A11yRole.NOTE,
+                    headingLevel = null,
+                ),
+            sourceRefs = listOf("goal.${goal.name.lowercase().replace(' ', '.')}"),
+        )
+    }
+
+    // -- Uncertainty (detailed only) ----------------------------------------
+
+    private fun buildUncertaintySegments(
+        snapshot: FinancialStateSnapshot,
+        material: List<NarrationSegment>,
+    ): List<NarrationSegment> {
+        val trendIsLow = snapshot.netWorthTrend.confidence.level == ConfidenceLevel.LOW
+        val trendRendered = material.any { it.id == "trend" }
+        if (!trendIsLow || !trendRendered) return emptyList()
+        val days = snapshot.netWorthTrend.periodDays
+        val text =
+            "One note on confidence: the net-worth trend is based on a short, " +
+                "$days-day window, so treat it as a rough early signal rather than a " +
+                "firm direction."
+        val screenReader =
+            "One note on confidence. The net-worth trend is based on a short, " +
+                "${spellInt(days.toLong())} day window, so treat it as a rough early signal " +
+                "rather than a firm direction."
+        return listOf(
+            NarrationSegment(
+                id = "uncertainty",
+                kind = SegmentKind.UNCERTAINTY,
+                text = text,
+                confidence = snapshot.netWorthTrend.confidence,
+                a11y =
+                    A11yMetadata(
+                        screenReaderText = screenReader,
+                        ariaLive = AriaLive.POLITE,
+                        role = A11yRole.NOTE,
+                        headingLevel = null,
+                    ),
+                sourceRefs = listOf("netWorthTrend"),
+            ),
+        )
+    }
+
+    // -- Word helpers -------------------------------------------------------
+
+    private fun magnitudeWord(changePct: Double): String {
+        val magnitude = kotlin.math.abs(changePct)
+        return when {
+            magnitude < SLIGHT_THRESHOLD -> "slightly"
+            magnitude < MODERATE_THRESHOLD -> "moderately"
+            else -> "notably"
+        }
+    }
+
+    private fun directionWord(direction: TrendDirection): String =
+        when (direction) {
+            TrendDirection.UP -> "higher"
+            TrendDirection.DOWN -> "lower"
+            TrendDirection.FLAT -> "about the same"
+        }
+
+    private companion object {
+        const val CONCISE_SEGMENT_LIMIT = 2
+        const val HEADLINE_HEADING_LEVEL = 2
+        const val CENTS_PER_DOLLAR = 100L
+        const val BUDGET_ATTENTION_THRESHOLD = 0.85
+        const val NEARLY_USED_THRESHOLD = 0.9
+        const val SLIGHT_THRESHOLD = 0.02
+        const val MODERATE_THRESHOLD = 0.05
+
+        val RULE_HIGH = Confidence(ConfidenceLevel.HIGH, 0.95, ConfidenceBasis.RULE)
+        val TEMPLATE_PROVENANCE =
+            Provenance(
+                generator = GeneratorKind.TEMPLATE,
+                deterministic = true,
+                modelId = null,
+                modelVersion = null,
+                runtime = null,
+            )
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/InvestmentScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/InvestmentScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -54,7 +55,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.finance.desktop.components.NarratedChart
 import com.finance.desktop.di.koinGet
+import com.finance.desktop.narration.ChartCategorySlice
+import com.finance.desktop.narration.ChartNarrator
+import com.finance.desktop.narration.ChartValuePoint
 import com.finance.desktop.theme.FinanceDesktopTheme
 import com.finance.desktop.viewmodel.AllocationSlice
 import com.finance.desktop.viewmodel.HoldingUi
@@ -306,14 +311,24 @@ private fun PerformanceChartCard(
             val lineColor = if (isPositive) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
             val fillColor = lineColor.copy(alpha = 0.1f)
 
-            Canvas(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp)
-                    .semantics {
-                        contentDescription = "Performance chart showing portfolio value over time"
-                    },
+            val narration = remember(data, selectedRange) {
+                ChartNarrator.narratePerformance(
+                    rangeText = selectedRange.narrationLabel(),
+                    rangeSpoken = selectedRange.narrationSpokenLabel(),
+                    points = data.map { ChartValuePoint(it.label, it.value.toDouble()) },
+                )
+            }
+
+            NarratedChart(
+                narration = narration,
+                panelTestTag = "cockpit.panel.performance",
+                table = { PerformanceDataTable(data) },
             ) {
+                Canvas(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                ) {
                 if (data.isEmpty()) return@Canvas
 
                 val minVal = data.minOf { it.value }
@@ -360,6 +375,7 @@ private fun PerformanceChartCard(
                     (1f - (data.last().value - minVal) / range)
                 drawCircle(lineColor, radius = 4f, center = Offset(lastX, lastY))
             }
+            }
         }
     }
 }
@@ -387,16 +403,20 @@ private fun AllocationChartCard(
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
 
             // Donut chart
-            Canvas(
-                modifier = Modifier
-                    .size(180.dp)
-                    .semantics {
-                        contentDescription = buildString {
-                            append("Asset allocation: ")
-                            data.forEach { append("${it.label} ${(it.percent * 100).toInt()}%, ") }
-                        }
-                    },
+            val narration = remember(data) {
+                ChartNarrator.narrateAllocation(
+                    data.map { ChartCategorySlice(it.label, it.percent.toDouble()) },
+                )
+            }
+
+            NarratedChart(
+                narration = narration,
+                panelTestTag = "cockpit.panel.allocation",
+                table = { AllocationDataTable(data) },
             ) {
+                Canvas(
+                    modifier = Modifier.size(180.dp),
+                ) {
                 val strokeWidth = 36f
                 val radius = (size.minDimension - strokeWidth) / 2
                 val center = Offset(size.width / 2, size.height / 2)
@@ -417,6 +437,7 @@ private fun AllocationChartCard(
                     )
                     startAngle += sweep
                 }
+            }
             }
 
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
@@ -576,4 +597,73 @@ private fun HoldingRow(holding: HoldingUi) {
             }
         }
     }
+}
+
+// ─── Chart narration data tables (text alternatives) ─────────────────────────
+
+@Composable
+private fun PerformanceDataTable(data: List<PerformancePoint>) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        data.forEach { point ->
+            val valueText = formatChartDollars(point.value)
+            Text(
+                text = "${point.label}: $valueText",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 2.dp)
+                    .semantics {
+                        contentDescription = "${point.label}, $valueText"
+                    },
+            )
+        }
+    }
+}
+
+@Composable
+private fun AllocationDataTable(data: List<AllocationSlice>) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        data.forEach { slice ->
+            val pct = (slice.percent * 100).toInt()
+            Text(
+                text = "${slice.label}: $pct%",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 2.dp)
+                    .semantics {
+                        contentDescription = "${slice.label}, $pct percent"
+                    },
+            )
+        }
+    }
+}
+
+private fun formatChartDollars(value: Float): String {
+    val digits = value.toLong().coerceAtLeast(0L).toString()
+    val grouped = StringBuilder()
+    val remainder = digits.length % 3
+    digits.forEachIndexed { index, char ->
+        if (index != 0 && (index - remainder) % 3 == 0) grouped.append(',')
+        grouped.append(char)
+    }
+    return "$" + grouped.toString()
+}
+
+private fun PerformanceRange.narrationLabel(): String = when (this) {
+    PerformanceRange.ONE_WEEK -> "1 week"
+    PerformanceRange.ONE_MONTH -> "1 month"
+    PerformanceRange.THREE_MONTHS -> "3 months"
+    PerformanceRange.SIX_MONTHS -> "6 months"
+    PerformanceRange.ONE_YEAR -> "1 year"
+    PerformanceRange.ALL_TIME -> "all time"
+}
+
+private fun PerformanceRange.narrationSpokenLabel(): String = when (this) {
+    PerformanceRange.ONE_WEEK -> "one week"
+    PerformanceRange.ONE_MONTH -> "one month"
+    PerformanceRange.THREE_MONTHS -> "three months"
+    PerformanceRange.SIX_MONTHS -> "six months"
+    PerformanceRange.ONE_YEAR -> "one year"
+    PerformanceRange.ALL_TIME -> "all time"
 }

--- a/apps/windows/src/test/kotlin/com/finance/desktop/narration/ChartNarratorTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/narration/ChartNarratorTest.kt
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.narration
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Deterministic tests for [ChartNarrator] — the narrator that turns a chart's
+ * already-computed series into the shared [Narration] contract so Canvas charts
+ * are speakable by Narrator / UI Automation. Pure and model-free.
+ */
+class ChartNarratorTest {
+
+    private val performancePoints =
+        listOf(
+            ChartValuePoint("Day 1", 40000.0),
+            ChartValuePoint("Day 2", 39000.0),
+            ChartValuePoint("Day 3", 41000.0),
+            ChartValuePoint("Day 4", 42000.0),
+        )
+
+    private val allocationSlices =
+        listOf(
+            ChartCategorySlice("US Stocks", 0.56),
+            ChartCategorySlice("International", 0.12),
+            ChartCategorySlice("Bonds", 0.20),
+            ChartCategorySlice("Real Estate", 0.07),
+            ChartCategorySlice("Cash", 0.05),
+        )
+
+    @Test
+    fun `performance headline states direction, endpoints and percent change`() {
+        val narration =
+            ChartNarrator.narratePerformance(
+                rangeText = "1 month",
+                rangeSpoken = "one month",
+                points = performancePoints,
+            )
+
+        assertEquals(
+            "Performance, 1 month. Portfolio rose from $40,000 to $42,000, up 5.0%.",
+            narration.headline.text,
+        )
+        assertEquals(
+            "Performance, one month. Portfolio rose from forty thousand dollars to " +
+                "forty-two thousand dollars, up 5.0 percent.",
+            narration.headline.a11y.screenReaderText,
+        )
+        assertEquals(2, narration.headline.a11y.headingLevel)
+        assertEquals(A11yRole.STATUS, narration.headline.a11y.role)
+    }
+
+    @Test
+    fun `performance range segment reports the low and high points`() {
+        val narration =
+            ChartNarrator.narratePerformance(
+                rangeText = "1 month",
+                rangeSpoken = "one month",
+                points = performancePoints,
+            )
+
+        val range = narration.segments.single()
+        assertEquals("performance.range", range.id)
+        assertEquals("Range: low $39,000 at Day 2, high $42,000 at Day 4.", range.text)
+        assertEquals(
+            "Range: low thirty-nine thousand dollars at Day 2, " +
+                "high forty-two thousand dollars at Day 4.",
+            range.a11y.screenReaderText,
+        )
+    }
+
+    @Test
+    fun `performance handles a declining series without alarmist wording`() {
+        val narration =
+            ChartNarrator.narratePerformance(
+                rangeText = "1 week",
+                rangeSpoken = "one week",
+                points =
+                    listOf(
+                        ChartValuePoint("Mon", 42000.0),
+                        ChartValuePoint("Fri", 40000.0),
+                    ),
+            )
+
+        assertTrue(narration.headline.text.contains("declined from $42,000 to $40,000, down"))
+        assertEquals(null, NarrationText.firstBannedTerm(narration.screenReaderText()))
+    }
+
+    @Test
+    fun `empty performance series narrates a no-data message`() {
+        val narration =
+            ChartNarrator.narratePerformance(
+                rangeText = "1 month",
+                rangeSpoken = "one month",
+                points = emptyList(),
+            )
+
+        assertEquals("Performance, 1 month. No performance data yet.", narration.headline.text)
+        assertTrue(narration.segments.isEmpty())
+    }
+
+    @Test
+    fun `allocation narration lists every slice with spoken percentages`() {
+        val narration = ChartNarrator.narrateAllocation(allocationSlices)
+
+        assertEquals(
+            "Asset allocation: US Stocks 56%, International 12%, Bonds 20%, " +
+                "Real Estate 7%, Cash 5%.",
+            narration.headline.text,
+        )
+        assertEquals(
+            "Asset allocation: US Stocks 56 percent, International 12 percent, " +
+                "Bonds 20 percent, Real Estate 7 percent, Cash 5 percent.",
+            narration.headline.a11y.screenReaderText,
+        )
+        assertTrue(narration.segments.isEmpty())
+    }
+
+    @Test
+    fun `empty allocation narrates a no-holdings message`() {
+        val narration = ChartNarrator.narrateAllocation(emptyList())
+
+        assertEquals("Asset allocation: no holdings yet.", narration.headline.text)
+    }
+
+    @Test
+    fun `chart narrations are polite, never assertive`() {
+        val performance =
+            ChartNarrator.narratePerformance(
+                rangeText = "1 month",
+                rangeSpoken = "one month",
+                points = performancePoints,
+            )
+        val allocation = ChartNarrator.narrateAllocation(allocationSlices)
+
+        val all = listOf(performance, allocation)
+        for (narration in all) {
+            val segments = listOf(narration.headline) + narration.segments
+            assertTrue(segments.none { it.a11y.ariaLive == AriaLive.ASSERTIVE })
+            assertTrue(segments.all { it.a11y.ariaLive == AriaLive.POLITE })
+            assertEquals(GeneratorKind.TEMPLATE, narration.provenance.generator)
+        }
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/narration/NarrationTextTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/narration/NarrationTextTest.kt
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.narration
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for the pure narration formatting helpers ([NarrationText]).
+ *
+ * These run in CI with no model and no UI — they pin the spelled-out number,
+ * money, percent, and date conventions the golden narrations depend on.
+ */
+class NarrationTextTest {
+
+    @Test
+    fun `spellInt spells small and compound numbers`() {
+        assertEquals("zero", NarrationText.spellInt(0))
+        assertEquals("eight", NarrationText.spellInt(8))
+        assertEquals("twenty-one", NarrationText.spellInt(21))
+        assertEquals("forty", NarrationText.spellInt(40))
+        assertEquals("eighty-eight", NarrationText.spellInt(88))
+    }
+
+    @Test
+    fun `spellInt spells hundreds thousands and millions`() {
+        assertEquals("three hundred fifteen", NarrationText.spellInt(315))
+        assertEquals("one thousand two hundred forty", NarrationText.spellInt(1240))
+        assertEquals("forty-two thousand", NarrationText.spellInt(42000))
+        assertEquals("four thousand six hundred", NarrationText.spellInt(4600))
+        assertEquals("one million", NarrationText.spellInt(1_000_000))
+    }
+
+    @Test
+    fun `ordinalDay spells direct and compound ordinals`() {
+        assertEquals("first", NarrationText.ordinalDay(1))
+        assertEquals("twentieth", NarrationText.ordinalDay(20))
+        assertEquals("twenty-fifth", NarrationText.ordinalDay(25))
+        assertEquals("thirty-first", NarrationText.ordinalDay(31))
+    }
+
+    @Test
+    fun `groupThousands inserts separators`() {
+        assertEquals("0", NarrationText.groupThousands(0))
+        assertEquals("999", NarrationText.groupThousands(999))
+        assertEquals("1,240", NarrationText.groupThousands(1240))
+        assertEquals("42,000", NarrationText.groupThousands(42000))
+        assertEquals("1,000,000", NarrationText.groupThousands(1_000_000))
+    }
+
+    @Test
+    fun `formatCents renders currency glyph form`() {
+        assertEquals("$88.00", NarrationText.formatCents(8800))
+        assertEquals("$315.00", NarrationText.formatCents(31500))
+        assertEquals("$1,240.50", NarrationText.formatCents(124050))
+    }
+
+    @Test
+    fun `spellCents spells whole and fractional dollars`() {
+        assertEquals("eighty-eight dollars", NarrationText.spellCents(8800))
+        assertEquals("three hundred dollars", NarrationText.spellCents(30000))
+        assertEquals(
+            "one thousand two hundred forty dollars and fifty cents",
+            NarrationText.spellCents(124050),
+        )
+        assertEquals("one dollar and one cent", NarrationText.spellCents(101))
+    }
+
+    @Test
+    fun `whole dollar helpers format and spell`() {
+        assertEquals("$40,000", NarrationText.formatWholeDollars(40000))
+        assertEquals("$4,600", NarrationText.formatWholeDollars(4600))
+        assertEquals("forty-two thousand dollars", NarrationText.spellWholeDollars(42000))
+        assertEquals("four thousand six hundred dollars", NarrationText.spellWholeDollars(4600))
+    }
+
+    @Test
+    fun `percent and one decimal are locale stable`() {
+        assertEquals(56, NarrationText.percentInt(0.56))
+        assertEquals(7, NarrationText.percentInt(0.07))
+        assertEquals(46, NarrationText.percentInt(0.46))
+        assertEquals("5.0", NarrationText.oneDecimal(5.0))
+        assertEquals("21.2", NarrationText.oneDecimal(21.249))
+    }
+
+    @Test
+    fun `dates render visible and spoken forms`() {
+        assertEquals("June 25", NarrationText.monthDayVisible("2026-06-25"))
+        assertEquals("June twenty-fifth", NarrationText.monthDayOrdinal("2026-06-25"))
+        assertEquals("January 1", NarrationText.monthDayVisible("2026-01-01"))
+    }
+
+    @Test
+    fun `capitalizeFirst upper-cases the leading letter only`() {
+        assertEquals("Three hundred fifteen", NarrationText.capitalizeFirst("three hundred fifteen"))
+        assertEquals("Your", NarrationText.capitalizeFirst("your"))
+        assertEquals("", NarrationText.capitalizeFirst(""))
+    }
+
+    @Test
+    fun `firstBannedTerm detects alarmist vocabulary case-insensitively`() {
+        assertEquals("overspent", NarrationText.firstBannedTerm("You have OVERSPENT this month"))
+        assertEquals("behind", NarrationText.firstBannedTerm("You are behind on savings"))
+        assertEquals(null, NarrationText.firstBannedTerm("Your Dining plan is fully used."))
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/narration/TemplateNarrationGeneratorTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/narration/TemplateNarrationGeneratorTest.kt
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.narration
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Golden tests for the deterministic [TemplateNarrationGenerator].
+ *
+ * The fixture snapshot and the expected concise/detailed narrations are the
+ * worked example from `docs/windows/ml-narration-pipeline-design.md` §9, stored
+ * as JSON under `src/test/resources/narration-fixtures`. Equality is asserted
+ * against the decoded data classes (not raw JSON text) so whitespace and field
+ * order are irrelevant — only the narration content is pinned. Everything runs
+ * with no model present.
+ */
+class TemplateNarrationGeneratorTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val generator = TemplateNarrationGenerator()
+
+    private fun loadResource(path: String): String =
+        requireNotNull(javaClass.getResourceAsStream(path)) { "missing test resource: $path" }
+            .bufferedReader()
+            .use { it.readText() }
+
+    private fun loadSnapshot(): FinancialStateSnapshot =
+        json.decodeFromString(
+            FinancialStateSnapshot.serializer(),
+            loadResource("/narration-fixtures/snapshots/02-bill-due-soon.json"),
+        )
+
+    private fun loadGolden(path: String): Narration =
+        json.decodeFromString(Narration.serializer(), loadResource(path))
+
+    @Test
+    fun `concise narration matches the golden fixture`() {
+        val snapshot = loadSnapshot()
+        val expected = loadGolden("/narration-fixtures/golden/02-bill-due-soon.concise.json")
+
+        val actual = generator.generate(snapshot, NarrationMode.CONCISE)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `detailed narration matches the golden fixture`() {
+        val snapshot = loadSnapshot()
+        val expected = loadGolden("/narration-fixtures/golden/02-bill-due-soon.detailed.json")
+
+        val actual = generator.generate(snapshot, NarrationMode.DETAILED)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `time-relevant bill leads the headline, not the low-confidence trend`() {
+        val narration = generator.generate(loadSnapshot(), NarrationMode.CONCISE)
+
+        assertEquals("summary", narration.headline.id)
+        assertEquals(SegmentKind.SUMMARY, narration.headline.kind)
+        assertTrue(narration.headline.text.startsWith("Your Electric bill"))
+    }
+
+    @Test
+    fun `concise mode keeps at most two segments and omits the goal and uncertainty`() {
+        val narration = generator.generate(loadSnapshot(), NarrationMode.CONCISE)
+
+        assertEquals(listOf("budget.dining", "trend"), narration.segments.map { it.id })
+    }
+
+    @Test
+    fun `detailed mode appends an explicit uncertainty segment for the low-confidence trend`() {
+        val narration = generator.generate(loadSnapshot(), NarrationMode.DETAILED)
+
+        assertEquals(
+            listOf("budget.dining", "trend", "goal.emergency.fund", "uncertainty"),
+            narration.segments.map { it.id },
+        )
+        val uncertainty = narration.segments.last()
+        assertEquals(SegmentKind.UNCERTAINTY, uncertainty.kind)
+        assertEquals(ConfidenceLevel.LOW, uncertainty.confidence.level)
+    }
+
+    @Test
+    fun `narration tone never uses banned, alarmist vocabulary`() {
+        for (mode in NarrationMode.entries) {
+            val narration = generator.generate(loadSnapshot(), mode)
+            val combined = narration.plainText() + " " + narration.screenReaderText()
+            val banned = NarrationText.firstBannedTerm(combined)
+            assertNull(banned, "mode $mode leaked banned term: $banned")
+            assertTrue(narration.plainText().contains("fully used"))
+        }
+    }
+
+    @Test
+    fun `every segment carries non-empty screen reader text and source references`() {
+        val narration = generator.generate(loadSnapshot(), NarrationMode.DETAILED)
+        val all = listOf(narration.headline) + narration.segments
+
+        for (segment in all) {
+            assertTrue(segment.a11y.screenReaderText.isNotBlank(), "blank SR text for ${segment.id}")
+            assertTrue(segment.sourceRefs.isNotEmpty(), "missing sourceRefs for ${segment.id}")
+        }
+    }
+
+    @Test
+    fun `accessibility metadata is never assertive and the headline is the only heading`() {
+        val narration = generator.generate(loadSnapshot(), NarrationMode.DETAILED)
+        val all = listOf(narration.headline) + narration.segments
+
+        assertTrue(all.none { it.a11y.ariaLive == AriaLive.ASSERTIVE })
+
+        val headings = all.filter { it.a11y.headingLevel != null }
+        assertEquals(1, headings.size)
+        assertEquals(narration.headline.id, headings.single().id)
+        assertEquals(2, narration.headline.a11y.headingLevel)
+        assertEquals(A11yRole.STATUS, narration.headline.a11y.role)
+    }
+
+    @Test
+    fun `provenance marks the output as a deterministic template with no model`() {
+        val narration = generator.generate(loadSnapshot(), NarrationMode.CONCISE)
+
+        assertEquals(GeneratorKind.TEMPLATE, narration.provenance.generator)
+        assertTrue(narration.provenance.deterministic)
+        assertNull(narration.provenance.modelId)
+        assertNull(narration.provenance.modelVersion)
+        assertNull(narration.provenance.runtime)
+    }
+
+    @Test
+    fun `net-worth headline is used when no bills are pending`() {
+        val snapshot = loadSnapshot().copy(upcomingBills = emptyList())
+
+        val narration = generator.generate(snapshot, NarrationMode.CONCISE)
+
+        assertNotNull(narration.headline)
+        assertTrue(narration.headline.text.startsWith("Your net worth is"))
+        assertEquals(listOf("netWorth", "cashOnHand"), narration.headline.sourceRefs)
+    }
+}

--- a/apps/windows/src/test/resources/narration-fixtures/golden/02-bill-due-soon.concise.json
+++ b/apps/windows/src/test/resources/narration-fixtures/golden/02-bill-due-soon.concise.json
@@ -1,0 +1,53 @@
+{
+  "mode": "concise",
+  "schemaVersion": 1,
+  "locale": "en-US",
+  "headline": {
+    "id": "summary",
+    "kind": "summary",
+    "text": "Your Electric bill of $88.00 is due June 25, and you have $1,240.50 on hand.",
+    "confidence": { "level": "high", "score": 0.95, "basis": "rule" },
+    "a11y": {
+      "screenReaderText": "Your Electric bill of eighty-eight dollars is due June twenty-fifth, and you have one thousand two hundred forty dollars and fifty cents on hand.",
+      "ariaLive": "polite",
+      "role": "status",
+      "headingLevel": 2
+    },
+    "sourceRefs": ["bill.electric", "cashOnHand"]
+  },
+  "segments": [
+    {
+      "id": "budget.dining",
+      "kind": "budget",
+      "text": "Your Dining plan is fully used — $315.00 of the $300.00 you planned. Want to adjust the plan or move funds?",
+      "confidence": { "level": "high", "score": 0.95, "basis": "rule" },
+      "a11y": {
+        "screenReaderText": "Your Dining plan is fully used. Three hundred fifteen dollars of the three hundred dollars you planned. Want to adjust the plan or move funds?",
+        "ariaLive": "polite",
+        "role": "note",
+        "headingLevel": null
+      },
+      "sourceRefs": ["budget.dining"]
+    },
+    {
+      "id": "trend",
+      "kind": "trend",
+      "text": "Early signal: your net worth looks slightly higher over the last 21 days. This may change as more history builds.",
+      "confidence": { "level": "low", "score": 0.42, "basis": "sample_size" },
+      "a11y": {
+        "screenReaderText": "Early signal. Your net worth looks slightly higher over the last twenty-one days. This may change as more history builds.",
+        "ariaLive": "polite",
+        "role": "note",
+        "headingLevel": null
+      },
+      "sourceRefs": ["netWorthTrend"]
+    }
+  ],
+  "provenance": {
+    "generator": "template",
+    "deterministic": true,
+    "modelId": null,
+    "modelVersion": null,
+    "runtime": null
+  }
+}

--- a/apps/windows/src/test/resources/narration-fixtures/golden/02-bill-due-soon.detailed.json
+++ b/apps/windows/src/test/resources/narration-fixtures/golden/02-bill-due-soon.detailed.json
@@ -1,0 +1,79 @@
+{
+  "mode": "detailed",
+  "schemaVersion": 1,
+  "locale": "en-US",
+  "headline": {
+    "id": "summary",
+    "kind": "summary",
+    "text": "Your Electric bill of $88.00 is due June 25, and you have $1,240.50 on hand.",
+    "confidence": { "level": "high", "score": 0.95, "basis": "rule" },
+    "a11y": {
+      "screenReaderText": "Your Electric bill of eighty-eight dollars is due June twenty-fifth, and you have one thousand two hundred forty dollars and fifty cents on hand.",
+      "ariaLive": "polite",
+      "role": "status",
+      "headingLevel": 2
+    },
+    "sourceRefs": ["bill.electric", "cashOnHand"]
+  },
+  "segments": [
+    {
+      "id": "budget.dining",
+      "kind": "budget",
+      "text": "Your Dining plan is fully used — $315.00 of the $300.00 you planned. Want to adjust the plan or move funds?",
+      "confidence": { "level": "high", "score": 0.95, "basis": "rule" },
+      "a11y": {
+        "screenReaderText": "Your Dining plan is fully used. Three hundred fifteen dollars of the three hundred dollars you planned. Want to adjust the plan or move funds?",
+        "ariaLive": "polite",
+        "role": "note",
+        "headingLevel": null
+      },
+      "sourceRefs": ["budget.dining"]
+    },
+    {
+      "id": "trend",
+      "kind": "trend",
+      "text": "Early signal: your net worth looks slightly higher over the last 21 days. This may change as more history builds.",
+      "confidence": { "level": "low", "score": 0.42, "basis": "sample_size" },
+      "a11y": {
+        "screenReaderText": "Early signal. Your net worth looks slightly higher over the last twenty-one days. This may change as more history builds.",
+        "ariaLive": "polite",
+        "role": "note",
+        "headingLevel": null
+      },
+      "sourceRefs": ["netWorthTrend"]
+    },
+    {
+      "id": "goal.emergency.fund",
+      "kind": "goal",
+      "text": "You've saved $4,600 toward your Emergency Fund — 46% there, on track for about 14 months at your recent pace.",
+      "confidence": { "level": "medium", "score": 0.7, "basis": "blended" },
+      "a11y": {
+        "screenReaderText": "You've saved four thousand six hundred dollars toward your Emergency Fund. 46 percent there, on track for about fourteen months at your recent pace.",
+        "ariaLive": "polite",
+        "role": "note",
+        "headingLevel": null
+      },
+      "sourceRefs": ["goal.emergency.fund"]
+    },
+    {
+      "id": "uncertainty",
+      "kind": "uncertainty",
+      "text": "One note on confidence: the net-worth trend is based on a short, 21-day window, so treat it as a rough early signal rather than a firm direction.",
+      "confidence": { "level": "low", "score": 0.42, "basis": "sample_size" },
+      "a11y": {
+        "screenReaderText": "One note on confidence. The net-worth trend is based on a short, twenty-one day window, so treat it as a rough early signal rather than a firm direction.",
+        "ariaLive": "polite",
+        "role": "note",
+        "headingLevel": null
+      },
+      "sourceRefs": ["netWorthTrend"]
+    }
+  ],
+  "provenance": {
+    "generator": "template",
+    "deterministic": true,
+    "modelId": null,
+    "modelVersion": null,
+    "runtime": null
+  }
+}

--- a/apps/windows/src/test/resources/narration-fixtures/snapshots/02-bill-due-soon.json
+++ b/apps/windows/src/test/resources/narration-fixtures/snapshots/02-bill-due-soon.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "asOf": "2026-06-22T00:00:00Z",
+  "locale": "en-US",
+  "currency": "USD",
+  "netWorth": { "cents": 4185000, "currency": "USD" },
+  "cashOnHand": { "cents": 124050, "currency": "USD" },
+  "safeToSpend": { "cents": 38000, "currency": "USD" },
+  "netWorthTrend": {
+    "direction": "up",
+    "changeCents": 52000,
+    "changePct": 0.0126,
+    "periodDays": 21,
+    "confidence": { "level": "low", "score": 0.42, "basis": "sample_size" }
+  },
+  "budgets": [
+    {
+      "categoryName": "Dining",
+      "plannedCents": 30000,
+      "spentCents": 31500,
+      "period": "monthly",
+      "isRollover": false,
+      "percentUsed": 1.05,
+      "confidence": { "level": "high", "score": 0.95, "basis": "rule" }
+    }
+  ],
+  "upcomingBills": [
+    { "name": "Electric", "amountCents": 8800, "dueDateIso": "2026-06-25", "status": "due" }
+  ],
+  "goals": [
+    {
+      "name": "Emergency Fund",
+      "targetCents": 1000000,
+      "currentCents": 460000,
+      "percentComplete": 0.46,
+      "monthsToTarget": 14,
+      "confidence": { "level": "medium", "score": 0.7, "basis": "blended" }
+    }
+  ],
+  "insights": [],
+  "signals": []
+}

--- a/docs/windows/chart-narration-validation-checklist.md
+++ b/docs/windows/chart-narration-validation-checklist.md
@@ -1,0 +1,116 @@
+# Chart Narration — Narrator & Accessibility Insights Validation Checklist
+
+Manual validation steps for the deterministic chart-narration slice (issue
+[#2707], part of [#2394]). These checks run on a **Windows build** of the
+desktop app and require a human with Narrator and
+[Accessibility Insights for Windows][aiwin]. They complement the automated JVM
+tests (`TemplateNarrationGeneratorTest`, `ChartNarratorTest`, `NarrationTextTest`)
+that already pin the narration **content** in CI with no model present.
+
+> Scope: this checklist validates the **template (deterministic)** narration and
+> its UI Automation surfacing. The optional ML/abstractive narration and its
+> on-hardware validation are tracked separately (see _Out of scope_).
+
+## Surfaces under test
+
+| Panel             | UIA test tag                | Source                                  |
+| ----------------- | --------------------------- | --------------------------------------- |
+| Performance chart | `cockpit.panel.performance` | `InvestmentScreen.PerformanceChartCard` |
+| Allocation donut  | `cockpit.panel.allocation`  | `InvestmentScreen.AllocationChartCard`  |
+
+Both panels render a Canvas chart wrapped in `NarratedChart`, which exposes a
+single merged summary node, a polite live region, an `Alt+R` replay shortcut, and
+a **View as table** toggle.
+
+## 1. Narrator — start here
+
+1. Start Narrator with **`Win` + `Ctrl` + `Enter`**.
+2. Open the app and navigate to the **Investments** screen.
+3. Tab to the **Performance** chart panel.
+
+- [ ] Narrator announces the chart **summary** (e.g. _"Performance, one month.
+      Portfolio rose from forty thousand dollars to forty-two thousand dollars,
+      up 5.0 percent."_) rather than reading the raw Canvas or nothing.
+- [ ] Money is spoken as **words** ("forty thousand dollars"), percentages keep
+      digits and speak **"percent"** ("5.0 percent").
+- [ ] The **Allocation** panel announces each slice with a spoken percentage
+      ("US Stocks 56 percent, …").
+- [ ] No alarmist or shaming words are spoken (never "overspent", "behind",
+      "danger", "warning"; a maxed budget is "fully used").
+
+## 2. Heading navigation
+
+1. With Narrator on, press **`H`** / **`Shift` + `H`** to move between headings.
+
+- [ ] Each chart panel's summary is reachable as a **heading (level 2)**.
+- [ ] Heading order is logical top-to-bottom (Performance before Allocation,
+      matching the visual order).
+
+## 3. Keyboard replay (`Alt` + `R`)
+
+1. Move keyboard focus onto a chart panel (Tab until it is focused).
+2. Press **`Alt` + `R`**.
+
+- [ ] The summary is **re-announced** by Narrator without moving focus.
+- [ ] Repeated `Alt` + `R` presses re-announce each time (the zero-width replay
+      nonce forces the live region to re-fire).
+- [ ] `Alt` + `R` does **not** trigger any other action or collide with Narrator
+      scan-mode quick keys.
+- [ ] The on-screen hint "Alt+R replays narration" is present and is itself
+      announced ("Press Alt plus R to replay the chart narration").
+
+## 4. Live region on data change
+
+1. Change the Performance **range** (e.g. 1W → 1M → 1Y) using the range chips.
+
+- [ ] Narrator **politely** announces the updated summary after each change
+      (it waits for a pause; it never interrupts mid-sentence).
+- [ ] The announcement is never **assertive** for routine state.
+
+## 5. "View as table" text alternative
+
+1. Activate the **View as table** toggle on a chart panel.
+
+- [ ] The toggle exposes a button **name** ("View as table" / "View as chart")
+      and a **state** of "chart" / "table" to UI Automation.
+- [ ] When toggled to a table, each row is keyboard-focusable and Narrator reads
+      label + value (e.g. "Day 4, $42,000" / "US Stocks, 56 percent").
+- [ ] Toggling back restores the chart and its merged summary node.
+
+## 6. Accessibility Insights for Windows
+
+1. Open **Accessibility Insights for Windows** and hover/inspect each panel.
+2. Run **Live Inspect** and the **automated FastPass** checks.
+
+- [ ] Each chart panel reports a **Name** equal to the narration summary.
+- [ ] The summary node has the expected **ControlType / role** (status/heading)
+      and **LiveSetting = Polite** on the live region.
+- [ ] The **View as table** button reports `Name`, `ControlType = Button`, and a
+      `LegacyIAccessible`/state description.
+- [ ] FastPass reports **no errors** for the chart panels (no missing names, no
+      keyboard traps).
+- [ ] Tab order through the panel (chart → View-as-table → next panel) is logical
+      and has no focus traps.
+
+## 7. High contrast & scaling
+
+1. Toggle a **High Contrast** theme (`Left Alt` + `Left Shift` + `Print Screen`).
+2. Increase **text scaling** in Windows display settings (e.g. 150%, 200%).
+
+- [ ] Narration text, the replay hint, and the toggle remain legible and are not
+      clipped at high contrast.
+- [ ] At larger scale factors the panels reflow without overlapping or losing the
+      narration/toggle affordances.
+
+## Out of scope (tracked elsewhere)
+
+- ML / abstractive narration (ONNX Runtime + DirectML) and its determinism /
+  privacy validation — see `docs/windows/ml-narration-pipeline-design.md` §11.
+- Recording on-hardware Narrator transcripts (`ml-transcripts/*`) once a
+  license-cleared model and a Windows CI runner exist.
+- Moving the narration contract types into shared `packages/core` commonMain
+  (owned by @kmp-engineer).
+
+[#2707]: https://github.com/jrmoulckers/finance/issues/2707
+[#2394]: https://github.com/jrmoulckers/finance/issues/2394
+[aiwin]: https://accessibilityinsights.io/docs/windows/overview/


### PR DESCRIPTION
## Summary

Implements the deterministic (non-ML) slice of Windows chart narration, per the contract in docs/windows/ml-narration-pipeline-design.md (sections 5 and 9) and the cockpit semantics spec docs/windows/ultrawide-portfolio-cockpit-layout.md (section 7).

Refs #2707 (part of #2394).

### What is included
- Narration contract types (narration/NarrationContract.kt): FinancialStateSnapshot input, Narration output with per-segment accessibility metadata (live-region politeness, role, heading level), confidence/uncertainty encoding, provenance, and concise/detailed modes. Serializable so goldens are plain JSON.
- Deterministic TemplateNarrationGenerator: non-alarmist phrasing ("fully used", never "overspent"), low-confidence hedging ("early signal"), and an explicit uncertainty segment in detailed mode. Reproduces the design section 9 worked example exactly.
- ChartNarrator: turns performance/allocation chart series into the same Narration contract (single labelled summary node plus range insight).
- Compose Desktop semantics mapping (accessibility/NarrationSemantics.kt, components/ChartNarration.kt): merged summary node, polite live region, heading(), a NarratedChart scaffold, and a "View as table" text alternative (WCAG 1.1.1).
- Keyboard replay: Alt+R on a focused chart re-emits the narration into the live region (a zero-width nonce forces Narrator to re-speak the same text).
- Wired into InvestmentScreen PerformanceChartCard and AllocationChartCard with focusable data tables and spoken range labels.
- Unit tests (JVM, model-free): golden fixtures (02-bill-due-soon) -> concise and detailed narration deep-equality, plus tone (no banned terms), uncertainty, accessibility (no assertive live regions, single heading), and provenance assertions; plus ChartNarrator and NarrationText tests.
- Validation checklist doc for Narrator (Win+Ctrl+Enter) and Accessibility Insights.

### Build / validation note
Local JDK/Gradle is NOT available in this environment, so the Gradle build / detekt / JVM tests were not run locally -- relying on remote CI to validate. Code carefully matches existing Compose/accessibility imports and patterns. prettier --check passes for the new .md/.json. eslint was not run locally because the repo package-lock.json is out of sync with package.json (pre-existing, unrelated) and no JS/TS was touched -- CI covers it.

## Remaining Work (out of scope here -- toolchain / human-gated)
- ML / abstractive narration (ONNX Runtime + DirectML, license-cleared model, Windows CI runner) -- design section 11 items 1-4.
- Move the narration contract types into shared packages/core commonMain (owned by @kmp-engineer) -- design section 11 item 5.
- On-hardware Narrator and Accessibility Insights manual validation (run the new docs/windows/chart-narration-validation-checklist.md on a Windows build).
- Record ml-transcripts/* once a license-cleared model exists.
