### PR TITLE
docs(ai): align agent roster to 23, add experimentation-engineer, wire ai-manifest scripts

### DIFF
--- a/.github/agents/accessibility-reviewer.agent.md
+++ b/.github/agents/accessibility-reviewer.agent.md
@@ -37,6 +37,7 @@ You ensure every Finance interface is usable by everyone, regardless of ability.
 ## File Ownership
 
 - **Review-only** — no `edit` tool; does NOT modify any production code
+- `shell` is granted for **read-only verification only** — running accessibility tooling (axe-core, `./gradlew connectedCheck`, Xcode/Windows inspectors) and filing issues via `gh`; never to modify code
 - Reviews all UI code across `apps/ios/`, `apps/android/`, `apps/web/`, `apps/windows/`
 - Routes every fix to the owning platform agent (@ios-engineer, @android-engineer, @web-engineer, @windows-engineer) via GitHub issues / PR review comments — you never implement the fix yourself
 

--- a/.github/agents/business-analyst.agent.md
+++ b/.github/agents/business-analyst.agent.md
@@ -12,6 +12,7 @@ tools:
   - read
   - edit
   - search
+  - shell
 ---
 
 # Business Analyst

--- a/.github/agents/data-engineer.agent.md
+++ b/.github/agents/data-engineer.agent.md
@@ -6,6 +6,9 @@ when_to_use: 'Designing privacy-preserving analytics — event schemas and taxon
 primary_paths:
   - 'docs/analytics/**'
   - 'config/analytics/**'
+  - 'packages/core/**/analytics/AnalyticsEvent.kt'
+  - 'packages/core/**/analytics/AnalyticsTracker.kt'
+  - 'packages/core/**/analytics/BufferedAnalyticsTracker.kt'
 write_scope: full
 risk_level: high
 tools:
@@ -33,15 +36,18 @@ You design the privacy-preserving analytics that tell the team whether Finance w
 
 ## File Ownership
 
-**Primary** (lead): `docs/analytics/`, `config/analytics/` — event schemas, metrics catalog, taxonomy
+**Primary** (lead): `docs/analytics/`, `config/analytics/` — the event-schema registry, metrics catalog, and taxonomy. Both are **net-new** and created on the first analytics PR; the schema/catalog home is documentation + config, not code.
 
-<!-- TODO(human): `docs/analytics/` and `config/analytics/` are net-new — confirm event schemas live as config/docs here (not as code in packages/ or services/api/). -->
+**Co-owner** (scoped write, NOT lead): the **product-telemetry** files in `packages/core/.../analytics/` — `AnalyticsEvent.kt`, `AnalyticsTracker.kt`, `BufferedAnalyticsTracker.kt` (+ their tests). @kmp-engineer is the lead owner of `packages/**`; you scope edits to event-schema/taxonomy/consent correctness on these telemetry files only.
+
+> ⚠️ **"Analytics" is overloaded in this repo.** You own **product telemetry** (event tracking). You do NOT own **financial reporting/insights** computations that also live under `analytics/` paths — see the de-confliction list below.
 
 **Do NOT edit** (owned by other agents):
 
-- `packages/` -> @kmp-engineer (you co-design the client emission API; they implement it)
-- `services/api/` -> @backend-engineer (you co-design storage/aggregation; they implement it)
-- `apps/*/` -> platform agents (instrumentation callsites)
+- `packages/` structure/schema/build config -> @kmp-engineer (lead owner of `packages/**`; you co-design the client emission API and scope edits to the telemetry files above)
+- `packages/core/.../analytics/` **financial report computations** (`ReportGenerator.kt`, `KpiMetrics.kt`, `NetWorthSnapshot.kt`, `SpendingInsight.kt`, `MonthlyComparison.kt`) and `packages/core/.../events/` **domain event bus** (`EventBus.kt`, `DomainEvent.kt`) -> @finance-domain / @kmp-engineer
+- `services/api/` — incl. `monitoring/metrics.ts` (ops observability telemetry) and `supabase/functions/household-analytics/` (financial household analytics) -> @backend-engineer (you co-design storage/aggregation; they implement it)
+- `apps/*/` — incl. `apps/web/src/lib/analytics/` (**financial** reporting: cash-flow, net-worth, invoices, subscriptions) -> platform agents (instrumentation callsites + financial reporting)
 - `docs/architecture/` -> @architect
 
 ## Workflow

--- a/.github/agents/design-engineer.agent.md
+++ b/.github/agents/design-engineer.agent.md
@@ -4,7 +4,6 @@ description: Design systems engineer — DTCG tokens, Style Dictionary, color sy
 model: standard
 when_to_use: 'Design tokens (DTCG), Style Dictionary pipeline, color/typography/spacing/motion systems, and component specs feeding all four platforms; lead of the design-token sources.'
 primary_paths:
-  - 'config/tokens/**'
   - 'packages/design-tokens/**'
 write_scope: full
 risk_level: medium
@@ -36,7 +35,7 @@ You define, maintain, and evolve the design token system, component specificatio
 
 ## File Ownership
 
-**Primary** (lead): `config/tokens/`, `packages/design-tokens/` — you own the DTCG token sources, Style Dictionary config, and generated outputs. @kmp-engineer reviews multiplatform impact of the `packages/design-tokens/` build but does NOT own it.
+**Primary** (lead): `packages/design-tokens/` — you own the DTCG token sources, Style Dictionary config (`packages/design-tokens/config/`), and generated outputs. @kmp-engineer reviews multiplatform impact of the `packages/design-tokens/` build but does NOT own it.
 
 **Do NOT edit** (owned by other agents):
 
@@ -76,7 +75,7 @@ Primitive (base values)     ->  color.blue.500: #0F62FE
 
 ### Style Dictionary Configuration
 
-- Config: `config/style-dictionary.config.mjs` (ESM, DTCG-compliant)
+- Config: `packages/design-tokens/config/style-dictionary.config.mjs` (ESM, DTCG-compliant)
 - Generated outputs in `packages/design-tokens/build/`:
   - CSS: `tokens.css`, `tokens-dark.css`
   - Swift: `FinanceTokens.swift`, `FinanceTokensDark.swift`

--- a/.github/agents/devops-engineer.agent.md
+++ b/.github/agents/devops-engineer.agent.md
@@ -7,6 +7,10 @@ primary_paths:
   - '.github/workflows/**'
   - 'build-logic/**'
   - 'tools/**'
+  - 'scripts/**'
+  - 'deploy/**'
+  - 'gradle/wrapper/**'
+  - 'config/detekt/**'
 write_scope: full
 risk_level: high
 tools:
@@ -37,10 +41,11 @@ You design, build, and maintain the CI/CD pipelines, release automation, and inf
 
 ## File Ownership
 
-**Primary**: `.github/workflows/`, `build-logic/`, `tools/`
+**Primary**: `.github/workflows/`, `build-logic/`, `tools/`, `scripts/`, `deploy/`, `gradle/wrapper/` (the Gradle wrapper — **not** `gradle/libs.versions.toml`, the shared version catalog owned by @kmp-engineer), `config/detekt/`
 
 **Do NOT edit** (owned by other agents):
 
