### PR TITLE
feat(web): compound-growth investment projections and contribution tracking (#2118)

### DIFF
--- a/apps/web/src/components/investments/InvestmentProjections.test.tsx
+++ b/apps/web/src/components/investments/InvestmentProjections.test.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { InvestmentProjections } from './InvestmentProjections';
+
+/** Stub window.matchMedia so prefers-reduced-motion checks don't throw. */
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+/** Mock Recharts — canvas/SVG APIs are unavailable in jsdom. */
+vi.mock('recharts', async () => {
+  const R = await import('react');
+  const mock = (name: string) =>
+    function MockComponent(props: Record<string, unknown>) {
+      return R.createElement('div', { 'data-testid': name }, props.children as React.ReactNode);
+    };
+  return {
+    ResponsiveContainer: mock('ResponsiveContainer'),
+    LineChart: mock('LineChart'),
+    Line: mock('Line'),
+    XAxis: mock('XAxis'),
+    YAxis: mock('YAxis'),
+    CartesianGrid: mock('CartesianGrid'),
+    Tooltip: mock('Tooltip'),
+    Legend: mock('Legend'),
+  };
+});
+
+describe('InvestmentProjections', () => {
+  it('renders the projection heading and a real-return disclaimer', () => {
+    render(<InvestmentProjections currentValueCents={1_000_000} />);
+
+    expect(screen.getByRole('heading', { name: 'Growth Projection' })).toBeInTheDocument();
+    expect(screen.getByText(/inflation-adjusted/i)).toBeInTheDocument();
+  });
+
+  it('exposes labelled scenario inputs', () => {
+    render(<InvestmentProjections currentValueCents={1_000_000} />);
+
+    expect(screen.getByLabelText('Monthly contribution')).toBeInTheDocument();
+    expect(screen.getByLabelText('Years to project')).toBeInTheDocument();
+    expect(screen.getByLabelText('Expected annual return')).toBeInTheDocument();
+  });
+
+  it('renders an accessible scenario summary table with three scenarios', () => {
+    render(<InvestmentProjections currentValueCents={1_000_000} />);
+
+    const table = screen.getByRole('table', { name: /Projected value after/i });
+    expect(within(table).getByRole('rowheader', { name: 'Conservative' })).toBeInTheDocument();
+    expect(within(table).getByRole('rowheader', { name: 'Expected' })).toBeInTheDocument();
+    expect(within(table).getByRole('rowheader', { name: 'Optimistic' })).toBeInTheDocument();
+  });
+
+  it('renders a chart with a text alternative (figure role)', () => {
+    render(<InvestmentProjections currentValueCents={1_000_000} />);
+
+    expect(
+      screen.getByRole('figure', { name: /Projected portfolio value by scenario/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders contribution tracking with a starting value', () => {
+    render(<InvestmentProjections currentValueCents={1_000_000} investedToDateCents={800_000} />);
+
+    expect(screen.getByText('Starting value')).toBeInTheDocument();
+    expect(screen.getByText('Invested to date')).toBeInTheDocument();
+    expect(screen.getByText('Recurring contribution')).toBeInTheDocument();
+  });
+
+  it('updates the projection horizon when the years input changes', () => {
+    render(<InvestmentProjections currentValueCents={1_000_000} />);
+
+    expect(screen.getByRole('table', { name: /after 20 years/i })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Years to project'), { target: { value: '10' } });
+
+    expect(screen.getByRole('table', { name: /after 10 years/i })).toBeInTheDocument();
+  });
+
+  it('keeps the optimistic scenario at least as large as the conservative one', () => {
+    render(<InvestmentProjections currentValueCents={1_000_000} />);
+
+    const table = screen.getByRole('table', { name: /Projected value after/i });
+    const rows = within(table).getAllByRole('row');
+    // Header row + 3 scenario rows.
+    expect(rows).toHaveLength(4);
+  });
+});

--- a/apps/web/src/components/investments/InvestmentProjections.tsx
+++ b/apps/web/src/components/investments/InvestmentProjections.tsx
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * InvestmentProjections — compound-growth projection card for the investments
+ * page (#2118).
+ *
+ * Lets an index-fund / FIRE-minded investor connect today's portfolio value and
+ * a recurring contribution to a range of future-value scenarios over a multi-year
+ * horizon. Pure projection math lives in `lib/investments/projections`; this
+ * component only owns the form state and presentation.
+ *
+ * Accessibility (WCAG 2.2 AA):
+ * - Every input has an associated `<label>` and `aria-describedby` help text.
+ * - The growth chart (shared `TrendLineChart`) ships a text summary, a keyboard
+ *   navigable data table, and is not the sole carrier of meaning.
+ * - The scenario summary is a real `<table>` with a caption and scoped headers;
+ *   gains are conveyed with text ("Growth"), never colour alone.
+ * - A polite live region announces the expected projected value as inputs change.
+ *
+ * Data scope: projects from LOCAL holdings + user assumptions only. Real-time
+ * price / brokerage ingestion is separate, blocked work (see PR notes).
+ */
+
+import React, { useId, useMemo, useState } from 'react';
+import { TrendLineChart } from '../charts';
+import { CurrencyDisplay } from '../common';
+import { formatCurrency } from '../../lib/currency';
+import {
+  buildProjectionChartData,
+  deriveProjectionScenarios,
+  projectPortfolioGrowth,
+} from '../../lib/investments/projections';
+
+export interface InvestmentProjectionsProps {
+  /** Current portfolio market value in cents (from the portfolio summary). */
+  readonly currentValueCents: number;
+  /** Optional amount invested to date in cents (sum of holding cost bases). */
+  readonly investedToDateCents?: number;
+  /** Currency code for formatting (defaults to USD). */
+  readonly currency?: string;
+}
+
+/** Default form assumptions for a long-horizon index-fund investor. */
+const DEFAULT_MONTHLY_CONTRIBUTION_DOLLARS = '500';
+const DEFAULT_YEARS = 20;
+const DEFAULT_EXPECTED_RETURN_PERCENT = 7;
+const SCENARIO_SPREAD = 0.03;
+
+/** Parse a dollar string into integer cents, guarding against bad input. */
+function dollarsToCents(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.round(parsed * 100);
+}
+
+/** Clamp a numeric input to a sensible inclusive range. */
+function clampNumber(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+export const InvestmentProjections: React.FC<InvestmentProjectionsProps> = ({
+  currentValueCents,
+  investedToDateCents,
+  currency = 'USD',
+}) => {
+  const fieldId = useId();
+  const contributionId = `${fieldId}-contribution`;
+  const contributionHelpId = `${fieldId}-contribution-help`;
+  const yearsId = `${fieldId}-years`;
+  const yearsHelpId = `${fieldId}-years-help`;
+  const returnId = `${fieldId}-return`;
+  const returnHelpId = `${fieldId}-return-help`;
+  const disclaimerId = `${fieldId}-disclaimer`;
+
+  const [monthlyContribution, setMonthlyContribution] = useState(
+    DEFAULT_MONTHLY_CONTRIBUTION_DOLLARS,
+  );
+  const [years, setYears] = useState(DEFAULT_YEARS);
+  const [expectedReturnPercent, setExpectedReturnPercent] = useState(
+    DEFAULT_EXPECTED_RETURN_PERCENT,
+  );
+
+  const contributionCents = dollarsToCents(monthlyContribution);
+
+  const result = useMemo(() => {
+    const scenarios = deriveProjectionScenarios(expectedReturnPercent / 100, SCENARIO_SPREAD);
+    return projectPortfolioGrowth({
+      currentValueCents,
+      contributionCents,
+      contributionFrequency: 'monthly',
+      years,
+      scenarios,
+    });
+  }, [currentValueCents, contributionCents, years, expectedReturnPercent]);
+
+  const chart = useMemo(() => buildProjectionChartData(result), [result]);
+
+  const expectedScenario =
+    result.scenarios.find((scenario) => scenario.scenario.id === 'expected') ??
+    result.scenarios[Math.floor(result.scenarios.length / 2)];
+
+  const liveSummary = expectedScenario
+    ? `Expected projection: ${formatCurrency(expectedScenario.finalValueCents, { currency })} after ${result.years} ${result.years === 1 ? 'year' : 'years'}.`
+    : '';
+
+  const cardStyle: React.CSSProperties = {
+    marginBottom: 'var(--spacing-6)',
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: 'var(--spacing-2) var(--spacing-3)',
+    border: '1px solid var(--semantic-border, #e5e7eb)',
+    borderRadius: 'var(--radius-md, 0.375rem)',
+    background: 'var(--semantic-background-primary, #fff)',
+    color: 'var(--semantic-text-primary, #111)',
+    font: 'inherit',
+  };
+
+  const helpStyle: React.CSSProperties = {
+    display: 'block',
+    marginTop: 'var(--spacing-1)',
+    fontSize: 'var(--type-scale-caption-font-size)',
+    color: 'var(--semantic-text-secondary)',
+  };
+
+  const cellStyle: React.CSSProperties = {
+    padding: 'var(--spacing-3)',
+    borderBottom: '1px solid var(--semantic-border, #e5e7eb)',
+    textAlign: 'right',
+  };
+
+  const headerCellStyle: React.CSSProperties = {
+    padding: 'var(--spacing-3)',
+    borderBottom: '2px solid var(--semantic-border, #e5e7eb)',
+    textAlign: 'right',
+  };
+
+  return (
+    <section className="page-section" aria-label="Compound-growth projection">
+      <div className="card" style={cardStyle}>
+        <h3 style={{ fontWeight: 'var(--font-weight-semibold)', marginTop: 0 }}>
+          Growth Projection
+        </h3>
+        <p id={disclaimerId} style={{ color: 'var(--semantic-text-secondary)', marginTop: 0 }}>
+          Estimates how today&rsquo;s holdings plus recurring contributions could compound over
+          time. Returns are treated as expected <strong>real</strong> (inflation-adjusted) rates, so
+          values are in today&rsquo;s dollars. Projections are illustrative, not a guarantee of
+          future performance.
+        </p>
+
+        {/* Scenario inputs */}
+        <div
+          style={{
+            display: 'grid',
+            gap: 'var(--spacing-4)',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+            marginBottom: 'var(--spacing-5)',
+          }}
+        >
+          <div className="form-group">
+            <label htmlFor={contributionId} style={{ fontWeight: 'var(--font-weight-medium)' }}>
+              Monthly contribution
+            </label>
+            <input
+              id={contributionId}
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step={50}
+              value={monthlyContribution}
+              onChange={(event) => setMonthlyContribution(event.target.value)}
+              aria-describedby={contributionHelpId}
+              style={inputStyle}
+            />
+            <span id={contributionHelpId} style={helpStyle}>
+              Amount added each month, in dollars.
+            </span>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor={yearsId} style={{ fontWeight: 'var(--font-weight-medium)' }}>
+              Years to project
+            </label>
+            <input
+              id={yearsId}
+              type="number"
+              inputMode="numeric"
+              min={1}
+              max={100}
+              step={1}
+              value={years}
+              onChange={(event) => setYears(clampNumber(Number(event.target.value), 1, 100))}
+              aria-describedby={yearsHelpId}
+              style={inputStyle}
+            />
+            <span id={yearsHelpId} style={helpStyle}>
+              Horizon in years (1&ndash;100).
+            </span>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor={returnId} style={{ fontWeight: 'var(--font-weight-medium)' }}>
+              Expected annual return
+            </label>
+            <input
+              id={returnId}
+              type="number"
+              inputMode="decimal"
+              min={-20}
+              max={20}
+              step={0.5}
+              value={expectedReturnPercent}
+              onChange={(event) =>
+                setExpectedReturnPercent(clampNumber(Number(event.target.value), -20, 20))
+              }
+              aria-describedby={returnHelpId}
+              style={inputStyle}
+            />
+            <span id={returnHelpId} style={helpStyle}>
+              Expected real return, % per year. Conservative and optimistic scenarios are derived at
+              &minus;3% and +3%.
+            </span>
+          </div>
+        </div>
+
+        {/* Polite live announcement for assistive tech */}
+        <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+          {liveSummary}
+        </p>
+
+        {/* Growth chart with built-in text + data-table alternatives */}
+        <TrendLineChart
+          data={chart.data as Array<{ label: string; [key: string]: string | number }>}
+          series={chart.series.map((s) => ({ dataKey: s.dataKey, name: s.name }))}
+          currency={currency}
+          title="Projected portfolio value by scenario"
+          height={320}
+        />
+
+        {/* Scenario summary table */}
+        <div style={{ overflowX: 'auto', marginTop: 'var(--spacing-5)' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <caption
+              style={{
+                textAlign: 'left',
+                fontWeight: 'var(--font-weight-semibold)',
+                marginBottom: 'var(--spacing-2)',
+              }}
+            >
+              Projected value after {result.years} {result.years === 1 ? 'year' : 'years'}
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col" style={{ ...headerCellStyle, textAlign: 'left' }}>
+                  Scenario
+                </th>
+                <th scope="col" style={headerCellStyle}>
+                  Annual return
+                </th>
+                <th scope="col" style={headerCellStyle}>
+                  Projected value
+                </th>
+                <th scope="col" style={headerCellStyle}>
+                  Total invested
+                </th>
+                <th scope="col" style={headerCellStyle}>
+                  Growth
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.scenarios.map((scenario) => (
+                <tr key={scenario.scenario.id}>
+                  <th scope="row" style={{ ...cellStyle, textAlign: 'left' }}>
+                    {scenario.scenario.label}
+                  </th>
+                  <td style={cellStyle}>
+                    {(scenario.scenario.annualReturnRate * 100).toFixed(1)}%
+                  </td>
+                  <td style={cellStyle}>
+                    <CurrencyDisplay amount={scenario.finalValueCents} currency={currency} />
+                  </td>
+                  <td style={cellStyle}>
+                    <CurrencyDisplay
+                      amount={scenario.totalContributionsCents}
+                      currency={currency}
+                    />
+                  </td>
+                  <td style={cellStyle}>
+                    <CurrencyDisplay amount={scenario.totalGrowthCents} currency={currency} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Contribution tracking */}
+        <div
+          style={{
+            display: 'grid',
+            gap: 'var(--spacing-4)',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+            marginTop: 'var(--spacing-5)',
+          }}
+          aria-label="Contribution tracking"
+          role="group"
+        >
+          <div>
+            <p className="card__title">Starting value</p>
+            <p className="card__value">
+              <CurrencyDisplay amount={result.startingValueCents} currency={currency} />
+            </p>
+          </div>
+          {typeof investedToDateCents === 'number' && (
+            <div>
+              <p className="card__title">Invested to date</p>
+              <p className="card__value">
+                <CurrencyDisplay amount={investedToDateCents} currency={currency} />
+              </p>
+            </div>
+          )}
+          <div>
+            <p className="card__title">Recurring contribution</p>
+            <p className="card__value">
+              <CurrencyDisplay amount={result.contributionCents} currency={currency} />
+            </p>
+          </div>
+          <div>
+            <p className="card__title">
+              Contributions over {result.years} {result.years === 1 ? 'year' : 'years'}
+            </p>
+            <p className="card__value">
+              <CurrencyDisplay
+                amount={expectedScenario?.totalContributionsCents ?? 0}
+                currency={currency}
+              />
+            </p>
+          </div>
+          <div>
+            <p className="card__title">Projected growth (expected)</p>
+            <p className="card__value">
+              <CurrencyDisplay
+                amount={expectedScenario?.totalGrowthCents ?? 0}
+                currency={currency}
+              />
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default InvestmentProjections;

--- a/apps/web/src/lib/investments/projections.test.ts
+++ b/apps/web/src/lib/investments/projections.test.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_PROJECTION_SCENARIOS,
+  MAX_PROJECTION_YEARS,
+  buildProjectionChartData,
+  clampProjectionYears,
+  deriveProjectionScenarios,
+  futureValueAnnuity,
+  futureValueLumpSum,
+  periodsPerYearForFrequency,
+  projectPortfolioGrowth,
+  projectScenario,
+  type ProjectionScenario,
+} from './projections';
+
+/** Assert every numeric field on a year point is a whole number (no float cents). */
+function expectAllInteger(values: readonly number[]): void {
+  for (const value of values) {
+    expect(Number.isInteger(value)).toBe(true);
+  }
+}
+
+describe('futureValueLumpSum', () => {
+  it('computes a known compound-interest value (P(1+r)^t)', () => {
+    // $1,000.00 at 7% for 10 years = 100000 * 1.07^10 = 196715.13… cents.
+    expect(futureValueLumpSum(100_000, 0.07, 10)).toBe(196_715);
+  });
+
+  it('returns the principal when there are zero periods', () => {
+    expect(futureValueLumpSum(250_000, 0.07, 0)).toBe(250_000);
+  });
+
+  it('returns the principal unchanged at a zero rate', () => {
+    expect(futureValueLumpSum(250_000, 0, 30)).toBe(250_000);
+  });
+
+  it('decays the principal at a negative rate', () => {
+    // -10% annual for 5 years, compounded annually.
+    expect(futureValueLumpSum(1_000_000, -0.1, 5)).toBe(590_490);
+  });
+
+  it('never returns NaN for non-finite inputs', () => {
+    expect(futureValueLumpSum(Number.NaN, 0.07, 10)).toBe(0);
+  });
+});
+
+describe('futureValueAnnuity', () => {
+  it('computes a known annuity future value (PMT((1+r)^n - 1)/r)', () => {
+    // $100.00/period at 5% for 10 periods = 10000 * ((1.05^10 - 1) / 0.05).
+    expect(futureValueAnnuity(10_000, 0.05, 10)).toBe(125_779);
+  });
+
+  it('falls back to PMT * n at a zero rate', () => {
+    expect(futureValueAnnuity(10_000, 0, 120)).toBe(1_200_000);
+  });
+
+  it('returns zero for zero payment or zero periods', () => {
+    expect(futureValueAnnuity(0, 0.05, 120)).toBe(0);
+    expect(futureValueAnnuity(10_000, 0.05, 0)).toBe(0);
+  });
+});
+
+describe('periodsPerYearForFrequency', () => {
+  it('maps monthly to 12 and annual to 1', () => {
+    expect(periodsPerYearForFrequency('monthly')).toBe(12);
+    expect(periodsPerYearForFrequency('annual')).toBe(1);
+  });
+});
+
+describe('clampProjectionYears', () => {
+  it('floors fractional years', () => {
+    expect(clampProjectionYears(3.9)).toBe(3);
+  });
+
+  it('clamps negative, zero, and non-finite to 0', () => {
+    expect(clampProjectionYears(-5)).toBe(0);
+    expect(clampProjectionYears(0)).toBe(0);
+    expect(clampProjectionYears(Number.NaN)).toBe(0);
+  });
+
+  it('caps at MAX_PROJECTION_YEARS', () => {
+    expect(clampProjectionYears(500)).toBe(MAX_PROJECTION_YEARS);
+  });
+});
+
+describe('projectScenario', () => {
+  const scenario: ProjectionScenario = {
+    id: 'expected',
+    label: 'Expected',
+    annualReturnRate: 0.07,
+  };
+
+  it('starts year 0 at the current value with no contributions or growth', () => {
+    const projection = projectScenario(1_000_000, 50_000, 12, 20, scenario);
+    const first = projection.series[0];
+    expect(first.year).toBe(0);
+    expect(first.endValueCents).toBe(1_000_000);
+    expect(first.cumulativeContributionsCents).toBe(0);
+    expect(first.cumulativeGrowthCents).toBe(0);
+  });
+
+  it('matches the closed-form lump-sum + annuity future value at the horizon', () => {
+    // 1,000,000 cents start, 50,000 cents/month, 7% real, 20 years, monthly.
+    const projection = projectScenario(1_000_000, 50_000, 12, 20, scenario);
+    expect(projection.finalValueCents).toBe(30_085_072);
+    expect(projection.totalContributionsCents).toBe(12_000_000);
+    expect(projection.totalGrowthCents).toBe(17_085_072);
+  });
+
+  it('keeps the series length equal to years + 1 and reports whole cents only', () => {
+    const projection = projectScenario(1_000_000, 50_000, 12, 20, scenario);
+    expect(projection.series).toHaveLength(21);
+    for (const point of projection.series) {
+      expectAllInteger([
+        point.startValueCents,
+        point.endValueCents,
+        point.contributionsThisYearCents,
+        point.growthThisYearCents,
+        point.cumulativeContributionsCents,
+        point.cumulativeGrowthCents,
+      ]);
+    }
+  });
+
+  it('reconciles end value to start + contributions + growth each year', () => {
+    const projection = projectScenario(500_000, 25_000, 12, 15, scenario);
+    for (const point of projection.series) {
+      expect(point.endValueCents).toBe(
+        point.startValueCents + point.contributionsThisYearCents + point.growthThisYearCents,
+      );
+    }
+  });
+});
+
+describe('projectPortfolioGrowth', () => {
+  const baseInput = {
+    currentValueCents: 1_000_000,
+    contributionCents: 50_000,
+    contributionFrequency: 'monthly' as const,
+    years: 20,
+  };
+
+  it('projects all three default scenarios', () => {
+    const result = projectPortfolioGrowth(baseInput);
+    expect(result.scenarios).toHaveLength(DEFAULT_PROJECTION_SCENARIOS.length);
+    expect(result.scenarios.map((s) => s.scenario.id)).toEqual([
+      'conservative',
+      'expected',
+      'optimistic',
+    ]);
+  });
+
+  it('produces a known final value for the expected scenario', () => {
+    const result = projectPortfolioGrowth(baseInput);
+    const expected = result.scenarios.find((s) => s.scenario.id === 'expected');
+    expect(expected?.finalValueCents).toBe(30_085_072);
+  });
+
+  it('orders scenario outcomes monotonically by return rate', () => {
+    const result = projectPortfolioGrowth(baseInput);
+    const [conservative, expected, optimistic] = result.scenarios;
+    expect(conservative.finalValueCents).toBeLessThanOrEqual(expected.finalValueCents);
+    expect(expected.finalValueCents).toBeLessThanOrEqual(optimistic.finalValueCents);
+  });
+
+  it('handles zero contributions as pure compound growth', () => {
+    const result = projectPortfolioGrowth({ ...baseInput, contributionCents: 0 });
+    const expected = result.scenarios.find((s) => s.scenario.id === 'expected');
+    expect(expected?.totalContributionsCents).toBe(0);
+    expect(expected?.finalValueCents).toBeGreaterThan(baseInput.currentValueCents);
+  });
+
+  it('produces zero growth when the return rate is zero', () => {
+    const result = projectPortfolioGrowth({
+      ...baseInput,
+      scenarios: [{ id: 'flat', label: 'Flat', annualReturnRate: 0 }],
+    });
+    const flat = result.scenarios[0];
+    expect(flat.totalGrowthCents).toBe(0);
+    expect(flat.finalValueCents).toBe(result.startingValueCents + flat.totalContributionsCents);
+  });
+
+  it('models a drawdown for a negative return with no contributions', () => {
+    const result = projectPortfolioGrowth({
+      currentValueCents: 1_000_000,
+      contributionCents: 0,
+      contributionFrequency: 'monthly',
+      years: 5,
+      scenarios: [{ id: 'bear', label: 'Bear', annualReturnRate: -0.1 }],
+    });
+    const bear = result.scenarios[0];
+    expect(bear.finalValueCents).toBe(605_261);
+    expect(bear.totalGrowthCents).toBeLessThan(0);
+  });
+
+  it('returns only the baseline when the horizon is zero years', () => {
+    const result = projectPortfolioGrowth({ ...baseInput, years: 0 });
+    const expected = result.scenarios.find((s) => s.scenario.id === 'expected');
+    expect(expected?.series).toHaveLength(1);
+    expect(expected?.finalValueCents).toBe(result.startingValueCents);
+  });
+
+  it('clamps long horizons to MAX_PROJECTION_YEARS', () => {
+    const result = projectPortfolioGrowth({ ...baseInput, years: 500 });
+    expect(result.years).toBe(MAX_PROJECTION_YEARS);
+    expect(result.scenarios[0].series).toHaveLength(MAX_PROJECTION_YEARS + 1);
+  });
+
+  it('clamps negative starting value and contributions to zero', () => {
+    const result = projectPortfolioGrowth({
+      currentValueCents: -100,
+      contributionCents: -100,
+      contributionFrequency: 'monthly',
+      years: 10,
+    });
+    expect(result.startingValueCents).toBe(0);
+    expect(result.contributionCents).toBe(0);
+    expect(result.scenarios.every((s) => s.finalValueCents === 0)).toBe(true);
+  });
+
+  it('matches a known monthly contribution (SIP) future value', () => {
+    // $100.00/month, 0 start, 6% real, 10 years => 1,638,793 cents.
+    const result = projectPortfolioGrowth({
+      currentValueCents: 0,
+      contributionCents: 10_000,
+      contributionFrequency: 'monthly',
+      years: 10,
+      scenarios: [{ id: 'sip', label: 'SIP', annualReturnRate: 0.06 }],
+    });
+    expect(result.scenarios[0].finalValueCents).toBe(1_638_793);
+  });
+});
+
+describe('deriveProjectionScenarios', () => {
+  it('centres on the expected rate with a symmetric spread', () => {
+    const scenarios = deriveProjectionScenarios(0.07, 0.03);
+    expect(scenarios[0].annualReturnRate).toBeCloseTo(0.04, 10);
+    expect(scenarios[1].annualReturnRate).toBeCloseTo(0.07, 10);
+    expect(scenarios[2].annualReturnRate).toBeCloseTo(0.1, 10);
+    expect(scenarios.map((s) => s.id)).toEqual(['conservative', 'expected', 'optimistic']);
+  });
+
+  it('keeps scenarios ordered by return rate', () => {
+    const scenarios = deriveProjectionScenarios(0.05);
+    expect(scenarios[0].annualReturnRate).toBeLessThan(scenarios[1].annualReturnRate);
+    expect(scenarios[1].annualReturnRate).toBeLessThan(scenarios[2].annualReturnRate);
+  });
+});
+
+describe('buildProjectionChartData', () => {
+  const result = projectPortfolioGrowth({
+    currentValueCents: 1_000_000,
+    contributionCents: 50_000,
+    contributionFrequency: 'monthly',
+    years: 20,
+  });
+
+  it('produces one row per year plus the baseline', () => {
+    const { data } = buildProjectionChartData(result);
+    expect(data).toHaveLength(21);
+    expect(data[0].label).toBe('Now');
+    expect(data[1].label).toBe('Yr 1');
+  });
+
+  it('exposes a series per scenario plus a total-invested baseline', () => {
+    const { series } = buildProjectionChartData(result);
+    expect(series.map((s) => s.dataKey)).toEqual([
+      'conservative',
+      'expected',
+      'optimistic',
+      'contributions',
+    ]);
+  });
+
+  it('tracks total invested (start + cumulative contributions) on the baseline', () => {
+    const { data } = buildProjectionChartData(result);
+    expect(data[0].contributions).toBe(result.startingValueCents);
+    const last = data[data.length - 1];
+    const expected = result.scenarios.find((s) => s.scenario.id === 'expected');
+    expect(last.contributions).toBe(
+      result.startingValueCents + (expected?.totalContributionsCents ?? 0),
+    );
+  });
+});

--- a/apps/web/src/lib/investments/projections.ts
+++ b/apps/web/src/lib/investments/projections.ts
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Compound-growth projection engine for investment portfolios (#2118).
+ *
+ * Pure, deterministic functions that project the future value of a current
+ * portfolio plus recurring contributions over a multi-year horizon, under
+ * multiple expected-return scenarios. Produces a year-by-year series suitable
+ * for charting and contribution tracking.
+ *
+ * ## Units & conventions
+ *
+ * - **Money is integer cents.** No floating-point money is ever returned;
+ *   intermediate growth is computed in floating point then rounded to whole
+ *   cents at every reported value.
+ * - **Return rates are decimals** — `0.07` means 7% per year. Rates may be
+ *   `0` (flat) or negative (drawdown) and the math degrades gracefully.
+ * - **Compounding follows the contribution cadence.** A monthly contribution
+ *   compounds monthly (periodic rate = annualRate / 12); an annual
+ *   contribution compounds annually (periodic rate = annualRate). This matches
+ *   the standard textbook ordinary-annuity / compound-interest formulas used
+ *   by mainstream financial calculators, which keeps the numbers explainable
+ *   and unit-testable.
+ *
+ * ## Real vs. nominal returns
+ *
+ * Rates are treated as **expected real (inflation-adjusted) annual returns**
+ * by default, so projected values are expressed in *today's* purchasing power.
+ * The arithmetic itself is rate-agnostic — callers may pass nominal rates, in
+ * which case the results are nominal. The UI surfaces this assumption to the
+ * user via a disclaimer.
+ *
+ * ## Data scope (issue #2118)
+ *
+ * This engine projects from the user's **local** holdings and contribution
+ * assumptions only. It does NOT ingest real-time market prices or brokerage
+ * data — that requires a market-data provider integration which is tracked as
+ * separate, blocked work (provider selection + credentials).
+ *
+ * References: issue #2118
+ */
+
+/** How often the recurring contribution is made (and how growth compounds). */
+export type ContributionFrequency = 'monthly' | 'annual';
+
+/** A named expected-return assumption used to drive one projection line. */
+export interface ProjectionScenario {
+  /** Stable identifier, also used as the chart series key. */
+  readonly id: string;
+  /** Human-readable label shown in the UI and chart legend. */
+  readonly label: string;
+  /** Expected annual return as a decimal (`0.07` = 7%); may be `0`/negative. */
+  readonly annualReturnRate: number;
+}
+
+/** Inputs to {@link projectPortfolioGrowth}. */
+export interface ProjectionInput {
+  /** Current portfolio market value in cents. Negative values clamp to 0. */
+  readonly currentValueCents: number;
+  /** Recurring contribution per period in cents. Negative values clamp to 0. */
+  readonly contributionCents: number;
+  /** Whether the contribution recurs monthly or annually. */
+  readonly contributionFrequency: ContributionFrequency;
+  /** Projection horizon in whole years (clamped to `[0, MAX_PROJECTION_YEARS]`). */
+  readonly years: number;
+  /** Optional scenario set; defaults to {@link DEFAULT_PROJECTION_SCENARIOS}. */
+  readonly scenarios?: readonly ProjectionScenario[];
+}
+
+/** A single year's snapshot within a scenario projection. */
+export interface ProjectionYearPoint {
+  /** Year offset from today (`0` is the starting/baseline value). */
+  readonly year: number;
+  /** Portfolio value in cents at the start of the year. */
+  readonly startValueCents: number;
+  /** Portfolio value in cents at the end of the year. */
+  readonly endValueCents: number;
+  /** Contributions made during this year, in cents. */
+  readonly contributionsThisYearCents: number;
+  /** Investment growth (gains) credited during this year, in cents. */
+  readonly growthThisYearCents: number;
+  /** Contributions made from the start through this year, in cents. */
+  readonly cumulativeContributionsCents: number;
+  /** Growth accrued from the start through this year, in cents. */
+  readonly cumulativeGrowthCents: number;
+}
+
+/** A full projection for one scenario, including its year-by-year series. */
+export interface ScenarioProjection {
+  readonly scenario: ProjectionScenario;
+  /** Portfolio value in cents at the end of the horizon. */
+  readonly finalValueCents: number;
+  /** Total contributions over the horizon, in cents. */
+  readonly totalContributionsCents: number;
+  /** Total growth over the horizon, in cents (can be negative). */
+  readonly totalGrowthCents: number;
+  /** Starting portfolio value in cents (year 0). */
+  readonly startingValueCents: number;
+  /** Year-by-year series including the year-0 baseline. */
+  readonly series: readonly ProjectionYearPoint[];
+}
+
+/** Result of {@link projectPortfolioGrowth}. */
+export interface ProjectionResult {
+  readonly startingValueCents: number;
+  readonly years: number;
+  readonly contributionCents: number;
+  readonly contributionFrequency: ContributionFrequency;
+  /** Compounding/contribution periods per year (12 for monthly, 1 for annual). */
+  readonly periodsPerYear: number;
+  readonly scenarios: readonly ScenarioProjection[];
+}
+
+/** Upper bound on the projection horizon to keep loops/values bounded. */
+export const MAX_PROJECTION_YEARS = 100;
+
+/** Default conservative / expected / optimistic real-return assumptions. */
+export const DEFAULT_PROJECTION_SCENARIOS: readonly ProjectionScenario[] = [
+  { id: 'conservative', label: 'Conservative', annualReturnRate: 0.04 },
+  { id: 'expected', label: 'Expected', annualReturnRate: 0.07 },
+  { id: 'optimistic', label: 'Optimistic', annualReturnRate: 0.09 },
+];
+
+/**
+ * Round to whole cents, guarding against non-finite values so a bad input
+ * (e.g. `NaN` from an empty form field) never propagates through the series.
+ */
+function roundCents(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value);
+}
+
+/** Number of compounding/contribution periods per year for a frequency. */
+export function periodsPerYearForFrequency(frequency: ContributionFrequency): number {
+  return frequency === 'monthly' ? 12 : 1;
+}
+
+/**
+ * Clamp a requested horizon to a whole number of years in
+ * `[0, MAX_PROJECTION_YEARS]`. Non-finite or negative inputs become `0`.
+ */
+export function clampProjectionYears(years: number): number {
+  if (!Number.isFinite(years) || years <= 0) return 0;
+  return Math.min(MAX_PROJECTION_YEARS, Math.floor(years));
+}
+
+/**
+ * Future value of a single lump sum after `periods` compounding periods.
+ *
+ * `FV = principal * (1 + periodicRate)^periods`
+ *
+ * @param principalCents Present value in cents.
+ * @param periodicRate Rate per period as a decimal (may be `0`/negative).
+ * @param periods Number of compounding periods (clamped at `0`).
+ * @returns Future value in whole cents.
+ */
+export function futureValueLumpSum(
+  principalCents: number,
+  periodicRate: number,
+  periods: number,
+): number {
+  if (periods <= 0) return roundCents(principalCents);
+  return roundCents(principalCents * Math.pow(1 + periodicRate, periods));
+}
+
+/**
+ * Future value of an **ordinary annuity** — a level payment made at the end of
+ * each period.
+ *
+ * `FV = payment * (((1 + r)^n - 1) / r)`, with the `r = 0` limit `FV = payment * n`.
+ *
+ * @param paymentCents Contribution per period in cents.
+ * @param periodicRate Rate per period as a decimal (may be `0`/negative).
+ * @param periods Number of payment/compounding periods.
+ * @returns Future value of the contribution stream in whole cents.
+ */
+export function futureValueAnnuity(
+  paymentCents: number,
+  periodicRate: number,
+  periods: number,
+): number {
+  if (periods <= 0 || paymentCents === 0) return 0;
+  if (periodicRate === 0) return roundCents(paymentCents * periods);
+  const growthFactor = Math.pow(1 + periodicRate, periods);
+  return roundCents(paymentCents * ((growthFactor - 1) / periodicRate));
+}
+
+/**
+ * Project a single scenario into a year-by-year series.
+ *
+ * Each year's end value is the closed-form sum of the compounded starting
+ * balance plus the future value of the contribution annuity, which keeps every
+ * reported figure consistent with the standard finance formulas above.
+ */
+export function projectScenario(
+  startingValueCents: number,
+  contributionCents: number,
+  periodsPerYear: number,
+  years: number,
+  scenario: ProjectionScenario,
+): ScenarioProjection {
+  const periodicRate = scenario.annualReturnRate / periodsPerYear;
+  const series: ProjectionYearPoint[] = [];
+
+  let previousEndCents = startingValueCents;
+  let previousCumulativeContributionsCents = 0;
+
+  for (let year = 0; year <= years; year += 1) {
+    const periods = periodsPerYear * year;
+    const endValueCents =
+      futureValueLumpSum(startingValueCents, periodicRate, periods) +
+      futureValueAnnuity(contributionCents, periodicRate, periods);
+    const cumulativeContributionsCents = roundCents(contributionCents * periods);
+    const cumulativeGrowthCents = endValueCents - startingValueCents - cumulativeContributionsCents;
+    const contributionsThisYearCents =
+      cumulativeContributionsCents - previousCumulativeContributionsCents;
+    const growthThisYearCents = endValueCents - previousEndCents - contributionsThisYearCents;
+
+    series.push({
+      year,
+      startValueCents: previousEndCents,
+      endValueCents,
+      contributionsThisYearCents,
+      growthThisYearCents,
+      cumulativeContributionsCents,
+      cumulativeGrowthCents,
+    });
+
+    previousEndCents = endValueCents;
+    previousCumulativeContributionsCents = cumulativeContributionsCents;
+  }
+
+  const last = series[series.length - 1];
+
+  return {
+    scenario,
+    startingValueCents,
+    finalValueCents: last.endValueCents,
+    totalContributionsCents: last.cumulativeContributionsCents,
+    totalGrowthCents: last.cumulativeGrowthCents,
+    series,
+  };
+}
+
+/**
+ * Project the future value of a portfolio plus recurring contributions across
+ * one or more return scenarios.
+ *
+ * @param input See {@link ProjectionInput}.
+ * @returns A {@link ProjectionResult} with one {@link ScenarioProjection} per scenario.
+ */
+export function projectPortfolioGrowth(input: ProjectionInput): ProjectionResult {
+  const scenarios =
+    input.scenarios && input.scenarios.length > 0 ? input.scenarios : DEFAULT_PROJECTION_SCENARIOS;
+  const years = clampProjectionYears(input.years);
+  const startingValueCents = roundCents(Math.max(0, input.currentValueCents));
+  const contributionCents = roundCents(Math.max(0, input.contributionCents));
+  const periodsPerYear = periodsPerYearForFrequency(input.contributionFrequency);
+
+  return {
+    startingValueCents,
+    years,
+    contributionCents,
+    contributionFrequency: input.contributionFrequency,
+    periodsPerYear,
+    scenarios: scenarios.map((scenario) =>
+      projectScenario(startingValueCents, contributionCents, periodsPerYear, years, scenario),
+    ),
+  };
+}
+
+/**
+ * Build conservative / expected / optimistic scenarios around an expected
+ * real-return assumption.
+ *
+ * @param expectedAnnualReturnRate Expected annual return as a decimal.
+ * @param spread Symmetric +/- spread applied to derive the bookend scenarios.
+ */
+export function deriveProjectionScenarios(
+  expectedAnnualReturnRate: number,
+  spread = 0.03,
+): readonly ProjectionScenario[] {
+  return [
+    {
+      id: 'conservative',
+      label: 'Conservative',
+      annualReturnRate: expectedAnnualReturnRate - spread,
+    },
+    { id: 'expected', label: 'Expected', annualReturnRate: expectedAnnualReturnRate },
+    {
+      id: 'optimistic',
+      label: 'Optimistic',
+      annualReturnRate: expectedAnnualReturnRate + spread,
+    },
+  ];
+}
+
+/** A chart-ready row: a `label` plus one numeric value per series key. */
+export interface ProjectionChartRow {
+  label: string;
+  [seriesKey: string]: number | string;
+}
+
+/** A chart series descriptor compatible with `TrendLineChart`. */
+export interface ProjectionChartSeries {
+  readonly dataKey: string;
+  readonly name: string;
+}
+
+/** Chart-ready representation of a projection result. */
+export interface ProjectionChartData {
+  readonly data: readonly ProjectionChartRow[];
+  readonly series: readonly ProjectionChartSeries[];
+}
+
+/**
+ * Convert a {@link ProjectionResult} into chart rows + series for the shared
+ * `TrendLineChart`. Adds a "Total invested" baseline (starting value plus
+ * cumulative contributions, no growth) so the gap between each scenario line
+ * and the baseline visualises compound growth — and is also conveyed in the
+ * chart's text/data-table alternatives (not by colour alone).
+ */
+export function buildProjectionChartData(result: ProjectionResult): ProjectionChartData {
+  const baseScenario = result.scenarios[0];
+  const rowCount = baseScenario ? baseScenario.series.length : 0;
+
+  const data: ProjectionChartRow[] = Array.from({ length: rowCount }, (_unused, index) => {
+    const row: ProjectionChartRow = {
+      label: index === 0 ? 'Now' : `Yr ${index}`,
+    };
+    for (const scenarioProjection of result.scenarios) {
+      const point = scenarioProjection.series[index];
+      row[scenarioProjection.scenario.id] = point ? point.endValueCents : 0;
+    }
+    const baselinePoint = baseScenario ? baseScenario.series[index] : undefined;
+    row.contributions = baselinePoint
+      ? result.startingValueCents + baselinePoint.cumulativeContributionsCents
+      : result.startingValueCents;
+    return row;
+  });
+
+  const series: ProjectionChartSeries[] = [
+    ...result.scenarios.map((scenarioProjection) => ({
+      dataKey: scenarioProjection.scenario.id,
+      name: scenarioProjection.scenario.label,
+    })),
+    { dataKey: 'contributions', name: 'Total invested' },
+  ];
+
+  return { data, series };
+}

--- a/apps/web/src/pages/InvestmentsPage.test.tsx
+++ b/apps/web/src/pages/InvestmentsPage.test.tsx
@@ -14,6 +14,10 @@ vi.mock('../components/DataExport', () => ({
   DataExport: () => <div data-testid="data-export" />,
 }));
 
+vi.mock('../components/investments/InvestmentProjections', () => ({
+  InvestmentProjections: () => <div data-testid="investment-projections" />,
+}));
+
 // Recharts uses DOM measurements that aren't available in jsdom.
 // Stub it out to avoid rendering errors.
 vi.mock('recharts', () => ({
@@ -135,6 +139,16 @@ describe('InvestmentsPage', () => {
     );
 
     expect(screen.getByText('Asset Allocation')).toBeInTheDocument();
+  });
+
+  it('renders the compound-growth projection section', () => {
+    render(
+      <MemoryRouter>
+        <InvestmentsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('investment-projections')).toBeInTheDocument();
   });
 
   it('renders investing beta sections with accessible table fallbacks', () => {

--- a/apps/web/src/pages/InvestmentsPage.tsx
+++ b/apps/web/src/pages/InvestmentsPage.tsx
@@ -22,6 +22,7 @@ import {
   InvestingBetaFeaturesPanel,
   useInvestingBetaFeatures,
 } from '../components/investments/InvestingBetaFeatures';
+import { InvestmentProjections } from '../components/investments/InvestmentProjections';
 import { useInvestments } from '../hooks';
 import { formatCurrency, formatGainLoss } from '../lib/currency';
 import type { Investment, InvestmentType } from '../kmp/bridge';
@@ -356,6 +357,12 @@ export const InvestmentsPage: React.FC = () => {
               </div>
             </section>
           )}
+
+          {/* Compound-growth projection (#2118) */}
+          <InvestmentProjections
+            currentValueCents={summary.totalValue}
+            investedToDateCents={summary.totalCostBasis}
+          />
 
           {/* Holdings Table */}
           <InvestingBetaFeaturesPanel investments={investments} features={betaFeatures} />


### PR DESCRIPTION
## Summary

Delivers the agent-completable slice of #2118 for the **web** app: a compound-growth **projection engine** plus an accessible **projection UI** with contribution tracking. Operates entirely on the user''s existing **local** holdings (SQLite-WASM) and contribution assumptions ? no fabricated market data.

Persona fit (index-fund / FIRE investor): connects today''s portfolio value + recurring contributions to future-value scenarios, so the investor can see how allocation and savings compound over a long horizon.

## What changed

**New projection engine** ? `apps/web/src/lib/investments/projections.ts` (pure, deterministic):
- `futureValueLumpSum` and `futureValueAnnuity` ? standard, documented compound-interest / ordinary-annuity formulas (`P(1+r)^n` and `PMT?((1+r)^n?1)/r`, with the `r=0` limit).
- `projectPortfolioGrowth` ? projects current value + recurring contributions across conservative / expected / optimistic scenarios with a **year-by-year series** for charting and a per-scenario summary (final value, total contributed, total growth).
- `deriveProjectionScenarios`, `buildProjectionChartData` helpers.
- Edge cases handled: **0 contributions**, **0 / negative return** (drawdown), **long horizons** (clamped to 100y), non-finite inputs, and negative starting value/contribution (clamped to 0).

**Projection UI** ? `apps/web/src/components/investments/InvestmentProjections.tsx`, surfaced on `InvestmentsPage`:
- Scenario inputs (monthly contribution, years, expected return) ? every control has a `<label>` + `aria-describedby` help text.
- Growth chart via the shared accessible `TrendLineChart` (ships a text summary, keyboard-navigable data table, and a "Total invested" baseline so growth is conveyed by more than colour).
- Scenario summary as a real `<table>` with caption + scoped headers; gains labelled as text ("Growth"), never colour alone.
- Contribution tracking (starting value, invested-to-date, recurring contribution, total contributions, projected growth) and a polite live region announcing the expected projected value.

## Conventions

- **Money is integer cents; rates are decimals ? no float money.**
- Returns are treated as expected **real** (inflation-adjusted) annual rates, so projected values are in today''s dollars; the assumption is stated in the UI and module docs (the math is rate-agnostic).

## Testing

- `apps/web/src/lib/investments/projections.test.ts` ? 31 tests: known compound-interest values, annuity future value, scenario monotonicity, zero/negative-return and zero-contribution edge cases, horizon clamping, whole-cent invariants.
- `apps/web/src/components/investments/InvestmentProjections.test.tsx` ? labelled inputs, accessible scenario table, chart text alternative, contribution tracking, reactive horizon updates.
- Full `apps/web` suite, `tsc -b`, and `vite build` all green (the two pre-existing/flaky failures outside this change ? `DashboardPage` landmarks and `dashboard-visualizations` ? were verified to fail on base / pass in isolation).

## Remaining Work

Real-time price / brokerage data ingestion is **out of scope and blocked** ? it is a separate task requiring a market-data provider integration (provider selection + credentials/secrets) and is not agent-completable here. This PR intentionally projects from **local** holdings/lots and user-entered contribution assumptions only; no "real" market data is fabricated. Once a market-data provider is wired up, the projection engine can consume live valuations without changes to its public API.

Refs #2118
