### PR TITLE
feat(web): beginner credit education and secured-card utilization tracker (#2174)

### DIFF
--- a/apps/web/src/components/layout/navConfig.tsx
+++ b/apps/web/src/components/layout/navConfig.tsx
@@ -200,6 +200,15 @@ export const NAV_CONFIG: readonly NavConfigItem[] = ensureStableNavOrder([
     description: 'Payoff planner, BNPL, student loans and credit cards.',
   },
   {
+    id: 'building-credit',
+    label: 'Building Credit',
+    href: '/building-credit',
+    icon: <Icon name={IconToken.SECURE} />,
+    group: 'plan',
+    mobilePriority: 20,
+    description: 'Beginner credit lessons and a secured-card utilization tracker.',
+  },
+  {
     id: 'goals',
     label: 'Goals',
     href: '/goals',

--- a/apps/web/src/lib/credit/credit-building-education.test.ts
+++ b/apps/web/src/lib/credit/credit-building-education.test.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the beginner credit-building education module.
+ *
+ * Covers: lesson data integrity, recommended ordering, tip data and the
+ * lesson lookup helper.
+ *
+ * References: issue #2174
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CREDIT_BUILDING_LESSONS,
+  CREDIT_BUILDING_TIPS,
+  getCreditLesson,
+} from './credit-building-education';
+
+describe('CREDIT_BUILDING_LESSONS', () => {
+  it('provides a non-empty, structured set of lessons', () => {
+    expect(CREDIT_BUILDING_LESSONS.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('gives every lesson a unique, stable id', () => {
+    const ids = CREDIT_BUILDING_LESSONS.map((lesson) => lesson.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(id).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it('gives every lesson non-empty plain-language content', () => {
+    for (const lesson of CREDIT_BUILDING_LESSONS) {
+      expect(lesson.title.trim().length).toBeGreaterThan(0);
+      expect(lesson.summary.trim().length).toBeGreaterThan(0);
+      expect(lesson.body.trim().length).toBeGreaterThan(0);
+      expect(lesson.takeaway.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('covers the core beginner topics', () => {
+    const ids = CREDIT_BUILDING_LESSONS.map((lesson) => lesson.id);
+    expect(ids).toContain('what-is-a-credit-score');
+    expect(ids).toContain('why-utilization-matters');
+    expect(ids).toContain('on-time-payments');
+    expect(ids).toContain('how-secured-cards-build-credit');
+  });
+
+  it('leads with what a credit score is', () => {
+    expect(CREDIT_BUILDING_LESSONS[0]?.id).toBe('what-is-a-credit-score');
+  });
+});
+
+describe('CREDIT_BUILDING_TIPS', () => {
+  it('provides a non-empty set of unique tips', () => {
+    expect(CREDIT_BUILDING_TIPS.length).toBeGreaterThan(0);
+    const ids = CREDIT_BUILDING_TIPS.map((tip) => tip.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('gives every tip non-empty text', () => {
+    for (const tip of CREDIT_BUILDING_TIPS) {
+      expect(tip.text.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('getCreditLesson', () => {
+  it('returns a lesson by id', () => {
+    const lesson = getCreditLesson('why-utilization-matters');
+    expect(lesson).toBeDefined();
+    expect(lesson?.title).toBe('Why utilization matters');
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(getCreditLesson('does-not-exist')).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/credit/credit-building-education.ts
+++ b/apps/web/src/lib/credit/credit-building-education.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Beginner credit-building education module.
+ *
+ * A small, structured set of plain-language lessons for someone building
+ * credit from zero. The content is deterministic, testable data - no I/O -
+ * surfaced by the Building Credit page alongside the secured-card
+ * utilization tracker.
+ *
+ * Lessons deliberately avoid jargon, point dollar amounts and scary numbers.
+ * Each lesson is short enough to read on a phone in under a minute.
+ *
+ * References: issue #2174
+ */
+
+/** A single plain-language credit-building lesson. */
+export interface CreditLesson {
+  /** Stable identifier (used for keys and deep links). */
+  readonly id: string;
+  /** Short, scannable title. */
+  readonly title: string;
+  /** One-line summary shown under the title. */
+  readonly summary: string;
+  /** Plain-language explanation, one short paragraph. */
+  readonly body: string;
+  /** The single most useful action or reminder. */
+  readonly takeaway: string;
+}
+
+/** A bite-size credit-building tip. */
+export interface CreditTip {
+  /** Stable identifier. */
+  readonly id: string;
+  /** One-sentence, actionable tip. */
+  readonly text: string;
+}
+
+/**
+ * The beginner credit-building lessons, in recommended reading order:
+ * what a score is -> why utilization matters -> on-time payments ->
+ * how secured cards build credit -> patience with credit history.
+ */
+export const CREDIT_BUILDING_LESSONS: readonly CreditLesson[] = [
+  {
+    id: 'what-is-a-credit-score',
+    title: 'What a credit score is',
+    summary: 'A number lenders use to gauge how reliably you repay.',
+    body: 'A credit score is a three-digit number, usually between 300 and 850, that sums up your track record of borrowing and repaying. Lenders look at it to decide whether to approve a loan or card and what interest rate to offer. You are not born with one; it builds over time as you use credit responsibly.',
+    takeaway: 'A higher score can mean easier approvals and lower interest, so it is worth building early.',
+  },
+  {
+    id: 'why-utilization-matters',
+    title: 'Why utilization matters',
+    summary: 'Using a small share of your limit signals you are in control.',
+    body: 'Utilization is how much of your available credit you are using. If your limit is $500 and your balance is $150, your utilization is 30%. Lenders generally like to see this under 30%, and lower is better. High utilization can make you look stretched, even if you pay the balance off later.',
+    takeaway: 'Keep your balance well below your limit, and pay it down before the statement closes.',
+  },
+  {
+    id: 'on-time-payments',
+    title: 'On-time payments',
+    summary: 'Payment history is the biggest piece of your score.',
+    body: 'Paying at least the minimum by the due date, every time, is the single most important habit for building credit. One late payment can stay on your record for years. Setting up autopay for at least the minimum is a simple safety net, even if you plan to pay the full balance by hand.',
+    takeaway: 'Never miss a due date; automate the minimum so a busy month cannot hurt your score.',
+  },
+  {
+    id: 'how-secured-cards-build-credit',
+    title: 'How secured cards build credit',
+    summary: 'A refundable deposit unlocks a starter card that reports to bureaus.',
+    body: 'A secured card asks for a refundable deposit, often equal to your credit limit, which lowers the risk for the lender so people with no history can get approved. You use it like a normal card, and the issuer reports your activity to the credit bureaus. Use a little each month, pay it off, and your history grows. Many issuers later refund the deposit and graduate you to a regular card.',
+    takeaway: 'Treat a secured card like a debit card: spend small, pay in full, and let the history build.',
+  },
+  {
+    id: 'credit-history-takes-time',
+    title: 'Credit history takes time',
+    summary: 'Length of history helps, so start now and stay patient.',
+    body: 'Part of your score reflects how long you have used credit, so there is no instant shortcut. The best move is to start with one account, keep it open and in good standing, and avoid opening lots of new accounts at once. Steady, boring habits over months and years are what move the number up.',
+    takeaway: 'Start one account now, keep it open, and let consistency do the slow, steady work.',
+  },
+];
+
+/** Quick, scannable credit-building reminders for the tips list. */
+export const CREDIT_BUILDING_TIPS: readonly CreditTip[] = [
+  {
+    id: 'tip-utilization-under-30',
+    text: 'Keep your balance under 30% of your limit - under 10% is even better.',
+  },
+  {
+    id: 'tip-autopay-minimum',
+    text: 'Turn on autopay for at least the minimum so you never miss a due date.',
+  },
+  {
+    id: 'tip-pay-before-statement',
+    text: 'Pay down the balance before the statement closes so a low number gets reported.',
+  },
+  {
+    id: 'tip-one-account',
+    text: 'Start with one account and avoid opening several new cards at once.',
+  },
+  {
+    id: 'tip-check-reports',
+    text: 'Check your free credit reports regularly for errors that could drag your score down.',
+  },
+];
+
+const LESSON_BY_ID: ReadonlyMap<string, CreditLesson> = new Map(
+  CREDIT_BUILDING_LESSONS.map((lesson) => [lesson.id, lesson]),
+);
+
+/**
+ * Look up a single lesson by id.
+ *
+ * @param id - The lesson id.
+ * @returns The lesson, or `undefined` when no lesson matches.
+ */
+export function getCreditLesson(id: string): CreditLesson | undefined {
+  return LESSON_BY_ID.get(id);
+}

--- a/apps/web/src/lib/credit/credit-building-education.ts
+++ b/apps/web/src/lib/credit/credit-building-education.ts
@@ -47,14 +47,16 @@ export const CREDIT_BUILDING_LESSONS: readonly CreditLesson[] = [
     title: 'What a credit score is',
     summary: 'A number lenders use to gauge how reliably you repay.',
     body: 'A credit score is a three-digit number, usually between 300 and 850, that sums up your track record of borrowing and repaying. Lenders look at it to decide whether to approve a loan or card and what interest rate to offer. You are not born with one; it builds over time as you use credit responsibly.',
-    takeaway: 'A higher score can mean easier approvals and lower interest, so it is worth building early.',
+    takeaway:
+      'A higher score can mean easier approvals and lower interest, so it is worth building early.',
   },
   {
     id: 'why-utilization-matters',
     title: 'Why utilization matters',
     summary: 'Using a small share of your limit signals you are in control.',
     body: 'Utilization is how much of your available credit you are using. If your limit is $500 and your balance is $150, your utilization is 30%. Lenders generally like to see this under 30%, and lower is better. High utilization can make you look stretched, even if you pay the balance off later.',
-    takeaway: 'Keep your balance well below your limit, and pay it down before the statement closes.',
+    takeaway:
+      'Keep your balance well below your limit, and pay it down before the statement closes.',
   },
   {
     id: 'on-time-payments',
@@ -68,7 +70,8 @@ export const CREDIT_BUILDING_LESSONS: readonly CreditLesson[] = [
     title: 'How secured cards build credit',
     summary: 'A refundable deposit unlocks a starter card that reports to bureaus.',
     body: 'A secured card asks for a refundable deposit, often equal to your credit limit, which lowers the risk for the lender so people with no history can get approved. You use it like a normal card, and the issuer reports your activity to the credit bureaus. Use a little each month, pay it off, and your history grows. Many issuers later refund the deposit and graduate you to a regular card.',
-    takeaway: 'Treat a secured card like a debit card: spend small, pay in full, and let the history build.',
+    takeaway:
+      'Treat a secured card like a debit card: spend small, pay in full, and let the history build.',
   },
   {
     id: 'credit-history-takes-time',

--- a/apps/web/src/lib/credit/secured-card-utilization.test.ts
+++ b/apps/web/src/lib/credit/secured-card-utilization.test.ts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the secured-card utilization helper.
+ *
+ * Covers: utilization math, classification thresholds, 0-limit / 0-balance /
+ * over-limit edge cases, target-balance and pay-down math, guidance
+ * selection, threshold normalization and input clamping.
+ *
+ * References: issue #2174
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeSecuredCardUtilization,
+  DEFAULT_SECURED_CARD_THRESHOLDS,
+  DEFAULT_TARGET_UTILIZATION_PERCENT,
+  formatUtilizationPercent,
+} from './secured-card-utilization';
+
+describe('computeSecuredCardUtilization', () => {
+  describe('utilization math', () => {
+    it('computes a basic percentage from balance and limit', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 15_000,
+        creditLimitCents: 50_000,
+      });
+      expect(result.utilizationPercent).toBe(30);
+    });
+
+    it('rounds utilization to one decimal place', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 10_000,
+        creditLimitCents: 30_000,
+      });
+      // 10000 / 30000 = 33.33% -> 33.3
+      expect(result.utilizationPercent).toBe(33.3);
+    });
+
+    it('reports 0% for a zero balance', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 0,
+        creditLimitCents: 50_000,
+      });
+      expect(result.utilizationPercent).toBe(0);
+      expect(result.level).toBe('good');
+    });
+  });
+
+  describe('classification thresholds', () => {
+    it('classifies utilization below 30% as good', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 14_500,
+        creditLimitCents: 50_000, // 29%
+      });
+      expect(result.level).toBe('good');
+      expect(result.levelLabel).toBe('On track');
+    });
+
+    it('classifies exactly 30% as caution (good is strictly below)', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 15_000,
+        creditLimitCents: 50_000, // 30%
+      });
+      expect(result.level).toBe('caution');
+      expect(result.levelLabel).toBe('Getting high');
+    });
+
+    it('classifies 30-50% as caution', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 20_000,
+        creditLimitCents: 50_000, // 40%
+      });
+      expect(result.level).toBe('caution');
+    });
+
+    it('classifies exactly 50% as caution (inclusive upper edge)', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 25_000,
+        creditLimitCents: 50_000, // 50%
+      });
+      expect(result.level).toBe('caution');
+    });
+
+    it('classifies above 50% as high', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 30_000,
+        creditLimitCents: 50_000, // 60%
+      });
+      expect(result.level).toBe('high');
+      expect(result.levelLabel).toBe('Too high');
+    });
+
+    it('honours custom thresholds', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 5_000,
+        creditLimitCents: 50_000, // 10%
+        thresholds: { goodBelowPercent: 10, cautionAtOrBelowPercent: 20 },
+      });
+      // 10% is not strictly below 10 -> caution
+      expect(result.level).toBe('caution');
+    });
+
+    it('normalizes thresholds when caution is below good', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 20_000,
+        creditLimitCents: 50_000, // 40%
+        thresholds: { goodBelowPercent: 60, cautionAtOrBelowPercent: 10 },
+      });
+      expect(result.thresholds.goodBelowPercent).toBe(60);
+      expect(result.thresholds.cautionAtOrBelowPercent).toBe(60);
+      // 40% < 60% good edge -> good
+      expect(result.level).toBe('good');
+    });
+  });
+
+  describe('zero-limit edge case', () => {
+    it('returns null utilization and unknown level when limit is 0', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 10_000,
+        creditLimitCents: 0,
+      });
+      expect(result.utilizationPercent).toBeNull();
+      expect(result.level).toBe('unknown');
+      expect(result.levelLabel).toBe('Add a limit');
+      expect(result.targetBalanceCents).toBeNull();
+      expect(result.remainingHeadroomCents).toBeNull();
+      expect(result.payDownToTargetCents).toBe(0);
+      expect(result.isOverLimit).toBe(false);
+    });
+
+    it('formats a null utilization as N/A', () => {
+      expect(formatUtilizationPercent(null)).toBe('N/A');
+    });
+  });
+
+  describe('over-limit edge case', () => {
+    it('reports utilization above 100% and flags over-limit', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 60_000,
+        creditLimitCents: 50_000, // 120%
+      });
+      expect(result.utilizationPercent).toBe(120);
+      expect(result.level).toBe('high');
+      expect(result.isOverLimit).toBe(true);
+      expect(result.remainingHeadroomCents).toBe(0);
+      expect(result.guidance).toContain('over your credit limit');
+    });
+
+    it('does not flag over-limit when balance equals the limit', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 50_000,
+        creditLimitCents: 50_000, // 100%
+      });
+      expect(result.isOverLimit).toBe(false);
+      expect(result.level).toBe('high');
+    });
+  });
+
+  describe('target balance and pay-down math', () => {
+    it('computes the target balance from the default 30% target', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 40_000,
+        creditLimitCents: 50_000,
+      });
+      expect(result.targetUtilizationPercent).toBe(DEFAULT_TARGET_UTILIZATION_PERCENT);
+      // 30% of 50000 = 15000
+      expect(result.targetBalanceCents).toBe(15_000);
+      // pay down 40000 - 15000 = 25000
+      expect(result.payDownToTargetCents).toBe(25_000);
+      expect(result.remainingHeadroomCents).toBe(10_000);
+    });
+
+    it('reports zero pay-down when already under the target', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 5_000,
+        creditLimitCents: 50_000, // 10%
+      });
+      expect(result.payDownToTargetCents).toBe(0);
+    });
+
+    it('honours a custom target utilization', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 25_000,
+        creditLimitCents: 50_000, // 50%
+        targetUtilizationPercent: 10,
+      });
+      // 10% of 50000 = 5000
+      expect(result.targetBalanceCents).toBe(5_000);
+      expect(result.payDownToTargetCents).toBe(20_000);
+    });
+  });
+
+  describe('guidance selection', () => {
+    it('asks for a limit when none is set', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 10_000,
+        creditLimitCents: 0,
+      });
+      expect(result.headline).toBe('Add your credit limit to see utilization');
+      expect(result.guidance.toLowerCase()).toContain('credit limit');
+    });
+
+    it('praises good utilization and mentions the good threshold', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 5_000,
+        creditLimitCents: 50_000, // 10%
+      });
+      expect(result.guidance).toContain('30%');
+      expect(result.headline).toContain('10%');
+    });
+
+    it('suggests a pay-down amount for caution utilization', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 20_000,
+        creditLimitCents: 50_000, // 40%
+      });
+      expect(result.level).toBe('caution');
+      expect(result.payDownToTargetCents).toBe(5_000);
+      expect(result.guidance).toContain('$50.00');
+    });
+
+    it('urges getting to target for high utilization', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 35_000,
+        creditLimitCents: 50_000, // 70%
+      });
+      expect(result.level).toBe('high');
+      expect(result.guidance.toLowerCase()).toContain('aim for');
+    });
+  });
+
+  describe('input clamping', () => {
+    it('clamps negative balances to zero', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: -10_000,
+        creditLimitCents: 50_000,
+      });
+      expect(result.balanceCents).toBe(0);
+      expect(result.utilizationPercent).toBe(0);
+    });
+
+    it('clamps negative limits to zero (treated as no limit)', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 10_000,
+        creditLimitCents: -50_000,
+      });
+      expect(result.creditLimitCents).toBe(0);
+      expect(result.level).toBe('unknown');
+    });
+
+    it('rounds fractional cents to whole cents', () => {
+      const result = computeSecuredCardUtilization({
+        balanceCents: 10_000.6,
+        creditLimitCents: 50_000.4,
+      });
+      expect(result.balanceCents).toBe(10_001);
+      expect(result.creditLimitCents).toBe(50_000);
+    });
+  });
+
+  it('exposes the default thresholds constant', () => {
+    expect(DEFAULT_SECURED_CARD_THRESHOLDS).toEqual({
+      goodBelowPercent: 30,
+      cautionAtOrBelowPercent: 50,
+    });
+  });
+});
+
+describe('formatUtilizationPercent', () => {
+  it('drops a trailing .0 for whole numbers', () => {
+    expect(formatUtilizationPercent(30)).toBe('30%');
+  });
+
+  it('keeps one decimal for fractional values', () => {
+    expect(formatUtilizationPercent(33.3)).toBe('33.3%');
+  });
+});

