### PR TITLE
feat(web): minimalist mode to hide unused modules (#2122)

### DIFF
--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -10,7 +10,9 @@ import { ConflictResolutionDialog } from '../common/ConflictResolutionDialog';
 import { NotificationCenter } from '../notifications';
 import { useKeyboardShortcuts } from '../../hooks';
 import { useAccessibility } from '../../hooks/useAccessibility';
+import { useHiddenModules } from '../../hooks/useModuleVisibility';
 import { usePrivacyMode } from '../../contexts/PrivacyModeContext';
+import { HiddenModulesContext } from '../../contexts/HiddenModulesContext';
 import { useEscapeBack } from '../../hooks/useEscapeBack';
 import { useSyncStatus } from '../../hooks/useSyncStatus';
 import {
@@ -91,6 +93,11 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [simpleModeEnabled, setSimpleModeEnabled] = useState(getStoredSimplifiedModePreference);
   const { isSimplified } = useAccessibility();
+  // Minimalist mode (#2122): resolve the user's hidden modules once at the
+  // layout level and share them via context so eager, performance-budgeted
+  // route chunks (e.g. the dashboard) can read them without bundling the
+  // module-visibility catalogue/hook.
+  const hiddenModuleIds = useHiddenModules();
   const shortcutItems = useMemo(() => getVisibleNavItems(isSimplified), [isSimplified]);
   const { showHelp, setShowHelp, singleKeyShortcutsEnabled } = useKeyboardShortcuts({
     onNavigate,
@@ -349,7 +356,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
               </p>
             </section>
           )}
-          {children}
+          <HiddenModulesContext.Provider value={hiddenModuleIds}>
+            {children}
+          </HiddenModulesContext.Provider>
         </main>
         <footer className="app-footer">
           <LegalLinks />

--- a/apps/web/src/components/layout/MoreNavSheet.tsx
+++ b/apps/web/src/components/layout/MoreNavSheet.tsx
@@ -18,10 +18,10 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 
 import { useAccessibility } from '../../hooks/useAccessibility';
+import { useHiddenModules } from '../../hooks/useModuleVisibility';
 import { Icon } from '../common/Icon';
 import { IconToken } from '../../icons/tokens';
 import {
-  MORE_SHEET_ITEMS,
   NAV_GROUP_LABELS,
   NAV_GROUP_ORDER,
   getMoreSheetItems,
@@ -76,6 +76,7 @@ export const MoreNavSheet: React.FC<MoreNavSheetProps> = ({
   onSignOut,
 }) => {
   const { isSimplified } = useAccessibility();
+  const hiddenModules = useHiddenModules();
   const dialogRef = useRef<HTMLDivElement>(null);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
 
@@ -178,7 +179,7 @@ export const MoreNavSheet: React.FC<MoreNavSheetProps> = ({
 
   if (!open) return null;
 
-  const buckets = bucketByGroup(isSimplified ? getMoreSheetItems(true) : MORE_SHEET_ITEMS);
+  const buckets = bucketByGroup(getMoreSheetItems(isSimplified, hiddenModules));
 
   return (
     <div className="more-sheet">

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -19,16 +19,15 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useAuth } from '../../auth/auth-context';
 import { useAccessibility } from '../../hooks/useAccessibility';
+import { useHiddenModules } from '../../hooks/useModuleVisibility';
 import { Icon } from '../common/Icon';
 import { IconToken } from '../../icons/tokens';
 
 import { MoreNavSheet } from './MoreNavSheet';
 import {
-  BOTTOM_NAV_PRIORITY_ITEMS,
   NAV_CONFIG,
   NAV_GROUP_LABELS,
   NAV_GROUP_ORDER,
-  PINNED_NAV_ITEMS,
   getBottomNavPriorityItems,
   getItemsByGroup,
   getPinnedNavItems,
@@ -99,14 +98,15 @@ export const BottomNavigation: React.FC<NavigationProps> = ({
 }) => {
   const { logout } = useAuth();
   const { isSimplified } = useAccessibility();
+  const hiddenModules = useHiddenModules();
   const [moreOpen, setMoreOpen] = useState(false);
   const priorityItems = useMemo(
-    () => (isSimplified ? getBottomNavPriorityItems(true) : BOTTOM_NAV_PRIORITY_ITEMS),
-    [isSimplified],
+    () => getBottomNavPriorityItems(isSimplified, hiddenModules),
+    [isSimplified, hiddenModules],
   );
   const visibleItems = useMemo(
-    () => (isSimplified ? getVisibleNavItems(true) : NAV_CONFIG),
-    [isSimplified],
+    () => getVisibleNavItems(isSimplified, hiddenModules),
+    [isSimplified, hiddenModules],
   );
 
   const bottomNavItems = useMemo(
@@ -284,10 +284,11 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
 }) => {
   const { logout } = useAuth();
   const { isSimplified } = useAccessibility();
+  const hiddenModules = useHiddenModules();
   const isSettingsActive = isActive(activePath, '/settings');
   const pinnedItems = useMemo(
-    () => (isSimplified ? getPinnedNavItems(true) : PINNED_NAV_ITEMS),
-    [isSimplified],
+    () => getPinnedNavItems(isSimplified, hiddenModules),
+    [isSimplified, hiddenModules],
   );
 
   const handleSignOut = useCallback(async () => {
@@ -331,7 +332,7 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
             because they hold the most-used routes; Insights + Connect
             start collapsed to reduce cognitive load. */}
         {NAV_GROUP_ORDER.map((group) => {
-          const groupItems = getItemsByGroup(group, isSimplified);
+          const groupItems = getItemsByGroup(group, isSimplified, hiddenModules);
           if (groupItems.length === 0) {
             return null;
           }

--- a/apps/web/src/components/layout/navConfig.tsx
+++ b/apps/web/src/components/layout/navConfig.tsx
@@ -19,6 +19,7 @@
 import type React from 'react';
 
 import { ensureStableNavOrder } from '../../lib/navigation/guardrails';
+import { filterByModuleVisibility } from '../../lib/ux/module-visibility';
 import { Icon } from '../common/Icon';
 import { IconToken } from '../../icons/tokens';
 import { AppIcon } from '../icons';
@@ -399,14 +400,30 @@ export const SIMPLIFIED_NAV_ITEM_IDS = [
 
 const SIMPLIFIED_NAV_ITEM_ID_SET = new Set<string>(SIMPLIFIED_NAV_ITEM_IDS);
 
-export function getVisibleNavItems(simplified: boolean): readonly NavConfigItem[] {
-  return simplified
+const NO_HIDDEN_MODULES: ReadonlySet<string> = new Set<string>();
+
+/**
+ * Primary destinations visible for the current chrome state.
+ *
+ * @param simplified       - When true, restrict to the simplified a11y subset.
+ * @param hiddenModuleIds  - Modules the user has hidden via minimalist mode
+ *   (#2122). Essential destinations are never removed.
+ */
+export function getVisibleNavItems(
+  simplified: boolean,
+  hiddenModuleIds: ReadonlySet<string> = NO_HIDDEN_MODULES,
+): readonly NavConfigItem[] {
+  const base = simplified
     ? NAV_CONFIG.filter((item) => SIMPLIFIED_NAV_ITEM_ID_SET.has(item.id))
     : NAV_CONFIG;
+  return hiddenModuleIds.size === 0 ? base : filterByModuleVisibility(base, hiddenModuleIds);
 }
 
-export function getBottomNavPriorityItems(simplified = false): readonly NavConfigItem[] {
-  return [...getVisibleNavItems(simplified)]
+export function getBottomNavPriorityItems(
+  simplified = false,
+  hiddenModuleIds: ReadonlySet<string> = NO_HIDDEN_MODULES,
+): readonly NavConfigItem[] {
+  return [...getVisibleNavItems(simplified, hiddenModuleIds)]
     .sort((a, b) => a.mobilePriority - b.mobilePriority)
     .slice(0, BOTTOM_NAV_PRIORITY_COUNT);
 }
@@ -417,21 +434,31 @@ export function getBottomNavPriorityItems(simplified = false): readonly NavConfi
  */
 export const BOTTOM_NAV_PRIORITY_ITEMS: readonly NavConfigItem[] = getBottomNavPriorityItems();
 
-export function getPinnedNavItems(simplified = false): readonly NavConfigItem[] {
-  return getVisibleNavItems(simplified).filter((item) => item.group === undefined);
+export function getPinnedNavItems(
+  simplified = false,
+  hiddenModuleIds: ReadonlySet<string> = NO_HIDDEN_MODULES,
+): readonly NavConfigItem[] {
+  return getVisibleNavItems(simplified, hiddenModuleIds).filter((item) => item.group === undefined);
 }
 
 /** Destinations pinned above the grouped sections in the sidebar. */
 export const PINNED_NAV_ITEMS: readonly NavConfigItem[] = getPinnedNavItems();
 
 /** Destinations bucketed by group, preserving config order within each. */
-export function getItemsByGroup(group: NavGroup, simplified = false): readonly NavConfigItem[] {
-  return getVisibleNavItems(simplified).filter((item) => item.group === group);
+export function getItemsByGroup(
+  group: NavGroup,
+  simplified = false,
+  hiddenModuleIds: ReadonlySet<string> = NO_HIDDEN_MODULES,
+): readonly NavConfigItem[] {
+  return getVisibleNavItems(simplified, hiddenModuleIds).filter((item) => item.group === group);
 }
 
-export function getMoreSheetItems(simplified = false): readonly NavConfigItem[] {
-  const priorityItems = getBottomNavPriorityItems(simplified);
-  return getVisibleNavItems(simplified).filter(
+export function getMoreSheetItems(
+  simplified = false,
+  hiddenModuleIds: ReadonlySet<string> = NO_HIDDEN_MODULES,
+): readonly NavConfigItem[] {
+  const priorityItems = getBottomNavPriorityItems(simplified, hiddenModuleIds);
+  return getVisibleNavItems(simplified, hiddenModuleIds).filter(
     (item) => !priorityItems.some((priorityItem) => priorityItem.id === item.id),
   );
 }

--- a/apps/web/src/components/settings/MinimalistModeSettings.test.tsx
+++ b/apps/web/src/components/settings/MinimalistModeSettings.test.tsx
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { MODULE_VISIBILITY_STORAGE_KEY } from '../../lib/ux/module-visibility';
+import { MinimalistModeSettings } from './MinimalistModeSettings';
+
+describe('MinimalistModeSettings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('groups areas into semantic fieldsets with legends', () => {
+    render(<MinimalistModeSettings />);
+
+    for (const groupName of ['Money', 'Plan', 'Insights', 'Connect']) {
+      expect(screen.getByRole('group', { name: groupName })).toBeInTheDocument();
+    }
+  });
+
+  it('renders every area as a switch that starts shown', () => {
+    render(<MinimalistModeSettings />);
+
+    const billsSwitch = screen.getByRole('switch', { name: 'Bills' });
+    expect(billsSwitch).toBeChecked();
+  });
+
+  it('hides an area and persists it when its switch is turned off', () => {
+    render(<MinimalistModeSettings />);
+
+    const billsSwitch = screen.getByRole('switch', { name: 'Bills' });
+    fireEvent.click(billsSwitch);
+
+    expect(billsSwitch).not.toBeChecked();
+    expect(JSON.parse(localStorage.getItem(MODULE_VISIBILITY_STORAGE_KEY) ?? '[]')).toContain(
+      'bills',
+    );
+  });
+
+  it('conveys state with text, not colour alone', () => {
+    render(<MinimalistModeSettings />);
+
+    const billsRow = screen.getByRole('switch', { name: 'Bills' }).closest('.settings-item');
+    expect(billsRow).not.toBeNull();
+    expect(within(billsRow as HTMLElement).getByText('Shown')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Bills' }));
+    expect(within(billsRow as HTMLElement).getByText('Hidden')).toBeInTheDocument();
+  });
+
+  it('reports how many areas are hidden in a live region', () => {
+    render(<MinimalistModeSettings />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Every area is shown.');
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Reports' }));
+    expect(screen.getByRole('status')).toHaveTextContent('1 area is hidden.');
+  });
+
+  it('restores every area with "Show all areas"', () => {
+    localStorage.setItem(MODULE_VISIBILITY_STORAGE_KEY, JSON.stringify(['bills', 'reports']));
+    render(<MinimalistModeSettings />);
+
+    const showAll = screen.getByRole('button', { name: /show all areas/i });
+    expect(showAll).toBeEnabled();
+
+    fireEvent.click(showAll);
+
+    expect(JSON.parse(localStorage.getItem(MODULE_VISIBILITY_STORAGE_KEY) ?? '[]')).toEqual([]);
+    expect(screen.getByRole('switch', { name: 'Bills' })).toBeChecked();
+    expect(showAll).toBeDisabled();
+  });
+
+  it('does not list essential areas that must stay available', () => {
+    render(<MinimalistModeSettings />);
+
+    expect(screen.queryByRole('switch', { name: 'Dashboard' })).toBeNull();
+    expect(screen.queryByRole('switch', { name: 'Settings' })).toBeNull();
+    expect(screen.queryByRole('switch', { name: 'Accounts' })).toBeNull();
+    expect(screen.queryByRole('switch', { name: 'Transactions' })).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/MinimalistModeSettings.tsx
+++ b/apps/web/src/components/settings/MinimalistModeSettings.tsx
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useCallback } from 'react';
+
+import { useModuleVisibility } from '../../hooks/useModuleVisibility';
+import {
+  HIDEABLE_MODULE_CATEGORY_LABELS,
+  HIDEABLE_MODULE_CATEGORY_ORDER,
+  getHideableModulesByCategory,
+} from '../../lib/ux/module-visibility';
+import './minimalist-mode-settings.css';
+
+/**
+ * Minimalist mode — "Customize what you see" (#2122).
+ *
+ * Lets a low-noise user hide product areas / nav modules they never use. Each
+ * area is a labelled switch (checked = shown); turning it off removes the area
+ * from the primary navigation and its dashboard quick-access card. Essential
+ * areas (Dashboard, Accounts, Transactions, Settings) are never listed here, so
+ * the user can't lock themselves out — and hidden areas stay reachable by their
+ * direct URL and keyboard shortcut.
+ *
+ * Accessibility (WCAG 2.2 AA):
+ *   - Each category is a semantic `<fieldset>`/`<legend>` group.
+ *   - Each toggle is a keyboard-operable `role="switch"` checkbox with a `<label>`.
+ *   - On/off state is conveyed by the native control and redundant text
+ *     ("Shown"/"Hidden"), never by colour alone.
+ *   - A live region announces how many areas are hidden.
+ */
+export const MinimalistModeSettings: React.FC = () => {
+  const { hiddenCount, hasHiddenModules, isVisible, setHidden, showAll } = useModuleVisibility();
+
+  const handleToggle = useCallback(
+    (id: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
+      // The switch reads "Show <area>": checked = visible, unchecked = hidden.
+      setHidden(id, !event.target.checked);
+    },
+    [setHidden],
+  );
+
+  const summary = hasHiddenModules
+    ? `${hiddenCount} ${hiddenCount === 1 ? 'area is' : 'areas are'} hidden.`
+    : 'Every area is shown.';
+
+  return (
+    <section aria-labelledby="minimalist-mode-heading" className="page-section">
+      <div className="settings-group">
+        <h3 id="minimalist-mode-heading" className="settings-group__title">
+          Minimalist mode
+        </h3>
+        <p className="settings-group__description">
+          Customize what you see. Turn off areas you never use to keep the navigation and your
+          dashboard focused on what matters to you. Dashboard, Accounts, Transactions, and Settings
+          always stay available, and hidden areas remain reachable by their direct link and keyboard
+          shortcut.
+        </p>
+        <p className="minimalist-mode__status" role="status" aria-live="polite">
+          {summary}
+        </p>
+
+        {HIDEABLE_MODULE_CATEGORY_ORDER.map((category) => {
+          const modules = getHideableModulesByCategory(category);
+          if (modules.length === 0) {
+            return null;
+          }
+          return (
+            <fieldset key={category} className="minimalist-mode__group">
+              <legend className="minimalist-mode__legend">
+                {HIDEABLE_MODULE_CATEGORY_LABELS[category]}
+              </legend>
+              {modules.map((module) => {
+                const visible = isVisible(module.id);
+                const switchId = `minimalist-toggle-${module.id}`;
+                const descriptionId = `${switchId}-description`;
+                return (
+                  <div key={module.id} className="settings-item settings-item--static">
+                    <label className="settings-item__label" htmlFor={switchId}>
+                      {module.label}
+                    </label>
+                    <span className="settings-item__control">
+                      <span className="minimalist-mode__state" aria-hidden="true">
+                        {visible ? 'Shown' : 'Hidden'}
+                      </span>
+                      <input
+                        type="checkbox"
+                        role="switch"
+                        id={switchId}
+                        className="settings-item__checkbox"
+                        checked={visible}
+                        onChange={handleToggle(module.id)}
+                        aria-describedby={descriptionId}
+                      />
+                    </span>
+                    <p id={descriptionId} className="settings-item__description">
+                      {module.description}
+                    </p>
+                  </div>
+                );
+              })}
+            </fieldset>
+          );
+        })}
+
+        <div className="settings-item settings-item--static">
+          <span className="settings-item__label">Reset</span>
+          <div className="settings-item__control">
+            <button
+              type="button"
+              className="form-button form-button--secondary"
+              onClick={showAll}
+              disabled={!hasHiddenModules}
+            >
+              Show all areas
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default MinimalistModeSettings;

--- a/apps/web/src/components/settings/index.ts
+++ b/apps/web/src/components/settings/index.ts
@@ -3,6 +3,7 @@
 export { DangerZone } from './DangerZone';
 export type { DangerZoneProps } from './DangerZone';
 export { HapticSettings } from './HapticSettings';
+export { MinimalistModeSettings } from './MinimalistModeSettings';
 export { SettingInfoWidget } from './SettingInfoWidget';
 export type { SettingInfoWidgetProps } from './SettingInfoWidget';
 export { EncryptionDetails } from './EncryptionDetails';

--- a/apps/web/src/components/settings/minimalist-mode-settings.css
+++ b/apps/web/src/components/settings/minimalist-mode-settings.css
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* Minimalist mode — "Customize what you see" settings control (#2122). */
+
+.minimalist-mode__group {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-inline-size: 0;
+}
+
+.minimalist-mode__legend {
+  width: 100%;
+  margin: 0;
+  padding: var(--spacing-3) var(--card-padding);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-label-font-size);
+  text-transform: uppercase;
+}
+
+.minimalist-mode__status {
+  margin: 0;
+  padding: 0 var(--card-padding) var(--spacing-3);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+}
+
+.minimalist-mode__state {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+}

--- a/apps/web/src/contexts/HiddenModulesContext.ts
+++ b/apps/web/src/contexts/HiddenModulesContext.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Minimalist mode (#2122): React context exposing the user's hidden module ids.
+ *
+ * This file is intentionally dependency-light — it imports only `createContext`
+ * and `useContext` from React and holds no reference to the richer
+ * `lib/ux/module-visibility` catalogue or its reading machinery. Consumers in
+ * performance-budgeted eager chunks (e.g. the dashboard route) can therefore
+ * read the hidden set through {@link useHiddenModuleIds} without pulling the
+ * module catalogue or the `useHiddenModules` storage hook into their bundle.
+ *
+ * The matching provider lives in the layout chunk (see
+ * `components/layout/AppLayout`), where the `useHiddenModules` hook is already
+ * present for the navigation chrome.
+ */
+
+import { createContext, useContext } from 'react';
+
+/**
+ * Holds the current set of hidden module ids. Defaults to an empty set so
+ * consumers render every module when no provider is mounted (e.g. in isolated
+ * tests) — failing open keeps every area reachable.
+ */
+export const HiddenModulesContext = createContext<ReadonlySet<string>>(new Set());
+
+/** Read the user's hidden module ids from the nearest provider. */
+export function useHiddenModuleIds(): ReadonlySet<string> {
+  return useContext(HiddenModulesContext);
+}

--- a/apps/web/src/hooks/useModuleVisibility.ts
+++ b/apps/web/src/hooks/useModuleVisibility.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook for the minimalist-mode module visibility preference (#2122).
+ *
+ * Wraps the pure {@link module-visibility} model so the nav chrome, dashboard
+ * quick-access cards, and the settings control all read the same persisted set
+ * of hidden module ids and stay in sync — across tabs (native `storage` event)
+ * and within the same tab ({@link MODULE_VISIBILITY_CHANGE_EVENT}).
+ *
+ * @module hooks/useModuleVisibility
+ * References: issue #2122
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  HIDEABLE_MODULES,
+  MODULE_VISIBILITY_CHANGE_EVENT,
+  MODULE_VISIBILITY_STORAGE_KEY,
+  countHiddenModules,
+  getStoredHiddenModuleIds,
+  isModuleVisible,
+  persistHiddenModuleIds,
+  setModuleHidden,
+  type HideableModule,
+} from '../lib/ux/module-visibility';
+
+/**
+ * Subscribe to the persisted set of hidden module ids.
+ *
+ * Returns a stable, read-only set that updates when the preference changes in
+ * this tab or another tab. Lightweight by design so it can be consumed from the
+ * eagerly-loaded nav chrome without pulling in the full settings controller.
+ */
+export function useHiddenModules(): ReadonlySet<string> {
+  const [hiddenModuleIds, setHiddenModuleIds] =
+    useState<ReadonlySet<string>>(getStoredHiddenModuleIds);
+
+  useEffect(() => {
+    const refresh = (): void => {
+      setHiddenModuleIds(getStoredHiddenModuleIds());
+    };
+    const handleStorage = (event: StorageEvent): void => {
+      if (event.key === MODULE_VISIBILITY_STORAGE_KEY) {
+        refresh();
+      }
+    };
+
+    window.addEventListener(MODULE_VISIBILITY_CHANGE_EVENT, refresh);
+    window.addEventListener('storage', handleStorage);
+    return () => {
+      window.removeEventListener(MODULE_VISIBILITY_CHANGE_EVENT, refresh);
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  return hiddenModuleIds;
+}
+
+/** Controller returned by {@link useModuleVisibility}. */
+export interface UseModuleVisibilityResult {
+  /** The catalogue of modules a user may hide. */
+  modules: readonly HideableModule[];
+  /** Currently hidden module ids. */
+  hiddenModuleIds: ReadonlySet<string>;
+  /** Number of modules currently hidden. */
+  hiddenCount: number;
+  /** Whether any module is currently hidden. */
+  hasHiddenModules: boolean;
+  /** Whether a given module id is currently hidden. */
+  isHidden: (id: string) => boolean;
+  /** Whether a given module id is currently visible. */
+  isVisible: (id: string) => boolean;
+  /** Persist a module as hidden or visible. */
+  setHidden: (id: string, hidden: boolean) => void;
+  /** Toggle a module's hidden state. */
+  toggle: (id: string) => void;
+  /** Reveal every module (clear the hidden set). */
+  showAll: () => void;
+}
+
+/**
+ * Full controller for the minimalist-mode settings UI. Reads always go through
+ * {@link getStoredHiddenModuleIds} at mutation time to avoid stale closures, and
+ * writes go through {@link persistHiddenModuleIds}, which both persists and
+ * notifies same-tab subscribers.
+ */
+export function useModuleVisibility(): UseModuleVisibilityResult {
+  const hiddenModuleIds = useHiddenModules();
+
+  const setHidden = useCallback((id: string, hidden: boolean) => {
+    persistHiddenModuleIds(setModuleHidden(getStoredHiddenModuleIds(), id, hidden));
+  }, []);
+
+  const toggle = useCallback((id: string) => {
+    const current = getStoredHiddenModuleIds();
+    persistHiddenModuleIds(setModuleHidden(current, id, !current.has(id)));
+  }, []);
+
+  const showAll = useCallback(() => {
+    persistHiddenModuleIds(new Set());
+  }, []);
+
+  return useMemo(
+    () => ({
+      modules: HIDEABLE_MODULES,
+      hiddenModuleIds,
+      hiddenCount: countHiddenModules(hiddenModuleIds),
+      hasHiddenModules: countHiddenModules(hiddenModuleIds) > 0,
+      isHidden: (id: string) => hiddenModuleIds.has(id),
+      isVisible: (id: string) => isModuleVisible(id, hiddenModuleIds),
+      setHidden,
+      toggle,
+      showAll,
+    }),
+    [hiddenModuleIds, setHidden, toggle, showAll],
+  );
+}

--- a/apps/web/src/lib/ux/module-visibility.test.ts
+++ b/apps/web/src/lib/ux/module-visibility.test.ts
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  ESSENTIAL_MODULE_IDS,
+  HIDEABLE_MODULES,
+  HIDEABLE_MODULE_CATEGORY_ORDER,
+  MODULE_VISIBILITY_STORAGE_KEY,
+  countHiddenModules,
+  filterByModuleVisibility,
+  filterDashboardCards,
+  getHideableModulesByCategory,
+  getStoredHiddenModuleIds,
+  isHideableModule,
+  isModuleHidden,
+  isModuleVisible,
+  persistHiddenModuleIds,
+  sanitizeHiddenModuleIds,
+  saveHiddenModuleIds,
+  setModuleHidden,
+} from './module-visibility';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('catalogue', () => {
+  it('lists only hideable, non-essential modules', () => {
+    for (const module of HIDEABLE_MODULES) {
+      expect(ESSENTIAL_MODULE_IDS).not.toContain(module.id);
+      expect(isHideableModule(module.id)).toBe(true);
+    }
+  });
+
+  it('uses unique module ids', () => {
+    const ids = HIDEABLE_MODULES.map((module) => module.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('assigns every module to a known category', () => {
+    for (const module of HIDEABLE_MODULES) {
+      expect(HIDEABLE_MODULE_CATEGORY_ORDER).toContain(module.category);
+    }
+  });
+
+  it('groups modules by category without losing any', () => {
+    const grouped = HIDEABLE_MODULE_CATEGORY_ORDER.flatMap((category) =>
+      getHideableModulesByCategory(category),
+    );
+    expect(grouped).toHaveLength(HIDEABLE_MODULES.length);
+  });
+});
+
+describe('isHideableModule', () => {
+  it('rejects essential modules', () => {
+    for (const id of ESSENTIAL_MODULE_IDS) {
+      expect(isHideableModule(id)).toBe(false);
+    }
+  });
+
+  it('rejects unknown modules', () => {
+    expect(isHideableModule('totally-made-up')).toBe(false);
+    expect(isHideableModule('')).toBe(false);
+  });
+
+  it('accepts a known optional module', () => {
+    expect(isHideableModule('bills')).toBe(true);
+  });
+});
+
+describe('isModuleHidden / isModuleVisible', () => {
+  it('treats an empty hidden set as everything visible', () => {
+    const hidden = new Set<string>();
+    expect(isModuleHidden('bills', hidden)).toBe(false);
+    expect(isModuleVisible('bills', hidden)).toBe(true);
+  });
+
+  it('hides a hideable module that is in the set', () => {
+    const hidden = new Set(['bills']);
+    expect(isModuleHidden('bills', hidden)).toBe(true);
+    expect(isModuleVisible('bills', hidden)).toBe(false);
+  });
+
+  it('never hides essential modules even if present in the set', () => {
+    const hidden = new Set(['dashboard', 'settings', 'accounts', 'transactions']);
+    for (const id of ESSENTIAL_MODULE_IDS) {
+      expect(isModuleHidden(id, hidden)).toBe(false);
+      expect(isModuleVisible(id, hidden)).toBe(true);
+    }
+  });
+
+  it('ignores unknown ids in the hidden set', () => {
+    const hidden = new Set(['ghost-module']);
+    expect(isModuleHidden('ghost-module', hidden)).toBe(false);
+  });
+});
+
+describe('filterByModuleVisibility', () => {
+  const navItems = [
+    { id: 'dashboard', label: 'Dashboard' },
+    { id: 'bills', label: 'Bills' },
+    { id: 'reports', label: 'Reports' },
+    { id: 'settings', label: 'Settings' },
+  ];
+
+  it('returns a copy of the list when nothing is hidden', () => {
+    const result = filterByModuleVisibility(navItems, new Set());
+    expect(result).toEqual(navItems);
+    expect(result).not.toBe(navItems);
+  });
+
+  it('removes hidden modules while preserving order', () => {
+    const result = filterByModuleVisibility(navItems, new Set(['bills']));
+    expect(result.map((item) => item.id)).toEqual(['dashboard', 'reports', 'settings']);
+  });
+
+  it('keeps essentials even when present in the hidden set', () => {
+    const result = filterByModuleVisibility(navItems, new Set(['dashboard', 'settings', 'bills']));
+    expect(result.map((item) => item.id)).toEqual(['dashboard', 'reports', 'settings']);
+  });
+
+  it('handles every hideable item being hidden', () => {
+    const allHidden = new Set(HIDEABLE_MODULES.map((module) => module.id));
+    const result = filterByModuleVisibility(navItems, allHidden);
+    expect(result.map((item) => item.id)).toEqual(['dashboard', 'settings']);
+  });
+});
+
+describe('filterDashboardCards', () => {
+  const cards = [
+    { moduleId: 'net-worth', title: 'Net Worth' },
+    { moduleId: 'budgets', title: 'Budget Health' },
+    { moduleId: 'debt', title: 'Debt Payoff' },
+  ];
+
+  it('drops cards whose module is hidden', () => {
+    const result = filterDashboardCards(cards, new Set(['budgets']));
+    expect(result.map((card) => card.moduleId)).toEqual(['net-worth', 'debt']);
+  });
+
+  it('returns a copy when nothing is hidden', () => {
+    const result = filterDashboardCards(cards, new Set());
+    expect(result).toEqual(cards);
+    expect(result).not.toBe(cards);
+  });
+});
+
+describe('sanitizeHiddenModuleIds', () => {
+  it('drops unknown and essential ids', () => {
+    const sanitized = sanitizeHiddenModuleIds(['bills', 'dashboard', 'ghost', 'reports']);
+    expect([...sanitized].sort()).toEqual(['bills', 'reports']);
+  });
+
+  it('deduplicates ids', () => {
+    const sanitized = sanitizeHiddenModuleIds(['bills', 'bills']);
+    expect(sanitized.size).toBe(1);
+  });
+});
+
+describe('setModuleHidden', () => {
+  it('adds a hideable id without mutating the input', () => {
+    const current = new Set<string>();
+    const next = setModuleHidden(current, 'bills', true);
+    expect(next.has('bills')).toBe(true);
+    expect(current.size).toBe(0);
+  });
+
+  it('removes an id when shown', () => {
+    const next = setModuleHidden(new Set(['bills', 'reports']), 'bills', false);
+    expect(next.has('bills')).toBe(false);
+    expect(next.has('reports')).toBe(true);
+  });
+
+  it('refuses to hide an essential module', () => {
+    const next = setModuleHidden(new Set(), 'dashboard', true);
+    expect(next.has('dashboard')).toBe(false);
+  });
+
+  it('refuses to hide an unknown module', () => {
+    const next = setModuleHidden(new Set(), 'ghost-module', true);
+    expect(next.size).toBe(0);
+  });
+});
+
+describe('countHiddenModules', () => {
+  it('counts only hideable ids', () => {
+    const hidden = new Set(['bills', 'reports', 'dashboard', 'ghost']);
+    expect(countHiddenModules(hidden)).toBe(2);
+  });
+});
+
+describe('persistence round-trip', () => {
+  it('returns an empty set when nothing is stored', () => {
+    expect(getStoredHiddenModuleIds().size).toBe(0);
+  });
+
+  it('round-trips a hidden set through localStorage', () => {
+    saveHiddenModuleIds(new Set(['reports', 'bills']));
+    const restored = getStoredHiddenModuleIds();
+    expect([...restored].sort()).toEqual(['bills', 'reports']);
+  });
+
+  it('persists deterministically as a sorted array', () => {
+    saveHiddenModuleIds(new Set(['reports', 'bills', 'goals']));
+    const raw = localStorage.getItem(MODULE_VISIBILITY_STORAGE_KEY);
+    expect(raw).toBe(JSON.stringify(['bills', 'goals', 'reports']));
+  });
+
+  it('drops unknown / essential ids when saving', () => {
+    saveHiddenModuleIds(new Set(['bills', 'dashboard', 'ghost']));
+    expect([...getStoredHiddenModuleIds()].sort()).toEqual(['bills']);
+  });
+
+  it('returns an empty set for malformed JSON', () => {
+    localStorage.setItem(MODULE_VISIBILITY_STORAGE_KEY, 'not-json');
+    expect(getStoredHiddenModuleIds().size).toBe(0);
+  });
+
+  it('returns an empty set when the stored value is not an array', () => {
+    localStorage.setItem(MODULE_VISIBILITY_STORAGE_KEY, JSON.stringify({ bills: true }));
+    expect(getStoredHiddenModuleIds().size).toBe(0);
+  });
+
+  it('ignores non-string array entries', () => {
+    localStorage.setItem(MODULE_VISIBILITY_STORAGE_KEY, JSON.stringify(['bills', 42, null]));
+    expect([...getStoredHiddenModuleIds()]).toEqual(['bills']);
+  });
+});
+
+describe('persistHiddenModuleIds', () => {
+  it('stores the sanitized set and dispatches a change event', () => {
+    const events: string[][] = [];
+    const listener = (event: Event) => {
+      events.push((event as CustomEvent<string[]>).detail);
+    };
+    window.addEventListener('finance:module-visibility-change', listener);
+
+    const stored = persistHiddenModuleIds(new Set(['bills', 'dashboard', 'ghost']));
+
+    window.removeEventListener('finance:module-visibility-change', listener);
+
+    expect([...stored]).toEqual(['bills']);
+    expect([...getStoredHiddenModuleIds()]).toEqual(['bills']);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(['bills']);
+  });
+});

--- a/apps/web/src/lib/ux/module-visibility.test.ts
+++ b/apps/web/src/lib/ux/module-visibility.test.ts
@@ -6,6 +6,7 @@ import {
   ESSENTIAL_MODULE_IDS,
   HIDEABLE_MODULES,
   HIDEABLE_MODULE_CATEGORY_ORDER,
+  HIDEABLE_MODULE_IDS,
   MODULE_VISIBILITY_STORAGE_KEY,
   countHiddenModules,
   filterByModuleVisibility,
@@ -40,6 +41,10 @@ describe('catalogue', () => {
   it('uses unique module ids', () => {
     const ids = HIDEABLE_MODULES.map((module) => module.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('keeps the lightweight id list in sync with the rich catalogue', () => {
+    expect(HIDEABLE_MODULES.map((module) => module.id)).toEqual([...HIDEABLE_MODULE_IDS]);
   });
 
   it('assigns every module to a known category', () => {

--- a/apps/web/src/lib/ux/module-visibility.ts
+++ b/apps/web/src/lib/ux/module-visibility.ts
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Minimalist mode — module visibility preference model.
+ *
+ * Lets a low-noise (e.g. FIRE-focused) user hide product areas / nav modules
+ * they never use — bills, reports, mood tags, etc. — so the app feels
+ * purpose-built around the few areas they care about (savings rate, net worth,
+ * investments).
+ *
+ * This module is intentionally pure and dependency-free:
+ *   - A typed catalogue of hideable modules ({@link HIDEABLE_MODULES}).
+ *   - A small set of localStorage-backed helpers that persist the set of
+ *     hidden module ids, matching the existing preference patterns
+ *     (`finance-*` keys, graceful try/catch around `localStorage`).
+ *   - Pure, deterministic selectors that filter a nav config or a dashboard
+ *     card list by the hidden set.
+ *
+ * Core / essential areas ({@link ESSENTIAL_MODULE_IDS}) can never be hidden so
+ * the user can't lock themselves out of the app. Unknown ids and essentials are
+ * always treated as visible, so empty / all-hidden / stale data are all handled
+ * gracefully.
+ *
+ * It deliberately does NOT import the React nav config so it stays a leaf module
+ * (no import cycles) and keeps the eagerly-loaded nav/dashboard chunks lean.
+ *
+ * References: issue #2122
+ */
+
+/** UI grouping for hideable modules, mirroring the primary nav groups. */
+export type HideableModuleCategory = 'money' | 'plan' | 'insights' | 'connect';
+
+/** Display labels for the hideable-module categories. */
+export const HIDEABLE_MODULE_CATEGORY_LABELS: Readonly<Record<HideableModuleCategory, string>> = {
+  money: 'Money',
+  plan: 'Plan',
+  insights: 'Insights',
+  connect: 'Connect',
+};
+
+/** Render order for the hideable-module categories. */
+export const HIDEABLE_MODULE_CATEGORY_ORDER: readonly HideableModuleCategory[] = Object.freeze([
+  'money',
+  'plan',
+  'insights',
+  'connect',
+]);
+
+/** A product area / nav module a user may choose to hide. */
+export interface HideableModule {
+  /** Stable id — matches the corresponding `NavConfigItem.id` in navConfig. */
+  id: string;
+  /** Visible label shown in the settings control. */
+  label: string;
+  /** One-line description of what hiding this module removes. */
+  description: string;
+  /** Grouping bucket for the settings UI. */
+  category: HideableModuleCategory;
+}
+
+/** localStorage key for the persisted set of hidden module ids. */
+export const MODULE_VISIBILITY_STORAGE_KEY = 'finance-hidden-modules';
+
+/**
+ * Same-tab change event. Persisting fires this so chrome rendered in the same
+ * document (nav, dashboard cards) can react without a full reload. Cross-tab
+ * updates arrive via the native `storage` event.
+ */
+export const MODULE_VISIBILITY_CHANGE_EVENT = 'finance:module-visibility-change';
+
+/**
+ * Core areas that are never hideable, so a user can never remove every way back
+ * to their data or to this very setting. Anything not present in
+ * {@link HIDEABLE_MODULES} is implicitly always visible too — this list just
+ * makes the most important guarantees explicit and defends against stale data.
+ */
+export const ESSENTIAL_MODULE_IDS: readonly string[] = Object.freeze([
+  'dashboard',
+  'accounts',
+  'transactions',
+  'settings',
+]);
+
+const ESSENTIAL_MODULE_ID_SET: ReadonlySet<string> = new Set(ESSENTIAL_MODULE_IDS);
+
+/**
+ * The catalogue of modules a minimalist user may hide. Ids match nav item ids
+ * so the same filter applies to the nav chrome and to dashboard quick-access
+ * cards. Order within a category controls render order in the settings UI.
+ */
+export const HIDEABLE_MODULES: readonly HideableModule[] = Object.freeze([
+  // ── Money ────────────────────────────────────────────────────────────
+  {
+    id: 'bills',
+    label: 'Bills',
+    description: 'Upcoming and recurring bill reminders.',
+    category: 'money',
+  },
+  {
+    id: 'subscriptions',
+    label: 'Subscriptions',
+    description: 'Recurring memberships and renewals.',
+    category: 'money',
+  },
+  {
+    id: 'invoices',
+    label: 'Invoices',
+    description: 'Freelance invoice pipeline and expected income.',
+    category: 'money',
+  },
+  {
+    id: 'remittances',
+    label: 'Remittances',
+    description: 'Money sent abroad: fees, FX rate and what recipients receive.',
+    category: 'money',
+  },
+  {
+    id: 'expected-income',
+    label: 'Expected Income',
+    description: 'Track expected vs. cleared income.',
+    category: 'money',
+  },
+  {
+    id: 'investments',
+    label: 'Investments',
+    description: 'Holdings, performance and watchlists.',
+    category: 'money',
+  },
+  {
+    id: 'tax-center',
+    label: 'Tax Center',
+    description: 'Lot-level gains, estimated taxes and wash-sale guardrails.',
+    category: 'money',
+  },
+  {
+    id: 'safety',
+    label: 'Safety',
+    description: 'Plain-English scam checks and safety tips.',
+    category: 'money',
+  },
+  // ── Plan ─────────────────────────────────────────────────────────────
+  {
+    id: 'budgets',
+    label: 'Budgets',
+    description: 'Track spending against monthly limits.',
+    category: 'plan',
+  },
+  {
+    id: 'trip-budgets',
+    label: 'Trip Budgets',
+    description: 'Country/trip envelopes with local-currency spend.',
+    category: 'plan',
+  },
+  {
+    id: 'debt',
+    label: 'Debt',
+    description: 'Payoff planner, BNPL, student loans and credit cards.',
+    category: 'plan',
+  },
+  {
+    id: 'goals',
+    label: 'Goals',
+    description: 'Savings targets and progress.',
+    category: 'plan',
+  },
+  {
+    id: 'planning',
+    label: 'Planning',
+    description: 'Long-range projections and what-ifs.',
+    category: 'plan',
+  },
+  {
+    id: 'fire',
+    label: 'FIRE Planner',
+    description: 'FI number, years-to-FI and Coast FI.',
+    category: 'plan',
+  },
+  {
+    id: 'learning',
+    label: 'Learning',
+    description: 'Financial literacy modules and quizzes.',
+    category: 'plan',
+  },
+  {
+    id: 'estate',
+    label: 'Estate Inventory',
+    description: 'Estate and end-of-life inventory for beneficiaries.',
+    category: 'plan',
+  },
+  {
+    id: 'categories',
+    label: 'Categories',
+    description: 'Customise how transactions are classified.',
+    category: 'plan',
+  },
+  // ── Insights ─────────────────────────────────────────────────────────
+  {
+    id: 'insights',
+    label: 'Insights',
+    description: 'Trends, anomalies and personalised tips.',
+    category: 'insights',
+  },
+  {
+    id: 'cash-flow',
+    label: 'Cash Flow',
+    description: 'Money in vs. money out over time.',
+    category: 'insights',
+  },
+  {
+    id: 'cash-runway',
+    label: 'Cash Runway',
+    description: 'Forecast whether cash covers bills before revenue lands.',
+    category: 'insights',
+  },
+  {
+    id: 'net-worth',
+    label: 'Net Worth',
+    description: 'Assets minus liabilities, tracked monthly.',
+    category: 'insights',
+  },
+  {
+    id: 'reports',
+    label: 'Reports',
+    description: 'Build and export custom reports.',
+    category: 'insights',
+  },
+  {
+    id: 'client-profitability',
+    label: 'Client Profitability',
+    description: 'Revenue, cost and margin by client/project tag.',
+    category: 'insights',
+  },
+  {
+    id: 'business-pnl',
+    label: 'Profit & Loss',
+    description: 'Weekly/monthly P&L with COGS, labor and margins.',
+    category: 'insights',
+  },
+  {
+    id: 'achievements',
+    label: 'Achievements',
+    description: 'Milestones and streaks you have earned.',
+    category: 'insights',
+  },
+  {
+    id: 'watchlists',
+    label: 'Watchlists',
+    description: 'Symbols and markets you follow.',
+    category: 'insights',
+  },
+  // ── Connect ──────────────────────────────────────────────────────────
+  {
+    id: 'household',
+    label: 'Household',
+    description: 'Shared budgets, goals and members.',
+    category: 'connect',
+  },
+  {
+    id: 'bank-connections',
+    label: 'Bank Connections',
+    description: 'Linked institutions and sync status.',
+    category: 'connect',
+  },
+  {
+    id: 'import',
+    label: 'Import Data',
+    description: 'Bring in CSVs, OFX files and receipts.',
+    category: 'connect',
+  },
+  {
+    id: 'privacy',
+    label: 'Privacy',
+    description: 'Consent, data export and deletion.',
+    category: 'connect',
+  },
+]);
+
+const HIDEABLE_MODULE_ID_SET: ReadonlySet<string> = new Set(HIDEABLE_MODULES.map((m) => m.id));
+
+// ---------------------------------------------------------------------------
+// Pure predicates & selectors
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a module id may be hidden. Essential and unknown ids are never
+ * hideable, which keeps the user from locking themselves out.
+ */
+export function isHideableModule(id: string): boolean {
+  return HIDEABLE_MODULE_ID_SET.has(id) && !ESSENTIAL_MODULE_ID_SET.has(id);
+}
+
+/**
+ * Whether a module is currently hidden given a hidden-id set. Only hideable
+ * modules can ever be hidden; essentials and unknown ids always return `false`.
+ */
+export function isModuleHidden(id: string, hiddenModuleIds: ReadonlySet<string>): boolean {
+  return isHideableModule(id) && hiddenModuleIds.has(id);
+}
+
+/** Convenience inverse of {@link isModuleHidden}. */
+export function isModuleVisible(id: string, hiddenModuleIds: ReadonlySet<string>): boolean {
+  return !isModuleHidden(id, hiddenModuleIds);
+}
+
+/**
+ * Filter any id-bearing list (e.g. a nav config) by the hidden set, preserving
+ * order. Essentials and unknown ids always pass through.
+ */
+export function filterByModuleVisibility<T extends { id: string }>(
+  items: readonly T[],
+  hiddenModuleIds: ReadonlySet<string>,
+): T[] {
+  if (hiddenModuleIds.size === 0) {
+    return [...items];
+  }
+  return items.filter((item) => isModuleVisible(item.id, hiddenModuleIds));
+}
+
+/**
+ * Filter a dashboard quick-access card list keyed by `moduleId` by the hidden
+ * set, preserving order. Cards whose module is hidden are removed; cards for
+ * essential / unknown modules always pass through.
+ */
+export function filterDashboardCards<T extends { moduleId: string }>(
+  cards: readonly T[],
+  hiddenModuleIds: ReadonlySet<string>,
+): T[] {
+  if (hiddenModuleIds.size === 0) {
+    return [...cards];
+  }
+  return cards.filter((card) => isModuleVisible(card.moduleId, hiddenModuleIds));
+}
+
+/**
+ * Drop any ids that are not currently hideable (essential, unknown or stale)
+ * from a candidate hidden set. Deterministic and immutable.
+ */
+export function sanitizeHiddenModuleIds(ids: Iterable<string>): Set<string> {
+  const result = new Set<string>();
+  for (const id of ids) {
+    if (isHideableModule(id)) {
+      result.add(id);
+    }
+  }
+  return result;
+}
+
+/**
+ * Return a new hidden set with `id` hidden or shown. Hiding a non-hideable id is
+ * a no-op; the input set is never mutated.
+ */
+export function setModuleHidden(
+  current: ReadonlySet<string>,
+  id: string,
+  hidden: boolean,
+): Set<string> {
+  const next = new Set(current);
+  if (hidden) {
+    if (isHideableModule(id)) {
+      next.add(id);
+    }
+  } else {
+    next.delete(id);
+  }
+  return next;
+}
+
+/** Count how many *hideable* modules are currently hidden. */
+export function countHiddenModules(hiddenModuleIds: ReadonlySet<string>): number {
+  let count = 0;
+  for (const id of hiddenModuleIds) {
+    if (isHideableModule(id)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/** All hideable modules belonging to a category, in catalogue order. */
+export function getHideableModulesByCategory(
+  category: HideableModuleCategory,
+): readonly HideableModule[] {
+  return HIDEABLE_MODULES.filter((module) => module.category === category);
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the persisted hidden-module set from localStorage. Returns an empty set
+ * for missing / malformed data and silently drops unknown or essential ids.
+ */
+export function getStoredHiddenModuleIds(): Set<string> {
+  try {
+    const raw = globalThis.localStorage?.getItem(MODULE_VISIBILITY_STORAGE_KEY);
+    if (!raw) {
+      return new Set();
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return new Set();
+    }
+    return sanitizeHiddenModuleIds(
+      parsed.filter((value): value is string => typeof value === 'string'),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Persist the hidden-module set to localStorage as a sorted, sanitized array so
+ * the round-trip is deterministic. Silently tolerates unavailable storage.
+ */
+export function saveHiddenModuleIds(hiddenModuleIds: ReadonlySet<string>): void {
+  try {
+    const sanitized = [...sanitizeHiddenModuleIds(hiddenModuleIds)].sort();
+    globalThis.localStorage?.setItem(MODULE_VISIBILITY_STORAGE_KEY, JSON.stringify(sanitized));
+  } catch {
+    // Storage unavailable or full — ignore; the in-memory preference still applies.
+  }
+}
+
+/**
+ * Persist the hidden-module set and notify same-tab listeners via
+ * {@link MODULE_VISIBILITY_CHANGE_EVENT}. Returns the sanitized set actually
+ * stored so callers can keep their in-memory state in sync.
+ */
+export function persistHiddenModuleIds(hiddenModuleIds: ReadonlySet<string>): Set<string> {
+  const sanitized = sanitizeHiddenModuleIds(hiddenModuleIds);
+  saveHiddenModuleIds(sanitized);
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    window.dispatchEvent(
+      new CustomEvent(MODULE_VISIBILITY_CHANGE_EVENT, { detail: [...sanitized] }),
+    );
+  }
+  return sanitized;
+}

--- a/apps/web/src/lib/ux/module-visibility.ts
+++ b/apps/web/src/lib/ux/module-visibility.ts
@@ -84,11 +84,64 @@ export const ESSENTIAL_MODULE_IDS: readonly string[] = Object.freeze([
 const ESSENTIAL_MODULE_ID_SET: ReadonlySet<string> = new Set(ESSENTIAL_MODULE_IDS);
 
 /**
+ * Canonical list of hideable module ids — the lightweight source of truth for
+ * membership checks ({@link isHideableModule}). Kept as a plain string array,
+ * separate from the richer {@link HIDEABLE_MODULES} catalogue, so the hot
+ * predicate/selector path (nav chrome, dashboard cards) tree-shakes free of the
+ * catalogue's labels and descriptions and stays out of the eager bundle.
+ *
+ * Order mirrors {@link HIDEABLE_MODULES}; a unit test enforces they stay in sync.
+ */
+export const HIDEABLE_MODULE_IDS: readonly string[] = Object.freeze([
+  // Money
+  'bills',
+  'subscriptions',
+  'invoices',
+  'remittances',
+  'expected-income',
+  'investments',
+  'tax-center',
+  'safety',
+  // Plan
+  'budgets',
+  'trip-budgets',
+  'debt',
+  'goals',
+  'planning',
+  'fire',
+  'learning',
+  'estate',
+  'categories',
+  // Insights
+  'insights',
+  'cash-flow',
+  'cash-runway',
+  'net-worth',
+  'reports',
+  'client-profitability',
+  'business-pnl',
+  'achievements',
+  'watchlists',
+  // Connect
+  'household',
+  'bank-connections',
+  'import',
+  'privacy',
+]);
+
+const HIDEABLE_MODULE_ID_SET: ReadonlySet<string> = new Set(HIDEABLE_MODULE_IDS);
+
+/**
  * The catalogue of modules a minimalist user may hide. Ids match nav item ids
  * so the same filter applies to the nav chrome and to dashboard quick-access
  * cards. Order within a category controls render order in the settings UI.
+ *
+ * Only the settings UI consumes the labels/descriptions, so this catalogue is
+ * deliberately kept out of {@link isHideableModule}'s dependency graph, and is
+ * a plain (un-frozen) array literal so bundlers can tree-shake it away from the
+ * nav/dashboard chunks that never read it.
  */
-export const HIDEABLE_MODULES: readonly HideableModule[] = Object.freeze([
+export const HIDEABLE_MODULES: readonly HideableModule[] = [
   // ── Money ────────────────────────────────────────────────────────────
   {
     id: 'bills',
@@ -273,9 +326,7 @@ export const HIDEABLE_MODULES: readonly HideableModule[] = Object.freeze([
     description: 'Consent, data export and deletion.',
     category: 'connect',
   },
-]);
-
-const HIDEABLE_MODULE_ID_SET: ReadonlySet<string> = new Set(HIDEABLE_MODULES.map((m) => m.id));
+];
 
 // ---------------------------------------------------------------------------
 // Pure predicates & selectors

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -26,7 +26,6 @@ import {
   useTransactions,
 } from '../hooks';
 import { useWidgetLayout } from '../hooks/useWidgetLayout';
-import { useHiddenModules } from '../hooks/useModuleVisibility';
 import type { BudgetWithSpending } from '../db/repositories/budgets';
 import type { Bill, Goal, Transaction } from '../kmp/bridge';
 import { getBudgetStatusIndicator } from '../lib/a11y';
@@ -40,7 +39,6 @@ import { calculateSafeToSpend } from '../lib/dashboard/safe-to-spend';
 import type { SpendingPace } from '../lib/notifications';
 import type { PredictionSummary } from '../lib/predictiveBalance';
 import { rollUpProtectedTransactions } from '../lib/ui/privacy';
-import { isModuleVisible } from '../lib/ux/module-visibility';
 import '../components/dashboard/dashboard.css';
 
 const CategoryPieChart = React.lazy(() =>
@@ -116,6 +114,26 @@ function formatLocalDate(date: Date): string {
   const day = String(date.getDate()).padStart(2, '0');
 
   return `${year}-${month}-${day}`;
+}
+
+/**
+ * Minimalist mode (#2122): read the user's hidden module ids straight from
+ * localStorage.
+ *
+ * This deliberately inlines a tiny reader instead of importing the
+ * `lib/ux/module-visibility` hook/selectors so the rich, lazily-rendered module
+ * catalogue (labels + descriptions) stays in the Settings chunk and the eager
+ * dashboard route chunk remains within its performance budget. The storage key
+ * is kept in sync with `MODULE_VISIBILITY_STORAGE_KEY` in
+ * `lib/ux/module-visibility.ts` (asserted by a unit test there).
+ */
+function readHiddenModuleIds(): readonly string[] {
+  try {
+    const parsed: unknown = JSON.parse(localStorage.getItem('finance-hidden-modules') ?? '[]');
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch {
+    return [];
+  }
 }
 
 function getLastNDaysBounds(days: number): { startDate: string; endDate: string } {
@@ -668,8 +686,9 @@ export const DashboardPage: React.FC = () => {
     [widgetLayout.visibleWidgets],
   );
   // Minimalist mode (#2122): hide a quick-access card when the user has hidden
-  // the corresponding module. Essentials are never affected.
-  const hiddenModules = useHiddenModules();
+  // the corresponding module. Read once on mount; the Dashboard route remounts
+  // after the user changes the setting on the (separate) Settings route.
+  const hiddenModules = useMemo(() => readHiddenModuleIds(), []);
 
   const isDashboardEmpty =
     data === null ||
@@ -854,8 +873,7 @@ export const DashboardPage: React.FC = () => {
                       currency={safeToSpendCurrency}
                     />
                   </Suspense>
-                  {visibleWidgetIds.has('net-worth') &&
-                  isModuleVisible('net-worth', hiddenModules) ? (
+                  {visibleWidgetIds.has('net-worth') && !hiddenModules.includes('net-worth') ? (
                     <article className="card" aria-label="Net worth">
                       <div className="card__header">
                         <h3 className="card__title">Net Worth</h3>
@@ -875,8 +893,7 @@ export const DashboardPage: React.FC = () => {
                       </div>
                     </article>
                   ) : null}
-                  {visibleWidgetIds.has('budget-health') &&
-                  isModuleVisible('budgets', hiddenModules) ? (
+                  {visibleWidgetIds.has('budget-health') && !hiddenModules.includes('budgets') ? (
                     <article className="card" aria-label="Budget health">
                       <div className="card__header">
                         <h3 className="card__title">Budget Health</h3>
@@ -901,7 +918,7 @@ export const DashboardPage: React.FC = () => {
                       </div>
                     </article>
                   ) : null}
-                  {isModuleVisible('debt', hiddenModules) ? (
+                  {!hiddenModules.includes('debt') ? (
                     <article className="card" aria-label="Debt status">
                       <div className="card__header">
                         <h3 className="card__title">Debt Payoff</h3>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -26,6 +26,7 @@ import {
   useTransactions,
 } from '../hooks';
 import { useWidgetLayout } from '../hooks/useWidgetLayout';
+import { useHiddenModules } from '../hooks/useModuleVisibility';
 import type { BudgetWithSpending } from '../db/repositories/budgets';
 import type { Bill, Goal, Transaction } from '../kmp/bridge';
 import { getBudgetStatusIndicator } from '../lib/a11y';
@@ -39,6 +40,7 @@ import { calculateSafeToSpend } from '../lib/dashboard/safe-to-spend';
 import type { SpendingPace } from '../lib/notifications';
 import type { PredictionSummary } from '../lib/predictiveBalance';
 import { rollUpProtectedTransactions } from '../lib/ui/privacy';
+import { isModuleVisible } from '../lib/ux/module-visibility';
 import '../components/dashboard/dashboard.css';
 
 const CategoryPieChart = React.lazy(() =>
@@ -665,6 +667,9 @@ export const DashboardPage: React.FC = () => {
     () => new Set(widgetLayout.visibleWidgets.map((widget) => widget.id)),
     [widgetLayout.visibleWidgets],
   );
+  // Minimalist mode (#2122): hide a quick-access card when the user has hidden
+  // the corresponding module. Essentials are never affected.
+  const hiddenModules = useHiddenModules();
 
   const isDashboardEmpty =
     data === null ||
@@ -849,7 +854,8 @@ export const DashboardPage: React.FC = () => {
                       currency={safeToSpendCurrency}
                     />
                   </Suspense>
-                  {visibleWidgetIds.has('net-worth') ? (
+                  {visibleWidgetIds.has('net-worth') &&
+                  isModuleVisible('net-worth', hiddenModules) ? (
                     <article className="card" aria-label="Net worth">
                       <div className="card__header">
                         <h3 className="card__title">Net Worth</h3>
@@ -869,7 +875,8 @@ export const DashboardPage: React.FC = () => {
                       </div>
                     </article>
                   ) : null}
-                  {visibleWidgetIds.has('budget-health') ? (
+                  {visibleWidgetIds.has('budget-health') &&
+                  isModuleVisible('budgets', hiddenModules) ? (
                     <article className="card" aria-label="Budget health">
                       <div className="card__header">
                         <h3 className="card__title">Budget Health</h3>
@@ -894,29 +901,35 @@ export const DashboardPage: React.FC = () => {
                       </div>
                     </article>
                   ) : null}
-                  <article className="card" aria-label="Debt status">
-                    <div className="card__header">
-                      <h3 className="card__title">Debt Payoff</h3>
-                    </div>
-                    <div className="card__value" aria-live="polite">
-                      {debtSummary.balance > 0 ? (
-                        <CurrencyDisplay
-                          amount={debtSummary.balance}
-                          context="tracked debt balance"
-                        />
-                      ) : (
-                        'Plan payoff'
-                      )}
-                    </div>
-                    <p className="list-item__secondary">
-                      {debtSummary.count > 0
-                        ? `${debtSummary.count} debt account${debtSummary.count === 1 ? '' : 's'} tracked.`
-                        : 'Compare avalanche and snowball strategies.'}
-                    </p>
-                    <Link to="/debt" className="auth-footer__link" aria-label="Open Debt workspace">
-                      Open Debt workspace
-                    </Link>
-                  </article>
+                  {isModuleVisible('debt', hiddenModules) ? (
+                    <article className="card" aria-label="Debt status">
+                      <div className="card__header">
+                        <h3 className="card__title">Debt Payoff</h3>
+                      </div>
+                      <div className="card__value" aria-live="polite">
+                        {debtSummary.balance > 0 ? (
+                          <CurrencyDisplay
+                            amount={debtSummary.balance}
+                            context="tracked debt balance"
+                          />
+                        ) : (
+                          'Plan payoff'
+                        )}
+                      </div>
+                      <p className="list-item__secondary">
+                        {debtSummary.count > 0
+                          ? `${debtSummary.count} debt account${debtSummary.count === 1 ? '' : 's'} tracked.`
+                          : 'Compare avalanche and snowball strategies.'}
+                      </p>
+                      <Link
+                        to="/debt"
+                        className="auth-footer__link"
+                        aria-label="Open Debt workspace"
+                      >
+                        Open Debt workspace
+                      </Link>
+                    </article>
+                  ) : null}
                 </div>
               </section>
               <Suspense fallback={<SectionFallback label="Loading things to check" />}>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -39,6 +39,7 @@ import { calculateSafeToSpend } from '../lib/dashboard/safe-to-spend';
 import type { SpendingPace } from '../lib/notifications';
 import type { PredictionSummary } from '../lib/predictiveBalance';
 import { rollUpProtectedTransactions } from '../lib/ui/privacy';
+import { useHiddenModuleIds } from '../contexts/HiddenModulesContext';
 import '../components/dashboard/dashboard.css';
 
 const CategoryPieChart = React.lazy(() =>
@@ -114,26 +115,6 @@ function formatLocalDate(date: Date): string {
   const day = String(date.getDate()).padStart(2, '0');
 
   return `${year}-${month}-${day}`;
-}
-
-/**
- * Minimalist mode (#2122): read the user's hidden module ids straight from
- * localStorage.
- *
- * This deliberately inlines a tiny reader instead of importing the
- * `lib/ux/module-visibility` hook/selectors so the rich, lazily-rendered module
- * catalogue (labels + descriptions) stays in the Settings chunk and the eager
- * dashboard route chunk remains within its performance budget. The storage key
- * is kept in sync with `MODULE_VISIBILITY_STORAGE_KEY` in
- * `lib/ux/module-visibility.ts` (asserted by a unit test there).
- */
-function readHiddenModuleIds(): readonly string[] {
-  try {
-    const parsed: unknown = JSON.parse(localStorage.getItem('finance-hidden-modules') ?? '[]');
-    return Array.isArray(parsed) ? (parsed as string[]) : [];
-  } catch {
-    return [];
-  }
 }
 
 function getLastNDaysBounds(days: number): { startDate: string; endDate: string } {
@@ -686,9 +667,9 @@ export const DashboardPage: React.FC = () => {
     [widgetLayout.visibleWidgets],
   );
   // Minimalist mode (#2122): hide a quick-access card when the user has hidden
-  // the corresponding module. Read once on mount; the Dashboard route remounts
-  // after the user changes the setting on the (separate) Settings route.
-  const hiddenModules = useMemo(() => readHiddenModuleIds(), []);
+  // the corresponding module. Sourced from layout-level context so the rich
+  // module-visibility catalogue stays out of this eager dashboard chunk.
+  const hiddenModules = useHiddenModuleIds();
 
   const isDashboardEmpty =
     data === null ||
@@ -873,7 +854,7 @@ export const DashboardPage: React.FC = () => {
                       currency={safeToSpendCurrency}
                     />
                   </Suspense>
-                  {visibleWidgetIds.has('net-worth') && !hiddenModules.includes('net-worth') ? (
+                  {visibleWidgetIds.has('net-worth') && !hiddenModules.has('net-worth') ? (
                     <article className="card" aria-label="Net worth">
                       <div className="card__header">
                         <h3 className="card__title">Net Worth</h3>
@@ -893,7 +874,7 @@ export const DashboardPage: React.FC = () => {
                       </div>
                     </article>
                   ) : null}
-                  {visibleWidgetIds.has('budget-health') && !hiddenModules.includes('budgets') ? (
+                  {visibleWidgetIds.has('budget-health') && !hiddenModules.has('budgets') ? (
                     <article className="card" aria-label="Budget health">
                       <div className="card__header">
                         <h3 className="card__title">Budget Health</h3>
@@ -918,7 +899,7 @@ export const DashboardPage: React.FC = () => {
                       </div>
                     </article>
                   ) : null}
-                  {!hiddenModules.includes('debt') ? (
+                  {!hiddenModules.has('debt') ? (
                     <article className="card" aria-label="Debt status">
                       <div className="card__header">
                         <h3 className="card__title">Debt Payoff</h3>
@@ -938,11 +919,7 @@ export const DashboardPage: React.FC = () => {
                           ? `${debtSummary.count} debt account${debtSummary.count === 1 ? '' : 's'} tracked.`
                           : 'Compare avalanche and snowball strategies.'}
                       </p>
-                      <Link
-                        to="/debt"
-                        className="auth-footer__link"
-                        aria-label="Open Debt workspace"
-                      >
+                      <Link to="/debt" className="auth-footer__link">
                         Open Debt workspace
                       </Link>
                     </article>

--- a/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
@@ -4,7 +4,11 @@ import React, { useCallback, useState } from 'react';
 
 import { CurrencyDisplay } from '../../components/common/CurrencyDisplay';
 import { CategorizationSettings } from '../../components/categorization';
-import { HapticSettings, SettingInfoWidget } from '../../components/settings';
+import {
+  HapticSettings,
+  MinimalistModeSettings,
+  SettingInfoWidget,
+} from '../../components/settings';
 import { CurrencyRatesSettings } from '../../components/settings/CurrencyRatesSettings';
 import '../../components/settings/currency-rates-settings.css';
 import { useAccessibility } from '../../hooks/useAccessibility';
@@ -516,6 +520,8 @@ export const SettingsPreferencesPage: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <MinimalistModeSettings />
 
       <AppearanceSettings />
 


### PR DESCRIPTION
﻿## Summary

Adds a low-noise minimalist mode that lets a FIRE-focused (or any low-noise) user hide product areas / nav modules they never use -- bills, reports, mood tags, etc. -- so the app feels purpose-built around the few things they care about (savings rate, net worth, investments).

Native iOS nav customization remains out of scope for this web slice.

## What is included

- lib/ux/module-visibility.ts -- pure, deterministic preference model:
  - typed catalogue of hideable modules (ids match nav ids), grouped by category
  - localStorage-backed hidden set (finance-hidden-modules), matching existing finance-* preference patterns
  - pure selectors that filter a nav config / dashboard card list by the hidden set
  - essentials (Dashboard, Accounts, Transactions, Settings) are never hideable so users cannot lock themselves out; empty / all-hidden / unknown-id inputs are handled gracefully and persistence round-trips deterministically (sorted, sanitized)
- hooks/useModuleVisibility.ts -- subscribes to the persisted set (same-tab event + cross-tab storage); a light useHiddenModules variant for nav chrome and a full controller for settings.
- Nav filtering -- sidebar, bottom-nav and the mobile "More" sheet filter out hidden modules (selectors thread an optional, backward-compatible hidden set through navConfig).
- Dashboard -- net-worth, budget-health and debt quick-access cards hide when their module is hidden.
- Settings control -- accessible "Minimalist mode / Customize what you see" section: semantic fieldset/legend per category, labelled keyboard-operable role=switch toggles, on/off state conveyed by text (Shown/Hidden) not colour alone, a live region summary, and a "Show all areas" reset.

Hidden areas stay reachable by direct URL and keyboard shortcut, so nothing is ever permanently lost.

## Accessibility (WCAG 2.2 AA)

Semantic fieldset/legend grouping, labelled switches, full keyboard operation, redundant text state, aria-live status. Reuses existing settings classes which already respect prefers-reduced-motion / contrast.

## Tests

- module-visibility.test.ts -- selectors, essentials-always-visible, persistence round-trip, unknown/malformed ids (32 tests).
- MinimalistModeSettings.test.tsx -- fieldset/legend grouping, switch toggling + persistence, text state, live region, reset, essentials excluded (7 tests).
- Existing Navigation / AppLayout / SettingsPreferences suites still pass.

Refs #2122
