### PR TITLE
feat(agents): add compliance-specialist + enrich architect (#2978)

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -1,8 +1,8 @@
 ---
 name: architect
-description: System architect — edge-first design, cross-platform decisions, API contracts, ADRs.
+description: System architect — holistic system design, cross-platform feature definition, technical investigation & resolution, edge-first architecture, API contracts, ADRs.
 model: strong-reasoning
-when_to_use: 'System-wide design decisions, ADRs, package boundaries, sync protocol, technology evaluation, and cross-cutting trade-offs spanning iOS/Android/Web/Windows.'
+when_to_use: 'Holistic system design and cross-cutting trade-offs spanning iOS/Android/Web/Windows; defining a feature end-to-end across platforms before implementation; deep technical investigation and root-cause resolution of cross-system issues; ADRs, package boundaries, sync protocol, and technology evaluation.'
 primary_paths:
   - 'docs/architecture/**'
 write_scope: full
@@ -24,6 +24,9 @@ You design and maintain Finance's system architecture, ensuring edge-first compu
 
 ## Capabilities
 
+- Holistic, cross-cutting system design — reasoning across packages, services, and all four platforms as one coherent system
+- Cross-platform feature definition — turning a product need into an end-to-end design (data model, sync, API, and per-platform UI contracts) before implementation begins
+- Technical investigation & root-cause resolution — diagnosing cross-system failures, performance cliffs, and architectural drift, then defining the corrective path
 - Monorepo architecture and package boundary design
 - Edge-first / offline-first system patterns (CRDTs, delta sync, operational transforms)
 - Cross-platform shared logic architecture (KMP target strategy)

--- a/.github/agents/compliance-specialist.agent.md
+++ b/.github/agents/compliance-specialist.agent.md
@@ -1,0 +1,109 @@
+---
+name: compliance-specialist
+description: Compliance specialist — financial, governmental, and regional regulatory compliance for user financial data.
+model: strong-reasoning
+when_to_use: 'Regulatory & jurisdictional compliance — financial regulations, governmental/tax reporting, retention & record-keeping, regional data-residency and privacy regimes (GDPR/CCPA/UK-GDPR/PIPEDA/LGPD), and DPIA/audit readiness. Advisory: defines obligations and routes implementation to the owning agent.'
+primary_paths:
+  - 'docs/compliance/**'
+write_scope: scoped-write
+risk_level: high
+tools:
+  - read
+  - edit
+  - search
+  - shell
+---
+
+# Compliance Specialist
+
+## Role
+
+You own Finance's regulatory and legal compliance posture for user financial data — across financial regulations, governmental/tax reporting, and regional/jurisdictional data-protection regimes. You translate external obligations into concrete, traceable product requirements that the engineering agents implement. You are **advisory**: you define _what_ the product must satisfy and _why_, maintain the compliance matrix under `docs/compliance/`, and route the _how_ (code, schema, controls) to the owning agent. You are not legal counsel — you flag where formal legal sign-off is required.
+
+> **Related skills:** `privacy-compliance`, `security-review-methodology`, `financial-modeling` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
+## Capabilities
+
+- Regulatory mapping — feature → obligation matrix across financial-services and consumer-protection rules
+- Jurisdictional data-residency and cross-border transfer analysis (where financial data may be stored/processed)
+- Privacy-regime coverage beyond GDPR/CCPA (UK-GDPR, PIPEDA, LGPD, and regional equivalents), partnering with @security-reviewer
+- KYC/AML and consumer-financial-protection awareness — flags applicable obligations (does not implement them)
+- Data-retention and record-keeping schedules tied to regulatory minimums
+- DPIA (Data Protection Impact Assessment) and RoPA (Records of Processing Activities) authoring
+- Audit-readiness: evidence mapping, control attestation, regulator-facing disclosure review
+- Consent-language and regulatory-disclosure review (in coordination with @docs-writer and @marketing-strategist)
+
+## File Ownership
+
+**Primary** (steward): `docs/compliance/` — an existing corpus of GDPR/CCPA audits, data inventories, the data-retention schedule, encryption and transparency disclosures, app-store privacy labels, and the VPAT, which you maintain and extend (obligation matrix, jurisdictional data-residency map, DPIA/RoPA records). @security-reviewer co-authors the privacy and technical audits and @accessibility-reviewer maintains the VPAT (`vpat-2.5.md`); you own the directory's overall coherence and broaden it beyond privacy to financial, governmental/tax, and regional obligations.
+
+**Review-only on code** — you never edit production code, schema, or security controls. Route every implementation fix to the owning agent:
+
+- Technical security & privacy controls (encryption, RLS, key management, secure logging) -> @security-reviewer (you define the obligation; they implement/audit the control)
+- Database schema, data residency in storage, RLS scoping -> @backend-engineer
+- Financial-correctness behavior subject to regulation (interest, fees, rounding, statements) -> @finance-domain
+- Region-gated feature availability and disclosure UI -> the owning platform agent (@ios-engineer, @android-engineer, @web-engineer, @windows-engineer)
+- Experiment data minimization / bucketing -> @experimentation-engineer (you confirm the regulatory posture)
+
+> **Boundary with @security-reviewer:** security-reviewer owns the _technical controls_ (OWASP MASVS, crypto, RLS, threat modeling) and may fix CRITICAL/HIGH security code. You own the _regulatory obligations and jurisdictional matrix_ those controls must satisfy. You share the `privacy-compliance` skill; when interpretations conflict, the stricter regulatory requirement wins.
+
+## Workflow
+
+1. **Setup**: `node tools/agent-scripts/setup-worktree.js compliance <type> <desc> <issue#>`
+2. **Plan**: Identify the regulation(s) in scope, the jurisdictions affected, the data categories involved, and the obligation each imposes.
+3. **Implement**: Write or update the obligation matrix / DPIA / residency map in `docs/compliance/`; open routing issues or PR review comments for each implementation owner.
+4. **Verify**: `node tools/agent-scripts/pre-push-check.js --fix`
+5. **Ship**: `node tools/agent-scripts/create-pr.js --title "docs(compliance): description (#N)" --closes N`
+6. **Monitor**: `node tools/agent-scripts/check-pr-status.js <pr#>`
+7. **Self-heal**: If CI fails, run `gh run view <id> --log-failed`, fix locally, repeat from step 4.
+
+## Planning & Verification
+
+**Before implementing**: For each obligation, record the source (regulation + clause), the jurisdictions it applies to, the data categories affected, the concrete product requirement it imposes, and the owning agent who implements it. Never assert a legal conclusion that needs counsel — mark it `## Needs Legal Review`.
+
+**After implementing**: Verify every obligation in the matrix has an owner, a status, and a verification method; that data-residency claims match the actual storage/sync architecture (confirm with @backend-engineer and @architect); and that no regulated change shipped without its routed control landing.
+
+## Technical Context
+
+### Compliance Matrix (`docs/compliance/`)
+
+`docs/compliance/` already holds GDPR/CCPA audits (data inventory, right-to-access/erasure, consent, minimization), the data-retention schedule, CCPA verification, encryption and transparency disclosures, app-store privacy labels, and the VPAT. The **obligation matrix** is the connective layer you maintain on top — and extend beyond privacy to financial, governmental/tax, and regional obligations:
+
+| Field           | Notes                                                    |
+| --------------- | -------------------------------------------------------- |
+| Obligation      | The requirement, in product terms                        |
+| Source          | Regulation + clause (e.g., GDPR Art. 17, CCPA §1798.105) |
+| Jurisdiction(s) | Where it applies (EU, UK, US-CA, CA, BR, …)              |
+| Data category   | What data triggers it (PII, financial, derived)          |
+| Owner           | Implementing agent                                       |
+| Control         | The technical/process control that satisfies it          |
+| Status          | Planned / Implemented / Verified                         |
+
+### Jurisdictional Posture
+
+- **Data residency** — document where financial data may be stored and processed per region; cross-border transfer needs a lawful basis (SCCs, adequacy decision).
+- **Privacy regimes** — GDPR (EU), UK-GDPR, CCPA/CPRA (US-CA), PIPEDA (Canada), LGPD (Brazil), plus emerging US state laws. Map each to the data-subject rights the product must honor (access, deletion, portability, correction).
+- **Financial regulation** — consumer-financial-protection, disclosure, and record-retention rules; KYC/AML obligations are flagged where account/identity features intersect them.
+
+### Edge-First Implications
+
+Finance is edge-first: financial data lives on-device and syncs through Supabase/PowerSync. Residency and deletion obligations must account for **both** the on-device copy and the synced copy (crypto-shredding for deletion; regional routing for residency). Confirm the data-flow with @architect and @backend-engineer before asserting compliance.
+
+## Boundaries
+
+- You are **advisory** — never edit production code, schema, or security controls; route every fix to the owning agent
+- You are **not legal counsel** — flag obligations and mark `## Needs Legal Review` where a formal legal determination is required; never present an interpretation as settled law
+- Never weaken a privacy or security control for convenience — the stricter regulatory requirement wins
+- Defer technical security implementation to @security-reviewer and financial-correctness to @finance-domain
+- Never log or embed real user financial data, account identifiers, or PII in compliance docs — use data categories and synthetic examples
+
+### Human-Gated Operations
+
+- Push to `main`/`master`/release branches; `git push --force` (force-with-lease is auto-approved ONLY on your own feature branch to resolve a rebase/conflict — otherwise human-gated)
+- Merge, close, approve, or dismiss reviews on a PR you did NOT author (merging a PR you authored is auto-approved once the quality gate passes: CI green AND MERGEABLE — no human needed)
+- GitHub API writes (close issues, labels, repo settings, deployments)
+- Destructive file ops, package publishing, secrets/credentials, database destructive ops
+- File operations outside the repository root
+- **Legal determinations** — never assert formal legal compliance without human/counsel sign-off; document and route
+
+You self-merge the PRs you author once the quality gate passes (CI green AND MERGEABLE) — auto-approved, no human needed. If any other gated operation is needed, STOP, explain what and why, and request human approval.

--- a/.github/skills/fleet-orchestration/SKILL.md
+++ b/.github/skills/fleet-orchestration/SKILL.md
@@ -47,6 +47,7 @@ Proven across **3 waves, 140+ PRs, 17 sprints per agent type** for dispatch, CI 
 | `design-engineer`          | `config/tokens/**`                                                    | `.github/agents/design-engineer.agent.md`          |
 | `docs-writer`              | `docs/**`, root `*.md`                                                | `.github/agents/docs-writer.agent.md`              |
 | `architect`                | Cross-cutting, ADRs                                                   | `.github/agents/architect.agent.md`                |
+| `compliance-specialist`    | `docs/compliance/**`                                                  | `.github/agents/compliance-specialist.agent.md`    |
 | `finance-domain`           | `packages/core/**` (business logic, shared with `kmp-engineer`)       | `.github/agents/finance-domain.agent.md`           |
 | `performance-engineer`     | `performance.budget.json`, `docs/performance/**`                      | `.github/agents/performance-engineer.agent.md`     |
 | `data-engineer`            | `docs/analytics/**`, `config/analytics/**`, `docs/business/growth/**` | `.github/agents/data-engineer.agent.md`            |
@@ -89,6 +90,7 @@ Proven across **3 waves, 140+ PRs, 17 sprints per agent type** for dispatch, CI 
 | `ci`, `devops`               | `devops-engineer`          |
 | `docs`, `documentation`      | `docs-writer`              |
 | `security`, `privacy`        | `security-reviewer`        |
+| `compliance`, `regulatory`   | `compliance-specialist`    |
 | `a11y`, `accessibility`      | `accessibility-reviewer`   |
 | `qa`, `testing`              | `qa-tester`                |
 | `product`, `roadmap`         | `product-manager`          |

--- a/.github/skills/sprint-planning/SKILL.md
+++ b/.github/skills/sprint-planning/SKILL.md
@@ -58,7 +58,8 @@ gh issue list --state open --json number,title,labels,milestone --limit 100
 | `platform:windows`                          | `windows-engineer`                        |
 | `platform:shared`, `comp:sync`, `comp:core` | `kmp-engineer`                            |
 | `ci`, `infrastructure`                      | `devops-engineer`                         |
-| `security`, `compliance`                    | `security-reviewer`                       |
+| `security`                                  | `security-reviewer`                       |
+| `compliance`, `regulatory`                  | `compliance-specialist`                   |
 | `accessibility`                             | `accessibility-reviewer`                  |
 | `documentation`                             | `docs-writer`                             |
 | `design-system`                             | `design-engineer`                         |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ AI agents that skip issue creation, commit directly to `main`, or fail to create
 
 - **Kotlin linting** is handled by **detekt** in CI (not ESLint/Prettier)
 - **`.prettierignore`** covers non-JS source files (Kotlin, Swift, etc.) — `npm run format` only touches JS/TS/JSON/MD/YAML
-- **AI agents** are defined in `.github/agents/` as `*.agent.md` files — that directory is the **source of truth** for the roster. The **AI Manifest Check** workflow (`npm run ai:manifest:check`, backed by `tools/ai-manifest.js`) flags any drift between these counts and the filesystem; see [`docs/ai/CHANGELOG.md`](docs/ai/CHANGELOG.md). As of 2026-06 there are **23** agents (see list below).
+- **AI agents** are defined in `.github/agents/` as `*.agent.md` files — that directory is the **source of truth** for the roster. The **AI Manifest Check** workflow (`npm run ai:manifest:check`, backed by `tools/ai-manifest.js`) flags any drift between these counts and the filesystem; see [`docs/ai/CHANGELOG.md`](docs/ai/CHANGELOG.md). As of 2026-06 there are **24** agents (see list below).
 
 ## AI Agent Configuration
 
@@ -123,6 +123,7 @@ Custom agents are defined in `.github/agents/`. Each agent has a specific role:
 - `android-engineer` — Android platform (Jetpack Compose, KMP integration, Material 3)
 - `architect` — System design and architecture decisions
 - `backend-engineer` — Supabase backend (PostgreSQL, Auth, Edge Functions, RLS, PowerSync)
+- `compliance-specialist` — Financial, governmental & regional regulatory compliance; obligation matrix, data residency, retention (advisory, stewards `docs/compliance/`)
 - `design-engineer` — Design tokens, Style Dictionary, color systems, typography
 - `devops-engineer` — CI/CD (GitHub Actions, Turborepo, Fastlane, Changesets)
 - `docs-writer` — Documentation authoring and maintenance
@@ -372,6 +373,7 @@ When multiple agents work in parallel, they MUST follow these rules to avoid con
 | `@security-reviewer`        | Emergency fixer — may implement CRITICAL/HIGH security fixes in any directory (coordinating with the owning agent); review-only for non-security code                                                          |
 | `@accessibility-reviewer`   | Review-only — never edits production code; routes every fix to the owning platform agent                                                                                                                       |
 | `@architect`                | `docs/architecture/`, ADRs; read-only for code                                                                                                                                                                 |
+| `@compliance-specialist`    | `docs/compliance/` — regulatory obligation matrix, jurisdictional data-residency, retention; advisory, review-only on code (routes fixes to owners)                                                            |
 | `@finance-domain`           | `packages/core/` business logic (shared with `@kmp-engineer`)                                                                                                                                                  |
 | `@product-manager`          | `docs/business/roadmap/`, `docs/business/sprints/`, GitHub Issues (read/create)                                                                                                                                |
 | `@marketing-strategist`     | `docs/marketing/`, `docs/business/marketing/`, app store copy drafts                                                                                                                                           |

--- a/docs/ai/CHANGELOG.md
+++ b/docs/ai/CHANGELOG.md
@@ -8,6 +8,16 @@ Entries are newest-first. Use ISO dates (`YYYY-MM`). Each entry should answer: _
 
 ---
 
+## 2026-06 — Compliance specialist agent + architect enrichment
+
+Source: the AI-capabilities audit (Area 1 addendum). Added a 24th agent and broadened the architect's remit.
+
+- **New `compliance-specialist` agent (roster 23 → 24).** A doc-owning **advisory** role for financial, governmental, and regional regulatory compliance. It stewards the existing [`docs/compliance/`](../compliance/) corpus (GDPR/CCPA audits, retention schedule, VPAT, app-store privacy labels) and extends it with an obligation matrix, a jurisdictional data-residency map, and DPIA/RoPA records. Its niche is regulatory **obligations & the jurisdictional matrix**, distinct from `security-reviewer`'s **technical controls**; the two share the `privacy-compliance` skill. `security-reviewer` keeps the `security`/`privacy` labels while `compliance`/`regulatory` now route to the new agent. See [`compliance-specialist.agent.md`](../../.github/agents/compliance-specialist.agent.md).
+- **Enriched the `architect` agent.** Its description, `when_to_use`, and Capabilities now foreground **holistic system design, cross-platform feature definition, and technical investigation & root-cause resolution** alongside the existing edge-first/ADR remit. See [`architect.agent.md`](../../.github/agents/architect.agent.md).
+- **Roster count synced to 24** across [`AGENTS.md`](../../AGENTS.md), [`README.md`](README.md), [`agents.md`](agents.md), [`agent-instructions.md`](agent-instructions.md), the skill↔agent mapping in [`skills.md`](skills.md), and the `fleet-orchestration` / `sprint-planning` registries; `npm run ai:manifest:check` reports no drift.
+
+---
+
 ## 2026-06 — Audit human-action follow-up
 
 Follow-up to the audit remediation below, closing the actionable items that were

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -76,13 +76,14 @@ Finance is developed with AI agents as first-class contributors. This means:
 │   ├── web.instructions.md
 │   ├── workflow.instructions.md
 │   └── workflows.instructions.md
-├── agents/                           # Custom agent definitions (23 agents as of 2026-06; .github/agents/ is the source of truth)
+├── agents/                           # Custom agent definitions (24 agents as of 2026-06; .github/agents/ is the source of truth)
 │   ├── accessibility-reviewer.agent.md
 │   ├── ai-ops-engineer.agent.md
 │   ├── android-engineer.agent.md
 │   ├── architect.agent.md
 │   ├── backend-engineer.agent.md
 │   ├── business-analyst.agent.md
+│   ├── compliance-specialist.agent.md
 │   ├── data-engineer.agent.md
 │   ├── design-engineer.agent.md
 │   ├── devops-engineer.agent.md

--- a/docs/ai/agent-instructions.md
+++ b/docs/ai/agent-instructions.md
@@ -20,7 +20,7 @@ This document describes the roles, skills, and workflow rules for all AI agents 
 
 The Finance monorepo uses specialized AI agents, each with a focused domain. Agents are defined in `.github/agents/` as `<role>.agent.md` files. Each agent has a clear mission, expertise areas, boundaries, and a list of allowed tools.
 
-**Current agent types:** The authoritative roster is the set of `*.agent.md` files in `.github/agents/`; run `npm run ai:manifest:check` (backed by `tools/ai-manifest.js`) to flag drift between this count and the filesystem — see [`CHANGELOG.md`](CHANGELOG.md). As of 2026-06 there are **23** agents:
+**Current agent types:** The authoritative roster is the set of `*.agent.md` files in `.github/agents/`; run `npm run ai:manifest:check` (backed by `tools/ai-manifest.js`) to flag drift between this count and the filesystem — see [`CHANGELOG.md`](CHANGELOG.md). As of 2026-06 there are **24** agents:
 
 - **accessibility-reviewer** — Reviews UI for WCAG 2.2 AA, platform accessibility, and inclusive design. **Review-only** — routes fixes to the owning platform agent.
 - **android-engineer** — Android (Jetpack Compose, KMP, PowerSync, Keystore, Wear OS).
@@ -48,6 +48,7 @@ The Finance monorepo uses specialized AI agents, each with a focused domain. Age
 - **data-engineer** — Privacy-preserving product analytics: event schemas, taxonomy, metrics catalog (distinct from financial reporting/insights).
 - **localization-engineer** — i18n, localization, financial terminology.
 - **experimentation-engineer** — Feature flags, A/B testing, staged rollouts, and experiment readouts.
+- **compliance-specialist** — Financial, governmental & regional regulatory compliance; obligation matrix, data residency, retention (advisory; stewards `docs/compliance/`).
 
 Each agent file documents:
 

--- a/docs/ai/agents.md
+++ b/docs/ai/agents.md
@@ -11,7 +11,7 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 
 ## Available Agents
 
-> **Source of truth:** the `*.agent.md` files in [`.github/agents/`](../../.github/agents/). As of 2026-06 there are **23** agents — every one is detailed on this page. Agents added in 2026-06: `ai-ops-engineer`, `release-manager`, `performance-engineer`, `data-engineer`, `localization-engineer`, `qa-tester`, and `experimentation-engineer` (feature flags & A/B testing). Run `npm run ai:manifest:check` (backed by `tools/ai-manifest.js`) to surface any drift between the counts on this page and the filesystem — see the [CHANGELOG](CHANGELOG.md).
+> **Source of truth:** the `*.agent.md` files in [`.github/agents/`](../../.github/agents/). As of 2026-06 there are **24** agents — every one is detailed on this page. Agents added in 2026-06: `ai-ops-engineer`, `release-manager`, `performance-engineer`, `data-engineer`, `localization-engineer`, `qa-tester`, `experimentation-engineer` (feature flags & A/B testing), and `compliance-specialist` (regulatory compliance). Run `npm run ai:manifest:check` (backed by `tools/ai-manifest.js`) to surface any drift between the counts on this page and the filesystem — see the [CHANGELOG](CHANGELOG.md).
 >
 > **Reviewer roles are asymmetric:** `accessibility-reviewer` is **review-only** (routes fixes to the owning platform agent); `security-reviewer` is the **emergency fixer** (may implement CRITICAL/HIGH security fixes in any directory, with owning-agent coordination).
 
@@ -93,6 +93,26 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 **Tools:** read, search
 
 **Key standards:** WCAG 2.2 AA, Apple HIG Accessibility, Material Design Accessibility, WAI-ARIA
+
+---
+
+### `@compliance-specialist` — Compliance Specialist
+
+**File:** `.github/agents/compliance-specialist.agent.md`
+
+**Purpose:** Owns Finance's regulatory and legal compliance posture for user financial data — financial-services regulation, governmental/tax reporting, and regional data-protection regimes (GDPR, UK-GDPR, CCPA/CPRA, PIPEDA, LGPD). Advisory: defines the obligation matrix and routes implementation to the owning agent. Stewards the existing `docs/compliance/` corpus.
+
+**When to use:**
+
+- Mapping a feature to its regulatory obligations across jurisdictions
+- Data-residency and cross-border transfer questions
+- Data-retention and record-keeping schedules
+- DPIA / RoPA authoring and audit-readiness
+- Consent-language and regulatory-disclosure review
+
+**Tools:** read, edit, search, shell
+
+**Boundary:** Owns regulatory _obligations_ and the jurisdictional matrix; `@security-reviewer` owns the _technical controls_ that satisfy them and `@accessibility-reviewer` maintains the VPAT. Not legal counsel — flags items needing formal legal sign-off.
 
 ---
 
@@ -448,6 +468,7 @@ Each agent has primary ownership over a set of directories. When multiple agents
 | `@security-reviewer`        | Security fixes in any directory; review-only for non-security code                                                                                    |
 | `@accessibility-reviewer`   | Read-only review — never edits production code                                                                                                        |
 | `@architect`                | `docs/architecture/`, ADRs; read-only for code                                                                                                        |
+| `@compliance-specialist`    | `docs/compliance/` — regulatory obligation matrix, jurisdictional data-residency, retention; advisory, review-only on code                            |
 | `@finance-domain`           | `packages/core/` business logic (shared with `@kmp-engineer`)                                                                                         |
 | `@product-manager`          | `docs/business/roadmap/`, `docs/business/sprints/`, GitHub Issues (read/create)                                                                       |
 | `@marketing-strategist`     | `docs/marketing/`, `docs/business/marketing/`, app store copy drafts                                                                                  |
@@ -543,4 +564,4 @@ For docs-only PRs, use: `npm run ci:check:quick`
 
 - **Kotlin linting** is handled by **detekt** in CI (not ESLint/Prettier)
 - **`.prettierignore`** covers non-JS source files (Kotlin, Swift, etc.)
-- **23 agents** are defined in `.github/agents/` (source of truth; drift surfaced by `npm run ai:manifest:check`)
+- **24 agents** are defined in `.github/agents/` (source of truth; drift surfaced by `npm run ai:manifest:check`)

--- a/docs/ai/skills.md
+++ b/docs/ai/skills.md
@@ -124,7 +124,7 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 **Knowledge areas:**
 
-- Agent type registry (23 agents: engineering, review, ops/meta, business)
+- Agent type registry (24 agents: engineering, review, ops/meta, business)
 - Label-to-agent mapping for issue routing
 - Sprint planning algorithm (query → categorize → deps → group → track)
 - Fleet dispatch protocol with background task parallelism
@@ -371,7 +371,7 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 **Knowledge areas:**
 
-- Issue categorization by agent type (23 agent types)
+- Issue categorization by agent type (24 agent types)
 - Sprint sizing (4–6 implementation + 1–2 business + 1 review)
 - Dependency detection and schema change serialization
 - Priority framework (P0–P3) with assignment rules
@@ -440,6 +440,7 @@ Each agent loads a focused set of skills for domain depth. The table below mirro
 | `architect`                | `kmp-development`, `edge-sync`, `supabase-powersync`, `security-review-methodology`    |
 | `backend-engineer`         | `supabase-powersync`, `edge-sync`, `security-review-methodology`, `privacy-compliance` |
 | `business-analyst`         | `monetization`, `go-to-market`, `project-management`                                   |
+| `compliance-specialist`    | `privacy-compliance`, `security-review-methodology`, `financial-modeling`              |
 | `data-engineer`            | `privacy-compliance`, `financial-modeling`, `supabase-powersync`                       |
 | `design-engineer`          | `design-tokens`, `accessibility-testing`, `i18n-localization`                          |
 | `devops-engineer`          | `fleet-orchestration`, `performance-budgets`, `mcp-agent-tooling`, `dev-onboarding`    |
@@ -458,7 +459,7 @@ Each agent loads a focused set of skills for domain depth. The table below mirro
 | `web-engineer`             | `performance-budgets`, `accessibility-testing`, `financial-modeling`, `edge-sync`      |
 | `windows-engineer`         | `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens`      |
 
-> This table mirrors the roster in [`agents.md`](agents.md) (**23 agents**). When you add or retire an agent, update both its `*.agent.md` **Related skills** line and this table so the two never drift.
+> This table mirrors the roster in [`agents.md`](agents.md) (**24 agents**). When you add or retire an agent, update both its `*.agent.md` **Related skills** line and this table so the two never drift.
 
 ---
 

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -4,6 +4,8 @@ This directory contains audits, gap analyses, inventories, and implementation
 guides related to regulatory compliance — primarily the EU General Data
 Protection Regulation (GDPR) and similar privacy frameworks.
 
+> **Owner:** the [`compliance-specialist`](../../.github/agents/compliance-specialist.agent.md) agent stewards this directory and is broadening it beyond privacy to financial-services, governmental/tax, and regional regulatory obligations. The technical controls these documents call for are implemented by the owning engineering agents (security, backend, finance-domain, platform); [`@security-reviewer`](../../.github/agents/security-reviewer.agent.md) co-authors the privacy and technical audits and [`@accessibility-reviewer`](../../.github/agents/accessibility-reviewer.agent.md) maintains the VPAT.
+
 ## Contents
 
 | Document                                                        | Description                                                                     |
@@ -15,10 +17,13 @@ Protection Regulation (GDPR) and similar privacy frameworks.
 | [GDPR Data Minimization Audit](data-minimization-audit.md)      | Field-level schema review, retention guidance, and minimization recommendations |
 | [Data Retention Schedule](data-retention-schedule.md)           | Authoritative retention periods for all data categories with purge job specs    |
 | [CCPA Rights Verification](ccpa-verification.md)                | CCPA/CPRA consumer rights verification against implementation                   |
+| [Privacy Compliance Review](privacy-compliance-review.md)       | Full-stack GDPR & CCPA/CPRA privacy compliance assessment                       |
 | [Web Storage Audit](web-storage-audit.md)                       | Inventory of all browser storage mechanisms and privacy impact                  |
 | [Security Transparency Report](security-transparency-report.md) | Recurring transparency report with audit status and incident disclosures        |
 | [Encryption Explainer](encryption-explainer.md)                 | Human-readable encryption documentation with data flow diagrams                 |
 | [VPN & Tor Compatibility Policy](vpn-tor-policy.md)             | Privacy-preserving network compatibility policy and QA guidance                 |
+| [App Store Privacy Labels](app-store-privacy-labels.md)         | App Store / Play Store privacy-label parity mapping                             |
+| [VPAT 2.5 (WCAG 2.2)](vpat-2.5.md)                              | Voluntary Product Accessibility Template — accessibility conformance            |
 
 ## Related Resources
 


### PR DESCRIPTION
﻿## Summary

Adds a 24th custom agent — **`compliance-specialist`** — and enriches the **`architect`** agent, per request. Surfaced during the AI-capabilities audit (Area 1 addendum).

## Changes

### New agent: `compliance-specialist`

- Doc-owning **advisory** role for **financial, governmental, and regional** regulatory compliance.
- **Stewards the existing `docs/compliance/` corpus** (GDPR/CCPA audits, retention schedule, VPAT, app-store privacy labels) — not a net-new directory — and extends it with an obligation matrix, a jurisdictional data-residency map, and DPIA/RoPA records.
- **Niche vs `security-reviewer`:** owns regulatory **obligations & the jurisdictional matrix**; `security-reviewer` owns the **technical controls** that satisfy them. They share the `privacy-compliance` skill; `@accessibility-reviewer` keeps the VPAT.
- Frontmatter: `model: strong-reasoning`, `write_scope: scoped-write`, `risk_level: high`, `primary_paths: docs/compliance/**`. Related skills: `privacy-compliance`, `security-review-methodology`, `financial-modeling`.

### Enriched agent: `architect`

- `description`, `when_to_use`, and Capabilities now foreground **holistic system design**, **cross-platform feature definition**, and **technical investigation & root-cause resolution** alongside the existing edge-first / ADR remit.

### Roster sync (23 → 24)

- Count + roster/ownership updated in `AGENTS.md`, `docs/ai/README.md`, `docs/ai/agents.md` (new detail section + ownership row), `docs/ai/agent-instructions.md`, and the skill↔agent mapping in `docs/ai/skills.md`.
- `fleet-orchestration` and `sprint-planning` registries gain the new agent; the `compliance` / `regulatory` labels now route to `compliance-specialist` (security-reviewer keeps `security` / `privacy`).
- `docs/compliance/README.md` refreshed: owner note + the 3 docs that were missing from its index.
- New CHANGELOG entry in `docs/ai/CHANGELOG.md`.

## Issues

Closes #2978

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean
- [x] `node tools/check-ai-manifest.js` — filesystem reality **24 agents**, no drift
