### PR TITLE
feat(web): foreign-currency transaction entry with rate capture (#2202)

### DIFF
--- a/apps/web/src/components/forms/CurrencyFxSection.tsx
+++ b/apps/web/src/components/forms/CurrencyFxSection.tsx
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+/**
+ * Currency picker + foreign-exchange entry fields (issue #2202).
+ *
+ * Loaded lazily by {@link TransactionForm} so the currency option list, the
+ * exchange-rate markup, and the foreign-currency conversion math all stay out
+ * of the (saturated) shared route bundles. The transaction-currency picker is
+ * always shown here; the exchange-rate fields appear only when the chosen
+ * currency differs from the account's base currency.
+ *
+ * All durable state lives in the parent form; this component derives the live
+ * base-currency equivalent for display only (the parent recomputes it
+ * deterministically at submit via the same lazily-loaded `fx-convert` module).
+ */
+
+import { type ChangeEvent, useEffect } from 'react';
+
+import { formatCurrency } from '../../lib/currency';
+import { convertToBaseMinorUnits } from '../../lib/currency/fx-convert';
+import { getCurrencyDecimals } from '../../lib/currency/minor-units';
+import {
+  getCurrencyLabel,
+  getCurrencySymbol,
+  getEntryCurrencyOptions,
+  type FxCurrencyOption,
+} from '../../lib/currency/entry-currencies';
+
+export interface CurrencyFxSectionProps {
+  /** Effective entry currency ISO code (override, else the account's). */
+  readonly entryCurrencyCode: string;
+  /** ISO code of the base (account) currency the amount converts to. */
+  readonly baseCurrencyCode: string;
+  /** Called with the chosen ISO code when the currency picker changes. */
+  readonly onCurrencyChange: (code: string) => void;
+  /** Reports the entry currency's display symbol so the amount field can show it. */
+  readonly onEntrySymbolResolved: (symbol: string) => void;
+  /** Signed amount the user typed, in the entry currency's integer minor units. */
+  readonly originalMinorUnits: number;
+  /** Current raw exchange-rate input value (base units per 1 foreign unit). */
+  readonly exchangeRateInput: string;
+  /** Called with the new raw value when the rate input changes. */
+  readonly onExchangeRateChange: (value: string) => void;
+  /** The rate validation message, when present. */
+  readonly rateError?: string;
+  /** ISO-8601 timestamp the rate was captured, or `null`. */
+  readonly rateCapturedAt: string | null;
+}
+
+/** Format the captured exchange-rate timestamp for a human-readable hint. */
+function formatRateCaptureTime(iso: string | null): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
+
+/** Curated options plus the active entry/base codes if not already present. */
+function buildOptions(entryCurrencyCode: string, baseCurrencyCode: string): FxCurrencyOption[] {
+  const options = getEntryCurrencyOptions();
+  const ensurePresent = (code: string) => {
+    if (code && !options.some((option) => option.code === code)) {
+      options.unshift({
+        code,
+        decimalPlaces: getCurrencyDecimals(code),
+        label: getCurrencyLabel(code),
+      });
+    }
+  };
+  ensurePresent(entryCurrencyCode);
+  ensurePresent(baseCurrencyCode);
+  return options;
+}
+
+export default function CurrencyFxSection({
+  entryCurrencyCode,
+  baseCurrencyCode,
+  onCurrencyChange,
+  onEntrySymbolResolved,
+  originalMinorUnits,
+  exchangeRateInput,
+  onExchangeRateChange,
+  rateError,
+  rateCapturedAt,
+}: CurrencyFxSectionProps) {
+  // Report the entry-currency symbol up to the parent's amount field. Done here
+  // (not in the parent) so the `Intl` symbol path stays out of the route bundle.
+  useEffect(() => {
+    onEntrySymbolResolved(getCurrencySymbol(entryCurrencyCode));
+  }, [entryCurrencyCode, onEntrySymbolResolved]);
+
+  const options = buildOptions(entryCurrencyCode, baseCurrencyCode);
+  const isForeignEntry = entryCurrencyCode !== baseCurrencyCode;
+  const rate = Number.parseFloat(exchangeRateInput);
+  const hasValidExchangeRate = exchangeRateInput.trim() !== '' && Number.isFinite(rate) && rate > 0;
+  const hasRateError = Boolean(rateError);
+  const baseEquivalentMinorUnits = hasValidExchangeRate
+    ? convertToBaseMinorUnits({
+        originalMinorUnits,
+        originalDecimals: getCurrencyDecimals(entryCurrencyCode),
+        baseDecimals: getCurrencyDecimals(baseCurrencyCode),
+        rate,
+      })
+    : 0;
+
+  return (
+    <>
+      {/* Currency (defaults from account, overridable for foreign spend) */}
+      <div className="form-group">
+        <label htmlFor="txn-currency" className="form-group__label">
+          Currency
+        </label>
+        <p id="txn-currency-help" className="form-group__help">
+          Defaults to the account currency. Switch it to log spend in a local currency (e.g. THB,
+          MXN, JPY) with the exchange rate you were charged.
+        </p>
+        <select
+          id="txn-currency"
+          className="form-select"
+          value={entryCurrencyCode}
+          onChange={(event: ChangeEvent<HTMLSelectElement>) => onCurrencyChange(event.target.value)}
+          aria-describedby="txn-currency-help"
+        >
+          {options.map((option) => (
+            <option key={option.code} value={option.code}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Exchange rate + live base-currency equivalent (foreign spend only) */}
+      {isForeignEntry && (
+        <div className="form-group">
+          <label
+            htmlFor="txn-exchange-rate"
+            className="form-group__label form-group__label--required"
+          >
+            Exchange rate
+          </label>
+          <p id="txn-exchange-rate-help" className="form-group__help">
+            {`1 ${entryCurrencyCode} = ? ${baseCurrencyCode}. Enter the rate (including fees) your bank or card actually applied.`}
+          </p>
+          <input
+            id="txn-exchange-rate"
+            className={`form-input${hasRateError ? ' form-input--error' : ''}`}
+            type="text"
+            inputMode="decimal"
+            value={exchangeRateInput}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              onExchangeRateChange(event.target.value)
+            }
+            aria-invalid={hasRateError}
+            aria-describedby={`txn-exchange-rate-help txn-fx-equivalent${
+              hasRateError ? ' txn-exchange-rate-error' : ''
+            }`}
+            aria-required="true"
+            autoComplete="off"
+            placeholder="0.00"
+          />
+          {hasRateError && (
+            <span id="txn-exchange-rate-error" className="form-error" role="alert">
+              {rateError}
+            </span>
+          )}
+          <p id="txn-fx-equivalent" className="form-hint" aria-live="polite">
+            {hasValidExchangeRate
+              ? `Base-currency equivalent: ${formatCurrency(baseEquivalentMinorUnits, {
+                  currency: baseCurrencyCode,
+                })} ${baseCurrencyCode}`
+              : `Enter a rate to see the ${baseCurrencyCode} equivalent.`}
+            {hasValidExchangeRate && rateCapturedAt
+              ? ` · rate captured ${formatRateCaptureTime(rateCapturedAt)}`
+              : ''}
+          </p>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/forms/TransactionForm.test.tsx
+++ b/apps/web/src/components/forms/TransactionForm.test.tsx
@@ -445,3 +445,144 @@ describe('TransactionForm', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Foreign-currency entry (issue #2202)
+// ---------------------------------------------------------------------------
+
+describe('TransactionForm — foreign-currency entry', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function typeAmount(digits: string) {
+    const amountInput = screen.getByLabelText('Amount');
+    for (const digit of digits) {
+      fireEvent.keyDown(amountInput, { key: digit });
+    }
+  }
+
+  it('defaults the currency picker from the selected account and follows account changes', async () => {
+    renderTransactionForm();
+
+    // The currency picker + FX fields load lazily once the form opens.
+    const currencyPicker = (await screen.findByLabelText('Currency')) as HTMLSelectElement;
+    // No account selected yet: defaults to the USD base.
+    expect(currencyPicker.value).toBe('USD');
+
+    // Selecting the EUR account moves the (untouched) currency to EUR.
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-2' } });
+    expect(currencyPicker.value).toBe('EUR');
+    // Same currency as the account => no exchange-rate field (no extra friction).
+    expect(screen.queryByLabelText('Exchange rate')).not.toBeInTheDocument();
+
+    // Selecting the USD account moves it back to USD.
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-1' } });
+    expect(currencyPicker.value).toBe('USD');
+  });
+
+  it('reveals the exchange-rate field and announces the base equivalent for foreign spend', async () => {
+    renderTransactionForm();
+
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-1' } });
+    typeAmount('100000'); // ฿1,000.00 (THB has 2 decimals)
+
+    // Override the currency to THB (picker loads lazily).
+    fireEvent.change(await screen.findByLabelText('Currency'), { target: { value: 'THB' } });
+
+    const rateField = await screen.findByLabelText('Exchange rate');
+    expect(rateField).toBeInTheDocument();
+    expect(rateField).toHaveAttribute('aria-required', 'true');
+
+    // Before a rate is entered, the live region prompts for one.
+    const equivalent = document.getElementById('txn-fx-equivalent');
+    expect(equivalent).toHaveAttribute('aria-live', 'polite');
+    expect(equivalent).toHaveTextContent(/Enter a rate to see the USD equivalent/i);
+
+    // 1 THB = 0.029 USD -> 1000.00 THB = $29.00 USD.
+    fireEvent.change(rateField, { target: { value: '0.029' } });
+    expect(equivalent).toHaveTextContent(/Base-currency equivalent/i);
+    expect(equivalent).toHaveTextContent(/29\.00/);
+    // The rate field is programmatically associated with the live equivalent.
+    expect(rateField.getAttribute('aria-describedby')).toContain('txn-fx-equivalent');
+  });
+
+  it('blocks submission with an associated error when the foreign rate is missing', async () => {
+    const { onSubmit } = renderTransactionForm();
+
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-1' } });
+    typeAmount('100000');
+    fireEvent.change(screen.getByLabelText('Payee'), { target: { value: 'Street food' } });
+    fireEvent.change(await screen.findByLabelText('Currency'), { target: { value: 'THB' } });
+    await screen.findByLabelText('Exchange rate');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add Transaction' }));
+    });
+
+    const rateField = screen.getByLabelText('Exchange rate');
+    expect(rateField).toHaveAttribute('aria-invalid', 'true');
+    expect(rateField.getAttribute('aria-describedby')).toContain('txn-exchange-rate-error');
+    expect(screen.getByText('Enter the exchange rate used.')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('stores the converted base amount and captures original amount, rate, and timestamp', async () => {
+    const { onSubmit } = renderTransactionForm();
+
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-1' } });
+    typeAmount('100000'); // ฿1,000.00
+    fireEvent.change(screen.getByLabelText('Payee'), { target: { value: 'Night market' } });
+    fireEvent.change(await screen.findByLabelText('Currency'), { target: { value: 'THB' } });
+    const rateField = await screen.findByLabelText('Exchange rate');
+    fireEvent.change(rateField, { target: { value: '0.029' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add Transaction' }));
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // Expense of 1000.00 THB at 0.029 -> -$29.00 stored in the USD account.
+        amount: { amount: -2900 },
+        currency: { code: 'USD', decimalPlaces: 2 },
+        payee: 'Night market',
+        customFields: expect.objectContaining({
+          fxAmtMinor: '-100000',
+          fxCcy: 'THB',
+          fxRate: '0.029',
+          fxBaseCcy: 'USD',
+          fxRateTs: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+        }),
+      }),
+    );
+  });
+
+  it('correctly converts a zero-decimal currency (JPY) into base cents', async () => {
+    const { onSubmit } = renderTransactionForm();
+
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-1' } });
+    fireEvent.change(await screen.findByLabelText('Currency'), { target: { value: 'JPY' } });
+    // JPY has 0 decimals: typing "10000" means ¥10,000 (not ¥100.00).
+    typeAmount('10000');
+    fireEvent.change(screen.getByLabelText('Payee'), { target: { value: 'Ramen' } });
+    // 1 JPY = 0.0067 USD -> 10000 JPY = $67.00.
+    const rateField = await screen.findByLabelText('Exchange rate');
+    fireEvent.change(rateField, { target: { value: '0.0067' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add Transaction' }));
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: { amount: -6700 },
+        currency: { code: 'USD', decimalPlaces: 2 },
+        customFields: expect.objectContaining({
+          fxAmtMinor: '-10000',
+          fxCcy: 'JPY',
+        }),
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/forms/TransactionForm.tsx
+++ b/apps/web/src/components/forms/TransactionForm.tsx
@@ -22,6 +22,8 @@
  */
 
 import {
+  Suspense,
+  lazy,
   useCallback,
   useEffect,
   useMemo,
@@ -41,11 +43,13 @@ import type {
   Account,
   Category,
   ContributionDesignation,
+  Currency,
   Transaction,
   TransactionSplit,
   TransactionStatus,
   TransactionType,
 } from '../../kmp/bridge';
+import { Currencies } from '../../kmp/bridge';
 import { BNPL_CUSTOM_FIELD_KEYS } from '../../lib/bnpl-liability';
 import {
   applyLocalTimestampToCustomFields,
@@ -70,6 +74,7 @@ import {
 } from '../../lib/mood-tags';
 import { buildDictationControlProps } from '../../lib/a11y/dictation-entry';
 import { validateTransactionSplits } from '../../lib/transactions/splits';
+import { getCurrencyDecimals, isFxFieldKey, readFxMetadata } from '../../lib/currency/minor-units';
 import { transactionSchema } from '../../lib/validation';
 import { DateInput } from '../common';
 import { CategoryConfirmation } from '../categorization';
@@ -78,6 +83,13 @@ import { CounterpartyInput } from '../transactions/CounterpartyInput';
 import { FormErrorSummary, type FormErrorSummaryItem } from './FormErrorSummary';
 
 import './forms.css';
+
+/**
+ * Currency picker + foreign-exchange entry fields, loaded lazily so their
+ * markup, the currency option list, and the conversion math stay out of the
+ * (saturated) shared route bundles until the transaction form is opened.
+ */
+const CurrencyFxSection = lazy(() => import('./CurrencyFxSection'));
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -195,10 +207,16 @@ function normalizeTransactionAmount(amountCents: number, type: TransactionType):
 
 function buildTransactionSnapshot(initialData?: Transaction) {
   const existingLocalTimestamp = localTimestampFromCustomFields(initialData?.customFields ?? null);
+  const fxMetadata = readFxMetadata(initialData?.customFields ?? null);
   const browserTimeZone = getBrowserTimeZone();
   return {
     transactionType: initialData?.type ?? 'EXPENSE',
-    amountCents: initialData?.amount.amount ?? 0,
+    // For a foreign-currency transaction, the form edits the ORIGINAL amount in
+    // the original currency; the stored `amount` is the converted base amount.
+    amountCents: fxMetadata?.originalAmountMinor ?? initialData?.amount.amount ?? 0,
+    transactionCurrencyCode: fxMetadata?.originalCurrency ?? '',
+    exchangeRateInput: fxMetadata?.rate ?? '',
+    rateCapturedAt: fxMetadata?.rateTimestamp ?? null,
     description: initialData?.payee ?? '',
     status: initialData?.status ?? 'PENDING',
     categoryId: initialData?.categoryId ?? '',
@@ -234,7 +252,7 @@ function buildTransactionSnapshot(initialData?: Transaction) {
     extraNotes: initialData?.extraNotes ?? '',
     customFieldEntries: initialData?.customFields
       ? Object.entries(initialData.customFields)
-          .filter(([key]) => !isLocalTimestampFieldKey(key))
+          .filter(([key]) => !isLocalTimestampFieldKey(key) && !isFxFieldKey(key))
           .map(([key, value]) => ({ key, value }))
       : [],
     localTime:
@@ -253,6 +271,7 @@ interface FormErrors {
   description?: string;
   accountId?: string;
   splits?: string;
+  rate?: string;
 }
 
 interface SplitFormRow {
@@ -329,16 +348,45 @@ export function TransactionForm({
 
   // -- state ---------------------------------------------------------------
   const [transactionType, setTransactionType] = useState<TransactionType>('EXPENSE');
+  const [accountId, setAccountId] = useState('');
+
+  // -- currency / foreign-exchange state -----------------------------------
+  // The transaction currency defaults from the selected account's currency but
+  // can be overridden per transaction (digital-nomad foreign spend). When a
+  // non-base currency is chosen we also capture the exchange rate used and the
+  // moment it was captured, so the base-currency (account) impact stays exact.
+  const [currencyCode, setCurrencyCode] = useState('');
+  const [currencyTouched, setCurrencyTouched] = useState(false);
+  const [exchangeRateInput, setExchangeRateInput] = useState('');
+  const [rateCapturedAt, setRateCapturedAt] = useState<string | null>(null);
+
+  const baseCurrency = useMemo<Currency>(() => {
+    const account = accounts.find((candidate) => candidate.id === accountId);
+    return account?.currency ?? Currencies.USD;
+  }, [accounts, accountId]);
+
+  // Effective entry currency: the user's override when set, else the account's.
+  const entryCurrencyCode = currencyTouched && currencyCode ? currencyCode : baseCurrency.code;
+  const entryCurrency = useMemo<Currency>(
+    () => ({ code: entryCurrencyCode, decimalPlaces: getCurrencyDecimals(entryCurrencyCode) }),
+    [entryCurrencyCode],
+  );
+  const isForeignEntry = entryCurrency.code !== baseCurrency.code;
+  // The amount field shows the entry-currency symbol (e.g. $, €, ฿). It is
+  // resolved inside the lazily-loaded CurrencyFxSection (which owns the `Intl`
+  // symbol path) and reported back here, keeping that code out of the shared
+  // route bundle. Defaults to "$" so a same-currency USD entry never flashes.
+  const [entrySymbol, setEntrySymbol] = useState('$');
+
   const amountInput = useAmountInput({
-    currencySymbol: '$',
-    decimalPlaces: 2,
+    currencySymbol: entrySymbol,
+    decimalPlaces: entryCurrency.decimalPlaces,
     allowNegative: transactionType !== 'INCOME',
   });
   const [description, setDescription] = useState('');
   const [status, setStatus] = useState<TransactionStatus>('PENDING');
   const [categoryId, setCategoryId] = useState('');
   const [splitRows, setSplitRows] = useState<SplitFormRow[]>([]);
-  const [accountId, setAccountId] = useState('');
   const [date, setDate] = useState(todayISO);
   const [notes, setNotes] = useState('');
   const [tagsInput, setTagsInput] = useState('');
@@ -376,6 +424,9 @@ export function TransactionForm({
     () => ({
       transactionType,
       amountCents: amountInput.cents,
+      transactionCurrencyCode: currencyTouched ? currencyCode : '',
+      exchangeRateInput,
+      rateCapturedAt,
       description,
       status,
       categoryId,
@@ -408,9 +459,12 @@ export function TransactionForm({
       bnplInstallmentCount,
       categoryId,
       counterpartyName,
+      currencyCode,
+      currencyTouched,
       customFieldEntries,
       date,
       description,
+      exchangeRateInput,
       externalReferenceId,
       extraNotes,
       isBnplLiability,
@@ -423,6 +477,7 @@ export function TransactionForm({
       merchantZip,
       moodTag,
       notes,
+      rateCapturedAt,
       retirementContributionDesignation,
       retirementContributionYear,
       splitRows,
@@ -497,6 +552,10 @@ export function TransactionForm({
     setCategoryId(initialSnapshot.categoryId);
     setSplitRows(initialSnapshot.splitRows);
     setAccountId(initialSnapshot.accountId);
+    setCurrencyCode(initialSnapshot.transactionCurrencyCode);
+    setCurrencyTouched(initialSnapshot.transactionCurrencyCode !== '');
+    setExchangeRateInput(initialSnapshot.exchangeRateInput);
+    setRateCapturedAt(initialSnapshot.rateCapturedAt);
     setDate(initialSnapshot.date);
     setNotes(initialSnapshot.notes);
     setTagsInput(initialSnapshot.tagsInput);
@@ -633,6 +692,16 @@ export function TransactionForm({
     [accounts, accountId],
   );
 
+  // -- foreign-currency conversion (derived) -------------------------------
+  // The base-currency equivalent itself is computed in the lazily-loaded
+  // CurrencyFxSection (display) and recomputed at submit, keeping the
+  // conversion math out of this widely-imported bundle.
+  const parsedExchangeRate = Number.parseFloat(exchangeRateInput);
+  const hasValidExchangeRate =
+    exchangeRateInput.trim() !== '' &&
+    Number.isFinite(parsedExchangeRate) &&
+    parsedExchangeRate > 0;
+
   const updateSplitRow = useCallback((id: string, updates: Partial<SplitFormRow>) => {
     setSplitRows((rows) => rows.map((row) => (row.id === id ? { ...row, ...updates } : row)));
   }, []);
@@ -678,6 +747,10 @@ export function TransactionForm({
         fieldErrors.splits = `${splitValidation.error ?? 'Split amounts must equal the transaction total.'} ${splitRemainderText}`;
       }
 
+      if (isForeignEntry && !hasValidExchangeRate) {
+        fieldErrors.rate = 'Enter the exchange rate used.';
+      }
+
       setErrors(fieldErrors);
 
       if (Object.keys(fieldErrors).length > 0) {
@@ -707,6 +780,32 @@ export function TransactionForm({
         delete customFields[BNPL_CUSTOM_FIELD_KEYS.installmentCount];
       }
 
+      // Foreign-currency entry: the user typed the ORIGINAL local amount; store
+      // the converted BASE (account) amount so balances stay correct, and keep
+      // the original amount, currency, rate, and rate timestamp in customFields.
+      // The conversion math is loaded lazily (only needed for foreign spend).
+      let baseAmountCents = normalizedAmountCents;
+      if (isForeignEntry) {
+        const { convertToBaseMinorUnits, buildFxCustomFields } =
+          await import('../../lib/currency/fx-convert');
+        baseAmountCents = convertToBaseMinorUnits({
+          originalMinorUnits: normalizedAmountCents,
+          originalDecimals: entryCurrency.decimalPlaces,
+          baseDecimals: baseCurrency.decimalPlaces,
+          rate: parsedExchangeRate,
+        });
+        Object.assign(
+          customFields,
+          buildFxCustomFields({
+            originalAmountMinor: normalizedAmountCents,
+            originalCurrency: entryCurrency.code,
+            rate: exchangeRateInput.trim(),
+            rateTimestamp: rateCapturedAt ?? new Date().toISOString(),
+            baseCurrency: baseCurrency.code,
+          }),
+        );
+      }
+
       // Preserve the captured local time + zone alongside the transaction in the
       // web store's flexible customFields bag (no schema change). Absent when the
       // user clears the field, which degrades to legacy date-only behavior.
@@ -723,8 +822,8 @@ export function TransactionForm({
         accountId,
         type: transactionType,
         status,
-        amount: { amount: normalizedAmountCents },
-        currency: selectedAccount.currency,
+        amount: { amount: baseAmountCents },
+        currency: baseCurrency,
         payee: description.trim(),
         date,
         categoryId:
@@ -780,6 +879,10 @@ export function TransactionForm({
         setCategoryId('');
         setSplitRows([]);
         setAccountId('');
+        setCurrencyCode('');
+        setCurrencyTouched(false);
+        setExchangeRateInput('');
+        setRateCapturedAt(null);
         setDate(todayISO());
         setNotes('');
         setTagsInput('');
@@ -814,6 +917,13 @@ export function TransactionForm({
       amountInput,
       description,
       accountId,
+      baseCurrency,
+      entryCurrency,
+      isForeignEntry,
+      hasValidExchangeRate,
+      parsedExchangeRate,
+      exchangeRateInput,
+      rateCapturedAt,
       selectedAccount,
       transactionType,
       status,
@@ -863,6 +973,7 @@ export function TransactionForm({
   const hasDescriptionError = Boolean(errors.description);
   const hasAccountError = Boolean(errors.accountId);
   const hasSplitError = Boolean(errors.splits);
+  const hasRateError = Boolean(errors.rate);
   const hasValidationErrors = Object.keys(errors).length > 0;
   const retirementContributionWarning =
     isRetirementContribution && selectedAccount
@@ -882,6 +993,9 @@ export function TransactionForm({
       : null,
     hasAccountError
       ? { fieldId: 'txn-account', label: 'Account', message: errors.accountId! }
+      : null,
+    hasRateError
+      ? { fieldId: 'txn-exchange-rate', label: 'Exchange rate', message: errors.rate! }
       : null,
     hasSplitError
       ? { fieldId: 'txn-splits-status', label: 'Splits', message: errors.splits! }
@@ -951,7 +1065,7 @@ export function TransactionForm({
                 data-dictation-label={dictationControls.amount.label}
                 amountInput={amountInput}
                 className={`form-input${hasAmountError ? ' form-input--error' : ''}`}
-                placeholder="$0.00"
+                placeholder={amountInput.placeholderValue}
                 aria-invalid={hasAmountError}
                 aria-describedby={`txn-amount-help${hasAmountError ? ' txn-amount-error' : ''}`}
                 aria-required="true"
@@ -964,6 +1078,27 @@ export function TransactionForm({
                 </span>
               )}
             </div>
+
+            {/* Currency picker + foreign-exchange fields (lazily loaded) */}
+            <Suspense fallback={<div className="form-group" aria-hidden="true" />}>
+              <CurrencyFxSection
+                entryCurrencyCode={entryCurrencyCode}
+                baseCurrencyCode={baseCurrency.code}
+                onCurrencyChange={(code) => {
+                  setCurrencyCode(code);
+                  setCurrencyTouched(true);
+                }}
+                onEntrySymbolResolved={setEntrySymbol}
+                originalMinorUnits={amountInput.cents}
+                exchangeRateInput={exchangeRateInput}
+                onExchangeRateChange={(value) => {
+                  setExchangeRateInput(value);
+                  setRateCapturedAt(new Date().toISOString());
+                }}
+                rateError={errors.rate}
+                rateCapturedAt={rateCapturedAt}
+              />
+            </Suspense>
 
             {/* Payee */}
             <div className="form-group">

--- a/apps/web/src/lib/currency/entry-currencies.ts
+++ b/apps/web/src/lib/currency/entry-currencies.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Entry-currency picker catalog for foreign-currency transaction entry.
+ *
+ * This module is intentionally separate from `minor-units.ts`: it is imported
+ * ONLY by the lazily-loaded {@link ../../components/forms/CurrencyFxSection}, so
+ * the (relatively large) currency code list and the `Intl.DisplayNames` label
+ * resolver stay OUT of the widely-imported route bundles and only load when the
+ * transaction form is actually opened.
+ *
+ * References: issue #2202 (web slice).
+ */
+
+import { getCurrencyDecimals, normalizeCurrencyCode } from './minor-units';
+
+/** Human-friendly label metadata for the entry currency picker. */
+export interface FxCurrencyOption {
+  /** ISO 4217 currency code (uppercase). */
+  readonly code: string;
+  /** Number of decimal places (minor units per major unit = 10 ** decimalPlaces). */
+  readonly decimalPlaces: number;
+  /** Display label for the option, e.g. "THB — Thai Baht". */
+  readonly label: string;
+}
+
+/**
+ * Currencies offered in the transaction entry picker, ordered with the most
+ * common nomad destinations first. Stored as codes only; the human-readable
+ * names are resolved at runtime via `Intl.DisplayNames` so the (relatively
+ * large) name strings stay out of the bundle.
+ */
+export const ENTRY_CURRENCY_CODES: readonly string[] = [
+  'USD',
+  'EUR',
+  'GBP',
+  'THB',
+  'MXN',
+  'JPY',
+  'KRW',
+  'VND',
+  'IDR',
+  'INR',
+  'SGD',
+  'MYR',
+  'PHP',
+  'AUD',
+  'CAD',
+  'BRL',
+  'TRY',
+  'AED',
+  'KWD',
+  'BHD',
+];
+
+let currencyDisplayNames: Intl.DisplayNames | null | undefined;
+
+/**
+ * Resolve a friendly label like "THB — Thai Baht" when the runtime can supply
+ * the localized name, otherwise fall back to the bare ISO code. Names are read
+ * from `Intl.DisplayNames` at runtime so they never inflate the bundle.
+ */
+export function getCurrencyLabel(code: string): string {
+  const normalized = normalizeCurrencyCode(code) ?? code;
+  if (currencyDisplayNames === undefined) {
+    try {
+      currencyDisplayNames = new Intl.DisplayNames(['en'], { type: 'currency' });
+    } catch {
+      currencyDisplayNames = null;
+    }
+  }
+  try {
+    const name = currencyDisplayNames?.of(normalized);
+    return name && name !== normalized ? `${normalized} — ${name}` : normalized;
+  } catch {
+    return normalized;
+  }
+}
+
+/** Build the entry-currency picker options (code + decimals + runtime label). */
+export function getEntryCurrencyOptions(): FxCurrencyOption[] {
+  return ENTRY_CURRENCY_CODES.map((code) => ({
+    code,
+    decimalPlaces: getCurrencyDecimals(code),
+    label: getCurrencyLabel(code),
+  }));
+}
+
+const symbolCache = new Map<string, string>();
+
+/**
+ * Resolve a narrow currency symbol (e.g. `$`, `€`, `฿`) for display.
+ *
+ * Falls back to the currency code itself when the runtime cannot resolve a
+ * symbol. Results are memoized because `Intl` formatting is comparatively
+ * expensive and the set of currencies is small. Lives in this lazy-only module
+ * so the `Intl.NumberFormat` symbol path stays out of the route bundles until
+ * the transaction form is opened.
+ */
+export function getCurrencySymbol(code: string | null | undefined): string {
+  const normalized = normalizeCurrencyCode(code) ?? 'USD';
+  const cached = symbolCache.get(normalized);
+  if (cached) return cached;
+
+  let symbol: string;
+  try {
+    const parts = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: normalized,
+      currencyDisplay: 'narrowSymbol',
+    }).formatToParts(0);
+    symbol = parts.find((part) => part.type === 'currency')?.value ?? normalized;
+  } catch {
+    symbol = normalized;
+  }
+
+  symbolCache.set(normalized, symbol);
+  return symbol;
+}

--- a/apps/web/src/lib/currency/fx-convert.ts
+++ b/apps/web/src/lib/currency/fx-convert.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+/**
+ * Foreign-currency conversion + persistence math (issue #2202).
+ *
+ * Split out from {@link ./minor-units} so it can live in the lazily-loaded
+ * foreign-currency chunk rather than the widely-imported transaction-form
+ * bundle: it is needed only when a user actually logs a foreign-currency spend
+ * (statically by the lazy `ForeignCurrencyFields` component for the live
+ * preview, and dynamically by `TransactionForm` at submit time).
+ *
+ * All amounts are signed INTEGER minor units — never floats — so cents are
+ * never silently lost.
+ */
+
+import { FX_FIELD_KEYS, type FxEntryMetadata } from './minor-units';
+
+/**
+ * Round a non-integer value to the nearest integer using "round half away from
+ * zero", applied to the magnitude so negative amounts round symmetrically.
+ *
+ * `Math.round` alone rounds half toward +Infinity (`Math.round(-0.5) === -0`),
+ * which would lose a cent asymmetrically for refunds/expenses. Splitting the
+ * sign keeps debits and credits consistent.
+ */
+export function roundToInteger(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  const sign = value < 0 ? -1 : 1;
+  return sign * Math.round(Math.abs(value));
+}
+
+/** Inputs for {@link convertToBaseMinorUnits}. */
+export interface ConvertToBaseInput {
+  /** Signed integer amount in the ORIGINAL (foreign) currency's minor units. */
+  readonly originalMinorUnits: number;
+  /** Decimal places of the ORIGINAL (foreign) currency. */
+  readonly originalDecimals: number;
+  /** Decimal places of the BASE (account) currency. */
+  readonly baseDecimals: number;
+  /**
+   * Exchange rate expressed as BASE units per 1 ORIGINAL unit
+   * (i.e. `1 foreign = rate base`). For THB->USD this is ~`0.0288`.
+   */
+  readonly rate: number;
+}
+
+/**
+ * Convert an integer foreign-currency amount into integer BASE-currency minor
+ * units using the supplied exchange rate, with correct cross-precision scaling
+ * and sign-safe rounding.
+ *
+ * The math, derived to stay in integer space as long as possible:
+ *
+ *   baseMinor = round( originalMinor * rate * 10^(baseDecimals - originalDecimals) )
+ *
+ * Returns `0` when the rate is not a positive finite number.
+ */
+export function convertToBaseMinorUnits(input: ConvertToBaseInput): number {
+  const { originalMinorUnits, originalDecimals, baseDecimals, rate } = input;
+
+  if (!Number.isFinite(rate) || rate <= 0 || !Number.isFinite(originalMinorUnits)) {
+    return 0;
+  }
+
+  const scale = 10 ** (baseDecimals - originalDecimals);
+  return roundToInteger(originalMinorUnits * rate * scale);
+}
+
+/** Build the `customFields` fragment that persists foreign-currency entry. */
+export function buildFxCustomFields(metadata: FxEntryMetadata): Record<string, string> {
+  const fields: Record<string, string> = {
+    [FX_FIELD_KEYS.originalAmountMinor]: String(metadata.originalAmountMinor),
+    [FX_FIELD_KEYS.originalCurrency]: metadata.originalCurrency,
+    [FX_FIELD_KEYS.rate]: metadata.rate,
+    [FX_FIELD_KEYS.baseCurrency]: metadata.baseCurrency,
+  };
+  if (metadata.rateTimestamp) {
+    fields[FX_FIELD_KEYS.rateTimestamp] = metadata.rateTimestamp;
+  }
+  return fields;
+}

--- a/apps/web/src/lib/currency/index.ts
+++ b/apps/web/src/lib/currency/index.ts
@@ -22,3 +22,27 @@ export {
 } from './rate-cache';
 
 export { ExchangeRateService } from './exchange-rate-service';
+
+export type { FxEntryMetadata } from './minor-units';
+export type { FxCurrencyOption } from './entry-currencies';
+export type { ConvertToBaseInput } from './fx-convert';
+
+export {
+  ENTRY_CURRENCY_CODES,
+  getEntryCurrencyOptions,
+  getCurrencyLabel,
+  getCurrencySymbol,
+} from './entry-currencies';
+
+export {
+  FX_FIELD_KEYS,
+  normalizeCurrencyCode,
+  getCurrencyDecimals,
+  minorUnitFactor,
+  parseAmountToMinorUnits,
+  minorUnitsToMajorNumber,
+  readFxMetadata,
+  isFxFieldKey,
+} from './minor-units';
+
+export { roundToInteger, convertToBaseMinorUnits, buildFxCustomFields } from './fx-convert';

--- a/apps/web/src/lib/currency/minor-units.test.ts
+++ b/apps/web/src/lib/currency/minor-units.test.ts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  getCurrencyDecimals,
+  minorUnitFactor,
+  minorUnitsToMajorNumber,
+  normalizeCurrencyCode,
+  parseAmountToMinorUnits,
+  readFxMetadata,
+} from './minor-units';
+import { ENTRY_CURRENCY_CODES, getEntryCurrencyOptions } from './entry-currencies';
+import { buildFxCustomFields, convertToBaseMinorUnits, roundToInteger } from './fx-convert';
+
+describe('getCurrencyDecimals', () => {
+  it('returns 2 for standard two-decimal currencies', () => {
+    expect(getCurrencyDecimals('USD')).toBe(2);
+    expect(getCurrencyDecimals('EUR')).toBe(2);
+    expect(getCurrencyDecimals('THB')).toBe(2);
+    expect(getCurrencyDecimals('MXN')).toBe(2);
+  });
+
+  it('returns 0 for zero-decimal currencies', () => {
+    expect(getCurrencyDecimals('JPY')).toBe(0);
+    expect(getCurrencyDecimals('KRW')).toBe(0);
+    expect(getCurrencyDecimals('VND')).toBe(0);
+  });
+
+  it('returns 3 for three-decimal Gulf currencies', () => {
+    expect(getCurrencyDecimals('KWD')).toBe(3);
+    expect(getCurrencyDecimals('BHD')).toBe(3);
+    expect(getCurrencyDecimals('OMR')).toBe(3);
+  });
+
+  it('is case-insensitive and tolerant of whitespace', () => {
+    expect(getCurrencyDecimals(' jpy ')).toBe(0);
+    expect(getCurrencyDecimals('usd')).toBe(2);
+  });
+
+  it('falls back to 2 for unknown or invalid codes', () => {
+    expect(getCurrencyDecimals('')).toBe(2);
+    expect(getCurrencyDecimals(null)).toBe(2);
+    expect(getCurrencyDecimals('ZZZ123')).toBe(2);
+  });
+});
+
+describe('minorUnitFactor', () => {
+  it('computes 10 ** decimals', () => {
+    expect(minorUnitFactor('USD')).toBe(100);
+    expect(minorUnitFactor('JPY')).toBe(1);
+    expect(minorUnitFactor('KWD')).toBe(1000);
+  });
+});
+
+describe('getEntryCurrencyOptions', () => {
+  it('includes the previously-missing nomad currencies THB and MXN', () => {
+    const codes = getEntryCurrencyOptions().map((c) => c.code);
+    expect(codes).toContain('THB');
+    expect(codes).toContain('MXN');
+    expect(ENTRY_CURRENCY_CODES).toContain('THB');
+    expect(ENTRY_CURRENCY_CODES).toContain('MXN');
+  });
+
+  it('covers 0/2/3-decimal currencies', () => {
+    const options = getEntryCurrencyOptions();
+    expect(options.some((c) => c.decimalPlaces === 0)).toBe(true);
+    expect(options.some((c) => c.decimalPlaces === 2)).toBe(true);
+    expect(options.some((c) => c.decimalPlaces === 3)).toBe(true);
+  });
+
+  it('declares decimalPlaces matching getCurrencyDecimals and a non-empty label', () => {
+    for (const option of getEntryCurrencyOptions()) {
+      expect(option.decimalPlaces).toBe(getCurrencyDecimals(option.code));
+      expect(option.label).toContain(option.code);
+      expect(option.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('normalizeCurrencyCode', () => {
+  it('uppercases valid 3-letter codes', () => {
+    expect(normalizeCurrencyCode('usd')).toBe('USD');
+    expect(normalizeCurrencyCode(' eur ')).toBe('EUR');
+  });
+
+  it('returns null for invalid input', () => {
+    expect(normalizeCurrencyCode('')).toBeNull();
+    expect(normalizeCurrencyCode(null)).toBeNull();
+    expect(normalizeCurrencyCode('US')).toBeNull();
+    expect(normalizeCurrencyCode('US1')).toBeNull();
+  });
+});
+
+describe('roundToInteger', () => {
+  it('rounds half away from zero symmetrically', () => {
+    expect(roundToInteger(0.5)).toBe(1);
+    expect(roundToInteger(-0.5)).toBe(-1);
+    expect(roundToInteger(2.4)).toBe(2);
+    expect(roundToInteger(-2.6)).toBe(-3);
+  });
+
+  it('returns 0 for non-finite input', () => {
+    expect(roundToInteger(Number.NaN)).toBe(0);
+    expect(roundToInteger(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe('parseAmountToMinorUnits', () => {
+  it('parses two-decimal currencies into integer cents', () => {
+    expect(parseAmountToMinorUnits('12.34', 'USD')).toBe(1234);
+    expect(parseAmountToMinorUnits('1,000', 'THB')).toBe(100000);
+    expect(parseAmountToMinorUnits('0.09', 'EUR')).toBe(9);
+  });
+
+  it('parses zero-decimal currencies with no minor units', () => {
+    expect(parseAmountToMinorUnits('1000', 'JPY')).toBe(1000);
+    // Extra fractional digits are truncated for a 0-decimal currency.
+    expect(parseAmountToMinorUnits('1000.50', 'JPY')).toBe(1000);
+  });
+
+  it('parses three-decimal currencies into thousandths', () => {
+    expect(parseAmountToMinorUnits('1.234', 'KWD')).toBe(1234);
+    expect(parseAmountToMinorUnits('1.2', 'BHD')).toBe(1200);
+  });
+
+  it('truncates excess fractional digits rather than rounding', () => {
+    expect(parseAmountToMinorUnits('1.239', 'USD')).toBe(123);
+  });
+
+  it('honours a leading minus sign', () => {
+    expect(parseAmountToMinorUnits('-5.00', 'USD')).toBe(-500);
+    expect(parseAmountToMinorUnits('\u22125', 'JPY')).toBe(-5);
+  });
+
+  it('returns null when there are no digits', () => {
+    expect(parseAmountToMinorUnits('', 'USD')).toBeNull();
+    expect(parseAmountToMinorUnits('abc', 'USD')).toBeNull();
+  });
+});
+
+describe('minorUnitsToMajorNumber', () => {
+  it('divides by the minor-unit factor', () => {
+    expect(minorUnitsToMajorNumber(123456, 'USD')).toBeCloseTo(1234.56);
+    expect(minorUnitsToMajorNumber(1000, 'JPY')).toBe(1000);
+    expect(minorUnitsToMajorNumber(1234, 'KWD')).toBeCloseTo(1.234);
+  });
+});
+
+describe('convertToBaseMinorUnits', () => {
+  it('converts a same-precision foreign amount with exact integer rounding', () => {
+    // 1000.00 THB at 1 THB = 0.029 USD => 29.00 USD
+    expect(
+      convertToBaseMinorUnits({
+        originalMinorUnits: 100000,
+        originalDecimals: 2,
+        baseDecimals: 2,
+        rate: 0.029,
+      }),
+    ).toBe(2900);
+  });
+
+  it('converts a 0-decimal foreign currency into 2-decimal base minor units', () => {
+    // 10000 JPY at 1 JPY = 0.0067 USD => 67.00 USD
+    expect(
+      convertToBaseMinorUnits({
+        originalMinorUnits: 10000,
+        originalDecimals: 0,
+        baseDecimals: 2,
+        rate: 0.0067,
+      }),
+    ).toBe(6700);
+  });
+
+  it('converts a 3-decimal foreign currency without losing cents', () => {
+    // 1.234 KWD at 1 KWD = 3.25 USD => 4.0105 USD => rounds to 4.01 USD (401 cents)
+    expect(
+      convertToBaseMinorUnits({
+        originalMinorUnits: 1234,
+        originalDecimals: 3,
+        baseDecimals: 2,
+        rate: 3.25,
+      }),
+    ).toBe(401);
+  });
+
+  it('converts a 2-decimal foreign currency into a 0-decimal base currency', () => {
+    // 250.00 MXN at 1 MXN = 7.5 JPY => 1875 JPY (0 decimals)
+    expect(
+      convertToBaseMinorUnits({
+        originalMinorUnits: 25000,
+        originalDecimals: 2,
+        baseDecimals: 0,
+        rate: 7.5,
+      }),
+    ).toBe(1875);
+  });
+
+  it('preserves sign and rounds magnitude symmetrically', () => {
+    // -345 MXN minor at rate that yields a half-cent: rounds away from zero
+    expect(
+      convertToBaseMinorUnits({
+        originalMinorUnits: -345,
+        originalDecimals: 2,
+        baseDecimals: 2,
+        rate: 0.05,
+      }),
+    ).toBe(-17); // 345 * 0.05 = 17.25 -> 17, sign preserved
+  });
+
+  it('rounds a half-minor-unit away from zero', () => {
+    // 10 units * rate 0.05 = 0.5 -> 1 (round half away from zero)
+    expect(
+      convertToBaseMinorUnits({
+        originalMinorUnits: 10,
+        originalDecimals: 2,
+        baseDecimals: 2,
+        rate: 0.05,
+      }),
+    ).toBe(1);
+  });
+
+  it('returns 0 for a non-positive or non-finite rate', () => {
+    const base = { originalMinorUnits: 100000, originalDecimals: 2, baseDecimals: 2 };
+    expect(convertToBaseMinorUnits({ ...base, rate: 0 })).toBe(0);
+    expect(convertToBaseMinorUnits({ ...base, rate: -1 })).toBe(0);
+    expect(convertToBaseMinorUnits({ ...base, rate: Number.NaN })).toBe(0);
+  });
+});
+
+describe('FX customFields round-trip', () => {
+  it('builds and reads back foreign-currency metadata', () => {
+    const fields = buildFxCustomFields({
+      originalAmountMinor: -100000,
+      originalCurrency: 'THB',
+      rate: '0.029',
+      rateTimestamp: '2026-06-22T10:00:00.000Z',
+      baseCurrency: 'USD',
+    });
+
+    expect(fields.fxCcy).toBe('THB');
+    expect(fields.fxAmtMinor).toBe('-100000');
+
+    const parsed = readFxMetadata(fields);
+    expect(parsed).toEqual({
+      originalAmountMinor: -100000,
+      originalCurrency: 'THB',
+      rate: '0.029',
+      rateTimestamp: '2026-06-22T10:00:00.000Z',
+      baseCurrency: 'USD',
+    });
+  });
+
+  it('omits the timestamp when not supplied and still parses', () => {
+    const fields = buildFxCustomFields({
+      originalAmountMinor: 5000,
+      originalCurrency: 'MXN',
+      rate: '0.058',
+      rateTimestamp: null,
+      baseCurrency: 'USD',
+    });
+
+    expect(fields.fxRateTs).toBeUndefined();
+    expect(readFxMetadata(fields)?.rateTimestamp).toBeNull();
+  });
+
+  it('returns null for absent or incomplete metadata', () => {
+    expect(readFxMetadata(null)).toBeNull();
+    expect(readFxMetadata({})).toBeNull();
+    expect(readFxMetadata({ fxCcy: 'THB' })).toBeNull();
+  });
+});

--- a/apps/web/src/lib/currency/minor-units.ts
+++ b/apps/web/src/lib/currency/minor-units.ts
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Pure, integer-safe minor-unit math for foreign-currency transaction entry.
+ *
+ * A digital nomad paid in USD but spending abroad needs to log the ACTUAL
+ * local-currency amount (e.g. THB, MXN, JPY) together with the exchange rate
+ * they were charged, and still see the base-currency (USD) impact on the
+ * account balance.
+ *
+ * Money is ALWAYS represented as INTEGER minor units (the smallest indivisible
+ * unit of the currency) — never as floating-point major units. The number of
+ * minor units per major unit differs per currency:
+ *
+ *   - 0-decimal currencies (JPY, KRW, VND, …): 1 major unit  = 1 minor unit
+ *   - 2-decimal currencies (USD, EUR, THB, MXN, …): 1 major unit = 100 minor units
+ *   - 3-decimal currencies (KWD, BHD, OMR, …): 1 major unit = 1000 minor units
+ *
+ * All functions here are pure and deterministic so they can be unit-tested in
+ * isolation and reused by the transaction form without pulling in React or any
+ * heavy currency dataset.
+ *
+ * References: issue #2202 (web slice). Native iOS create flow + shared models
+ * remain owned elsewhere.
+ */
+
+// ---------------------------------------------------------------------------
+// Per-currency minor units (decimal places)
+// ---------------------------------------------------------------------------
+
+/** Default decimal places when a currency is unknown to the explicit table. */
+const DEFAULT_DECIMAL_PLACES = 2;
+
+/**
+ * Explicit ISO 4217 minor-unit table for the currencies surfaced in the
+ * transaction entry picker. Curated for common digital-nomad destinations and
+ * deliberately small so it can be imported directly (no lazy chunk needed).
+ *
+ * Only the non-default (0- and 3-decimal) currencies are listed explicitly;
+ * everything else resolves to the runtime `Intl` precision (2 for almost all
+ * currencies), which keeps this table — and the route-ledger bundle — lean.
+ */
+const CURRENCY_DECIMALS: Readonly<Record<string, number>> = {
+  // 0-decimal (no minor unit in everyday use)
+  JPY: 0,
+  KRW: 0,
+  VND: 0,
+  IDR: 0,
+  CLP: 0,
+  // 3-decimal (Gulf dinars)
+  KWD: 3,
+  BHD: 3,
+  OMR: 3,
+  JOD: 3,
+  TND: 3,
+};
+
+/** Normalize an arbitrary input into a 3-letter uppercase code, or `null`. */
+export function normalizeCurrencyCode(code: string | null | undefined): string | null {
+  if (!code) return null;
+  const normalized = code.trim().toUpperCase();
+  return /^[A-Z]{3}$/.test(normalized) ? normalized : null;
+}
+
+/**
+ * Number of decimal places (minor units exponent) for a currency.
+ *
+ * Falls back to the runtime `Intl` data for unknown-but-valid codes, then to a
+ * safe default of 2 so the function never throws.
+ */
+export function getCurrencyDecimals(code: string | null | undefined): number {
+  const normalized = normalizeCurrencyCode(code);
+  if (!normalized) return DEFAULT_DECIMAL_PLACES;
+
+  const known = CURRENCY_DECIMALS[normalized];
+  if (known !== undefined) return known;
+
+  try {
+    return (
+      new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: normalized,
+      }).resolvedOptions().maximumFractionDigits ?? DEFAULT_DECIMAL_PLACES
+    );
+  } catch {
+    return DEFAULT_DECIMAL_PLACES;
+  }
+}
+
+/** Minor units per major unit (e.g. 100 for USD, 1 for JPY, 1000 for KWD). */
+export function minorUnitFactor(code: string | null | undefined): number {
+  return 10 ** getCurrencyDecimals(code);
+}
+
+// ---------------------------------------------------------------------------
+// Parsing / formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a free-text amount (e.g. `"1,234.5"`, `"1000"`) into signed INTEGER
+ * minor units for the given currency. Returns `null` when the input contains
+ * no digits.
+ *
+ * Extra fractional digits beyond the currency's precision are truncated (not
+ * rounded) so the parsed value reflects exactly what the user can express in
+ * that currency.
+ */
+export function parseAmountToMinorUnits(
+  input: string,
+  code: string | null | undefined,
+): number | null {
+  const decimals = getCurrencyDecimals(code);
+  const normalized = input.replace(/\u2212/g, '-').trim();
+  const negative = normalized.startsWith('-');
+  const digits = normalized.replace(/[^0-9.]/g, '');
+  if (!digits) return null;
+
+  const [wholeRaw = '0', fractionRaw = ''] = digits.split('.', 2);
+  const whole = wholeRaw.replace(/^0+(?=\d)/, '') || '0';
+
+  let magnitude: number;
+  if (decimals === 0) {
+    magnitude = Number.parseInt(whole, 10) || 0;
+  } else {
+    const fraction = fractionRaw.slice(0, decimals).padEnd(decimals, '0');
+    magnitude = Number.parseInt(`${whole}${fraction}`, 10);
+    if (Number.isNaN(magnitude)) magnitude = 0;
+  }
+
+  return negative ? -magnitude : magnitude;
+}
+
+/**
+ * Convert signed INTEGER minor units back to a plain major-unit number
+ * (e.g. `123456` USD minor units -> `1234.56`). Intended for math/serialization,
+ * not user display — use the locale-aware formatters for that.
+ */
+export function minorUnitsToMajorNumber(
+  minorUnits: number,
+  code: string | null | undefined,
+): number {
+  return minorUnits / minorUnitFactor(code);
+}
+
+// ---------------------------------------------------------------------------
+// Persisted FX metadata (web `customFields` round-trip)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reserved `customFields` keys used to persist the foreign-currency entry
+ * details alongside a transaction in the web store's flexible `customFields`
+ * bag (no SQLDelight schema change required), mirroring how local-timestamp and
+ * BNPL metadata are stored. Kept stable so create -> persist -> edit agree.
+ */
+export const FX_FIELD_KEYS = {
+  /** Signed integer original amount, in the original currency's minor units. */
+  originalAmountMinor: 'fxAmtMinor',
+  /** ISO 4217 code of the original (foreign) currency. */
+  originalCurrency: 'fxCcy',
+  /** Exchange rate used: base units per 1 original unit. */
+  rate: 'fxRate',
+  /** ISO-8601 timestamp the rate was captured. */
+  rateTimestamp: 'fxRateTs',
+  /** ISO 4217 code of the base (account) currency the amount was converted to. */
+  baseCurrency: 'fxBaseCcy',
+} as const;
+
+const FX_FIELD_KEY_SET = new Set<string>(Object.values(FX_FIELD_KEYS));
+
+/** Whether a `customFields` key is one of the reserved FX-entry keys. */
+export function isFxFieldKey(key: string): boolean {
+  return FX_FIELD_KEY_SET.has(key);
+}
+
+/** Parsed foreign-currency entry metadata read back from `customFields`. */
+export interface FxEntryMetadata {
+  readonly originalAmountMinor: number;
+  readonly originalCurrency: string;
+  readonly rate: string;
+  readonly rateTimestamp: string | null;
+  readonly baseCurrency: string;
+}
+
+/**
+ * Read foreign-currency entry metadata from a transaction's `customFields`,
+ * or `null` when absent/invalid. Never throws.
+ */
+export function readFxMetadata(
+  customFields: Record<string, string> | null | undefined,
+): FxEntryMetadata | null {
+  if (!customFields) return null;
+
+  const originalCurrency = normalizeCurrencyCode(customFields[FX_FIELD_KEYS.originalCurrency]);
+  const rawAmount = customFields[FX_FIELD_KEYS.originalAmountMinor];
+  const rate = customFields[FX_FIELD_KEYS.rate];
+  if (!originalCurrency || rawAmount === undefined || rate === undefined) {
+    return null;
+  }
+
+  const originalAmountMinor = Number.parseInt(rawAmount, 10);
+  if (!Number.isFinite(originalAmountMinor)) return null;
+
+  const baseCurrency = normalizeCurrencyCode(customFields[FX_FIELD_KEYS.baseCurrency]) ?? 'USD';
+
+  return {
+    originalAmountMinor,
+    originalCurrency,
+    rate,
+    rateTimestamp: customFields[FX_FIELD_KEYS.rateTimestamp] ?? null,
+    baseCurrency,
+  };
+}


### PR DESCRIPTION
## Summary
Wires foreign-currency entry into the web create/edit transaction flow for digital nomads (Refs #2202, web slice).

### Verified gap
`TransactionForm.tsx` hardcoded `decimalPlaces: 2` and always set `currency: selectedAccount.currency` with **no** currency picker, exchange-rate input, or base-currency conversion. Exchange-rate hooks (`useExchangeRates`, `useMultiCurrency`) and a currency lib existed but were never surfaced in the create/edit form; THB/MXN were unreachable from entry. So the foreign-spend entry path was genuinely missing.

### Changes
- **`apps/web/src/lib/currency/minor-units.ts` (new)** — pure, integer-safe minor-unit math. Stores amounts as **integer minor units** (never floats), converts foreign → base with correct cross-precision, sign-safe rounding, and per-currency decimals for 0/2/3-decimal currencies. Adds THB, MXN, and other common nomad currencies. Round-trips original amount / currency / rate / timestamp via the web `customFields` bag.
- **`TransactionForm.tsx`** — currency picker defaulting from the selected account (overridable per transaction). When a non-base currency is chosen it reveals an exchange-rate field, shows the live base-currency equivalent, and captures the rate timestamp. The amount input now parses/formats using the chosen currency's decimal count instead of fixed cents. The stored `amount` stays in the account/base currency so balances remain correct; FX details persist in `customFields`. Same-currency entry is unchanged (no extra friction).

### Accessibility (WCAG 2.2 AA)
- Currency and exchange-rate fields have associated `<label>`s and help text.
- The live base equivalent is in an `aria-live="polite"` region and associated with the rate field via `aria-describedby`.
- The invalid-rate error is programmatically associated (`aria-invalid` + `aria-describedby` + error-summary link); no color-only signaling; fully keyboard reachable.

### Tests
- `minor-units.test.ts`: 0/2/3-decimal conversion with exact integer rounding (no lost cents), parsing, and FX `customFields` round-trip (30 tests).
- `TransactionForm.test.tsx`: default-from-account + follow-account, foreign-currency reveal + live base equivalent, missing-rate validation, and converted-amount / FX-capture submission including a 0-decimal (JPY) case (5 new tests).

All 49 local tests green; ESLint + Prettier clean.

Refs #2202

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
