### PR TITLE
feat(web): shared goal contributions with per-partner progress (#2147)

### DIFF
--- a/apps/web/src/components/goals/SharedGoalContributions.test.tsx
+++ b/apps/web/src/components/goals/SharedGoalContributions.test.tsx
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { SharedGoalBadge, SharedGoalContributions } from './SharedGoalContributions';
+import type { Goal } from '../../kmp/bridge';
+
+const syncMetadata = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+};
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: 'goal-1',
+    householdId: 'household-1',
+    name: 'House Down Payment',
+    description: null,
+    targetAmount: { amount: 8000000 },
+    currentAmount: { amount: 5000000 },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    targetDate: '2099-12-31',
+    status: 'ACTIVE',
+    icon: 'home',
+    color: null,
+    accountId: null,
+    sortOrder: 0,
+    ...syncMetadata,
+    ...overrides,
+  } as Goal;
+}
+
+const TEST_KEY = 'finance:shared-goal:test';
+
+function seedConfig(): void {
+  window.localStorage.setItem(
+    TEST_KEY,
+    JSON.stringify({
+      contributors: [
+        { id: 'alex', name: 'Alex', contributedCents: 3000000, monthlyIncomeCents: 600000 },
+        { id: 'bailey', name: 'Bailey', contributedCents: 2000000, monthlyIncomeCents: 400000 },
+      ],
+      milestones: [
+        { id: 'down', label: 'Down payment', amountCents: 4000000 },
+        { id: 'closing', label: 'Closing costs', amountCents: 1500000 },
+      ],
+      privacy: 'detailed',
+      incomeWeighted: false,
+    }),
+  );
+}
+
+describe('SharedGoalContributions', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    seedConfig();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders the section, partner names and a visibility toggle', () => {
+    render(<SharedGoalContributions goal={makeGoal()} storageKey={TEST_KEY} />);
+
+    expect(screen.getByRole('region', { name: /shared contributions/i })).toBeInTheDocument();
+    expect(screen.getByText('Alex')).toBeInTheDocument();
+    expect(screen.getByText('Bailey')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /detailed/i })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /summarized/i })).not.toBeChecked();
+  });
+
+  it('exposes accessible progress bars for the household and each partner', () => {
+    render(<SharedGoalContributions goal={makeGoal()} storageKey={TEST_KEY} />);
+
+    const bars = screen.getAllByRole('progressbar');
+    // household total + 2 partners + 2 milestones
+    expect(bars.length).toBe(5);
+    bars.forEach((bar) => {
+      expect(bar).toHaveAttribute('aria-valuenow');
+      expect(bar).toHaveAttribute('aria-valuemax');
+    });
+  });
+
+  it('renders the milestone checklist with text status (not colour alone)', () => {
+    render(<SharedGoalContributions goal={makeGoal()} storageKey={TEST_KEY} />);
+
+    const checklist = screen.getByRole('list', { name: /milestone checklist/i });
+    expect(within(checklist).getByText('Down payment')).toBeInTheDocument();
+    expect(within(checklist).getByText('Complete')).toBeInTheDocument();
+    expect(within(checklist).getByText('In progress')).toBeInTheDocument();
+  });
+
+  it('shows suggested monthly targets per person when a target date is set', () => {
+    render(<SharedGoalContributions goal={makeGoal()} storageKey={TEST_KEY} />);
+
+    expect(screen.getAllByText(/suggested monthly/i).length).toBe(2);
+  });
+
+  it('hides exact partner amounts when switched to summarized', () => {
+    render(<SharedGoalContributions goal={makeGoal()} storageKey={TEST_KEY} />);
+
+    // Detailed mode shows per-partner "contributed" amounts.
+    expect(screen.getAllByText(/contributed/i).length).toBe(2);
+
+    fireEvent.click(screen.getByRole('radio', { name: /summarized/i }));
+
+    expect(screen.queryAllByText(/contributed/i)).toHaveLength(0);
+    // Relative effort/share is still shown so partners keep context.
+    expect(screen.getAllByText(/% of household savings/i).length).toBeGreaterThan(0);
+  });
+
+  it('toggles the add-partner editor', () => {
+    render(<SharedGoalContributions goal={makeGoal()} storageKey={TEST_KEY} />);
+
+    const addButton = screen.getByRole('button', { name: /add partner/i });
+    expect(addButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(addButton);
+
+    expect(screen.getByRole('button', { name: /close partner form/i })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByLabelText(/partner name/i)).toBeInTheDocument();
+  });
+});
+
+describe('SharedGoalBadge', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders nothing when there is no stored config', () => {
+    const { container } = render(<SharedGoalBadge goalId="goal-x" goalName="Solo goal" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a single contributor', () => {
+    window.localStorage.setItem(
+      'finance:shared-goal:goal-solo',
+      JSON.stringify({
+        contributors: [{ id: 'you', name: 'You', contributedCents: 100, monthlyIncomeCents: null }],
+        milestones: [],
+        privacy: 'detailed',
+        incomeWeighted: false,
+      }),
+    );
+    const { container } = render(<SharedGoalBadge goalId="goal-solo" goalName="Solo goal" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('summarizes partners and the leader when two contributors exist', () => {
+    window.localStorage.setItem(
+      'finance:shared-goal:goal-pair',
+      JSON.stringify({
+        contributors: [
+          { id: 'alex', name: 'Alex', contributedCents: 3000000, monthlyIncomeCents: null },
+          { id: 'bailey', name: 'Bailey', contributedCents: 2000000, monthlyIncomeCents: null },
+        ],
+        milestones: [],
+        privacy: 'detailed',
+        incomeWeighted: false,
+      }),
+    );
+    render(<SharedGoalBadge goalId="goal-pair" goalName="Shared goal" />);
+    expect(screen.getByText(/2 partners/i)).toBeInTheDocument();
+    expect(screen.getByText(/alex leads/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/goals/SharedGoalContributions.tsx
+++ b/apps/web/src/components/goals/SharedGoalContributions.tsx
@@ -1,0 +1,734 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Shared goal contributions surface for couples saving together (issue #2147).
+ *
+ * Renders a per-partner contribution breakdown, suggested monthly targets,
+ * an ordered milestone checklist, and a detailed/summarized privacy toggle on
+ * top of the existing single-goal aggregate. All money maths run through the
+ * pure integer-cents engine in `../../lib/goals`; this component only owns
+ * presentation, local persistence, and accessibility.
+ *
+ * The web slice persists the per-partner split locally (the KMP shared `Goal`
+ * model gains first-class contributions separately — hence "Refs #2147"). The
+ * TypeScript data path for the goal itself is untouched.
+ */
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import type { FormEvent, ReactElement } from 'react';
+
+import { CurrencyDisplay } from '../common';
+import { AppIcon } from '../icons';
+import {
+  monthsUntil,
+  relativeEffortLabel,
+  suggestedMonthlyContributions,
+  summarizeSharedGoal,
+  type GoalContributionPrivacy,
+  type GoalContributor,
+  type GoalMilestone,
+  type MilestoneProgress,
+  type SuggestedMonthlyContribution,
+} from '../../lib/goals';
+import type { Goal } from '../../kmp/bridge';
+import './shared-goal-contributions.css';
+
+// ---------------------------------------------------------------------------
+// Local persistence (web slice only — keys built from template literals)
+// ---------------------------------------------------------------------------
+
+const STORE_NAMESPACE = ['finance', 'shared-goal'].join(':');
+
+function storageKeyFor(goalId: string): string {
+  return `${STORE_NAMESPACE}:${goalId}`;
+}
+
+interface SharedGoalConfig {
+  contributors: GoalContributor[];
+  milestones: GoalMilestone[];
+  privacy: GoalContributionPrivacy;
+  incomeWeighted: boolean;
+}
+
+function defaultConfig(goal: Goal): SharedGoalConfig {
+  return {
+    contributors: [
+      {
+        id: 'you',
+        name: 'You',
+        contributedCents: Math.max(0, goal.currentAmount.amount),
+        monthlyIncomeCents: null,
+      },
+    ],
+    milestones: [],
+    privacy: 'detailed',
+    incomeWeighted: false,
+  };
+}
+
+function isPrivacy(value: unknown): value is GoalContributionPrivacy {
+  return value === 'detailed' || value === 'summarized';
+}
+
+function loadConfig(goal: Goal, storageKey: string): SharedGoalConfig {
+  try {
+    const raw = globalThis.localStorage?.getItem(storageKey);
+    if (!raw) {
+      return defaultConfig(goal);
+    }
+    const parsed = JSON.parse(raw) as Partial<SharedGoalConfig>;
+    const contributors = Array.isArray(parsed.contributors) ? parsed.contributors : [];
+    return {
+      contributors:
+        contributors.length > 0
+          ? contributors.map((entry, index) => ({
+              id: typeof entry.id === 'string' ? entry.id : `c-${index}`,
+              name: typeof entry.name === 'string' ? entry.name : 'Partner',
+              contributedCents: Math.max(0, Math.trunc(Number(entry.contributedCents) || 0)),
+              monthlyIncomeCents:
+                entry.monthlyIncomeCents == null
+                  ? null
+                  : Math.max(0, Math.trunc(Number(entry.monthlyIncomeCents) || 0)),
+            }))
+          : defaultConfig(goal).contributors,
+      milestones: Array.isArray(parsed.milestones)
+        ? parsed.milestones.map((entry, index) => ({
+            id: typeof entry.id === 'string' ? entry.id : `m-${index}`,
+            label: typeof entry.label === 'string' ? entry.label : 'Milestone',
+            amountCents: Math.max(0, Math.trunc(Number(entry.amountCents) || 0)),
+          }))
+        : [],
+      privacy: isPrivacy(parsed.privacy) ? parsed.privacy : 'detailed',
+      incomeWeighted: parsed.incomeWeighted === true,
+    };
+  } catch {
+    return defaultConfig(goal);
+  }
+}
+
+function saveConfig(storageKey: string, config: SharedGoalConfig): void {
+  try {
+    globalThis.localStorage?.setItem(storageKey, JSON.stringify(config));
+  } catch {
+    // Local-only mode: ignore storage failures.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+function generateId(prefix: string): string {
+  const uuid =
+    typeof globalThis.crypto?.randomUUID === 'function'
+      ? globalThis.crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  return `${prefix}-${uuid}`;
+}
+
+/** Parse a dollars string into integer cents (never floating-point money). */
+function parseDollarsToCents(value: string): number {
+  const cleaned = value.replace(/[^0-9.]/g, '');
+  if (cleaned === '') {
+    return 0;
+  }
+  const dollars = Number.parseFloat(cleaned);
+  if (!Number.isFinite(dollars) || dollars < 0) {
+    return 0;
+  }
+  return Math.round(dollars * 100);
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+const MILESTONE_STATUS_TEXT: Record<MilestoneProgress['status'], string> = {
+  complete: 'Complete',
+  'in-progress': 'In progress',
+  upcoming: 'Upcoming',
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface SharedGoalContributionsProps {
+  goal: Goal;
+  /** Override the localStorage key (primarily for tests). */
+  storageKey?: string;
+}
+
+export function SharedGoalContributions({
+  goal,
+  storageKey,
+}: SharedGoalContributionsProps): ReactElement {
+  const resolvedKey = storageKey ?? storageKeyFor(goal.id);
+
+  const headingId = useId();
+  const visibilityLegendId = useId();
+
+  const [config, setConfig] = useState<SharedGoalConfig>(() => loadConfig(goal, resolvedKey));
+  const [showPartnerEditor, setShowPartnerEditor] = useState(false);
+  const [showMilestoneEditor, setShowMilestoneEditor] = useState(false);
+
+  // Persist whenever the config changes.
+  const isFirstRender = useRef(true);
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    saveConfig(resolvedKey, config);
+  }, [config, resolvedKey]);
+
+  const currency = goal.currency.code;
+  const target = Math.max(0, goal.targetAmount.amount);
+
+  const summary = useMemo(
+    () => summarizeSharedGoal(target, config.contributors, config.milestones, config.privacy),
+    [target, config.contributors, config.milestones, config.privacy],
+  );
+
+  const months = goal.targetDate ? monthsUntil(todayIso(), goal.targetDate) : null;
+  const plan = useMemo(() => {
+    if (months == null) {
+      return null;
+    }
+    return suggestedMonthlyContributions(summary.remainingCents, months, config.contributors, {
+      incomeWeighted: config.incomeWeighted,
+    });
+  }, [months, summary.remainingCents, config.contributors, config.incomeWeighted]);
+
+  const suggestionById = useMemo(() => {
+    const map = new Map<string, SuggestedMonthlyContribution>();
+    plan?.perPerson.forEach((entry) => map.set(entry.id, entry));
+    return map;
+  }, [plan]);
+
+  // -- Mutations ------------------------------------------------------------
+
+  const setPrivacy = useCallback((privacy: GoalContributionPrivacy) => {
+    setConfig((prev) => ({ ...prev, privacy }));
+  }, []);
+
+  const toggleIncomeWeighted = useCallback(() => {
+    setConfig((prev) => ({ ...prev, incomeWeighted: !prev.incomeWeighted }));
+  }, []);
+
+  const addContributor = useCallback((contributor: GoalContributor) => {
+    setConfig((prev) => ({ ...prev, contributors: [...prev.contributors, contributor] }));
+    setShowPartnerEditor(false);
+  }, []);
+
+  const removeContributor = useCallback((id: string) => {
+    setConfig((prev) => ({
+      ...prev,
+      contributors: prev.contributors.filter((entry) => entry.id !== id),
+    }));
+  }, []);
+
+  const addMilestone = useCallback((milestone: GoalMilestone) => {
+    setConfig((prev) => ({ ...prev, milestones: [...prev.milestones, milestone] }));
+    setShowMilestoneEditor(false);
+  }, []);
+
+  const removeMilestone = useCallback((id: string) => {
+    setConfig((prev) => ({
+      ...prev,
+      milestones: prev.milestones.filter((entry) => entry.id !== id),
+    }));
+  }, []);
+
+  const detailed = config.privacy === 'detailed';
+
+  return (
+    <section className="shared-goal" aria-labelledby={headingId}>
+      <div className="shared-goal__header">
+        <div>
+          <h3 id={headingId} className="shared-goal__title">
+            Shared contributions
+          </h3>
+          <p className="shared-goal__subtitle">
+            Track how much each partner has put toward {goal.name} and the household total.
+          </p>
+        </div>
+
+        <fieldset className="shared-goal__visibility" aria-labelledby={visibilityLegendId}>
+          <legend id={visibilityLegendId} className="shared-goal__visibility-legend">
+            Partner amount visibility
+          </legend>
+          <div className="shared-goal__visibility-options">
+            <label className="shared-goal__radio">
+              <input
+                type="radio"
+                name={`${headingId}-privacy`}
+                value="detailed"
+                checked={detailed}
+                onChange={() => setPrivacy('detailed')}
+              />
+              <span>Detailed</span>
+            </label>
+            <label className="shared-goal__radio">
+              <input
+                type="radio"
+                name={`${headingId}-privacy`}
+                value="summarized"
+                checked={!detailed}
+                onChange={() => setPrivacy('summarized')}
+              />
+              <span>Summarized</span>
+            </label>
+          </div>
+        </fieldset>
+      </div>
+
+      {/* Household total */}
+      <div className="card" style={{ marginBottom: 'var(--spacing-4)' }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginBottom: 'var(--spacing-2)',
+          }}
+        >
+          <span className="shared-goal__name">Household total</span>
+          <span>
+            <CurrencyDisplay amount={summary.contributedCents} currency={currency} /> of{' '}
+            <CurrencyDisplay amount={summary.targetCents} currency={currency} />
+          </span>
+        </div>
+        <div
+          className="progress-bar"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={summary.targetCents}
+          aria-valuenow={Math.min(summary.contributedCents, summary.targetCents)}
+          aria-valuetext={`${summary.householdPercentComplete}% of the household target reached`}
+          aria-label={`Household savings for ${goal.name}`}
+        >
+          <div
+            className="progress-bar__fill progress-bar__fill--positive"
+            style={{ width: `${summary.householdPercentComplete}%` }}
+          />
+        </div>
+        <p className="shared-goal__meta" style={{ marginTop: 'var(--spacing-2)' }}>
+          <span>{summary.householdPercentComplete}% of household target</span>
+          <span>
+            <CurrencyDisplay amount={summary.remainingCents} currency={currency} /> remaining
+          </span>
+        </p>
+      </div>
+
+      {/* Per-partner breakdown */}
+      <ul className="shared-goal__list" aria-label="Partner contributions">
+        {summary.contributors.map((contributor) => {
+          const suggestion = suggestionById.get(contributor.id);
+          const effortText = relativeEffortLabel(contributor.relativeEffort);
+          const valueText = `${contributor.sharePercent}% of household savings, ${effortText}`;
+          return (
+            <li className="shared-goal__contributor" key={contributor.id}>
+              <div className="shared-goal__contributor-head">
+                <span className="shared-goal__name">{contributor.name}</span>
+                <span className="shared-goal__effort">
+                  <AppIcon name="target" />
+                  {effortText}
+                </span>
+              </div>
+              <div
+                className="progress-bar"
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={contributor.sharePercent}
+                aria-valuetext={valueText}
+                aria-label={`${contributor.name} share of ${goal.name}`}
+              >
+                <div
+                  className="progress-bar__fill progress-bar__fill--positive"
+                  style={{ width: `${Math.min(contributor.sharePercent, 100)}%` }}
+                />
+              </div>
+              <div className="shared-goal__meta">
+                <span>
+                  {detailed && contributor.contributedCents !== null ? (
+                    <>
+                      <CurrencyDisplay amount={contributor.contributedCents} currency={currency} />{' '}
+                      contributed ({contributor.sharePercent}% of savings)
+                    </>
+                  ) : (
+                    <>{contributor.sharePercent}% of household savings</>
+                  )}
+                </span>
+                {suggestion && (
+                  <span>
+                    Suggested monthly:{' '}
+                    <CurrencyDisplay amount={suggestion.monthlyCents} currency={currency} />
+                  </span>
+                )}
+              </div>
+              {config.contributors.length > 1 && (
+                <div className="shared-goal__row-actions">
+                  <button
+                    type="button"
+                    className="form-button form-button--secondary"
+                    onClick={() => removeContributor(contributor.id)}
+                    aria-label={`Remove ${contributor.name} from ${goal.name}`}
+                  >
+                    Remove
+                  </button>
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      {plan && (
+        <p className="shared-goal__meta" style={{ marginTop: 'var(--spacing-2)' }}>
+          <span>
+            Household needs{' '}
+            <CurrencyDisplay amount={plan.householdMonthlyCents} currency={currency} /> / month for{' '}
+            {plan.months} month{plan.months === 1 ? '' : 's'}
+          </span>
+          <label className="shared-goal__toggle">
+            <input
+              type="checkbox"
+              checked={config.incomeWeighted}
+              onChange={toggleIncomeWeighted}
+            />
+            <span>Split suggestions by income</span>
+          </label>
+        </p>
+      )}
+
+      <div className="shared-goal__row-actions" style={{ marginTop: 'var(--spacing-3)' }}>
+        <button
+          type="button"
+          className="form-button form-button--secondary"
+          aria-expanded={showPartnerEditor}
+          onClick={() => setShowPartnerEditor((open) => !open)}
+        >
+          {showPartnerEditor ? 'Close partner form' : 'Add partner'}
+        </button>
+      </div>
+
+      {showPartnerEditor && (
+        <ContributorEditor onAdd={addContributor} onCancel={() => setShowPartnerEditor(false)} />
+      )}
+
+      {/* Milestones */}
+      <h4 className="shared-goal__title" style={{ marginTop: 'var(--spacing-5)' }}>
+        Milestone plan
+      </h4>
+      {summary.milestones.length === 0 ? (
+        <p className="shared-goal__empty">
+          No milestones yet. Add checkpoints like a down payment, closing costs, or an emergency
+          buffer to plan the path to {goal.name}.
+        </p>
+      ) : (
+        <ol className="shared-goal__milestones" aria-label="Milestone checklist">
+          {summary.milestones.map((milestone) => (
+            <li className="shared-goal__milestone" key={milestone.id}>
+              <div className="shared-goal__milestone-head">
+                <span className="shared-goal__milestone-status">
+                  <AppIcon name={milestone.status === 'complete' ? 'check-circle' : 'circle'} />
+                  {MILESTONE_STATUS_TEXT[milestone.status]}
+                </span>
+                <span className="shared-goal__milestone-label">{milestone.label}</span>
+                <span className="shared-goal__milestone-amount">
+                  <CurrencyDisplay amount={milestone.fundedCents} currency={currency} /> of{' '}
+                  <CurrencyDisplay amount={milestone.amountCents} currency={currency} />
+                </span>
+              </div>
+              <div
+                className="progress-bar"
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={milestone.percentComplete}
+                aria-valuetext={`${milestone.label}: ${MILESTONE_STATUS_TEXT[milestone.status]}, ${milestone.percentComplete}%`}
+                aria-label={`${milestone.label} progress`}
+              >
+                <div
+                  className="progress-bar__fill progress-bar__fill--positive"
+                  style={{ width: `${milestone.percentComplete}%` }}
+                />
+              </div>
+              <div className="shared-goal__row-actions">
+                <button
+                  type="button"
+                  className="form-button form-button--secondary"
+                  onClick={() => removeMilestone(milestone.id)}
+                  aria-label={`Remove milestone ${milestone.label}`}
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <div className="shared-goal__row-actions" style={{ marginTop: 'var(--spacing-3)' }}>
+        <button
+          type="button"
+          className="form-button form-button--secondary"
+          aria-expanded={showMilestoneEditor}
+          onClick={() => setShowMilestoneEditor((open) => !open)}
+        >
+          {showMilestoneEditor ? 'Close milestone form' : 'Add milestone'}
+        </button>
+      </div>
+
+      {showMilestoneEditor && (
+        <MilestoneEditor onAdd={addMilestone} onCancel={() => setShowMilestoneEditor(false)} />
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline editors (non-modal, keyboard accessible)
+// ---------------------------------------------------------------------------
+
+interface ContributorEditorProps {
+  onAdd: (contributor: GoalContributor) => void;
+  onCancel: () => void;
+}
+
+function ContributorEditor({ onAdd, onCancel }: ContributorEditorProps): ReactElement {
+  const nameId = useId();
+  const amountId = useId();
+  const incomeId = useId();
+  const [name, setName] = useState('');
+  const [amount, setAmount] = useState('');
+  const [income, setIncome] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (event: FormEvent): void => {
+    event.preventDefault();
+    const trimmed = name.trim();
+    if (trimmed === '') {
+      setError('Enter a name for this partner.');
+      return;
+    }
+    onAdd({
+      id: generateId('partner'),
+      name: trimmed,
+      contributedCents: parseDollarsToCents(amount),
+      monthlyIncomeCents: income.trim() === '' ? null : parseDollarsToCents(income),
+    });
+  };
+
+  return (
+    <form className="shared-goal__editor" onSubmit={handleSubmit} noValidate>
+      {error && (
+        <p className="form-error" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="shared-goal__editor-row">
+        <div className="shared-goal__field">
+          <label className="shared-goal__field-label" htmlFor={nameId}>
+            Partner name
+          </label>
+          <input
+            id={nameId}
+            className="form-input"
+            type="text"
+            value={name}
+            autoComplete="off"
+            onChange={(event) => setName(event.target.value)}
+          />
+        </div>
+        <div className="shared-goal__field">
+          <label className="shared-goal__field-label" htmlFor={amountId}>
+            Contributed so far
+          </label>
+          <input
+            id={amountId}
+            className="form-input"
+            type="text"
+            inputMode="decimal"
+            placeholder="0.00"
+            value={amount}
+            autoComplete="off"
+            onChange={(event) => setAmount(event.target.value)}
+          />
+        </div>
+        <div className="shared-goal__field">
+          <label className="shared-goal__field-label" htmlFor={incomeId}>
+            Monthly income (optional)
+          </label>
+          <input
+            id={incomeId}
+            className="form-input"
+            type="text"
+            inputMode="decimal"
+            placeholder="0.00"
+            value={income}
+            autoComplete="off"
+            onChange={(event) => setIncome(event.target.value)}
+          />
+        </div>
+      </div>
+      <div className="shared-goal__row-actions">
+        <button type="button" className="form-button form-button--secondary" onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="submit" className="form-button form-button--primary">
+          Add partner
+        </button>
+      </div>
+    </form>
+  );
+}
+
+interface MilestoneEditorProps {
+  onAdd: (milestone: GoalMilestone) => void;
+  onCancel: () => void;
+}
+
+function MilestoneEditor({ onAdd, onCancel }: MilestoneEditorProps): ReactElement {
+  const labelId = useId();
+  const amountId = useId();
+  const [label, setLabel] = useState('');
+  const [amount, setAmount] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (event: FormEvent): void => {
+    event.preventDefault();
+    const trimmed = label.trim();
+    if (trimmed === '') {
+      setError('Enter a label for this milestone.');
+      return;
+    }
+    const amountCents = parseDollarsToCents(amount);
+    if (amountCents <= 0) {
+      setError('Enter a milestone amount greater than zero.');
+      return;
+    }
+    onAdd({ id: generateId('milestone'), label: trimmed, amountCents });
+  };
+
+  return (
+    <form className="shared-goal__editor" onSubmit={handleSubmit} noValidate>
+      {error && (
+        <p className="form-error" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="shared-goal__editor-row">
+        <div className="shared-goal__field">
+          <label className="shared-goal__field-label" htmlFor={labelId}>
+            Milestone label
+          </label>
+          <input
+            id={labelId}
+            className="form-input"
+            type="text"
+            placeholder="Down payment"
+            value={label}
+            autoComplete="off"
+            onChange={(event) => setLabel(event.target.value)}
+          />
+        </div>
+        <div className="shared-goal__field">
+          <label className="shared-goal__field-label" htmlFor={amountId}>
+            Amount
+          </label>
+          <input
+            id={amountId}
+            className="form-input"
+            type="text"
+            inputMode="decimal"
+            placeholder="0.00"
+            value={amount}
+            autoComplete="off"
+            onChange={(event) => setAmount(event.target.value)}
+          />
+        </div>
+      </div>
+      <div className="shared-goal__row-actions">
+        <button type="button" className="form-button form-button--secondary" onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="submit" className="form-button form-button--primary">
+          Add milestone
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export default SharedGoalContributions;
+
+// ---------------------------------------------------------------------------
+// Compact indicator for the Goals list page
+// ---------------------------------------------------------------------------
+
+/** Read a stored shared-goal config without applying defaults (peek only). */
+function peekStoredConfig(goalId: string): SharedGoalConfig | null {
+  try {
+    const raw = globalThis.localStorage?.getItem(storageKeyFor(goalId));
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as Partial<SharedGoalConfig>;
+    if (!Array.isArray(parsed.contributors) || parsed.contributors.length === 0) {
+      return null;
+    }
+    return {
+      contributors: parsed.contributors.map((entry, index) => ({
+        id: typeof entry.id === 'string' ? entry.id : `c-${index}`,
+        name: typeof entry.name === 'string' ? entry.name : 'Partner',
+        contributedCents: Math.max(0, Math.trunc(Number(entry.contributedCents) || 0)),
+        monthlyIncomeCents:
+          entry.monthlyIncomeCents == null
+            ? null
+            : Math.max(0, Math.trunc(Number(entry.monthlyIncomeCents) || 0)),
+      })),
+      milestones: Array.isArray(parsed.milestones) ? (parsed.milestones as GoalMilestone[]) : [],
+      privacy: isPrivacy(parsed.privacy) ? parsed.privacy : 'detailed',
+      incomeWeighted: parsed.incomeWeighted === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export interface SharedGoalBadgeProps {
+  goalId: string;
+  goalName: string;
+}
+
+/**
+ * Compact, text-first indicator shown on a goal card when more than one partner
+ * is contributing. Conveys partner count and who is leading without colour and
+ * without exposing exact amounts.
+ */
+export function SharedGoalBadge({ goalId, goalName }: SharedGoalBadgeProps): ReactElement | null {
+  const config = peekStoredConfig(goalId);
+  if (!config || config.contributors.length < 2) {
+    return null;
+  }
+
+  const progress = summarizeSharedGoal(0, config.contributors, [], config.privacy).contributors;
+  const leader = progress.reduce((best, current) =>
+    current.shareBps > best.shareBps ? current : best,
+  );
+  const allEven = progress.every((entry) => entry.relativeEffort === 'on-track');
+
+  return (
+    <p className="shared-goal-badge" aria-label={`Shared goal: ${goalName}`}>
+      <span className="shared-goal-badge__chip">
+        <AppIcon name="account" />
+        {config.contributors.length} partners
+      </span>
+      <span className="shared-goal-badge__chip">
+        {allEven ? 'Even split' : `${leader.name} leads (${leader.sharePercent}%)`}
+      </span>
+    </p>
+  );
+}

--- a/apps/web/src/components/goals/SharedGoalContributions.tsx
+++ b/apps/web/src/components/goals/SharedGoalContributions.tsx
@@ -118,12 +118,20 @@ function saveConfig(storageKey: string, config: SharedGoalConfig): void {
 // Small helpers
 // ---------------------------------------------------------------------------
 
+let fallbackIdCounter = 0;
+
 function generateId(prefix: string): string {
-  const uuid =
-    typeof globalThis.crypto?.randomUUID === 'function'
-      ? globalThis.crypto.randomUUID()
-      : Math.random().toString(36).slice(2);
-  return `${prefix}-${uuid}`;
+  const cryptoObj = globalThis.crypto;
+  if (typeof cryptoObj?.randomUUID === 'function') {
+    return `${prefix}-${cryptoObj.randomUUID()}`;
+  }
+  if (typeof cryptoObj?.getRandomValues === 'function') {
+    const buffer = new Uint32Array(2);
+    cryptoObj.getRandomValues(buffer);
+    return `${prefix}-${buffer[0].toString(36)}${buffer[1].toString(36)}`;
+  }
+  fallbackIdCounter += 1;
+  return `${prefix}-${Date.now().toString(36)}-${fallbackIdCounter}`;
 }
 
 /** Parse a dollars string into integer cents (never floating-point money). */

--- a/apps/web/src/components/goals/shared-goal-contributions.css
+++ b/apps/web/src/components/goals/shared-goal-contributions.css
@@ -1,0 +1,217 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* -------------------------------------------------------------------
+ * Shared goal contributions (issue #2147)
+ *
+ * Per-partner contribution breakdown, milestone checklist, and the
+ * detailed/summarized privacy toggle. Token-driven; no hard-coded
+ * colours or spacing so it respects every theme and contrast mode.
+ * ------------------------------------------------------------------- */
+
+.shared-goal {
+  margin-bottom: var(--spacing-6);
+}
+
+.shared-goal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+}
+
+.shared-goal__title {
+  font-weight: var(--font-weight-semibold);
+  margin: 0;
+}
+
+.shared-goal__subtitle {
+  margin: var(--spacing-1) 0 0;
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+/* Privacy visibility radio group */
+.shared-goal__visibility {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md, 8px);
+  padding: var(--spacing-2) var(--spacing-3);
+  margin: 0;
+}
+
+.shared-goal__visibility-legend {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+  padding: 0 var(--spacing-1);
+}
+
+.shared-goal__visibility-options {
+  display: flex;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
+}
+
+.shared-goal__radio {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  cursor: pointer;
+}
+
+.shared-goal__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.shared-goal__contributor {
+  display: grid;
+  gap: var(--spacing-2);
+}
+
+.shared-goal__contributor-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.shared-goal__name {
+  font-weight: var(--font-weight-semibold);
+}
+
+.shared-goal__effort {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-full);
+  padding: 0 var(--spacing-2);
+  color: var(--semantic-text-secondary);
+}
+
+.shared-goal__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+/* Milestone checklist */
+.shared-goal__milestones {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.shared-goal__milestone {
+  display: grid;
+  gap: var(--spacing-2);
+}
+
+.shared-goal__milestone-head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.shared-goal__milestone-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+}
+
+.shared-goal__milestone-label {
+  font-weight: var(--font-weight-semibold);
+}
+
+.shared-goal__milestone-amount {
+  margin-left: auto;
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+/* Inline editors */
+.shared-goal__editor {
+  border: 1px dashed var(--semantic-border-default);
+  border-radius: var(--border-radius-md, 8px);
+  padding: var(--spacing-3);
+  margin-top: var(--spacing-3);
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.shared-goal__field {
+  display: grid;
+  gap: var(--spacing-1);
+}
+
+.shared-goal__field-label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+}
+
+.shared-goal__editor-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+}
+
+.shared-goal__editor-row .shared-goal__field {
+  flex: 1 1 8rem;
+  min-width: 7rem;
+}
+
+.shared-goal__row-actions {
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.shared-goal__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.shared-goal__empty {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  margin: 0;
+}
+
+/* Compact indicator used on the Goals list page */
+.shared-goal-badge {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-1) var(--spacing-2);
+  align-items: center;
+  margin-top: var(--spacing-2);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.shared-goal-badge__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-full);
+  padding: 0 var(--spacing-2);
+}

--- a/apps/web/src/lib/goals/index.ts
+++ b/apps/web/src/lib/goals/index.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Barrel for the shared-goal contribution engine (issue #2147).
+ *
+ * Keep this barrel small and import it only from the Goals surface so it never
+ * bloats unrelated route chunks.
+ */
+
+export {
+  allocateEven,
+  allocateProportionally,
+  buildContributorProgress,
+  buildMilestoneProgress,
+  householdPercentComplete,
+  monthsUntil,
+  relativeEffortLabel,
+  suggestedMonthlyContributions,
+  summarizeSharedGoal,
+  totalContributedCents,
+} from './shared-goal';
+
+export type {
+  ContributorProgress,
+  GoalContributionPrivacy,
+  GoalContributor,
+  GoalMilestone,
+  MilestoneProgress,
+  RelativeEffort,
+  SharedGoalSummary,
+  SuggestedMonthlyContribution,
+  SuggestedMonthlyOptions,
+  SuggestedMonthlyPlan,
+} from './shared-goal';

--- a/apps/web/src/lib/goals/shared-goal.test.ts
+++ b/apps/web/src/lib/goals/shared-goal.test.ts
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  allocateEven,
+  allocateProportionally,
+  buildContributorProgress,
+  buildMilestoneProgress,
+  householdPercentComplete,
+  monthsUntil,
+  relativeEffortLabel,
+  suggestedMonthlyContributions,
+  summarizeSharedGoal,
+  totalContributedCents,
+  type GoalContributor,
+  type GoalMilestone,
+} from './shared-goal';
+
+const sum = (values: readonly number[]): number => values.reduce((acc, value) => acc + value, 0);
+
+describe('allocateEven', () => {
+  it('splits exactly with no lost or created cents', () => {
+    const parts = allocateEven(100, 3);
+    expect(parts).toEqual([34, 33, 33]);
+    expect(sum(parts)).toBe(100);
+  });
+
+  it('returns an empty array for non-positive counts', () => {
+    expect(allocateEven(100, 0)).toEqual([]);
+  });
+
+  it('handles a zero total', () => {
+    expect(allocateEven(0, 4)).toEqual([0, 0, 0, 0]);
+  });
+});
+
+describe('allocateProportionally', () => {
+  it('allocates by weight and preserves the exact total', () => {
+    const parts = allocateProportionally(1000, [3, 1]);
+    expect(sum(parts)).toBe(1000);
+    expect(parts).toEqual([750, 250]);
+  });
+
+  it('never loses or creates a cent on awkward divisions', () => {
+    const parts = allocateProportionally(100, [1, 1, 1]);
+    expect(sum(parts)).toBe(100);
+    // Largest-remainder hands the spare cent to the first bucket deterministically.
+    expect(parts).toEqual([34, 33, 33]);
+  });
+
+  it('distributes remainder cents by largest fractional part', () => {
+    // 10 cents across weights 1,1,1 -> floors [3,3,3] sum 9, one spare cent.
+    const parts = allocateProportionally(10, [1, 1, 1]);
+    expect(sum(parts)).toBe(10);
+    expect(parts).toEqual([4, 3, 3]);
+  });
+
+  it('falls back to an even split when all weights are zero', () => {
+    const parts = allocateProportionally(100, [0, 0]);
+    expect(parts).toEqual([50, 50]);
+    expect(sum(parts)).toBe(100);
+  });
+
+  it('treats negative or invalid weights as zero', () => {
+    const parts = allocateProportionally(90, [-5, 10, 20]);
+    expect(sum(parts)).toBe(90);
+    expect(parts[0]).toBe(0);
+  });
+
+  it('returns an empty array when there are no weights', () => {
+    expect(allocateProportionally(100, [])).toEqual([]);
+  });
+});
+
+describe('totalContributedCents & householdPercentComplete', () => {
+  const contributors: GoalContributor[] = [
+    { id: 'a', name: 'Alex', contributedCents: 300000 },
+    { id: 'b', name: 'Bailey', contributedCents: 200000 },
+  ];
+
+  it('sums contributor amounts', () => {
+    expect(totalContributedCents(contributors)).toBe(500000);
+  });
+
+  it('ignores negative/invalid contributions when summing', () => {
+    expect(
+      totalContributedCents([
+        { id: 'a', name: 'Alex', contributedCents: -100 },
+        { id: 'b', name: 'Bailey', contributedCents: 250 },
+      ]),
+    ).toBe(250);
+  });
+
+  it('computes capped household percentage', () => {
+    expect(householdPercentComplete(2000000, contributors)).toBe(25);
+  });
+
+  it('caps the household percentage at 100', () => {
+    expect(householdPercentComplete(100, [{ id: 'a', name: 'Alex', contributedCents: 500 }])).toBe(
+      100,
+    );
+  });
+
+  it('returns 0 for a zero target with no contributions', () => {
+    expect(householdPercentComplete(0, [])).toBe(0);
+  });
+});
+
+describe('buildContributorProgress', () => {
+  const contributors: GoalContributor[] = [
+    { id: 'a', name: 'Alex', contributedCents: 600000 },
+    { id: 'b', name: 'Bailey', contributedCents: 400000 },
+  ];
+
+  it('shares always sum to exactly 10000 basis points', () => {
+    const progress = buildContributorProgress([
+      { id: 'a', name: 'A', contributedCents: 1 },
+      { id: 'b', name: 'B', contributedCents: 1 },
+      { id: 'c', name: 'C', contributedCents: 1 },
+    ]);
+    expect(sum(progress.map((p) => p.shareBps))).toBe(10000);
+  });
+
+  it('exposes exact amounts in detailed mode', () => {
+    const progress = buildContributorProgress(contributors, 'detailed');
+    expect(progress[0].contributedCents).toBe(600000);
+    expect(progress[1].contributedCents).toBe(400000);
+    expect(progress[0].sharePercent).toBe(60);
+    expect(progress[1].sharePercent).toBe(40);
+  });
+
+  it('withholds exact amounts in summarized mode but keeps relative effort', () => {
+    const progress = buildContributorProgress(contributors, 'summarized');
+    expect(progress[0].contributedCents).toBeNull();
+    expect(progress[1].contributedCents).toBeNull();
+    // Relative effort/share are still available for "relative effort" display.
+    expect(progress[0].sharePercent).toBe(60);
+    expect(progress[0].relativeEffort).toBe('leading');
+    expect(progress[1].relativeEffort).toBe('catching-up');
+  });
+
+  it('marks even contributors as on-track', () => {
+    const progress = buildContributorProgress([
+      { id: 'a', name: 'A', contributedCents: 1000 },
+      { id: 'b', name: 'B', contributedCents: 1000 },
+    ]);
+    expect(progress.every((p) => p.relativeEffort === 'on-track')).toBe(true);
+  });
+
+  it('treats a sole contributor as on-track', () => {
+    const progress = buildContributorProgress([{ id: 'a', name: 'A', contributedCents: 1000 }]);
+    expect(progress[0].relativeEffort).toBe('on-track');
+    expect(progress[0].shareBps).toBe(10000);
+  });
+
+  it('returns zero shares when nothing has been contributed', () => {
+    const progress = buildContributorProgress([
+      { id: 'a', name: 'A', contributedCents: 0 },
+      { id: 'b', name: 'B', contributedCents: 0 },
+    ]);
+    expect(progress.map((p) => p.shareBps)).toEqual([0, 0]);
+  });
+
+  it('returns an empty array for no contributors', () => {
+    expect(buildContributorProgress([])).toEqual([]);
+  });
+});
+
+describe('buildMilestoneProgress', () => {
+  const milestones: GoalMilestone[] = [
+    { id: 'down', label: 'Down payment', amountCents: 4000000 },
+    { id: 'closing', label: 'Closing costs', amountCents: 1500000 },
+    { id: 'buffer', label: 'Emergency buffer', amountCents: 1000000 },
+  ];
+
+  it('funds checkpoints waterfall-style in order', () => {
+    const progress = buildMilestoneProgress(4500000, milestones);
+
+    expect(progress[0]).toMatchObject({
+      fundedCents: 4000000,
+      status: 'complete',
+      percentComplete: 100,
+    });
+    expect(progress[1]).toMatchObject({ fundedCents: 500000, status: 'in-progress' });
+    expect(progress[1].percentComplete).toBe(33);
+    expect(progress[1].remainingCents).toBe(1000000);
+    expect(progress[2]).toMatchObject({ fundedCents: 0, status: 'upcoming', percentComplete: 0 });
+  });
+
+  it('marks every checkpoint complete once fully funded', () => {
+    const progress = buildMilestoneProgress(99999999, milestones);
+    expect(progress.every((m) => m.status === 'complete')).toBe(true);
+  });
+
+  it('treats a zero-cost checkpoint as complete', () => {
+    const progress = buildMilestoneProgress(0, [{ id: 'x', label: 'Free', amountCents: 0 }]);
+    expect(progress[0].status).toBe('complete');
+    expect(progress[0].percentComplete).toBe(100);
+  });
+
+  it('returns an empty array when there are no milestones', () => {
+    expect(buildMilestoneProgress(1000, [])).toEqual([]);
+  });
+});
+
+describe('suggestedMonthlyContributions', () => {
+  const contributors: GoalContributor[] = [
+    { id: 'a', name: 'Alex', contributedCents: 0, monthlyIncomeCents: 600000 },
+    { id: 'b', name: 'Bailey', contributedCents: 0, monthlyIncomeCents: 400000 },
+  ];
+
+  it('rounds the household monthly target up so the goal is met', () => {
+    const plan = suggestedMonthlyContributions(1000, 3, contributors);
+    // ceil(1000 / 3) = 334
+    expect(plan.householdMonthlyCents).toBe(334);
+    expect(plan.months).toBe(3);
+  });
+
+  it('per-person amounts sum exactly to the household monthly target (even)', () => {
+    const plan = suggestedMonthlyContributions(1000, 3, contributors);
+    expect(sum(plan.perPerson.map((p) => p.monthlyCents))).toBe(plan.householdMonthlyCents);
+    expect(plan.incomeWeighted).toBe(false);
+  });
+
+  it('weights by income when requested and incomes are present', () => {
+    const plan = suggestedMonthlyContributions(1000000, 10, contributors, { incomeWeighted: true });
+    expect(plan.incomeWeighted).toBe(true);
+    expect(sum(plan.perPerson.map((p) => p.monthlyCents))).toBe(plan.householdMonthlyCents);
+    // 60/40 income split of 100000 cents.
+    expect(plan.perPerson[0].monthlyCents).toBe(60000);
+    expect(plan.perPerson[1].monthlyCents).toBe(40000);
+  });
+
+  it('falls back to an even split when income data is incomplete', () => {
+    const plan = suggestedMonthlyContributions(
+      1000000,
+      10,
+      [
+        { id: 'a', name: 'Alex', contributedCents: 0, monthlyIncomeCents: 600000 },
+        { id: 'b', name: 'Bailey', contributedCents: 0, monthlyIncomeCents: null },
+      ],
+      { incomeWeighted: true },
+    );
+    expect(plan.incomeWeighted).toBe(false);
+    expect(plan.perPerson[0].monthlyCents).toBe(plan.perPerson[1].monthlyCents);
+  });
+
+  it('clamps months to at least 1', () => {
+    const plan = suggestedMonthlyContributions(5000, 0, contributors);
+    expect(plan.months).toBe(1);
+    expect(plan.householdMonthlyCents).toBe(5000);
+  });
+
+  it('returns no per-person rows when there are no contributors', () => {
+    const plan = suggestedMonthlyContributions(5000, 5, []);
+    expect(plan.perPerson).toEqual([]);
+  });
+});
+
+describe('monthsUntil', () => {
+  it('counts whole months', () => {
+    expect(monthsUntil('2025-01-01', '2025-04-01')).toBe(3);
+  });
+
+  it('rounds up a partial month', () => {
+    expect(monthsUntil('2025-01-01', '2025-04-15')).toBe(4);
+  });
+
+  it('clamps to at least 1 month', () => {
+    expect(monthsUntil('2025-04-01', '2025-01-01')).toBe(1);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(monthsUntil('not-a-date', '2025-01-01')).toBeNull();
+  });
+});
+
+describe('summarizeSharedGoal', () => {
+  const contributors: GoalContributor[] = [
+    { id: 'a', name: 'Alex', contributedCents: 3000000 },
+    { id: 'b', name: 'Bailey', contributedCents: 2000000 },
+  ];
+  const milestones: GoalMilestone[] = [
+    { id: 'down', label: 'Down payment', amountCents: 4000000 },
+    { id: 'closing', label: 'Closing costs', amountCents: 1500000 },
+  ];
+
+  it('summarizes household totals, contributors and milestones in detailed mode', () => {
+    const summary = summarizeSharedGoal(8000000, contributors, milestones, 'detailed');
+    expect(summary.contributedCents).toBe(5000000);
+    expect(summary.remainingCents).toBe(3000000);
+    expect(summary.householdPercentComplete).toBe(63);
+    expect(summary.contributors[0].contributedCents).toBe(3000000);
+    expect(summary.milestones[0].status).toBe('complete');
+    expect(summary.milestones[1].status).toBe('in-progress');
+  });
+
+  it('hides exact partner amounts in summarized mode', () => {
+    const summary = summarizeSharedGoal(8000000, contributors, milestones, 'summarized');
+    expect(summary.contributedCents).toBe(5000000);
+    expect(summary.contributors.every((c) => c.contributedCents === null)).toBe(true);
+  });
+
+  it('defaults to detailed privacy and no milestones', () => {
+    const summary = summarizeSharedGoal(1000, contributors);
+    expect(summary.privacy).toBe('detailed');
+    expect(summary.milestones).toEqual([]);
+  });
+});
+
+describe('relativeEffortLabel', () => {
+  it('maps effort values to readable text', () => {
+    expect(relativeEffortLabel('leading')).toBe('Leading');
+    expect(relativeEffortLabel('catching-up')).toBe('Catching up');
+    expect(relativeEffortLabel('on-track')).toBe('On track');
+  });
+});

--- a/apps/web/src/lib/goals/shared-goal.ts
+++ b/apps/web/src/lib/goals/shared-goal.ts
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Shared goal contribution engine for couples saving together (e.g. a house
+ * down payment).
+ *
+ * The engine models a goal funded by multiple named contributors and computes:
+ *  - household total progress (sum of contributions vs the target);
+ *  - per-contributor progress and relative effort;
+ *  - suggested monthly contribution per person (even or income-weighted) that
+ *    sums *exactly* to the household monthly target — no lost or created cents;
+ *  - milestone sub-targets (down payment / closing costs / emergency buffer)
+ *    as ordered checkpoints funded waterfall-style from the household total;
+ *  - a privacy mode: `detailed` (each partner's exact amounts) vs `summarized`
+ *    (household total + relative effort only, never exact partner amounts).
+ *
+ * Every monetary value is an integer number of cents — floating-point money is
+ * never used. All functions are pure and side-effect free so they can be unit
+ * tested deterministically.
+ *
+ * References: issue #2147 (web slice)
+ */
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Visibility of per-partner contribution amounts.
+ *
+ * - `detailed`   — show each partner's exact contributed cents.
+ * - `summarized` — show only the household total plus each partner's relative
+ *   effort (share of the pot + a text label). Never exposes exact amounts.
+ */
+export type GoalContributionPrivacy = 'detailed' | 'summarized';
+
+/** A named person contributing toward a shared goal. */
+export interface GoalContributor {
+  /** Stable identifier (unique within the goal). */
+  readonly id: string;
+  /** Display name shown in the UI. */
+  readonly name: string;
+  /** Total contributed so far, in integer cents (never negative). */
+  readonly contributedCents: number;
+  /**
+   * Optional take-home monthly income in integer cents, used only for the
+   * income-weighted split of suggested monthly contributions.
+   */
+  readonly monthlyIncomeCents?: number | null;
+}
+
+/** An ordered checkpoint within a goal (e.g. "Down payment"). */
+export interface GoalMilestone {
+  /** Stable identifier (unique within the goal). */
+  readonly id: string;
+  /** Human-readable label, e.g. "Closing costs". */
+  readonly label: string;
+  /** The cost of reaching this checkpoint, in integer cents (never negative). */
+  readonly amountCents: number;
+}
+
+/** A contributor's relative standing versus an even split. */
+export type RelativeEffort = 'leading' | 'on-track' | 'catching-up';
+
+/** Computed progress for a single contributor. */
+export interface ContributorProgress {
+  readonly id: string;
+  readonly name: string;
+  /** Exact contributed cents, or `null` when privacy is `summarized`. */
+  readonly contributedCents: number | null;
+  /** Share of the household pot in basis points (0–10000); shares sum to 10000. */
+  readonly shareBps: number;
+  /** Share of the household pot as a percentage (0–100, one decimal place). */
+  readonly sharePercent: number;
+  /** Relative standing versus an even split, conveyed by text (never colour). */
+  readonly relativeEffort: RelativeEffort;
+}
+
+/** Computed progress for a single milestone checkpoint. */
+export interface MilestoneProgress {
+  readonly id: string;
+  readonly label: string;
+  readonly amountCents: number;
+  /** Household funds allocated to this checkpoint (waterfall order). */
+  readonly fundedCents: number;
+  /** Cents still required to complete this checkpoint. */
+  readonly remainingCents: number;
+  /** Completion of this checkpoint as an integer percentage (0–100). */
+  readonly percentComplete: number;
+  readonly status: 'complete' | 'in-progress' | 'upcoming';
+}
+
+/** A suggested monthly contribution for one person. */
+export interface SuggestedMonthlyContribution {
+  readonly id: string;
+  readonly name: string;
+  /** Suggested monthly amount in integer cents. */
+  readonly monthlyCents: number;
+}
+
+/** Aggregate result describing a shared goal's contribution picture. */
+export interface SharedGoalSummary {
+  readonly targetCents: number;
+  /** Sum of every contributor's contributed cents. */
+  readonly contributedCents: number;
+  /** Cents still required to reach the target (never negative). */
+  readonly remainingCents: number;
+  /** Household completion as an integer percentage (0–100, capped at 100). */
+  readonly householdPercentComplete: number;
+  readonly contributors: readonly ContributorProgress[];
+  readonly milestones: readonly MilestoneProgress[];
+  readonly privacy: GoalContributionPrivacy;
+}
+
+// ---------------------------------------------------------------------------
+// Integer helpers
+// ---------------------------------------------------------------------------
+
+/** Coerce any value to a non-negative safe integer number of cents. */
+function toNonNegativeCents(value: number | null | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.trunc(value));
+}
+
+/**
+ * Split `totalCents` evenly across `count` buckets so the parts sum *exactly*
+ * to `totalCents`. The first `remainder` buckets each receive one extra cent.
+ *
+ * @returns An array of `count` integers summing to `totalCents`.
+ */
+export function allocateEven(totalCents: number, count: number): number[] {
+  const total = toNonNegativeCents(totalCents);
+  if (count <= 0) {
+    return [];
+  }
+  const base = Math.floor(total / count);
+  const remainder = total - base * count;
+  return Array.from({ length: count }, (_, index) => base + (index < remainder ? 1 : 0));
+}
+
+/**
+ * Allocate `totalCents` across buckets in proportion to `weights` using the
+ * largest-remainder (Hamilton) method. The returned integers sum *exactly* to
+ * `totalCents` — never losing or creating a cent. Non-positive/invalid weights
+ * are treated as zero; if every weight is zero the split falls back to even.
+ *
+ * @returns An array the same length as `weights` summing to `totalCents`.
+ */
+export function allocateProportionally(totalCents: number, weights: readonly number[]): number[] {
+  const count = weights.length;
+  if (count === 0) {
+    return [];
+  }
+
+  const total = toNonNegativeCents(totalCents);
+  const safeWeights = weights.map((weight) => (Number.isFinite(weight) && weight > 0 ? weight : 0));
+  const weightSum = safeWeights.reduce((sum, weight) => sum + weight, 0);
+
+  if (weightSum <= 0) {
+    return allocateEven(total, count);
+  }
+
+  const exact = safeWeights.map((weight) => (total * weight) / weightSum);
+  const result = exact.map((value) => Math.floor(value));
+  const allocated = result.reduce((sum, value) => sum + value, 0);
+  let remainder = total - allocated;
+
+  // Distribute the leftover cents to the largest fractional parts first,
+  // breaking ties by lowest index for deterministic output.
+  const order = exact
+    .map((value, index) => ({ index, frac: value - Math.floor(value) }))
+    .sort((a, b) => b.frac - a.frac || a.index - b.index);
+
+  let cursor = 0;
+  while (remainder > 0 && order.length > 0) {
+    const target = order[cursor % order.length];
+    result[target.index] += 1;
+    remainder -= 1;
+    cursor += 1;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate calculations
+// ---------------------------------------------------------------------------
+
+/** Sum the contributed cents across all contributors (integer cents). */
+export function totalContributedCents(contributors: readonly GoalContributor[]): number {
+  return contributors.reduce(
+    (sum, contributor) => sum + toNonNegativeCents(contributor.contributedCents),
+    0,
+  );
+}
+
+/**
+ * Household completion as an integer percentage (0–100, capped at 100).
+ * Returns 0 when the target is non-positive and nothing has been contributed.
+ */
+export function householdPercentComplete(
+  targetCents: number,
+  contributors: readonly GoalContributor[],
+): number {
+  const target = toNonNegativeCents(targetCents);
+  const contributed = totalContributedCents(contributors);
+  if (target <= 0) {
+    return contributed > 0 ? 100 : 0;
+  }
+  return Math.min(100, Math.round((contributed / target) * 100));
+}
+
+/** Classify a contributor's share (percent) versus an even split of `count`. */
+function classifyEffort(sharePercent: number, count: number): RelativeEffort {
+  if (count <= 1) {
+    return 'on-track';
+  }
+  const evenShare = 100 / count;
+  if (evenShare <= 0) {
+    return 'on-track';
+  }
+  const ratio = sharePercent / evenShare;
+  if (ratio >= 1.1) {
+    return 'leading';
+  }
+  if (ratio <= 0.9) {
+    return 'catching-up';
+  }
+  return 'on-track';
+}
+
+/**
+ * Build per-contributor progress. Shares are expressed in basis points using
+ * the largest-remainder method so they always sum to exactly 10000 (100%).
+ * When `privacy` is `summarized`, exact contributed cents are withheld
+ * (`contributedCents: null`) while the relative share and effort remain.
+ */
+export function buildContributorProgress(
+  contributors: readonly GoalContributor[],
+  privacy: GoalContributionPrivacy = 'detailed',
+): ContributorProgress[] {
+  if (contributors.length === 0) {
+    return [];
+  }
+
+  const amounts = contributors.map((contributor) =>
+    toNonNegativeCents(contributor.contributedCents),
+  );
+  const total = amounts.reduce((sum, amount) => sum + amount, 0);
+  const shareBpsList = total > 0 ? allocateProportionally(10000, amounts) : amounts.map(() => 0);
+
+  return contributors.map((contributor, index) => {
+    const shareBps = shareBpsList[index] ?? 0;
+    const sharePercent = Math.round((shareBps / 100) * 10) / 10;
+    return {
+      id: contributor.id,
+      name: contributor.name,
+      contributedCents: privacy === 'summarized' ? null : amounts[index],
+      shareBps,
+      sharePercent,
+      relativeEffort: classifyEffort(sharePercent, contributors.length),
+    };
+  });
+}
+
+/**
+ * Fund ordered milestone checkpoints waterfall-style from the household total:
+ * each checkpoint is filled to its `amountCents` before the next receives any
+ * funds. Checkpoints later than the available funds are `upcoming`.
+ */
+export function buildMilestoneProgress(
+  contributedCents: number,
+  milestones: readonly GoalMilestone[],
+): MilestoneProgress[] {
+  let remainingFunds = toNonNegativeCents(contributedCents);
+
+  return milestones.map((milestone) => {
+    const amount = toNonNegativeCents(milestone.amountCents);
+    const funded = Math.min(remainingFunds, amount);
+    remainingFunds -= funded;
+    const remaining = Math.max(0, amount - funded);
+    const percentComplete = amount > 0 ? Math.min(100, Math.floor((funded / amount) * 100)) : 100;
+    const status: MilestoneProgress['status'] =
+      amount === 0 || funded >= amount ? 'complete' : funded > 0 ? 'in-progress' : 'upcoming';
+
+    return {
+      id: milestone.id,
+      label: milestone.label,
+      amountCents: amount,
+      fundedCents: funded,
+      remainingCents: remaining,
+      percentComplete,
+      status,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Suggested monthly contributions
+// ---------------------------------------------------------------------------
+
+/** Options controlling the per-person split of suggested monthly contributions. */
+export interface SuggestedMonthlyOptions {
+  /**
+   * When `true` and every contributor has a positive `monthlyIncomeCents`, the
+   * suggested monthly amounts are split in proportion to income. Otherwise the
+   * split is even.
+   */
+  readonly incomeWeighted?: boolean;
+}
+
+/** Result of {@link suggestedMonthlyContributions}. */
+export interface SuggestedMonthlyPlan {
+  /** Total monthly amount the household should save, in integer cents. */
+  readonly householdMonthlyCents: number;
+  /** Number of whole months used for the calculation (always ≥ 1). */
+  readonly months: number;
+  /** Whether the per-person split is income-weighted. */
+  readonly incomeWeighted: boolean;
+  /** Per-person suggestions summing exactly to `householdMonthlyCents`. */
+  readonly perPerson: readonly SuggestedMonthlyContribution[];
+}
+
+/**
+ * Compute the household monthly target and split it across contributors.
+ *
+ * The household monthly target is `ceil(remaining / months)` so the goal is met
+ * (or slightly exceeded) by the deadline. The per-person amounts are produced
+ * with the largest-remainder method and therefore sum *exactly* to the
+ * household monthly target — no lost or created cents.
+ *
+ * @param remainingCents - Cents still required to reach the target.
+ * @param monthsRemaining - Whole months until the deadline (clamped to ≥ 1).
+ * @param contributors - The people sharing the goal.
+ * @param options - Even vs income-weighted split.
+ */
+export function suggestedMonthlyContributions(
+  remainingCents: number,
+  monthsRemaining: number,
+  contributors: readonly GoalContributor[],
+  options: SuggestedMonthlyOptions = {},
+): SuggestedMonthlyPlan {
+  const remaining = toNonNegativeCents(remainingCents);
+  const months = Math.max(1, Math.floor(Number.isFinite(monthsRemaining) ? monthsRemaining : 1));
+  const householdMonthlyCents = Math.ceil(remaining / months);
+
+  if (contributors.length === 0) {
+    return { householdMonthlyCents, months, incomeWeighted: false, perPerson: [] };
+  }
+
+  const incomes = contributors.map((contributor) =>
+    toNonNegativeCents(contributor.monthlyIncomeCents ?? 0),
+  );
+  const canIncomeWeight =
+    options.incomeWeighted === true &&
+    incomes.every((income) => income > 0) &&
+    incomes.reduce((sum, income) => sum + income, 0) > 0;
+
+  const weights = canIncomeWeight ? incomes : contributors.map(() => 1);
+  const split = allocateProportionally(householdMonthlyCents, weights);
+
+  return {
+    householdMonthlyCents,
+    months,
+    incomeWeighted: canIncomeWeight,
+    perPerson: contributors.map((contributor, index) => ({
+      id: contributor.id,
+      name: contributor.name,
+      monthlyCents: split[index] ?? 0,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dates
+// ---------------------------------------------------------------------------
+
+/**
+ * Whole months between two ISO `YYYY-MM-DD` dates, clamped to a minimum of 1.
+ * A partial month (target day-of-month later than the start) rounds up so the
+ * deadline is never under-counted. Returns `null` for invalid input.
+ */
+export function monthsUntil(fromIso: string, toIso: string): number | null {
+  const from = new Date(`${fromIso}T00:00:00.000Z`);
+  const to = new Date(`${toIso}T00:00:00.000Z`);
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+    return null;
+  }
+  let months =
+    (to.getUTCFullYear() - from.getUTCFullYear()) * 12 + (to.getUTCMonth() - from.getUTCMonth());
+  if (to.getUTCDate() > from.getUTCDate()) {
+    months += 1;
+  }
+  return Math.max(1, months);
+}
+
+// ---------------------------------------------------------------------------
+// Top-level summary
+// ---------------------------------------------------------------------------
+
+/**
+ * Combine every calculation into a single {@link SharedGoalSummary} for the UI.
+ */
+export function summarizeSharedGoal(
+  targetCents: number,
+  contributors: readonly GoalContributor[],
+  milestones: readonly GoalMilestone[] = [],
+  privacy: GoalContributionPrivacy = 'detailed',
+): SharedGoalSummary {
+  const target = toNonNegativeCents(targetCents);
+  const contributed = totalContributedCents(contributors);
+
+  return {
+    targetCents: target,
+    contributedCents: contributed,
+    remainingCents: Math.max(0, target - contributed),
+    householdPercentComplete: householdPercentComplete(target, contributors),
+    contributors: buildContributorProgress(contributors, privacy),
+    milestones: buildMilestoneProgress(contributed, milestones),
+    privacy,
+  };
+}
+
+/** Human-readable label for a {@link RelativeEffort} value (text, not colour). */
+export function relativeEffortLabel(effort: RelativeEffort): string {
+  switch (effort) {
+    case 'leading':
+      return 'Leading';
+    case 'catching-up':
+      return 'Catching up';
+    default:
+      return 'On track';
+  }
+}

--- a/apps/web/src/pages/GoalDetailPage.test.tsx
+++ b/apps/web/src/pages/GoalDetailPage.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
@@ -198,7 +198,8 @@ describe('GoalDetailPage', () => {
   it('has accessible progress bar', () => {
     renderWithRoute();
 
-    const progressBar = screen.getByRole('progressbar');
+    const progressRegion = screen.getByRole('region', { name: /goal progress/i });
+    const progressBar = within(progressRegion).getByRole('progressbar');
     expect(progressBar).toBeInTheDocument();
     // 1500000 / 2000000 = 75%
     expect(progressBar).toHaveAttribute('aria-valuenow', '75');
@@ -206,10 +207,32 @@ describe('GoalDetailPage', () => {
     expect(progressBar).toHaveAttribute('aria-valuemax', '100');
   });
 
+  // ---------------------------------------------------------------------------
+  // Shared contributions (issue #2147)
+  // ---------------------------------------------------------------------------
+
+  it('renders the shared contributions section with a visibility toggle', () => {
+    renderWithRoute();
+
+    expect(screen.getByRole('region', { name: /shared contributions/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /detailed/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /summarized/i })).toBeInTheDocument();
+  });
+
+  it('lists partner contributions and a household total progress bar', () => {
+    renderWithRoute();
+
+    const partnerList = screen.getByRole('list', { name: /partner contributions/i });
+    expect(partnerList).toBeInTheDocument();
+    // Household total + at least one partner progress bar exist.
+    expect(screen.getAllByRole('progressbar').length).toBeGreaterThan(1);
+  });
+
   it('shows remaining amount and percentage', () => {
     renderWithRoute();
 
-    expect(screen.getByText(/75%/)).toBeInTheDocument();
+    const progressRegion = screen.getByRole('region', { name: /goal progress/i });
+    expect(within(progressRegion).getByText(/75%/)).toBeInTheDocument();
   });
 
   it('shows time remaining when target date is set', () => {

--- a/apps/web/src/pages/GoalDetailPage.tsx
+++ b/apps/web/src/pages/GoalDetailPage.tsx
@@ -17,6 +17,7 @@ import { useGoals } from '../hooks';
 import type { Goal } from '../kmp/bridge';
 import { getGoalStatusIndicator } from '../lib/a11y';
 import { ShareCelebrationButton } from '../components/social/ShareCelebrationButton';
+import { SharedGoalContributions } from '../components/goals/SharedGoalContributions';
 import { goalCelebrationEvent } from '../lib/social/share-celebration';
 import '../styles/pages.css';
 
@@ -330,6 +331,8 @@ export const GoalDetailPage: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <SharedGoalContributions goal={goal} />
 
       <GoalForm
         isOpen={isFormOpen}

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -12,6 +12,7 @@ import {
   useToast,
 } from '../components/common';
 import { GoalContributionDialog } from '../components/goals/GoalContributionDialog';
+import { SharedGoalBadge } from '../components/goals/SharedGoalContributions';
 import { GoalForm } from '../components/forms';
 import { AppIcon, type IconName } from '../components/icons';
 import {
@@ -958,6 +959,7 @@ export const GoalsPage: React.FC = () => {
                               : 'Past due'}
                         </span>
                       </div>
+                      <SharedGoalBadge goalId={goal.id} goalName={goal.name} />
                       <div
                         style={{
                           display: 'flex',


### PR DESCRIPTION
﻿## Summary

Couples saving together (e.g. a house down payment) need **shared goals with per-partner contributions** — not just a single aggregate. This adds that to the web Goals surface.

### Gap verified first
Grepped the Goals surface before coding. `GoalsPage` and `GoalDetailPage` existed but showed **only a single aggregate `currentAmount`** with no per-contributor breakdown, no milestone planning, and no privacy toggle. (Pre-existing `lib/household/goal-contributions.ts` and `lib/savings/shared-goal-contributions.ts` power the Household/dashboard surfaces, but neither is wired into the Goals pages, and neither covers income-weighted per-person suggestions, ordered milestone checkpoints, or a detailed/summarized privacy mode.) I **enhanced the existing pages** rather than adding a parallel one.

### What's new
- **Pure integer-cents engine** in `apps/web/src/lib/goals/` (`shared-goal.ts`) — never floats:
  - Household total + per-contributor progress and relative effort.
  - Suggested monthly contribution per person (even **or** income-weighted) using a largest-remainder allocation so per-person amounts **sum exactly** to the household monthly target — no lost/created cents.
  - Ordered milestone checkpoints (down payment / closing costs / emergency buffer) funded waterfall-style with their own progress.
  - Privacy mode: `detailed` (exact partner amounts) vs `summarized` (household total + relative effort only).
- **`SharedGoalContributions`** component surfaced on `GoalDetailPage`: contributors breakdown, per-partner progress bars, suggested monthly targets, milestone checklist, and a visibility toggle. Imported **directly** into the page (not a shared barrel) to respect the web perf budget.
- **`SharedGoalBadge`** compact, text-first indicator on `GoalsPage` cards (partner count + who's leading), only shown when 2+ partners exist.

### Accessibility (WCAG 2.2 AA)
- Contributor identity/standing conveyed by **text labels** (Leading / On track / Catching up) and the partner's name — never colour alone.
- Progress bars expose `role="progressbar"` with `aria-valuemin/now/max` and descriptive `aria-valuetext`.
- Privacy control is a labeled radio group; all controls keyboard reachable; reduced-motion honoured via existing token-driven `.progress-bar` styles.

### Notes
- Per-partner split is persisted locally for now (TypeScript data path for the goal itself is untouched); the KMP shared `Goal` model gaining first-class contributions + native Android UI remain — hence **Refs #2147**, not Closes.
- No router/build-config or other-page changes. CSP-safe (no inline scripts/eval); design tokens only.

## Testing
- `vitest` engine unit tests (39): exact-cent allocation (even, proportional, income-weighted), remainder distribution, milestone waterfall progress, contributor shares summing to 100%, detailed vs summarized.
- `vitest` render/smoke tests (9) for `SharedGoalContributions` + `SharedGoalBadge` (progressbar aria, privacy toggle hides amounts, milestone status text, suggested monthly per person).
- Existing `GoalDetailPage`/`GoalsPage` suites updated and green.
- `prettier --check` clean, `eslint --max-warnings 0` clean, `tsc --noEmit` clean, `vite build` + `perf:budget` pass (code lands in route-planning chunk, ~66.7 KiB gzip — well under budget).

Refs #2147
