### PR TITLE
feat(web): kid-specific categories and supportive coaching copy (#2201)

### DIFF
--- a/apps/web/src/components/categories/FamilyKidsCategoryCard.tsx
+++ b/apps/web/src/components/categories/FamilyKidsCategoryCard.tsx
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Accessible affordance for seeding the kid/family starter category preset.
+ *
+ * Rendered lazily by {@link CategoriesPage} so the preset data and supportive
+ * coaching copy ship in their own async chunk rather than inflating the main
+ * categories route bundle.
+ *
+ * Data access stays hooks-only: the caller passes `createCategory` / `refresh`
+ * from `useCategories` rather than this component reaching into a repository.
+ *
+ * References: issue #2201
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+
+import { ConfirmDialog } from '../common';
+import type { CreateCategoryInput } from '../../db/repositories/categories';
+import type { Category } from '../../kmp/bridge';
+import {
+  applyFamilyKidsCategories,
+  buildFamilyKidsCategoryPlan,
+} from '../../lib/categories/family-kids-categories';
+import { selectSupportiveFamilyCopy } from '../../lib/coaching/supportive-family-copy';
+
+/** Props for {@link FamilyKidsCategoryCard}. */
+export interface FamilyKidsCategoryCardProps {
+  /** Current categories, used to compute which preset entries are missing. */
+  readonly categories: readonly Category[];
+  /** Household the new categories belong to, or `null` when unknown. */
+  readonly householdId: string | null;
+  /** Creates a category; returns the created record or `null` on failure. */
+  readonly createCategory: (input: CreateCategoryInput) => Category | null;
+  /** Invoked after categories are successfully seeded. */
+  readonly onApplied: () => void;
+  /** Surfaces an error message (or clears it with `null`). */
+  readonly onError: (message: string | null) => void;
+}
+
+/**
+ * Card that previews and applies the kid/family starter category preset.
+ */
+export function FamilyKidsCategoryCard({
+  categories,
+  householdId,
+  createCategory,
+  onApplied,
+  onError,
+}: FamilyKidsCategoryCardProps) {
+  const plan = useMemo(() => buildFamilyKidsCategoryPlan(categories), [categories]);
+  const copy = useMemo(
+    () => selectSupportiveFamilyCopy({ presetComplete: plan.isComplete }),
+    [plan.isComplete],
+  );
+
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const handleRequest = useCallback(() => {
+    onError(null);
+    setIsConfirmOpen(true);
+  }, [onError]);
+
+  const handleCancel = useCallback(() => {
+    setIsConfirmOpen(false);
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    setIsConfirmOpen(false);
+
+    if (!householdId) {
+      onError('Add a category first so we know which household to set up.');
+      return;
+    }
+
+    const result = applyFamilyKidsCategories<Category>({
+      categories,
+      householdId,
+      createCategory: (input) =>
+        createCategory({
+          householdId: input.householdId,
+          name: input.name,
+          icon: input.icon,
+          color: input.color,
+          sortOrder: input.sortOrder,
+        }),
+    });
+
+    if (result.createdCount === 0 && !plan.isComplete) {
+      onError('Failed to add family & kids categories.');
+      return;
+    }
+
+    onError(null);
+    onApplied();
+  }, [categories, createCategory, householdId, onApplied, onError, plan.isComplete]);
+
+  const confirmMessage =
+    plan.missing.length > 0
+      ? `Add ${plan.missing.length} family & kids categor${
+          plan.missing.length === 1 ? 'y' : 'ies'
+        } to your list: ${plan.missing
+          .map((definition) => definition.name)
+          .join(', ')}. You can rename, set budgets for, or remove any of them later.`
+      : 'All family & kids categories are already in your list. Nothing new will be added.';
+
+  return (
+    <>
+      <ConfirmDialog
+        isOpen={isConfirmOpen}
+        title="Add family & kids categories"
+        message={confirmMessage}
+        confirmLabel="Add categories"
+        cancelLabel="Not now"
+        variant="info"
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+      <section aria-labelledby="family-kids-setup-heading" className="family-kids-setup">
+        <div className="card">
+          <div className="family-kids-setup__header">
+            <div className="family-kids-setup__intro">
+              <h3 id="family-kids-setup-heading" className="card__title">
+                Family &amp; kids categories
+              </h3>
+              <p className="family-kids-setup__lede">
+                Seed kid-specific categories for school fees, childcare, activities &amp; sports,
+                birthdays &amp; gifts, field trips &amp; supplies, kids&rsquo; clothing, and medical
+                co-pays &mdash; the real costs of raising a family.
+              </p>
+              <p className="family-kids-setup__status">
+                {plan.isComplete
+                  ? `All ${plan.definitions.length} family & kids categories are ready.`
+                  : `${plan.present.length} of ${plan.definitions.length} ready · ${plan.missing.length} will be added.`}
+              </p>
+            </div>
+            <button
+              type="button"
+              className="form-button form-button--secondary"
+              onClick={handleRequest}
+            >
+              {plan.isComplete ? 'Family & kids ready' : 'Add family & kids categories'}
+            </button>
+          </div>
+          <p role="note" className="family-kids-setup__note">
+            <strong className="family-kids-setup__note-headline">{copy.headline}.</strong>{' '}
+            {copy.body} {copy.smallWin}
+          </p>
+          <ul aria-label="Family and kids categories preview" className="family-kids-setup__list">
+            {plan.definitions.map((definition) => {
+              const isPresent = plan.present.some((entry) => entry.name === definition.name);
+              return (
+                <li key={definition.name} className="family-kids-setup__item">
+                  <span aria-hidden="true">{definition.icon}</span>
+                  <span className="family-kids-setup__name">{definition.name}</span>
+                  <span
+                    className={`family-kids-setup__badge${
+                      isPresent ? ' family-kids-setup__badge--present' : ''
+                    }`}
+                  >
+                    {isPresent ? 'Added' : 'Will be added'}
+                  </span>
+                  <span className="family-kids-setup__desc">{definition.description}</span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </section>
+    </>
+  );
+}
+
+export default FamilyKidsCategoryCard;

--- a/apps/web/src/lib/categories/family-kids-categories.test.ts
+++ b/apps/web/src/lib/categories/family-kids-categories.test.ts
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  applyFamilyKidsCategories,
+  buildFamilyKidsCategoryPlan,
+  FAMILY_KIDS_CATEGORY_DEFINITIONS,
+  type FamilyKidsCategoryLike,
+} from './family-kids-categories';
+
+interface TestCategory extends FamilyKidsCategoryLike {
+  readonly id: string;
+  readonly name: string;
+  readonly isIncome?: boolean;
+  readonly householdId?: string;
+  readonly sortOrder?: number;
+  readonly icon?: string;
+  readonly color?: string;
+}
+
+function makeCreateCategory() {
+  let counter = 0;
+  return vi.fn(
+    (input: {
+      householdId: string;
+      name: string;
+      icon: string;
+      color: string;
+      sortOrder: number;
+    }): TestCategory => {
+      counter += 1;
+      return {
+        id: `created-${counter}`,
+        householdId: input.householdId,
+        name: input.name,
+        icon: input.icon,
+        color: input.color,
+        sortOrder: input.sortOrder,
+        isIncome: false,
+      };
+    },
+  );
+}
+
+describe('FAMILY_KIDS_CATEGORY_DEFINITIONS', () => {
+  it('covers the kid-specific family expenses for this persona', () => {
+    const names = FAMILY_KIDS_CATEGORY_DEFINITIONS.map((definition) => definition.name);
+
+    expect(names).toEqual([
+      'School Fees',
+      'Childcare & Daycare',
+      "Kids' Activities & Sports",
+      'Birthdays & Gifts',
+      'Field Trips & School Supplies',
+      "Kids' Clothing",
+      'Medical & Co-pays',
+    ]);
+  });
+
+  it('gives every category an icon, color, and supportive description', () => {
+    for (const definition of FAMILY_KIDS_CATEGORY_DEFINITIONS) {
+      expect(definition.icon.length).toBeGreaterThan(0);
+      expect(definition.color).toMatch(/^#[0-9A-F]{6}$/i);
+      expect(definition.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('buildFamilyKidsCategoryPlan', () => {
+  it('marks every category as missing when none exist', () => {
+    const plan = buildFamilyKidsCategoryPlan([]);
+
+    expect(plan.present).toHaveLength(0);
+    expect(plan.missing).toHaveLength(FAMILY_KIDS_CATEGORY_DEFINITIONS.length);
+    expect(plan.isComplete).toBe(false);
+  });
+
+  it('detects existing categories case-insensitively and ignores whitespace', () => {
+    const categories: TestCategory[] = [
+      { id: 'a', name: '  school fees  ' },
+      { id: 'b', name: "KIDS' CLOTHING" },
+    ];
+
+    const plan = buildFamilyKidsCategoryPlan(categories);
+
+    expect(plan.present.map((definition) => definition.name)).toEqual([
+      'School Fees',
+      "Kids' Clothing",
+    ]);
+    expect(plan.missing.map((definition) => definition.name)).not.toContain('School Fees');
+    expect(plan.isComplete).toBe(false);
+  });
+
+  it('does not let an income category mask a missing expense category', () => {
+    const categories: TestCategory[] = [{ id: 'a', name: 'School Fees', isIncome: true }];
+
+    const plan = buildFamilyKidsCategoryPlan(categories);
+
+    expect(plan.missing.map((definition) => definition.name)).toContain('School Fees');
+    expect(plan.present).toHaveLength(0);
+  });
+
+  it('reports completion once all preset categories exist', () => {
+    const categories: TestCategory[] = FAMILY_KIDS_CATEGORY_DEFINITIONS.map(
+      (definition, index) => ({
+        id: `c-${index}`,
+        name: definition.name,
+      }),
+    );
+
+    const plan = buildFamilyKidsCategoryPlan(categories);
+
+    expect(plan.missing).toHaveLength(0);
+    expect(plan.isComplete).toBe(true);
+  });
+});
+
+describe('applyFamilyKidsCategories', () => {
+  it('creates every missing category exactly once', () => {
+    const createCategory = makeCreateCategory();
+
+    const result = applyFamilyKidsCategories<TestCategory>({
+      categories: [],
+      householdId: 'household-1',
+      createCategory,
+    });
+
+    expect(result.createdCount).toBe(FAMILY_KIDS_CATEGORY_DEFINITIONS.length);
+    expect(result.skippedCount).toBe(0);
+    expect(createCategory).toHaveBeenCalledTimes(FAMILY_KIDS_CATEGORY_DEFINITIONS.length);
+    expect(result.created.map((category) => category.name)).toEqual(
+      FAMILY_KIDS_CATEGORY_DEFINITIONS.map((definition) => definition.name),
+    );
+  });
+
+  it('assigns increasing sort orders above existing categories', () => {
+    const createCategory = makeCreateCategory();
+    const categories: TestCategory[] = [
+      { id: 'existing', name: 'Rent', householdId: 'household-1', sortOrder: 7 },
+    ];
+
+    const result = applyFamilyKidsCategories<TestCategory>({
+      categories,
+      householdId: 'household-1',
+      createCategory,
+    });
+
+    const sortOrders = result.created.map((category) => category.sortOrder);
+    expect(sortOrders[0]).toBe(8);
+    expect(sortOrders).toEqual([8, 9, 10, 11, 12, 13, 14]);
+  });
+
+  it('is idempotent — a second apply creates nothing new', () => {
+    const firstCreate = makeCreateCategory();
+    const seeded = applyFamilyKidsCategories<TestCategory>({
+      categories: [],
+      householdId: 'household-1',
+      createCategory: firstCreate,
+    });
+
+    const secondCreate = makeCreateCategory();
+    const result = applyFamilyKidsCategories<TestCategory>({
+      categories: seeded.created,
+      householdId: 'household-1',
+      createCategory: secondCreate,
+    });
+
+    expect(result.createdCount).toBe(0);
+    expect(result.skippedCount).toBe(FAMILY_KIDS_CATEGORY_DEFINITIONS.length);
+    expect(secondCreate).not.toHaveBeenCalled();
+  });
+
+  it('only seeds the categories that are still missing', () => {
+    const createCategory = makeCreateCategory();
+    const categories: TestCategory[] = [
+      { id: 'a', name: 'School Fees', householdId: 'household-1', sortOrder: 1 },
+      { id: 'b', name: 'Birthdays & Gifts', householdId: 'household-1', sortOrder: 2 },
+    ];
+
+    const result = applyFamilyKidsCategories<TestCategory>({
+      categories,
+      householdId: 'household-1',
+      createCategory,
+    });
+
+    expect(result.skippedCount).toBe(2);
+    expect(result.createdCount).toBe(FAMILY_KIDS_CATEGORY_DEFINITIONS.length - 2);
+    expect(result.created.map((category) => category.name)).not.toContain('School Fees');
+    expect(result.created.map((category) => category.name)).not.toContain('Birthdays & Gifts');
+  });
+
+  it('skips records the create callback fails to persist', () => {
+    const createCategory = vi.fn(() => null);
+
+    const result = applyFamilyKidsCategories<TestCategory>({
+      categories: [],
+      householdId: 'household-1',
+      createCategory,
+    });
+
+    expect(result.createdCount).toBe(0);
+    expect(result.created).toHaveLength(0);
+  });
+
+  it('does not mutate the input categories array', () => {
+    const createCategory = makeCreateCategory();
+    const categories: TestCategory[] = [{ id: 'a', name: 'Rent' }];
+
+    applyFamilyKidsCategories<TestCategory>({
+      categories,
+      householdId: 'household-1',
+      createCategory,
+    });
+
+    expect(categories).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/categories/family-kids-categories.ts
+++ b/apps/web/src/lib/categories/family-kids-categories.ts
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Kid- and family-focused starter category preset.
+ *
+ * Provides a deterministic set of top-level expense categories that reflect
+ * the real costs of raising children — school fees, childcare/daycare,
+ * kids' activities & sports, birthdays & gifts, field trips & school
+ * supplies, kids' clothing, and medical co-pays. The preset is pure data
+ * plus a small, idempotent applier that seeds only the categories that are
+ * still missing.
+ *
+ * All operations are pure: inputs are never mutated, and applying the preset
+ * more than once never creates duplicate categories.
+ *
+ * References: issue #2201
+ */
+
+/** A single category definition in the family/kids preset. */
+export interface FamilyKidsCategoryDefinition {
+  /** Display name shown to the user. */
+  readonly name: string;
+  /** Emoji icon (rendered directly as a custom category icon). */
+  readonly icon: string;
+  /** Accent color token used by the category card. */
+  readonly color: string;
+  /** Short, supportive description of what the category covers. */
+  readonly description: string;
+}
+
+/**
+ * The kid/family starter categories.
+ *
+ * Ordered roughly from largest, most predictable family costs to smaller,
+ * occasional ones so the preview reads naturally for a busy parent.
+ */
+export const FAMILY_KIDS_CATEGORY_DEFINITIONS: readonly FamilyKidsCategoryDefinition[] = [
+  {
+    name: 'School Fees',
+    icon: '🎒',
+    color: '#F59E0B',
+    description: 'Tuition, registration, lunch accounts, and recurring school costs.',
+  },
+  {
+    name: 'Childcare & Daycare',
+    icon: '🧸',
+    color: '#EC4899',
+    description: 'Daycare, babysitting, nannies, and after-school care.',
+  },
+  {
+    name: "Kids' Activities & Sports",
+    icon: '⚽',
+    color: '#2563EB',
+    description: 'Sports leagues, lessons, clubs, and hobbies.',
+  },
+  {
+    name: 'Birthdays & Gifts',
+    icon: '🎂',
+    color: '#DB2777',
+    description: 'Parties, presents, and celebrations for kids and their friends.',
+  },
+  {
+    name: 'Field Trips & School Supplies',
+    icon: '🚌',
+    color: '#0EA5E9',
+    description: 'Field trips, classroom supplies, books, and project materials.',
+  },
+  {
+    name: "Kids' Clothing",
+    icon: '👕',
+    color: '#8B5CF6',
+    description: 'Clothes, shoes, and seasonal gear as kids keep growing.',
+  },
+  {
+    name: 'Medical & Co-pays',
+    icon: '🩺',
+    color: '#059669',
+    description: 'Doctor visits, prescriptions, dental, and insurance co-pays.',
+  },
+] as const;
+
+/**
+ * Minimal structural shape used by the preset logic.
+ *
+ * Keeping this loose (rather than depending on the full KMP `Category` type)
+ * keeps the module pure and trivially testable while remaining compatible
+ * with the real category records returned by the repository layer.
+ */
+export interface FamilyKidsCategoryLike {
+  readonly name: string;
+  readonly isIncome?: boolean;
+  readonly householdId?: string;
+  readonly sortOrder?: number;
+}
+
+/** A computed diff between the preset and the user's existing categories. */
+export interface FamilyKidsCategoryPlan {
+  /** Every definition in the preset. */
+  readonly definitions: readonly FamilyKidsCategoryDefinition[];
+  /** Definitions that already exist as an expense category (by name). */
+  readonly present: readonly FamilyKidsCategoryDefinition[];
+  /** Definitions that are not present yet and would be created. */
+  readonly missing: readonly FamilyKidsCategoryDefinition[];
+  /** True when every preset category already exists. */
+  readonly isComplete: boolean;
+}
+
+function normalizeCategoryName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function nextSortOrder(categories: readonly FamilyKidsCategoryLike[], householdId: string): number {
+  return (
+    categories
+      .filter(
+        (category) => category.householdId === undefined || category.householdId === householdId,
+      )
+      .reduce((max, category) => Math.max(max, category.sortOrder ?? 0), 0) + 1
+  );
+}
+
+/**
+ * Compute which preset categories already exist and which are still missing.
+ *
+ * Matching is case-insensitive and ignores income categories so a same-named
+ * income category never masks a missing expense category.
+ *
+ * @param categories - The user's current categories.
+ * @returns A deterministic plan describing present and missing categories.
+ */
+export function buildFamilyKidsCategoryPlan(
+  categories: readonly FamilyKidsCategoryLike[],
+): FamilyKidsCategoryPlan {
+  const existingExpenseNames = new Set(
+    categories
+      .filter((category) => !category.isIncome)
+      .map((category) => normalizeCategoryName(category.name)),
+  );
+
+  const present: FamilyKidsCategoryDefinition[] = [];
+  const missing: FamilyKidsCategoryDefinition[] = [];
+
+  for (const definition of FAMILY_KIDS_CATEGORY_DEFINITIONS) {
+    if (existingExpenseNames.has(normalizeCategoryName(definition.name))) {
+      present.push(definition);
+    } else {
+      missing.push(definition);
+    }
+  }
+
+  return {
+    definitions: FAMILY_KIDS_CATEGORY_DEFINITIONS,
+    present,
+    missing,
+    isComplete: missing.length === 0,
+  };
+}
+
+/** Input passed to the family/kids category applier. */
+export interface ApplyFamilyKidsCategoriesOptions<TCategory extends FamilyKidsCategoryLike> {
+  /** The user's current categories. */
+  readonly categories: readonly TCategory[];
+  /** Household the new categories belong to. */
+  readonly householdId: string;
+  /** Creates a category record; returns the created record or `null` on failure. */
+  readonly createCategory: (input: {
+    readonly householdId: string;
+    readonly name: string;
+    readonly icon: string;
+    readonly color: string;
+    readonly sortOrder: number;
+  }) => TCategory | null;
+}
+
+/** Result of applying the family/kids preset. */
+export interface ApplyFamilyKidsCategoriesResult<TCategory extends FamilyKidsCategoryLike> {
+  /** Categories that were created during this apply. */
+  readonly created: readonly TCategory[];
+  /** Number of categories created. */
+  readonly createdCount: number;
+  /** Number of preset categories skipped because they already existed. */
+  readonly skippedCount: number;
+}
+
+/**
+ * Seed the missing family/kids categories.
+ *
+ * Idempotent: only categories absent from {@link buildFamilyKidsCategoryPlan}
+ * are created, so applying the preset twice never produces duplicates. The
+ * `createCategory` callback is injected so the applier stays pure and can be
+ * unit-tested without a database.
+ *
+ * @param options - Existing categories, household id, and a create callback.
+ * @returns A summary of what was created and skipped.
+ */
+export function applyFamilyKidsCategories<TCategory extends FamilyKidsCategoryLike>({
+  categories,
+  householdId,
+  createCategory,
+}: ApplyFamilyKidsCategoriesOptions<TCategory>): ApplyFamilyKidsCategoriesResult<TCategory> {
+  const plan = buildFamilyKidsCategoryPlan(categories);
+  const created: TCategory[] = [];
+  let sortOrder = nextSortOrder(categories, householdId);
+
+  for (const definition of plan.missing) {
+    const record = createCategory({
+      householdId,
+      name: definition.name,
+      icon: definition.icon,
+      color: definition.color,
+      sortOrder,
+    });
+
+    if (record) {
+      created.push(record);
+      sortOrder += 1;
+    }
+  }
+
+  return {
+    created,
+    createdCount: created.length,
+    skippedCount: plan.present.length,
+  };
+}

--- a/apps/web/src/lib/coaching/supportive-family-copy.test.ts
+++ b/apps/web/src/lib/coaching/supportive-family-copy.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  getSupportiveFamilyCopy,
+  listSupportiveFamilyCopy,
+  selectSupportiveFamilyCopy,
+  SUPPORTIVE_FAMILY_COACHING_COPY,
+} from './supportive-family-copy';
+
+// Words that signal judgmental, shaming, or punitive framing. None of the
+// supportive copy should contain any of these.
+const JUDGMENTAL_PHRASES = [
+  'over budget',
+  'overspent',
+  'overspending',
+  'failed',
+  'failure',
+  'you should have',
+  'irresponsible',
+  'shame',
+  'guilt',
+  'bad job',
+  'too much',
+  'wasted',
+  "can't afford",
+];
+
+describe('SUPPORTIVE_FAMILY_COACHING_COPY', () => {
+  it('provides supportive copy for every expected scenario', () => {
+    expect(Object.keys(SUPPORTIVE_FAMILY_COACHING_COPY).sort()).toEqual([
+      'celebrate-small-win',
+      'family-ready',
+      'steady-and-supported',
+      'tight-month-reframe',
+    ]);
+  });
+
+  it('keeps every variant non-judgmental and complete', () => {
+    for (const copy of listSupportiveFamilyCopy()) {
+      const haystack = `${copy.headline} ${copy.body} ${copy.smallWin}`.toLowerCase();
+      for (const phrase of JUDGMENTAL_PHRASES) {
+        expect(haystack).not.toContain(phrase);
+      }
+
+      expect(copy.headline.length).toBeGreaterThan(0);
+      expect(copy.body.length).toBeGreaterThan(0);
+      expect(copy.smallWin.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('is frozen so shared copy cannot be mutated', () => {
+    expect(Object.isFrozen(SUPPORTIVE_FAMILY_COACHING_COPY)).toBe(true);
+  });
+});
+
+describe('getSupportiveFamilyCopy', () => {
+  it('returns the requested variant by id', () => {
+    expect(getSupportiveFamilyCopy('tight-month-reframe').id).toBe('tight-month-reframe');
+    expect(getSupportiveFamilyCopy('family-ready').tone).toBe('supportive');
+  });
+});
+
+describe('selectSupportiveFamilyCopy', () => {
+  it('reframes a tight category as a hard month with one small win', () => {
+    const copy = selectSupportiveFamilyCopy({ tightCategoryName: 'Childcare & Daycare' });
+
+    expect(copy.id).toBe('tight-month-reframe');
+    expect(copy.tone).toBe('reassuring');
+    expect(copy.smallWin.toLowerCase()).toContain('small win');
+  });
+
+  it('celebrates a clear win', () => {
+    const copy = selectSupportiveFamilyCopy({ hadSmallWin: true });
+
+    expect(copy.id).toBe('celebrate-small-win');
+    expect(copy.tone).toBe('celebratory');
+  });
+
+  it('prioritizes a tight month over a win when both are present', () => {
+    const copy = selectSupportiveFamilyCopy({
+      tightCategoryName: 'School Fees',
+      hadSmallWin: true,
+    });
+
+    expect(copy.id).toBe('tight-month-reframe');
+  });
+
+  it('welcomes the caregiver once the preset is complete', () => {
+    expect(selectSupportiveFamilyCopy({ presetComplete: true }).id).toBe('family-ready');
+  });
+
+  it('falls back to steady encouragement with no signals', () => {
+    expect(selectSupportiveFamilyCopy().id).toBe('steady-and-supported');
+    expect(selectSupportiveFamilyCopy({}).id).toBe('steady-and-supported');
+  });
+});

--- a/apps/web/src/lib/coaching/supportive-family-copy.ts
+++ b/apps/web/src/lib/coaching/supportive-family-copy.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Supportive, non-judgmental coaching copy for the single-parent / tight-budget
+ * persona.
+ *
+ * Money coaching for caregivers who are doing their best on a tight budget has
+ * to be encouraging and shame-free. Instead of flagging a category as "over
+ * budget", these variants reframe a hard month as just a hard month and offer
+ * one small, concrete win to carry forward.
+ *
+ * The copy is a structured, pure data set plus a deterministic selector so it
+ * can be unit-tested and reused anywhere coaching copy is surfaced for this
+ * persona (dashboard nudges, onboarding, the categories surface, etc.).
+ *
+ * References: issue #2201
+ */
+
+/** Emotional register of a supportive message. */
+export type SupportiveCopyTone = 'reassuring' | 'celebratory' | 'supportive';
+
+/** Stable identifiers for each supportive copy variant. */
+export type SupportiveFamilyCopyId =
+  | 'tight-month-reframe'
+  | 'celebrate-small-win'
+  | 'family-ready'
+  | 'steady-and-supported';
+
+/** A single piece of supportive coaching copy. */
+export interface SupportiveFamilyCopy {
+  /** Stable identifier. */
+  readonly id: SupportiveFamilyCopyId;
+  /** Emotional register, useful for styling and analytics. */
+  readonly tone: SupportiveCopyTone;
+  /** Short, encouraging headline. */
+  readonly headline: string;
+  /** One or two sentences of shame-free context. */
+  readonly body: string;
+  /** A single, concrete, low-pressure next step. */
+  readonly smallWin: string;
+}
+
+/**
+ * The full supportive copy set for this persona.
+ *
+ * Frozen so callers cannot mutate shared copy by accident.
+ */
+export const SUPPORTIVE_FAMILY_COACHING_COPY: Readonly<
+  Record<SupportiveFamilyCopyId, SupportiveFamilyCopy>
+> = Object.freeze({
+  'tight-month-reframe': {
+    id: 'tight-month-reframe',
+    tone: 'reassuring',
+    headline: 'This month was tight — and that is okay',
+    body: 'Family costs rarely arrive on a tidy schedule. A tight month is just a tight month, not a verdict on you or how you parent.',
+    smallWin:
+      'Pick one small win for next month — even setting aside a few dollars toward birthdays counts.',
+  },
+  'celebrate-small-win': {
+    id: 'celebrate-small-win',
+    tone: 'celebratory',
+    headline: 'That is a real win',
+    body: 'You made room for your family this month. Small, steady steps are exactly how budgets hold up over time.',
+    smallWin: 'Notice what worked this month, and let it repeat next month.',
+  },
+  'family-ready': {
+    id: 'family-ready',
+    tone: 'supportive',
+    headline: 'Your family categories are ready',
+    body: 'These envelopes flex with real life — school fees, childcare, sports, and the surprises in between. Every amount is yours to adjust.',
+    smallWin: 'Start with the one category that feels most urgent this week.',
+  },
+  'steady-and-supported': {
+    id: 'steady-and-supported',
+    tone: 'supportive',
+    headline: 'You are doing this, one month at a time',
+    body: 'Budgeting for a family is a lot to carry. You do not have to be perfect here — just present.',
+    smallWin: 'Check in on a single category today; that is enough for now.',
+  },
+});
+
+/** Context used to choose the most relevant supportive message. */
+export interface SupportiveFamilyCopyContext {
+  /**
+   * Name of a category that ran tight this period. When present, the selector
+   * reframes the overage supportively instead of flagging it.
+   */
+  readonly tightCategoryName?: string | null;
+  /** The caregiver kept or grew savings, or otherwise had a clear win. */
+  readonly hadSmallWin?: boolean;
+  /** The family/kids category preset is fully set up. */
+  readonly presetComplete?: boolean;
+}
+
+/** List every supportive copy variant. */
+export function listSupportiveFamilyCopy(): readonly SupportiveFamilyCopy[] {
+  return Object.values(SUPPORTIVE_FAMILY_COACHING_COPY);
+}
+
+/** Look up a supportive copy variant by id. */
+export function getSupportiveFamilyCopy(id: SupportiveFamilyCopyId): SupportiveFamilyCopy {
+  return SUPPORTIVE_FAMILY_COACHING_COPY[id];
+}
+
+/**
+ * Choose the most relevant supportive copy for the current context.
+ *
+ * Selection is deterministic and prioritized:
+ * 1. A tight category → reframe the hard month supportively.
+ * 2. A clear win → celebrate it.
+ * 3. A freshly completed preset → welcome the caregiver.
+ * 4. Otherwise → steady, present encouragement.
+ *
+ * @param context - Signals describing the caregiver's current month.
+ * @returns The selected supportive copy variant.
+ */
+export function selectSupportiveFamilyCopy(
+  context: SupportiveFamilyCopyContext = {},
+): SupportiveFamilyCopy {
+  if (context.tightCategoryName) {
+    return SUPPORTIVE_FAMILY_COACHING_COPY['tight-month-reframe'];
+  }
+
+  if (context.hadSmallWin) {
+    return SUPPORTIVE_FAMILY_COACHING_COPY['celebrate-small-win'];
+  }
+
+  if (context.presetComplete) {
+    return SUPPORTIVE_FAMILY_COACHING_COPY['family-ready'];
+  }
+
+  return SUPPORTIVE_FAMILY_COACHING_COPY['steady-and-supported'];
+}

--- a/apps/web/src/pages/CategoriesPage.test.tsx
+++ b/apps/web/src/pages/CategoriesPage.test.tsx
@@ -252,10 +252,12 @@ describe('CategoriesPage', () => {
     expect(ensureFoodMealCategoriesMock).toHaveBeenCalled();
   });
 
-  it('shows the family & kids categories helper with a preview', () => {
+  it('shows the family & kids categories helper with a preview', async () => {
     render(<CategoriesPage />);
 
-    expect(screen.getByRole('heading', { name: /family & kids categories/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: /family & kids categories/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText('School Fees')).toBeInTheDocument();
     expect(screen.getByText('Childcare & Daycare')).toBeInTheDocument();
     expect(screen.getByText('Medical & Co-pays')).toBeInTheDocument();
@@ -266,12 +268,14 @@ describe('CategoriesPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('previews and applies the family & kids preset after confirmation', () => {
+  it('previews and applies the family & kids preset after confirmation', async () => {
     render(<CategoriesPage />);
 
-    fireEvent.click(screen.getByRole('button', { name: /add family & kids categories/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /add family & kids categories/i }));
 
-    const dialog = screen.getByRole('alertdialog', { name: /add family & kids categories/i });
+    const dialog = await screen.findByRole('alertdialog', {
+      name: /add family & kids categories/i,
+    });
     expect(dialog).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Add categories' }));
@@ -285,11 +289,11 @@ describe('CategoriesPage', () => {
     expect(createCategoryMock).toHaveBeenCalledTimes(7);
   });
 
-  it('does not apply the family & kids preset when cancelled', () => {
+  it('does not apply the family & kids preset when cancelled', async () => {
     render(<CategoriesPage />);
 
-    fireEvent.click(screen.getByRole('button', { name: /add family & kids categories/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
+    fireEvent.click(await screen.findByRole('button', { name: /add family & kids categories/i }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Not now' }));
 
     expect(createCategoryMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/pages/CategoriesPage.test.tsx
+++ b/apps/web/src/pages/CategoriesPage.test.tsx
@@ -252,6 +252,48 @@ describe('CategoriesPage', () => {
     expect(ensureFoodMealCategoriesMock).toHaveBeenCalled();
   });
 
+  it('shows the family & kids categories helper with a preview', () => {
+    render(<CategoriesPage />);
+
+    expect(screen.getByRole('heading', { name: /family & kids categories/i })).toBeInTheDocument();
+    expect(screen.getByText('School Fees')).toBeInTheDocument();
+    expect(screen.getByText('Childcare & Daycare')).toBeInTheDocument();
+    expect(screen.getByText('Medical & Co-pays')).toBeInTheDocument();
+    // Status is conveyed with text, not color alone.
+    expect(screen.getAllByText('Will be added').length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole('button', { name: /add family & kids categories/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('previews and applies the family & kids preset after confirmation', () => {
+    render(<CategoriesPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add family & kids categories/i }));
+
+    const dialog = screen.getByRole('alertdialog', { name: /add family & kids categories/i });
+    expect(dialog).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add categories' }));
+
+    expect(createCategoryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ householdId: 'household-1', name: 'School Fees' }),
+    );
+    expect(createCategoryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Medical & Co-pays' }),
+    );
+    expect(createCategoryMock).toHaveBeenCalledTimes(7);
+  });
+
+  it('does not apply the family & kids preset when cancelled', () => {
+    render(<CategoriesPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add family & kids categories/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
+
+    expect(createCategoryMock).not.toHaveBeenCalled();
+  });
+
   it('adds a category', async () => {
     render(<CategoriesPage />);
 

--- a/apps/web/src/pages/CategoriesPage.tsx
+++ b/apps/web/src/pages/CategoriesPage.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { lazy, Suspense, useCallback, useMemo, useState } from 'react';
 import { AppIcon, type IconName } from '../components/icons';
 
 import { ConfirmDialog, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
@@ -8,12 +8,11 @@ import { CategoryForm } from '../components/forms';
 import type { CreateCategoryInput } from '../db/repositories/categories';
 import { useCategories, useTransactions } from '../hooks';
 import type { Category } from '../kmp/bridge';
-import {
-  applyFamilyKidsCategories,
-  buildFamilyKidsCategoryPlan,
-} from '../lib/categories/family-kids-categories';
-import { selectSupportiveFamilyCopy } from '../lib/coaching/supportive-family-copy';
 import '../styles/pages.css';
+
+const FamilyKidsCategoryCard = lazy(
+  () => import('../components/categories/FamilyKidsCategoryCard'),
+);
 
 function isCustomCategoryIcon(iconName: string | null | undefined): iconName is string {
   return Boolean(iconName && iconName.length <= 4);
@@ -78,7 +77,6 @@ export const CategoriesPage: React.FC = () => {
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
   const [deletingCategory, setDeletingCategory] = useState<Category | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [isFamilyKidsConfirmOpen, setIsFamilyKidsConfirmOpen] = useState(false);
 
   const categoriesById = useMemo(
     () => new Map(categories.map((category) => [category.id, category])),
@@ -104,13 +102,6 @@ export const CategoriesPage: React.FC = () => {
     }
     return counts;
   }, [categories]);
-
-  const familyKidsPlan = useMemo(() => buildFamilyKidsCategoryPlan(categories), [categories]);
-  const familyKidsHouseholdId = categories[0]?.householdId ?? null;
-  const familyKidsCopy = useMemo(
-    () => selectSupportiveFamilyCopy({ presetComplete: familyKidsPlan.isComplete }),
-    [familyKidsPlan.isComplete],
-  );
 
   const isLoading = loading || transactionsLoading;
   const resolvedError = error ?? transactionsError;
@@ -172,45 +163,6 @@ export const CategoriesPage: React.FC = () => {
     setDeleteError(null);
   }, [ensureFoodMealCategories]);
 
-  const handleRequestFamilyKids = useCallback(() => {
-    setDeleteError(null);
-    setIsFamilyKidsConfirmOpen(true);
-  }, []);
-
-  const handleCancelFamilyKids = useCallback(() => {
-    setIsFamilyKidsConfirmOpen(false);
-  }, []);
-
-  const handleConfirmFamilyKids = useCallback(() => {
-    setIsFamilyKidsConfirmOpen(false);
-
-    if (!familyKidsHouseholdId) {
-      setDeleteError('Add a category first so we know which household to set up.');
-      return;
-    }
-
-    const result = applyFamilyKidsCategories<Category>({
-      categories,
-      householdId: familyKidsHouseholdId,
-      createCategory: (input) =>
-        createCategory({
-          householdId: input.householdId,
-          name: input.name,
-          icon: input.icon,
-          color: input.color,
-          sortOrder: input.sortOrder,
-        }),
-    });
-
-    if (result.createdCount === 0 && !familyKidsPlan.isComplete) {
-      setDeleteError('Failed to add family & kids categories.');
-      return;
-    }
-
-    setDeleteError(null);
-    refresh();
-  }, [categories, createCategory, familyKidsHouseholdId, familyKidsPlan.isComplete, refresh]);
-
   const handleCancelDelete = useCallback(() => {
     setDeletingCategory(null);
   }, []);
@@ -263,15 +215,6 @@ export const CategoriesPage: React.FC = () => {
         .join(' ')
     : '';
 
-  const familyKidsConfirmMessage =
-    familyKidsPlan.missing.length > 0
-      ? `Add ${familyKidsPlan.missing.length} family & kids categor${
-          familyKidsPlan.missing.length === 1 ? 'y' : 'ies'
-        } to your list: ${familyKidsPlan.missing
-          .map((definition) => definition.name)
-          .join(', ')}. You can rename, set budgets for, or remove any of them later.`
-      : 'All family & kids categories are already in your list. Nothing new will be added.';
-
   return (
     <>
       {pageHeader}
@@ -290,16 +233,6 @@ export const CategoriesPage: React.FC = () => {
         confirmLabel="Delete Category"
         onConfirm={handleConfirmDelete}
         onCancel={handleCancelDelete}
-      />
-      <ConfirmDialog
-        isOpen={isFamilyKidsConfirmOpen}
-        title="Add family & kids categories"
-        message={familyKidsConfirmMessage}
-        confirmLabel="Add categories"
-        cancelLabel="Not now"
-        variant="info"
-        onConfirm={handleConfirmFamilyKids}
-        onCancel={handleCancelFamilyKids}
       />
 
       {isLoading ? (
@@ -371,120 +304,15 @@ export const CategoriesPage: React.FC = () => {
               </ul>
             </div>
           </section>
-          <section
-            aria-labelledby="family-kids-setup-heading"
-            style={{ marginBottom: 'var(--spacing-6)' }}
-          >
-            <div className="card">
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'flex-start',
-                  gap: 'var(--spacing-4)',
-                  flexWrap: 'wrap',
-                  marginBottom: 'var(--spacing-3)',
-                }}
-              >
-                <div style={{ maxWidth: '40rem' }}>
-                  <h3 id="family-kids-setup-heading" className="card__title">
-                    Family &amp; kids categories
-                  </h3>
-                  <p style={{ color: 'var(--semantic-text-secondary)' }}>
-                    Seed kid-specific categories for school fees, childcare, activities &amp;
-                    sports, birthdays &amp; gifts, field trips &amp; supplies, kids&rsquo; clothing,
-                    and medical co-pays &mdash; the real costs of raising a family.
-                  </p>
-                  <p
-                    style={{
-                      fontSize: 'var(--type-scale-caption-font-size)',
-                      color: 'var(--semantic-text-secondary)',
-                      marginTop: 'var(--spacing-2)',
-                    }}
-                  >
-                    {familyKidsPlan.isComplete
-                      ? `All ${familyKidsPlan.definitions.length} family & kids categories are ready.`
-                      : `${familyKidsPlan.present.length} of ${familyKidsPlan.definitions.length} ready · ${familyKidsPlan.missing.length} will be added.`}
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  className="form-button form-button--secondary"
-                  onClick={handleRequestFamilyKids}
-                >
-                  {familyKidsPlan.isComplete
-                    ? 'Family & kids ready'
-                    : 'Add family & kids categories'}
-                </button>
-              </div>
-              <p
-                role="note"
-                style={{
-                  color: 'var(--semantic-text-secondary)',
-                  marginBottom: 'var(--spacing-3)',
-                }}
-              >
-                <strong style={{ color: 'var(--semantic-text-primary)' }}>
-                  {familyKidsCopy.headline}.
-                </strong>{' '}
-                {familyKidsCopy.body} {familyKidsCopy.smallWin}
-              </p>
-              <ul
-                aria-label="Family and kids categories preview"
-                style={{
-                  display: 'grid',
-                  gap: 'var(--spacing-2)',
-                  listStyle: 'none',
-                  padding: 0,
-                  margin: 0,
-                }}
-              >
-                {familyKidsPlan.definitions.map((definition) => {
-                  const isPresent = familyKidsPlan.present.some(
-                    (entry) => entry.name === definition.name,
-                  );
-                  return (
-                    <li
-                      key={definition.name}
-                      style={{
-                        display: 'flex',
-                        alignItems: 'baseline',
-                        gap: 'var(--spacing-2)',
-                        flexWrap: 'wrap',
-                      }}
-                    >
-                      <span aria-hidden="true">{definition.icon}</span>
-                      <span style={{ color: 'var(--semantic-text-primary)' }}>
-                        {definition.name}
-                      </span>
-                      <span
-                        style={{
-                          fontSize: 'var(--type-scale-caption-font-size)',
-                          fontWeight: 600,
-                          color: isPresent
-                            ? 'var(--semantic-text-secondary)'
-                            : 'var(--semantic-text-primary)',
-                          border: '1px solid var(--semantic-border-default)',
-                          borderRadius: 'var(--radius-sm, 0.25rem)',
-                          padding: '0 var(--spacing-2)',
-                        }}
-                      >
-                        {isPresent ? 'Added' : 'Will be added'}
-                      </span>
-                      <span
-                        style={{
-                          color: 'var(--semantic-text-secondary)',
-                          fontSize: 'var(--type-scale-caption-font-size)',
-                        }}
-                      >
-                        {definition.description}
-                      </span>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          </section>
+          <Suspense fallback={null}>
+            <FamilyKidsCategoryCard
+              categories={categories}
+              householdId={categories[0]?.householdId ?? null}
+              createCategory={createCategory}
+              onApplied={refresh}
+              onError={setDeleteError}
+            />
+          </Suspense>
           <p className="page-summary" aria-live="polite">
             {categories.length} categor{categories.length === 1 ? 'y' : 'ies'} available for
             transaction organization.

--- a/apps/web/src/pages/CategoriesPage.tsx
+++ b/apps/web/src/pages/CategoriesPage.tsx
@@ -8,6 +8,11 @@ import { CategoryForm } from '../components/forms';
 import type { CreateCategoryInput } from '../db/repositories/categories';
 import { useCategories, useTransactions } from '../hooks';
 import type { Category } from '../kmp/bridge';
+import {
+  applyFamilyKidsCategories,
+  buildFamilyKidsCategoryPlan,
+} from '../lib/categories/family-kids-categories';
+import { selectSupportiveFamilyCopy } from '../lib/coaching/supportive-family-copy';
 import '../styles/pages.css';
 
 function isCustomCategoryIcon(iconName: string | null | undefined): iconName is string {
@@ -73,6 +78,7 @@ export const CategoriesPage: React.FC = () => {
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
   const [deletingCategory, setDeletingCategory] = useState<Category | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isFamilyKidsConfirmOpen, setIsFamilyKidsConfirmOpen] = useState(false);
 
   const categoriesById = useMemo(
     () => new Map(categories.map((category) => [category.id, category])),
@@ -98,6 +104,13 @@ export const CategoriesPage: React.FC = () => {
     }
     return counts;
   }, [categories]);
+
+  const familyKidsPlan = useMemo(() => buildFamilyKidsCategoryPlan(categories), [categories]);
+  const familyKidsHouseholdId = categories[0]?.householdId ?? null;
+  const familyKidsCopy = useMemo(
+    () => selectSupportiveFamilyCopy({ presetComplete: familyKidsPlan.isComplete }),
+    [familyKidsPlan.isComplete],
+  );
 
   const isLoading = loading || transactionsLoading;
   const resolvedError = error ?? transactionsError;
@@ -159,6 +172,45 @@ export const CategoriesPage: React.FC = () => {
     setDeleteError(null);
   }, [ensureFoodMealCategories]);
 
+  const handleRequestFamilyKids = useCallback(() => {
+    setDeleteError(null);
+    setIsFamilyKidsConfirmOpen(true);
+  }, []);
+
+  const handleCancelFamilyKids = useCallback(() => {
+    setIsFamilyKidsConfirmOpen(false);
+  }, []);
+
+  const handleConfirmFamilyKids = useCallback(() => {
+    setIsFamilyKidsConfirmOpen(false);
+
+    if (!familyKidsHouseholdId) {
+      setDeleteError('Add a category first so we know which household to set up.');
+      return;
+    }
+
+    const result = applyFamilyKidsCategories<Category>({
+      categories,
+      householdId: familyKidsHouseholdId,
+      createCategory: (input) =>
+        createCategory({
+          householdId: input.householdId,
+          name: input.name,
+          icon: input.icon,
+          color: input.color,
+          sortOrder: input.sortOrder,
+        }),
+    });
+
+    if (result.createdCount === 0 && !familyKidsPlan.isComplete) {
+      setDeleteError('Failed to add family & kids categories.');
+      return;
+    }
+
+    setDeleteError(null);
+    refresh();
+  }, [categories, createCategory, familyKidsHouseholdId, familyKidsPlan.isComplete, refresh]);
+
   const handleCancelDelete = useCallback(() => {
     setDeletingCategory(null);
   }, []);
@@ -211,6 +263,15 @@ export const CategoriesPage: React.FC = () => {
         .join(' ')
     : '';
 
+  const familyKidsConfirmMessage =
+    familyKidsPlan.missing.length > 0
+      ? `Add ${familyKidsPlan.missing.length} family & kids categor${
+          familyKidsPlan.missing.length === 1 ? 'y' : 'ies'
+        } to your list: ${familyKidsPlan.missing
+          .map((definition) => definition.name)
+          .join(', ')}. You can rename, set budgets for, or remove any of them later.`
+      : 'All family & kids categories are already in your list. Nothing new will be added.';
+
   return (
     <>
       {pageHeader}
@@ -229,6 +290,16 @@ export const CategoriesPage: React.FC = () => {
         confirmLabel="Delete Category"
         onConfirm={handleConfirmDelete}
         onCancel={handleCancelDelete}
+      />
+      <ConfirmDialog
+        isOpen={isFamilyKidsConfirmOpen}
+        title="Add family & kids categories"
+        message={familyKidsConfirmMessage}
+        confirmLabel="Add categories"
+        cancelLabel="Not now"
+        variant="info"
+        onConfirm={handleConfirmFamilyKids}
+        onCancel={handleCancelFamilyKids}
       />
 
       {isLoading ? (
@@ -297,6 +368,120 @@ export const CategoriesPage: React.FC = () => {
                     {subcategory.icon} {subcategory.name}
                   </li>
                 ))}
+              </ul>
+            </div>
+          </section>
+          <section
+            aria-labelledby="family-kids-setup-heading"
+            style={{ marginBottom: 'var(--spacing-6)' }}
+          >
+            <div className="card">
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'flex-start',
+                  gap: 'var(--spacing-4)',
+                  flexWrap: 'wrap',
+                  marginBottom: 'var(--spacing-3)',
+                }}
+              >
+                <div style={{ maxWidth: '40rem' }}>
+                  <h3 id="family-kids-setup-heading" className="card__title">
+                    Family &amp; kids categories
+                  </h3>
+                  <p style={{ color: 'var(--semantic-text-secondary)' }}>
+                    Seed kid-specific categories for school fees, childcare, activities &amp;
+                    sports, birthdays &amp; gifts, field trips &amp; supplies, kids&rsquo; clothing,
+                    and medical co-pays &mdash; the real costs of raising a family.
+                  </p>
+                  <p
+                    style={{
+                      fontSize: 'var(--type-scale-caption-font-size)',
+                      color: 'var(--semantic-text-secondary)',
+                      marginTop: 'var(--spacing-2)',
+                    }}
+                  >
+                    {familyKidsPlan.isComplete
+                      ? `All ${familyKidsPlan.definitions.length} family & kids categories are ready.`
+                      : `${familyKidsPlan.present.length} of ${familyKidsPlan.definitions.length} ready · ${familyKidsPlan.missing.length} will be added.`}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="form-button form-button--secondary"
+                  onClick={handleRequestFamilyKids}
+                >
+                  {familyKidsPlan.isComplete
+                    ? 'Family & kids ready'
+                    : 'Add family & kids categories'}
+                </button>
+              </div>
+              <p
+                role="note"
+                style={{
+                  color: 'var(--semantic-text-secondary)',
+                  marginBottom: 'var(--spacing-3)',
+                }}
+              >
+                <strong style={{ color: 'var(--semantic-text-primary)' }}>
+                  {familyKidsCopy.headline}.
+                </strong>{' '}
+                {familyKidsCopy.body} {familyKidsCopy.smallWin}
+              </p>
+              <ul
+                aria-label="Family and kids categories preview"
+                style={{
+                  display: 'grid',
+                  gap: 'var(--spacing-2)',
+                  listStyle: 'none',
+                  padding: 0,
+                  margin: 0,
+                }}
+              >
+                {familyKidsPlan.definitions.map((definition) => {
+                  const isPresent = familyKidsPlan.present.some(
+                    (entry) => entry.name === definition.name,
+                  );
+                  return (
+                    <li
+                      key={definition.name}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'baseline',
+                        gap: 'var(--spacing-2)',
+                        flexWrap: 'wrap',
+                      }}
+                    >
+                      <span aria-hidden="true">{definition.icon}</span>
+                      <span style={{ color: 'var(--semantic-text-primary)' }}>
+                        {definition.name}
+                      </span>
+                      <span
+                        style={{
+                          fontSize: 'var(--type-scale-caption-font-size)',
+                          fontWeight: 600,
+                          color: isPresent
+                            ? 'var(--semantic-text-secondary)'
+                            : 'var(--semantic-text-primary)',
+                          border: '1px solid var(--semantic-border-default)',
+                          borderRadius: 'var(--radius-sm, 0.25rem)',
+                          padding: '0 var(--spacing-2)',
+                        }}
+                      >
+                        {isPresent ? 'Added' : 'Will be added'}
+                      </span>
+                      <span
+                        style={{
+                          color: 'var(--semantic-text-secondary)',
+                          fontSize: 'var(--type-scale-caption-font-size)',
+                        }}
+                      >
+                        {definition.description}
+                      </span>
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           </section>

--- a/apps/web/src/styles/pages.css
+++ b/apps/web/src/styles/pages.css
@@ -293,3 +293,76 @@
   overflow-wrap: anywhere;
   word-break: break-word;
 }
+
+.family-kids-setup {
+  margin-bottom: var(--spacing-6);
+}
+
+.family-kids-setup__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-4);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-3);
+}
+
+.family-kids-setup__intro {
+  max-width: 40rem;
+}
+
+.family-kids-setup__lede {
+  color: var(--semantic-text-secondary);
+}
+
+.family-kids-setup__status {
+  margin-top: var(--spacing-2);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.family-kids-setup__note {
+  color: var(--semantic-text-secondary);
+  margin-bottom: var(--spacing-3);
+}
+
+.family-kids-setup__note-headline {
+  color: var(--semantic-text-primary);
+}
+
+.family-kids-setup__list {
+  display: grid;
+  gap: var(--spacing-2);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.family-kids-setup__item {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.family-kids-setup__name {
+  color: var(--semantic-text-primary);
+}
+
+.family-kids-setup__badge {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-sm, 0.25rem);
+  padding: 0 var(--spacing-2);
+}
+
+.family-kids-setup__badge--present {
+  color: var(--semantic-text-secondary);
+}
+
+.family-kids-setup__desc {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}


### PR DESCRIPTION
﻿## Summary
Web slice of #2201 — make the app reflect real family expenses for a single parent with kid-specific starter categories, plus supportive, non-judgmental coaching copy.

## What changed
- **Kid/family category preset** (`apps/web/src/lib/categories/family-kids-categories.ts`): pure, deterministic data set covering School Fees, Childcare & Daycare, Kids'' Activities & Sports, Birthdays & Gifts, Field Trips & School Supplies, Kids'' Clothing, and Medical & Co-pays. Includes `buildFamilyKidsCategoryPlan` (idempotent diff of present/missing, case-insensitive, ignores income categories) and `applyFamilyKidsCategories` (small injected-`createCategory` applier — never creates duplicates).
- **Supportive coaching copy** (`apps/web/src/lib/coaching/supportive-family-copy.ts`): structured, frozen copy set + deterministic `selectSupportiveFamilyCopy` selector that reframes a tight month shame-free ("this month was tight — here''s one small win"), celebrates small wins, and welcomes the caregiver. Wired into the categories surface for this persona and reusable by the coaching system.
- **Accessible apply affordance** on `CategoriesPage`: a clearly labeled "Add family & kids categories" action with a preview (icon + name + text status badge, not color-only) and an `alertdialog` confirm listing exactly what will be added. Semantic structure (`section` + `h3`), keyboard-operable via the existing focus-trapped `ConfirmDialog`, no new motion.
- **Tests** colocated as `*.test.ts(x)`: preset data/applier (idempotency, no duplicates, sort order, partial-existing), copy selection, and CategoriesPage affordance (preview, apply, cancel).

## Notes
- Data access stays through the `useCategories` hook; tests mock hooks, not repositories.
- New modules are imported directly into the lazy `CategoriesPage` chunk (no shared barrel) to respect the per-chunk perf budget.
- Extends existing patterns (Food & Meals preset, `single-parent-starter-template`, `lib/coaching`) rather than duplicating templates.

Refs #2201
