### PR TITLE
docs(skills): complete skills audit - mapping, schema, coverage (#2970)

### DIFF
--- a/.github/agents/accessibility-reviewer.agent.md
+++ b/.github/agents/accessibility-reviewer.agent.md
@@ -22,6 +22,8 @@ tools:
 
 You ensure every Finance interface is usable by everyone, regardless of ability. You review UI code across all four platforms for WCAG 2.2 AA compliance, screen reader support, keyboard navigation, color contrast, and motion sensitivity. Accessibility ships with every feature — it is never deferred.
 
+> **Related skills:** `accessibility-testing`, `ux-testing`, `design-tokens` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - WCAG 2.2 AA/AAA audit across iOS (VoiceOver), Android (TalkBack), Web (NVDA/JAWS), Windows (Narrator)

--- a/.github/agents/ai-ops-engineer.agent.md
+++ b/.github/agents/ai-ops-engineer.agent.md
@@ -23,6 +23,8 @@ tools:
 
 You design, maintain, and evaluate the AI agent fleet that builds Finance. You own the agent, skill, instruction, and prompt configuration under `.github/`, the capability manifest, and the conventions that keep every agent's ownership, tools, and permissions internally consistent and non-overlapping. You are the steward of how the fleet reasons, what each agent may touch, and how changes are evaluated.
 
+> **Related skills:** `prompt-engineering`, `mcp-agent-tooling`, `issue-management` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Agent definition authoring (`.agent.md`) with consistent frontmatter schema

--- a/.github/agents/android-engineer.agent.md
+++ b/.github/agents/android-engineer.agent.md
@@ -20,6 +20,8 @@ tools:
 
 You build and maintain the Android and Wear OS clients for Finance using Jetpack Compose and Material 3. You integrate KMP shared business logic as direct Kotlin dependencies, implement biometric auth via Android Keystore, and ensure full TalkBack accessibility across all screens.
 
+> **Related skills:** `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Jetpack Compose UI with Material 3 dynamic theming (Material You)

--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -20,6 +20,8 @@ tools:
 
 You design and maintain Finance's system architecture, ensuring edge-first computation, privacy by design, and native platform experiences. You define package boundaries, design the sync protocol, evaluate technology choices, and document decisions as Architecture Decision Records.
 
+> **Related skills:** `kmp-development`, `edge-sync`, `supabase-powersync`, `security-review-methodology` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Monorepo architecture and package boundary design

--- a/.github/agents/backend-engineer.agent.md
+++ b/.github/agents/backend-engineer.agent.md
@@ -20,6 +20,8 @@ tools:
 
 You own the sync layer connecting edge clients to the cloud — Supabase (PostgreSQL, Auth, Edge Functions, RLS) and the PowerSync sync engine. You ensure data flows securely between devices and server with zero data loss, proper tenant isolation, and reversible migrations.
 
+> **Related skills:** `supabase-powersync`, `edge-sync`, `security-review-methodology`, `privacy-compliance` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - PostgreSQL schema design (integer cents, proper types, audit trails)

--- a/.github/agents/business-analyst.agent.md
+++ b/.github/agents/business-analyst.agent.md
@@ -21,6 +21,8 @@ tools:
 
 You define pricing strategy, benchmark against competitors, model revenue, and design freemium tier boundaries for Finance. You bridge the gap between product vision and sustainable business outcomes while maintaining the privacy-first, no-ads monetization model.
 
+> **Related skills:** `monetization`, `go-to-market`, `project-management` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Freemium tier design and feature gating strategy

--- a/.github/agents/data-engineer.agent.md
+++ b/.github/agents/data-engineer.agent.md
@@ -25,6 +25,8 @@ tools:
 
 You design the privacy-preserving analytics that tell the team whether Finance works for users — without ever compromising the privacy-first promise. You own the event schemas, the metrics catalog, and the taxonomy. Every event is consent-gated, free of PII and raw financial data, and aggregated by design. You define the schema; the owning agents emit and store it.
 
+> **Related skills:** `privacy-compliance`, `financial-modeling`, `supabase-powersync` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Event schema and taxonomy design (names, properties, versioning)

--- a/.github/agents/design-engineer.agent.md
+++ b/.github/agents/design-engineer.agent.md
@@ -20,6 +20,8 @@ tools:
 
 You define, maintain, and evolve the design token system, component specifications, and visual language that ensure a consistent, accessible, and platform-native experience across iOS, Android, Web, and Windows. Tokens are the single source of truth for all visual properties.
 
+> **Related skills:** `design-tokens`, `accessibility-testing`, `i18n-localization` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Design tokens following the DTCG JSON specification

--- a/.github/agents/devops-engineer.agent.md
+++ b/.github/agents/devops-engineer.agent.md
@@ -26,6 +26,8 @@ tools:
 
 You design, build, and maintain the CI/CD pipelines, release automation, and infrastructure tooling for Finance's Turborepo monorepo. You ensure fast, reliable, and secure delivery across all four platforms with affected-only testing and aggressive caching.
 
+> **Related skills:** `fleet-orchestration`, `performance-budgets`, `mcp-agent-tooling`, `dev-onboarding` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - GitHub Actions workflow authoring (reusable workflows, matrix builds, path-based filtering)

--- a/.github/agents/docs-writer.agent.md
+++ b/.github/agents/docs-writer.agent.md
@@ -21,6 +21,8 @@ tools:
 
 You create, maintain, and improve all project documentation so that both human developers and AI agents can effectively understand and contribute to the Finance monorepo. Documentation ships alongside code — never after.
 
+> **Related skills:** `dev-onboarding`, `project-management`, `prompt-engineering` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Technical writing and documentation architecture

--- a/.github/agents/experimentation-engineer.agent.md
+++ b/.github/agents/experimentation-engineer.agent.md
@@ -20,6 +20,8 @@ tools:
 
 You own the feature-flag lifecycle and the experimentation system for Finance — staged rollouts, A/B tests, holdouts, and kill switches. You decide _how_ a change reaches users (dark launch → internal → percentage ramp → 100% → cleanup) and read out whether it worked. You define the flag and the rollout strategy; the owning feature team builds behind the flag, @data-engineer designs the success metrics, and @devops-engineer wires the validation CI. Experiments are privacy-first: users are never bucketed on PII or raw financial data.
 
+> **Related skills:** `edge-sync`, `privacy-compliance`, `financial-modeling` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Feature-flag definition and lifecycle (creation, rollout %, expiry, cleanup, flag-debt control)

--- a/.github/agents/finance-domain.agent.md
+++ b/.github/agents/finance-domain.agent.md
@@ -20,6 +20,8 @@ tools:
 
 You ensure all financial logic in Finance is correct, complete, and follows industry best practices. You bridge financial concepts and software implementation — advising on budgeting methodologies, transaction categorization, goal tracking, and multi-currency handling.
 
+> **Related skills:** `financial-modeling`, `edge-sync`, `privacy-compliance` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Budgeting methodologies (envelope/zero-based, 50/30/20, pay-yourself-first)

--- a/.github/agents/ios-engineer.agent.md
+++ b/.github/agents/ios-engineer.agent.md
@@ -20,6 +20,8 @@ tools:
 
 You implement and maintain the native Apple platform experience for Finance across iPhone, iPad, Mac, Apple Watch, and App Clips. All platform code lives in `apps/ios/`. You use SwiftUI exclusively, integrate KMP shared logic via XCFramework, and ensure VoiceOver accessibility on every screen.
 
+> **Related skills:** `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - SwiftUI with `@Observable` (Observation framework, iOS 17+) for all view models

--- a/.github/agents/kmp-engineer.agent.md
+++ b/.github/agents/kmp-engineer.agent.md
@@ -22,6 +22,8 @@ tools:
 
 You are the subject-matter expert on all Kotlin Multiplatform shared code in `packages/`. You design, implement, and maintain the shared business logic, database schemas, networking layer, and Gradle build configuration that powers every client platform (iOS, Android, Web, Windows).
 
+> **Related skills:** `kmp-development`, `edge-sync`, `financial-modeling`, `supabase-powersync` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - KMP project configuration (commonMain, iosMain, androidMain, jvmMain, jsMain)

--- a/.github/agents/localization-engineer.agent.md
+++ b/.github/agents/localization-engineer.agent.md
@@ -21,6 +21,8 @@ tools:
 
 You make Finance correct and natural in every supported locale. You own the source-of-truth locale catalogs and the financial-terminology glossary, and you ensure money, dates, and numbers format per locale convention. Financial terms are precise and consistent across languages — a mistranslated "balance" or "credit" can mislead users about their money, so terminology accuracy is a correctness concern, not just polish.
 
+> **Related skills:** `i18n-localization`, `financial-modeling`, `design-tokens` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Internationalization (i18n) key design tied to the KMP `Strings` expect/actual pattern

--- a/.github/agents/marketing-strategist.agent.md
+++ b/.github/agents/marketing-strategist.agent.md
@@ -21,6 +21,8 @@ tools:
 
 You develop go-to-market strategy, craft brand messaging, optimize app store presence, and drive user acquisition for Finance — all while maintaining the project's privacy-first, non-manipulative values. No dark patterns, no guilt-based upsells, no deceptive growth tactics.
 
+> **Related skills:** `go-to-market`, `monetization`, `i18n-localization` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - App Store Optimization (ASO) for iOS, Android, Web, and Windows stores

--- a/.github/agents/performance-engineer.agent.md
+++ b/.github/agents/performance-engineer.agent.md
@@ -21,6 +21,8 @@ tools:
 
 You own the performance budgets and the methodology for measuring, profiling, and regression-testing Finance across all four platforms. You quantify startup time, memory, frame rate, bundle size, and sync latency, then translate findings into concrete optimizations that the owning platform agents implement. You measure first; you never optimize on a hunch.
 
+> **Related skills:** `performance-budgets`, `kmp-development`, `edge-sync` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Performance budget definition and enforcement (`performance.budget.json`)

--- a/.github/agents/product-manager.agent.md
+++ b/.github/agents/product-manager.agent.md
@@ -21,6 +21,8 @@ tools:
 
 You own the product roadmap, plan sprints, triage issues, groom the backlog, and coordinate work across all agent types so that engineering, design, and business priorities stay aligned. Every sprint includes both engineering and business tasks.
 
+> **Related skills:** `project-management`, `sprint-planning`, `issue-management`, `fleet-orchestration` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Product roadmap and milestone management

--- a/.github/agents/qa-tester.agent.md
+++ b/.github/agents/qa-tester.agent.md
@@ -21,6 +21,8 @@ tools:
 
 You orchestrate interactive testing sessions where a human tests the app while you investigate bugs, file issues, and guide what to test next. You are a **session orchestrator**, not a backlog owner — you handle live bug intake and immediate investigation, then hand off to the product-manager for prioritization and sprint planning.
 
+> **Related skills:** `ux-testing`, `issue-management`, `accessibility-testing` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Guide humans through structured testing scenarios

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -23,6 +23,8 @@ tools:
 
 You coordinate releases across all four platforms. You manage Changesets and semantic versioning, author release notes and changelogs, sequence the release, and prepare (but never execute) store submissions. You ensure every release is traceable, reversible in intent, and gated on the go/no-go criteria before anything ships.
 
+> **Related skills:** `project-management`, `sprint-planning`, `dev-onboarding` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Changesets workflow (per-package semver, `.changeset/` entries, version PRs)

--- a/.github/agents/security-reviewer.agent.md
+++ b/.github/agents/security-reviewer.agent.md
@@ -20,6 +20,8 @@ tools:
 
 You identify and prevent security vulnerabilities, privacy violations, and compliance issues before they reach production. For a financial app handling sensitive personal and financial data, security is non-negotiable. You review code, audit artifacts, and can directly fix CRITICAL/HIGH severity issues.
 
+> **Related skills:** `security-review-methodology`, `privacy-compliance`, `supabase-powersync`, `edge-sync` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - OWASP Top 10 and SANS Top 25 vulnerability assessment

--- a/.github/agents/web-engineer.agent.md
+++ b/.github/agents/web-engineer.agent.md
@@ -20,6 +20,8 @@ tools:
 
 You build and maintain the Progressive Web App for Finance using React 19 and TypeScript. You ensure offline-first capability via SQLite-WASM (OPFS), accessible interfaces with ARIA, secure client-side data handling with Web Crypto, and seamless integration with KMP shared logic through the `src/kmp/` bridge.
 
+> **Related skills:** `performance-budgets`, `accessibility-testing`, `financial-modeling`, `edge-sync` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - React 19 hooks-only data architecture (useAccounts, useTransactions, etc.)

--- a/.github/agents/windows-engineer.agent.md
+++ b/.github/agents/windows-engineer.agent.md
@@ -20,6 +20,8 @@ tools:
 
 You build and maintain the Windows desktop client for Finance using Compose Desktop (JVM target). Windows is a first-class beta target — the architecture mirrors Android: Koin 4.0.1 for DI, ViewModel pattern for state management, Repository pattern for data access, and KMP shared packages for all business logic.
 
+> **Related skills:** `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
 ## Capabilities
 
 - Compose Desktop (JVM target) UI development

--- a/.github/skills/dev-onboarding/SKILL.md
+++ b/.github/skills/dev-onboarding/SKILL.md
@@ -8,6 +8,17 @@ description: >
 
 # Developer Onboarding Skill
 
+## Purpose
+
+This skill covers **developer environment setup and onboarding** — prerequisites, first-time setup, local scripts, Husky/lint-staged guardrails, and troubleshooting day-one tooling. Deeper platform build config and multi-agent operations belong to the related skills below.
+
+## Out of Scope
+
+- KMP source-set layout, Gradle targets, and SQLDelight config → use `kmp-development`.
+- Supabase local stack, RLS, and Edge Functions → use `supabase-powersync`.
+- MCP server wiring and agent tool permissions → use `mcp-agent-tooling`.
+- Sprint planning, agent dispatch, CI healing, and merges → use `sprint-planning` and `fleet-orchestration`.
+
 ## Prerequisites
 
 | Tool           | Version | Purpose                 |

--- a/.github/skills/financial-modeling/SKILL.md
+++ b/.github/skills/financial-modeling/SKILL.md
@@ -9,6 +9,17 @@ description: >
 
 # Financial Modeling Skill
 
+## Purpose
+
+This skill covers **financial calculation and domain modeling** — money representation in cents, currency handling, budgeting models, transaction and recurring processing, goal tracking, net-worth/reporting, and data-export semantics. Sync transport, backend schema, and pricing live in the related skills below.
+
+## Out of Scope
+
+- Offline sync, mutation queues, and conflict resolution → use `edge-sync`.
+- PostgreSQL schema, RLS, migrations, and Edge Functions → use `supabase-powersync`.
+- Kotlin source-set layout, SQLDelight syntax, and Gradle targets → use `kmp-development`.
+- Pricing tiers, IAP, and subscription entitlements → use `monetization`.
+
 ## Money Representation — The Golden Rule
 
 **Never use floating-point for money.** All monetary values are `Long` cents.

--- a/.github/skills/fleet-orchestration/SKILL.md
+++ b/.github/skills/fleet-orchestration/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: fleet-orchestration
 description: >
-  Fleet orchestration for parallel multi-agent sprint execution. Use when
-  deploying multiple agents across worktrees, planning sprints, or
-  coordinating parallel PR workflows.
+  Fleet orchestration for parallel multi-agent sprint execution. Use for
+  topics related to deploying multiple agents across worktrees, sprint
+  dispatch, worktree coordination, parallel PR workflows, CI self-healing,
+  or merge ordering.
 ---
 
 # Fleet Orchestration Skill
@@ -34,25 +35,38 @@ Proven across **3 waves, 140+ PRs, 17 sprints per agent type** for dispatch, CI 
 
 ### Engineering Agents
 
-| Agent              | File Ownership                     | Definition                                 |
-| ------------------ | ---------------------------------- | ------------------------------------------ |
-| `android-engineer` | `apps/android/**`                  | `.github/agents/android-engineer.agent.md` |
-| `ios-engineer`     | `apps/ios/**`                      | `.github/agents/ios-engineer.agent.md`     |
-| `web-engineer`     | `apps/web/**`                      | `.github/agents/web-engineer.agent.md`     |
-| `windows-engineer` | `apps/windows/**`                  | `.github/agents/windows-engineer.agent.md` |
-| `kmp-engineer`     | `packages/**`                      | `.github/agents/kmp-engineer.agent.md`     |
-| `backend-engineer` | `services/**`                      | `.github/agents/backend-engineer.agent.md` |
-| `devops-engineer`  | `.github/workflows/**`, `tools/**` | `.github/agents/devops-engineer.agent.md`  |
-| `design-engineer`  | `config/tokens/**`                 | `.github/agents/design-engineer.agent.md`  |
-| `docs-writer`      | `docs/**`, root `*.md`             | `.github/agents/docs-writer.agent.md`      |
-| `architect`        | Cross-cutting, ADRs                | `.github/agents/architect.agent.md`        |
+| Agent                      | File Ownership                                                        | Definition                                         |
+| -------------------------- | --------------------------------------------------------------------- | -------------------------------------------------- |
+| `android-engineer`         | `apps/android/**`                                                     | `.github/agents/android-engineer.agent.md`         |
+| `ios-engineer`             | `apps/ios/**`                                                         | `.github/agents/ios-engineer.agent.md`             |
+| `web-engineer`             | `apps/web/**`                                                         | `.github/agents/web-engineer.agent.md`             |
+| `windows-engineer`         | `apps/windows/**`                                                     | `.github/agents/windows-engineer.agent.md`         |
+| `kmp-engineer`             | `packages/**`                                                         | `.github/agents/kmp-engineer.agent.md`             |
+| `backend-engineer`         | `services/**`                                                         | `.github/agents/backend-engineer.agent.md`         |
+| `devops-engineer`          | `.github/workflows/**`, `tools/**`                                    | `.github/agents/devops-engineer.agent.md`          |
+| `design-engineer`          | `config/tokens/**`                                                    | `.github/agents/design-engineer.agent.md`          |
+| `docs-writer`              | `docs/**`, root `*.md`                                                | `.github/agents/docs-writer.agent.md`              |
+| `architect`                | Cross-cutting, ADRs                                                   | `.github/agents/architect.agent.md`                |
+| `finance-domain`           | `packages/core/**` (business logic, shared with `kmp-engineer`)       | `.github/agents/finance-domain.agent.md`           |
+| `performance-engineer`     | `performance.budget.json`, `docs/performance/**`                      | `.github/agents/performance-engineer.agent.md`     |
+| `data-engineer`            | `docs/analytics/**`, `config/analytics/**`, `docs/business/growth/**` | `.github/agents/data-engineer.agent.md`            |
+| `localization-engineer`    | `config/i18n/**`, `docs/i18n/**`                                      | `.github/agents/localization-engineer.agent.md`    |
+| `experimentation-engineer` | `config/feature-flags/**`                                             | `.github/agents/experimentation-engineer.agent.md` |
 
 ### Review Agents (read-only — never own implementation)
 
-| Agent                    | Purpose                     |
-| ------------------------ | --------------------------- |
-| `security-reviewer`      | Security and privacy audits |
-| `accessibility-reviewer` | WCAG 2.2 AA compliance      |
+| Agent                    | Purpose                                               |
+| ------------------------ | ----------------------------------------------------- |
+| `security-reviewer`      | Security and privacy audits (may fix CRITICAL/HIGH)   |
+| `accessibility-reviewer` | WCAG 2.2 AA compliance                                |
+| `qa-tester`              | Live QA + bug discovery; files issues (no code edits) |
+
+### Ops & Meta Agents
+
+| Agent             | Purpose                                                                                |
+| ----------------- | -------------------------------------------------------------------------------------- |
+| `release-manager` | Changesets, versioning, release notes, store-submission prep                           |
+| `ai-ops-engineer` | Owns `.github/agents/`, `.github/skills/`, `.github/instructions/`, `.github/prompts/` |
 
 ### Business Agents
 
@@ -64,21 +78,29 @@ Proven across **3 waves, 140+ PRs, 17 sprints per agent type** for dispatch, CI 
 
 ### Label-to-Agent Mapping
 
-| Label                    | Agent                    |
-| ------------------------ | ------------------------ |
-| `platform:android`       | `android-engineer`       |
-| `platform:ios`           | `ios-engineer`           |
-| `platform:web`           | `web-engineer`           |
-| `platform:windows`       | `windows-engineer`       |
-| `platform:shared`, `kmp` | `kmp-engineer`           |
-| `backend`, `supabase`    | `backend-engineer`       |
-| `ci`, `devops`           | `devops-engineer`        |
-| `docs`, `documentation`  | `docs-writer`            |
-| `security`, `privacy`    | `security-reviewer`      |
-| `a11y`, `accessibility`  | `accessibility-reviewer` |
-| `product`, `roadmap`     | `product-manager`        |
-| `marketing`, `launch`    | `marketing-strategist`   |
-| `business`, `pricing`    | `business-analyst`       |
+| Label                        | Agent                      |
+| ---------------------------- | -------------------------- |
+| `platform:android`           | `android-engineer`         |
+| `platform:ios`               | `ios-engineer`             |
+| `platform:web`               | `web-engineer`             |
+| `platform:windows`           | `windows-engineer`         |
+| `platform:shared`, `kmp`     | `kmp-engineer`             |
+| `backend`, `supabase`        | `backend-engineer`         |
+| `ci`, `devops`               | `devops-engineer`          |
+| `docs`, `documentation`      | `docs-writer`              |
+| `security`, `privacy`        | `security-reviewer`        |
+| `a11y`, `accessibility`      | `accessibility-reviewer`   |
+| `qa`, `testing`              | `qa-tester`                |
+| `product`, `roadmap`         | `product-manager`          |
+| `marketing`, `launch`        | `marketing-strategist`     |
+| `business`, `pricing`        | `business-analyst`         |
+| `performance`                | `performance-engineer`     |
+| `i18n`, `localization`       | `localization-engineer`    |
+| `analytics`, `metrics`       | `data-engineer`            |
+| `experiment`, `feature-flag` | `experimentation-engineer` |
+| `release`                    | `release-manager`          |
+| `agent`, `skill`, `prompt`   | `ai-ops-engineer`          |
+| `finance`, `domain`          | `finance-domain`           |
 
 ## Wave Sizing (Proven Metrics)
 

--- a/.github/skills/go-to-market/SKILL.md
+++ b/.github/skills/go-to-market/SKILL.md
@@ -2,11 +2,22 @@
 name: go-to-market
 description: >
   Go-to-market strategy, marketing, and launch planning for the Finance app.
-  Use for app store optimization, launch communications, content strategy, user
-  acquisition, and growth planning.
+  Use for topics related to app store optimization, launch communications,
+  content strategy, user acquisition, or growth planning.
 ---
 
 # Go-to-Market Skill
+
+## Purpose
+
+This skill covers **go-to-market strategy** — App Store Optimization, launch communications, content strategy, privacy-first messaging, and growth/acquisition planning across all four platforms. Pricing mechanics and delivery tracking belong to the related skills below.
+
+## Out of Scope
+
+- Pricing tiers, IAP, subscriptions, and revenue analytics → use `monetization`.
+- Issue lifecycle, milestones, and release tracking → use `project-management`.
+- Privacy claims and regulatory wording that messaging relies on → use `privacy-compliance`.
+- Localized store copy and financial terminology → use `i18n-localization`.
 
 **Current state**: 15+ marketing docs delivered across ASO, launch comms, content strategy, and premium messaging. All four platforms (iOS, Android, Web, Windows) are first-class beta targets.
 

--- a/.github/skills/monetization/SKILL.md
+++ b/.github/skills/monetization/SKILL.md
@@ -1,10 +1,21 @@
 ---
 name: monetization
 description: >
-  Monetization strategy, pricing, and subscription management for the Finance app. Use for freemium tier design, IAP implementation, pricing analysis, revenue optimization, and subscription lifecycle.
+  Monetization strategy, pricing, and subscription management for the Finance app. Use for topics related to freemium tier design, IAP implementation, pricing analysis, revenue optimization, or subscription lifecycle.
 ---
 
 # Monetization Skill
+
+## Purpose
+
+This skill covers **monetization and subscription management** — freemium tier boundaries, platform IAP integration, cross-platform entitlement sync, pricing analysis, and revenue metrics. Marketing reach and on-device financial math belong to the related skills below.
+
+## Out of Scope
+
+- ASO, launch comms, and content/growth strategy → use `go-to-market`.
+- Budgets, cents math, reports, and export → use `financial-modeling`.
+- Entitlement sync transport, RLS, and Edge Functions → use `supabase-powersync`.
+- Privacy-as-premium claims and regulatory basis → use `privacy-compliance`.
 
 ## Validated Pricing
 

--- a/.github/skills/performance-budgets/SKILL.md
+++ b/.github/skills/performance-budgets/SKILL.md
@@ -64,3 +64,7 @@ This skill covers **performance budget definition, regression triage, and accept
 - Regression issues include the failing route, metric, actual value, budget value, and likely owner path.
 - Fixes preserve accessibility and privacy; do not remove skeletons, labels, or secure checks solely for speed.
 - Bundle increases justify any new dependency and confirm it is route-split where possible.
+
+## Checklist
+
+Apply [`WEB_CHECKLIST.md`](./WEB_CHECKLIST.md) when triaging or signing off a web performance-budget change.

--- a/.github/skills/privacy-compliance/SKILL.md
+++ b/.github/skills/privacy-compliance/SKILL.md
@@ -8,6 +8,17 @@ description: >
 
 # Privacy Compliance Skill
 
+## Purpose
+
+This skill covers **privacy regulation and data protection** — GDPR/CCPA obligations, consent, data export/portability, deletion and crypto-shredding, encryption requirements, and privacy-review triggers for a financial app. Implementation of sync, backend, and security internals belongs to the related skills below.
+
+## Out of Scope
+
+- Offline sync and client mutation handling → use `edge-sync`.
+- Supabase RLS, Edge Functions, and migration mechanics → use `supabase-powersync`.
+- Security-review methodology, threat modeling, and OWASP MASVS → use `security-review-methodology`.
+- Pricing of privacy-premium tiers → use `monetization`.
+
 ## Privacy Architecture Advantage
 
 Finance's edge-first architecture provides **structural privacy** — not just policy-based:

--- a/.github/skills/project-management/SKILL.md
+++ b/.github/skills/project-management/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: project-management
 description: >
-  Project management patterns for the Finance monorepo. Use for issue lifecycle,
-  roadmap planning, milestone tracking, backlog grooming, release management,
-  and cross-team coordination.
+  Project management patterns for the Finance monorepo. Use for topics related
+  to issue lifecycle, roadmap planning, milestone tracking, backlog grooming,
+  release management, or cross-team coordination.
 ---
 
 # Project Management Skill

--- a/.github/skills/security-review-methodology/SKILL.md
+++ b/.github/skills/security-review-methodology/SKILL.md
@@ -81,3 +81,7 @@ This skill covers **how to perform high-signal security and privacy reviews** fo
 - Logs include request bodies, transaction details, balances, tokens, or export payloads.
 - Client stores tokens or financial secrets outside platform secure storage / approved encrypted layers.
 - Offline mutation replay can duplicate transfers, bypass validation, or resurrect soft-deleted records.
+
+## Checklist
+
+Apply [`CHECKLIST.md`](./CHECKLIST.md) as the sign-off gate for every security review.

--- a/.github/skills/sprint-planning/SKILL.md
+++ b/.github/skills/sprint-planning/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: sprint-planning
 description: >
-  Sprint planning and backlog management for multi-agent development. Use when
-  planning sprints, prioritizing issues, decomposing work, or balancing
-  workloads across agent types.
+  Sprint planning and backlog management for multi-agent development. Use for
+  topics related to sprint planning, prioritizing issues, decomposing work, or
+  balancing workloads across agent types.
 ---
 
 # Sprint Planning Skill
@@ -67,6 +67,14 @@ gh issue list --state open --json number,title,labels,milestone --limit 100
 | `monetization`, `pricing`                   | `business-analyst`                        |
 | `marketing`, `launch`, `growth`             | `marketing-strategist`                    |
 | `roadmap`, `planning`, `triage`             | `product-manager`                         |
+| `performance`                               | `performance-engineer`                    |
+| `i18n`, `localization`                      | `localization-engineer`                   |
+| `analytics`, `metrics`                      | `data-engineer`                           |
+| `experiment`, `feature-flag`                | `experimentation-engineer`                |
+| `release`                                   | `release-manager`                         |
+| `qa`, `testing`                             | `qa-tester`                               |
+| `agent`, `skill`, `prompt`                  | `ai-ops-engineer`                         |
+| `finance`, `domain`                         | `finance-domain`                          |
 
 ### Step 3: Handle ambiguity
 

--- a/docs/ai/skills.md
+++ b/docs/ai/skills.md
@@ -12,7 +12,44 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 ## Available Skills
 
-> **Source of truth:** the directories under [`.github/skills/`](../../.github/skills/). As of 2026-06 there are **20** skills. This page describes the established skills in detail; skills added in 2026-06 — `accessibility-testing`, `security-review-methodology`, `design-tokens`, `performance-budgets`, `i18n-localization`, `mcp-agent-tooling`, and `prompt-engineering` — are listed in [Agent Instructions](agent-instructions.md#agent-skills). A generated `ai-manifest` is planned to keep these counts in sync — see the [CHANGELOG](CHANGELOG.md).
+> **Source of truth:** the directories under [`.github/skills/`](../../.github/skills/). As of 2026-06 there are **20** skills, each detailed below in alphabetical order. The generated `ai-manifest` check keeps these counts in sync (`npm run ai:manifest:check`) — see the [CHANGELOG](CHANGELOG.md).
+
+### `accessibility-testing` — Accessibility Testing (WCAG 2.2 AA)
+
+**File:** `.github/skills/accessibility-testing/SKILL.md`
+
+**Trigger keywords:** WCAG 2.2 AA, a11y testing, screen readers, keyboard navigation, focus management, contrast, reduced motion, TalkBack, VoiceOver, Narrator, inclusive QA
+
+**Knowledge areas:**
+
+- Repo-specific accessibility surfaces across the four platforms
+- Test methodology (keyboard, screen reader, contrast, reduced motion)
+- Per-platform a11y checklist (TalkBack, VoiceOver, Narrator)
+- Acceptance criteria for accessibility issues
+
+**Supporting files:** `.github/skills/accessibility-testing/CHECKLIST.md` — per-platform sign-off checklist
+
+**When activated:** Whenever an agent validates accessibility, screen-reader support, keyboard navigation, or WCAG compliance.
+
+---
+
+### `design-tokens` — Design Token System
+
+**File:** `.github/skills/design-tokens/SKILL.md`
+
+**Trigger keywords:** DTCG tokens, Style Dictionary, color tokens, semantic tokens, component tokens, chart palettes, typography, spacing, motion, contrast, theming, generated token outputs
+
+**Knowledge areas:**
+
+- DTCG token model (core, semantic, and component layers)
+- Style Dictionary configuration and generated outputs
+- Repo-specific token paths
+- Token authoring rules
+- Finance-specific checks (chart palettes, contrast)
+
+**When activated:** Whenever an agent works on design tokens, theming, color systems, or Style Dictionary outputs.
+
+---
 
 ### `dev-onboarding` — Developer Environment Setup
 
@@ -87,7 +124,7 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 **Knowledge areas:**
 
-- Agent type registry (15 agents: engineering, review, business)
+- Agent type registry (23 agents: engineering, review, ops/meta, business)
 - Label-to-agent mapping for issue routing
 - Sprint planning algorithm (query → categorize → deps → group → track)
 - Fleet dispatch protocol with background task parallelism
@@ -122,6 +159,45 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 ---
 
+### `i18n-localization` — Internationalization & Localization
+
+**File:** `.github/skills/i18n-localization/SKILL.md`
+
+**Trigger keywords:** i18n, localization, translations, locale packs, string keys, currency/date/number formatting, pluralization, text expansion, right-to-left readiness, financial terminology
+
+**Knowledge areas:**
+
+- Repo-specific i18n paths and locale catalogs
+- String key naming rules
+- Financial formatting rules (currency, date, number, pluralization)
+- Localization review checklist
+
+**Supporting files:** `.github/skills/i18n-localization/CHECKLIST.md` — localization review checklist
+
+**When activated:** Whenever an agent works on translations, locale formatting, string keys, or RTL readiness.
+
+---
+
+### `issue-management` — Issue Quality & Cross-Platform Scoping
+
+**File:** `.github/skills/issue-management/SKILL.md`
+
+**Trigger keywords:** issue filing, bug reports, platform scoping, cross-platform duplicates, label taxonomy, issue quality
+
+**Knowledge areas:**
+
+- Canonical label taxonomy and platform labels
+- Cross-platform scoping decision tree (when to create platform duplicates)
+- Mandatory pre-filing validation gate
+- Issue body quality standards (bug and enhancement templates)
+- Duplicate identification and linking
+- PowerShell-safe / Node-based batch issue creation
+- Mandatory post-session audit
+
+**When activated:** Whenever an agent files issues, scopes work across platforms, or manages duplicates.
+
+---
+
 ### `kmp-development` — Kotlin Multiplatform Development
 
 **File:** `.github/skills/kmp-development/SKILL.md`
@@ -150,6 +226,23 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 ---
 
+### `mcp-agent-tooling` — MCP & Agent Tooling
+
+**File:** `.github/skills/mcp-agent-tooling/SKILL.md`
+
+**Trigger keywords:** Model Context Protocol, MCP servers, .vscode/mcp.json, Copilot tools, agent scripts, tool permissions, token scopes, workspace filesystem access, safe agent automation
+
+**Knowledge areas:**
+
+- Current MCP servers and their configuration (`.vscode/mcp.json`)
+- Repo-specific tooling paths
+- Safe tooling rules (tool permissions, token scopes, filesystem boundary)
+- Review checklist for MCP changes
+
+**When activated:** Whenever an agent works on MCP servers, agent tool configuration, or tool permissions.
+
+---
+
 ### `monetization` — Pricing & Subscription Management
 
 **File:** `.github/skills/monetization/SKILL.md`
@@ -168,6 +261,26 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 - Offline grace period for subscriptions
 
 **When activated:** Whenever an agent works on monetization, pricing strategy, or subscription management.
+
+---
+
+### `performance-budgets` — Performance Budgets
+
+**File:** `.github/skills/performance-budgets/SKILL.md`
+
+**Trigger keywords:** Lighthouse, Core Web Vitals, LCP, INP, CLS, TBT, bundle budgets, lazy chunks, route budgets, startup performance, service workers, performance regression triage
+
+**Knowledge areas:**
+
+- Web PWA route and bundle budgets (`performance.budget.json`, Lighthouse CI)
+- Current Web budget targets (LCP, INP, CLS, TBT, JS gzip ceilings)
+- Repo-specific budget tools and checkers
+- Regression triage workflow
+- Acceptance criteria for performance issues
+
+**Supporting files:** `.github/skills/performance-budgets/WEB_CHECKLIST.md` — web performance-budget sign-off checklist
+
+**When activated:** Whenever an agent works on performance budgets, Core Web Vitals, bundle size, or regression triage.
 
 ---
 
@@ -214,6 +327,42 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 ---
 
+### `prompt-engineering` — Prompt Engineering
+
+**File:** `.github/skills/prompt-engineering/SKILL.md`
+
+**Trigger keywords:** prompt design, reusable prompts, Copilot instructions, agent handoffs, context packaging, task decomposition prompts, review prompts, reducing ambiguity
+
+**Knowledge areas:**
+
+- Repo-specific prompt assets (`.github/prompts/`)
+- Prompt shape for Finance work (goal, context, owned files, tasks, validation, completion)
+- Prompt quality rules
+- Anti-patterns to avoid
+
+**When activated:** Whenever an agent designs prompts, authors Copilot instructions, or packages context for agent handoffs.
+
+---
+
+### `security-review-methodology` — Security & Privacy Review
+
+**File:** `.github/skills/security-review-methodology/SKILL.md`
+
+**Trigger keywords:** threat modeling, OWASP MASVS, security review, vulnerability assessment, auth, crypto, RLS, Edge Functions, financial data exposure, secure logging, abuse prevention
+
+**Knowledge areas:**
+
+- Repo-specific security review surfaces (web, shared, sync crypto, backend functions, CI)
+- Review workflow (asset definition, trust boundaries, authZ, data minimization, crypto, abuse controls)
+- Finding template and severity/confidence classification
+- Red flags (service-role misuse, RLS gaps, sensitive logging, offline replay)
+
+**Supporting files:** `.github/skills/security-review-methodology/CHECKLIST.md` — security review sign-off checklist
+
+**When activated:** Whenever an agent performs a security or privacy review, threat models a change, or assesses financial-data risk.
+
+---
+
 ### `sprint-planning` — Sprint Planning & Backlog Management
 
 **File:** `.github/skills/sprint-planning/SKILL.md`
@@ -222,7 +371,7 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 **Knowledge areas:**
 
-- Issue categorization by agent type (15 agent types)
+- Issue categorization by agent type (23 agent types)
 - Sprint sizing (4–6 implementation + 1–2 business + 1 review)
 - Dependency detection and schema change serialization
 - Priority framework (P0–P3) with assignment rules
@@ -260,20 +409,75 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 ---
 
+### `ux-testing` — UX & QA Testing
+
+**File:** `.github/skills/ux-testing/SKILL.md`
+
+**Trigger keywords:** alpha testing, beta testing, QA, bug discovery, testing scenarios, manual testing, user experience validation
+
+**Knowledge areas:**
+
+- Testing session structure (setup, platform maturity, session flow)
+- Mandatory pre-filing gate (scope, code refs, duplicates, labels)
+- Bug investigation methodology and parallel dispatch
+- Ordered testing scenarios (auth, navigation, transactions, import, budgets/goals, charts, settings)
+- Severity classification and bug report template
+- PowerShell-safe batch issue filing and post-session audit
+
+**When activated:** Whenever an agent runs a live testing session, discovers bugs, or validates user experience.
+
+---
+
+## Skill ↔ Agent Mapping
+
+Each agent loads a focused set of skills for domain depth. The table below mirrors the **Related skills** line in every [`.github/agents/*.agent.md`](../../.github/agents/) file (the source of truth). Skills not listed for an agent still activate automatically when their trigger keywords match — this mapping captures the _primary_ skills each role should reach for.
+
+| Agent                      | Related skills                                                                         |
+| -------------------------- | -------------------------------------------------------------------------------------- |
+| `accessibility-reviewer`   | `accessibility-testing`, `ux-testing`, `design-tokens`                                 |
+| `ai-ops-engineer`          | `prompt-engineering`, `mcp-agent-tooling`, `issue-management`                          |
+| `android-engineer`         | `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens`      |
+| `architect`                | `kmp-development`, `edge-sync`, `supabase-powersync`, `security-review-methodology`    |
+| `backend-engineer`         | `supabase-powersync`, `edge-sync`, `security-review-methodology`, `privacy-compliance` |
+| `business-analyst`         | `monetization`, `go-to-market`, `project-management`                                   |
+| `data-engineer`            | `privacy-compliance`, `financial-modeling`, `supabase-powersync`                       |
+| `design-engineer`          | `design-tokens`, `accessibility-testing`, `i18n-localization`                          |
+| `devops-engineer`          | `fleet-orchestration`, `performance-budgets`, `mcp-agent-tooling`, `dev-onboarding`    |
+| `docs-writer`              | `dev-onboarding`, `project-management`, `prompt-engineering`                           |
+| `experimentation-engineer` | `edge-sync`, `privacy-compliance`, `financial-modeling`                                |
+| `finance-domain`           | `financial-modeling`, `edge-sync`, `privacy-compliance`                                |
+| `ios-engineer`             | `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens`      |
+| `kmp-engineer`             | `kmp-development`, `edge-sync`, `financial-modeling`, `supabase-powersync`             |
+| `localization-engineer`    | `i18n-localization`, `financial-modeling`, `design-tokens`                             |
+| `marketing-strategist`     | `go-to-market`, `monetization`, `i18n-localization`                                    |
+| `performance-engineer`     | `performance-budgets`, `kmp-development`, `edge-sync`                                  |
+| `product-manager`          | `project-management`, `sprint-planning`, `issue-management`, `fleet-orchestration`     |
+| `qa-tester`                | `ux-testing`, `issue-management`, `accessibility-testing`                              |
+| `release-manager`          | `project-management`, `sprint-planning`, `dev-onboarding`                              |
+| `security-reviewer`        | `security-review-methodology`, `privacy-compliance`, `supabase-powersync`, `edge-sync` |
+| `web-engineer`             | `performance-budgets`, `accessibility-testing`, `financial-modeling`, `edge-sync`      |
+| `windows-engineer`         | `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens`      |
+
+> This table mirrors the roster in [`agents.md`](agents.md) (**23 agents**). When you add or retire an agent, update both its `*.agent.md` **Related skills** line and this table so the two never drift.
+
+---
+
 ## Adding a New Skill
 
 1. Create a directory: `.github/skills/<skill-name>/`
-2. Create `SKILL.md` with YAML frontmatter:
+2. Create `SKILL.md` with YAML frontmatter (the `name` must match the directory):
    ```yaml
    ---
    name: skill-name
    description: >
-     Clear description with trigger keywords for when the skill should activate.
+     One-line summary, then "Use for topics related to <comma-separated
+     trigger keywords>." so the skill activates on the right work.
    ---
    ```
-3. Write comprehensive Markdown body with domain knowledge, patterns, examples, and guidelines
-4. Optionally add supporting files (scripts, templates, reference docs) in the skill directory
-5. Update this document (`docs/ai/skills.md`) with the new skill's details
+3. Start the body with `# <Skill Name> Skill`, then `## Purpose` and `## Out of Scope` (route adjacent concerns to related skills) before detailed guidance — see `.github/instructions/skills.instructions.md`
+4. Add domain knowledge, decision trees, checklists, and examples; prefer crisp tables over broad prose
+5. Optionally add supporting files (checklists, scripts, templates) in the skill directory and surface them in the entry above
+6. Update this document (`docs/ai/skills.md`) with the new skill's details, in alphabetical order
 
 ## Skill Naming Convention
 


### PR DESCRIPTION
﻿## Summary

Completes the **Area 2 (Skills)** pass of the AI-capabilities audit. Brings all 20 skills into schema compliance, completes the agent registry/label maps to the full 23-agent roster, and adds a first-class skill-to-agent mapping so every agent declares the skills it should reach for.

## Changes

**Skill schema & content (`.github/skills/`)**

- Backfilled `## Purpose` + `## Out of Scope` into 5 skills (dev-onboarding, financial-modeling, go-to-market, monetization, privacy-compliance)
- Standardized 5 divergent skill descriptions to the canonical "Use for topics related to ..." opener
- Completed the fleet-orchestration Agent Registry and sprint-planning label-to-agent map to all 23 agents
- Surfaced the 2 previously-orphaned bundled checklists (performance-budgets, security-review-methodology) via `## Checklist` sections

**Skill-to-agent cross-reference**

- Added a one-line **Related skills** callout to all 23 `.github/agents/*.agent.md` files
- Added a **Skill <-> Agent Mapping** table to `docs/ai/skills.md` mirroring those lines

**Catalog accuracy (`docs/ai/skills.md`)**

- Added the 9 missing skill entries (now all 20 documented, alphabetical)
- Fixed "15 agents" -> "23 agents" references; aligned the "Adding a New Skill" recipe with the Purpose/Out-of-Scope schema
- Restored alphabetical order (security-review-methodology before sprint-planning)

## Validation

- [x] `npm run format:check` - all files Prettier-clean
- [x] `npx eslint . --max-warnings 0` - clean
- [x] `node tools/check-ai-manifest.js` - no drift (23 agents / 20 skills)

## Issues

Closes #2970
