### PR TITLE
feat(web): net worth forward projection overlay (#2116)

### DIFF
--- a/apps/web/src/components/charts/NetWorthProjectionChart.test.tsx
+++ b/apps/web/src/components/charts/NetWorthProjectionChart.test.tsx
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for NetWorthProjectionChart.
+ *
+ * Recharts SVG APIs are unavailable in jsdom, so the chart primitives are
+ * mocked (matching the project's other chart tests). Behaviour, accessibility
+ * structure, and the actual-vs-projected distinction are asserted via the DOM.
+ *
+ * References: issue #2116
+ */
+
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { NetWorthProjectionChart } from './NetWorthProjectionChart';
+import type { NetWorthSeriesPoint } from '../../lib/visualization/net-worth-projection';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+vi.mock('recharts', async () => {
+  const React = await import('react');
+  const mock = (name: string) =>
+    function MockComponent(props: Record<string, unknown>) {
+      return React.createElement('div', { 'data-testid': name }, props.children as never);
+    };
+  return {
+    ResponsiveContainer: mock('ResponsiveContainer'),
+    LineChart: mock('LineChart'),
+    Line: mock('Line'),
+    XAxis: mock('XAxis'),
+    YAxis: mock('YAxis'),
+    CartesianGrid: mock('CartesianGrid'),
+    Tooltip: mock('Tooltip'),
+    ReferenceLine: mock('ReferenceLine'),
+  };
+});
+
+function makeHistory(values: number[], startIso = '2026-01-15'): NetWorthSeriesPoint[] {
+  const base = new Date(`${startIso}T00:00:00.000Z`);
+  return values.map((netWorthCents, index) => {
+    const date = new Date(base);
+    date.setUTCMonth(base.getUTCMonth() + index);
+    return {
+      label: date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' }),
+      netWorthCents,
+      dateIso: date.toISOString().slice(0, 10),
+    };
+  });
+}
+
+const GROWING = makeHistory([1_000_000, 1_250_000, 1_500_000, 1_750_000, 2_000_000, 2_250_000]);
+
+describe('NetWorthProjectionChart', () => {
+  it('renders the title and a keyboard-operable range selector', () => {
+    render(<NetWorthProjectionChart history={GROWING} />);
+
+    const group = screen.getByRole('group', { name: 'Projection range' });
+    expect(group).toBeInTheDocument();
+    expect(within(group).getAllByRole('button')).toHaveLength(4);
+    expect(within(group).getByRole('button', { name: /last 3 months/ })).toBeInTheDocument();
+    expect(within(group).getByRole('button', { name: /all history/i })).toBeInTheDocument();
+    // Default range is pre-selected.
+    expect(within(group).getByRole('button', { name: /last 6 months/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('conveys actual vs projected with a pattern-based legend, not color alone', () => {
+    render(<NetWorthProjectionChart history={GROWING} />);
+    expect(screen.getByText(/Actual net worth \(solid line\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Projected forecast \(dashed line\)/)).toBeInTheDocument();
+  });
+
+  it('shows the derived pace assumptions and a not-advice disclaimer', () => {
+    render(<NetWorthProjectionChart history={GROWING} />);
+    const assumptions = screen.getByText(/Forecast assumes a steady/);
+    expect(assumptions).toHaveTextContent(/growth/);
+    expect(assumptions).toHaveTextContent(/not financial advice/i);
+  });
+
+  it('lists actual and projected points in an accessible data table', () => {
+    render(<NetWorthProjectionChart history={GROWING} />);
+    const table = screen.getByRole('table', { name: /data table/ });
+    expect(within(table).getAllByText('Actual').length).toBeGreaterThan(0);
+    expect(within(table).getAllByText('Projected').length).toBeGreaterThan(0);
+  });
+
+  it('updates the selection when a different range is chosen', () => {
+    render(<NetWorthProjectionChart history={GROWING} />);
+    const threeMonth = screen.getByRole('button', { name: /last 3 months/ });
+    fireEvent.click(threeMonth);
+    expect(threeMonth).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /last 6 months/ })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('shows a friendly message instead of a projection for short history', () => {
+    render(<NetWorthProjectionChart history={makeHistory([1_000_000])} />);
+    expect(screen.getByText(/At least two months of net-worth history/)).toBeInTheDocument();
+    expect(screen.queryByText(/Forecast assumes/)).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when there is no history at all', () => {
+    render(<NetWorthProjectionChart history={[]} />);
+    expect(screen.getByText(/Add account balances and transactions/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/charts/NetWorthProjectionChart.tsx
+++ b/apps/web/src/components/charts/NetWorthProjectionChart.tsx
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * NetWorthProjectionChart — net worth growth line with a forward projection
+ * overlay derived from the recent contribution pace.
+ *
+ * Imported directly by NetWorthPage (a lazy route) and intentionally kept out
+ * of the charts barrel so it never lands in eagerly-imported chunks. Reuses the
+ * existing recharts dependency (no new charting library) and the shared chart
+ * accessibility + palette helpers.
+ *
+ * Accessibility (WCAG 2.2 AA):
+ * - Actual vs projected are distinguished by line pattern (solid vs dashed) and
+ *   an explicit legend + data-table "Type" column — never by color alone.
+ * - Range control is a keyboard-operable button group with `aria-pressed`.
+ * - A visually-hidden, keyboard-navigable data table mirrors every point.
+ * - Animation is disabled under `prefers-reduced-motion`.
+ *
+ * References: issue #2116
+ */
+
+import { type FC, useId, useMemo, useState } from 'react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { CHART_COLORS, formatChartCurrency } from './chart-palette';
+import {
+  AccessibleChartDataTable,
+  CHART_KEYBOARD_INSTRUCTIONS,
+  useChartKeyboardNavigation,
+} from './chart-accessibility';
+import {
+  PROJECTION_RANGES,
+  projectNetWorth,
+  rangeToHorizonMonths,
+  sliceSeriesToRange,
+  type NetWorthSeriesPoint,
+  type ProjectionRange,
+} from '../../lib/visualization/net-worth-projection';
+import './net-worth-projection.css';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface NetWorthProjectionChartProps {
+  /** Trailing monthly net-worth history, oldest first. Amounts in cents. */
+  history: readonly NetWorthSeriesPoint[];
+  /** ISO 4217 currency code for formatting. */
+  currency?: string;
+  /** Chart height in pixels. */
+  height?: number;
+  /** Chart title. */
+  title?: string;
+  /** Default selected range. */
+  defaultRange?: ProjectionRange;
+}
+
+interface CombinedRow {
+  readonly label: string;
+  readonly actual: number | null;
+  readonly projected: number | null;
+}
+
+const ACTUAL_COLOR = CHART_COLORS[0];
+const PROJECTED_COLOR = CHART_COLORS[1];
+const PROJECTED_DASH = '6 5';
+
+const RANGE_DESCRIPTIONS: Record<ProjectionRange, string> = {
+  '3M': 'Show the last 3 months and a 3-month projection',
+  '6M': 'Show the last 6 months and a 6-month projection',
+  '1Y': 'Show the last 12 months and a 12-month projection',
+  All: 'Show all history and a derived projection',
+};
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function centsToMajor(cents: number): number {
+  return cents / 100;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface RangeSelectorProps {
+  selected: ProjectionRange;
+  onChange: (range: ProjectionRange) => void;
+}
+
+const RangeSelector: FC<RangeSelectorProps> = ({ selected, onChange }) => (
+  <div className="nw-projection__range" role="group" aria-label="Projection range">
+    {PROJECTION_RANGES.map((range) => (
+      <button
+        key={range}
+        type="button"
+        className={`nw-projection__range-btn${
+          selected === range ? ' nw-projection__range-btn--active' : ''
+        }`}
+        onClick={() => onChange(range)}
+        aria-pressed={selected === range}
+        aria-label={RANGE_DESCRIPTIONS[range]}
+      >
+        {range}
+      </button>
+    ))}
+  </div>
+);
+
+/** Pattern-based legend so actual/projected are not conveyed by color alone. */
+const ProjectionLegend: FC = () => (
+  <ul className="nw-projection__legend" aria-label="Chart legend">
+    <li className="nw-projection__legend-item">
+      <svg
+        className="nw-projection__legend-swatch"
+        width="28"
+        height="10"
+        viewBox="0 0 28 10"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <line x1="0" y1="5" x2="28" y2="5" stroke={ACTUAL_COLOR} strokeWidth="3" />
+      </svg>
+      <span>Actual net worth (solid line)</span>
+    </li>
+    <li className="nw-projection__legend-item">
+      <svg
+        className="nw-projection__legend-swatch"
+        width="28"
+        height="10"
+        viewBox="0 0 28 10"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <line
+          x1="0"
+          y1="5"
+          x2="28"
+          y2="5"
+          stroke={PROJECTED_COLOR}
+          strokeWidth="3"
+          strokeDasharray={PROJECTED_DASH}
+        />
+      </svg>
+      <span>Projected forecast (dashed line)</span>
+    </li>
+  </ul>
+);
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
+  history,
+  currency = 'USD',
+  height = 320,
+  title = 'Net Worth Growth & Projection',
+  defaultRange = '6M',
+}) => {
+  const chartId = useId();
+  const disableAnimation = prefersReducedMotion();
+  const [range, setRange] = useState<ProjectionRange>(defaultRange);
+
+  const visible = useMemo(() => sliceSeriesToRange(history, range), [history, range]);
+
+  const projection = useMemo(() => {
+    const horizonMonths = rangeToHorizonMonths(range, visible.length);
+    return projectNetWorth(visible, { horizonMonths, method: 'regression' });
+  }, [visible, range]);
+
+  const boundaryLabel = visible.length > 0 ? visible[visible.length - 1]!.label : null;
+
+  const chartData = useMemo<CombinedRow[]>(() => {
+    const actualRows: CombinedRow[] = visible.map((point, index) => ({
+      label: point.label,
+      actual: centsToMajor(point.netWorthCents),
+      // Repeat the last actual value on the projected series so the dashed
+      // line connects seamlessly to the solid line.
+      projected:
+        index === visible.length - 1 && projection.hasProjection
+          ? centsToMajor(point.netWorthCents)
+          : null,
+    }));
+    const projectedRows: CombinedRow[] = projection.points.map((point) => ({
+      label: point.label,
+      actual: null,
+      projected: centsToMajor(point.netWorthCents),
+    }));
+    return [...actualRows, ...projectedRows];
+  }, [visible, projection]);
+
+  const description = useMemo(() => {
+    if (visible.length === 0) return `${title}: no net worth history yet.`;
+    const values = visible.map((point) => point.netWorthCents);
+    const min = formatChartCurrency(centsToMajor(Math.min(...values)), currency);
+    const max = formatChartCurrency(centsToMajor(Math.max(...values)), currency);
+    const projectedNote = projection.hasProjection
+      ? ` Projected ${projection.horizonMonths} months forward to ${formatChartCurrency(
+          centsToMajor(projection.endNetWorthCents),
+          currency,
+        )}.`
+      : ' No projection is shown for this range yet.';
+    return `${title}: ${visible.length} actual points ranging ${min} to ${max}.${projectedNote}`;
+  }, [visible, projection, currency, title]);
+
+  const paceText = useMemo(() => {
+    const magnitude = formatChartCurrency(
+      centsToMajor(Math.abs(projection.monthlyPaceCents)),
+      currency,
+    );
+    const direction =
+      projection.paceDirection === 'up'
+        ? 'growth'
+        : projection.paceDirection === 'down'
+          ? 'decline'
+          : 'change';
+    return `${magnitude}/month ${direction}`;
+  }, [projection, currency]);
+
+  const assumptionsText = projection.hasProjection
+    ? `Forecast assumes a steady ${paceText} (${projection.methodSummary}), projected ${projection.horizonMonths} months ahead. Estimate only — not financial advice.`
+    : projection.reason;
+
+  const dataPointRows = useMemo(() => {
+    const actualRows = visible.map((point, index) => {
+      const formattedValue = formatChartCurrency(centsToMajor(point.netWorthCents), currency);
+      return {
+        id: `${chartId}-actual-${index}`,
+        rowHeader: point.label,
+        cells: ['Actual', formattedValue],
+        ariaLabel: `${point.label}: actual net worth ${formattedValue}`,
+      };
+    });
+    const projectedRows = projection.points.map((point, index) => {
+      const formattedValue = formatChartCurrency(centsToMajor(point.netWorthCents), currency);
+      return {
+        id: `${chartId}-projected-${index}`,
+        rowHeader: point.label,
+        cells: ['Projected', formattedValue],
+        ariaLabel: `${point.label}: projected net worth ${formattedValue}`,
+      };
+    });
+    return [...actualRows, ...projectedRows];
+  }, [visible, projection, currency, chartId]);
+
+  const { announcement, handleFocus, handleKeyDown } = useChartKeyboardNavigation(dataPointRows);
+
+  return (
+    <div
+      className="nw-projection"
+      role="figure"
+      aria-label={description}
+      aria-roledescription="net worth projection chart"
+    >
+      <div className="nw-projection__header">
+        <h3 id={`${chartId}-title`} className="chart-title">
+          {title}
+        </h3>
+        <RangeSelector selected={range} onChange={setRange} />
+      </div>
+
+      <p id={`${chartId}-desc`} className="sr-only">
+        {description}
+      </p>
+      <p id={`${chartId}-instructions`} className="sr-only">
+        {CHART_KEYBOARD_INSTRUCTIONS}
+      </p>
+
+      {visible.length === 0 ? (
+        <p className="nw-projection__empty" role="status">
+          Add account balances and transactions to see your net worth grow over time.
+        </p>
+      ) : (
+        <>
+          <ProjectionLegend />
+
+          <div
+            role="group"
+            aria-label={`${title} data navigator`}
+            aria-roledescription="interactive chart"
+            aria-describedby={`${chartId}-desc ${chartId}-instructions ${chartId}-table-caption ${chartId}-live`}
+            aria-keyshortcuts="ArrowLeft ArrowRight Home End"
+            tabIndex={0}
+            onFocus={handleFocus}
+            onKeyDown={handleKeyDown}
+          >
+            <ResponsiveContainer width="100%" height={height}>
+              <LineChart
+                data={chartData}
+                margin={{ top: 8, right: 16, bottom: 8, left: 16 }}
+                role="img"
+                aria-label={description}
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke="var(--semantic-border-default, #E5E7EB)"
+                />
+                <XAxis
+                  dataKey="label"
+                  tick={{ fill: 'var(--semantic-text-secondary, #6B7280)', fontSize: 12 }}
+                />
+                <YAxis
+                  tickFormatter={(value: number) => formatChartCurrency(value, currency)}
+                  tick={{ fill: 'var(--semantic-text-secondary, #6B7280)', fontSize: 12 }}
+                  width={80}
+                />
+                <Tooltip
+                  formatter={(value) => formatChartCurrency(Number(value ?? 0), currency)}
+                  contentStyle={{
+                    background: 'var(--semantic-background-elevated, #FFFFFF)',
+                    border: '1px solid var(--semantic-border-default, #E5E7EB)',
+                    borderRadius: '0.375rem',
+                  }}
+                />
+                {projection.hasProjection && boundaryLabel !== null && (
+                  <ReferenceLine
+                    x={boundaryLabel}
+                    stroke="var(--semantic-text-secondary, #6B7280)"
+                    strokeDasharray="2 4"
+                    label={{
+                      value: 'Now',
+                      position: 'top',
+                      fill: 'var(--semantic-text-secondary, #6B7280)',
+                      fontSize: 11,
+                    }}
+                  />
+                )}
+                <Line
+                  type="monotone"
+                  dataKey="actual"
+                  name="Actual"
+                  stroke={ACTUAL_COLOR}
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                  activeDot={{ r: 6 }}
+                  connectNulls={false}
+                  isAnimationActive={!disableAnimation}
+                  animationDuration={600}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="projected"
+                  name="Projected"
+                  stroke={PROJECTED_COLOR}
+                  strokeWidth={2}
+                  strokeDasharray={PROJECTED_DASH}
+                  dot={{ r: 3 }}
+                  activeDot={{ r: 6 }}
+                  connectNulls
+                  isAnimationActive={!disableAnimation}
+                  animationDuration={600}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          {assumptionsText && (
+            <p className="nw-projection__assumptions" aria-live="polite">
+              {assumptionsText}
+            </p>
+          )}
+
+          <div
+            id={`${chartId}-live`}
+            className="sr-only"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {announcement}
+          </div>
+
+          <AccessibleChartDataTable
+            captionId={`${chartId}-table-caption`}
+            title={title}
+            rowHeaderLabel="Period"
+            columns={[
+              { key: 'type', header: 'Type' },
+              { key: 'netWorth', header: 'Net worth' },
+            ]}
+            rows={dataPointRows}
+          />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default NetWorthProjectionChart;

--- a/apps/web/src/components/charts/net-worth-projection.css
+++ b/apps/web/src/components/charts/net-worth-projection.css
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* -------------------------------------------------------------------
+ * NetWorthProjectionChart — net worth growth line with a forward
+ * projection overlay. Styles consume design tokens only.
+ * References: issue #2116
+ * ------------------------------------------------------------------- */
+
+.nw-projection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3, 0.75rem);
+}
+
+.nw-projection__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2, 0.5rem);
+}
+
+/* Range selector ---------------------------------------------------- */
+
+.nw-projection__range {
+  display: inline-flex;
+  gap: var(--spacing-1, 0.25rem);
+}
+
+.nw-projection__range-btn {
+  min-width: 2.75rem;
+  padding: var(--spacing-1, 0.25rem) var(--spacing-2, 0.5rem);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: 0.375rem;
+  background: var(--semantic-background-elevated, #ffffff);
+  color: var(--semantic-text-secondary, #6b7280);
+  font-size: var(--font-size-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.nw-projection__range-btn:hover {
+  background: var(--semantic-background-secondary, #f3f4f6);
+  color: var(--semantic-text-primary, #111827);
+}
+
+.nw-projection__range-btn:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #2563eb);
+  outline-offset: 2px;
+}
+
+.nw-projection__range-btn--active {
+  background: var(--semantic-background-secondary, #eef2ff);
+  border-color: var(--semantic-border-strong, #c7d2fe);
+  color: var(--semantic-text-primary, #1d4ed8);
+}
+
+/* Legend ------------------------------------------------------------ */
+
+.nw-projection__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-4, 1rem);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.nw-projection__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2, 0.5rem);
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-secondary, #6b7280);
+}
+
+.nw-projection__legend-swatch {
+  flex: 0 0 auto;
+}
+
+/* Assumptions ------------------------------------------------------- */
+
+.nw-projection__assumptions {
+  margin: 0;
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-secondary, #6b7280);
+}
+
+.nw-projection__empty {
+  margin: 0;
+  padding: var(--spacing-4, 1rem);
+  border: 1px dashed var(--semantic-border-default, #e5e7eb);
+  border-radius: 0.5rem;
+  color: var(--semantic-text-secondary, #6b7280);
+  text-align: center;
+}
+
+/* Respect reduced-motion preferences. */
+@media (prefers-reduced-motion: reduce) {
+  .nw-projection__range-btn {
+    transition: none;
+  }
+}

--- a/apps/web/src/hooks/useNetWorth.ts
+++ b/apps/web/src/hooks/useNetWorth.ts
@@ -17,6 +17,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useDatabase } from '../db/DatabaseProvider';
 import { getAllAccounts } from '../db/repositories/accounts';
+import { getAllTransactions } from '../db/repositories/transactions';
 import {
   computeCurrentNetWorth,
   computeAssetClassBreakdown,
@@ -27,6 +28,8 @@ import type {
   AssetClassBreakdown,
   NetWorthMilestone,
 } from '../lib/analytics/net-worth';
+import { buildNetWorthHistorySeries } from '../lib/visualization/net-worth-history';
+import type { NetWorthSeriesPoint } from '../lib/visualization/net-worth-projection';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,6 +43,8 @@ export interface UseNetWorthResult {
   assetClasses: AssetClassBreakdown[];
   /** Detected milestones with reached status. */
   milestones: NetWorthMilestone[];
+  /** Trailing monthly net-worth history, oldest first (for trend + projection). */
+  history: NetWorthSeriesPoint[];
   /** True while data is being computed. */
   loading: boolean;
   /** Human-readable error message or null. */
@@ -59,6 +64,7 @@ export function useNetWorth(): UseNetWorthResult {
   const [currentNetWorth, setCurrentNetWorth] = useState<NetWorthDataPoint | null>(null);
   const [assetClasses, setAssetClasses] = useState<AssetClassBreakdown[]>([]);
   const [milestones, setMilestones] = useState<NetWorthMilestone[]>([]);
+  const [history, setHistory] = useState<NetWorthSeriesPoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState(0);
@@ -74,14 +80,17 @@ export function useNetWorth(): UseNetWorthResult {
 
     try {
       const accounts = getAllAccounts(db);
+      const transactions = getAllTransactions(db);
 
       const nw = computeCurrentNetWorth(accounts);
       const classes = computeAssetClassBreakdown(accounts);
       const ms = detectMilestones(nw.netWorth, nw.liabilities);
+      const series = buildNetWorthHistorySeries(accounts, transactions);
 
       setCurrentNetWorth(nw);
       setAssetClasses(classes);
       setMilestones(ms);
+      setHistory(series);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to compute net worth.');
     } finally {
@@ -89,5 +98,5 @@ export function useNetWorth(): UseNetWorthResult {
     }
   }, [db, refreshToken]);
 
-  return { currentNetWorth, assetClasses, milestones, loading, error, refresh };
+  return { currentNetWorth, assetClasses, milestones, history, loading, error, refresh };
 }

--- a/apps/web/src/lib/visualization/net-worth-history.test.ts
+++ b/apps/web/src/lib/visualization/net-worth-history.test.ts
@@ -33,7 +33,11 @@ function makeAccount(
 }
 
 function makeTransaction(
-  overrides: Partial<Transaction> & { type: Transaction['type']; amount: number; date: string },
+  overrides: Omit<Partial<Transaction>, 'amount'> & {
+    type: Transaction['type'];
+    amount: number;
+    date: string;
+  },
 ): Transaction {
   return {
     id: overrides.id ?? `txn-${overrides.date}-${overrides.amount}`,
@@ -61,6 +65,13 @@ function makeTransaction(
     statementDescription: null,
     customFields: null,
     extraNotes: null,
+    counterpartyName: null,
+    counterpartyAccountId: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
   } as Transaction;
 }
 

--- a/apps/web/src/lib/visualization/net-worth-history.test.ts
+++ b/apps/web/src/lib/visualization/net-worth-history.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the net worth history reconstruction helper.
+ *
+ * References: issue #2116
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildNetWorthHistorySeries } from './net-worth-history';
+import type { Account, Transaction } from '../../kmp/bridge';
+
+function makeAccount(
+  overrides: Partial<Account> & { type: Account['type']; balance: number },
+): Account {
+  return {
+    id: overrides.id ?? 'acct-1',
+    householdId: 'hh-1',
+    name: overrides.name ?? 'Test Account',
+    type: overrides.type,
+    currency: { code: 'USD', decimalPlaces: 2 },
+    currentBalance: { amount: overrides.balance } as Account['currentBalance'],
+    isArchived: overrides.isArchived ?? false,
+    sortOrder: 0,
+    icon: null,
+    color: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  } as Account;
+}
+
+function makeTransaction(
+  overrides: Partial<Transaction> & { type: Transaction['type']; amount: number; date: string },
+): Transaction {
+  return {
+    id: overrides.id ?? `txn-${overrides.date}-${overrides.amount}`,
+    householdId: 'hh-1',
+    accountId: 'acct-1',
+    categoryId: null,
+    type: overrides.type,
+    status: 'CLEARED',
+    amount: { amount: overrides.amount } as Transaction['amount'],
+    currency: { code: 'USD', decimalPlaces: 2 },
+    payee: null,
+    note: null,
+    date: overrides.date,
+    transferAccountId: null,
+    transferTransactionId: null,
+    isRecurring: false,
+    recurringRuleId: null,
+    tags: [],
+    merchantAddress: null,
+    merchantCity: null,
+    merchantState: null,
+    merchantZip: null,
+    merchantCountry: null,
+    externalReferenceId: null,
+    statementDescription: null,
+    customFields: null,
+    extraNotes: null,
+  } as Transaction;
+}
+
+// Fixed reference date so windows are deterministic.
+const NOW = new Date('2026-06-15T12:00:00.000Z');
+
+describe('buildNetWorthHistorySeries', () => {
+  it('returns an empty series when months is zero or negative', () => {
+    const accounts = [makeAccount({ type: 'CHECKING', balance: 100_000 })];
+    expect(buildNetWorthHistorySeries(accounts, [], 0, NOW)).toEqual([]);
+    expect(buildNetWorthHistorySeries(accounts, [], -3, NOW)).toEqual([]);
+  });
+
+  it('produces one point per requested month, oldest first', () => {
+    const accounts = [makeAccount({ type: 'CHECKING', balance: 500_000 })];
+    const series = buildNetWorthHistorySeries(accounts, [], 6, NOW);
+    expect(series).toHaveLength(6);
+    expect(series.every((point) => point.dateIso !== undefined)).toBe(true);
+    // The latest window ends at "today".
+    expect(series[series.length - 1]!.dateIso).toBe('2026-06-15');
+  });
+
+  it('holds net worth flat across months when there are no transactions', () => {
+    const accounts = [makeAccount({ type: 'CHECKING', balance: 500_000 })];
+    const series = buildNetWorthHistorySeries(accounts, [], 4, NOW);
+    expect(series.map((point) => point.netWorthCents)).toEqual([
+      500_000, 500_000, 500_000, 500_000,
+    ]);
+  });
+
+  it('reconstructs earlier net worth by removing later cash flow', () => {
+    // Current net worth = 500k. A 100k income posted this month means the
+    // prior months sat 100k lower.
+    const accounts = [makeAccount({ type: 'CHECKING', balance: 500_000 })];
+    const transactions = [makeTransaction({ type: 'INCOME', amount: 100_000, date: '2026-06-10' })];
+    const series = buildNetWorthHistorySeries(accounts, transactions, 3, NOW);
+
+    expect(series[series.length - 1]!.netWorthCents).toBe(500_000);
+    expect(series[0]!.netWorthCents).toBe(400_000);
+    expect(series[1]!.netWorthCents).toBe(400_000);
+  });
+
+  it('treats expenses as reducing earlier net worth', () => {
+    // A 50k expense this month means prior months were 50k higher.
+    const accounts = [makeAccount({ type: 'CHECKING', balance: 200_000 })];
+    const transactions = [makeTransaction({ type: 'EXPENSE', amount: 50_000, date: '2026-06-05' })];
+    const series = buildNetWorthHistorySeries(accounts, transactions, 2, NOW);
+
+    expect(series[series.length - 1]!.netWorthCents).toBe(200_000);
+    expect(series[0]!.netWorthCents).toBe(250_000);
+  });
+
+  it('subtracts liability balances from current net worth', () => {
+    const accounts = [
+      makeAccount({ type: 'CHECKING', balance: 300_000 }),
+      makeAccount({ id: 'cc-1', type: 'CREDIT_CARD', balance: 50_000 }),
+    ];
+    const series = buildNetWorthHistorySeries(accounts, [], 2, NOW);
+    expect(series.every((point) => point.netWorthCents === 250_000)).toBe(true);
+  });
+
+  it('ignores transfers when rolling net worth backwards', () => {
+    const accounts = [makeAccount({ type: 'CHECKING', balance: 500_000 })];
+    const transactions = [
+      makeTransaction({ type: 'TRANSFER', amount: 100_000, date: '2026-06-09' }),
+    ];
+    const series = buildNetWorthHistorySeries(accounts, transactions, 3, NOW);
+    expect(series.every((point) => point.netWorthCents === 500_000)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/visualization/net-worth-history.ts
+++ b/apps/web/src/lib/visualization/net-worth-history.ts
@@ -40,7 +40,7 @@ export function buildNetWorthHistorySeries(
   const monthCount = Math.max(0, Math.floor(months));
   if (monthCount === 0) return [];
 
-  const currentNetWorthCents = computeCurrentNetWorth(accounts).netWorth;
+  const currentNetWorthCents = computeCurrentNetWorth([...accounts]).netWorth;
   const windows = buildPeriodWindows('monthly', now, monthCount);
 
   return windows.map((window) => {

--- a/apps/web/src/lib/visualization/net-worth-history.ts
+++ b/apps/web/src/lib/visualization/net-worth-history.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Build a monthly net-worth history series from local account + transaction
+ * data, reusing the existing insights data path so the projection chart stays
+ * consistent with the rest of the app.
+ *
+ * Net worth at the end of each historical month is reconstructed backwards from
+ * the *current* net worth by removing the cash flow of transactions posted
+ * after that month — the same technique used by `calculateNetWorthTrend`.
+ *
+ * All monetary values are integer cents.
+ *
+ * References: issue #2116
+ */
+
+import type { Account, Transaction } from '../../kmp/bridge';
+import { computeCurrentNetWorth } from '../analytics/net-worth';
+import { buildPeriodWindows, cashFlowFromAmount } from '../insights/helpers';
+import type { NetWorthSeriesPoint } from './net-worth-projection';
+
+/** Default number of trailing months reconstructed (covers up to the 1Y range). */
+export const DEFAULT_HISTORY_MONTHS = 12;
+
+/**
+ * Reconstructs a trailing monthly net-worth history.
+ *
+ * @param accounts - All accounts (archived accounts are ignored for totals).
+ * @param transactions - All transactions used to roll net worth backwards.
+ * @param months - Number of trailing months to produce. Defaults to 12.
+ * @param now - Reference "today". Defaults to the current date.
+ * @returns Net-worth points oldest-first; empty when `months` <= 0.
+ */
+export function buildNetWorthHistorySeries(
+  accounts: readonly Account[],
+  transactions: readonly Transaction[],
+  months: number = DEFAULT_HISTORY_MONTHS,
+  now: Date = new Date(),
+): NetWorthSeriesPoint[] {
+  const monthCount = Math.max(0, Math.floor(months));
+  if (monthCount === 0) return [];
+
+  const currentNetWorthCents = computeCurrentNetWorth(accounts).netWorth;
+  const windows = buildPeriodWindows('monthly', now, monthCount);
+
+  return windows.map((window) => {
+    const laterCashFlow = transactions.reduce((sum, transaction) => {
+      if (transaction.date > window.endDate) {
+        return sum + cashFlowFromAmount(transaction.type, transaction.amount.amount);
+      }
+      return sum;
+    }, 0);
+
+    return {
+      label: window.label,
+      dateIso: window.endDate,
+      netWorthCents: currentNetWorthCents - laterCashFlow,
+    };
+  });
+}

--- a/apps/web/src/lib/visualization/net-worth-projection.test.ts
+++ b/apps/web/src/lib/visualization/net-worth-projection.test.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the net worth forward-projection engine.
+ *
+ * References: issue #2116
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_PROJECTION_MONTHS,
+  PROJECTION_RANGES,
+  deriveMonthlyPaceCents,
+  projectNetWorth,
+  rangeToHorizonMonths,
+  sliceSeriesToRange,
+  type NetWorthSeriesPoint,
+} from './net-worth-projection';
+
+function makeSeries(values: number[], startIso = '2026-01-31'): NetWorthSeriesPoint[] {
+  const base = new Date(`${startIso}T00:00:00.000Z`);
+  return values.map((netWorthCents, index) => {
+    const date = new Date(base);
+    date.setUTCMonth(base.getUTCMonth() + index);
+    return {
+      label: date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' }),
+      netWorthCents,
+      dateIso: date.toISOString().slice(0, 10),
+    };
+  });
+}
+
+describe('deriveMonthlyPaceCents', () => {
+  it('returns zero for fewer than two points', () => {
+    expect(deriveMonthlyPaceCents([])).toBe(0);
+    expect(deriveMonthlyPaceCents(makeSeries([100_000]))).toBe(0);
+  });
+
+  it('derives a positive pace for a steadily growing series', () => {
+    const series = makeSeries([100_000, 150_000, 200_000, 250_000]);
+    expect(deriveMonthlyPaceCents(series, 'average')).toBe(50_000);
+    expect(deriveMonthlyPaceCents(series, 'regression')).toBe(50_000);
+  });
+
+  it('derives a negative pace for a declining series', () => {
+    const series = makeSeries([400_000, 300_000, 200_000]);
+    expect(deriveMonthlyPaceCents(series, 'average')).toBe(-100_000);
+    expect(deriveMonthlyPaceCents(series, 'regression')).toBe(-100_000);
+  });
+
+  it('derives a flat pace for a flat series', () => {
+    const series = makeSeries([250_000, 250_000, 250_000, 250_000]);
+    expect(deriveMonthlyPaceCents(series, 'average')).toBe(0);
+    expect(deriveMonthlyPaceCents(series, 'regression')).toBe(0);
+  });
+
+  it('regression smooths noise where the average uses only endpoints', () => {
+    // Noisy middle: the average uses only first/last (50k/mo), while the
+    // least-squares slope fits every point and lands lower (10k/mo).
+    const series = makeSeries([100_000, 400_000, 200_000, 100_000, 300_000]);
+    expect(deriveMonthlyPaceCents(series, 'average')).toBe(50_000);
+    expect(deriveMonthlyPaceCents(series, 'regression')).toBe(10_000);
+  });
+
+  it('always returns an integer number of cents', () => {
+    const series = makeSeries([0, 100_001, 200_005]);
+    const pace = deriveMonthlyPaceCents(series, 'regression');
+    expect(Number.isInteger(pace)).toBe(true);
+  });
+});
+
+describe('projectNetWorth', () => {
+  it('guards against empty history', () => {
+    const result = projectNetWorth([], { horizonMonths: 6 });
+    expect(result.hasProjection).toBe(false);
+    expect(result.points).toHaveLength(0);
+    expect(result.reason).toMatch(/two months/i);
+  });
+
+  it('guards against single-point history', () => {
+    const result = projectNetWorth(makeSeries([100_000]), { horizonMonths: 6 });
+    expect(result.hasProjection).toBe(false);
+    expect(result.startNetWorthCents).toBe(100_000);
+    expect(result.reason).toBeTruthy();
+  });
+
+  it('projects a growing series forward with integer cents', () => {
+    const series = makeSeries([100_000, 150_000, 200_000]);
+    const result = projectNetWorth(series, { horizonMonths: 3, method: 'average' });
+
+    expect(result.hasProjection).toBe(true);
+    expect(result.monthlyPaceCents).toBe(50_000);
+    expect(result.paceDirection).toBe('up');
+    expect(result.startNetWorthCents).toBe(200_000);
+    expect(result.points.map((point) => point.netWorthCents)).toEqual([250_000, 300_000, 350_000]);
+    expect(result.points.map((point) => point.monthOffset)).toEqual([1, 2, 3]);
+    expect(result.endNetWorthCents).toBe(350_000);
+    result.points.forEach((point) => expect(Number.isInteger(point.netWorthCents)).toBe(true));
+  });
+
+  it('projects a declining series downward', () => {
+    const series = makeSeries([300_000, 250_000, 200_000]);
+    const result = projectNetWorth(series, { horizonMonths: 2, method: 'average' });
+    expect(result.paceDirection).toBe('down');
+    expect(result.points.map((point) => point.netWorthCents)).toEqual([150_000, 100_000]);
+  });
+
+  it('holds a flat series flat', () => {
+    const series = makeSeries([250_000, 250_000, 250_000]);
+    const result = projectNetWorth(series, { horizonMonths: 3 });
+    expect(result.paceDirection).toBe('flat');
+    expect(result.points.every((point) => point.netWorthCents === 250_000)).toBe(true);
+  });
+
+  it('clamps the horizon to the maximum', () => {
+    const series = makeSeries([100_000, 110_000]);
+    const result = projectNetWorth(series, { horizonMonths: 999 });
+    expect(result.horizonMonths).toBe(MAX_PROJECTION_MONTHS);
+    expect(result.points).toHaveLength(MAX_PROJECTION_MONTHS);
+  });
+
+  it('produces no projection for a zero or negative horizon', () => {
+    const series = makeSeries([100_000, 110_000]);
+    expect(projectNetWorth(series, { horizonMonths: 0 }).hasProjection).toBe(false);
+    expect(projectNetWorth(series, { horizonMonths: -4 }).hasProjection).toBe(false);
+    expect(projectNetWorth(series, { horizonMonths: -4 }).reason).toMatch(/horizon/i);
+  });
+
+  it('derives the horizon from a range when none is given', () => {
+    const series = makeSeries([100_000, 110_000, 120_000, 130_000, 140_000, 150_000]);
+    expect(projectNetWorth(series, { range: '3M' }).points).toHaveLength(3);
+    expect(projectNetWorth(series, { range: '6M' }).points).toHaveLength(6);
+  });
+
+  it('labels projected points from the basis date when present', () => {
+    const series = makeSeries([100_000, 150_000], '2026-05-15');
+    const result = projectNetWorth(series, { horizonMonths: 2 });
+    // Basis last point is Jun 2026 → projections land in Jul and Aug.
+    expect(result.points.map((point) => point.label)).toEqual(['Jul', 'Aug']);
+    expect(result.points[0]!.dateIso?.slice(0, 7)).toBe('2026-07');
+  });
+
+  it('falls back to relative labels without a basis date', () => {
+    const series: NetWorthSeriesPoint[] = [
+      { label: 'A', netWorthCents: 100_000 },
+      { label: 'B', netWorthCents: 120_000 },
+    ];
+    const result = projectNetWorth(series, { horizonMonths: 2 });
+    expect(result.points.map((point) => point.label)).toEqual(['+1mo', '+2mo']);
+    expect(result.points[0]!.dateIso).toBeUndefined();
+  });
+});
+
+describe('range helpers', () => {
+  it('exposes the four ranges in display order', () => {
+    expect(PROJECTION_RANGES).toEqual(['3M', '6M', '1Y', 'All']);
+  });
+
+  it('slices trailing windows for fixed ranges', () => {
+    const series = makeSeries([1, 2, 3, 4, 5, 6, 7, 8].map((n) => n * 100_000));
+    expect(sliceSeriesToRange(series, '3M')).toHaveLength(3);
+    expect(sliceSeriesToRange(series, '6M')).toHaveLength(6);
+    expect(sliceSeriesToRange(series, '1Y')).toHaveLength(8); // fewer than 12 available
+    expect(sliceSeriesToRange(series, 'All')).toHaveLength(8);
+    expect(sliceSeriesToRange(series, '3M').map((p) => p.netWorthCents)).toEqual([
+      600_000, 700_000, 800_000,
+    ]);
+  });
+
+  it('maps fixed ranges to fixed horizons', () => {
+    expect(rangeToHorizonMonths('3M', 5)).toBe(3);
+    expect(rangeToHorizonMonths('6M', 5)).toBe(6);
+    expect(rangeToHorizonMonths('1Y', 5)).toBe(12);
+  });
+
+  it('derives the All horizon from history length within bounds', () => {
+    expect(rangeToHorizonMonths('All', 2)).toBe(3); // floor(1) clamped up to 3
+    expect(rangeToHorizonMonths('All', 12)).toBe(6);
+    expect(rangeToHorizonMonths('All', 1000)).toBe(MAX_PROJECTION_MONTHS);
+  });
+});

--- a/apps/web/src/lib/visualization/net-worth-projection.ts
+++ b/apps/web/src/lib/visualization/net-worth-projection.ts
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Net worth forward-projection engine.
+ *
+ * Pure, deterministic helpers that take a historical net-worth series and
+ * project it forward based on the *recent contribution pace* derived from the
+ * series itself — no user-entered growth assumptions. All monetary values are
+ * integer cents.
+ *
+ * Two deterministic pace estimators are supported:
+ * - `average`    — mean of consecutive month-over-month deltas.
+ * - `regression` — ordinary least-squares slope over the series (default).
+ *
+ * Short histories (fewer than two points) yield no projection so the UI can
+ * show a friendly "need more history" message rather than a misleading line.
+ *
+ * References: issue #2116
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Pace-estimation strategy used to derive the monthly trend. */
+export type ProjectionMethod = 'average' | 'regression';
+
+/** Selectable time range that drives both the visible window and the horizon. */
+export type ProjectionRange = '3M' | '6M' | '1Y' | 'All';
+
+/** Direction of the derived pace, for color-independent labelling. */
+export type PaceDirection = 'up' | 'down' | 'flat';
+
+/** A single historical net-worth observation. Amount in integer cents. */
+export interface NetWorthSeriesPoint {
+  /** Short display label (e.g. "Mar"). */
+  readonly label: string;
+  /** Net worth at this point in integer cents. */
+  readonly netWorthCents: number;
+  /** Optional ISO date (YYYY-MM-DD) anchoring the point for future labelling. */
+  readonly dateIso?: string;
+}
+
+/** A single projected (forecast) net-worth point. Amount in integer cents. */
+export interface NetWorthProjectionPoint {
+  /** Short display label (e.g. "Jul"). */
+  readonly label: string;
+  /** Projected net worth in integer cents. */
+  readonly netWorthCents: number;
+  /** 1-based number of months beyond the last actual point. */
+  readonly monthOffset: number;
+  /** Optional projected ISO date, when the basis point carries one. */
+  readonly dateIso?: string;
+}
+
+/** Result of a forward projection. */
+export interface NetWorthProjectionResult {
+  /** True when at least one projected point was produced. */
+  readonly hasProjection: boolean;
+  /** Pace strategy used. */
+  readonly method: ProjectionMethod;
+  /** Derived monthly pace in integer cents (signed). */
+  readonly monthlyPaceCents: number;
+  /** Direction of the derived pace. */
+  readonly paceDirection: PaceDirection;
+  /** Number of historical points the pace was derived from. */
+  readonly basisPoints: number;
+  /** Net worth at the last actual point, in integer cents. */
+  readonly startNetWorthCents: number;
+  /** Net worth at the final projected point (or start when none), in cents. */
+  readonly endNetWorthCents: number;
+  /** Number of months projected forward. */
+  readonly horizonMonths: number;
+  /** Projected points, oldest first. */
+  readonly points: readonly NetWorthProjectionPoint[];
+  /** Currency-free, human-readable description of the method. */
+  readonly methodSummary: string;
+  /** Why no projection was produced, or null when one was. */
+  readonly reason: string | null;
+}
+
+/** Options for {@link projectNetWorth}. */
+export interface ProjectNetWorthOptions {
+  /** Pace estimator. Defaults to `regression`. */
+  readonly method?: ProjectionMethod;
+  /** Explicit horizon in months. Takes precedence over `range`. */
+  readonly horizonMonths?: number;
+  /** Range used to derive the horizon when `horizonMonths` is omitted. */
+  readonly range?: ProjectionRange;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Selectable ranges in display order. */
+export const PROJECTION_RANGES: readonly ProjectionRange[] = ['3M', '6M', '1Y', 'All'];
+
+/** Number of trailing months each fixed range covers. */
+const RANGE_WINDOW_MONTHS: Record<Exclude<ProjectionRange, 'All'>, number> = {
+  '3M': 3,
+  '6M': 6,
+  '1Y': 12,
+};
+
+/** Hard cap on how far forward we project regardless of input. */
+export const MAX_PROJECTION_MONTHS = 24;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function roundCents(value: number): number {
+  return Number.isFinite(value) ? Math.round(value) : 0;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function paceDirectionOf(paceCents: number): PaceDirection {
+  if (paceCents > 0) return 'up';
+  if (paceCents < 0) return 'down';
+  return 'flat';
+}
+
+function methodSummaryOf(method: ProjectionMethod, basisPoints: number): string {
+  const window = `the last ${basisPoints} ${basisPoints === 1 ? 'month' : 'months'}`;
+  return method === 'regression'
+    ? `linear trend across ${window}`
+    : `average monthly change across ${window}`;
+}
+
+function addMonthsIso(iso: string, months: number): string {
+  const base = new Date(`${iso.slice(0, 10)}T00:00:00.000Z`);
+  base.setUTCMonth(base.getUTCMonth() + months);
+  return base.toISOString().slice(0, 10);
+}
+
+function monthShortLabel(iso: string): string {
+  const date = new Date(`${iso.slice(0, 10)}T00:00:00.000Z`);
+  return date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' });
+}
+
+function projectedLabel(lastPoint: NetWorthSeriesPoint, monthOffset: number): string {
+  if (lastPoint.dateIso) {
+    return monthShortLabel(addMonthsIso(lastPoint.dateIso, monthOffset));
+  }
+  return `+${monthOffset}mo`;
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the trailing slice of a series for the given range.
+ *
+ * @param series - Full net-worth history, oldest first.
+ * @param range - Selected range.
+ * @returns A new array containing the trailing window (all points for `All`).
+ */
+export function sliceSeriesToRange(
+  series: readonly NetWorthSeriesPoint[],
+  range: ProjectionRange,
+): NetWorthSeriesPoint[] {
+  if (range === 'All') return series.slice();
+  const window = RANGE_WINDOW_MONTHS[range];
+  return series.slice(Math.max(0, series.length - window));
+}
+
+/**
+ * Derives the projection horizon in months for a range.
+ *
+ * Fixed ranges map directly (3M→3, 6M→6, 1Y→12). `All` derives half of the
+ * available history, bounded to a sensible [3, {@link MAX_PROJECTION_MONTHS}].
+ *
+ * @param range - Selected range.
+ * @param historyLength - Number of available historical points.
+ * @returns Horizon in months.
+ */
+export function rangeToHorizonMonths(range: ProjectionRange, historyLength: number): number {
+  if (range === 'All') {
+    return clamp(Math.floor(historyLength / 2), 3, MAX_PROJECTION_MONTHS);
+  }
+  return RANGE_WINDOW_MONTHS[range];
+}
+
+/**
+ * Derives the monthly net-worth pace (integer cents) from a series.
+ *
+ * @param series - Net-worth history, oldest first (needs >= 2 points).
+ * @param method - Pace estimator. Defaults to `regression`.
+ * @returns Signed integer cents per month; 0 when undeterminable.
+ */
+export function deriveMonthlyPaceCents(
+  series: readonly NetWorthSeriesPoint[],
+  method: ProjectionMethod = 'regression',
+): number {
+  if (series.length < 2) return 0;
+
+  const values = series.map((point) => point.netWorthCents);
+  const n = values.length;
+
+  if (method === 'average') {
+    const first = values[0]!;
+    const last = values[n - 1]!;
+    return roundCents((last - first) / (n - 1));
+  }
+
+  // Ordinary least-squares slope over evenly spaced x = 0..n-1.
+  const meanX = (n - 1) / 2;
+  const meanY = values.reduce((sum, value) => sum + value, 0) / n;
+  let numerator = 0;
+  let denominator = 0;
+  for (let i = 0; i < n; i += 1) {
+    const dx = i - meanX;
+    numerator += dx * (values[i]! - meanY);
+    denominator += dx * dx;
+  }
+  if (denominator === 0) return 0;
+  return roundCents(numerator / denominator);
+}
+
+/**
+ * Projects net worth forward from a historical series.
+ *
+ * The pace is derived from the supplied series (treat the caller's window as
+ * "recent"). Each projected point is `start + pace * monthOffset`, keeping every
+ * value an exact integer cent. Series shorter than two points return a result
+ * flagged `hasProjection: false` with a friendly {@link NetWorthProjectionResult.reason}.
+ *
+ * @param series - Net-worth history, oldest first.
+ * @param options - Method and horizon controls.
+ * @returns A deterministic {@link NetWorthProjectionResult}.
+ */
+export function projectNetWorth(
+  series: readonly NetWorthSeriesPoint[],
+  options: ProjectNetWorthOptions = {},
+): NetWorthProjectionResult {
+  const method = options.method ?? 'regression';
+  const lastPoint = series.length > 0 ? series[series.length - 1]! : null;
+  const startNetWorthCents = lastPoint?.netWorthCents ?? 0;
+
+  if (series.length < 2) {
+    return {
+      hasProjection: false,
+      method,
+      monthlyPaceCents: 0,
+      paceDirection: 'flat',
+      basisPoints: series.length,
+      startNetWorthCents,
+      endNetWorthCents: startNetWorthCents,
+      horizonMonths: 0,
+      points: [],
+      methodSummary: methodSummaryOf(method, series.length),
+      reason: 'At least two months of net-worth history are needed to project forward.',
+    };
+  }
+
+  const requestedHorizon =
+    options.horizonMonths ?? rangeToHorizonMonths(options.range ?? 'All', series.length);
+  const horizonMonths = clamp(Math.floor(requestedHorizon), 0, MAX_PROJECTION_MONTHS);
+  const monthlyPaceCents = deriveMonthlyPaceCents(series, method);
+  const paceDirection = paceDirectionOf(monthlyPaceCents);
+  const methodSummary = methodSummaryOf(method, series.length);
+
+  if (horizonMonths <= 0) {
+    return {
+      hasProjection: false,
+      method,
+      monthlyPaceCents,
+      paceDirection,
+      basisPoints: series.length,
+      startNetWorthCents,
+      endNetWorthCents: startNetWorthCents,
+      horizonMonths: 0,
+      points: [],
+      methodSummary,
+      reason: 'The selected horizon is zero months, so there is nothing to project.',
+    };
+  }
+
+  const points: NetWorthProjectionPoint[] = [];
+  for (let monthOffset = 1; monthOffset <= horizonMonths; monthOffset += 1) {
+    const point: NetWorthProjectionPoint = {
+      label: projectedLabel(lastPoint!, monthOffset),
+      netWorthCents: startNetWorthCents + monthlyPaceCents * monthOffset,
+      monthOffset,
+      ...(lastPoint!.dateIso ? { dateIso: addMonthsIso(lastPoint!.dateIso, monthOffset) } : {}),
+    };
+    points.push(point);
+  }
+
+  return {
+    hasProjection: true,
+    method,
+    monthlyPaceCents,
+    paceDirection,
+    basisPoints: series.length,
+    startNetWorthCents,
+    endNetWorthCents: points[points.length - 1]!.netWorthCents,
+    horizonMonths,
+    points,
+    methodSummary,
+    reason: null,
+  };
+}

--- a/apps/web/src/pages/NetWorthPage.test.tsx
+++ b/apps/web/src/pages/NetWorthPage.test.tsx
@@ -22,6 +22,12 @@ vi.mock('../components/charts/chart-palette', () => ({
   CHART_COLORS: ['#648FFF', '#FE6100', '#785EF0', '#FFB000', '#DC267F', '#009E73'],
 }));
 
+// Stub the projection chart — recharts SVG APIs are unavailable in jsdom and the
+// chart is covered by its own test. Mock hooks/heavy components, not repositories.
+vi.mock('../components/charts/NetWorthProjectionChart', () => ({
+  NetWorthProjectionChart: () => <div data-testid="net-worth-projection-chart" />,
+}));
+
 import { useNetWorth } from '../hooks/useNetWorth';
 
 const mockUseNetWorth = vi.mocked(useNetWorth);
@@ -36,6 +42,7 @@ describe('NetWorthPage', () => {
       currentNetWorth: null,
       assetClasses: [],
       milestones: [],
+      history: [],
       loading: true,
       error: null,
       refresh: vi.fn(),
@@ -50,6 +57,7 @@ describe('NetWorthPage', () => {
       currentNetWorth: null,
       assetClasses: [],
       milestones: [],
+      history: [],
       loading: false,
       error: 'Failed to load',
       refresh: vi.fn(),
@@ -64,6 +72,7 @@ describe('NetWorthPage', () => {
       currentNetWorth: null,
       assetClasses: [],
       milestones: [],
+      history: [],
       loading: false,
       error: null,
       refresh: vi.fn(),
@@ -111,6 +120,7 @@ describe('NetWorthPage', () => {
           reached: false,
         },
       ],
+      history: [],
       loading: false,
       error: null,
       refresh: vi.fn(),
@@ -123,5 +133,32 @@ describe('NetWorthPage', () => {
     expect(screen.getByText('Milestones')).toBeInTheDocument();
     expect(screen.getByText('First $1K')).toBeInTheDocument();
     expect(screen.getByText('First $50K')).toBeInTheDocument();
+  });
+
+  it('renders the net worth projection section when history is available', () => {
+    mockUseNetWorth.mockReturnValue({
+      currentNetWorth: {
+        label: '2024-03-15',
+        assets: 2000000,
+        liabilities: 500000,
+        netWorth: 1500000,
+      },
+      assetClasses: [],
+      milestones: [],
+      history: [
+        { label: 'Jan', netWorthCents: 1000000, dateIso: '2024-01-31' },
+        { label: 'Feb', netWorthCents: 1250000, dateIso: '2024-02-29' },
+        { label: 'Mar', netWorthCents: 1500000, dateIso: '2024-03-15' },
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    render(<NetWorthPage />);
+    expect(
+      screen.getByRole('region', { name: 'Net worth growth and projection' }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('net-worth-projection-chart')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/NetWorthPage.tsx
+++ b/apps/web/src/pages/NetWorthPage.tsx
@@ -22,6 +22,7 @@ import {
   LoadingSpinner,
 } from '../components/common';
 import { AppIcon } from '../components/icons';
+import { NetWorthProjectionChart } from '../components/charts/NetWorthProjectionChart';
 import { useNetWorth } from '../hooks/useNetWorth';
 import type { AssetClassBreakdown, NetWorthMilestone } from '../lib/analytics/net-worth';
 import { CHART_COLORS } from '../components/charts/chart-palette';
@@ -98,7 +99,8 @@ const MilestoneList: React.FC<MilestoneListProps> = ({ milestones }) => (
 // ---------------------------------------------------------------------------
 
 export const NetWorthPage: React.FC = () => {
-  const { currentNetWorth, assetClasses, milestones, loading, error, refresh } = useNetWorth();
+  const { currentNetWorth, assetClasses, milestones, history, loading, error, refresh } =
+    useNetWorth();
 
   if (loading) {
     return (
@@ -205,6 +207,13 @@ export const NetWorthPage: React.FC = () => {
           </article>
         </div>
       </section>
+
+      {/* Net worth growth + forward projection */}
+      {history.length > 0 && (
+        <section className="analytics-section" aria-label="Net worth growth and projection">
+          <NetWorthProjectionChart history={history} />
+        </section>
+      )}
 
       {/* Asset class breakdown */}
       {assetClasses.length > 0 && (


### PR DESCRIPTION
﻿## Summary
Adds a lightweight forward **net worth projection** overlay to the web NetWorthPage for the minimalist investor who wants a clean growth chart with time ranges plus a forecast based on current contribution pace.

## What changed
- **Projection engine** (lib/visualization/net-worth-projection.ts) — pure, deterministic. Derives the recent monthly pace from the historical series via OLS **regression** (default) or **average** of consecutive deltas, then projects forward. All money in **integer cents**. Guards short/empty history (>= 2 points required) and clamps the horizon. Range -> horizon mapping for 3M/6M/1Y/All.
- **History builder** (lib/visualization/net-worth-history.ts) — reconstructs a trailing monthly net-worth series from the **existing insights data path** (accounts + transactions, same technique as `calculateNetWorthTrend`); no duplicate DB logic.
- **useNetWorth** now also exposes `history` (additive).
- **NetWorthProjectionChart** (components/charts/) — recharts overlay (**no new chart dep**) distinguishing **actual (solid)** vs **projected (dashed)** by pattern + legend + a data-table `Type` column (never color alone). Keyboard-operable 3M/6M/1Y/All range selector, assumptions/disclaimer text, respects `prefers-reduced-motion`. Imported **directly** into the lazy NetWorthPage and kept out of shared barrels to protect the bundle budget.

## Accessibility (WCAG 2.2 AA)
- Semantic section landmark; figure + roledescription; sr-only description & keyboard instructions.
- Range control = native button group with `aria-pressed`.
- Actual vs projected conveyed by pattern + legend + text, not color.
- Visually-hidden, keyboard-navigable data table mirrors every point.

## Testing
- 27 engine/history unit tests (pace derivation: growing/flat/declining, regression vs average, short-history guard, horizon bounds, integer cents, range/slice helpers).
- 7 chart component tests (legend, assumptions, range switching, data table, short/empty states) + updated NetWorthPage tests.
- `npm run format:check` clean, `npx eslint . --max-warnings 0` clean, `vite build` + `perf:budget` pass.

Refs #2116
