### PR TITLE
feat(web): group gig payouts by platform in cash flow (#2133)

### DIFF
--- a/apps/web/src/components/gig/GigPlatformEarningsSection.test.tsx
+++ b/apps/web/src/components/gig/GigPlatformEarningsSection.test.tsx
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Render tests for GigPlatformEarningsSection.
+ *
+ * Mocks the useGigPlatformEarnings hook (not repositories) per project
+ * conventions. Reconciliation/percent helpers run for real (pure functions).
+ *
+ * References: issue #2133
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+
+vi.mock('../../hooks/useGigPlatformEarnings', () => ({
+  useGigPlatformEarnings: vi.fn(),
+}));
+
+vi.mock('../charts/chart-palette', () => ({
+  CHART_COLORS: ['#648FFF', '#FE6100', '#785EF0', '#FFB000', '#DC267F', '#009E73'],
+}));
+
+import { GigPlatformEarningsSection } from './GigPlatformEarningsSection';
+import { useGigPlatformEarnings } from '../../hooks/useGigPlatformEarnings';
+import type { UseGigPlatformEarningsResult } from '../../hooks/useGigPlatformEarnings';
+
+const mockHook = vi.mocked(useGigPlatformEarnings);
+
+function baseResult(
+  overrides: Partial<UseGigPlatformEarningsResult> = {},
+): UseGigPlatformEarningsResult {
+  return {
+    earnings: {
+      platforms: [
+        {
+          platform: 'Uber',
+          amounts: { today: 5000, week: 8000, month: 12000 },
+          counts: { today: 1, week: 2, month: 3 },
+        },
+        {
+          platform: 'DoorDash',
+          amounts: { today: 0, week: 2000, month: 6000 },
+          counts: { today: 0, week: 1, month: 2 },
+        },
+      ],
+      combined: { today: 5000, week: 10000, month: 18000 },
+      combinedCounts: { today: 1, week: 3, month: 5 },
+    },
+    rules: [
+      {
+        id: 'builtin-uber',
+        platform: 'Uber',
+        matchField: 'any',
+        keywords: ['uber'],
+        enabled: true,
+        isBuiltIn: true,
+        createdAt: '1970-01-01T00:00:00.000Z',
+      },
+    ],
+    expectedPayouts: { Uber: 12000 },
+    knownPlatforms: ['DoorDash', 'Uber'],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    addRule: vi.fn(),
+    toggleRule: vi.fn(),
+    removeRule: vi.fn(),
+    setExpectedPayout: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('GigPlatformEarningsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a loading state', () => {
+    mockHook.mockReturnValue(baseResult({ loading: true }));
+    render(<GigPlatformEarningsSection />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows an error alert', () => {
+    mockHook.mockReturnValue(baseResult({ loading: false, error: 'boom' }));
+    render(<GigPlatformEarningsSection />);
+    expect(screen.getByRole('alert')).toHaveTextContent('boom');
+  });
+
+  it('renders the heading, period tabs and combined live region', () => {
+    mockHook.mockReturnValue(baseResult());
+    render(<GigPlatformEarningsSection />);
+    expect(screen.getByRole('heading', { name: 'Gig Platform Earnings' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Today' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'This week' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'This month' })).toBeInTheDocument();
+    // combined total lives in an aria-live region
+    expect(screen.getByText(/Combined today earnings:/i)).toBeInTheDocument();
+  });
+
+  it('renders the by-platform breakdown', () => {
+    mockHook.mockReturnValue(baseResult());
+    render(<GigPlatformEarningsSection />);
+    const list = screen.getByRole('list', { name: 'Earnings by gig platform' });
+    expect(within(list).getByText('Uber')).toBeInTheDocument();
+    expect(within(list).getByText('DoorDash')).toBeInTheDocument();
+    // progressbars carry a text alternative for the bar
+    expect(
+      screen.getByRole('progressbar', { name: /Uber: \d+% of gig earnings/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('switches period when a tab is clicked and updates reconciliation caption', () => {
+    mockHook.mockReturnValue(baseResult());
+    render(<GigPlatformEarningsSection />);
+    // default period today → reconciliation caption mentions today
+    expect(screen.getByText(/deposit received \(today\)/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: 'This month' }));
+    expect(screen.getByRole('tab', { name: 'This month' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByText(/deposit received \(this month\)/i)).toBeInTheDocument();
+  });
+
+  it('filters the breakdown by platform', () => {
+    mockHook.mockReturnValue(baseResult());
+    render(<GigPlatformEarningsSection />);
+    const filter = screen.getByLabelText('Filter by platform');
+    fireEvent.change(filter, { target: { value: 'Uber' } });
+    const list = screen.getByRole('list', { name: 'Earnings by gig platform' });
+    expect(within(list).getByText('Uber')).toBeInTheDocument();
+    expect(within(list).queryByText('DoorDash')).not.toBeInTheDocument();
+  });
+
+  it('renders a reconciliation table with status and an editable expected input', () => {
+    mockHook.mockReturnValue(baseResult());
+    render(<GigPlatformEarningsSection />);
+    const table = screen.getByRole('table');
+    // Uber expected 12000c vs received today 5000c → Short
+    expect(within(table).getByText('Short')).toBeInTheDocument();
+    expect(screen.getByLabelText('Expected payout for Uber')).toBeInTheDocument();
+  });
+
+  it('commits an expected-payout edit on blur', () => {
+    const setExpectedPayout = vi.fn();
+    mockHook.mockReturnValue(baseResult({ setExpectedPayout }));
+    render(<GigPlatformEarningsSection />);
+    const input = screen.getByLabelText('Expected payout for Uber');
+    fireEvent.change(input, { target: { value: '75.50' } });
+    fireEvent.blur(input);
+    expect(setExpectedPayout).toHaveBeenCalledWith('Uber', 7550);
+  });
+
+  it('exposes a rule manager disclosure with the mapping rules', () => {
+    mockHook.mockReturnValue(baseResult());
+    render(<GigPlatformEarningsSection />);
+    expect(screen.getByText('Manage platform mapping rules')).toBeInTheDocument();
+    const ruleList = screen.getByRole('list', { name: 'Platform mapping rules' });
+    expect(within(ruleList).getByText('Uber')).toBeInTheDocument();
+    expect(screen.getByLabelText('Add a platform mapping rule')).toBeInTheDocument();
+  });
+
+  it('adds a rule through the form', () => {
+    const addRule = vi.fn().mockReturnValue({ id: 'x' });
+    mockHook.mockReturnValue(baseResult({ addRule }));
+    render(<GigPlatformEarningsSection />);
+    fireEvent.change(screen.getByLabelText('Platform name'), { target: { value: 'Shipt' } });
+    fireEvent.change(screen.getByLabelText('Keywords (comma separated)'), {
+      target: { value: 'shipt, shopt' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add rule' }));
+    expect(addRule).toHaveBeenCalledWith({
+      platform: 'Shipt',
+      matchField: 'any',
+      keywords: ['shipt', 'shopt'],
+    });
+  });
+});

--- a/apps/web/src/components/gig/GigPlatformEarningsSection.tsx
+++ b/apps/web/src/components/gig/GigPlatformEarningsSection.tsx
@@ -1,0 +1,533 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * GigPlatformEarningsSection — surfaces gig-platform payouts (Uber, DoorDash,
+ * Instacart, Lyft, Grubhub, ...) inside the Cash Flow page.
+ *
+ * Features:
+ *   - period segmented control (today / this week / this month) as accessible tabs,
+ *   - combined cross-platform total with an aria-live announcement,
+ *   - by-platform breakdown (the by-platform "Income Sources" view) with text
+ *     amounts + percentages (no colour-only signalling),
+ *   - expected-vs-received reconciliation in a real data table,
+ *   - a platform filter, and
+ *   - a disclosure to manage the mapping rules.
+ *
+ * Data access goes exclusively through the {@link useGigPlatformEarnings} hook;
+ * aggregation lives in the pure platform-earnings engine.
+ *
+ * Imported DIRECTLY by CashFlowPage (not via a shared barrel) so it stays in
+ * the code-split Cash Flow chunk and does not inflate other route bundles.
+ *
+ * References: issue #2133
+ */
+
+import React, { useId, useMemo, useState } from 'react';
+
+import { CHART_COLORS } from '../charts/chart-palette';
+import { CurrencyDisplay } from '../common/CurrencyDisplay';
+import { useGigPlatformEarnings } from '../../hooks/useGigPlatformEarnings';
+import { formatCentsDisplay, parseAmountInput } from '../../hooks/useAmountInput';
+import { platformPercent, reconcilePlatformPayouts } from '../../lib/gig/platform-earnings';
+import type {
+  GigMatchField,
+  GigPeriodKey,
+  PlatformEarnings,
+  PlatformEarningsResult,
+  PlatformReconciliation,
+} from '../../lib/gig/platform-types';
+import './gig-platform.css';
+
+const ALL_PLATFORMS = '__all__';
+
+const PERIODS: { key: GigPeriodKey; label: string }[] = [
+  { key: 'today', label: 'Today' },
+  { key: 'week', label: 'This week' },
+  { key: 'month', label: 'This month' },
+];
+
+const MATCH_FIELDS: { value: GigMatchField; label: string }[] = [
+  { value: 'any', label: 'Any field' },
+  { value: 'payee', label: 'Payee' },
+  { value: 'description', label: 'Description' },
+  { value: 'account', label: 'Account' },
+];
+
+// ---------------------------------------------------------------------------
+// Period tabs
+// ---------------------------------------------------------------------------
+
+interface PeriodTabsProps {
+  value: GigPeriodKey;
+  onChange: (period: GigPeriodKey) => void;
+  baseId: string;
+}
+
+const PeriodTabs: React.FC<PeriodTabsProps> = ({ value, onChange, baseId }) => (
+  <div className="analytics-period-selector" role="tablist" aria-label="Earnings period">
+    {PERIODS.map((period) => {
+      const selected = value === period.key;
+      return (
+        <button
+          key={period.key}
+          type="button"
+          role="tab"
+          id={`${baseId}-tab-${period.key}`}
+          aria-selected={selected}
+          aria-controls={`${baseId}-panel`}
+          tabIndex={selected ? 0 : -1}
+          className={`analytics-period-selector__btn ${
+            selected ? 'analytics-period-selector__btn--active' : ''
+          }`}
+          onClick={() => onChange(period.key)}
+        >
+          {period.label}
+        </button>
+      );
+    })}
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Breakdown list
+// ---------------------------------------------------------------------------
+
+interface PlatformBreakdownProps {
+  platforms: PlatformEarnings[];
+  result: PlatformEarningsResult;
+  period: GigPeriodKey;
+}
+
+const PlatformBreakdown: React.FC<PlatformBreakdownProps> = ({ platforms, result, period }) => {
+  if (platforms.length === 0) {
+    return (
+      <p className="gig-empty">
+        No gig-platform earnings for this period. Map payees, descriptions, or accounts to a
+        platform below to start tracking payouts.
+      </p>
+    );
+  }
+
+  return (
+    <div className="analytics-breakdown" role="list" aria-label="Earnings by gig platform">
+      {platforms.map((platform, idx) => {
+        const amount = platform.amounts[period];
+        const count = platform.counts[period];
+        const percent = platformPercent(platform, result, period);
+        const color = CHART_COLORS[idx % CHART_COLORS.length];
+        return (
+          <div key={platform.platform} className="analytics-breakdown__item" role="listitem">
+            <div className="analytics-breakdown__bar-wrapper">
+              <div className="analytics-breakdown__header">
+                <span className="analytics-breakdown__name">
+                  {platform.platform}
+                  <span className="analytics-breakdown__amount">
+                    {' '}
+                    · {count} {count === 1 ? 'payout' : 'payouts'}
+                  </span>
+                </span>
+                <span className="analytics-breakdown__amount">
+                  <CurrencyDisplay amount={amount} context={`${platform.platform} earnings`} />
+                </span>
+              </div>
+              <div
+                className="analytics-breakdown__track"
+                role="progressbar"
+                aria-valuenow={percent}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${platform.platform}: ${percent}% of gig earnings`}
+              >
+                <div
+                  className="analytics-breakdown__fill"
+                  style={{ width: `${percent}%`, backgroundColor: color }}
+                />
+              </div>
+            </div>
+            <span className="analytics-breakdown__percent">{percent}%</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Reconciliation
+// ---------------------------------------------------------------------------
+
+const STATUS_META: Record<
+  PlatformReconciliation['status'],
+  { label: string; symbol: string; className: string }
+> = {
+  matched: { label: 'On track', symbol: '✓', className: 'gig-status--matched' },
+  over: { label: 'Over expected', symbol: '▲', className: 'gig-status--over' },
+  under: { label: 'Short', symbol: '▼', className: 'gig-status--under' },
+  pending: { label: 'Awaiting deposit', symbol: '…', className: 'gig-status--pending' },
+};
+
+interface ReconciliationRowProps {
+  row: PlatformReconciliation;
+  onCommit: (platform: string, cents: number) => void;
+}
+
+const ReconciliationRow: React.FC<ReconciliationRowProps> = ({ row, onCommit }) => {
+  const initial = row.expectedCents > 0 ? formatCentsDisplay(row.expectedCents, '$') : '';
+  const [draft, setDraft] = useState(initial);
+  const status = STATUS_META[row.status];
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    const cents = trimmed === '' ? 0 : parseAmountInput(trimmed, 2, false);
+    onCommit(row.platform, cents);
+  };
+
+  return (
+    <tr>
+      <th scope="row">{row.platform}</th>
+      <td className="gig-num">
+        <input
+          className="gig-input"
+          type="text"
+          inputMode="decimal"
+          aria-label={`Expected payout for ${row.platform}`}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              commit();
+            }
+          }}
+        />
+      </td>
+      <td className="gig-num">
+        <CurrencyDisplay amount={row.receivedCents} context={`${row.platform} received`} />
+      </td>
+      <td className="gig-num">
+        <CurrencyDisplay amount={row.varianceCents} showSign context={`${row.platform} variance`} />
+      </td>
+      <td>
+        <span className={`gig-status ${status.className}`}>
+          <span className="gig-status__symbol" aria-hidden="true">
+            {status.symbol}
+          </span>
+          {status.label}
+        </span>
+      </td>
+    </tr>
+  );
+};
+
+interface ReconciliationTableProps {
+  rows: PlatformReconciliation[];
+  period: GigPeriodKey;
+  onCommit: (platform: string, cents: number) => void;
+}
+
+const PERIOD_NOUN: Record<GigPeriodKey, string> = {
+  today: 'today',
+  week: 'this week',
+  month: 'this month',
+};
+
+const ReconciliationTable: React.FC<ReconciliationTableProps> = ({ rows, period, onCommit }) => {
+  if (rows.length === 0) {
+    return (
+      <p className="gig-empty">
+        Enter an expected payout for a platform to reconcile it against the deposits received{' '}
+        {PERIOD_NOUN[period]}.
+      </p>
+    );
+  }
+  return (
+    <div className="gig-table-wrapper">
+      <table className="gig-table">
+        <caption>Expected payout vs. deposit received ({PERIOD_NOUN[period]})</caption>
+        <thead>
+          <tr>
+            <th scope="col">Platform</th>
+            <th scope="col" className="gig-num">
+              Expected
+            </th>
+            <th scope="col" className="gig-num">
+              Received
+            </th>
+            <th scope="col" className="gig-num">
+              Variance
+            </th>
+            <th scope="col">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <ReconciliationRow key={row.platform} row={row} onCommit={onCommit} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Rule manager
+// ---------------------------------------------------------------------------
+
+interface RuleManagerProps {
+  rules: ReturnType<typeof useGigPlatformEarnings>['rules'];
+  onAdd: ReturnType<typeof useGigPlatformEarnings>['addRule'];
+  onToggle: (id: string) => void;
+  onRemove: (id: string) => boolean;
+  baseId: string;
+}
+
+const RuleManager: React.FC<RuleManagerProps> = ({ rules, onAdd, onToggle, onRemove, baseId }) => {
+  const [platform, setPlatform] = useState('');
+  const [field, setField] = useState<GigMatchField>('any');
+  const [keywords, setKeywords] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const keywordList = keywords
+      .split(',')
+      .map((k) => k.trim())
+      .filter((k) => k.length > 0);
+    if (!platform.trim()) {
+      setFormError('Enter a platform name.');
+      return;
+    }
+    if (keywordList.length === 0) {
+      setFormError('Enter at least one keyword.');
+      return;
+    }
+    const created = onAdd({ platform: platform.trim(), matchField: field, keywords: keywordList });
+    if (created) {
+      setPlatform('');
+      setKeywords('');
+      setField('any');
+      setFormError(null);
+    } else {
+      setFormError('Could not create the rule.');
+    }
+  };
+
+  return (
+    <details className="gig-rules">
+      <summary className="gig-rules__summary">Manage platform mapping rules</summary>
+
+      <ul className="gig-rule-list" aria-label="Platform mapping rules">
+        {rules.map((rule) => {
+          const toggleId = `${baseId}-rule-${rule.id}`;
+          return (
+            <li key={rule.id} className="gig-rule-item">
+              <span className="gig-rule-item__name">{rule.platform}</span>
+              <span className="gig-rule-item__meta">
+                {rule.matchField} contains {rule.keywords.join(', ')}
+                {rule.isBuiltIn ? ' (built-in)' : ''}
+              </span>
+              <span className="gig-toggle">
+                <input
+                  id={toggleId}
+                  type="checkbox"
+                  checked={rule.enabled}
+                  onChange={() => onToggle(rule.id)}
+                />
+                <label htmlFor={toggleId}>Enabled</label>
+              </span>
+              <button
+                type="button"
+                className="gig-btn"
+                onClick={() => onRemove(rule.id)}
+                aria-label={`Remove ${rule.platform} rule`}
+              >
+                Remove
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <form className="gig-rule-form" onSubmit={submit} aria-label="Add a platform mapping rule">
+        <div className="gig-field">
+          <label className="gig-field__label" htmlFor={`${baseId}-new-platform`}>
+            Platform name
+          </label>
+          <input
+            id={`${baseId}-new-platform`}
+            className="gig-input"
+            style={{ width: '12rem', textAlign: 'left' }}
+            type="text"
+            value={platform}
+            onChange={(e) => setPlatform(e.target.value)}
+            placeholder="e.g. Shipt"
+          />
+        </div>
+        <div className="gig-field">
+          <label className="gig-field__label" htmlFor={`${baseId}-new-field`}>
+            Match field
+          </label>
+          <select
+            id={`${baseId}-new-field`}
+            className="gig-select"
+            value={field}
+            onChange={(e) => setField(e.target.value as GigMatchField)}
+          >
+            {MATCH_FIELDS.map((f) => (
+              <option key={f.value} value={f.value}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="gig-field">
+          <label className="gig-field__label" htmlFor={`${baseId}-new-keywords`}>
+            Keywords (comma separated)
+          </label>
+          <input
+            id={`${baseId}-new-keywords`}
+            className="gig-input"
+            style={{ width: '16rem', textAlign: 'left' }}
+            type="text"
+            value={keywords}
+            onChange={(e) => setKeywords(e.target.value)}
+            placeholder="e.g. shipt, shopt llc"
+            aria-describedby={formError ? `${baseId}-form-error` : undefined}
+          />
+        </div>
+        <button type="submit" className="gig-btn gig-btn--primary">
+          Add rule
+        </button>
+        {formError ? (
+          <p id={`${baseId}-form-error`} className="gig-empty" role="alert">
+            {formError}
+          </p>
+        ) : null}
+      </form>
+    </details>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Section
+// ---------------------------------------------------------------------------
+
+export const GigPlatformEarningsSection: React.FC = () => {
+  const {
+    earnings,
+    rules,
+    expectedPayouts,
+    knownPlatforms,
+    loading,
+    error,
+    addRule,
+    toggleRule,
+    removeRule,
+    setExpectedPayout,
+  } = useGigPlatformEarnings();
+
+  const [period, setPeriod] = useState<GigPeriodKey>('today');
+  const [filter, setFilter] = useState<string>(ALL_PLATFORMS);
+  const baseId = useId();
+
+  const visiblePlatforms = useMemo(() => {
+    if (filter === ALL_PLATFORMS) return [...earnings.platforms];
+    return earnings.platforms.filter((p) => p.platform === filter);
+  }, [earnings.platforms, filter]);
+
+  const reconciliation = useMemo(() => {
+    const expected = Object.entries(expectedPayouts).map(([platform, expectedCents]) => ({
+      platform,
+      expectedCents,
+    }));
+    const rows = reconcilePlatformPayouts(expected, earnings, { period });
+    if (filter === ALL_PLATFORMS) return rows;
+    return rows.filter((r) => r.platform === filter);
+  }, [expectedPayouts, earnings, period, filter]);
+
+  const combinedTotal = earnings.combined[period];
+  const combinedCount = earnings.combinedCounts[period];
+  const periodLabel = PERIODS.find((p) => p.key === period)?.label ?? '';
+
+  if (loading) {
+    return (
+      <section className="analytics-section" aria-label="Gig platform earnings">
+        <h3 className="analytics-section__title">Gig Platform Earnings</h3>
+        <p className="gig-empty" role="status">
+          Loading gig-platform earnings…
+        </p>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="analytics-section" aria-label="Gig platform earnings">
+        <h3 className="analytics-section__title">Gig Platform Earnings</h3>
+        <p className="gig-empty" role="alert">
+          {error}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="analytics-section" aria-label="Gig platform earnings">
+      <h3 className="analytics-section__title">Gig Platform Earnings</h3>
+
+      <div className="gig-controls">
+        <PeriodTabs value={period} onChange={setPeriod} baseId={baseId} />
+        <div className="gig-field">
+          <label className="gig-field__label" htmlFor={`${baseId}-filter`}>
+            Filter by platform
+          </label>
+          <select
+            id={`${baseId}-filter`}
+            className="gig-select"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          >
+            <option value={ALL_PLATFORMS}>All platforms</option>
+            {knownPlatforms.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <p className="gig-combined" aria-live="polite">
+        <span className="gig-combined__label">Combined {periodLabel.toLowerCase()} earnings:</span>
+        <span className="gig-combined__value">
+          <CurrencyDisplay amount={combinedTotal} context="combined gig earnings" />
+        </span>
+        <span className="gig-combined__meta">
+          across {earnings.platforms.length}{' '}
+          {earnings.platforms.length === 1 ? 'platform' : 'platforms'} · {combinedCount}{' '}
+          {combinedCount === 1 ? 'payout' : 'payouts'}
+        </span>
+      </p>
+
+      <div id={`${baseId}-panel`} role="tabpanel" aria-labelledby={`${baseId}-tab-${period}`}>
+        <PlatformBreakdown platforms={visiblePlatforms} result={earnings} period={period} />
+      </div>
+
+      <h4 className="analytics-section__title" style={{ marginTop: 'var(--spacing-5)' }}>
+        Payout reconciliation
+      </h4>
+      <ReconciliationTable rows={reconciliation} period={period} onCommit={setExpectedPayout} />
+
+      <RuleManager
+        rules={rules}
+        onAdd={addRule}
+        onToggle={toggleRule}
+        onRemove={removeRule}
+        baseId={baseId}
+      />
+    </section>
+  );
+};
+
+export default GigPlatformEarningsSection;

--- a/apps/web/src/components/gig/gig-platform.css
+++ b/apps/web/src/components/gig/gig-platform.css
@@ -1,0 +1,247 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for the gig-platform earnings section on the Cash Flow page.
+ *
+ * Uses design-token CSS custom properties for all visual values. Status is
+ * never conveyed by colour alone — every status badge also carries text.
+ *
+ * References: issue #2133
+ */
+
+.gig-combined {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--spacing-2);
+  margin: 0 0 var(--spacing-4) 0;
+}
+
+.gig-combined__label {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.gig-combined__value {
+  font-size: var(--type-scale-headline-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+}
+
+.gig-combined__meta {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.gig-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
+}
+
+.gig-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.gig-field__label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-secondary);
+}
+
+.gig-select,
+.gig-input {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-elevated);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+  min-height: 40px;
+}
+
+.gig-input {
+  width: 9rem;
+  text-align: right;
+}
+
+.gig-empty {
+  font-size: var(--type-scale-body-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * Reconciliation table
+ * ------------------------------------------------------------------------- */
+
+.gig-table-wrapper {
+  overflow-x: auto;
+}
+
+.gig-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--type-scale-body-font-size);
+}
+
+.gig-table caption {
+  text-align: left;
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin-bottom: var(--spacing-2);
+}
+
+.gig-table th,
+.gig-table td {
+  padding: var(--spacing-2) var(--spacing-3);
+  border-bottom: 1px solid var(--semantic-border-default);
+  text-align: left;
+}
+
+.gig-table th[scope='col'] {
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+}
+
+.gig-table td.gig-num,
+.gig-table th.gig-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------------------------------------------------------------------------
+ * Status badges — text + symbol, never colour alone
+ * ------------------------------------------------------------------------- */
+
+.gig-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: 2px var(--spacing-2);
+  border-radius: var(--border-radius-sm);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  border: 1px solid var(--semantic-border-default);
+}
+
+.gig-status__symbol {
+  font-weight: var(--font-weight-bold);
+}
+
+.gig-status--matched {
+  color: var(--semantic-status-positive);
+  border-color: var(--semantic-status-positive);
+}
+
+.gig-status--over {
+  color: var(--semantic-status-info, var(--semantic-text-primary));
+  border-color: var(--semantic-border-strong, var(--semantic-border-default));
+}
+
+.gig-status--under {
+  color: var(--semantic-status-negative);
+  border-color: var(--semantic-status-negative);
+}
+
+.gig-status--pending {
+  color: var(--semantic-text-secondary);
+  border-color: var(--semantic-border-default);
+}
+
+/* ---------------------------------------------------------------------------
+ * Rule management
+ * ------------------------------------------------------------------------- */
+
+.gig-rules {
+  margin-top: var(--spacing-4);
+}
+
+.gig-rules__summary {
+  cursor: pointer;
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-primary);
+}
+
+.gig-rule-list {
+  list-style: none;
+  margin: var(--spacing-3) 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.gig-rule-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-elevated);
+}
+
+.gig-rule-item__name {
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+}
+
+.gig-rule-item__meta {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  flex: 1;
+  min-width: 0;
+}
+
+.gig-rule-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  border: 1px dashed var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+}
+
+.gig-btn {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-elevated);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  min-height: 36px;
+}
+
+.gig-btn:hover {
+  background: var(--semantic-background-secondary);
+}
+
+.gig-btn--primary {
+  background: var(--semantic-action-primary, var(--semantic-text-primary));
+  border-color: transparent;
+  color: var(--semantic-on-action-primary, var(--semantic-background-default));
+}
+
+.gig-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gig-btn,
+  .gig-status {
+    transition: none;
+  }
+}

--- a/apps/web/src/hooks/useGigPlatformEarnings.ts
+++ b/apps/web/src/hooks/useGigPlatformEarnings.ts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook for grouping cash-flow income into gig-platform earnings.
+ *
+ * Combines:
+ *   - user-managed mapping rules (persisted in localStorage, seeded with
+ *     built-in defaults for Uber/DoorDash/Instacart/Lyft/Grubhub),
+ *   - expected-payout reconciliation targets (localStorage), and
+ *   - local transaction + account data (read through repositories) to compute
+ *     today / this week / this month earnings per platform.
+ *
+ * All aggregation is delegated to the pure {@link computePlatformEarnings}
+ * engine so the data path stays testable and float-free.
+ *
+ * References: issue #2133
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useDatabase } from '../db/DatabaseProvider';
+import { getAllAccounts } from '../db/repositories/accounts';
+import { getTransactionsByDateRange } from '../db/repositories/transactions';
+import type { Transaction } from '../kmp/bridge';
+import { computePeriodBounds, computePlatformEarnings } from '../lib/gig/platform-earnings';
+import {
+  createGigPlatformRule,
+  deleteGigPlatformRule,
+  loadExpectedPayouts,
+  loadGigPlatformRules,
+  setExpectedPayout as persistExpectedPayout,
+  toggleGigPlatformRule,
+  type CreateGigRuleInput,
+} from '../lib/gig/platform-rules-storage';
+import type { GigPlatformRule, PlatformEarningsResult } from '../lib/gig/platform-types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+const EMPTY_RESULT: PlatformEarningsResult = {
+  platforms: [],
+  combined: { today: 0, week: 0, month: 0 },
+  combinedCounts: { today: 0, week: 0, month: 0 },
+};
+
+/** Shape returned by {@link useGigPlatformEarnings}. */
+export interface UseGigPlatformEarningsResult {
+  /** Per-platform earnings + combined totals for today/week/month. */
+  readonly earnings: PlatformEarningsResult;
+  /** All mapping rules (user rules first, then built-ins). */
+  readonly rules: GigPlatformRule[];
+  /** Map of platform → expected payout (cents) for reconciliation. */
+  readonly expectedPayouts: Record<string, number>;
+  /** Distinct platform names known from rules (for filtering UIs). */
+  readonly knownPlatforms: string[];
+  /** True while data is being computed. */
+  readonly loading: boolean;
+  /** Human-readable error message, or null. */
+  readonly error: string | null;
+  /** Recompute earnings and reload rules/targets. */
+  readonly refresh: () => void;
+  /** Create a custom mapping rule. Returns the rule or null on error. */
+  readonly addRule: (input: CreateGigRuleInput) => GigPlatformRule | null;
+  /** Toggle a rule's enabled state. */
+  readonly toggleRule: (id: string) => void;
+  /** Remove a rule by id. Returns true when removed. */
+  readonly removeRule: (id: string) => boolean;
+  /** Set (or clear, with 0) the expected payout for a platform, in cents. */
+  readonly setExpectedPayout: (platform: string, cents: number) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatLocalDate(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+    d.getDate(),
+  ).padStart(2, '0')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes gig-platform earnings from local transactions and user rules.
+ */
+export function useGigPlatformEarnings(): UseGigPlatformEarningsResult {
+  const db = useDatabase();
+
+  const [earnings, setEarnings] = useState<PlatformEarningsResult>(EMPTY_RESULT);
+  const [rules, setRules] = useState<GigPlatformRule[]>([]);
+  const [expectedPayouts, setExpectedPayouts] = useState<Record<string, number>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    setRefreshToken((t) => t + 1);
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    try {
+      const loadedRules = loadGigPlatformRules();
+      const loadedExpected = loadExpectedPayouts();
+
+      // Query window: from the earliest of (start of week, start of month) up
+      // to today — this covers all three earnings buckets in one read.
+      const now = new Date();
+      const bounds = computePeriodBounds(now, 1);
+      const startTs = Math.min(bounds.weekStart, bounds.monthStart);
+      const startDate = formatLocalDate(startTs);
+      const endDate = formatLocalDate(bounds.todayStart);
+
+      const transactions: Transaction[] = getTransactionsByDateRange(db, startDate, endDate);
+      const accounts = getAllAccounts(db);
+      const accountNames = new Map<string, string>();
+      for (const acct of accounts) accountNames.set(acct.id, acct.name);
+
+      const result = computePlatformEarnings(transactions, loadedRules, {
+        referenceDate: now,
+        weekStartsOn: 1,
+        accountNames,
+      });
+
+      setRules(loadedRules);
+      setExpectedPayouts(loadedExpected);
+      setEarnings(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to compute gig-platform earnings.');
+    } finally {
+      setLoading(false);
+    }
+  }, [db, refreshToken]);
+
+  const addRule = useCallback(
+    (input: CreateGigRuleInput): GigPlatformRule | null => {
+      try {
+        const rule = createGigPlatformRule(input);
+        refresh();
+        return rule;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to create rule.');
+        return null;
+      }
+    },
+    [refresh],
+  );
+
+  const toggleRule = useCallback(
+    (id: string): void => {
+      toggleGigPlatformRule(id);
+      refresh();
+    },
+    [refresh],
+  );
+
+  const removeRule = useCallback(
+    (id: string): boolean => {
+      const removed = deleteGigPlatformRule(id);
+      if (removed) refresh();
+      return removed;
+    },
+    [refresh],
+  );
+
+  const setExpectedPayout = useCallback((platform: string, cents: number): void => {
+    const next = persistExpectedPayout(platform, cents);
+    setExpectedPayouts({ ...next });
+  }, []);
+
+  const knownPlatforms = useMemo(() => {
+    const names = new Set<string>();
+    for (const rule of rules) names.add(rule.platform);
+    for (const p of earnings.platforms) names.add(p.platform);
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }, [rules, earnings.platforms]);
+
+  return {
+    earnings,
+    rules,
+    expectedPayouts,
+    knownPlatforms,
+    loading,
+    error,
+    refresh,
+    addRule,
+    toggleRule,
+    removeRule,
+    setExpectedPayout,
+  };
+}

--- a/apps/web/src/lib/gig/platform-earnings.test.ts
+++ b/apps/web/src/lib/gig/platform-earnings.test.ts
@@ -1,0 +1,460 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the gig-platform earnings engine: rule matching, period bucketing,
+ * banker's rounding, reconciliation, and edge cases.
+ *
+ * References: issue #2133
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  bankersRound,
+  computePeriodBounds,
+  computePlatformEarnings,
+  DEFAULT_GIG_PLATFORM_RULES,
+  matchTransactionPlatform,
+  platformPercent,
+  reconcilePlatformPayouts,
+} from './platform-earnings';
+import type { ExpectedPayout, GigPlatformRule } from './platform-types';
+import type { Transaction } from '../../kmp/bridge';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeTx(opts: {
+  id?: string;
+  date: string;
+  type?: 'INCOME' | 'EXPENSE' | 'TRANSFER';
+  amountCents: number;
+  payee?: string | null;
+  note?: string | null;
+  statementDescription?: string | null;
+  counterpartyName?: string | null;
+  accountId?: string;
+}): Transaction {
+  return {
+    id: opts.id ?? crypto.randomUUID(),
+    householdId: 'hh-1',
+    accountId: opts.accountId ?? 'acct-1',
+    categoryId: null,
+    type: opts.type ?? 'INCOME',
+    status: 'CLEARED',
+    amount: { amount: opts.amountCents },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    payee: opts.payee ?? null,
+    note: opts.note ?? null,
+    date: opts.date,
+    transferAccountId: null,
+    transferTransactionId: null,
+    isRecurring: false,
+    recurringRuleId: null,
+    tags: [],
+    merchantAddress: null,
+    merchantCity: null,
+    merchantState: null,
+    merchantZip: null,
+    merchantCountry: null,
+    externalReferenceId: null,
+    statementDescription: opts.statementDescription ?? null,
+    customFields: null,
+    extraNotes: null,
+    counterpartyName: opts.counterpartyName ?? null,
+    counterpartyAccountId: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  } as Transaction;
+}
+
+// A fixed Wednesday so week/month boundaries are deterministic.
+// 2024-01-01 is a Monday → 2024-01-15 is a Monday, 2024-01-17 is a Wednesday.
+const REF = new Date(2024, 0, 17, 12, 0, 0);
+
+// ---------------------------------------------------------------------------
+// Banker's rounding
+// ---------------------------------------------------------------------------
+
+describe('bankersRound', () => {
+  it('rounds halves to the nearest even integer', () => {
+    expect(bankersRound(0.5)).toBe(0);
+    expect(bankersRound(1.5)).toBe(2);
+    expect(bankersRound(2.5)).toBe(2);
+    expect(bankersRound(3.5)).toBe(4);
+  });
+
+  it('rounds non-halves normally', () => {
+    expect(bankersRound(2.4)).toBe(2);
+    expect(bankersRound(2.6)).toBe(3);
+    expect(bankersRound(0)).toBe(0);
+  });
+
+  it('handles negative values symmetrically', () => {
+    expect(bankersRound(-0.5)).toBe(0);
+    expect(bankersRound(-1.5)).toBe(-2);
+    expect(bankersRound(-2.5)).toBe(-2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule matching
+// ---------------------------------------------------------------------------
+
+describe('matchTransactionPlatform', () => {
+  it('matches the built-in platforms by payee (case-insensitive)', () => {
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, payee: 'UBER BV' }),
+        DEFAULT_GIG_PLATFORM_RULES,
+      ),
+    ).toBe('Uber');
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, payee: 'DoorDash Inc' }),
+        DEFAULT_GIG_PLATFORM_RULES,
+      ),
+    ).toBe('DoorDash');
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, payee: 'instacart' }),
+        DEFAULT_GIG_PLATFORM_RULES,
+      ),
+    ).toBe('Instacart');
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, payee: 'LYFT, INC.' }),
+        DEFAULT_GIG_PLATFORM_RULES,
+      ),
+    ).toBe('Lyft');
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, payee: 'Grub Hub' }),
+        DEFAULT_GIG_PLATFORM_RULES,
+      ),
+    ).toBe('Grubhub');
+  });
+
+  it('matches the DoorDash "dasher" alias and the Instacart "maplebear" alias', () => {
+    expect(
+      matchTransactionPlatform(
+        makeTx({
+          date: '2024-01-17',
+          amountCents: 1,
+          statementDescription: 'DASHER DIRECT DEPOSIT',
+        }),
+        DEFAULT_GIG_PLATFORM_RULES,
+      ),
+    ).toBe('DoorDash');
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, counterpartyName: 'Maplebear Inc' }),
+        DEFAULT_GIG_PLATFORM_RULES,
+      ),
+    ).toBe('Instacart');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, payee: 'ACME Payroll' }),
+        DEFAULT_GIG_PLATFORM_RULES,
+      ),
+    ).toBeNull();
+  });
+
+  it('respects the matchField — a payee-only rule ignores the description', () => {
+    const rule: GigPlatformRule = {
+      id: 'r1',
+      platform: 'Spark',
+      matchField: 'payee',
+      keywords: ['spark'],
+      enabled: true,
+      isBuiltIn: false,
+      createdAt: '2024-01-01T00:00:00Z',
+    };
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, note: 'spark driver' }),
+        [rule],
+      ),
+    ).toBeNull();
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, payee: 'Spark Driver' }),
+        [rule],
+      ),
+    ).toBe('Spark');
+  });
+
+  it('matches against the account name for account-field rules', () => {
+    const rule: GigPlatformRule = {
+      id: 'r2',
+      platform: 'Uber',
+      matchField: 'account',
+      keywords: ['rideshare'],
+      enabled: true,
+      isBuiltIn: false,
+      createdAt: '2024-01-01T00:00:00Z',
+    };
+    const accountNames = new Map([['acct-9', 'Rideshare Checking']]);
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, accountId: 'acct-9' }),
+        [rule],
+        accountNames,
+      ),
+    ).toBe('Uber');
+  });
+
+  it('skips disabled rules', () => {
+    const rule: GigPlatformRule = {
+      id: 'r3',
+      platform: 'Uber',
+      matchField: 'any',
+      keywords: ['uber'],
+      enabled: false,
+      isBuiltIn: false,
+      createdAt: '2024-01-01T00:00:00Z',
+    };
+    expect(
+      matchTransactionPlatform(makeTx({ date: '2024-01-17', amountCents: 1, payee: 'Uber' }), [
+        rule,
+      ]),
+    ).toBeNull();
+  });
+
+  it('with overlapping rules the FIRST enabled match wins', () => {
+    const userRule: GigPlatformRule = {
+      id: 'user',
+      platform: 'Uber Eats',
+      matchField: 'any',
+      keywords: ['uber eats'],
+      enabled: true,
+      isBuiltIn: false,
+      createdAt: '2024-01-02T00:00:00Z',
+    };
+    // user rule placed first → takes precedence over the built-in "uber" rule
+    const rules = [userRule, ...DEFAULT_GIG_PLATFORM_RULES];
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, payee: 'UBER EATS' }),
+        rules,
+      ),
+    ).toBe('Uber Eats');
+    // a plain Uber payout still falls through to the built-in
+    expect(
+      matchTransactionPlatform(
+        makeTx({ date: '2024-01-17', amountCents: 1, payee: 'UBER BV' }),
+        rules,
+      ),
+    ).toBe('Uber');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Period bucketing
+// ---------------------------------------------------------------------------
+
+describe('computePeriodBounds', () => {
+  it('computes the Monday-start week containing the reference date', () => {
+    const bounds = computePeriodBounds(REF, 1);
+    expect(bounds.weekStart).toBe(new Date(2024, 0, 15).getTime());
+    expect(bounds.weekEnd).toBe(new Date(2024, 0, 21).getTime());
+    expect(bounds.monthStart).toBe(new Date(2024, 0, 1).getTime());
+    expect(bounds.monthEnd).toBe(new Date(2024, 0, 31).getTime());
+    expect(bounds.todayStart).toBe(new Date(2024, 0, 17).getTime());
+  });
+
+  it('supports a Sunday-start week', () => {
+    const bounds = computePeriodBounds(REF, 0);
+    expect(bounds.weekStart).toBe(new Date(2024, 0, 14).getTime());
+    expect(bounds.weekEnd).toBe(new Date(2024, 0, 20).getTime());
+  });
+});
+
+describe('computePlatformEarnings — period bucketing', () => {
+  const rules = DEFAULT_GIG_PLATFORM_RULES;
+
+  it('buckets transactions into today / week / month across boundaries', () => {
+    const txns = [
+      makeTx({ date: '2024-01-17', amountCents: 5000, payee: 'Uber' }), // today + week + month
+      makeTx({ date: '2024-01-15', amountCents: 3000, payee: 'Uber' }), // week + month (Mon)
+      makeTx({ date: '2024-01-21', amountCents: 2000, payee: 'Uber' }), // week + month (Sun end)
+      makeTx({ date: '2024-01-10', amountCents: 1000, payee: 'Uber' }), // month only
+      makeTx({ date: '2024-01-14', amountCents: 700, payee: 'Uber' }), // month only (prev Sun)
+      makeTx({ date: '2023-12-31', amountCents: 9999, payee: 'Uber' }), // outside all windows
+      makeTx({ date: '2024-02-01', amountCents: 8888, payee: 'Uber' }), // outside all windows
+    ];
+
+    const result = computePlatformEarnings(txns, rules, { referenceDate: REF, weekStartsOn: 1 });
+    const uber = result.platforms.find((p) => p.platform === 'Uber');
+    expect(uber).toBeDefined();
+    expect(uber?.amounts.today).toBe(5000);
+    expect(uber?.amounts.week).toBe(5000 + 3000 + 2000);
+    expect(uber?.amounts.month).toBe(5000 + 3000 + 2000 + 1000 + 700);
+    expect(uber?.counts.today).toBe(1);
+    expect(uber?.counts.week).toBe(3);
+    expect(uber?.counts.month).toBe(5);
+
+    expect(result.combined.today).toBe(5000);
+    expect(result.combined.week).toBe(10000);
+    expect(result.combined.month).toBe(11700);
+  });
+
+  it('ignores EXPENSE and TRANSFER transactions', () => {
+    const txns = [
+      makeTx({ date: '2024-01-17', amountCents: 5000, payee: 'Uber', type: 'INCOME' }),
+      makeTx({ date: '2024-01-17', amountCents: 4000, payee: 'Uber', type: 'EXPENSE' }),
+      makeTx({ date: '2024-01-17', amountCents: 3000, payee: 'Uber', type: 'TRANSFER' }),
+    ];
+    const result = computePlatformEarnings(txns, rules, { referenceDate: REF });
+    expect(result.combined.today).toBe(5000);
+  });
+
+  it('groups unmapped income under "Other" and sorts it last', () => {
+    const txns = [
+      makeTx({ date: '2024-01-17', amountCents: 1000, payee: 'Mystery LLC' }),
+      makeTx({ date: '2024-01-17', amountCents: 9000, payee: 'Uber' }),
+    ];
+    const result = computePlatformEarnings(txns, rules, { referenceDate: REF });
+    expect(result.platforms.map((p) => p.platform)).toEqual(['Uber', 'Other']);
+    const other = result.platforms.find((p) => p.platform === 'Other');
+    expect(other?.amounts.today).toBe(1000);
+  });
+
+  it('sorts platforms by month earnings descending', () => {
+    const txns = [
+      makeTx({ date: '2024-01-17', amountCents: 2000, payee: 'Lyft' }),
+      makeTx({ date: '2024-01-17', amountCents: 5000, payee: 'Uber' }),
+      makeTx({ date: '2024-01-17', amountCents: 3000, payee: 'DoorDash' }),
+    ];
+    const result = computePlatformEarnings(txns, rules, { referenceDate: REF });
+    expect(result.platforms.map((p) => p.platform)).toEqual(['Uber', 'DoorDash', 'Lyft']);
+  });
+
+  it('returns empty totals when there are no transactions', () => {
+    const result = computePlatformEarnings([], rules, { referenceDate: REF });
+    expect(result.platforms).toHaveLength(0);
+    expect(result.combined).toEqual({ today: 0, week: 0, month: 0 });
+  });
+
+  it('ignores malformed dates', () => {
+    const txns = [makeTx({ date: 'not-a-date', amountCents: 1234, payee: 'Uber' })];
+    const result = computePlatformEarnings(txns, rules, { referenceDate: REF });
+    expect(result.platforms).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Percentages
+// ---------------------------------------------------------------------------
+
+describe('platformPercent', () => {
+  it('computes a banker-rounded percent of the period total', () => {
+    const txns = [
+      makeTx({ date: '2024-01-17', amountCents: 2500, payee: 'Uber' }),
+      makeTx({ date: '2024-01-17', amountCents: 7500, payee: 'Lyft' }),
+    ];
+    const result = computePlatformEarnings(txns, DEFAULT_GIG_PLATFORM_RULES, {
+      referenceDate: REF,
+    });
+    const uber = result.platforms.find((p) => p.platform === 'Uber')!;
+    const lyft = result.platforms.find((p) => p.platform === 'Lyft')!;
+    expect(platformPercent(uber, result, 'today')).toBe(25);
+    expect(platformPercent(lyft, result, 'today')).toBe(75);
+  });
+
+  it('returns 0 when the period total is zero', () => {
+    const result = computePlatformEarnings([], DEFAULT_GIG_PLATFORM_RULES, { referenceDate: REF });
+    const fake = {
+      platform: 'Uber',
+      amounts: { today: 0, week: 0, month: 0 },
+      counts: { today: 0, week: 0, month: 0 },
+    };
+    expect(platformPercent(fake, result, 'today')).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reconciliation
+// ---------------------------------------------------------------------------
+
+describe('reconcilePlatformPayouts', () => {
+  const rules = DEFAULT_GIG_PLATFORM_RULES;
+
+  function resultFor(amountCents: number, platform = 'Uber') {
+    return computePlatformEarnings(
+      [makeTx({ date: '2024-01-17', amountCents, payee: platform })],
+      rules,
+      { referenceDate: REF },
+    );
+  }
+
+  it('reports "matched" when received equals expected', () => {
+    const expected: ExpectedPayout[] = [{ platform: 'Uber', expectedCents: 5000 }];
+    const rows = reconcilePlatformPayouts(expected, resultFor(5000));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ status: 'matched', varianceCents: 0, receivedCents: 5000 });
+  });
+
+  it('reports "under" when received is less than expected', () => {
+    const expected: ExpectedPayout[] = [{ platform: 'Uber', expectedCents: 5000 }];
+    const rows = reconcilePlatformPayouts(expected, resultFor(4200));
+    expect(rows[0].status).toBe('under');
+    expect(rows[0].varianceCents).toBe(-800);
+  });
+
+  it('reports "over" when received exceeds expected', () => {
+    const expected: ExpectedPayout[] = [{ platform: 'Uber', expectedCents: 5000 }];
+    const rows = reconcilePlatformPayouts(expected, resultFor(5300));
+    expect(rows[0].status).toBe('over');
+    expect(rows[0].varianceCents).toBe(300);
+  });
+
+  it('reports "pending" when nothing has been received yet', () => {
+    const expected: ExpectedPayout[] = [{ platform: 'Lyft', expectedCents: 5000 }];
+    const rows = reconcilePlatformPayouts(expected, resultFor(5000, 'Uber'));
+    const lyft = rows.find((r) => r.platform === 'Lyft');
+    expect(lyft?.status).toBe('pending');
+    expect(lyft?.receivedCents).toBe(0);
+  });
+
+  it('treats variance within tolerance as matched', () => {
+    const expected: ExpectedPayout[] = [{ platform: 'Uber', expectedCents: 5000 }];
+    const rows = reconcilePlatformPayouts(expected, resultFor(5002), { toleranceCents: 5 });
+    expect(rows[0].status).toBe('matched');
+  });
+
+  it('includes platforms with deposits but no expected entry', () => {
+    const rows = reconcilePlatformPayouts([], resultFor(5000));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ platform: 'Uber', expectedCents: 0, status: 'over' });
+  });
+
+  it('omits rows with neither expected nor received amount', () => {
+    const expected: ExpectedPayout[] = [{ platform: 'Grubhub', expectedCents: 0 }];
+    const rows = reconcilePlatformPayouts(expected, resultFor(5000, 'Uber'));
+    expect(rows.find((r) => r.platform === 'Grubhub')).toBeUndefined();
+  });
+
+  it('reconciles against the requested period', () => {
+    const txns = [
+      makeTx({ date: '2024-01-17', amountCents: 1000, payee: 'Uber' }), // today + week + month
+      makeTx({ date: '2024-01-10', amountCents: 4000, payee: 'Uber' }), // month only
+    ];
+    const result = computePlatformEarnings(txns, rules, { referenceDate: REF });
+    const expected: ExpectedPayout[] = [{ platform: 'Uber', expectedCents: 5000 }];
+
+    const todayRows = reconcilePlatformPayouts(expected, result, { period: 'today' });
+    expect(todayRows[0].receivedCents).toBe(1000);
+    expect(todayRows[0].status).toBe('under');
+
+    const monthRows = reconcilePlatformPayouts(expected, result, { period: 'month' });
+    expect(monthRows[0].receivedCents).toBe(5000);
+    expect(monthRows[0].status).toBe('matched');
+  });
+});

--- a/apps/web/src/lib/gig/platform-earnings.ts
+++ b/apps/web/src/lib/gig/platform-earnings.ts
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Gig-platform earnings engine.
+ *
+ * Pure functions that:
+ *   1. map income transactions to a gig platform (Uber, DoorDash, Instacart,
+ *      Lyft, Grubhub, ...) via user-defined keyword rules with built-in
+ *      defaults,
+ *   2. aggregate earnings by platform for today / this week / this month plus
+ *      a combined (cross-platform) total, and
+ *   3. reconcile an expected payout against the deposits actually received.
+ *
+ * All monetary values are integer cents. No floating-point money: divisions
+ * (percentages) use banker's rounding (round-half-to-even) to stay
+ * deterministic and unbiased.
+ *
+ * References: issue #2133
+ */
+
+import type { Transaction } from '../../kmp/bridge';
+import {
+  OTHER_PLATFORM_LABEL,
+  type ExpectedPayout,
+  type GigMatchField,
+  type GigPeriodAmounts,
+  type GigPeriodKey,
+  type GigPlatformRule,
+  type PlatformEarnings,
+  type PlatformEarningsOptions,
+  type PlatformEarningsResult,
+  type PlatformReconciliation,
+  type ReconciliationOptions,
+  type ReconciliationStatus,
+} from './platform-types';
+
+// ---------------------------------------------------------------------------
+// Built-in defaults
+// ---------------------------------------------------------------------------
+
+/**
+ * Sensible built-in mapping rules. These match against ANY text field
+ * (payee, note, statement description, counterparty, account name) so that
+ * payouts are recognised regardless of how the deposit was recorded.
+ */
+export const DEFAULT_GIG_PLATFORM_RULES: readonly GigPlatformRule[] = [
+  {
+    id: 'builtin-uber',
+    platform: 'Uber',
+    matchField: 'any',
+    keywords: ['uber'],
+    enabled: true,
+    isBuiltIn: true,
+    createdAt: '1970-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'builtin-doordash',
+    platform: 'DoorDash',
+    matchField: 'any',
+    keywords: ['doordash', 'door dash', 'dasher'],
+    enabled: true,
+    isBuiltIn: true,
+    createdAt: '1970-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'builtin-instacart',
+    platform: 'Instacart',
+    matchField: 'any',
+    keywords: ['instacart', 'maplebear'],
+    enabled: true,
+    isBuiltIn: true,
+    createdAt: '1970-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'builtin-lyft',
+    platform: 'Lyft',
+    matchField: 'any',
+    keywords: ['lyft'],
+    enabled: true,
+    isBuiltIn: true,
+    createdAt: '1970-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'builtin-grubhub',
+    platform: 'Grubhub',
+    matchField: 'any',
+    keywords: ['grubhub', 'grub hub'],
+    enabled: true,
+    isBuiltIn: true,
+    createdAt: '1970-01-01T00:00:00.000Z',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Rounding (banker's / round-half-to-even)
+// ---------------------------------------------------------------------------
+
+/**
+ * Round a value to the nearest integer using banker's rounding (round half to
+ * even). Exact halves resolve toward the nearest even integer, which removes
+ * the upward bias of {@link Math.round}.
+ *
+ * @example bankersRound(2.5) === 2; bankersRound(3.5) === 4; bankersRound(2.4) === 2
+ */
+export function bankersRound(value: number): number {
+  const floor = Math.floor(value);
+  const diff = value - floor;
+  if (diff > 0.5) return floor + 1;
+  if (diff < 0.5) return floor;
+  // Exactly .5 — round to the nearest even integer.
+  return floor % 2 === 0 ? floor : floor + 1;
+}
+
+// ---------------------------------------------------------------------------
+// Rule matching
+// ---------------------------------------------------------------------------
+
+/** Build the lower-cased text a rule's keywords are matched against. */
+function matchTextFor(
+  tx: Transaction,
+  field: GigMatchField,
+  accountNames: ReadonlyMap<string, string>,
+): string {
+  const accountName = accountNames.get(tx.accountId) ?? '';
+  let parts: (string | null)[];
+  switch (field) {
+    case 'payee':
+      parts = [tx.payee, tx.counterpartyName];
+      break;
+    case 'description':
+      parts = [tx.note, tx.statementDescription];
+      break;
+    case 'account':
+      parts = [accountName];
+      break;
+    case 'any':
+    default:
+      parts = [tx.payee, tx.counterpartyName, tx.note, tx.statementDescription, accountName];
+      break;
+  }
+  return parts
+    .filter((p): p is string => typeof p === 'string' && p.length > 0)
+    .join(' ')
+    .toLowerCase();
+}
+
+/**
+ * Resolve the platform a transaction maps to.
+ *
+ * Rules are evaluated in array order; the FIRST enabled rule with a keyword
+ * contained in the transaction's text wins (so user rules placed ahead of the
+ * built-ins take precedence). Returns `null` when nothing matches.
+ */
+export function matchTransactionPlatform(
+  tx: Transaction,
+  rules: readonly GigPlatformRule[],
+  accountNames: ReadonlyMap<string, string> = new Map(),
+): string | null {
+  for (const rule of rules) {
+    if (!rule.enabled || rule.keywords.length === 0) continue;
+    const text = matchTextFor(tx, rule.matchField, accountNames);
+    if (!text) continue;
+    const hit = rule.keywords.some((keyword) => {
+      const needle = keyword.trim().toLowerCase();
+      return needle.length > 0 && text.includes(needle);
+    });
+    if (hit) return rule.platform;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Period bucketing
+// ---------------------------------------------------------------------------
+
+interface PeriodBounds {
+  readonly todayStart: number;
+  readonly weekStart: number;
+  readonly weekEnd: number;
+  readonly monthStart: number;
+  readonly monthEnd: number;
+}
+
+/** Local midnight timestamp for the given Y/M/D (month is 0-based). */
+function midnight(year: number, month: number, day: number): number {
+  return new Date(year, month, day).getTime();
+}
+
+/** Parse an ISO local date ("YYYY-MM-DD") to a local-midnight timestamp. */
+function parseLocalDateMidnight(date: string): number | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(date);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  return midnight(year, month, day);
+}
+
+/** Compute today/week/month boundaries from a reference date. */
+export function computePeriodBounds(
+  referenceDate: Date = new Date(),
+  weekStartsOn: 0 | 1 = 1,
+): PeriodBounds {
+  const y = referenceDate.getFullYear();
+  const m = referenceDate.getMonth();
+  const d = referenceDate.getDate();
+
+  const todayStart = midnight(y, m, d);
+
+  const dow = new Date(y, m, d).getDay(); // 0=Sun … 6=Sat
+  const back = (dow - weekStartsOn + 7) % 7;
+  const weekStartDate = new Date(y, m, d - back);
+  const weekStart = weekStartDate.getTime();
+  const weekEndDate = new Date(
+    weekStartDate.getFullYear(),
+    weekStartDate.getMonth(),
+    weekStartDate.getDate() + 6,
+  );
+  const weekEnd = weekEndDate.getTime();
+
+  const monthStart = midnight(y, m, 1);
+  const monthEnd = midnight(y, m + 1, 0); // day 0 of next month = last day this month
+
+  return { todayStart, weekStart, weekEnd, monthStart, monthEnd };
+}
+
+/** Determine which of today/week/month a transaction date falls into. */
+function periodFlags(
+  ts: number,
+  bounds: PeriodBounds,
+): { today: boolean; week: boolean; month: boolean } {
+  return {
+    today: ts === bounds.todayStart,
+    week: ts >= bounds.weekStart && ts <= bounds.weekEnd,
+    month: ts >= bounds.monthStart && ts <= bounds.monthEnd,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+const ZERO_AMOUNTS: GigPeriodAmounts = { today: 0, week: 0, month: 0 };
+
+interface MutableAmounts {
+  today: number;
+  week: number;
+  month: number;
+}
+
+/**
+ * Aggregate income transactions into per-platform earnings for today / this
+ * week / this month, plus combined cross-platform totals.
+ *
+ * Only `INCOME` transactions are considered (gig payouts are deposits).
+ * Transactions that match no rule are grouped under "Other".
+ */
+export function computePlatformEarnings(
+  transactions: readonly Transaction[],
+  rules: readonly GigPlatformRule[],
+  options: PlatformEarningsOptions = {},
+): PlatformEarningsResult {
+  const bounds = computePeriodBounds(options.referenceDate, options.weekStartsOn ?? 1);
+  const accountNames = options.accountNames ?? new Map<string, string>();
+
+  const amountsByPlatform = new Map<string, MutableAmounts>();
+  const countsByPlatform = new Map<string, MutableAmounts>();
+  const combined: MutableAmounts = { today: 0, week: 0, month: 0 };
+  const combinedCounts: MutableAmounts = { today: 0, week: 0, month: 0 };
+
+  for (const tx of transactions) {
+    if (tx.type !== 'INCOME') continue;
+    const ts = parseLocalDateMidnight(tx.date);
+    if (ts === null) continue;
+    const flags = periodFlags(ts, bounds);
+    if (!flags.today && !flags.week && !flags.month) continue;
+
+    const platform = matchTransactionPlatform(tx, rules, accountNames) ?? OTHER_PLATFORM_LABEL;
+    const amount = tx.amount.amount;
+
+    const amounts = amountsByPlatform.get(platform) ?? { today: 0, week: 0, month: 0 };
+    const counts = countsByPlatform.get(platform) ?? { today: 0, week: 0, month: 0 };
+
+    if (flags.today) {
+      amounts.today += amount;
+      counts.today += 1;
+      combined.today += amount;
+      combinedCounts.today += 1;
+    }
+    if (flags.week) {
+      amounts.week += amount;
+      counts.week += 1;
+      combined.week += amount;
+      combinedCounts.week += 1;
+    }
+    if (flags.month) {
+      amounts.month += amount;
+      counts.month += 1;
+      combined.month += amount;
+      combinedCounts.month += 1;
+    }
+
+    amountsByPlatform.set(platform, amounts);
+    countsByPlatform.set(platform, counts);
+  }
+
+  const platforms: PlatformEarnings[] = [];
+  for (const [platform, amounts] of amountsByPlatform.entries()) {
+    platforms.push({
+      platform,
+      amounts: { today: amounts.today, week: amounts.week, month: amounts.month },
+      counts: countsByPlatform.get(platform) ?? ZERO_AMOUNTS,
+    });
+  }
+
+  platforms.sort((a, b) => {
+    // "Other" always sorts last for readability.
+    if (a.platform === OTHER_PLATFORM_LABEL && b.platform !== OTHER_PLATFORM_LABEL) return 1;
+    if (b.platform === OTHER_PLATFORM_LABEL && a.platform !== OTHER_PLATFORM_LABEL) return -1;
+    if (b.amounts.month !== a.amounts.month) return b.amounts.month - a.amounts.month;
+    if (b.amounts.week !== a.amounts.week) return b.amounts.week - a.amounts.week;
+    if (b.amounts.today !== a.amounts.today) return b.amounts.today - a.amounts.today;
+    return a.platform.localeCompare(b.platform);
+  });
+
+  return {
+    platforms,
+    combined: { today: combined.today, week: combined.week, month: combined.month },
+    combinedCounts: {
+      today: combinedCounts.today,
+      week: combinedCounts.week,
+      month: combinedCounts.month,
+    },
+  };
+}
+
+/**
+ * Percentage (0–100, banker's-rounded) a platform contributes to the combined
+ * earnings for a given period. Returns 0 when the period total is zero.
+ */
+export function platformPercent(
+  platform: PlatformEarnings,
+  result: PlatformEarningsResult,
+  period: GigPeriodKey,
+): number {
+  const total = result.combined[period];
+  if (total <= 0) return 0;
+  return bankersRound((platform.amounts[period] / total) * 100);
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation
+// ---------------------------------------------------------------------------
+
+function reconciliationStatus(
+  receivedCents: number,
+  expectedCents: number,
+  toleranceCents: number,
+): ReconciliationStatus {
+  if (receivedCents === 0 && expectedCents > 0) return 'pending';
+  const variance = receivedCents - expectedCents;
+  if (variance > toleranceCents) return 'over';
+  if (variance < -toleranceCents) return 'under';
+  return 'matched';
+}
+
+/**
+ * Reconcile expected payouts against the deposits actually received.
+ *
+ * The received amount is taken from the platform's earnings for the chosen
+ * period (default: this month). A platform with neither an expected payout nor
+ * any received amount is omitted.
+ */
+export function reconcilePlatformPayouts(
+  expected: readonly ExpectedPayout[],
+  result: PlatformEarningsResult,
+  options: ReconciliationOptions = {},
+): PlatformReconciliation[] {
+  const period = options.period ?? 'month';
+  const tolerance = Math.max(0, options.toleranceCents ?? 0);
+
+  const receivedByPlatform = new Map<string, number>();
+  for (const p of result.platforms) {
+    receivedByPlatform.set(p.platform, p.amounts[period]);
+  }
+
+  const seen = new Set<string>();
+  const rows: PlatformReconciliation[] = [];
+
+  for (const entry of expected) {
+    seen.add(entry.platform);
+    const receivedCents = receivedByPlatform.get(entry.platform) ?? 0;
+    const expectedCents = entry.expectedCents;
+    if (expectedCents === 0 && receivedCents === 0) continue;
+    rows.push({
+      platform: entry.platform,
+      expectedCents,
+      receivedCents,
+      varianceCents: receivedCents - expectedCents,
+      status: reconciliationStatus(receivedCents, expectedCents, tolerance),
+    });
+  }
+
+  // Include platforms with received deposits but no expected payout entry.
+  for (const p of result.platforms) {
+    if (seen.has(p.platform)) continue;
+    const receivedCents = p.amounts[period];
+    if (receivedCents === 0) continue;
+    rows.push({
+      platform: p.platform,
+      expectedCents: 0,
+      receivedCents,
+      varianceCents: receivedCents,
+      status: reconciliationStatus(receivedCents, 0, tolerance),
+    });
+  }
+
+  return rows;
+}

--- a/apps/web/src/lib/gig/platform-rules-storage.test.ts
+++ b/apps/web/src/lib/gig/platform-rules-storage.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for gig-platform rule + expected-payout localStorage persistence.
+ *
+ * References: issue #2133
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createGigPlatformRule,
+  deleteGigPlatformRule,
+  loadExpectedPayouts,
+  loadGigPlatformRules,
+  saveGigPlatformRules,
+  setExpectedPayout,
+  toggleGigPlatformRule,
+} from './platform-rules-storage';
+import { DEFAULT_GIG_PLATFORM_RULES } from './platform-earnings';
+
+describe('platform-rules-storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('seeds the built-in defaults when nothing is stored', () => {
+    const rules = loadGigPlatformRules();
+    expect(rules).toHaveLength(DEFAULT_GIG_PLATFORM_RULES.length);
+    expect(rules.map((r) => r.platform)).toContain('Uber');
+    expect(rules.every((r) => r.isBuiltIn)).toBe(true);
+  });
+
+  it('returns defaults (and does not throw) on corrupt storage', () => {
+    localStorage.setItem('finance-gig-platform-rules', '{not valid json');
+    const rules = loadGigPlatformRules();
+    expect(rules.length).toBe(DEFAULT_GIG_PLATFORM_RULES.length);
+  });
+
+  it('filters out malformed persisted rules', () => {
+    localStorage.setItem(
+      'finance-gig-platform-rules',
+      JSON.stringify([
+        {
+          id: 'ok',
+          platform: 'X',
+          matchField: 'any',
+          keywords: ['x'],
+          enabled: true,
+          isBuiltIn: false,
+          createdAt: 'now',
+        },
+        { bogus: true },
+      ]),
+    );
+    const rules = loadGigPlatformRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0].platform).toBe('X');
+  });
+
+  it('creates a custom rule and prepends it (user precedence)', () => {
+    const rule = createGigPlatformRule({
+      platform: 'Shipt',
+      matchField: 'payee',
+      keywords: ['shipt'],
+    });
+    expect(rule.isBuiltIn).toBe(false);
+    const rules = loadGigPlatformRules();
+    expect(rules[0].platform).toBe('Shipt');
+    expect(rules.length).toBe(DEFAULT_GIG_PLATFORM_RULES.length + 1);
+  });
+
+  it('trims keywords and rejects empty input', () => {
+    expect(() =>
+      createGigPlatformRule({ platform: '  ', matchField: 'any', keywords: ['x'] }),
+    ).toThrow();
+    expect(() =>
+      createGigPlatformRule({ platform: 'X', matchField: 'any', keywords: ['  ', ''] }),
+    ).toThrow();
+    const rule = createGigPlatformRule({
+      platform: 'X',
+      matchField: 'any',
+      keywords: ['  foo  ', 'bar'],
+    });
+    expect(rule.keywords).toEqual(['foo', 'bar']);
+  });
+
+  it('toggles a rule enabled flag and persists it', () => {
+    saveGigPlatformRules([...DEFAULT_GIG_PLATFORM_RULES]);
+    const uber = loadGigPlatformRules().find((r) => r.platform === 'Uber')!;
+    expect(uber.enabled).toBe(true);
+    const toggled = toggleGigPlatformRule(uber.id);
+    expect(toggled?.enabled).toBe(false);
+    expect(loadGigPlatformRules().find((r) => r.id === uber.id)?.enabled).toBe(false);
+  });
+
+  it('deletes a rule', () => {
+    const rule = createGigPlatformRule({
+      platform: 'Shipt',
+      matchField: 'any',
+      keywords: ['shipt'],
+    });
+    expect(deleteGigPlatformRule(rule.id)).toBe(true);
+    expect(loadGigPlatformRules().find((r) => r.id === rule.id)).toBeUndefined();
+    expect(deleteGigPlatformRule('nope')).toBe(false);
+  });
+
+  it('stores and clears expected payouts', () => {
+    setExpectedPayout('Uber', 50000);
+    expect(loadExpectedPayouts()).toEqual({ Uber: 50000 });
+    setExpectedPayout('DoorDash', 12345);
+    expect(loadExpectedPayouts()).toEqual({ Uber: 50000, DoorDash: 12345 });
+    // zero / negative removes the entry
+    setExpectedPayout('Uber', 0);
+    expect(loadExpectedPayouts()).toEqual({ DoorDash: 12345 });
+  });
+
+  it('returns an empty map on corrupt expected-payout storage', () => {
+    localStorage.setItem('finance-gig-expected-payouts', 'oops');
+    expect(loadExpectedPayouts()).toEqual({});
+  });
+});

--- a/apps/web/src/lib/gig/platform-rules-storage.ts
+++ b/apps/web/src/lib/gig/platform-rules-storage.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * localStorage persistence for gig-platform mapping rules and expected payouts.
+ *
+ * Follows the same pattern as the tagging rule engine: a single JSON array
+ * under one key, with defensive parsing that never throws. Built-in default
+ * rules seed the list on first load so platforms are recognised out of the box.
+ *
+ * References: issue #2133
+ */
+
+import { DEFAULT_GIG_PLATFORM_RULES } from './platform-earnings';
+import type { GigMatchField, GigPlatformRule } from './platform-types';
+
+const RULES_STORAGE_KEY = 'finance-gig-platform-rules';
+const EXPECTED_STORAGE_KEY = 'finance-gig-expected-payouts';
+
+// ---------------------------------------------------------------------------
+// Rules
+// ---------------------------------------------------------------------------
+
+const VALID_FIELDS: ReadonlySet<GigMatchField> = new Set<GigMatchField>([
+  'payee',
+  'description',
+  'account',
+  'any',
+]);
+
+function isValidRule(value: unknown): value is GigPlatformRule {
+  if (typeof value !== 'object' || value === null) return false;
+  const rule = value as Record<string, unknown>;
+  return (
+    typeof rule.id === 'string' &&
+    typeof rule.platform === 'string' &&
+    typeof rule.matchField === 'string' &&
+    VALID_FIELDS.has(rule.matchField as GigMatchField) &&
+    Array.isArray(rule.keywords) &&
+    rule.keywords.every((k) => typeof k === 'string') &&
+    typeof rule.enabled === 'boolean' &&
+    typeof rule.isBuiltIn === 'boolean' &&
+    typeof rule.createdAt === 'string'
+  );
+}
+
+/**
+ * Load all gig-platform rules. Returns the built-in defaults (a fresh copy)
+ * when nothing has been persisted yet, and never throws.
+ */
+export function loadGigPlatformRules(): GigPlatformRule[] {
+  try {
+    const raw = localStorage.getItem(RULES_STORAGE_KEY);
+    if (!raw) return DEFAULT_GIG_PLATFORM_RULES.map((r) => ({ ...r, keywords: [...r.keywords] }));
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return DEFAULT_GIG_PLATFORM_RULES.map((r) => ({ ...r, keywords: [...r.keywords] }));
+    }
+    return parsed.filter(isValidRule);
+  } catch {
+    return DEFAULT_GIG_PLATFORM_RULES.map((r) => ({ ...r, keywords: [...r.keywords] }));
+  }
+}
+
+/** Persist the full list of gig-platform rules. */
+export function saveGigPlatformRules(rules: readonly GigPlatformRule[]): void {
+  localStorage.setItem(RULES_STORAGE_KEY, JSON.stringify(rules));
+}
+
+/** Input for creating a new custom rule. */
+export interface CreateGigRuleInput {
+  readonly platform: string;
+  readonly matchField: GigMatchField;
+  readonly keywords: readonly string[];
+  readonly enabled?: boolean;
+}
+
+function makeId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `gig-${crypto.randomUUID()}`;
+    }
+  } catch {
+    /* fall through */
+  }
+  return `gig-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Create and persist a new custom rule. User rules are prepended so they take
+ * precedence over the built-in defaults during matching.
+ */
+export function createGigPlatformRule(input: CreateGigRuleInput): GigPlatformRule {
+  const platform = input.platform.trim();
+  if (!platform) throw new Error('Platform name is required.');
+  const keywords = input.keywords.map((k) => k.trim()).filter((k) => k.length > 0);
+  if (keywords.length === 0) throw new Error('At least one keyword is required.');
+
+  const rule: GigPlatformRule = {
+    id: makeId(),
+    platform,
+    matchField: input.matchField,
+    keywords,
+    enabled: input.enabled ?? true,
+    isBuiltIn: false,
+    createdAt: new Date().toISOString(),
+  };
+
+  const rules = loadGigPlatformRules();
+  saveGigPlatformRules([rule, ...rules]);
+  return rule;
+}
+
+/** Toggle a rule's `enabled` flag. Returns the updated rule, or null. */
+export function toggleGigPlatformRule(id: string): GigPlatformRule | null {
+  const rules = loadGigPlatformRules();
+  let updated: GigPlatformRule | null = null;
+  const next = rules.map((rule) => {
+    if (rule.id !== id) return rule;
+    updated = { ...rule, enabled: !rule.enabled };
+    return updated;
+  });
+  if (updated) saveGigPlatformRules(next);
+  return updated;
+}
+
+/** Delete a rule by id. Returns true when a rule was removed. */
+export function deleteGigPlatformRule(id: string): boolean {
+  const rules = loadGigPlatformRules();
+  const next = rules.filter((rule) => rule.id !== id);
+  if (next.length === rules.length) return false;
+  saveGigPlatformRules(next);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Expected payouts
+// ---------------------------------------------------------------------------
+
+/** Load the platform → expected-cents map. Never throws. */
+export function loadExpectedPayouts(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(EXPECTED_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return {};
+    const result: Record<string, number> = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        result[key] = Math.trunc(value);
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+/** Persist the platform → expected-cents map. */
+export function saveExpectedPayouts(map: Record<string, number>): void {
+  localStorage.setItem(EXPECTED_STORAGE_KEY, JSON.stringify(map));
+}
+
+/**
+ * Set (or clear) the expected payout for one platform. Passing 0 removes the
+ * entry. Returns the updated map.
+ */
+export function setExpectedPayout(platform: string, cents: number): Record<string, number> {
+  const map = loadExpectedPayouts();
+  if (!Number.isFinite(cents) || cents <= 0) {
+    delete map[platform];
+  } else {
+    map[platform] = Math.trunc(cents);
+  }
+  saveExpectedPayouts(map);
+  return map;
+}

--- a/apps/web/src/lib/gig/platform-types.ts
+++ b/apps/web/src/lib/gig/platform-types.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Types for grouping gig-platform payouts (Uber, DoorDash, Instacart, Lyft,
+ * Grubhub, ...) out of the cash-flow income stream.
+ *
+ * All monetary values are integer cents (never floats) to match the rest of
+ * the financial-modeling stack.
+ *
+ * References: issue #2133
+ */
+
+/** Which transaction field a mapping rule matches against. */
+export type GigMatchField = 'payee' | 'description' | 'account' | 'any';
+
+/**
+ * A user-defined (or built-in) rule that maps an income transaction to a gig
+ * platform by case-insensitive keyword/substring matching.
+ */
+export interface GigPlatformRule {
+  /** Stable identifier. */
+  readonly id: string;
+  /** Display name of the platform this rule maps to (e.g. "Uber"). */
+  readonly platform: string;
+  /** Transaction field the keywords are matched against. */
+  readonly matchField: GigMatchField;
+  /** Case-insensitive substrings; a rule fires if ANY keyword is contained. */
+  readonly keywords: readonly string[];
+  /** Whether the rule participates in matching. */
+  readonly enabled: boolean;
+  /** Built-in defaults shipped with the app (vs. user-created). */
+  readonly isBuiltIn: boolean;
+  /** ISO-8601 creation timestamp. */
+  readonly createdAt: string;
+}
+
+/** The three rolling periods earnings are bucketed into. */
+export type GigPeriodKey = 'today' | 'week' | 'month';
+
+/** A value measured across all three periods. */
+export interface GigPeriodAmounts {
+  /** Value for the current day (in cents, or a count). */
+  readonly today: number;
+  /** Value for the current week (in cents, or a count). */
+  readonly week: number;
+  /** Value for the current month (in cents, or a count). */
+  readonly month: number;
+}
+
+/** Aggregated earnings for a single platform across the three periods. */
+export interface PlatformEarnings {
+  /** Platform display name; unmapped income is grouped under "Other". */
+  readonly platform: string;
+  /** Earnings (income) totals in cents per period. */
+  readonly amounts: GigPeriodAmounts;
+  /** Number of income transactions per period. */
+  readonly counts: GigPeriodAmounts;
+}
+
+/** Full result of {@link computePlatformEarnings}. */
+export interface PlatformEarningsResult {
+  /** Per-platform breakdown, sorted by month earnings descending. */
+  readonly platforms: readonly PlatformEarnings[];
+  /** Combined (cross-platform) earnings totals in cents per period. */
+  readonly combined: GigPeriodAmounts;
+  /** Combined (cross-platform) transaction counts per period. */
+  readonly combinedCounts: GigPeriodAmounts;
+}
+
+/** Options controlling period bucketing for {@link computePlatformEarnings}. */
+export interface PlatformEarningsOptions {
+  /** Reference "now" used to compute today/week/month. Defaults to current time. */
+  readonly referenceDate?: Date;
+  /** Day the week starts on (0 = Sunday, 1 = Monday). Defaults to Monday. */
+  readonly weekStartsOn?: 0 | 1;
+  /** Map of accountId → account name, for "account"/"any" field matching. */
+  readonly accountNames?: ReadonlyMap<string, string>;
+}
+
+/** A user-entered expected payout for a platform (in cents). */
+export interface ExpectedPayout {
+  readonly platform: string;
+  /** Expected payout amount in cents. */
+  readonly expectedCents: number;
+}
+
+/** Outcome of reconciling expected payouts against received deposits. */
+export type ReconciliationStatus = 'matched' | 'over' | 'under' | 'pending';
+
+/** Reconciliation of expected vs. received payout for one platform. */
+export interface PlatformReconciliation {
+  readonly platform: string;
+  /** Expected payout in cents. */
+  readonly expectedCents: number;
+  /** Received deposits in cents for the period under review. */
+  readonly receivedCents: number;
+  /** received − expected, in cents (positive means more than expected). */
+  readonly varianceCents: number;
+  /** Reconciliation status. */
+  readonly status: ReconciliationStatus;
+}
+
+/** Options for {@link reconcilePlatformPayouts}. */
+export interface ReconciliationOptions {
+  /** Period whose received amount is compared against the expected payout. */
+  readonly period?: GigPeriodKey;
+  /** Absolute cents tolerance treated as a match (e.g. rounding noise). */
+  readonly toleranceCents?: number;
+}
+
+/** Label used for income that does not map to any gig platform. */
+export const OTHER_PLATFORM_LABEL = 'Other';

--- a/apps/web/src/pages/CashFlowPage.test.tsx
+++ b/apps/web/src/pages/CashFlowPage.test.tsx
@@ -22,6 +22,12 @@ vi.mock('../components/charts/chart-palette', () => ({
   CHART_COLORS: ['#648FFF', '#FE6100', '#785EF0', '#FFB000', '#DC267F', '#009E73'],
 }));
 
+// Mock the gig-earnings section (covered by its own tests) so this page test
+// does not need the database-backed useGigPlatformEarnings hook.
+vi.mock('../components/gig/GigPlatformEarningsSection', () => ({
+  GigPlatformEarningsSection: () => null,
+}));
+
 import { useCashFlow } from '../hooks/useCashFlow';
 
 const mockUseCashFlow = vi.mocked(useCashFlow);

--- a/apps/web/src/pages/CashFlowPage.tsx
+++ b/apps/web/src/pages/CashFlowPage.tsx
@@ -23,6 +23,9 @@ import { useCashFlow } from '../hooks/useCashFlow';
 import type { MonthlyAggregate, IncomeSource } from '../lib/analytics/cash-flow';
 import { forecastMonthEndBalance } from '../lib/budgeting-beta';
 import { CHART_COLORS } from '../components/charts/chart-palette';
+// Imported directly (not via a shared barrel) so this gig-earnings UI stays in
+// the code-split Cash Flow chunk and does not inflate other route bundles.
+import { GigPlatformEarningsSection } from '../components/gig/GigPlatformEarningsSection';
 import './analytics.css';
 
 // ---------------------------------------------------------------------------
@@ -379,6 +382,9 @@ export const CashFlowPage: React.FC = () => {
           <IncomeSourceList sources={incomeSources} />
         </section>
       )}
+
+      {/* Gig-platform payouts: an income-sources view grouped by gig platform */}
+      <GigPlatformEarningsSection />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Implements the web slice of **#2133 - Payouts grouped by gig platform**, extending the existing cash-flow analytics so gig drivers can see what each platform actually pays out and reconcile expected vs. received deposits.

Builds on the referenced existing code: `apps/web/src/lib/analytics/cash-flow.ts` (income grouped by `categoryId` only) and `apps/web/src/pages/CashFlowPage.tsx` (the "Income Sources" view) - adding a parallel **by-platform** income view.

## What's included

**Pure engine - `apps/web/src/lib/gig/`**
- `platform-types.ts` - types for rules, period amounts, earnings, reconciliation.
- `platform-earnings.ts`: maps income to a gig platform via user-defined, case-insensitive keyword rules (match payee / description / account / any) with **built-in defaults** for Uber, DoorDash, Instacart, Lyft, Grubhub; aggregates earnings by platform for **today / this week / this month** + a **combined** total; supports **expected-vs-received reconciliation** (matched / over / under / pending, with tolerance). Integer **cents**, **banker's rounding** for percentages, pure functions, **no float money**. Follows the `financial-modeling` skill.
- `platform-rules-storage.ts` - localStorage persistence for rules + expected payouts (defensive parsing; seeds built-ins).

**Hook - `apps/web/src/hooks/useGigPlatformEarnings.ts`**
- Reads local transactions + accounts via repositories, computes earnings via the pure engine, manages rule CRUD + expected-payout targets. No network/credentials.

**UI - `apps/web/src/components/gig/GigPlatformEarningsSection.tsx`** (+ `gig-platform.css`)
- Surfaced directly on `CashFlowPage`. Period toggle as accessible **tabs**, **aria-live** combined total, by-platform breakdown (text amounts + percentages), **platform filter**, semantic **reconciliation table**, and a disclosure to **manage mapping rules**.

## Accessibility (WCAG 2.2 AA)
- Labeled controls; period toggles as `role=tablist`/`tab` with a `tabpanel`; combined total in `aria-live=polite`; reconciliation as a `<table>` with `<caption>` + `scope`; status by **text + symbol**, never colour alone; keyboard-navigable; `prefers-reduced-motion` respected.

## Bundle / perf budget
- Imported **directly** into `CashFlowPage` (not a shared barrel), so it stays in the code-split `route-planning` chunk (~56 KiB gzip). `npm run perf:budget` passes (215 KB gzip lazy-chunk budget).

## Tests
- `platform-earnings.test.ts` (28), `platform-rules-storage.test.ts` (9), `GigPlatformEarningsSection.test.tsx` (10); existing `CashFlowPage.test.tsx` updated. `tsc --noEmit`, `eslint --max-warnings 0`, `prettier` all clean.

## Out of scope (tracked separately)
- Native Android by-platform filtering and mileage-by-platform economics remain for the platform agents.

Refs #2133