--- a/apps/web/src/lib/credit/secured-card-utilization.ts
+++ b/apps/web/src/lib/credit/secured-card-utilization.ts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Secured-card utilization helper for people building credit from zero.
+ *
+ * Given a secured card's balance and credit limit (both **integer cents**),
+ * this computes the utilization percentage, classifies it with a friendly
+ * three-tier scale (good / caution / high), and produces plain-language
+ * guidance toward a low target utilization.
+ *
+ * The percentage math (safe divide-by-zero, balance clamping, rounding) is
+ * reused from the shared credit-card engine via
+ * {@link calculateCreditUtilizationSummary} so there is a single source of
+ * truth for how utilization is calculated across the app.
+ *
+ * Pure and deterministic - no I/O, no side effects, no time dependence.
+ *
+ * References: issue #2174
+ */
+
+import { calculateCreditUtilizationSummary } from '../debt-credit-card-engine';
+import { formatCurrency } from '../currency';
+import type { CreditCard } from '../debt-types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Beginner-friendly utilization band.
+ *
+ * - `good`    - utilization below the good threshold (default < 30%).
+ * - `caution` - between the good and caution thresholds (default 30-50%).
+ * - `high`    - above the caution threshold (default > 50%).
+ * - `unknown` - no usable credit limit, so utilization cannot be computed.
+ */
+export type SecuredCardUtilizationLevel = 'good' | 'caution' | 'high' | 'unknown';
+
+/** Configurable band edges for the friendly three-tier scale. */
+export interface SecuredCardUtilizationThresholds {
+  /** Utilization strictly below this percent is `good` (default 30). */
+  readonly goodBelowPercent: number;
+  /** Utilization at or below this percent (and not `good`) is `caution` (default 50). */
+  readonly cautionAtOrBelowPercent: number;
+}
+
+/** Inputs for {@link computeSecuredCardUtilization}. */
+export interface SecuredCardUtilizationInput {
+  /** Current statement/posted balance in integer cents. */
+  readonly balanceCents: number;
+  /** Credit limit in integer cents (0 or missing means "no limit set"). */
+  readonly creditLimitCents: number;
+  /** Utilization the guidance steers toward, as a percent (default 30). */
+  readonly targetUtilizationPercent?: number;
+  /** Optional override of the band thresholds. */
+  readonly thresholds?: SecuredCardUtilizationThresholds;
+}
+
+/** Deterministic result describing a single secured card's utilization. */
+export interface SecuredCardUtilization {
+  /** Balance used for the calculation (clamped to >= 0). */
+  readonly balanceCents: number;
+  /** Credit limit used for the calculation (clamped to >= 0). */
+  readonly creditLimitCents: number;
+  /** Utilization percent rounded to one decimal, or `null` when no limit. */
+  readonly utilizationPercent: number | null;
+  /** Friendly band the utilization falls into. */
+  readonly level: SecuredCardUtilizationLevel;
+  /** Short, human-readable label for the band (e.g. "On track"). */
+  readonly levelLabel: string;
+  /** True when the balance exceeds the credit limit. */
+  readonly isOverLimit: boolean;
+  /** Target utilization the guidance steers toward, as a percent. */
+  readonly targetUtilizationPercent: number;
+  /** Highest balance that stays at/under the target, or `null` when no limit. */
+  readonly targetBalanceCents: number | null;
+  /** Cents to pay down to reach the target (0 when already at/under target). */
+  readonly payDownToTargetCents: number;
+  /** Unused credit remaining (limit - balance, >= 0), or `null` when no limit. */
+  readonly remainingHeadroomCents: number | null;
+  /** One-line, plain-language summary of where things stand. */
+  readonly headline: string;
+  /** Plain-language guidance toward the target utilization. */
+  readonly guidance: string;
+  /** The thresholds actually applied (after normalization). */
+  readonly thresholds: SecuredCardUtilizationThresholds;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default friendly band edges: good < 30%, caution 30-50%, high > 50%. */
+export const DEFAULT_SECURED_CARD_THRESHOLDS: SecuredCardUtilizationThresholds = {
+  goodBelowPercent: 30,
+  cautionAtOrBelowPercent: 50,
+};
+
+/** Default utilization the guidance steers people toward. */
+export const DEFAULT_TARGET_UTILIZATION_PERCENT = 30;
+
+const LEVEL_LABEL: Record<SecuredCardUtilizationLevel, string> = {
+  good: 'On track',
+  caution: 'Getting high',
+  high: 'Too high',
+  unknown: 'Add a limit',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return value;
+}
+
+function normalizeThresholds(
+  thresholds: SecuredCardUtilizationThresholds,
+): SecuredCardUtilizationThresholds {
+  const goodBelowPercent = Math.max(0, thresholds.goodBelowPercent);
+  return {
+    goodBelowPercent,
+    cautionAtOrBelowPercent: Math.max(goodBelowPercent, thresholds.cautionAtOrBelowPercent),
+  };
+}
+
+function buildSyntheticCard(balanceCents: number, creditLimitCents: number): CreditCard {
+  return {
+    id: 'secured-card',
+    name: 'Secured card',
+    balanceCents,
+    creditLimitCents,
+    minimumPaymentCents: 0,
+    dueDate: '',
+    annualRateBps: 0,
+    statementDate: '',
+  };
+}
+
+function classify(
+  utilizationPercent: number | null,
+  thresholds: SecuredCardUtilizationThresholds,
+): SecuredCardUtilizationLevel {
+  if (utilizationPercent === null) return 'unknown';
+  if (utilizationPercent < thresholds.goodBelowPercent) return 'good';
+  if (utilizationPercent <= thresholds.cautionAtOrBelowPercent) return 'caution';
+  return 'high';
+}
+
+/** Render a utilization percent without a trailing ".0" (e.g. "30%", "12.5%"). */
+export function formatUtilizationPercent(utilizationPercent: number | null): string {
+  if (utilizationPercent === null) return 'N/A';
+  const rounded = Math.round(utilizationPercent * 10) / 10;
+  return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}%`;
+}
+
+function buildHeadline(
+  level: SecuredCardUtilizationLevel,
+  utilizationPercent: number | null,
+): string {
+  const pct = formatUtilizationPercent(utilizationPercent);
+  switch (level) {
+    case 'unknown':
+      return 'Add your credit limit to see utilization';
+    case 'good':
+      return `You're using ${pct} of your limit`;
+    case 'caution':
+      return `Your utilization is creeping up at ${pct}`;
+    case 'high':
+      return `Your utilization is high at ${pct}`;
+  }
+}
+
+function buildGuidance(
+  level: SecuredCardUtilizationLevel,
+  options: {
+    readonly isOverLimit: boolean;
+    readonly targetUtilizationPercent: number;
+    readonly payDownToTargetCents: number;
+    readonly goodBelowPercent: number;
+  },
+): string {
+  const { isOverLimit, targetUtilizationPercent, payDownToTargetCents, goodBelowPercent } = options;
+  const payDown = formatCurrency(payDownToTargetCents);
+  const needsPayDown = payDownToTargetCents > 0;
+
+  switch (level) {
+    case 'unknown':
+      return 'Enter your secured card credit limit so we can show your utilization, which is the share of your limit you are using. Keeping it low is one of the simplest ways to build credit.';
+    case 'good':
+      return `Nice work. Staying under ${goodBelowPercent}% utilization is one of the fastest ways to build credit. Keep paying on time and let your balance report low each month.`;
+    case 'caution': {
+      const base = needsPayDown
+        ? `You are above the ${goodBelowPercent}% mark lenders like to see. Paying about ${payDown} before your statement closes would bring you to your ${targetUtilizationPercent}% target.`
+        : `You are right around your ${targetUtilizationPercent}% target. Bringing the balance a little lower gives you more breathing room.`;
+      return base;
+    }
+    case 'high': {
+      const overLimitPrefix = isOverLimit
+        ? 'You are over your credit limit. Pay it down right away to avoid fees and protect your score. '
+        : '';
+      const base = needsPayDown
+        ? `High utilization can hold your score back. Aim for ${targetUtilizationPercent}% or less. Paying about ${payDown} would get you there.`
+        : `High utilization can hold your score back. Keep paying it down toward ${targetUtilizationPercent}% or less.`;
+      return `${overLimitPrefix}${base}`;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a secured card's utilization, classification and guidance.
+ *
+ * Edge cases handled deterministically:
+ * - **0 limit** -> `utilizationPercent` is `null`, level `unknown` (N/A).
+ * - **0 balance** -> `0%`, level `good`.
+ * - **over-limit** (balance > limit) -> utilization above 100%, level `high`,
+ *   `isOverLimit` true.
+ *
+ * @param input - Balance and limit in integer cents, plus optional target.
+ * @returns A {@link SecuredCardUtilization} describing the card.
+ */
+export function computeSecuredCardUtilization(
+  input: SecuredCardUtilizationInput,
+): SecuredCardUtilization {
+  const thresholds = normalizeThresholds(input.thresholds ?? DEFAULT_SECURED_CARD_THRESHOLDS);
+  const targetUtilizationPercent = clampPercent(
+    input.targetUtilizationPercent ?? DEFAULT_TARGET_UTILIZATION_PERCENT,
+  );
+  const balanceCents = Math.max(0, Math.round(input.balanceCents));
+  const creditLimitCents = Math.max(0, Math.round(input.creditLimitCents));
+
+  // Reuse the shared utilization math from the credit-card engine so the
+  // divide-by-zero handling, balance clamping and rounding stay consistent.
+  const summary = calculateCreditUtilizationSummary([
+    buildSyntheticCard(balanceCents, creditLimitCents),
+  ]);
+  const utilizationPercent = summary.cards[0]?.utilizationPercent ?? null;
+
+  const level = classify(utilizationPercent, thresholds);
+  const isOverLimit = creditLimitCents > 0 && balanceCents > creditLimitCents;
+
+  const targetBalanceCents =
+    creditLimitCents > 0
+      ? Math.floor((creditLimitCents * targetUtilizationPercent) / 100)
+      : null;
+  const payDownToTargetCents =
+    targetBalanceCents === null ? 0 : Math.max(0, balanceCents - targetBalanceCents);
+  const remainingHeadroomCents =
+    creditLimitCents > 0 ? Math.max(0, creditLimitCents - balanceCents) : null;
+
+  return {
+    balanceCents,
+    creditLimitCents,
+    utilizationPercent,
+    level,
+    levelLabel: LEVEL_LABEL[level],
+    isOverLimit,
+    targetUtilizationPercent,
+    targetBalanceCents,
+    payDownToTargetCents,
+    remainingHeadroomCents,
+    headline: buildHeadline(level, utilizationPercent),
+    guidance: buildGuidance(level, {
+      isOverLimit,
+      targetUtilizationPercent,
+      payDownToTargetCents,
+      goodBelowPercent: thresholds.goodBelowPercent,
+    }),
+    thresholds,
+  };
+}

--- a/apps/web/src/lib/credit/secured-card-utilization.ts
+++ b/apps/web/src/lib/credit/secured-card-utilization.ts
@@ -247,9 +247,7 @@ export function computeSecuredCardUtilization(
   const isOverLimit = creditLimitCents > 0 && balanceCents > creditLimitCents;
 
   const targetBalanceCents =
-    creditLimitCents > 0
-      ? Math.floor((creditLimitCents * targetUtilizationPercent) / 100)
-      : null;
+    creditLimitCents > 0 ? Math.floor((creditLimitCents * targetUtilizationPercent) / 100) : null;
   const payDownToTargetCents =
     targetBalanceCents === null ? 0 : Math.max(0, balanceCents - targetBalanceCents);
   const remainingHeadroomCents =

--- a/apps/web/src/pages/BuildingCreditPage.css
+++ b/apps/web/src/pages/BuildingCreditPage.css
@@ -1,0 +1,349 @@
+.building-credit {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.building-credit__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.building-credit__eyebrow {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.building-credit__title {
+  font-size: var(--type-scale-display-font-size);
+  font-weight: var(--type-scale-display-font-weight);
+  margin: 0;
+}
+
+.building-credit__description {
+  color: var(--semantic-text-secondary);
+  margin: 0;
+  max-width: 72ch;
+}
+
+.building-credit__card {
+  background: var(--semantic-surface-primary, var(--card-background));
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-4);
+}
+
+.building-credit__card-title {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  margin: 0 0 var(--spacing-2);
+}
+
+.building-credit__card-intro {
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-4);
+  max-width: 72ch;
+}
+
+/* -- Tracker inputs ---------------------------------------------------- */
+
+.building-credit__fields {
+  display: grid;
+  gap: var(--spacing-3);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.building-credit__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.building-credit__label {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+}
+
+.building-credit__money-input {
+  align-items: center;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-md);
+  display: flex;
+  gap: var(--spacing-1);
+  padding: 0 var(--spacing-3);
+}
+
+.building-credit__money-prefix {
+  color: var(--semantic-text-secondary);
+}
+
+.building-credit__money-input .building-credit__input {
+  border: none;
+  flex: 1;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.building-credit__input {
+  background: transparent;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-md);
+  color: var(--semantic-text-primary);
+  font: inherit;
+  padding: var(--spacing-2) var(--spacing-3);
+  width: 100%;
+}
+
+.building-credit__input:focus-visible {
+  outline: 2px solid var(--semantic-status-info);
+  outline-offset: 1px;
+}
+
+/* -- Tracker result ---------------------------------------------------- */
+
+.building-credit__result {
+  border: 1px solid var(--semantic-border-default);
+  border-left-width: 4px;
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-4);
+  padding: var(--spacing-4);
+}
+
+.building-credit__result--good {
+  border-left-color: var(--semantic-status-positive);
+}
+
+.building-credit__result--caution {
+  border-left-color: var(--semantic-status-warning);
+}
+
+.building-credit__result--high {
+  border-left-color: var(--semantic-status-negative);
+}
+
+.building-credit__result--unknown {
+  border-left-color: var(--semantic-status-info);
+}
+
+.building-credit__result-heading {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+
+.building-credit__result-icon {
+  flex-shrink: 0;
+}
+
+.building-credit__result--good .building-credit__result-icon {
+  color: var(--semantic-status-positive);
+}
+
+.building-credit__result--caution .building-credit__result-icon {
+  color: var(--semantic-status-warning);
+}
+
+.building-credit__result--high .building-credit__result-icon {
+  color: var(--semantic-status-negative);
+}
+
+.building-credit__result--unknown .building-credit__result-icon {
+  color: var(--semantic-status-info);
+}
+
+.building-credit__result-headline {
+  font-weight: 600;
+  margin: 0;
+}
+
+.building-credit__badge {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-sm, 6px);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  margin-left: auto;
+  padding: 2px var(--spacing-2);
+}
+
+.building-credit__utilization-figure {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  margin: 0;
+}
+
+.building-credit__utilization-percent {
+  font-size: var(--type-scale-display-font-size);
+  font-weight: var(--type-scale-display-font-weight);
+}
+
+.building-credit__utilization-detail {
+  color: var(--semantic-text-secondary);
+}
+
+.building-credit__meter {
+  background: var(--semantic-surface-secondary, var(--semantic-border-default));
+  border-radius: var(--radius-pill, 999px);
+  height: 10px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.building-credit__meter-fill {
+  border-radius: inherit;
+  height: 100%;
+  transition: width 320ms ease;
+}
+
+.building-credit__meter--static .building-credit__meter-fill {
+  transition: none;
+}
+
+.building-credit__meter-fill--good {
+  background: var(--semantic-status-positive);
+}
+
+.building-credit__meter-fill--caution {
+  background: var(--semantic-status-warning);
+}
+
+.building-credit__meter-fill--high {
+  background: var(--semantic-status-negative);
+}
+
+.building-credit__meter-fill--unknown {
+  background: var(--semantic-status-info);
+}
+
+.building-credit__guidance {
+  margin: 0;
+}
+
+.building-credit__pay-down {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  margin: 0;
+}
+
+.building-credit__pay-down-row {
+  align-items: baseline;
+  display: flex;
+  gap: var(--spacing-2);
+  justify-content: space-between;
+}
+
+.building-credit__pay-down-label {
+  color: var(--semantic-text-secondary);
+  margin: 0;
+}
+
+.building-credit__pay-down-value {
+  font-weight: 600;
+  margin: 0;
+}
+
+/* -- Lessons ----------------------------------------------------------- */
+
+.building-credit__lessons {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.building-credit__lesson {
+  border-top: 1px solid var(--semantic-border-default);
+  padding-top: var(--spacing-4);
+}
+
+.building-credit__lesson:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.building-credit__lesson-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.building-credit__lesson-title {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  margin: 0;
+}
+
+.building-credit__lesson-summary {
+  color: var(--semantic-text-secondary);
+  font-weight: 600;
+  margin: 0;
+}
+
+.building-credit__lesson-text {
+  margin: 0;
+  max-width: 72ch;
+}
+
+.building-credit__lesson-takeaway {
+  align-items: flex-start;
+  background: var(--semantic-surface-secondary, transparent);
+  border-radius: var(--radius-md);
+  display: flex;
+  gap: var(--spacing-2);
+  margin: 0;
+  padding: var(--spacing-2) var(--spacing-3);
+}
+
+.building-credit__lesson-takeaway-icon {
+  color: var(--semantic-status-positive);
+  flex-shrink: 0;
+  margin-top: 3px;
+}
+
+.building-credit__lesson-takeaway-label {
+  font-weight: 600;
+}
+
+/* -- Quick tips -------------------------------------------------------- */
+
+.building-credit__tips {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.building-credit__tip {
+  align-items: flex-start;
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+.building-credit__tip-icon {
+  color: var(--semantic-status-positive);
+  flex-shrink: 0;
+  margin-top: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .building-credit__meter-fill {
+    transition: none;
+  }
+}

--- a/apps/web/src/pages/BuildingCreditPage.test.tsx
+++ b/apps/web/src/pages/BuildingCreditPage.test.tsx
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for BuildingCreditPage.
+ *
+ * Covers: accessible structure (landmark, headings, labeled inputs), the
+ * lessons content, and the secured-card utilization tracker reacting to
+ * balance/limit input with the correct classification and guidance.
+ *
+ * References: issue #2174
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { BuildingCreditPage } from './BuildingCreditPage';
+
+describe('BuildingCreditPage', () => {
+  it('renders an accessible main landmark and page heading', () => {
+    render(<BuildingCreditPage />);
+
+    expect(screen.getByRole('main', { name: 'Building credit' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Building credit' })).toBeInTheDocument();
+  });
+
+  it('labels every tracker input for assistive technology', () => {
+    render(<BuildingCreditPage />);
+
+    expect(screen.getByLabelText('Current balance')).toBeInTheDocument();
+    expect(screen.getByLabelText('Credit limit')).toBeInTheDocument();
+    expect(screen.getByLabelText('Target utilization')).toBeInTheDocument();
+  });
+
+  it('prompts for a limit before one is entered', () => {
+    render(<BuildingCreditPage />);
+
+    expect(screen.getByText('Add your credit limit to see utilization')).toBeInTheDocument();
+    expect(screen.getByText('Add a limit')).toBeInTheDocument();
+  });
+
+  it('computes utilization and classification from balance and limit', () => {
+    render(<BuildingCreditPage />);
+
+    fireEvent.change(screen.getByLabelText('Current balance'), { target: { value: '150' } });
+    fireEvent.change(screen.getByLabelText('Credit limit'), { target: { value: '500' } });
+
+    // 150 / 500 = 30% -> caution
+    expect(screen.getByText('Getting high')).toBeInTheDocument();
+    expect(
+      screen.getByText('Your utilization is creeping up at 30%'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('meter', { name: 'Credit utilization' })).toHaveAttribute(
+      'aria-valuenow',
+      '30',
+    );
+  });
+
+  it('classifies a low balance as on track', () => {
+    render(<BuildingCreditPage />);
+
+    fireEvent.change(screen.getByLabelText('Current balance'), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText('Credit limit'), { target: { value: '500' } });
+
+    // 50 / 500 = 10% -> good
+    expect(screen.getByText('On track')).toBeInTheDocument();
+  });
+
+  it('warns and shows a pay-down amount for high utilization', () => {
+    render(<BuildingCreditPage />);
+
+    fireEvent.change(screen.getByLabelText('Current balance'), { target: { value: '400' } });
+    fireEvent.change(screen.getByLabelText('Credit limit'), { target: { value: '500' } });
+
+    // 400 / 500 = 80% -> high; pay down to 30% (=$150) -> $250.00
+    expect(screen.getByText('Too high')).toBeInTheDocument();
+    expect(screen.getByText('$250.00')).toBeInTheDocument();
+  });
+
+  it('renders the beginner credit lessons as headings', () => {
+    render(<BuildingCreditPage />);
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'What a credit score is' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Why utilization matters' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'How secured cards build credit' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/BuildingCreditPage.test.tsx
+++ b/apps/web/src/pages/BuildingCreditPage.test.tsx
@@ -46,9 +46,7 @@ describe('BuildingCreditPage', () => {
 
     // 150 / 500 = 30% -> caution
     expect(screen.getByText('Getting high')).toBeInTheDocument();
-    expect(
-      screen.getByText('Your utilization is creeping up at 30%'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Your utilization is creeping up at 30%')).toBeInTheDocument();
     expect(screen.getByRole('meter', { name: 'Credit utilization' })).toHaveAttribute(
       'aria-valuenow',
       '30',

--- a/apps/web/src/pages/BuildingCreditPage.tsx
+++ b/apps/web/src/pages/BuildingCreditPage.tsx
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * BuildingCreditPage - beginner credit education plus a secured-card
+ * utilization tracker for someone building credit from zero.
+ *
+ * Two parts, both fully on-device:
+ *   1. Plain-language lessons: what a credit score is, why utilization
+ *      matters, on-time payments and how secured cards build credit.
+ *   2. A secured-card utilization tracker: enter your balance and limit to
+ *      see your utilization, a friendly classification (good / caution /
+ *      high) and guidance toward a low target.
+ *
+ * All money is integer cents via the pure helper in
+ * `lib/credit/secured-card-utilization`. Status is conveyed by text plus
+ * icon, never colour alone, and the meter respects reduced motion.
+ *
+ * References: issue #2174
+ */
+
+import { useMemo, useState } from 'react';
+
+import { Icon } from '../components/common';
+import { IconToken } from '../icons/tokens';
+import { useReducedMotion } from '../hooks/useReducedMotion';
+import { formatCurrency } from '../lib/currency';
+import {
+  CREDIT_BUILDING_LESSONS,
+  CREDIT_BUILDING_TIPS,
+} from '../lib/credit/credit-building-education';
+import {
+  computeSecuredCardUtilization,
+  formatUtilizationPercent,
+  type SecuredCardUtilizationLevel,
+} from '../lib/credit/secured-card-utilization';
+
+import './BuildingCreditPage.css';
+
+const PAGE_DESCRIPTION =
+  'New to credit? Start here. Learn how credit works in plain language, then use the secured card tracker to keep your utilization low. Everything stays on your device.';
+
+const TRACKER_INTRO =
+  'Enter your card balance and credit limit to see how much of your limit you are using. Keeping this low helps your credit grow.';
+
+const NO_LIMIT_DETAIL = 'Utilization is not available until you add a credit limit.';
+
+const TARGET_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 30, label: '30% (lender comfort zone)' },
+  { value: 20, label: '20% (stronger)' },
+  { value: 10, label: '10% (best)' },
+];
+
+const LEVEL_ICON: Record<SecuredCardUtilizationLevel, IconToken> = {
+  good: IconToken.SUCCESS,
+  caution: IconToken.WARNING,
+  high: IconToken.WARNING,
+  unknown: IconToken.INFO,
+};
+
+/** Parse a user-entered dollar string into integer cents (>= 0). */
+function dollarsToCents(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 0;
+  }
+  return Math.round(parsed * 100);
+}
+
+export function BuildingCreditPage() {
+  const reducedMotion = useReducedMotion();
+
+  const [balanceInput, setBalanceInput] = useState('');
+  const [limitInput, setLimitInput] = useState('');
+  const [targetPercent, setTargetPercent] = useState(30);
+
+  const utilization = useMemo(
+    () =>
+      computeSecuredCardUtilization({
+        balanceCents: dollarsToCents(balanceInput),
+        creditLimitCents: dollarsToCents(limitInput),
+        targetUtilizationPercent: targetPercent,
+      }),
+    [balanceInput, limitInput, targetPercent],
+  );
+
+  const hasLimit = utilization.utilizationPercent !== null;
+  const meterPercent =
+    utilization.utilizationPercent === null
+      ? 0
+      : Math.min(100, Math.max(0, utilization.utilizationPercent));
+
+  const statusIcon = LEVEL_ICON[utilization.level];
+  const resultClassName = `building-credit__result building-credit__result--${utilization.level}`;
+  const meterClassName = reducedMotion
+    ? 'building-credit__meter building-credit__meter--static'
+    : 'building-credit__meter';
+  const meterFillClassName = `building-credit__meter-fill building-credit__meter-fill--${utilization.level}`;
+  const utilizationLabel = formatUtilizationPercent(utilization.utilizationPercent);
+  const meterValueText = `${utilizationLabel} of credit limit used`;
+  const usageDetail = hasLimit
+    ? `${formatCurrency(utilization.balanceCents)} of ${formatCurrency(utilization.creditLimitCents)} used`
+    : NO_LIMIT_DETAIL;
+  const showPayDown = hasLimit && utilization.payDownToTargetCents > 0;
+
+  return (
+    <main className="building-credit" aria-labelledby="building-credit-title">
+      <header className="building-credit__header">
+        <p className="building-credit__eyebrow">Building credit from zero</p>
+        <h1 id="building-credit-title" className="building-credit__title">
+          Building credit
+        </h1>
+        <p className="building-credit__description">{PAGE_DESCRIPTION}</p>
+      </header>
+
+      <section className="building-credit__card" aria-labelledby="building-credit-tracker-title">
+        <h2 id="building-credit-tracker-title" className="building-credit__card-title">
+          Secured card utilization tracker
+        </h2>
+        <p className="building-credit__card-intro">{TRACKER_INTRO}</p>
+
+        <div className="building-credit__fields">
+          <div className="building-credit__field">
+            <label className="building-credit__label" htmlFor="building-credit-balance">
+              Current balance
+            </label>
+            <div className="building-credit__money-input">
+              <span className="building-credit__money-prefix" aria-hidden="true">
+                $
+              </span>
+              <input
+                id="building-credit-balance"
+                className="building-credit__input"
+                type="number"
+                inputMode="decimal"
+                min="0"
+                step="0.01"
+                placeholder="150.00"
+                value={balanceInput}
+                onChange={(changeEvent) => setBalanceInput(changeEvent.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="building-credit__field">
+            <label className="building-credit__label" htmlFor="building-credit-limit">
+              Credit limit
+            </label>
+            <div className="building-credit__money-input">
+              <span className="building-credit__money-prefix" aria-hidden="true">
+                $
+              </span>
+              <input
+                id="building-credit-limit"
+                className="building-credit__input"
+                type="number"
+                inputMode="decimal"
+                min="0"
+                step="0.01"
+                placeholder="500.00"
+                value={limitInput}
+                onChange={(changeEvent) => setLimitInput(changeEvent.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="building-credit__field">
+            <label className="building-credit__label" htmlFor="building-credit-target">
+              Target utilization
+            </label>
+            <select
+              id="building-credit-target"
+              className="building-credit__input"
+              value={targetPercent}
+              onChange={(changeEvent) => setTargetPercent(Number(changeEvent.target.value))}
+            >
+              {TARGET_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className={resultClassName} role="status">
+          <div className="building-credit__result-heading">
+            <Icon name={statusIcon} className="building-credit__result-icon" aria-hidden="true" />
+            <p className="building-credit__result-headline">{utilization.headline}</p>
+            <span className="building-credit__badge">{utilization.levelLabel}</span>
+          </div>
+
+          <p className="building-credit__utilization-figure">
+            <span className="building-credit__utilization-percent">{utilizationLabel}</span>
+            <span className="building-credit__utilization-detail">{usageDetail}</span>
+          </p>
+
+          {hasLimit && (
+            <div
+              className={meterClassName}
+              role="meter"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Math.round(meterPercent)}
+              aria-valuetext={meterValueText}
+              aria-label="Credit utilization"
+            >
+              <div className={meterFillClassName} style={{ width: `${meterPercent}%` }} />
+            </div>
+          )}
+
+          <p className="building-credit__guidance">{utilization.guidance}</p>
+
+          {showPayDown && (
+            <dl className="building-credit__pay-down">
+              <div className="building-credit__pay-down-row">
+                <dt className="building-credit__pay-down-label">
+                  Pay down to reach {utilization.targetUtilizationPercent}%
+                </dt>
+                <dd className="building-credit__pay-down-value">
+                  {formatCurrency(utilization.payDownToTargetCents)}
+                </dd>
+              </div>
+              {utilization.targetBalanceCents !== null && (
+                <div className="building-credit__pay-down-row">
+                  <dt className="building-credit__pay-down-label">Target balance</dt>
+                  <dd className="building-credit__pay-down-value">
+                    {formatCurrency(utilization.targetBalanceCents)} or less
+                  </dd>
+                </div>
+              )}
+            </dl>
+          )}
+        </div>
+      </section>
+
+      <section className="building-credit__card" aria-labelledby="building-credit-lessons-title">
+        <h2 id="building-credit-lessons-title" className="building-credit__card-title">
+          Credit basics
+        </h2>
+        <ol className="building-credit__lessons">
+          {CREDIT_BUILDING_LESSONS.map((lesson) => {
+            const headingId = `lesson-${lesson.id}`;
+            return (
+              <li key={lesson.id} className="building-credit__lesson">
+                <article className="building-credit__lesson-body" aria-labelledby={headingId}>
+                  <h3 id={headingId} className="building-credit__lesson-title">
+                    {lesson.title}
+                  </h3>
+                  <p className="building-credit__lesson-summary">{lesson.summary}</p>
+                  <p className="building-credit__lesson-text">{lesson.body}</p>
+                  <p className="building-credit__lesson-takeaway">
+                    <Icon
+                      name={IconToken.CHECK}
+                      size={16}
+                      className="building-credit__lesson-takeaway-icon"
+                      aria-hidden="true"
+                    />
+                    {`Takeaway: ${lesson.takeaway}`}
+                  </p>
+                </article>
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+
+      <section className="building-credit__card" aria-labelledby="building-credit-tips-title">
+        <h2 id="building-credit-tips-title" className="building-credit__card-title">
+          Quick tips
+        </h2>
+        <ul className="building-credit__tips">
+          {CREDIT_BUILDING_TIPS.map((tip) => (
+            <li key={tip.id} className="building-credit__tip">
+              <Icon
+                name={IconToken.SUCCESS}
+                size={16}
+                className="building-credit__tip-icon"
+                aria-hidden="true"
+              />
+              <span>{tip.text}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}
+
+export default BuildingCreditPage;

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -75,6 +75,7 @@ const NetWorth = lazy(() => import('./pages/NetWorthPage'));
 const Subscriptions = lazy(() => import('./pages/SubscriptionsPage'));
 const BankConnections = lazy(() => import('./pages/BankConnectionsPage'));
 const Debt = lazy(() => import('./pages/DebtPage'));
+const BuildingCredit = lazy(() => import('./pages/BuildingCreditPage'));
 const FirePlanner = lazy(() => import('./pages/FirePlannerPage'));
 const Remittances = lazy(() => import('./pages/RemittancesPage'));
 const ExpectedIncome = lazy(() => import('./pages/ExpectedIncomePage'));
@@ -386,6 +387,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Debt">
             <Debt />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/building-credit"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Building Credit">
+            <BuildingCredit />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Summary

Adds a beginner-friendly **Building Credit** experience (web slice of #2174) for a newcomer building credit from zero: plain-language credit lessons plus a deterministic secured-card utilization tracker.

## What's included

- **Secured-card utilization helper** ( + apps/web/src/lib/credit/secured-card-utilization.ts + ): pure, deterministic. Given balance + credit limit (integer cents) it computes utilization %, classifies it (good < 30%, caution 30-50%, high > 50%, unknown when limit is 0), and produces plain-language guidance toward a target utilization (default 30%). Safe divide-by-zero (limit 0 -> N/A), 0-balance, and over-limit cases handled. Reuses the existing  + calculateCreditUtilizationSummary +  engine math (no duplication) and the shared currency formatter.
- **Beginner credit-building education module** ( + apps/web/src/lib/credit/credit-building-education.ts + ): a small structured, testable set of plain-language lessons (what a credit score is, why utilization matters, on-time payments, how secured cards build credit, credit history takes time) and quick tips.
- **Accessible Building Credit page** ( + apps/web/src/pages/BuildingCreditPage.tsx + ) at  + /building-credit + , reachable from the Plan nav group: semantic headings, labeled inputs, keyboard-operable tracker, status conveyed by text + icon (not color alone),  + role=meter +  for utilization,  + role=status +  result region, and reduced-motion support. WCAG 2.2 AA oriented.
- **Vitest unit tests** colocated as  + *.test.ts(x) +  covering utilization math, classification thresholds, 0-limit / 0-balance / over-limit, guidance selection, lesson data integrity, and page rendering/a11y.

## Notes

- Lazy-loaded as its own route chunk (imports new components directly) to respect the per-chunk perf budget.
- TypeScript data path unchanged; no business logic added outside existing engines (reuses them).

Refs #2174