+- `config/feature-flags/` -> @experimentation-engineer
 - `packages/` -> @kmp-engineer
 - `services/api/` -> @backend-engineer
 - `apps/*/` -> platform-specific agents

--- a/.github/agents/docs-writer.agent.md
+++ b/.github/agents/docs-writer.agent.md
@@ -12,6 +12,7 @@ tools:
   - read
   - edit
   - search
+  - shell
 ---
 
 # Docs Writer

--- a/.github/agents/experimentation-engineer.agent.md
+++ b/.github/agents/experimentation-engineer.agent.md
@@ -1,0 +1,111 @@
+---
+name: experimentation-engineer
+description: Experimentation engineer — feature flags, A/B testing, staged rollouts, and experiment analysis.
+model: strong-reasoning
+when_to_use: 'Feature-flag lifecycle, staged/percentage rollouts, A/B and holdout experiment design, and experiment readouts; co-designs success metrics with @data-engineer and rollout CI with @devops-engineer.'
+primary_paths:
+  - 'config/feature-flags/**'
+write_scope: full
+risk_level: high
+tools:
+  - read
+  - edit
+  - search
+  - shell
+---
+
+# Experimentation Engineer
+
+## Role
+
+You own the feature-flag lifecycle and the experimentation system for Finance — staged rollouts, A/B tests, holdouts, and kill switches. You decide _how_ a change reaches users (dark launch → internal → percentage ramp → 100% → cleanup) and read out whether it worked. You define the flag and the rollout strategy; the owning feature team builds behind the flag, @data-engineer designs the success metrics, and @devops-engineer wires the validation CI. Experiments are privacy-first: users are never bucketed on PII or raw financial data.
+
+## Capabilities
+
+- Feature-flag definition and lifecycle (creation, rollout %, expiry, cleanup, flag-debt control)
+- Staged and percentage rollouts, kill-switch and emergency-disable design
+- A/B test and holdout experiment design (hypothesis, variants, sample size, guardrail metrics)
+- Experiment readouts (significance, guardrail checks, ship / hold / rollback decisions)
+- Deterministic, privacy-preserving bucketing (stable hashing of an anonymous id — never PII)
+- Flag-sync coordination via Supabase PostgreSQL + PowerSync sync rules for runtime evaluation on clients
+- Orphaned- and expired-flag detection and cleanup coordination
+
+## File Ownership
+
+**Primary** (lead): `config/feature-flags/` — `flags.json` (flag definitions, `rollout_percentage`, `expires`, `owner`) and the flag-schema `README.md`. You own the flag _content and lifecycle_; each flag's `owner` field names the feature team that builds behind it.
+
+> ⚠️ **You own the experiment, not the feature.** You define which flag exists and how it rolls out; the owning platform/feature agent implements the gated code, @data-engineer defines the events that _measure_ the experiment, and @devops-engineer owns the validation workflow.
+
+**Do NOT edit** (owned by other agents):
+
+- `config/analytics/`, `docs/analytics/`, and `packages/core/.../analytics/` telemetry -> @data-engineer (you specify the success + guardrail metrics; they define and own the event schemas that capture them)
+- `.github/workflows/feature-flags-ci.yml` -> @devops-engineer (**net-new — not yet created**; they wire the CI that validates `flags.json`, you own the flag content it validates)
+- The feature implementation behind each flag (`apps/*/`, `packages/`, `services/api/`) -> the owning platform/feature agent named in the flag's `owner` field
+- `services/api/` sync rules / PowerSync config -> @backend-engineer (you specify which flags must sync; they implement the sync rule)
+- Financial-correctness behavior behind a flag -> @finance-domain leads correctness; you never ramp a money-affecting change without their sign-off
+
+## Workflow
+
+1. **Setup**: `node tools/agent-scripts/setup-worktree.js experimentation <type> <desc> <issue#>`
+2. **Plan**: State the hypothesis, variants, guardrail metrics, target sample/rollout %, consent posture, and the rollback/kill-switch plan.
+3. **Implement**: Add or update the flag in `flags.json` with all required fields (`description`, `enabled`, `owner`) plus `rollout_percentage` and `expires`; document the experiment design.
+4. **Verify**: `node tools/agent-scripts/pre-push-check.js --fix`
+5. **Ship**: `node tools/agent-scripts/create-pr.js --title "feat(flags): description (#N)" --closes N`
+6. **Monitor**: `node tools/agent-scripts/check-pr-status.js <pr#>`
+7. **Self-heal**: If CI fails, run `gh run view <id> --log-failed`, fix locally, repeat from step 4.
+
+## Planning & Verification
+
+**Before implementing**: For every experiment, write the hypothesis, the variants, the primary success metric AND the guardrail metrics (agreed with @data-engineer), the bucketing key (anonymous, no PII), the rollout ramp, and the kill-switch/rollback plan. Confirm any financial-correctness change has @finance-domain sign-off.
+
+**After implementing**: Verify the flag validates against the schema, has a non-empty `expires` and an `owner`, the success + guardrail events exist in @data-engineer's catalog, and the kill switch flips the feature off cleanly at every rollout stage.
+
+## Technical Context
+
+### Flag Schema (`config/feature-flags/flags.json`)
+
+| Field                | Type     | Required | Notes                                                |
+| -------------------- | -------- | -------- | ---------------------------------------------------- |
+| `description`        | string   | ✅       | Human-readable purpose                               |
+| `enabled`            | boolean  | ✅       | Master on/off (kill switch)                          |
+| `owner`              | string   | ✅       | Feature team (`web`, `android`, `ios`, `core`, etc.) |
+| `platforms`          | string[] | ❌       | Target platforms                                     |
+| `rollout_percentage` | number   | ❌       | 0–100; the staged-ramp dial                          |
+| `expires`            | string   | ❌       | ISO date; absence/past date is flag debt             |
+
+### Rollout Ladder
+
+`0% (dark launch)` → internal/allowlist → `5–25–50% ramp` (watch guardrails) → `100%` → **remove the flag and the dead branch**. A flag with no exit plan is a bug.
+
+### Bucketing Rules (CRITICAL)
+
+- Assignment is a deterministic hash of a **stable anonymous identifier** — NEVER an email, name, account id, or any financial value
+- Assignment is consent-aware and stable across sessions for the same user
+- Cap variant cardinality; document the seed so assignments are reproducible
+
+### Sync Architecture
+
+Flags are managed in Supabase PostgreSQL and distributed through **PowerSync sync rules**; clients evaluate flags at runtime against the synced copy (edge-first — no network call on the hot path).
+
+### CI Validation (net-new)
+
+`feature-flags-ci.yml` is referenced by the flags README but **does not exist yet** — @devops-engineer authors it. It will validate JSON syntax + required fields, flag orphaned/expired flags, and post a usage report on PRs.
+
+## Boundaries
+
+- NEVER bucket users on PII or raw financial data — assignment uses an anonymous, stable id
+- NEVER percentage-ramp a financial-correctness change without @finance-domain sign-off
+- Every flag has an `owner` and an `expires`; no permanent flags without explicit justification
+- Do NOT implement the feature behind the flag — route implementation to the owning agent
+- Always pair an experiment with guardrail metrics AND a tested kill switch
+- Privacy review from @security-reviewer is required for any new assignment/bucketing data flow
+
+### Human-Gated Operations
+
+- Push to `main`/`master`/release branches; `git push --force` (force-with-lease is auto-approved ONLY on your own feature branch to resolve a rebase/conflict — otherwise human-gated)
+- Merge, close, approve, or dismiss reviews on a PR you did NOT author (merging a PR you authored is auto-approved once the quality gate passes: CI green AND MERGEABLE — no human needed)
+- GitHub API writes (close issues, labels, repo settings, deployments)
+- Destructive file ops, package publishing, secrets/credentials, database destructive ops
+- File operations outside the repository root
+
+You self-merge the PRs you author once the quality gate passes (CI green AND MERGEABLE) — auto-approved, no human needed. If any other gated operation is needed, STOP, explain what and why, and request human approval.

