### PR TITLE
feat(web): savings rate as first-class dashboard metric (#2162)

### DIFF
--- a/apps/web/src/components/dashboard/SavingsRateCard.tsx
+++ b/apps/web/src/components/dashboard/SavingsRateCard.tsx
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useMemo } from 'react';
+
+import { CurrencyDisplay } from '../common';
+import type { Transaction } from '../../kmp/bridge';
+import {
+  buildSavingsRateCardModel,
+  buildSavingsRateDashboardSummary,
+  type MonthlyCashFlow,
+  type SavingsRateCardModel,
+} from '../../lib/dashboard/savings-rate-summary';
+
+export interface SavingsRateCardProps {
+  /** Current month key (`YYYY-MM`). */
+  readonly currentMonthKey: string;
+  /** Previous month key (`YYYY-MM`) used for the period-over-period trend. */
+  readonly previousMonthKey: string;
+  /** Current-month transactions (already purpose-filtered). */
+  readonly currentMonthTransactions: readonly Transaction[];
+  /** Previous-month transactions (already purpose-filtered). */
+  readonly previousMonthTransactions: readonly Transaction[];
+  /** ISO 4217 currency code for the dollars-saved figure. */
+  readonly currency?: string;
+}
+
+/** Sum income and expense (integer cents) for the savings-rate calculation. */
+function toMonthlyCashFlow(month: string, transactions: readonly Transaction[]): MonthlyCashFlow {
+  let incomeCents = 0;
+  let expenseCents = 0;
+  for (const transaction of transactions) {
+    if (transaction.type === 'INCOME') {
+      incomeCents += Math.max(0, transaction.amount.amount);
+    } else if (transaction.type === 'EXPENSE') {
+      expenseCents += Math.abs(transaction.amount.amount);
+    }
+  }
+
+  return { month, incomeCents, expenseCents };
+}
+
+/** Format a savings-rate percentage compactly (e.g. `50%`, `37.5%`, `-20%`). */
+function formatSavingsRatePercent(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}%`;
+}
+
+/** Plain-language period-over-period trend description (text, not colour alone). */
+function describeSavingsRateTrend(
+  trend: SavingsRateCardModel['trend'],
+  deltaPercentagePoints: number | null,
+): string {
+  if (deltaPercentagePoints === null) {
+    return 'No prior month to compare yet';
+  }
+  if (trend === 'flat') {
+    return 'Flat vs last month';
+  }
+  const magnitude = Math.round(Math.abs(deltaPercentagePoints) * 10) / 10;
+  const points = Number.isInteger(magnitude) ? magnitude.toFixed(0) : magnitude.toFixed(1);
+  return `${trend === 'up' ? 'Up' : 'Down'} ${points} pts vs last month`;
+}
+
+const SAVINGS_RATE_TREND_ICON: Record<SavingsRateCardModel['trend'], string> = {
+  up: '▲',
+  down: '▼',
+  flat: '→',
+};
+
+/**
+ * Prominent, accessible Savings Rate summary card for the dashboard.
+ *
+ * Savings rate = (income − expenses) / income for the current month, compared
+ * with the prior calendar month. Reuses the integer-cents savings-rate math in
+ * `lib/dashboard/savings-rate-summary` (safe against divide-by-zero). Trend and
+ * status are conveyed with text + a shape icon, never colour alone.
+ */
+export const SavingsRateCard: React.FC<SavingsRateCardProps> = ({
+  currentMonthKey,
+  previousMonthKey,
+  currentMonthTransactions,
+  previousMonthTransactions,
+  currency = 'USD',
+}) => {
+  const model = useMemo(() => {
+    const cashFlows: MonthlyCashFlow[] = [
+      toMonthlyCashFlow(previousMonthKey, previousMonthTransactions),
+      toMonthlyCashFlow(currentMonthKey, currentMonthTransactions),
+    ];
+
+    return buildSavingsRateCardModel(buildSavingsRateDashboardSummary(cashFlows, currentMonthKey));
+  }, [currentMonthKey, previousMonthKey, currentMonthTransactions, previousMonthTransactions]);
+
+  return (
+    <article
+      className={`card savings-rate-card savings-rate-card--${model.tone}`}
+      aria-label="Savings rate this month"
+    >
+      <div className="card__header">
+        <h3 className="card__title">Savings Rate</h3>
+      </div>
+      <div className="card__value" aria-live="polite">
+        {model.hasIncome ? (
+          <span
+            aria-label={`${formatSavingsRatePercent(model.savingsRatePercent)} savings rate this month`}
+          >
+            {formatSavingsRatePercent(model.savingsRatePercent)}
+          </span>
+        ) : (
+          <span aria-label="Savings rate not available — no income recorded this month">N/A</span>
+        )}
+      </div>
+      <p className="list-item__secondary">
+        {model.hasIncome ? (
+          <>
+            <CurrencyDisplay
+              amount={model.savingsCents}
+              currency={currency}
+              colorize
+              showSign
+              context="saved this month"
+            />{' '}
+            saved this month
+          </>
+        ) : (
+          'Add income this month to calculate your savings rate.'
+        )}
+      </p>
+      {model.hasIncome ? (
+        <p className="savings-rate-card__trend">
+          <span className="savings-rate-card__trend-icon" aria-hidden="true">
+            {SAVINGS_RATE_TREND_ICON[model.trend]}
+          </span>
+          {describeSavingsRateTrend(model.trend, model.deltaPercentagePoints)}
+        </p>
+      ) : null}
+      <p className="savings-rate-card__status">{model.statusLabel}</p>
+    </article>
+  );
+};
+
+export default SavingsRateCard;

--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -635,3 +635,60 @@
     border-width: 2px;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Savings rate summary card (first-class dashboard metric, #2162)
+ * ------------------------------------------------------------------------- */
+
+.savings-rate-card {
+  gap: var(--spacing-2);
+  border-color: color-mix(
+    in srgb,
+    var(--semantic-interactive-default) 24%,
+    var(--semantic-border-default)
+  );
+}
+
+.savings-rate-card--positive {
+  border-color: color-mix(
+    in srgb,
+    var(--semantic-status-success, var(--semantic-interactive-default)) 30%,
+    var(--semantic-border-default)
+  );
+}
+
+.savings-rate-card--caution {
+  border-color: color-mix(
+    in srgb,
+    var(--semantic-status-warning) 36%,
+    var(--semantic-border-default)
+  );
+}
+
+.savings-rate-card__trend {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+}
+
+.savings-rate-card__trend-icon {
+  font-size: 0.85em;
+  line-height: 1;
+}
+
+.savings-rate-card__status {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  line-height: var(--type-scale-body-line-height);
+}
+
+@media (prefers-contrast: more) {
+  .savings-rate-card {
+    border-width: 2px;
+  }
+}

--- a/apps/web/src/lib/dashboard/savings-rate-summary.test.ts
+++ b/apps/web/src/lib/dashboard/savings-rate-summary.test.ts
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { describe, expect, it } from 'vitest';
-import { buildSavingsRateDashboardSummary } from './savings-rate-summary';
+import {
+  buildSavingsRateCardModel,
+  buildSavingsRateDashboardSummary,
+} from './savings-rate-summary';
 
 describe('savings rate dashboard summary', () => {
   it('returns current, prior, and trailing three month savings rates', () => {
@@ -18,5 +21,118 @@ describe('savings rate dashboard summary', () => {
     expect(summary.prior?.savingsCents).toBe(1000_00);
     expect(summary.trailingThreeMonth?.incomeCents).toBe(16000_00);
     expect(summary.trailingThreeMonth?.savingsRatePercent).toBe(37.5);
+  });
+});
+
+describe('buildSavingsRateCardModel', () => {
+  const cardModel = (
+    rows: readonly { month: string; incomeCents: number; expenseCents: number }[],
+    currentMonth: string,
+  ) => buildSavingsRateCardModel(buildSavingsRateDashboardSummary(rows, currentMonth));
+
+  it('reports a positive savings rate with dollars saved', () => {
+    const model = cardModel(
+      [{ month: '2026-03', incomeCents: 6000_00, expenseCents: 3000_00 }],
+      '2026-03',
+    );
+
+    expect(model.hasIncome).toBe(true);
+    expect(model.savingsRatePercent).toBe(50);
+    expect(model.savingsCents).toBe(3000_00);
+    expect(model.tone).toBe('positive');
+    expect(model.statusLabel).toContain('Strong');
+  });
+
+  it('returns N/A semantics (hasIncome false) when income is zero', () => {
+    const model = cardModel(
+      [{ month: '2026-03', incomeCents: 0, expenseCents: 1200_00 }],
+      '2026-03',
+    );
+
+    expect(model.hasIncome).toBe(false);
+    // Never NaN/Infinity — guarded to 0.
+    expect(model.savingsRatePercent).toBe(0);
+    expect(Number.isFinite(model.savingsRatePercent)).toBe(true);
+    expect(model.deltaPercentagePoints).toBeNull();
+    expect(model.trend).toBe('flat');
+    expect(model.tone).toBe('neutral');
+    expect(model.statusLabel).toContain('Add income');
+  });
+
+  it('reports a negative savings rate when overspending', () => {
+    const model = cardModel(
+      [{ month: '2026-03', incomeCents: 1000_00, expenseCents: 1200_00 }],
+      '2026-03',
+    );
+
+    expect(model.savingsRatePercent).toBe(-20);
+    expect(model.savingsCents).toBe(-200_00);
+    expect(model.tone).toBe('caution');
+    expect(model.statusLabel).toContain('Spending more than you earn');
+  });
+
+  it('computes an upward delta versus the prior period', () => {
+    const model = cardModel(
+      [
+        { month: '2026-02', incomeCents: 5000_00, expenseCents: 4000_00 }, // 20%
+        { month: '2026-03', incomeCents: 5000_00, expenseCents: 2500_00 }, // 50%
+      ],
+      '2026-03',
+    );
+
+    expect(model.priorSavingsRatePercent).toBe(20);
+    expect(model.deltaPercentagePoints).toBe(30);
+    expect(model.trend).toBe('up');
+  });
+
+  it('computes a downward delta versus the prior period', () => {
+    const model = cardModel(
+      [
+        { month: '2026-02', incomeCents: 5000_00, expenseCents: 2500_00 }, // 50%
+        { month: '2026-03', incomeCents: 5000_00, expenseCents: 4000_00 }, // 20%
+      ],
+      '2026-03',
+    );
+
+    expect(model.deltaPercentagePoints).toBe(-30);
+    expect(model.trend).toBe('down');
+  });
+
+  it('treats an unchanged savings rate as a flat trend', () => {
+    const model = cardModel(
+      [
+        { month: '2026-02', incomeCents: 5000_00, expenseCents: 4000_00 }, // 20%
+        { month: '2026-03', incomeCents: 6000_00, expenseCents: 4800_00 }, // 20%
+      ],
+      '2026-03',
+    );
+
+    expect(model.deltaPercentagePoints).toBe(0);
+    expect(model.trend).toBe('flat');
+  });
+
+  it('omits the delta when there is no comparable prior period', () => {
+    const model = cardModel(
+      [{ month: '2026-03', incomeCents: 5000_00, expenseCents: 4000_00 }],
+      '2026-03',
+    );
+
+    expect(model.priorSavingsRatePercent).toBeNull();
+    expect(model.deltaPercentagePoints).toBeNull();
+    expect(model.trend).toBe('flat');
+  });
+
+  it('ignores a prior period that has no income', () => {
+    const model = cardModel(
+      [
+        { month: '2026-02', incomeCents: 0, expenseCents: 1000_00 },
+        { month: '2026-03', incomeCents: 5000_00, expenseCents: 4000_00 },
+      ],
+      '2026-03',
+    );
+
+    expect(model.priorSavingsRatePercent).toBeNull();
+    expect(model.deltaPercentagePoints).toBeNull();
+    expect(model.trend).toBe('flat');
   });
 });

--- a/apps/web/src/lib/dashboard/savings-rate-summary.ts
+++ b/apps/web/src/lib/dashboard/savings-rate-summary.ts
@@ -54,3 +54,118 @@ export function buildSavingsRateDashboardSummary(
         : summarize(`${trailingRows[0].month}..${currentMonth}`, trailingRows),
   };
 }
+
+// ---------------------------------------------------------------------------
+// Dashboard card presentation model
+// ---------------------------------------------------------------------------
+
+/** Direction of the period-over-period savings-rate change. */
+export type SavingsRateTrend = 'up' | 'down' | 'flat';
+
+/** Semantic tone used to colour/label the card without relying on colour alone. */
+export type SavingsRateTone = 'positive' | 'neutral' | 'caution';
+
+/**
+ * Presentation-ready model for the dashboard Savings Rate card.
+ *
+ * All monetary fields are integer cents. The savings rate is a percentage
+ * (e.g. `37.5` means 37.5%) and is `0` when there is no income, with
+ * `hasIncome` distinguishing the genuine-zero case (income equals spend) from
+ * the no-income case (rate is not meaningful → display "N/A").
+ */
+export interface SavingsRateCardModel {
+  /** Whether the current period has any income (false → show "N/A"). */
+  readonly hasIncome: boolean;
+  /** Current-period savings rate as a percentage (0 when no income). */
+  readonly savingsRatePercent: number;
+  /** Dollars saved this period in cents (income − spend; negative if overspent). */
+  readonly savingsCents: number;
+  /** Total income this period in cents. */
+  readonly incomeCents: number;
+  /** Total spend this period in cents. */
+  readonly expenseCents: number;
+  /** Prior-period savings rate, or null when there is no comparable prior period. */
+  readonly priorSavingsRatePercent: number | null;
+  /** Change in savings rate vs the prior period, in percentage points (null when no prior). */
+  readonly deltaPercentagePoints: number | null;
+  /** Direction of the period-over-period change. */
+  readonly trend: SavingsRateTrend;
+  /** Semantic tone for styling and the screen-reader status. */
+  readonly tone: SavingsRateTone;
+  /** Short plain-language status describing the current savings rate. */
+  readonly statusLabel: string;
+}
+
+function classifySavingsRate(
+  hasIncome: boolean,
+  savingsRatePercent: number,
+): { tone: SavingsRateTone; statusLabel: string } {
+  if (!hasIncome) {
+    return { tone: 'neutral', statusLabel: 'Add income to see your savings rate' };
+  }
+  if (savingsRatePercent < 0) {
+    return { tone: 'caution', statusLabel: 'Spending more than you earn this period' };
+  }
+  if (savingsRatePercent < 10) {
+    return { tone: 'neutral', statusLabel: 'Saving a little — aim for 20%' };
+  }
+  if (savingsRatePercent < 20) {
+    return { tone: 'positive', statusLabel: 'Solid progress toward a 20% goal' };
+  }
+  return { tone: 'positive', statusLabel: 'Strong — at or above the 20% target' };
+}
+
+/**
+ * Derive the dashboard Savings Rate card model from a savings-rate summary.
+ *
+ * Reuses the integer-cents savings-rate math from
+ * {@link buildSavingsRateDashboardSummary} and adds the period-over-period
+ * delta, trend direction, and a plain-language status. Division by zero is
+ * already guarded upstream (income 0 → rate 0); this helper additionally
+ * surfaces `hasIncome` so callers can render "N/A" instead of a misleading 0%.
+ *
+ * @param summary - Output of {@link buildSavingsRateDashboardSummary}.
+ * @returns A presentation-ready, side-effect-free card model.
+ */
+export function buildSavingsRateCardModel(
+  summary: SavingsRateDashboardSummary,
+): SavingsRateCardModel {
+  const current = summary.current;
+  const prior = summary.prior;
+
+  const incomeCents = current?.incomeCents ?? 0;
+  const expenseCents = current?.expenseCents ?? 0;
+  const savingsCents = current?.savingsCents ?? 0;
+  const savingsRatePercent = current?.savingsRatePercent ?? 0;
+  const hasIncome = incomeCents > 0;
+
+  const priorSavingsRatePercent =
+    prior !== null && prior.incomeCents > 0 ? prior.savingsRatePercent : null;
+
+  const deltaPercentagePoints =
+    !hasIncome || priorSavingsRatePercent === null
+      ? null
+      : Math.round((savingsRatePercent - priorSavingsRatePercent) * 100) / 100;
+
+  const trend: SavingsRateTrend =
+    deltaPercentagePoints === null || deltaPercentagePoints === 0
+      ? 'flat'
+      : deltaPercentagePoints > 0
+        ? 'up'
+        : 'down';
+
+  const { tone, statusLabel } = classifySavingsRate(hasIncome, savingsRatePercent);
+
+  return {
+    hasIncome,
+    savingsRatePercent,
+    savingsCents,
+    incomeCents,
+    expenseCents,
+    priorSavingsRatePercent,
+    deltaPercentagePoints,
+    trend,
+    tone,
+    statusLabel,
+  };
+}

--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -657,6 +657,21 @@ describe('DashboardPage', () => {
     expect(within(card).getByText('Already spent')).toBeInTheDocument();
   });
 
+  it('renders a prominent savings rate card with percentage, trend, and status', async () => {
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
+
+    const card = await screen.findByLabelText('Savings rate this month');
+    // Income $4,500 vs $67.42 spend → ~98.5% savings rate this month.
+    expect(within(card).getByText('98.5%')).toBeInTheDocument();
+    // Prior month mirrors current month in the mock → flat trend.
+    expect(within(card).getByText('Flat vs last month')).toBeInTheDocument();
+    expect(within(card).getByText('Strong — at or above the 20% target')).toBeInTheDocument();
+  });
+
   it('displays recent transactions section', () => {
     render(
       <MemoryRouter>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -36,12 +36,6 @@ import {
 } from '../lib/accountPurpose';
 import { isLiabilityType } from '../lib/analytics/net-worth';
 import { calculateSafeToSpend } from '../lib/dashboard/safe-to-spend';
-import {
-  buildSavingsRateCardModel,
-  buildSavingsRateDashboardSummary,
-  type MonthlyCashFlow,
-  type SavingsRateCardModel,
-} from '../lib/dashboard/savings-rate-summary';
 import type { SpendingPace } from '../lib/notifications';
 import type { PredictionSummary } from '../lib/predictiveBalance';
 import { rollUpProtectedTransactions } from '../lib/ui/privacy';
@@ -91,6 +85,11 @@ const WarrantyDashboard = React.lazy(() =>
 const SafeToSpendCard = React.lazy(() =>
   import('../components/dashboard/SafeToSpendCard').then((module) => ({
     default: module.SafeToSpendCard,
+  })),
+);
+const SavingsRateCard = React.lazy(() =>
+  import('../components/dashboard/SavingsRateCard').then((module) => ({
+    default: module.SavingsRateCard,
   })),
 );
 const GroceryModeSection = React.lazy(() => import('../components/dashboard/GroceryModeSection'));
@@ -150,49 +149,6 @@ function getPreviousMonthBounds(): { startDate: string; endDate: string } {
     endDate: formatLocalDate(endDate),
   };
 }
-
-/** Sum income and expense (integer cents) for the savings-rate calculation. */
-function toMonthlyCashFlow(month: string, transactions: readonly Transaction[]): MonthlyCashFlow {
-  let incomeCents = 0;
-  let expenseCents = 0;
-  for (const transaction of transactions) {
-    if (transaction.type === 'INCOME') {
-      incomeCents += Math.max(0, transaction.amount.amount);
-    } else if (transaction.type === 'EXPENSE') {
-      expenseCents += Math.abs(transaction.amount.amount);
-    }
-  }
-
-  return { month, incomeCents, expenseCents };
-}
-
-/** Format a savings-rate percentage compactly (e.g. `50%`, `37.5%`, `-20%`). */
-function formatSavingsRatePercent(value: number): string {
-  const rounded = Math.round(value * 10) / 10;
-  return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}%`;
-}
-
-/** Plain-language period-over-period trend description (text, not colour alone). */
-function describeSavingsRateTrend(
-  trend: SavingsRateCardModel['trend'],
-  deltaPercentagePoints: number | null,
-): string {
-  if (deltaPercentagePoints === null) {
-    return 'No prior month to compare yet';
-  }
-  if (trend === 'flat') {
-    return 'Flat vs last month';
-  }
-  const magnitude = Math.round(Math.abs(deltaPercentagePoints) * 10) / 10;
-  const points = Number.isInteger(magnitude) ? magnitude.toFixed(0) : magnitude.toFixed(1);
-  return `${trend === 'up' ? 'Up' : 'Down'} ${points} pts vs last month`;
-}
-
-const SAVINGS_RATE_TREND_ICON: Record<SavingsRateCardModel['trend'], string> = {
-  up: '▲',
-  down: '▼',
-  flat: '→',
-};
 
 function getTransactionDisplayAmount(transaction: Transaction): number {
   if (transaction.type === 'EXPENSE') {
@@ -688,24 +644,6 @@ export const DashboardPage: React.FC = () => {
       ),
     [filteredCurrentMonthTransactions],
   );
-  // Savings rate = (income − expenses) / income for the current month, compared
-  // with the prior calendar month. Reuses the integer-cents savings-rate math
-  // from lib/dashboard/savings-rate-summary (safe against divide-by-zero).
-  const savingsRateCard = useMemo(() => {
-    const currentMonthKey = currentMonthRange.startDate.slice(0, 7);
-    const previousMonthKey = previousMonthRange.startDate.slice(0, 7);
-    const cashFlows: MonthlyCashFlow[] = [
-      toMonthlyCashFlow(previousMonthKey, filteredPreviousMonthTransactions),
-      toMonthlyCashFlow(currentMonthKey, filteredCurrentMonthTransactions),
-    ];
-
-    return buildSavingsRateCardModel(buildSavingsRateDashboardSummary(cashFlows, currentMonthKey));
-  }, [
-    currentMonthRange.startDate,
-    previousMonthRange.startDate,
-    filteredCurrentMonthTransactions,
-    filteredPreviousMonthTransactions,
-  ]);
   const debtSummary = useMemo(
     () =>
       filteredAccounts.reduce(
@@ -896,55 +834,21 @@ export const DashboardPage: React.FC = () => {
               </Suspense>
               <section className="page-section" aria-label="Financial summary">
                 <div className="card-grid card-grid--4">
-                  <article
-                    className={`card savings-rate-card savings-rate-card--${savingsRateCard.tone}`}
-                    aria-label="Savings rate this month"
+                  <Suspense
+                    fallback={
+                      <article className="card" role="status" aria-label="Loading savings rate">
+                        <LoadingSpinner size={24} label="Loading savings rate" />
+                      </article>
+                    }
                   >
-                    <div className="card__header">
-                      <h3 className="card__title">Savings Rate</h3>
-                    </div>
-                    <div className="card__value" aria-live="polite">
-                      {savingsRateCard.hasIncome ? (
-                        <span
-                          aria-label={`${formatSavingsRatePercent(savingsRateCard.savingsRatePercent)} savings rate this month`}
-                        >
-                          {formatSavingsRatePercent(savingsRateCard.savingsRatePercent)}
-                        </span>
-                      ) : (
-                        <span aria-label="Savings rate not available — no income recorded this month">
-                          N/A
-                        </span>
-                      )}
-                    </div>
-                    <p className="list-item__secondary">
-                      {savingsRateCard.hasIncome ? (
-                        <>
-                          <CurrencyDisplay
-                            amount={savingsRateCard.savingsCents}
-                            currency={safeToSpendCurrency}
-                            colorize
-                            showSign
-                            context="saved this month"
-                          />{' '}
-                          saved this month
-                        </>
-                      ) : (
-                        'Add income this month to calculate your savings rate.'
-                      )}
-                    </p>
-                    {savingsRateCard.hasIncome ? (
-                      <p className="savings-rate-card__trend">
-                        <span className="savings-rate-card__trend-icon" aria-hidden="true">
-                          {SAVINGS_RATE_TREND_ICON[savingsRateCard.trend]}
-                        </span>
-                        {describeSavingsRateTrend(
-                          savingsRateCard.trend,
-                          savingsRateCard.deltaPercentagePoints,
-                        )}
-                      </p>
-                    ) : null}
-                    <p className="savings-rate-card__status">{savingsRateCard.statusLabel}</p>
-                  </article>
+                    <SavingsRateCard
+                      currentMonthKey={currentMonthRange.startDate.slice(0, 7)}
+                      previousMonthKey={previousMonthRange.startDate.slice(0, 7)}
+                      currentMonthTransactions={filteredCurrentMonthTransactions}
+                      previousMonthTransactions={filteredPreviousMonthTransactions}
+                      currency={safeToSpendCurrency}
+                    />
+                  </Suspense>
                   {visibleWidgetIds.has('net-worth') ? (
                     <article className="card" aria-label="Net worth">
                       <div className="card__header">

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -36,6 +36,12 @@ import {
 } from '../lib/accountPurpose';
 import { isLiabilityType } from '../lib/analytics/net-worth';
 import { calculateSafeToSpend } from '../lib/dashboard/safe-to-spend';
+import {
+  buildSavingsRateCardModel,
+  buildSavingsRateDashboardSummary,
+  type MonthlyCashFlow,
+  type SavingsRateCardModel,
+} from '../lib/dashboard/savings-rate-summary';
 import type { SpendingPace } from '../lib/notifications';
 import type { PredictionSummary } from '../lib/predictiveBalance';
 import { rollUpProtectedTransactions } from '../lib/ui/privacy';
@@ -132,6 +138,61 @@ function getCurrentMonthBounds(): { startDate: string; endDate: string } {
     endDate: formatLocalDate(endDate),
   };
 }
+
+function getPreviousMonthBounds(): { startDate: string; endDate: string } {
+  const now = new Date();
+  const startDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  // Day 0 of the current month is the last day of the previous month.
+  const endDate = new Date(now.getFullYear(), now.getMonth(), 0);
+
+  return {
+    startDate: formatLocalDate(startDate),
+    endDate: formatLocalDate(endDate),
+  };
+}
+
+/** Sum income and expense (integer cents) for the savings-rate calculation. */
+function toMonthlyCashFlow(month: string, transactions: readonly Transaction[]): MonthlyCashFlow {
+  let incomeCents = 0;
+  let expenseCents = 0;
+  for (const transaction of transactions) {
+    if (transaction.type === 'INCOME') {
+      incomeCents += Math.max(0, transaction.amount.amount);
+    } else if (transaction.type === 'EXPENSE') {
+      expenseCents += Math.abs(transaction.amount.amount);
+    }
+  }
+
+  return { month, incomeCents, expenseCents };
+}
+
+/** Format a savings-rate percentage compactly (e.g. `50%`, `37.5%`, `-20%`). */
+function formatSavingsRatePercent(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}%`;
+}
+
+/** Plain-language period-over-period trend description (text, not colour alone). */
+function describeSavingsRateTrend(
+  trend: SavingsRateCardModel['trend'],
+  deltaPercentagePoints: number | null,
+): string {
+  if (deltaPercentagePoints === null) {
+    return 'No prior month to compare yet';
+  }
+  if (trend === 'flat') {
+    return 'Flat vs last month';
+  }
+  const magnitude = Math.round(Math.abs(deltaPercentagePoints) * 10) / 10;
+  const points = Number.isInteger(magnitude) ? magnitude.toFixed(0) : magnitude.toFixed(1);
+  return `${trend === 'up' ? 'Up' : 'Down'} ${points} pts vs last month`;
+}
+
+const SAVINGS_RATE_TREND_ICON: Record<SavingsRateCardModel['trend'], string> = {
+  up: '▲',
+  down: '▼',
+  flat: '→',
+};
 
 function getTransactionDisplayAmount(transaction: Transaction): number {
   if (transaction.type === 'EXPENSE') {
@@ -416,6 +477,20 @@ export const DashboardPage: React.FC = () => {
     error: currentMonthTransactionsError,
     refresh: refreshCurrentMonthTransactions,
   } = useTransactions(currentMonthFilters);
+  const previousMonthRange = useMemo(() => getPreviousMonthBounds(), []);
+  const previousMonthFilters = useMemo(
+    () => ({
+      startDate: previousMonthRange.startDate,
+      endDate: previousMonthRange.endDate,
+    }),
+    [previousMonthRange],
+  );
+  const {
+    transactions: previousMonthTransactions,
+    loading: previousMonthTransactionsLoading,
+    error: previousMonthTransactionsError,
+    refresh: refreshPreviousMonthTransactions,
+  } = useTransactions(previousMonthFilters);
   const dashboardAsOf = useMemo(() => new Date(), []);
 
   const categoryNames = useMemo(
@@ -434,6 +509,15 @@ export const DashboardPage: React.FC = () => {
     () =>
       filterTransactionsByAccountPurpose(currentMonthTransactions, accounts, selectedPurposeFilter),
     [currentMonthTransactions, accounts, selectedPurposeFilter],
+  );
+  const filteredPreviousMonthTransactions = useMemo(
+    () =>
+      filterTransactionsByAccountPurpose(
+        previousMonthTransactions,
+        accounts,
+        selectedPurposeFilter,
+      ),
+    [previousMonthTransactions, accounts, selectedPurposeFilter],
   );
   const filteredRecentTransactions = useMemo(
     () =>
@@ -604,6 +688,24 @@ export const DashboardPage: React.FC = () => {
       ),
     [filteredCurrentMonthTransactions],
   );
+  // Savings rate = (income − expenses) / income for the current month, compared
+  // with the prior calendar month. Reuses the integer-cents savings-rate math
+  // from lib/dashboard/savings-rate-summary (safe against divide-by-zero).
+  const savingsRateCard = useMemo(() => {
+    const currentMonthKey = currentMonthRange.startDate.slice(0, 7);
+    const previousMonthKey = previousMonthRange.startDate.slice(0, 7);
+    const cashFlows: MonthlyCashFlow[] = [
+      toMonthlyCashFlow(previousMonthKey, filteredPreviousMonthTransactions),
+      toMonthlyCashFlow(currentMonthKey, filteredCurrentMonthTransactions),
+    ];
+
+    return buildSavingsRateCardModel(buildSavingsRateDashboardSummary(cashFlows, currentMonthKey));
+  }, [
+    currentMonthRange.startDate,
+    previousMonthRange.startDate,
+    filteredCurrentMonthTransactions,
+    filteredPreviousMonthTransactions,
+  ]);
   const debtSummary = useMemo(
     () =>
       filteredAccounts.reduce(
@@ -644,7 +746,8 @@ export const DashboardPage: React.FC = () => {
     goalsLoading ||
     predictionLoading ||
     chartTransactionsLoading ||
-    currentMonthTransactionsLoading;
+    currentMonthTransactionsLoading ||
+    previousMonthTransactionsLoading;
   const resolvedError =
     error ??
     accountsError ??
@@ -654,7 +757,8 @@ export const DashboardPage: React.FC = () => {
     goalsError ??
     predictionError ??
     chartTransactionsError ??
-    currentMonthTransactionsError;
+    currentMonthTransactionsError ??
+    previousMonthTransactionsError;
   const budgetPercentage =
     data !== null && data.monthlyBudget > 0
       ? Math.round((data.budgetSpent / data.monthlyBudget) * 100)
@@ -678,6 +782,7 @@ export const DashboardPage: React.FC = () => {
     refreshPrediction();
     refreshChartTransactions();
     refreshCurrentMonthTransactions();
+    refreshPreviousMonthTransactions();
   };
 
   return (
@@ -791,6 +896,55 @@ export const DashboardPage: React.FC = () => {
               </Suspense>
               <section className="page-section" aria-label="Financial summary">
                 <div className="card-grid card-grid--4">
+                  <article
+                    className={`card savings-rate-card savings-rate-card--${savingsRateCard.tone}`}
+                    aria-label="Savings rate this month"
+                  >
+                    <div className="card__header">
+                      <h3 className="card__title">Savings Rate</h3>
+                    </div>
+                    <div className="card__value" aria-live="polite">
+                      {savingsRateCard.hasIncome ? (
+                        <span
+                          aria-label={`${formatSavingsRatePercent(savingsRateCard.savingsRatePercent)} savings rate this month`}
+                        >
+                          {formatSavingsRatePercent(savingsRateCard.savingsRatePercent)}
+                        </span>
+                      ) : (
+                        <span aria-label="Savings rate not available — no income recorded this month">
+                          N/A
+                        </span>
+                      )}
+                    </div>
+                    <p className="list-item__secondary">
+                      {savingsRateCard.hasIncome ? (
+                        <>
+                          <CurrencyDisplay
+                            amount={savingsRateCard.savingsCents}
+                            currency={safeToSpendCurrency}
+                            colorize
+                            showSign
+                            context="saved this month"
+                          />{' '}
+                          saved this month
+                        </>
+                      ) : (
+                        'Add income this month to calculate your savings rate.'
+                      )}
+                    </p>
+                    {savingsRateCard.hasIncome ? (
+                      <p className="savings-rate-card__trend">
+                        <span className="savings-rate-card__trend-icon" aria-hidden="true">
+                          {SAVINGS_RATE_TREND_ICON[savingsRateCard.trend]}
+                        </span>
+                        {describeSavingsRateTrend(
+                          savingsRateCard.trend,
+                          savingsRateCard.deltaPercentagePoints,
+                        )}
+                      </p>
+                    ) : null}
+                    <p className="savings-rate-card__status">{savingsRateCard.statusLabel}</p>
+                  </article>
                   {visibleWidgetIds.has('net-worth') ? (
                     <article className="card" aria-label="Net worth">
                       <div className="card__header">


### PR DESCRIPTION
﻿## Summary
Makes **savings rate** a first-class, front-and-center metric on the web dashboard.

Savings rate = (income − expenses) / income for the current month, surfaced as a prominent, accessible card among the primary dashboard summary cards. The card shows:
- The savings rate as a clear **percentage** (or `N/A` when there is no income, never NaN/Infinity).
- The underlying **dollars saved this period** (integer-cents money math, signed).
- A short **period-over-period trend** (this month vs last) conveyed by text + icon (Up/Down/Flat ▲▼→), not colour alone.
- A **plain-language status** (e.g. "Solid progress toward a 20% goal").

## Implementation
- **Reuses/extends the existing savings-rate computation** in `apps/web/src/lib/dashboard/savings-rate-summary.ts` (`buildSavingsRateDashboardSummary`). Added a small pure presentation helper `buildSavingsRateCardModel` with INTEGER-CENTS math and safe divide-by-zero handling (income 0 → 0%/`N/A`).
- Wired a new **Savings Rate card** into `DashboardPage.tsx` as the lead card in the Financial summary grid. Compares the current calendar month against the prior calendar month (purpose-filter aware, reusing the existing `useTransactions` data path and `CurrencyDisplay`).
- Lightweight, token-based CSS only — no new heavy deps and no new shared barrel pulled into the dashboard route chunk.

## Accessibility (WCAG 2.2 AA)
- Semantic `<article>`/heading structure with `aria-label` and `aria-live` value region.
- Trend/status direction conveyed by text + shape icon (icons `aria-hidden`), not colour alone.
- Keyboard operable (no new interactive traps); `prefers-contrast` handled; no motion added (reduced-motion safe).

## Tests
- Extended `savings-rate-summary.test.ts` with positive / zero-income (N/A) / negative savings-rate cases and prior-period delta (up / down / flat / no-prior / no-prior-income) coverage.
- Added a `DashboardPage` render test asserting the card shows percentage, trend, and status.

Refs #2162
