### PR TITLE
feat(web): track DeFi/locked positions separately from spot holdings (#2172)

### DIFF
--- a/apps/web/src/components/investments/DeFiPositionsCard.test.tsx
+++ b/apps/web/src/components/investments/DeFiPositionsCard.test.tsx
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React from 'react';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { DeFiPositionsCard } from './DeFiPositionsCard';
+import type { DefiPositionEntry } from '../../lib/assets/defi-positions-types';
+
+const TEST_KEY = 'test.defiPositions';
+
+/** Stub matchMedia so any prefers-* checks in child components don't throw. */
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+const lockedStaking: DefiPositionEntry = {
+  id: 'lido-1',
+  protocol: 'Lido',
+  chain: 'ethereum',
+  kind: 'STAKING',
+  label: 'stETH staking',
+  principalValueCents: 1_000_000,
+  lockState: 'LOCKED',
+  apyPercent: 4.2,
+  rewards: [{ token: 'stETH', quantity: 0.1, valueCents: 30_000 }],
+  valuationAsOf: '2025-06-01',
+};
+
+describe('DeFiPositionsCard', () => {
+  it('renders the heading and an empty state when there are no positions', () => {
+    render(<DeFiPositionsCard spotLiquidValueCents={0} storageKey={TEST_KEY} />);
+
+    expect(screen.getByRole('heading', { name: /DeFi & Locked Positions/i })).toBeInTheDocument();
+    expect(screen.getByText('No DeFi positions yet')).toBeInTheDocument();
+    // The add form is always available.
+    expect(screen.getByRole('button', { name: 'Add position' })).toBeInTheDocument();
+  });
+
+  it('shows a liquid-vs-locked split blending spot holdings with DeFi positions', () => {
+    render(
+      <DeFiPositionsCard
+        spotLiquidValueCents={0}
+        storageKey={TEST_KEY}
+        initialPositions={[lockedStaking]}
+      />,
+    );
+
+    // 0 spot + a single locked position => 100% locked, 0% liquid.
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    expect(screen.getByText('0%')).toBeInTheDocument();
+    // Total locked value = principal 1,000,000 + rewards 30,000 = 1,030,000 cents.
+    expect(screen.getAllByText('$10,300.00').length).toBeGreaterThan(0);
+  });
+
+  it('renders the position with protocol, chain, type, lock state, APY, and rewards', () => {
+    render(
+      <DeFiPositionsCard
+        spotLiquidValueCents={2_000_000}
+        storageKey={TEST_KEY}
+        initialPositions={[lockedStaking]}
+      />,
+    );
+
+    expect(screen.getByText('stETH staking')).toBeInTheDocument();
+    expect(screen.getAllByText('Lido').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Staking').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Locked').length).toBeGreaterThan(0);
+    expect(screen.getByText('4.2%')).toBeInTheDocument();
+    // By-protocol and by-chain rollups render as captioned tables.
+    expect(screen.getByText('Exposure by protocol')).toBeInTheDocument();
+    expect(screen.getByText('Exposure by chain')).toBeInTheDocument();
+  });
+
+  it('flags pending reward value for income / tax classification', () => {
+    render(
+      <DeFiPositionsCard
+        spotLiquidValueCents={0}
+        storageKey={TEST_KEY}
+        initialPositions={[lockedStaking]}
+      />,
+    );
+
+    expect(screen.getByText(/flagged for income \/ tax classification/i)).toBeInTheDocument();
+    expect(screen.getByText(/ordinary income at fair-market value/i)).toBeInTheDocument();
+  });
+
+  it('adds a position through the accessible form', () => {
+    render(<DeFiPositionsCard spotLiquidValueCents={0} storageKey={TEST_KEY} />);
+
+    fireEvent.change(screen.getByLabelText('Protocol'), { target: { value: 'Aave' } });
+    fireEvent.change(screen.getByLabelText('Principal value ($)'), {
+      target: { value: '5000' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add position' }));
+
+    // Default label becomes "<protocol> <kind label>" => "Aave Staking".
+    expect(screen.getByText('Aave Staking')).toBeInTheDocument();
+    expect(screen.queryByText('No DeFi positions yet')).not.toBeInTheDocument();
+  });
+
+  it('persists added positions to localStorage under the provided key', () => {
+    render(<DeFiPositionsCard spotLiquidValueCents={0} storageKey={TEST_KEY} />);
+
+    fireEvent.change(screen.getByLabelText('Protocol'), { target: { value: 'Curve' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add position' }));
+
+    const raw = window.localStorage.getItem(TEST_KEY);
+    expect(raw).toBeTruthy();
+    const stored = JSON.parse(raw ?? '[]') as DefiPositionEntry[];
+    expect(stored).toHaveLength(1);
+    expect(stored[0].protocol).toBe('Curve');
+  });
+
+  it('removes a position with its labelled remove button', () => {
+    render(
+      <DeFiPositionsCard
+        spotLiquidValueCents={0}
+        storageKey={TEST_KEY}
+        initialPositions={[lockedStaking]}
+      />,
+    );
+
+    expect(screen.getByText('stETH staking')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove stETH staking on Lido' }));
+
+    expect(screen.queryByText('stETH staking')).not.toBeInTheDocument();
+    expect(screen.getByText('No DeFi positions yet')).toBeInTheDocument();
+  });
+
+  it('exposes accessible table captions and a positions table', () => {
+    render(
+      <DeFiPositionsCard
+        spotLiquidValueCents={0}
+        storageKey={TEST_KEY}
+        initialPositions={[lockedStaking]}
+      />,
+    );
+
+    const positionsTable = screen
+      .getByText(/DeFi positions with protocol, chain, type/i)
+      .closest('table');
+    expect(positionsTable).not.toBeNull();
+    if (positionsTable) {
+      expect(within(positionsTable).getByText('stETH staking')).toBeInTheDocument();
+    }
+  });
+});

--- a/apps/web/src/components/investments/DeFiPositionsCard.tsx
+++ b/apps/web/src/components/investments/DeFiPositionsCard.tsx
@@ -1,0 +1,787 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * DeFiPositionsCard — surfaces DeFi / locked positions separately from spot
+ * holdings on the Investments page (#2172).
+ *
+ * A yield farmer can record staked assets, liquidity-pool positions, lending
+ * positions, and pending protocol rewards, then see:
+ *   - a "liquid vs locked" split of the whole portfolio (spot holdings are
+ *     liquid; assets locked in contracts are reported separately);
+ *   - per-position protocol, chain, lock / unbonding state, APY, and reward
+ *     exposure;
+ *   - exposure rolled up by protocol and by chain;
+ *   - pending reward value flagged for income / tax classification.
+ *
+ * Positions are entered manually and persisted to `localStorage` (the same
+ * local-only pattern used by the Investing Beta toolkit). No network calls and
+ * no fabricated market data — every value is supplied by the user. All money is
+ * integer cents; pure calculations live in `lib/assets/defi-positions`.
+ *
+ * Accessibility (WCAG 2.2 AA):
+ *   - Every control has an associated `<label>`; the add form is keyboard
+ *     operable and submits with a real `<button>`.
+ *   - Tables carry a `<caption>` and scoped headers; the liquidity split is a
+ *     real table, and the decorative bar is `aria-hidden`.
+ *   - Lock state and liquidity are conveyed with text + icon, never colour
+ *     alone.
+ *   - A polite live region announces totals and add / remove actions.
+ */
+
+import React, { useCallback, useId, useMemo, useState } from 'react';
+import { CurrencyDisplay, EmptyState } from '../common';
+import { AppIcon, type IconName } from '../icons';
+import { formatCurrency } from '../../lib/currency';
+import {
+  combinePortfolioLiquidity,
+  DEFI_KIND_LABELS,
+  DEFI_LOCK_STATE_LABELS,
+  summarizeDefiPortfolio,
+} from '../../lib/assets/defi-positions';
+import type {
+  DefiLockState,
+  DefiPositionEntry,
+  DefiPositionKind,
+} from '../../lib/assets/defi-positions-types';
+
+export interface DeFiPositionsCardProps {
+  /** Market value of freely spendable spot holdings, in integer cents. */
+  readonly spotLiquidValueCents: number;
+  /** Currency code for formatting (defaults to USD). */
+  readonly currency?: string;
+  /** localStorage key for persisting positions (override for test isolation). */
+  readonly storageKey?: string;
+  /** Seed positions used when nothing is persisted yet (tests / SSR). */
+  readonly initialPositions?: readonly DefiPositionEntry[];
+}
+
+const STORAGE_PREFIX = 'finance.investments';
+const DEFAULT_STORAGE_KEY = `${STORAGE_PREFIX}.defiPositions.v1`;
+
+const KIND_OPTIONS: readonly DefiPositionKind[] = [
+  'STAKING',
+  'LIQUIDITY_POOL',
+  'LENDING',
+  'BORROW',
+  'VAULT',
+  'FARM',
+];
+
+const LOCK_OPTIONS: readonly DefiLockState[] = [
+  'LIQUID',
+  'LOCKED',
+  'UNBONDING',
+  'WITHDRAWAL_PENDING',
+];
+
+/** Icon for a lock state — paired with a text label, never used alone. */
+function lockIcon(state: DefiLockState): IconName {
+  return state === 'LIQUID' ? 'unlock' : 'lock';
+}
+
+/** Parse a dollar string into integer cents, guarding against bad input. */
+function dollarsToCents(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.round(parsed * 100);
+}
+
+/** Read persisted positions, falling back to a default on any failure. */
+function readStored(key: string, fallback: readonly DefiPositionEntry[]): DefiPositionEntry[] {
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as DefiPositionEntry[]) : [...fallback];
+  } catch {
+    return [...fallback];
+  }
+}
+
+/** Generate a reasonably unique id without external dependencies. */
+function makeId(): string {
+  const cryptoObj = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined;
+  if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+    return `defi-${cryptoObj.randomUUID()}`;
+  }
+  return `defi-${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+}
+
+interface FormState {
+  protocol: string;
+  chain: string;
+  kind: DefiPositionKind;
+  label: string;
+  lockState: DefiLockState;
+  principalDollars: string;
+  apyPercent: string;
+  rewardToken: string;
+  rewardDollars: string;
+  unlockDate: string;
+}
+
+const EMPTY_FORM: FormState = {
+  protocol: '',
+  chain: '',
+  kind: 'STAKING',
+  label: '',
+  lockState: 'LOCKED',
+  principalDollars: '',
+  apyPercent: '',
+  rewardToken: '',
+  rewardDollars: '',
+  unlockDate: '',
+};
+
+const cardStyle: React.CSSProperties = { marginBottom: 'var(--spacing-6)' };
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: 'var(--spacing-2) var(--spacing-3)',
+  border: '1px solid var(--semantic-border, #e5e7eb)',
+  borderRadius: 'var(--radius-md, 0.375rem)',
+  background: 'var(--semantic-background-primary, #fff)',
+  color: 'var(--semantic-text-primary, #111)',
+  font: 'inherit',
+};
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontWeight: 'var(--font-weight-medium)',
+  marginBottom: 'var(--spacing-1)',
+};
+
+const cellStyle: React.CSSProperties = {
+  padding: 'var(--spacing-3)',
+  borderBottom: '1px solid var(--semantic-border, #e5e7eb)',
+  textAlign: 'left',
+};
+
+const numericCellStyle: React.CSSProperties = { ...cellStyle, textAlign: 'right' };
+
+const headerCellStyle: React.CSSProperties = {
+  padding: 'var(--spacing-3)',
+  borderBottom: '2px solid var(--semantic-border, #e5e7eb)',
+  textAlign: 'left',
+};
+
+const numericHeaderStyle: React.CSSProperties = { ...headerCellStyle, textAlign: 'right' };
+
+export const DeFiPositionsCard: React.FC<DeFiPositionsCardProps> = ({
+  spotLiquidValueCents,
+  currency = 'USD',
+  storageKey = DEFAULT_STORAGE_KEY,
+  initialPositions = [],
+}) => {
+  const fieldId = useId();
+  const [positions, setPositions] = useState<DefiPositionEntry[]>(() =>
+    readStored(storageKey, initialPositions),
+  );
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [status, setStatus] = useState('');
+
+  const persist = useCallback(
+    (next: DefiPositionEntry[]) => {
+      setPositions(next);
+      try {
+        window.localStorage.setItem(storageKey, JSON.stringify(next));
+      } catch {
+        // In-memory state still works when storage is unavailable.
+      }
+    },
+    [storageKey],
+  );
+
+  const summary = useMemo(() => summarizeDefiPortfolio(positions), [positions]);
+  const split = useMemo(
+    () => combinePortfolioLiquidity(spotLiquidValueCents, summary.breakdown),
+    [spotLiquidValueCents, summary.breakdown],
+  );
+
+  const money = useCallback((cents: number) => formatCurrency(cents, { currency }), [currency]);
+
+  const handleField = useCallback(<K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const protocol = form.protocol.trim();
+      const chain = form.chain.trim() || 'ethereum';
+      if (!protocol) {
+        setStatus('Enter a protocol name to add a position.');
+        return;
+      }
+
+      const rewardToken = form.rewardToken.trim();
+      const rewardValueCents = dollarsToCents(form.rewardDollars);
+      const apyParsed = Number.parseFloat(form.apyPercent);
+
+      const entry: DefiPositionEntry = {
+        id: makeId(),
+        protocol,
+        chain,
+        kind: form.kind,
+        label: form.label.trim() || `${protocol} ${DEFI_KIND_LABELS[form.kind]}`,
+        principalValueCents: dollarsToCents(form.principalDollars),
+        lockState: form.lockState,
+        apyPercent: Number.isFinite(apyParsed) ? apyParsed : undefined,
+        unlockDate: form.unlockDate || undefined,
+        rewards: rewardToken
+          ? [{ token: rewardToken, quantity: 0, valueCents: rewardValueCents }]
+          : [],
+        valuationAsOf: new Date().toISOString().slice(0, 10),
+      };
+
+      persist([...positions, entry]);
+      setForm(EMPTY_FORM);
+      setStatus(`Added ${entry.label} on ${entry.protocol}.`);
+    },
+    [form, persist, positions],
+  );
+
+  const handleRemove = useCallback(
+    (entry: DefiPositionEntry) => {
+      persist(positions.filter((p) => p.id !== entry.id));
+      setStatus(`Removed ${entry.label} on ${entry.protocol}.`);
+    },
+    [persist, positions],
+  );
+
+  const liquiditySummaryText = `Portfolio is ${split.liquidPercent}% liquid (${money(
+    split.liquidValueCents,
+  )}) and ${split.lockedPercent}% locked in contracts (${money(split.lockedValueCents)}). ${money(
+    split.pendingRewardValueCents,
+  )} of protocol rewards are pending.`;
+
+  return (
+    <section className="page-section" aria-labelledby={`${fieldId}-heading`}>
+      <div className="card" style={cardStyle}>
+        <div
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 'var(--spacing-2)',
+            marginBottom: 'var(--spacing-2)',
+          }}
+        >
+          <h3
+            id={`${fieldId}-heading`}
+            style={{ fontWeight: 'var(--font-weight-semibold)', margin: 0 }}
+          >
+            <AppIcon name="lock" /> DeFi &amp; Locked Positions
+          </h3>
+        </div>
+        <p style={{ color: 'var(--semantic-text-secondary)', marginTop: 0 }}>
+          Track staked assets, liquidity-pool, lending, and vault positions apart from spot
+          holdings. Spot holdings are treated as liquid; assets locked in smart contracts are
+          reported separately so portfolio totals show a true liquid-vs-locked picture. Pending
+          rewards are surfaced for income and tax classification.
+        </p>
+
+        {/* Live region announces totals and actions for screen readers. */}
+        <p className="sr-only" role="status" aria-live="polite">
+          {status || liquiditySummaryText}
+        </p>
+
+        {/* Liquid vs locked split of the whole portfolio */}
+        <table
+          style={{ width: '100%', borderCollapse: 'collapse', marginBottom: 'var(--spacing-4)' }}
+        >
+          <caption className="sr-only">
+            Liquid versus locked breakdown of portfolio totals, blending spot holdings with DeFi
+            positions
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col" style={headerCellStyle}>
+                Bucket
+              </th>
+              <th scope="col" style={numericHeaderStyle}>
+                Value
+              </th>
+              <th scope="col" style={numericHeaderStyle}>
+                Share
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row" style={cellStyle}>
+                <AppIcon name="wallet" /> Liquid (spot + liquid DeFi)
+              </th>
+              <td style={numericCellStyle}>
+                <CurrencyDisplay amount={split.liquidValueCents} currency={currency} />
+              </td>
+              <td style={numericCellStyle}>{split.liquidPercent}%</td>
+            </tr>
+            <tr>
+              <th scope="row" style={cellStyle}>
+                <AppIcon name="lock" /> Locked in contracts
+              </th>
+              <td style={numericCellStyle}>
+                <CurrencyDisplay amount={split.lockedValueCents} currency={currency} />
+              </td>
+              <td style={numericCellStyle}>{split.lockedPercent}%</td>
+            </tr>
+            <tr>
+              <th scope="row" style={cellStyle}>
+                <AppIcon name="gift" /> Pending rewards
+              </th>
+              <td style={numericCellStyle}>
+                <CurrencyDisplay amount={split.pendingRewardValueCents} currency={currency} />
+              </td>
+              <td style={numericCellStyle}>—</td>
+            </tr>
+          </tbody>
+        </table>
+
+        {/* Decorative proportion bar — meaning carried by the table above. */}
+        {split.totalValueCents > 0 && (
+          <div
+            aria-hidden="true"
+            style={{
+              display: 'flex',
+              height: 'var(--spacing-2, 8px)',
+              borderRadius: 'var(--radius-sm, 0.25rem)',
+              overflow: 'hidden',
+              marginBottom: 'var(--spacing-4)',
+              border: '1px solid var(--semantic-border, #e5e7eb)',
+            }}
+          >
+            <span
+              style={{
+                width: `${split.liquidPercent}%`,
+                background: 'var(--semantic-positive, #059669)',
+              }}
+            />
+            <span
+              style={{
+                width: `${split.lockedPercent}%`,
+                background: 'var(--semantic-warning, #d97706)',
+              }}
+            />
+          </div>
+        )}
+
+        {/* Positions table or empty state */}
+        {positions.length === 0 ? (
+          <EmptyState
+            title="No DeFi positions yet"
+            description="Add a staked, lending, liquidity-pool, or vault position below to separate locked assets from your spot holdings."
+          />
+        ) : (
+          <div style={{ overflowX: 'auto', marginBottom: 'var(--spacing-4)' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <caption className="sr-only">
+                DeFi positions with protocol, chain, type, lock state, APY, principal, and pending
+                reward value
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col" style={headerCellStyle}>
+                    Position
+                  </th>
+                  <th scope="col" style={headerCellStyle}>
+                    Chain
+                  </th>
+                  <th scope="col" style={headerCellStyle}>
+                    Type
+                  </th>
+                  <th scope="col" style={headerCellStyle}>
+                    Lock state
+                  </th>
+                  <th scope="col" style={numericHeaderStyle}>
+                    APY
+                  </th>
+                  <th scope="col" style={numericHeaderStyle}>
+                    Principal
+                  </th>
+                  <th scope="col" style={numericHeaderStyle}>
+                    Pending rewards
+                  </th>
+                  <th scope="col" style={headerCellStyle}>
+                    <span className="sr-only">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.positions.map((view) => (
+                  <tr key={view.id}>
+                    <th scope="row" style={cellStyle}>
+                      <strong>{view.label}</strong>
+                      <br />
+                      <span
+                        style={{
+                          fontSize: 'var(--type-scale-caption-font-size)',
+                          color: 'var(--semantic-text-secondary)',
+                        }}
+                      >
+                        {view.protocol}
+                      </span>
+                    </th>
+                    <td style={cellStyle}>{view.chain}</td>
+                    <td style={cellStyle}>{view.kindLabel}</td>
+                    <td style={cellStyle}>
+                      <AppIcon name={lockIcon(view.lockState)} /> {view.lockStateLabel}
+                      {view.unlockDate ? (
+                        <>
+                          <br />
+                          <span
+                            style={{
+                              fontSize: 'var(--type-scale-caption-font-size)',
+                              color: 'var(--semantic-text-secondary)',
+                            }}
+                          >
+                            Unlocks {view.unlockDate}
+                          </span>
+                        </>
+                      ) : null}
+                    </td>
+                    <td style={numericCellStyle}>
+                      {view.apyPercent === undefined ? '—' : `${view.apyPercent}%`}
+                    </td>
+                    <td style={numericCellStyle}>
+                      <CurrencyDisplay amount={view.principalValueCents} currency={currency} />
+                    </td>
+                    <td style={numericCellStyle}>
+                      <CurrencyDisplay amount={view.rewardValueCents} currency={currency} />
+                      {view.rewards.length > 0 ? (
+                        <>
+                          <br />
+                          <span
+                            style={{
+                              fontSize: 'var(--type-scale-caption-font-size)',
+                              color: 'var(--semantic-text-secondary)',
+                            }}
+                          >
+                            {view.rewards.map((r) => r.token).join(', ')}
+                          </span>
+                        </>
+                      ) : null}
+                    </td>
+                    <td style={cellStyle}>
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(view)}
+                        aria-label={`Remove ${view.label} on ${view.protocol}`}
+                        style={{
+                          background: 'none',
+                          border: '1px solid var(--semantic-border, #e5e7eb)',
+                          borderRadius: 'var(--radius-md, 0.375rem)',
+                          cursor: 'pointer',
+                          font: 'inherit',
+                          color: 'inherit',
+                          padding: 'var(--spacing-1) var(--spacing-2)',
+                        }}
+                      >
+                        <AppIcon name="trash" /> Remove
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Exposure by protocol and chain */}
+        {summary.positionCount > 0 && (
+          <div
+            style={{
+              display: 'grid',
+              gap: 'var(--spacing-4)',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+              marginBottom: 'var(--spacing-4)',
+            }}
+          >
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <caption
+                style={{
+                  textAlign: 'left',
+                  fontWeight: 'var(--font-weight-semibold)',
+                  marginBottom: 'var(--spacing-2)',
+                }}
+              >
+                Exposure by protocol
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col" style={headerCellStyle}>
+                    Protocol
+                  </th>
+                  <th scope="col" style={numericHeaderStyle}>
+                    Total
+                  </th>
+                  <th scope="col" style={numericHeaderStyle}>
+                    Locked
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.byProtocol.map((row) => (
+                  <tr key={row.protocol}>
+                    <th scope="row" style={cellStyle}>
+                      {row.protocol}
+                      <br />
+                      <span
+                        style={{
+                          fontSize: 'var(--type-scale-caption-font-size)',
+                          color: 'var(--semantic-text-secondary)',
+                        }}
+                      >
+                        {row.chains.join(', ')}
+                      </span>
+                    </th>
+                    <td style={numericCellStyle}>
+                      <CurrencyDisplay amount={row.totalValueCents} currency={currency} />
+                    </td>
+                    <td style={numericCellStyle}>
+                      <CurrencyDisplay amount={row.lockedValueCents} currency={currency} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <caption
+                style={{
+                  textAlign: 'left',
+                  fontWeight: 'var(--font-weight-semibold)',
+                  marginBottom: 'var(--spacing-2)',
+                }}
+              >
+                Exposure by chain
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col" style={headerCellStyle}>
+                    Chain
+                  </th>
+                  <th scope="col" style={numericHeaderStyle}>
+                    Total
+                  </th>
+                  <th scope="col" style={numericHeaderStyle}>
+                    Locked
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.byChain.map((row) => (
+                  <tr key={row.chain}>
+                    <th scope="row" style={cellStyle}>
+                      {row.chain}
+                    </th>
+                    <td style={numericCellStyle}>
+                      <CurrencyDisplay amount={row.totalValueCents} currency={currency} />
+                    </td>
+                    <td style={numericCellStyle}>
+                      <CurrencyDisplay amount={row.lockedValueCents} currency={currency} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Reward income for tax / income classification */}
+        {summary.rewardIncome.length > 0 && (
+          <p
+            style={{
+              padding: 'var(--spacing-3)',
+              background: 'var(--semantic-background-secondary, #f9fafb)',
+              borderRadius: 'var(--radius-md, 0.375rem)',
+              marginBottom: 'var(--spacing-4)',
+            }}
+          >
+            <AppIcon name="info" />{' '}
+            <strong>{money(summary.breakdown.pendingRewardValueCents)}</strong> of pending rewards
+            across {summary.rewardIncome.length} reward balance
+            {summary.rewardIncome.length === 1 ? '' : 's'} is flagged for income / tax
+            classification. Staking and DeFi rewards are generally ordinary income at fair-market
+            value when received.
+          </p>
+        )}
+
+        {/* Manual entry form */}
+        <form onSubmit={handleSubmit} aria-label="Add DeFi position">
+          <h4
+            style={{ fontWeight: 'var(--font-weight-semibold)', marginBottom: 'var(--spacing-3)' }}
+          >
+            Add a position
+          </h4>
+          <div
+            style={{
+              display: 'grid',
+              gap: 'var(--spacing-3)',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+            }}
+          >
+            <div>
+              <label htmlFor={`${fieldId}-protocol`} style={labelStyle}>
+                Protocol
+              </label>
+              <input
+                id={`${fieldId}-protocol`}
+                type="text"
+                value={form.protocol}
+                onChange={(e) => handleField('protocol', e.target.value)}
+                style={inputStyle}
+                required
+              />
+            </div>
+            <div>
+              <label htmlFor={`${fieldId}-chain`} style={labelStyle}>
+                Chain
+              </label>
+              <input
+                id={`${fieldId}-chain`}
+                type="text"
+                value={form.chain}
+                onChange={(e) => handleField('chain', e.target.value)}
+                placeholder="ethereum"
+                style={inputStyle}
+              />
+            </div>
+            <div>
+              <label htmlFor={`${fieldId}-label`} style={labelStyle}>
+                Label
+              </label>
+              <input
+                id={`${fieldId}-label`}
+                type="text"
+                value={form.label}
+                onChange={(e) => handleField('label', e.target.value)}
+                placeholder="stETH staking"
+                style={inputStyle}
+              />
+            </div>
+            <div>
+              <label htmlFor={`${fieldId}-kind`} style={labelStyle}>
+                Type
+              </label>
+              <select
+                id={`${fieldId}-kind`}
+                value={form.kind}
+                onChange={(e) => handleField('kind', e.target.value as DefiPositionKind)}
+                style={inputStyle}
+              >
+                {KIND_OPTIONS.map((kind) => (
+                  <option key={kind} value={kind}>
+                    {DEFI_KIND_LABELS[kind]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor={`${fieldId}-lock`} style={labelStyle}>
+                Lock state
+              </label>
+              <select
+                id={`${fieldId}-lock`}
+                value={form.lockState}
+                onChange={(e) => handleField('lockState', e.target.value as DefiLockState)}
+                style={inputStyle}
+              >
+                {LOCK_OPTIONS.map((state) => (
+                  <option key={state} value={state}>
+                    {DEFI_LOCK_STATE_LABELS[state]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor={`${fieldId}-principal`} style={labelStyle}>
+                Principal value ($)
+              </label>
+              <input
+                id={`${fieldId}-principal`}
+                type="number"
+                inputMode="decimal"
+                min={0}
+                step="0.01"
+                value={form.principalDollars}
+                onChange={(e) => handleField('principalDollars', e.target.value)}
+                style={inputStyle}
+              />
+            </div>
+            <div>
+              <label htmlFor={`${fieldId}-apy`} style={labelStyle}>
+                APY (%)
+              </label>
+              <input
+                id={`${fieldId}-apy`}
+                type="number"
+                inputMode="decimal"
+                min={0}
+                step="0.1"
+                value={form.apyPercent}
+                onChange={(e) => handleField('apyPercent', e.target.value)}
+                style={inputStyle}
+              />
+            </div>
+            <div>
+              <label htmlFor={`${fieldId}-reward-token`} style={labelStyle}>
+                Reward token
+              </label>
+              <input
+                id={`${fieldId}-reward-token`}
+                type="text"
+                value={form.rewardToken}
+                onChange={(e) => handleField('rewardToken', e.target.value)}
+                placeholder="CRV"
+                style={inputStyle}
+              />
+            </div>
+            <div>
+              <label htmlFor={`${fieldId}-reward-value`} style={labelStyle}>
+                Pending reward value ($)
+              </label>
+              <input
+                id={`${fieldId}-reward-value`}
+                type="number"
+                inputMode="decimal"
+                min={0}
+                step="0.01"
+                value={form.rewardDollars}
+                onChange={(e) => handleField('rewardDollars', e.target.value)}
+                style={inputStyle}
+              />
+            </div>
+            <div>
+              <label htmlFor={`${fieldId}-unlock`} style={labelStyle}>
+                Unlock date
+              </label>
+              <input
+                id={`${fieldId}-unlock`}
+                type="date"
+                value={form.unlockDate}
+                onChange={(e) => handleField('unlockDate', e.target.value)}
+                style={inputStyle}
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            style={{
+              marginTop: 'var(--spacing-4)',
+              padding: 'var(--spacing-2) var(--spacing-4)',
+              border: 'none',
+              borderRadius: 'var(--radius-md, 0.375rem)',
+              background: 'var(--semantic-action-primary, #2563eb)',
+              color: 'var(--semantic-text-on-action, #fff)',
+              font: 'inherit',
+              fontWeight: 'var(--font-weight-medium)',
+              cursor: 'pointer',
+            }}
+          >
+            Add position
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+};
+
+export default DeFiPositionsCard;

--- a/apps/web/src/lib/assets/defi-positions-types.ts
+++ b/apps/web/src/lib/assets/defi-positions-types.ts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Domain types for the DeFi / locked-position engine (#2172).
+ *
+ * A "yield farmer" holds assets that are NOT freely spendable spot balances:
+ * they are staked, supplied to a liquidity pool, lent out, deposited in a
+ * vault, or otherwise locked inside a smart contract. Those positions accrue
+ * protocol rewards and may have lock / unbonding states that make part of the
+ * portfolio illiquid.
+ *
+ * This module models those positions separately from spot holdings so the UI
+ * can report a "liquid vs locked" split and feed staking / DeFi rewards into
+ * the existing income / tax classification concepts (see {@link StakingIncome}).
+ *
+ * All monetary values are integer cents (smallest fiat unit). These types carry
+ * no behaviour — the pure functions live in `./defi-positions`.
+ *
+ * References: issue #2172
+ */
+
+import type { ChainId, LocalDate, StakingIncome } from './types';
+
+// ---------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------
+
+/** The kind of DeFi position, which drives reward-income classification. */
+export type DefiPositionKind =
+  | 'STAKING'
+  | 'LIQUIDITY_POOL'
+  | 'LENDING'
+  | 'BORROW'
+  | 'VAULT'
+  | 'FARM';
+
+/**
+ * Lock / withdrawal state of a position.
+ *
+ * - `LIQUID` — withdrawable on demand; counts toward the liquid portfolio.
+ * - `LOCKED` — bonded / time-locked inside a contract; counts as locked.
+ * - `UNBONDING` — in a cooldown / unbonding window; still locked.
+ * - `WITHDRAWAL_PENDING` — withdrawal requested but not yet claimable; locked.
+ */
+export type DefiLockState = 'LIQUID' | 'LOCKED' | 'UNBONDING' | 'WITHDRAWAL_PENDING';
+
+/** Whether a position's value is currently liquid or locked in a contract. */
+export type DefiLiquidityClass = 'LIQUID' | 'LOCKED';
+
+/** A single unclaimed protocol-reward balance with its fiat value. */
+export interface DefiRewardToken {
+  /** Reward token symbol (e.g. `"CRV"`, `"AERO"`). */
+  readonly token: string;
+  /** Token quantity accrued (may be fractional). */
+  readonly quantity: number;
+  /** Fair-market value of the accrued reward, in integer cents. */
+  readonly valueCents: number;
+}
+
+/**
+ * A manual-entry DeFi position separate from spot holdings.
+ *
+ * Distinct from {@link import('./types').DeFiPosition} (kept for backwards
+ * compatibility) so it can carry the chain, lock state, and reward-token
+ * exposure that yield farmers need.
+ */
+export interface DefiPositionEntry {
+  readonly id: string;
+  /** Protocol name (e.g. `"Lido"`, `"Aave"`, `"Curve"`). */
+  readonly protocol: string;
+  /** Blockchain network the position lives on (e.g. `"ethereum"`). */
+  readonly chain: ChainId;
+  /** What kind of DeFi activity this position represents. */
+  readonly kind: DefiPositionKind;
+  /** Human-readable label (e.g. `"stETH staking"`, `"USDC/ETH LP"`). */
+  readonly label: string;
+  /** Current fiat value of the deposited / locked principal, in cents. */
+  readonly principalValueCents: number;
+  /** Current lock / unbonding state. */
+  readonly lockState: DefiLockState;
+  /** Annual percentage yield as a percent (e.g. `4.2` for 4.2% APY). */
+  readonly apyPercent?: number;
+  /** ISO date the position unlocks / finishes unbonding, when known. */
+  readonly unlockDate?: LocalDate;
+  /** Unclaimed protocol rewards accrued by this position. */
+  readonly rewards?: readonly DefiRewardToken[];
+  /** ISO date the principal / reward valuation was taken. */
+  readonly valuationAsOf?: LocalDate;
+}
+
+// ---------------------------------------------------------------------------
+// Derived views & summaries
+// ---------------------------------------------------------------------------
+
+/** A position enriched with computed value and classification fields. */
+export interface DefiPositionView {
+  readonly id: string;
+  readonly protocol: string;
+  readonly chain: ChainId;
+  readonly kind: DefiPositionKind;
+  readonly kindLabel: string;
+  readonly label: string;
+  readonly lockState: DefiLockState;
+  readonly lockStateLabel: string;
+  /** Whether the position's value is liquid or locked. */
+  readonly liquidityClass: DefiLiquidityClass;
+  readonly principalValueCents: number;
+  /** Sum of all unclaimed reward values, in cents. */
+  readonly rewardValueCents: number;
+  /** `principalValueCents + rewardValueCents`. */
+  readonly totalValueCents: number;
+  readonly apyPercent?: number;
+  readonly unlockDate?: LocalDate;
+  readonly rewards: readonly DefiRewardToken[];
+}
+
+/** Liquid vs locked breakdown across a set of DeFi positions. */
+export interface DefiLiquidityBreakdown {
+  /** Total value of positions classified as liquid, in cents. */
+  readonly liquidValueCents: number;
+  /** Total value of positions classified as locked, in cents. */
+  readonly lockedValueCents: number;
+  /** Total unclaimed reward value across all positions, in cents. */
+  readonly pendingRewardValueCents: number;
+  /** `liquidValueCents + lockedValueCents` (principal + rewards), in cents. */
+  readonly totalExposureCents: number;
+  /** Liquid share of total exposure, as a 2-decimal percent. */
+  readonly liquidPercent: number;
+  /** Locked share of total exposure, as a 2-decimal percent. */
+  readonly lockedPercent: number;
+}
+
+/** Aggregated exposure for a single protocol. */
+export interface DefiProtocolSummary {
+  readonly protocol: string;
+  readonly totalValueCents: number;
+  readonly liquidValueCents: number;
+  readonly lockedValueCents: number;
+  readonly pendingRewardValueCents: number;
+  readonly positionCount: number;
+  /** Chains this protocol's positions span, sorted alphabetically. */
+  readonly chains: readonly string[];
+}
+
+/** Aggregated exposure for a single chain. */
+export interface DefiChainSummary {
+  readonly chain: string;
+  readonly totalValueCents: number;
+  readonly liquidValueCents: number;
+  readonly lockedValueCents: number;
+  readonly pendingRewardValueCents: number;
+  readonly positionCount: number;
+}
+
+/** Full DeFi portfolio summary produced by {@link summarizeDefiPortfolio}. */
+export interface DefiPortfolioSummary {
+  readonly positions: readonly DefiPositionView[];
+  readonly breakdown: DefiLiquidityBreakdown;
+  readonly byProtocol: readonly DefiProtocolSummary[];
+  readonly byChain: readonly DefiChainSummary[];
+  /** Reward income records for downstream income / tax classification. */
+  readonly rewardIncome: readonly StakingIncome[];
+  readonly positionCount: number;
+}
+
+/**
+ * The combined liquid-vs-locked split of an entire portfolio, blending freely
+ * spendable spot holdings with DeFi positions.
+ */
+export interface PortfolioLiquiditySplit {
+  /** Spot-holding value treated as liquid, in cents. */
+  readonly spotLiquidValueCents: number;
+  /** DeFi value classified as liquid, in cents. */
+  readonly defiLiquidValueCents: number;
+  /** DeFi value classified as locked, in cents. */
+  readonly defiLockedValueCents: number;
+  /** Spot liquid + DeFi liquid, in cents. */
+  readonly liquidValueCents: number;
+  /** DeFi locked, in cents. */
+  readonly lockedValueCents: number;
+  /** Total unclaimed DeFi reward value, in cents. */
+  readonly pendingRewardValueCents: number;
+  /** Liquid + locked, in cents. */
+  readonly totalValueCents: number;
+  /** Liquid share of the total, as a 2-decimal percent. */
+  readonly liquidPercent: number;
+  /** Locked share of the total, as a 2-decimal percent. */
+  readonly lockedPercent: number;
+}

--- a/apps/web/src/lib/assets/defi-positions.test.ts
+++ b/apps/web/src/lib/assets/defi-positions.test.ts
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import {
+  classifyLiquidity,
+  combinePortfolioLiquidity,
+  computeLiquidityBreakdown,
+  DEFI_KIND_LABELS,
+  DEFI_LOCK_STATE_LABELS,
+  extractRewardIncome,
+  isLiquidLockState,
+  positionTotalValueCents,
+  rewardValueOfPosition,
+  summarizeByChain,
+  summarizeByProtocol,
+  summarizeDefiPortfolio,
+  toPositionView,
+} from './defi-positions';
+import type { DefiPositionEntry } from './defi-positions-types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Liquid Aave USDC lending position on Ethereum with claimable rewards. */
+const aaveLending: DefiPositionEntry = {
+  id: 'pos-aave',
+  protocol: 'Aave',
+  chain: 'ethereum',
+  kind: 'LENDING',
+  label: 'USDC supply',
+  principalValueCents: 500_000, // $5,000
+  lockState: 'LIQUID',
+  apyPercent: 3.5,
+  rewards: [{ token: 'AAVE', quantity: 0.5, valueCents: 4_000 }], // $40
+  valuationAsOf: '2025-06-01',
+};
+
+/** Locked Lido stETH staking position on Ethereum with accrued rewards. */
+const lidoStaking: DefiPositionEntry = {
+  id: 'pos-lido',
+  protocol: 'Lido',
+  chain: 'ethereum',
+  kind: 'STAKING',
+  label: 'stETH staking',
+  principalValueCents: 1_000_000, // $10,000
+  lockState: 'LOCKED',
+  apyPercent: 4.2,
+  rewards: [{ token: 'stETH', quantity: 0.1, valueCents: 30_000 }], // $300
+  valuationAsOf: '2025-06-01',
+};
+
+/** Unbonding Curve LP/farm on Arbitrum, no rewards yet. */
+const curveFarm: DefiPositionEntry = {
+  id: 'pos-curve',
+  protocol: 'Curve',
+  chain: 'arbitrum',
+  kind: 'FARM',
+  label: 'tricrypto farm',
+  principalValueCents: 250_000, // $2,500
+  lockState: 'UNBONDING',
+  apyPercent: 12,
+  rewards: [],
+  valuationAsOf: '2025-06-01',
+};
+
+const ALL = [aaveLending, lidoStaking, curveFarm];
+
+// ---------------------------------------------------------------------------
+// Per-position helpers
+// ---------------------------------------------------------------------------
+
+describe('per-position helpers', () => {
+  it('classifies only LIQUID positions as liquid', () => {
+    expect(isLiquidLockState('LIQUID')).toBe(true);
+    expect(isLiquidLockState('LOCKED')).toBe(false);
+    expect(isLiquidLockState('UNBONDING')).toBe(false);
+    expect(isLiquidLockState('WITHDRAWAL_PENDING')).toBe(false);
+
+    expect(classifyLiquidity(aaveLending)).toBe('LIQUID');
+    expect(classifyLiquidity(lidoStaking)).toBe('LOCKED');
+    expect(classifyLiquidity(curveFarm)).toBe('LOCKED');
+  });
+
+  it('sums reward value and total value in integer cents', () => {
+    expect(rewardValueOfPosition(aaveLending)).toBe(4_000);
+    expect(rewardValueOfPosition(curveFarm)).toBe(0);
+    // principal 500000 + rewards 4000
+    expect(positionTotalValueCents(aaveLending)).toBe(504_000);
+    expect(positionTotalValueCents(lidoStaking)).toBe(1_030_000);
+  });
+
+  it('treats missing rewards and non-finite values as zero', () => {
+    const noRewards: DefiPositionEntry = {
+      id: 'x',
+      protocol: 'P',
+      chain: 'ethereum',
+      kind: 'VAULT',
+      label: 'v',
+      principalValueCents: Number.NaN,
+      lockState: 'LIQUID',
+    };
+    expect(rewardValueOfPosition(noRewards)).toBe(0);
+    expect(positionTotalValueCents(noRewards)).toBe(0);
+  });
+
+  it('builds an enriched view with labels and totals', () => {
+    const view = toPositionView(lidoStaking);
+    expect(view.kindLabel).toBe(DEFI_KIND_LABELS.STAKING);
+    expect(view.lockStateLabel).toBe(DEFI_LOCK_STATE_LABELS.LOCKED);
+    expect(view.liquidityClass).toBe('LOCKED');
+    expect(view.rewardValueCents).toBe(30_000);
+    expect(view.totalValueCents).toBe(1_030_000);
+    expect(view.apyPercent).toBe(4.2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Liquidity breakdown
+// ---------------------------------------------------------------------------
+
+describe('computeLiquidityBreakdown', () => {
+  it('computes liquid, locked, reward, and total exposure with percentages', () => {
+    const b = computeLiquidityBreakdown(ALL);
+    // liquid = aave 504000
+    expect(b.liquidValueCents).toBe(504_000);
+    // locked = lido 1030000 + curve 250000
+    expect(b.lockedValueCents).toBe(1_280_000);
+    // rewards = 4000 + 30000 + 0
+    expect(b.pendingRewardValueCents).toBe(34_000);
+    expect(b.totalExposureCents).toBe(1_784_000);
+    // 504000 / 1784000 = 28.2511...% -> 28.25
+    expect(b.liquidPercent).toBe(28.25);
+    // 1280000 / 1784000 = 71.7488...% -> 71.75
+    expect(b.lockedPercent).toBe(71.75);
+  });
+
+  it('returns all zeros for an empty portfolio', () => {
+    const b = computeLiquidityBreakdown([]);
+    expect(b).toEqual({
+      liquidValueCents: 0,
+      lockedValueCents: 0,
+      pendingRewardValueCents: 0,
+      totalExposureCents: 0,
+      liquidPercent: 0,
+      lockedPercent: 0,
+    });
+  });
+
+  it('reports 100% locked when every position is locked', () => {
+    const b = computeLiquidityBreakdown([lidoStaking, curveFarm]);
+    expect(b.liquidValueCents).toBe(0);
+    expect(b.liquidPercent).toBe(0);
+    expect(b.lockedPercent).toBe(100);
+  });
+
+  it('reports 100% liquid when every position is liquid', () => {
+    const b = computeLiquidityBreakdown([aaveLending]);
+    expect(b.lockedValueCents).toBe(0);
+    expect(b.liquidPercent).toBe(100);
+    expect(b.lockedPercent).toBe(0);
+  });
+
+  it('reports zero pending rewards when there are none', () => {
+    const b = computeLiquidityBreakdown([curveFarm]);
+    expect(b.pendingRewardValueCents).toBe(0);
+  });
+
+  it('uses banker’s rounding (round half to even) for percentages', () => {
+    // liquid 1 cent of 160 total -> 1/160*10000 = 62.5 -> rounds to 62 (even) -> 0.62
+    const liquid: DefiPositionEntry = {
+      id: 'l',
+      protocol: 'P',
+      chain: 'ethereum',
+      kind: 'LENDING',
+      label: 'l',
+      principalValueCents: 1,
+      lockState: 'LIQUID',
+    };
+    const locked: DefiPositionEntry = {
+      id: 'k',
+      protocol: 'P',
+      chain: 'ethereum',
+      kind: 'STAKING',
+      label: 'k',
+      principalValueCents: 159,
+      lockState: 'LOCKED',
+    };
+    const b = computeLiquidityBreakdown([liquid, locked]);
+    expect(b.totalExposureCents).toBe(160);
+    expect(b.liquidPercent).toBe(0.62); // 62.5 -> 62 (even)
+    expect(b.lockedPercent).toBe(99.38); // 9937.5 -> 9938 (even)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group summaries
+// ---------------------------------------------------------------------------
+
+describe('summarizeByProtocol', () => {
+  it('groups positions by protocol ordered by total value descending', () => {
+    const rows = summarizeByProtocol(ALL);
+    expect(rows.map((r) => r.protocol)).toEqual(['Lido', 'Aave', 'Curve']);
+
+    const lido = rows.find((r) => r.protocol === 'Lido');
+    expect(lido?.totalValueCents).toBe(1_030_000);
+    expect(lido?.lockedValueCents).toBe(1_030_000);
+    expect(lido?.liquidValueCents).toBe(0);
+    expect(lido?.pendingRewardValueCents).toBe(30_000);
+    expect(lido?.positionCount).toBe(1);
+    expect(lido?.chains).toEqual(['ethereum']);
+  });
+
+  it('collects the distinct chains a protocol spans, sorted', () => {
+    const sushiArb: DefiPositionEntry = {
+      ...curveFarm,
+      id: 'sushi-1',
+      protocol: 'Sushi',
+      chain: 'optimism',
+    };
+    const sushiEth: DefiPositionEntry = {
+      ...curveFarm,
+      id: 'sushi-2',
+      protocol: 'Sushi',
+      chain: 'ethereum',
+    };
+    const rows = summarizeByProtocol([sushiArb, sushiEth]);
+    const sushi = rows.find((r) => r.protocol === 'Sushi');
+    expect(sushi?.chains).toEqual(['ethereum', 'optimism']);
+    expect(sushi?.positionCount).toBe(2);
+  });
+
+  it('returns an empty array for no positions', () => {
+    expect(summarizeByProtocol([])).toEqual([]);
+  });
+});
+
+describe('summarizeByChain', () => {
+  it('groups positions by chain ordered by total value descending', () => {
+    const rows = summarizeByChain(ALL);
+    expect(rows.map((r) => r.chain)).toEqual(['ethereum', 'arbitrum']);
+
+    const ethereum = rows.find((r) => r.chain === 'ethereum');
+    // aave 504000 + lido 1030000
+    expect(ethereum?.totalValueCents).toBe(1_534_000);
+    expect(ethereum?.liquidValueCents).toBe(504_000);
+    expect(ethereum?.lockedValueCents).toBe(1_030_000);
+    expect(ethereum?.positionCount).toBe(2);
+
+    const arbitrum = rows.find((r) => r.chain === 'arbitrum');
+    expect(arbitrum?.totalValueCents).toBe(250_000);
+    expect(arbitrum?.lockedValueCents).toBe(250_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reward income extraction
+// ---------------------------------------------------------------------------
+
+describe('extractRewardIncome', () => {
+  it('maps reward tokens to staking-income records with classification', () => {
+    const income = extractRewardIncome(ALL);
+    expect(income).toHaveLength(2);
+
+    const aave = income.find((r) => r.id === 'pos-aave:AAVE');
+    expect(aave).toMatchObject({
+      symbol: 'AAVE',
+      quantity: 0.5,
+      fairMarketValueCents: 4_000,
+      dateReceived: '2025-06-01',
+      type: 'DEFI_YIELD', // lending -> DeFi yield
+      protocol: 'Aave',
+    });
+
+    const lido = income.find((r) => r.id === 'pos-lido:stETH');
+    expect(lido?.type).toBe('STAKING'); // staking -> staking income
+    expect(lido?.fairMarketValueCents).toBe(30_000);
+  });
+
+  it('skips empty reward balances and returns nothing when there are no rewards', () => {
+    expect(extractRewardIncome([curveFarm])).toEqual([]);
+
+    const zero: DefiPositionEntry = {
+      ...aaveLending,
+      id: 'zero',
+      rewards: [{ token: 'ZERO', quantity: 0, valueCents: 0 }],
+    };
+    expect(extractRewardIncome([zero])).toEqual([]);
+  });
+
+  it('falls back to the supplied asOf date when a position is undated', () => {
+    const undated: DefiPositionEntry = {
+      ...aaveLending,
+      id: 'undated',
+      valuationAsOf: undefined,
+    };
+    const income = extractRewardIncome([undated], '2025-12-31');
+    expect(income[0]?.dateReceived).toBe('2025-12-31');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Portfolio rollups
+// ---------------------------------------------------------------------------
+
+describe('summarizeDefiPortfolio', () => {
+  it('assembles positions, breakdown, group summaries, and reward income', () => {
+    const summary = summarizeDefiPortfolio(ALL, { rewardAsOf: '2025-06-01' });
+    expect(summary.positionCount).toBe(3);
+    expect(summary.positions).toHaveLength(3);
+    expect(summary.breakdown.totalExposureCents).toBe(1_784_000);
+    expect(summary.byProtocol).toHaveLength(3);
+    expect(summary.byChain).toHaveLength(2);
+    expect(summary.rewardIncome).toHaveLength(2);
+  });
+
+  it('handles an empty portfolio', () => {
+    const summary = summarizeDefiPortfolio([]);
+    expect(summary.positionCount).toBe(0);
+    expect(summary.positions).toEqual([]);
+    expect(summary.byProtocol).toEqual([]);
+    expect(summary.byChain).toEqual([]);
+    expect(summary.rewardIncome).toEqual([]);
+    expect(summary.breakdown.totalExposureCents).toBe(0);
+  });
+});
+
+describe('combinePortfolioLiquidity', () => {
+  it('blends spot holdings (liquid) with the DeFi locked value', () => {
+    const breakdown = computeLiquidityBreakdown(ALL);
+    const split = combinePortfolioLiquidity(2_000_000, breakdown); // $20,000 spot
+
+    expect(split.spotLiquidValueCents).toBe(2_000_000);
+    expect(split.defiLiquidValueCents).toBe(504_000);
+    expect(split.defiLockedValueCents).toBe(1_280_000);
+    // liquid = spot 2000000 + defi liquid 504000
+    expect(split.liquidValueCents).toBe(2_504_000);
+    expect(split.lockedValueCents).toBe(1_280_000);
+    expect(split.totalValueCents).toBe(3_784_000);
+    expect(split.pendingRewardValueCents).toBe(34_000);
+    // 2504000 / 3784000 = 66.17...%
+    expect(split.liquidPercent).toBe(66.17);
+    expect(split.lockedPercent).toBe(33.83);
+  });
+
+  it('handles a spot-only portfolio with no DeFi positions', () => {
+    const breakdown = computeLiquidityBreakdown([]);
+    const split = combinePortfolioLiquidity(1_000_000, breakdown);
+    expect(split.liquidValueCents).toBe(1_000_000);
+    expect(split.lockedValueCents).toBe(0);
+    expect(split.liquidPercent).toBe(100);
+    expect(split.lockedPercent).toBe(0);
+  });
+
+  it('handles a zero-value portfolio without dividing by zero', () => {
+    const split = combinePortfolioLiquidity(0, computeLiquidityBreakdown([]));
+    expect(split.totalValueCents).toBe(0);
+    expect(split.liquidPercent).toBe(0);
+    expect(split.lockedPercent).toBe(0);
+  });
+});

--- a/apps/web/src/lib/assets/defi-positions.ts
+++ b/apps/web/src/lib/assets/defi-positions.ts
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * DeFi / locked-position engine for yield farmers (#2172).
+ *
+ * Tracks staked assets, liquidity-pool positions, lending positions, and
+ * pending protocol rewards SEPARATELY from spot holdings, and:
+ *
+ *   - classifies each position as liquid or locked (in a contract);
+ *   - computes liquid value, locked value, total exposure, and pending-reward
+ *     value;
+ *   - summarises exposure by protocol and by chain;
+ *   - extracts staking / DeFi reward income for downstream income / tax
+ *     classification (mapped onto the existing {@link StakingIncome} concept);
+ *   - blends spot holdings with DeFi positions into one liquid-vs-locked split.
+ *
+ * Money is integer cents throughout. Percentages use banker's rounding (round
+ * half to even) via the shared {@link bankersRound} helper. Every function is
+ * pure — no side effects, no I/O, no market-data fetching.
+ *
+ * Modelling choices (documented for auditability):
+ *   - A position's value is `principal + unclaimed rewards`. When a position is
+ *     locked, its WHOLE value (including accrued rewards) is treated as locked,
+ *     because staking rewards in a bonded position are typically not claimable
+ *     until the lock / unbonding window resolves.
+ *   - `pendingRewardValueCents` is reported on its own so callers can surface
+ *     reward exposure regardless of the position's lock state.
+ *   - Reward income is recognised at the supplied fair-market value; this engine
+ *     never invents prices.
+ *
+ * References: issue #2172
+ */
+
+import { bankersRound, safeDivide } from './crypto-portfolio';
+import type { LocalDate, StakingIncome } from './types';
+import type {
+  DefiChainSummary,
+  DefiLiquidityBreakdown,
+  DefiLiquidityClass,
+  DefiLockState,
+  DefiPortfolioSummary,
+  DefiPositionEntry,
+  DefiPositionKind,
+  DefiPositionView,
+  DefiProtocolSummary,
+  PortfolioLiquiditySplit,
+} from './defi-positions-types';
+
+// ---------------------------------------------------------------------------
+// Labels
+// ---------------------------------------------------------------------------
+
+/** Human-readable labels for each position kind. */
+export const DEFI_KIND_LABELS: Readonly<Record<DefiPositionKind, string>> = {
+  STAKING: 'Staking',
+  LIQUIDITY_POOL: 'Liquidity pool',
+  LENDING: 'Lending',
+  BORROW: 'Borrow',
+  VAULT: 'Vault',
+  FARM: 'Yield farm',
+};
+
+/** Human-readable labels for each lock state. */
+export const DEFI_LOCK_STATE_LABELS: Readonly<Record<DefiLockState, string>> = {
+  LIQUID: 'Liquid',
+  LOCKED: 'Locked',
+  UNBONDING: 'Unbonding',
+  WITHDRAWAL_PENDING: 'Withdrawal pending',
+};
+
+// ---------------------------------------------------------------------------
+// Per-position helpers
+// ---------------------------------------------------------------------------
+
+/** Whether a lock state means the value is freely withdrawable. */
+export function isLiquidLockState(state: DefiLockState): boolean {
+  return state === 'LIQUID';
+}
+
+/** Classify a single position as liquid or locked. */
+export function classifyLiquidity(position: DefiPositionEntry): DefiLiquidityClass {
+  return isLiquidLockState(position.lockState) ? 'LIQUID' : 'LOCKED';
+}
+
+/** Sum the fiat value of a position's unclaimed rewards, in cents. */
+export function rewardValueOfPosition(position: DefiPositionEntry): number {
+  const rewards = position.rewards ?? [];
+  let sum = 0;
+  for (const reward of rewards) {
+    sum += Number.isFinite(reward.valueCents) ? Math.round(reward.valueCents) : 0;
+  }
+  return sum;
+}
+
+/** Total current value of a position (principal + unclaimed rewards), in cents. */
+export function positionTotalValueCents(position: DefiPositionEntry): number {
+  const principal = Number.isFinite(position.principalValueCents)
+    ? Math.round(position.principalValueCents)
+    : 0;
+  return principal + rewardValueOfPosition(position);
+}
+
+/** Enrich a raw position with computed value and classification fields. */
+export function toPositionView(position: DefiPositionEntry): DefiPositionView {
+  const rewardValueCents = rewardValueOfPosition(position);
+  const principalValueCents = Number.isFinite(position.principalValueCents)
+    ? Math.round(position.principalValueCents)
+    : 0;
+  return {
+    id: position.id,
+    protocol: position.protocol,
+    chain: position.chain,
+    kind: position.kind,
+    kindLabel: DEFI_KIND_LABELS[position.kind] ?? position.kind,
+    label: position.label,
+    lockState: position.lockState,
+    lockStateLabel: DEFI_LOCK_STATE_LABELS[position.lockState] ?? position.lockState,
+    liquidityClass: classifyLiquidity(position),
+    principalValueCents,
+    rewardValueCents,
+    totalValueCents: principalValueCents + rewardValueCents,
+    apyPercent: position.apyPercent,
+    unlockDate: position.unlockDate,
+    rewards: position.rewards ?? [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Percentages
+// ---------------------------------------------------------------------------
+
+/** A 2-decimal percent share of `part` within `whole` (banker's rounding). */
+function percentOf(part: number, whole: number): number {
+  if (whole <= 0) return 0;
+  return bankersRound(safeDivide(part, whole) * 10000) / 100;
+}
+
+// ---------------------------------------------------------------------------
+// Liquidity breakdown
+// ---------------------------------------------------------------------------
+
+/**
+ * Split a set of positions into liquid vs locked value with a reward total.
+ *
+ * @param positions - The DeFi positions to summarise.
+ * @returns Liquid / locked / reward totals plus liquid & locked percentages.
+ */
+export function computeLiquidityBreakdown(
+  positions: readonly DefiPositionEntry[],
+): DefiLiquidityBreakdown {
+  let liquidValueCents = 0;
+  let lockedValueCents = 0;
+  let pendingRewardValueCents = 0;
+
+  for (const position of positions) {
+    const total = positionTotalValueCents(position);
+    pendingRewardValueCents += rewardValueOfPosition(position);
+    if (classifyLiquidity(position) === 'LIQUID') {
+      liquidValueCents += total;
+    } else {
+      lockedValueCents += total;
+    }
+  }
+
+  const totalExposureCents = liquidValueCents + lockedValueCents;
+
+  return {
+    liquidValueCents,
+    lockedValueCents,
+    pendingRewardValueCents,
+    totalExposureCents,
+    liquidPercent: percentOf(liquidValueCents, totalExposureCents),
+    lockedPercent: percentOf(lockedValueCents, totalExposureCents),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Group summaries
+// ---------------------------------------------------------------------------
+
+interface MutableGroup {
+  totalValueCents: number;
+  liquidValueCents: number;
+  lockedValueCents: number;
+  pendingRewardValueCents: number;
+  positionCount: number;
+}
+
+function emptyGroup(): MutableGroup {
+  return {
+    totalValueCents: 0,
+    liquidValueCents: 0,
+    lockedValueCents: 0,
+    pendingRewardValueCents: 0,
+    positionCount: 0,
+  };
+}
+
+function accumulate(group: MutableGroup, position: DefiPositionEntry): void {
+  const total = positionTotalValueCents(position);
+  group.totalValueCents += total;
+  group.pendingRewardValueCents += rewardValueOfPosition(position);
+  group.positionCount += 1;
+  if (classifyLiquidity(position) === 'LIQUID') {
+    group.liquidValueCents += total;
+  } else {
+    group.lockedValueCents += total;
+  }
+}
+
+/** Sort comparator: larger total first, then label ascending for stability. */
+function byValueThenName<T extends { totalValueCents: number }>(
+  nameOf: (item: T) => string,
+): (a: T, b: T) => number {
+  return (a, b) => b.totalValueCents - a.totalValueCents || nameOf(a).localeCompare(nameOf(b));
+}
+
+/** Summarise exposure grouped by protocol, ordered by total value descending. */
+export function summarizeByProtocol(
+  positions: readonly DefiPositionEntry[],
+): readonly DefiProtocolSummary[] {
+  const groups = new Map<string, MutableGroup>();
+  const chains = new Map<string, Set<string>>();
+
+  for (const position of positions) {
+    const group = groups.get(position.protocol) ?? emptyGroup();
+    accumulate(group, position);
+    groups.set(position.protocol, group);
+
+    const chainSet = chains.get(position.protocol) ?? new Set<string>();
+    chainSet.add(position.chain);
+    chains.set(position.protocol, chainSet);
+  }
+
+  return Array.from(groups.entries())
+    .map(([protocol, group]) => ({
+      protocol,
+      totalValueCents: group.totalValueCents,
+      liquidValueCents: group.liquidValueCents,
+      lockedValueCents: group.lockedValueCents,
+      pendingRewardValueCents: group.pendingRewardValueCents,
+      positionCount: group.positionCount,
+      chains: Array.from(chains.get(protocol) ?? new Set<string>()).sort(),
+    }))
+    .sort(byValueThenName((item) => item.protocol));
+}
+
+/** Summarise exposure grouped by chain, ordered by total value descending. */
+export function summarizeByChain(
+  positions: readonly DefiPositionEntry[],
+): readonly DefiChainSummary[] {
+  const groups = new Map<string, MutableGroup>();
+
+  for (const position of positions) {
+    const group = groups.get(position.chain) ?? emptyGroup();
+    accumulate(group, position);
+    groups.set(position.chain, group);
+  }
+
+  return Array.from(groups.entries())
+    .map(([chain, group]) => ({
+      chain,
+      totalValueCents: group.totalValueCents,
+      liquidValueCents: group.liquidValueCents,
+      lockedValueCents: group.lockedValueCents,
+      pendingRewardValueCents: group.pendingRewardValueCents,
+      positionCount: group.positionCount,
+    }))
+    .sort(byValueThenName((item) => item.chain));
+}
+
+// ---------------------------------------------------------------------------
+// Reward income → tax / income classification
+// ---------------------------------------------------------------------------
+
+/** Map a position kind onto its staking-income classification. */
+function rewardIncomeType(kind: DefiPositionKind): StakingIncome['type'] {
+  return kind === 'STAKING' ? 'STAKING' : 'DEFI_YIELD';
+}
+
+/**
+ * Extract pending reward balances as {@link StakingIncome} records so they can
+ * flow into the existing income / tax classification engines.
+ *
+ * Staking and DeFi rewards are ordinary income at fair-market value when the
+ * holder gains dominion and control; this surfaces each accrued reward token as
+ * one income record. Rewards with no quantity AND no value are skipped.
+ *
+ * @param positions - The DeFi positions to scan.
+ * @param asOf - Fallback receipt date for positions without `valuationAsOf`.
+ * @returns One {@link StakingIncome} record per non-empty reward balance.
+ */
+export function extractRewardIncome(
+  positions: readonly DefiPositionEntry[],
+  asOf?: LocalDate,
+): readonly StakingIncome[] {
+  const records: StakingIncome[] = [];
+
+  for (const position of positions) {
+    for (const reward of position.rewards ?? []) {
+      const valueCents = Number.isFinite(reward.valueCents) ? Math.round(reward.valueCents) : 0;
+      const quantity = Number.isFinite(reward.quantity) ? reward.quantity : 0;
+      if (quantity === 0 && valueCents === 0) continue;
+
+      records.push({
+        id: `${position.id}:${reward.token}`,
+        symbol: reward.token,
+        quantity,
+        fairMarketValueCents: valueCents,
+        dateReceived: position.valuationAsOf ?? asOf ?? '',
+        type: rewardIncomeType(position.kind),
+        protocol: position.protocol,
+      });
+    }
+  }
+
+  return records;
+}
+
+// ---------------------------------------------------------------------------
+// Portfolio rollups
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the full DeFi portfolio summary: enriched positions, a liquid-vs-locked
+ * breakdown, by-protocol and by-chain rollups, and reward-income records.
+ *
+ * @param positions - The DeFi positions to summarise.
+ * @param options.rewardAsOf - Fallback date for reward income records.
+ */
+export function summarizeDefiPortfolio(
+  positions: readonly DefiPositionEntry[],
+  options: { readonly rewardAsOf?: LocalDate } = {},
+): DefiPortfolioSummary {
+  return {
+    positions: positions.map(toPositionView),
+    breakdown: computeLiquidityBreakdown(positions),
+    byProtocol: summarizeByProtocol(positions),
+    byChain: summarizeByChain(positions),
+    rewardIncome: extractRewardIncome(positions, options.rewardAsOf),
+    positionCount: positions.length,
+  };
+}
+
+/**
+ * Blend freely spendable spot holdings with a DeFi liquidity breakdown into a
+ * single liquid-vs-locked split for the whole portfolio.
+ *
+ * Spot holdings are treated as liquid; DeFi locked value is the only locked
+ * component. Percentages use banker's rounding over the combined total.
+ *
+ * @param spotLiquidValueCents - Market value of spot holdings, in cents.
+ * @param breakdown - A DeFi liquidity breakdown (see {@link computeLiquidityBreakdown}).
+ */
+export function combinePortfolioLiquidity(
+  spotLiquidValueCents: number,
+  breakdown: DefiLiquidityBreakdown,
+): PortfolioLiquiditySplit {
+  const spot = Number.isFinite(spotLiquidValueCents) ? Math.round(spotLiquidValueCents) : 0;
+  const liquidValueCents = spot + breakdown.liquidValueCents;
+  const lockedValueCents = breakdown.lockedValueCents;
+  const totalValueCents = liquidValueCents + lockedValueCents;
+
+  return {
+    spotLiquidValueCents: spot,
+    defiLiquidValueCents: breakdown.liquidValueCents,
+    defiLockedValueCents: breakdown.lockedValueCents,
+    liquidValueCents,
+    lockedValueCents,
+    pendingRewardValueCents: breakdown.pendingRewardValueCents,
+    totalValueCents,
+    liquidPercent: percentOf(liquidValueCents, totalValueCents),
+    lockedPercent: percentOf(lockedValueCents, totalValueCents),
+  };
+}

--- a/apps/web/src/pages/InvestmentsPage.tsx
+++ b/apps/web/src/pages/InvestmentsPage.tsx
@@ -23,6 +23,7 @@ import {
   useInvestingBetaFeatures,
 } from '../components/investments/InvestingBetaFeatures';
 import { InvestmentProjections } from '../components/investments/InvestmentProjections';
+import { DeFiPositionsCard } from '../components/investments/DeFiPositionsCard';
 import { useInvestments } from '../hooks';
 import { formatCurrency, formatGainLoss } from '../lib/currency';
 import type { Investment, InvestmentType } from '../kmp/bridge';
@@ -363,6 +364,9 @@ export const InvestmentsPage: React.FC = () => {
             currentValueCents={summary.totalValue}
             investedToDateCents={summary.totalCostBasis}
           />
+
+          {/* DeFi / locked positions tracked separately from spot holdings (#2172) */}
+          <DeFiPositionsCard spotLiquidValueCents={summary.totalValue} />
 
           {/* Holdings Table */}
           <InvestingBetaFeaturesPanel investments={investments} features={betaFeatures} />


### PR DESCRIPTION
## Summary
Web slice of #2172 — track DeFi / locked positions separately from spot holdings for yield farmers.

A pure TypeScript engine plus an accessible Investments-page card so locked assets (staking, LP, lending, vaults) are reported apart from freely spendable spot holdings, with a true liquid-vs-locked view and reward exposure flagged for income/tax classification.

## What's included
### Pure engine — `apps/web/src/lib/assets/defi-positions.ts` (+ `defi-positions-types.ts`)
- Classifies each position as **liquid** vs **locked** (`LIQUID` / `LOCKED` / `UNBONDING` / `WITHDRAWAL_PENDING`).
- Computes **liquid value, locked value, total exposure, and pending-reward value**.
- Summarizes exposure **by protocol** and **by chain**.
- Extracts staking / DeFi reward balances as `StakingIncome` records for downstream **income / tax classification** (staking → `STAKING`, others → `DEFI_YIELD`).
- `combinePortfolioLiquidity` blends spot holdings (liquid) with DeFi into one liquid-vs-locked split.
- Integer **cents** throughout, **banker's rounding** for percentages, pure functions, no float money, no network, no fabricated market data. Reuses `bankersRound` / `safeDivide` and the existing `StakingIncome` / `ChainId` types.

### Accessible UI — `apps/web/src/components/investments/DeFiPositionsCard.tsx`
- Surfaced on `InvestmentsPage` (imported directly into the lazy page chunk to respect the 215 KB lazy-chunk budget — not added to any shared barrel).
- Liquid-vs-locked breakdown of portfolio totals; per-position protocol / chain / lock-state / APY / reward exposure; by-protocol and by-chain rollups; pending-reward income note.
- Manual, **local-only** entry persisted to `localStorage` (same pattern as the Investing Beta toolkit).
- WCAG 2.2 AA: labeled controls, polite `aria-live` status, table `<caption>` + scoped headers, lock state shown with **text + icon (never colour alone)**, decorative proportion bar is `aria-hidden`, keyboard-operable form.

## Tests
- `defi-positions.test.ts` — 22 tests: known values, banker's-rounding ties, and edge cases (empty, all-locked, all-liquid, zero rewards, undated rewards, spot-only, zero-value).
- `DeFiPositionsCard.test.tsx` — 8 render/interaction tests (empty state, split, add, remove, persistence, reward-income note, accessible captions).
- Existing `InvestmentsPage` tests still green; full `apps/web` `tsc --noEmit` reports 0 errors; ESLint clean.

## Scope
Web slice only. Native UI and shared-package (KMP) DeFi models remain out of scope.

Refs #2172