### PR TITLE
feat(web): debt payoff rings with payoff date and interest-saved (#2175)

### DIFF
--- a/apps/web/src/components/debt/DebtPayoffRings.css
+++ b/apps/web/src/components/debt/DebtPayoffRings.css
@@ -1,0 +1,267 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/*
+ * Styles for the DebtPayoffRings "fitness rings" payoff surface (#2175).
+ * Uses design tokens (with safe fallbacks) and respects prefers-reduced-motion.
+ */
+
+.debt-payoff-rings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6, 1.5rem);
+}
+
+.debt-payoff-rings__header h2 {
+  margin: 0 0 var(--spacing-1, 0.25rem);
+  font-size: var(--font-size-xl, 1.25rem);
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-text-primary, #111827);
+}
+
+.debt-payoff-rings__subtitle {
+  margin: 0;
+  color: var(--semantic-text-secondary, #4b5563);
+  font-size: var(--font-size-sm, 0.875rem);
+}
+
+.debt-payoff-rings__selector {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1, 0.25rem);
+  max-width: 24rem;
+}
+
+.debt-payoff-rings__selector label,
+.debt-payoff-rings__whatif-input label {
+  font-size: var(--font-size-sm, 0.875rem);
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--semantic-text-primary, #111827);
+}
+
+.debt-payoff-rings__selector select,
+.debt-payoff-rings__whatif-input input {
+  padding: var(--spacing-2, 0.5rem) var(--spacing-3, 0.75rem);
+  border: 1px solid var(--semantic-border, #d1d5db);
+  border-radius: var(--radius-md, 0.375rem);
+  background: var(--semantic-background-primary, #ffffff);
+  color: var(--semantic-text-primary, #111827);
+  font-size: var(--font-size-base, 1rem);
+}
+
+.debt-payoff-rings__selector select:focus-visible,
+.debt-payoff-rings__whatif-input input:focus-visible {
+  outline: 2px solid var(--semantic-primary, #2563eb);
+  outline-offset: 2px;
+}
+
+/* --- Ring card --------------------------------------------------------- */
+
+.debt-payoff-rings__card {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-6, 1.5rem);
+  padding: var(--spacing-6, 1.5rem);
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-radius: var(--radius-lg, 0.5rem);
+  background: var(--semantic-background-primary, #ffffff);
+}
+
+.debt-payoff-ring {
+  position: relative;
+  width: 140px;
+  height: 140px;
+  flex: 0 0 auto;
+}
+
+.debt-payoff-ring__svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.debt-payoff-ring__track,
+.debt-payoff-ring__value {
+  fill: none;
+  stroke-width: 12;
+}
+
+.debt-payoff-ring__track {
+  stroke: var(--semantic-border, #e5e7eb);
+}
+
+.debt-payoff-ring__value {
+  stroke: var(--semantic-primary, #2563eb);
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.4s ease;
+}
+
+.debt-payoff-ring__percent {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-xl, 1.5rem);
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-text-primary, #111827);
+}
+
+.debt-payoff-rings__summary {
+  flex: 1 1 16rem;
+  min-width: 14rem;
+}
+
+.debt-payoff-rings__progress-text {
+  margin: 0 0 var(--spacing-3, 0.75rem);
+  font-size: var(--font-size-lg, 1.125rem);
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--semantic-text-primary, #111827);
+}
+
+.debt-payoff-rings__stats,
+.debt-payoff-rings__savings-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: var(--spacing-3, 0.75rem);
+  margin: 0;
+}
+
+.debt-payoff-rings__stat dt {
+  font-size: var(--font-size-xs, 0.75rem);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--semantic-text-secondary, #6b7280);
+}
+
+.debt-payoff-rings__stat dd {
+  margin: 0;
+  font-size: var(--font-size-base, 1rem);
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-text-primary, #111827);
+}
+
+/* --- Milestones -------------------------------------------------------- */
+
+.debt-payoff-rings__milestones h3,
+.debt-payoff-rings__whatif h3 {
+  margin: 0 0 var(--spacing-3, 0.75rem);
+  font-size: var(--font-size-lg, 1.125rem);
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-text-primary, #111827);
+}
+
+.debt-milestone-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2, 0.5rem);
+}
+
+.debt-milestone {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3, 0.75rem);
+  padding: var(--spacing-3, 0.75rem);
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-radius: var(--radius-md, 0.375rem);
+  background: var(--semantic-background-secondary, #f9fafb);
+}
+
+.debt-milestone__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: var(--radius-full, 9999px);
+  font-weight: var(--font-weight-bold, 700);
+  border: 2px solid var(--semantic-border, #d1d5db);
+  color: var(--semantic-text-secondary, #6b7280);
+}
+
+.debt-milestone__label {
+  flex: 1 1 auto;
+  color: var(--semantic-text-primary, #111827);
+}
+
+.debt-milestone__status {
+  font-size: var(--font-size-xs, 0.75rem);
+  font-weight: var(--font-weight-medium, 500);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--semantic-text-secondary, #6b7280);
+}
+
+.debt-milestone[data-reached='true'] {
+  border-color: var(--semantic-positive, #16a34a);
+  background: var(--semantic-positive-bg, #f0fdf4);
+}
+
+.debt-milestone[data-reached='true'] .debt-milestone__icon {
+  border-color: var(--semantic-positive, #16a34a);
+  background: var(--semantic-positive, #16a34a);
+  color: var(--semantic-background-primary, #ffffff);
+}
+
+.debt-milestone[data-reached='true'] .debt-milestone__status {
+  color: var(--semantic-positive, #16a34a);
+}
+
+/* --- What-if comparison ------------------------------------------------ */
+
+.debt-payoff-rings__whatif {
+  padding: var(--spacing-6, 1.5rem);
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-radius: var(--radius-lg, 0.5rem);
+  background: var(--semantic-background-primary, #ffffff);
+}
+
+.debt-payoff-rings__whatif-input {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1, 0.25rem);
+  max-width: 20rem;
+  margin-bottom: var(--spacing-4, 1rem);
+}
+
+.debt-payoff-rings__savings {
+  margin: 0 0 var(--spacing-3, 0.75rem);
+  color: var(--semantic-text-primary, #111827);
+}
+
+/* --- Reduced motion ---------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .debt-payoff-ring__value {
+    transition: none;
+  }
+}
+
+/* --- Dark theme -------------------------------------------------------- */
+
+@media (prefers-color-scheme: dark) {
+  .debt-payoff-rings__card,
+  .debt-payoff-rings__whatif {
+    background: var(--semantic-background-primary, #1f2937);
+    border-color: var(--semantic-border, #374151);
+  }
+
+  .debt-milestone {
+    background: var(--semantic-background-secondary, #111827);
+    border-color: var(--semantic-border, #374151);
+  }
+}
+
+[data-theme='dark'] .debt-payoff-rings__card,
+[data-theme='dark'] .debt-payoff-rings__whatif {
+  background: var(--semantic-background-primary, #1f2937);
+  border-color: var(--semantic-border, #374151);
+}
+
+[data-theme='dark'] .debt-milestone {
+  background: var(--semantic-background-secondary, #111827);
+  border-color: var(--semantic-border, #374151);
+}

--- a/apps/web/src/components/debt/DebtPayoffRings.test.tsx
+++ b/apps/web/src/components/debt/DebtPayoffRings.test.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Render tests for the DebtPayoffRings component (#2175).
+ *
+ * Verifies the accessible ring (text alternative), estimated payoff date,
+ * milestone ladder, debt selection, and the extra-payment what-if comparison.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { DebtPayoffRings } from './DebtPayoffRings';
+import type { Debt } from '../../lib/debt-types';
+
+const TODAY = '2025-01-01';
+
+const autoLoan: Debt = {
+  id: 'auto',
+  name: 'Auto Loan',
+  balanceCents: 620_000, // $6,200 remaining
+  originalBalanceCents: 1_000_000, // of $10,000 → 38% paid
+  annualRateBps: 1200,
+  minimumPaymentCents: 30_000,
+  type: 'auto_loan',
+};
+
+const paidLoan: Debt = {
+  id: 'paid',
+  name: 'Personal Loan',
+  balanceCents: 0,
+  originalBalanceCents: 500_000,
+  annualRateBps: 900,
+  minimumPaymentCents: 20_000,
+  type: 'personal_loan',
+};
+
+describe('DebtPayoffRings', () => {
+  it('renders an empty state when there are no debts', () => {
+    render(<DebtPayoffRings debts={[]} todayIso={TODAY} />);
+    expect(screen.getByText('No debt accounts to visualize')).toBeDefined();
+  });
+
+  it('renders the ring with an accessible text alternative and payoff date', () => {
+    render(<DebtPayoffRings debts={[autoLoan]} todayIso={TODAY} />);
+
+    const ring = screen.getByRole('img');
+    expect(ring.getAttribute('aria-label')).toContain('38% paid');
+    expect(ring.getAttribute('aria-label')).toContain('Auto Loan');
+
+    // Visible progress text alternative (no colour-only signalling).
+    expect(screen.getByText('38% paid — $3,800 of $10,000')).toBeDefined();
+
+    // Estimated payoff date is surfaced as a year.
+    const payoffDate = screen.getByText('Estimated payoff date').nextElementSibling;
+    expect(payoffDate?.textContent).toMatch(/\d{4}/);
+  });
+
+  it('renders the milestone ladder with reached and in-progress states', () => {
+    render(<DebtPayoffRings debts={[autoLoan]} todayIso={TODAY} />);
+    const milestones = screen.getByRole('list');
+    // 38% paid → only the 25% milestone is reached.
+    expect(within(milestones).getAllByText('Reached')).toHaveLength(1);
+    expect(within(milestones).getAllByText('In progress')).toHaveLength(3);
+    expect(within(milestones).getByText(/25% paid off — milestone reached/)).toBeDefined();
+  });
+
+  it('computes months saved and interest saved for an extra payment', () => {
+    render(<DebtPayoffRings debts={[autoLoan]} todayIso={TODAY} />);
+
+    const extraInput = screen.getByLabelText('Extra monthly payment ($)');
+    fireEvent.change(extraInput, { target: { value: '200' } });
+
+    const results = screen.getByRole('status');
+    expect(within(results).getByText('Months saved')).toBeDefined();
+    expect(within(results).getByText('Interest saved')).toBeDefined();
+    expect(within(results).getByText(/saves \$/)).toBeDefined();
+  });
+
+  it('prompts for an extra payment before one is entered', () => {
+    render(<DebtPayoffRings debts={[autoLoan]} todayIso={TODAY} />);
+    const results = screen.getByRole('status');
+    expect(results.getAttribute('aria-live')).toBe('polite');
+    expect(within(results).getByText(/Add an extra monthly payment/)).toBeDefined();
+  });
+
+  it('lets the user switch between debt accounts', () => {
+    render(<DebtPayoffRings debts={[autoLoan, paidLoan]} todayIso={TODAY} />);
+
+    expect(screen.getByRole('img').getAttribute('aria-label')).toContain('38% paid');
+
+    const selector = screen.getByLabelText('Debt account');
+    fireEvent.change(selector, { target: { value: 'paid' } });
+
+    expect(screen.getByRole('img').getAttribute('aria-label')).toContain('100% paid');
+    expect(screen.getAllByText('Paid off').length).toBeGreaterThan(0);
+  });
+
+  it('does not show a debt selector for a single debt', () => {
+    render(<DebtPayoffRings debts={[autoLoan]} todayIso={TODAY} />);
+    expect(screen.queryByLabelText('Debt account')).toBeNull();
+  });
+});

--- a/apps/web/src/components/debt/DebtPayoffRings.tsx
+++ b/apps/web/src/components/debt/DebtPayoffRings.tsx
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * DebtPayoffRings — a highly visual, "fitness rings" debt-payoff surface (#2175).
+ *
+ * For a selected loan/debt account it renders:
+ *  - a payoff progress ring (paid principal vs. original principal) with a full
+ *    text alternative so it never relies on colour alone;
+ *  - the estimated payoff date and time remaining;
+ *  - a payoff milestone ladder (25 / 50 / 75 / 100%);
+ *  - an extra-payment "what if" comparison (months saved + interest saved).
+ *
+ * All financial maths lives in the pure engine at `lib/debt/payoff.ts`; this
+ * component is purely presentational and accessible. Data arrives via props
+ * (never a direct repository import).
+ *
+ * Accessibility:
+ *  - The ring is an `img` with an aria-label describing the value in words.
+ *  - Inputs are labelled; computed what-if results announce via `aria-live`.
+ *  - Milestone state is conveyed with text + icon, not colour alone.
+ *  - Ring animation is disabled under `prefers-reduced-motion` (see CSS).
+ */
+
+import React, { useId, useMemo, useState } from 'react';
+import { EmptyState } from '../common';
+import {
+  buildPayoffRingViewModel,
+  formatUsdCents,
+  type LoanPayoffInput,
+} from '../../lib/debt/payoff';
+import type { Debt } from '../../lib/debt-types';
+import './DebtPayoffRings.css';
+
+export interface DebtPayoffRingsProps {
+  /** Loan/debt accounts to visualise. */
+  readonly debts: readonly Debt[];
+  /** Anchor date (YYYY-MM-DD) for payoff projections. Defaults to today. */
+  readonly todayIso?: string;
+}
+
+const RING_RADIUS = 52;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+function toLoanInput(debt: Debt): LoanPayoffInput {
+  return {
+    id: debt.id,
+    name: debt.name,
+    balanceCents: debt.balanceCents,
+    originalPrincipalCents: Math.max(
+      debt.originalBalanceCents ?? debt.balanceCents,
+      debt.balanceCents,
+    ),
+    annualRateBps: debt.annualRateBps,
+    minimumPaymentCents: debt.minimumPaymentCents,
+  };
+}
+
+function parseExtraPaymentCents(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed * 100) : 0;
+}
+
+export function DebtPayoffRings({ debts, todayIso }: DebtPayoffRingsProps): React.ReactElement {
+  const baseId = useId();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [extraPayment, setExtraPayment] = useState('');
+
+  const selectedDebt = useMemo(() => {
+    if (debts.length === 0) return null;
+    return debts.find((debt) => debt.id === selectedId) ?? debts[0];
+  }, [debts, selectedId]);
+
+  const extraPaymentCents = parseExtraPaymentCents(extraPayment);
+
+  const viewModel = useMemo(() => {
+    if (!selectedDebt) return null;
+    return buildPayoffRingViewModel(toLoanInput(selectedDebt), extraPaymentCents, {
+      startDateIso: todayIso,
+    });
+  }, [selectedDebt, extraPaymentCents, todayIso]);
+
+  const titleId = `${baseId}-title`;
+  const selectId = `${baseId}-debt`;
+  const extraId = `${baseId}-extra`;
+  const resultsId = `${baseId}-results`;
+
+  if (!selectedDebt || !viewModel) {
+    return (
+      <EmptyState
+        title="No debt accounts to visualize"
+        description="Add a loan or debt account to see payoff progress rings, your estimated payoff date, and how extra payments cut interest."
+      />
+    );
+  }
+
+  const { progress, milestones, comparison, activeProjection } = viewModel;
+  const clampedPercent = Math.max(0, Math.min(100, progress.percentPaid));
+  const dashOffset = RING_CIRCUMFERENCE * (1 - clampedPercent / 100);
+
+  return (
+    <section className="debt-payoff-rings" aria-labelledby={titleId}>
+      <header className="debt-payoff-rings__header">
+        <h2 id={titleId}>Payoff Rings</h2>
+        <p className="debt-payoff-rings__subtitle">
+          Close each debt like a fitness ring. Track payoff progress, your estimated payoff date,
+          and how extra payments shrink interest.
+        </p>
+      </header>
+
+      {debts.length > 1 && (
+        <div className="debt-payoff-rings__selector">
+          <label htmlFor={selectId}>Debt account</label>
+          <select
+            id={selectId}
+            value={selectedDebt.id}
+            onChange={(event) => setSelectedId(event.target.value)}
+          >
+            {debts.map((debt) => (
+              <option key={debt.id} value={debt.id}>
+                {debt.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div className="debt-payoff-rings__card">
+        <div className="debt-payoff-ring" role="img" aria-label={viewModel.ringAriaLabel}>
+          <svg
+            className="debt-payoff-ring__svg"
+            viewBox="0 0 120 120"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <circle className="debt-payoff-ring__track" cx="60" cy="60" r={RING_RADIUS} />
+            <circle
+              className="debt-payoff-ring__value"
+              cx="60"
+              cy="60"
+              r={RING_RADIUS}
+              strokeDasharray={RING_CIRCUMFERENCE}
+              strokeDashoffset={dashOffset}
+            />
+          </svg>
+          <span className="debt-payoff-ring__percent" aria-hidden="true">
+            {Math.round(clampedPercent)}%
+          </span>
+        </div>
+
+        <div className="debt-payoff-rings__summary">
+          <p className="debt-payoff-rings__progress-text">{progress.textAlternative}</p>
+          <dl className="debt-payoff-rings__stats">
+            <div className="debt-payoff-rings__stat">
+              <dt>Estimated payoff date</dt>
+              <dd>{viewModel.payoffDateLabel}</dd>
+            </div>
+            <div className="debt-payoff-rings__stat">
+              <dt>Time remaining</dt>
+              <dd>{viewModel.payoffDurationLabel}</dd>
+            </div>
+            <div className="debt-payoff-rings__stat">
+              <dt>Projected interest</dt>
+              <dd>
+                {activeProjection.amortizes
+                  ? formatUsdCents(activeProjection.totalInterestCents)
+                  : 'Not on track'}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+
+      <section className="debt-payoff-rings__milestones" aria-label="Payoff milestones">
+        <h3>Milestones</h3>
+        <ul className="debt-milestone-list" role="list">
+          {milestones.map((milestone) => (
+            <li
+              key={milestone.thresholdPercent}
+              className="debt-milestone"
+              data-reached={milestone.isReached}
+            >
+              <span className="debt-milestone__icon" aria-hidden="true">
+                {milestone.isReached ? '✓' : '○'}
+              </span>
+              <span className="debt-milestone__label">{milestone.label}</span>
+              <span className="debt-milestone__status">
+                {milestone.isReached ? 'Reached' : 'In progress'}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="debt-payoff-rings__whatif" aria-label="Extra payment what-if comparison">
+        <h3>What if you pay extra?</h3>
+        <div className="debt-payoff-rings__whatif-input">
+          <label htmlFor={extraId}>Extra monthly payment ($)</label>
+          <input
+            id={extraId}
+            type="number"
+            inputMode="decimal"
+            min="0"
+            step="0.01"
+            value={extraPayment}
+            onChange={(event) => setExtraPayment(event.target.value)}
+            aria-describedby={resultsId}
+          />
+        </div>
+        <div
+          id={resultsId}
+          className="debt-payoff-rings__whatif-results"
+          role="status"
+          aria-live="polite"
+        >
+          <p className="debt-payoff-rings__savings">{viewModel.savingsMessage}</p>
+          {comparison.hasImpact && (
+            <dl className="debt-payoff-rings__savings-stats">
+              <div className="debt-payoff-rings__stat">
+                <dt>Months saved</dt>
+                <dd>{comparison.monthsSaved}</dd>
+              </div>
+              <div className="debt-payoff-rings__stat">
+                <dt>Interest saved</dt>
+                <dd>{formatUsdCents(comparison.interestSavedCents)}</dd>
+              </div>
+            </dl>
+          )}
+        </div>
+      </section>
+    </section>
+  );
+}
+
+export default DebtPayoffRings;

--- a/apps/web/src/lib/debt/payoff.test.ts
+++ b/apps/web/src/lib/debt/payoff.test.ts
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the single-loan debt payoff engine (#2175).
+ *
+ * Covers known amortization values, banker's rounding ties, and edge cases:
+ * 0% APR, already-paid debts, and never-amortizing minimum payments.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  addMonthsToIso,
+  bankersRound,
+  buildPayoffRingViewModel,
+  calculatePayoffMilestones,
+  calculatePayoffProgress,
+  compareExtraPayment,
+  formatMonthsDuration,
+  formatPercent,
+  formatUsdCents,
+  monthlyInterestCents,
+  projectPayoff,
+  type LoanPayoffInput,
+} from './payoff';
+
+const START_ISO = '2025-01-01';
+
+function loan(overrides: Partial<LoanPayoffInput> = {}): LoanPayoffInput {
+  return {
+    id: 'loan-1',
+    name: 'Test Loan',
+    balanceCents: 1_000_000, // $10,000
+    originalPrincipalCents: 1_000_000,
+    annualRateBps: 1200, // 12% APR
+    minimumPaymentCents: 30_000, // $300
+    ...overrides,
+  };
+}
+
+describe('bankersRound', () => {
+  it('rounds halves to the nearest even integer', () => {
+    expect(bankersRound(0.5)).toBe(0);
+    expect(bankersRound(1.5)).toBe(2);
+    expect(bankersRound(2.5)).toBe(2);
+    expect(bankersRound(3.5)).toBe(4);
+    expect(bankersRound(-0.5)).toBe(0);
+    expect(bankersRound(-1.5)).toBe(-2);
+  });
+
+  it('rounds non-tie values normally', () => {
+    expect(bankersRound(1.4)).toBe(1);
+    expect(bankersRound(1.6)).toBe(2);
+    expect(bankersRound(8329.1666)).toBe(8329);
+  });
+
+  it('returns 0 for non-finite input', () => {
+    expect(bankersRound(Number.NaN)).toBe(0);
+    expect(bankersRound(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe('monthlyInterestCents', () => {
+  it('computes monthly interest from APR with monthly compounding', () => {
+    // $10,000 at 12% APR → 1% monthly → $100.
+    expect(monthlyInterestCents(1_000_000, 1200)).toBe(10_000);
+    // $5,000 at 19.99% APR → 1,999/120,000 monthly.
+    expect(monthlyInterestCents(500_000, 1999)).toBe(8329);
+  });
+
+  it('returns 0 for zero/negative balance or rate', () => {
+    expect(monthlyInterestCents(0, 1200)).toBe(0);
+    expect(monthlyInterestCents(-100, 1200)).toBe(0);
+    expect(monthlyInterestCents(1_000_000, 0)).toBe(0);
+  });
+});
+
+describe('formatUsdCents', () => {
+  it('formats whole dollars without trailing cents', () => {
+    expect(formatUsdCents(1_000_000)).toBe('$10,000');
+    expect(formatUsdCents(0)).toBe('$0');
+  });
+
+  it('formats fractional dollars with two decimals', () => {
+    expect(formatUsdCents(380_050)).toBe('$3,800.50');
+    expect(formatUsdCents(-1_25)).toBe('-$1.25');
+  });
+});
+
+describe('formatPercent', () => {
+  it('drops a redundant trailing .0', () => {
+    expect(formatPercent(62)).toBe('62%');
+    expect(formatPercent(62.5)).toBe('62.5%');
+    expect(formatPercent(33.33)).toBe('33.3%');
+  });
+});
+
+describe('addMonthsToIso', () => {
+  it('advances by whole months across year boundaries', () => {
+    expect(addMonthsToIso('2025-01-01', 0)).toBe('2025-01-01');
+    expect(addMonthsToIso('2025-01-01', 12)).toBe('2026-01-01');
+    expect(addMonthsToIso('2025-11-01', 3)).toBe('2026-02-01');
+  });
+});
+
+describe('projectPayoff — known amortization values', () => {
+  it('amortizes a 0% APR loan as pure principal reduction', () => {
+    const result = projectPayoff(
+      loan({ annualRateBps: 0, balanceCents: 100_000, minimumPaymentCents: 10_000 }),
+      10_000,
+      { startDateIso: START_ISO },
+    );
+    expect(result.amortizes).toBe(true);
+    expect(result.monthsToPayoff).toBe(10);
+    expect(result.totalInterestCents).toBe(0);
+    expect(result.totalPrincipalCents).toBe(100_000);
+    expect(result.totalPaidCents).toBe(100_000);
+    expect(result.estimatedPayoffDateIso).toBe('2025-11-01');
+  });
+
+  it('produces correct first-month split for a 12% APR loan', () => {
+    const result = projectPayoff(loan(), 30_000, { startDateIso: START_ISO });
+    const first = result.schedule[0];
+    expect(first.month).toBe(1);
+    expect(first.interestCents).toBe(10_000); // 1% of $10,000
+    expect(first.principalCents).toBe(20_000); // $300 - $100
+    expect(first.remainingBalanceCents).toBe(980_000);
+    expect(result.amortizes).toBe(true);
+    expect(result.monthsToPayoff).toBeGreaterThan(0);
+  });
+
+  it('conserves money: total paid equals principal plus interest', () => {
+    const result = projectPayoff(loan(), 30_000, { startDateIso: START_ISO });
+    expect(result.totalPaidCents).toBe(result.totalPrincipalCents + result.totalInterestCents);
+    expect(result.totalPrincipalCents).toBe(1_000_000);
+  });
+
+  it('never overpays — the final payment clears the exact balance', () => {
+    const result = projectPayoff(loan(), 30_000, { startDateIso: START_ISO });
+    const last = result.schedule[result.schedule.length - 1];
+    expect(last.remainingBalanceCents).toBe(0);
+  });
+});
+
+describe('projectPayoff — edge cases', () => {
+  it('treats an already-paid debt as a zero-month payoff', () => {
+    const result = projectPayoff(loan({ balanceCents: 0 }), 30_000, { startDateIso: START_ISO });
+    expect(result.amortizes).toBe(true);
+    expect(result.monthsToPayoff).toBe(0);
+    expect(result.schedule).toHaveLength(0);
+    expect(result.totalInterestCents).toBe(0);
+    expect(result.estimatedPayoffDateIso).toBe(START_ISO);
+  });
+
+  it('flags a non-amortizing payment below the monthly interest', () => {
+    // $5,000 at 24% APR → $100/month interest; pay only $50.
+    const result = projectPayoff(
+      loan({ balanceCents: 500_000, annualRateBps: 2400, minimumPaymentCents: 5_000 }),
+      5_000,
+      { startDateIso: START_ISO },
+    );
+    expect(result.amortizes).toBe(false);
+    expect(result.monthsToPayoff).toBeNull();
+    expect(result.estimatedPayoffDateIso).toBeNull();
+    expect(result.schedule).toHaveLength(0);
+  });
+
+  it('flags a payment exactly equal to the monthly interest as non-amortizing', () => {
+    // $10,000 at 12% APR → $100/month interest; pay exactly $100.
+    const result = projectPayoff(loan({ minimumPaymentCents: 10_000 }), 10_000, {
+      startDateIso: START_ISO,
+    });
+    expect(result.amortizes).toBe(false);
+    expect(result.monthsToPayoff).toBeNull();
+  });
+});
+
+describe('calculatePayoffProgress', () => {
+  it('computes percent paid and a text alternative', () => {
+    const progress = calculatePayoffProgress(
+      loan({ originalPrincipalCents: 1_000_000, balanceCents: 380_000 }),
+    );
+    expect(progress.paidPrincipalCents).toBe(620_000);
+    expect(progress.percentPaid).toBe(62);
+    expect(progress.isPaidOff).toBe(false);
+    expect(progress.textAlternative).toBe('62% paid — $6,200 of $10,000');
+  });
+
+  it('reports 100% paid when the balance is cleared', () => {
+    const progress = calculatePayoffProgress(loan({ balanceCents: 0 }));
+    expect(progress.percentPaid).toBe(100);
+    expect(progress.isPaidOff).toBe(true);
+  });
+
+  it('never reports negative progress when balance exceeds original', () => {
+    const progress = calculatePayoffProgress(
+      loan({ originalPrincipalCents: 500_000, balanceCents: 800_000 }),
+    );
+    expect(progress.percentPaid).toBe(0);
+    expect(progress.paidPrincipalCents).toBe(0);
+    // Original principal is normalised up to the current balance.
+    expect(progress.originalPrincipalCents).toBe(800_000);
+  });
+});
+
+describe('calculatePayoffMilestones', () => {
+  it('marks reached milestones and reports remaining principal for the rest', () => {
+    const milestones = calculatePayoffMilestones(
+      loan({ originalPrincipalCents: 1_000_000, balanceCents: 380_000 }),
+    );
+    const byThreshold = Object.fromEntries(milestones.map((m) => [m.thresholdPercent, m]));
+    expect(byThreshold[25].isReached).toBe(true);
+    expect(byThreshold[50].isReached).toBe(true);
+    expect(byThreshold[75].isReached).toBe(false);
+    expect(byThreshold[75].remainingToReachCents).toBe(130_000); // $7,500 target - $6,200 paid
+    expect(byThreshold[100].isReached).toBe(false);
+    expect(byThreshold[75].label).toContain('to go');
+    expect(byThreshold[25].label).toContain('milestone reached');
+  });
+
+  it('marks all milestones reached when paid off', () => {
+    const milestones = calculatePayoffMilestones(loan({ balanceCents: 0 }));
+    expect(milestones.every((m) => m.isReached)).toBe(true);
+    expect(milestones.every((m) => m.remainingToReachCents === 0)).toBe(true);
+  });
+});
+
+describe('compareExtraPayment', () => {
+  it('reports months saved and interest saved for an extra payment', () => {
+    const comparison = compareExtraPayment(loan(), 20_000, { startDateIso: START_ISO });
+    expect(comparison.baseline.amortizes).toBe(true);
+    expect(comparison.accelerated.amortizes).toBe(true);
+    expect(comparison.monthsSaved).not.toBeNull();
+    expect(comparison.monthsSaved!).toBeGreaterThan(0);
+    expect(comparison.interestSavedCents).toBeGreaterThan(0);
+    expect(comparison.hasImpact).toBe(true);
+    // Accelerated plan finishes sooner than baseline.
+    expect(comparison.accelerated.monthsToPayoff!).toBeLessThan(
+      comparison.baseline.monthsToPayoff!,
+    );
+  });
+
+  it('reports no impact for a zero extra payment', () => {
+    const comparison = compareExtraPayment(loan(), 0, { startDateIso: START_ISO });
+    expect(comparison.hasImpact).toBe(false);
+    expect(comparison.monthsSaved).toBe(0);
+    expect(comparison.interestSavedCents).toBe(0);
+  });
+
+  it('does not fabricate savings when the baseline never amortizes', () => {
+    const comparison = compareExtraPayment(
+      loan({ balanceCents: 500_000, annualRateBps: 2400, minimumPaymentCents: 5_000 }),
+      100_000,
+      { startDateIso: START_ISO },
+    );
+    expect(comparison.baseline.amortizes).toBe(false);
+    expect(comparison.interestSavedCents).toBe(0);
+    expect(comparison.monthsSaved).toBeNull();
+    expect(comparison.hasImpact).toBe(false);
+  });
+});
+
+describe('buildPayoffRingViewModel', () => {
+  it('assembles progress, payoff date, milestones, and savings copy', () => {
+    const vm = buildPayoffRingViewModel(
+      loan({ originalPrincipalCents: 1_000_000, balanceCents: 620_000 }),
+      20_000,
+      { startDateIso: START_ISO },
+    );
+    expect(vm.progress.percentPaid).toBe(38);
+    expect(vm.payoffDateLabel).toMatch(/\d{4}/);
+    expect(vm.payoffDurationLabel).not.toBe('');
+    expect(vm.nextMilestone).not.toBeNull();
+    expect(vm.ringAriaLabel).toContain('Test Loan payoff ring');
+    expect(vm.ringAriaLabel).toContain('38% paid');
+    expect(vm.comparison.hasImpact).toBe(true);
+    expect(vm.savingsMessage).toContain('saves');
+  });
+
+  it('uses the accelerated projection for the payoff date when extra is applied', () => {
+    const baselineVm = buildPayoffRingViewModel(loan(), 0, { startDateIso: START_ISO });
+    const acceleratedVm = buildPayoffRingViewModel(loan(), 50_000, { startDateIso: START_ISO });
+    expect(acceleratedVm.activeProjection.monthsToPayoff!).toBeLessThan(
+      baselineVm.activeProjection.monthsToPayoff!,
+    );
+  });
+
+  it('describes a paid-off debt without a payoff date', () => {
+    const vm = buildPayoffRingViewModel(loan({ balanceCents: 0 }), 0, { startDateIso: START_ISO });
+    expect(vm.progress.isPaidOff).toBe(true);
+    expect(vm.payoffDateLabel).toBe('Paid off');
+    expect(vm.ringAriaLabel).toContain('paid off');
+  });
+
+  it('explains a non-amortizing minimum payment', () => {
+    const vm = buildPayoffRingViewModel(
+      loan({ balanceCents: 500_000, annualRateBps: 2400, minimumPaymentCents: 5_000 }),
+      0,
+      { startDateIso: START_ISO },
+    );
+    expect(vm.payoffDateLabel).toBe('No payoff at this payment');
+    expect(vm.savingsMessage).toContain('does not cover');
+  });
+});
+
+describe('formatMonthsDuration', () => {
+  it('formats years and months', () => {
+    expect(formatMonthsDuration(0)).toBe('paid off');
+    expect(formatMonthsDuration(1)).toBe('1 month');
+    expect(formatMonthsDuration(12)).toBe('1 year');
+    expect(formatMonthsDuration(14)).toBe('1 year, 2 months');
+    expect(formatMonthsDuration(null)).toBe('no payoff at this payment');
+  });
+});

--- a/apps/web/src/lib/debt/payoff.ts
+++ b/apps/web/src/lib/debt/payoff.ts
@@ -1,0 +1,512 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Single-loan debt payoff engine — the "fitness rings" payoff surface (#2175).
+ *
+ * Pure, deterministic functions powering a highly visual debt-payoff card:
+ * an amortization schedule, the estimated payoff date, total interest, payoff
+ * progress (paid principal vs. original principal), payoff milestones, and an
+ * extra-payment "what if" comparison (months saved + interest saved vs. the
+ * baseline minimum payment).
+ *
+ * Money is integer minor units (cents). Interest compounds monthly from an APR
+ * expressed in basis points. All rounding uses banker's rounding (round half to
+ * even) to avoid systematic bias. No floating-point money is ever stored or
+ * returned — every monetary value in/out is an integer number of cents.
+ *
+ * These functions are intentionally free of React, DOM, and storage concerns so
+ * they can be unit-tested in isolation and reused by other payoff surfaces.
+ *
+ * References: issue #2175
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum number of months to simulate before declaring a payment plan
+ * non-amortizing. Prevents infinite loops when the payment never retires the
+ * balance (e.g., minimum payment below the monthly interest accrual).
+ */
+export const MAX_PAYOFF_MONTHS = 1200; // 100 years
+
+/** Months per calendar year. */
+const MONTHS_PER_YEAR = 12;
+
+/** Basis-points divisor (10,000 bps = 100%). */
+const BPS_DIVISOR = 10_000;
+
+/** Floating tolerance used when detecting exact rounding ties. */
+const TIE_EPSILON = 1e-9;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Normalised input describing a single loan/debt to model. */
+export interface LoanPayoffInput {
+  /** Stable identifier (used for selection in the UI). */
+  readonly id: string;
+  /** Human-readable name (e.g., "Auto Loan"). */
+  readonly name: string;
+  /** Current outstanding balance in cents. */
+  readonly balanceCents: number;
+  /** Original principal in cents, used as the payoff-progress baseline. */
+  readonly originalPrincipalCents: number;
+  /** Annual percentage rate in basis points (1999 = 19.99%). */
+  readonly annualRateBps: number;
+  /** Baseline minimum monthly payment in cents. */
+  readonly minimumPaymentCents: number;
+}
+
+/** A single month within an amortization schedule. */
+export interface PayoffScheduleEntry {
+  /** 1-indexed month number. */
+  readonly month: number;
+  /** Payment applied this month in cents. */
+  readonly paymentCents: number;
+  /** Portion of the payment applied to principal in cents. */
+  readonly principalCents: number;
+  /** Portion of the payment applied to interest in cents. */
+  readonly interestCents: number;
+  /** Remaining balance after this payment in cents. */
+  readonly remainingBalanceCents: number;
+}
+
+/** A full payoff projection for a fixed monthly payment. */
+export interface PayoffProjection {
+  /** Fixed monthly payment modelled, in cents. */
+  readonly monthlyPaymentCents: number;
+  /** Month-by-month amortization entries (empty when already paid off). */
+  readonly schedule: readonly PayoffScheduleEntry[];
+  /** Months until paid off, or `null` if the payment never amortizes. */
+  readonly monthsToPayoff: number | null;
+  /** Total interest paid across the plan in cents. */
+  readonly totalInterestCents: number;
+  /** Total principal repaid across the plan in cents. */
+  readonly totalPrincipalCents: number;
+  /** Total amount paid (principal + interest) in cents. */
+  readonly totalPaidCents: number;
+  /** ISO date (YYYY-MM-DD) of the final payment, or `null` if non-amortizing. */
+  readonly estimatedPayoffDateIso: string | null;
+  /** Whether the balance is fully retired within the modelling horizon. */
+  readonly amortizes: boolean;
+}
+
+/** Payoff progress measured against the original principal. */
+export interface PayoffProgress {
+  readonly originalPrincipalCents: number;
+  readonly currentBalanceCents: number;
+  readonly paidPrincipalCents: number;
+  /** Percent of original principal paid off (0–100, one decimal place). */
+  readonly percentPaid: number;
+  /** Text alternative for the ring, e.g. "62% paid — $6,200 of $10,000". */
+  readonly textAlternative: string;
+  /** Whether the balance is fully cleared. */
+  readonly isPaidOff: boolean;
+}
+
+/** Supported payoff milestone thresholds. */
+export type PayoffMilestoneThreshold = 25 | 50 | 75 | 100;
+
+/** A single payoff milestone and its reached/remaining state. */
+export interface PayoffMilestone {
+  readonly thresholdPercent: PayoffMilestoneThreshold;
+  readonly isReached: boolean;
+  /** Principal still to pay before reaching this milestone (0 once reached). */
+  readonly remainingToReachCents: number;
+  /** Screen-reader friendly label (never relies on colour alone). */
+  readonly label: string;
+}
+
+/** Comparison of an extra-payment plan against the baseline minimum payment. */
+export interface ExtraPaymentComparison {
+  /** Extra payment modelled on top of the minimum, in cents. */
+  readonly extraPaymentCents: number;
+  /** Baseline projection (minimum payment only). */
+  readonly baseline: PayoffProjection;
+  /** Accelerated projection (minimum + extra payment). */
+  readonly accelerated: PayoffProjection;
+  /** Months saved vs. baseline, or `null` if either plan never amortizes. */
+  readonly monthsSaved: number | null;
+  /** Interest saved vs. baseline in cents (0 unless both plans amortize). */
+  readonly interestSavedCents: number;
+  /** Whether the comparison produces a meaningful saving to surface. */
+  readonly hasImpact: boolean;
+}
+
+/** Assembled view model for the payoff rings card. */
+export interface PayoffRingViewModel {
+  readonly input: LoanPayoffInput;
+  readonly progress: PayoffProgress;
+  /** Projection for the currently-modelled payment (minimum + extra). */
+  readonly activeProjection: PayoffProjection;
+  readonly milestones: readonly PayoffMilestone[];
+  readonly comparison: ExtraPaymentComparison;
+  /** Next unreached milestone, or `null` when all are reached. */
+  readonly nextMilestone: PayoffMilestone | null;
+  /** Composite aria-label describing the ring, payoff date, and savings. */
+  readonly ringAriaLabel: string;
+  /** Human-readable estimated payoff date ("Mar 2031" / fallback copy). */
+  readonly payoffDateLabel: string;
+  /** Human-readable remaining duration ("3 years, 2 months"). */
+  readonly payoffDurationLabel: string;
+  /** Interest-saved messaging for the active extra-payment scenario. */
+  readonly savingsMessage: string;
+}
+
+// ---------------------------------------------------------------------------
+// Rounding & formatting helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Rounds to the nearest integer using banker's rounding (round half to even /
+ * IEEE 754 HALF_EVEN). Exact ties resolve toward the nearest even integer.
+ *
+ *   bankersRound(0.5) → 0
+ *   bankersRound(1.5) → 2
+ *   bankersRound(2.5) → 2
+ *   bankersRound(3.5) → 4
+ */
+export function bankersRound(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  const floor = Math.floor(value);
+  const fraction = value - floor;
+  if (Math.abs(fraction - 0.5) < TIE_EPSILON) {
+    return floor % 2 === 0 ? floor : floor + 1;
+  }
+  return Math.round(value);
+}
+
+/** Rounds a percentage to a single decimal place. */
+function roundToOneDecimal(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/**
+ * Formats an integer cent amount as a US dollar string. Whole-dollar amounts
+ * omit the trailing cents (e.g. "$10,000"); fractional amounts keep two
+ * decimals (e.g. "$3,800.50"). Used for ring text alternatives and labels.
+ */
+export function formatUsdCents(cents: number): string {
+  const safe = Number.isFinite(cents) ? Math.round(cents) : 0;
+  const sign = safe < 0 ? '-' : '';
+  const abs = Math.abs(safe);
+  const dollars = Math.floor(abs / 100);
+  const remainder = abs % 100;
+  const dollarText = dollars.toLocaleString('en-US');
+  return remainder === 0
+    ? `${sign}$${dollarText}`
+    : `${sign}$${dollarText}.${remainder.toString().padStart(2, '0')}`;
+}
+
+/** Formats a percentage, dropping a redundant trailing ".0". */
+export function formatPercent(value: number): string {
+  const rounded = roundToOneDecimal(value);
+  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
+}
+
+/** Formats an ISO date (YYYY-MM-DD) as "Mon YYYY" in UTC. */
+export function formatMonthYear(dateIso: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${dateIso}T00:00:00.000Z`));
+}
+
+/** Formats a number of months as a friendly duration string. */
+export function formatMonthsDuration(months: number | null): string {
+  if (months === null) return 'no payoff at this payment';
+  if (months <= 0) return 'paid off';
+  const years = Math.floor(months / MONTHS_PER_YEAR);
+  const remainingMonths = months % MONTHS_PER_YEAR;
+  const parts: string[] = [];
+  if (years > 0) parts.push(`${years} year${years === 1 ? '' : 's'}`);
+  if (remainingMonths > 0) {
+    parts.push(`${remainingMonths} month${remainingMonths === 1 ? '' : 's'}`);
+  }
+  return parts.join(', ');
+}
+
+/**
+ * Adds a whole number of months to an ISO date (YYYY-MM-DD), in UTC.
+ * Returns the resulting ISO date string.
+ */
+export function addMonthsToIso(startIso: string, months: number): string {
+  const [year, month, day] = startIso.split('-').map((part) => Number.parseInt(part, 10));
+  const safeYear = Number.isFinite(year) ? year : 1970;
+  const safeMonth = Number.isFinite(month) ? Math.max(1, month) : 1;
+  const safeDay = Number.isFinite(day) ? Math.max(1, day) : 1;
+  const date = new Date(Date.UTC(safeYear, safeMonth - 1, safeDay));
+  date.setUTCMonth(date.getUTCMonth() + Math.max(0, Math.round(months)));
+  return date.toISOString().slice(0, 10);
+}
+
+/** Returns today's date as an ISO (YYYY-MM-DD) string in UTC. */
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Core calculations
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculates one month of interest on a balance in cents using monthly
+ * compounding derived from an APR in basis points. Result is banker's-rounded.
+ */
+export function monthlyInterestCents(balanceCents: number, annualRateBps: number): number {
+  if (balanceCents <= 0 || annualRateBps <= 0) return 0;
+  const monthlyRate = annualRateBps / BPS_DIVISOR / MONTHS_PER_YEAR;
+  return bankersRound(balanceCents * monthlyRate);
+}
+
+/** Normalises the original principal so it is never below the current balance. */
+function normalizeOriginalPrincipal(input: LoanPayoffInput): number {
+  return Math.max(0, input.originalPrincipalCents, Math.max(0, input.balanceCents));
+}
+
+/**
+ * Builds a full amortization projection for a fixed monthly payment.
+ *
+ * Handles the key edge cases:
+ *  - Already paid off (balance ≤ 0) → zero-month, fully-amortized result.
+ *  - 0% APR → pure principal reduction.
+ *  - Non-amortizing payment (≤ monthly interest) → `amortizes: false`,
+ *    `monthsToPayoff: null`, `estimatedPayoffDateIso: null`.
+ *
+ * @param input Loan to amortize.
+ * @param monthlyPaymentCents Fixed monthly payment in cents.
+ * @param options Optional anchor date for the estimated payoff date.
+ */
+export function projectPayoff(
+  input: LoanPayoffInput,
+  monthlyPaymentCents: number,
+  options: { readonly startDateIso?: string } = {},
+): PayoffProjection {
+  const startIso = options.startDateIso ?? todayIso();
+  const payment = Math.max(0, Math.round(monthlyPaymentCents));
+  let balance = Math.max(0, Math.round(input.balanceCents));
+
+  if (balance <= 0) {
+    return {
+      monthlyPaymentCents: payment,
+      schedule: [],
+      monthsToPayoff: 0,
+      totalInterestCents: 0,
+      totalPrincipalCents: 0,
+      totalPaidCents: 0,
+      estimatedPayoffDateIso: startIso,
+      amortizes: true,
+    };
+  }
+
+  const schedule: PayoffScheduleEntry[] = [];
+  let totalInterest = 0;
+  let totalPrincipal = 0;
+  let totalPaid = 0;
+  let month = 0;
+  let amortizes = false;
+
+  while (balance > 0 && month < MAX_PAYOFF_MONTHS) {
+    const interest = monthlyInterestCents(balance, input.annualRateBps);
+    const appliedPayment = Math.min(payment, balance + interest);
+    const principal = Math.max(0, appliedPayment - interest);
+
+    // The payment does not cover interest — the balance can never shrink.
+    if (principal <= 0) {
+      break;
+    }
+
+    month += 1;
+    balance = Math.max(0, balance - principal);
+    totalInterest += interest;
+    totalPrincipal += principal;
+    totalPaid += appliedPayment;
+    schedule.push({
+      month,
+      paymentCents: appliedPayment,
+      principalCents: principal,
+      interestCents: interest,
+      remainingBalanceCents: balance,
+    });
+
+    if (balance <= 0) {
+      amortizes = true;
+      break;
+    }
+  }
+
+  if (!amortizes) {
+    return {
+      monthlyPaymentCents: payment,
+      schedule,
+      monthsToPayoff: null,
+      totalInterestCents: totalInterest,
+      totalPrincipalCents: totalPrincipal,
+      totalPaidCents: totalPaid,
+      estimatedPayoffDateIso: null,
+      amortizes: false,
+    };
+  }
+
+  return {
+    monthlyPaymentCents: payment,
+    schedule,
+    monthsToPayoff: month,
+    totalInterestCents: totalInterest,
+    totalPrincipalCents: totalPrincipal,
+    totalPaidCents: totalPaid,
+    estimatedPayoffDateIso: addMonthsToIso(startIso, month),
+    amortizes: true,
+  };
+}
+
+/** Computes payoff progress (paid principal vs. original principal). */
+export function calculatePayoffProgress(input: LoanPayoffInput): PayoffProgress {
+  const original = normalizeOriginalPrincipal(input);
+  const current = Math.max(0, Math.round(input.balanceCents));
+  const paid = Math.max(0, original - current);
+  const percentPaid = original > 0 ? roundToOneDecimal((paid * 100) / original) : 100;
+  return {
+    originalPrincipalCents: original,
+    currentBalanceCents: current,
+    paidPrincipalCents: paid,
+    percentPaid,
+    textAlternative: `${formatPercent(percentPaid)} paid — ${formatUsdCents(paid)} of ${formatUsdCents(original)}`,
+    isPaidOff: current <= 0,
+  };
+}
+
+const MILESTONE_THRESHOLDS: readonly PayoffMilestoneThreshold[] = [25, 50, 75, 100];
+
+/** Computes the payoff milestone ladder (25/50/75/100% of principal repaid). */
+export function calculatePayoffMilestones(input: LoanPayoffInput): readonly PayoffMilestone[] {
+  const progress = calculatePayoffProgress(input);
+  const original = progress.originalPrincipalCents;
+  return MILESTONE_THRESHOLDS.map((thresholdPercent) => {
+    const isReached = progress.percentPaid >= thresholdPercent;
+    const targetPaidCents = Math.ceil((thresholdPercent / 100) * original);
+    const remainingToReachCents = isReached
+      ? 0
+      : Math.max(0, targetPaidCents - progress.paidPrincipalCents);
+    return {
+      thresholdPercent,
+      isReached,
+      remainingToReachCents,
+      label: isReached
+        ? `${thresholdPercent}% paid off — milestone reached`
+        : `${thresholdPercent}% paid off — ${formatUsdCents(remainingToReachCents)} to go`,
+    };
+  });
+}
+
+/**
+ * Compares an extra-payment plan against the baseline minimum payment,
+ * returning months saved and interest saved.
+ */
+export function compareExtraPayment(
+  input: LoanPayoffInput,
+  extraPaymentCents: number,
+  options: { readonly startDateIso?: string } = {},
+): ExtraPaymentComparison {
+  const extra = Math.max(0, Math.round(extraPaymentCents));
+  const baseline = projectPayoff(input, input.minimumPaymentCents, options);
+  const accelerated = projectPayoff(input, input.minimumPaymentCents + extra, options);
+
+  const monthsSaved =
+    baseline.monthsToPayoff !== null && accelerated.monthsToPayoff !== null
+      ? Math.max(0, baseline.monthsToPayoff - accelerated.monthsToPayoff)
+      : null;
+
+  const interestSavedCents =
+    baseline.amortizes && accelerated.amortizes
+      ? Math.max(0, baseline.totalInterestCents - accelerated.totalInterestCents)
+      : 0;
+
+  const hasImpact =
+    extra > 0 && baseline.amortizes && accelerated.amortizes && interestSavedCents > 0;
+
+  return {
+    extraPaymentCents: extra,
+    baseline,
+    accelerated,
+    monthsSaved,
+    interestSavedCents,
+    hasImpact,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// View model assembly
+// ---------------------------------------------------------------------------
+
+function buildSavingsMessage(comparison: ExtraPaymentComparison): string {
+  if (!comparison.baseline.amortizes) {
+    return 'Your minimum payment does not cover the monthly interest, so the balance will keep growing. Increase the payment to start making progress.';
+  }
+  if (comparison.extraPaymentCents <= 0) {
+    return 'Add an extra monthly payment to see how much interest and time you could save.';
+  }
+  if (!comparison.hasImpact) {
+    return `An extra ${formatUsdCents(comparison.extraPaymentCents)} per month does not change this payoff.`;
+  }
+  const months = comparison.monthsSaved ?? 0;
+  const monthsText =
+    months > 0 ? `${formatMonthsDuration(months)} sooner` : 'the same payoff timeline';
+  return `An extra ${formatUsdCents(comparison.extraPaymentCents)} per month pays this off ${monthsText} and saves ${formatUsdCents(comparison.interestSavedCents)} in interest.`;
+}
+
+/**
+ * Assembles the complete payoff-rings view model for a single loan and a chosen
+ * extra payment. Keeps the React component thin and fully unit-testable.
+ */
+export function buildPayoffRingViewModel(
+  input: LoanPayoffInput,
+  extraPaymentCents: number,
+  options: { readonly startDateIso?: string } = {},
+): PayoffRingViewModel {
+  const progress = calculatePayoffProgress(input);
+  const milestones = calculatePayoffMilestones(input);
+  const comparison = compareExtraPayment(input, extraPaymentCents, options);
+  const activeProjection =
+    comparison.extraPaymentCents > 0 ? comparison.accelerated : comparison.baseline;
+  const nextMilestone = milestones.find((milestone) => !milestone.isReached) ?? null;
+
+  const payoffDateLabel = progress.isPaidOff
+    ? 'Paid off'
+    : activeProjection.estimatedPayoffDateIso
+      ? formatMonthYear(activeProjection.estimatedPayoffDateIso)
+      : 'No payoff at this payment';
+
+  const payoffDurationLabel = progress.isPaidOff
+    ? 'Paid off'
+    : formatMonthsDuration(activeProjection.monthsToPayoff);
+
+  const savingsMessage = buildSavingsMessage(comparison);
+
+  const payoffPhrase = progress.isPaidOff
+    ? 'This debt is paid off.'
+    : activeProjection.estimatedPayoffDateIso
+      ? `Estimated payoff ${payoffDateLabel}.`
+      : 'No payoff date at the current payment.';
+
+  const savingsPhrase = comparison.hasImpact
+    ? ` Extra payments save ${formatUsdCents(comparison.interestSavedCents)} in interest.`
+    : '';
+
+  return {
+    input,
+    progress,
+    activeProjection,
+    milestones,
+    comparison,
+    nextMilestone,
+    ringAriaLabel: `${input.name} payoff ring: ${progress.textAlternative}. ${payoffPhrase}${savingsPhrase}`,
+    payoffDateLabel,
+    payoffDurationLabel,
+    savingsMessage,
+  };
+}

--- a/apps/web/src/pages/DebtPage.test.tsx
+++ b/apps/web/src/pages/DebtPage.test.tsx
@@ -131,9 +131,10 @@ describe('DebtPage', () => {
     expect(screen.getByText('Debt Management')).toBeDefined();
   });
 
-  it('renders all four tabs', () => {
+  it('renders all five tabs', () => {
     render(<DebtPage />);
     expect(screen.getByText('Payoff Planner')).toBeDefined();
+    expect(screen.getByText('Payoff Rings')).toBeDefined();
     expect(screen.getByText('BNPL Dashboard')).toBeDefined();
     expect(screen.getByText('Student Loans')).toBeDefined();
     expect(screen.getByText('Credit Cards')).toBeDefined();
@@ -334,10 +335,29 @@ describe('DebtPage', () => {
     expect(tablist).toBeDefined();
 
     const tabs = screen.getAllByRole('tab');
-    expect(tabs).toHaveLength(4);
+    expect(tabs).toHaveLength(5);
 
     const tabpanel = screen.getByRole('tabpanel');
     expect(tabpanel).toBeDefined();
+  });
+
+  it('shows the payoff rings surface with payoff date and milestones', () => {
+    mockUseAccountsState.accounts = [
+      buildAccount({
+        id: 'auto-1',
+        name: 'Auto Loan',
+        type: 'LOAN',
+        currentBalance: { amount: -620_000 },
+      }),
+    ];
+    render(<DebtPage />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Payoff Rings' }));
+
+    expect(screen.getByText('Payoff Rings', { selector: 'h2' })).toBeDefined();
+    expect(screen.getByRole('img').getAttribute('aria-label')).toContain('Auto Loan');
+    expect(screen.getByText('Estimated payoff date')).toBeDefined();
+    expect(screen.getByText('Milestones')).toBeDefined();
+    expect(screen.getByLabelText('Extra monthly payment ($)')).toBeDefined();
   });
 
   it('tab panel is labeled by its tab', () => {

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -82,15 +82,19 @@ import {
   type RefinanceBaselineId,
 } from '../lib/debt/refinance-baseline-options';
 import type { Account } from '../kmp/bridge';
+// Imported directly (not via a shared barrel) so it stays code-split into the
+// lazy Debt page chunk and does not inflate other route bundles (#2175).
+import { DebtPayoffRings } from '../components/debt/DebtPayoffRings';
 
 // ---------------------------------------------------------------------------
 // Tab types
 // ---------------------------------------------------------------------------
 
-type DebtTab = 'payoff' | 'bnpl' | 'student-loans' | 'credit-cards';
+type DebtTab = 'payoff' | 'payoff-rings' | 'bnpl' | 'student-loans' | 'credit-cards';
 
 const TAB_LABELS: Record<DebtTab, string> = {
   payoff: 'Payoff Planner',
+  'payoff-rings': 'Payoff Rings',
   bnpl: 'BNPL Dashboard',
   'student-loans': 'Student Loans',
   'credit-cards': 'Credit Cards',
@@ -461,12 +465,35 @@ export function DebtPage(): React.ReactElement {
         className="debt-page__panel"
       >
         {activeTab === 'payoff' && <PayoffPlannerPanel />}
+        {activeTab === 'payoff-rings' && <PayoffRingsPanel />}
         {activeTab === 'bnpl' && <BnplDashboardPanel />}
         {activeTab === 'student-loans' && <StudentLoanPanel />}
         {activeTab === 'credit-cards' && <CreditCardPanel />}
       </div>
     </section>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Payoff Rings panel (#2175)
+// ---------------------------------------------------------------------------
+
+/**
+ * Dedicated "fitness rings" payoff surface. Visualises payoff progress,
+ * estimated payoff date, milestones, and an extra-payment what-if comparison
+ * for each loan/debt account derived from local account data.
+ */
+function PayoffRingsPanel(): React.ReactElement {
+  const { accounts } = useAccounts();
+  const todayIso = useMemo(() => new Date().toISOString().slice(0, 10), []);
+  const debts = useMemo(
+    () =>
+      accounts
+        .map(accountToDebt)
+        .filter((debt): debt is Debt => debt !== null && debt.balanceCents > 0),
+    [accounts],
+  );
+  return <DebtPayoffRings debts={debts} todayIso={todayIso} />;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a dedicated, highly visual **"fitness rings"** debt-payoff surface to the web Debt page (issue #2175, web slice).

For any loan/debt account derived from local account data, users get a payoff progress ring, an estimated payoff date, payoff milestones, and an extra-payment "what if" comparison.

## What changed

### Pure engine ? `apps/web/src/lib/debt/payoff.ts`
Integer minor units (cents), banker's rounding (round half to even), monthly compounding from APR (basis points). No floating-point money. Pure, deterministic, fully unit-tested:
- single-loan amortization schedule
- estimated payoff date + time remaining
- total interest / total principal / total paid
- payoff progress % (paid principal vs. original principal) with a text alternative
- payoff milestone ladder (25 / 50 / 75 / 100%)
- extra-payment comparison: **months saved** + **interest saved** vs. the baseline minimum payment
- edge cases: 0% APR, already-paid, and never-amortizing minimum payment (payment <= monthly interest)

### Accessible UI ? `apps/web/src/components/debt/DebtPayoffRings.tsx` (+ CSS)
Surfaced via a new **"Payoff Rings"** tab on the existing Debt page.
- progress ring is an `img` with a full text alternative (e.g. `38% paid ? $3,800 of $10,000`)
- **no colour-only signalling** ? milestones use icon + "Reached" / "In progress" text
- labelled `select` (debt picker) and `number` input (extra payment)
- computed what-if results announced via `role="status"` / `aria-live="polite"`
- keyboard-navigable; ring animation disabled under `prefers-reduced-motion`; dark-mode tokens

### Integration
- Imported **directly** into the lazy `DebtPage` (not a shared barrel) so it stays code-split into that route chunk. Verified: the component lands in the `route-planning` chunk (~53 KB gzip), well under the 215 KB lazy-chunk budget; `perf:budget` passes.
- All data access goes through the `useAccounts` hook (no direct repository imports).

## Testing
- `apps/web/src/lib/debt/payoff.test.ts` ? 29 engine tests (known amortization values, rounding ties, edge cases)
- `apps/web/src/components/debt/DebtPayoffRings.test.tsx` ? 7 render/interaction tests
- `apps/web/src/pages/DebtPage.test.tsx` ? updated tab assertions + new Payoff Rings integration test
- prettier + eslint (`--max-warnings 0`) clean; `tsc --noEmit` clean for the changed files; production build + perf budget pass locally

## Out of scope (follow-ups)
iOS / Android / Windows / widget / watch milestone surfaces remain to be implemented as their own platform slices.

Refs #2175
