### PR TITLE
feat(web): weekly/monthly P&L with COGS, labor, and margins (#2184)

### DIFF
--- a/apps/web/src/components/layout/navConfig.tsx
+++ b/apps/web/src/components/layout/navConfig.tsx
@@ -310,6 +310,15 @@ export const NAV_CONFIG: readonly NavConfigItem[] = ensureStableNavOrder([
     description: 'Revenue, cost and margin by client/project tag.',
   },
   {
+    id: 'business-pnl',
+    label: 'Profit & Loss',
+    href: '/business-pnl',
+    icon: <ReportsIcon />,
+    group: 'insights',
+    mobilePriority: 27,
+    description: 'Weekly/monthly P&L with COGS, labor and margins.',
+  },
+  {
     id: 'achievements',
     label: 'Achievements',
     href: '/achievements',

--- a/apps/web/src/lib/business/profit-and-loss.test.ts
+++ b/apps/web/src/lib/business/profit-and-loss.test.ts
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import type { Transaction, TransactionStatus, TransactionType } from '../../kmp/bridge';
+import {
+  DEFAULT_PNL_TAGS,
+  buildProfitAndLoss,
+  classifyTransaction,
+  compilePnlTagSets,
+  formatMarginPercent,
+  marginBasisPoints,
+  periodKey,
+  periodLabel,
+  weekStartKey,
+} from './profit-and-loss';
+
+// ---------------------------------------------------------------------------
+// Test factory
+// ---------------------------------------------------------------------------
+
+let nextId = 0;
+
+function makeTransaction(options: {
+  date: string;
+  type: TransactionType;
+  amountCents: number;
+  tags?: readonly string[];
+  status?: TransactionStatus;
+}): Transaction {
+  nextId += 1;
+  return {
+    id: `txn-${nextId}`,
+    householdId: 'hh-1',
+    accountId: 'acct-1',
+    categoryId: null,
+    type: options.type,
+    status: options.status ?? 'CLEARED',
+    amount: { amount: options.amountCents },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    payee: null,
+    note: null,
+    date: options.date,
+    transferAccountId: null,
+    transferTransactionId: null,
+    isRecurring: false,
+    recurringRuleId: null,
+    tags: options.tags ?? [],
+    merchantAddress: null,
+    merchantCity: null,
+    merchantState: null,
+    merchantZip: null,
+    merchantCountry: null,
+    externalReferenceId: null,
+    statementDescription: null,
+    customFields: null,
+    extraNotes: null,
+    counterpartyName: null,
+    counterpartyAccountId: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// marginBasisPoints
+// ---------------------------------------------------------------------------
+
+describe('marginBasisPoints', () => {
+  it('computes integer basis points from integer cents', () => {
+    // 700_000 / 1_000_000 = 70% = 7000 bps
+    expect(marginBasisPoints(700_000, 1_000_000)).toBe(7000);
+  });
+
+  it('rounds to the nearest integer basis point (no float drift)', () => {
+    // 6667 / 10000 = 66.67% -> 6667 bps, exact integer
+    expect(marginBasisPoints(6_667, 10_000)).toBe(6667);
+  });
+
+  it('supports negative margins', () => {
+    expect(marginBasisPoints(-20_000, 100_000)).toBe(-2000);
+  });
+
+  it('returns null when revenue is zero', () => {
+    expect(marginBasisPoints(5_000, 0)).toBeNull();
+  });
+
+  it('returns null when revenue is negative', () => {
+    expect(marginBasisPoints(5_000, -100)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatMarginPercent
+// ---------------------------------------------------------------------------
+
+describe('formatMarginPercent', () => {
+  it('formats positive basis points to one decimal percent', () => {
+    expect(formatMarginPercent(7000)).toBe('70.0%');
+    expect(formatMarginPercent(2537)).toBe('25.4%');
+  });
+
+  it('formats negative basis points with a leading minus (not color-only)', () => {
+    expect(formatMarginPercent(-1200)).toBe('-12.0%');
+  });
+
+  it('formats null as N/A', () => {
+    expect(formatMarginPercent(null)).toBe('N/A');
+  });
+
+  it('honours a custom fraction-digit count', () => {
+    expect(formatMarginPercent(6667, 2)).toBe('66.67%');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Period helpers
+// ---------------------------------------------------------------------------
+
+describe('weekStartKey', () => {
+  it('snaps to the Monday of the ISO week', () => {
+    expect(weekStartKey('2024-01-15')).toBe('2024-01-15'); // Monday
+    expect(weekStartKey('2024-01-17')).toBe('2024-01-15'); // Wednesday
+    expect(weekStartKey('2024-01-21')).toBe('2024-01-15'); // Sunday
+    expect(weekStartKey('2024-01-22')).toBe('2024-01-22'); // next Monday
+  });
+
+  it('returns the input unchanged for an invalid date', () => {
+    expect(weekStartKey('not-a-date')).toBe('not-a-date');
+  });
+});
+
+describe('periodKey / periodLabel', () => {
+  it('keys monthly periods as YYYY-MM', () => {
+    expect(periodKey('2024-03-09', 'monthly')).toBe('2024-03');
+    expect(periodLabel('2024-03', 'monthly')).toBe('Mar 2024');
+  });
+
+  it('keys weekly periods as the Monday week start', () => {
+    expect(periodKey('2024-01-17', 'weekly')).toBe('2024-01-15');
+    expect(periodLabel('2024-01-15', 'weekly')).toBe('Week of 2024-01-15');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyTransaction
+// ---------------------------------------------------------------------------
+
+describe('classifyTransaction', () => {
+  const tagSets = compilePnlTagSets();
+
+  it('treats untagged income as revenue and untagged expense as overhead', () => {
+    expect(
+      classifyTransaction(
+        makeTransaction({ date: '2024-01-01', type: 'INCOME', amountCents: 1 }),
+        tagSets,
+      ),
+    ).toBe('revenue');
+    expect(
+      classifyTransaction(
+        makeTransaction({ date: '2024-01-01', type: 'EXPENSE', amountCents: 1 }),
+        tagSets,
+      ),
+    ).toBe('overhead');
+  });
+
+  it('routes tagged transactions to their explicit bucket', () => {
+    expect(
+      classifyTransaction(
+        makeTransaction({ date: '2024-01-01', type: 'EXPENSE', amountCents: 1, tags: ['cogs'] }),
+        tagSets,
+      ),
+    ).toBe('cogs');
+    expect(
+      classifyTransaction(
+        makeTransaction({
+          date: '2024-01-01',
+          type: 'EXPENSE',
+          amountCents: 1,
+          tags: ['pnl:labor'],
+        }),
+        tagSets,
+      ),
+    ).toBe('labor');
+  });
+
+  it('matches tags case-insensitively', () => {
+    expect(
+      classifyTransaction(
+        makeTransaction({ date: '2024-01-01', type: 'EXPENSE', amountCents: 1, tags: ['COGS'] }),
+        tagSets,
+      ),
+    ).toBe('cogs');
+  });
+
+  it('ignores transfers and voided transactions', () => {
+    expect(
+      classifyTransaction(
+        makeTransaction({ date: '2024-01-01', type: 'TRANSFER', amountCents: 1 }),
+        tagSets,
+      ),
+    ).toBeNull();
+    expect(
+      classifyTransaction(
+        makeTransaction({ date: '2024-01-01', type: 'INCOME', amountCents: 1, status: 'VOID' }),
+        tagSets,
+      ),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildProfitAndLoss
+// ---------------------------------------------------------------------------
+
+describe('buildProfitAndLoss', () => {
+  it('computes gross/net profit and margins for a profitable month', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 1_000_000 }), // revenue $10,000
+        makeTransaction({
+          date: '2024-01-06',
+          type: 'EXPENSE',
+          amountCents: 300_000,
+          tags: ['cogs'],
+        }),
+        makeTransaction({
+          date: '2024-01-07',
+          type: 'EXPENSE',
+          amountCents: 200_000,
+          tags: ['labor'],
+        }),
+        makeTransaction({
+          date: '2024-01-08',
+          type: 'EXPENSE',
+          amountCents: 100_000,
+          tags: ['overhead'],
+        }),
+      ],
+      { granularity: 'monthly' },
+    );
+
+    const { totals } = statement;
+    expect(totals.revenueCents).toBe(1_000_000);
+    expect(totals.cogsCents).toBe(300_000);
+    expect(totals.laborCents).toBe(200_000);
+    expect(totals.overheadCents).toBe(100_000);
+    expect(totals.grossProfitCents).toBe(700_000);
+    expect(totals.operatingExpensesCents).toBe(300_000);
+    expect(totals.netProfitCents).toBe(400_000);
+    expect(totals.grossMarginBps).toBe(7000); // 70.0%
+    expect(totals.netMarginBps).toBe(4000); // 40.0%
+    expect(totals.transactionCount).toBe(4);
+    expect(formatMarginPercent(totals.netMarginBps)).toBe('40.0%');
+  });
+
+  it('reports a negative net profit when operating expenses exceed gross profit', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-02-01', type: 'INCOME', amountCents: 100_000 }), // $1,000
+        makeTransaction({
+          date: '2024-02-02',
+          type: 'EXPENSE',
+          amountCents: 40_000,
+          tags: ['cogs'],
+        }),
+        makeTransaction({
+          date: '2024-02-03',
+          type: 'EXPENSE',
+          amountCents: 50_000,
+          tags: ['labor'],
+        }),
+        makeTransaction({
+          date: '2024-02-04',
+          type: 'EXPENSE',
+          amountCents: 30_000,
+          tags: ['overhead'],
+        }),
+      ],
+      { granularity: 'monthly' },
+    );
+
+    const { totals } = statement;
+    expect(totals.grossProfitCents).toBe(60_000);
+    expect(totals.netProfitCents).toBe(-20_000);
+    expect(totals.grossMarginBps).toBe(6000); // 60.0%
+    expect(totals.netMarginBps).toBe(-2000); // -20.0%
+    expect(formatMarginPercent(totals.netMarginBps)).toBe('-20.0%');
+  });
+
+  it('returns null margins (N/A) when there is no revenue', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({
+          date: '2024-03-10',
+          type: 'EXPENSE',
+          amountCents: 5_000,
+          tags: ['overhead'],
+        }),
+      ],
+      { granularity: 'monthly' },
+    );
+
+    const { totals } = statement;
+    expect(totals.revenueCents).toBe(0);
+    expect(totals.netProfitCents).toBe(-5_000);
+    expect(totals.grossMarginBps).toBeNull();
+    expect(totals.netMarginBps).toBeNull();
+    expect(formatMarginPercent(totals.grossMarginBps)).toBe('N/A');
+  });
+
+  it('treats negative expense amounts as positive cost magnitudes', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 100_000 }),
+        makeTransaction({
+          date: '2024-01-06',
+          type: 'EXPENSE',
+          amountCents: -40_000,
+          tags: ['cogs'],
+        }),
+      ],
+      { granularity: 'monthly' },
+    );
+
+    expect(statement.totals.cogsCents).toBe(40_000);
+    expect(statement.totals.grossProfitCents).toBe(60_000);
+  });
+
+  it('groups transactions into monthly periods sorted chronologically', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-02-15', type: 'INCOME', amountCents: 200_000 }),
+        makeTransaction({ date: '2024-01-15', type: 'INCOME', amountCents: 100_000 }),
+        makeTransaction({
+          date: '2024-01-20',
+          type: 'EXPENSE',
+          amountCents: 50_000,
+          tags: ['cogs'],
+        }),
+      ],
+      { granularity: 'monthly' },
+    );
+
+    expect(statement.periods.map((p) => p.key)).toEqual(['2024-01', '2024-02']);
+    expect(statement.periods[0].label).toBe('Jan 2024');
+    expect(statement.periods[0].revenueCents).toBe(100_000);
+    expect(statement.periods[0].cogsCents).toBe(50_000);
+    expect(statement.periods[1].revenueCents).toBe(200_000);
+    // Combined totals span both periods.
+    expect(statement.totals.revenueCents).toBe(300_000);
+  });
+
+  it('groups transactions into Monday-based weekly periods', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-01-15', type: 'INCOME', amountCents: 100_000 }), // week of 01-15
+        makeTransaction({
+          date: '2024-01-18',
+          type: 'EXPENSE',
+          amountCents: 20_000,
+          tags: ['cogs'],
+        }), // same week
+        makeTransaction({ date: '2024-01-23', type: 'INCOME', amountCents: 50_000 }), // week of 01-22
+      ],
+      { granularity: 'weekly' },
+    );
+
+    expect(statement.periods.map((p) => p.key)).toEqual(['2024-01-15', '2024-01-22']);
+    expect(statement.periods[0].label).toBe('Week of 2024-01-15');
+    expect(statement.periods[0].revenueCents).toBe(100_000);
+    expect(statement.periods[0].cogsCents).toBe(20_000);
+    expect(statement.periods[1].revenueCents).toBe(50_000);
+  });
+
+  it('excludes transactions outside the date range', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2023-12-31', type: 'INCOME', amountCents: 999_999 }), // before range
+        makeTransaction({ date: '2024-01-10', type: 'INCOME', amountCents: 100_000 }), // in range
+        makeTransaction({ date: '2024-02-01', type: 'INCOME', amountCents: 999_999 }), // after range
+      ],
+      { granularity: 'monthly', startDate: '2024-01-01', endDate: '2024-01-31' },
+    );
+
+    expect(statement.totals.revenueCents).toBe(100_000);
+    expect(statement.periods).toHaveLength(1);
+  });
+
+  it('ignores transfers and voided transactions', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 100_000 }),
+        makeTransaction({ date: '2024-01-06', type: 'TRANSFER', amountCents: 500_000 }),
+        makeTransaction({
+          date: '2024-01-07',
+          type: 'EXPENSE',
+          amountCents: 999_999,
+          status: 'VOID',
+        }),
+      ],
+      { granularity: 'monthly' },
+    );
+
+    expect(statement.totals.revenueCents).toBe(100_000);
+    expect(statement.totals.overheadCents).toBe(0);
+    expect(statement.totals.transactionCount).toBe(1);
+  });
+
+  it('produces exact integer basis points for repeating ratios', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 10_000 }), // $100
+        makeTransaction({
+          date: '2024-01-06',
+          type: 'EXPENSE',
+          amountCents: 3_333,
+          tags: ['cogs'],
+        }),
+      ],
+      { granularity: 'monthly' },
+    );
+
+    expect(statement.totals.grossProfitCents).toBe(6_667);
+    expect(statement.totals.grossMarginBps).toBe(6667); // exact integer, no float drift
+    expect(Number.isInteger(statement.totals.grossMarginBps)).toBe(true);
+    expect(formatMarginPercent(statement.totals.grossMarginBps)).toBe('66.7%');
+  });
+
+  it('defaults to monthly granularity', () => {
+    const statement = buildProfitAndLoss([
+      makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 100_000 }),
+    ]);
+    expect(statement.granularity).toBe('monthly');
+    expect(statement.periods[0].key).toBe('2024-01');
+  });
+
+  it('returns empty periods and zeroed totals for no transactions', () => {
+    const statement = buildProfitAndLoss([]);
+    expect(statement.periods).toEqual([]);
+    expect(statement.totals.revenueCents).toBe(0);
+    expect(statement.totals.netProfitCents).toBe(0);
+    expect(statement.totals.netMarginBps).toBeNull();
+  });
+
+  it('honours custom bucket tag overrides', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 100_000 }),
+        makeTransaction({
+          date: '2024-01-06',
+          type: 'EXPENSE',
+          amountCents: 25_000,
+          tags: ['ingredients'],
+        }),
+      ],
+      { granularity: 'monthly', cogsTags: ['ingredients'] },
+    );
+
+    expect(statement.totals.cogsCents).toBe(25_000);
+    expect(statement.totals.overheadCents).toBe(0);
+  });
+});
+
+describe('DEFAULT_PNL_TAGS', () => {
+  it('exposes a marker list for every bucket', () => {
+    expect(DEFAULT_PNL_TAGS.revenue.length).toBeGreaterThan(0);
+    expect(DEFAULT_PNL_TAGS.cogs).toContain('cogs');
+    expect(DEFAULT_PNL_TAGS.labor).toContain('payroll');
+    expect(DEFAULT_PNL_TAGS.overhead).toContain('opex');
+  });
+});

