### PR TITLE
feat(web): forward-looking cash runway forecast (#2185)

### DIFF
--- a/apps/web/src/components/layout/navConfig.tsx
+++ b/apps/web/src/components/layout/navConfig.tsx
@@ -274,6 +274,15 @@ export const NAV_CONFIG: readonly NavConfigItem[] = ensureStableNavOrder([
     description: 'Money in vs. money out over time.',
   },
   {
+    id: 'cash-runway',
+    label: 'Cash Runway',
+    href: '/cash-runway',
+    icon: <Icon name={IconToken.CHART_LINE} />,
+    group: 'insights',
+    mobilePriority: 27,
+    description: 'Forecast whether cash covers payroll, taxes and bills before revenue lands.',
+  },
+  {
     id: 'net-worth',
     label: 'Net Worth',
     href: '/net-worth',

--- a/apps/web/src/lib/cashflow/cash-runway.test.ts
+++ b/apps/web/src/lib/cashflow/cash-runway.test.ts
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { expandEventOccurrences, forecastCashRunway, type ScheduledCashEvent } from './cash-runway';
+
+const TODAY = '2025-01-01';
+
+function event(
+  overrides: Partial<ScheduledCashEvent> & Pick<ScheduledCashEvent, 'id'>,
+): ScheduledCashEvent {
+  return {
+    label: overrides.label ?? overrides.id,
+    direction: 'outflow',
+    amountCents: 0,
+    date: TODAY,
+    ...overrides,
+  };
+}
+
+describe('expandEventOccurrences', () => {
+  it('returns a single occurrence for one-time events in range', () => {
+    const occurrences = expandEventOccurrences(
+      event({ id: 'rent', direction: 'outflow', amountCents: 120000, date: '2025-01-10' }),
+      TODAY,
+      '2025-03-01',
+    );
+
+    expect(occurrences).toHaveLength(1);
+    expect(occurrences[0]).toMatchObject({
+      sourceId: 'rent',
+      date: '2025-01-10',
+      amountCents: -120000,
+      direction: 'outflow',
+    });
+  });
+
+  it('skips occurrences before the horizon start', () => {
+    const occurrences = expandEventOccurrences(
+      event({ id: 'old', amountCents: 5000, date: '2024-12-15' }),
+      TODAY,
+      '2025-03-01',
+    );
+
+    expect(occurrences).toHaveLength(0);
+  });
+
+  it('expands weekly recurrence into anchored occurrences within the horizon', () => {
+    const occurrences = expandEventOccurrences(
+      event({ id: 'payroll', amountCents: 50000, date: '2025-01-03', frequency: 'weekly' }),
+      TODAY,
+      '2025-01-31',
+    );
+
+    expect(occurrences.map((o) => o.date)).toEqual([
+      '2025-01-03',
+      '2025-01-10',
+      '2025-01-17',
+      '2025-01-24',
+      '2025-01-31',
+    ]);
+  });
+
+  it('expands monthly recurrence and clamps to month end', () => {
+    const occurrences = expandEventOccurrences(
+      event({ id: 'loan', amountCents: 30000, date: '2025-01-31', frequency: 'monthly' }),
+      TODAY,
+      '2025-04-30',
+    );
+
+    // Jan 31 → Feb 28 (clamped) → Mar 31 → Apr 30 (clamped).
+    expect(occurrences.map((o) => o.date)).toEqual([
+      '2025-01-31',
+      '2025-02-28',
+      '2025-03-31',
+      '2025-04-30',
+    ]);
+  });
+
+  it('signs inflows positive and outflows negative', () => {
+    const [inflow] = expandEventOccurrences(
+      event({ id: 'invoice', direction: 'inflow', amountCents: 90000, date: '2025-01-05' }),
+      TODAY,
+      '2025-02-01',
+    );
+
+    expect(inflow.amountCents).toBe(90000);
+  });
+});
+
+describe('forecastCashRunway', () => {
+  it('reports a healthy runway when cash never goes negative', () => {
+    const forecast = forecastCashRunway({
+      startingCashCents: 1_000_000,
+      today: TODAY,
+      horizonWeeks: 4,
+      events: [
+        event({ id: 'payroll', amountCents: 200000, date: '2025-01-15' }),
+        event({ id: 'revenue', direction: 'inflow', amountCents: 300000, date: '2025-01-20' }),
+      ],
+    });
+
+    expect(forecast.status).toBe('healthy');
+    expect(forecast.shortfallDate).toBeNull();
+    expect(forecast.runwayDays).toBeNull();
+    expect(forecast.endingBalanceCents).toBe(1_100_000);
+    expect(forecast.totalNetCents).toBe(100000);
+  });
+
+  it('detects the first date the balance goes negative', () => {
+    const forecast = forecastCashRunway({
+      startingCashCents: 250000,
+      today: TODAY,
+      horizonWeeks: 6,
+      events: [
+        event({ id: 'payroll', amountCents: 150000, date: '2025-01-10' }),
+        event({ id: 'taxes', amountCents: 200000, date: '2025-01-20' }),
+        event({ id: 'invoice', direction: 'inflow', amountCents: 400000, date: '2025-01-25' }),
+      ],
+    });
+
+    expect(forecast.status).toBe('shortfall');
+    // 250000 - 150000 = 100000 on the 10th; - 200000 = -100000 on the 20th.
+    expect(forecast.shortfallDate).toBe('2025-01-20');
+    expect(forecast.runwayDays).toBe(19);
+  });
+
+  it('nets multiple same-day events into a single timeline point', () => {
+    const forecast = forecastCashRunway({
+      startingCashCents: 500000,
+      today: TODAY,
+      horizonWeeks: 2,
+      events: [
+        event({ id: 'payroll', amountCents: 180000, date: '2025-01-08' }),
+        event({ id: 'rent', amountCents: 120000, date: '2025-01-08' }),
+        event({ id: 'client', direction: 'inflow', amountCents: 250000, date: '2025-01-08' }),
+      ],
+    });
+
+    expect(forecast.timeline).toHaveLength(1);
+    const [point] = forecast.timeline;
+    expect(point.date).toBe('2025-01-08');
+    expect(point.inflowCents).toBe(250000);
+    expect(point.outflowCents).toBe(300000);
+    expect(point.netChangeCents).toBe(-50000);
+    expect(point.balanceCents).toBe(450000);
+    expect(point.events).toHaveLength(3);
+    // Outflows are ordered before inflows, larger magnitude first.
+    expect(point.events.map((e) => e.sourceId)).toEqual(['payroll', 'rent', 'client']);
+  });
+
+  it('tracks the minimum projected balance and its date', () => {
+    const forecast = forecastCashRunway({
+      startingCashCents: 300000,
+      today: TODAY,
+      horizonWeeks: 8,
+      events: [
+        event({ id: 'bill-1', amountCents: 100000, date: '2025-01-05' }),
+        event({ id: 'bill-2', amountCents: 150000, date: '2025-01-12' }),
+        event({ id: 'revenue', direction: 'inflow', amountCents: 500000, date: '2025-01-19' }),
+      ],
+    });
+
+    // Balances: 200000 (5th), 50000 (12th, the trough), 550000 (19th).
+    expect(forecast.minBalanceCents).toBe(50000);
+    expect(forecast.minBalanceDate).toBe('2025-01-12');
+    expect(forecast.endingBalanceCents).toBe(550000);
+  });
+
+  it('keeps the opening balance as the minimum when every event is an inflow', () => {
+    const forecast = forecastCashRunway({
+      startingCashCents: 75000,
+      today: TODAY,
+      horizonWeeks: 4,
+      events: [
+        event({ id: 'revenue', direction: 'inflow', amountCents: 100000, date: '2025-01-15' }),
+      ],
+    });
+
+    expect(forecast.minBalanceCents).toBe(75000);
+    expect(forecast.minBalanceDate).toBe(TODAY);
+    expect(forecast.status).toBe('healthy');
+  });
+
+  it('flags an already-negative opening balance as a shortfall on the start date', () => {
+    const forecast = forecastCashRunway({
+      startingCashCents: -5000,
+      today: TODAY,
+      horizonWeeks: 4,
+      events: [],
+    });
+
+    expect(forecast.status).toBe('shortfall');
+    expect(forecast.shortfallDate).toBe(TODAY);
+    expect(forecast.runwayDays).toBe(0);
+    expect(forecast.timeline).toHaveLength(0);
+  });
+
+  it('expands recurring outflows across the horizon and accumulates totals', () => {
+    const forecast = forecastCashRunway({
+      startingCashCents: 1_000_000,
+      today: TODAY,
+      horizonWeeks: 4,
+      events: [
+        event({ id: 'payroll', amountCents: 200000, date: '2025-01-03', frequency: 'weekly' }),
+      ],
+    });
+
+    // Horizon ends 2025-01-29. Weekly payroll on Jan 3, 10, 17, 24 falls in
+    // range; Jan 31 is beyond the horizon → 4 occurrences.
+    expect(forecast.endDate).toBe('2025-01-29');
+    expect(forecast.timeline).toHaveLength(4);
+    expect(forecast.totalOutflowCents).toBe(800000);
+    expect(forecast.totalInflowCents).toBe(0);
+    expect(forecast.endingBalanceCents).toBe(200000);
+    expect(forecast.status).toBe('healthy');
+  });
+
+  it('excludes occurrences beyond the horizon end', () => {
+    const forecast = forecastCashRunway({
+      startingCashCents: 1_000_000,
+      today: TODAY,
+      horizonWeeks: 2,
+      events: [
+        event({ id: 'monthly-bill', amountCents: 50000, date: '2025-01-05', frequency: 'monthly' }),
+      ],
+    });
+
+    // Horizon ends 2025-01-15, so only the Jan 5 occurrence is in range.
+    expect(forecast.endDate).toBe('2025-01-15');
+    expect(forecast.timeline).toHaveLength(1);
+    expect(forecast.timeline[0].date).toBe('2025-01-05');
+  });
+
+  it('orders the timeline deterministically by date ascending', () => {
+    const forecast = forecastCashRunway({
+      startingCashCents: 1_000_000,
+      today: TODAY,
+      horizonWeeks: 12,
+      events: [
+        event({ id: 'c', amountCents: 1000, date: '2025-02-01' }),
+        event({ id: 'a', amountCents: 1000, date: '2025-01-05' }),
+        event({ id: 'b', amountCents: 1000, date: '2025-01-20' }),
+      ],
+    });
+
+    expect(forecast.timeline.map((p) => p.date)).toEqual([
+      '2025-01-05',
+      '2025-01-20',
+      '2025-02-01',
+    ]);
+  });
+
+  it('defaults to a 12-week horizon when none is provided', () => {
+    const forecast = forecastCashRunway({
+      startingCashCents: 100000,
+      today: TODAY,
+      events: [],
+    });
+
+    expect(forecast.horizonWeeks).toBe(12);
+    expect(forecast.endDate).toBe('2025-03-26');
+  });
+});

--- a/apps/web/src/lib/cashflow/cash-runway.ts
+++ b/apps/web/src/lib/cashflow/cash-runway.ts
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Cash runway forecasting engine.
+ *
+ * Projects a small business's running cash balance forward, day-by-day, from a
+ * known starting cash position plus a set of scheduled inflows (expected
+ * revenue, invoice payments) and outflows (payroll, taxes, recurring truck /
+ * business bills). It answers the question:
+ *
+ *   "Can I cover payroll / taxes / bills before revenue lands?"
+ *
+ * The engine surfaces:
+ *   - an ordered, day-by-day projected-balance timeline,
+ *   - the first date the balance would go negative (the "runway"),
+ *   - the minimum projected balance and the date it occurs,
+ *   - total projected inflow, outflow and net change over the horizon.
+ *
+ * Design rules:
+ *   - ALL monetary values are integer **cents**. No floats, no rounding drift.
+ *   - Pure functions, no side effects — fully deterministic and testable.
+ *   - Recurring events are expanded into discrete occurrences inside the
+ *     horizon. Anchored stepping (k * interval from the anchor date) avoids
+ *     calendar drift.
+ *   - Events on the same day are netted into a single timeline point.
+ *   - Ordering is deterministic: timeline points by date ascending; events
+ *     within a day by direction (outflow first), then amount desc, then id.
+ *
+ * References: issue #2185
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Local calendar date in `YYYY-MM-DD` form. */
+export type IsoDate = string;
+
+/** Whether a scheduled event adds (inflow) or removes (outflow) cash. */
+export type CashEventDirection = 'inflow' | 'outflow';
+
+/** How often a scheduled event repeats within the horizon. */
+export type RecurrenceFrequency =
+  | 'once'
+  | 'weekly'
+  | 'biweekly'
+  | 'monthly'
+  | 'quarterly'
+  | 'yearly';
+
+/** A scheduled cash movement, optionally recurring. */
+export interface ScheduledCashEvent {
+  /** Stable identifier for the source event. */
+  readonly id: string;
+  /** Human-readable label (e.g. "Payroll", "Q3 estimated tax", "Truck lease"). */
+  readonly label: string;
+  /** Inflow adds cash; outflow removes it. */
+  readonly direction: CashEventDirection;
+  /**
+   * Magnitude in integer cents. Always non-negative; {@link direction}
+   * determines the sign applied to the running balance.
+   */
+  readonly amountCents: number;
+  /** First (or only) occurrence date, `YYYY-MM-DD`. */
+  readonly date: IsoDate;
+  /** Repeat cadence; defaults to `'once'`. */
+  readonly frequency?: RecurrenceFrequency;
+  /** Optional grouping for display (e.g. "payroll", "taxes", "bills"). */
+  readonly category?: string;
+}
+
+/** A single materialised occurrence of a scheduled event within the horizon. */
+export interface CashEventOccurrence {
+  /** Unique id for this occurrence (`<sourceId>@<date>`). */
+  readonly id: string;
+  /** Identifier of the originating {@link ScheduledCashEvent}. */
+  readonly sourceId: string;
+  /** Label carried from the source event. */
+  readonly label: string;
+  /** Direction carried from the source event. */
+  readonly direction: CashEventDirection;
+  /** Signed cents: inflows positive, outflows negative. */
+  readonly amountCents: number;
+  /** Occurrence date, `YYYY-MM-DD`. */
+  readonly date: IsoDate;
+  /** Optional category carried from the source event. */
+  readonly category?: string;
+}
+
+/** Projected state for a single day that has at least one event. */
+export interface ProjectedBalancePoint {
+  /** Day this point describes, `YYYY-MM-DD`. */
+  readonly date: IsoDate;
+  /** Total inflow on this day (non-negative cents). */
+  readonly inflowCents: number;
+  /** Total outflow on this day (non-negative cents). */
+  readonly outflowCents: number;
+  /** Net change applied on this day (signed cents). */
+  readonly netChangeCents: number;
+  /** Running balance after this day's events (signed cents). */
+  readonly balanceCents: number;
+  /** Occurrences contributing to this day, in deterministic order. */
+  readonly events: readonly CashEventOccurrence[];
+}
+
+/** Overall runway health. */
+export type RunwayStatus = 'healthy' | 'shortfall';
+
+/** Result of a cash runway projection. */
+export interface CashRunwayForecast {
+  /** Starting cash balance in cents (echoed for convenience). */
+  readonly startingCashCents: number;
+  /** Forecast horizon length in weeks. */
+  readonly horizonWeeks: number;
+  /** Inclusive start of the horizon (anchor "today"). */
+  readonly startDate: IsoDate;
+  /** Inclusive end of the horizon. */
+  readonly endDate: IsoDate;
+  /** Ordered timeline of days that carry events within the horizon. */
+  readonly timeline: readonly ProjectedBalancePoint[];
+  /** First date the balance is `< 0`, or `null` if it never goes negative. */
+  readonly shortfallDate: IsoDate | null;
+  /** `'shortfall'` when the balance dips below zero within the horizon. */
+  readonly status: RunwayStatus;
+  /** Whole days from {@link startDate} to {@link shortfallDate}, or `null`. */
+  readonly runwayDays: number | null;
+  /** Lowest projected balance over the horizon (signed cents). */
+  readonly minBalanceCents: number;
+  /** Date the {@link minBalanceCents} is first reached. */
+  readonly minBalanceDate: IsoDate;
+  /** Total inflow over the horizon (non-negative cents). */
+  readonly totalInflowCents: number;
+  /** Total outflow over the horizon (non-negative cents). */
+  readonly totalOutflowCents: number;
+  /** Net projected change over the horizon (signed cents). */
+  readonly totalNetCents: number;
+  /** Projected balance at the end of the horizon (signed cents). */
+  readonly endingBalanceCents: number;
+}
+
+/** Inputs to {@link forecastCashRunway}. */
+export interface CashRunwayInput {
+  /** Current cash balance in integer cents. */
+  readonly startingCashCents: number;
+  /** Scheduled inflows and outflows. */
+  readonly events: readonly ScheduledCashEvent[];
+  /** Forecast horizon in whole weeks. Defaults to 12. */
+  readonly horizonWeeks?: number;
+  /** Anchor "today" (`YYYY-MM-DD`). Defaults to the system local date. */
+  readonly today?: IsoDate;
+}
+
+// ---------------------------------------------------------------------------
+// Date helpers (local-date, drift-free)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_HORIZON_WEEKS = 12;
+/** Safety cap on recurrence expansion so a malformed event can't loop forever. */
+const MAX_OCCURRENCES_PER_EVENT = 1000;
+
+/** Parse a `YYYY-MM-DD` string into a local `Date` at midnight. */
+function parseLocalDate(date: IsoDate): Date {
+  const [year, month, day] = date.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+/** Format a `Date` as a local `YYYY-MM-DD` string. */
+function formatLocalDate(date: Date): IsoDate {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** Return today's local date in `YYYY-MM-DD` form. */
+export function todayIsoDate(now: Date = new Date()): IsoDate {
+  return formatLocalDate(now);
+}
+
+/** Add a whole number of days to a date string. */
+function addDays(date: IsoDate, days: number): IsoDate {
+  const next = parseLocalDate(date);
+  next.setDate(next.getDate() + days);
+  return formatLocalDate(next);
+}
+
+/**
+ * Add a whole number of months to a date string, clamping the day to the last
+ * valid day of the target month (e.g. Jan 31 + 1 month → Feb 28/29).
+ */
+function addMonths(date: IsoDate, months: number): IsoDate {
+  const parsed = parseLocalDate(date);
+  const targetYear = parsed.getFullYear();
+  const targetMonthIndex = parsed.getMonth() + months;
+  const lastDayOfTargetMonth = new Date(targetYear, targetMonthIndex + 1, 0).getDate();
+  const clampedDay = Math.min(parsed.getDate(), lastDayOfTargetMonth);
+  return formatLocalDate(new Date(targetYear, targetMonthIndex, clampedDay));
+}
+
+/** Whole days from `start` to `end` (negative if `end` precedes `start`). */
+function daysBetween(start: IsoDate, end: IsoDate): number {
+  const startMs = parseLocalDate(start).getTime();
+  const endMs = parseLocalDate(end).getTime();
+  return Math.round((endMs - startMs) / (1000 * 60 * 60 * 24));
+}
+
+/** Step the k-th occurrence of an event from its anchor date. */
+function occurrenceDate(anchor: IsoDate, frequency: RecurrenceFrequency, step: number): IsoDate {
+  switch (frequency) {
+    case 'weekly':
+      return addDays(anchor, step * 7);
+    case 'biweekly':
+      return addDays(anchor, step * 14);
+    case 'monthly':
+      return addMonths(anchor, step);
+    case 'quarterly':
+      return addMonths(anchor, step * 3);
+    case 'yearly':
+      return addMonths(anchor, step * 12);
+    case 'once':
+    default:
+      return anchor;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Expansion
+// ---------------------------------------------------------------------------
+
+/**
+ * Expand a scheduled event into the discrete occurrences that fall within the
+ * inclusive `[startDate, endDate]` horizon.
+ *
+ * Occurrences strictly before `startDate` are skipped — the starting cash
+ * balance is assumed to already reflect anything that happened before today.
+ */
+export function expandEventOccurrences(
+  event: ScheduledCashEvent,
+  startDate: IsoDate,
+  endDate: IsoDate,
+): CashEventOccurrence[] {
+  const frequency = event.frequency ?? 'once';
+  const magnitude = Math.max(0, Math.trunc(event.amountCents));
+  const signedAmount = event.direction === 'outflow' ? -magnitude : magnitude;
+  const occurrences: CashEventOccurrence[] = [];
+
+  for (let step = 0; step < MAX_OCCURRENCES_PER_EVENT; step += 1) {
+    const date = occurrenceDate(event.date, frequency, step);
+
+    if (date > endDate) {
+      break;
+    }
+
+    if (date >= startDate) {
+      occurrences.push({
+        id: `${event.id}@${date}`,
+        sourceId: event.id,
+        label: event.label,
+        direction: event.direction,
+        amountCents: signedAmount,
+        date,
+        category: event.category,
+      });
+    }
+
+    if (frequency === 'once') {
+      break;
+    }
+  }
+
+  return occurrences;
+}
+
+// ---------------------------------------------------------------------------
+// Ordering
+// ---------------------------------------------------------------------------
+
+const DIRECTION_ORDER: Record<CashEventDirection, number> = {
+  outflow: 0,
+  inflow: 1,
+};
+
+/** Deterministic ordering for occurrences sharing a date. */
+function compareOccurrences(a: CashEventOccurrence, b: CashEventOccurrence): number {
+  const directionDelta = DIRECTION_ORDER[a.direction] - DIRECTION_ORDER[b.direction];
+  if (directionDelta !== 0) return directionDelta;
+
+  // Larger magnitude first (outflows are negative, so compare absolute value).
+  const magnitudeDelta = Math.abs(b.amountCents) - Math.abs(a.amountCents);
+  if (magnitudeDelta !== 0) return magnitudeDelta;
+
+  return a.id.localeCompare(b.id);
+}
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Project a forward-looking cash runway from a starting balance and a set of
+ * scheduled (optionally recurring) inflows and outflows.
+ *
+ * @param input - Starting cash, scheduled events, horizon and anchor date.
+ * @returns A deterministic {@link CashRunwayForecast}.
+ */
+export function forecastCashRunway(input: CashRunwayInput): CashRunwayForecast {
+  const horizonWeeks =
+    input.horizonWeeks !== undefined && input.horizonWeeks > 0
+      ? Math.trunc(input.horizonWeeks)
+      : DEFAULT_HORIZON_WEEKS;
+  const startingCashCents = Math.trunc(input.startingCashCents);
+  const startDate = input.today ?? todayIsoDate();
+  const endDate = addDays(startDate, horizonWeeks * 7);
+
+  // 1. Expand every event into in-horizon occurrences.
+  const occurrences = input.events.flatMap((event) =>
+    expandEventOccurrences(event, startDate, endDate),
+  );
+
+  // 2. Group occurrences by day so same-day events net into one point.
+  const byDate = new Map<IsoDate, CashEventOccurrence[]>();
+  for (const occurrence of occurrences) {
+    const bucket = byDate.get(occurrence.date);
+    if (bucket) {
+      bucket.push(occurrence);
+    } else {
+      byDate.set(occurrence.date, [occurrence]);
+    }
+  }
+
+  const orderedDates = [...byDate.keys()].sort((a, b) => a.localeCompare(b));
+
+  // 3. Walk the timeline, accumulating the running balance.
+  const timeline: ProjectedBalancePoint[] = [];
+  let runningBalance = startingCashCents;
+  let totalInflowCents = 0;
+  let totalOutflowCents = 0;
+
+  // The minimum candidate starts at the opening balance on the start date.
+  let minBalanceCents = startingCashCents;
+  let minBalanceDate = startDate;
+
+  // A shortfall before any events means cash is already underwater today.
+  let shortfallDate: IsoDate | null = startingCashCents < 0 ? startDate : null;
+
+  for (const date of orderedDates) {
+    const dayEvents = (byDate.get(date) ?? []).slice().sort(compareOccurrences);
+
+    let inflowCents = 0;
+    let outflowCents = 0;
+    for (const occurrence of dayEvents) {
+      if (occurrence.amountCents >= 0) {
+        inflowCents += occurrence.amountCents;
+      } else {
+        outflowCents += -occurrence.amountCents;
+      }
+    }
+
+    const netChangeCents = inflowCents - outflowCents;
+    runningBalance += netChangeCents;
+    totalInflowCents += inflowCents;
+    totalOutflowCents += outflowCents;
+
+    if (runningBalance < minBalanceCents) {
+      minBalanceCents = runningBalance;
+      minBalanceDate = date;
+    }
+
+    if (shortfallDate === null && runningBalance < 0) {
+      shortfallDate = date;
+    }
+
+    timeline.push({
+      date,
+      inflowCents,
+      outflowCents,
+      netChangeCents,
+      balanceCents: runningBalance,
+      events: dayEvents,
+    });
+  }
+
+  return {
+    startingCashCents,
+    horizonWeeks,
+    startDate,
+    endDate,
+    timeline,
+    shortfallDate,
+    status: shortfallDate === null ? 'healthy' : 'shortfall',
+    runwayDays: shortfallDate === null ? null : Math.max(0, daysBetween(startDate, shortfallDate)),
+    minBalanceCents,
+    minBalanceDate,
+    totalInflowCents,
+    totalOutflowCents,
+    totalNetCents: totalInflowCents - totalOutflowCents,
+    endingBalanceCents: runningBalance,
+  };
+}

--- a/apps/web/src/pages/CashRunwayPage.css
+++ b/apps/web/src/pages/CashRunwayPage.css
@@ -1,0 +1,294 @@
+.cash-runway {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.cash-runway__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.cash-runway__eyebrow {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.cash-runway__title {
+  font-size: var(--type-scale-display-font-size);
+  font-weight: var(--type-scale-display-font-weight);
+  margin: 0;
+}
+
+.cash-runway__description {
+  color: var(--semantic-text-secondary);
+  margin: 0;
+  max-width: 72ch;
+}
+
+.cash-runway__card {
+  background: var(--semantic-surface-primary, var(--card-background));
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-4);
+}
+
+.cash-runway__card-title {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  margin: 0 0 var(--spacing-3);
+}
+
+.cash-runway__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  max-width: 260px;
+}
+
+.cash-runway__label {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+}
+
+.cash-runway__input {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-md);
+  font: inherit;
+  padding: var(--spacing-2) var(--spacing-3);
+}
+
+/* ── Status banner ────────────────────────────────────────────────────── */
+
+.cash-runway__status {
+  border: 1px solid var(--semantic-border-default);
+  border-left-width: 4px;
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  padding: var(--spacing-4);
+}
+
+.cash-runway__status--healthy {
+  border-left-color: var(--semantic-success-text, #047857);
+}
+
+.cash-runway__status--shortfall {
+  border-left-color: var(--semantic-danger-text, #b91c1c);
+}
+
+.cash-runway__status-heading {
+  align-items: center;
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+.cash-runway__status-icon {
+  flex-shrink: 0;
+}
+
+.cash-runway__status--healthy .cash-runway__status-icon {
+  color: var(--semantic-success-text, #047857);
+}
+
+.cash-runway__status--shortfall .cash-runway__status-icon {
+  color: var(--semantic-danger-text, #b91c1c);
+}
+
+.cash-runway__status-title {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: 700;
+  margin: 0;
+}
+
+.cash-runway__status-detail {
+  color: var(--semantic-text-secondary);
+  margin: 0;
+}
+
+/* ── Summary metrics ──────────────────────────────────────────────────── */
+
+.cash-runway__summary-grid {
+  display: grid;
+  gap: var(--spacing-3);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin: 0;
+}
+
+.cash-runway__metric {
+  border: 1px solid var(--semantic-border-muted, var(--semantic-border-default));
+  border-radius: var(--radius-md);
+  padding: var(--spacing-3);
+}
+
+.cash-runway__metric-label {
+  color: var(--semantic-text-secondary);
+  display: block;
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.cash-runway__metric-value {
+  display: block;
+  font-size: var(--type-scale-title-font-size);
+  font-weight: 700;
+  margin: var(--spacing-1) 0 0;
+}
+
+.cash-runway__metric-value--positive {
+  color: var(--semantic-success-text, #047857);
+}
+
+.cash-runway__metric-value--negative {
+  color: var(--semantic-danger-text, #b91c1c);
+}
+
+.cash-runway__metric-sub {
+  color: var(--semantic-text-secondary);
+  display: block;
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 400;
+}
+
+/* ── Timeline ─────────────────────────────────────────────────────────── */
+
+.cash-runway__timeline-intro {
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-3);
+}
+
+.cash-runway__timeline {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cash-runway__day {
+  border: 1px solid var(--semantic-border-muted, var(--semantic-border-default));
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+}
+
+.cash-runway__day-head {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  justify-content: space-between;
+}
+
+.cash-runway__day-date {
+  font-weight: 600;
+}
+
+.cash-runway__day-balance {
+  align-items: center;
+  display: inline-flex;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  gap: var(--spacing-1);
+}
+
+.cash-runway__day-balance--negative {
+  color: var(--semantic-danger-text, #b91c1c);
+}
+
+.cash-runway__day-balance-icon {
+  flex-shrink: 0;
+}
+
+.cash-runway__bar-track {
+  background: var(--semantic-surface-secondary, #f3f4f6);
+  border-radius: var(--radius-sm, 4px);
+  height: 8px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.cash-runway__bar {
+  background: var(--semantic-success-text, #047857);
+  border-radius: inherit;
+  height: 100%;
+  min-width: 2px;
+}
+
+.cash-runway__bar--negative {
+  background: var(--semantic-danger-text, #b91c1c);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .cash-runway__bar-track:not(.cash-runway__bar-track--static) .cash-runway__bar {
+    transition: width 240ms ease-out;
+  }
+}
+
+.cash-runway__events {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cash-runway__event {
+  align-items: baseline;
+  display: flex;
+  gap: var(--spacing-3);
+  justify-content: space-between;
+}
+
+.cash-runway__event-label {
+  display: flex;
+  flex-direction: column;
+}
+
+.cash-runway__event-category {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.cash-runway__event-amount {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.cash-runway__event-amount--inflow {
+  color: var(--semantic-success-text, #047857);
+}
+
+.cash-runway__event-amount--outflow {
+  color: var(--semantic-danger-text, #b91c1c);
+}
+
+.cash-runway__empty {
+  color: var(--semantic-text-secondary);
+  margin: 0;
+}
+
+.cash-runway__sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/apps/web/src/pages/CashRunwayPage.tsx
+++ b/apps/web/src/pages/CashRunwayPage.tsx
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * CashRunwayPage — forward-looking cash runway forecast for small businesses.
+ *
+ * Combines current cash balances, upcoming bills (payroll, taxes, recurring
+ * truck / business bills) and expected invoice payments into a day-by-day
+ * projection of the running cash balance. Surfaces:
+ *   - the runway date (when cash would go negative) and overall status,
+ *   - the minimum projected balance and the date it is reached,
+ *   - a timeline of projected balances with the events that drive them.
+ *
+ * Answers: "Can I cover payroll / taxes / bills before revenue lands?"
+ *
+ * All money is handled in integer cents via the pure engine in
+ * `lib/cashflow/cash-runway`. Data is read exclusively through hooks.
+ *
+ * References: issue #2185
+ */
+
+import { useMemo, useState } from 'react';
+
+import { EmptyState, Icon } from '../components/common';
+import { IconToken } from '../icons/tokens';
+import { useAccounts } from '../hooks/useAccounts';
+import { useBills } from '../hooks/useBills';
+import { useInvoices } from '../hooks/useInvoices';
+import { useReducedMotion } from '../hooks/useReducedMotion';
+import { formatCurrency } from '../lib/currency';
+import {
+  forecastCashRunway,
+  todayIsoDate,
+  type RecurrenceFrequency,
+  type ScheduledCashEvent,
+} from '../lib/cashflow/cash-runway';
+import type { Account, BillFrequency } from '../kmp/bridge';
+
+import './CashRunwayPage.css';
+
+const CASH_ACCOUNT_TYPES: ReadonlySet<Account['type']> = new Set(['CHECKING', 'SAVINGS', 'CASH']);
+
+const HORIZON_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 4, label: '4 weeks' },
+  { value: 8, label: '8 weeks' },
+  { value: 12, label: '12 weeks' },
+  { value: 26, label: '26 weeks' },
+];
+
+const BILL_FREQUENCY_TO_RECURRENCE: Record<BillFrequency, RecurrenceFrequency> = {
+  ONE_TIME: 'once',
+  WEEKLY: 'weekly',
+  BIWEEKLY: 'biweekly',
+  MONTHLY: 'monthly',
+  QUARTERLY: 'quarterly',
+  YEARLY: 'yearly',
+};
+
+/** Format a `YYYY-MM-DD` date for display, e.g. "Jan 15, 2025". */
+function formatDate(isoDate: string): string {
+  const parsed = new Date(`${isoDate}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) {
+    return isoDate;
+  }
+  return parsed.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+/** Clamp a past date forward to today so overdue items count as imminent. */
+function notBefore(isoDate: string, today: string): string {
+  return isoDate < today ? today : isoDate;
+}
+
+export function CashRunwayPage() {
+  const [horizonWeeks, setHorizonWeeks] = useState(12);
+
+  const today = useMemo(() => todayIsoDate(), []);
+  const reducedMotion = useReducedMotion();
+
+  const { accounts, loading: accountsLoading } = useAccounts();
+  const { bills } = useBills();
+  const { invoices } = useInvoices();
+
+  const startingCashCents = useMemo(
+    () =>
+      accounts
+        .filter((account) => !account.isArchived && CASH_ACCOUNT_TYPES.has(account.type))
+        .reduce((sum, account) => sum + account.currentBalance.amount, 0),
+    [accounts],
+  );
+
+  const events = useMemo<ScheduledCashEvent[]>(() => {
+    const billEvents = bills
+      .filter((bill) => bill.status === 'UPCOMING' || bill.status === 'OVERDUE')
+      .map<ScheduledCashEvent>((bill) => ({
+        id: `bill:${bill.id}`,
+        label: bill.name || bill.payee,
+        direction: 'outflow',
+        amountCents: Math.abs(bill.amount.amount),
+        date: notBefore(bill.dueDate, today),
+        frequency: BILL_FREQUENCY_TO_RECURRENCE[bill.frequency],
+        category: 'Bill',
+      }));
+
+    const invoiceEvents = invoices
+      .filter((invoice) => invoice.status === 'Sent' || invoice.status === 'Overdue')
+      .map<ScheduledCashEvent>((invoice) => ({
+        id: `invoice:${invoice.id}`,
+        label: invoice.clientName,
+        direction: 'inflow',
+        amountCents: Math.abs(invoice.amountCents),
+        date: notBefore(invoice.expectedPayDate, today),
+        frequency: 'once',
+        category: 'Expected payment',
+      }));
+
+    return [...billEvents, ...invoiceEvents];
+  }, [bills, invoices, today]);
+
+  const forecast = useMemo(
+    () => forecastCashRunway({ startingCashCents, events, horizonWeeks, today }),
+    [events, horizonWeeks, startingCashCents, today],
+  );
+
+  const hasInputs = events.length > 0 || startingCashCents !== 0;
+
+  const scaleCents = useMemo(() => {
+    const magnitudes = forecast.timeline.map((point) => Math.abs(point.balanceCents));
+    return Math.max(Math.abs(forecast.startingCashCents), ...magnitudes, 1);
+  }, [forecast]);
+
+  const isShortfall = forecast.status === 'shortfall';
+  const statusIcon = isShortfall ? IconToken.WARNING : IconToken.SUCCESS;
+  const statusHeadline = isShortfall
+    ? `Projected cash shortfall on ${formatDate(forecast.shortfallDate ?? forecast.startDate)}`
+    : `Cash stays positive through ${formatDate(forecast.endDate)}`;
+  const statusDetail = isShortfall
+    ? forecast.runwayDays === 0
+      ? 'Your cash is already below zero. Bring in revenue or defer outflows now.'
+      : `You have about ${forecast.runwayDays} day${
+          forecast.runwayDays === 1 ? '' : 's'
+        } of runway before scheduled outflows exceed available cash.`
+    : 'Scheduled outflows stay covered by your starting cash and expected inflows over the selected horizon.';
+
+  return (
+    <main className="cash-runway" aria-labelledby="cash-runway-title">
+      <header className="cash-runway__header">
+        <p className="cash-runway__eyebrow">Small business cash flow</p>
+        <h1 id="cash-runway-title" className="cash-runway__title">
+          Cash Runway
+        </h1>
+        <p className="cash-runway__description">
+          Project your running cash balance forward to see whether you can cover payroll, taxes and
+          recurring bills before revenue lands. Figures are planning estimates in your account
+          currency.
+        </p>
+      </header>
+
+      <section className="cash-runway__card" aria-labelledby="cash-runway-controls-title">
+        <h2 id="cash-runway-controls-title" className="cash-runway__card-title">
+          Forecast horizon
+        </h2>
+        <div className="cash-runway__field">
+          <label className="cash-runway__label" htmlFor="cash-runway-horizon">
+            Project ahead
+          </label>
+          <select
+            id="cash-runway-horizon"
+            className="cash-runway__input"
+            value={horizonWeeks}
+            onChange={(changeEvent) => setHorizonWeeks(Number(changeEvent.target.value))}
+          >
+            {HORIZON_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </section>
+
+      {hasInputs ? (
+        <>
+          <section
+            className={`cash-runway__status cash-runway__status--${forecast.status}`}
+            aria-labelledby="cash-runway-status-title"
+          >
+            <div className="cash-runway__status-heading">
+              <Icon name={statusIcon} className="cash-runway__status-icon" />
+              <h2 id="cash-runway-status-title" className="cash-runway__status-title">
+                {statusHeadline}
+              </h2>
+            </div>
+            <p className="cash-runway__status-detail">{statusDetail}</p>
+          </section>
+
+          <section className="cash-runway__card" aria-labelledby="cash-runway-summary-title">
+            <h2 id="cash-runway-summary-title" className="cash-runway__card-title">
+              Summary
+            </h2>
+            <dl className="cash-runway__summary-grid">
+              <div className="cash-runway__metric">
+                <dt className="cash-runway__metric-label">Starting cash</dt>
+                <dd className="cash-runway__metric-value">
+                  {formatCurrency(forecast.startingCashCents)}
+                </dd>
+              </div>
+              <div className="cash-runway__metric">
+                <dt className="cash-runway__metric-label">Runway</dt>
+                <dd className="cash-runway__metric-value">
+                  {isShortfall
+                    ? formatDate(forecast.shortfallDate ?? forecast.startDate)
+                    : 'No shortfall'}
+                </dd>
+              </div>
+              <div className="cash-runway__metric">
+                <dt className="cash-runway__metric-label">Minimum balance</dt>
+                <dd
+                  className={`cash-runway__metric-value${
+                    forecast.minBalanceCents < 0 ? ' cash-runway__metric-value--negative' : ''
+                  }`}
+                >
+                  {formatCurrency(forecast.minBalanceCents)}
+                  <span className="cash-runway__metric-sub">
+                    on {formatDate(forecast.minBalanceDate)}
+                  </span>
+                </dd>
+              </div>
+              <div className="cash-runway__metric">
+                <dt className="cash-runway__metric-label">Expected inflows</dt>
+                <dd className="cash-runway__metric-value cash-runway__metric-value--positive">
+                  {formatCurrency(forecast.totalInflowCents)}
+                </dd>
+              </div>
+              <div className="cash-runway__metric">
+                <dt className="cash-runway__metric-label">Scheduled outflows</dt>
+                <dd className="cash-runway__metric-value cash-runway__metric-value--negative">
+                  {formatCurrency(forecast.totalOutflowCents)}
+                </dd>
+              </div>
+              <div className="cash-runway__metric">
+                <dt className="cash-runway__metric-label">Projected ending cash</dt>
+                <dd
+                  className={`cash-runway__metric-value${
+                    forecast.endingBalanceCents < 0 ? ' cash-runway__metric-value--negative' : ''
+                  }`}
+                >
+                  {formatCurrency(forecast.endingBalanceCents)}
+                </dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="cash-runway__card" aria-labelledby="cash-runway-timeline-title">
+            <h2 id="cash-runway-timeline-title" className="cash-runway__card-title">
+              Projected balance timeline
+            </h2>
+            <p className="cash-runway__timeline-intro">
+              Starting cash of {formatCurrency(forecast.startingCashCents)} on{' '}
+              {formatDate(forecast.startDate)}
+              {forecast.timeline.length === 0
+                ? ' with no scheduled events in this horizon.'
+                : ', then each day with a scheduled inflow or outflow:'}
+            </p>
+
+            {forecast.timeline.length > 0 ? (
+              <ol className="cash-runway__timeline">
+                {forecast.timeline.map((point) => {
+                  const widthPercent = Math.max(
+                    2,
+                    Math.round((Math.abs(point.balanceCents) / scaleCents) * 100),
+                  );
+                  const negative = point.balanceCents < 0;
+                  return (
+                    <li key={point.date} className="cash-runway__day">
+                      <div className="cash-runway__day-head">
+                        <span className="cash-runway__day-date">{formatDate(point.date)}</span>
+                        <span
+                          className={`cash-runway__day-balance${
+                            negative ? ' cash-runway__day-balance--negative' : ''
+                          }`}
+                        >
+                          {negative ? (
+                            <Icon
+                              name={IconToken.WARNING}
+                              size={16}
+                              className="cash-runway__day-balance-icon"
+                            />
+                          ) : null}
+                          {formatCurrency(point.balanceCents)}
+                          {negative ? (
+                            <span className="cash-runway__sr-only"> (shortfall)</span>
+                          ) : null}
+                        </span>
+                      </div>
+                      <div
+                        className={`cash-runway__bar-track${
+                          reducedMotion ? ' cash-runway__bar-track--static' : ''
+                        }`}
+                        aria-hidden="true"
+                      >
+                        <div
+                          className={`cash-runway__bar${
+                            negative ? ' cash-runway__bar--negative' : ''
+                          }`}
+                          style={{ width: `${widthPercent}%` }}
+                        />
+                      </div>
+                      <ul className="cash-runway__events">
+                        {point.events.map((occurrence) => (
+                          <li key={occurrence.id} className="cash-runway__event">
+                            <span className="cash-runway__event-label">
+                              {occurrence.label}
+                              {occurrence.category ? (
+                                <span className="cash-runway__event-category">
+                                  {occurrence.category}
+                                </span>
+                              ) : null}
+                            </span>
+                            <span
+                              className={`cash-runway__event-amount cash-runway__event-amount--${occurrence.direction}`}
+                            >
+                              {formatCurrency(occurrence.amountCents, {
+                                signDisplay: 'exceptZero',
+                              })}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </li>
+                  );
+                })}
+              </ol>
+            ) : (
+              <p className="cash-runway__empty">
+                No scheduled bills or expected payments fall within the next {horizonWeeks} weeks.
+              </p>
+            )}
+          </section>
+        </>
+      ) : (
+        <EmptyState
+          title={accountsLoading ? 'Loading your cash position…' : 'No cash data yet'}
+          description="Add a checking, savings or cash account and schedule bills or expected invoice payments to project your cash runway."
+        />
+      )}
+    </main>
+  );
+}
+
+export default CashRunwayPage;

--- a/apps/web/src/pages/index.ts
+++ b/apps/web/src/pages/index.ts
@@ -32,6 +32,7 @@ export { GigDriverPage } from './GigDriverPage';
 export { PlanningPage } from './PlanningPage';
 export { HouseholdPage } from './HouseholdPage';
 export { CashFlowPage } from './CashFlowPage';
+export { CashRunwayPage } from './CashRunwayPage';
 export { InvoicesPage } from './InvoicesPage';
 export { NetWorthPage } from './NetWorthPage';
 export { SubscriptionsPage } from './SubscriptionsPage';

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -68,6 +68,7 @@ const EstateInventory = lazy(() => import('./pages/EstateInventoryPage'));
 const PrivacyDashboard = lazy(() => import('./pages/PrivacyDashboardPage'));
 const Onboarding = lazy(() => import('./pages/OnboardingPage'));
 const CashFlow = lazy(() => import('./pages/CashFlowPage'));
+const CashRunway = lazy(() => import('./pages/CashRunwayPage'));
 const Invoices = lazy(() => import('./pages/InvoicesPage'));
 const NetWorth = lazy(() => import('./pages/NetWorthPage'));
 const Subscriptions = lazy(() => import('./pages/SubscriptionsPage'));
@@ -642,6 +643,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Cash Flow">
             <CashFlow />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/cash-runway"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Cash Runway">
+            <CashRunway />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Summary

Adds a forward-looking **cash runway** forecast for small-business owners: given current cash plus known upcoming outflows (payroll, taxes, recurring truck/business bills) and expected inflows, it projects the running cash balance day-by-day over a configurable horizon and surfaces when cash would go negative.

Answers: *"Can I cover payroll / taxes / bills before revenue lands?"*

## What's included

- **Pure forecasting engine**  + "pps/web/src/lib/cashflow/cash-runway.ts" +  ? deterministic, side-effect-free, **all money in integer cents**:
  - expands recurring events into anchored occurrences within the horizon (drift-free; monthly clamps to month end),
  - nets same-day events into a single timeline point,
  - returns the ordered projected-balance timeline, first negative-balance date ("runway"), minimum balance + its date, and projected inflow/outflow/net totals.
- **Accessible page**  + "pps/web/src/pages/CashRunwayPage.tsx" +  (route  + "/cash-runway" + , Insights nav) ? summary metrics, a text+icon status banner (status not conveyed by color alone), and a projected-balance timeline list with per-day events. Semantic  + "<dl>/<ol>" + , labelled controls, keyboard-operable, respects  + "prefers-reduced-motion" + . No chart library added (lightweight CSS bars) to stay well under the per-chunk perf budget.
- **Vitest unit tests** for the engine (shortfall detection, no-shortfall, recurring expansion, same-day netting, min-balance, horizon bounds, ordering) ? 15 passing.

## Notes

- Data is read exclusively through hooks ( + "useAccounts, useBills, useInvoices" + ); no direct repository imports in components.
- Native UI and KMP shared models remain out of scope for this web slice.

Refs #2185
