### PR TITLE
feat(web): brokerage trade import + cross-broker reconciliation (#2120)

### DIFF
--- a/apps/web/src/components/import/BrokerageImportPanel.test.tsx
+++ b/apps/web/src/components/import/BrokerageImportPanel.test.tsx
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { BrokerageImportPanel } from './BrokerageImportPanel';
+
+const FIDELITY_CSV = [
+  'Run Date,Action,Symbol,Quantity,Price ($),Commission ($),Amount ($)',
+  '01/03/2024,YOU BOUGHT,AAPL,10,150.00,4.95,-1504.95',
+  '02/14/2024,YOU BOUGHT,AAPL,5,160.00,4.95,-804.95',
+].join('\n');
+
+/** Drive the paste → confirm-mapping flow for a single broker export. */
+function addExport(broker: string, csv: string): void {
+  fireEvent.change(screen.getByLabelText(/broker name/i), { target: { value: broker } });
+  fireEvent.change(screen.getByLabelText(/paste csv text/i), { target: { value: csv } });
+  fireEvent.click(screen.getByRole('button', { name: /add pasted csv/i }));
+  fireEvent.click(screen.getByRole('button', { name: /confirm .* add export/i }));
+}
+
+describe('BrokerageImportPanel', () => {
+  it('renders the heading and accessible inputs', () => {
+    render(<BrokerageImportPanel />);
+    expect(
+      screen.getByRole('heading', { name: /brokerage trade import & reconciliation/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/broker name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/paste csv text/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/choose a broker trade-confirmation csv file to import/i),
+    ).toBeInTheDocument();
+  });
+
+  it('requires a broker name before loading a paste', () => {
+    render(<BrokerageImportPanel />);
+    fireEvent.change(screen.getByLabelText(/paste csv text/i), {
+      target: { value: FIDELITY_CSV },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add pasted csv/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/broker name/i);
+  });
+
+  it('shows a column-mapping confirmation with auto-detected fields', () => {
+    render(<BrokerageImportPanel />);
+    fireEvent.change(screen.getByLabelText(/broker name/i), { target: { value: 'Fidelity' } });
+    fireEvent.change(screen.getByLabelText(/paste csv text/i), {
+      target: { value: FIDELITY_CSV },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add pasted csv/i }));
+
+    // Auto-detected required mappings are pre-selected.
+    expect(screen.getByRole('combobox', { name: /trade date/i })).toHaveValue('Run Date');
+    expect(screen.getByRole('combobox', { name: /symbol/i })).toHaveValue('Symbol');
+    expect(screen.getByRole('combobox', { name: /price per share/i })).toHaveValue('Price ($)');
+  });
+
+  it('reconciles a confirmed export into a unified holdings summary', () => {
+    render(<BrokerageImportPanel />);
+    addExport('Fidelity', FIDELITY_CSV);
+
+    expect(screen.getByRole('group', { name: /reconciliation summary/i })).toBeInTheDocument();
+
+    const holdingsTable = screen.getByRole('table', {
+      name: /unified holdings reconciled across all added brokers/i,
+    });
+    const aaplRow = within(holdingsTable).getByRole('row', { name: /AAPL/i });
+    // 10 + 5 shares, cost basis 230990 cents = $2,309.90
+    expect(within(aaplRow).getByText('15')).toBeInTheDocument();
+    expect(within(aaplRow).getByText('$2,309.90')).toBeInTheDocument();
+  });
+
+  it('pools the same symbol across two brokers and flags cross-broker duplicates', () => {
+    render(<BrokerageImportPanel />);
+    const csv = 'Date,Action,Symbol,Quantity,Price\n2024-01-01,Buy,AAPL,10,150.00';
+    addExport('Fidelity', csv);
+    addExport('Schwab', csv);
+
+    const summary = screen.getByRole('group', { name: /reconciliation summary/i });
+    expect(summary).toHaveTextContent(/2 brokers/i);
+    expect(summary).toHaveTextContent(/Fidelity, Schwab/);
+
+    // Identical trade across two brokers should surface a reconciliation finding.
+    expect(screen.getByRole('heading', { name: /reconciliation findings/i })).toBeInTheDocument();
+  });
+
+  it('clears all state on start over', () => {
+    render(<BrokerageImportPanel />);
+    addExport('Fidelity', FIDELITY_CSV);
+    expect(screen.getByRole('group', { name: /reconciliation summary/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /start over/i }));
+    expect(
+      screen.queryByRole('group', { name: /reconciliation summary/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/import/BrokerageImportPanel.tsx
+++ b/apps/web/src/components/import/BrokerageImportPanel.tsx
@@ -1,0 +1,589 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Accessible brokerage trade-import + cross-broker reconciliation surface.
+ *
+ * Self-contained component: it owns its own local UI state (no persistence —
+ * this slice previews and reconciles trades only). The user adds one broker
+ * export at a time (file or paste), confirms the auto-detected column mapping,
+ * and the panel renders a parsed-trade preview plus a unified holdings summary
+ * reconciled across every added broker. The pure engine lives in
+ * `lib/investments/brokerage-import` and does all money math in integer cents.
+ *
+ * It is imported directly by {@link BrokerageImportPage} (never via the shared
+ * `components/import` barrel) so its weight stays inside the brokerage route's
+ * own lazy chunk and does not inflate other import routes.
+ *
+ * Accessibility:
+ *   - Labeled broker-name input, paste field and file picker
+ *   - Column mapping is a `<fieldset>` with one labeled `<select>` per field
+ *   - Preview / holdings tables use a `<caption>` and `scope="col"` headers
+ *   - Action is shown with an icon **and** text label (never colour alone)
+ *   - Summary and status use `aria-live="polite"`; errors use `role="alert"`
+ *   - Reconciliation findings carry a text + icon severity indicator
+ *
+ * References: issue #2120
+ */
+
+import React, { useCallback, useId, useMemo, useState } from 'react';
+
+import { formatCurrency, formatGainLoss } from '../../lib/currency';
+import { parseCsv } from '../../lib/csv-parser';
+import {
+  buildBrokerageImportPlan,
+  parseBrokerageCsv,
+  suggestColumnMapping,
+  type BrokerageAction,
+  type BrokerageColumnMapping,
+  type BrokerageParseResult,
+} from '../../lib/investments/brokerage-import';
+import { AppIcon, type IconName } from '../icons';
+import { FileDropZone } from './FileDropZone';
+
+import './brokerage-import-panel.css';
+
+const KNOWN_BROKERS = [
+  'Fidelity',
+  'Schwab',
+  'Robinhood',
+  'E*TRADE',
+  'Vanguard',
+  'Merrill',
+] as const;
+
+const MAX_PREVIEW_ROWS = 3;
+const MAX_TRADE_ROWS = 100;
+
+/** Logical mapping fields shown in the confirmation step, in display order. */
+const MAPPING_FIELDS: readonly {
+  key: keyof BrokerageColumnMapping;
+  label: string;
+  required: boolean;
+}[] = [
+  { key: 'date', label: 'Trade date', required: true },
+  { key: 'action', label: 'Action (buy / sell / dividend)', required: true },
+  { key: 'symbol', label: 'Symbol', required: true },
+  { key: 'quantity', label: 'Quantity', required: true },
+  { key: 'price', label: 'Price per share', required: true },
+  { key: 'fees', label: 'Fees / commission', required: false },
+  { key: 'amount', label: 'Net amount', required: false },
+];
+
+const ACTION_META: Record<BrokerageAction, { label: string; icon: IconName }> = {
+  BUY: { label: 'Buy', icon: 'trending-up' },
+  SELL: { label: 'Sell', icon: 'trending-down' },
+  DIV: { label: 'Dividend', icon: 'gift' },
+};
+
+interface PendingSource {
+  readonly broker: string;
+  readonly content: string;
+  readonly headers: readonly string[];
+  readonly previewRows: readonly string[][];
+  readonly mapping: BrokerageColumnMapping;
+}
+
+function formatQuantity(quantity: number): string {
+  return quantity.toLocaleString(undefined, { maximumFractionDigits: 6 });
+}
+
+export const BrokerageImportPanel: React.FC = () => {
+  const brokerInputId = useId();
+  const pasteInputId = useId();
+  const summaryId = useId();
+
+  const [brokerName, setBrokerName] = useState('');
+  const [pasteText, setPasteText] = useState('');
+  const [sources, setSources] = useState<readonly BrokerageParseResult[]>([]);
+  const [pending, setPending] = useState<PendingSource | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string>('');
+
+  const plan = useMemo(() => buildBrokerageImportPlan(sources), [sources]);
+
+  const loadContent = useCallback(
+    (content: string) => {
+      setParseError(null);
+      const broker = brokerName.trim();
+      if (!broker) {
+        setParseError('Enter the broker name before adding an export.');
+        return;
+      }
+      const { headers, rows } = parseCsv(content, { hasHeader: true });
+      if (headers.length === 0 || rows.length === 0) {
+        setParseError('No rows found. Make sure the file is a CSV with a header row.');
+        return;
+      }
+      setPending({
+        broker,
+        content,
+        headers,
+        previewRows: rows.slice(0, MAX_PREVIEW_ROWS),
+        mapping: suggestColumnMapping(headers),
+      });
+    },
+    [brokerName],
+  );
+
+  const handleFile = useCallback(
+    (file: File) => {
+      file
+        .text()
+        .then((text) => loadContent(text))
+        .catch(() => setParseError('Could not read that file. Please try another CSV.'));
+    },
+    [loadContent],
+  );
+
+  const handlePaste = useCallback(() => {
+    if (pasteText.trim().length === 0) {
+      setParseError('Paste the CSV text first, then add it.');
+      return;
+    }
+    loadContent(pasteText);
+  }, [loadContent, pasteText]);
+
+  const setMappingField = useCallback((key: keyof BrokerageColumnMapping, value: string) => {
+    setPending((prev) => (prev ? { ...prev, mapping: { ...prev.mapping, [key]: value } } : prev));
+  }, []);
+
+  const mappingReady = useMemo(() => {
+    if (!pending) return false;
+    return MAPPING_FIELDS.filter((f) => f.required).every(
+      (f) => (pending.mapping[f.key] ?? '').length > 0,
+    );
+  }, [pending]);
+
+  const confirmMapping = useCallback(() => {
+    if (!pending || !mappingReady) return;
+    const result = parseBrokerageCsv(pending.content, {
+      broker: pending.broker,
+      mapping: pending.mapping,
+    });
+    setSources((prev) => [...prev, result]);
+    setPending(null);
+    setPasteText('');
+    setBrokerName('');
+    setStatusMessage(
+      `Added ${result.trades.length} trade${result.trades.length === 1 ? '' : 's'} from ${
+        result.broker
+      }${result.errors.length > 0 ? `; ${result.errors.length} row(s) skipped.` : '.'}`,
+    );
+  }, [pending, mappingReady]);
+
+  const cancelPending = useCallback(() => {
+    setPending(null);
+    setParseError(null);
+  }, []);
+
+  const removeSource = useCallback((index: number) => {
+    setSources((prev) => prev.filter((_, i) => i !== index));
+    setStatusMessage('Removed a broker export from the reconciliation.');
+  }, []);
+
+  const reset = useCallback(() => {
+    setSources([]);
+    setPending(null);
+    setBrokerName('');
+    setPasteText('');
+    setParseError(null);
+    setStatusMessage('Cleared all imported trades.');
+  }, []);
+
+  const hasData = sources.length > 0;
+  const previewTrades = plan.trades.slice(0, MAX_TRADE_ROWS);
+
+  return (
+    <section className="brokerage-import" aria-labelledby="brokerage-import-heading">
+      <h2 id="brokerage-import-heading" className="brokerage-import__title">
+        Brokerage Trade Import &amp; Reconciliation
+      </h2>
+      <p className="brokerage-import__intro">
+        Export a trade-confirmation CSV from each broker (Fidelity, Schwab, Robinhood and others),
+        add them one at a time, and we reconcile buys, sells and dividends into a single holdings
+        view with average cost basis. Connecting a live brokerage account is not available here —
+        all parsing happens on this device and nothing is saved automatically.
+      </p>
+
+      {/* ----------------------------------------------------------------- */}
+      {/* Add a broker export                                               */}
+      {/* ----------------------------------------------------------------- */}
+      <div className="brokerage-import__add">
+        <div className="brokerage-import__field">
+          <label htmlFor={brokerInputId} className="brokerage-import__label">
+            Broker name
+          </label>
+          <input
+            id={brokerInputId}
+            className="form-input"
+            type="text"
+            list={`${brokerInputId}-list`}
+            value={brokerName}
+            onChange={(event) => setBrokerName(event.target.value)}
+            placeholder="e.g. Fidelity"
+            autoComplete="off"
+          />
+          <datalist id={`${brokerInputId}-list`}>
+            {KNOWN_BROKERS.map((broker) => (
+              <option key={broker} value={broker} />
+            ))}
+          </datalist>
+        </div>
+
+        <FileDropZone
+          accept=".csv"
+          onFile={handleFile}
+          inputLabel="Choose a broker trade-confirmation CSV file to import"
+          hint=".csv files up to 10 MB — set the broker name first"
+        />
+
+        <div className="brokerage-import__field">
+          <label htmlFor={pasteInputId} className="brokerage-import__label">
+            …or paste CSV text
+          </label>
+          <textarea
+            id={pasteInputId}
+            className="form-input brokerage-import__paste"
+            value={pasteText}
+            onChange={(event) => setPasteText(event.target.value)}
+            rows={4}
+            placeholder="Date,Action,Symbol,Quantity,Price,Fees&#10;2024-01-03,Buy,AAPL,10,150.00,4.95"
+          />
+          <button
+            type="button"
+            className="form-button form-button--secondary"
+            onClick={handlePaste}
+          >
+            Add pasted CSV
+          </button>
+        </div>
+      </div>
+
+      {parseError !== null && (
+        <p className="brokerage-import__error" role="alert">
+          <AppIcon name="alert-triangle" />
+          {parseError}
+        </p>
+      )}
+
+      {/* ----------------------------------------------------------------- */}
+      {/* Column mapping confirmation                                       */}
+      {/* ----------------------------------------------------------------- */}
+      {pending !== null && (
+        <div className="brokerage-import__mapping">
+          <fieldset className="brokerage-import__fieldset">
+            <legend className="brokerage-import__legend">
+              Confirm columns for {pending.broker}
+            </legend>
+            <p className="brokerage-import__hint">
+              We matched these columns automatically. Adjust any that look wrong, then confirm.
+            </p>
+            <div className="brokerage-import__map-grid">
+              {MAPPING_FIELDS.map((field) => {
+                const selectId = `brokerage-map-${field.key}`;
+                return (
+                  <div key={field.key} className="brokerage-import__field">
+                    <label htmlFor={selectId} className="brokerage-import__label">
+                      {field.label}
+                      {field.required ? (
+                        <span className="brokerage-import__required"> (required)</span>
+                      ) : (
+                        <span className="brokerage-import__optional"> (optional)</span>
+                      )}
+                    </label>
+                    <select
+                      id={selectId}
+                      className="form-select"
+                      value={pending.mapping[field.key] ?? ''}
+                      onChange={(event) => setMappingField(field.key, event.target.value)}
+                      aria-required={field.required}
+                    >
+                      <option value="">{field.required ? 'Select a column' : 'Not in file'}</option>
+                      {pending.headers.map((header) => (
+                        <option key={header} value={header}>
+                          {header}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <div className="brokerage-import__table-wrapper">
+            <table className="brokerage-import__table">
+              <caption className="brokerage-import__caption">
+                Preview of the first {pending.previewRows.length} row(s) from {pending.broker}.
+              </caption>
+              <thead>
+                <tr>
+                  {pending.headers.map((header) => (
+                    <th key={header} scope="col">
+                      {header}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {pending.previewRows.map((row, rowIndex) => (
+                  <tr key={rowIndex}>
+                    {pending.headers.map((header, colIndex) => (
+                      <td key={header}>{row[colIndex] ?? ''}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="brokerage-import__actions">
+            <button
+              type="button"
+              className="form-button form-button--secondary"
+              onClick={cancelPending}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="form-button form-button--primary"
+              onClick={confirmMapping}
+              disabled={!mappingReady}
+              aria-disabled={!mappingReady}
+            >
+              Confirm &amp; add export
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ----------------------------------------------------------------- */}
+      {/* Added sources                                                     */}
+      {/* ----------------------------------------------------------------- */}
+      {hasData && (
+        <>
+          <div
+            className="brokerage-import__summary"
+            role="group"
+            aria-labelledby={summaryId}
+            aria-live="polite"
+          >
+            <h3 id={summaryId} className="brokerage-import__summary-title">
+              Reconciliation summary
+            </h3>
+            <p className="brokerage-import__sources">
+              {plan.brokers.length} broker{plan.brokers.length === 1 ? '' : 's'}:{' '}
+              {plan.brokers.join(', ')}
+            </p>
+            <dl className="brokerage-import__stats">
+              <div className="brokerage-import__stat">
+                <dt>Trades parsed</dt>
+                <dd>{plan.totals.tradeCount}</dd>
+              </div>
+              <div className="brokerage-import__stat">
+                <dt>Net invested</dt>
+                <dd>{formatCurrency(plan.totals.netInvestedCents)}</dd>
+              </div>
+              <div className="brokerage-import__stat">
+                <dt>Dividends</dt>
+                <dd>{formatCurrency(plan.totals.dividendsCents)}</dd>
+              </div>
+              <div className="brokerage-import__stat">
+                <dt>Total fees</dt>
+                <dd>{formatCurrency(plan.totals.feesCents)}</dd>
+              </div>
+            </dl>
+          </div>
+
+          <ul className="brokerage-import__source-list">
+            {sources.map((source, index) => (
+              <li key={`${source.broker}-${index}`} className="brokerage-import__source-item">
+                <span>
+                  {source.broker} — {source.trades.length} trade
+                  {source.trades.length === 1 ? '' : 's'}
+                  {source.errors.length > 0 ? `, ${source.errors.length} skipped` : ''}
+                </span>
+                <button
+                  type="button"
+                  className="form-button form-button--secondary brokerage-import__remove"
+                  onClick={() => removeSource(index)}
+                >
+                  Remove
+                  <span className="sr-only"> {source.broker} export</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          {/* Reconciled holdings ------------------------------------------- */}
+          <div className="brokerage-import__table-wrapper">
+            <table className="brokerage-import__table">
+              <caption className="brokerage-import__caption">
+                Unified holdings reconciled across all added brokers (average cost basis).
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Symbol</th>
+                  <th scope="col" className="brokerage-import__num">
+                    Net quantity
+                  </th>
+                  <th scope="col" className="brokerage-import__num">
+                    Cost basis
+                  </th>
+                  <th scope="col" className="brokerage-import__num">
+                    Avg cost
+                  </th>
+                  <th scope="col" className="brokerage-import__num">
+                    Realized
+                  </th>
+                  <th scope="col" className="brokerage-import__num">
+                    Dividends
+                  </th>
+                  <th scope="col">Brokers</th>
+                </tr>
+              </thead>
+              <tbody>
+                {plan.holdings.map((holding) => (
+                  <tr key={holding.symbol}>
+                    <th scope="row">{holding.symbol}</th>
+                    <td className="brokerage-import__num">{formatQuantity(holding.netQuantity)}</td>
+                    <td className="brokerage-import__num">
+                      {formatCurrency(holding.costBasisCents)}
+                    </td>
+                    <td className="brokerage-import__num">
+                      {formatCurrency(holding.averageCostCents)}
+                    </td>
+                    <td className="brokerage-import__num">
+                      {formatGainLoss(holding.realizedGainCents)}
+                    </td>
+                    <td className="brokerage-import__num">
+                      {formatCurrency(holding.dividendsCents)}
+                    </td>
+                    <td>{holding.brokers.join(', ')}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Warnings ------------------------------------------------------ */}
+          {plan.warnings.length > 0 && (
+            <div className="brokerage-import__warnings">
+              <h3 className="brokerage-import__warnings-title">
+                Reconciliation findings ({plan.warnings.length})
+              </h3>
+              <ul className="brokerage-import__warning-list">
+                {plan.warnings.map((warning, index) => (
+                  <li key={`${warning.type}-${index}`} className="brokerage-import__warning-item">
+                    <AppIcon name={warning.severity === 'warning' ? 'alert-triangle' : 'info'} />
+                    <span>
+                      <span className="brokerage-import__warning-tag">
+                        {warning.severity === 'warning' ? 'Warning: ' : 'Note: '}
+                      </span>
+                      {warning.message}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Parsed-trade preview ----------------------------------------- */}
+          <div className="brokerage-import__table-wrapper">
+            <table className="brokerage-import__table">
+              <caption className="brokerage-import__caption">
+                Parsed trades ({plan.trades.length}
+                {plan.trades.length > MAX_TRADE_ROWS ? `, showing first ${MAX_TRADE_ROWS}` : ''}).
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Broker</th>
+                  <th scope="col">Date</th>
+                  <th scope="col">Symbol</th>
+                  <th scope="col">Action</th>
+                  <th scope="col" className="brokerage-import__num">
+                    Quantity
+                  </th>
+                  <th scope="col" className="brokerage-import__num">
+                    Price
+                  </th>
+                  <th scope="col" className="brokerage-import__num">
+                    Fees
+                  </th>
+                  <th scope="col" className="brokerage-import__num">
+                    Cash flow
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {previewTrades.map((trade) => {
+                  const meta = ACTION_META[trade.action];
+                  return (
+                    <tr key={trade.id}>
+                      <td>{trade.broker}</td>
+                      <td>{trade.date}</td>
+                      <td>{trade.symbol}</td>
+                      <td>
+                        <span className="brokerage-import__action">
+                          <AppIcon name={meta.icon} />
+                          <span>{meta.label}</span>
+                        </span>
+                      </td>
+                      <td className="brokerage-import__num">{formatQuantity(trade.quantity)}</td>
+                      <td className="brokerage-import__num">{formatCurrency(trade.priceCents)}</td>
+                      <td className="brokerage-import__num">{formatCurrency(trade.feesCents)}</td>
+                      <td className="brokerage-import__num">
+                        {formatGainLoss(trade.cashFlowCents)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Skipped rows -------------------------------------------------- */}
+          {plan.errors.length > 0 && (
+            <div className="brokerage-import__warnings">
+              <h3 className="brokerage-import__warnings-title">
+                Skipped rows ({plan.errors.length})
+              </h3>
+              <table className="brokerage-import__table">
+                <caption className="sr-only">Rows that could not be parsed</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Broker</th>
+                    <th scope="col">Line</th>
+                    <th scope="col">Reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {plan.errors.map((error, index) => (
+                    <tr key={`${error.broker}-${error.line}-${index}`}>
+                      <td>{error.broker}</td>
+                      <td>{error.line}</td>
+                      <td>{error.message}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <div className="brokerage-import__actions">
+            <button type="button" className="form-button form-button--secondary" onClick={reset}>
+              Start over
+            </button>
+          </div>
+        </>
+      )}
+
+      <div className="brokerage-import__status" role="status" aria-live="polite">
+        {statusMessage}
+      </div>
+    </section>
+  );
+};
+
+export default BrokerageImportPanel;

--- a/apps/web/src/components/import/brokerage-import-panel.css
+++ b/apps/web/src/components/import/brokerage-import-panel.css
@@ -1,0 +1,332 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Brokerage trade-import + reconciliation surface styles.
+ *
+ * Token-only: colours, spacing, typography, radius and borders come from the
+ * design-token custom properties (same pattern as p2p-import-panel.css). Trade
+ * actions and reconciliation findings are communicated with text + icon, never
+ * colour alone, so they stay legible for colour-vision differences and in
+ * high-contrast mode. No motion is introduced, so reduced-motion is respected
+ * by construction.
+ */
+
+.brokerage-import {
+  max-width: var(--layout-content-max-width, 1040px);
+  margin: 0 auto;
+  padding: var(--spacing-4);
+  color: var(--semantic-text-primary);
+}
+
+.brokerage-import__title {
+  font-size: var(--type-scale-headline-font-size);
+  font-weight: var(--type-scale-headline-font-weight);
+  margin: 0 0 var(--spacing-2);
+}
+
+.brokerage-import__intro {
+  font-size: var(--type-scale-body-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-5);
+  max-width: 72ch;
+}
+
+/* ---------------------------------------------------------------------------
+ * Add a broker export
+ * ------------------------------------------------------------------------- */
+
+.brokerage-import__add {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
+}
+
+.brokerage-import__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.brokerage-import__label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+}
+
+.brokerage-import__required {
+  color: var(--semantic-status-negative);
+  font-weight: var(--font-weight-medium);
+}
+
+.brokerage-import__optional {
+  color: var(--semantic-text-secondary);
+  font-weight: var(--font-weight-regular, 400);
+}
+
+.brokerage-import__paste {
+  width: 100%;
+  min-height: 6rem;
+  font-family: var(--font-family-mono, monospace);
+  resize: vertical;
+}
+
+.brokerage-import__error {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+  border: 1px solid var(--semantic-status-negative);
+  border-radius: var(--border-radius-md);
+  color: var(--semantic-status-negative);
+  background: var(--semantic-background-secondary);
+  margin: 0 0 var(--spacing-4);
+}
+
+/* ---------------------------------------------------------------------------
+ * Column mapping
+ * ------------------------------------------------------------------------- */
+
+.brokerage-import__mapping {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+  padding: var(--spacing-4);
+  margin-bottom: var(--spacing-5);
+}
+
+.brokerage-import__fieldset {
+  border: none;
+  padding: 0;
+  margin: 0 0 var(--spacing-4);
+}
+
+.brokerage-import__legend {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  padding: 0;
+  margin: 0 0 var(--spacing-2);
+}
+
+.brokerage-import__hint {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-3);
+}
+
+.brokerage-import__map-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: var(--spacing-3);
+}
+
+/* ---------------------------------------------------------------------------
+ * Summary
+ * ------------------------------------------------------------------------- */
+
+.brokerage-import__summary {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+  padding: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
+}
+
+.brokerage-import__summary-title {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  margin: 0 0 var(--spacing-1);
+}
+
+.brokerage-import__sources {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-3);
+}
+
+.brokerage-import__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: var(--spacing-3);
+  margin: 0;
+}
+
+.brokerage-import__stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.brokerage-import__stat dt {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.brokerage-import__stat dd {
+  margin: 0;
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------------------------------------------------------------------------
+ * Added source list
+ * ------------------------------------------------------------------------- */
+
+.brokerage-import__source-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--spacing-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.brokerage-import__source-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  font-size: var(--type-scale-body-font-size);
+}
+
+.brokerage-import__remove {
+  flex-shrink: 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * Tables
+ * ------------------------------------------------------------------------- */
+
+.brokerage-import__table-wrapper {
+  overflow-x: auto;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  margin-bottom: var(--spacing-5);
+}
+
+.brokerage-import__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--type-scale-body-font-size);
+}
+
+.brokerage-import__caption {
+  caption-side: top;
+  text-align: left;
+  padding: var(--spacing-3);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.brokerage-import__table th,
+.brokerage-import__table td {
+  text-align: left;
+  padding: var(--spacing-2) var(--spacing-3);
+  border-bottom: 1px solid var(--semantic-border-default);
+  vertical-align: top;
+}
+
+.brokerage-import__table thead th {
+  background: var(--semantic-background-secondary);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+  position: sticky;
+  top: 0;
+}
+
+.brokerage-import__table tbody th[scope='row'] {
+  font-weight: var(--font-weight-semibold);
+}
+
+.brokerage-import__num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.brokerage-import__action {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-weight: var(--font-weight-medium);
+}
+
+/* ---------------------------------------------------------------------------
+ * Warnings
+ * ------------------------------------------------------------------------- */
+
+.brokerage-import__warnings {
+  margin-bottom: var(--spacing-5);
+}
+
+.brokerage-import__warnings-title {
+  font-size: var(--type-scale-title-font-size);
+  margin: 0 0 var(--spacing-2);
+}
+
+.brokerage-import__warning-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.brokerage-import__warning-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-secondary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+.brokerage-import__warning-tag {
+  font-weight: var(--font-weight-semibold);
+}
+
+/* ---------------------------------------------------------------------------
+ * Actions + status
+ * ------------------------------------------------------------------------- */
+
+.brokerage-import__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-4);
+}
+
+.brokerage-import__status {
+  margin-top: var(--spacing-3);
+  font-size: var(--type-scale-body-font-size);
+  color: var(--semantic-status-positive);
+}
+
+@media (min-width: 720px) {
+  .brokerage-import__add {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .brokerage-import__add > .brokerage-import__field {
+    min-width: 16rem;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .brokerage-import__summary,
+  .brokerage-import__mapping,
+  .brokerage-import__table-wrapper,
+  .brokerage-import__source-item,
+  .brokerage-import__warning-item {
+    border-width: 2px;
+  }
+}

--- a/apps/web/src/lib/investments/brokerage-import.test.ts
+++ b/apps/web/src/lib/investments/brokerage-import.test.ts
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildBrokerageImportPlan,
+  detectDuplicates,
+  importBrokerageCsvs,
+  normalizeAction,
+  parseBrokerageCsv,
+  reconcileTrades,
+  suggestColumnMapping,
+  type BrokerageParseResult,
+} from './brokerage-import';
+
+// ---------------------------------------------------------------------------
+// Fixtures — representative broker CSV header variants
+// ---------------------------------------------------------------------------
+
+const FIDELITY_CSV = [
+  'Run Date,Action,Symbol,Quantity,Price ($),Commission ($),Amount ($)',
+  '01/03/2024,YOU BOUGHT,AAPL,10,150.00,4.95,-1504.95',
+  '02/14/2024,YOU BOUGHT,AAPL,5,160.00,4.95,-804.95',
+  '03/20/2024,DIVIDEND RECEIVED,AAPL,0,0,0,12.50',
+].join('\n');
+
+const SCHWAB_CSV = [
+  'Date,Action,Symbol,Quantity,Price,Fees & Comm,Amount',
+  '02/01/2024,Buy,MSFT,8,400.00,0.00,-3200.00',
+  '03/15/2024,Sell,MSFT,3,420.00,1.00,1259.00',
+].join('\n');
+
+function parseFidelity(): BrokerageParseResult {
+  return parseBrokerageCsv(FIDELITY_CSV, { broker: 'Fidelity' });
+}
+
+// ---------------------------------------------------------------------------
+// normalizeAction
+// ---------------------------------------------------------------------------
+
+describe('normalizeAction', () => {
+  it.each([
+    ['YOU BOUGHT', 'BUY'],
+    ['Buy', 'BUY'],
+    ['purchase', 'BUY'],
+    ['Sell', 'SELL'],
+    ['YOU SOLD', 'SELL'],
+    ['Sale', 'SELL'],
+    ['Dividend Received', 'DIV'],
+    ['Reinvest Dividend', 'DIV'],
+    ['DRIP', 'DIV'],
+  ])('maps "%s" to %s', (input, expected) => {
+    expect(normalizeAction(input)).toBe(expected);
+  });
+
+  it('returns null for empty or unknown actions', () => {
+    expect(normalizeAction('')).toBeNull();
+    expect(normalizeAction('journal')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// suggestColumnMapping
+// ---------------------------------------------------------------------------
+
+describe('suggestColumnMapping', () => {
+  it('auto-detects Fidelity-style headers', () => {
+    const mapping = suggestColumnMapping([
+      'Run Date',
+      'Action',
+      'Symbol',
+      'Quantity',
+      'Price ($)',
+      'Commission ($)',
+      'Amount ($)',
+    ]);
+    expect(mapping.date).toBe('Run Date');
+    expect(mapping.action).toBe('Action');
+    expect(mapping.symbol).toBe('Symbol');
+    expect(mapping.quantity).toBe('Quantity');
+    expect(mapping.price).toBe('Price ($)');
+    expect(mapping.fees).toBe('Commission ($)');
+    expect(mapping.amount).toBe('Amount ($)');
+  });
+
+  it('detects Robinhood-style header variants', () => {
+    const mapping = suggestColumnMapping([
+      'Activity Date',
+      'Instrument',
+      'Trans Code',
+      'Shares',
+      'Average Price',
+      'Net Amount',
+    ]);
+    expect(mapping.date).toBe('Activity Date');
+    expect(mapping.symbol).toBe('Instrument');
+    expect(mapping.action).toBe('Trans Code');
+    expect(mapping.quantity).toBe('Shares');
+    expect(mapping.price).toBe('Average Price');
+    expect(mapping.amount).toBe('Net Amount');
+  });
+
+  it('leaves unmatched fields empty', () => {
+    const mapping = suggestColumnMapping(['Foo', 'Bar']);
+    expect(mapping.date).toBe('');
+    expect(mapping.symbol).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBrokerageCsv — happy path + fee handling
+// ---------------------------------------------------------------------------
+
+describe('parseBrokerageCsv', () => {
+  it('parses buys, dividends and computes integer-cent cash flow incl. fees', () => {
+    const result = parseFidelity();
+    expect(result.errors).toHaveLength(0);
+    expect(result.trades).toHaveLength(3);
+
+    const [buy1, buy2, div] = result.trades;
+
+    expect(buy1.symbol).toBe('AAPL');
+    expect(buy1.action).toBe('BUY');
+    expect(buy1.quantity).toBe(10);
+    expect(buy1.priceCents).toBe(15000);
+    expect(buy1.feesCents).toBe(495);
+    expect(buy1.grossCents).toBe(150000);
+    // BUY cash flow is negative and includes fees: -(150000 + 495)
+    expect(buy1.cashFlowCents).toBe(-150495);
+
+    expect(buy2.quantity).toBe(5);
+    expect(buy2.grossCents).toBe(80000);
+    expect(buy2.cashFlowCents).toBe(-80495);
+
+    expect(div.action).toBe('DIV');
+    expect(div.grossCents).toBe(1250);
+    expect(div.cashFlowCents).toBe(1250);
+  });
+
+  it('handles sells net of fees with positive cash flow', () => {
+    const result = parseBrokerageCsv(SCHWAB_CSV, { broker: 'Schwab' });
+    expect(result.errors).toHaveLength(0);
+    const sell = result.trades.find((t) => t.action === 'SELL');
+    expect(sell).toBeDefined();
+    expect(sell!.quantity).toBe(3);
+    expect(sell!.grossCents).toBe(126000);
+    expect(sell!.feesCents).toBe(100);
+    // SELL proceeds are net of fees: 126000 - 100
+    expect(sell!.cashFlowCents).toBe(125900);
+  });
+
+  it('uppercases symbols and resolves the broker label', () => {
+    const csv = 'Date,Action,Symbol,Quantity,Price\n2024-01-01,buy,nvda,2,500.00';
+    const result = parseBrokerageCsv(csv, { broker: 'Robinhood' });
+    expect(result.trades[0].symbol).toBe('NVDA');
+    expect(result.trades[0].broker).toBe('Robinhood');
+  });
+
+  it('derives price from the net amount when no price column exists', () => {
+    const csv = 'Date,Action,Symbol,Quantity,Amount,Fees\n2024-01-01,buy,VTI,4,-1000.00,4.00';
+    const result = parseBrokerageCsv(csv, { broker: 'Custom' });
+    const trade = result.trades[0];
+    // gross = |amount| - fees = 100000 - 400 = 99600; price = 99600 / 4
+    expect(trade.grossCents).toBe(99600);
+    expect(trade.priceCents).toBe(24900);
+    expect(trade.cashFlowCents).toBe(-100000);
+  });
+
+  it('respects explicit mapping overrides', () => {
+    const csv = 'When,What,Tkr,Units,Cost\n2024-01-01,Buy,TSLA,1,250.00';
+    const result = parseBrokerageCsv(csv, {
+      broker: 'Manual',
+      mapping: {
+        date: 'When',
+        action: 'What',
+        symbol: 'Tkr',
+        quantity: 'Units',
+        price: 'Cost',
+      },
+    });
+    expect(result.errors).toHaveLength(0);
+    expect(result.trades[0].symbol).toBe('TSLA');
+    expect(result.trades[0].priceCents).toBe(25000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Malformed rows
+  // -------------------------------------------------------------------------
+
+  it('collects malformed rows as errors without throwing', () => {
+    const csv = [
+      'Date,Action,Symbol,Quantity,Price',
+      ',Buy,AAPL,10,150.00', // missing date
+      '2024-01-02,Buy,,10,150.00', // missing symbol
+      '2024-01-03,journal,AAPL,10,150.00', // unrecognized action
+      '2024-01-04,Buy,AAPL,abc,150.00', // invalid quantity
+      '2024-01-05,Buy,AAPL,10,', // missing price
+      '2024-01-06,Buy,AAPL,10,150.00', // valid
+    ].join('\n');
+    const result = parseBrokerageCsv(csv, { broker: 'Fidelity' });
+    expect(result.trades).toHaveLength(1);
+    expect(result.errors).toHaveLength(5);
+    expect(result.errors.map((e) => e.line)).toEqual([2, 3, 4, 5, 6]);
+    expect(result.errors[0].message).toMatch(/date/i);
+    expect(result.errors[1].message).toMatch(/symbol/i);
+    expect(result.errors[2].message).toMatch(/action/i);
+    expect(result.errors[3].message).toMatch(/quantity/i);
+    expect(result.errors[4].message).toMatch(/price/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconcileTrades — single broker, average cost
+// ---------------------------------------------------------------------------
+
+describe('reconcileTrades (single broker)', () => {
+  it('aggregates buys into a position with average cost incl. fees', () => {
+    const { trades } = parseFidelity();
+    const { holdings } = reconcileTrades(trades);
+    expect(holdings).toHaveLength(1);
+    const aapl = holdings[0];
+    expect(aapl.symbol).toBe('AAPL');
+    expect(aapl.netQuantity).toBe(15);
+    // cost basis = (150000 + 495) + (80000 + 495) = 230990
+    expect(aapl.costBasisCents).toBe(230990);
+    // average cost = round(230990 / 15) = 15399 (banker's rounding of 15399.33)
+    expect(aapl.averageCostCents).toBe(15399);
+    expect(aapl.dividendsCents).toBe(1250);
+    expect(aapl.totalFeesCents).toBe(990);
+    expect(aapl.buyCount).toBe(2);
+    expect(aapl.sellCount).toBe(0);
+  });
+
+  it('computes realized gain and reduces basis on a sell (average cost)', () => {
+    const result = parseBrokerageCsv(SCHWAB_CSV, { broker: 'Schwab' });
+    const { holdings } = reconcileTrades(result.trades);
+    const msft = holdings[0];
+    expect(msft.symbol).toBe('MSFT');
+    expect(msft.netQuantity).toBe(5);
+    // buy: 8 @ 400 + 0 fee = 320000 basis; avg = 40000/share
+    // sell 3 @ 420 - 1 fee: proceeds 125900, cost removed 120000 -> realized 5900
+    expect(msft.realizedGainCents).toBe(5900);
+    // remaining basis = 320000 - 120000 = 200000
+    expect(msft.costBasisCents).toBe(200000);
+    expect(msft.averageCostCents).toBe(40000);
+  });
+
+  it('flags an oversold position when sells exceed buys', () => {
+    const csv = [
+      'Date,Action,Symbol,Quantity,Price',
+      '2024-01-01,Buy,GME,5,20.00',
+      '2024-02-01,Sell,GME,8,25.00',
+    ].join('\n');
+    const result = parseBrokerageCsv(csv, { broker: 'Robinhood' });
+    const { holdings, warnings } = reconcileTrades(result.trades);
+    expect(holdings[0].netQuantity).toBe(-3);
+    expect(holdings[0].costBasisCents).toBe(0);
+    expect(warnings.some((w) => w.type === 'oversold-position')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-broker reconciliation
+// ---------------------------------------------------------------------------
+
+describe('cross-broker reconciliation', () => {
+  it('pools the same symbol across brokers into one unified holding', () => {
+    const fidelity = parseBrokerageCsv(
+      'Date,Action,Symbol,Quantity,Price,Fees\n2024-01-01,Buy,AAPL,10,150.00,5.00',
+      { broker: 'Fidelity' },
+    );
+    const schwab = parseBrokerageCsv(
+      'Date,Action,Symbol,Quantity,Price,Fees\n2024-02-01,Buy,AAPL,10,170.00,0.00',
+      { broker: 'Schwab' },
+    );
+    const plan = buildBrokerageImportPlan([fidelity, schwab]);
+
+    expect(plan.brokers).toEqual(['Fidelity', 'Schwab']);
+    expect(plan.holdings).toHaveLength(1);
+    const aapl = plan.holdings[0];
+    expect(aapl.netQuantity).toBe(20);
+    // basis = (150000 + 500) + (170000 + 0) = 320500
+    expect(aapl.costBasisCents).toBe(320500);
+    expect(aapl.averageCostCents).toBe(16025);
+    expect(aapl.brokers).toEqual(['Fidelity', 'Schwab']);
+    expect(aapl.contributions).toEqual([
+      { broker: 'Fidelity', quantity: 10, costBasisCents: 150500 },
+      { broker: 'Schwab', quantity: 10, costBasisCents: 170000 },
+    ]);
+  });
+
+  it('aggregates totals across brokers in integer cents', () => {
+    const plan = importBrokerageCsvs([
+      {
+        content: 'Date,Action,Symbol,Quantity,Price,Fees\n2024-01-01,Buy,AAPL,10,150.00,5.00',
+        options: { broker: 'Fidelity' },
+      },
+      {
+        content: 'Date,Action,Symbol,Quantity,Price\n2024-02-01,Buy,MSFT,2,400.00',
+        options: { broker: 'Schwab' },
+      },
+    ]);
+    expect(plan.totals.tradeCount).toBe(2);
+    expect(plan.totals.buyCount).toBe(2);
+    expect(plan.totals.feesCents).toBe(500);
+    // net invested = (150000 + 500) + 80000 = 230500
+    expect(plan.totals.netInvestedCents).toBe(230500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Duplicate detection
+// ---------------------------------------------------------------------------
+
+describe('detectDuplicates', () => {
+  it('flags an identical trade duplicated within one broker export', () => {
+    const csv = [
+      'Date,Action,Symbol,Quantity,Price',
+      '2024-01-01,Buy,AAPL,10,150.00',
+      '2024-01-01,Buy,AAPL,10,150.00',
+    ].join('\n');
+    const result = parseBrokerageCsv(csv, { broker: 'Fidelity' });
+    const groups = detectDuplicates(result.trades);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].crossBroker).toBe(false);
+    expect(groups[0].tradeIds).toHaveLength(2);
+  });
+
+  it('flags identical trades appearing across two brokers as cross-broker', () => {
+    const a = parseBrokerageCsv(
+      'Date,Action,Symbol,Quantity,Price\n2024-01-01,Buy,AAPL,10,150.00',
+      {
+        broker: 'Fidelity',
+      },
+    );
+    const b = parseBrokerageCsv(
+      'Date,Action,Symbol,Quantity,Price\n2024-01-01,Buy,AAPL,10,150.00',
+      {
+        broker: 'Schwab',
+      },
+    );
+    const plan = buildBrokerageImportPlan([a, b]);
+    expect(plan.duplicates).toHaveLength(1);
+    expect(plan.duplicates[0].crossBroker).toBe(true);
+    expect(plan.warnings.some((w) => w.type === 'duplicate-cross-broker')).toBe(true);
+  });
+
+  it('does not flag distinct trades as duplicates', () => {
+    const result = parseFidelity();
+    expect(detectDuplicates(result.trades)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBrokerageImportPlan — orchestration / determinism
+// ---------------------------------------------------------------------------
+
+describe('buildBrokerageImportPlan', () => {
+  it('is deterministic regardless of source order', () => {
+    const fidelity = parseBrokerageCsv(
+      'Date,Action,Symbol,Quantity,Price\n2024-02-01,Buy,AAPL,5,160.00',
+      { broker: 'Fidelity' },
+    );
+    const schwab = parseBrokerageCsv(
+      'Date,Action,Symbol,Quantity,Price\n2024-01-01,Buy,AAPL,10,150.00',
+      { broker: 'Schwab' },
+    );
+    const planA = buildBrokerageImportPlan([fidelity, schwab]);
+    const planB = buildBrokerageImportPlan([schwab, fidelity]);
+    expect(planA.holdings).toEqual(planB.holdings);
+    expect(planA.totals).toEqual(planB.totals);
+    // trades are sorted by date
+    expect(planA.trades.map((t) => t.date)).toEqual(['2024-01-01', '2024-02-01']);
+  });
+
+  it('surfaces parse errors from every source', () => {
+    const good = parseBrokerageCsv(
+      'Date,Action,Symbol,Quantity,Price\n2024-01-01,Buy,AAPL,1,10.00',
+      {
+        broker: 'Fidelity',
+      },
+    );
+    const bad = parseBrokerageCsv('Date,Action,Symbol,Quantity,Price\n,Buy,AAPL,1,10.00', {
+      broker: 'Schwab',
+    });
+    const plan = buildBrokerageImportPlan([good, bad]);
+    expect(plan.errors).toHaveLength(1);
+    expect(plan.errors[0].broker).toBe('Schwab');
+  });
+
+  it('handles an empty set of sources', () => {
+    const plan = buildBrokerageImportPlan([]);
+    expect(plan.trades).toHaveLength(0);
+    expect(plan.holdings).toHaveLength(0);
+    expect(plan.totals.tradeCount).toBe(0);
+  });
+});

--- a/apps/web/src/lib/investments/brokerage-import.ts
+++ b/apps/web/src/lib/investments/brokerage-import.ts
@@ -1,0 +1,731 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Brokerage trade-confirmation CSV import + cross-broker reconciliation engine.
+ *
+ * Pure, deterministic, dependency-light TypeScript. The pipeline is:
+ *
+ *   1. {@link suggestColumnMapping}    — headers → best-guess column mapping
+ *   2. {@link parseBrokerageCsv}       — tolerant CSV → {@link ParsedTrade}[]
+ *   3. {@link reconcileTrades}         — fold trades into per-symbol holdings,
+ *                                        detect duplicates and oversold positions
+ *   4. {@link buildBrokerageImportPlan}— orchestrates 2–3 across many brokers
+ *
+ * A user exports trade-confirmation CSVs from multiple brokers (Fidelity,
+ * Schwab, Robinhood, …) with slightly different column names. The engine maps
+ * those header variants onto a common shape, then reconciles buys / sells /
+ * dividends into a single unified holdings view with average cost basis.
+ *
+ * ALL money math is in **integer cents** — never floating point for currency.
+ * Share quantities are decimal counts (fractional shares are common) and are
+ * rounded to six decimal places for stable aggregation and comparison. Banker's
+ * rounding (round-half-to-even) is delegated to the shared import utilities.
+ *
+ * This module performs no I/O and never touches the database; the UI layer owns
+ * file reading and any persistence. References: issue #2120.
+ */
+
+import { parseCsv } from '../csv-parser';
+import { parseCurrencyToCents, parseDate } from '../import/csv-parser';
+import { bankersRound } from '../import/utils';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Trade actions the engine understands. `DIV` is a cash/-reinvested dividend. */
+export type BrokerageAction = 'BUY' | 'SELL' | 'DIV';
+
+/** Logical field → CSV header-name mapping. */
+export interface BrokerageColumnMapping {
+  readonly date: string;
+  readonly symbol: string;
+  readonly action: string;
+  readonly quantity: string;
+  readonly price: string;
+  /** Optional explicit fee/commission column. */
+  readonly fees?: string;
+  /** Optional net-amount column (used to derive price/dividend when absent). */
+  readonly amount?: string;
+}
+
+/** Options for {@link parseBrokerageCsv}. */
+export interface BrokerageParseOptions {
+  /** Human-readable broker label, e.g. `"Fidelity"`. Used for reconciliation. */
+  readonly broker: string;
+  /** Column mapping overrides; missing fields fall back to auto-detection. */
+  readonly mapping?: Partial<BrokerageColumnMapping>;
+  /** Explicit date format (e.g. `"MM/DD/YYYY"`); auto-detected when omitted. */
+  readonly dateFormat?: string;
+  /** Whether the first row is a header row. @default true */
+  readonly hasHeader?: boolean;
+  /** Delimiter override; auto-detected when omitted. */
+  readonly delimiter?: string;
+}
+
+/** A single normalized, parsed trade row. */
+export interface ParsedTrade {
+  readonly broker: string;
+  /** 1-based source line number (header counted). */
+  readonly line: number;
+  /** ISO-8601 trade date (`YYYY-MM-DD`). */
+  readonly date: string;
+  /** Upper-cased ticker symbol. */
+  readonly symbol: string;
+  readonly action: BrokerageAction;
+  /** Absolute share quantity (fractional allowed). */
+  readonly quantity: number;
+  /** Price per share, integer cents (>= 0). */
+  readonly priceCents: number;
+  /** Fees / commission, integer cents (>= 0). */
+  readonly feesCents: number;
+  /** Gross trade value before fees, integer cents (`round(qty * price)`). */
+  readonly grossCents: number;
+  /** Signed cash impact: BUY negative, SELL / DIV positive. */
+  readonly cashFlowCents: number;
+  /** Stable, broker-agnostic key used for duplicate detection. */
+  readonly dedupeKey: string;
+  /** Unique id for this parsed row (includes broker + line). */
+  readonly id: string;
+}
+
+/** A row that could not be parsed. */
+export interface BrokerageParseError {
+  readonly broker: string;
+  readonly line: number;
+  readonly message: string;
+  readonly raw: string;
+}
+
+/** Result of parsing a single broker's CSV. */
+export interface BrokerageParseResult {
+  readonly broker: string;
+  readonly trades: readonly ParsedTrade[];
+  readonly errors: readonly BrokerageParseError[];
+  /** The resolved (auto-detected + overridden) column mapping. */
+  readonly mapping: BrokerageColumnMapping;
+  /** Detected CSV headers. */
+  readonly headers: readonly string[];
+}
+
+/** Per-broker contribution to a reconciled holding. */
+export interface BrokerContribution {
+  readonly broker: string;
+  readonly quantity: number;
+  readonly costBasisCents: number;
+}
+
+/** A single symbol reconciled across all brokers. */
+export interface ReconciledHolding {
+  readonly symbol: string;
+  /** Net open quantity (buys minus sells), rounded to 6 dp. */
+  readonly netQuantity: number;
+  /** Remaining cost basis of the open position, integer cents. */
+  readonly costBasisCents: number;
+  /** Average cost per share of the open position, integer cents. */
+  readonly averageCostCents: number;
+  /** Realized gain/loss from closed lots (proceeds minus basis), integer cents. */
+  readonly realizedGainCents: number;
+  /** Total dividends received, integer cents. */
+  readonly dividendsCents: number;
+  /** Total fees paid across all trades, integer cents. */
+  readonly totalFeesCents: number;
+  /** Brokers that contributed trades for this symbol. */
+  readonly brokers: readonly string[];
+  /** Remaining quantity / basis attributed to each broker. */
+  readonly contributions: readonly BrokerContribution[];
+  readonly buyCount: number;
+  readonly sellCount: number;
+}
+
+/** Categories of reconciliation warning. */
+export type BrokerageWarningType =
+  | 'duplicate-within-broker'
+  | 'duplicate-cross-broker'
+  | 'oversold-position';
+
+/** A group of trades flagged as duplicates of one another. */
+export interface DuplicateGroup {
+  readonly key: string;
+  readonly symbol: string;
+  readonly tradeIds: readonly string[];
+  /** True when the duplicate spans more than one broker. */
+  readonly crossBroker: boolean;
+}
+
+/** A non-fatal reconciliation finding surfaced to the user. */
+export interface BrokerageWarning {
+  readonly type: BrokerageWarningType;
+  readonly severity: 'info' | 'warning';
+  readonly symbol?: string;
+  readonly message: string;
+  readonly tradeIds: readonly string[];
+}
+
+/** Aggregate totals across the whole import. */
+export interface BrokerageTotals {
+  readonly tradeCount: number;
+  readonly buyCount: number;
+  readonly sellCount: number;
+  readonly dividendCount: number;
+  /** Net cash invested: buy costs minus sell proceeds, integer cents. */
+  readonly netInvestedCents: number;
+  readonly dividendsCents: number;
+  readonly feesCents: number;
+}
+
+/** The full, recomputable import plan. */
+export interface BrokerageImportPlan {
+  readonly trades: readonly ParsedTrade[];
+  readonly holdings: readonly ReconciledHolding[];
+  readonly duplicates: readonly DuplicateGroup[];
+  readonly warnings: readonly BrokerageWarning[];
+  readonly errors: readonly BrokerageParseError[];
+  readonly brokers: readonly string[];
+  readonly totals: BrokerageTotals;
+}
+
+// ---------------------------------------------------------------------------
+// Column-mapping detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Header aliases per logical field, in priority order. Lower-cased; matched
+ * first by exact equality, then by substring inclusion for robustness against
+ * broker-specific suffixes (e.g. `"Price (USD)"` → `price`).
+ */
+const COLUMN_ALIASES: Record<keyof BrokerageColumnMapping, readonly string[]> = {
+  date: [
+    'trade date',
+    'run date',
+    'activity date',
+    'settlement date',
+    'transaction date',
+    'as of date',
+    'date',
+  ],
+  symbol: ['symbol', 'ticker', 'instrument', 'security id', 'security', 'cusip'],
+  action: [
+    'action',
+    'transaction type',
+    'trans code',
+    'activity type',
+    'buy/sell',
+    'side',
+    'type',
+    'activity',
+    'transaction',
+    'description',
+  ],
+  quantity: ['quantity', 'shares', 'share quantity', 'no. of shares', 'units', 'qty'],
+  price: [
+    'price per share',
+    'execution price',
+    'average price',
+    'avg price',
+    'share price',
+    'unit price',
+    'trade price',
+    'price',
+  ],
+  fees: [
+    'fees & comm',
+    'commission/fees',
+    'commission',
+    'total fees',
+    'reg fee',
+    'fees',
+    'fee',
+    'comm',
+  ],
+  amount: ['net amount', 'net cash', 'amount', 'proceeds', 'total', 'value', 'cost'],
+};
+
+/** Normalize a header for comparison (lower-case, collapse whitespace). */
+function normalizeHeader(header: string): string {
+  return header.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+/** Find the first header that matches one of `aliases` (exact then substring). */
+function matchHeader(headers: readonly string[], aliases: readonly string[]): string | undefined {
+  const normalized = headers.map((h) => ({ raw: h, norm: normalizeHeader(h) }));
+  for (const alias of aliases) {
+    const exact = normalized.find((h) => h.norm === alias);
+    if (exact) return exact.raw;
+  }
+  for (const alias of aliases) {
+    const partial = normalized.find((h) => h.norm.includes(alias));
+    if (partial) return partial.raw;
+  }
+  return undefined;
+}
+
+/**
+ * Suggest a column mapping from a CSV's headers using {@link COLUMN_ALIASES}.
+ * Fields that cannot be matched are left as empty strings (the UI prompts the
+ * user to resolve them).
+ */
+export function suggestColumnMapping(headers: readonly string[]): BrokerageColumnMapping {
+  return {
+    date: matchHeader(headers, COLUMN_ALIASES.date) ?? '',
+    symbol: matchHeader(headers, COLUMN_ALIASES.symbol) ?? '',
+    action: matchHeader(headers, COLUMN_ALIASES.action) ?? '',
+    quantity: matchHeader(headers, COLUMN_ALIASES.quantity) ?? '',
+    price: matchHeader(headers, COLUMN_ALIASES.price) ?? '',
+    fees: matchHeader(headers, COLUMN_ALIASES.fees) ?? '',
+    amount: matchHeader(headers, COLUMN_ALIASES.amount) ?? '',
+  };
+}
+
+/** Merge auto-detected mapping with caller overrides. */
+function resolveMapping(
+  headers: readonly string[],
+  overrides?: Partial<BrokerageColumnMapping>,
+): BrokerageColumnMapping {
+  const detected = suggestColumnMapping(headers);
+  return {
+    date: overrides?.date ?? detected.date,
+    symbol: overrides?.symbol ?? detected.symbol,
+    action: overrides?.action ?? detected.action,
+    quantity: overrides?.quantity ?? detected.quantity,
+    price: overrides?.price ?? detected.price,
+    fees: overrides?.fees ?? detected.fees,
+    amount: overrides?.amount ?? detected.amount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Value parsing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a raw action string to a {@link BrokerageAction}. Tolerant of broker
+ * phrasings ("YOU BOUGHT", "Buy", "Sold", "Reinvest Dividend", …).
+ * Returns `null` when the action cannot be recognized.
+ */
+export function normalizeAction(raw: string): BrokerageAction | null {
+  const s = raw.trim().toLowerCase();
+  if (!s) return null;
+  if (s.includes('div') || s.includes('reinvest') || s.includes('drip')) return 'DIV';
+  if (s.includes('sell') || s.includes('sold') || s.includes('sale')) return 'SELL';
+  if (s.includes('buy') || s.includes('bought') || s.includes('purchase')) return 'BUY';
+  return null;
+}
+
+/** Round a share quantity to 6 decimal places for stable aggregation. */
+function roundQuantity(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+/** Parse a raw share-quantity string into a finite number, or `null`. */
+function parseQuantity(raw: string): number | null {
+  const cleaned = raw.trim().replace(/,/g, '');
+  if (cleaned.length === 0) return null;
+  const value = Number.parseFloat(cleaned);
+  if (!Number.isFinite(value)) return null;
+  return roundQuantity(value);
+}
+
+/** Resolve a mapped field's raw cell value from a row. */
+function fieldValue(
+  row: readonly string[],
+  headers: readonly string[],
+  column: string | undefined,
+): string {
+  if (!column) return '';
+  const index = headers.findIndex((h) => normalizeHeader(h) === normalizeHeader(column));
+  if (index < 0) return '';
+  return row[index] ?? '';
+}
+
+// ---------------------------------------------------------------------------
+// CSV parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single broker's trade-confirmation CSV into normalized trades.
+ *
+ * Malformed rows are collected into {@link BrokerageParseResult.errors} rather
+ * than throwing, so one bad row never aborts the whole import.
+ */
+export function parseBrokerageCsv(
+  content: string,
+  options: BrokerageParseOptions,
+): BrokerageParseResult {
+  const broker = options.broker.trim() || 'Unknown broker';
+  const { headers, rows } = parseCsv(content, {
+    hasHeader: options.hasHeader ?? true,
+    delimiter: options.delimiter,
+  });
+  const mapping = resolveMapping(headers, options.mapping);
+
+  const trades: ParsedTrade[] = [];
+  const errors: BrokerageParseError[] = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const line = i + (options.hasHeader === false ? 1 : 2);
+    const row = rows[i];
+    const raw = row.join(',');
+
+    try {
+      const trade = parseRow(row, headers, mapping, broker, line, options.dateFormat);
+      if ('message' in trade) {
+        errors.push({ broker, line, message: trade.message, raw });
+      } else {
+        trades.push(trade);
+      }
+    } catch {
+      errors.push({ broker, line, message: 'Unexpected error parsing row', raw });
+    }
+  }
+
+  return { broker, trades, errors, mapping, headers };
+}
+
+/** Parse one row into a {@link ParsedTrade} or a `{ message }` failure. */
+function parseRow(
+  row: readonly string[],
+  headers: readonly string[],
+  mapping: BrokerageColumnMapping,
+  broker: string,
+  line: number,
+  dateFormat?: string,
+): ParsedTrade | { message: string } {
+  const dateRaw = fieldValue(row, headers, mapping.date);
+  if (!dateRaw.trim()) return { message: 'Missing trade date' };
+  const date = parseDate(dateRaw, dateFormat);
+  if (!date) return { message: `Unable to parse date "${dateRaw}"` };
+
+  const action = normalizeAction(fieldValue(row, headers, mapping.action));
+  if (!action) {
+    const rawAction = fieldValue(row, headers, mapping.action).trim();
+    return { message: rawAction ? `Unrecognized action "${rawAction}"` : 'Missing action' };
+  }
+
+  const symbol = fieldValue(row, headers, mapping.symbol).trim().toUpperCase();
+  if (!symbol) return { message: 'Missing symbol' };
+
+  const feesRaw = fieldValue(row, headers, mapping.fees);
+  const feesCents = feesRaw.trim() ? Math.abs(parseCurrencyToCents(feesRaw) ?? 0) : 0;
+
+  const amountRaw = fieldValue(row, headers, mapping.amount);
+  const amountCents = amountRaw.trim() ? parseCurrencyToCents(amountRaw) : null;
+
+  let quantity: number;
+  let priceCents: number;
+  let grossCents: number;
+
+  if (action === 'DIV') {
+    const qty = parseQuantity(fieldValue(row, headers, mapping.quantity));
+    const priceRaw = fieldValue(row, headers, mapping.price);
+    const priceParsed = priceRaw.trim() ? parseCurrencyToCents(priceRaw) : null;
+    // Dividend value comes from the amount column, else qty * price, else price.
+    const dividend =
+      amountCents !== null
+        ? Math.abs(amountCents)
+        : qty !== null && priceParsed !== null
+          ? Math.abs(bankersRound(qty * priceParsed))
+          : priceParsed !== null
+            ? Math.abs(priceParsed)
+            : null;
+    if (dividend === null) return { message: 'Missing dividend amount' };
+    quantity = qty ?? 0;
+    priceCents = priceParsed !== null ? Math.abs(priceParsed) : 0;
+    grossCents = dividend;
+  } else {
+    const qty = parseQuantity(fieldValue(row, headers, mapping.quantity));
+    if (qty === null || qty === 0) return { message: 'Missing or invalid quantity' };
+    quantity = Math.abs(qty);
+
+    const priceRaw = fieldValue(row, headers, mapping.price);
+    const priceParsed = priceRaw.trim() ? parseCurrencyToCents(priceRaw) : null;
+    if (priceParsed !== null) {
+      priceCents = Math.abs(priceParsed);
+      grossCents = bankersRound(quantity * priceCents);
+    } else if (amountCents !== null) {
+      // Derive gross/price from the net amount when no price column exists.
+      grossCents = Math.max(0, Math.abs(amountCents) - feesCents);
+      priceCents = quantity > 0 ? bankersRound(grossCents / quantity) : 0;
+    } else {
+      return { message: 'Missing price' };
+    }
+  }
+
+  const cashFlowCents =
+    action === 'BUY'
+      ? -(grossCents + feesCents)
+      : action === 'SELL'
+        ? grossCents - feesCents
+        : grossCents;
+
+  const dedupeKey = [
+    date,
+    symbol,
+    action,
+    Math.round(quantity * 1_000_000),
+    grossCents,
+    feesCents,
+  ].join('|');
+  const id = `${broker}#${line}#${dedupeKey}`;
+
+  return {
+    broker,
+    line,
+    date,
+    symbol,
+    action,
+    quantity,
+    priceCents,
+    feesCents,
+    grossCents,
+    cashFlowCents,
+    dedupeKey,
+    id,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation
+// ---------------------------------------------------------------------------
+
+interface MutableContribution {
+  quantity: number;
+  costBasisCents: number;
+}
+
+/** Stable sort of trades: by date, then symbol, then source line. */
+function sortTrades(trades: readonly ParsedTrade[]): ParsedTrade[] {
+  return [...trades].sort((a, b) => {
+    if (a.date !== b.date) return a.date < b.date ? -1 : 1;
+    if (a.symbol !== b.symbol) return a.symbol < b.symbol ? -1 : 1;
+    if (a.broker !== b.broker) return a.broker < b.broker ? -1 : 1;
+    return a.line - b.line;
+  });
+}
+
+/**
+ * Reconcile parsed trades into per-symbol holdings using the **average cost**
+ * method, pooling lots across every broker into a single unified position.
+ * Also detects duplicate trades and oversold positions.
+ */
+export function reconcileTrades(trades: readonly ParsedTrade[]): {
+  holdings: ReconciledHolding[];
+  duplicates: DuplicateGroup[];
+  warnings: BrokerageWarning[];
+} {
+  const sorted = sortTrades(trades);
+  const bySymbol = new Map<string, ParsedTrade[]>();
+  for (const trade of sorted) {
+    const list = bySymbol.get(trade.symbol);
+    if (list) list.push(trade);
+    else bySymbol.set(trade.symbol, [trade]);
+  }
+
+  const holdings: ReconciledHolding[] = [];
+  const warnings: BrokerageWarning[] = [];
+
+  for (const [symbol, symbolTrades] of bySymbol) {
+    let runningQty = 0;
+    let runningCostCents = 0;
+    let realizedGainCents = 0;
+    let dividendsCents = 0;
+    let totalFeesCents = 0;
+    let buyCount = 0;
+    let sellCount = 0;
+    const contributions = new Map<string, MutableContribution>();
+    const oversoldIds: string[] = [];
+
+    const contributionFor = (broker: string): MutableContribution => {
+      let c = contributions.get(broker);
+      if (!c) {
+        c = { quantity: 0, costBasisCents: 0 };
+        contributions.set(broker, c);
+      }
+      return c;
+    };
+
+    for (const trade of symbolTrades) {
+      totalFeesCents += trade.feesCents;
+      const contribution = contributionFor(trade.broker);
+
+      if (trade.action === 'BUY') {
+        const lotCost = trade.grossCents + trade.feesCents;
+        runningCostCents += lotCost;
+        runningQty = roundQuantity(runningQty + trade.quantity);
+        contribution.quantity = roundQuantity(contribution.quantity + trade.quantity);
+        contribution.costBasisCents += lotCost;
+        buyCount += 1;
+      } else if (trade.action === 'SELL') {
+        sellCount += 1;
+        const avgCost = runningQty > 0 ? runningCostCents / runningQty : 0;
+        const closedQty = runningQty > 0 ? Math.min(trade.quantity, runningQty) : 0;
+        const costRemoved = bankersRound(avgCost * closedQty);
+        const proceeds = trade.grossCents - trade.feesCents;
+        realizedGainCents += proceeds - costRemoved;
+        runningCostCents = Math.max(0, runningCostCents - costRemoved);
+        runningQty = roundQuantity(runningQty - trade.quantity);
+        contribution.quantity = roundQuantity(contribution.quantity - trade.quantity);
+        contribution.costBasisCents = Math.max(0, contribution.costBasisCents - costRemoved);
+        if (runningQty < -1e-6) oversoldIds.push(trade.id);
+      } else {
+        dividendsCents += trade.grossCents;
+      }
+    }
+
+    const netQuantity = roundQuantity(runningQty);
+    const hasOpenPosition = netQuantity > 1e-9;
+    const costBasisCents = hasOpenPosition ? Math.round(runningCostCents) : 0;
+    const averageCostCents = hasOpenPosition ? bankersRound(runningCostCents / netQuantity) : 0;
+
+    const brokers = [...contributions.keys()].sort();
+    const contributionList: BrokerContribution[] = brokers.map((broker) => {
+      const c = contributions.get(broker)!;
+      return {
+        broker,
+        quantity: roundQuantity(c.quantity),
+        costBasisCents: Math.max(0, Math.round(c.costBasisCents)),
+      };
+    });
+
+    if (oversoldIds.length > 0) {
+      warnings.push({
+        type: 'oversold-position',
+        severity: 'warning',
+        symbol,
+        message: `Sells for ${symbol} exceed recorded buys — a buy may be missing from another broker's export.`,
+        tradeIds: oversoldIds,
+      });
+    }
+
+    holdings.push({
+      symbol,
+      netQuantity,
+      costBasisCents,
+      averageCostCents,
+      realizedGainCents,
+      dividendsCents,
+      totalFeesCents,
+      brokers,
+      contributions: contributionList,
+      buyCount,
+      sellCount,
+    });
+  }
+
+  holdings.sort((a, b) => (a.symbol < b.symbol ? -1 : a.symbol > b.symbol ? 1 : 0));
+
+  const duplicates = detectDuplicates(sorted);
+  for (const group of duplicates) {
+    warnings.push({
+      type: group.crossBroker ? 'duplicate-cross-broker' : 'duplicate-within-broker',
+      severity: group.crossBroker ? 'info' : 'warning',
+      symbol: group.symbol,
+      message: group.crossBroker
+        ? `Identical ${group.symbol} trade found in more than one broker export — confirm it is not the same trade counted twice.`
+        : `Identical ${group.symbol} trade appears ${group.tradeIds.length} times in one export — likely a duplicate import.`,
+      tradeIds: group.tradeIds,
+    });
+  }
+
+  return { holdings, duplicates, warnings };
+}
+
+/**
+ * Detect duplicate trades. Trades sharing a {@link ParsedTrade.dedupeKey} are
+ * grouped; a group spanning multiple brokers is flagged `crossBroker`.
+ */
+export function detectDuplicates(trades: readonly ParsedTrade[]): DuplicateGroup[] {
+  const groups = new Map<string, ParsedTrade[]>();
+  for (const trade of trades) {
+    const list = groups.get(trade.dedupeKey);
+    if (list) list.push(trade);
+    else groups.set(trade.dedupeKey, [trade]);
+  }
+
+  const result: DuplicateGroup[] = [];
+  for (const [key, group] of groups) {
+    if (group.length < 2) continue;
+    const brokers = new Set(group.map((t) => t.broker));
+    result.push({
+      key,
+      symbol: group[0].symbol,
+      tradeIds: group.map((t) => t.id),
+      crossBroker: brokers.size > 1,
+    });
+  }
+  result.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Plan orchestration
+// ---------------------------------------------------------------------------
+
+/** A parsed-and-ready broker source fed into {@link buildBrokerageImportPlan}. */
+export type BrokerageSource = BrokerageParseResult;
+
+/** Compute aggregate totals across every parsed trade. */
+function computeTotals(trades: readonly ParsedTrade[]): BrokerageTotals {
+  let buyCount = 0;
+  let sellCount = 0;
+  let dividendCount = 0;
+  let netInvestedCents = 0;
+  let dividendsCents = 0;
+  let feesCents = 0;
+
+  for (const trade of trades) {
+    feesCents += trade.feesCents;
+    if (trade.action === 'BUY') {
+      buyCount += 1;
+      netInvestedCents += trade.grossCents + trade.feesCents;
+    } else if (trade.action === 'SELL') {
+      sellCount += 1;
+      netInvestedCents -= trade.grossCents - trade.feesCents;
+    } else {
+      dividendCount += 1;
+      dividendsCents += trade.grossCents;
+    }
+  }
+
+  return {
+    tradeCount: trades.length,
+    buyCount,
+    sellCount,
+    dividendCount,
+    netInvestedCents,
+    dividendsCents,
+    feesCents,
+  };
+}
+
+/**
+ * Build a complete, recomputable import plan from one or more parsed broker
+ * sources. The trades are pooled, reconciled into unified holdings, and
+ * duplicate / oversold findings are surfaced as warnings.
+ */
+export function buildBrokerageImportPlan(sources: readonly BrokerageSource[]): BrokerageImportPlan {
+  const trades = sortTrades(sources.flatMap((source) => source.trades));
+  const errors = sources.flatMap((source) => source.errors);
+  const brokers = [...new Set(sources.map((source) => source.broker))].sort();
+  const { holdings, duplicates, warnings } = reconcileTrades(trades);
+
+  return {
+    trades,
+    holdings,
+    duplicates,
+    warnings,
+    errors,
+    brokers,
+    totals: computeTotals(trades),
+  };
+}
+
+/**
+ * Convenience wrapper: parse each raw broker CSV and build the plan in one call.
+ */
+export function importBrokerageCsvs(
+  inputs: readonly { content: string; options: BrokerageParseOptions }[],
+): BrokerageImportPlan {
+  const sources = inputs.map((input) => parseBrokerageCsv(input.content, input.options));
+  return buildBrokerageImportPlan(sources);
+}

--- a/apps/web/src/pages/BrokerageImportPage.tsx
+++ b/apps/web/src/pages/BrokerageImportPage.tsx
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Brokerage trade-import + cross-broker reconciliation page.
+ *
+ * Thin wiring layer. The {@link BrokerageImportPanel} is self-contained (it owns
+ * its own local parse/reconcile state — this slice previews and reconciles only,
+ * with no persistence) and is imported directly (not via the shared
+ * `components/import` barrel) so its weight stays inside this route's own lazy
+ * chunk and does not inflate other import routes.
+ *
+ * References: issue #2120
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+// Direct import keeps this heavy component code-split into the brokerage route chunk.
+import { BrokerageImportPanel } from '../components/import/BrokerageImportPanel';
+
+export const BrokerageImportPage: React.FC = () => {
+  return (
+    <div className="brokerage-import-page">
+      <p className="brokerage-import-page__back">
+        <Link to="/import">← Back to all imports</Link>
+      </p>
+      <BrokerageImportPanel />
+    </div>
+  );
+};
+
+export default BrokerageImportPage;

--- a/apps/web/src/pages/ImportPage.tsx
+++ b/apps/web/src/pages/ImportPage.tsx
@@ -135,6 +135,11 @@ export const ImportPage: React.FC = () => {
         <Link to="/import/p2p">Import a Venmo / Cash App CSV</Link> to automatically separate
         reimbursements from real spending.
       </p>
+      <p className="import-section-description">
+        Trade across multiple brokers?{' '}
+        <Link to="/import/brokerage">Import brokerage trade CSVs</Link> to reconcile buys, sells and
+        dividends into a unified holdings view.
+      </p>
 
       <StepIndicator currentStep={importState.step} />
 

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -37,6 +37,7 @@ const SettingsAdvanced = lazy(() => import('./pages/settings/SettingsAdvancedPag
 const SettingsAbout = lazy(() => import('./pages/settings/SettingsAboutPage'));
 const DataImportWizard = lazy(() => import('./pages/DataImportWizardPage'));
 const P2PImport = lazy(() => import('./pages/P2PImportPage'));
+const BrokerageImport = lazy(() => import('./pages/BrokerageImportPage'));
 const ReceiptOcr = lazy(() => import('./pages/ReceiptOcrPage'));
 const Login = lazy(() => import('./pages/LoginPage'));
 const Signup = lazy(() => import('./pages/SignupPage'));
@@ -712,6 +713,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="P2P Import">
             <P2PImport />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/import/brokerage"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Brokerage Import">
+            <BrokerageImport />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Summary
Web slice of issue #2120 ? brokerage trade-confirmation CSV import with cross-broker reconciliation. Users export trade CSVs from multiple brokers (Fidelity, Schwab, Robinhood, ?), add them one at a time, and the app reconciles buys/sells/dividends into a unified holdings view with average cost basis.

Live broker API connections, KMP shared models, and native UI remain out of scope ? this is the web parsing/reconciliation engine + accessible UI surface only.

## What's included
- **Pure engine** pps/web/src/lib/investments/brokerage-import.ts
  - Tolerant CSV parsing with a small column-mapping layer (auto-detects broker header variants, accepts overrides).
  - **All money math in integer cents** (no floats for currency); share quantities rounded to 6 dp for stable aggregation; banker's rounding via shared import utils.
  - Per-symbol average-cost reconciliation pooled across brokers: net quantity, remaining cost basis, average cost, realized gain, dividends, fees, per-broker contributions.
  - Duplicate detection (within-broker and cross-broker) and oversold-position warnings.
  - Malformed rows collected as errors instead of throwing.
- **Accessible UI** BrokerageImportPanel (imported directly into the lazy `/import/brokerage` page ? not added to the `components/import` barrel, to keep it out of shared chunks and within the perf budget)
  - File picker + paste input, column-mapping confirmation step, parsed-trade preview, reconciled holdings summary, and reconciliation findings.
  - WCAG 2.2 AA: semantic `<table>`/`<fieldset>`/labels, `scope` headers + captions, action shown via icon **and** text (no color-only signals), `aria-live` summary/status, `role="alert"` errors, fully keyboard operable, token-only CSS that respects reduced motion / high contrast.
- **Tests** (Vitest): engine unit tests (happy path, multi-broker reconciliation, duplicate detection, fee handling, dividends, oversold, malformed rows, determinism) + panel interaction tests. 36 new tests, all green.

## Verification
- `prettier --check` clean, `eslint . --max-warnings 0` clean, `tsc --noEmit` 0 errors.
- `vitest run` for new specs + `ImportPage` regression: 82 passing.
- New code reachable only via its own lazy route chunk; no shared barrel/eager imports.

Refs #2120