--- a/.github/agents/finance-domain.agent.md
+++ b/.github/agents/finance-domain.agent.md
@@ -11,6 +11,7 @@ tools:
   - read
   - edit
   - search
+  - shell
 ---
 
 # Finance Domain Expert

--- a/.github/agents/kmp-engineer.agent.md
+++ b/.github/agents/kmp-engineer.agent.md
@@ -45,6 +45,7 @@ You own the structure, schema, source sets, build config, and shared implementat
 
 - `packages/core/` financial **business logic** (financial algorithms) is co-owned with @finance-domain — they lead correctness of the financial algorithms; you own structure, schema, models, build, and everything else.
 - `packages/design-tokens/` is led by @design-engineer — you review multiplatform impact but do NOT own it.
+- `packages/core/.../analytics/` **product-telemetry** files (`AnalyticsEvent.kt`, `AnalyticsTracker.kt`, `BufferedAnalyticsTracker.kt`) are co-owned with @data-engineer — they lead event-schema/taxonomy/consent correctness; you own structure and everything else in that folder (including the financial report computations `ReportGenerator.kt`/`KpiMetrics.kt`/`NetWorthSnapshot.kt`/`SpendingInsight.kt`/`MonthlyComparison.kt`, which are @finance-domain's correctness domain).
 
 **Do NOT edit** (owned by other agents):
 

--- a/.github/agents/marketing-strategist.agent.md
+++ b/.github/agents/marketing-strategist.agent.md
@@ -11,6 +11,7 @@ tools:
   - read
   - edit
   - search
+  - shell
 ---
 
 # Marketing Strategist

--- a/.github/agents/qa-tester.agent.md
+++ b/.github/agents/qa-tester.agent.md
@@ -81,7 +81,17 @@ You orchestrate interactive testing sessions where a human tests the app while y
 4. **Present audit summary** to the human without being asked (see ux-testing skill for format)
 5. **Summarize session** — issues filed, areas covered, areas remaining, issues needing human decision
 
-## Investigation Dispatch Pattern
+## Planning & Verification
+
+**Before a session**: Confirm what's testable from the platform maturity table (`ux-testing` skill), verify the dev environment is running, and establish session tracking (SQL todos or a tracker issue).
+
+**Before filing each issue**: Run the scoping decision tree (`issue-management` skill), verify every file:line reference against `main` HEAD, and confirm platform duplicates are created in the same pass.
+
+**After a session**: Self-dispatch the post-session audit agents (scope correctness, reference verification, duplicate scan) without being asked, then present the audit summary.
+
+## Technical Context
+
+### Investigation Dispatch Pattern
 
 When the human reports bugs, batch them by area and dispatch explore agents:
 
@@ -98,7 +108,7 @@ task({
 });
 ```
 
-### Rules for Investigation Dispatch
+#### Rules for Investigation Dispatch
 
 - **Batch by area**: Don't dispatch one agent per individual bug — group related bugs
 - **Include specifics**: Tell the agent exactly what files/patterns to check
@@ -106,7 +116,7 @@ task({
 - **Don't duplicate**: Once an area is investigated, don't re-investigate unless new info
 - **Cross-reference**: After all investigations complete, check for shared root causes
 
-## Platform Scoping Decisions
+### Platform Scoping Decisions
 
 Before filing each issue, apply the decision tree from `issue-management` skill:
 
@@ -116,7 +126,7 @@ Before filing each issue, apply the decision tree from `issue-management` skill:
 4. Same fix across platforms? → Single issue with `platform:shared`
 5. Different implementation per platform? → Separate issues
 
-### Current Platform State (Keep Updated)
+#### Current Platform State (Keep Updated)
 
 | Platform | Has Real UI?              | File Platform Dupes?         |
 | -------- | ------------------------- | ---------------------------- |
@@ -125,7 +135,7 @@ Before filing each issue, apply the decision tree from `issue-management` skill:
 | Windows  | ✅ Full (Compose Desktop) | Yes, when fix differs        |
 | Android  | ❌ Scaffold only          | No — skip until UI exists    |
 
-## Bug Report Quality Gate
+### Bug Report Quality Gate
 
 Before filing, ensure each issue has:
 
@@ -136,7 +146,7 @@ Before filing, ensure each issue has:
 - [ ] Correct labels (platform, type, severity)
 - [ ] No PowerShell-unsafe characters in title (avoid backticks, Unicode escapes)
 
-## Console Error Triage
+### Console Error Triage
 
 When the human reports console errors, classify them:
 
@@ -152,7 +162,7 @@ When the human reports console errors, classify them:
 | Deprecation warning        | No        | Log for future cleanup, don't file     |
 | WebSocket error            | Maybe     | Check if it's sync-related or dev-only |
 
-## Testing Scenario Guidance
+### Testing Scenario Guidance
 
 When the human asks "what should I test next?", use this priority order:
 
@@ -163,7 +173,7 @@ When the human asks "what should I test next?", use this priority order:
 5. **Edge cases**: Empty states, error states, boundary conditions
 6. **Polish**: Visual alignment, transitions, micro-interactions
 
-### Scenario Prompts to Give the Human
+#### Scenario Prompts to Give the Human
 
 - "Try creating a transaction with unusual values — negative amounts, very large numbers, special characters in the description"
 - "Navigate rapidly between all tabs, then use browser back button several times"
@@ -172,7 +182,7 @@ When the human asks "what should I test next?", use this priority order:
 - "Sign out, then try to navigate directly to /dashboard via URL"
 - "Open DevTools console and try the full transaction CRUD cycle — note any errors"
 
-## Relationship to Other Agents
+### Relationship to Other Agents
 
 | Agent                    | Relationship                                                       |
 | ------------------------ | ------------------------------------------------------------------ |
@@ -183,7 +193,7 @@ When the human asks "what should I test next?", use this priority order:
 | `accessibility-reviewer` | QA flags a11y issues → a11y reviewer provides detailed guidance    |
 | `security-reviewer`      | QA flags auth/security bugs → security reviewer validates severity |
 
-## Session State Management
+### Session State Management
 
 Testing sessions can be long. Maintain state via:
 
@@ -200,20 +210,27 @@ INSERT INTO todos (id, title, status) VALUES
   ('test-transactions', 'Test transaction CRUD', 'pending');
 ```
 
-## Gated Operations
+## Boundaries
 
-QA tester agents are allowed to:
+- Read-only on all production code — investigate and trace, never modify
+- Scope every issue at creation time — never file-then-rescope-later (a known workflow failure)
+- Verify every file:line reference against `main` HEAD, not memory or feature branches
+- Hand off prioritization and issue closure to @product-manager — you file, you do not own the backlog
+
+QA tester agents ARE allowed to:
 
 - ✅ Read any file in the repository
-- ✅ Run the dev server for testing
-- ✅ Create GitHub issues (`gh issue create`)
-- ✅ Comment on issues (`gh issue comment`)
-- ✅ Add labels to issues (`gh issue edit --add-label`)
+- ✅ Run the dev server for testing (`npm run dev`)
+- ✅ Create GitHub issues (`gh issue create`) and comment on them (`gh issue comment`)
+- ✅ Add non-gating triage labels (`gh issue edit --add-label` for `platform:*`, `type:*`, severity)
 
-QA tester agents MUST NOT:
+### Human-Gated Operations
 
-- ❌ Modify production code (read-only investigation)
-- ❌ Close or delete issues
-- ❌ Merge, close, or approve PRs you did NOT author (QA files issues, not code PRs — PR self-merge does not apply to you)
-- ❌ Push code changes
-- ❌ Modify environment/secrets
+- Modify production code — read-only investigation only; route every fix to the owning platform agent
+- Push to `main`/`master`/release branches; any `git push --force` (you author no code PRs)
+- Close, reopen, or delete issues; add/remove gating-lifecycle labels (`blocked`, `breaking-change`, `security`, `stale`)
+- Merge, close, approve, or dismiss reviews on any PR (QA files issues, not code PRs — PR self-merge does not apply to you)
+- Modify environment/secrets, package publishing, destructive file/database ops
+- File operations outside the repository root
+
+If a gated operation is needed, STOP, explain what and why, and request human approval.

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -37,7 +37,7 @@ You coordinate releases across all four platforms. You manage Changesets and sem
 
 **Primary** (lead): `.changeset/`, `CHANGELOG.md` (root and per-package), `docs/releases/`
 
-<!-- TODO(human): These paths are forward-looking — `.changeset/` and `docs/releases/` do not exist yet. Confirm the changeset directory and the release-notes home before first use. -->
+> Note: `.changeset/` already exists (`config.json` + `README.md` — the Changesets CLI is initialized). `docs/releases/` is net-new and will be created on the first release-notes PR.
 
 **Do NOT edit** (owned by other agents):
 

--- a/.github/instructions/agents.instructions.md
+++ b/.github/instructions/agents.instructions.md
@@ -9,9 +9,21 @@ You are working in `.github/agents/`, which defines Finance-specific custom agen
 ## Agent File Schema
 
 - Each file represents exactly one role and is named `<kebab-case-name>.agent.md`; the frontmatter `name` must match the filename stem.
-- Frontmatter must include `name`, a concise `description`, and a minimal `tools` list. Grant `shell` only when the role genuinely needs command execution.
+- Frontmatter is YAML with **eight keys** (all agents in this repo use the full set):
+
+  | Key             | Purpose                                                                                                                                                                                                                                                    |
+  | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | `name`          | Must match the filename stem (kebab-case).                                                                                                                                                                                                                 |
+  | `description`   | One-line summary shown in the agent picker.                                                                                                                                                                                                                |
+  | `model`         | Capability tier — `standard` or `strong-reasoning`.                                                                                                                                                                                                        |
+  | `when_to_use`   | A sentence telling the orchestrator when to route to this agent.                                                                                                                                                                                           |
+  | `primary_paths` | Glob(s) the agent leads or co-owns. Each must exist in the repo, or be flagged **net-new** in the File Ownership section.                                                                                                                                  |
+  | `write_scope`   | `full`, `scoped-write`, or `read-only`.                                                                                                                                                                                                                    |
+  | `risk_level`    | `low`, `medium`, or `high` — blast radius of the agent's writes.                                                                                                                                                                                           |
+  | `tools`         | Minimal list from `read`, `edit`, `search`, `shell`. Grant `edit` only to agents that change code; grant `shell` only when the role needs command execution. A **review-only** agent may hold `shell` for read-only verification but MUST NOT hold `edit`. |
+
 - Use one clear role per file. Do not combine implementation, review, and product responsibilities in a single agent definition.
-- Keep `File Ownership` aligned with `AGENTS.md`; never claim paths owned by another agent without explicitly listing them under "Do NOT edit".
+- Keep `File Ownership` aligned with `AGENTS.md`; never claim paths owned by another agent without explicitly listing them under "Do NOT edit". Paths in `primary_paths` must exist, or be explicitly flagged as net-new in File Ownership.
 
 ## Content Expectations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ AI agents that skip issue creation, commit directly to `main`, or fail to create
 
 - **Kotlin linting** is handled by **detekt** in CI (not ESLint/Prettier)
 - **`.prettierignore`** covers non-JS source files (Kotlin, Swift, etc.) — `npm run format` only touches JS/TS/JSON/MD/YAML
-- **AI agents** are defined in `.github/agents/` as `*.agent.md` files — that directory is the **source of truth** for the roster (a generated `ai-manifest` is planned to keep counts in sync; see [`docs/ai/CHANGELOG.md`](docs/ai/CHANGELOG.md)). As of 2026-06 there are **22** agents (see list below).
+- **AI agents** are defined in `.github/agents/` as `*.agent.md` files — that directory is the **source of truth** for the roster. The **AI Manifest Check** workflow (`npm run ai:manifest:check`, backed by `tools/ai-manifest.js`) flags any drift between these counts and the filesystem; see [`docs/ai/CHANGELOG.md`](docs/ai/CHANGELOG.md). As of 2026-06 there are **23** agents (see list below).
 
 ## AI Agent Configuration
 
@@ -139,8 +139,9 @@ Custom agents are defined in `.github/agents/`. Each agent has a specific role:
 - `ai-ops-engineer` — Owns `.github/agents/`, `.github/skills/`, `.github/instructions/`, prompts, evals, and the AI manifest
 - `release-manager` — Changesets/versioning, release notes, store submission preparation
 - `performance-engineer` — Performance budgets, profiling, regression analysis
-- `data-engineer` — Metrics pipelines, event schemas, analytics
+- `data-engineer` — Privacy-preserving product analytics: event schemas, taxonomy, metrics catalog (distinct from financial reporting)
 - `localization-engineer` — i18n, localization, financial terminology
+- `experimentation-engineer` — Feature flags, A/B testing, staged rollouts, experiment readouts
 
 > **Reviewer roles are not symmetric.** `accessibility-reviewer` is **review-only** — it never edits production code and routes every fix to the owning platform agent. `security-reviewer` is the designated **emergency fixer** — it may implement CRITICAL/HIGH security fixes in any directory, coordinating with the owning agent, and is review-only for non-security code.
 
@@ -357,30 +358,31 @@ When multiple agents work in parallel, they MUST follow these rules to avoid con
 
 **File ownership by agent:**
 
-| Agent                     | Primary ownership                                                                                                                                     |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@kmp-engineer`           | `packages/`                                                                                                                                           |
-| `@backend-engineer`       | `services/api/`                                                                                                                                       |
-| `@web-engineer`           | `apps/web/`                                                                                                                                           |
-| `@android-engineer`       | `apps/android/`                                                                                                                                       |
-| `@ios-engineer`           | `apps/ios/`                                                                                                                                           |
-| `@windows-engineer`       | `apps/windows/`                                                                                                                                       |
-| `@design-engineer`        | `config/tokens/`, generated token files                                                                                                               |
-| `@devops-engineer`        | `.github/workflows/`, `build-logic/`, `tools/`                                                                                                        |
-| `@docs-writer`            | `docs/`, `*.md` files in root                                                                                                                         |
-| `@security-reviewer`      | Emergency fixer — may implement CRITICAL/HIGH security fixes in any directory (coordinating with the owning agent); review-only for non-security code |
-| `@accessibility-reviewer` | Review-only — never edits production code; routes every fix to the owning platform agent                                                              |
-| `@architect`              | `docs/architecture/`, ADRs; read-only for code                                                                                                        |
-| `@finance-domain`         | `packages/core/` business logic (shared with `@kmp-engineer`)                                                                                         |
-| `@product-manager`        | `docs/business/`, GitHub Issues (read/create)                                                                                                         |
-| `@marketing-strategist`   | `docs/marketing/`, app store copy drafts                                                                                                              |
-| `@business-analyst`       | `docs/business/`, pricing/revenue docs                                                                                                                |
-| `@qa-tester`              | Read-only on code; orchestrates testing sessions and files GitHub Issues                                                                              |
-| `@ai-ops-engineer`        | `.github/agents/`, `.github/skills/`, `.github/instructions/`, prompts/evals, AI manifest                                                             |
-| `@release-manager`        | `.changeset/`, version/release-notes files, store-submission prep docs                                                                                |
-| `@performance-engineer`   | `performance.budget.json`, profiling/benchmark configs, perf docs                                                                                     |
-| `@data-engineer`          | Metrics pipelines, event schemas, analytics configs                                                                                                   |
-| `@localization-engineer`  | i18n resource files, localization tooling, financial terminology                                                                                      |
+| Agent                       | Primary ownership                                                                                                                                                              |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@kmp-engineer`             | `packages/`                                                                                                                                                                    |
+| `@backend-engineer`         | `services/api/`                                                                                                                                                                |
+| `@web-engineer`             | `apps/web/`                                                                                                                                                                    |
+| `@android-engineer`         | `apps/android/`                                                                                                                                                                |
+| `@ios-engineer`             | `apps/ios/`                                                                                                                                                                    |
+| `@windows-engineer`         | `apps/windows/`                                                                                                                                                                |
+| `@design-engineer`          | `packages/design-tokens/` (token sources, Style Dictionary config + generated outputs)                                                                                         |
+| `@devops-engineer`          | `.github/workflows/`, `build-logic/`, `tools/`, `scripts/`, `deploy/`, `gradle/wrapper/`, `config/detekt/`                                                                     |
+| `@docs-writer`              | `docs/`, `*.md` files in root                                                                                                                                                  |
+| `@security-reviewer`        | Emergency fixer — may implement CRITICAL/HIGH security fixes in any directory (coordinating with the owning agent); review-only for non-security code                          |
+| `@accessibility-reviewer`   | Review-only — never edits production code; routes every fix to the owning platform agent                                                                                       |
+| `@architect`                | `docs/architecture/`, ADRs; read-only for code                                                                                                                                 |
+| `@finance-domain`           | `packages/core/` business logic (shared with `@kmp-engineer`)                                                                                                                  |
+| `@product-manager`          | `docs/business/roadmap/`, GitHub Issues (read/create)                                                                                                                          |
+| `@marketing-strategist`     | `docs/marketing/`, app store copy drafts                                                                                                                                       |
+| `@business-analyst`         | `docs/business/pricing/`, `docs/business/revenue/`                                                                                                                             |
+| `@qa-tester`                | Read-only on code; orchestrates testing sessions and files GitHub Issues                                                                                                       |
+| `@ai-ops-engineer`          | `.github/agents/`, `.github/skills/`, `.github/instructions/`, prompts/evals, AI manifest                                                                                      |
+| `@release-manager`          | `.changeset/`, version/release-notes files, store-submission prep docs                                                                                                         |
+| `@performance-engineer`     | `performance.budget.json`, profiling/benchmark configs, perf docs                                                                                                              |
+| `@data-engineer`            | `docs/analytics/`, `config/analytics/` (net-new) + telemetry files in `packages/core/.../analytics/` (co-owned w/ `@kmp-engineer`); product analytics, NOT financial reporting |
+| `@localization-engineer`    | `config/i18n/`, `docs/i18n/` (net-new); locale catalogs, financial terminology                                                                                                 |
+| `@experimentation-engineer` | `config/feature-flags/`; A/B tests + staged rollouts (success metrics co-designed w/ `@data-engineer`, validation CI w/ `@devops-engineer`)                                    |
 
 **Coordination protocol:**
 

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -76,7 +76,7 @@ Finance is developed with AI agents as first-class contributors. This means:
 │   ├── web.instructions.md
 │   ├── workflow.instructions.md
 │   └── workflows.instructions.md
-├── agents/                           # Custom agent definitions (22 agents as of 2026-06; .github/agents/ is the source of truth)
+├── agents/                           # Custom agent definitions (23 agents as of 2026-06; .github/agents/ is the source of truth)
 │   ├── accessibility-reviewer.agent.md
 │   ├── ai-ops-engineer.agent.md
 │   ├── android-engineer.agent.md

--- a/docs/ai/agent-instructions.md
+++ b/docs/ai/agent-instructions.md
@@ -20,7 +20,7 @@ This document describes the roles, skills, and workflow rules for all AI agents 
 
 The Finance monorepo uses specialized AI agents, each with a focused domain. Agents are defined in `.github/agents/` as `<role>.agent.md` files. Each agent has a clear mission, expertise areas, boundaries, and a list of allowed tools.
 
-**Current agent types:** The authoritative roster is the set of `*.agent.md` files in `.github/agents/` (a generated `ai-manifest` is planned to keep this in sync — see [`CHANGELOG.md`](CHANGELOG.md)). As of 2026-06 there are **22** agents:
+**Current agent types:** The authoritative roster is the set of `*.agent.md` files in `.github/agents/`; run `npm run ai:manifest:check` (backed by `tools/ai-manifest.js`) to flag drift between this count and the filesystem — see [`CHANGELOG.md`](CHANGELOG.md). As of 2026-06 there are **23** agents:
 
 - **accessibility-reviewer** — Reviews UI for WCAG 2.2 AA, platform accessibility, and inclusive design. **Review-only** — routes fixes to the owning platform agent.
 - **android-engineer** — Android (Jetpack Compose, KMP, PowerSync, Keystore, Wear OS).
@@ -45,8 +45,9 @@ The Finance monorepo uses specialized AI agents, each with a focused domain. Age
 - **ai-ops-engineer** — Owns `.github/agents/`, `.github/skills/`, `.github/instructions/`, prompts, evals, and the AI manifest.
 - **release-manager** — Changesets/versioning, release notes, store-submission preparation.
 - **performance-engineer** — Performance budgets, profiling, regression analysis.
-- **data-engineer** — Metrics pipelines, event schemas, analytics.
+- **data-engineer** — Privacy-preserving product analytics: event schemas, taxonomy, metrics catalog (distinct from financial reporting/insights).
 - **localization-engineer** — i18n, localization, financial terminology.
+- **experimentation-engineer** — Feature flags, A/B testing, staged rollouts, and experiment readouts.
 
 Each agent file documents:
 
@@ -186,4 +187,4 @@ If a task requires a gated operation, agents must STOP, explain, and request hum
 
 ---
 
-_Last reviewed: 2026-06. The authoritative roster/skill lists are the `.github/agents/` and `.github/skills/` directories; this summary is kept in sync manually until the generated `ai-manifest` lands (see [CHANGELOG.md](CHANGELOG.md))._
+_Last reviewed: 2026-06. The authoritative roster/skill lists are the `.github/agents/` and `.github/skills/` directories; `npm run ai:manifest:check` flags any drift between this summary and the filesystem (see [CHANGELOG.md](CHANGELOG.md))._

--- a/docs/ai/agents.md
+++ b/docs/ai/agents.md
@@ -5,13 +5,13 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 ## How Agents Work
 
 1. Agent definitions live in `.github/agents/<name>.agent.md`
-2. Each file contains YAML frontmatter (name, description, tools) and a Markdown body with detailed instructions
+2. Each file contains YAML frontmatter (`name`, `description`, `model`, `when_to_use`, `primary_paths`, `write_scope`, `risk_level`, `tools`) and a Markdown body with the standard sections (Role, Capabilities, File Ownership, Workflow, Planning & Verification, Technical Context, Boundaries, Human-Gated Operations) — see [`agents.instructions.md`](../../.github/instructions/agents.instructions.md)
 3. Copilot loads the relevant agent when invoked by name in chat (e.g., `@architect`)
 4. The GitHub Copilot Coding Agent can also use these definitions when working on issues autonomously
 
 ## Available Agents
 
-> **Source of truth:** the `*.agent.md` files in [`.github/agents/`](../../.github/agents/). As of 2026-06 there are **22** agents. This page describes the established roster in detail; the full current list (including agents added in 2026-06 — `ai-ops-engineer`, `release-manager`, `performance-engineer`, `data-engineer`, `localization-engineer`, and `qa-tester`) is summarized in [Agent Instructions](agent-instructions.md#agent-types). A generated `ai-manifest` is planned to keep these in sync — see the [CHANGELOG](CHANGELOG.md).
+> **Source of truth:** the `*.agent.md` files in [`.github/agents/`](../../.github/agents/). As of 2026-06 there are **23** agents — every one is detailed on this page. Agents added in 2026-06: `ai-ops-engineer`, `release-manager`, `performance-engineer`, `data-engineer`, `localization-engineer`, `qa-tester`, and `experimentation-engineer` (feature flags & A/B testing). Run `npm run ai:manifest:check` (backed by `tools/ai-manifest.js`) to surface any drift between the counts on this page and the filesystem — see the [CHANGELOG](CHANGELOG.md).
 >
 > **Reviewer roles are asymmetric:** `accessibility-reviewer` is **review-only** (routes fixes to the owning platform agent); `security-reviewer` is the **emergency fixer** (may implement CRITICAL/HIGH security fixes in any directory, with owning-agent coordination).
 
@@ -47,7 +47,7 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 - Updating AI workflow documentation
 - Writing onboarding guides
 
-**Tools:** read, edit, search
+**Tools:** read, edit, search, shell
 
 ---
 
@@ -111,7 +111,7 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 - Multi-currency support
 - Shared/family finance features
 
-**Tools:** read, edit, search
+**Tools:** read, edit, search, shell
 
 **Critical rule:** Never use floating point for money. Use integer cents or fixed-precision decimals.
 
@@ -294,7 +294,7 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 - Defining user acquisition strategy and channels
 - Drafting privacy-focused messaging
 
-**Tools:** read, edit, search
+**Tools:** read, edit, search, shell
 
 ---
 
@@ -312,7 +312,119 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 - Designing freemium boundaries that drive conversion
 - Evaluating subscription platform options
 
-**Tools:** read, edit, search
+**Tools:** read, edit, search, shell
+
+---
+
+### `@ai-ops-engineer` — AI Ops Engineer
+
+**File:** `.github/agents/ai-ops-engineer.agent.md`
+
+**Purpose:** Owns the AI configuration surface — agent definitions, skills, path instructions, prompts, evals, and the generated AI manifest. Keeps the roster coherent and self-consistent.
+
+**When to use:**
+
+- Adding, editing, or auditing `.github/agents/`, `.github/skills/`, `.github/instructions/`, `.github/prompts/`
+- Designing prompt templates, agent hand-offs, and evals
+- Regenerating the AI manifest after roster/skill changes
+
+**Tools:** read, edit, search, shell
+
+---
+
+### `@release-manager` — Release Manager
+
+**File:** `.github/agents/release-manager.agent.md`
+
+**Purpose:** Runs Changesets/semver versioning, authors release notes and changelogs, and prepares store submissions (submission stays human-gated).
+
+**When to use:**
+
+- Adding Changeset entries and updating changelogs
+- Drafting user-facing and technical release notes
+- Sequencing a multi-platform release and go/no-go readiness
+
+**Tools:** read, edit, search, shell
+
+---
+
+### `@performance-engineer` — Performance Engineer
+
+**File:** `.github/agents/performance-engineer.agent.md`
+
+**Purpose:** Owns performance budgets, cross-platform profiling, benchmarking, and regression triage (Core Web Vitals, startup, bundle size).
+
+**When to use:**
+
+- Defining or tuning `performance.budget.json`
+- Investigating LCP/INP/CLS, startup, or bundle-size regressions
+- Setting up profiling/benchmark configs
+
+**Tools:** read, edit, search, shell
+
+---
+
+### `@data-engineer` — Data Engineer
+
+**File:** `.github/agents/data-engineer.agent.md`
+
+**Purpose:** Designs privacy-preserving **product analytics** — event schemas, taxonomy, and the metrics catalog. Owns the schema/catalog (in `docs/analytics/` + `config/analytics/`, net-new) and co-owns the telemetry files in `packages/core/.../analytics/`. Not to be confused with financial reporting/insights, which belong to `@finance-domain`/platform agents.
+
+**When to use:**
+
+- Defining or versioning analytics event schemas and taxonomy
+- Designing consent-gated, PII-free metrics and the metrics catalog
+- Co-designing client emission (with `@kmp-engineer`) and storage (with `@backend-engineer`)
+
+**Tools:** read, edit, search, shell
+
+---
+
+### `@experimentation-engineer` — Experimentation Engineer
+
+**File:** `.github/agents/experimentation-engineer.agent.md`
+
+**Purpose:** Owns feature flags, A/B tests, staged rollouts, and experiment readouts. Leads `config/feature-flags/`; pairs with `@data-engineer` on success metrics and `@devops-engineer` on validation CI.
+
+**When to use:**
+
+- Adding or ramping a feature flag (`flags.json`) with rollout % and expiry
+- Designing an A/B test or holdout (hypothesis, variants, guardrails)
+- Reading out an experiment and deciding ship/hold/rollback
+
+**Tools:** read, edit, search, shell
+
+---
+
+### `@localization-engineer` — Localization Engineer
+
+**File:** `.github/agents/localization-engineer.agent.md`
+
+**Purpose:** Owns i18n/l10n — locale catalogs, string-key conventions, the financial-terminology glossary, and formatting (currency/date/number, pluralization, RTL readiness). Leads `config/i18n/` + `docs/i18n/` (net-new); platform string code stays with platform/KMP agents.
+
+**When to use:**
+
+- Defining locale packs, string keys, and the financial-terminology glossary
+- Reviewing currency/date/number formatting and pluralization
+- Assessing text expansion and right-to-left readiness
+
+**Tools:** read, edit, search, shell
+
+---
+
+### `@qa-tester` — QA Tester
+
+**File:** `.github/agents/qa-tester.agent.md`
+
+**Purpose:** Orchestrates live testing sessions, discovers and investigates bugs, and files well-scoped GitHub issues. **Read-only on code** — never modifies production code; hands off to `@product-manager` for prioritization.
+
+**When to use:**
+
+- Running an interactive testing session across web/iOS/Android/Windows
+- Triaging console errors and scoping bugs (platform duplicates) before filing
+- Dispatching parallel investigation agents for reported bugs
+
+**Tools:** read, search, shell
 
 ---
 
@@ -322,24 +434,33 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 
 Each agent has primary ownership over a set of directories. When multiple agents run in parallel (fleet mode), only the owning agent edits files in its area:
 
-| Agent                     | Primary ownership                                                  |
-| ------------------------- | ------------------------------------------------------------------ |
-| `@kmp-engineer`           | `packages/`                                                        |
-| `@backend-engineer`       | `services/api/`                                                    |
-| `@web-engineer`           | `apps/web/`                                                        |
-| `@android-engineer`       | `apps/android/`                                                    |
-| `@ios-engineer`           | `apps/ios/`                                                        |
-| `@windows-engineer`       | `apps/windows/`                                                    |
-| `@design-engineer`        | `config/tokens/`, generated token files                            |
-| `@devops-engineer`        | `.github/workflows/`, `build-logic/`, `tools/`                     |
-| `@docs-writer`            | `docs/`, root `*.md` files                                         |
-| `@security-reviewer`      | Security fixes in any directory; review-only for non-security code |
-| `@accessibility-reviewer` | Read-only review — never edits production code                     |
-| `@architect`              | `docs/architecture/`, ADRs; read-only for code                     |
-| `@finance-domain`         | `packages/core/` business logic (shared with `@kmp-engineer`)      |
-| `@product-manager`        | `docs/business/`, GitHub Issues (read/create)                      |
-| `@marketing-strategist`   | `docs/marketing/`, app store copy drafts                           |
-| `@business-analyst`       | `docs/business/`, pricing/revenue docs                             |
+| Agent                       | Primary ownership                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `@kmp-engineer`             | `packages/`                                                                                                                  |
+| `@backend-engineer`         | `services/api/`                                                                                                              |
+| `@web-engineer`             | `apps/web/`                                                                                                                  |
+| `@android-engineer`         | `apps/android/`                                                                                                              |
+| `@ios-engineer`             | `apps/ios/`                                                                                                                  |
+| `@windows-engineer`         | `apps/windows/`                                                                                                              |
+| `@design-engineer`          | `packages/design-tokens/` (token sources, Style Dictionary config + outputs)                                                 |
+| `@devops-engineer`          | `.github/workflows/`, `build-logic/`, `tools/`, `scripts/`, `deploy/`, `gradle/wrapper/`, `config/detekt/`                   |
+| `@docs-writer`              | `docs/`, root `*.md` files                                                                                                   |
+| `@security-reviewer`        | Security fixes in any directory; review-only for non-security code                                                           |
+| `@accessibility-reviewer`   | Read-only review — never edits production code                                                                               |
+| `@architect`                | `docs/architecture/`, ADRs; read-only for code                                                                               |
+| `@finance-domain`           | `packages/core/` business logic (shared with `@kmp-engineer`)                                                                |
+| `@product-manager`          | `docs/business/roadmap/`†, GitHub Issues (read/create)                                                                       |
+| `@marketing-strategist`     | `docs/marketing/`, app store copy drafts                                                                                     |
+| `@business-analyst`         | `docs/business/pricing/`†, `docs/business/revenue/`†                                                                         |
+| `@ai-ops-engineer`          | `.github/agents/`, `.github/skills/`, `.github/instructions/`, `.github/prompts/`                                            |
+| `@data-engineer`            | `docs/analytics/`†, `config/analytics/`† + telemetry files in `packages/core/.../analytics/` (co-owned with `@kmp-engineer`) |
+| `@experimentation-engineer` | `config/feature-flags/`                                                                                                      |
+| `@performance-engineer`     | `performance.budget.json`, `docs/performance/`†                                                                              |
+| `@localization-engineer`    | `config/i18n/`†, `docs/i18n/`†                                                                                               |
+| `@release-manager`          | `.changeset/`, `CHANGELOG.md` (root + per-package), `docs/releases/`†                                                        |
+| `@qa-tester`                | Read-only across `apps/*`, `packages/`, `services/api/`; files GitHub Issues                                                 |
+
+> † Net-new / planned home — created on first use (see the owning agent's File Ownership section). Cross-cutting code (analytics, i18n, performance) lives in platform-owned dirs; these agents own the schema/catalog/config + docs.
 
 **Shared config** (`gradle/libs.versions.toml`, `settings.gradle.kts`, `package.json`, `turbo.json`) — one agent per run. Assign to `@kmp-engineer` (Gradle) or `@devops-engineer` (Node/CI).
 
@@ -351,21 +472,27 @@ Each agent has primary ownership over a set of directories. When multiple agents
 
 ### Adding a New Agent
 
-1. Create `.github/agents/<name>.agent.md` with YAML frontmatter:
+1. Create `.github/agents/<name>.agent.md` with the full eight-key YAML frontmatter:
    ```yaml
    ---
    name: <agent-name>
-   description: >
-     Clear description of the agent's purpose and when to use it.
+   description: One-line summary shown in the agent picker.
+   model: standard # or strong-reasoning
+   when_to_use: 'A sentence telling the orchestrator when to route here.'
+   primary_paths:
+     - 'path/the/agent/owns/**'
+   write_scope: full # or scoped-write | read-only
+   risk_level: low # or medium | high
    tools:
      - read
      - edit
      - search
    ---
    ```
-2. Write the Markdown body with: Mission, Expertise Areas, Key Responsibilities, and Boundaries
-3. Update this document (`docs/ai/agents.md`) with the new agent's details
-4. Test the agent by invoking it in Copilot Chat
+2. Write the Markdown body with the **eight standard sections**: Role, Capabilities, File Ownership, Workflow, Planning & Verification, Technical Context, Boundaries, and Human-Gated Operations (see [`agents.instructions.md`](../../.github/instructions/agents.instructions.md))
+3. Update this document (`docs/ai/agents.md`) and [`agent-instructions.md`](agent-instructions.md) with the new agent, and add its ownership row above
+4. Run `npm run ai:manifest:check` to confirm the roster/skill counts in the docs still match the filesystem
+5. Test the agent by invoking it in Copilot Chat
 
 ## Best Practices
 
@@ -416,4 +543,4 @@ For docs-only PRs, use: `npm run ci:check:quick`
 
 - **Kotlin linting** is handled by **detekt** in CI (not ESLint/Prettier)
 - **`.prettierignore`** covers non-JS source files (Kotlin, Swift, etc.)
-- **16 agents** are defined in `.github/agents/`
+- **23 agents** are defined in `.github/agents/` (source of truth; drift surfaced by `npm run ai:manifest:check`)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "ready-for-pr": "node tools/ready-for-pr.js",
     "clean": "node tools/gradle.js clean && turbo run clean",
     "cleanup:worktrees": "node tools/cleanup-worktrees.js",
+    "ai:manifest": "node tools/ai-manifest.js",
+    "ai:manifest:check": "node tools/check-ai-manifest.js",
     "agent:worktree": "node tools/agent-scripts/setup-worktree.js",
     "agent:check": "node tools/agent-scripts/pre-push-check.js",
     "agent:pr": "node tools/agent-scripts/create-pr.js",


### PR DESCRIPTION
## Summary

First slice of the AI-capabilities audit (issue #2955): a full accuracy pass over the **custom-agent roster** and its documentation, the addition of one new agent, and wiring up the existing AI-manifest tooling as first-class npm scripts.

This lands work-streams **WS1–WS5**. The `docs/business/` reorganization (**WS6**) is intentionally held for a separate PR pending a file-mapping sign-off, so this PR uses `Refs #2955` rather than `Closes`.

## Changes

### New agent (roster 22 → 23)

- **`@experimentation-engineer`** — owns the feature-flag lifecycle and experimentation system (`config/feature-flags/**`): staged/percentage rollouts, A/B tests, holdouts, kill switches, and experiment readouts. Success metrics are co-designed with `@data-engineer`; rollout validation CI with `@devops-engineer`. Privacy-first (never buckets on PII/financial data).

### Agent definition fixes

- **design-engineer** — corrected token paths (`config/tokens/` → `packages/design-tokens/`, incl. the Style Dictionary config path).
- **qa-tester** — rewritten to the canonical 8-section agent schema (was the lone outlier).
- **4 authoring agents** (business-analyst, docs-writer, finance-domain, marketing-strategist) — granted `shell` so they can run the lint/format/preview commands their workflows already assume.
- **accessibility-reviewer** — documented that its `shell` grant is read-only verification (it never edits production code).
- **devops-engineer** — ownership expanded to the dirs it already maintains (`scripts/`, `deploy/`, `gradle/wrapper/`, `config/detekt/`); added a "do NOT edit `config/feature-flags/`" boundary now that experimentation-engineer owns it.
- **release-manager** — replaced a stale TODO with an accurate note (`.changeset/` exists; `docs/releases/` is net-new).
- **data-engineer / kmp-engineer** — scoped data-engineer to **product-telemetry** co-ownership only (`AnalyticsEvent`/`AnalyticsTracker`/`BufferedAnalyticsTracker`) and de-conflicted the overloaded **"analytics"** term (product telemetry vs. financial reporting vs. ops observability), so it no longer appears to claim the financial-reporting code owned by finance-domain/web/backend.

### Documentation accuracy

- **`.github/instructions/agents.instructions.md`** — now documents the **real 8-key frontmatter schema** (name/description/model/when_to_use/primary_paths/write_scope/risk_level/tools) with the allowed value sets, replacing the outdated minimal-3-key description.
- **`docs/ai/agents.md`** — count 22→23, 7 missing agent entries added, ownership table rebuilt, "Adding a New Agent" rewritten to the 8-key/8-section reality, footer count fixed.
- **`AGENTS.md`** — roster list + ownership table updated to 23 agents with corrected paths.
- **`docs/ai/README.md`, `docs/ai/agent-instructions.md`** — agent counts corrected to 23.

### AI-manifest tooling (wiring, not new code)

- Discovered the repo already ships `tools/ai-manifest.js` (generator) + `tools/check-ai-manifest.js` (doc-vs-filesystem drift check), already referenced by the `AI Manifest Check` workflow but **never wired into `package.json`**.
- Added the two documented scripts: **`npm run ai:manifest`** and **`npm run ai:manifest:check`** (names already specified in `tools/README.md`).
- Reconciled all docs to reference this real tooling instead of a non-existent committed JSON file.
- `npm run ai:manifest:check` now reports **no drift** (23 agents · 20 skills · 13 instructions · 7 MCP servers).

## Validation

- `npm run format:check` — passes
- `npx eslint . --max-warnings 0` — passes
- `node tools/check-ai-manifest.js` — no drift
- All 23 agent files verified against the 8-section schema

## Issues

Refs #2955

## Notes

- `package-lock.json` was intentionally **not** modified (the two new scripts add no dependencies).
- **WS6 (docs/business reorg)** follows in a separate PR after the 46-file mapping is signed off; several agent `primary_paths` (`docs/business/roadmap`, `pricing`, `revenue`) already reference the planned subdirs, consistent with the repo's existing net-new-path convention.