--- a/apps/web/src/lib/business/profit-and-loss.ts
+++ b/apps/web/src/lib/business/profit-and-loss.ts
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Small-business Profit & Loss (P&L) engine.
+ *
+ * Builds a weekly or monthly profit-and-loss statement from categorized
+ * transactions for an owner-operator (e.g. a food-truck) who needs to know
+ * whether the business is actually profitable after the cost of goods sold,
+ * labor and other operating expenses.
+ *
+ * Each transaction is classified into one of four P&L buckets:
+ *
+ *   - `revenue`  — money the business takes in (sales).
+ *   - `cogs`     — cost of goods sold (ingredients, supplies resold, ...).
+ *   - `labor`    — wages / payroll / contractor pay.
+ *   - `overhead` — other operating expenses (rent, fuel, insurance, ...).
+ *
+ * The classic statement is then derived:
+ *
+ *   gross profit       = revenue − COGS
+ *   operating expenses = labor + overhead
+ *   net profit         = gross profit − operating expenses
+ *   gross margin %     = gross profit / revenue
+ *   net margin %       = net profit / revenue
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * MONEY & MARGINS — every monetary value is an INTEGER number of cents and is
+ * only summed/subtracted (never divided) so totals stay exact. Margins are
+ * returned as INTEGER **basis points** (1% = 100 bps, computed as
+ * `round(part * 10_000 / revenue)`) so the percentage carries no accumulated
+ * floating-point error; UI formatting divides by 100 only at display time.
+ * When revenue is zero the margin is `null` (N/A) rather than a divide-by-zero.
+ * ──────────────────────────────────────────────────────────────────────────
+ *
+ * This module is pure and deterministic: same input → same output, no clock,
+ * no I/O. Splits are not expanded — a transaction's whole amount is allocated
+ * to its single classified bucket.
+ *
+ * References: issue #2184.
+ */
+
+import type { LocalDate, Transaction } from '../../kmp/bridge';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The four buckets that make up a profit-and-loss statement. */
+export type PnlCategory = 'revenue' | 'cogs' | 'labor' | 'overhead';
+
+/** Reporting cadence for the statement. */
+export type PnlGranularity = 'weekly' | 'monthly';
+
+/**
+ * Tag markers (case-insensitive, matched as whole tags) that force a
+ * transaction into a specific P&L bucket regardless of its income/expense
+ * type. Explicit tags always win over the type-based fallback.
+ */
+export interface PnlTagConfig {
+  readonly revenueTags?: readonly string[];
+  readonly cogsTags?: readonly string[];
+  readonly laborTags?: readonly string[];
+  readonly overheadTags?: readonly string[];
+}
+
+export interface PnlOptions extends PnlTagConfig {
+  /** Reporting cadence. Default `'monthly'`. */
+  readonly granularity?: PnlGranularity;
+  /** Inclusive lower date bound (`YYYY-MM-DD`). */
+  readonly startDate?: LocalDate;
+  /** Inclusive upper date bound (`YYYY-MM-DD`). */
+  readonly endDate?: LocalDate;
+}
+
+/** The aggregated money + margin figures for a slice of activity. */
+export interface PnlTotals {
+  /** Total sales (cents, ≥ 0). */
+  readonly revenueCents: number;
+  /** Cost of goods sold (cents, ≥ 0). */
+  readonly cogsCents: number;
+  /** Labor / payroll cost (cents, ≥ 0). */
+  readonly laborCents: number;
+  /** Other operating expenses (cents, ≥ 0). */
+  readonly overheadCents: number;
+  /** Gross profit: revenue − COGS (cents, may be negative). */
+  readonly grossProfitCents: number;
+  /** Operating expenses below the gross line: labor + overhead (cents, ≥ 0). */
+  readonly operatingExpensesCents: number;
+  /** Net profit: gross profit − operating expenses (cents, may be negative). */
+  readonly netProfitCents: number;
+  /** Gross margin in integer basis points; `null` when revenue is 0. */
+  readonly grossMarginBps: number | null;
+  /** Net margin in integer basis points; `null` when revenue is 0. */
+  readonly netMarginBps: number | null;
+  /** Count of transactions that contributed to this slice. */
+  readonly transactionCount: number;
+}
+
+/** A single reporting period (one week or one month). */
+export interface PnlPeriod extends PnlTotals {
+  /** Sort/identity key — `YYYY-MM-DD` (week start) or `YYYY-MM` (month). */
+  readonly key: string;
+  /** Human-readable label, e.g. `"Week of 2024-01-15"` or `"Jan 2024"`. */
+  readonly label: string;
+}
+
+/** The full statement: per-period rows plus combined totals. */
+export interface PnlStatement {
+  readonly granularity: PnlGranularity;
+  /** Periods sorted ascending by key (chronological). */
+  readonly periods: readonly PnlPeriod[];
+  /** Combined totals across every included period. */
+  readonly totals: PnlTotals;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+/**
+ * Default whole-tag markers for each P&L bucket. A transaction tagged with any
+ * of these (case-insensitive) is forced into that bucket. Untagged income
+ * falls back to `revenue` and untagged expenses to `overhead`.
+ */
+export const DEFAULT_PNL_TAGS: Readonly<Record<PnlCategory, readonly string[]>> = Object.freeze({
+  revenue: Object.freeze(['pnl:revenue', 'revenue', 'sales']),
+  cogs: Object.freeze(['pnl:cogs', 'cogs', 'cost-of-goods']),
+  labor: Object.freeze(['pnl:labor', 'labor', 'payroll', 'wages']),
+  overhead: Object.freeze(['pnl:overhead', 'overhead', 'opex', 'operating-expense']),
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Coerce to a finite, non-negative integer cent magnitude. */
+function magnitudeCents(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.abs(Math.round(value));
+}
+
+function normalizeTag(tag: string): string {
+  return tag.trim().toLowerCase();
+}
+
+function normalizeTagList(
+  tags: readonly string[] | undefined,
+  fallback: readonly string[],
+): Set<string> {
+  const source = tags && tags.length > 0 ? tags : fallback;
+  return new Set(source.map(normalizeTag).filter((tag) => tag !== ''));
+}
+
+function isInDateRange(
+  transaction: Transaction,
+  startDate?: LocalDate,
+  endDate?: LocalDate,
+): boolean {
+  if (startDate !== undefined && transaction.date < startDate) {
+    return false;
+  }
+  if (endDate !== undefined && transaction.date > endDate) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Margin in integer basis points (1% = 100 bps), or `null` when revenue is not
+ * positive. Uses integer cents in the ratio so no float dollars are involved;
+ * only the final basis-point figure is rounded.
+ */
+export function marginBasisPoints(partCents: number, revenueCents: number): number | null {
+  if (revenueCents <= 0) {
+    return null;
+  }
+  return Math.round((partCents * 10_000) / revenueCents);
+}
+
+/**
+ * Format a basis-point margin for display.
+ *
+ * @example
+ * formatMarginPercent(2537);  // "25.4%"
+ * formatMarginPercent(-1200); // "-12.0%"
+ * formatMarginPercent(null);  // "N/A"
+ */
+export function formatMarginPercent(bps: number | null, fractionDigits = 1): string {
+  if (bps === null || !Number.isFinite(bps)) {
+    return 'N/A';
+  }
+  return `${(bps / 100).toFixed(fractionDigits)}%`;
+}
+
+const MONTH_NAMES = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const;
+
+/**
+ * Monday-based ISO week-start date key (`YYYY-MM-DD`) for a `YYYY-MM-DD` input.
+ * Invalid dates are returned unchanged so they still bucket deterministically.
+ */
+export function weekStartKey(date: LocalDate): string {
+  const dt = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(dt.getTime())) {
+    return date;
+  }
+  const day = dt.getUTCDay(); // 0 = Sunday … 6 = Saturday
+  const offsetToMonday = day === 0 ? -6 : 1 - day;
+  dt.setUTCDate(dt.getUTCDate() + offsetToMonday);
+  return dt.toISOString().slice(0, 10);
+}
+
+/** Bucket key for a transaction date under the chosen cadence. */
+export function periodKey(date: LocalDate, granularity: PnlGranularity): string {
+  if (granularity === 'weekly') {
+    return weekStartKey(date);
+  }
+  return date.slice(0, 7); // YYYY-MM
+}
+
+/** Human-readable label for a bucket key. */
+export function periodLabel(key: string, granularity: PnlGranularity): string {
+  if (granularity === 'weekly') {
+    return `Week of ${key}`;
+  }
+  const [year, month] = key.split('-');
+  const monthIndex = Number(month) - 1;
+  const monthName = MONTH_NAMES[monthIndex] ?? month;
+  return `${monthName} ${year}`;
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+export interface CompiledPnlTagSets {
+  readonly revenue: Set<string>;
+  readonly cogs: Set<string>;
+  readonly labor: Set<string>;
+  readonly overhead: Set<string>;
+}
+
+/** Pre-compile the configured (or default) tag markers into lookup sets. */
+export function compilePnlTagSets(config: PnlTagConfig = {}): CompiledPnlTagSets {
+  return {
+    revenue: normalizeTagList(config.revenueTags, DEFAULT_PNL_TAGS.revenue),
+    cogs: normalizeTagList(config.cogsTags, DEFAULT_PNL_TAGS.cogs),
+    labor: normalizeTagList(config.laborTags, DEFAULT_PNL_TAGS.labor),
+    overhead: normalizeTagList(config.overheadTags, DEFAULT_PNL_TAGS.overhead),
+  };
+}
+
+function hasTag(tags: readonly string[], markers: Set<string>): boolean {
+  return tags.some((tag) => markers.has(normalizeTag(tag)));
+}
+
+/**
+ * Classify a transaction into a P&L bucket, or `null` if it should be ignored
+ * (transfers and voided transactions).
+ *
+ * Priority: explicit bucket tags win (checked COGS → labor → overhead →
+ * revenue), otherwise income falls back to `revenue` and expenses to
+ * `overhead` (other operating expense).
+ */
+export function classifyTransaction(
+  transaction: Transaction,
+  tagSets: CompiledPnlTagSets,
+): PnlCategory | null {
+  if (transaction.type === 'TRANSFER' || transaction.status === 'VOID') {
+    return null;
+  }
+
+  const tags = transaction.tags ?? [];
+  if (hasTag(tags, tagSets.cogs)) return 'cogs';
+  if (hasTag(tags, tagSets.labor)) return 'labor';
+  if (hasTag(tags, tagSets.overhead)) return 'overhead';
+  if (hasTag(tags, tagSets.revenue)) return 'revenue';
+
+  return transaction.type === 'INCOME' ? 'revenue' : 'overhead';
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+interface MutableBucket {
+  revenueCents: number;
+  cogsCents: number;
+  laborCents: number;
+  overheadCents: number;
+  transactionCount: number;
+}
+
+function emptyBucket(): MutableBucket {
+  return {
+    revenueCents: 0,
+    cogsCents: 0,
+    laborCents: 0,
+    overheadCents: 0,
+    transactionCount: 0,
+  };
+}
+
+function addToBucket(bucket: MutableBucket, category: PnlCategory, cents: number): void {
+  switch (category) {
+    case 'revenue':
+      bucket.revenueCents += cents;
+      break;
+    case 'cogs':
+      bucket.cogsCents += cents;
+      break;
+    case 'labor':
+      bucket.laborCents += cents;
+      break;
+    case 'overhead':
+      bucket.overheadCents += cents;
+      break;
+  }
+  bucket.transactionCount += 1;
+}
+
+function finalizeBucket(bucket: MutableBucket): PnlTotals {
+  const grossProfitCents = bucket.revenueCents - bucket.cogsCents;
+  const operatingExpensesCents = bucket.laborCents + bucket.overheadCents;
+  const netProfitCents = grossProfitCents - operatingExpensesCents;
+
+  return {
+    revenueCents: bucket.revenueCents,
+    cogsCents: bucket.cogsCents,
+    laborCents: bucket.laborCents,
+    overheadCents: bucket.overheadCents,
+    grossProfitCents,
+    operatingExpensesCents,
+    netProfitCents,
+    grossMarginBps: marginBasisPoints(grossProfitCents, bucket.revenueCents),
+    netMarginBps: marginBasisPoints(netProfitCents, bucket.revenueCents),
+    transactionCount: bucket.transactionCount,
+  };
+}
+
+/**
+ * Build a weekly or monthly profit-and-loss statement from transactions.
+ *
+ * Transfers and voided transactions are ignored. Other transactions are
+ * classified (see {@link classifyTransaction}), grouped into the chosen
+ * period, and reduced into per-period plus combined totals.
+ *
+ * @example
+ * ```ts
+ * const statement = buildProfitAndLoss(transactions, { granularity: 'monthly' });
+ * statement.totals.netProfitCents;   // exact integer cents
+ * formatMarginPercent(statement.totals.netMarginBps); // "12.5%"
+ * ```
+ */
+export function buildProfitAndLoss(
+  transactions: readonly Transaction[],
+  options: PnlOptions = {},
+): PnlStatement {
+  const granularity: PnlGranularity = options.granularity ?? 'monthly';
+  const tagSets = compilePnlTagSets(options);
+
+  const buckets = new Map<string, MutableBucket>();
+  const combined = emptyBucket();
+
+  for (const transaction of transactions) {
+    if (!isInDateRange(transaction, options.startDate, options.endDate)) {
+      continue;
+    }
+
+    const category = classifyTransaction(transaction, tagSets);
+    if (category === null) {
+      continue;
+    }
+
+    const cents = magnitudeCents(transaction.amount.amount);
+    const key = periodKey(transaction.date, granularity);
+    const bucket = buckets.get(key) ?? emptyBucket();
+    addToBucket(bucket, category, cents);
+    buckets.set(key, bucket);
+
+    addToBucket(combined, category, cents);
+  }
+
+  const periods = [...buckets.entries()]
+    .map(([key, bucket]) => ({
+      key,
+      label: periodLabel(key, granularity),
+      ...finalizeBucket(bucket),
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+
+  return {
+    granularity,
+    periods,
+    totals: finalizeBucket(combined),
+  };
+}

--- a/apps/web/src/pages/BusinessPnlPage.css
+++ b/apps/web/src/pages/BusinessPnlPage.css
@@ -1,0 +1,281 @@
+.business-pnl {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.business-pnl__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.business-pnl__eyebrow {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.business-pnl__title {
+  font-size: var(--type-scale-display-font-size);
+  font-weight: var(--type-scale-display-font-weight);
+  margin: 0;
+}
+
+.business-pnl__description {
+  color: var(--semantic-text-secondary);
+  margin: 0;
+  max-width: 72ch;
+}
+
+.business-pnl__description code {
+  background: var(--semantic-background-secondary);
+  border-radius: var(--radius-sm, 4px);
+  font-size: 0.9em;
+  padding: 0 var(--spacing-1);
+}
+
+.business-pnl__card {
+  background: var(--semantic-surface-primary);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-4);
+}
+
+.business-pnl__card-title {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  margin: 0 0 var(--spacing-3);
+}
+
+/* Controls -------------------------------------------------------------- */
+
+.business-pnl__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-4);
+  align-items: flex-end;
+}
+
+.business-pnl__toggle {
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-inline-size: 0;
+}
+
+.business-pnl__toggle-legend {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  margin-bottom: var(--spacing-1);
+  padding: 0;
+}
+
+.business-pnl__toggle-options {
+  display: inline-flex;
+  gap: var(--spacing-1);
+  background: var(--semantic-background-secondary);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-1);
+}
+
+.business-pnl__toggle-option {
+  border-radius: var(--radius-sm, 4px);
+  color: var(--semantic-text-secondary);
+  cursor: pointer;
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  padding: var(--spacing-2) var(--spacing-3);
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.business-pnl__toggle-option--active {
+  background: var(--semantic-surface-primary);
+  box-shadow: var(--shadow-sm);
+  color: var(--semantic-text-primary);
+}
+
+/* Visually hide the native radio but keep it focusable for keyboard/AT. */
+.business-pnl__toggle-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.business-pnl__toggle-option:focus-within {
+  outline: 2px solid var(--semantic-focus-ring, #2563eb);
+  outline-offset: 2px;
+}
+
+.business-pnl__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+}
+
+.business-pnl__filter {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.business-pnl__label {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+}
+
+.business-pnl__input {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-md);
+  font: inherit;
+  padding: var(--spacing-2) var(--spacing-3);
+}
+
+/* Summary --------------------------------------------------------------- */
+
+.business-pnl__summary-grid {
+  display: grid;
+  gap: var(--spacing-3);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.business-pnl__metric {
+  border: 1px solid var(--semantic-border-muted, var(--semantic-border-default));
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  padding: var(--spacing-3);
+}
+
+.business-pnl__metric-label {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.business-pnl__metric-value {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: 700;
+}
+
+.business-pnl__metric-sub {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.business-pnl__amount--positive {
+  color: var(--semantic-success-text, #047857);
+}
+
+.business-pnl__amount--negative {
+  color: var(--semantic-danger-text, #b91c1c);
+}
+
+.business-pnl__status {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+}
+
+.business-pnl__status--profit {
+  color: var(--semantic-success-text, #047857);
+}
+
+.business-pnl__status--loss {
+  color: var(--semantic-danger-text, #b91c1c);
+}
+
+.business-pnl__status--breakeven {
+  color: var(--semantic-text-secondary);
+}
+
+/* Tables ---------------------------------------------------------------- */
+
+.business-pnl__table-wrapper {
+  overflow-x: auto;
+}
+
+.business-pnl__table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.business-pnl__table:not(.business-pnl__table--statement) {
+  min-width: 760px;
+}
+
+.business-pnl__caption {
+  caption-side: top;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  margin-bottom: var(--spacing-2);
+  text-align: left;
+}
+
+.business-pnl__table th,
+.business-pnl__table td {
+  border-bottom: 1px solid var(--semantic-border-default);
+  padding: var(--spacing-2) var(--spacing-3);
+  text-align: right;
+}
+
+.business-pnl__table th:first-child,
+.business-pnl__table td:first-child {
+  text-align: left;
+}
+
+.business-pnl__row-margin {
+  color: var(--semantic-text-secondary);
+  display: block;
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 400;
+}
+
+.business-pnl__row--emphasis th,
+.business-pnl__row--emphasis td {
+  font-weight: 700;
+}
+
+.business-pnl__empty {
+  color: var(--semantic-text-secondary);
+  margin: 0;
+}
+
+.business-pnl__empty code {
+  background: var(--semantic-background-secondary);
+  border-radius: var(--radius-sm, 4px);
+  padding: 0 var(--spacing-1);
+}
+
+.business-pnl__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .business-pnl__toggle-option {
+    transition: none;
+  }
+}

--- a/apps/web/src/pages/BusinessPnlPage.test.tsx
+++ b/apps/web/src/pages/BusinessPnlPage.test.tsx
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for BusinessPnlPage.
+ *
+ * Mocks the `useTransactions` hook (not repositories) per project conventions.
+ * References: issue #2184.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { Transaction, TransactionType } from '../kmp/bridge';
+import { BusinessPnlPage } from './BusinessPnlPage';
+
+vi.mock('../hooks/useTransactions', () => ({
+  useTransactions: vi.fn(),
+}));
+
+import { useTransactions } from '../hooks/useTransactions';
+
+const mockUseTransactions = vi.mocked(useTransactions);
+
+let nextId = 0;
+
+function makeTransaction(options: {
+  date: string;
+  type: TransactionType;
+  amountCents: number;
+  tags?: readonly string[];
+}): Transaction {
+  nextId += 1;
+  return {
+    id: `txn-${nextId}`,
+    householdId: 'hh-1',
+    accountId: 'acct-1',
+    categoryId: null,
+    type: options.type,
+    status: 'CLEARED',
+    amount: { amount: options.amountCents },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    payee: null,
+    note: null,
+    date: options.date,
+    transferAccountId: null,
+    transferTransactionId: null,
+    isRecurring: false,
+    recurringRuleId: null,
+    tags: options.tags ?? [],
+    merchantAddress: null,
+    merchantCity: null,
+    merchantState: null,
+    merchantZip: null,
+    merchantCountry: null,
+    externalReferenceId: null,
+    statementDescription: null,
+    customFields: null,
+    extraNotes: null,
+    counterpartyName: null,
+    counterpartyAccountId: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  };
+}
+
+const SAMPLE_TRANSACTIONS: Transaction[] = [
+  makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 1_000_000 }),
+  makeTransaction({ date: '2024-01-06', type: 'EXPENSE', amountCents: 300_000, tags: ['cogs'] }),
+  makeTransaction({ date: '2024-01-07', type: 'EXPENSE', amountCents: 200_000, tags: ['labor'] }),
+  makeTransaction({
+    date: '2024-01-08',
+    type: 'EXPENSE',
+    amountCents: 100_000,
+    tags: ['overhead'],
+  }),
+];
+
+function mockResult(overrides: Partial<ReturnType<typeof useTransactions>> = {}) {
+  return {
+    transactions: SAMPLE_TRANSACTIONS,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    createTransaction: vi.fn(),
+    updateTransaction: vi.fn(),
+    deleteTransaction: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useTransactions>;
+}
+
+describe('BusinessPnlPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a loading spinner while transactions load', () => {
+    mockUseTransactions.mockReturnValue(mockResult({ transactions: [], loading: true }));
+    render(<BusinessPnlPage />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows an error banner on failure', () => {
+    mockUseTransactions.mockReturnValue(mockResult({ transactions: [], error: 'Boom' }));
+    render(<BusinessPnlPage />);
+    expect(screen.getByText('Boom')).toBeInTheDocument();
+  });
+
+  it('renders an accessible P&L statement with gross and net margins', () => {
+    mockUseTransactions.mockReturnValue(mockResult());
+    render(<BusinessPnlPage />);
+
+    expect(screen.getByRole('heading', { level: 1, name: /profit & loss/i })).toBeInTheDocument();
+
+    // Summary figures (scoped to the summary group to avoid the breakdown table).
+    const summary = screen.getByRole('group', { name: /profit and loss summary/i });
+    expect(within(summary).getByText('$10,000.00')).toBeInTheDocument(); // revenue
+    expect(within(summary).getByText(/70\.0% margin/)).toBeInTheDocument(); // gross margin
+    expect(within(summary).getByText(/Profit · 40\.0% margin/)).toBeInTheDocument(); // net + status
+  });
+
+  it('exposes a keyboard-operable weekly/monthly period toggle', async () => {
+    const user = userEvent.setup();
+    mockUseTransactions.mockReturnValue(mockResult());
+    render(<BusinessPnlPage />);
+
+    const monthly = screen.getByRole('radio', { name: 'Monthly' });
+    const weekly = screen.getByRole('radio', { name: 'Weekly' });
+    expect(monthly).toBeChecked();
+    expect(weekly).not.toBeChecked();
+
+    await user.click(weekly);
+    expect(weekly).toBeChecked();
+    expect(screen.getByRole('heading', { name: /weekly breakdown/i })).toBeInTheDocument();
+  });
+
+  it('renders a per-period breakdown table row', () => {
+    mockUseTransactions.mockReturnValue(mockResult());
+    render(<BusinessPnlPage />);
+
+    const periodTable = screen.getByRole('region', { name: /profit and loss by period/i });
+    const row = within(periodTable).getByRole('rowheader', { name: 'Jan 2024' });
+    expect(row).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no transactions', () => {
+    mockUseTransactions.mockReturnValue(mockResult({ transactions: [] }));
+    render(<BusinessPnlPage />);
+    expect(screen.getByText(/No revenue or expense transactions/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/BusinessPnlPage.tsx
+++ b/apps/web/src/pages/BusinessPnlPage.tsx
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Business Profit & Loss page.
+ *
+ * Renders a weekly or monthly P&L statement for a small-business owner from
+ * their categorized transactions: revenue − COGS = gross profit, less labor
+ * and other operating expenses = net profit, with gross and net margins.
+ *
+ * Data is read exclusively through the `useTransactions` hook; all P&L maths
+ * happen in the pure {@link buildProfitAndLoss} engine. References: issue #2184.
+ */
+
+import { useMemo, useState } from 'react';
+
+import { DateInput, ErrorBanner, LoadingSpinner } from '../components/common';
+import { useTransactions } from '../hooks/useTransactions';
+import { formatCurrency } from '../lib/currency';
+import {
+  buildProfitAndLoss,
+  formatMarginPercent,
+  type PnlGranularity,
+  type PnlTotals,
+} from '../lib/business/profit-and-loss';
+
+import './BusinessPnlPage.css';
+
+const GRANULARITY_OPTIONS: ReadonlyArray<{ value: PnlGranularity; label: string }> = [
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'monthly', label: 'Monthly' },
+];
+
+type NetStatus = 'profit' | 'loss' | 'breakeven';
+
+function netStatusOf(netProfitCents: number): NetStatus {
+  if (netProfitCents > 0) return 'profit';
+  if (netProfitCents < 0) return 'loss';
+  return 'breakeven';
+}
+
+const NET_STATUS_LABEL: Record<NetStatus, string> = {
+  profit: 'Profit',
+  loss: 'Loss',
+  breakeven: 'Break-even',
+};
+
+function amountClass(cents: number): string {
+  if (cents > 0) return ' business-pnl__amount--positive';
+  if (cents < 0) return ' business-pnl__amount--negative';
+  return '';
+}
+
+export function BusinessPnlPage() {
+  const [granularity, setGranularity] = useState<PnlGranularity>('monthly');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  const transactionFilters = useMemo(
+    () => ({
+      startDate: startDate || undefined,
+      endDate: endDate || undefined,
+    }),
+    [endDate, startDate],
+  );
+
+  const { transactions, loading, error, refresh } = useTransactions(transactionFilters);
+
+  const statement = useMemo(
+    () =>
+      buildProfitAndLoss(transactions, {
+        granularity,
+        startDate: startDate || undefined,
+        endDate: endDate || undefined,
+      }),
+    [endDate, granularity, startDate, transactions],
+  );
+
+  if (loading) {
+    return <LoadingSpinner label="Loading profit and loss statement" />;
+  }
+
+  if (error) {
+    return <ErrorBanner message={error} onRetry={refresh} />;
+  }
+
+  const totals = statement.totals;
+  const netStatus = netStatusOf(totals.netProfitCents);
+  const periodNoun = granularity === 'weekly' ? 'week' : 'month';
+
+  return (
+    <main className="business-pnl" aria-labelledby="business-pnl-title">
+      <header className="business-pnl__header">
+        <p className="business-pnl__eyebrow">Small-business reporting</p>
+        <h1 id="business-pnl-title" className="business-pnl__title">
+          Profit &amp; Loss
+        </h1>
+        <p className="business-pnl__description">
+          See whether your business is actually profitable each {periodNoun}. Tag transactions with{' '}
+          <code>cogs</code>, <code>labor</code> or <code>overhead</code> to break out cost of goods
+          sold, labor and other operating expenses; untagged income counts as revenue and untagged
+          expenses as overhead.
+        </p>
+      </header>
+
+      <section className="business-pnl__card" aria-labelledby="business-pnl-controls-title">
+        <h2 id="business-pnl-controls-title" className="business-pnl__card-title">
+          Period &amp; date range
+        </h2>
+        <div className="business-pnl__controls">
+          <fieldset className="business-pnl__toggle">
+            <legend className="business-pnl__toggle-legend">Reporting period</legend>
+            <div className="business-pnl__toggle-options">
+              {GRANULARITY_OPTIONS.map((option) => {
+                const selected = granularity === option.value;
+                return (
+                  <label
+                    key={option.value}
+                    className={`business-pnl__toggle-option${
+                      selected ? ' business-pnl__toggle-option--active' : ''
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="business-pnl-granularity"
+                      className="business-pnl__toggle-input"
+                      value={option.value}
+                      checked={selected}
+                      onChange={() => setGranularity(option.value)}
+                    />
+                    <span>{option.label}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <div className="business-pnl__filters">
+            <div className="business-pnl__filter">
+              <label className="business-pnl__label" htmlFor="business-pnl-start-date">
+                Start date
+              </label>
+              <DateInput
+                id="business-pnl-start-date"
+                className="business-pnl__input"
+                value={startDate}
+                onChange={(event) => setStartDate(event.target.value)}
+              />
+            </div>
+            <div className="business-pnl__filter">
+              <label className="business-pnl__label" htmlFor="business-pnl-end-date">
+                End date
+              </label>
+              <DateInput
+                id="business-pnl-end-date"
+                className="business-pnl__input"
+                value={endDate}
+                onChange={(event) => setEndDate(event.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="business-pnl__card" aria-labelledby="business-pnl-summary-title">
+        <h2 id="business-pnl-summary-title" className="business-pnl__card-title">
+          Summary
+        </h2>
+        <div
+          className="business-pnl__summary-grid"
+          role="group"
+          aria-label="Profit and loss summary"
+        >
+          <div className="business-pnl__metric">
+            <span className="business-pnl__metric-label">Revenue</span>
+            <span className="business-pnl__metric-value">
+              {formatCurrency(totals.revenueCents)}
+            </span>
+          </div>
+          <div className="business-pnl__metric">
+            <span className="business-pnl__metric-label">Gross profit</span>
+            <span className={`business-pnl__metric-value${amountClass(totals.grossProfitCents)}`}>
+              {formatCurrency(totals.grossProfitCents)}
+            </span>
+            <span className="business-pnl__metric-sub">
+              {formatMarginPercent(totals.grossMarginBps)} margin
+            </span>
+          </div>
+          <div className="business-pnl__metric">
+            <span className="business-pnl__metric-label">Operating expenses</span>
+            <span className="business-pnl__metric-value">
+              {formatCurrency(totals.operatingExpensesCents)}
+            </span>
+            <span className="business-pnl__metric-sub">Labor + overhead</span>
+          </div>
+          <div className="business-pnl__metric">
+            <span className="business-pnl__metric-label">Net profit</span>
+            <span className={`business-pnl__metric-value${amountClass(totals.netProfitCents)}`}>
+              {formatCurrency(totals.netProfitCents)}
+            </span>
+            <span className={`business-pnl__status business-pnl__status--${netStatus}`}>
+              {NET_STATUS_LABEL[netStatus]} · {formatMarginPercent(totals.netMarginBps)} margin
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section className="business-pnl__card" aria-labelledby="business-pnl-statement-title">
+        <h2 id="business-pnl-statement-title" className="business-pnl__card-title">
+          Statement
+        </h2>
+        <div className="business-pnl__table-wrapper" tabIndex={0}>
+          <table className="business-pnl__table business-pnl__table--statement">
+            <caption className="business-pnl__caption">
+              Profit and loss line items across the selected range.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Line item</th>
+                <th scope="col">Amount</th>
+              </tr>
+            </thead>
+            <tbody>
+              <StatementRow label="Revenue" cents={totals.revenueCents} />
+              <StatementRow label="Cost of goods sold" cents={totals.cogsCents} kind="cost" />
+              <StatementRow
+                label="Gross profit"
+                cents={totals.grossProfitCents}
+                emphasis
+                marginBps={totals.grossMarginBps}
+                marginLabel="Gross margin"
+              />
+              <StatementRow label="Labor" cents={totals.laborCents} kind="cost" />
+              <StatementRow
+                label="Other operating expenses"
+                cents={totals.overheadCents}
+                kind="cost"
+              />
+              <StatementRow
+                label="Net profit"
+                cents={totals.netProfitCents}
+                emphasis
+                marginBps={totals.netMarginBps}
+                marginLabel="Net margin"
+              />
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="business-pnl__card" aria-labelledby="business-pnl-periods-title">
+        <h2 id="business-pnl-periods-title" className="business-pnl__card-title">
+          {granularity === 'weekly' ? 'Weekly' : 'Monthly'} breakdown
+        </h2>
+        {statement.periods.length > 0 ? (
+          <div
+            className="business-pnl__table-wrapper"
+            role="region"
+            aria-label="Profit and loss by period"
+            tabIndex={0}
+          >
+            <table className="business-pnl__table">
+              <caption className="business-pnl__caption business-pnl__sr-only">
+                Revenue, costs, profit and margins for each {periodNoun}.
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Period</th>
+                  <th scope="col">Revenue</th>
+                  <th scope="col">COGS</th>
+                  <th scope="col">Gross profit</th>
+                  <th scope="col">Gross margin</th>
+                  <th scope="col">Operating expenses</th>
+                  <th scope="col">Net profit</th>
+                  <th scope="col">Net margin</th>
+                </tr>
+              </thead>
+              <tbody>
+                {statement.periods.map((period) => (
+                  <tr key={period.key}>
+                    <th scope="row">{period.label}</th>
+                    <td>{formatCurrency(period.revenueCents)}</td>
+                    <td>{formatCurrency(period.cogsCents)}</td>
+                    <td className={amountClass(period.grossProfitCents).trim()}>
+                      {formatCurrency(period.grossProfitCents)}
+                    </td>
+                    <td>{formatMarginPercent(period.grossMarginBps)}</td>
+                    <td>{formatCurrency(period.operatingExpensesCents)}</td>
+                    <td className={amountClass(period.netProfitCents).trim()}>
+                      {formatCurrency(period.netProfitCents)}
+                    </td>
+                    <td>{formatMarginPercent(period.netMarginBps)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="business-pnl__empty">
+            No revenue or expense transactions in this range yet. Add transactions (and tag costs as{' '}
+            <code>cogs</code>, <code>labor</code> or <code>overhead</code>) to build your statement.
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}
+
+interface StatementRowProps {
+  label: string;
+  cents: number;
+  /** `cost` rows are subtracted from revenue, shown with a leading minus. */
+  kind?: 'amount' | 'cost';
+  /** Emphasized subtotal rows (gross profit / net profit). */
+  emphasis?: boolean;
+  marginBps?: PnlTotals['grossMarginBps'];
+  marginLabel?: string;
+}
+
+function StatementRow({
+  label,
+  cents,
+  kind = 'amount',
+  emphasis = false,
+  marginBps,
+  marginLabel,
+}: StatementRowProps) {
+  const rowClass = emphasis ? ' business-pnl__row--emphasis' : '';
+  const valueClass = emphasis ? amountClass(cents) : '';
+  const display = kind === 'cost' ? `(${formatCurrency(cents)})` : formatCurrency(cents);
+
+  return (
+    <tr className={`business-pnl__row${rowClass}`}>
+      <th scope="row">
+        {label}
+        {marginLabel ? (
+          <span className="business-pnl__row-margin">
+            {marginLabel}: {formatMarginPercent(marginBps ?? null)}
+          </span>
+        ) : null}
+      </th>
+      <td className={valueClass.trim()}>{display}</td>
+    </tr>
+  );
+}
+
+export default BusinessPnlPage;

--- a/apps/web/src/pages/index.ts
+++ b/apps/web/src/pages/index.ts
@@ -28,6 +28,7 @@ export { BillDetailPage } from './BillDetailPage';
 export { CreateBillPage } from './CreateBillPage';
 export { ReportBuilderPage } from './ReportBuilderPage';
 export { ClientProfitabilityPage } from './ClientProfitabilityPage';
+export { BusinessPnlPage } from './BusinessPnlPage';
 export { GigDriverPage } from './GigDriverPage';
 export { PlanningPage } from './PlanningPage';
 export { HouseholdPage } from './HouseholdPage';

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -55,6 +55,7 @@ const Watchlists = lazy(() => import('./pages/WatchlistsPage'));
 const Household = lazy(() => import('./pages/HouseholdPage'));
 const ReportBuilder = lazy(() => import('./pages/ReportBuilderPage'));
 const ClientProfitability = lazy(() => import('./pages/ClientProfitabilityPage'));
+const BusinessPnl = lazy(() => import('./pages/BusinessPnlPage'));
 const GigDriver = lazy(() => import('./pages/GigDriverPage'));
 const Investments = lazy(() => import('./pages/InvestmentsPage'));
 const InvestmentDetail = lazy(() => import('./pages/InvestmentDetailPage'));
@@ -435,6 +436,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Client Profitability">
             <ClientProfitability />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/business-pnl"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Profit & Loss">
+            <BusinessPnl />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Summary
Adds a weekly/monthly **Profit & Loss** view for small-business owners (e.g. a food-truck operator) who categorize transactions into revenue / COGS / labor / overhead and need to know whether the business is actually profitable.

## What's included (web slice of #2184)
- **Pure P&L engine** (pps/web/src/lib/business/profit-and-loss.ts): buckets categorized transactions into revenue / COGS / labor / other-opex over weekly or monthly periods and computes gross profit (revenue − COGS), operating expenses (labor + overhead), net profit, and gross/net margins.
  - All money is **integer cents**; margins are **integer basis points** (computed via `round(part * 10_000 / revenue)`) so percentages carry no float drift — formatting divides by 100 only at display time.
  - Zero-revenue is handled (margin = `null` → `N/A`, no divide-by-zero). Transfers and voided transactions are ignored.
  - Classification: explicit `cogs` / `labor` / `overhead` / `revenue` tags win; otherwise untagged income → revenue, untagged expense → overhead. Tag markers are configurable.
- **Accessible page** (`BusinessPnlPage`) at `/business-pnl`: weekly/monthly period toggle (native radio group), summary cards, a line-item statement table, and a per-period breakdown table.
  - WCAG 2.2 AA: semantic `<table>`/`<caption>`/headings, `scope` on header cells, keyboard-operable toggle, no color-only signals (explicit Profit/Loss/Break-even text + signed amounts), `prefers-reduced-motion` respected.
- Wired into `routes.tsx` (lazy chunk), `navConfig.tsx` (Insights group) and the `pages` barrel.

## Tests
- `profit-and-loss.test.ts` (30 tests): margin math, zero-revenue → N/A, negative net, weekly/monthly grouping, classification, date-range filtering, integer-bps rounding.
- `BusinessPnlPage.test.tsx` (6 tests): loading, error, statement render with margins, keyboard toggle, per-period table, empty state. Mocks the `useTransactions` hook (not repositories).

Data access is hooks-only; the page is light (no chart deps) so it stays well within the lazy-chunk perf budget. KMP shared models and native UI remain out of scope.

Refs #2184