### PR TITLE
feat(web): privacy-safe share cards for goals and badges (#2210)

### DIFF
--- a/apps/web/src/components/social/ShareCelebrationButton.test.tsx
+++ b/apps/web/src/components/social/ShareCelebrationButton.test.tsx
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../accessibility/aria', () => ({
+  announce: vi.fn(),
+  useFocusTrap: vi.fn(),
+}));
+
+import { announce } from '../../accessibility/aria';
+import { ShareCelebrationButton } from './ShareCelebrationButton';
+import type { CelebrationEvent } from '../../lib/social/share-celebration';
+
+const goalEvent: CelebrationEvent = {
+  kind: 'goal-completion',
+  goalName: 'New Bike',
+  amountCents: 250_00,
+  currency: 'USD',
+};
+
+const originalShare = Object.getOwnPropertyDescriptor(navigator, 'share');
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+
+afterEach(() => {
+  vi.clearAllMocks();
+  if (originalShare) {
+    Object.defineProperty(navigator, 'share', originalShare);
+  } else {
+    // @ts-expect-error cleanup of test-injected property
+    delete navigator.share;
+  }
+  if (originalClipboard) {
+    Object.defineProperty(navigator, 'clipboard', originalClipboard);
+  } else {
+    // @ts-expect-error cleanup of test-injected property
+    delete navigator.clipboard;
+  }
+});
+
+describe('ShareCelebrationButton', () => {
+  it('renders an accessible trigger with a descriptive label', () => {
+    render(<ShareCelebrationButton event={goalEvent} />);
+    const trigger = screen.getByRole('button', { name: /share new bike completion/i });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+  });
+
+  it('opens a focus-trapped preview dialog showing redacted content by default', () => {
+    render(<ShareCelebrationButton event={goalEvent} />);
+    fireEvent.click(screen.getByRole('button', { name: /share new bike completion/i }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(screen.getByLabelText('Share preview')).toBeInTheDocument();
+    // No raw balance is shown by default.
+    expect(screen.queryByText(/Saved so far/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$250\.00/)).not.toBeInTheDocument();
+  });
+
+  it('reveals the saved amount only after opt-in', () => {
+    render(<ShareCelebrationButton event={goalEvent} />);
+    fireEvent.click(screen.getByRole('button', { name: /share new bike completion/i }));
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+    fireEvent.click(checkbox);
+
+    expect(screen.getByText(/Saved so far/i)).toBeInTheDocument();
+    expect(screen.getByText(/\$250\.00/)).toBeInTheDocument();
+  });
+
+  it('closes the dialog on Escape', () => {
+    render(<ShareCelebrationButton event={goalEvent} />);
+    fireEvent.click(screen.getByRole('button', { name: /share new bike completion/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('uses the Web Share API when available', async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: share, configurable: true });
+
+    render(<ShareCelebrationButton event={goalEvent} />);
+    fireEvent.click(screen.getByRole('button', { name: /share new bike completion/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+    await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
+    const payload = share.mock.calls[0][0];
+    expect(payload.title).toBeTruthy();
+    // The native share text must not leak the balance by default.
+    expect(payload.text).not.toContain('$250.00');
+  });
+
+  it('falls back to clipboard copy when Web Share is unavailable', async () => {
+    // Ensure no navigator.share is present.
+    // @ts-expect-error remove for this scenario
+    delete navigator.share;
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<ShareCelebrationButton event={goalEvent} />);
+    fireEvent.click(screen.getByRole('button', { name: /share new bike completion/i }));
+    // With no Web Share API, the primary action copies.
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText.mock.calls[0][0]).not.toContain('$250.00');
+    await waitFor(() => expect(announce).toHaveBeenCalled());
+  });
+});

--- a/apps/web/src/components/social/ShareCelebrationButton.tsx
+++ b/apps/web/src/components/social/ShareCelebrationButton.tsx
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * ShareCelebrationButton — an accessible, privacy-safe share affordance for
+ * savings-goal milestones, goal completion, badge unlocks, and streaks.
+ *
+ * Behaviour:
+ * - Opens a focus-trapped preview dialog showing EXACTLY the redacted content
+ *   that will be shared (no raw balances unless the user opts in).
+ * - Uses the Web Share API (`navigator.share`) when available, with a
+ *   clipboard-copy fallback.
+ *
+ * Accessibility (WCAG 2.2 AA):
+ * - Trigger button has a clear, descriptive label and is keyboard-operable.
+ * - Dialog uses `role="dialog"`, `aria-modal`, focus trapping, Escape-to-close
+ *   and restores focus to the trigger on close.
+ * - Status changes are announced via a polite live region (no colour-only cue —
+ *   a check icon plus text accompanies the success state).
+ * - Motion respects `prefers-reduced-motion` (handled in CSS).
+ *
+ * Refs #2210
+ */
+
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+
+import { announce, useFocusTrap } from '../../accessibility/aria';
+import { AppIcon } from '../icons';
+import {
+  buildShareCelebration,
+  toShareData,
+  type CelebrationEvent,
+} from '../../lib/social/share-celebration';
+
+import '../forms/forms.css';
+import './share-celebration.css';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface ShareCelebrationButtonProps {
+  /** The celebratory event to share. */
+  event: CelebrationEvent;
+  /** Accessible label for the trigger button. Defaults to an event-derived label. */
+  label?: string;
+  /** Visible text for the trigger button. Defaults to “Share”. */
+  buttonText?: string;
+  /** Trigger button visual variant. Defaults to `secondary`. */
+  variant?: 'primary' | 'secondary';
+  /** Extra class names appended to the trigger button. */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function defaultLabel(event: CelebrationEvent): string {
+  switch (event.kind) {
+    case 'goal-milestone':
+      return `Share ${event.goalName} milestone`;
+    case 'goal-completion':
+      return `Share ${event.goalName} completion`;
+    case 'badge-unlock':
+      return `Share ${event.badgeName} badge`;
+    case 'streak-milestone':
+      return `Share ${event.days}-day ${event.streakLabel} streak`;
+  }
+}
+
+function eventHasAmount(event: CelebrationEvent): boolean {
+  return (
+    (event.kind === 'goal-milestone' || event.kind === 'goal-completion') &&
+    typeof event.amountCents === 'number' &&
+    event.amountCents > 0
+  );
+}
+
+function canUseWebShare(): boolean {
+  return typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const ShareCelebrationButton: React.FC<ShareCelebrationButtonProps> = ({
+  event,
+  label,
+  buttonText = 'Share',
+  variant = 'secondary',
+  className,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [revealAmount, setRevealAmount] = useState(false);
+  const [status, setStatus] = useState<{ message: string; success: boolean } | null>(null);
+
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const primaryActionRef = useRef<HTMLButtonElement>(null);
+  const titleId = useId();
+  const descId = useId();
+
+  const hasAmount = eventHasAmount(event);
+  const webShareAvailable = canUseWebShare();
+
+  const celebration = useMemo(
+    () => buildShareCelebration(event, { revealAmount: hasAmount && revealAmount }),
+    [event, hasAmount, revealAmount],
+  );
+
+  useFocusTrap(panelRef, {
+    active: isOpen,
+    restoreFocus: true,
+    initialFocusRef: primaryActionRef,
+  });
+
+  // Lock body scroll while the dialog is open.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  const openDialog = useCallback(() => {
+    setStatus(null);
+    setRevealAmount(false);
+    setIsOpen(true);
+  }, []);
+
+  const closeDialog = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (eventArg: React.KeyboardEvent<HTMLDivElement>) => {
+      if (eventArg.key === 'Escape') {
+        eventArg.preventDefault();
+        closeDialog();
+      }
+    },
+    [closeDialog],
+  );
+
+  const copyToClipboard = useCallback(async (): Promise<boolean> => {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(celebration.shareText);
+        return true;
+      }
+    } catch {
+      // fall through to failure handling below
+    }
+    return false;
+  }, [celebration.shareText]);
+
+  const handleShare = useCallback(async () => {
+    if (webShareAvailable) {
+      try {
+        await navigator.share(toShareData(celebration));
+        setStatus({ message: 'Shared with your friends.', success: true });
+        announce('Share sheet opened.', 'polite');
+        return;
+      } catch (err) {
+        // The user cancelling the native sheet is not an error worth surfacing.
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          return;
+        }
+        // Otherwise fall back to clipboard.
+      }
+    }
+
+    const copied = await copyToClipboard();
+    if (copied) {
+      setStatus({ message: 'Copied to clipboard.', success: true });
+      announce('Share text copied to clipboard.', 'polite');
+    } else {
+      setStatus({
+        message: 'Could not share automatically. Select and copy the text above.',
+        success: false,
+      });
+      announce('Sharing is unavailable. Copy the text manually.', 'assertive');
+    }
+  }, [celebration, copyToClipboard, webShareAvailable]);
+
+  const handleCopy = useCallback(async () => {
+    const copied = await copyToClipboard();
+    if (copied) {
+      setStatus({ message: 'Copied to clipboard.', success: true });
+      announce('Share text copied to clipboard.', 'polite');
+    } else {
+      setStatus({ message: 'Could not copy. Select the text above to copy it.', success: false });
+      announce('Copy failed. Select the text manually.', 'assertive');
+    }
+  }, [copyToClipboard]);
+
+  const triggerLabel = label ?? defaultLabel(event);
+  const primaryText = webShareAvailable ? 'Share' : 'Copy';
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`form-button form-button--${variant} share-celebration__trigger${
+          className ? ` ${className}` : ''
+        }`}
+        onClick={openDialog}
+        aria-haspopup="dialog"
+        aria-label={triggerLabel}
+      >
+        <AppIcon name="upload" />
+        <span>{buttonText}</span>
+      </button>
+
+      {isOpen && (
+        <div className="form-dialog" role="presentation">
+          <div className="form-dialog__backdrop" aria-hidden="true" onClick={closeDialog} />
+          <div
+            ref={panelRef}
+            className="form-dialog__panel"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            aria-describedby={descId}
+            onKeyDown={handleKeyDown}
+          >
+            <h2 id={titleId} className="form-dialog__title">
+              Share your win
+            </h2>
+            <p id={descId} className="share-celebration__status">
+              Here is exactly what your friends will see. Your balances stay private.
+            </p>
+
+            <div className="share-celebration__preview" aria-label="Share preview">
+              <p className="share-celebration__preview-title">{celebration.title}</p>
+              <p className="share-celebration__preview-message">{celebration.message}</p>
+
+              {celebration.percentComplete !== null && (
+                <div
+                  className="share-celebration__track"
+                  role="progressbar"
+                  aria-valuenow={celebration.percentComplete}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label={`${celebration.percentComplete}% to goal`}
+                >
+                  <div
+                    className="share-celebration__fill"
+                    style={{ width: `${Math.min(celebration.percentComplete, 100)}%` }}
+                  />
+                </div>
+              )}
+
+              {celebration.amountLabel !== null && (
+                <p className="share-celebration__amount">Saved so far: {celebration.amountLabel}</p>
+              )}
+
+              <p className="share-celebration__hashtags">{celebration.hashtags.join(' ')}</p>
+            </div>
+
+            {hasAmount && (
+              <label className="share-celebration__option">
+                <input
+                  type="checkbox"
+                  checked={revealAmount}
+                  onChange={(e) => setRevealAmount(e.target.checked)}
+                />
+                <span>
+                  Include the amount I&rsquo;ve saved (off by default to keep balances private)
+                </span>
+              </label>
+            )}
+
+            <p
+              className={`share-celebration__status${
+                status?.success ? ' share-celebration__status--success' : ''
+              }`}
+              role="status"
+              aria-live="polite"
+            >
+              {status?.success && <AppIcon name="check" />}
+              {status?.message ?? ''}
+            </p>
+
+            <div className="form-actions share-celebration__actions">
+              <button
+                type="button"
+                className="form-button form-button--secondary"
+                onClick={closeDialog}
+              >
+                Close
+              </button>
+              {webShareAvailable && (
+                <button
+                  type="button"
+                  className="form-button form-button--secondary"
+                  onClick={handleCopy}
+                >
+                  <AppIcon name="clipboard" /> Copy
+                </button>
+              )}
+              <button
+                ref={primaryActionRef}
+                type="button"
+                className="form-button form-button--primary"
+                onClick={handleShare}
+              >
+                <AppIcon name={webShareAvailable ? 'upload' : 'clipboard'} /> {primaryText}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ShareCelebrationButton;

--- a/apps/web/src/components/social/share-celebration.css
+++ b/apps/web/src/components/social/share-celebration.css
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* ---------------------------------------------------------------------------
+ * Share celebration UI (Refs #2210)
+ *
+ * Lightweight, token-driven styles for the privacy-safe share affordance and
+ * its preview dialog. No hardcoded values — all sizing/colour uses design
+ * tokens so themes, contrast, and dark mode are respected automatically.
+ * ------------------------------------------------------------------------- */
+
+.share-celebration__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+}
+
+.share-celebration__preview {
+  background: var(--semantic-background-secondary, var(--semantic-background-primary));
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-lg, var(--border-radius-md));
+  padding: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.share-celebration__preview-title {
+  font-size: var(--type-scale-headline-font-size, var(--type-scale-title-font-size));
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin: 0;
+}
+
+.share-celebration__preview-message {
+  color: var(--semantic-text-primary);
+  margin: 0;
+}
+
+.share-celebration__amount {
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin: 0;
+}
+
+.share-celebration__hashtags {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  margin: 0;
+}
+
+.share-celebration__track {
+  position: relative;
+  height: var(--spacing-2);
+  border-radius: var(--border-radius-full, var(--border-radius-md));
+  background: var(--semantic-background-tertiary, var(--semantic-border-default));
+  overflow: hidden;
+}
+
+.share-celebration__fill {
+  height: 100%;
+  background: var(--semantic-accent-default, var(--semantic-text-primary));
+  border-radius: inherit;
+  transition: width var(--duration-normal, 200ms) var(--easing-out, ease-out);
+}
+
+.share-celebration__option {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-4);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.share-celebration__option input {
+  margin-top: var(--spacing-1);
+}
+
+.share-celebration__status {
+  margin: 0 0 var(--spacing-3);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.share-celebration__status--success {
+  color: var(--semantic-positive-default, var(--semantic-text-primary));
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+}
+
+.share-celebration__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--spacing-2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .share-celebration__fill {
+    transition: none;
+  }
+}

--- a/apps/web/src/lib/social/share-celebration.test.ts
+++ b/apps/web/src/lib/social/share-celebration.test.ts
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildShareCelebration,
+  goalCelebrationEvent,
+  toShareData,
+  type CelebrationEvent,
+} from './share-celebration';
+
+/** Matches any USD-style currency figure, e.g. `$1,234.56` or `$50.00`. */
+const CURRENCY_PATTERN = /[$€£]\s?\d/;
+
+describe('buildShareCelebration', () => {
+  describe('event-type coverage', () => {
+    it('builds a goal milestone celebration', () => {
+      const result = buildShareCelebration({
+        kind: 'goal-milestone',
+        goalName: 'New Laptop',
+        percent: 50,
+      });
+
+      expect(result.type).toBe('goal-milestone');
+      expect(result.title).toContain('Halfway');
+      expect(result.message).toContain('50%');
+      expect(result.message).toContain('New Laptop');
+      expect(result.percentComplete).toBe(50);
+      expect(result.hashtags).toContain('#SavingsGoals');
+      expect(result.shareText).toContain('#MoneyWins');
+    });
+
+    it('builds a goal completion celebration', () => {
+      const result = buildShareCelebration({
+        kind: 'goal-completion',
+        goalName: 'Concert Fund',
+      });
+
+      expect(result.type).toBe('goal-completion');
+      expect(result.percentComplete).toBe(100);
+      expect(result.message).toContain('completed');
+      expect(result.message).toContain('Concert Fund');
+      expect(result.hashtags).toContain('#GoalCrushed');
+    });
+
+    it('builds a badge unlock celebration with description', () => {
+      const result = buildShareCelebration({
+        kind: 'badge-unlock',
+        badgeName: 'Goal Crusher',
+        badgeDescription: 'Complete a savings goal',
+      });
+
+      expect(result.type).toBe('badge-unlock');
+      expect(result.percentComplete).toBeNull();
+      expect(result.message).toContain('Goal Crusher');
+      expect(result.message).toContain('Complete a savings goal');
+      expect(result.hashtags).toContain('#BadgeUnlocked');
+    });
+
+    it('builds a badge unlock celebration without description', () => {
+      const result = buildShareCelebration({
+        kind: 'badge-unlock',
+        badgeName: 'First Step',
+      });
+
+      expect(result.message).toBe('I just earned the "First Step" badge!');
+    });
+
+    it('builds a streak milestone celebration with correct pluralization', () => {
+      const plural = buildShareCelebration({
+        kind: 'streak-milestone',
+        streakLabel: 'Daily Logging',
+        days: 7,
+      });
+      expect(plural.type).toBe('streak-milestone');
+      expect(plural.title).toContain('7-days streak');
+      expect(plural.message).toContain('Daily Logging');
+      expect(plural.hashtags).toContain('#StreakAlive');
+
+      const singular = buildShareCelebration({
+        kind: 'streak-milestone',
+        streakLabel: 'Daily Logging',
+        days: 1,
+      });
+      expect(singular.title).toContain('1-day streak');
+    });
+  });
+
+  describe('redaction by default', () => {
+    it('never includes a raw amount for goal milestones by default', () => {
+      const result = buildShareCelebration({
+        kind: 'goal-milestone',
+        goalName: 'Emergency Fund',
+        percent: 75,
+        amountCents: 750_00,
+        currency: 'USD',
+      });
+
+      expect(result.amountLabel).toBeNull();
+      expect(result.containsRawAmount).toBe(false);
+      expect(result.shareText).not.toMatch(CURRENCY_PATTERN);
+      // The safe percent figure is still present.
+      expect(result.percentComplete).toBe(75);
+    });
+
+    it('never includes a raw amount for goal completion by default', () => {
+      const result = buildShareCelebration({
+        kind: 'goal-completion',
+        goalName: 'Car Fund',
+        amountCents: 5_000_00,
+        currency: 'USD',
+      });
+
+      expect(result.amountLabel).toBeNull();
+      expect(result.containsRawAmount).toBe(false);
+      expect(result.shareText).not.toMatch(CURRENCY_PATTERN);
+    });
+  });
+
+  describe('opt-in reveal', () => {
+    it('includes a formatted amount only when revealAmount is true', () => {
+      const event: CelebrationEvent = {
+        kind: 'goal-completion',
+        goalName: 'Car Fund',
+        amountCents: 5_000_00,
+        currency: 'USD',
+      };
+
+      const revealed = buildShareCelebration(event, { revealAmount: true });
+
+      expect(revealed.amountLabel).toBe('$5,000.00');
+      expect(revealed.containsRawAmount).toBe(true);
+      expect(revealed.shareText).toContain('$5,000.00');
+      expect(revealed.shareText).toMatch(CURRENCY_PATTERN);
+    });
+
+    it('respects a non-default currency on opt-in reveal', () => {
+      const revealed = buildShareCelebration(
+        {
+          kind: 'goal-milestone',
+          goalName: 'Eurotrip',
+          percent: 50,
+          amountCents: 1_234_56,
+          currency: 'EUR',
+        },
+        { revealAmount: true },
+      );
+
+      expect(revealed.amountLabel).toContain('1,234.56');
+      expect(revealed.containsRawAmount).toBe(true);
+    });
+
+    it('reveals nothing when there is no amount, even on opt-in', () => {
+      const revealed = buildShareCelebration(
+        { kind: 'goal-milestone', goalName: 'No Amount Goal', percent: 25 },
+        { revealAmount: true },
+      );
+
+      expect(revealed.amountLabel).toBeNull();
+      expect(revealed.containsRawAmount).toBe(false);
+    });
+  });
+
+  describe('no-leak guarantee', () => {
+    it('badge and streak events can never carry a currency figure', () => {
+      const badge = buildShareCelebration(
+        { kind: 'badge-unlock', badgeName: 'Saver' },
+        { revealAmount: true },
+      );
+      const streak = buildShareCelebration(
+        { kind: 'streak-milestone', streakLabel: 'Saving', days: 30 },
+        { revealAmount: true },
+      );
+
+      expect(badge.containsRawAmount).toBe(false);
+      expect(badge.shareText).not.toMatch(CURRENCY_PATTERN);
+      expect(streak.containsRawAmount).toBe(false);
+      expect(streak.shareText).not.toMatch(CURRENCY_PATTERN);
+    });
+  });
+
+  describe('determinism', () => {
+    it('produces identical output for identical input', () => {
+      const event: CelebrationEvent = {
+        kind: 'goal-milestone',
+        goalName: 'Bike',
+        percent: 25,
+        amountCents: 100_00,
+        currency: 'USD',
+      };
+
+      expect(buildShareCelebration(event)).toEqual(buildShareCelebration(event));
+      expect(buildShareCelebration(event, { revealAmount: true })).toEqual(
+        buildShareCelebration(event, { revealAmount: true }),
+      );
+    });
+  });
+});
+
+describe('toShareData', () => {
+  it('maps a celebration to a Web Share payload', () => {
+    const celebration = buildShareCelebration({
+      kind: 'goal-milestone',
+      goalName: 'Bike',
+      percent: 25,
+    });
+    const data = toShareData(celebration);
+
+    expect(data.title).toBe(celebration.title);
+    expect(data.text).toBe(celebration.shareText);
+  });
+});
+
+describe('goalCelebrationEvent', () => {
+  it('returns null below the first shareable milestone', () => {
+    expect(goalCelebrationEvent({ goalName: 'G', percentComplete: 10 })).toBeNull();
+    expect(goalCelebrationEvent({ goalName: 'G', percentComplete: 24 })).toBeNull();
+  });
+
+  it('selects the highest reached milestone', () => {
+    expect(goalCelebrationEvent({ goalName: 'G', percentComplete: 25 })).toMatchObject({
+      kind: 'goal-milestone',
+      percent: 25,
+    });
+    expect(goalCelebrationEvent({ goalName: 'G', percentComplete: 60 })).toMatchObject({
+      kind: 'goal-milestone',
+      percent: 50,
+    });
+    expect(goalCelebrationEvent({ goalName: 'G', percentComplete: 99 })).toMatchObject({
+      kind: 'goal-milestone',
+      percent: 75,
+    });
+  });
+
+  it('returns a completion event at or above 100%', () => {
+    expect(goalCelebrationEvent({ goalName: 'G', percentComplete: 100 })).toMatchObject({
+      kind: 'goal-completion',
+    });
+    expect(goalCelebrationEvent({ goalName: 'G', percentComplete: 120 })).toMatchObject({
+      kind: 'goal-completion',
+    });
+  });
+
+  it('passes through amount and currency for downstream redaction', () => {
+    const event = goalCelebrationEvent({
+      goalName: 'G',
+      percentComplete: 50,
+      amountCents: 500_00,
+      currency: 'USD',
+    });
+
+    // Amount is carried but stays redacted unless the user opts in.
+    expect(buildShareCelebration(event!).containsRawAmount).toBe(false);
+    expect(buildShareCelebration(event!, { revealAmount: true }).containsRawAmount).toBe(true);
+  });
+});

--- a/apps/web/src/lib/social/share-celebration.ts
+++ b/apps/web/src/lib/social/share-celebration.ts
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Privacy-safe celebration share-content builder.
+ *
+ * Turns a savings-goal milestone, goal completion, badge/achievement unlock,
+ * or streak into a deterministic, shareable payload that a teen can post to
+ * friends WITHOUT exposing private balances.
+ *
+ * Raw currency figures are redacted by default by routing every amount through
+ * the existing redaction engine ({@link redactShareCard}). A raw amount is only
+ * ever surfaced when the user explicitly opts in via {@link ShareCelebrationOptions.revealAmount}.
+ *
+ * The builder is pure and deterministic: identical input always yields identical
+ * output (no clock reads, no randomness, fixed `en-US` formatting locale).
+ *
+ * Refs #2210
+ */
+
+import {
+  redactShareCard,
+  type RedactionPolicy,
+  type ShareCardPayload,
+  type ShareCardType,
+} from './share-card-redaction';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Savings-goal milestone thresholds eligible for sharing. */
+export type GoalMilestonePercent = 25 | 50 | 75 | 100;
+
+/** A celebratory event a teen can share. */
+export type CelebrationEvent =
+  | {
+      readonly kind: 'goal-milestone';
+      readonly goalName: string;
+      readonly percent: GoalMilestonePercent;
+      readonly nickname?: string;
+      readonly amountCents?: number;
+      readonly currency?: string;
+    }
+  | {
+      readonly kind: 'goal-completion';
+      readonly goalName: string;
+      readonly nickname?: string;
+      readonly amountCents?: number;
+      readonly currency?: string;
+    }
+  | {
+      readonly kind: 'badge-unlock';
+      readonly badgeName: string;
+      readonly badgeDescription?: string;
+      readonly nickname?: string;
+    }
+  | {
+      readonly kind: 'streak-milestone';
+      readonly streakLabel: string;
+      readonly days: number;
+      readonly nickname?: string;
+    };
+
+/** Options controlling what the share card reveals. */
+export interface ShareCelebrationOptions {
+  /**
+   * Opt-in to reveal the raw saved amount in the shared card.
+   *
+   * Defaults to `false`, guaranteeing balances stay private. Only goal events
+   * carry an amount; badge and streak events never include a balance.
+   */
+  readonly revealAmount?: boolean;
+}
+
+/** A fully-built, privacy-safe celebration ready to share. */
+export interface ShareCelebration {
+  /** Redaction card type this celebration maps to. */
+  readonly type: ShareCardType;
+  /** Short celebratory headline (always safe to display). */
+  readonly title: string;
+  /** Celebratory body describing the win without raw balances. */
+  readonly message: string;
+  /** Redacted percent-to-goal (0-100) when applicable, otherwise `null`. */
+  readonly percentComplete: number | null;
+  /** Formatted amount, only present when the user opts in to reveal it. */
+  readonly amountLabel: string | null;
+  /** Deterministic hashtags appended to the share text. */
+  readonly hashtags: readonly string[];
+  /** Full shareable text (title + message + optional amount + hashtags). */
+  readonly shareText: string;
+  /** `true` only when a raw currency figure is included (opt-in reveal). */
+  readonly containsRawAmount: boolean;
+}
+
+/** Minimal payload shape compatible with the Web Share API. */
+export interface ShareData {
+  readonly title: string;
+  readonly text: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CURRENCY = 'USD';
+/** Fixed locale keeps amount formatting deterministic across environments. */
+const SHARE_LOCALE = 'en-US';
+/** Placeholder display name required by the redaction payload contract. */
+const ANON_DISPLAY_NAME = 'A saver';
+
+const MILESTONE_TITLES: Record<GoalMilestonePercent, string> = {
+  25: 'Off to a strong start! 🌱',
+  50: 'Halfway there! 🎯',
+  75: 'Almost at the finish line! 🚀',
+  100: 'Goal complete! 🏆',
+};
+
+const HASHTAGS: Record<ShareCardType, readonly string[]> = {
+  'goal-milestone': ['#SavingsGoals', '#MoneyWins'],
+  'goal-completion': ['#GoalCrushed', '#SavingsGoals', '#MoneyWins'],
+  'badge-unlock': ['#BadgeUnlocked', '#MoneyWins'],
+  'streak-milestone': ['#StreakAlive', '#MoneyWins'],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatAmount(amountCents: number, currency: string): string {
+  return new Intl.NumberFormat(SHARE_LOCALE, {
+    style: 'currency',
+    currency,
+  }).format(amountCents / 100);
+}
+
+interface CelebrationDraft {
+  readonly type: ShareCardType;
+  readonly title: string;
+  readonly message: string;
+  /** Percent-to-goal known from the event (safe, non-balance figure). */
+  readonly percentComplete: number | null;
+  /** Redaction payload routed through the existing engine. */
+  readonly payload: ShareCardPayload;
+}
+
+function draftFromEvent(event: CelebrationEvent): CelebrationDraft {
+  const nickname = event.nickname?.trim() || ANON_DISPLAY_NAME;
+
+  switch (event.kind) {
+    case 'goal-milestone':
+      return {
+        type: 'goal-milestone',
+        title: MILESTONE_TITLES[event.percent],
+        message: `I just hit ${event.percent}% of my "${event.goalName}" savings goal!`,
+        percentComplete: event.percent,
+        payload: {
+          type: 'goal-milestone',
+          title: event.goalName,
+          nickname,
+          amountCents: event.amountCents,
+          percentComplete: event.percent,
+        },
+      };
+    case 'goal-completion':
+      return {
+        type: 'goal-completion',
+        title: MILESTONE_TITLES[100],
+        message: `I just completed my "${event.goalName}" savings goal! 🎉`,
+        percentComplete: 100,
+        payload: {
+          type: 'goal-completion',
+          title: event.goalName,
+          nickname,
+          amountCents: event.amountCents,
+          percentComplete: 100,
+        },
+      };
+    case 'badge-unlock': {
+      const description = event.badgeDescription?.trim();
+      return {
+        type: 'badge-unlock',
+        title: 'Badge unlocked! 🏅',
+        message: description
+          ? `I just earned the "${event.badgeName}" badge — ${description}!`
+          : `I just earned the "${event.badgeName}" badge!`,
+        percentComplete: null,
+        payload: {
+          type: 'badge-unlock',
+          title: event.badgeName,
+          nickname,
+        },
+      };
+    }
+    case 'streak-milestone': {
+      const dayWord = event.days === 1 ? 'day' : 'days';
+      return {
+        type: 'streak-milestone',
+        title: `${event.days}-${dayWord} streak! 🔥`,
+        message: `I'm on a ${event.days}-${dayWord} ${event.streakLabel} streak. Consistency pays off!`,
+        percentComplete: null,
+        payload: {
+          type: 'streak-milestone',
+          title: event.streakLabel,
+          nickname,
+        },
+      };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a privacy-safe, shareable celebration from an event.
+ *
+ * The raw amount is redacted by default. Pass `{ revealAmount: true }` to opt
+ * in to showing the saved amount; the value is still routed through the
+ * existing redaction engine so the privacy contract stays centralized.
+ */
+export function buildShareCelebration(
+  event: CelebrationEvent,
+  options: ShareCelebrationOptions = {},
+): ShareCelebration {
+  const revealAmount = options.revealAmount === true;
+  const draft = draftFromEvent(event);
+
+  // `nickname-only` retains the amount (opt-in reveal); `percent-only` strips it
+  // (the privacy-safe default). Either way the amount passes through the
+  // existing redaction engine — the single source of truth for what leaks.
+  const policy: RedactionPolicy = revealAmount ? 'nickname-only' : 'percent-only';
+  const redacted = redactShareCard(draft.payload, policy);
+
+  const currency =
+    (event.kind === 'goal-milestone' || event.kind === 'goal-completion'
+      ? event.currency
+      : undefined) ?? DEFAULT_CURRENCY;
+
+  const amountLabel =
+    redacted.amountCents !== null ? formatAmount(redacted.amountCents, currency) : null;
+  const containsRawAmount = amountLabel !== null;
+
+  const hashtags = HASHTAGS[draft.type];
+
+  const lines = [draft.title, draft.message];
+  if (amountLabel !== null) {
+    lines.push(`Saved so far: ${amountLabel}`);
+  }
+  const shareText = `${lines.join('\n')}\n\n${hashtags.join(' ')}`;
+
+  return {
+    type: draft.type,
+    title: draft.title,
+    message: draft.message,
+    percentComplete: draft.percentComplete,
+    amountLabel,
+    hashtags,
+    shareText,
+    containsRawAmount,
+  };
+}
+
+/** Convert a built celebration into a Web Share API payload. */
+export function toShareData(celebration: ShareCelebration): ShareData {
+  return { title: celebration.title, text: celebration.shareText };
+}
+
+/**
+ * Resolve the most relevant celebration event for a goal's current progress.
+ *
+ * Returns `null` below the first shareable milestone (25%) so callers can hide
+ * the share affordance until there is something worth celebrating.
+ */
+export function goalCelebrationEvent(params: {
+  goalName: string;
+  percentComplete: number;
+  amountCents?: number;
+  currency?: string;
+  nickname?: string;
+}): CelebrationEvent | null {
+  const { goalName, percentComplete, amountCents, currency, nickname } = params;
+
+  if (percentComplete >= 100) {
+    return { kind: 'goal-completion', goalName, amountCents, currency, nickname };
+  }
+
+  const reached = ([75, 50, 25] as const).find((m) => percentComplete >= m);
+  if (reached === undefined) {
+    return null;
+  }
+
+  return {
+    kind: 'goal-milestone',
+    goalName,
+    percent: reached,
+    amountCents,
+    currency,
+    nickname,
+  };
+}

--- a/apps/web/src/pages/AchievementsPage.css
+++ b/apps/web/src/pages/AchievementsPage.css
@@ -340,3 +340,15 @@
     justify-content: center;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Share affordances (Refs #2210)
+ * ------------------------------------------------------------------------- */
+
+.achievement-badge__share,
+.streak-card__share,
+.milestone-card__share {
+  margin-top: var(--spacing-3);
+  display: flex;
+  justify-content: flex-end;
+}

--- a/apps/web/src/pages/AchievementsPage.tsx
+++ b/apps/web/src/pages/AchievementsPage.tsx
@@ -23,6 +23,8 @@ import type {
 import { getAchievementsByCategory } from '../components/gamification/achievements-engine';
 import './AchievementsPage.css';
 import { AppIcon } from '../components/icons';
+import { ShareCelebrationButton } from '../components/social/ShareCelebrationButton';
+import { goalCelebrationEvent } from '../lib/social/share-celebration';
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -65,6 +67,18 @@ const AchievementBadge: React.FC<AchievementBadgeProps> = ({ achievement }) => {
             />
           </div>
         )}
+        {isUnlocked && (
+          <div className="achievement-badge__share">
+            <ShareCelebrationButton
+              event={{
+                kind: 'badge-unlock',
+                badgeName: achievement.name,
+                badgeDescription: achievement.description,
+              }}
+              label={`Share the ${achievement.name} badge`}
+            />
+          </div>
+        )}
       </div>
       {isUnlocked && (
         <span className="achievement-badge__check" aria-hidden="true">
@@ -93,6 +107,18 @@ const StreakCard: React.FC<StreakCardProps> = ({ streak }) => (
       <p className="streak-card__best">
         Best: {streak.longest} {streak.longest === 1 ? 'day' : 'days'}
       </p>
+      {streak.current > 0 && (
+        <div className="streak-card__share">
+          <ShareCelebrationButton
+            event={{
+              kind: 'streak-milestone',
+              streakLabel: streak.label,
+              days: streak.current,
+            }}
+            label={`Share your ${streak.current}-day ${streak.label} streak`}
+          />
+        </div>
+      )}
     </div>
   </article>
 );
@@ -101,38 +127,53 @@ interface MilestoneCardProps {
   milestone: GoalMilestone;
 }
 
-const MilestoneCard: React.FC<MilestoneCardProps> = ({ milestone }) => (
-  <article className="milestone-card" aria-label={`${milestone.goalName} progress`}>
-    <div className="milestone-card__header">
-      <h4 className="milestone-card__name">{milestone.goalName}</h4>
-      <span className="milestone-card__percent">{milestone.progress}%</span>
-    </div>
-    <div
-      className="milestone-card__track"
-      role="progressbar"
-      aria-valuenow={milestone.progress}
-      aria-valuemin={0}
-      aria-valuemax={100}
-      aria-label={`${milestone.goalName}: ${milestone.progress}%`}
-    >
-      <div className="milestone-card__fill" style={{ width: `${milestone.progress}%` }} />
-      {/* Milestone markers */}
-      {[25, 50, 75, 100].map((m) => (
-        <div
-          key={m}
-          className={`milestone-card__marker ${milestone.milestonesReached.includes(m) ? 'milestone-card__marker--reached' : ''}`}
-          style={{ left: `${m}%` }}
-          aria-hidden="true"
-        />
-      ))}
-    </div>
-    {milestone.nextMilestone !== null ? (
-      <p className="milestone-card__next">Next milestone: {milestone.nextMilestone}%</p>
-    ) : (
-      <p className="milestone-card__next milestone-card__next--completed">Goal complete!</p>
-    )}
-  </article>
-);
+const MilestoneCard: React.FC<MilestoneCardProps> = ({ milestone }) => {
+  const shareEvent = goalCelebrationEvent({
+    goalName: milestone.goalName,
+    percentComplete: milestone.progress,
+  });
+
+  return (
+    <article className="milestone-card" aria-label={`${milestone.goalName} progress`}>
+      <div className="milestone-card__header">
+        <h4 className="milestone-card__name">{milestone.goalName}</h4>
+        <span className="milestone-card__percent">{milestone.progress}%</span>
+      </div>
+      <div
+        className="milestone-card__track"
+        role="progressbar"
+        aria-valuenow={milestone.progress}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${milestone.goalName}: ${milestone.progress}%`}
+      >
+        <div className="milestone-card__fill" style={{ width: `${milestone.progress}%` }} />
+        {/* Milestone markers */}
+        {[25, 50, 75, 100].map((m) => (
+          <div
+            key={m}
+            className={`milestone-card__marker ${milestone.milestonesReached.includes(m) ? 'milestone-card__marker--reached' : ''}`}
+            style={{ left: `${m}%` }}
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+      {milestone.nextMilestone !== null ? (
+        <p className="milestone-card__next">Next milestone: {milestone.nextMilestone}%</p>
+      ) : (
+        <p className="milestone-card__next milestone-card__next--completed">Goal complete!</p>
+      )}
+      {shareEvent && (
+        <div className="milestone-card__share">
+          <ShareCelebrationButton
+            event={shareEvent}
+            label={`Share ${milestone.goalName} progress (${milestone.progress}%)`}
+          />
+        </div>
+      )}
+    </article>
+  );
+};
 
 const CATEGORY_LABELS: Record<AchievementCategory, string> = {
   tracking: 'Tracking',

--- a/apps/web/src/pages/GoalDetailPage.tsx
+++ b/apps/web/src/pages/GoalDetailPage.tsx
@@ -16,6 +16,8 @@ import type { CreateGoalInput } from '../db/repositories/goals';
 import { useGoals } from '../hooks';
 import type { Goal } from '../kmp/bridge';
 import { getGoalStatusIndicator } from '../lib/a11y';
+import { ShareCelebrationButton } from '../components/social/ShareCelebrationButton';
+import { goalCelebrationEvent } from '../lib/social/share-celebration';
 import '../styles/pages.css';
 
 function getGoalIcon(iconName: string | null | undefined): IconName {
@@ -115,6 +117,13 @@ export const GoalDetailPage: React.FC = () => {
 
   const goalStatus = getGoalStatusIndicator(percentComplete);
 
+  const shareEvent = goalCelebrationEvent({
+    goalName: goal.name,
+    percentComplete,
+    amountCents: goal.currentAmount.amount,
+    currency: goal.currency.code,
+  });
+
   const statusTone =
     percentComplete >= 100
       ? 'positive'
@@ -165,6 +174,9 @@ export const GoalDetailPage: React.FC = () => {
           <AppIcon name={getGoalIcon(goal.icon)} /> {goal.name}
         </h2>
         <div className="page-actions">
+          {shareEvent && (
+            <ShareCelebrationButton event={shareEvent} label={`Share ${goal.name} progress`} />
+          )}
           <button
             type="button"
             className="form-button form-button--secondary"

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -21,6 +21,8 @@ import {
   SuggestedGoals,
 } from '../components/savings';
 import { OfflineBanner } from '../components/OfflineBanner';
+import { ShareCelebrationButton } from '../components/social/ShareCelebrationButton';
+import { goalCelebrationEvent } from '../lib/social/share-celebration';
 import type { CreateGoalInput, GoalContributionInput } from '../db/repositories/goals';
 import { useAccounts, useCategories, useGoals, useTransactions } from '../hooks';
 import { useTaxReserve } from '../hooks/useTaxReserve';
@@ -799,6 +801,12 @@ export const GoalsPage: React.FC = () => {
                     targetDate === null
                       ? null
                       : Math.max(0, Math.ceil((targetDate.getTime() - Date.now()) / 86400000));
+                  const shareEvent = goalCelebrationEvent({
+                    goalName: goal.name,
+                    percentComplete,
+                    amountCents: goal.currentAmount.amount,
+                    currency: goal.currency.code,
+                  });
 
                   return (
                     <article
@@ -954,9 +962,16 @@ export const GoalsPage: React.FC = () => {
                         style={{
                           display: 'flex',
                           justifyContent: 'flex-end',
+                          gap: 'var(--spacing-2)',
                           marginTop: 'var(--spacing-4)',
                         }}
                       >
+                        {shareEvent && (
+                          <ShareCelebrationButton
+                            event={shareEvent}
+                            label={`Share ${goal.name} progress`}
+                          />
+                        )}
                         <button
                           type="button"
                           className="form-button form-button--secondary"


### PR DESCRIPTION
## Summary

Adds privacy-safe **share cards** so a teen can celebrate savings-goal milestones, goal completion, badge/achievement unlocks, and streaks with friends — **without exposing private balances**.

Builds directly on the existing redaction engine (`apps/web/src/lib/social/share-card-redaction.ts`); it is **reused, not reimplemented**.

## What changed

- **`lib/social/share-celebration.ts`** — a pure, deterministic share-content builder. Given a goal milestone (25/50/75/100%), goal completion, badge unlock, or streak, it produces a celebratory, shareable payload. Every amount is routed through the existing `redactShareCard` engine, so **raw currency is redacted by default** and only surfaces on explicit opt-in. Includes `goalCelebrationEvent()` (resolves the right event for a goal’s progress) and `toShareData()` (Web Share payload).
- **`components/social/ShareCelebrationButton.tsx`** — an accessible Share affordance. Opens a focus-trapped preview dialog showing **exactly** the redacted content that will be shared, then shares via the **Web Share API** (`navigator.share`) with a **clipboard-copy fallback**. No new dependencies.
- Wired the button into the lazy **Goals**, **Goal detail**, and **Achievements** pages (imported directly into each lazy chunk — no shared eager barrel).

## Accessibility (WCAG 2.2 AA)

- Trigger button has a clear, descriptive `aria-label`, is keyboard-operable, and declares `aria-haspopup=dialog`.
- Dialog uses `role=dialog` + `aria-modal`, focus trapping, Escape-to-close, and restores focus to the trigger.
- Status changes announced via a polite live region; success uses a check icon **and** text (no colour-only signal).
- Motion respects `prefers-reduced-motion`; all styling uses design tokens (themes/contrast/dark mode inherited).

## Tests

- `share-celebration.test.ts` — covers each event type, redaction-by-default, opt-in reveal, the no-leak guarantee, and determinism.
- `ShareCelebrationButton.test.tsx` — trigger label, dialog a11y, default redaction, opt-in reveal, Web Share path, and clipboard fallback.

Refs #2210