### PR TITLE
feat(web): safe-to-spend card with pinned category and upcoming bills (#2199)

### DIFF
--- a/apps/web/src/components/dashboard/GroceryModeCard.test.tsx
+++ b/apps/web/src/components/dashboard/GroceryModeCard.test.tsx
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { GroceryModeCard, type GroceryModeCardProps } from './GroceryModeCard';
+import type { UpcomingBillInput } from '../../lib/dashboard/grocery-mode';
+
+const RENT: UpcomingBillInput = {
+  id: 'rent',
+  name: 'Rent',
+  amountCents: 120_000,
+  dueDate: '2025-07-03',
+  critical: true,
+  paid: false,
+};
+
+const POWER: UpcomingBillInput = {
+  id: 'power',
+  name: 'Electric',
+  amountCents: 8_500,
+  dueDate: '2025-07-02',
+  critical: true,
+  paid: false,
+};
+
+function makeProps(overrides: Partial<GroceryModeCardProps> = {}): GroceryModeCardProps {
+  return {
+    availableFundsCents: 200_000,
+    reservedCents: 0,
+    bills: [RENT, POWER],
+    categoryOptions: [
+      { id: 'groceries', name: 'Groceries', budgetCents: 60_000, spentCents: 38_000 },
+      { id: 'dining', name: 'Dining', budgetCents: 20_000, spentCents: 20_000 },
+    ],
+    today: '2025-07-01',
+    incomeDates: [],
+    fallbackPayday: '2025-07-04',
+    currency: 'USD',
+    defaultPinnedCategoryId: null,
+    ...overrides,
+  };
+}
+
+describe('GroceryModeCard', () => {
+  it('renders the grocery mode eyebrow and a payday-aware title', () => {
+    render(<GroceryModeCard {...makeProps()} />);
+    expect(screen.getByText('Grocery mode')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /safe to spend before Friday, Jul 4/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('exposes the answer as a polite live region', () => {
+    render(<GroceryModeCard {...makeProps()} />);
+    const statuses = screen.getAllByRole('status');
+    expect(statuses.length).toBeGreaterThanOrEqual(1);
+    expect(statuses.some((node) => node.getAttribute('aria-live') === 'polite')).toBe(true);
+  });
+
+  it('shows the safe-to-spend answer after setting aside bills', () => {
+    // 200000 funds - (120000 + 8500) bills = 71500 -> $715.00
+    render(<GroceryModeCard {...makeProps()} />);
+    expect(
+      screen.getByText(/You have \$715\.00 to spend before Friday, Jul 4/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/after setting aside \$1,285\.00 for bills/i)).toBeInTheDocument();
+  });
+
+  it('lists the upcoming critical bills, soonest first', () => {
+    render(<GroceryModeCard {...makeProps()} />);
+    const list = screen.getByRole('list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent('Electric');
+    expect(items[1]).toHaveTextContent('Rent');
+  });
+
+  it('shows a reassuring empty message when no critical bills are due', () => {
+    render(<GroceryModeCard {...makeProps({ bills: [] })} />);
+    expect(screen.getByText(/No critical bills are due before Friday, Jul 4/i)).toBeInTheDocument();
+    expect(screen.queryByRole('list')).toBeNull();
+  });
+
+  it('offers a labelled, keyboard-navigable category selector', () => {
+    render(<GroceryModeCard {...makeProps()} />);
+    const select = screen.getByRole('combobox', { name: /track a category/i });
+    expect(select).toBeInTheDocument();
+    expect(within(select).getByRole('option', { name: /none/i })).toBeInTheDocument();
+    expect(within(select).getByRole('option', { name: 'Groceries' })).toBeInTheDocument();
+  });
+
+  it('announces the pinned category remaining when one is selected', () => {
+    render(<GroceryModeCard {...makeProps()} />);
+    const select = screen.getByRole('combobox', { name: /track a category/i });
+    fireEvent.change(select, { target: { value: 'groceries' } });
+    // 60000 budget - 38000 spent = 22000 -> $220.00
+    expect(screen.getByText(/\$220\.00 left in your Groceries budget/i)).toBeInTheDocument();
+  });
+
+  it('uses gentle copy when a pinned category budget is fully used', () => {
+    render(<GroceryModeCard {...makeProps({ defaultPinnedCategoryId: 'dining' })} />);
+    expect(screen.getByText(/used up your Dining budget for now/i)).toBeInTheDocument();
+    expect(screen.getByText(/no stress, it resets next period/i)).toBeInTheDocument();
+  });
+
+  it('answers an affordability check in the affirmative', () => {
+    render(<GroceryModeCard {...makeProps()} />);
+    const input = screen.getByRole('textbox', { name: /can i afford/i });
+    fireEvent.change(input, { target: { value: '50' } });
+    expect(screen.getByText(/Yes — go for it/i)).toBeInTheDocument();
+    expect(screen.getByText(/still have \$665\.00 free/i)).toBeInTheDocument();
+  });
+
+  it('answers an unaffordable check with supportive, non-alarming copy', () => {
+    render(<GroceryModeCard {...makeProps()} />);
+    const input = screen.getByRole('textbox', { name: /can i afford/i });
+    fireEvent.change(input, { target: { value: '900' } });
+    // 71500 safe - 90000 = -18500 short -> $185.00
+    expect(screen.getByText(/Not just yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/\$185\.00 more than you have free/i)).toBeInTheDocument();
+    expect(screen.getByText(/Maybe wait until Friday, Jul 4/i)).toBeInTheDocument();
+  });
+
+  it('frames a tight budget supportively rather than as a red alert', () => {
+    render(
+      <GroceryModeCard {...makeProps({ availableFundsCents: 100_000, bills: [RENT, POWER] })} />,
+    );
+    // 100000 - 128500 = -28500 short
+    expect(screen.getByText(/Money's a little tight right now/i)).toBeInTheDocument();
+    expect(screen.getByText(/you're about \$285\.00 short/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/It may help to hold off on extras until Friday, Jul 4/i),
+    ).toBeInTheDocument();
+  });
+
+  it('works without a known payday, using the generic horizon', () => {
+    render(<GroceryModeCard {...makeProps({ fallbackPayday: null, bills: [] })} />);
+    expect(screen.getByRole('heading', { name: /safe to spend right now/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /You have \$2,000\.00 to spend right now\. No critical bills are due first\./i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('estimates the next payday from recent income dates', () => {
+    // A single monthly paycheck on Jun 20 projects forward ~30 days to Jul 20.
+    render(<GroceryModeCard {...makeProps({ incomeDates: ['2025-06-20'], bills: [] })} />);
+    expect(
+      screen.getByRole('heading', { name: /safe to spend before .*Jul 20/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/GroceryModeCard.tsx
+++ b/apps/web/src/components/dashboard/GroceryModeCard.tsx
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Grocery mode card — a fast, supportive "can I afford this?" / "safe to spend
+ * before payday" glance for the dashboard.
+ *
+ * Surfaces:
+ *   - The amount that's safe to spend before the next payday.
+ *   - A pinned high-frequency category (e.g. Groceries) and its remaining budget.
+ *   - The critical bills due before payday, for context.
+ *   - A quick "can I afford $___ right now?" check.
+ *
+ * Accessibility:
+ *   - The computed answers live in `aria-live="polite"` regions so screen
+ *     reader users hear updates as they change the pinned category or type an
+ *     amount.
+ *   - Tone is conveyed by an icon **and** supportive text — never by colour
+ *     alone (WCAG 2.2 AA, 1.4.1 Use of Color).
+ *   - Controls are native, labelled and keyboard-navigable.
+ *   - Copy is gentle and non-alarming, even when money is tight.
+ *
+ * All calculation lives in the pure `lib/dashboard/grocery-mode` engine; this
+ * component only formats and presents the result.
+ *
+ * References: issue #2199
+ */
+
+import React, { useCallback, useId, useMemo, useState } from 'react';
+
+import { CurrencyDisplay } from '../common';
+import { AppIcon, type IconName } from '../icons';
+import { useIsPrivacyModeActive } from '../../contexts/PrivacyModeContext';
+import { formatCurrency } from '../../lib/currency';
+import {
+  computeSafeToSpend,
+  estimateNextPayday,
+  evaluateAffordability,
+  parseAmountToCents,
+  type PinnedCategoryInput,
+  type UpcomingBillInput,
+} from '../../lib/dashboard/grocery-mode';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A category the user can pin to track, with its current-period budget. */
+export interface GroceryCategoryOption {
+  readonly id: string;
+  readonly name: string;
+  readonly budgetCents: number;
+  readonly spentCents: number;
+}
+
+export interface GroceryModeCardProps {
+  /** Current spendable balance (signed) in integer cents. */
+  readonly availableFundsCents: number;
+  /** Amount already earmarked (e.g. savings goals) in integer cents. */
+  readonly reservedCents?: number;
+  /** Bills to consider; the engine filters by status, date and criticality. */
+  readonly bills: readonly UpcomingBillInput[];
+  /** Categories the user can pin to track (typically active monthly budgets). */
+  readonly categoryOptions: readonly GroceryCategoryOption[];
+  /** Today's date as an ISO `YYYY-MM-DD` string. */
+  readonly today: string;
+  /**
+   * Recent income transaction dates (ISO `YYYY-MM-DD`), used to estimate the
+   * next payday. When empty or inconclusive, {@link fallbackPayday} is used.
+   */
+  readonly incomeDates?: readonly string[];
+  /**
+   * The payday to assume when income history can't produce one (e.g. end of the
+   * current month), as `YYYY-MM-DD`, or `null` when none is known.
+   */
+  readonly fallbackPayday?: string | null;
+  /** ISO 4217 currency code (default: `"USD"`). */
+  readonly currency?: string;
+  /** Category id to pin initially, when known. */
+  readonly defaultPinnedCategoryId?: string | null;
+}
+
+const NONE_VALUE = '';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatPaydayLabel(nextPayday: string | null): string {
+  if (!nextPayday) return 'your next paycheck';
+  const ms = Date.parse(`${nextPayday.slice(0, 10)}T00:00:00Z`);
+  if (!Number.isFinite(ms)) return 'your next paycheck';
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(ms));
+}
+
+function formatDueLabel(dueDate: string): string {
+  const ms = Date.parse(`${dueDate.slice(0, 10)}T00:00:00Z`);
+  if (!Number.isFinite(ms)) return dueDate;
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(ms));
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const GroceryModeCard: React.FC<GroceryModeCardProps> = ({
+  availableFundsCents,
+  reservedCents = 0,
+  bills,
+  categoryOptions,
+  today,
+  incomeDates,
+  fallbackPayday = null,
+  currency = 'USD',
+  defaultPinnedCategoryId = null,
+}) => {
+  const fieldPrefix = useId();
+  const isPrivacyMode = useIsPrivacyModeActive();
+
+  const [pinnedCategoryId, setPinnedCategoryId] = useState<string>(
+    defaultPinnedCategoryId ?? NONE_VALUE,
+  );
+  const [affordRaw, setAffordRaw] = useState<string>('');
+
+  const nextPayday = useMemo(
+    () => estimateNextPayday(incomeDates ?? [], today) ?? fallbackPayday,
+    [incomeDates, today, fallbackPayday],
+  );
+
+  const pinnedCategory = useMemo<PinnedCategoryInput | null>(() => {
+    const match = categoryOptions.find((option) => option.id === pinnedCategoryId);
+    if (!match) return null;
+    return {
+      categoryId: match.id,
+      name: match.name,
+      budgetCents: match.budgetCents,
+      spentCents: match.spentCents,
+    };
+  }, [categoryOptions, pinnedCategoryId]);
+
+  const result = useMemo(
+    () =>
+      computeSafeToSpend({
+        availableFundsCents,
+        reservedCents,
+        bills,
+        today,
+        nextPayday,
+        pinnedCategory,
+      }),
+    [availableFundsCents, reservedCents, bills, today, nextPayday, pinnedCategory],
+  );
+
+  const affordCents = parseAmountToCents(affordRaw);
+  const affordability =
+    affordCents === null ? null : evaluateAffordability(result.safeToSpendCents, affordCents);
+
+  const handleCategoryChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    setPinnedCategoryId(event.target.value);
+  }, []);
+
+  const handleAffordChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setAffordRaw(event.target.value);
+  }, []);
+
+  const money = useCallback(
+    (cents: number): string =>
+      isPrivacyMode ? 'a hidden amount' : formatCurrency(cents, { currency }),
+    [currency, isPrivacyMode],
+  );
+
+  const paydayLabel = formatPaydayLabel(nextPayday);
+  const beforePaydayClause = result.hasPayday ? ` before ${paydayLabel}` : ' right now';
+  const isTight = result.safeToSpendCents < 0;
+  const isExactlyCovered = result.safeToSpendCents === 0;
+
+  const toneIcon: IconName = isTight ? 'info' : 'check-circle';
+  const tone = isTight ? 'tight' : 'calm';
+  const displaySafeToSpend = Math.max(0, result.safeToSpendCents);
+
+  let answerSentence: string;
+  if (isTight) {
+    answerSentence =
+      `Money's a little tight right now. After ${money(result.upcomingCriticalBillsCents)} of bills ` +
+      `due${beforePaydayClause}, you're about ${money(Math.abs(result.safeToSpendCents))} short. ` +
+      `It may help to hold off on extras until ${paydayLabel}.`;
+  } else if (isExactlyCovered) {
+    answerSentence =
+      `You're right on track — your money is fully set aside for bills` +
+      `${beforePaydayClause}. There's nothing extra to spend just yet.`;
+  } else if (result.upcomingCriticalBillsCents > 0) {
+    answerSentence =
+      `You have ${money(result.safeToSpendCents)} to spend${beforePaydayClause}, ` +
+      `after setting aside ${money(result.upcomingCriticalBillsCents)} for bills due first.`;
+  } else {
+    answerSentence = `You have ${money(result.safeToSpendCents)} to spend${beforePaydayClause}. No critical bills are due first.`;
+  }
+
+  const dailySentence =
+    result.dailyAllowanceCents !== null && result.daysUntilPayday !== null
+      ? `That's about ${money(result.dailyAllowanceCents)} a day for the next ${result.daysUntilPayday} ${result.daysUntilPayday === 1 ? 'day' : 'days'}.`
+      : null;
+
+  const pinned = result.pinnedCategory;
+  const pinnedSentence = pinned
+    ? pinned.remainingCents > 0
+      ? `You still have ${money(pinned.remainingCents)} left in your ${pinned.name} budget.`
+      : `You've used up your ${pinned.name} budget for now — no stress, it resets next period.`
+    : null;
+
+  const categorySelectId = `${fieldPrefix}-category`;
+  const affordInputId = `${fieldPrefix}-afford`;
+  const affordResultId = `${fieldPrefix}-afford-result`;
+
+  return (
+    <article
+      className={`card grocery-mode-card grocery-mode-card--${tone}`}
+      aria-labelledby={`${fieldPrefix}-title`}
+    >
+      <header className="grocery-mode-card__header">
+        <p className="grocery-mode-card__eyebrow">
+          <AppIcon name="shopping-cart" className="grocery-mode-card__eyebrow-icon" />
+          Grocery mode
+        </p>
+        <h3 id={`${fieldPrefix}-title`} className="grocery-mode-card__title">
+          {result.hasPayday ? `Safe to spend before ${paydayLabel}` : 'Safe to spend right now'}
+        </h3>
+      </header>
+
+      <p className="grocery-mode-card__amount" aria-hidden="true">
+        <AppIcon name={toneIcon} className="grocery-mode-card__amount-icon" />
+        <CurrencyDisplay amount={displaySafeToSpend} currency={currency} />
+      </p>
+
+      <div className="grocery-mode-card__answer" role="status" aria-live="polite">
+        <p className="grocery-mode-card__answer-text">{answerSentence}</p>
+        {dailySentence && <p className="grocery-mode-card__answer-meta">{dailySentence}</p>}
+        {pinnedSentence && <p className="grocery-mode-card__answer-pinned">{pinnedSentence}</p>}
+      </div>
+
+      {result.upcomingBills.length > 0 ? (
+        <div className="grocery-mode-card__bills">
+          <p className="grocery-mode-card__bills-title">
+            {result.hasPayday
+              ? `Bills set aside before ${paydayLabel}`
+              : 'Critical bills set aside'}
+          </p>
+          <ul className="grocery-mode-card__bills-list">
+            {result.upcomingBills.map((bill) => (
+              <li key={bill.id} className="grocery-mode-card__bill">
+                <span className="grocery-mode-card__bill-name">{bill.name}</span>
+                <span className="grocery-mode-card__bill-due">{formatDueLabel(bill.dueDate)}</span>
+                <span className="grocery-mode-card__bill-amount">
+                  <CurrencyDisplay
+                    amount={bill.amountCents}
+                    currency={currency}
+                    context={`${bill.name} bill due ${formatDueLabel(bill.dueDate)}`}
+                  />
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <p className="grocery-mode-card__bills-empty">
+          No critical bills are due{result.hasPayday ? ` before ${paydayLabel}` : ' soon'} — nice
+          and clear.
+        </p>
+      )}
+
+      <div className="grocery-mode-card__controls">
+        {categoryOptions.length > 0 && (
+          <div className="grocery-mode-card__field">
+            <label htmlFor={categorySelectId} className="grocery-mode-card__label">
+              Track a category
+            </label>
+            <select
+              id={categorySelectId}
+              className="grocery-mode-card__select"
+              value={pinnedCategoryId}
+              onChange={handleCategoryChange}
+            >
+              <option value={NONE_VALUE}>None — just the overall answer</option>
+              {categoryOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div className="grocery-mode-card__field">
+          <label htmlFor={affordInputId} className="grocery-mode-card__label">
+            Can I afford…?
+          </label>
+          <div className="grocery-mode-card__afford-input">
+            <span className="grocery-mode-card__afford-prefix" aria-hidden="true">
+              $
+            </span>
+            <input
+              id={affordInputId}
+              className="grocery-mode-card__input"
+              type="text"
+              inputMode="decimal"
+              autoComplete="off"
+              placeholder="0.00"
+              value={affordRaw}
+              onChange={handleAffordChange}
+              aria-describedby={affordability ? affordResultId : undefined}
+            />
+          </div>
+        </div>
+      </div>
+
+      <p
+        id={affordResultId}
+        className={`grocery-mode-card__afford-result grocery-mode-card__afford-result--${
+          affordability?.affordable ? 'yes' : 'no'
+        }`}
+        role="status"
+        aria-live="polite"
+      >
+        {affordability && (
+          <>
+            <AppIcon
+              name={affordability.affordable ? 'check-circle' : 'info'}
+              className="grocery-mode-card__afford-icon"
+            />
+            <span>
+              {affordability.affordable
+                ? `Yes — go for it. You'd still have ${money(affordability.remainingAfterCents)} free${beforePaydayClause}.`
+                : `Not just yet — that's about ${money(affordability.shortfallCents)} more than you have free${beforePaydayClause}. Maybe wait until ${paydayLabel}.`}
+            </span>
+          </>
+        )}
+      </p>
+    </article>
+  );
+};
+
+export default GroceryModeCard;

--- a/apps/web/src/components/dashboard/GroceryModeSection.test.tsx
+++ b/apps/web/src/components/dashboard/GroceryModeSection.test.tsx
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { GroceryModeSection, type GroceryModeSectionProps } from './GroceryModeSection';
+
+function makeProps(overrides: Partial<GroceryModeSectionProps> = {}): GroceryModeSectionProps {
+  return {
+    accounts: [{ type: 'CHECKING', currentBalance: { amount: 200_000 } }],
+    reservedCents: 0,
+    bills: [
+      {
+        id: 'rent',
+        name: 'Rent',
+        amount: { amount: 120_000 },
+        dueDate: '2025-07-03',
+        status: 'UPCOMING',
+      },
+      {
+        id: 'gym',
+        name: 'Gym',
+        amount: { amount: 5_000 },
+        dueDate: '2025-07-02',
+        status: 'PAID',
+      },
+    ],
+    budgets: [
+      {
+        categoryId: 'cat-groceries',
+        name: 'Groceries',
+        amount: { amount: 60_000 },
+        spentAmount: { amount: 38_000 },
+      },
+    ],
+    categoryNames: new Map([['cat-groceries', 'Groceries']]),
+    transactions: [],
+    today: '2025-07-01',
+    fallbackPayday: '2025-07-04',
+    currency: 'USD',
+    ...overrides,
+  };
+}
+
+describe('GroceryModeSection', () => {
+  it('maps domain bills/budgets into the card, ignoring paid bills', () => {
+    render(<GroceryModeSection {...makeProps()} />);
+    // Only the unpaid critical Rent ($1,200) is reserved -> $2,000 - $1,200 = $800.
+    expect(
+      screen.getByText(/You have \$800\.00 to spend before Friday, Jul 4/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Gym')).toBeNull();
+  });
+
+  it('auto-pins a grocery-like category by default', () => {
+    render(<GroceryModeSection {...makeProps()} />);
+    // 60000 budget - 38000 spent = 22000 -> $220.00 remaining, shown by default.
+    expect(screen.getByText(/\$220\.00 left in your Groceries budget/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/GroceryModeSection.tsx
+++ b/apps/web/src/components/dashboard/GroceryModeSection.tsx
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Grocery mode section — the thin dashboard adapter for {@link GroceryModeCard}.
+ *
+ * It maps the dashboard's domain models (bills, budgets) into the small,
+ * presentation-agnostic shapes the card expects, then renders the card. Keeping
+ * this glue here (rather than inline in `DashboardPage`) lets the whole feature
+ * — adapter, card and pure engine — stay in a single lazily-loaded chunk so it
+ * never weighs down the already-large dashboard route bundle.
+ *
+ * The card itself stays pure and easily testable; this wrapper owns the
+ * (intentionally minimal) coupling to the app's data shapes.
+ *
+ * References: issue #2199
+ */
+
+import React, { useMemo } from 'react';
+
+import { GroceryModeCard, type GroceryCategoryOption } from './GroceryModeCard';
+import type { UpcomingBillInput } from '../../lib/dashboard/grocery-mode';
+import { isLiabilityType } from '../../lib/analytics/net-worth';
+import type { AccountType } from '../../kmp/bridge';
+
+/** Minimal shape of an account this section needs (a superset of the bridge model). */
+export interface GroceryModeSectionAccount {
+  readonly type: AccountType;
+  readonly currentBalance: { readonly amount: number };
+}
+
+/** Minimal shape of a transaction this section needs. */
+export interface GroceryModeSectionTransaction {
+  readonly type: string;
+  readonly date: string;
+}
+
+/** Minimal shape of a bill this section needs (a superset of the bridge model). */
+export interface GroceryModeSectionBill {
+  readonly id: string;
+  readonly name: string;
+  readonly amount: { readonly amount: number };
+  readonly dueDate: string;
+  readonly status: string;
+}
+
+/** Minimal shape of a budget-with-spending this section needs. */
+export interface GroceryModeSectionBudget {
+  readonly categoryId: string;
+  readonly name: string;
+  readonly amount: { readonly amount: number };
+  readonly spentAmount: { readonly amount: number };
+}
+
+export interface GroceryModeSectionProps {
+  /** Accounts whose (non-liability) balances make up the spendable funds. */
+  readonly accounts: readonly GroceryModeSectionAccount[];
+  /** Amount already earmarked (e.g. savings goals) in integer cents. */
+  readonly reservedCents: number;
+  /** Bills to consider; mapped to the engine's input shape. */
+  readonly bills: readonly GroceryModeSectionBill[];
+  /** Active budgets, offered as pinnable categories. */
+  readonly budgets: readonly GroceryModeSectionBudget[];
+  /** Friendly category names, keyed by category id. */
+  readonly categoryNames: ReadonlyMap<string, string>;
+  /** Recent transactions; income entries seed the payday estimate. */
+  readonly transactions: readonly GroceryModeSectionTransaction[];
+  /** Today's date as an ISO `YYYY-MM-DD` string. */
+  readonly today: string;
+  /** Payday to assume when income history is inconclusive, or `null`. */
+  readonly fallbackPayday: string | null;
+  /** ISO 4217 currency code. */
+  readonly currency: string;
+}
+
+/** Matches common high-frequency spending categories worth pinning by default. */
+const DEFAULT_CATEGORY_PATTERN = /grocer|food|supermarket/i;
+
+export const GroceryModeSection: React.FC<GroceryModeSectionProps> = ({
+  accounts,
+  reservedCents,
+  bills,
+  budgets,
+  categoryNames,
+  transactions,
+  today,
+  fallbackPayday,
+  currency,
+}) => {
+  const availableFundsCents = useMemo(
+    () =>
+      accounts.reduce(
+        (sum, account) =>
+          isLiabilityType(account.type) ? sum : sum + account.currentBalance.amount,
+        0,
+      ),
+    [accounts],
+  );
+
+  const incomeDates = useMemo(
+    () =>
+      transactions
+        .filter((transaction) => transaction.type === 'INCOME')
+        .map((transaction) => transaction.date),
+    [transactions],
+  );
+
+  const cardBills = useMemo<UpcomingBillInput[]>(
+    () =>
+      bills.map((bill) => ({
+        id: bill.id,
+        name: bill.name,
+        amountCents: bill.amount.amount,
+        dueDate: bill.dueDate,
+        critical: bill.status === 'UPCOMING' || bill.status === 'OVERDUE',
+        paid: bill.status === 'PAID',
+      })),
+    [bills],
+  );
+
+  const categoryOptions = useMemo<GroceryCategoryOption[]>(
+    () =>
+      budgets.map((budget) => ({
+        id: budget.categoryId,
+        name: categoryNames.get(budget.categoryId) ?? budget.name,
+        budgetCents: budget.amount.amount,
+        spentCents: budget.spentAmount.amount,
+      })),
+    [budgets, categoryNames],
+  );
+
+  const defaultPinnedCategoryId = useMemo(
+    () => categoryOptions.find((option) => DEFAULT_CATEGORY_PATTERN.test(option.name))?.id ?? null,
+    [categoryOptions],
+  );
+
+  return (
+    <section className="page-section grocery-mode-section" aria-label="Grocery mode">
+      <GroceryModeCard
+        availableFundsCents={availableFundsCents}
+        reservedCents={reservedCents}
+        bills={cardBills}
+        categoryOptions={categoryOptions}
+        today={today}
+        incomeDates={incomeDates}
+        fallbackPayday={fallbackPayday}
+        currency={currency}
+        defaultPinnedCategoryId={defaultPinnedCategoryId}
+      />
+    </section>
+  );
+};
+
+export default GroceryModeSection;

--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -389,3 +389,249 @@
     border-width: 2px;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Grocery mode card (#2199)
+ * ------------------------------------------------------------------------- */
+
+.grocery-mode-section {
+  margin-top: var(--spacing-4);
+}
+
+.grocery-mode-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  border-color: color-mix(
+    in srgb,
+    var(--semantic-interactive-default) 28%,
+    var(--semantic-border-default)
+  );
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--semantic-interactive-default) 9%, var(--semantic-background-primary)),
+    var(--semantic-background-primary)
+  );
+}
+
+.grocery-mode-card--tight {
+  border-color: color-mix(
+    in srgb,
+    var(--semantic-status-warning) 38%,
+    var(--semantic-border-default)
+  );
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--semantic-status-warning) 12%, var(--semantic-background-primary)),
+    var(--semantic-background-primary)
+  );
+}
+
+.grocery-mode-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.grocery-mode-card__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.grocery-mode-card__title {
+  margin: 0;
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-title-font-size);
+  line-height: var(--type-scale-title-line-height);
+}
+
+.grocery-mode-card__amount {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin: 0;
+  color: var(--semantic-interactive-default);
+  font-size: clamp(2.5rem, 7vw, 4.5rem);
+  font-weight: var(--font-weight-bold);
+  line-height: 1;
+  overflow-wrap: anywhere;
+}
+
+.grocery-mode-card--tight .grocery-mode-card__amount {
+  color: var(--semantic-status-warning);
+}
+
+.grocery-mode-card__amount-icon {
+  width: 0.7em;
+  height: 0.7em;
+  flex-shrink: 0;
+}
+
+.grocery-mode-card__answer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.grocery-mode-card__answer-text {
+  margin: 0;
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+  line-height: var(--type-scale-body-line-height);
+}
+
+.grocery-mode-card__answer-meta,
+.grocery-mode-card__answer-pinned {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  line-height: var(--type-scale-body-line-height);
+}
+
+.grocery-mode-card__bills {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: color-mix(in srgb, var(--semantic-background-secondary) 72%, transparent);
+}
+
+.grocery-mode-card__bills-title {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+}
+
+.grocery-mode-card__bills-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.grocery-mode-card__bill {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: var(--spacing-2);
+  align-items: baseline;
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+.grocery-mode-card__bill-due {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.grocery-mode-card__bill-amount {
+  font-weight: var(--font-weight-semibold);
+}
+
+.grocery-mode-card__bills-empty {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+.grocery-mode-card__controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 12rem), 1fr));
+  gap: var(--spacing-3);
+}
+
+.grocery-mode-card__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.grocery-mode-card__label {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+}
+
+.grocery-mode-card__select,
+.grocery-mode-card__input {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+  font: inherit;
+}
+
+.grocery-mode-card__afford-input {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding-left: var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+}
+
+.grocery-mode-card__afford-prefix {
+  color: var(--semantic-text-secondary);
+  font-weight: var(--font-weight-semibold);
+}
+
+.grocery-mode-card__afford-input .grocery-mode-card__input {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  padding-left: 0;
+}
+
+.grocery-mode-card__select:focus-visible,
+.grocery-mode-card__input:focus-visible,
+.grocery-mode-card__afford-input:focus-within {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.grocery-mode-card__afford-result {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  margin: 0;
+  min-height: 1.25rem;
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+  line-height: var(--type-scale-body-line-height);
+}
+
+.grocery-mode-card__afford-result--yes {
+  color: var(--semantic-status-success, var(--semantic-text-primary));
+}
+
+.grocery-mode-card__afford-result--no {
+  color: var(--semantic-text-primary);
+}
+
+.grocery-mode-card__afford-icon {
+  flex-shrink: 0;
+  margin-top: 0.1em;
+}
+
+@media (prefers-contrast: more) {
+  .grocery-mode-card,
+  .grocery-mode-card__bills,
+  .grocery-mode-card__select,
+  .grocery-mode-card__input,
+  .grocery-mode-card__afford-input {
+    border-width: 2px;
+  }
+}

--- a/apps/web/src/lib/dashboard/grocery-mode.test.ts
+++ b/apps/web/src/lib/dashboard/grocery-mode.test.ts
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  bankersRound,
+  computeSafeToSpend,
+  estimateNextPayday,
+  evaluateAffordability,
+  parseAmountToCents,
+  pinnedCategoryRemaining,
+  type SafeToSpendInput,
+  type UpcomingBillInput,
+} from './grocery-mode';
+
+function bill(overrides: Partial<UpcomingBillInput> = {}): UpcomingBillInput {
+  return {
+    id: 'bill-1',
+    name: 'Rent',
+    amountCents: 120_000,
+    dueDate: '2025-07-04',
+    critical: true,
+    paid: false,
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<SafeToSpendInput> = {}): SafeToSpendInput {
+  return {
+    availableFundsCents: 500_00,
+    reservedCents: 0,
+    bills: [],
+    today: '2025-07-01',
+    nextPayday: '2025-07-05',
+    pinnedCategory: null,
+    ...overrides,
+  };
+}
+
+describe('bankersRound', () => {
+  it('rounds halves to the nearest even integer', () => {
+    expect(bankersRound(0.5)).toBe(0);
+    expect(bankersRound(1.5)).toBe(2);
+    expect(bankersRound(2.5)).toBe(2);
+    expect(bankersRound(3.5)).toBe(4);
+    expect(bankersRound(-2.5)).toBe(-2);
+    expect(bankersRound(-3.5)).toBe(-4);
+  });
+
+  it('rounds non-halves normally', () => {
+    expect(bankersRound(2.4)).toBe(2);
+    expect(bankersRound(2.6)).toBe(3);
+    expect(bankersRound(-2.6)).toBe(-3);
+  });
+
+  it('returns 0 for non-finite input', () => {
+    expect(bankersRound(Number.NaN)).toBe(0);
+    expect(bankersRound(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe('pinnedCategoryRemaining', () => {
+  it('returns null when no category is pinned', () => {
+    expect(pinnedCategoryRemaining(null)).toBeNull();
+    expect(pinnedCategoryRemaining(undefined)).toBeNull();
+  });
+
+  it('computes remaining as budget minus spent', () => {
+    const result = pinnedCategoryRemaining({
+      categoryId: 'cat-1',
+      name: 'Groceries',
+      budgetCents: 60_000,
+      spentCents: 42_350,
+    });
+    expect(result?.remainingCents).toBe(17_650);
+  });
+
+  it('clamps a fully-spent category to zero (never negative)', () => {
+    const result = pinnedCategoryRemaining({
+      categoryId: 'cat-1',
+      name: 'Groceries',
+      budgetCents: 60_000,
+      spentCents: 75_000,
+    });
+    expect(result?.remainingCents).toBe(0);
+  });
+
+  it('normalises invalid amounts to non-negative integers', () => {
+    const result = pinnedCategoryRemaining({
+      categoryId: 'cat-1',
+      name: 'Groceries',
+      budgetCents: Number.NaN,
+      spentCents: -500,
+    });
+    expect(result?.budgetCents).toBe(0);
+    expect(result?.spentCents).toBe(0);
+    expect(result?.remainingCents).toBe(0);
+  });
+});
+
+describe('computeSafeToSpend', () => {
+  it('computes a known value: funds minus critical bills minus reserved', () => {
+    const result = computeSafeToSpend(
+      input({
+        availableFundsCents: 1_000_00,
+        reservedCents: 50_00,
+        bills: [
+          bill({ id: 'b1', amountCents: 200_00, dueDate: '2025-07-03' }),
+          bill({ id: 'b2', name: 'Power', amountCents: 75_00, dueDate: '2025-07-04' }),
+        ],
+        today: '2025-07-01',
+        nextPayday: '2025-07-05',
+      }),
+    );
+    // 100000 - (20000 + 7500) - 5000 = 67500
+    expect(result.upcomingCriticalBillsCents).toBe(275_00);
+    expect(result.reservedCents).toBe(50_00);
+    expect(result.safeToSpendCents).toBe(675_00);
+  });
+
+  it('excludes bills due after the next payday', () => {
+    const result = computeSafeToSpend(
+      input({
+        bills: [
+          bill({ id: 'before', amountCents: 100_00, dueDate: '2025-07-04' }),
+          bill({ id: 'after', amountCents: 999_00, dueDate: '2025-07-10' }),
+        ],
+        today: '2025-07-01',
+        nextPayday: '2025-07-05',
+      }),
+    );
+    expect(result.upcomingCriticalBillsCents).toBe(100_00);
+    expect(result.upcomingBills).toHaveLength(1);
+    expect(result.upcomingBills[0].id).toBe('before');
+  });
+
+  it('excludes bills due before today (already passed)', () => {
+    const result = computeSafeToSpend(
+      input({
+        bills: [bill({ id: 'past', amountCents: 100_00, dueDate: '2025-06-28' })],
+        today: '2025-07-01',
+        nextPayday: '2025-07-05',
+      }),
+    );
+    expect(result.upcomingCriticalBillsCents).toBe(0);
+    expect(result.upcomingBills).toHaveLength(0);
+  });
+
+  it('excludes paid and non-critical bills', () => {
+    const result = computeSafeToSpend(
+      input({
+        bills: [
+          bill({ id: 'paid', amountCents: 100_00, dueDate: '2025-07-03', paid: true }),
+          bill({ id: 'optional', amountCents: 100_00, dueDate: '2025-07-03', critical: false }),
+          bill({ id: 'counted', amountCents: 25_00, dueDate: '2025-07-03' }),
+        ],
+      }),
+    );
+    expect(result.upcomingCriticalBillsCents).toBe(25_00);
+    expect(result.upcomingBills.map((b) => b.id)).toEqual(['counted']);
+  });
+
+  it('sorts upcoming bills by soonest due date first', () => {
+    const result = computeSafeToSpend(
+      input({
+        bills: [
+          bill({ id: 'late', dueDate: '2025-07-04', amountCents: 10_00 }),
+          bill({ id: 'early', dueDate: '2025-07-02', amountCents: 10_00 }),
+          bill({ id: 'mid', dueDate: '2025-07-03', amountCents: 10_00 }),
+        ],
+      }),
+    );
+    expect(result.upcomingBills.map((b) => b.id)).toEqual(['early', 'mid', 'late']);
+  });
+
+  it('handles no upcoming bills (safe to spend equals available funds)', () => {
+    const result = computeSafeToSpend(
+      input({ availableFundsCents: 320_00, reservedCents: 0, bills: [] }),
+    );
+    expect(result.upcomingCriticalBillsCents).toBe(0);
+    expect(result.safeToSpendCents).toBe(320_00);
+  });
+
+  it('allows a negative safe-to-spend when bills exceed available funds', () => {
+    const result = computeSafeToSpend(
+      input({
+        availableFundsCents: 50_00,
+        bills: [bill({ amountCents: 200_00, dueDate: '2025-07-03' })],
+      }),
+    );
+    expect(result.safeToSpendCents).toBe(-150_00);
+  });
+
+  it('preserves a genuinely negative (overdrawn) available balance', () => {
+    const result = computeSafeToSpend(input({ availableFundsCents: -25_00, bills: [] }));
+    expect(result.availableFundsCents).toBe(-25_00);
+    expect(result.safeToSpendCents).toBe(-25_00);
+  });
+
+  it('includes all upcoming critical bills when no payday is known', () => {
+    const result = computeSafeToSpend(
+      input({
+        bills: [
+          bill({ id: 'b1', amountCents: 100_00, dueDate: '2025-07-03' }),
+          bill({ id: 'b2', amountCents: 200_00, dueDate: '2025-09-01' }),
+        ],
+        nextPayday: null,
+      }),
+    );
+    expect(result.hasPayday).toBe(false);
+    expect(result.daysUntilPayday).toBeNull();
+    expect(result.dailyAllowanceCents).toBeNull();
+    expect(result.upcomingCriticalBillsCents).toBe(300_00);
+  });
+
+  it('reports whole days until payday', () => {
+    const result = computeSafeToSpend(input({ today: '2025-07-01', nextPayday: '2025-07-05' }));
+    expect(result.daysUntilPayday).toBe(4);
+  });
+
+  it("computes a per-day allowance with banker's rounding", () => {
+    // 10 cents over 4 days = 2.5 -> rounds to even (2)
+    const result = computeSafeToSpend(
+      input({ availableFundsCents: 10, bills: [], today: '2025-07-01', nextPayday: '2025-07-05' }),
+    );
+    expect(result.safeToSpendCents).toBe(10);
+    expect(result.daysUntilPayday).toBe(4);
+    expect(result.dailyAllowanceCents).toBe(2);
+  });
+
+  it('omits the per-day allowance when safe-to-spend is not positive', () => {
+    const result = computeSafeToSpend(
+      input({
+        availableFundsCents: 0,
+        bills: [bill({ amountCents: 100, dueDate: '2025-07-03' })],
+      }),
+    );
+    expect(result.safeToSpendCents).toBeLessThan(0);
+    expect(result.dailyAllowanceCents).toBeNull();
+  });
+
+  it('surfaces the pinned category remaining alongside the answer', () => {
+    const result = computeSafeToSpend(
+      input({
+        availableFundsCents: 400_00,
+        pinnedCategory: {
+          categoryId: 'cat-groceries',
+          name: 'Groceries',
+          budgetCents: 60_000,
+          spentCents: 38_000,
+        },
+      }),
+    );
+    expect(result.pinnedCategory?.name).toBe('Groceries');
+    expect(result.pinnedCategory?.remainingCents).toBe(22_000);
+    // Pinned category does not reduce the headline safe-to-spend figure.
+    expect(result.safeToSpendCents).toBe(400_00);
+  });
+
+  it('returns a null pinned category when none is selected', () => {
+    const result = computeSafeToSpend(input({ pinnedCategory: null }));
+    expect(result.pinnedCategory).toBeNull();
+  });
+
+  it('normalises non-finite and fractional inputs to integer cents', () => {
+    const result = computeSafeToSpend(
+      input({
+        availableFundsCents: 100.9,
+        reservedCents: Number.NaN,
+        bills: [bill({ amountCents: -50, dueDate: '2025-07-03' })],
+      }),
+    );
+    expect(result.availableFundsCents).toBe(100);
+    expect(result.reservedCents).toBe(0);
+    expect(result.upcomingCriticalBillsCents).toBe(0);
+  });
+});
+
+describe('evaluateAffordability', () => {
+  it('says yes when the purchase fits and reports what is left', () => {
+    const result = evaluateAffordability(100_00, 30_00);
+    expect(result.affordable).toBe(true);
+    expect(result.remainingAfterCents).toBe(70_00);
+    expect(result.shortfallCents).toBe(0);
+  });
+
+  it('treats spending down to exactly zero as affordable', () => {
+    const result = evaluateAffordability(50_00, 50_00);
+    expect(result.affordable).toBe(true);
+    expect(result.remainingAfterCents).toBe(0);
+  });
+
+  it('says no when the purchase exceeds the safe-to-spend amount', () => {
+    const result = evaluateAffordability(40_00, 65_00);
+    expect(result.affordable).toBe(false);
+    expect(result.remainingAfterCents).toBe(-25_00);
+    expect(result.shortfallCents).toBe(25_00);
+  });
+
+  it('is never affordable against a negative safe-to-spend amount', () => {
+    const result = evaluateAffordability(-10_00, 0);
+    expect(result.amountCents).toBe(0);
+    expect(result.affordable).toBe(false);
+    expect(result.shortfallCents).toBe(10_00);
+  });
+
+  it('normalises a negative or fractional requested amount', () => {
+    expect(evaluateAffordability(100_00, -20).amountCents).toBe(0);
+    expect(evaluateAffordability(100_00, 12.99).amountCents).toBe(12);
+  });
+});
+
+describe('parseAmountToCents', () => {
+  it('returns null for empty or malformed input', () => {
+    expect(parseAmountToCents('')).toBeNull();
+    expect(parseAmountToCents('   ')).toBeNull();
+    expect(parseAmountToCents('abc')).toBeNull();
+    expect(parseAmountToCents('-5')).toBeNull();
+    expect(parseAmountToCents('.')).toBeNull();
+  });
+
+  it('parses whole and decimal dollar amounts to integer cents', () => {
+    expect(parseAmountToCents('45')).toBe(45_00);
+    expect(parseAmountToCents('45.5')).toBe(45_50);
+    expect(parseAmountToCents('45.50')).toBe(45_50);
+    expect(parseAmountToCents('.99')).toBe(99);
+    expect(parseAmountToCents('0')).toBe(0);
+  });
+
+  it('tolerates currency symbols, commas and whitespace', () => {
+    expect(parseAmountToCents(' $1,234.56 ')).toBe(1_234_56);
+  });
+
+  it("applies banker's rounding on the sub-cent digit", () => {
+    // 1.225 -> 122 (ties to even), 1.235 -> 124 (ties to even)
+    expect(parseAmountToCents('1.225')).toBe(122);
+    expect(parseAmountToCents('1.235')).toBe(124);
+    // a non-tie above five always rounds up
+    expect(parseAmountToCents('1.226')).toBe(123);
+  });
+});
+
+describe('estimateNextPayday', () => {
+  it('returns null when there are no income dates', () => {
+    expect(estimateNextPayday([], '2025-07-01')).toBeNull();
+  });
+
+  it('returns null when today is invalid', () => {
+    expect(estimateNextPayday(['2025-06-15'], 'not-a-date')).toBeNull();
+  });
+
+  it('projects a biweekly cadence forward past today', () => {
+    const next = estimateNextPayday(['2025-06-06', '2025-06-20', '2025-07-04'], '2025-07-10');
+    // 14-day cadence from 2025-07-04 -> next after today is 2025-07-18
+    expect(next).toBe('2025-07-18');
+  });
+
+  it('assumes a monthly cadence from a single paycheck', () => {
+    const next = estimateNextPayday(['2025-06-15'], '2025-07-01');
+    expect(next).toBe('2025-07-15');
+  });
+
+  it('snaps a near-weekly cadence to seven days', () => {
+    const next = estimateNextPayday(['2025-07-01', '2025-07-09'], '2025-07-10');
+    // gap is 8 days, snapped to 7 -> from 2025-07-09 next is 2025-07-16
+    expect(next).toBe('2025-07-16');
+  });
+
+  it('ignores unparseable income dates', () => {
+    const next = estimateNextPayday(['bad', '2025-06-15', ''], '2025-07-01');
+    expect(next).toBe('2025-07-15');
+  });
+});

--- a/apps/web/src/lib/dashboard/grocery-mode.ts
+++ b/apps/web/src/lib/dashboard/grocery-mode.ts
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Grocery mode — a fast, glanceable "can I afford this?" / "safe to spend
+ * before payday" engine for the dashboard.
+ *
+ * The goal is a supportive, low-stress answer to an everyday question while
+ * standing in a checkout line: how much can I comfortably spend right now
+ * without putting the bills that are due before my next paycheck at risk?
+ *
+ * ── What it computes ───────────────────────────────────────────────────────
+ *   • availableBeforePayday = currentAvailableFunds
+ *                             − upcoming critical bills due before payday
+ *                             − optionally reserved amounts (e.g. savings)
+ *   • pinnedCategoryRemaining = pinned category budget − spent (clamped ≥ 0)
+ *   • dailyAllowance = availableBeforePayday ÷ days until payday (banker's round)
+ *   • affordability = whether a hypothetical purchase fits inside the
+ *     safe-to-spend amount, plus what would be left afterwards.
+ *
+ * ── Money & date conventions ───────────────────────────────────────────────
+ *   • All monetary values are **integer minor units** (cents). Never floats.
+ *   • Sums/differences of integer cents stay integers — no rounding needed.
+ *   • The only division (the per-day allowance) is rounded back to integer
+ *     cents with **banker's rounding** (round-half-to-even).
+ *   • Dates are ISO `YYYY-MM-DD` calendar strings, compared lexically and
+ *     parsed as UTC midnight so day-count math is timezone-stable.
+ *   • `availableFunds` is **signed** (an overdrawn account can legitimately be
+ *     negative); every other input is normalised to a non-negative integer so
+ *     missing/garbage upstream data can never inflate the answer.
+ *
+ * Pure & side-effect free: every function is deterministic given its inputs.
+ *
+ * References: issue #2199
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A bill that may fall due before the next payday. */
+export interface UpcomingBillInput {
+  /** Stable identifier (used for React keys and de-duplication). */
+  readonly id: string;
+  /** Human-readable name, e.g. "Rent" or "Electric". */
+  readonly name: string;
+  /** Amount due in integer cents. */
+  readonly amountCents: number;
+  /** Due date as an ISO `YYYY-MM-DD` calendar string. */
+  readonly dueDate: string;
+  /** Whether this is a committed obligation that must be protected. */
+  readonly critical: boolean;
+  /** Whether the bill has already been paid (and so no longer reserved). */
+  readonly paid: boolean;
+}
+
+/** The high-frequency category a user has pinned (e.g. Groceries). */
+export interface PinnedCategoryInput {
+  readonly categoryId: string;
+  readonly name: string;
+  /** Budgeted amount for the current period, in integer cents. */
+  readonly budgetCents: number;
+  /** Amount already spent in the current period, in integer cents. */
+  readonly spentCents: number;
+}
+
+/** Inputs for {@link computeSafeToSpend}. */
+export interface SafeToSpendInput {
+  /** Current spendable balance (signed) in integer cents. */
+  readonly availableFundsCents: number;
+  /** Optional amount already earmarked (e.g. savings goals) in cents. */
+  readonly reservedCents?: number;
+  /** All bills to consider; the engine filters by status, date and criticality. */
+  readonly bills: readonly UpcomingBillInput[];
+  /** Today's date as an ISO `YYYY-MM-DD` calendar string. */
+  readonly today: string;
+  /** The next payday as `YYYY-MM-DD`, or `null` when unknown. */
+  readonly nextPayday: string | null;
+  /** The pinned category, when one is selected. */
+  readonly pinnedCategory?: PinnedCategoryInput | null;
+}
+
+/** A bill surfaced as upcoming context, sorted by due date. */
+export interface UpcomingBillSummary {
+  readonly id: string;
+  readonly name: string;
+  readonly amountCents: number;
+  readonly dueDate: string;
+}
+
+/** The remaining budget for the pinned category. */
+export interface PinnedCategoryResult {
+  readonly categoryId: string;
+  readonly name: string;
+  readonly budgetCents: number;
+  readonly spentCents: number;
+  /** `budget − spent`, clamped to a non-negative integer. */
+  readonly remainingCents: number;
+}
+
+/** Result of {@link computeSafeToSpend}. */
+export interface SafeToSpendResult {
+  /** Normalised available funds (signed) in cents. */
+  readonly availableFundsCents: number;
+  /** Sum of the upcoming critical bills counted, in cents. */
+  readonly upcomingCriticalBillsCents: number;
+  /** Reserved amount applied, in cents. */
+  readonly reservedCents: number;
+  /** The headline figure: what's safe to spend before payday (signed). */
+  readonly safeToSpendCents: number;
+  /** Whether a usable payday date was supplied. */
+  readonly hasPayday: boolean;
+  /** Whole days from today until payday, or `null` when unknown. */
+  readonly daysUntilPayday: number | null;
+  /** Per-day allowance until payday (banker's rounded), or `null`. */
+  readonly dailyAllowanceCents: number | null;
+  /** The critical bills counted, sorted by soonest due date first. */
+  readonly upcomingBills: readonly UpcomingBillSummary[];
+  /** The pinned category's remaining budget, or `null` when none is pinned. */
+  readonly pinnedCategory: PinnedCategoryResult | null;
+}
+
+/** Result of {@link evaluateAffordability}. */
+export interface AffordabilityResult {
+  /** The (normalised, non-negative) purchase amount asked about, in cents. */
+  readonly amountCents: number;
+  /** Whether the purchase fits within the safe-to-spend amount. */
+  readonly affordable: boolean;
+  /** What would remain safe to spend afterwards (signed), in cents. */
+  readonly remainingAfterCents: number;
+  /** The shortfall when not affordable (≥ 0), in cents. */
+  readonly shortfallCents: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Numeric & date helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Banker's rounding (round half to even, IEEE-754 / `RoundingMode.HALF_EVEN`).
+ *
+ * Examples: `0.5 → 0`, `1.5 → 2`, `2.5 → 2`, `3.5 → 4`, `-2.5 → -2`.
+ *
+ * Non-finite input yields `0` so a stray `NaN`/`Infinity` can never surface as
+ * a misleading amount.
+ */
+export function bankersRound(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  const floored = Math.floor(value);
+  const diff = value - floored;
+  if (Math.abs(diff - 0.5) < Number.EPSILON) {
+    return floored % 2 === 0 ? floored : floored + 1;
+  }
+  return Math.round(value);
+}
+
+/** Normalise to a signed integer number of cents (defends against NaN). */
+function toSignedCents(value: number): number {
+  return Number.isFinite(value) ? Math.trunc(value) : 0;
+}
+
+/** Normalise to a non-negative integer number of cents. */
+function toNonNegativeCents(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+}
+
+/** Parse an ISO `YYYY-MM-DD` string to a UTC epoch ms, or `NaN` when invalid. */
+function parseIsoDate(value: string | null | undefined): number {
+  if (typeof value !== 'string' || value.length < 10) return Number.NaN;
+  return Date.parse(`${value.slice(0, 10)}T00:00:00Z`);
+}
+
+/** Convert a UTC epoch ms back to an ISO `YYYY-MM-DD` calendar string. */
+function toIsoDate(epochMs: number): string {
+  return new Date(epochMs).toISOString().slice(0, 10);
+}
+
+/** Whole days between two ISO dates (`end − start`); `null` when either is invalid. */
+function wholeDaysBetween(start: string, end: string): number | null {
+  const startMs = parseIsoDate(start);
+  const endMs = parseIsoDate(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return null;
+  return Math.round((endMs - startMs) / MS_PER_DAY);
+}
+
+/** Median of a non-empty list of numbers. */
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/** Snap a raw interval to the nearest common pay cadence in days. */
+function snapToCadence(intervalDays: number): number {
+  const cadences = [7, 14, 15, 30];
+  for (const cadence of cadences) {
+    if (Math.abs(intervalDays - cadence) <= 2) return cadence;
+  }
+  return intervalDays;
+}
+
+// ---------------------------------------------------------------------------
+// Payday estimation
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate the next payday from a history of income transaction dates.
+ *
+ * Uses the median gap between consecutive paychecks, snapped to a common
+ * cadence (weekly / biweekly / semi-monthly / monthly), then projects forward
+ * from the most recent paycheck until the date lands strictly after `today`.
+ * With a single paycheck it assumes a monthly cadence. Returns `null` when no
+ * usable income dates are supplied — callers should fall back to another
+ * horizon (e.g. end of month) in that case.
+ *
+ * @param incomeDates - ISO `YYYY-MM-DD` dates of recent income transactions.
+ * @param today - Today's date as an ISO `YYYY-MM-DD` string.
+ * @returns The projected next payday as `YYYY-MM-DD`, or `null`.
+ */
+export function estimateNextPayday(incomeDates: readonly string[], today: string): string | null {
+  const todayMs = parseIsoDate(today);
+  if (!Number.isFinite(todayMs)) return null;
+
+  const sorted = incomeDates
+    .map(parseIsoDate)
+    .filter((ms) => Number.isFinite(ms))
+    .sort((left, right) => left - right);
+  if (sorted.length === 0) return null;
+
+  let intervalDays = 30;
+  if (sorted.length >= 2) {
+    const gaps = sorted
+      .slice(1)
+      .map((ms, index) => Math.round((ms - sorted[index]) / MS_PER_DAY))
+      .filter((gap) => gap > 0);
+    if (gaps.length > 0) intervalDays = snapToCadence(Math.round(median(gaps)));
+  }
+
+  const stepMs = Math.max(1, intervalDays) * MS_PER_DAY;
+  let next = sorted[sorted.length - 1];
+  for (let guard = 0; next <= todayMs && guard < 1000; guard += 1) {
+    next += stepMs;
+  }
+  return toIsoDate(next);
+}
+
+// ---------------------------------------------------------------------------
+// Pinned category
+// ---------------------------------------------------------------------------
+
+/**
+ * Remaining budget for a pinned category: `budget − spent`, clamped ≥ 0.
+ *
+ * @param category - The pinned category, or `null`/`undefined` when none.
+ * @returns A {@link PinnedCategoryResult}, or `null` when no category is pinned.
+ */
+export function pinnedCategoryRemaining(
+  category: PinnedCategoryInput | null | undefined,
+): PinnedCategoryResult | null {
+  if (!category) return null;
+  const budgetCents = toNonNegativeCents(category.budgetCents);
+  const spentCents = toNonNegativeCents(category.spentCents);
+  return {
+    categoryId: category.categoryId,
+    name: category.name,
+    budgetCents,
+    spentCents,
+    remainingCents: Math.max(0, budgetCents - spentCents),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Money input parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a user-entered amount (e.g. `"45"`, `"45.50"`, `"$1,234.5"`) into
+ * integer cents using **integer math** and **banker's rounding** on the
+ * sub-cent digit, following the financial-modeling skill.
+ *
+ * Leading currency symbols, thousands separators and surrounding whitespace are
+ * tolerated. Returns `null` for empty or malformed input (so the UI can stay
+ * quiet until a valid number is typed) and rejects negative input, since the
+ * affordability question is always about a non-negative purchase.
+ *
+ * @param input - The raw string from a text input.
+ * @returns Integer cents, or `null` when the input is not a valid amount.
+ */
+export function parseAmountToCents(input: string): number | null {
+  const cleaned = input.trim().replace(/[$,\s]/g, '');
+  if (cleaned === '') return null;
+
+  const match = cleaned.match(/^(\d*)(?:\.(\d*))?$/);
+  if (!match || (!match[1] && !match[2])) return null;
+
+  const whole = match[1] || '0';
+  const fraction = match[2] ?? '';
+  const baseCents =
+    Number.parseInt(whole, 10) * 100 +
+    Number.parseInt((fraction.slice(0, 2) || '0').padEnd(2, '0'), 10);
+  const thirdDigit = Number.parseInt(fraction[2] ?? '0', 10);
+  const hasRemainder = [...fraction.slice(3)].some((digit) => digit !== '0');
+  const roundUp = thirdDigit > 5 || (thirdDigit === 5 && (hasRemainder || baseCents % 2 === 1));
+  const cents = baseCents + (roundUp ? 1 : 0);
+
+  return Number.isSafeInteger(cents) ? cents : null;
+}
+
+// ---------------------------------------------------------------------------
+// Safe to spend
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the safe-to-spend answer for grocery mode.
+ *
+ * Counts only bills that are **critical, unpaid, and due on/after today** and,
+ * when a payday is known, **on/before that payday**. Without a payday it still
+ * answers using every upcoming critical bill so the figure stays meaningful.
+ *
+ * @param input - {@link SafeToSpendInput}.
+ * @returns {@link SafeToSpendResult}.
+ */
+export function computeSafeToSpend(input: SafeToSpendInput): SafeToSpendResult {
+  const availableFundsCents = toSignedCents(input.availableFundsCents);
+  const reservedCents = toNonNegativeCents(input.reservedCents ?? 0);
+
+  const paydayMs = parseIsoDate(input.nextPayday);
+  const hasPayday = Number.isFinite(paydayMs);
+  const todayMs = parseIsoDate(input.today);
+  const hasToday = Number.isFinite(todayMs);
+
+  const counted = input.bills
+    .filter((bill) => {
+      if (!bill.critical || bill.paid) return false;
+      const dueMs = parseIsoDate(bill.dueDate);
+      if (!Number.isFinite(dueMs)) return false;
+      if (hasToday && dueMs < todayMs) return false;
+      if (hasPayday && dueMs > paydayMs) return false;
+      return true;
+    })
+    .sort((left, right) => left.dueDate.localeCompare(right.dueDate));
+
+  const upcomingCriticalBillsCents = counted.reduce(
+    (sum, bill) => sum + toNonNegativeCents(bill.amountCents),
+    0,
+  );
+
+  const safeToSpendCents = availableFundsCents - upcomingCriticalBillsCents - reservedCents;
+
+  const daysUntilPayday =
+    hasPayday && hasToday
+      ? Math.max(0, wholeDaysBetween(input.today, input.nextPayday as string) ?? 0)
+      : null;
+
+  const dailyAllowanceCents =
+    daysUntilPayday !== null && daysUntilPayday >= 1 && safeToSpendCents > 0
+      ? bankersRound(safeToSpendCents / daysUntilPayday)
+      : null;
+
+  return {
+    availableFundsCents,
+    upcomingCriticalBillsCents,
+    reservedCents,
+    safeToSpendCents,
+    hasPayday,
+    daysUntilPayday,
+    dailyAllowanceCents,
+    upcomingBills: counted.map((bill) => ({
+      id: bill.id,
+      name: bill.name,
+      amountCents: toNonNegativeCents(bill.amountCents),
+      dueDate: bill.dueDate,
+    })),
+    pinnedCategory: pinnedCategoryRemaining(input.pinnedCategory),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Affordability
+// ---------------------------------------------------------------------------
+
+/**
+ * Answer "can I afford this right now?" against a safe-to-spend amount.
+ *
+ * The purchase amount is normalised to a non-negative integer of cents. A
+ * purchase is affordable when it fits within (≤) the safe-to-spend figure;
+ * spending it exactly to zero still counts as affordable.
+ *
+ * @param safeToSpendCents - The headline safe-to-spend figure, in cents.
+ * @param amountCents - The hypothetical purchase amount, in cents.
+ * @returns {@link AffordabilityResult}.
+ */
+export function evaluateAffordability(
+  safeToSpendCents: number,
+  amountCents: number,
+): AffordabilityResult {
+  const amount = toNonNegativeCents(amountCents);
+  const safe = toSignedCents(safeToSpendCents);
+  const remainingAfterCents = safe - amount;
+  return {
+    amountCents: amount,
+    affordable: remainingAfterCents >= 0,
+    remainingAfterCents,
+    shortfallCents: remainingAfterCents < 0 ? -remainingAfterCents : 0,
+  };
+}

--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -634,14 +634,14 @@ describe('DashboardPage', () => {
     expect(await screen.findByText('What needs attention now')).toBeInTheDocument();
   });
 
-  it('renders a safe-to-spend card with a plain-language explanation and breakdown', () => {
+  it('renders a safe-to-spend card with a plain-language explanation and breakdown', async () => {
     render(
       <MemoryRouter>
         <DashboardPage />
       </MemoryRouter>,
     );
 
-    const card = screen.getByLabelText('Safe to spend this month');
+    const card = await screen.findByLabelText('Safe to spend this month');
     expect(within(card).getByText('Safe to Spend This Month')).toBeInTheDocument();
     expect(
       within(card).getByText(
@@ -739,13 +739,17 @@ describe('DashboardPage', () => {
       </MemoryRouter>,
     );
     expect(screen.getByRole('region', { name: /financial summary/i })).toBeInTheDocument();
+    // The mood journal is a lazily-loaded landmark; `findByRole` re-scans the
+    // dashboard accessibility tree on every poll. Allow extra time so the
+    // dynamic import can resolve and the role query settle, even when the full
+    // test suite runs in parallel and CPU is contended.
     expect(
-      await screen.findByRole('region', { name: /mood and spending journal/i }),
+      await screen.findByRole('region', { name: /mood and spending journal/i }, { timeout: 3000 }),
     ).toBeInTheDocument();
     expect(screen.getByRole('region', { name: /recent transactions/i })).toBeInTheDocument();
   });
 
-  it('covers dashboard financial values when privacy screen is active and reveals them when inactive', () => {
+  it('covers dashboard financial values when privacy screen is active and reveals them when inactive', async () => {
     const renderDashboard = (initialValue: boolean) =>
       render(
         <PrivacyModeProvider initialValue={initialValue}>
@@ -756,6 +760,9 @@ describe('DashboardPage', () => {
       );
 
     const active = renderDashboard(true);
+    // The safe-to-spend card is lazily code-split; wait for it before reading
+    // the rendered text so the privacy-masking assertion is meaningful.
+    await screen.findByLabelText('Safe to spend this month');
     const activeText = document.body.textContent ?? '';
     const screenCoverage = evaluatePrivacyScreenCoverage([
       {
@@ -791,6 +798,7 @@ describe('DashboardPage', () => {
     window.localStorage.clear();
 
     renderDashboard(false);
+    await screen.findByLabelText('Safe to spend this month');
     expect(document.body).toHaveTextContent('$37,250.00');
     expect(document.body).toHaveTextContent('$67.42');
     expect(document.body).toHaveTextContent('$3,200');

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -11,7 +11,6 @@ import {
   LoadingSpinner,
   SyncIndicator,
 } from '../components/common';
-import { SafeToSpendCard } from '../components/dashboard/SafeToSpendCard';
 import { OfflineBanner } from '../components/OfflineBanner';
 import {
   useAccounts,
@@ -80,6 +79,15 @@ const WarrantyDashboard = React.lazy(() =>
     default: module.WarrantyDashboard,
   })),
 );
+// Lazily code-split so these spending-answer cards do not weigh down the
+// (already large) dashboard route chunk — each loads as its own small async
+// chunk on demand.
+const SafeToSpendCard = React.lazy(() =>
+  import('../components/dashboard/SafeToSpendCard').then((module) => ({
+    default: module.SafeToSpendCard,
+  })),
+);
+const GroceryModeSection = React.lazy(() => import('../components/dashboard/GroceryModeSection'));
 
 const ChartFallback = () => <LoadingSpinner size={24} label="Loading chart" />;
 const SectionFallback = ({ label }: { readonly label: string }) => (
@@ -509,6 +517,17 @@ export const DashboardPage: React.FC = () => {
     dashboardAsOf,
   ]);
 
+  // Grocery mode — fast "can I afford this?" / safe-to-spend-before-payday card.
+  // The account/bill/category/income mapping lives in the lazily-loaded
+  // GroceryModeSection so it stays out of the dashboard route chunk; only the
+  // reserved-funds and "today" scalars (which reuse local helpers) are computed
+  // here from data already in scope.
+  const groceryReservedCents = useMemo(
+    () => getPlannedGoalContributionsCents(filteredGoals, dashboardAsOf),
+    [filteredGoals, dashboardAsOf],
+  );
+  const groceryToday = useMemo(() => formatLocalDate(dashboardAsOf), [dashboardAsOf]);
+
   const chartPrivacyRollup = useMemo(
     () => rollUpProtectedTransactions(filteredChartTransactions, categories),
     [filteredChartTransactions, categories],
@@ -750,8 +769,26 @@ export const DashboardPage: React.FC = () => {
                 className="page-section safe-to-spend-section"
                 aria-label="Monthly spending answer"
               >
-                <SafeToSpendCard breakdown={safeToSpendBreakdown} currency={safeToSpendCurrency} />
+                <Suspense fallback={<SectionFallback label="Loading monthly spending answer" />}>
+                  <SafeToSpendCard
+                    breakdown={safeToSpendBreakdown}
+                    currency={safeToSpendCurrency}
+                  />
+                </Suspense>
               </section>
+              <Suspense fallback={<SectionFallback label="Loading grocery mode" />}>
+                <GroceryModeSection
+                  accounts={filteredAccounts}
+                  reservedCents={groceryReservedCents}
+                  bills={filteredBills}
+                  budgets={activeMonthlyBudgets}
+                  categoryNames={categoryNames}
+                  transactions={filteredCurrentMonthTransactions}
+                  today={groceryToday}
+                  fallbackPayday={currentMonthRange.endDate}
+                  currency={safeToSpendCurrency}
+                />
+              </Suspense>
               <section className="page-section" aria-label="Financial summary">
                 <div className="card-grid card-grid--4">
                   {visibleWidgetIds.has('net-worth') ? (


### PR DESCRIPTION
## Summary

Adds a supportive "Grocery mode" / safe-to-spend-before-payday experience to the web dashboard for issue #2199 ? a fast, glanceable answer to "can I afford this right now?"

- Pure TypeScript engine (apps/web/src/lib/dashboard/grocery-mode.ts): integer minor units (cents), banker's rounding, no float money, pure functions. Computes:
  - available-to-spend before the next payday = current available funds minus sum(upcoming critical, unpaid bills due before payday) minus optional reserved amounts,
  - remaining for a pinned high-frequency category (e.g. Groceries) = category budget remaining,
  - a boolean affordability answer for a hypothetical purchase amount,
  - a next-payday estimate from historical income dates (median gap snapped to weekly/biweekly/semi-monthly/monthly; single date falls back to monthly), with a fallback date.
- Accessible card (GroceryModeCard + thin lazy GroceryModeSection wrapper) surfaced on the Dashboard:
  - pinned-category selector (native labeled select), the safe-to-spend amount, upcoming critical-bill context, and a quick "can I afford $___?" check (inputMode decimal),
  - WCAG 2.2 AA: the computed answer lives in a role="status" aria-live="polite" region; tone is conveyed by icon + supportive text, never color alone; the big number is aria-hidden with an accessible-name sibling; all controls are labeled and keyboard-navigable.
  - Supportive, non-alarming copy: "You have $X left for groceries before Friday's bills" ? not red-alert framing.

## Tests

- Engine: 37 vitest cases (known values, banker's rounding, parsing/sub-cent, payday estimation, edge cases: no upcoming bills, negative available, no pinned category, affordability boundaries).
- Component: 13 GroceryModeCard render/interaction tests + 2 GroceryModeSection tests.
- Dashboard wiring: existing DashboardPage suite still green (privacy + safe-to-spend tests updated for the now lazy-loaded card).

## Perf budget

The dashboard is a heavily-loaded route enforcing a 215KB gzip lazy-chunk budget. To stay under it, the existing SafeToSpendCard and the new GroceryModeSection are lazily code-split (per the #2782 dashboard sub-feature code-splitting pattern) rather than added to a shared eager barrel. Local route-dashboard gzip = 214,638 B (budget 215,000) and npm run perf:budget passes.

## Out of scope (future surfaces)

This is the web slice only. The iOS App Clip, lock-screen, and home-screen widget surfaces for grocery mode remain follow-up work.

Refs #2199
