### PR TITLE
feat(web): bill calendar aligned with payday (#2196)

### DIFF
--- a/apps/web/src/components/bills/BillCalendarView.test.tsx
+++ b/apps/web/src/components/bills/BillCalendarView.test.tsx
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BillCalendarView } from './BillCalendarView';
+import type { Bill } from '../../kmp/bridge';
+
+const SCHEDULE_STORAGE_NAME = 'finance.bills.paydaySchedule.v1';
+
+const SYNC_METADATA = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+} as const;
+
+/** ISO local date offset from today by `days`. */
+function isoOffset(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function makeBill(overrides: Partial<Bill> & { name: string; dueDate: string }): Bill {
+  return {
+    ...SYNC_METADATA,
+    id: `bill-${overrides.name}`,
+    householdId: 'h1',
+    payee: 'Payee',
+    amount: { amount: 5000 },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    frequency: 'MONTHLY',
+    status: 'UPCOMING',
+    categoryId: null,
+    accountId: null,
+    note: null,
+    isAutoPay: false,
+    reminderDaysBefore: 3,
+    lastPaidDate: null,
+    ...overrides,
+  };
+}
+
+function seedSchedule(incomeDollars: string): void {
+  window.localStorage.setItem(
+    SCHEDULE_STORAGE_NAME,
+    JSON.stringify({ cadence: 'MONTHLY', anchorDate: isoOffset(0), incomeDollars }),
+  );
+}
+
+describe('BillCalendarView', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders an accessible payday schedule form', () => {
+    render(<BillCalendarView bills={[]} />);
+
+    const form = screen.getByRole('form', { name: 'Payday schedule' });
+    expect(within(form).getByLabelText('Pay cadence')).toBeInTheDocument();
+    expect(within(form).getByLabelText('A recent payday')).toBeInTheDocument();
+    expect(within(form).getByLabelText('Expected income per paycheck')).toBeInTheDocument();
+  });
+
+  it('groups upcoming bills under a payday heading', () => {
+    seedSchedule('2000');
+    const bills = [makeBill({ name: 'Electric', dueDate: isoOffset(5), amount: { amount: 5000 } })];
+
+    render(<BillCalendarView bills={bills} />);
+
+    expect(screen.getByRole('region', { name: 'Bills by pay period' })).toBeInTheDocument();
+    expect(screen.getAllByText(/^Payday/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Electric').length).toBeGreaterThan(0);
+  });
+
+  it('shows a covered status when income exceeds bills due', () => {
+    seedSchedule('2000'); // $2,000 income
+    const bills = [makeBill({ name: 'Phone', dueDate: isoOffset(3), amount: { amount: 5000 } })];
+
+    render(<BillCalendarView bills={bills} />);
+
+    expect(screen.getAllByText(/Covered/).length).toBeGreaterThan(0);
+  });
+
+  it('shows a shortfall status when bills exceed income', () => {
+    seedSchedule('40'); // $40 income, well under the bill
+    const bills = [makeBill({ name: 'Rent', dueDate: isoOffset(3), amount: { amount: 120000 } })];
+
+    render(<BillCalendarView bills={bills} />);
+
+    expect(screen.getAllByText(/Short by/).length).toBeGreaterThan(0);
+  });
+
+  it('prompts for income before computing coverage', () => {
+    seedSchedule(''); // no income provided
+    const bills = [makeBill({ name: 'Water', dueDate: isoOffset(3), amount: { amount: 4000 } })];
+
+    render(<BillCalendarView bills={bills} />);
+
+    expect(screen.getAllByText(/Add income to check coverage/).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/components/bills/BillCalendarView.tsx
+++ b/apps/web/src/components/bills/BillCalendarView.tsx
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Bill calendar timeline aligned with the user's pay cycle.
+ *
+ * Answers "what bills hit before my next payday?" by grouping upcoming bill
+ * occurrences into pay periods (payday -> next payday), showing the total due
+ * before each payday, and whether the expected income for that period covers
+ * the bills due in it.
+ *
+ * The pure scheduling logic lives in `lib/bills/bill-calendar`; this component
+ * only owns presentation, the payday-schedule form, and local persistence.
+ *
+ * Accessibility (WCAG 2.2 AA):
+ *  - Semantic headings and an ordered list of periods.
+ *  - All controls have associated labels.
+ *  - Coverage status is conveyed by text + icon, never colour alone.
+ *  - No motion is introduced, so reduced-motion preferences are respected.
+ *
+ * References: issue #2196
+ */
+
+import React, { useId, useMemo, useState } from 'react';
+import { CurrencyDisplay } from '../common';
+import { AppIcon } from '../icons';
+import {
+  buildBillCalendar,
+  DEFAULT_PERIODS_TO_SHOW,
+  PAYDAY_CADENCE_LABELS,
+  type PayPeriod,
+  type PaydayCadence,
+} from '../../lib/bills/bill-calendar';
+import type { Bill } from '../../kmp/bridge';
+
+/** Props for {@link BillCalendarView}. */
+export interface BillCalendarViewProps {
+  /** Bills to schedule against the pay cycle. */
+  bills: Bill[];
+}
+
+const SCHEDULE_STORAGE_NAME = 'finance.bills.paydaySchedule.v1';
+
+const CADENCE_OPTIONS: PaydayCadence[] = ['WEEKLY', 'BIWEEKLY', 'SEMI_MONTHLY', 'MONTHLY'];
+
+interface StoredSchedule {
+  cadence: PaydayCadence;
+  anchorDate: string;
+  incomeDollars: string;
+}
+
+/** Today as an ISO local date (`YYYY-MM-DD`). */
+function todayIso(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Format an ISO local date as a short, human-readable label. */
+function formatDate(iso: string): string {
+  const date = new Date(`${iso}T00:00:00`);
+  return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+/** Convert a dollars string into integer cents. */
+function dollarsToCents(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.round(parsed * 100);
+}
+
+function loadSchedule(): StoredSchedule {
+  const fallback: StoredSchedule = {
+    cadence: 'BIWEEKLY',
+    anchorDate: todayIso(),
+    incomeDollars: '',
+  };
+  try {
+    const raw = window.localStorage.getItem(SCHEDULE_STORAGE_NAME);
+    if (raw === null) return fallback;
+    const parsed = JSON.parse(raw) as Partial<StoredSchedule>;
+    return {
+      cadence: CADENCE_OPTIONS.includes(parsed.cadence as PaydayCadence)
+        ? (parsed.cadence as PaydayCadence)
+        : fallback.cadence,
+      anchorDate:
+        typeof parsed.anchorDate === 'string' && parsed.anchorDate.length > 0
+          ? parsed.anchorDate
+          : fallback.anchorDate,
+      incomeDollars: typeof parsed.incomeDollars === 'string' ? parsed.incomeDollars : '',
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function persistSchedule(schedule: StoredSchedule): void {
+  try {
+    window.localStorage.setItem(SCHEDULE_STORAGE_NAME, JSON.stringify(schedule));
+  } catch {
+    // Persistence is best-effort; ignore quota/availability errors.
+  }
+}
+
+const captionStyle: React.CSSProperties = {
+  fontSize: 'var(--type-scale-caption-font-size)',
+  color: 'var(--semantic-text-secondary)',
+};
+
+/** Coverage status pill rendered with text + icon (never colour alone). */
+function CoverageStatus({
+  period,
+  incomeProvided,
+}: {
+  period: PayPeriod;
+  incomeProvided: boolean;
+}): React.ReactElement {
+  if (!incomeProvided) {
+    return (
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 'var(--spacing-1)',
+          color: 'var(--semantic-text-secondary)',
+          fontSize: 'var(--type-scale-caption-font-size)',
+        }}
+      >
+        <AppIcon name="info" /> Add income to check coverage
+      </span>
+    );
+  }
+
+  const covered = period.covered;
+  const magnitude = Math.abs(period.coverageCents);
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 'var(--spacing-1)',
+        fontWeight: 'var(--font-weight-semibold)',
+        color: covered ? 'var(--semantic-positive, #059669)' : 'var(--semantic-negative, #dc2626)',
+        fontSize: 'var(--type-scale-caption-font-size)',
+      }}
+    >
+      <AppIcon name={covered ? 'check-circle' : 'alert-triangle'} />
+      {covered ? (
+        <>
+          Covered · <CurrencyDisplay amount={magnitude} context="income left after bills" /> left
+        </>
+      ) : (
+        <>
+          Short by <CurrencyDisplay amount={magnitude} context="shortfall before payday" />
+        </>
+      )}
+    </span>
+  );
+}
+
+/** A single pay-period card. */
+function PayPeriodCard({
+  period,
+  incomeProvided,
+}: {
+  period: PayPeriod;
+  incomeProvided: boolean;
+}): React.ReactElement {
+  const headingId = `pay-period-${period.index}`;
+  return (
+    <article className="card" aria-labelledby={headingId}>
+      <h4 id={headingId} style={{ margin: 0, fontWeight: 'var(--font-weight-semibold)' }}>
+        <AppIcon name="wallet" /> Payday {formatDate(period.paydayDate)}
+      </h4>
+      <p
+        style={{ ...captionStyle, marginTop: 'var(--spacing-1)', marginBottom: 'var(--spacing-3)' }}
+      >
+        Bills due before {formatDate(period.nextPaydayDate)}
+      </p>
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+          gap: 'var(--spacing-3)',
+          flexWrap: 'wrap',
+          marginBottom: 'var(--spacing-3)',
+        }}
+      >
+        <span>
+          <span style={captionStyle}>Due before payday</span>
+          <br />
+          <span className="card__value" style={{ margin: 0 }}>
+            <CurrencyDisplay amount={period.totalDueCents} context="total bills due this period" />
+          </span>
+        </span>
+        <CoverageStatus period={period} incomeProvided={incomeProvided} />
+      </div>
+
+      {period.bills.length === 0 ? (
+        <p style={captionStyle}>No bills due before this payday.</p>
+      ) : (
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+          {period.bills.map((bill) => (
+            <li
+              key={`${bill.billId}-${bill.dueDate}`}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'baseline',
+                gap: 'var(--spacing-3)',
+                padding: 'var(--spacing-2) 0',
+                borderTop: '1px solid var(--semantic-border, #e5e7eb)',
+              }}
+            >
+              <span style={{ minWidth: 0 }}>
+                <span style={{ fontWeight: 'var(--font-weight-medium)' }}>{bill.name}</span>
+                <br />
+                <span style={captionStyle}>
+                  {bill.payee} · Due {formatDate(bill.dueDate)}
+                  {bill.isAutoPay ? ' · Auto-pay' : ''}
+                </span>
+              </span>
+              <CurrencyDisplay
+                amount={bill.amountCents}
+                currency={bill.currencyCode}
+                context={`${bill.name} due ${formatDate(bill.dueDate)}`}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </article>
+  );
+}
+
+/** Payday-aligned bill calendar/timeline view. */
+export const BillCalendarView: React.FC<BillCalendarViewProps> = ({ bills }) => {
+  const fieldIdPrefix = useId();
+  const [today] = useState(todayIso);
+  const [schedule, setSchedule] = useState<StoredSchedule>(loadSchedule);
+
+  const updateSchedule = (patch: Partial<StoredSchedule>): void => {
+    setSchedule((prev) => {
+      const next = { ...prev, ...patch };
+      persistSchedule(next);
+      return next;
+    });
+  };
+
+  const incomeCents = dollarsToCents(schedule.incomeDollars);
+  const incomeProvided = incomeCents > 0;
+
+  const calendar = useMemo(
+    () =>
+      buildBillCalendar({
+        bills,
+        schedule: {
+          cadence: schedule.cadence,
+          anchorDate: schedule.anchorDate,
+          expectedIncomeCents: incomeCents,
+        },
+        fromDate: today,
+        periodsToShow: DEFAULT_PERIODS_TO_SHOW,
+      }),
+    [bills, schedule.cadence, schedule.anchorDate, incomeCents, today],
+  );
+
+  const cadenceId = `${fieldIdPrefix}-cadence`;
+  const anchorId = `${fieldIdPrefix}-anchor`;
+  const incomeId = `${fieldIdPrefix}-income`;
+
+  return (
+    <section aria-label="Bills by pay period">
+      <form
+        className="card"
+        aria-label="Payday schedule"
+        style={{ marginBottom: 'var(--spacing-4)' }}
+        onSubmit={(e) => e.preventDefault()}
+      >
+        <fieldset style={{ border: 'none', margin: 0, padding: 0 }}>
+          <legend style={{ fontWeight: 'var(--font-weight-semibold)', padding: 0 }}>
+            Your payday schedule
+          </legend>
+          <p style={{ ...captionStyle, marginTop: 'var(--spacing-1)' }}>
+            Tell us your pay cycle to see which bills fall in each pay period.
+          </p>
+
+          <div
+            style={{
+              display: 'flex',
+              gap: 'var(--spacing-4)',
+              flexWrap: 'wrap',
+              marginTop: 'var(--spacing-2)',
+            }}
+          >
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-1)' }}>
+              <label htmlFor={cadenceId}>Pay cadence</label>
+              <select
+                id={cadenceId}
+                value={schedule.cadence}
+                onChange={(e) => updateSchedule({ cadence: e.target.value as PaydayCadence })}
+                style={{
+                  padding: 'var(--spacing-2) var(--spacing-3)',
+                  borderRadius: 'var(--radius-sm, 4px)',
+                  border: '1px solid var(--semantic-border, #d1d5db)',
+                  backgroundColor: 'var(--semantic-background-primary)',
+                  color: 'var(--semantic-text-primary)',
+                  fontSize: 'var(--type-scale-body-font-size)',
+                }}
+              >
+                {CADENCE_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {PAYDAY_CADENCE_LABELS[option]}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-1)' }}>
+              <label htmlFor={anchorId}>A recent payday</label>
+              <input
+                id={anchorId}
+                type="date"
+                value={schedule.anchorDate}
+                onChange={(e) => updateSchedule({ anchorDate: e.target.value })}
+                disabled={schedule.cadence === 'SEMI_MONTHLY'}
+                aria-describedby={
+                  schedule.cadence === 'SEMI_MONTHLY' ? `${anchorId}-hint` : undefined
+                }
+                style={{
+                  padding: 'var(--spacing-2) var(--spacing-3)',
+                  borderRadius: 'var(--radius-sm, 4px)',
+                  border: '1px solid var(--semantic-border, #d1d5db)',
+                  backgroundColor: 'var(--semantic-background-primary)',
+                  color: 'var(--semantic-text-primary)',
+                  fontSize: 'var(--type-scale-body-font-size)',
+                }}
+              />
+              {schedule.cadence === 'SEMI_MONTHLY' && (
+                <span id={`${anchorId}-hint`} style={captionStyle}>
+                  Paid on the 15th &amp; last day
+                </span>
+              )}
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-1)' }}>
+              <label htmlFor={incomeId}>Expected income per paycheck</label>
+              <input
+                id={incomeId}
+                type="number"
+                inputMode="decimal"
+                min="0"
+                step="0.01"
+                placeholder="0.00"
+                value={schedule.incomeDollars}
+                onChange={(e) => updateSchedule({ incomeDollars: e.target.value })}
+                style={{
+                  padding: 'var(--spacing-2) var(--spacing-3)',
+                  borderRadius: 'var(--radius-sm, 4px)',
+                  border: '1px solid var(--semantic-border, #d1d5db)',
+                  backgroundColor: 'var(--semantic-background-primary)',
+                  color: 'var(--semantic-text-primary)',
+                  fontSize: 'var(--type-scale-body-font-size)',
+                }}
+              />
+            </div>
+          </div>
+        </fieldset>
+      </form>
+
+      <p aria-live="polite" style={{ ...captionStyle, marginBottom: 'var(--spacing-3)' }}>
+        Next {calendar.periods.length} pay periods ·{' '}
+        <CurrencyDisplay amount={calendar.totalDueCents} context="total bills due" /> in bills
+        {incomeProvided && (
+          <> · {calendar.totalCoverageCents >= 0 ? 'covered overall' : 'shortfall overall'}</>
+        )}
+      </p>
+
+      <ol
+        style={{
+          listStyle: 'none',
+          margin: 0,
+          padding: 0,
+          display: 'grid',
+          gap: 'var(--spacing-4)',
+        }}
+      >
+        {calendar.periods.map((period) => (
+          <li key={period.index}>
+            <PayPeriodCard period={period} incomeProvided={incomeProvided} />
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+};
+
+export default BillCalendarView;

--- a/apps/web/src/lib/bills/bill-calendar.test.ts
+++ b/apps/web/src/lib/bills/bill-calendar.test.ts
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildBillCalendar,
+  expandBillOccurrences,
+  generatePaydays,
+  type PaydaySchedule,
+} from './bill-calendar';
+import type { Bill, BillFrequency, BillStatus } from '../../kmp/bridge';
+
+// ---------------------------------------------------------------------------
+// Test factories
+// ---------------------------------------------------------------------------
+
+const SYNC_METADATA = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+} as const;
+
+function makeBill(overrides: {
+  id?: string;
+  name?: string;
+  payee?: string;
+  amountCents: number;
+  dueDate: string;
+  frequency?: BillFrequency;
+  status?: BillStatus;
+  isAutoPay?: boolean;
+}): Bill {
+  return {
+    ...SYNC_METADATA,
+    id: overrides.id ?? `bill-${overrides.dueDate}-${overrides.amountCents}`,
+    householdId: 'h1',
+    name: overrides.name ?? 'Bill',
+    payee: overrides.payee ?? 'Payee',
+    amount: { amount: overrides.amountCents },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    dueDate: overrides.dueDate,
+    frequency: overrides.frequency ?? 'MONTHLY',
+    status: overrides.status ?? 'UPCOMING',
+    categoryId: null,
+    accountId: null,
+    note: null,
+    isAutoPay: overrides.isAutoPay ?? false,
+    reminderDaysBefore: 3,
+    lastPaidDate: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// generatePaydays
+// ---------------------------------------------------------------------------
+
+describe('generatePaydays', () => {
+  it('generates biweekly paydays anchored to a known payday', () => {
+    const schedule: PaydaySchedule = {
+      cadence: 'BIWEEKLY',
+      anchorDate: '2025-01-03', // a Friday payday
+      expectedIncomeCents: 200_000,
+    };
+    // from a date mid-cycle; most recent payday on/before is 2025-01-17.
+    const paydays = generatePaydays(schedule, '2025-01-20', 4);
+    expect(paydays).toEqual(['2025-01-17', '2025-01-31', '2025-02-14', '2025-02-28']);
+  });
+
+  it('returns the anchor itself when fromDate equals a payday', () => {
+    const schedule: PaydaySchedule = {
+      cadence: 'BIWEEKLY',
+      anchorDate: '2025-01-03',
+      expectedIncomeCents: 200_000,
+    };
+    const paydays = generatePaydays(schedule, '2025-01-31', 2);
+    expect(paydays).toEqual(['2025-01-31', '2025-02-14']);
+  });
+
+  it('handles a future anchor date by stepping backwards', () => {
+    const schedule: PaydaySchedule = {
+      cadence: 'WEEKLY',
+      anchorDate: '2025-02-07',
+      expectedIncomeCents: 100_000,
+    };
+    const paydays = generatePaydays(schedule, '2025-01-20', 3);
+    // most recent weekly payday on/before 2025-01-20 is 2025-01-17.
+    expect(paydays).toEqual(['2025-01-17', '2025-01-24', '2025-01-31']);
+  });
+
+  it('generates semi-monthly paydays on the 15th and last day of the month', () => {
+    const schedule: PaydaySchedule = {
+      cadence: 'SEMI_MONTHLY',
+      anchorDate: '2025-01-15',
+      expectedIncomeCents: 150_000,
+    };
+    const paydays = generatePaydays(schedule, '2025-02-10', 4);
+    expect(paydays).toEqual(['2025-01-31', '2025-02-15', '2025-02-28', '2025-03-15']);
+  });
+
+  it('generates monthly paydays clamped to the last valid day for short months', () => {
+    const schedule: PaydaySchedule = {
+      cadence: 'MONTHLY',
+      anchorDate: '2025-01-31',
+      expectedIncomeCents: 300_000,
+    };
+    const paydays = generatePaydays(schedule, '2025-01-31', 4);
+    // Feb clamps to the 28th, March returns to the 31st (no drift).
+    expect(paydays).toEqual(['2025-01-31', '2025-02-28', '2025-03-31', '2025-04-30']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expandBillOccurrences
+// ---------------------------------------------------------------------------
+
+describe('expandBillOccurrences', () => {
+  it('expands a monthly bill into one occurrence per month in the window', () => {
+    const bill = makeBill({ amountCents: 5_000, dueDate: '2025-01-10', frequency: 'MONTHLY' });
+    const occ = expandBillOccurrences([bill], '2025-01-01', '2025-04-01');
+    expect(occ.map((o) => o.dueDate)).toEqual(['2025-01-10', '2025-02-10', '2025-03-10']);
+  });
+
+  it('keeps a one-time bill only when it falls inside the window', () => {
+    const inside = makeBill({ amountCents: 1_000, dueDate: '2025-01-15', frequency: 'ONE_TIME' });
+    const outside = makeBill({ amountCents: 1_000, dueDate: '2025-05-15', frequency: 'ONE_TIME' });
+    const occ = expandBillOccurrences([inside, outside], '2025-01-01', '2025-04-01');
+    expect(occ).toHaveLength(1);
+    expect(occ[0].dueDate).toBe('2025-01-15');
+  });
+
+  it('excludes PAID and CANCELLED bills', () => {
+    const paid = makeBill({ amountCents: 1_000, dueDate: '2025-01-10', status: 'PAID' });
+    const cancelled = makeBill({ amountCents: 1_000, dueDate: '2025-01-10', status: 'CANCELLED' });
+    const active = makeBill({ amountCents: 1_000, dueDate: '2025-01-10', status: 'UPCOMING' });
+    const occ = expandBillOccurrences([paid, cancelled, active], '2025-01-01', '2025-02-01');
+    expect(occ).toHaveLength(1);
+    expect(occ[0].billId).toBe(active.id);
+  });
+
+  it('expands weekly bills every 7 days from the base due date', () => {
+    const bill = makeBill({ amountCents: 1_200, dueDate: '2025-01-02', frequency: 'WEEKLY' });
+    const occ = expandBillOccurrences([bill], '2025-01-01', '2025-01-30');
+    expect(occ.map((o) => o.dueDate)).toEqual([
+      '2025-01-02',
+      '2025-01-09',
+      '2025-01-16',
+      '2025-01-23',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBillCalendar — bucketing + totals + coverage
+// ---------------------------------------------------------------------------
+
+describe('buildBillCalendar', () => {
+  const biweekly: PaydaySchedule = {
+    cadence: 'BIWEEKLY',
+    anchorDate: '2025-01-03',
+    expectedIncomeCents: 200_000,
+  };
+
+  it('buckets bills into the correct biweekly pay period', () => {
+    const bills = [
+      // due 2025-01-20 -> period [2025-01-17, 2025-01-31)
+      makeBill({
+        name: 'Rent',
+        amountCents: 120_000,
+        dueDate: '2025-01-20',
+        frequency: 'ONE_TIME',
+      }),
+      // due 2025-02-01 -> period [2025-01-31, 2025-02-14)
+      makeBill({
+        name: 'Internet',
+        amountCents: 8_000,
+        dueDate: '2025-02-01',
+        frequency: 'ONE_TIME',
+      }),
+    ];
+    const calendar = buildBillCalendar({
+      bills,
+      schedule: biweekly,
+      fromDate: '2025-01-20',
+      periodsToShow: 3,
+    });
+
+    expect(calendar.periods.map((p) => p.paydayDate)).toEqual([
+      '2025-01-17',
+      '2025-01-31',
+      '2025-02-14',
+    ]);
+    expect(calendar.periods[0].bills.map((b) => b.name)).toEqual(['Rent']);
+    expect(calendar.periods[1].bills.map((b) => b.name)).toEqual(['Internet']);
+    expect(calendar.periods[2].bills).toHaveLength(0);
+  });
+
+  it('computes the total due before each payday', () => {
+    const bills = [
+      makeBill({ amountCents: 50_000, dueDate: '2025-01-20', frequency: 'ONE_TIME' }),
+      makeBill({ amountCents: 25_000, dueDate: '2025-01-28', frequency: 'ONE_TIME' }),
+    ];
+    const calendar = buildBillCalendar({
+      bills,
+      schedule: biweekly,
+      fromDate: '2025-01-20',
+      periodsToShow: 1,
+    });
+    expect(calendar.periods[0].totalDueCents).toBe(75_000);
+    expect(calendar.totalDueCents).toBe(75_000);
+  });
+
+  it('flags a covered period and reports the surplus', () => {
+    const bills = [
+      makeBill({ amountCents: 120_000, dueDate: '2025-01-20', frequency: 'ONE_TIME' }),
+    ];
+    const calendar = buildBillCalendar({
+      bills,
+      schedule: biweekly,
+      fromDate: '2025-01-20',
+      periodsToShow: 1,
+    });
+    expect(calendar.periods[0].covered).toBe(true);
+    expect(calendar.periods[0].coverageCents).toBe(80_000); // 200000 - 120000
+  });
+
+  it('flags a shortfall when bills exceed expected income', () => {
+    const bills = [
+      makeBill({ amountCents: 180_000, dueDate: '2025-01-20', frequency: 'ONE_TIME' }),
+      makeBill({ amountCents: 60_000, dueDate: '2025-01-25', frequency: 'ONE_TIME' }),
+    ];
+    const calendar = buildBillCalendar({
+      bills,
+      schedule: biweekly,
+      fromDate: '2025-01-20',
+      periodsToShow: 1,
+    });
+    expect(calendar.periods[0].covered).toBe(false);
+    expect(calendar.periods[0].coverageCents).toBe(-40_000); // 200000 - 240000
+  });
+
+  it('spreads a recurring monthly bill across multiple pay periods', () => {
+    const bills = [
+      makeBill({ name: 'Phone', amountCents: 9_000, dueDate: '2025-01-18', frequency: 'MONTHLY' }),
+    ];
+    const calendar = buildBillCalendar({
+      bills,
+      schedule: biweekly,
+      fromDate: '2025-01-17',
+      periodsToShow: 3,
+    });
+    // 2025-01-18 -> period 0 [01-17,01-31); 2025-02-18 -> period 2 [02-14,02-28).
+    expect(calendar.periods[0].bills.map((b) => b.dueDate)).toEqual(['2025-01-18']);
+    expect(calendar.periods[1].bills).toHaveLength(0);
+    expect(calendar.periods[2].bills.map((b) => b.dueDate)).toEqual(['2025-02-18']);
+  });
+
+  it('buckets bills into semi-monthly pay periods', () => {
+    const semiMonthly: PaydaySchedule = {
+      cadence: 'SEMI_MONTHLY',
+      anchorDate: '2025-01-15',
+      expectedIncomeCents: 150_000,
+    };
+    const bills = [
+      // due 2025-02-05 -> period [2025-01-31, 2025-02-15)
+      makeBill({ name: 'Car', amountCents: 40_000, dueDate: '2025-02-05', frequency: 'ONE_TIME' }),
+      // due 2025-02-20 -> period [2025-02-15, 2025-02-28)
+      makeBill({ name: 'Gym', amountCents: 5_000, dueDate: '2025-02-20', frequency: 'ONE_TIME' }),
+    ];
+    const calendar = buildBillCalendar({
+      bills,
+      schedule: semiMonthly,
+      fromDate: '2025-02-01',
+      periodsToShow: 2,
+    });
+    expect(calendar.periods.map((p) => p.paydayDate)).toEqual(['2025-01-31', '2025-02-15']);
+    expect(calendar.periods[0].bills.map((b) => b.name)).toEqual(['Car']);
+    expect(calendar.periods[1].bills.map((b) => b.name)).toEqual(['Gym']);
+  });
+
+  it('buckets bills into monthly pay periods and totals income across periods', () => {
+    const monthly: PaydaySchedule = {
+      cadence: 'MONTHLY',
+      anchorDate: '2025-01-01',
+      expectedIncomeCents: 300_000,
+    };
+    const bills = [
+      makeBill({ name: 'Rent', amountCents: 150_000, dueDate: '2025-01-05', frequency: 'MONTHLY' }),
+    ];
+    const calendar = buildBillCalendar({
+      bills,
+      schedule: monthly,
+      fromDate: '2025-01-03',
+      periodsToShow: 2,
+    });
+    expect(calendar.periods.map((p) => p.paydayDate)).toEqual(['2025-01-01', '2025-02-01']);
+    expect(calendar.periods[0].bills.map((b) => b.dueDate)).toEqual(['2025-01-05']);
+    expect(calendar.periods[1].bills.map((b) => b.dueDate)).toEqual(['2025-02-05']);
+    expect(calendar.totalIncomeCents).toBe(600_000);
+    expect(calendar.totalDueCents).toBe(300_000);
+    expect(calendar.totalCoverageCents).toBe(300_000);
+  });
+
+  it('orders bills within a period by due date then name', () => {
+    const bills = [
+      makeBill({ name: 'Zebra', amountCents: 1_000, dueDate: '2025-01-25', frequency: 'ONE_TIME' }),
+      makeBill({ name: 'Apple', amountCents: 1_000, dueDate: '2025-01-20', frequency: 'ONE_TIME' }),
+      makeBill({ name: 'Beta', amountCents: 1_000, dueDate: '2025-01-20', frequency: 'ONE_TIME' }),
+    ];
+    const calendar = buildBillCalendar({
+      bills,
+      schedule: biweekly,
+      fromDate: '2025-01-17',
+      periodsToShow: 1,
+    });
+    expect(calendar.periods[0].bills.map((b) => b.name)).toEqual(['Apple', 'Beta', 'Zebra']);
+  });
+
+  it('returns empty periods when there are no bills', () => {
+    const calendar = buildBillCalendar({
+      bills: [],
+      schedule: biweekly,
+      fromDate: '2025-01-20',
+      periodsToShow: 3,
+    });
+    expect(calendar.periods).toHaveLength(3);
+    expect(calendar.totalDueCents).toBe(0);
+    expect(calendar.periods.every((p) => p.covered)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/bills/bill-calendar.ts
+++ b/apps/web/src/lib/bills/bill-calendar.ts
@@ -1,0 +1,423 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Bill calendar engine — aligns upcoming bills with a payday schedule.
+ *
+ * Given a payday cadence (weekly, biweekly, semi-monthly, monthly) plus a list
+ * of recurring/scheduled bills, this engine:
+ *   1. Generates the upcoming paydays that bound each pay period.
+ *   2. Expands each recurring bill into concrete occurrences inside the horizon.
+ *   3. Buckets those occurrences into pay periods (payday -> next payday).
+ *   4. Computes the total due before each payday and whether the expected
+ *      income for the period covers the bills due in it.
+ *
+ * Pure, deterministic functions — no side effects, no reliance on `Date.now()`.
+ * The caller supplies `fromDate` ("today") so results are fully testable.
+ *
+ * All monetary values are integer cents to avoid floating-point errors.
+ *
+ * References: issue #2196
+ */
+
+import type { Bill, BillFrequency, LocalDate, SyncId } from '../../kmp/bridge';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Cadence on which the user is paid. */
+export type PaydayCadence = 'WEEKLY' | 'BIWEEKLY' | 'SEMI_MONTHLY' | 'MONTHLY';
+
+/** Human-readable labels for each payday cadence. */
+export const PAYDAY_CADENCE_LABELS: Record<PaydayCadence, string> = {
+  WEEKLY: 'Weekly',
+  BIWEEKLY: 'Every two weeks',
+  SEMI_MONTHLY: 'Twice a month (15th & last day)',
+  MONTHLY: 'Monthly',
+};
+
+/** Configuration describing when a user is paid and how much they net. */
+export interface PaydaySchedule {
+  /** Cadence of paydays. */
+  readonly cadence: PaydayCadence;
+  /**
+   * A known payday (ISO local date). Used as the anchor for WEEKLY/BIWEEKLY
+   * and as the day-of-month for MONTHLY. Ignored for SEMI_MONTHLY (which is
+   * fixed to the 15th and last day of each month).
+   */
+  readonly anchorDate: LocalDate;
+  /** Expected net income deposited each payday, in integer cents. */
+  readonly expectedIncomeCents: number;
+}
+
+/** A single concrete occurrence of a bill on a specific date. */
+export interface BillOccurrence {
+  /** Identifier of the source bill. */
+  readonly billId: SyncId;
+  /** Display name of the bill. */
+  readonly name: string;
+  /** Payee for the bill. */
+  readonly payee: string;
+  /** Amount due for this occurrence, in integer cents. */
+  readonly amountCents: number;
+  /** ISO 4217 currency code. */
+  readonly currencyCode: string;
+  /** ISO local date this occurrence is due. */
+  readonly dueDate: LocalDate;
+  /** Frequency of the source bill. */
+  readonly frequency: BillFrequency;
+  /** Whether the source bill is set to auto-pay. */
+  readonly isAutoPay: boolean;
+}
+
+/** A pay period running from one payday up to (but not including) the next. */
+export interface PayPeriod {
+  /** Zero-based index of the period within the calendar. */
+  readonly index: number;
+  /** Payday that begins this period (income lands here). */
+  readonly paydayDate: LocalDate;
+  /** The next payday, which closes this period (exclusive). */
+  readonly nextPaydayDate: LocalDate;
+  /** Expected income deposited for this period, in integer cents. */
+  readonly expectedIncomeCents: number;
+  /** Bill occurrences due within this period, ordered by due date. */
+  readonly bills: readonly BillOccurrence[];
+  /** Sum of all bill occurrences due in this period, in integer cents. */
+  readonly totalDueCents: number;
+  /** Expected income minus total due (negative means a shortfall). */
+  readonly coverageCents: number;
+  /** `true` when expected income covers the bills due in this period. */
+  readonly covered: boolean;
+}
+
+/** Result of {@link buildBillCalendar}. */
+export interface BillCalendar {
+  /** Cadence used to build the calendar. */
+  readonly cadence: PaydayCadence;
+  /** The reference "today" the calendar was built from. */
+  readonly fromDate: LocalDate;
+  /** Pay periods ordered from the current period forward. */
+  readonly periods: readonly PayPeriod[];
+  /** Total bills due across all periods, in integer cents. */
+  readonly totalDueCents: number;
+  /** Total expected income across all periods, in integer cents. */
+  readonly totalIncomeCents: number;
+  /** Total income minus total due across all periods, in integer cents. */
+  readonly totalCoverageCents: number;
+}
+
+/** Options for {@link buildBillCalendar}. */
+export interface BuildBillCalendarOptions {
+  /** Bills to schedule. PAID and CANCELLED bills are ignored. */
+  readonly bills: readonly Bill[];
+  /** Payday schedule describing income cadence and amount. */
+  readonly schedule: PaydaySchedule;
+  /** Reference "today" as an ISO local date. */
+  readonly fromDate: LocalDate;
+  /** Number of pay periods to project (default 3). */
+  readonly periodsToShow?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic date helpers (operate purely on ISO "YYYY-MM-DD" strings)
+// ---------------------------------------------------------------------------
+
+interface YMD {
+  readonly y: number;
+  readonly m: number; // 1-12
+  readonly d: number; // 1-31
+}
+
+/** Parse an ISO local date into year/month/day integers. */
+function parseDate(iso: LocalDate): YMD {
+  const [y, m, d] = iso.split('-').map((part) => Number.parseInt(part, 10));
+  return { y, m, d };
+}
+
+/** Pad a number to two digits. */
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+/** Format year/month/day integers as an ISO local date. */
+function toIso(y: number, m: number, d: number): LocalDate {
+  return `${y}-${pad2(m)}-${pad2(d)}`;
+}
+
+/** Number of days in the given month (m is 1-12). */
+function lastDayOfMonth(y: number, m: number): number {
+  return new Date(Date.UTC(y, m, 0)).getUTCDate();
+}
+
+/** Add `n` days to an ISO local date (deterministic via UTC). */
+function addDays(iso: LocalDate, n: number): LocalDate {
+  const { y, m, d } = parseDate(iso);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  date.setUTCDate(date.getUTCDate() + n);
+  return toIso(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate());
+}
+
+/**
+ * Add `n` whole months to an ISO local date, clamping the day-of-month to the
+ * length of the target month (e.g. Jan 31 + 1 month = Feb 28/29). The day is
+ * always derived from the original date so repeated calls do not drift.
+ */
+function addMonths(iso: LocalDate, n: number): LocalDate {
+  const { y, m, d } = parseDate(iso);
+  const monthIndex = y * 12 + (m - 1) + n;
+  const ny = Math.floor(monthIndex / 12);
+  const nm = (monthIndex % 12) + 1;
+  const day = Math.min(d, lastDayOfMonth(ny, nm));
+  return toIso(ny, nm, day);
+}
+
+/** Whole days from `a` to `b` (positive when `b` is after `a`). */
+function daysBetween(a: LocalDate, b: LocalDate): number {
+  const da = parseDate(a);
+  const db = parseDate(b);
+  const ma = Date.UTC(da.y, da.m - 1, da.d);
+  const mb = Date.UTC(db.y, db.m - 1, db.d);
+  return Math.round((mb - ma) / 86_400_000);
+}
+
+// ---------------------------------------------------------------------------
+// Payday generation
+// ---------------------------------------------------------------------------
+
+/** Safety cap so malformed inputs can never loop forever. */
+const MAX_OCCURRENCE_ITERATIONS = 600;
+
+function generateFixedStepPaydays(
+  anchorDate: LocalDate,
+  fromDate: LocalDate,
+  stepDays: number,
+  count: number,
+): LocalDate[] {
+  // Find the most recent payday on or before `fromDate`.
+  const diff = daysBetween(anchorDate, fromDate);
+  const k = Math.floor(diff / stepDays);
+  const start = addDays(anchorDate, k * stepDays);
+  const paydays: LocalDate[] = [];
+  for (let i = 0; i < count; i++) {
+    paydays.push(addDays(start, i * stepDays));
+  }
+  return paydays;
+}
+
+function generateMonthlyPaydays(
+  anchorDate: LocalDate,
+  fromDate: LocalDate,
+  count: number,
+): LocalDate[] {
+  const anchorDay = parseDate(anchorDate).d;
+  const from = parseDate(fromDate);
+  let year = from.y;
+  let month = from.m;
+  // If this month's payday has not happened yet, start from the previous month.
+  const candidateDay = Math.min(anchorDay, lastDayOfMonth(year, month));
+  if (toIso(year, month, candidateDay) > fromDate) {
+    month -= 1;
+    if (month < 1) {
+      month = 12;
+      year -= 1;
+    }
+  }
+  const paydays: LocalDate[] = [];
+  for (let i = 0; i < count; i++) {
+    // Re-anchor on `anchorDay` each step so short months never cause drift.
+    const monthIndex = year * 12 + (month - 1) + i;
+    const py = Math.floor(monthIndex / 12);
+    const pm = (monthIndex % 12) + 1;
+    const day = Math.min(anchorDay, lastDayOfMonth(py, pm));
+    paydays.push(toIso(py, pm, day));
+  }
+  return paydays;
+}
+
+function generateSemiMonthlyPaydays(fromDate: LocalDate, count: number): LocalDate[] {
+  const from = parseDate(fromDate);
+  // Begin a month early so the most-recent payday is always captured.
+  let year = from.y;
+  let month = from.m - 1;
+  if (month < 1) {
+    month = 12;
+    year -= 1;
+  }
+  const all: LocalDate[] = [];
+  while (all.length < count + 4) {
+    all.push(toIso(year, month, 15));
+    all.push(toIso(year, month, lastDayOfMonth(year, month)));
+    month += 1;
+    if (month > 12) {
+      month = 1;
+      year += 1;
+    }
+  }
+  // `all` is already ascending (15th < last day; months ascending).
+  let startIdx = 0;
+  for (let i = 0; i < all.length; i++) {
+    if (all[i] <= fromDate) {
+      startIdx = i;
+    } else {
+      break;
+    }
+  }
+  return all.slice(startIdx, startIdx + count);
+}
+
+/**
+ * Generate `count` paydays starting from the most recent payday on or before
+ * `fromDate`, ordered ascending.
+ */
+export function generatePaydays(
+  schedule: PaydaySchedule,
+  fromDate: LocalDate,
+  count: number,
+): LocalDate[] {
+  const safeCount = Math.max(0, Math.trunc(count));
+  if (safeCount === 0) return [];
+
+  switch (schedule.cadence) {
+    case 'WEEKLY':
+      return generateFixedStepPaydays(schedule.anchorDate, fromDate, 7, safeCount);
+    case 'BIWEEKLY':
+      return generateFixedStepPaydays(schedule.anchorDate, fromDate, 14, safeCount);
+    case 'MONTHLY':
+      return generateMonthlyPaydays(schedule.anchorDate, fromDate, safeCount);
+    case 'SEMI_MONTHLY':
+      return generateSemiMonthlyPaydays(fromDate, safeCount);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bill occurrence expansion
+// ---------------------------------------------------------------------------
+
+/** Compute the date of the `i`-th occurrence of a bill from its base due date. */
+function occurrenceAt(baseDueDate: LocalDate, frequency: BillFrequency, i: number): LocalDate {
+  switch (frequency) {
+    case 'ONE_TIME':
+      return baseDueDate;
+    case 'WEEKLY':
+      return addDays(baseDueDate, i * 7);
+    case 'BIWEEKLY':
+      return addDays(baseDueDate, i * 14);
+    case 'MONTHLY':
+      return addMonths(baseDueDate, i);
+    case 'QUARTERLY':
+      return addMonths(baseDueDate, i * 3);
+    case 'YEARLY':
+      return addMonths(baseDueDate, i * 12);
+  }
+}
+
+function toOccurrence(bill: Bill, dueDate: LocalDate): BillOccurrence {
+  return {
+    billId: bill.id,
+    name: bill.name,
+    payee: bill.payee,
+    amountCents: bill.amount.amount,
+    currencyCode: bill.currency.code,
+    dueDate,
+    frequency: bill.frequency,
+    isAutoPay: bill.isAutoPay,
+  };
+}
+
+/**
+ * Expand recurring bills into concrete occurrences within the half-open window
+ * `[windowStart, windowEndExclusive)`. PAID and CANCELLED bills are ignored.
+ */
+export function expandBillOccurrences(
+  bills: readonly Bill[],
+  windowStart: LocalDate,
+  windowEndExclusive: LocalDate,
+): BillOccurrence[] {
+  const occurrences: BillOccurrence[] = [];
+
+  for (const bill of bills) {
+    if (bill.status === 'PAID' || bill.status === 'CANCELLED') continue;
+
+    const base = bill.dueDate;
+
+    if (bill.frequency === 'ONE_TIME') {
+      if (base >= windowStart && base < windowEndExclusive) {
+        occurrences.push(toOccurrence(bill, base));
+      }
+      continue;
+    }
+
+    for (let i = 0; i < MAX_OCCURRENCE_ITERATIONS; i++) {
+      const date = occurrenceAt(base, bill.frequency, i);
+      if (date >= windowEndExclusive) break;
+      if (date >= windowStart) {
+        occurrences.push(toOccurrence(bill, date));
+      }
+    }
+  }
+
+  return occurrences;
+}
+
+// ---------------------------------------------------------------------------
+// Calendar assembly
+// ---------------------------------------------------------------------------
+
+/** Default number of pay periods to project. */
+export const DEFAULT_PERIODS_TO_SHOW = 3;
+
+/**
+ * Build a payday-aligned bill calendar: pay periods with the bills due in each,
+ * the total due before each payday, and per-period income coverage.
+ */
+export function buildBillCalendar(options: BuildBillCalendarOptions): BillCalendar {
+  const { bills, schedule, fromDate } = options;
+  const periodsToShow = Math.max(1, Math.trunc(options.periodsToShow ?? DEFAULT_PERIODS_TO_SHOW));
+
+  // One extra payday is needed to close the final period.
+  const paydays = generatePaydays(schedule, fromDate, periodsToShow + 1);
+
+  const windowStart = paydays[0];
+  const windowEnd = paydays[paydays.length - 1];
+  const occurrences = expandBillOccurrences(bills, windowStart, windowEnd);
+
+  const grouped: BillOccurrence[][] = Array.from({ length: periodsToShow }, () => []);
+  for (const occ of occurrences) {
+    for (let i = 0; i < periodsToShow; i++) {
+      if (occ.dueDate >= paydays[i] && occ.dueDate < paydays[i + 1]) {
+        grouped[i].push(occ);
+        break;
+      }
+    }
+  }
+
+  const periods: PayPeriod[] = grouped.map((periodBills, index) => {
+    const sorted = [...periodBills].sort(
+      (a, b) => a.dueDate.localeCompare(b.dueDate) || a.name.localeCompare(b.name),
+    );
+    const totalDueCents = sorted.reduce((sum, occ) => sum + occ.amountCents, 0);
+    const coverageCents = schedule.expectedIncomeCents - totalDueCents;
+    return {
+      index,
+      paydayDate: paydays[index],
+      nextPaydayDate: paydays[index + 1],
+      expectedIncomeCents: schedule.expectedIncomeCents,
+      bills: sorted,
+      totalDueCents,
+      coverageCents,
+      covered: coverageCents >= 0,
+    };
+  });
+
+  const totalDueCents = periods.reduce((sum, p) => sum + p.totalDueCents, 0);
+  const totalIncomeCents = periods.reduce((sum, p) => sum + p.expectedIncomeCents, 0);
+
+  return {
+    cadence: schedule.cadence,
+    fromDate,
+    periods,
+    totalDueCents,
+    totalIncomeCents,
+    totalCoverageCents: totalIncomeCents - totalDueCents,
+  };
+}

--- a/apps/web/src/pages/BillsPage.tsx
+++ b/apps/web/src/pages/BillsPage.tsx
@@ -19,6 +19,10 @@ import {
 import { useBills } from '../hooks';
 import type { Bill, BillFrequency, BillStatus } from '../kmp/bridge';
 import { AppIcon, type IconName } from '../components/icons';
+import { BillCalendarView } from '../components/bills/BillCalendarView';
+
+/** Which Bills view is active. */
+type BillsView = 'list' | 'payday';
 
 /** Human-readable labels for bill frequency. */
 const FREQUENCY_LABELS: Record<BillFrequency, string> = {
@@ -110,6 +114,7 @@ export const BillsPage: React.FC = () => {
   const [deletingBill, setDeletingBill] = useState<Bill | null>(null);
   const [isDeletingBill, setIsDeletingBill] = useState(false);
   const [statusFilter, setStatusFilter] = useState<BillStatus | 'ALL'>('ALL');
+  const [view, setView] = useState<BillsView>('list');
 
   const filteredBills =
     statusFilter === 'ALL' ? bills : bills.filter((b) => b.status === statusFilter);
@@ -263,161 +268,213 @@ export const BillsPage: React.FC = () => {
             </div>
           </section>
 
-          {/* Filter */}
+          {/* View toggle: list vs. payday-aligned calendar */}
           <div
+            role="group"
+            aria-label="Choose bills view"
             style={{
+              display: 'inline-flex',
+              gap: 'var(--spacing-1)',
               marginBottom: 'var(--spacing-4)',
-              display: 'flex',
-              gap: 'var(--spacing-2)',
-              flexWrap: 'wrap',
+              padding: 'var(--spacing-1)',
+              borderRadius: 'var(--radius-md, 8px)',
+              backgroundColor: 'var(--semantic-surface-secondary, #f3f4f6)',
             }}
           >
-            <label htmlFor="bill-status-filter" className="sr-only">
-              Filter by status
-            </label>
-            <select
-              id="bill-status-filter"
-              value={statusFilter}
-              onChange={(e) => setStatusFilter(e.target.value as BillStatus | 'ALL')}
-              aria-label="Filter bills by status"
+            <button
+              type="button"
+              className="form-button"
+              aria-pressed={view === 'list'}
+              onClick={() => setView('list')}
               style={{
-                padding: 'var(--spacing-2) var(--spacing-3)',
-                borderRadius: 'var(--radius-sm, 4px)',
-                border: '1px solid var(--semantic-border, #d1d5db)',
-                backgroundColor: 'var(--semantic-background-primary)',
+                fontSize: 'var(--type-scale-caption-font-size)',
+                backgroundColor:
+                  view === 'list' ? 'var(--semantic-background-primary)' : 'transparent',
                 color: 'var(--semantic-text-primary)',
-                fontSize: 'var(--type-scale-body-font-size)',
               }}
             >
-              <option value="ALL">All Bills</option>
-              <option value="UPCOMING">Upcoming</option>
-              <option value="OVERDUE">Overdue</option>
-              <option value="PAID">Paid</option>
-              <option value="CANCELLED">Cancelled</option>
-            </select>
+              <AppIcon name="clipboard" /> List
+            </button>
+            <button
+              type="button"
+              className="form-button"
+              aria-pressed={view === 'payday'}
+              onClick={() => setView('payday')}
+              style={{
+                fontSize: 'var(--type-scale-caption-font-size)',
+                backgroundColor:
+                  view === 'payday' ? 'var(--semantic-background-primary)' : 'transparent',
+                color: 'var(--semantic-text-primary)',
+              }}
+            >
+              <AppIcon name="wallet" /> By payday
+            </button>
           </div>
 
-          {/* Bills List */}
-          <section aria-label="Bill list">
-            <div className="card-grid">
-              {filteredBills.map((bill) => (
-                <article
-                  key={bill.id}
-                  className="card"
-                  aria-label={`${bill.name}: ${STATUS_LABELS[bill.status]}`}
+          {view === 'payday' ? (
+            <BillCalendarView bills={bills} />
+          ) : (
+            <>
+              {/* Filter */}
+              <div
+                style={{
+                  marginBottom: 'var(--spacing-4)',
+                  display: 'flex',
+                  gap: 'var(--spacing-2)',
+                  flexWrap: 'wrap',
+                }}
+              >
+                <label htmlFor="bill-status-filter" className="sr-only">
+                  Filter by status
+                </label>
+                <select
+                  id="bill-status-filter"
+                  value={statusFilter}
+                  onChange={(e) => setStatusFilter(e.target.value as BillStatus | 'ALL')}
+                  aria-label="Filter bills by status"
+                  style={{
+                    padding: 'var(--spacing-2) var(--spacing-3)',
+                    borderRadius: 'var(--radius-sm, 4px)',
+                    border: '1px solid var(--semantic-border, #d1d5db)',
+                    backgroundColor: 'var(--semantic-background-primary)',
+                    color: 'var(--semantic-text-primary)',
+                    fontSize: 'var(--type-scale-body-font-size)',
+                  }}
                 >
-                  <div
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'flex-start',
-                      gap: 'var(--spacing-3)',
-                      marginBottom: 'var(--spacing-3)',
-                    }}
-                  >
-                    <h3 style={{ fontWeight: 'var(--font-weight-semibold)', margin: 0 }}>
-                      <Link
-                        to={`/bills/${bill.id}`}
-                        style={{ textDecoration: 'none', color: 'inherit' }}
-                        aria-label={`View details for ${bill.name}`}
+                  <option value="ALL">All Bills</option>
+                  <option value="UPCOMING">Upcoming</option>
+                  <option value="OVERDUE">Overdue</option>
+                  <option value="PAID">Paid</option>
+                  <option value="CANCELLED">Cancelled</option>
+                </select>
+              </div>
+
+              {/* Bills List */}
+              <section aria-label="Bill list">
+                <div className="card-grid">
+                  {filteredBills.map((bill) => (
+                    <article
+                      key={bill.id}
+                      className="card"
+                      aria-label={`${bill.name}: ${STATUS_LABELS[bill.status]}`}
+                    >
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'flex-start',
+                          gap: 'var(--spacing-3)',
+                          marginBottom: 'var(--spacing-3)',
+                        }}
                       >
-                        <AppIcon name={getStatusIcon(bill.status)} /> {bill.name}
-                      </Link>
-                    </h3>
-                    <span
-                      style={{
-                        ...getStatusStyle(bill.status),
-                        padding: 'var(--spacing-1) var(--spacing-2)',
-                        borderRadius: 'var(--radius-sm, 4px)',
-                        fontSize: 'var(--type-scale-caption-font-size)',
-                        fontWeight: 'var(--font-weight-semibold)',
-                        flexShrink: 0,
-                      }}
-                    >
-                      {STATUS_LABELS[bill.status]}
-                    </span>
-                  </div>
+                        <h3 style={{ fontWeight: 'var(--font-weight-semibold)', margin: 0 }}>
+                          <Link
+                            to={`/bills/${bill.id}`}
+                            style={{ textDecoration: 'none', color: 'inherit' }}
+                            aria-label={`View details for ${bill.name}`}
+                          >
+                            <AppIcon name={getStatusIcon(bill.status)} /> {bill.name}
+                          </Link>
+                        </h3>
+                        <span
+                          style={{
+                            ...getStatusStyle(bill.status),
+                            padding: 'var(--spacing-1) var(--spacing-2)',
+                            borderRadius: 'var(--radius-sm, 4px)',
+                            fontSize: 'var(--type-scale-caption-font-size)',
+                            fontWeight: 'var(--font-weight-semibold)',
+                            flexShrink: 0,
+                          }}
+                        >
+                          {STATUS_LABELS[bill.status]}
+                        </span>
+                      </div>
 
-                  <div
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'baseline',
-                      marginBottom: 'var(--spacing-2)',
-                    }}
-                  >
-                    <p className="card__value" style={{ margin: 0 }}>
-                      <CurrencyDisplay amount={bill.amount.amount} currency={bill.currency.code} />
-                    </p>
-                    <span
-                      style={{
-                        fontSize: 'var(--type-scale-caption-font-size)',
-                        color: 'var(--semantic-text-secondary)',
-                      }}
-                    >
-                      {FREQUENCY_LABELS[bill.frequency]}
-                    </span>
-                  </div>
-
-                  <p
-                    style={{
-                      fontSize: 'var(--type-scale-caption-font-size)',
-                      color: 'var(--semantic-text-secondary)',
-                      marginBottom: 'var(--spacing-2)',
-                    }}
-                  >
-                    {bill.payee} · {formatDueDate(bill.dueDate)}
-                  </p>
-
-                  {bill.isAutoPay && (
-                    <p
-                      style={{
-                        fontSize: 'var(--type-scale-caption-font-size)',
-                        color: 'var(--semantic-positive, #059669)',
-                        marginBottom: 'var(--spacing-2)',
-                      }}
-                    >
-                      <AppIcon name="lightning" /> Auto-pay enabled
-                    </p>
-                  )}
-
-                  <div
-                    style={{
-                      display: 'flex',
-                      gap: 'var(--spacing-2)',
-                      marginTop: 'var(--spacing-3)',
-                    }}
-                  >
-                    {bill.status === 'UPCOMING' || bill.status === 'OVERDUE' ? (
-                      <button
-                        type="button"
-                        className="form-button form-button--primary"
-                        onClick={() => handleMarkPaid(bill.id)}
-                        aria-label={`Mark ${bill.name} as paid`}
-                        style={{ fontSize: 'var(--type-scale-caption-font-size)' }}
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'baseline',
+                          marginBottom: 'var(--spacing-2)',
+                        }}
                       >
-                        Mark Paid
-                      </button>
-                    ) : null}
-                    <button
-                      type="button"
-                      className="icon-button"
-                      onClick={() => handleRequestDelete(bill)}
-                      aria-label={`Delete ${bill.name}`}
-                    >
-                      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                        <path d="M3 6h18" />
-                        <path d="M8 6V4h8v2" />
-                        <path d="M19 6l-1 14H6L5 6" />
-                        <path d="M10 11v6" />
-                        <path d="M14 11v6" />
-                      </svg>
-                    </button>
-                  </div>
-                </article>
-              ))}
-            </div>
-          </section>
+                        <p className="card__value" style={{ margin: 0 }}>
+                          <CurrencyDisplay
+                            amount={bill.amount.amount}
+                            currency={bill.currency.code}
+                          />
+                        </p>
+                        <span
+                          style={{
+                            fontSize: 'var(--type-scale-caption-font-size)',
+                            color: 'var(--semantic-text-secondary)',
+                          }}
+                        >
+                          {FREQUENCY_LABELS[bill.frequency]}
+                        </span>
+                      </div>
+
+                      <p
+                        style={{
+                          fontSize: 'var(--type-scale-caption-font-size)',
+                          color: 'var(--semantic-text-secondary)',
+                          marginBottom: 'var(--spacing-2)',
+                        }}
+                      >
+                        {bill.payee} · {formatDueDate(bill.dueDate)}
+                      </p>
+
+                      {bill.isAutoPay && (
+                        <p
+                          style={{
+                            fontSize: 'var(--type-scale-caption-font-size)',
+                            color: 'var(--semantic-positive, #059669)',
+                            marginBottom: 'var(--spacing-2)',
+                          }}
+                        >
+                          <AppIcon name="lightning" /> Auto-pay enabled
+                        </p>
+                      )}
+
+                      <div
+                        style={{
+                          display: 'flex',
+                          gap: 'var(--spacing-2)',
+                          marginTop: 'var(--spacing-3)',
+                        }}
+                      >
+                        {bill.status === 'UPCOMING' || bill.status === 'OVERDUE' ? (
+                          <button
+                            type="button"
+                            className="form-button form-button--primary"
+                            onClick={() => handleMarkPaid(bill.id)}
+                            aria-label={`Mark ${bill.name} as paid`}
+                            style={{ fontSize: 'var(--type-scale-caption-font-size)' }}
+                          >
+                            Mark Paid
+                          </button>
+                        ) : null}
+                        <button
+                          type="button"
+                          className="icon-button"
+                          onClick={() => handleRequestDelete(bill)}
+                          aria-label={`Delete ${bill.name}`}
+                        >
+                          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                            <path d="M3 6h18" />
+                            <path d="M8 6V4h8v2" />
+                            <path d="M19 6l-1 14H6L5 6" />
+                            <path d="M10 11v6" />
+                            <path d="M14 11v6" />
+                          </svg>
+                        </button>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            </>
+          )}
         </>
       )}
 


### PR DESCRIPTION
## Summary

Adds a payday-aligned bill calendar to the web app's Bills surface, answering "what bills hit before my next payday?"

### Engine (`apps/web/src/lib/bills/bill-calendar.ts`)
- Pure, deterministic functions (no `Date.now()` ? the caller supplies `fromDate`).
- Generates paydays for **weekly, biweekly, semi-monthly (15th & last day), and monthly** cadences, handling edge cases (biweekly anchor date, monthly day-of-month clamping for short months with no drift).
- Expands recurring/scheduled bills into concrete occurrences within the horizon (ONE_TIME / WEEKLY / BIWEEKLY / MONTHLY / QUARTERLY / YEARLY); excludes PAID/CANCELLED.
- Buckets occurrences into pay periods (payday -> next payday), computes total due before each payday and per-period coverage (expected income - bills due).
- **All money in integer cents.**

### UI (`apps/web/src/components/bills/BillCalendarView.tsx`)
- New **"By payday"** view toggle on `BillsPage` (imported directly into the lazy page ? no shared barrel, keeps the route chunk lean).
- Per-period cards show the before-payday total and a **covered/short** indicator conveyed by **text + icon, never colour alone**.
- Payday schedule form (cadence, recent payday, expected income) persisted to localStorage.
- WCAG 2.2 AA: semantic headings, labelled controls, keyboard operable, no motion introduced (reduced-motion respected).

### Tests
- `bill-calendar.test.ts` ? 18 engine unit tests (period bucketing for biweekly/semi-monthly/monthly, before-payday totals, coverage shortfall, recurrence expansion, payday edge cases).
- `BillCalendarView.test.tsx` ? 5 accessible-rendering tests.

Native UI + KMP shared models are out of scope for this slice.

Refs #2196
