### PR TITLE
feat(web): trip and country budgets with local-currency rollup (#2205)

### DIFF
--- a/apps/web/src/components/layout/navConfig.tsx
+++ b/apps/web/src/components/layout/navConfig.tsx
@@ -173,6 +173,15 @@ export const NAV_CONFIG: readonly NavConfigItem[] = ensureStableNavOrder([
     description: 'Track spending against monthly limits.',
   },
   {
+    id: 'trip-budgets',
+    label: 'Trip Budgets',
+    href: '/trip-budgets',
+    icon: <AppIcon name="globe" size={24} />,
+    group: 'plan',
+    mobilePriority: 19,
+    description: 'Country/trip envelopes with local-currency spend and home-currency roll-up.',
+  },
+  {
     id: 'debt',
     label: 'Debt',
     href: '/debt',

--- a/apps/web/src/lib/budgets/__tests__/trip-budgets.test.ts
+++ b/apps/web/src/lib/budgets/__tests__/trip-budgets.test.ts
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the pure trip / country budget engine (issue #2205).
+ *
+ * Covers: date-window filtering, country matching, FX roll-up with known
+ * rates, banker's rounding, remaining-vs-planned, and archived-state handling
+ * that preserves historical totals. All money is integer minor units.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  archiveTripBudget,
+  computeTripTotals,
+  convertMinorUnits,
+  filterTripTransactions,
+  summarizeTripBudget,
+  summarizeTripBudgets,
+  transactionInTripWindow,
+  transactionMatchesTrip,
+  tripDurationDays,
+  tripStatus,
+  unarchiveTripBudget,
+} from '../trip-budgets';
+import type { TripBudget, TripTransaction } from '../types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeTrip(overrides: Partial<TripBudget> = {}): TripBudget {
+  return {
+    id: 'trip-bkk',
+    name: 'Bangkok Jan–Mar',
+    country: 'Thailand',
+    startDate: '2026-01-01',
+    endDate: '2026-03-31',
+    localCurrency: 'THB',
+    homeCurrency: 'USD',
+    plannedLocalMinor: 100_000, // ฿1,000.00
+    fxRateHomePerLocal: 0.03, // 1 satang = 0.03 cents → ฿1 = $0.03
+    archived: false,
+    archivedAt: null,
+    archivedSnapshot: null,
+    ...overrides,
+  };
+}
+
+function makeTx(overrides: Partial<TripTransaction> = {}): TripTransaction {
+  return {
+    id: 'tx-1',
+    amountMinor: 25_000, // ฿250.00
+    currency: 'THB',
+    date: '2026-02-15',
+    country: 'Thailand',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// FX conversion (banker's rounding)
+// ---------------------------------------------------------------------------
+
+describe('convertMinorUnits', () => {
+  it('converts local minor units to home minor units with a known rate', () => {
+    // ฿500.00 (50,000 satang) at ฿1 = $0.03 → $15.00 (1,500 cents).
+    expect(convertMinorUnits(50_000, 0.03)).toBe(1_500);
+  });
+
+  it('uses banker\u2019s rounding (HALF_EVEN) on exact halves', () => {
+    expect(convertMinorUnits(5, 0.5)).toBe(2); // 2.5 → 2 (even)
+    expect(convertMinorUnits(7, 0.5)).toBe(4); // 3.5 → 4 (even)
+    expect(convertMinorUnits(9, 0.5)).toBe(4); // 4.5 → 4 (even)
+    expect(convertMinorUnits(11, 0.5)).toBe(6); // 5.5 → 6 (even)
+  });
+
+  it('returns 0 for non-finite inputs instead of NaN money', () => {
+    expect(convertMinorUnits(Number.NaN, 0.03)).toBe(0);
+    expect(convertMinorUnits(1000, Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Date-window + country filtering
+// ---------------------------------------------------------------------------
+
+describe('transactionInTripWindow', () => {
+  const trip = makeTrip();
+
+  it('includes the inclusive start and end boundaries', () => {
+    expect(transactionInTripWindow(trip, makeTx({ date: '2026-01-01' }))).toBe(true);
+    expect(transactionInTripWindow(trip, makeTx({ date: '2026-03-31' }))).toBe(true);
+  });
+
+  it('excludes dates before the window and after the window', () => {
+    expect(transactionInTripWindow(trip, makeTx({ date: '2025-12-31' }))).toBe(false);
+    expect(transactionInTripWindow(trip, makeTx({ date: '2026-04-01' }))).toBe(false);
+  });
+});
+
+describe('transactionMatchesTrip', () => {
+  const trip = makeTrip();
+
+  it('matches an in-window transaction in the trip country', () => {
+    expect(transactionMatchesTrip(trip, makeTx())).toBe(true);
+  });
+
+  it('matches country case-insensitively', () => {
+    expect(transactionMatchesTrip(trip, makeTx({ country: 'thailand' }))).toBe(true);
+  });
+
+  it('excludes a transaction from a different country', () => {
+    expect(transactionMatchesTrip(trip, makeTx({ country: 'Vietnam' }))).toBe(false);
+  });
+
+  it('matches any country when the trip country is empty', () => {
+    const anyCountry = makeTrip({ country: '' });
+    expect(transactionMatchesTrip(anyCountry, makeTx({ country: 'Laos' }))).toBe(true);
+  });
+
+  it('never matches excluded transactions', () => {
+    expect(transactionMatchesTrip(trip, makeTx({ excluded: true }))).toBe(false);
+  });
+
+  it('honours an explicit trip assignment and bypasses the country filter', () => {
+    // Country mismatch but explicitly assigned, in-window → matches.
+    expect(transactionMatchesTrip(trip, makeTx({ tripId: 'trip-bkk', country: 'Cambodia' }))).toBe(
+      true,
+    );
+  });
+
+  it('does not match a transaction assigned to a different trip', () => {
+    expect(transactionMatchesTrip(trip, makeTx({ tripId: 'other-trip' }))).toBe(false);
+  });
+
+  it('keeps the date window authoritative even for assigned transactions', () => {
+    expect(transactionMatchesTrip(trip, makeTx({ tripId: 'trip-bkk', date: '2025-11-01' }))).toBe(
+      false,
+    );
+  });
+});
+
+describe('filterTripTransactions', () => {
+  it('returns only matching transactions in original order', () => {
+    const trip = makeTrip();
+    const txs = [
+      makeTx({ id: 'a', date: '2026-02-01' }),
+      makeTx({ id: 'b', date: '2025-12-01' }), // out of window
+      makeTx({ id: 'c', date: '2026-03-15', country: 'Vietnam' }), // wrong country
+      makeTx({ id: 'd', date: '2026-03-20' }),
+    ];
+    expect(filterTripTransactions(trip, txs).map((t) => t.id)).toEqual(['a', 'd']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Totals + roll-up
+// ---------------------------------------------------------------------------
+
+describe('computeTripTotals', () => {
+  it('rolls local spend up into the home currency with the trip FX rate', () => {
+    const trip = makeTrip();
+    const txs = [
+      makeTx({ id: 'a', amountMinor: 30_000 }), // ฿300.00
+      makeTx({ id: 'b', amountMinor: 20_000 }), // ฿200.00
+    ];
+
+    const totals = computeTripTotals(trip, txs);
+
+    expect(totals.transactionCount).toBe(2);
+    expect(totals.localSpentMinor).toBe(50_000); // ฿500.00
+    expect(totals.homeSpentMinor).toBe(1_500); // $15.00 at 0.03
+    expect(totals.plannedLocalMinor).toBe(100_000);
+    expect(totals.plannedHomeMinor).toBe(3_000); // $30.00
+    expect(totals.remainingLocalMinor).toBe(50_000);
+    expect(totals.remainingHomeMinor).toBe(1_500);
+    expect(totals.utilizationBps).toBe(5_000); // 50.00%
+    expect(totals.overBudget).toBe(false);
+  });
+
+  it('treats absolute value of signed amounts as spend', () => {
+    const trip = makeTrip();
+    const totals = computeTripTotals(trip, [makeTx({ amountMinor: -40_000 })]);
+    expect(totals.localSpentMinor).toBe(40_000);
+  });
+
+  it('converts foreign-currency spend into local minor units with localRates', () => {
+    const trip = makeTrip();
+    // €10.00 (1,000 minor) at 1 EUR = 38 THB → ฿380.00 (38,000 satang).
+    const tx = makeTx({ currency: 'EUR', amountMinor: 1_000 });
+    const totals = computeTripTotals(trip, [tx], { localRates: { EUR: 38 } });
+    expect(totals.localSpentMinor).toBe(38_000);
+    expect(totals.homeSpentMinor).toBe(1_140); // 38,000 * 0.03
+  });
+
+  it('assumes foreign spend is already local when no rate is provided', () => {
+    const trip = makeTrip();
+    const totals = computeTripTotals(trip, [makeTx({ currency: 'EUR', amountMinor: 1_000 })]);
+    expect(totals.localSpentMinor).toBe(1_000);
+  });
+
+  it('flags an over-budget trip with a negative remaining balance', () => {
+    const trip = makeTrip({ plannedLocalMinor: 40_000 });
+    const totals = computeTripTotals(trip, [makeTx({ amountMinor: 50_000 })]);
+    expect(totals.overBudget).toBe(true);
+    expect(totals.remainingLocalMinor).toBe(-10_000);
+    expect(totals.utilizationBps).toBe(12_500); // 125.00%
+  });
+
+  it('handles a trip with no spend (all zeros, full remaining)', () => {
+    const trip = makeTrip();
+    const totals = computeTripTotals(trip, []);
+    expect(totals.transactionCount).toBe(0);
+    expect(totals.localSpentMinor).toBe(0);
+    expect(totals.homeSpentMinor).toBe(0);
+    expect(totals.remainingLocalMinor).toBe(100_000);
+    expect(totals.utilizationBps).toBe(0);
+    expect(totals.overBudget).toBe(false);
+  });
+
+  it('handles a trip with no planned amount without dividing by zero', () => {
+    const trip = makeTrip({ plannedLocalMinor: 0 });
+    const totals = computeTripTotals(trip, [makeTx({ amountMinor: 25_000 })]);
+    expect(totals.plannedLocalMinor).toBe(0);
+    expect(totals.utilizationBps).toBe(0);
+    expect(totals.overBudget).toBe(false);
+    expect(totals.remainingLocalMinor).toBe(-25_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Overlapping trips
+// ---------------------------------------------------------------------------
+
+describe('overlapping trips', () => {
+  it('counts an unassigned transaction in every overlapping trip it matches', () => {
+    const bangkok = makeTrip({ id: 'bkk', startDate: '2026-01-01', endDate: '2026-02-28' });
+    const sameWindow = makeTrip({
+      id: 'bkk-work',
+      name: 'Bangkok coworking',
+      startDate: '2026-02-01',
+      endDate: '2026-03-31',
+    });
+    const tx = makeTx({ date: '2026-02-15', amountMinor: 10_000 });
+
+    expect(computeTripTotals(bangkok, [tx]).localSpentMinor).toBe(10_000);
+    expect(computeTripTotals(sameWindow, [tx]).localSpentMinor).toBe(10_000);
+  });
+
+  it('keeps an explicitly-assigned transaction out of an overlapping sibling trip', () => {
+    const tripA = makeTrip({ id: 'a' });
+    const tripB = makeTrip({ id: 'b', name: 'Sibling' });
+    const tx = makeTx({ tripId: 'a', amountMinor: 10_000 });
+
+    expect(computeTripTotals(tripA, [tx]).localSpentMinor).toBe(10_000);
+    expect(computeTripTotals(tripB, [tx]).localSpentMinor).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle / status
+// ---------------------------------------------------------------------------
+
+describe('tripStatus', () => {
+  const trip = makeTrip();
+
+  it('reports upcoming before the window starts', () => {
+    expect(tripStatus(trip, '2025-12-15')).toBe('upcoming');
+  });
+
+  it('reports active inside the window', () => {
+    expect(tripStatus(trip, '2026-02-10')).toBe('active');
+  });
+
+  it('reports ended after the window', () => {
+    expect(tripStatus(trip, '2026-04-10')).toBe('ended');
+  });
+
+  it('reports archived regardless of date when archived', () => {
+    expect(tripStatus(makeTrip({ archived: true }), '2026-02-10')).toBe('archived');
+  });
+});
+
+describe('tripDurationDays', () => {
+  it('counts the window inclusively', () => {
+    expect(tripDurationDays(makeTrip({ startDate: '2026-01-01', endDate: '2026-01-31' }))).toBe(31);
+    expect(tripDurationDays(makeTrip({ startDate: '2026-01-01', endDate: '2026-01-01' }))).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Archiving — preserves historical totals
+// ---------------------------------------------------------------------------
+
+describe('archiveTripBudget', () => {
+  it('freezes the totals at archive time and preserves them when transactions change', () => {
+    const trip = makeTrip();
+    const txs = [
+      makeTx({ id: 'a', amountMinor: 30_000 }),
+      makeTx({ id: 'b', amountMinor: 20_000 }),
+    ];
+
+    const archived = archiveTripBudget(trip, txs, '2026-04-01');
+
+    expect(archived.archived).toBe(true);
+    expect(archived.archivedAt).toBe('2026-04-01');
+    expect(archived.archivedSnapshot?.localSpentMinor).toBe(50_000);
+
+    // Transactions disappear later — the archived snapshot must not change.
+    const totalsAfterDataLoss = computeTripTotals(archived, []);
+    expect(totalsAfterDataLoss.localSpentMinor).toBe(50_000);
+    expect(totalsAfterDataLoss.homeSpentMinor).toBe(1_500);
+  });
+
+  it('round-trips through unarchive back to live computation', () => {
+    const trip = makeTrip();
+    const txs = [makeTx({ amountMinor: 30_000 })];
+    const archived = archiveTripBudget(trip, txs, '2026-04-01');
+    const reopened = unarchiveTripBudget(archived);
+
+    expect(reopened.archived).toBe(false);
+    expect(reopened.archivedSnapshot).toBeNull();
+    // With transactions removed the live total is now zero.
+    expect(computeTripTotals(reopened, []).localSpentMinor).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reports + cross-trip roll-up
+// ---------------------------------------------------------------------------
+
+describe('summarizeTripBudget', () => {
+  it('attaches status and matched transaction ids to the totals', () => {
+    const trip = makeTrip();
+    const txs = [makeTx({ id: 'a' }), makeTx({ id: 'b', country: 'Vietnam' })];
+    const report = summarizeTripBudget(trip, txs, '2026-02-10');
+
+    expect(report.id).toBe('trip-bkk');
+    expect(report.status).toBe('active');
+    expect(report.includedTransactionIds).toEqual(['a']);
+    expect(report.localCurrency).toBe('THB');
+    expect(report.homeCurrency).toBe('USD');
+  });
+});
+
+describe('summarizeTripBudgets', () => {
+  it('rolls active trips into a single home-currency total and excludes archived trips', () => {
+    const bangkok = makeTrip({ id: 'bkk' });
+    const lisbon = makeTrip({
+      id: 'lis',
+      name: 'Lisbon',
+      country: 'Portugal',
+      localCurrency: 'EUR',
+      homeCurrency: 'USD',
+      plannedLocalMinor: 200_000,
+      fxRateHomePerLocal: 1.08,
+    });
+    const archivedTrip = archiveTripBudget(
+      makeTrip({ id: 'old', name: 'Old trip' }),
+      [makeTx({ amountMinor: 99_000 })],
+      '2025-12-31',
+    );
+
+    const txs = [
+      makeTx({ id: 'a', amountMinor: 50_000 }), // Bangkok ฿500 → $15
+      makeTx({ id: 'b', country: 'Portugal', currency: 'EUR', amountMinor: 100_000 }), // Lisbon €1,000 → $1,080
+    ];
+
+    const summary = summarizeTripBudgets([bangkok, lisbon, archivedTrip], txs, '2026-02-10');
+
+    expect(summary.activeTripCount).toBe(2);
+    expect(summary.homeCurrency).toBe('USD');
+    // Bangkok planned $30 + Lisbon planned €2,000 → $2,160 = $2,190.
+    expect(summary.totalPlannedHomeMinor).toBe(3_000 + 216_000);
+    // Bangkok spent $15 + Lisbon spent $1,080.
+    expect(summary.totalSpentHomeMinor).toBe(1_500 + 108_000);
+    expect(summary.totalRemainingHomeMinor).toBe(
+      summary.totalPlannedHomeMinor - summary.totalSpentHomeMinor,
+    );
+  });
+});

--- a/apps/web/src/lib/budgets/index.ts
+++ b/apps/web/src/lib/budgets/index.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Public barrel for the trip / country budget engine (issue #2205).
+ *
+ * This barrel exports only the pure engine and its types. It is imported
+ * directly by `TripBudgetsPage` (a lazily code-split route) and never pulled
+ * into a shared, eagerly-loaded barrel — keeping the page within the per-chunk
+ * gzip performance budget.
+ */
+
+export * from './trip-budgets';
+export type {
+  TripBudget,
+  TripBudgetReport,
+  TripBudgetStatus,
+  TripBudgetTotals,
+  TripTotalsOptions,
+  TripTransaction,
+} from './types';

--- a/apps/web/src/lib/budgets/trip-budgets.ts
+++ b/apps/web/src/lib/budgets/trip-budgets.ts
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Pure trip / country budget engine for the web app (issue #2205).
+ *
+ * Implements "trip envelopes" for digital nomads: a budget scoped to a named
+ * trip / country with a start/end date window (e.g. "Bangkok Jan–Mar"). It
+ * computes spend inside the trip window, totals in the trip's local currency,
+ * a roll-up into a single home currency, remaining-versus-planned, and an
+ * archived state that freezes historical totals.
+ *
+ * Design rules (per the `financial-modeling` skill):
+ *   - Money is **integer minor units** (cents, satang, pence …) everywhere.
+ *     No floating-point money is produced or stored.
+ *   - Rounding uses **banker's rounding** (HALF_EVEN) via `bankersRound`.
+ *   - All functions are **pure** — no I/O, no clocks, no mutation of inputs.
+ *
+ * FX-RATE CONTRACT (read carefully):
+ *   `TripBudget.fxRateHomePerLocal` is a **caller-provided / stored** rate and
+ *   is NEVER fetched from the network. It is the number of **home minor units
+ *   per 1 local minor unit**. For the common case where both currencies use
+ *   two decimal places (e.g. THB↔USD, EUR↔USD, GBP↔USD) this equals the usual
+ *   mid-market major-unit rate (e.g. 1 THB = 0.028 USD → `0.028`). For pairs
+ *   whose minor-unit scales differ (e.g. JPY has 0 decimals) the caller must
+ *   pre-scale the rate so it remains "home minor per local minor".
+ *
+ * Likewise `TripTotalsOptions.localRates` lets callers convert spend recorded
+ * in a foreign currency into the trip's local currency using stored multipliers
+ * — also never a network lookup.
+ *
+ * References: issue #2205
+ */
+
+import { bankersRound, daysBetween } from '../budgeting/utils';
+import type {
+  TripBudget,
+  TripBudgetReport,
+  TripBudgetStatus,
+  TripBudgetTotals,
+  TripTotalsOptions,
+  TripTransaction,
+} from './types';
+
+export type {
+  TripBudget,
+  TripBudgetReport,
+  TripBudgetStatus,
+  TripBudgetTotals,
+  TripTotalsOptions,
+  TripTransaction,
+} from './types';
+
+/** One whole unit, expressed in basis points (100% = 10000bps). */
+const BASIS_POINTS_SCALE = 10_000;
+
+// ---------------------------------------------------------------------------
+// Normalisation helpers
+// ---------------------------------------------------------------------------
+
+/** Upper-case + trim an ISO 4217 currency code for comparison. */
+export function normalizeCurrency(code: string): string {
+  return code.trim().toUpperCase();
+}
+
+/** Lower-case + trim a country label for case-insensitive matching. */
+export function normalizeCountry(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// FX conversion (minor → minor, banker's rounding)
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an integer minor-unit amount using a caller-provided rate.
+ *
+ * @param amountMinor - Integer minor units in the source currency.
+ * @param rate - Target minor units per 1 source minor unit (see FX contract).
+ * @returns Integer minor units in the target currency (banker's-rounded).
+ */
+export function convertMinorUnits(amountMinor: number, rate: number): number {
+  if (!Number.isFinite(amountMinor) || !Number.isFinite(rate)) {
+    return 0;
+  }
+  return bankersRound(amountMinor * rate);
+}
+
+/**
+ * Convert a single transaction's amount into the trip's local minor units.
+ *
+ * Transactions already in the trip's local currency pass through unchanged.
+ * Foreign-currency transactions use `localRates[currency]` when supplied,
+ * otherwise the amount is assumed to already be in local minor units (the
+ * documented, network-free fallback).
+ */
+function transactionLocalMinor(
+  trip: TripBudget,
+  transaction: TripTransaction,
+  localRates: Readonly<Record<string, number>> | undefined,
+): number {
+  const magnitude = Math.abs(transaction.amountMinor);
+  const txCurrency = normalizeCurrency(transaction.currency);
+  const localCurrency = normalizeCurrency(trip.localCurrency);
+
+  if (txCurrency === localCurrency) {
+    return magnitude;
+  }
+
+  const rate = localRates?.[txCurrency];
+  if (rate !== undefined && Number.isFinite(rate)) {
+    return convertMinorUnits(magnitude, rate);
+  }
+
+  return magnitude;
+}
+
+// ---------------------------------------------------------------------------
+// Date-window + country filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a transaction falls inside the trip's inclusive date window.
+ *
+ * ISO `YYYY-MM-DD` strings sort lexicographically, so plain string comparison
+ * is correct and avoids any timezone ambiguity.
+ */
+export function transactionInTripWindow(trip: TripBudget, transaction: TripTransaction): boolean {
+  return transaction.date >= trip.startDate && transaction.date <= trip.endDate;
+}
+
+/**
+ * Whether a transaction belongs to a trip budget.
+ *
+ * Rules (in order):
+ *   1. Excluded transactions never match.
+ *   2. The date window is always authoritative — out-of-window never matches.
+ *   3. An explicit `tripId` assignment matches only that trip (and bypasses the
+ *      country filter), supporting manual overrides such as layover purchases.
+ *   4. Otherwise an empty trip country matches any country; a set country must
+ *      match the transaction country case-insensitively.
+ */
+export function transactionMatchesTrip(trip: TripBudget, transaction: TripTransaction): boolean {
+  if (transaction.excluded) {
+    return false;
+  }
+  if (!transactionInTripWindow(trip, transaction)) {
+    return false;
+  }
+
+  const assignedTripId = transaction.tripId?.trim();
+  if (assignedTripId) {
+    return assignedTripId === trip.id;
+  }
+
+  const tripCountry = normalizeCountry(trip.country);
+  if (tripCountry === '') {
+    return true;
+  }
+  return normalizeCountry(transaction.country) === tripCountry;
+}
+
+/** Return only the transactions that match the trip, preserving order. */
+export function filterTripTransactions(
+  trip: TripBudget,
+  transactions: readonly TripTransaction[],
+): TripTransaction[] {
+  return transactions.filter((transaction) => transactionMatchesTrip(trip, transaction));
+}
+
+// ---------------------------------------------------------------------------
+// Totals
+// ---------------------------------------------------------------------------
+
+/** Build a {@link TripBudgetTotals} from a settled local spend figure. */
+function buildTotals(
+  trip: TripBudget,
+  localSpentMinor: number,
+  transactionCount: number,
+): TripBudgetTotals {
+  const plannedLocalMinor = Math.max(0, Math.trunc(trip.plannedLocalMinor));
+  const rate = trip.fxRateHomePerLocal;
+
+  const homeSpentMinor = convertMinorUnits(localSpentMinor, rate);
+  const plannedHomeMinor = convertMinorUnits(plannedLocalMinor, rate);
+
+  const utilizationBps =
+    plannedLocalMinor > 0
+      ? bankersRound((localSpentMinor / plannedLocalMinor) * BASIS_POINTS_SCALE)
+      : 0;
+
+  return {
+    transactionCount,
+    localSpentMinor,
+    homeSpentMinor,
+    plannedLocalMinor,
+    plannedHomeMinor,
+    remainingLocalMinor: plannedLocalMinor - localSpentMinor,
+    remainingHomeMinor: plannedHomeMinor - homeSpentMinor,
+    utilizationBps,
+    overBudget: plannedLocalMinor > 0 && localSpentMinor > plannedLocalMinor,
+  };
+}
+
+/**
+ * Compute the spend totals for a trip budget.
+ *
+ * For an archived trip with a stored snapshot the frozen snapshot is returned
+ * verbatim, preserving historical totals even if the transactions change.
+ */
+export function computeTripTotals(
+  trip: TripBudget,
+  transactions: readonly TripTransaction[],
+  options: TripTotalsOptions = {},
+): TripBudgetTotals {
+  if (trip.archived && trip.archivedSnapshot) {
+    return trip.archivedSnapshot;
+  }
+
+  const matched = filterTripTransactions(trip, transactions);
+  const localSpentMinor = matched.reduce(
+    (sum, transaction) => sum + transactionLocalMinor(trip, transaction, options.localRates),
+    0,
+  );
+  return buildTotals(trip, localSpentMinor, matched.length);
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+/** Derive a trip's lifecycle status relative to a reference `today` date. */
+export function tripStatus(trip: TripBudget, today: string): TripBudgetStatus {
+  if (trip.archived) {
+    return 'archived';
+  }
+  if (today < trip.startDate) {
+    return 'upcoming';
+  }
+  if (today > trip.endDate) {
+    return 'ended';
+  }
+  return 'active';
+}
+
+/** Inclusive length of the trip window in whole days (minimum 1). */
+export function tripDurationDays(trip: TripBudget): number {
+  return Math.max(1, daysBetween(trip.startDate, trip.endDate) + 1);
+}
+
+/**
+ * Produce a full report (totals + status + matched ids) for a trip budget.
+ */
+export function summarizeTripBudget(
+  trip: TripBudget,
+  transactions: readonly TripTransaction[],
+  today: string,
+  options: TripTotalsOptions = {},
+): TripBudgetReport {
+  const totals = computeTripTotals(trip, transactions, options);
+  const includedTransactionIds = filterTripTransactions(trip, transactions).map(
+    (transaction) => transaction.id,
+  );
+
+  return {
+    ...totals,
+    id: trip.id,
+    name: trip.name,
+    country: trip.country,
+    localCurrency: normalizeCurrency(trip.localCurrency),
+    homeCurrency: normalizeCurrency(trip.homeCurrency),
+    startDate: trip.startDate,
+    endDate: trip.endDate,
+    archived: trip.archived,
+    status: tripStatus(trip, today),
+    includedTransactionIds,
+  };
+}
+
+/**
+ * Summarise every trip and roll their home-currency totals into a single
+ * cross-trip figure. Trips with mismatched home currencies are summed verbatim
+ * (the caller is responsible for keeping a consistent home currency); the
+ * returned `homeCurrency` is taken from the first active trip.
+ */
+export function summarizeTripBudgets(
+  trips: readonly TripBudget[],
+  transactions: readonly TripTransaction[],
+  today: string,
+  options: TripTotalsOptions = {},
+): {
+  readonly reports: readonly TripBudgetReport[];
+  readonly homeCurrency: string;
+  readonly totalPlannedHomeMinor: number;
+  readonly totalSpentHomeMinor: number;
+  readonly totalRemainingHomeMinor: number;
+  readonly activeTripCount: number;
+} {
+  const reports = trips.map((trip) => summarizeTripBudget(trip, transactions, today, options));
+  const active = reports.filter((report) => !report.archived);
+
+  const totalPlannedHomeMinor = active.reduce((sum, report) => sum + report.plannedHomeMinor, 0);
+  const totalSpentHomeMinor = active.reduce((sum, report) => sum + report.homeSpentMinor, 0);
+
+  return {
+    reports,
+    homeCurrency: active[0]?.homeCurrency ?? reports[0]?.homeCurrency ?? 'USD',
+    totalPlannedHomeMinor,
+    totalSpentHomeMinor,
+    totalRemainingHomeMinor: totalPlannedHomeMinor - totalSpentHomeMinor,
+    activeTripCount: active.length,
+  };
+}
+
+/**
+ * Archive a finished trip, freezing its current totals into a snapshot so the
+ * historical figures survive later transaction edits. Any pre-existing snapshot
+ * is ignored so the snapshot reflects the live state at archive time.
+ */
+export function archiveTripBudget(
+  trip: TripBudget,
+  transactions: readonly TripTransaction[],
+  archivedAt: string,
+  options: TripTotalsOptions = {},
+): TripBudget {
+  const liveTotals = computeTripTotals(
+    { ...trip, archived: false, archivedSnapshot: null },
+    transactions,
+    options,
+  );
+  return {
+    ...trip,
+    archived: true,
+    archivedAt,
+    archivedSnapshot: liveTotals,
+  };
+}
+
+/** Re-open an archived trip, discarding the frozen snapshot. */
+export function unarchiveTripBudget(trip: TripBudget): TripBudget {
+  return {
+    ...trip,
+    archived: false,
+    archivedAt: null,
+    archivedSnapshot: null,
+  };
+}

--- a/apps/web/src/lib/budgets/types.ts
+++ b/apps/web/src/lib/budgets/types.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Type definitions for the trip / country budget engine.
+ *
+ * These model a "trip envelope" — a budget scoped to a named destination and a
+ * start/end date window (e.g. "Bangkok Jan–Mar") — for digital-nomad style
+ * budgeting where spending happens in a local currency but must roll up into a
+ * single home currency for reporting.
+ *
+ * Money is represented end-to-end as **integer minor units** (e.g. cents,
+ * satang, pence). No value in this module is ever a floating-point amount of
+ * money. See `trip-budgets.ts` for the FX-rate contract.
+ *
+ * References: issue #2205
+ */
+
+/** Lifecycle status derived from the trip window and archive flag. */
+export type TripBudgetStatus = 'upcoming' | 'active' | 'ended' | 'archived';
+
+/**
+ * A budget scoped to a named trip / country with a date window.
+ *
+ * `plannedLocalMinor` and all derived spend totals are integer minor units of
+ * `localCurrency`. `fxRateHomePerLocal` is a caller-provided conversion factor
+ * (never fetched from the network) — see `convertMinorUnits` for its exact
+ * meaning.
+ */
+export interface TripBudget {
+  /** Stable identifier. */
+  readonly id: string;
+  /** Human-friendly trip name, e.g. "Bangkok Jan–Mar". */
+  readonly name: string;
+  /**
+   * Country / region label the trip is scoped to. An empty string means the
+   * trip matches transactions from any country (date window only).
+   */
+  readonly country: string;
+  /** Inclusive trip start date (ISO 8601 `YYYY-MM-DD`). */
+  readonly startDate: string;
+  /** Inclusive trip end date (ISO 8601 `YYYY-MM-DD`). */
+  readonly endDate: string;
+  /** ISO 4217 currency the trip is budgeted in (the destination currency). */
+  readonly localCurrency: string;
+  /** ISO 4217 currency totals roll up into for cross-trip reporting. */
+  readonly homeCurrency: string;
+  /** Planned spend for the whole trip, integer minor units of `localCurrency`. */
+  readonly plannedLocalMinor: number;
+  /**
+   * Caller-provided / stored FX rate. Home minor units per 1 local minor unit.
+   * Never fetched live — see the `trip-budgets.ts` header for the contract.
+   */
+  readonly fxRateHomePerLocal: number;
+  /** When true, the trip is archived and reports use the frozen snapshot. */
+  readonly archived: boolean;
+  /** ISO date the trip was archived, when applicable. */
+  readonly archivedAt?: string | null;
+  /**
+   * Totals captured at archive time so historical reporting is preserved even
+   * if the underlying transactions change later.
+   */
+  readonly archivedSnapshot?: TripBudgetTotals | null;
+}
+
+/**
+ * A spend entry considered for a trip budget.
+ *
+ * `amountMinor` is a spend magnitude in `currency` minor units; the engine
+ * takes its absolute value defensively so callers may pass signed expenses.
+ */
+export interface TripTransaction {
+  /** Stable identifier. */
+  readonly id: string;
+  /** Spend magnitude in `currency` minor units. */
+  readonly amountMinor: number;
+  /** ISO 4217 currency the amount is recorded in. */
+  readonly currency: string;
+  /** Transaction date (ISO 8601 `YYYY-MM-DD`). */
+  readonly date: string;
+  /** Country / region the spend occurred in. */
+  readonly country?: string | null;
+  /**
+   * Explicit trip assignment. When set, the transaction only matches the trip
+   * with this id (and bypasses the country filter), but the date window still
+   * applies. Use it to pull a layover purchase into the right envelope.
+   */
+  readonly tripId?: string | null;
+  /** When true, the transaction is excluded (e.g. a refund or transfer). */
+  readonly excluded?: boolean;
+}
+
+/** Computed totals for a trip budget, all in integer minor units. */
+export interface TripBudgetTotals {
+  /** Number of transactions that matched the trip. */
+  readonly transactionCount: number;
+  /** Total spend in `localCurrency` minor units. */
+  readonly localSpentMinor: number;
+  /** Total spend rolled up into `homeCurrency` minor units. */
+  readonly homeSpentMinor: number;
+  /** Planned amount in `localCurrency` minor units. */
+  readonly plannedLocalMinor: number;
+  /** Planned amount rolled up into `homeCurrency` minor units. */
+  readonly plannedHomeMinor: number;
+  /** Planned minus spent in local minor units (negative when over budget). */
+  readonly remainingLocalMinor: number;
+  /** Planned minus spent in home minor units (negative when over budget). */
+  readonly remainingHomeMinor: number;
+  /** Spent ÷ planned expressed in basis points (10000 = 100%); 0 when no plan. */
+  readonly utilizationBps: number;
+  /** True when there is a plan and spend has exceeded it. */
+  readonly overBudget: boolean;
+}
+
+/** A trip budget plus its computed totals and lifecycle status. */
+export interface TripBudgetReport extends TripBudgetTotals {
+  readonly id: string;
+  readonly name: string;
+  readonly country: string;
+  readonly localCurrency: string;
+  readonly homeCurrency: string;
+  readonly startDate: string;
+  readonly endDate: string;
+  readonly archived: boolean;
+  readonly status: TripBudgetStatus;
+  /** Ids of the transactions that currently match the trip window/country. */
+  readonly includedTransactionIds: readonly string[];
+}
+
+/** Options for {@link computeTripTotals} / {@link summarizeTripBudget}. */
+export interface TripTotalsOptions {
+  /**
+   * Optional map of transaction-currency → local-minor multiplier, used to
+   * convert spend recorded in a currency other than the trip's local currency
+   * into local minor units. Keyed by ISO 4217 code (case-insensitive).
+   *
+   * When a non-local transaction currency is absent from this map the engine
+   * assumes the amount is already expressed in local minor units (documented
+   * fallback — never a network lookup).
+   */
+  readonly localRates?: Readonly<Record<string, number>>;
+}

--- a/apps/web/src/pages/TripBudgetsPage.css
+++ b/apps/web/src/pages/TripBudgetsPage.css
@@ -1,0 +1,424 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for the Trip & Country Budgets page (TripBudgetsPage.tsx).
+ *
+ * All visual values come from design-token CSS custom properties. Status is
+ * always paired with a text label and icon in the markup, so colour here is
+ * reinforcement only — never the sole signal (WCAG 2.2 AA).
+ *
+ * References: issue #2205
+ */
+
+.trip-page {
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.trip-page__header {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-5);
+}
+
+.trip-page__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  flex: 0 0 auto;
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-interactive-default);
+}
+
+.trip-page__title {
+  font-size: var(--type-scale-headline-font-size);
+  font-weight: var(--type-scale-headline-font-weight);
+  color: var(--semantic-text-primary);
+  margin: 0;
+}
+
+.trip-page__subtitle {
+  margin: var(--spacing-1) 0 0 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-font-size);
+  max-width: 70ch;
+}
+
+/* --------------------------------------------------------------------------
+ * Roll-up summary (aria-live)
+ * ------------------------------------------------------------------------ */
+
+.trip-summary {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-secondary);
+  padding: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+}
+
+.trip-summary__text {
+  margin: 0;
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+/* --------------------------------------------------------------------------
+ * Layout
+ * ------------------------------------------------------------------------ */
+
+.trip-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-6);
+}
+
+@media (min-width: 960px) {
+  .trip-layout {
+    grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+    align-items: start;
+  }
+}
+
+.trip-section {
+  margin-bottom: var(--spacing-6);
+}
+
+.trip-section__heading {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+.trip-empty {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-font-size);
+  margin: 0;
+}
+
+/* --------------------------------------------------------------------------
+ * Trip cards
+ * ------------------------------------------------------------------------ */
+
+.trip-cards {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-5);
+}
+
+@media (min-width: 640px) {
+  .trip-cards {
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  }
+}
+
+.trip-card {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+  padding: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.trip-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.trip-card__name {
+  margin: 0;
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+}
+
+.trip-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-1);
+  margin: var(--spacing-1) 0 0 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.trip-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  flex: 0 0 auto;
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: var(--border-radius-sm);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  border: 1px solid var(--semantic-border-default);
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-text-secondary);
+}
+
+.trip-badge--active {
+  color: var(--semantic-status-positive);
+  border-color: var(--semantic-status-positive);
+}
+
+.trip-badge--upcoming {
+  color: var(--semantic-status-info);
+  border-color: var(--semantic-status-info);
+}
+
+.trip-badge--ended {
+  color: var(--semantic-text-secondary);
+}
+
+.trip-badge--archived {
+  color: var(--semantic-text-secondary);
+  border-style: dashed;
+}
+
+.trip-card__progress {
+  height: 0.5rem;
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-secondary);
+  overflow: hidden;
+}
+
+.trip-card__progress-fill {
+  height: 100%;
+  background: var(--semantic-status-positive);
+  transition: width 0.2s ease;
+}
+
+.trip-card__progress-fill--over {
+  background: var(--semantic-status-negative);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .trip-card__progress-fill {
+    transition: none;
+  }
+}
+
+.trip-card__figures {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-2);
+  margin: 0;
+}
+
+.trip-card__figure {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.trip-card__figure dt {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  margin: 0;
+}
+
+.trip-card__figure dd {
+  margin: 0;
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  text-align: right;
+}
+
+.trip-card__muted {
+  color: var(--semantic-text-secondary);
+  font-weight: var(--font-weight-medium);
+}
+
+.trip-card__over {
+  color: var(--semantic-status-negative);
+}
+
+.trip-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  border-top: 1px solid var(--semantic-border-default);
+  padding-top: var(--spacing-3);
+}
+
+.trip-card__count {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+/* --------------------------------------------------------------------------
+ * Forms
+ * ------------------------------------------------------------------------ */
+
+.trip-side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-5);
+}
+
+.trip-form {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+  padding: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.trip-form__heading {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+  margin: 0;
+}
+
+.trip-form__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-3);
+}
+
+.trip-form__error {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  margin: 0;
+  color: var(--semantic-status-negative);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.trip-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.trip-field__label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-primary);
+}
+
+.trip-field__input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--spacing-2);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+.trip-field__input:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 1px;
+}
+
+.trip-field__hint {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+/* --------------------------------------------------------------------------
+ * Buttons
+ * ------------------------------------------------------------------------ */
+
+.trip-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: var(--border-radius-sm);
+  font-size: var(--type-scale-body-font-size);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.trip-button:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.trip-button--primary {
+  background: var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse);
+}
+
+.trip-button--primary:hover {
+  background: var(--semantic-interactive-hover);
+}
+
+.trip-button--primary:disabled {
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-text-disabled);
+  cursor: not-allowed;
+}
+
+.trip-button--ghost {
+  background: transparent;
+  color: var(--semantic-interactive-default);
+  border-color: var(--semantic-border-default);
+}
+
+.trip-button--ghost:hover {
+  background: var(--semantic-background-secondary);
+}
+
+/* --------------------------------------------------------------------------
+ * Ledger table
+ * ------------------------------------------------------------------------ */
+
+.trip-ledger__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+}
+
+.trip-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--type-scale-body-font-size);
+}
+
+.trip-table__caption {
+  text-align: left;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  margin-bottom: var(--spacing-2);
+}
+
+.trip-table th,
+.trip-table td {
+  text-align: left;
+  padding: var(--spacing-2);
+  border-bottom: 1px solid var(--semantic-border-default);
+}
+
+.trip-table th {
+  color: var(--semantic-text-secondary);
+  font-weight: var(--font-weight-semibold);
+}
+
+.trip-table__amount {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}

--- a/apps/web/src/pages/TripBudgetsPage.test.tsx
+++ b/apps/web/src/pages/TripBudgetsPage.test.tsx
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Render tests for TripBudgetsPage.
+ *
+ * The page is fully self-contained (pure engine + local state, no hooks or
+ * repositories), so these tests exercise the real wiring: labelled inputs,
+ * the seeded worked example, the aria-live roll-up, creating a trip, logging
+ * spend, archiving, and filtering the ledger.
+ *
+ * References: issue #2205
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+
+import { TripBudgetsPage } from './TripBudgetsPage';
+
+describe('TripBudgetsPage', () => {
+  it('renders the page heading and labelled create-trip inputs', () => {
+    render(<TripBudgetsPage />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Trip & Country Budgets', level: 2 }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByLabelText('Trip name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Country / region')).toBeInTheDocument();
+    expect(screen.getByLabelText('Start date')).toBeInTheDocument();
+    expect(screen.getByLabelText('End date')).toBeInTheDocument();
+    expect(screen.getByLabelText('Local currency')).toBeInTheDocument();
+    expect(screen.getByLabelText('Home currency')).toBeInTheDocument();
+    expect(screen.getByLabelText('Planned amount (local currency)')).toBeInTheDocument();
+    expect(screen.getByLabelText('FX rate (home per 1 local)')).toBeInTheDocument();
+  });
+
+  it('exposes the home-currency roll-up in an aria-live status region', () => {
+    render(<TripBudgetsPage />);
+
+    const status = screen.getByRole('status', { name: 'Home-currency roll-up' });
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    // Seeded Bangkok trip: ฿20,500 spent rolls up to $574 of $2,520 planned.
+    expect(status).toHaveTextContent(/\$574\.00/);
+    expect(status).toHaveTextContent(/\$2,520\.00/);
+  });
+
+  it('shows the seeded trip with local spend and home-currency roll-up', () => {
+    render(<TripBudgetsPage />);
+
+    const card = screen
+      .getByRole('heading', { name: 'Bangkok Jan–Mar', level: 4 })
+      .closest('article') as HTMLElement;
+
+    expect(within(card).getByText(/20,500/)).toBeInTheDocument(); // local spend
+    expect(within(card).getByText(/\$574\.00/)).toBeInTheDocument(); // home roll-up
+    expect(within(card).getByText('2 transactions')).toBeInTheDocument();
+  });
+
+  it('validates the create-trip form and surfaces an alert', () => {
+    render(<TripBudgetsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create trip envelope' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Give the trip a name.');
+  });
+
+  it('creates a new trip envelope from the form', () => {
+    render(<TripBudgetsPage />);
+
+    fireEvent.change(screen.getByLabelText('Trip name'), { target: { value: 'Lisbon Spring' } });
+    fireEvent.change(screen.getByLabelText('Country / region'), { target: { value: 'Portugal' } });
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026-04-01' } });
+    fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2026-06-30' } });
+    fireEvent.change(screen.getByLabelText('Local currency'), { target: { value: 'EUR' } });
+    fireEvent.change(screen.getByLabelText('Planned amount (local currency)'), {
+      target: { value: '2000' },
+    });
+    fireEvent.change(screen.getByLabelText('FX rate (home per 1 local)'), {
+      target: { value: '1.08' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create trip envelope' }));
+
+    expect(screen.getByRole('heading', { name: 'Lisbon Spring', level: 4 })).toBeInTheDocument();
+  });
+
+  it('logs local-currency spend and updates the trip transaction count', () => {
+    render(<TripBudgetsPage />);
+
+    fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2026-02-20' } });
+    fireEvent.change(screen.getByLabelText('Amount (local currency)'), {
+      target: { value: '1500' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add spend' }));
+
+    const card = screen
+      .getByRole('heading', { name: 'Bangkok Jan–Mar', level: 4 })
+      .closest('article') as HTMLElement;
+    expect(within(card).getByText('3 transactions')).toBeInTheDocument();
+  });
+
+  it('archives a finished trip and offers to reopen it', () => {
+    render(<TripBudgetsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Archive Bangkok Jan/ }));
+
+    expect(screen.getByRole('heading', { name: 'Archived trips', level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Reopen Bangkok Jan/ })).toBeInTheDocument();
+  });
+
+  it('renders an accessible spend ledger with a caption and trip filter', () => {
+    render(<TripBudgetsPage />);
+
+    expect(screen.getByLabelText('Filter by trip')).toBeInTheDocument();
+    const table = screen.getByRole('table');
+    expect(within(table).getByText(/Spend entries/)).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Date' })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Amount' })).toBeInTheDocument();
+    // Two seeded rows in the tbody.
+    expect(within(table).getAllByRole('row')).toHaveLength(3); // header + 2 data rows
+  });
+});

--- a/apps/web/src/pages/TripBudgetsPage.tsx
+++ b/apps/web/src/pages/TripBudgetsPage.tsx
@@ -1,0 +1,750 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * TripBudgetsPage — trip / country "envelopes" for digital nomads (#2205).
+ *
+ * Lets a traveller budget a named trip in its local currency (e.g. "Bangkok
+ * Jan–Mar" in THB), log local-currency spend, watch progress in both the local
+ * currency and a rolled-up home currency, filter spend by trip, and archive a
+ * finished trip without losing its historical totals.
+ *
+ * All money maths lives in the pure engine (`../lib/budgets`); this page is
+ * presentation + local state only. Amounts are integer minor units end-to-end
+ * and the home-currency roll-up uses each trip's caller-entered FX rate — never
+ * a live/network rate (see the engine header for the FX contract). For input
+ * convenience the page assumes two-decimal currencies (THB, USD, EUR, GBP …),
+ * so the entered FX rate equals the engine's "home-minor per local-minor" rate.
+ *
+ * Accessibility (WCAG 2.2 AA):
+ * - Every date / amount / currency control has an associated <label htmlFor>
+ *   and an aria-describedby hint.
+ * - Computed roll-up totals live in an aria-live status region.
+ * - Trip status and over-budget state are conveyed with an icon **and** text,
+ *   never colour alone.
+ * - The spend ledger is a real <table> with a <caption> text alternative and
+ *   scoped headers; the trip filter is a labelled <select>.
+ *
+ * References: issue #2205
+ */
+
+import React, { useId, useMemo, useState } from 'react';
+
+import { AppIcon, type IconName } from '../components/icons';
+import { formatCurrency } from '../lib/currency';
+import {
+  archiveTripBudget,
+  summarizeTripBudget,
+  summarizeTripBudgets,
+  unarchiveTripBudget,
+  type TripBudget,
+  type TripBudgetReport,
+  type TripBudgetStatus,
+  type TripTransaction,
+} from '../lib/budgets';
+
+import './TripBudgetsPage.css';
+
+// ---------------------------------------------------------------------------
+// Parsing helpers (string inputs → integer minor units / rates)
+// ---------------------------------------------------------------------------
+
+/** Parse a major-unit string (e.g. "1200.50") into non-negative minor units. */
+function parseMajorToMinor(value: string): number {
+  const major = Number.parseFloat(value);
+  if (!Number.isFinite(major) || major < 0) return 0;
+  return Math.round(major * 100);
+}
+
+/** Parse a positive FX rate string; returns 0 when blank/invalid. */
+function parseRate(value: string): number {
+  const rate = Number.parseFloat(value);
+  if (!Number.isFinite(rate) || rate < 0) return 0;
+  return rate;
+}
+
+/** Today's date as an ISO `YYYY-MM-DD` string in the local timezone. */
+function todayIso(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(
+    now.getDate(),
+  ).padStart(2, '0')}`;
+}
+
+/** Format an ISO date as e.g. "1 Jan 2026" for compact display. */
+function formatIsoDate(iso: string): string {
+  const parsed = new Date(`${iso}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+// ---------------------------------------------------------------------------
+// Status presentation (icon + text — never colour alone)
+// ---------------------------------------------------------------------------
+
+const STATUS_META: Record<TripBudgetStatus, { label: string; icon: IconName }> = {
+  upcoming: { label: 'Upcoming', icon: 'calendar' },
+  active: { label: 'Active', icon: 'plane' },
+  ended: { label: 'Ended', icon: 'check-circle' },
+  archived: { label: 'Archived', icon: 'package' },
+};
+
+// ---------------------------------------------------------------------------
+// Seed data — a worked example so the page is useful on first load
+// ---------------------------------------------------------------------------
+
+const SEED_TRIPS: readonly TripBudget[] = [
+  {
+    id: 'trip-bangkok',
+    name: 'Bangkok Jan–Mar',
+    country: 'Thailand',
+    startDate: '2026-01-01',
+    endDate: '2026-03-31',
+    localCurrency: 'THB',
+    homeCurrency: 'USD',
+    plannedLocalMinor: 9_000_000, // ฿90,000.00
+    fxRateHomePerLocal: 0.028,
+    archived: false,
+    archivedAt: null,
+    archivedSnapshot: null,
+  },
+];
+
+const SEED_TRANSACTIONS: readonly TripTransaction[] = [
+  {
+    id: 'seed-1',
+    amountMinor: 1_200_000, // ฿12,000.00
+    currency: 'THB',
+    date: '2026-01-05',
+    country: 'Thailand',
+    tripId: 'trip-bangkok',
+  },
+  {
+    id: 'seed-2',
+    amountMinor: 850_000, // ฿8,500.00
+    currency: 'THB',
+    date: '2026-02-10',
+    country: 'Thailand',
+    tripId: 'trip-bangkok',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Field sub-components
+// ---------------------------------------------------------------------------
+
+interface FieldProps {
+  id: string;
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}
+
+/** A labelled form control with an optional screen-reader hint. */
+const Field: React.FC<FieldProps> = ({ id, label, hint, children }) => (
+  <div className="trip-field">
+    <label className="trip-field__label" htmlFor={id}>
+      {label}
+    </label>
+    {children}
+    {hint ? (
+      <p id={`${id}-hint`} className="trip-field__hint">
+        {hint}
+      </p>
+    ) : null}
+  </div>
+);
+
+interface TripCardProps {
+  report: TripBudgetReport;
+  onArchive: (id: string) => void;
+  onUnarchive: (id: string) => void;
+}
+
+/** A single trip envelope card with local + home progress. */
+const TripCard: React.FC<TripCardProps> = ({ report, onArchive, onUnarchive }) => {
+  const status = STATUS_META[report.status];
+  const utilisationPercent = Math.min(100, Math.round(report.utilizationBps / 100));
+  const remainingLabel = report.remainingLocalMinor < 0 ? 'Over by' : 'Remaining';
+  const remainingMinor = Math.abs(report.remainingLocalMinor);
+
+  const localSpent = formatCurrency(report.localSpentMinor, { currency: report.localCurrency });
+  const localPlanned = formatCurrency(report.plannedLocalMinor, { currency: report.localCurrency });
+  const homeSpent = formatCurrency(report.homeSpentMinor, { currency: report.homeCurrency });
+  const homePlanned = formatCurrency(report.plannedHomeMinor, { currency: report.homeCurrency });
+
+  return (
+    <article className="trip-card" aria-labelledby={`${report.id}-name`}>
+      <header className="trip-card__header">
+        <div>
+          <h4 className="trip-card__name" id={`${report.id}-name`}>
+            {report.name}
+          </h4>
+          <p className="trip-card__meta">
+            <AppIcon name="map-pin" size={16} />
+            <span>{report.country || 'Any country'}</span>
+            <span aria-hidden="true">·</span>
+            <AppIcon name="calendar" size={16} />
+            <span>
+              {formatIsoDate(report.startDate)} – {formatIsoDate(report.endDate)}
+            </span>
+          </p>
+        </div>
+        <span className={`trip-badge trip-badge--${report.status}`}>
+          <AppIcon name={status.icon} size={16} />
+          <span>{status.label}</span>
+        </span>
+      </header>
+
+      <div
+        className="trip-card__progress"
+        role="progressbar"
+        aria-valuenow={utilisationPercent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${report.name} budget used: ${utilisationPercent}%`}
+      >
+        <div
+          className={`trip-card__progress-fill${
+            report.overBudget ? ' trip-card__progress-fill--over' : ''
+          }`}
+          style={{ width: `${utilisationPercent}%` }}
+        />
+      </div>
+
+      <dl className="trip-card__figures">
+        <div className="trip-card__figure">
+          <dt>Spent (local)</dt>
+          <dd>
+            {localSpent} <span className="trip-card__muted">of {localPlanned}</span>
+          </dd>
+        </div>
+        <div className="trip-card__figure">
+          <dt>Home roll-up</dt>
+          <dd>
+            {homeSpent} <span className="trip-card__muted">of {homePlanned}</span>
+          </dd>
+        </div>
+        <div className="trip-card__figure">
+          <dt>{remainingLabel}</dt>
+          <dd className={report.overBudget ? 'trip-card__over' : undefined}>
+            {report.overBudget ? (
+              <AppIcon name="alert-triangle" size={16} />
+            ) : (
+              <AppIcon name="check-circle" size={16} />
+            )}{' '}
+            {formatCurrency(remainingMinor, { currency: report.localCurrency })}
+            {report.overBudget ? ' over budget' : ''}
+          </dd>
+        </div>
+      </dl>
+
+      <footer className="trip-card__footer">
+        <span className="trip-card__count">
+          {report.transactionCount} {report.transactionCount === 1 ? 'transaction' : 'transactions'}
+        </span>
+        {report.archived ? (
+          <button
+            type="button"
+            className="trip-button trip-button--ghost"
+            onClick={() => onUnarchive(report.id)}
+          >
+            Reopen {report.name}
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="trip-button trip-button--ghost"
+            onClick={() => onArchive(report.id)}
+          >
+            Archive {report.name}
+          </button>
+        )}
+      </footer>
+    </article>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+let nextLocalId = 1;
+function makeId(prefix: string): string {
+  nextLocalId += 1;
+  return `${prefix}-${Date.now().toString(36)}-${nextLocalId}`;
+}
+
+export const TripBudgetsPage: React.FC = () => {
+  const idPrefix = useId();
+  const fid = (suffix: string): string => `${idPrefix}-${suffix}`;
+  const today = useMemo(() => todayIso(), []);
+
+  const [trips, setTrips] = useState<TripBudget[]>(() => [...SEED_TRIPS]);
+  const [transactions, setTransactions] = useState<TripTransaction[]>(() => [...SEED_TRANSACTIONS]);
+  const [filterTripId, setFilterTripId] = useState<string>('all');
+
+  // Create-trip form state.
+  const [tripName, setTripName] = useState('');
+  const [tripCountry, setTripCountry] = useState('');
+  const [tripStart, setTripStart] = useState('');
+  const [tripEnd, setTripEnd] = useState('');
+  const [tripLocalCurrency, setTripLocalCurrency] = useState('THB');
+  const [tripHomeCurrency, setTripHomeCurrency] = useState('USD');
+  const [tripPlanned, setTripPlanned] = useState('');
+  const [tripRate, setTripRate] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // Add-spend form state.
+  const [spendTripId, setSpendTripId] = useState('');
+  const [spendDate, setSpendDate] = useState('');
+  const [spendAmount, setSpendAmount] = useState('');
+  const [spendCountry, setSpendCountry] = useState('');
+
+  const reports = useMemo(
+    () => trips.map((trip) => summarizeTripBudget(trip, transactions, today)),
+    [trips, transactions, today],
+  );
+  const rollup = useMemo(
+    () => summarizeTripBudgets(trips, transactions, today),
+    [trips, transactions, today],
+  );
+
+  const activeReports = reports.filter((report) => !report.archived);
+  const archivedReports = reports.filter((report) => report.archived);
+
+  const visibleTransactions = useMemo(() => {
+    const sorted = [...transactions].sort((a, b) => (a.date < b.date ? 1 : -1));
+    if (filterTripId === 'all') return sorted;
+    return sorted.filter((tx) => tx.tripId === filterTripId);
+  }, [transactions, filterTripId]);
+
+  const tripById = useMemo(() => new Map(trips.map((trip) => [trip.id, trip])), [trips]);
+
+  const handleCreateTrip = (event: React.FormEvent): void => {
+    event.preventDefault();
+    const planned = parseMajorToMinor(tripPlanned);
+    const rate = parseRate(tripRate);
+
+    if (!tripName.trim()) {
+      setFormError('Give the trip a name.');
+      return;
+    }
+    if (!tripStart || !tripEnd || tripEnd < tripStart) {
+      setFormError('Enter a start date and an end date on or after it.');
+      return;
+    }
+    if (rate <= 0) {
+      setFormError('Enter the FX rate (home currency per 1 unit of local currency).');
+      return;
+    }
+
+    const newTrip: TripBudget = {
+      id: makeId('trip'),
+      name: tripName.trim(),
+      country: tripCountry.trim(),
+      startDate: tripStart,
+      endDate: tripEnd,
+      localCurrency: tripLocalCurrency.trim().toUpperCase() || 'USD',
+      homeCurrency: tripHomeCurrency.trim().toUpperCase() || 'USD',
+      plannedLocalMinor: planned,
+      fxRateHomePerLocal: rate,
+      archived: false,
+      archivedAt: null,
+      archivedSnapshot: null,
+    };
+
+    setTrips((current) => [...current, newTrip]);
+    setFormError(null);
+    setTripName('');
+    setTripCountry('');
+    setTripStart('');
+    setTripEnd('');
+    setTripPlanned('');
+    setTripRate('');
+  };
+
+  const handleAddSpend = (event: React.FormEvent): void => {
+    event.preventDefault();
+    const tripId = spendTripId || activeReports[0]?.id;
+    const trip = tripId ? tripById.get(tripId) : undefined;
+    const amount = parseMajorToMinor(spendAmount);
+    if (!trip || !spendDate || amount <= 0) {
+      return;
+    }
+
+    const newTx: TripTransaction = {
+      id: makeId('tx'),
+      amountMinor: amount,
+      currency: trip.localCurrency,
+      date: spendDate,
+      country: spendCountry.trim() || trip.country,
+      tripId: trip.id,
+    };
+    setTransactions((current) => [...current, newTx]);
+    setSpendAmount('');
+    setSpendDate('');
+    setSpendCountry('');
+  };
+
+  const handleArchive = (id: string): void => {
+    setTrips((current) =>
+      current.map((trip) => (trip.id === id ? archiveTripBudget(trip, transactions, today) : trip)),
+    );
+  };
+
+  const handleUnarchive = (id: string): void => {
+    setTrips((current) =>
+      current.map((trip) => (trip.id === id ? unarchiveTripBudget(trip) : trip)),
+    );
+  };
+
+  const summaryText = useMemo(() => {
+    if (rollup.activeTripCount === 0) {
+      return 'No active trips yet. Create a trip envelope to start tracking spend abroad.';
+    }
+    const spent = formatCurrency(rollup.totalSpentHomeMinor, { currency: rollup.homeCurrency });
+    const planned = formatCurrency(rollup.totalPlannedHomeMinor, { currency: rollup.homeCurrency });
+    const remaining = formatCurrency(Math.abs(rollup.totalRemainingHomeMinor), {
+      currency: rollup.homeCurrency,
+    });
+    const verb = rollup.totalRemainingHomeMinor < 0 ? 'over by' : 'leaving';
+    const tripWord = rollup.activeTripCount === 1 ? 'trip' : 'trips';
+    return `Across ${rollup.activeTripCount} active ${tripWord}, you have spent ${spent} of ${planned} planned, ${verb} ${remaining} in your home currency.`;
+  }, [rollup]);
+
+  return (
+    <div className="trip-page">
+      <header className="trip-page__header">
+        <span className="trip-page__icon" aria-hidden="true">
+          <AppIcon name="globe" />
+        </span>
+        <div>
+          <h2 className="trip-page__title">Trip &amp; Country Budgets</h2>
+          <p className="trip-page__subtitle">
+            Budget a trip in its local currency, track spend inside the trip dates, and roll every
+            envelope up into one home-currency view. Archive a trip when it ends — its history stays
+            intact.
+          </p>
+        </div>
+      </header>
+
+      <section
+        className="trip-summary"
+        aria-label="Home-currency roll-up"
+        role="status"
+        aria-live="polite"
+      >
+        <p className="trip-summary__text">{summaryText}</p>
+      </section>
+
+      <div className="trip-layout">
+        <section className="trip-section" aria-labelledby={fid('trips-heading')}>
+          <h3 className="trip-section__heading" id={fid('trips-heading')}>
+            Active trips
+          </h3>
+          {activeReports.length === 0 ? (
+            <p className="trip-empty">
+              No active trips. Use the form to plan your next destination.
+            </p>
+          ) : (
+            <div className="trip-cards">
+              {activeReports.map((report) => (
+                <TripCard
+                  key={report.id}
+                  report={report}
+                  onArchive={handleArchive}
+                  onUnarchive={handleUnarchive}
+                />
+              ))}
+            </div>
+          )}
+
+          {archivedReports.length > 0 ? (
+            <>
+              <h3 className="trip-section__heading" id={fid('archived-heading')}>
+                Archived trips
+              </h3>
+              <div className="trip-cards">
+                {archivedReports.map((report) => (
+                  <TripCard
+                    key={report.id}
+                    report={report}
+                    onArchive={handleArchive}
+                    onUnarchive={handleUnarchive}
+                  />
+                ))}
+              </div>
+            </>
+          ) : null}
+        </section>
+
+        <aside className="trip-side">
+          <form
+            className="trip-form"
+            aria-labelledby={fid('create-heading')}
+            onSubmit={handleCreateTrip}
+          >
+            <h3 className="trip-form__heading" id={fid('create-heading')}>
+              Plan a new trip
+            </h3>
+
+            <Field id={fid('name')} label="Trip name" hint="e.g. Bangkok Jan–Mar">
+              <input
+                id={fid('name')}
+                className="trip-field__input"
+                type="text"
+                value={tripName}
+                onChange={(event) => setTripName(event.target.value)}
+                aria-describedby={`${fid('name')}-hint`}
+              />
+            </Field>
+
+            <Field
+              id={fid('country')}
+              label="Country / region"
+              hint="Matches spend tagged to this place."
+            >
+              <input
+                id={fid('country')}
+                className="trip-field__input"
+                type="text"
+                value={tripCountry}
+                onChange={(event) => setTripCountry(event.target.value)}
+                aria-describedby={`${fid('country')}-hint`}
+              />
+            </Field>
+
+            <div className="trip-form__row">
+              <Field id={fid('start')} label="Start date">
+                <input
+                  id={fid('start')}
+                  className="trip-field__input"
+                  type="date"
+                  value={tripStart}
+                  onChange={(event) => setTripStart(event.target.value)}
+                />
+              </Field>
+              <Field id={fid('end')} label="End date">
+                <input
+                  id={fid('end')}
+                  className="trip-field__input"
+                  type="date"
+                  value={tripEnd}
+                  onChange={(event) => setTripEnd(event.target.value)}
+                />
+              </Field>
+            </div>
+
+            <div className="trip-form__row">
+              <Field id={fid('local')} label="Local currency" hint="ISO code, e.g. THB.">
+                <input
+                  id={fid('local')}
+                  className="trip-field__input"
+                  type="text"
+                  maxLength={3}
+                  value={tripLocalCurrency}
+                  onChange={(event) => setTripLocalCurrency(event.target.value)}
+                  aria-describedby={`${fid('local')}-hint`}
+                />
+              </Field>
+              <Field id={fid('home')} label="Home currency" hint="Roll-up currency, e.g. USD.">
+                <input
+                  id={fid('home')}
+                  className="trip-field__input"
+                  type="text"
+                  maxLength={3}
+                  value={tripHomeCurrency}
+                  onChange={(event) => setTripHomeCurrency(event.target.value)}
+                  aria-describedby={`${fid('home')}-hint`}
+                />
+              </Field>
+            </div>
+
+            <Field
+              id={fid('planned')}
+              label="Planned amount (local currency)"
+              hint="Total you intend to spend on this trip."
+            >
+              <input
+                id={fid('planned')}
+                className="trip-field__input"
+                type="number"
+                inputMode="decimal"
+                min={0}
+                step="0.01"
+                value={tripPlanned}
+                onChange={(event) => setTripPlanned(event.target.value)}
+                aria-describedby={`${fid('planned')}-hint`}
+              />
+            </Field>
+
+            <Field
+              id={fid('rate')}
+              label="FX rate (home per 1 local)"
+              hint="Stored rate — for example 0.028 home dollars per local unit. Never fetched live."
+            >
+              <input
+                id={fid('rate')}
+                className="trip-field__input"
+                type="number"
+                inputMode="decimal"
+                min={0}
+                step="0.0001"
+                value={tripRate}
+                onChange={(event) => setTripRate(event.target.value)}
+                aria-describedby={`${fid('rate')}-hint`}
+              />
+            </Field>
+
+            {formError ? (
+              <p className="trip-form__error" role="alert">
+                <AppIcon name="alert-circle" size={16} /> {formError}
+              </p>
+            ) : null}
+
+            <button type="submit" className="trip-button trip-button--primary">
+              Create trip envelope
+            </button>
+          </form>
+
+          <form
+            className="trip-form"
+            aria-labelledby={fid('spend-heading')}
+            onSubmit={handleAddSpend}
+          >
+            <h3 className="trip-form__heading" id={fid('spend-heading')}>
+              Log local-currency spend
+            </h3>
+
+            <Field id={fid('spend-trip')} label="Trip">
+              <select
+                id={fid('spend-trip')}
+                className="trip-field__input"
+                value={spendTripId || activeReports[0]?.id || ''}
+                onChange={(event) => setSpendTripId(event.target.value)}
+              >
+                {activeReports.length === 0 ? (
+                  <option value="">No active trips</option>
+                ) : (
+                  activeReports.map((report) => (
+                    <option key={report.id} value={report.id}>
+                      {report.name} ({report.localCurrency})
+                    </option>
+                  ))
+                )}
+              </select>
+            </Field>
+
+            <Field id={fid('spend-date')} label="Date">
+              <input
+                id={fid('spend-date')}
+                className="trip-field__input"
+                type="date"
+                value={spendDate}
+                onChange={(event) => setSpendDate(event.target.value)}
+              />
+            </Field>
+
+            <Field
+              id={fid('spend-amount')}
+              label="Amount (local currency)"
+              hint="Recorded in the selected trip's local currency."
+            >
+              <input
+                id={fid('spend-amount')}
+                className="trip-field__input"
+                type="number"
+                inputMode="decimal"
+                min={0}
+                step="0.01"
+                value={spendAmount}
+                onChange={(event) => setSpendAmount(event.target.value)}
+                aria-describedby={`${fid('spend-amount')}-hint`}
+              />
+            </Field>
+
+            <Field id={fid('spend-country')} label="Country (optional)">
+              <input
+                id={fid('spend-country')}
+                className="trip-field__input"
+                type="text"
+                value={spendCountry}
+                onChange={(event) => setSpendCountry(event.target.value)}
+              />
+            </Field>
+
+            <button
+              type="submit"
+              className="trip-button trip-button--primary"
+              disabled={activeReports.length === 0}
+            >
+              Add spend
+            </button>
+          </form>
+        </aside>
+      </div>
+
+      <section className="trip-section" aria-labelledby={fid('ledger-heading')}>
+        <div className="trip-ledger__head">
+          <h3 className="trip-section__heading" id={fid('ledger-heading')}>
+            Spend ledger
+          </h3>
+          <Field id={fid('filter')} label="Filter by trip">
+            <select
+              id={fid('filter')}
+              className="trip-field__input"
+              value={filterTripId}
+              onChange={(event) => setFilterTripId(event.target.value)}
+            >
+              <option value="all">All trips</option>
+              {trips.map((trip) => (
+                <option key={trip.id} value={trip.id}>
+                  {trip.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+
+        {visibleTransactions.length === 0 ? (
+          <p className="trip-empty">No spend logged for this view yet.</p>
+        ) : (
+          <table className="trip-table">
+            <caption className="trip-table__caption">
+              Spend entries{filterTripId === 'all' ? ' across all trips' : ' for the selected trip'}
+              , newest first, shown in each trip&apos;s local currency.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Date</th>
+                <th scope="col">Trip</th>
+                <th scope="col">Country</th>
+                <th scope="col" className="trip-table__amount">
+                  Amount
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleTransactions.map((tx) => {
+                const trip = tx.tripId ? tripById.get(tx.tripId) : undefined;
+                const currency = trip?.localCurrency ?? tx.currency;
+                return (
+                  <tr key={tx.id}>
+                    <td>{formatIsoDate(tx.date)}</td>
+                    <td>{trip?.name ?? 'Unassigned'}</td>
+                    <td>{tx.country || '—'}</td>
+                    <td className="trip-table__amount">
+                      {formatCurrency(Math.abs(tx.amountMinor), { currency })}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default TripBudgetsPage;

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -20,6 +20,7 @@ const Transactions = lazy(() => import('./pages/TransactionsPage'));
 const TransactionDetail = lazy(() => import('./pages/TransactionDetailPage'));
 const Budgets = lazy(() => import('./pages/BudgetsPage'));
 const BudgetDetail = lazy(() => import('./pages/BudgetDetailPage'));
+const TripBudgets = lazy(() => import('./pages/TripBudgetsPage'));
 const Categories = lazy(() => import('./pages/CategoriesPage'));
 const Goals = lazy(() => import('./pages/GoalsPage'));
 const GoalDetail = lazy(() => import('./pages/GoalDetailPage'));
@@ -330,6 +331,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Budget Detail">
             <BudgetDetail />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/trip-budgets"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Trip & Country Budgets">
+            <TripBudgets />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Web slice ? Issue #2205: Digital-nomad trip / country budgets

Adds trip "envelopes" so a traveller can budget a named trip/country with a date
window (e.g. **"Bangkok Jan?Mar"**), spend in the local currency, and roll every
trip up into a single home-currency view ? then archive a finished trip without
losing its history.

### What's included
- **Pure engine** `apps/web/src/lib/budgets/` (`trip-budgets.ts` + `types.ts`):
  - Models a trip budget: name, country, inclusive start/end dates, local
    currency, home currency, planned amount (local minor units) and a stored FX
    rate.
  - Computes: spend inside the trip window (date-range + country filtering),
    local-currency totals, a **home-currency roll-up**, remaining-vs-planned,
    utilisation, and over-budget state.
  - **Archived-state handling** freezes totals into a snapshot so historical
    reporting survives later transaction edits; `unarchive` returns to live
    computation.
  - Integer **minor units** everywhere, **banker's rounding** (HALF_EVEN), pure
    functions, **no float money**.
  - **FX contract:** the rate is **caller-provided / stored ? never fetched from
    the network** (documented in the engine header).
- **Accessible UI** ? new lazy page `pages/TripBudgetsPage.tsx` (+ `.css`),
  registered directly via `lazy(() => import('./pages/TripBudgetsPage'))` in
  `routes.tsx` with a nav entry in `navConfig.tsx`. Create trips, log
  local-currency spend, see local + home progress, filter the ledger by trip,
  and archive/reopen trips.

### Accessibility (WCAG 2.2 AA)
- Every date / amount / currency control has a `<label htmlFor>` + `aria-describedby` hint.
- The home-currency roll-up lives in an `aria-live="polite"` status region.
- Trip status and over-budget are conveyed with an **icon AND text** ? never colour alone.
- Real `<table>` with a `<caption>` text alternative + scoped headers; the trip filter is a labelled `<select>`; keyboard navigable.
- Honours `prefers-reduced-motion` for the progress fill.

### Tests
- **32** engine unit tests: date-window filtering (inclusive boundaries), FX
  roll-up with known rates, banker's rounding, and edge cases ? trip with no
  spend, overlapping trips, explicit-assignment override, archived snapshot
  preservation, cross-trip roll-up.
- **8** component render tests: labelled inputs, seeded worked example, aria-live
  roll-up, create trip, log spend, archive/reopen, accessible ledger.

### Performance budget
The page is code-split into its own dedicated lazy chunk (`TripBudgetsPage-*.js`)
and imports the engine + `AppIcon` + `formatCurrency` directly (no shared
barrel, no charts), so it stays within the 215KB gzip lazy-chunk budget. Verified
locally with `tools/check-web-performance-budget.mjs` (passed; initial JS 17 KiB).

### Out of scope (tracked under the issue)
- iOS native trip budgeting + cross-border timezone handling.
- Persisting trip budgets/spend through the SQLite-WASM repository layer and the
  KMP shared budgeting module (this slice uses a self-contained local model,
  mirroring the existing FIRE planner page).

Refs #2205
