### PR TITLE
feat(web): expected vs cleared income tracking (#2193)

### DIFF
--- a/apps/web/src/components/layout/navConfig.tsx
+++ b/apps/web/src/components/layout/navConfig.tsx
@@ -135,6 +135,15 @@ export const NAV_CONFIG: readonly NavConfigItem[] = ensureStableNavOrder([
     description: 'Track money sent abroad: fees, FX rate and what recipients receive.',
   },
   {
+    id: 'expected-income',
+    label: 'Expected Income',
+    href: '/expected-income',
+    icon: <Icon name={IconToken.INCOME} />,
+    group: 'money',
+    mobilePriority: 15,
+    description: 'Track expected vs. cleared income so late money is not counted as spendable.',
+  },
+  {
     id: 'investments',
     label: 'Investments',
     href: '/investments',

--- a/apps/web/src/lib/income/expected-income-store.ts
+++ b/apps/web/src/lib/income/expected-income-store.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Local persistence for expected-income items.
+ *
+ * Mirrors the mileage-tracker pattern: items live in `localStorage` and a DOM
+ * event is dispatched on change so any mounted view can refresh. This keeps the
+ * expected-income surface self-contained and offline-first without touching the
+ * primary SQLite data path.
+ *
+ * Refs #2193
+ */
+
+import {
+  CONFIDENCE_LEVELS,
+  type ConfidenceLevel,
+  type ExpectedIncomeItem,
+} from './expected-income';
+
+const STORAGE_KEY = 'finance:expected-income';
+export const EXPECTED_INCOME_CHANGED_EVENT = 'finance:expected-income-changed';
+
+/** Fields a caller supplies when adding or editing an item. */
+export interface ExpectedIncomeDraft {
+  label: string;
+  amountCents: number;
+  expectedDate: string;
+  confidence: ConfidenceLevel;
+  cleared?: boolean;
+}
+
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `expected-income-${Date.now()}-${Math.round(Math.random() * 1_000_000)}`;
+}
+
+function isConfidenceLevel(value: unknown): value is ConfidenceLevel {
+  return typeof value === 'string' && (CONFIDENCE_LEVELS as readonly string[]).includes(value);
+}
+
+function notifyChanged(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.dispatchEvent(new Event(EXPECTED_INCOME_CHANGED_EVENT));
+}
+
+function sanitizeDraft(
+  draft: ExpectedIncomeDraft,
+  existing?: ExpectedIncomeItem,
+): ExpectedIncomeItem {
+  const label = draft.label.trim();
+  if (!label) {
+    throw new Error('A label is required.');
+  }
+
+  const expectedDate = draft.expectedDate.trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(expectedDate)) {
+    throw new Error('A valid expected date (YYYY-MM-DD) is required.');
+  }
+
+  if (!Number.isFinite(draft.amountCents) || draft.amountCents < 0) {
+    throw new Error('Amount must be a non-negative number of cents.');
+  }
+
+  return {
+    id: existing?.id ?? generateId(),
+    label,
+    amountCents: Math.round(draft.amountCents),
+    expectedDate,
+    confidence: isConfidenceLevel(draft.confidence) ? draft.confidence : 'medium',
+    cleared: draft.cleared ?? existing?.cleared ?? false,
+  };
+}
+
+function writeItems(items: ExpectedIncomeItem[]): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    notifyChanged();
+  } catch {
+    // Ignore storage failures in constrained / private-mode browsers.
+  }
+}
+
+/** Read all persisted expected-income items, ignoring malformed entries. */
+export function loadExpectedIncomeItems(): ExpectedIncomeItem[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((entry): entry is ExpectedIncomeItem => {
+      return (
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as ExpectedIncomeItem).id === 'string' &&
+        typeof (entry as ExpectedIncomeItem).label === 'string' &&
+        typeof (entry as ExpectedIncomeItem).amountCents === 'number' &&
+        typeof (entry as ExpectedIncomeItem).expectedDate === 'string' &&
+        isConfidenceLevel((entry as ExpectedIncomeItem).confidence) &&
+        typeof (entry as ExpectedIncomeItem).cleared === 'boolean'
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
+/** Add a new expected-income item and return it. */
+export function createExpectedIncomeItem(draft: ExpectedIncomeDraft): ExpectedIncomeItem {
+  const created = sanitizeDraft(draft);
+  writeItems([created, ...loadExpectedIncomeItems()]);
+  return created;
+}
+
+/** Toggle (or set) whether an item has cleared/been received. */
+export function setExpectedIncomeCleared(id: string, cleared: boolean): boolean {
+  const items = loadExpectedIncomeItems();
+  let changed = false;
+  const next = items.map((entry) => {
+    if (entry.id === id) {
+      changed = true;
+      return { ...entry, cleared };
+    }
+    return entry;
+  });
+  if (changed) {
+    writeItems(next);
+  }
+  return changed;
+}
+
+/** Delete an item by id. Returns `true` if an item was removed. */
+export function deleteExpectedIncomeItem(id: string): boolean {
+  const items = loadExpectedIncomeItems();
+  const remaining = items.filter((entry) => entry.id !== id);
+  if (remaining.length === items.length) {
+    return false;
+  }
+  writeItems(remaining);
+  return true;
+}

--- a/apps/web/src/lib/income/expected-income.test.ts
+++ b/apps/web/src/lib/income/expected-income.test.ts
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONFIDENCE_WEIGHTS,
+  confidenceWeight,
+  isOverdue,
+  sortExpectedIncome,
+  summarizeExpectedIncome,
+  type ConfidenceLevel,
+  type ExpectedIncomeItem,
+} from './expected-income';
+
+const REFERENCE = '2026-06-15';
+
+function item(overrides: Partial<ExpectedIncomeItem> = {}): ExpectedIncomeItem {
+  return {
+    id: overrides.id ?? 'item-1',
+    label: overrides.label ?? 'Child support — June',
+    amountCents: overrides.amountCents ?? 50_000,
+    expectedDate: overrides.expectedDate ?? '2026-06-20',
+    confidence: overrides.confidence ?? 'high',
+    cleared: overrides.cleared ?? false,
+  };
+}
+
+describe('confidenceWeight', () => {
+  it('maps each level to its configured weight', () => {
+    expect(confidenceWeight('high')).toBe(CONFIDENCE_WEIGHTS.high);
+    expect(confidenceWeight('medium')).toBe(CONFIDENCE_WEIGHTS.medium);
+    expect(confidenceWeight('low')).toBe(CONFIDENCE_WEIGHTS.low);
+  });
+
+  it('falls back to the low weight for unknown levels', () => {
+    expect(confidenceWeight('unknown' as ConfidenceLevel)).toBe(CONFIDENCE_WEIGHTS.low);
+  });
+});
+
+describe('isOverdue', () => {
+  it('flags pending items before the reference date', () => {
+    expect(isOverdue(item({ expectedDate: '2026-06-10', cleared: false }), REFERENCE)).toBe(true);
+  });
+
+  it('does not flag items expected exactly on the reference date', () => {
+    expect(isOverdue(item({ expectedDate: REFERENCE, cleared: false }), REFERENCE)).toBe(false);
+  });
+
+  it('does not flag future items', () => {
+    expect(isOverdue(item({ expectedDate: '2026-06-30', cleared: false }), REFERENCE)).toBe(false);
+  });
+
+  it('never flags cleared items even if the date passed', () => {
+    expect(isOverdue(item({ expectedDate: '2026-06-01', cleared: true }), REFERENCE)).toBe(false);
+  });
+
+  it('treats unparseable dates as not overdue', () => {
+    expect(isOverdue(item({ expectedDate: 'not-a-date', cleared: false }), REFERENCE)).toBe(false);
+  });
+});
+
+describe('summarizeExpectedIncome', () => {
+  it('returns an all-zero summary for an empty list', () => {
+    const summary = summarizeExpectedIncome([], REFERENCE);
+    expect(summary).toEqual({
+      totalCount: 0,
+      clearedCount: 0,
+      pendingCount: 0,
+      overdueCount: 0,
+      realizedCents: 0,
+      expectedNotYetReceivedCents: 0,
+      confidenceWeightedExpectedCents: 0,
+      overdueCents: 0,
+      plannedTotalCents: 0,
+      plannedConfidenceAdjustedCents: 0,
+    });
+  });
+
+  it('keeps realized cash separate from expected money', () => {
+    const summary = summarizeExpectedIncome(
+      [
+        item({ id: 'a', amountCents: 30_000, cleared: true }),
+        item({ id: 'b', amountCents: 50_000, cleared: false, expectedDate: '2026-06-25' }),
+      ],
+      REFERENCE,
+    );
+
+    // Spendable now is ONLY the cleared item.
+    expect(summary.realizedCents).toBe(30_000);
+    // Expected money is reported on its own.
+    expect(summary.expectedNotYetReceivedCents).toBe(50_000);
+    // Planned including expected combines both.
+    expect(summary.plannedTotalCents).toBe(80_000);
+    expect(summary.clearedCount).toBe(1);
+    expect(summary.pendingCount).toBe(1);
+    expect(summary.totalCount).toBe(2);
+  });
+
+  it('never counts expected-but-uncleared money as realized', () => {
+    const summary = summarizeExpectedIncome(
+      [item({ amountCents: 100_000, cleared: false })],
+      REFERENCE,
+    );
+    expect(summary.realizedCents).toBe(0);
+    expect(summary.expectedNotYetReceivedCents).toBe(100_000);
+  });
+
+  it('weights expected money by confidence and rounds to whole cents', () => {
+    const summary = summarizeExpectedIncome(
+      [
+        item({ id: 'high', amountCents: 100_000, confidence: 'high', cleared: false }),
+        item({ id: 'medium', amountCents: 100_000, confidence: 'medium', cleared: false }),
+        item({ id: 'low', amountCents: 100_000, confidence: 'low', cleared: false }),
+      ],
+      '2026-07-01',
+    );
+
+    // 100000*1 + 100000*0.6 + 100000*0.3 = 100000 + 60000 + 30000
+    expect(summary.confidenceWeightedExpectedCents).toBe(190_000);
+    expect(summary.expectedNotYetReceivedCents).toBe(300_000);
+  });
+
+  it('rounds fractional confidence weights deterministically', () => {
+    // 12345 * 0.6 = 7407 exactly; 12345 * 0.3 = 3703.5 -> 3704 (half away from zero)
+    const summary = summarizeExpectedIncome(
+      [
+        item({ id: 'm', amountCents: 12_345, confidence: 'medium', cleared: false }),
+        item({ id: 'l', amountCents: 12_345, confidence: 'low', cleared: false }),
+      ],
+      '2026-07-01',
+    );
+    expect(summary.confidenceWeightedExpectedCents).toBe(7_407 + 3_704);
+  });
+
+  it('counts and totals overdue pending items', () => {
+    const summary = summarizeExpectedIncome(
+      [
+        item({ id: 'late1', amountCents: 40_000, expectedDate: '2026-06-01', cleared: false }),
+        item({ id: 'late2', amountCents: 25_000, expectedDate: '2026-06-10', cleared: false }),
+        item({ id: 'future', amountCents: 60_000, expectedDate: '2026-06-30', cleared: false }),
+        item({ id: 'paid', amountCents: 99_000, expectedDate: '2026-05-01', cleared: true }),
+      ],
+      REFERENCE,
+    );
+
+    expect(summary.overdueCount).toBe(2);
+    expect(summary.overdueCents).toBe(65_000);
+    // Cleared past-due item is realized, not overdue.
+    expect(summary.realizedCents).toBe(99_000);
+  });
+
+  it('handles an all-cleared list (everything realized, nothing expected)', () => {
+    const summary = summarizeExpectedIncome(
+      [
+        item({ id: 'a', amountCents: 20_000, cleared: true }),
+        item({ id: 'b', amountCents: 35_000, cleared: true }),
+      ],
+      REFERENCE,
+    );
+    expect(summary.realizedCents).toBe(55_000);
+    expect(summary.expectedNotYetReceivedCents).toBe(0);
+    expect(summary.confidenceWeightedExpectedCents).toBe(0);
+    expect(summary.overdueCount).toBe(0);
+    expect(summary.plannedTotalCents).toBe(55_000);
+    expect(summary.plannedConfidenceAdjustedCents).toBe(55_000);
+  });
+
+  it('handles an all-pending list (nothing realized)', () => {
+    const summary = summarizeExpectedIncome(
+      [
+        item({ id: 'a', amountCents: 20_000, confidence: 'high', cleared: false }),
+        item({ id: 'b', amountCents: 40_000, confidence: 'medium', cleared: false }),
+      ],
+      '2026-07-01',
+    );
+    expect(summary.realizedCents).toBe(0);
+    expect(summary.expectedNotYetReceivedCents).toBe(60_000);
+    expect(summary.confidenceWeightedExpectedCents).toBe(20_000 + 24_000);
+    expect(summary.plannedTotalCents).toBe(60_000);
+    expect(summary.plannedConfidenceAdjustedCents).toBe(44_000);
+  });
+
+  it('computes the conservative planned total from realized plus weighted expected', () => {
+    const summary = summarizeExpectedIncome(
+      [
+        item({ id: 'cleared', amountCents: 30_000, cleared: true }),
+        item({ id: 'pending', amountCents: 50_000, confidence: 'low', cleared: false }),
+      ],
+      '2026-07-01',
+    );
+    expect(summary.plannedTotalCents).toBe(80_000); // 30k + 50k full expected
+    expect(summary.plannedConfidenceAdjustedCents).toBe(30_000 + 15_000); // 30k + 50k*0.3
+  });
+
+  it('treats non-finite amounts as zero', () => {
+    const summary = summarizeExpectedIncome(
+      [item({ amountCents: Number.NaN, cleared: false })],
+      REFERENCE,
+    );
+    expect(summary.expectedNotYetReceivedCents).toBe(0);
+    expect(summary.confidenceWeightedExpectedCents).toBe(0);
+  });
+
+  it('is deterministic for the same inputs', () => {
+    const items = [
+      item({ id: 'a', amountCents: 12_300, cleared: true }),
+      item({ id: 'b', amountCents: 45_600, confidence: 'medium', cleared: false }),
+    ];
+    expect(summarizeExpectedIncome(items, REFERENCE)).toEqual(
+      summarizeExpectedIncome(items, REFERENCE),
+    );
+  });
+});
+
+describe('sortExpectedIncome', () => {
+  it('orders overdue items first, then by soonest date, then label', () => {
+    const items = [
+      item({ id: 'future', label: 'Future', expectedDate: '2026-06-30', cleared: false }),
+      item({ id: 'late-b', label: 'Bravo late', expectedDate: '2026-06-05', cleared: false }),
+      item({ id: 'late-a', label: 'Alpha late', expectedDate: '2026-06-05', cleared: false }),
+      item({ id: 'cleared', label: 'Cleared', expectedDate: '2026-06-01', cleared: true }),
+    ];
+
+    const sorted = sortExpectedIncome(items, REFERENCE);
+    expect(sorted.map((entry) => entry.id)).toEqual(['late-a', 'late-b', 'cleared', 'future']);
+  });
+
+  it('does not mutate the input array', () => {
+    const items = [
+      item({ id: 'b', expectedDate: '2026-06-30' }),
+      item({ id: 'a', expectedDate: '2026-06-01', cleared: false }),
+    ];
+    const snapshot = items.map((entry) => entry.id);
+    sortExpectedIncome(items, REFERENCE);
+    expect(items.map((entry) => entry.id)).toEqual(snapshot);
+  });
+});

--- a/apps/web/src/lib/income/expected-income.ts
+++ b/apps/web/src/lib/income/expected-income.ts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Expected-income engine.
+ *
+ * Tracks money a household is *expecting* (e.g. child support that is often
+ * late) separately from money that has actually *cleared*. The goal is to let
+ * a user plan bills without pretending uncertain money has already arrived.
+ *
+ * Core principle: **spendable / realized cash never includes expected-but-not-
+ * cleared income.** Expected money is reported in its own totals so the user
+ * can clearly see "certain money I have now" vs "money I am only hoping for".
+ *
+ * All monetary values are **integer cents**. Every function here is pure and
+ * deterministic — given the same items and reference date it always returns the
+ * same result (no `Date.now()`, no `Math.random()`).
+ *
+ * Refs #2193
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Confidence that an expected payment will actually arrive. */
+export type ConfidenceLevel = 'high' | 'medium' | 'low';
+
+/** All confidence levels, ordered most → least reliable. */
+export const CONFIDENCE_LEVELS: readonly ConfidenceLevel[] = Object.freeze([
+  'high',
+  'medium',
+  'low',
+]);
+
+/**
+ * Weight applied to an expected (uncleared) amount when computing the
+ * confidence-weighted total. `high` counts in full; lower confidence discounts
+ * the amount so planning leans conservative.
+ */
+export const CONFIDENCE_WEIGHTS: Readonly<Record<ConfidenceLevel, number>> = Object.freeze({
+  high: 1,
+  medium: 0.6,
+  low: 0.3,
+});
+
+/** Human-readable label for a confidence level. */
+export const CONFIDENCE_LABELS: Readonly<Record<ConfidenceLevel, string>> = Object.freeze({
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+});
+
+/** A single expected-income item (e.g. one child-support payment). */
+export interface ExpectedIncomeItem {
+  /** Stable identifier. */
+  id: string;
+  /** Short description shown to the user (e.g. "Child support — June"). */
+  label: string;
+  /** Amount in integer cents. Should be non-negative. */
+  amountCents: number;
+  /** Date the money is expected, as an ISO `YYYY-MM-DD` string. */
+  expectedDate: string;
+  /** How reliable this payment is. */
+  confidence: ConfidenceLevel;
+  /** `true` once the money has actually been received / cleared. */
+  cleared: boolean;
+}
+
+/** Aggregated view separating realized (certain) money from expected money. */
+export interface ExpectedIncomeSummary {
+  /** Total number of items. */
+  totalCount: number;
+  /** Number of items already cleared/received. */
+  clearedCount: number;
+  /** Number of items still pending (not yet cleared). */
+  pendingCount: number;
+  /** Number of pending items whose expected date is in the past. */
+  overdueCount: number;
+  /**
+   * Realized cash, in cents — the sum of **cleared** items only.
+   * This is the spendable-now figure; it must never include expected money.
+   */
+  realizedCents: number;
+  /** Sum of items that are expected but **not yet cleared**, in cents. */
+  expectedNotYetReceivedCents: number;
+  /**
+   * Confidence-weighted expected total, in cents — each pending item's amount
+   * is multiplied by its confidence weight, then rounded to whole cents.
+   */
+  confidenceWeightedExpectedCents: number;
+  /** Sum of pending items that are past their expected date, in cents. */
+  overdueCents: number;
+  /**
+   * "Planned including expected" total, in cents — realized cash plus all
+   * expected-but-uncleared money. Combines certain and uncertain money; pair it
+   * with {@link realizedCents} so the user sees both sides.
+   */
+  plannedTotalCents: number;
+  /**
+   * Conservative planned total, in cents — realized cash plus the
+   * confidence-weighted expected money rather than the full expected amount.
+   */
+  plannedConfidenceAdjustedCents: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Round half away from zero to whole cents. Deterministic — used so the
+ * confidence-weighted total is stable regardless of host environment.
+ */
+function roundCents(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.sign(value) * Math.round(Math.abs(value));
+}
+
+/**
+ * Convert an ISO `YYYY-MM-DD` date into a comparable `YYYYMMDD` integer.
+ * Returns `NaN` for unparseable input so callers can treat it as "no date".
+ */
+function dateKey(date: string): number {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(date.trim());
+  if (!match) {
+    return Number.NaN;
+  }
+  return Number(`${match[1]}${match[2]}${match[3]}`);
+}
+
+/** Weight for a confidence level, defaulting to `low` for unknown values. */
+export function confidenceWeight(level: ConfidenceLevel): number {
+  return CONFIDENCE_WEIGHTS[level] ?? CONFIDENCE_WEIGHTS.low;
+}
+
+/**
+ * Whether an item is overdue relative to `referenceDate`: it is still pending
+ * (not cleared) and its expected date is strictly before the reference date.
+ * Items expected exactly on the reference date are **not** overdue.
+ */
+export function isOverdue(item: ExpectedIncomeItem, referenceDate: string): boolean {
+  if (item.cleared) {
+    return false;
+  }
+  const itemKey = dateKey(item.expectedDate);
+  const refKey = dateKey(referenceDate);
+  if (Number.isNaN(itemKey) || Number.isNaN(refKey)) {
+    return false;
+  }
+  return itemKey < refKey;
+}
+
+// ---------------------------------------------------------------------------
+// Main aggregation
+// ---------------------------------------------------------------------------
+
+/** A zeroed summary, returned for an empty item list. */
+function emptySummary(): ExpectedIncomeSummary {
+  return {
+    totalCount: 0,
+    clearedCount: 0,
+    pendingCount: 0,
+    overdueCount: 0,
+    realizedCents: 0,
+    expectedNotYetReceivedCents: 0,
+    confidenceWeightedExpectedCents: 0,
+    overdueCents: 0,
+    plannedTotalCents: 0,
+    plannedConfidenceAdjustedCents: 0,
+  };
+}
+
+/**
+ * Summarise a list of expected-income items, separating realized (cleared)
+ * cash from expected (uncleared) money.
+ *
+ * @param items         - Expected-income items (any order).
+ * @param referenceDate - ISO `YYYY-MM-DD` "today" used for overdue detection.
+ * @returns A deterministic {@link ExpectedIncomeSummary}.
+ */
+export function summarizeExpectedIncome(
+  items: readonly ExpectedIncomeItem[],
+  referenceDate: string,
+): ExpectedIncomeSummary {
+  if (items.length === 0) {
+    return emptySummary();
+  }
+
+  const summary = emptySummary();
+  summary.totalCount = items.length;
+
+  for (const item of items) {
+    const amount = Number.isFinite(item.amountCents) ? Math.trunc(item.amountCents) : 0;
+
+    if (item.cleared) {
+      summary.clearedCount += 1;
+      summary.realizedCents += amount;
+      continue;
+    }
+
+    summary.pendingCount += 1;
+    summary.expectedNotYetReceivedCents += amount;
+    summary.confidenceWeightedExpectedCents += roundCents(
+      amount * confidenceWeight(item.confidence),
+    );
+
+    if (isOverdue(item, referenceDate)) {
+      summary.overdueCount += 1;
+      summary.overdueCents += amount;
+    }
+  }
+
+  summary.plannedTotalCents = summary.realizedCents + summary.expectedNotYetReceivedCents;
+  summary.plannedConfidenceAdjustedCents =
+    summary.realizedCents + summary.confidenceWeightedExpectedCents;
+
+  return summary;
+}
+
+/**
+ * Sort items for display: overdue first, then by soonest expected date, then by
+ * label. Pure — returns a new array and never mutates the input.
+ */
+export function sortExpectedIncome(
+  items: readonly ExpectedIncomeItem[],
+  referenceDate: string,
+): ExpectedIncomeItem[] {
+  return [...items].sort((a, b) => {
+    const aOverdue = isOverdue(a, referenceDate) ? 0 : 1;
+    const bOverdue = isOverdue(b, referenceDate) ? 0 : 1;
+    if (aOverdue !== bOverdue) {
+      return aOverdue - bOverdue;
+    }
+
+    const aKey = dateKey(a.expectedDate);
+    const bKey = dateKey(b.expectedDate);
+    if (!Number.isNaN(aKey) && !Number.isNaN(bKey) && aKey !== bKey) {
+      return aKey - bKey;
+    }
+
+    return a.label.localeCompare(b.label);
+  });
+}

--- a/apps/web/src/lib/income/index.ts
+++ b/apps/web/src/lib/income/index.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Public surface for the expected-income feature (engine + local store).
+ *
+ * Imported only by the lazily-loaded ExpectedIncomePage, so it does not add
+ * weight to any other route's bundle.
+ *
+ * Refs #2193
+ */
+
+export * from './expected-income';
+export * from './expected-income-store';

--- a/apps/web/src/pages/ExpectedIncomePage.css
+++ b/apps/web/src/pages/ExpectedIncomePage.css
@@ -1,0 +1,310 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+.expected-income {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.expected-income__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.expected-income__eyebrow {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.expected-income__title {
+  font-size: var(--type-scale-display-font-size);
+  font-weight: var(--type-scale-display-font-weight);
+  margin: 0;
+}
+
+.expected-income__description {
+  color: var(--semantic-text-secondary);
+  margin: 0;
+  max-width: 72ch;
+}
+
+.expected-income__live {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  margin: 0;
+  min-height: 1.25em;
+}
+
+.expected-income__section-title {
+  align-items: center;
+  display: flex;
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  gap: var(--spacing-2);
+  margin: 0 0 var(--spacing-3);
+}
+
+/* ── Form ──────────────────────────────────────────────────────────────── */
+
+.expected-income__form-section,
+.expected-income__summary,
+.expected-income__list-section {
+  background: var(--semantic-background-elevated, var(--semantic-background-primary));
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-lg, var(--border-radius-lg, var(--border-radius-md)));
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-4);
+}
+
+.expected-income__form {
+  display: grid;
+  gap: var(--spacing-3);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.expected-income__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.expected-income__field--checkbox {
+  align-items: center;
+  flex-direction: row;
+  gap: var(--spacing-2);
+}
+
+.expected-income__label,
+.expected-income__checkbox-label {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+}
+
+.expected-income__input {
+  background: var(--semantic-background-primary);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-md, var(--border-radius-md));
+  color: var(--semantic-text-primary);
+  font: inherit;
+  padding: var(--spacing-2) var(--spacing-3);
+}
+
+.expected-income__input:focus-visible,
+.expected-income__checkbox:focus-visible,
+.expected-income__button:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.expected-income__checkbox {
+  block-size: 1.15rem;
+  inline-size: 1.15rem;
+}
+
+.expected-income__hint {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.expected-income__error {
+  border: 1px solid var(--semantic-status-negative);
+  border-radius: var(--radius-md, var(--border-radius-md));
+  color: var(--semantic-status-negative);
+  font-size: var(--type-scale-caption-font-size);
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: var(--spacing-2) var(--spacing-3);
+}
+
+.expected-income__form-actions {
+  align-items: center;
+  display: flex;
+  grid-column: 1 / -1;
+}
+
+/* ── Buttons ───────────────────────────────────────────────────────────── */
+
+.expected-income__button {
+  background: var(--semantic-background-primary);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-md, var(--border-radius-md));
+  color: var(--semantic-text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  padding: var(--spacing-2) var(--spacing-3);
+  transition: background-color 150ms ease;
+}
+
+.expected-income__button:hover {
+  background: var(--semantic-background-secondary);
+}
+
+.expected-income__button--primary {
+  background: var(--semantic-status-info);
+  border-color: var(--semantic-status-info);
+  color: var(--semantic-text-inverse);
+}
+
+.expected-income__button--danger {
+  border-color: var(--semantic-status-negative);
+  color: var(--semantic-status-negative);
+}
+
+/* ── Summary cards ─────────────────────────────────────────────────────── */
+
+.expected-income__summary-grid {
+  display: grid;
+  gap: var(--spacing-3);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.expected-income__card {
+  background: var(--semantic-background-primary);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-md, var(--border-radius-md));
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  padding: var(--spacing-3);
+}
+
+.expected-income__card-title {
+  align-items: center;
+  color: var(--semantic-text-secondary);
+  display: flex;
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  gap: var(--spacing-1);
+  margin: 0;
+}
+
+.expected-income__card-value {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: 700;
+  margin: 0;
+}
+
+.expected-income__card-note {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  margin: 0;
+}
+
+.expected-income__card--realized {
+  border-inline-start: 4px solid var(--semantic-status-positive);
+}
+
+.expected-income__card--expected {
+  border-inline-start: 4px solid var(--semantic-status-info);
+}
+
+.expected-income__card--planned {
+  border-inline-start: 4px solid var(--semantic-border-default);
+}
+
+.expected-income__card--overdue {
+  border-inline-start: 4px solid var(--semantic-status-warning);
+}
+
+.expected-income__card-icon {
+  color: var(--semantic-status-warning);
+}
+
+/* ── Item list ─────────────────────────────────────────────────────────── */
+
+.expected-income__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.expected-income__item {
+  align-items: center;
+  background: var(--semantic-background-primary);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-md, var(--border-radius-md));
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  justify-content: space-between;
+  padding: var(--spacing-3);
+}
+
+.expected-income__item.is-overdue {
+  border-inline-start: 4px solid var(--semantic-status-warning);
+}
+
+.expected-income__item.is-cleared {
+  border-inline-start: 4px solid var(--semantic-status-positive);
+}
+
+.expected-income__item.is-pending {
+  border-inline-start: 4px solid var(--semantic-status-info);
+}
+
+.expected-income__item-main {
+  display: flex;
+  flex: 1 1 14rem;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  min-inline-size: 0;
+}
+
+.expected-income__item-title {
+  font-size: var(--type-scale-body-font-size);
+  font-weight: 600;
+  margin: 0;
+}
+
+.expected-income__item-meta {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  margin: 0;
+}
+
+.expected-income__item-amount {
+  color: var(--semantic-text-primary);
+  font-weight: 600;
+}
+
+.expected-income__status {
+  align-items: center;
+  display: inline-flex;
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  gap: var(--spacing-1);
+}
+
+.expected-income__status.is-cleared {
+  color: var(--semantic-status-positive);
+}
+
+.expected-income__status.is-overdue {
+  color: var(--semantic-status-warning);
+}
+
+.expected-income__status.is-pending {
+  color: var(--semantic-status-info);
+}
+
+.expected-income__item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .expected-income__button {
+    transition: none;
+  }
+}

--- a/apps/web/src/pages/ExpectedIncomePage.test.tsx
+++ b/apps/web/src/pages/ExpectedIncomePage.test.tsx
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for ExpectedIncomePage (#2193).
+ *
+ * Uses the real localStorage-backed store (cleared between tests) to verify the
+ * add/list flow and that the page keeps spendable-now money separate from
+ * expected money.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+
+import { ExpectedIncomePage } from './ExpectedIncomePage';
+
+function addPayment(options: {
+  name: string;
+  amount: string;
+  date: string;
+  confidence?: 'High' | 'Medium' | 'Low';
+  received?: boolean;
+}) {
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: options.name } });
+  fireEvent.change(screen.getByLabelText('Amount'), { target: { value: options.amount } });
+  fireEvent.change(screen.getByLabelText('Expected date'), { target: { value: options.date } });
+  if (options.confidence) {
+    fireEvent.change(screen.getByLabelText('Confidence'), {
+      target: { value: options.confidence.toLowerCase() },
+    });
+  }
+  if (options.received) {
+    fireEvent.click(screen.getByLabelText('Already received (counts as spendable now)'));
+  }
+  fireEvent.click(screen.getByRole('button', { name: 'Add payment' }));
+}
+
+describe('ExpectedIncomePage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders the heading and an empty state initially', () => {
+    render(<ExpectedIncomePage />);
+    expect(
+      screen.getByRole('heading', { level: 1, name: /expected vs\. cleared income/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('No expected income yet')).toBeInTheDocument();
+  });
+
+  it('keeps cleared money spendable now and expected money separate', () => {
+    render(<ExpectedIncomePage />);
+
+    // A cleared (received) payment becomes spendable now.
+    addPayment({ name: 'Cleared paycheck', amount: '300.00', date: '2026-06-01', received: true });
+    // An expected (uncleared) payment must NOT be spendable now.
+    addPayment({ name: 'Child support', amount: '500.00', date: '2026-06-25' });
+
+    const realizedCard = screen
+      .getByRole('heading', { name: 'Spendable now' })
+      .closest('.expected-income__card') as HTMLElement;
+    expect(within(realizedCard).getByText('$300.00')).toBeInTheDocument();
+
+    const expectedCard = screen
+      .getByRole('heading', { name: 'Expected (not yet received)' })
+      .closest('.expected-income__card') as HTMLElement;
+    expect(within(expectedCard).getByText('$500.00')).toBeInTheDocument();
+
+    // Both items are listed.
+    expect(screen.getByRole('heading', { level: 3, name: 'Cleared paycheck' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Child support' })).toBeInTheDocument();
+  });
+
+  it('toggles an expected payment to received and back', () => {
+    render(<ExpectedIncomePage />);
+    addPayment({ name: 'Child support', amount: '500.00', date: '2026-06-25' });
+
+    const markReceived = screen.getByRole('button', { name: 'Mark received' });
+    fireEvent.click(markReceived);
+
+    // After clearing, spendable-now reflects the amount.
+    const realizedCard = screen
+      .getByRole('heading', { name: 'Spendable now' })
+      .closest('.expected-income__card') as HTMLElement;
+    expect(within(realizedCard).getByText('$500.00')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Mark not received' })).toBeInTheDocument();
+  });
+
+  it('deletes a payment', () => {
+    render(<ExpectedIncomePage />);
+    addPayment({ name: 'One-off gift', amount: '100.00', date: '2026-06-10' });
+    expect(screen.getByRole('heading', { level: 3, name: 'One-off gift' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete One-off gift' }));
+    expect(
+      screen.queryByRole('heading', { level: 3, name: 'One-off gift' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('No expected income yet')).toBeInTheDocument();
+  });
+
+  it('validates the amount field', () => {
+    render(<ExpectedIncomePage />);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Bad amount' } });
+    fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add payment' }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/amount/i);
+  });
+});

--- a/apps/web/src/pages/ExpectedIncomePage.tsx
+++ b/apps/web/src/pages/ExpectedIncomePage.tsx
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * ExpectedIncomePage — track expected income separately from cleared cash.
+ *
+ * Built for a household that receives money which is sometimes late (e.g.
+ * child support). The page keeps a hard line between:
+ *   - **Spendable now** — money that has actually cleared, and
+ *   - **Expected** — money that is only hoped for and must not be spent yet.
+ *
+ * It also surfaces a confidence-weighted view and flags overdue payments so
+ * bills can be planned realistically. All money is integer cents; the
+ * aggregation is delegated to the pure engine in `lib/income`.
+ *
+ * Refs #2193
+ */
+
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
+
+import { EmptyState, Icon } from '../components/common';
+import { IconToken } from '../icons/tokens';
+import { formatCurrency } from '../lib/currency';
+import {
+  CONFIDENCE_LABELS,
+  CONFIDENCE_LEVELS,
+  EXPECTED_INCOME_CHANGED_EVENT,
+  createExpectedIncomeItem,
+  deleteExpectedIncomeItem,
+  isOverdue,
+  loadExpectedIncomeItems,
+  setExpectedIncomeCleared,
+  sortExpectedIncome,
+  summarizeExpectedIncome,
+  type ConfidenceLevel,
+  type ExpectedIncomeItem,
+} from '../lib/income';
+
+import './ExpectedIncomePage.css';
+
+/** Local-date "today" as an ISO `YYYY-MM-DD` string (avoids UTC drift). */
+function todayIso(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** Friendly date label, falling back to the raw ISO string. */
+function formatExpectedDate(iso: string): string {
+  const parsed = new Date(`${iso}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) {
+    return iso;
+  }
+  return parsed.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+interface StatusDescriptor {
+  label: string;
+  icon: IconToken;
+  className: string;
+}
+
+function describeStatus(item: ExpectedIncomeItem, referenceDate: string): StatusDescriptor {
+  if (item.cleared) {
+    return { label: 'Received', icon: IconToken.SUCCESS, className: 'is-cleared' };
+  }
+  if (isOverdue(item, referenceDate)) {
+    return { label: 'Overdue', icon: IconToken.WARNING, className: 'is-overdue' };
+  }
+  return { label: 'Expected', icon: IconToken.PENDING, className: 'is-pending' };
+}
+
+export function ExpectedIncomePage() {
+  const [items, setItems] = useState<ExpectedIncomeItem[]>(() => loadExpectedIncomeItems());
+  const [referenceDate] = useState<string>(() => todayIso());
+
+  const [label, setLabel] = useState('');
+  const [amount, setAmount] = useState('');
+  const [expectedDate, setExpectedDate] = useState(referenceDate);
+  const [confidence, setConfidence] = useState<ConfidenceLevel>('medium');
+  const [cleared, setCleared] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState('');
+
+  useEffect(() => {
+    const refresh = () => setItems(loadExpectedIncomeItems());
+    refresh();
+    window.addEventListener(EXPECTED_INCOME_CHANGED_EVENT, refresh);
+    return () => window.removeEventListener(EXPECTED_INCOME_CHANGED_EVENT, refresh);
+  }, []);
+
+  const summary = useMemo(
+    () => summarizeExpectedIncome(items, referenceDate),
+    [items, referenceDate],
+  );
+  const sortedItems = useMemo(
+    () => sortExpectedIncome(items, referenceDate),
+    [items, referenceDate],
+  );
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      const trimmedLabel = label.trim();
+      if (!trimmedLabel) {
+        setFormError('Enter a name for this expected payment.');
+        return;
+      }
+
+      const dollars = Number.parseFloat(amount);
+      if (!Number.isFinite(dollars) || dollars < 0) {
+        setFormError('Enter an amount of 0 or more.');
+        return;
+      }
+
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(expectedDate)) {
+        setFormError('Choose the date you expect the money.');
+        return;
+      }
+
+      try {
+        createExpectedIncomeItem({
+          label: trimmedLabel,
+          amountCents: Math.round(dollars * 100),
+          expectedDate,
+          confidence,
+          cleared,
+        });
+      } catch (error) {
+        setFormError(error instanceof Error ? error.message : 'Could not save this item.');
+        return;
+      }
+
+      setFormError(null);
+      setStatusMessage(
+        `Added “${trimmedLabel}” as ${cleared ? 'received' : 'expected'} income of ${formatCurrency(
+          Math.round(dollars * 100),
+        )}.`,
+      );
+      setLabel('');
+      setAmount('');
+      setExpectedDate(referenceDate);
+      setConfidence('medium');
+      setCleared(false);
+    },
+    [amount, cleared, confidence, expectedDate, label, referenceDate],
+  );
+
+  const handleToggleCleared = useCallback((item: ExpectedIncomeItem) => {
+    const next = !item.cleared;
+    setExpectedIncomeCleared(item.id, next);
+    setStatusMessage(
+      `Marked “${item.label}” as ${next ? 'received (now spendable)' : 'still expected'}.`,
+    );
+  }, []);
+
+  const handleDelete = useCallback((item: ExpectedIncomeItem) => {
+    deleteExpectedIncomeItem(item.id);
+    setStatusMessage(`Removed “${item.label}”.`);
+  }, []);
+
+  return (
+    <main className="expected-income" aria-labelledby="expected-income-title">
+      <header className="expected-income__header">
+        <p className="expected-income__eyebrow">Income planning</p>
+        <h1 id="expected-income-title" className="expected-income__title">
+          Expected vs. Cleared Income
+        </h1>
+        <p className="expected-income__description">
+          Track money you are <em>expecting</em> separately from money that has actually arrived.
+          Only cleared payments count as spendable now — expected money is shown on its own so you
+          can plan bills without pretending late money has landed.
+        </p>
+      </header>
+
+      {/* Live region for confirmations / status updates. */}
+      <p className="expected-income__live" role="status" aria-live="polite">
+        {statusMessage}
+      </p>
+
+      <section
+        className="expected-income__form-section"
+        aria-labelledby="expected-income-form-title"
+      >
+        <h2 id="expected-income-form-title" className="expected-income__section-title">
+          Add an expected payment
+        </h2>
+        <form className="expected-income__form" onSubmit={handleSubmit} noValidate>
+          <div className="expected-income__field">
+            <label className="expected-income__label" htmlFor="expected-income-label">
+              Name
+            </label>
+            <input
+              id="expected-income-label"
+              className="expected-income__input"
+              type="text"
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              placeholder="e.g. Child support — June"
+              autoComplete="off"
+              required
+            />
+          </div>
+
+          <div className="expected-income__field">
+            <label className="expected-income__label" htmlFor="expected-income-amount">
+              Amount
+            </label>
+            <input
+              id="expected-income-amount"
+              className="expected-income__input"
+              type="number"
+              min="0"
+              step="0.01"
+              inputMode="decimal"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              placeholder="0.00"
+              required
+            />
+          </div>
+
+          <div className="expected-income__field">
+            <label className="expected-income__label" htmlFor="expected-income-date">
+              Expected date
+            </label>
+            <input
+              id="expected-income-date"
+              className="expected-income__input"
+              type="date"
+              value={expectedDate}
+              onChange={(event) => setExpectedDate(event.target.value)}
+              required
+            />
+          </div>
+
+          <div className="expected-income__field">
+            <label className="expected-income__label" htmlFor="expected-income-confidence">
+              Confidence
+            </label>
+            <select
+              id="expected-income-confidence"
+              className="expected-income__input"
+              value={confidence}
+              onChange={(event) => setConfidence(event.target.value as ConfidenceLevel)}
+              aria-describedby="expected-income-confidence-hint"
+            >
+              {CONFIDENCE_LEVELS.map((level) => (
+                <option key={level} value={level}>
+                  {CONFIDENCE_LABELS[level]}
+                </option>
+              ))}
+            </select>
+            <span id="expected-income-confidence-hint" className="expected-income__hint">
+              How sure are you this payment will arrive? Lower confidence discounts it in the
+              conservative plan.
+            </span>
+          </div>
+
+          <div className="expected-income__field expected-income__field--checkbox">
+            <input
+              id="expected-income-cleared"
+              className="expected-income__checkbox"
+              type="checkbox"
+              checked={cleared}
+              onChange={(event) => setCleared(event.target.checked)}
+            />
+            <label className="expected-income__checkbox-label" htmlFor="expected-income-cleared">
+              Already received (counts as spendable now)
+            </label>
+          </div>
+
+          {formError ? (
+            <p className="expected-income__error" role="alert">
+              {formError}
+            </p>
+          ) : null}
+
+          <div className="expected-income__form-actions">
+            <button
+              type="submit"
+              className="expected-income__button expected-income__button--primary"
+            >
+              Add payment
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="expected-income__summary" aria-labelledby="expected-income-summary-title">
+        <h2 id="expected-income-summary-title" className="expected-income__section-title">
+          Where your money stands
+        </h2>
+        <div className="expected-income__summary-grid">
+          <div className="expected-income__card expected-income__card--realized">
+            <h3 className="expected-income__card-title">Spendable now</h3>
+            <p className="expected-income__card-value">{formatCurrency(summary.realizedCents)}</p>
+            <p className="expected-income__card-note">
+              Cleared payments only — money you actually have.
+            </p>
+          </div>
+
+          <div className="expected-income__card expected-income__card--expected">
+            <h3 className="expected-income__card-title">Expected (not yet received)</h3>
+            <p className="expected-income__card-value">
+              {formatCurrency(summary.expectedNotYetReceivedCents)}
+            </p>
+            <p className="expected-income__card-note">
+              Hoped-for money. Not spendable until it clears.
+            </p>
+          </div>
+
+          <div className="expected-income__card">
+            <h3 className="expected-income__card-title">Conservative expected</h3>
+            <p className="expected-income__card-value">
+              {formatCurrency(summary.confidenceWeightedExpectedCents)}
+            </p>
+            <p className="expected-income__card-note">Expected money discounted by confidence.</p>
+          </div>
+
+          <div
+            className={`expected-income__card${
+              summary.overdueCount > 0 ? ' expected-income__card--overdue' : ''
+            }`}
+          >
+            <h3 className="expected-income__card-title">
+              <Icon name={IconToken.WARNING} size={18} className="expected-income__card-icon" />
+              Overdue
+            </h3>
+            <p className="expected-income__card-value">
+              {summary.overdueCount} {summary.overdueCount === 1 ? 'payment' : 'payments'}
+            </p>
+            <p className="expected-income__card-note">
+              {formatCurrency(summary.overdueCents)} past its expected date, still uncleared.
+            </p>
+          </div>
+
+          <div className="expected-income__card expected-income__card--planned">
+            <h3 className="expected-income__card-title">Planned incl. expected</h3>
+            <p className="expected-income__card-value">
+              {formatCurrency(summary.plannedTotalCents)}
+            </p>
+            <p className="expected-income__card-note">
+              Spendable now plus all expected money. Treat the uncertain part with care.
+            </p>
+          </div>
+
+          <div className="expected-income__card expected-income__card--planned">
+            <h3 className="expected-income__card-title">Conservative plan</h3>
+            <p className="expected-income__card-value">
+              {formatCurrency(summary.plannedConfidenceAdjustedCents)}
+            </p>
+            <p className="expected-income__card-note">
+              Spendable now plus confidence-weighted expected money.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section
+        className="expected-income__list-section"
+        aria-labelledby="expected-income-list-title"
+      >
+        <h2 id="expected-income-list-title" className="expected-income__section-title">
+          Payments ({summary.totalCount})
+        </h2>
+
+        {sortedItems.length === 0 ? (
+          <EmptyState
+            title="No expected income yet"
+            description="Add a payment above to start separating money you have from money you are still waiting on."
+          />
+        ) : (
+          <ul className="expected-income__list">
+            {sortedItems.map((item) => {
+              const status = describeStatus(item, referenceDate);
+              return (
+                <li key={item.id} className={`expected-income__item ${status.className}`}>
+                  <div className="expected-income__item-main">
+                    <h3 className="expected-income__item-title">{item.label}</h3>
+                    <p className="expected-income__item-meta">
+                      <span className="expected-income__item-amount">
+                        {formatCurrency(item.amountCents)}
+                      </span>
+                      {' · '}
+                      <time dateTime={item.expectedDate}>
+                        {formatExpectedDate(item.expectedDate)}
+                      </time>
+                      {' · '}
+                      <span className="expected-income__item-confidence">
+                        {CONFIDENCE_LABELS[item.confidence]} confidence
+                      </span>
+                    </p>
+                  </div>
+
+                  <span className={`expected-income__status ${status.className}`}>
+                    <Icon name={status.icon} size={18} className="expected-income__status-icon" />
+                    <span className="expected-income__status-text">{status.label}</span>
+                  </span>
+
+                  <div className="expected-income__item-actions">
+                    <button
+                      type="button"
+                      className="expected-income__button"
+                      onClick={() => handleToggleCleared(item)}
+                    >
+                      {item.cleared ? 'Mark not received' : 'Mark received'}
+                    </button>
+                    <button
+                      type="button"
+                      className="expected-income__button expected-income__button--danger"
+                      onClick={() => handleDelete(item)}
+                      aria-label={`Delete ${item.label}`}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}
+
+export default ExpectedIncomePage;

--- a/apps/web/src/pages/index.ts
+++ b/apps/web/src/pages/index.ts
@@ -36,3 +36,4 @@ export { InvoicesPage } from './InvoicesPage';
 export { NetWorthPage } from './NetWorthPage';
 export { SubscriptionsPage } from './SubscriptionsPage';
 export { BankConnectionsPage } from './BankConnectionsPage';
+export { ExpectedIncomePage } from './ExpectedIncomePage';

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -74,6 +74,7 @@ const BankConnections = lazy(() => import('./pages/BankConnectionsPage'));
 const Debt = lazy(() => import('./pages/DebtPage'));
 const FirePlanner = lazy(() => import('./pages/FirePlannerPage'));
 const Remittances = lazy(() => import('./pages/RemittancesPage'));
+const ExpectedIncome = lazy(() => import('./pages/ExpectedIncomePage'));
 
 /**
  * Loading fallback shown while a lazy route chunk is being fetched.
@@ -680,6 +681,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Remittances">
             <Remittances />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/expected-income"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Expected Income">
+            <ExpectedIncome />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Summary
Adds a web slice for tracking **expected income separately from cleared income** so a household that receives sometimes-late money (e.g. child support) can plan bills without pretending uncertain money has already arrived.

Refs #2193

## What's included
- **Pure engine** in `apps/web/src/lib/income/expected-income.ts` (all money in integer cents, fully deterministic):
  - `realizedCents` (cleared = spendable now) kept strictly separate from `expectedNotYetReceivedCents`
  - `confidenceWeightedExpectedCents` (high/medium/low weighting)
  - overdue detection (`overdueCount` / `overdueCents`) vs a reference date
  - combined `plannedTotalCents` and conservative `plannedConfidenceAdjustedCents` views that separate certain vs uncertain money
  - handles empty / all-cleared / all-pending / edge cases
- **Local store** (`expected-income-store.ts`) — offline-first `localStorage` persistence with a change event, mirroring the existing mileage-tracker pattern; does not touch the SQLite data path.
- **Accessible page** `ExpectedIncomePage` at `/expected-income` (added to routes + `navConfig` Money group): add/list items, clear breakdown of *spendable now* vs *expected*, overdue items flagged by **text + icon (not colour alone)**. Semantic structure, labelled inputs, keyboard operable, `role=status`/`role=alert` live regions, `prefers-reduced-motion` respected, design-token CSS only.
- **Vitest tests**: 20 engine tests (realized vs expected separation, confidence weighting, overdue detection, empty/edge cases, determinism) + 5 page tests.

## Verification
- `vitest run` for new files: 25 passed
- `prettier --check` clean; `eslint . --max-warnings 0` clean
- `DashboardPage.tsx` intentionally untouched (owned by another agent this sprint)