### PR TITLE
feat(web): P2P (Venmo/Cash App) import with reimbursement-aware categorization (#2158)

### DIFF
--- a/apps/web/src/components/import/P2PImportPanel.test.tsx
+++ b/apps/web/src/components/import/P2PImportPanel.test.tsx
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildP2PImportPlan } from '../../lib/p2p-import';
+import type { P2PImportPlan } from '../../lib/p2p-import-types';
+import { P2PImportPanel, type P2PImportPanelProps } from './P2PImportPanel';
+
+const VENMO_SPLIT_CSV = [
+  'Datetime,Type,Status,Note,From,To,Amount (total),Amount (fee)',
+  '2024-01-10T18:00:00,Payment,Complete,Pizza night,Me,Joes Pizza,- $60.00,',
+  '2024-01-11T09:00:00,Payment,Complete,pizza,Alice,Me,+ $20.00,',
+  '2024-01-11T09:05:00,Payment,Complete,pizza,Bob,Me,+ $20.00,',
+].join('\n');
+
+function buildPlan(): P2PImportPlan {
+  return buildP2PImportPlan(VENMO_SPLIT_CSV);
+}
+
+function renderPanel(overrides: Partial<P2PImportPanelProps> = {}) {
+  const props: P2PImportPanelProps = {
+    fileName: 'venmo.csv',
+    plan: buildPlan(),
+    overrides: {},
+    parseError: null,
+    accounts: [
+      { id: 'acc-1', name: 'Checking' },
+      { id: 'acc-2', name: 'Savings' },
+    ],
+    selectedAccountId: null,
+    importing: false,
+    saveResult: null,
+    onLoadFile: vi.fn(),
+    onSetOverride: vi.fn(),
+    onSelectAccount: vi.fn(),
+    onConfirmImport: vi.fn(),
+    onReset: vi.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<P2PImportPanel {...props} />) };
+}
+
+describe('P2PImportPanel', () => {
+  it('renders the heading, intro, and a labeled file input', () => {
+    renderPanel({ plan: null });
+    expect(screen.getByRole('heading', { name: /venmo & cash app import/i })).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/choose a venmo or cash app csv file to import/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/import into account/i)).toBeInTheDocument();
+  });
+
+  it('announces the net spending summary in a live region', () => {
+    renderPanel();
+    const summary = screen.getByRole('group', { name: /import summary/i });
+    expect(summary).toHaveAttribute('aria-live', 'polite');
+    expect(within(summary).getByText(/net spending to import/i)).toBeInTheDocument();
+    expect(within(summary).getByText(/reimbursements excluded/i)).toBeInTheDocument();
+  });
+
+  it('shows classification with text labels, not colour alone', () => {
+    renderPanel();
+    // The outflow is spending; the two inflows are reimbursements.
+    expect(
+      screen.getByText('Spending', { selector: '.p2p-import__class-label' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText('Reimbursement', { selector: '.p2p-import__class-label' }),
+    ).toHaveLength(2);
+  });
+
+  it('renders a preview table with column headers', () => {
+    renderPanel();
+    expect(screen.getByRole('columnheader', { name: /date/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /classification/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /treat as/i })).toBeInTheDocument();
+  });
+
+  it('invokes onSetOverride when an override is changed', () => {
+    const { props } = renderPanel();
+    const selects = screen.getAllByRole('combobox');
+    // selects[0] is the account selector; per-row override selects follow.
+    fireEvent.change(selects[2], { target: { value: 'spending' } });
+    expect(props.onSetOverride).toHaveBeenCalledWith(1, 'spending');
+  });
+
+  it('clears an override when set back to auto', () => {
+    const { props } = renderPanel({ overrides: { 1: 'spending' } });
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[2], { target: { value: '' } });
+    expect(props.onSetOverride).toHaveBeenCalledWith(1, null);
+  });
+
+  it('invokes onSelectAccount when the destination account changes', () => {
+    const { props } = renderPanel();
+    fireEvent.change(screen.getByLabelText(/import into account/i), {
+      target: { value: 'acc-2' },
+    });
+    expect(props.onSelectAccount).toHaveBeenCalledWith('acc-2');
+  });
+
+  it('disables import until a destination account is selected', () => {
+    const { rerender, props } = renderPanel();
+    const button = screen.getByRole('button', { name: /import \d+ net transaction/i });
+    expect(button).toBeDisabled();
+
+    rerender(<P2PImportPanel {...props} selectedAccountId="acc-1" />);
+    const enabled = screen.getByRole('button', { name: /import \d+ net transaction/i });
+    expect(enabled).toBeEnabled();
+    fireEvent.click(enabled);
+    expect(props.onConfirmImport).toHaveBeenCalled();
+  });
+
+  it('surfaces a parse error with role="alert"', () => {
+    renderPanel({ plan: null, parseError: 'Unrecognized file' });
+    expect(screen.getByRole('alert')).toHaveTextContent('Unrecognized file');
+  });
+
+  it('reports the save result in a status region', () => {
+    renderPanel({ saveResult: { created: 1, excluded: 2, failed: 0 } });
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent(/imported 1 net transaction/i);
+    expect(status).toHaveTextContent(/2 reimbursement or transfer rows excluded/i);
+  });
+
+  it('lists skipped rows when the plan has parse errors', () => {
+    const csv = ['date,description,counterparty,amount,type', ',bad,Someone,- $5.00,payment'].join(
+      '\n',
+    );
+    renderPanel({ plan: buildP2PImportPlan(csv) });
+    expect(screen.getByText(/skipped rows/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/import/P2PImportPanel.tsx
+++ b/apps/web/src/components/import/P2PImportPanel.tsx
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Accessible Venmo / Cash App (P2P) import surface.
+ *
+ * Presentational component: all state and persistence live in the
+ * {@link useP2PImport} hook, which the page wires in. It previews parsed rows,
+ * shows the spending / reimbursement / transfer classification with a text
+ * label *and* an icon (never color alone), lets the user override each row, and
+ * confirms the net (budget-affecting) totals before saving.
+ *
+ * Accessibility:
+ *   - Labeled file input and account selector
+ *   - Preview table with a caption and `scope="col"` headers
+ *   - Classification uses text + icon (no color-only signaling)
+ *   - Per-row override is a keyboard-navigable native `<select>`
+ *   - Summary and status updates use `aria-live="polite"`; errors use `role="alert"`
+ */
+
+import React, { useId, useMemo } from 'react';
+
+import { formatCurrency } from '../../lib/currency';
+import { buildImportableTransactions } from '../../lib/p2p-import';
+import type {
+  P2PClassification,
+  P2PClassifiedRow,
+  P2PImportPlan,
+  P2POverride,
+} from '../../lib/p2p-import-types';
+import { AppIcon, type IconName } from '../icons';
+import { FileDropZone } from './FileDropZone';
+
+import './p2p-import-panel.css';
+
+export interface P2PImportAccountOption {
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface P2PImportSaveSummary {
+  readonly created: number;
+  readonly excluded: number;
+  readonly failed: number;
+}
+
+export interface P2PImportPanelProps {
+  fileName: string | null;
+  plan: P2PImportPlan | null;
+  overrides: Readonly<Record<number, P2POverride>>;
+  parseError: string | null;
+  accounts: readonly P2PImportAccountOption[];
+  selectedAccountId: string | null;
+  importing: boolean;
+  saveResult: P2PImportSaveSummary | null;
+  onLoadFile: (file: File) => void;
+  onSetOverride: (index: number, override: P2POverride | null) => void;
+  onSelectAccount: (id: string) => void;
+  onConfirmImport: () => void;
+  onReset: () => void;
+}
+
+const CLASSIFICATION_META: Record<
+  P2PClassification,
+  { label: string; icon: IconName; description: string }
+> = {
+  spending: {
+    label: 'Spending',
+    icon: 'shopping-cart',
+    description: 'Counts toward your budget and cash-flow.',
+  },
+  reimbursement: {
+    label: 'Reimbursement',
+    icon: 'refresh',
+    description: 'Excluded from budget so it cannot distort your spending.',
+  },
+  transfer: {
+    label: 'Transfer',
+    icon: 'bank',
+    description: 'Money moved between accounts — excluded from spending.',
+  },
+};
+
+const OVERRIDE_OPTIONS: readonly { value: '' | P2POverride; label: string }[] = [
+  { value: '', label: 'Auto (suggested)' },
+  { value: 'spending', label: 'Spending' },
+  { value: 'split-with-friends', label: 'Split with friends' },
+  { value: 'roommate-reimbursement', label: 'Roommate reimbursement' },
+  { value: 'transfer', label: 'Transfer' },
+];
+
+function formatCents(cents: number): string {
+  return formatCurrency(cents, { signDisplay: 'always' });
+}
+
+function formatPlain(cents: number): string {
+  return formatCurrency(Math.abs(cents));
+}
+
+export const P2PImportPanel: React.FC<P2PImportPanelProps> = ({
+  fileName,
+  plan,
+  overrides,
+  parseError,
+  accounts,
+  selectedAccountId,
+  importing,
+  saveResult,
+  onLoadFile,
+  onSetOverride,
+  onSelectAccount,
+  onConfirmImport,
+  onReset,
+}) => {
+  const accountSelectId = useId();
+  const summaryId = useId();
+
+  const anchorByMember = useMemo(() => {
+    const map = new Map<number, P2PClassifiedRow>();
+    if (plan === null) return map;
+    const byIndex = new Map(plan.rows.map((row) => [row.index, row]));
+    for (const group of plan.groups) {
+      const anchor = byIndex.get(group.anchorIndex);
+      if (!anchor) continue;
+      for (const memberIndex of group.memberIndices) {
+        map.set(memberIndex, anchor);
+      }
+    }
+    return map;
+  }, [plan]);
+
+  const groupByAnchor = useMemo(() => {
+    const map = new Map<number, P2PImportPlan['groups'][number]>();
+    if (plan === null) return map;
+    for (const group of plan.groups) {
+      map.set(group.anchorIndex, group);
+    }
+    return map;
+  }, [plan]);
+
+  const importableCount = useMemo(
+    () => (plan === null ? 0 : buildImportableTransactions(plan).length),
+    [plan],
+  );
+
+  const canImport =
+    plan !== null && selectedAccountId !== null && importableCount > 0 && !importing;
+
+  return (
+    <section className="p2p-import" aria-labelledby="p2p-import-heading">
+      <h2 id="p2p-import-heading" className="p2p-import__title">
+        Venmo &amp; Cash App Import
+      </h2>
+      <p className="p2p-import__intro">
+        Import a Venmo or Cash App activity export (.csv). We detect likely reimbursements — money
+        friends pay you back or your roommate share — and keep them out of your budget so your
+        spending stays accurate. Connecting a live account is not available here; export a CSV from
+        the Venmo or Cash App website first.
+      </p>
+
+      <div className="p2p-import__controls">
+        <div className="p2p-import__account">
+          <label htmlFor={accountSelectId} className="p2p-import__label">
+            Import into account
+          </label>
+          <select
+            id={accountSelectId}
+            className="form-select"
+            value={selectedAccountId ?? ''}
+            onChange={(event) => onSelectAccount(event.target.value)}
+            aria-required="true"
+          >
+            <option value="" disabled>
+              Select an account
+            </option>
+            {accounts.map((account) => (
+              <option key={account.id} value={account.id}>
+                {account.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <FileDropZone
+          accept=".csv"
+          onFile={onLoadFile}
+          inputLabel="Choose a Venmo or Cash App CSV file to import"
+          hint={fileName ? `Selected: ${fileName}` : '.csv files up to 10 MB'}
+        />
+      </div>
+
+      {parseError !== null && (
+        <p className="p2p-import__error" role="alert">
+          <AppIcon name="alert-triangle" />
+          {parseError}
+        </p>
+      )}
+
+      {plan !== null && (
+        <>
+          <div
+            className="p2p-import__summary"
+            role="group"
+            aria-labelledby={summaryId}
+            aria-live="polite"
+          >
+            <h3 id={summaryId} className="p2p-import__summary-title">
+              Import summary ({plan.provider})
+            </h3>
+            <dl className="p2p-import__stats">
+              <div className="p2p-import__stat">
+                <dt>Net spending to import</dt>
+                <dd>{formatPlain(plan.summary.netSpendingCents)}</dd>
+              </div>
+              <div className="p2p-import__stat">
+                <dt>Reimbursements excluded</dt>
+                <dd>{formatPlain(plan.summary.excludedFromBudgetCents)}</dd>
+              </div>
+              <div className="p2p-import__stat">
+                <dt>Reimbursement rows</dt>
+                <dd>{plan.summary.reimbursementCount}</dd>
+              </div>
+              <div className="p2p-import__stat">
+                <dt>Transfers</dt>
+                <dd>{plan.summary.transferCount}</dd>
+              </div>
+            </dl>
+            <p className="p2p-import__summary-note">
+              {plan.summary.netGroupCount > 0
+                ? `${plan.summary.netGroupCount} spend${
+                    plan.summary.netGroupCount === 1 ? '' : 's'
+                  } netted against reimbursements. `
+                : ''}
+              {importableCount} net transaction{importableCount === 1 ? '' : 's'} will be saved;
+              reimbursements and transfers are excluded from your budget.
+            </p>
+          </div>
+
+          <div className="p2p-import__table-wrapper">
+            <table className="p2p-import__table">
+              <caption className="p2p-import__caption">
+                Parsed P2P activity with suggested classification. Use the &ldquo;Treat as&rdquo;
+                control to correct any row.
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Date</th>
+                  <th scope="col">Counterparty</th>
+                  <th scope="col">Note</th>
+                  <th scope="col" className="p2p-import__amount-col">
+                    Amount
+                  </th>
+                  <th scope="col">Classification</th>
+                  <th scope="col">Treat as</th>
+                </tr>
+              </thead>
+              <tbody>
+                {plan.rows.map((row) => {
+                  const meta = CLASSIFICATION_META[row.effectiveClassification];
+                  const overrideValue = overrides[row.index] ?? '';
+                  const group = groupByAnchor.get(row.index);
+                  const anchor = anchorByMember.get(row.index);
+                  return (
+                    <tr key={row.index}>
+                      <td>{row.date}</td>
+                      <td>{row.counterparty || '—'}</td>
+                      <td>{row.note || '—'}</td>
+                      <td className="p2p-import__amount-col">{formatCents(row.amountCents)}</td>
+                      <td>
+                        <span className="p2p-import__class">
+                          <AppIcon name={meta.icon} />
+                          <span className="p2p-import__class-label">{meta.label}</span>
+                          {row.override !== null && (
+                            <span className="p2p-import__class-tag"> (overridden)</span>
+                          )}
+                        </span>
+                        <span className="p2p-import__reason">
+                          {group
+                            ? `Net ${formatPlain(group.netSpendingCents)} after ${formatPlain(
+                                group.reimbursedCents,
+                              )} reimbursed.`
+                            : anchor
+                              ? `Reimburses ${anchor.note || anchor.counterparty || 'a spend'}.`
+                              : (row.reasons[0] ?? meta.description)}
+                        </span>
+                      </td>
+                      <td>
+                        <label className="sr-only" htmlFor={`p2p-override-${row.index}`}>
+                          Treat the {formatPlain(row.amountCents)} {row.counterparty || 'P2P'} entry
+                          on {row.date} as
+                        </label>
+                        <select
+                          id={`p2p-override-${row.index}`}
+                          className="form-select p2p-import__override"
+                          value={overrideValue}
+                          onChange={(event) =>
+                            onSetOverride(
+                              row.index,
+                              event.target.value === ''
+                                ? null
+                                : (event.target.value as P2POverride),
+                            )
+                          }
+                        >
+                          {OVERRIDE_OPTIONS.map((option) => (
+                            <option key={option.value || 'auto'} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {plan.errors.length > 0 && (
+            <div className="p2p-import__errors">
+              <h3 className="p2p-import__errors-title">Skipped rows ({plan.errors.length})</h3>
+              <table className="p2p-import__table">
+                <caption className="sr-only">Rows that could not be parsed</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Line</th>
+                    <th scope="col">Reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {plan.errors.map((error, index) => (
+                    <tr key={`${error.line}-${index}`}>
+                      <td>{error.line}</td>
+                      <td>{error.message}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <div className="p2p-import__actions">
+            <button type="button" className="form-button form-button--secondary" onClick={onReset}>
+              Start over
+            </button>
+            <button
+              type="button"
+              className="form-button form-button--primary"
+              onClick={onConfirmImport}
+              disabled={!canImport}
+              aria-disabled={!canImport}
+            >
+              {importing
+                ? 'Importing…'
+                : `Import ${importableCount} net transaction${importableCount === 1 ? '' : 's'}`}
+            </button>
+          </div>
+        </>
+      )}
+
+      <div className="p2p-import__status" role="status" aria-live="polite">
+        {saveResult !== null &&
+          `Imported ${saveResult.created} net transaction${
+            saveResult.created === 1 ? '' : 's'
+          }. ${saveResult.excluded} reimbursement or transfer row${
+            saveResult.excluded === 1 ? '' : 's'
+          } excluded from your budget.${
+            saveResult.failed > 0 ? ` ${saveResult.failed} failed.` : ''
+          }`}
+      </div>
+    </section>
+  );
+};
+
+export default P2PImportPanel;

--- a/apps/web/src/components/import/p2p-import-panel.css
+++ b/apps/web/src/components/import/p2p-import-panel.css
@@ -1,0 +1,226 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Venmo / Cash App (P2P) import surface styles.
+ *
+ * Token-only: colours, spacing, typography, radius and borders come from the
+ * design-tokens custom properties (same pattern as import.css). Classification
+ * is communicated with text + icon, never colour alone, so it remains legible
+ * for users with colour-vision differences and in high-contrast mode.
+ */
+
+.p2p-import {
+  max-width: var(--layout-content-max-width, 1040px);
+  margin: 0 auto;
+  padding: var(--spacing-4);
+  color: var(--semantic-text-primary);
+}
+
+.p2p-import__title {
+  font-size: var(--type-scale-headline-font-size);
+  font-weight: var(--type-scale-headline-font-weight);
+  margin: 0 0 var(--spacing-2);
+}
+
+.p2p-import__intro {
+  font-size: var(--type-scale-body-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-5);
+  max-width: 70ch;
+}
+
+.p2p-import__controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-5);
+}
+
+.p2p-import__account {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.p2p-import__label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+}
+
+.p2p-import__error {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+  border: 1px solid var(--semantic-status-negative);
+  border-radius: var(--border-radius-md);
+  color: var(--semantic-status-negative);
+  background: var(--semantic-background-secondary);
+  margin: 0 0 var(--spacing-4);
+}
+
+/* ---------------------------------------------------------------------------
+ * Summary
+ * ------------------------------------------------------------------------- */
+
+.p2p-import__summary {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+  padding: var(--spacing-4);
+  margin-bottom: var(--spacing-5);
+}
+
+.p2p-import__summary-title {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  margin: 0 0 var(--spacing-3);
+  text-transform: capitalize;
+}
+
+.p2p-import__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: var(--spacing-3);
+  margin: 0 0 var(--spacing-3);
+}
+
+.p2p-import__stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.p2p-import__stat dt {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.p2p-import__stat dd {
+  margin: 0;
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--font-weight-semibold);
+}
+
+.p2p-import__summary-note {
+  margin: 0;
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+/* ---------------------------------------------------------------------------
+ * Preview table
+ * ------------------------------------------------------------------------- */
+
+.p2p-import__table-wrapper {
+  overflow-x: auto;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  margin-bottom: var(--spacing-5);
+}
+
+.p2p-import__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--type-scale-body-font-size);
+}
+
+.p2p-import__caption {
+  caption-side: top;
+  text-align: left;
+  padding: var(--spacing-3);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.p2p-import__table th,
+.p2p-import__table td {
+  text-align: left;
+  padding: var(--spacing-2) var(--spacing-3);
+  border-bottom: 1px solid var(--semantic-border-default);
+  vertical-align: top;
+}
+
+.p2p-import__table thead th {
+  background: var(--semantic-background-secondary);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+  position: sticky;
+  top: 0;
+}
+
+.p2p-import__amount-col {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.p2p-import__class {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-weight: var(--font-weight-medium);
+}
+
+.p2p-import__class-tag {
+  color: var(--semantic-text-secondary);
+  font-weight: var(--font-weight-medium);
+}
+
+.p2p-import__reason {
+  display: block;
+  margin-top: var(--spacing-1);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  max-width: 32ch;
+}
+
+.p2p-import__override {
+  min-width: 12rem;
+}
+
+/* ---------------------------------------------------------------------------
+ * Errors + actions
+ * ------------------------------------------------------------------------- */
+
+.p2p-import__errors {
+  margin-bottom: var(--spacing-5);
+}
+
+.p2p-import__errors-title {
+  font-size: var(--type-scale-title-font-size);
+  color: var(--semantic-status-warning);
+  margin: 0 0 var(--spacing-2);
+}
+
+.p2p-import__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
+}
+
+.p2p-import__status {
+  margin-top: var(--spacing-3);
+  font-size: var(--type-scale-body-font-size);
+  color: var(--semantic-status-positive);
+}
+
+@media (min-width: 720px) {
+  .p2p-import__controls {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .p2p-import__account {
+    min-width: 16rem;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .p2p-import__summary,
+  .p2p-import__table-wrapper {
+    border-width: 2px;
+  }
+}

--- a/apps/web/src/hooks/useP2PImport.ts
+++ b/apps/web/src/hooks/useP2PImport.ts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Hook that drives the Venmo / Cash App (P2P) import surface.
+ *
+ * It owns the parsed {@link P2PImportPlan}, user overrides, the selected
+ * destination account, and the save action. All data access goes through the
+ * {@link useTransactions} and {@link useAccounts} hooks — components never
+ * touch repositories directly. Reimbursements and transfers are excluded from
+ * the saved (budget-affecting) transactions so they cannot distort budgets,
+ * cash-flow, or insights.
+ *
+ * References: issue #2158
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+
+import type { SyncId } from '../kmp/bridge';
+import { applyOverrides, buildImportableTransactions, buildP2PImportPlan } from '../lib/p2p-import';
+import type { P2PImportPlan, P2POverride } from '../lib/p2p-import-types';
+import { useAccounts } from './useAccounts';
+import { useTransactions } from './useTransactions';
+
+const MAX_P2P_CSV_BYTES = 10 * 1024 * 1024; // 10 MB
+
+export interface P2PImportSaveResult {
+  /** Net spending transactions written to the ledger. */
+  readonly created: number;
+  /** Reimbursements + transfers intentionally excluded from the budget. */
+  readonly excluded: number;
+  /** Rows that failed to save. */
+  readonly failed: number;
+}
+
+export interface UseP2PImportResult {
+  fileName: string | null;
+  plan: P2PImportPlan | null;
+  overrides: Readonly<Record<number, P2POverride>>;
+  parseError: string | null;
+  selectedAccountId: string | null;
+  importing: boolean;
+  saveResult: P2PImportSaveResult | null;
+  loadFile: (file: File) => Promise<void>;
+  setOverride: (index: number, override: P2POverride | null) => void;
+  setSelectedAccountId: (id: string) => void;
+  confirmImport: () => void;
+  reset: () => void;
+}
+
+export function useP2PImport(): UseP2PImportResult {
+  const { accounts } = useAccounts();
+  const { createTransaction } = useTransactions();
+
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [basePlan, setBasePlan] = useState<P2PImportPlan | null>(null);
+  const [overrides, setOverrides] = useState<Record<number, P2POverride>>({});
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [saveResult, setSaveResult] = useState<P2PImportSaveResult | null>(null);
+
+  // Recompute the plan with the current overrides without re-parsing the file.
+  const plan = useMemo<P2PImportPlan | null>(() => {
+    if (basePlan === null) return null;
+    if (Object.keys(overrides).length === 0) return basePlan;
+    return applyOverrides(basePlan, overrides);
+  }, [basePlan, overrides]);
+
+  const loadFile = useCallback(async (file: File): Promise<void> => {
+    setSaveResult(null);
+    setOverrides({});
+
+    if (file.size > MAX_P2P_CSV_BYTES) {
+      setParseError('File is too large. Please choose a CSV under 10 MB.');
+      setBasePlan(null);
+      setFileName(null);
+      return;
+    }
+
+    try {
+      const content = await file.text();
+      const nextPlan = buildP2PImportPlan(content);
+      if (nextPlan.provider === null) {
+        setParseError(
+          'This file does not look like a Venmo or Cash App export. Expected date, note, and amount columns.',
+        );
+        setBasePlan(null);
+        setFileName(file.name);
+        return;
+      }
+      setParseError(null);
+      setBasePlan(nextPlan);
+      setFileName(file.name);
+    } catch {
+      setParseError('Could not read the selected file.');
+      setBasePlan(null);
+      setFileName(null);
+    }
+  }, []);
+
+  const setOverride = useCallback((index: number, override: P2POverride | null): void => {
+    setSaveResult(null);
+    setOverrides((prev) => {
+      const next = { ...prev };
+      if (override === null) {
+        delete next[index];
+      } else {
+        next[index] = override;
+      }
+      return next;
+    });
+  }, []);
+
+  const confirmImport = useCallback((): void => {
+    if (plan === null || selectedAccountId === null || importing) return;
+
+    const account = accounts.find((candidate) => candidate.id === selectedAccountId);
+    if (account === undefined) {
+      setParseError('Select a valid destination account before importing.');
+      return;
+    }
+
+    setImporting(true);
+    const importable = buildImportableTransactions(plan);
+
+    let created = 0;
+    let failed = 0;
+
+    for (const transaction of importable) {
+      const tags = transaction.isNetted ? ['p2p-import', 'net-of-reimbursement'] : ['p2p-import'];
+      const noteSuffix = transaction.isNetted
+        ? ` (net of ${formatReimbursed(transaction.reimbursedCents)} reimbursed)`
+        : '';
+      const result = createTransaction({
+        householdId: account.householdId as SyncId,
+        accountId: account.id,
+        type: 'EXPENSE',
+        amount: { amount: Math.abs(transaction.amountCents) },
+        payee: transaction.payee || null,
+        note: `${transaction.note || 'P2P payment'}${noteSuffix}`.trim(),
+        date: transaction.date,
+        tags,
+      });
+      if (result !== null) {
+        created += 1;
+      } else {
+        failed += 1;
+      }
+    }
+
+    const excluded = plan.summary.reimbursementCount + plan.summary.transferCount;
+    setSaveResult({ created, excluded, failed });
+    setImporting(false);
+  }, [accounts, createTransaction, importing, plan, selectedAccountId]);
+
+  const reset = useCallback((): void => {
+    setFileName(null);
+    setBasePlan(null);
+    setOverrides({});
+    setParseError(null);
+    setSaveResult(null);
+    setImporting(false);
+  }, []);
+
+  return {
+    fileName,
+    plan,
+    overrides,
+    parseError,
+    selectedAccountId,
+    importing,
+    saveResult,
+    loadFile,
+    setOverride,
+    setSelectedAccountId,
+    confirmImport,
+    reset,
+  };
+}
+
+function formatReimbursed(cents: number): string {
+  const dollars = Math.abs(cents) / 100;
+  return `$${dollars.toFixed(2)}`;
+}

--- a/apps/web/src/lib/__tests__/p2p-import.test.ts
+++ b/apps/web/src/lib/__tests__/p2p-import.test.ts
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyOverrides,
+  buildImportableTransactions,
+  buildP2PImportPlan,
+  classifyRow,
+  detectP2PProvider,
+  netReimbursements,
+  parseP2PCsv,
+} from '../p2p-import';
+import type { P2PParsedRow } from '../p2p-import-types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const VENMO_HEADER = 'Datetime,Type,Status,Note,From,To,Amount (total),Amount (fee)';
+
+/** You front pizza, two friends Venmo you back. */
+const VENMO_SPLIT_CSV = [
+  VENMO_HEADER,
+  '2024-01-10T18:00:00,Payment,Complete,Pizza night,Me,Joes Pizza,- $60.00,',
+  '2024-01-11T09:00:00,Payment,Complete,pizza,Alice,Me,+ $20.00,',
+  '2024-01-11T09:05:00,Payment,Complete,pizza,Bob,Me,+ $20.00,',
+].join('\n');
+
+/** Roommate back-and-forth: same counterparty pays you their half. */
+const VENMO_ROOMMATE_CSV = [
+  VENMO_HEADER,
+  '2024-05-01T12:00:00,Payment,Complete,Groceries this week,Me,Pat,- $80.00,',
+  '2024-05-03T12:00:00,Payment,Complete,my half,Pat,Me,+ $40.00,',
+].join('\n');
+
+const CASHAPP_HEADER =
+  'Transaction ID,Date,Transaction Type,Currency,Amount,Fee,Net Amount,Status,Notes,Name of sender/receiver';
+
+const CASHAPP_CSV = [
+  CASHAPP_HEADER,
+  'CA-1,2024-03-01,Sent P2P,USD,$45.00,$0.00,$45.00,COMPLETE,Dinner with crew,Joes Diner',
+  'CA-2,2024-03-02,Received P2P,USD,$15.00,$0.00,$15.00,COMPLETE,dinner,Alex',
+].join('\n');
+
+const GENERIC_HEADER = 'date,description,counterparty,amount,type';
+
+function parsedRow(overrides: Partial<P2PParsedRow>): P2PParsedRow {
+  return {
+    index: 0,
+    provider: 'generic',
+    date: '2024-01-01',
+    note: '',
+    counterparty: '',
+    amountCents: -1000,
+    feeCents: 0,
+    flowType: 'payment',
+    rawFields: {},
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Provider detection
+// ---------------------------------------------------------------------------
+
+describe('detectP2PProvider', () => {
+  it('detects Venmo headers', () => {
+    expect(detectP2PProvider(VENMO_HEADER.split(','))).toBe('venmo');
+  });
+
+  it('detects Cash App headers', () => {
+    expect(detectP2PProvider(CASHAPP_HEADER.split(','))).toBe('cashapp');
+  });
+
+  it('falls back to generic when date and amount columns exist', () => {
+    expect(detectP2PProvider(GENERIC_HEADER.split(','))).toBe('generic');
+  });
+
+  it('returns null for unrecognized headers', () => {
+    expect(detectP2PProvider(['foo', 'bar', 'baz'])).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CSV parsing
+// ---------------------------------------------------------------------------
+
+describe('parseP2PCsv', () => {
+  it('parses Venmo rows with correct signs and counterparties', () => {
+    const result = parseP2PCsv(VENMO_SPLIT_CSV);
+    expect(result.provider).toBe('venmo');
+    expect(result.errors).toHaveLength(0);
+    expect(result.rows).toHaveLength(3);
+
+    const [outflow, inflow] = result.rows;
+    expect(outflow.amountCents).toBe(-6000);
+    expect(outflow.counterparty).toBe('Joes Pizza');
+    expect(inflow.amountCents).toBe(2000);
+    expect(inflow.counterparty).toBe('Alice');
+  });
+
+  it('uses the transaction-type direction hint for Cash App sent/received rows', () => {
+    const result = parseP2PCsv(CASHAPP_CSV);
+    expect(result.provider).toBe('cashapp');
+    const [sent, received] = result.rows;
+    expect(sent.amountCents).toBe(-4500); // "Sent P2P" forces an outflow
+    expect(sent.counterparty).toBe('Joes Diner');
+    expect(received.amountCents).toBe(1500); // "Received P2P" stays an inflow
+    expect(received.counterparty).toBe('Alex');
+  });
+
+  it('collects malformed rows as errors instead of throwing', () => {
+    const csv = [
+      GENERIC_HEADER,
+      ',payment,Someone,- $10.00,payment', // missing date
+      '2024-07-01,bad amount,Someone,abc,payment', // unparseable amount
+      '2024-07-02,good,Someone,- $5.00,payment',
+    ].join('\n');
+
+    const result = parseP2PCsv(csv);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0].message).toMatch(/date/i);
+    expect(result.errors[1].message).toMatch(/amount/i);
+    expect(result.rows).toHaveLength(1);
+  });
+
+  it('returns a provider of null and an error for unrecognized files', () => {
+    const result = parseP2PCsv('foo,bar\n1,2');
+    expect(result.provider).toBeNull();
+    expect(result.rows).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('preserves integer cents with banker\u2019s rounding', () => {
+    const csv = [
+      GENERIC_HEADER,
+      '2024-01-01,half even down,Cafe,1.225,payment',
+      '2024-01-01,half even up,Cafe,1.235,payment',
+      '2024-01-01,outflow,Cafe,-2.005,payment',
+    ].join('\n');
+
+    const { rows } = parseP2PCsv(csv);
+    expect(rows[0].amountCents).toBe(122); // 1.225 -> 122 (round half to even)
+    expect(rows[1].amountCents).toBe(124); // 1.235 -> 124
+    expect(rows[2].amountCents).toBe(-200); // -2.005 -> -200
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Classification heuristics
+// ---------------------------------------------------------------------------
+
+describe('classifyRow', () => {
+  it('classifies a bank transfer flow type as a transfer', () => {
+    const row = parsedRow({ flowType: 'transfer', amountCents: -20000, note: 'Standard Transfer' });
+    expect(classifyRow(row).classification).toBe('transfer');
+  });
+
+  it('classifies a note with cash-out wording as a transfer', () => {
+    const row = parsedRow({ note: 'Cash out to bank', amountCents: -5000 });
+    expect(classifyRow(row).classification).toBe('transfer');
+  });
+
+  it('detects self-transfers via selfNames', () => {
+    const row = parsedRow({ counterparty: 'Jamie Self', amountCents: 30000, note: 'moving money' });
+    const result = classifyRow(row, { selfNames: ['Jamie Self'] });
+    expect(result.classification).toBe('transfer');
+    expect(result.reasons.join(' ')).toMatch(/self-transfer/i);
+  });
+
+  it('classifies an incoming payment with a split note as a reimbursement', () => {
+    const row = parsedRow({ amountCents: 2500, note: 'split the uber' });
+    expect(classifyRow(row).classification).toBe('reimbursement');
+  });
+
+  it('classifies a paid request (inflow) as a reimbursement', () => {
+    const row = parsedRow({ amountCents: 4000, flowType: 'request', note: 'tickets' });
+    const result = classifyRow(row);
+    expect(result.classification).toBe('reimbursement');
+    expect(result.confidence).toBeGreaterThanOrEqual(80);
+  });
+
+  it('treats an unexplained inflow as a reimbursement by default', () => {
+    const row = parsedRow({ amountCents: 1000, note: '' });
+    expect(classifyRow(row).classification).toBe('reimbursement');
+  });
+
+  it('classifies a plain outgoing payment as spending', () => {
+    const row = parsedRow({ amountCents: -3000, note: 'Hardware store' });
+    expect(classifyRow(row).classification).toBe('spending');
+  });
+
+  it('keeps an outgoing "split" payment as spending (you fronted it)', () => {
+    const row = parsedRow({ amountCents: -10000, note: 'Dinner split' });
+    expect(classifyRow(row).classification).toBe('spending');
+  });
+
+  it('classifies an outgoing "my half" payment as a reimbursement pass-through', () => {
+    const row = parsedRow({ amountCents: -50000, note: 'my half of rent' });
+    expect(classifyRow(row).classification).toBe('reimbursement');
+  });
+
+  it('always returns human-readable reasons (no color-only signaling)', () => {
+    const row = parsedRow({ amountCents: -3000, note: 'coffee' });
+    expect(classifyRow(row).reasons.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Netting / pairing
+// ---------------------------------------------------------------------------
+
+describe('netReimbursements', () => {
+  it('nets reimbursement inflows against a spend by overlapping note', () => {
+    const rows = [
+      {
+        index: 0,
+        date: '2024-01-10',
+        note: 'Pizza night',
+        counterparty: 'Joes Pizza',
+        amountCents: -6000,
+        effectiveClassification: 'spending' as const,
+      },
+      {
+        index: 1,
+        date: '2024-01-11',
+        note: 'pizza',
+        counterparty: 'Alice',
+        amountCents: 2000,
+        effectiveClassification: 'reimbursement' as const,
+      },
+      {
+        index: 2,
+        date: '2024-01-11',
+        note: 'pizza',
+        counterparty: 'Bob',
+        amountCents: 2000,
+        effectiveClassification: 'reimbursement' as const,
+      },
+    ];
+
+    const { groups } = netReimbursements(rows);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].memberIndices).toEqual([1, 2]);
+    expect(groups[0].grossSpendingCents).toBe(6000);
+    expect(groups[0].reimbursedCents).toBe(4000);
+    expect(groups[0].netSpendingCents).toBe(2000);
+  });
+
+  it('pairs by counterparty even when the notes differ', () => {
+    const rows = [
+      {
+        index: 0,
+        date: '2024-05-01',
+        note: 'Groceries this week',
+        counterparty: 'Pat',
+        amountCents: -8000,
+        effectiveClassification: 'spending' as const,
+      },
+      {
+        index: 1,
+        date: '2024-05-03',
+        note: 'my half',
+        counterparty: 'Pat',
+        amountCents: 4000,
+        effectiveClassification: 'reimbursement' as const,
+      },
+    ];
+
+    const { groups, groupByIndex } = netReimbursements(rows);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].netSpendingCents).toBe(4000);
+    expect(groupByIndex.get(0)).toBe('net-0');
+    expect(groupByIndex.get(1)).toBe('net-0');
+  });
+
+  it('does not pair a reimbursement that precedes the spend', () => {
+    const rows = [
+      {
+        index: 0,
+        date: '2024-01-20',
+        note: 'dinner',
+        counterparty: 'Cafe',
+        amountCents: -5000,
+        effectiveClassification: 'spending' as const,
+      },
+      {
+        index: 1,
+        date: '2024-01-01',
+        note: 'dinner',
+        counterparty: 'Cafe',
+        amountCents: 2500,
+        effectiveClassification: 'reimbursement' as const,
+      },
+    ];
+    expect(netReimbursements(rows).groups).toHaveLength(0);
+  });
+
+  it('does not pair beyond the matching window', () => {
+    const rows = [
+      {
+        index: 0,
+        date: '2024-01-01',
+        note: 'dinner',
+        counterparty: 'Cafe',
+        amountCents: -5000,
+        effectiveClassification: 'spending' as const,
+      },
+      {
+        index: 1,
+        date: '2024-03-01',
+        note: 'dinner',
+        counterparty: 'Cafe',
+        amountCents: 2500,
+        effectiveClassification: 'reimbursement' as const,
+      },
+    ];
+    expect(netReimbursements(rows, { windowDays: 30 }).groups).toHaveLength(0);
+  });
+
+  it('clamps net spend to zero and records over-reimbursement', () => {
+    const rows = [
+      {
+        index: 0,
+        date: '2024-01-01',
+        note: 'concert tickets',
+        counterparty: 'Box Office',
+        amountCents: -3000,
+        effectiveClassification: 'spending' as const,
+      },
+      {
+        index: 1,
+        date: '2024-01-02',
+        note: 'concert tickets',
+        counterparty: 'Sam',
+        amountCents: 5000,
+        effectiveClassification: 'reimbursement' as const,
+      },
+    ];
+    const { groups } = netReimbursements(rows);
+    expect(groups[0].netSpendingCents).toBe(0);
+    expect(groups[0].overReimbursedCents).toBe(2000);
+  });
+
+  it('leaves an unmatched request reimbursement standalone', () => {
+    const rows = [
+      {
+        index: 0,
+        date: '2024-08-01',
+        note: 'concert tickets',
+        counterparty: 'Taylor',
+        amountCents: 5000,
+        effectiveClassification: 'reimbursement' as const,
+      },
+    ];
+    const { groups, groupByIndex } = netReimbursements(rows);
+    expect(groups).toHaveLength(0);
+    expect(groupByIndex.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full plan
+// ---------------------------------------------------------------------------
+
+describe('buildP2PImportPlan', () => {
+  it('builds a netted plan for a Venmo split', () => {
+    const plan = buildP2PImportPlan(VENMO_SPLIT_CSV);
+    expect(plan.provider).toBe('venmo');
+    expect(plan.groups).toHaveLength(1);
+    expect(plan.summary.grossSpendingCents).toBe(6000);
+    expect(plan.summary.reimbursementCents).toBe(4000);
+    expect(plan.summary.netSpendingCents).toBe(2000);
+    expect(plan.summary.excludedFromBudgetCents).toBe(4000);
+    expect(plan.summary.spendingCount).toBe(1);
+    expect(plan.summary.reimbursementCount).toBe(2);
+
+    const anchor = plan.rows[0];
+    expect(anchor.effectiveClassification).toBe('spending');
+    expect(anchor.netGroupId).toBe('net-0');
+    expect(plan.rows[1].excludedFromBudget).toBe(true);
+  });
+
+  it('builds a netted plan for a Cash App export', () => {
+    const plan = buildP2PImportPlan(CASHAPP_CSV);
+    expect(plan.provider).toBe('cashapp');
+    expect(plan.summary.netSpendingCents).toBe(3000);
+    expect(plan.groups[0].reimbursedCents).toBe(1500);
+  });
+
+  it('pairs the roommate reimbursement by counterparty', () => {
+    const plan = buildP2PImportPlan(VENMO_ROOMMATE_CSV);
+    expect(plan.groups).toHaveLength(1);
+    expect(plan.summary.netSpendingCents).toBe(4000);
+  });
+
+  it('surfaces parse errors on the plan', () => {
+    const plan = buildP2PImportPlan('foo,bar\n1,2');
+    expect(plan.provider).toBeNull();
+    expect(plan.errors).toHaveLength(1);
+    expect(plan.rows).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Overrides
+// ---------------------------------------------------------------------------
+
+describe('applyOverrides', () => {
+  it('reclassifies a default inflow as spending when overridden', () => {
+    const base = buildP2PImportPlan(VENMO_SPLIT_CSV);
+    const updated = applyOverrides(base, { 1: 'spending' });
+    expect(updated.rows[1].effectiveClassification).toBe('spending');
+    expect(updated.rows[1].excludedFromBudget).toBe(false);
+    // The remaining reimbursement no longer fully nets the pizza spend.
+    expect(updated.summary.reimbursementCount).toBe(1);
+  });
+
+  it('keeps a split-with-friends inflow excluded as a reimbursement', () => {
+    const base = buildP2PImportPlan(VENMO_SPLIT_CSV);
+    const updated = applyOverrides(base, { 1: 'split-with-friends' });
+    expect(updated.rows[1].effectiveClassification).toBe('reimbursement');
+    expect(updated.rows[1].override).toBe('split-with-friends');
+  });
+
+  it('marks an outgoing payment as a roommate reimbursement', () => {
+    const csv = [
+      VENMO_HEADER,
+      '2024-09-01T10:00:00,Payment,Complete,rent,Me,Landlord,- $1200.00,',
+    ].join('\n');
+    const base = buildP2PImportPlan(csv);
+    expect(base.rows[0].effectiveClassification).toBe('spending');
+
+    const updated = applyOverrides(base, { 0: 'roommate-reimbursement' });
+    expect(updated.rows[0].effectiveClassification).toBe('reimbursement');
+    expect(updated.rows[0].excludedFromBudget).toBe(true);
+    expect(updated.summary.netSpendingCents).toBe(0);
+  });
+
+  it('treats an outgoing split-with-friends payment as fronted spending', () => {
+    const csv = [
+      VENMO_HEADER,
+      '2024-09-01T10:00:00,Payment,Complete,group gift,Me,Store,- $90.00,',
+    ].join('\n');
+    const base = buildP2PImportPlan(csv);
+    const updated = applyOverrides(base, { 0: 'split-with-friends' });
+    expect(updated.rows[0].effectiveClassification).toBe('spending');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Importable transactions
+// ---------------------------------------------------------------------------
+
+describe('buildImportableTransactions', () => {
+  it('emits net spending transactions and excludes reimbursements/transfers', () => {
+    const plan = buildP2PImportPlan(VENMO_SPLIT_CSV);
+    const importable = buildImportableTransactions(plan);
+    expect(importable).toHaveLength(1);
+    expect(importable[0].amountCents).toBe(-2000);
+    expect(importable[0].reimbursedCents).toBe(4000);
+    expect(importable[0].isNetted).toBe(true);
+  });
+
+  it('omits a fully reimbursed spend (net zero)', () => {
+    const csv = [
+      VENMO_HEADER,
+      '2024-01-10T18:00:00,Payment,Complete,Pizza night,Me,Joes Pizza,- $40.00,',
+      '2024-01-11T09:00:00,Payment,Complete,pizza,Alice,Me,+ $20.00,',
+      '2024-01-11T09:05:00,Payment,Complete,pizza,Bob,Me,+ $20.00,',
+    ].join('\n');
+    const plan = buildP2PImportPlan(csv);
+    expect(plan.summary.netSpendingCents).toBe(0);
+    expect(buildImportableTransactions(plan)).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/p2p-import-types.ts
+++ b/apps/web/src/lib/p2p-import-types.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Types for the peer-to-peer (Venmo / Cash App) import engine.
+ *
+ * The engine parses exported P2P activity, classifies every entry as true
+ * spending, a reimbursement, or a bank transfer, and nets matched
+ * reimbursement flows into a single transaction so that money you fronted for
+ * friends (or owed to a roommate) does not distort budgets, cash-flow, or
+ * insights.
+ *
+ * All monetary values are integer **minor units (cents)**. There is never any
+ * floating-point money in this module.
+ */
+
+/** Supported P2P export sources. `generic` is a tolerant fallback schema. */
+export type P2PProvider = 'venmo' | 'cashapp' | 'generic';
+
+/** The kind of money movement described by a single row. */
+export type P2PFlowType = 'payment' | 'request' | 'transfer';
+
+/** How a row affects (or is excluded from) budgets and cash-flow. */
+export type P2PClassification = 'spending' | 'reimbursement' | 'transfer';
+
+/**
+ * User-supplied override for a single row. `split-with-friends` and
+ * `roommate-reimbursement` both reclassify a row as a reimbursement so it is
+ * kept out of budget-distorting totals, while preserving the user's intent for
+ * display and auditing.
+ */
+export type P2POverride = 'split-with-friends' | 'roommate-reimbursement' | 'spending' | 'transfer';
+
+/** A single tolerant-parsed P2P row before classification. */
+export interface P2PParsedRow {
+  /** 0-based index of the data row within the source file. */
+  readonly index: number;
+  /** Source provider this row was parsed from. */
+  readonly provider: P2PProvider;
+  /** ISO 8601 date (YYYY-MM-DD). */
+  readonly date: string;
+  /** Free-text note / description. */
+  readonly note: string;
+  /** Other party's display name (never persisted raw to the budget). */
+  readonly counterparty: string;
+  /** Signed amount in cents: positive = money in, negative = money out. */
+  readonly amountCents: number;
+  /** Provider fee in cents (always >= 0). */
+  readonly feeCents: number;
+  /** Flow type derived from the provider's type column. */
+  readonly flowType: P2PFlowType;
+  /** Raw header → value map for auditing. */
+  readonly rawFields: Readonly<Record<string, string>>;
+}
+
+/** A row that could not be parsed. */
+export interface P2PParseError {
+  /** 1-based data line number (header excluded). */
+  readonly line: number;
+  /** Human-readable reason. */
+  readonly message: string;
+  /** The offending raw row joined for display. */
+  readonly raw: string;
+}
+
+/** Result of the tolerant CSV parse step. */
+export interface P2PParseResult {
+  /** Detected provider, or null when the file is unrecognized. */
+  readonly provider: P2PProvider | null;
+  /** Successfully parsed rows. */
+  readonly rows: readonly P2PParsedRow[];
+  /** Rows that failed to parse. */
+  readonly errors: readonly P2PParseError[];
+}
+
+/** A classified row, after heuristics and any user override are applied. */
+export interface P2PClassifiedRow extends P2PParsedRow {
+  /** Heuristic classification (ignores overrides). */
+  readonly classification: P2PClassification;
+  /** Confidence of the heuristic classification, 0–100. */
+  readonly confidence: number;
+  /** Human-readable reasons supporting the classification (no color-only UI). */
+  readonly reasons: readonly string[];
+  /** User override, or null when none was supplied. */
+  readonly override: P2POverride | null;
+  /** Classification actually used after applying the override. */
+  readonly effectiveClassification: P2PClassification;
+  /** True when this row is kept out of budget/cash-flow/insights. */
+  readonly excludedFromBudget: boolean;
+  /** Id of the net group this row belongs to, or null. */
+  readonly netGroupId: string | null;
+}
+
+/**
+ * A spending outflow with one or more reimbursement inflows netted against it,
+ * collapsed into a single net transaction.
+ */
+export interface P2PNetGroup {
+  /** Stable id (`net-<anchorIndex>`). */
+  readonly id: string;
+  /** Row index of the spending outflow that anchors the group. */
+  readonly anchorIndex: number;
+  /** Row indices of the reimbursement inflows folded into the net. */
+  readonly memberIndices: readonly number[];
+  /** Counterparty of the anchor row. */
+  readonly counterparty: string;
+  /** Note of the anchor row. */
+  readonly note: string;
+  /** Date of the anchor row (ISO 8601). */
+  readonly date: string;
+  /** Gross spending magnitude in cents (always >= 0). */
+  readonly grossSpendingCents: number;
+  /** Total reimbursed in cents (always >= 0). */
+  readonly reimbursedCents: number;
+  /** Net spending after reimbursement, clamped to >= 0. */
+  readonly netSpendingCents: number;
+  /** Amount reimbursed beyond the gross spend, clamped to >= 0. */
+  readonly overReimbursedCents: number;
+}
+
+/** Aggregate totals describing the whole import. */
+export interface P2PImportSummary {
+  readonly totalRows: number;
+  readonly spendingCount: number;
+  readonly reimbursementCount: number;
+  readonly transferCount: number;
+  readonly netGroupCount: number;
+  /** Sum of |amount| for spending outflows before netting. */
+  readonly grossSpendingCents: number;
+  /** Sum of reimbursement inflows. */
+  readonly reimbursementCents: number;
+  /** Budget-affecting spend after netting reimbursements. */
+  readonly netSpendingCents: number;
+  /** Sum of |amount| reclassified as reimbursement (kept out of budget). */
+  readonly excludedFromBudgetCents: number;
+}
+
+/** The full, recomputable import plan. */
+export interface P2PImportPlan {
+  readonly provider: P2PProvider | null;
+  readonly rows: readonly P2PClassifiedRow[];
+  readonly groups: readonly P2PNetGroup[];
+  readonly errors: readonly P2PParseError[];
+  readonly summary: P2PImportSummary;
+}
+
+/** A budget-affecting transaction the user can confirm and save. */
+export interface P2PImportableTransaction {
+  /** Anchor row index this transaction is derived from. */
+  readonly anchorIndex: number;
+  /** ISO 8601 date. */
+  readonly date: string;
+  /** Counterparty / payee for display. */
+  readonly payee: string;
+  /** Note for the saved transaction. */
+  readonly note: string;
+  /** Signed amount in cents (negative = expense). */
+  readonly amountCents: number;
+  /** Amount netted out of this transaction (>= 0). */
+  readonly reimbursedCents: number;
+  /** True when reimbursements were netted into the amount. */
+  readonly isNetted: boolean;
+}
+
+/** Options for the classification step. */
+export interface P2PClassifyOptions {
+  /** Your own names / handles, used to detect self-transfers. */
+  readonly selfNames?: readonly string[];
+}
+
+/** Options for the reimbursement netting step. */
+export interface P2PNetOptions {
+  /** Maximum days between a spend and a reimbursement to pair them. @default 30 */
+  readonly windowDays?: number;
+}
+
+/** Options for the full {@link buildP2PImportPlan} pipeline. */
+export interface P2PImportOptions extends P2PClassifyOptions, P2PNetOptions {
+  /** Force a provider instead of auto-detecting. */
+  readonly provider?: P2PProvider;
+  /** Per-row overrides keyed by row index. */
+  readonly overrides?: Readonly<Record<number, P2POverride>>;
+}

--- a/apps/web/src/lib/p2p-import.ts
+++ b/apps/web/src/lib/p2p-import.ts
@@ -1,0 +1,875 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Peer-to-peer (Venmo / Cash App) import engine.
+ *
+ * Pure, dependency-light TypeScript. The pipeline is:
+ *
+ *   1. {@link parseP2PCsv}        — tolerant CSV → {@link P2PParsedRow}[]
+ *   2. {@link classifyRow}        — spending vs reimbursement vs transfer
+ *   3. {@link netReimbursements}  — fold matched reimbursements into net groups
+ *   4. {@link buildP2PImportPlan} — orchestrates 1–3 into a recomputable plan
+ *
+ * Reimbursements (and transfers) are flagged so callers can keep them out of
+ * budget, cash-flow and insight totals. All money is integer cents — never
+ * floating point. Banker's rounding is delegated to the shared currency parser.
+ */
+
+import { parseCsv } from './csv-parser';
+import { parseCurrencyToCents, parseDate } from './import/csv-parser';
+import type {
+  P2PClassification,
+  P2PClassifiedRow,
+  P2PClassifyOptions,
+  P2PFlowType,
+  P2PImportableTransaction,
+  P2PImportOptions,
+  P2PImportPlan,
+  P2PImportSummary,
+  P2PNetGroup,
+  P2PNetOptions,
+  P2POverride,
+  P2PParsedRow,
+  P2PParseError,
+  P2PParseResult,
+  P2PProvider,
+} from './p2p-import-types';
+
+export type {
+  P2PClassification,
+  P2PClassifiedRow,
+  P2PClassifyOptions,
+  P2PFlowType,
+  P2PImportableTransaction,
+  P2PImportOptions,
+  P2PImportPlan,
+  P2PImportSummary,
+  P2PNetGroup,
+  P2PNetOptions,
+  P2POverride,
+  P2PParsedRow,
+  P2PParseError,
+  P2PParseResult,
+  P2PProvider,
+} from './p2p-import-types';
+
+// ---------------------------------------------------------------------------
+// Keyword dictionaries (lower-case, normalized)
+// ---------------------------------------------------------------------------
+
+/** Strong "you owe me / I owe you / we split this" signals. */
+const STRONG_REIMBURSE_KEYWORDS = [
+  'split',
+  'splitting',
+  'splits',
+  'split the',
+  'share',
+  'shared',
+  'sharing',
+  'my half',
+  'your half',
+  'my share',
+  'your share',
+  'my portion',
+  'my part',
+  'reimburse',
+  'reimbursement',
+  'reimbursing',
+  'owe',
+  'owed',
+  'you owe',
+  'i owe',
+  'owe you',
+  'pay you back',
+  'paid you back',
+  'pay me back',
+  'paying back',
+  'back for',
+  'got you',
+  'got u',
+  'cover for',
+  'covered',
+  'settle up',
+  'settling up',
+  'chip in',
+  'chipin',
+  'iou',
+  'venmo me',
+  'cash app me',
+] as const;
+
+/**
+ * Outflow phrases that mean *you are repaying your own share* (a pass-through),
+ * as opposed to fronting a shared cost. These reclassify an outflow as a
+ * reimbursement so it stays out of the budget.
+ */
+const OUTFLOW_PASS_THROUGH_KEYWORDS = [
+  'pay you back',
+  'paid you back',
+  'paying back',
+  'back for',
+  'my half',
+  'my share',
+  'my portion',
+  'my part',
+  'i owe',
+  'owe you',
+  'reimburse',
+  'reimbursing',
+  'settle up',
+  'settling up',
+  'iou',
+  'cover for',
+] as const;
+
+/** Categories that are *often* shared but are not proof of a reimbursement. */
+const SHARED_EXPENSE_KEYWORDS = [
+  'rent',
+  'utilities',
+  'utility',
+  'electric',
+  'electricity',
+  'power bill',
+  'wifi',
+  'internet',
+  'water bill',
+  'cable',
+  'dinner',
+  'lunch',
+  'brunch',
+  'breakfast',
+  'pizza',
+  'drinks',
+  'bar tab',
+  'tab',
+  'groceries',
+  'grocery',
+  'uber',
+  'lyft',
+  'ride',
+  'taxi',
+  'cab',
+  'ticket',
+  'tickets',
+  'concert',
+  'hotel',
+  'airbnb',
+  'trip',
+  'vacation',
+  'parking',
+] as const;
+
+/** Phrases that indicate a bank cash-out / top-up rather than spending. */
+const TRANSFER_KEYWORDS = [
+  'cash out',
+  'cashout',
+  'cash in',
+  'cashin',
+  'transfer to bank',
+  'transfer from bank',
+  'bank transfer',
+  'instant transfer',
+  'standard transfer',
+  'add cash',
+  'add money',
+  'added money',
+  'reload',
+  'top up',
+  'top-up',
+  'atm',
+  'withdraw',
+  'withdrawal',
+  'to bank',
+  'from bank',
+] as const;
+
+/** Tokens ignored when comparing notes for netting. */
+const NOTE_STOPWORDS = new Set([
+  'the',
+  'for',
+  'and',
+  'you',
+  'your',
+  'our',
+  'with',
+  'this',
+  'that',
+  'from',
+  'was',
+  'are',
+  'but',
+  'split',
+  'share',
+  'back',
+  'pay',
+  'paid',
+  'owe',
+]);
+
+const DEFAULT_NET_WINDOW_DAYS = 30;
+const NET_MATCH_THRESHOLD = 30;
+
+// ---------------------------------------------------------------------------
+// Column resolution
+// ---------------------------------------------------------------------------
+
+interface ColumnMap {
+  date: number;
+  type: number;
+  note: number;
+  from: number;
+  to: number;
+  name: number;
+  amount: number;
+  fee: number;
+}
+
+const VENMO_HINTS = ['datetime', 'note', 'amount total'] as const;
+const CASHAPP_HINTS = ['transaction type', 'net amount', 'notes'] as const;
+
+/** Lower-case + collapse non-alphanumerics to single spaces. */
+function normalizeHeader(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Find a column index by trying each alias as an exact then partial match. */
+function findColumn(headers: readonly string[], aliases: readonly string[]): number {
+  const normalized = headers.map(normalizeHeader);
+  for (const alias of aliases) {
+    const exact = normalized.indexOf(alias);
+    if (exact >= 0) return exact;
+  }
+  for (const alias of aliases) {
+    const partial = normalized.findIndex((header) => header.includes(alias));
+    if (partial >= 0) return partial;
+  }
+  return -1;
+}
+
+/**
+ * Detect which P2P provider a header row came from. Returns `generic` for any
+ * file that at least exposes a date and an amount column, or null otherwise.
+ */
+export function detectP2PProvider(headers: readonly string[]): P2PProvider | null {
+  const normalized = headers.map(normalizeHeader);
+  const has = (alias: string): boolean => normalized.some((header) => header.includes(alias));
+
+  const venmoScore = VENMO_HINTS.filter((hint) => has(hint)).length;
+  const cashAppScore = CASHAPP_HINTS.filter((hint) => has(hint)).length;
+
+  if (venmoScore >= 2 && venmoScore >= cashAppScore) return 'venmo';
+  if (cashAppScore >= 2) return 'cashapp';
+
+  const hasDate = findColumn(headers, ['date', 'datetime', 'time']) >= 0;
+  const hasAmount = findColumn(headers, ['amount', 'amount total', 'net amount', 'total']) >= 0;
+  if (hasDate && hasAmount) return 'generic';
+
+  return null;
+}
+
+function resolveColumns(headers: readonly string[]): ColumnMap {
+  return {
+    date: findColumn(headers, ['datetime', 'date', 'transaction date', 'time']),
+    type: findColumn(headers, ['transaction type', 'type']),
+    note: findColumn(headers, ['note', 'notes', 'description', 'memo']),
+    from: findColumn(headers, ['from']),
+    to: findColumn(headers, ['to']),
+    name: findColumn(headers, [
+      'name',
+      'name of sender receiver',
+      'counterparty',
+      'payee',
+      'sender',
+      'recipient',
+    ]),
+    amount: findColumn(headers, ['amount total', 'amount', 'net amount', 'total']),
+    fee: findColumn(headers, ['amount fee', 'fee', 'fees']),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Flow type & direction
+// ---------------------------------------------------------------------------
+
+function deriveFlowType(typeText: string, note: string): P2PFlowType {
+  const haystack = `${normalizeHeader(typeText)} ${normalizeHeader(note)}`;
+  if (/\b(transfer|cash out|cashout|cash in|cashin|withdraw|reload|atm)\b/.test(haystack)) {
+    return 'transfer';
+  }
+  if (/\b(request|charge)\b/.test(normalizeHeader(typeText))) {
+    return 'request';
+  }
+  return 'payment';
+}
+
+/** Direction hint from an explicit type phrase: +1 inflow, -1 outflow, 0 none. */
+function directionHintFromType(typeText: string): -1 | 0 | 1 {
+  const normalized = normalizeHeader(typeText);
+  if (/\b(received|cash in|cashin|deposit|incoming|refund)\b/.test(normalized)) return 1;
+  if (/\b(sent|cash out|cashout|withdraw|outgoing|paid out)\b/.test(normalized)) return -1;
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Tolerantly parse a Venmo / Cash App (or generic) CSV export into structured
+ * rows. Malformed rows (missing date or unparseable amount) are collected as
+ * errors instead of throwing.
+ */
+export function parseP2PCsv(content: string, providerHint?: P2PProvider): P2PParseResult {
+  const { headers, rows } = parseCsv(content);
+  const provider = providerHint ?? detectP2PProvider(headers);
+
+  if (provider === null) {
+    return {
+      provider: null,
+      rows: [],
+      errors: [{ line: 0, message: 'Unrecognized P2P CSV: no date/amount columns found', raw: '' }],
+    };
+  }
+
+  const columns = resolveColumns(headers);
+  const parsed: P2PParsedRow[] = [];
+  const errors: P2PParseError[] = [];
+
+  rows.forEach((row, rowIndex) => {
+    const line = rowIndex + 1;
+    const cell = (col: number): string => (col >= 0 ? (row[col] ?? '').trim() : '');
+
+    const dateRaw = cell(columns.date);
+    const amountRaw = cell(columns.amount);
+
+    const date = parseDate(dateRaw);
+    if (!date) {
+      errors.push({ line, message: 'Missing or invalid date', raw: row.join(',') });
+      return;
+    }
+
+    const parsedAmount = parseCurrencyToCents(amountRaw);
+    if (parsedAmount === null) {
+      errors.push({ line, message: 'Missing or invalid amount', raw: row.join(',') });
+      return;
+    }
+
+    const typeText = cell(columns.type);
+    const note = cell(columns.note);
+    const flowType = deriveFlowType(typeText, note);
+
+    // Resolve a signed amount. Trust an explicit type direction hint when it
+    // conflicts with the parsed sign (e.g. Cash App "Sent" rows that are
+    // exported as positive numbers).
+    let amountCents = parsedAmount;
+    const hint = directionHintFromType(typeText);
+    if (hint !== 0 && amountCents !== 0 && Math.sign(amountCents) !== hint) {
+      amountCents = hint * Math.abs(amountCents);
+    }
+
+    // Counterparty: Venmo splits across From/To by direction; everyone else
+    // uses a single name column.
+    let counterparty = cell(columns.name);
+    if (!counterparty) {
+      counterparty = amountCents < 0 ? cell(columns.to) : cell(columns.from);
+    }
+    if (!counterparty) {
+      counterparty = amountCents < 0 ? cell(columns.from) : cell(columns.to);
+    }
+
+    const feeCents = Math.abs(parseCurrencyToCents(cell(columns.fee)) ?? 0);
+
+    parsed.push({
+      index: rowIndex,
+      provider,
+      date,
+      note,
+      counterparty,
+      amountCents,
+      feeCents,
+      flowType,
+      rawFields: buildRawFields(headers, row),
+    });
+  });
+
+  return { provider, rows: parsed, errors };
+}
+
+function buildRawFields(
+  headers: readonly string[],
+  row: readonly string[],
+): Record<string, string> {
+  const fields: Record<string, string> = {};
+  const width = Math.max(headers.length, row.length);
+  for (let i = 0; i < width; i++) {
+    const key = i < headers.length && headers[i] ? headers[i] : `col_${i}`;
+    fields[key] = row[i] ?? '';
+  }
+  return fields;
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+interface ClassificationResult {
+  readonly classification: P2PClassification;
+  readonly confidence: number;
+  readonly reasons: readonly string[];
+}
+
+function includesAny(haystack: string, needles: readonly string[]): boolean {
+  return needles.some((needle) => haystack.includes(needle));
+}
+
+function normalizeName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Classify a single parsed row as spending, reimbursement, or transfer using
+ * note keywords, the flow type, the amount direction, and (optionally) the
+ * user's own names to spot self-transfers. Pure and deterministic.
+ */
+export function classifyRow(row: P2PParsedRow, options?: P2PClassifyOptions): ClassificationResult {
+  const note = normalizeName(row.note);
+
+  // --- Transfers (highest priority) ---------------------------------------
+  if (row.flowType === 'transfer') {
+    return { classification: 'transfer', confidence: 95, reasons: ['Marked as a bank transfer'] };
+  }
+  if (includesAny(note, TRANSFER_KEYWORDS)) {
+    return {
+      classification: 'transfer',
+      confidence: 85,
+      reasons: ['Note describes a bank cash-out or top-up'],
+    };
+  }
+  const selfNames = (options?.selfNames ?? []).map(normalizeName).filter(Boolean);
+  const counterparty = normalizeName(row.counterparty);
+  if (counterparty && selfNames.includes(counterparty)) {
+    return {
+      classification: 'transfer',
+      confidence: 80,
+      reasons: ['Counterparty matches one of your own accounts (self-transfer)'],
+    };
+  }
+
+  const hasStrong = includesAny(note, STRONG_REIMBURSE_KEYWORDS);
+  const hasSharedNoun = includesAny(note, SHARED_EXPENSE_KEYWORDS);
+
+  // --- Inflows ------------------------------------------------------------
+  if (row.amountCents > 0) {
+    if (hasStrong) {
+      return {
+        classification: 'reimbursement',
+        confidence: 90,
+        reasons: ['Incoming payment with a split / owe note'],
+      };
+    }
+    if (row.flowType === 'request') {
+      return {
+        classification: 'reimbursement',
+        confidence: 82,
+        reasons: ['You requested this money — collecting a shared cost'],
+      };
+    }
+    if (hasSharedNoun) {
+      return {
+        classification: 'reimbursement',
+        confidence: 72,
+        reasons: ['Incoming payment references a commonly-shared expense'],
+      };
+    }
+    return {
+      classification: 'reimbursement',
+      confidence: 55,
+      reasons: ['Incoming P2P payment treated as a reimbursement by default'],
+    };
+  }
+
+  // --- Outflows -----------------------------------------------------------
+  if (row.amountCents < 0) {
+    if (includesAny(note, OUTFLOW_PASS_THROUGH_KEYWORDS)) {
+      return {
+        classification: 'reimbursement',
+        confidence: 76,
+        reasons: ['Outgoing payment looks like repaying your own share'],
+      };
+    }
+    if (hasStrong) {
+      return {
+        classification: 'spending',
+        confidence: 65,
+        reasons: ['Outgoing shared payment — incoming repayments will be netted against it'],
+      };
+    }
+    if (hasSharedNoun) {
+      return {
+        classification: 'spending',
+        confidence: 60,
+        reasons: ['Outgoing payment for a commonly-shared category — review for splits'],
+      };
+    }
+    return {
+      classification: 'spending',
+      confidence: 75,
+      reasons: ['Outgoing payment treated as spending'],
+    };
+  }
+
+  // --- Zero amount --------------------------------------------------------
+  return { classification: 'transfer', confidence: 50, reasons: ['Zero-amount entry'] };
+}
+
+/**
+ * Resolve an override to an effective classification. `split-with-friends`
+ * depends on direction: an outflow you made is a shared cost you fronted (kept
+ * as spending so repayments net against it), while an inflow is a friend
+ * repaying you (a reimbursement).
+ */
+function overrideToClassification(override: P2POverride, amountCents: number): P2PClassification {
+  switch (override) {
+    case 'split-with-friends':
+      return amountCents < 0 ? 'spending' : 'reimbursement';
+    case 'roommate-reimbursement':
+      return 'reimbursement';
+    case 'transfer':
+      return 'transfer';
+    case 'spending':
+      return 'spending';
+    default:
+      return 'spending';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Netting / pairing
+// ---------------------------------------------------------------------------
+
+interface NettableRow {
+  readonly index: number;
+  readonly date: string;
+  readonly note: string;
+  readonly counterparty: string;
+  readonly amountCents: number;
+  readonly effectiveClassification: P2PClassification;
+}
+
+function noteTokens(note: string): Set<string> {
+  const tokens = normalizeName(note)
+    .split(' ')
+    .filter((token) => token.length >= 3 && !NOTE_STOPWORDS.has(token));
+  return new Set(tokens);
+}
+
+function noteOverlap(a: string, b: string): number {
+  const setA = noteTokens(a);
+  const setB = noteTokens(b);
+  if (setA.size === 0 || setB.size === 0) return 0;
+  let intersection = 0;
+  for (const token of setA) {
+    if (setB.has(token)) intersection++;
+  }
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function daysApart(a: string, b: string): number {
+  const msPerDay = 86_400_000;
+  const ta = new Date(`${a}T00:00:00Z`).getTime();
+  const tb = new Date(`${b}T00:00:00Z`).getTime();
+  return Math.abs(Math.round((ta - tb) / msPerDay));
+}
+
+/**
+ * Match reimbursement inflows to spending outflows and fold them into net
+ * groups. A reimbursement is paired to the best-scoring spend that occurred no
+ * later than the reimbursement (within `windowDays`), sharing either the same
+ * counterparty or overlapping note tokens.
+ *
+ * Returns the net groups plus a map of every row index to its group id.
+ */
+export function netReimbursements(
+  rows: readonly NettableRow[],
+  options?: P2PNetOptions,
+): { groups: P2PNetGroup[]; groupByIndex: Map<number, string> } {
+  const windowDays = options?.windowDays ?? DEFAULT_NET_WINDOW_DAYS;
+
+  const anchors = rows
+    .filter((row) => row.effectiveClassification === 'spending' && row.amountCents < 0)
+    .slice()
+    .sort((a, b) => a.date.localeCompare(b.date) || a.index - b.index);
+
+  const reimbursements = rows
+    .filter((row) => row.effectiveClassification === 'reimbursement' && row.amountCents > 0)
+    .slice()
+    .sort((a, b) => a.date.localeCompare(b.date) || a.index - b.index);
+
+  const membersByAnchor = new Map<number, number[]>();
+  const reimbursedByAnchor = new Map<number, number>();
+
+  for (const inflow of reimbursements) {
+    let bestAnchor: NettableRow | null = null;
+    let bestScore = -1;
+
+    for (const anchor of anchors) {
+      // Reimbursements should not precede the spend they offset.
+      if (anchor.date > inflow.date) continue;
+      const dd = daysApart(anchor.date, inflow.date);
+      if (dd > windowDays) continue;
+
+      const sameCounterparty =
+        normalizeName(anchor.counterparty).length > 0 &&
+        normalizeName(anchor.counterparty) === normalizeName(inflow.counterparty);
+      const overlap = noteOverlap(anchor.note, inflow.note);
+
+      if (!sameCounterparty && overlap === 0) continue;
+
+      let score = 0;
+      if (sameCounterparty) score += 60;
+      score += Math.round(overlap * 50);
+      score += Math.max(0, 10 - dd); // recency bonus
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestAnchor = anchor;
+      }
+    }
+
+    if (bestAnchor && bestScore >= NET_MATCH_THRESHOLD) {
+      const list = membersByAnchor.get(bestAnchor.index) ?? [];
+      list.push(inflow.index);
+      membersByAnchor.set(bestAnchor.index, list);
+      reimbursedByAnchor.set(
+        bestAnchor.index,
+        (reimbursedByAnchor.get(bestAnchor.index) ?? 0) + inflow.amountCents,
+      );
+    }
+  }
+
+  const groups: P2PNetGroup[] = [];
+  const groupByIndex = new Map<number, string>();
+
+  for (const anchor of anchors) {
+    const members = membersByAnchor.get(anchor.index);
+    if (!members || members.length === 0) continue;
+
+    const gross = Math.abs(anchor.amountCents);
+    const reimbursed = reimbursedByAnchor.get(anchor.index) ?? 0;
+    const net = Math.max(0, gross - reimbursed);
+    const over = Math.max(0, reimbursed - gross);
+    const id = `net-${anchor.index}`;
+
+    groups.push({
+      id,
+      anchorIndex: anchor.index,
+      memberIndices: members.slice().sort((a, b) => a - b),
+      counterparty: anchor.counterparty,
+      note: anchor.note,
+      date: anchor.date,
+      grossSpendingCents: gross,
+      reimbursedCents: reimbursed,
+      netSpendingCents: net,
+      overReimbursedCents: over,
+    });
+
+    groupByIndex.set(anchor.index, id);
+    for (const memberIndex of members) {
+      groupByIndex.set(memberIndex, id);
+    }
+  }
+
+  return { groups, groupByIndex };
+}
+
+// ---------------------------------------------------------------------------
+// Plan assembly
+// ---------------------------------------------------------------------------
+
+function summarize(
+  rows: readonly P2PClassifiedRow[],
+  groups: readonly P2PNetGroup[],
+): P2PImportSummary {
+  let spendingCount = 0;
+  let reimbursementCount = 0;
+  let transferCount = 0;
+  let grossSpendingCents = 0;
+  let reimbursementCents = 0;
+  let excludedFromBudgetCents = 0;
+
+  const netByAnchor = new Map<number, number>();
+  const anchoredMagnitude = new Map<number, number>();
+  for (const group of groups) {
+    netByAnchor.set(group.anchorIndex, group.netSpendingCents);
+    anchoredMagnitude.set(group.anchorIndex, group.grossSpendingCents);
+  }
+
+  let netSpendingCents = 0;
+
+  for (const row of rows) {
+    switch (row.effectiveClassification) {
+      case 'spending': {
+        spendingCount++;
+        if (row.amountCents < 0) {
+          grossSpendingCents += Math.abs(row.amountCents);
+          netSpendingCents += netByAnchor.has(row.index)
+            ? (netByAnchor.get(row.index) ?? 0)
+            : Math.abs(row.amountCents);
+        }
+        break;
+      }
+      case 'reimbursement': {
+        reimbursementCount++;
+        excludedFromBudgetCents += Math.abs(row.amountCents);
+        if (row.amountCents > 0) reimbursementCents += row.amountCents;
+        break;
+      }
+      case 'transfer': {
+        transferCount++;
+        break;
+      }
+    }
+  }
+
+  return {
+    totalRows: rows.length,
+    spendingCount,
+    reimbursementCount,
+    transferCount,
+    netGroupCount: groups.length,
+    grossSpendingCents,
+    reimbursementCents,
+    netSpendingCents,
+    excludedFromBudgetCents,
+  };
+}
+
+function assemblePlan(parsed: P2PParseResult, options?: P2PImportOptions): P2PImportPlan {
+  const overrides = options?.overrides ?? {};
+
+  // First pass: classification + override resolution.
+  const classifications = parsed.rows.map((row) => {
+    const result = classifyRow(row, options);
+    const override = overrides[row.index] ?? null;
+    const effectiveClassification = override
+      ? overrideToClassification(override, row.amountCents)
+      : result.classification;
+    return { row, result, override, effectiveClassification };
+  });
+
+  const nettable: NettableRow[] = classifications.map(({ row, effectiveClassification }) => ({
+    index: row.index,
+    date: row.date,
+    note: row.note,
+    counterparty: row.counterparty,
+    amountCents: row.amountCents,
+    effectiveClassification,
+  }));
+
+  const { groups, groupByIndex } = netReimbursements(nettable, options);
+
+  const rows: P2PClassifiedRow[] = classifications.map(
+    ({ row, result, override, effectiveClassification }) => ({
+      ...row,
+      classification: result.classification,
+      confidence: result.confidence,
+      reasons: result.reasons,
+      override,
+      effectiveClassification,
+      excludedFromBudget: effectiveClassification !== 'spending',
+      netGroupId: groupByIndex.get(row.index) ?? null,
+    }),
+  );
+
+  return {
+    provider: parsed.provider,
+    rows,
+    groups,
+    errors: parsed.errors,
+    summary: summarize(rows, groups),
+  };
+}
+
+/**
+ * Parse, classify, and net a P2P CSV export into a recomputable import plan.
+ */
+export function buildP2PImportPlan(content: string, options?: P2PImportOptions): P2PImportPlan {
+  const parsed = parseP2PCsv(content, options?.provider);
+  return assemblePlan(parsed, options);
+}
+
+/**
+ * Recompute a plan after the user changes overrides, without re-parsing the
+ * source file. The plan's parsed rows are reused verbatim.
+ */
+export function applyOverrides(
+  plan: P2PImportPlan,
+  overrides: Readonly<Record<number, P2POverride>>,
+  options?: P2PClassifyOptions & P2PNetOptions,
+): P2PImportPlan {
+  const parsed: P2PParseResult = {
+    provider: plan.provider,
+    rows: plan.rows.map(stripClassification),
+    errors: plan.errors,
+  };
+  return assemblePlan(parsed, { ...options, overrides });
+}
+
+function stripClassification(row: P2PClassifiedRow): P2PParsedRow {
+  return {
+    index: row.index,
+    provider: row.provider,
+    date: row.date,
+    note: row.note,
+    counterparty: row.counterparty,
+    amountCents: row.amountCents,
+    feeCents: row.feeCents,
+    flowType: row.flowType,
+    rawFields: row.rawFields,
+  };
+}
+
+/**
+ * Produce the budget-affecting transactions to save. Each spending outflow
+ * becomes one expense at its net (post-reimbursement) amount; reimbursements
+ * and transfers are excluded so they never distort the budget. Fully
+ * reimbursed spends (net zero) are omitted.
+ */
+export function buildImportableTransactions(plan: P2PImportPlan): P2PImportableTransaction[] {
+  const netByAnchor = new Map<number, P2PNetGroup>();
+  for (const group of plan.groups) {
+    netByAnchor.set(group.anchorIndex, group);
+  }
+
+  const importable: P2PImportableTransaction[] = [];
+
+  for (const row of plan.rows) {
+    if (row.effectiveClassification !== 'spending' || row.amountCents >= 0) continue;
+
+    const group = netByAnchor.get(row.index);
+    const gross = Math.abs(row.amountCents);
+    const net = group ? group.netSpendingCents : gross;
+    if (net <= 0) continue;
+
+    importable.push({
+      anchorIndex: row.index,
+      date: row.date,
+      payee: row.counterparty,
+      note: row.note,
+      amountCents: -net,
+      reimbursedCents: group ? group.reimbursedCents : 0,
+      isNetted: group != null,
+    });
+  }
+
+  return importable;
+}

--- a/apps/web/src/pages/ImportPage.tsx
+++ b/apps/web/src/pages/ImportPage.tsx
@@ -130,6 +130,11 @@ export const ImportPage: React.FC = () => {
         Have a receipt? <Link to="/import/receipt-ocr">Scan it on this device</Link> to pre-fill
         quick entry and itemized splits.
       </p>
+      <p className="import-section-description">
+        Paying friends on Venmo or Cash App?{' '}
+        <Link to="/import/p2p">Import a Venmo / Cash App CSV</Link> to automatically separate
+        reimbursements from real spending.
+      </p>
 
       <StepIndicator currentStep={importState.step} />
 

--- a/apps/web/src/pages/P2PImportPage.tsx
+++ b/apps/web/src/pages/P2PImportPage.tsx
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Venmo / Cash App (P2P) import page.
+ *
+ * Thin wiring layer: the {@link useP2PImport} hook owns all state and
+ * persistence, {@link useAccounts} supplies the destination accounts, and the
+ * presentational {@link P2PImportPanel} renders the accessible UI. The panel is
+ * imported directly (not via the shared `components/import` barrel) so it stays
+ * in this route's own lazy chunk and does not inflate other import routes.
+ *
+ * References: issue #2158
+ */
+
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+
+// Direct import keeps this heavy component code-split into the P2P route chunk.
+import { P2PImportPanel } from '../components/import/P2PImportPanel';
+import { useAccounts } from '../hooks/useAccounts';
+import { useP2PImport } from '../hooks/useP2PImport';
+
+export const P2PImportPage: React.FC = () => {
+  const { accounts } = useAccounts();
+  const p2p = useP2PImport();
+
+  const accountOptions = useMemo(
+    () => accounts.map((account) => ({ id: account.id, name: account.name })),
+    [accounts],
+  );
+
+  return (
+    <div className="p2p-import-page">
+      <p className="p2p-import-page__back">
+        <Link to="/import">← Back to all imports</Link>
+      </p>
+      <P2PImportPanel
+        fileName={p2p.fileName}
+        plan={p2p.plan}
+        overrides={p2p.overrides}
+        parseError={p2p.parseError}
+        accounts={accountOptions}
+        selectedAccountId={p2p.selectedAccountId}
+        importing={p2p.importing}
+        saveResult={p2p.saveResult}
+        onLoadFile={p2p.loadFile}
+        onSetOverride={p2p.setOverride}
+        onSelectAccount={p2p.setSelectedAccountId}
+        onConfirmImport={p2p.confirmImport}
+        onReset={p2p.reset}
+      />
+    </div>
+  );
+};
+
+export default P2PImportPage;

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -36,6 +36,7 @@ const SettingsSync = lazy(() => import('./pages/settings/SettingsSyncPage'));
 const SettingsAdvanced = lazy(() => import('./pages/settings/SettingsAdvancedPage'));
 const SettingsAbout = lazy(() => import('./pages/settings/SettingsAboutPage'));
 const DataImportWizard = lazy(() => import('./pages/DataImportWizardPage'));
+const P2PImport = lazy(() => import('./pages/P2PImportPage'));
 const ReceiptOcr = lazy(() => import('./pages/ReceiptOcrPage'));
 const Login = lazy(() => import('./pages/LoginPage'));
 const Signup = lazy(() => import('./pages/SignupPage'));
@@ -690,6 +691,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Data Import Wizard">
             <DataImportWizard />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/import/p2p"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="P2P Import">
+            <P2PImport />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Summary

Adds a Venmo / Cash App **CSV import** path that is reimbursement-aware, so money friends pay you back (split bills) or roommate reimbursements no longer distort your budget, cash-flow, or insights.

Existing CSV import + categorization (ImportPage / DataImportWizard) is unchanged; this adds a dedicated P2P-aware surface at `/import/p2p` (linked from the Import page).

## Pure engine — `apps/web/src/lib/p2p-import.ts` (+ `p2p-import-types.ts`)

- **Tolerant parsing** of Venmo / Cash App / generic exports (date, note/description, counterparty, amount, type `payment`/`request`/`transfer`). Malformed rows are collected as errors instead of throwing.
- **Classification** of each row as `spending` vs `reimbursement` vs `transfer` using note keywords (`split`, `rent`, `pizza`, `my half` …), flow type, amount direction, and self-name detection for bank cash-outs / top-ups.
- **Netting / pairing**: reimbursement inflows are matched to the spend they offset (same counterparty or overlapping note tokens within a time window) and folded into a single **net** transaction.
- **Budget protection**: reimbursements/transfers are flagged `excludedFromBudget` and never saved as budget-affecting rows; only net spending is imported.
- Integer **minor units (cents)** throughout with banker's rounding — no floating-point money (follows the financial-modeling skill).

## Accessible UI

- `useP2PImport` hook owns parse/override/save state (all data access goes through hooks; never repositories).
- `P2PImportPanel`: labeled file input + account selector, preview table with a caption and `scope=col` headers, classification shown as **text label + icon (no colour-only signalling)**, keyboard-navigable per-row overrides (*split with friends* / *roommate reimbursement* / *spending* / *transfer*), `aria-live` summary, `role=alert` errors.
- New **lazy** `/import/p2p` route; the panel is imported **directly** (not via the shared `components/import` barrel) so it stays code-split — its own **6.4 kB gzip** chunk, comfortably under the 215 kB lazy-chunk budget.

## Tests

- **35** engine unit tests: CSV parsing, classification heuristics, reimbursement netting/pairing, banker's rounding, overrides, and edge cases (malformed rows, unmatched request, self-transfer, over-reimbursement).
- **11** component render tests for `P2PImportPanel` (labels, summary live region, text classification, override + account callbacks, import gating, alerts, status).
- `vitest` (46 new tests), `eslint --max-warnings 0`, `tsc --noEmit`, `vite build` and `perf:budget` all pass locally.

## Out of scope

CSV import + reimbursement-aware categorization is delivered. **Live Venmo / Cash App account connection is intentionally not included** — it requires credentials/OAuth and is human-gated; no fabricated network data is used.

Refs #2158