### PR TITLE
feat(web): teen achievement streaks, near-win cues, celebrations (#2211)

### DIFF
--- a/apps/web/src/components/gamification/achievements-engine.test.ts
+++ b/apps/web/src/components/gamification/achievements-engine.test.ts
@@ -23,6 +23,7 @@ function makeInput(overrides: Partial<GamificationInput> = {}): GamificationInpu
     accountCount: 0,
     totalSaved: 0,
     categoriesUsed: 0,
+    loggedToday: false,
     ...overrides,
   };
 }
@@ -159,6 +160,32 @@ describe('achievements-engine', () => {
       expect(state.streaks[0].current).toBe(5);
       expect(state.streaks[0].longest).toBe(12);
       expect(state.streaks[0].type).toBe('daily_logging');
+    });
+
+    it('attaches a count near-win metric to locked habit badges', () => {
+      const state = computeGamification(makeInput({ transactionCount: 8 }));
+      const badge = state.achievements.find((a) => a.id === 'transaction-10');
+      expect(badge?.status).toBe('locked');
+      expect(badge?.nearWin).toEqual({ remaining: 2, unit: 'check-in', format: 'count' });
+    });
+
+    it('attaches a currency near-win metric to locked saving badges', () => {
+      const state = computeGamification(makeInput({ totalSaved: 90000 }));
+      const badge = state.achievements.find((a) => a.id === 'saved-1000');
+      expect(badge?.status).toBe('locked');
+      expect(badge?.nearWin).toEqual({ remaining: 10000, unit: 'saved', format: 'currency' });
+    });
+
+    it('omits near-win metric once a badge is unlocked', () => {
+      const state = computeGamification(makeInput({ transactionCount: 10 }));
+      const badge = state.achievements.find((a) => a.id === 'transaction-10');
+      expect(badge?.status).toBe('unlocked');
+      expect(badge?.nearWin).toBeUndefined();
+    });
+
+    it('passes loggedToday through to the state', () => {
+      expect(computeGamification(makeInput({ loggedToday: true })).loggedToday).toBe(true);
+      expect(computeGamification(makeInput({ loggedToday: false })).loggedToday).toBe(false);
     });
   });
 

--- a/apps/web/src/components/gamification/achievements-engine.ts
+++ b/apps/web/src/components/gamification/achievements-engine.ts
@@ -21,6 +21,24 @@ export type AchievementCategory = 'budgeting' | 'saving' | 'tracking' | 'milesto
 /** Achievement unlock status. */
 export type AchievementStatus = 'locked' | 'unlocked' | 'new';
 
+/** How a near-win `remaining` value should be rendered. */
+export type NearWinFormat = 'count' | 'currency';
+
+/**
+ * Near-win metric describing how much remains before a locked badge unlocks.
+ *
+ * Only ever derived from healthy-habit signals (consistent check-ins, saving,
+ * on-time budgeting) — never from raw spending volume.
+ */
+export interface AchievementNearWin {
+  /** How many more units (count) or cents (currency) remain to unlock. */
+  readonly remaining: number;
+  /** Singular unit noun, e.g. 'check-in', 'day', 'on-time month', 'goal'. */
+  readonly unit: string;
+  /** Whether `remaining` is a plain count or a currency (cents) amount. */
+  readonly format: NearWinFormat;
+}
+
 /** A single achievement badge definition. */
 export interface Achievement {
   /** Unique identifier. */
@@ -37,6 +55,11 @@ export interface Achievement {
   readonly status: AchievementStatus;
   /** Progress toward unlocking (0-100). */
   readonly progress: number;
+  /**
+   * Near-win metric for locked badges that reward healthy habits. Absent when
+   * the badge is unlocked or has no "do N more" habit (e.g. positive net worth).
+   */
+  readonly nearWin?: AchievementNearWin;
   /** Optional date when achieved (ISO string). */
   readonly unlockedAt?: string;
 }
@@ -100,6 +123,11 @@ export interface GamificationInput {
   totalSaved: number;
   /** Number of categories used. */
   categoriesUsed: number;
+  /**
+   * True when today's streak action (logging at least one transaction) has
+   * already happened. Drives the streak-keep-alive near-win cue.
+   */
+  loggedToday: boolean;
 }
 
 /** Complete gamification state. */
@@ -111,6 +139,8 @@ export interface GamificationState {
   level: number;
   levelName: string;
   pointsToNextLevel: number;
+  /** True when today's daily streak action has already been completed. */
+  loggedToday: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -125,6 +155,16 @@ interface AchievementDefinition {
   category: AchievementCategory;
   check: (input: GamificationInput) => { unlocked: boolean; progress: number };
   points: number;
+  /**
+   * Optional healthy-habit near-win metric. Only present on badges that reward
+   * consistency, saving, or on-time behavior — never raw spending volume. When
+   * present and the badge is locked, the engine surfaces a "N more" cue.
+   */
+  nearWin?: {
+    unit: string;
+    format?: NearWinFormat;
+    metric: (input: GamificationInput) => { current: number; target: number };
+  };
 }
 
 const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
@@ -139,6 +179,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.transactionCount >= 1,
       progress: Math.min(input.transactionCount, 1) * 100,
     }),
+    nearWin: {
+      unit: 'check-in',
+      metric: (input) => ({ current: input.transactionCount, target: 1 }),
+    },
     points: 10,
   },
   {
@@ -151,6 +195,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.transactionCount >= 10,
       progress: Math.min(Math.round((input.transactionCount / 10) * 100), 100),
     }),
+    nearWin: {
+      unit: 'check-in',
+      metric: (input) => ({ current: input.transactionCount, target: 10 }),
+    },
     points: 25,
   },
   {
@@ -163,6 +211,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.transactionCount >= 100,
       progress: Math.min(Math.round((input.transactionCount / 100) * 100), 100),
     }),
+    nearWin: {
+      unit: 'check-in',
+      metric: (input) => ({ current: input.transactionCount, target: 100 }),
+    },
     points: 50,
   },
   {
@@ -175,6 +227,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.transactionCount >= 500,
       progress: Math.min(Math.round((input.transactionCount / 500) * 100), 100),
     }),
+    nearWin: {
+      unit: 'check-in',
+      metric: (input) => ({ current: input.transactionCount, target: 500 }),
+    },
     points: 100,
   },
   {
@@ -187,6 +243,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.longestDailyLoggingStreak >= 7,
       progress: Math.min(Math.round((input.longestDailyLoggingStreak / 7) * 100), 100),
     }),
+    nearWin: {
+      unit: 'day',
+      metric: (input) => ({ current: input.longestDailyLoggingStreak, target: 7 }),
+    },
     points: 30,
   },
   {
@@ -199,6 +259,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.longestDailyLoggingStreak >= 30,
       progress: Math.min(Math.round((input.longestDailyLoggingStreak / 30) * 100), 100),
     }),
+    nearWin: {
+      unit: 'day',
+      metric: (input) => ({ current: input.longestDailyLoggingStreak, target: 30 }),
+    },
     points: 75,
   },
 
@@ -213,6 +277,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.budgetCount >= 1,
       progress: Math.min(input.budgetCount, 1) * 100,
     }),
+    nearWin: {
+      unit: 'budget',
+      metric: (input) => ({ current: input.budgetCount, target: 1 }),
+    },
     points: 15,
   },
   {
@@ -225,6 +293,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.budgetAdherenceMonths >= 1,
       progress: Math.min(input.budgetAdherenceMonths, 1) * 100,
     }),
+    nearWin: {
+      unit: 'on-time month',
+      metric: (input) => ({ current: input.budgetAdherenceMonths, target: 1 }),
+    },
     points: 30,
   },
   {
@@ -237,6 +309,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.budgetAdherenceMonths >= 3,
       progress: Math.min(Math.round((input.budgetAdherenceMonths / 3) * 100), 100),
     }),
+    nearWin: {
+      unit: 'on-time month',
+      metric: (input) => ({ current: input.budgetAdherenceMonths, target: 3 }),
+    },
     points: 75,
   },
 
@@ -251,6 +327,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.goalCount >= 1,
       progress: Math.min(input.goalCount, 1) * 100,
     }),
+    nearWin: {
+      unit: 'goal',
+      metric: (input) => ({ current: input.goalCount, target: 1 }),
+    },
     points: 15,
   },
   {
@@ -263,6 +343,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.goalsCompleted >= 1,
       progress: Math.min(input.goalsCompleted, 1) * 100,
     }),
+    nearWin: {
+      unit: 'completed goal',
+      metric: (input) => ({ current: input.goalsCompleted, target: 1 }),
+    },
     points: 50,
   },
   {
@@ -275,6 +359,11 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.totalSaved >= 100000,
       progress: Math.min(Math.round((input.totalSaved / 100000) * 100), 100),
     }),
+    nearWin: {
+      unit: 'saved',
+      format: 'currency',
+      metric: (input) => ({ current: input.totalSaved, target: 100000 }),
+    },
     points: 40,
   },
   {
@@ -287,6 +376,11 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.totalSaved >= 1000000,
       progress: Math.min(Math.round((input.totalSaved / 1000000) * 100), 100),
     }),
+    nearWin: {
+      unit: 'saved',
+      format: 'currency',
+      metric: (input) => ({ current: input.totalSaved, target: 1000000 }),
+    },
     points: 100,
   },
 
@@ -301,6 +395,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.accountCount >= 1,
       progress: Math.min(input.accountCount, 1) * 100,
     }),
+    nearWin: {
+      unit: 'account',
+      metric: (input) => ({ current: input.accountCount, target: 1 }),
+    },
     points: 10,
   },
   {
@@ -313,6 +411,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.accountCount >= 3,
       progress: Math.min(Math.round((input.accountCount / 3) * 100), 100),
     }),
+    nearWin: {
+      unit: 'account',
+      metric: (input) => ({ current: input.accountCount, target: 3 }),
+    },
     points: 25,
   },
   {
@@ -325,6 +427,10 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
       unlocked: input.categoriesUsed >= 5,
       progress: Math.min(Math.round((input.categoriesUsed / 5) * 100), 100),
     }),
+    nearWin: {
+      unit: 'category',
+      metric: (input) => ({ current: input.categoriesUsed, target: 5 }),
+    },
     points: 20,
   },
   {
@@ -388,14 +494,30 @@ export function computeGamification(input: GamificationInput): GamificationState
   // Compute achievements
   const achievements: Achievement[] = ACHIEVEMENT_DEFINITIONS.map((def) => {
     const result = def.check(input);
+    const status: AchievementStatus = result.unlocked ? 'unlocked' : 'locked';
+
+    let nearWin: AchievementNearWin | undefined;
+    if (!result.unlocked && def.nearWin) {
+      const { current, target } = def.nearWin.metric(input);
+      const remaining = Math.max(0, target - current);
+      if (remaining > 0) {
+        nearWin = {
+          remaining,
+          unit: def.nearWin.unit,
+          format: def.nearWin.format ?? 'count',
+        };
+      }
+    }
+
     return {
       id: def.id,
       name: def.name,
       description: def.description,
       icon: def.icon,
       category: def.category,
-      status: result.unlocked ? 'unlocked' : 'locked',
+      status,
       progress: result.progress,
+      ...(nearWin ? { nearWin } : {}),
     };
   });
 
@@ -444,6 +566,7 @@ export function computeGamification(input: GamificationInput): GamificationState
     level: levelInfo.level,
     levelName: levelInfo.name,
     pointsToNextLevel: levelInfo.pointsToNext,
+    loggedToday: input.loggedToday,
   };
 }
 

--- a/apps/web/src/components/gamification/index.ts
+++ b/apps/web/src/components/gamification/index.ts
@@ -9,8 +9,20 @@ export type {
   Achievement,
   AchievementCategory,
   AchievementStatus,
+  AchievementNearWin,
+  NearWinFormat,
   StreakData,
   GoalMilestone,
   GamificationInput,
   GamificationState,
 } from './achievements-engine';
+export {
+  computeNearWinCues,
+  streakKeepAliveCue,
+  goalNearWinCue,
+  badgeNearWinCue,
+  selectNewlyUnlocked,
+  formatRemainingCurrency,
+  pluralizeUnit,
+} from './near-win-engine';
+export type { NearWinCue, NearWinKind, NearWinOptions, UnlockCelebration } from './near-win-engine';

--- a/apps/web/src/components/gamification/near-win-engine.test.ts
+++ b/apps/web/src/components/gamification/near-win-engine.test.ts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import type {
+  Achievement,
+  GamificationState,
+  GoalMilestone,
+  StreakData,
+} from './achievements-engine';
+import {
+  badgeNearWinCue,
+  computeNearWinCues,
+  formatRemainingCurrency,
+  goalNearWinCue,
+  pluralizeUnit,
+  selectNewlyUnlocked,
+  streakKeepAliveCue,
+} from './near-win-engine';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeBadge(overrides: Partial<Achievement> = {}): Achievement {
+  return {
+    id: 'transaction-10',
+    name: 'Getting Started',
+    description: 'Log 10 transactions',
+    icon: 'edit',
+    category: 'tracking',
+    status: 'locked',
+    progress: 80,
+    nearWin: { remaining: 2, unit: 'check-in', format: 'count' },
+    ...overrides,
+  };
+}
+
+function makeStreak(overrides: Partial<StreakData> = {}): StreakData {
+  return {
+    current: 5,
+    longest: 12,
+    type: 'daily_logging',
+    label: 'Daily Logging',
+    ...overrides,
+  };
+}
+
+function makeMilestone(overrides: Partial<GoalMilestone> = {}): GoalMilestone {
+  return {
+    goalId: 'g1',
+    goalName: 'Car Fund',
+    progress: 40,
+    milestonesReached: [25],
+    nextMilestone: 50,
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<GamificationState> = {}): GamificationState {
+  return {
+    achievements: [],
+    streaks: [],
+    milestones: [],
+    totalPoints: 0,
+    level: 1,
+    levelName: 'Newcomer',
+    pointsToNextLevel: 50,
+    loggedToday: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+describe('pluralizeUnit', () => {
+  it('keeps the singular form for a count of 1', () => {
+    expect(pluralizeUnit('check-in', 1)).toBe('check-in');
+    expect(pluralizeUnit('category', 1)).toBe('category');
+  });
+
+  it('adds an "s" for regular nouns', () => {
+    expect(pluralizeUnit('check-in', 2)).toBe('check-ins');
+    expect(pluralizeUnit('day', 3)).toBe('days');
+    expect(pluralizeUnit('on-time month', 2)).toBe('on-time months');
+  });
+
+  it('uses "ies" for consonant + y nouns', () => {
+    expect(pluralizeUnit('category', 4)).toBe('categories');
+  });
+});
+
+describe('formatRemainingCurrency', () => {
+  it('rounds cents up to whole dollars', () => {
+    expect(formatRemainingCurrency(10000)).toBe('$100');
+    expect(formatRemainingCurrency(10050)).toBe('$101');
+    expect(formatRemainingCurrency(0)).toBe('$0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Badge near-win
+// ---------------------------------------------------------------------------
+
+describe('badgeNearWinCue', () => {
+  it('computes "N more" for a locked count badge', () => {
+    const cue = badgeNearWinCue(
+      makeBadge({ nearWin: { remaining: 2, unit: 'check-in', format: 'count' } }),
+    );
+    expect(cue).not.toBeNull();
+    expect(cue?.kind).toBe('badge');
+    expect(cue?.message).toBe('2 more check-ins to earn Getting Started.');
+    expect(cue?.progress).toBe(80);
+  });
+
+  it('uses singular noun for a remaining of 1', () => {
+    const cue = badgeNearWinCue(
+      makeBadge({
+        name: 'First Step',
+        nearWin: { remaining: 1, unit: 'check-in', format: 'count' },
+      }),
+    );
+    expect(cue?.message).toBe('1 more check-in to earn First Step.');
+  });
+
+  it('formats currency badges with whole dollars', () => {
+    const cue = badgeNearWinCue(
+      makeBadge({
+        id: 'saved-1000',
+        name: 'First Thousand',
+        nearWin: { remaining: 25000, unit: 'saved', format: 'currency' },
+      }),
+    );
+    expect(cue?.message).toBe('$250 more saved to earn First Thousand.');
+  });
+
+  it('returns null for unlocked badges', () => {
+    expect(badgeNearWinCue(makeBadge({ status: 'unlocked' }))).toBeNull();
+  });
+
+  it('returns null when there is no near-win metric', () => {
+    expect(badgeNearWinCue(makeBadge({ nearWin: undefined }))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streak keep-alive
+// ---------------------------------------------------------------------------
+
+describe('streakKeepAliveCue', () => {
+  it('produces a keep-alive cue when today is still pending', () => {
+    const cue = streakKeepAliveCue([makeStreak({ current: 5 })], false);
+    expect(cue).not.toBeNull();
+    expect(cue?.kind).toBe('streak');
+    expect(cue?.progress).toBeNull();
+    expect(cue?.message).toBe('Log today to keep your 5-day daily logging streak alive.');
+  });
+
+  it('returns null once today has been logged', () => {
+    expect(streakKeepAliveCue([makeStreak({ current: 5 })], true)).toBeNull();
+  });
+
+  it('returns null when there is no active streak to protect', () => {
+    expect(streakKeepAliveCue([makeStreak({ current: 0 })], false)).toBeNull();
+    expect(streakKeepAliveCue([], false)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Goal near-win
+// ---------------------------------------------------------------------------
+
+describe('goalNearWinCue', () => {
+  it('frames the next milestone as one more contribution', () => {
+    const cue = goalNearWinCue(makeMilestone({ progress: 40, nextMilestone: 50 }));
+    expect(cue).not.toBeNull();
+    expect(cue?.kind).toBe('goal');
+    expect(cue?.progress).toBe(40);
+    expect(cue?.message).toBe("You're 10% away — one more contribution to hit 50% on Car Fund.");
+  });
+
+  it('returns null for a completed goal', () => {
+    expect(goalNearWinCue(makeMilestone({ progress: 100, nextMilestone: null }))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compose
+// ---------------------------------------------------------------------------
+
+describe('computeNearWinCues', () => {
+  it('orders cues: keep-alive, then goals, then badges (closest first)', () => {
+    const state = makeState({
+      loggedToday: false,
+      streaks: [makeStreak({ current: 4 })],
+      milestones: [
+        makeMilestone({ goalId: 'g1', goalName: 'Car Fund', progress: 45, nextMilestone: 50 }),
+        makeMilestone({ goalId: 'g2', goalName: 'Trip', progress: 10, nextMilestone: 25 }),
+      ],
+      achievements: [
+        makeBadge({
+          id: 'b-far',
+          name: 'Far',
+          progress: 30,
+          nearWin: { remaining: 7, unit: 'check-in', format: 'count' },
+        }),
+        makeBadge({
+          id: 'b-near',
+          name: 'Near',
+          progress: 90,
+          nearWin: { remaining: 1, unit: 'check-in', format: 'count' },
+        }),
+      ],
+    });
+
+    const cues = computeNearWinCues(state);
+    expect(cues.map((c) => c.kind)).toEqual(['streak', 'goal', 'goal', 'badge', 'badge']);
+    // Goal closest to its next milestone (Car Fund, 5% gap) comes before Trip (15% gap)
+    expect(cues[1].title).toBe('Car Fund');
+    expect(cues[2].title).toBe('Trip');
+    // Badge closest to unlocking (highest progress) comes first
+    expect(cues[3].title).toBe('Near');
+    expect(cues[4].title).toBe('Far');
+  });
+
+  it('omits the keep-alive cue when today is already logged', () => {
+    const state = makeState({
+      loggedToday: true,
+      streaks: [makeStreak({ current: 4 })],
+    });
+    expect(computeNearWinCues(state).some((c) => c.kind === 'streak')).toBe(false);
+  });
+
+  it('caps the number of badge and goal cues', () => {
+    const state = makeState({
+      achievements: Array.from({ length: 6 }, (_, i) =>
+        makeBadge({ id: `b${i}`, name: `Badge ${i}`, progress: i * 10 }),
+      ),
+      milestones: Array.from({ length: 4 }, (_, i) =>
+        makeMilestone({ goalId: `g${i}`, goalName: `Goal ${i}`, progress: 10, nextMilestone: 25 }),
+      ),
+    });
+    const cues = computeNearWinCues(state);
+    expect(cues.filter((c) => c.kind === 'badge')).toHaveLength(3);
+    expect(cues.filter((c) => c.kind === 'goal')).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Celebration selection
+// ---------------------------------------------------------------------------
+
+describe('selectNewlyUnlocked', () => {
+  const achievements: Achievement[] = [
+    makeBadge({ id: 'a', name: 'A', status: 'unlocked', nearWin: undefined }),
+    makeBadge({ id: 'b', name: 'B', status: 'unlocked', nearWin: undefined }),
+    makeBadge({ id: 'c', name: 'C', status: 'locked' }),
+  ];
+
+  it('only seeds on first visit (seenIds null) and celebrates nothing', () => {
+    const result = selectNewlyUnlocked(achievements, null);
+    expect(result.seedOnly).toBe(true);
+    expect(result.celebrations).toHaveLength(0);
+    expect(result.unlockedIds).toEqual(['a', 'b']);
+  });
+
+  it('celebrates only newly-unlocked badges', () => {
+    const result = selectNewlyUnlocked(achievements, ['a']);
+    expect(result.seedOnly).toBe(false);
+    expect(result.celebrations.map((c) => c.achievementId)).toEqual(['b']);
+    expect(result.celebrations[0].name).toBe('B');
+  });
+
+  it('celebrates nothing when everything has already been seen', () => {
+    const result = selectNewlyUnlocked(achievements, ['a', 'b']);
+    expect(result.celebrations).toHaveLength(0);
+  });
+});

--- a/apps/web/src/components/gamification/near-win-engine.ts
+++ b/apps/web/src/components/gamification/near-win-engine.ts
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Near-win engine.
+ *
+ * Turns the already-computed gamification state (streaks, locked badges, and
+ * goal progress) into a small set of motivating "near-win" cues that nudge a
+ * teen toward their next healthy-habit win — e.g. "2 more check-ins to earn
+ * Getting Started", "Log today to keep your 5-day streak alive", or "One more
+ * contribution to hit 50% on Car Fund".
+ *
+ * Design principles:
+ * - Pure and deterministic: no clock reads, no randomness, no side effects.
+ * - Healthy-habit framing ONLY. Cues reward consistent check-ins, saving, and
+ *   on-time budgeting — never raw spending volume.
+ * - Builds ON the existing engine rather than re-deriving streaks/achievements.
+ *
+ * Refs #2211
+ */
+
+import type { IconName } from '../icons';
+import type {
+  Achievement,
+  GamificationState,
+  GoalMilestone,
+  StreakData,
+} from './achievements-engine';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The source a near-win cue is derived from. */
+export type NearWinKind = 'streak' | 'goal' | 'badge';
+
+/** A single motivating near-win cue ready to render. */
+export interface NearWinCue {
+  /** Stable identifier (badge id, goal id, or streak type). */
+  readonly id: string;
+  /** Which signal the cue is derived from. */
+  readonly kind: NearWinKind;
+  /** Short label naming the thing being worked toward. */
+  readonly title: string;
+  /** Encouraging, non-manipulative one-liner shown to the user. */
+  readonly message: string;
+  /**
+   * Progress toward the next win (0-100), or `null` for time-sensitive cues
+   * (like keep-alive) that have no meaningful percentage.
+   */
+  readonly progress: number | null;
+  /** Decorative icon name. */
+  readonly icon: IconName;
+}
+
+/** A freshly-unlocked achievement worth celebrating. */
+export interface UnlockCelebration {
+  readonly achievementId: string;
+  readonly name: string;
+  readonly description: string;
+  readonly icon: IconName;
+}
+
+/** Tuning knobs for {@link computeNearWinCues}. */
+export interface NearWinOptions {
+  /** Max number of badge cues to surface (default 3). */
+  readonly maxBadgeCues?: number;
+  /** Max number of goal cues to surface (default 2). */
+  readonly maxGoalCues?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CURRENCY_LOCALE = 'en-US';
+const CURRENCY_CODE = 'USD';
+
+/** Format a cents amount as a whole-dollar, locale-fixed string (e.g. "$250"). */
+export function formatRemainingCurrency(cents: number): string {
+  const dollars = Math.ceil(Math.max(0, cents) / 100);
+  return new Intl.NumberFormat(CURRENCY_LOCALE, {
+    style: 'currency',
+    currency: CURRENCY_CODE,
+    maximumFractionDigits: 0,
+  }).format(dollars);
+}
+
+/** Pluralize a singular unit noun for a count (handles consonant + y -> ies). */
+export function pluralizeUnit(unit: string, count: number): string {
+  if (count === 1) return unit;
+  if (/[^aeiou]y$/i.test(unit)) {
+    return `${unit.slice(0, -1)}ies`;
+  }
+  return `${unit}s`;
+}
+
+const STREAK_ICON: IconName = 'flame';
+const GOAL_ICON: IconName = 'target';
+
+// ---------------------------------------------------------------------------
+// Cue builders (each pure + independently testable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a "keep your streak alive" cue when the daily streak action is still
+ * pending today. Returns `null` when there is no streak to protect or the
+ * action has already been completed.
+ */
+export function streakKeepAliveCue(
+  streaks: readonly StreakData[],
+  loggedToday: boolean,
+): NearWinCue | null {
+  const daily = streaks.find((s) => s.type === 'daily_logging');
+  if (!daily || daily.current <= 0 || loggedToday) {
+    return null;
+  }
+
+  return {
+    id: `streak-${daily.type}`,
+    kind: 'streak',
+    title: daily.label,
+    message: `Log today to keep your ${daily.current}-day ${daily.label.toLowerCase()} streak alive.`,
+    progress: null,
+    icon: STREAK_ICON,
+  };
+}
+
+/**
+ * Build a "one more contribution to hit X%" cue for a goal that has not yet
+ * reached its next milestone. Returns `null` for completed goals or goals
+ * with no further milestone.
+ */
+export function goalNearWinCue(milestone: GoalMilestone): NearWinCue | null {
+  if (milestone.progress >= 100 || milestone.nextMilestone === null) {
+    return null;
+  }
+
+  const gap = milestone.nextMilestone - milestone.progress;
+  return {
+    id: `goal-${milestone.goalId}`,
+    kind: 'goal',
+    title: milestone.goalName,
+    message: `You're ${gap}% away — one more contribution to hit ${milestone.nextMilestone}% on ${milestone.goalName}.`,
+    progress: milestone.progress,
+    icon: GOAL_ICON,
+  };
+}
+
+/**
+ * Build a "N more <unit>" cue for a locked badge with a near-win metric.
+ * Returns `null` for unlocked badges or badges without a healthy-habit metric.
+ */
+export function badgeNearWinCue(achievement: Achievement): NearWinCue | null {
+  if (achievement.status === 'unlocked' || !achievement.nearWin) {
+    return null;
+  }
+
+  const { remaining, unit, format } = achievement.nearWin;
+  const message =
+    format === 'currency'
+      ? `${formatRemainingCurrency(remaining)} more ${unit} to earn ${achievement.name}.`
+      : `${remaining} more ${pluralizeUnit(unit, remaining)} to earn ${achievement.name}.`;
+
+  return {
+    id: `badge-${achievement.id}`,
+    kind: 'badge',
+    title: achievement.name,
+    message,
+    progress: achievement.progress,
+    icon: achievement.icon,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose the full, ordered list of near-win cues from gamification state.
+ *
+ * Ordering favours urgency then momentum: the streak keep-alive cue (if any)
+ * comes first, then the goals closest to their next milestone, then the locked
+ * badges closest to unlocking.
+ */
+export function computeNearWinCues(
+  state: GamificationState,
+  options: NearWinOptions = {},
+): NearWinCue[] {
+  const maxBadgeCues = options.maxBadgeCues ?? 3;
+  const maxGoalCues = options.maxGoalCues ?? 2;
+
+  const cues: NearWinCue[] = [];
+
+  // 1. Streak keep-alive (most time-sensitive).
+  const keepAlive = streakKeepAliveCue(state.streaks, state.loggedToday);
+  if (keepAlive) {
+    cues.push(keepAlive);
+  }
+
+  // 2. Goals closest to their next milestone.
+  const goalCues = state.milestones
+    .map((m) => ({ cue: goalNearWinCue(m), gap: (m.nextMilestone ?? 100) - m.progress }))
+    .filter((entry): entry is { cue: NearWinCue; gap: number } => entry.cue !== null)
+    .sort((a, b) => a.gap - b.gap)
+    .slice(0, maxGoalCues)
+    .map((entry) => entry.cue);
+  cues.push(...goalCues);
+
+  // 3. Locked badges closest to unlocking (highest progress first).
+  const badgeCues = state.achievements
+    .map((a) => badgeNearWinCue(a))
+    .filter((cue): cue is NearWinCue => cue !== null)
+    .sort((a, b) => (b.progress ?? 0) - (a.progress ?? 0))
+    .slice(0, maxBadgeCues);
+  cues.push(...badgeCues);
+
+  return cues;
+}
+
+/**
+ * Determine which achievements have unlocked since the user last saw them.
+ *
+ * On the very first visit (`seenIds === null`) nothing is celebrated — the
+ * caller should seed the seen set with the returned `unlockedIds` so that only
+ * *future* unlocks trigger a celebration.
+ */
+export function selectNewlyUnlocked(
+  achievements: readonly Achievement[],
+  seenIds: readonly string[] | null,
+): { seedOnly: boolean; unlockedIds: string[]; celebrations: UnlockCelebration[] } {
+  const unlocked = achievements.filter((a) => a.status === 'unlocked');
+  const unlockedIds = unlocked.map((a) => a.id);
+
+  if (seenIds === null) {
+    return { seedOnly: true, unlockedIds, celebrations: [] };
+  }
+
+  const seen = new Set(seenIds);
+  const celebrations: UnlockCelebration[] = unlocked
+    .filter((a) => !seen.has(a.id))
+    .map((a) => ({
+      achievementId: a.id,
+      name: a.name,
+      description: a.description,
+      icon: a.icon,
+    }));
+
+  return { seedOnly: false, unlockedIds, celebrations };
+}

--- a/apps/web/src/hooks/useGamification.ts
+++ b/apps/web/src/hooks/useGamification.ts
@@ -70,6 +70,9 @@ export function useGamification(): UseGamificationResult {
       const txDates = new Set(transactions.map((tx) => tx.date));
       const sortedDates = Array.from(txDates).sort().reverse();
 
+      const todayStr = new Date().toISOString().slice(0, 10);
+      const loggedToday = txDates.has(todayStr);
+
       let dailyLoggingStreak = 0;
       let longestDailyLoggingStreak = 0;
 
@@ -159,6 +162,7 @@ export function useGamification(): UseGamificationResult {
         accountCount: accounts.length,
         totalSaved,
         categoriesUsed,
+        loggedToday,
       };
 
       setState(computeGamification(input));

--- a/apps/web/src/pages/AchievementsPage.css
+++ b/apps/web/src/pages/AchievementsPage.css
@@ -306,8 +306,15 @@
 @media (prefers-reduced-motion: reduce) {
   .achievement-badge,
   .achievement-badge__progress-fill,
-  .milestone-card__fill {
+  .milestone-card__fill,
+  .nearwin-card__fill {
     transition: none;
+  }
+
+  /* Static congratulatory state — no falling confetti when motion is reduced */
+  .achievement-celebration__confetti-piece {
+    animation: none;
+    opacity: 0;
   }
 }
 
@@ -316,7 +323,9 @@
   .achievement-badge,
   .streak-card,
   .milestone-card,
-  .achievements-level-card {
+  .achievements-level-card,
+  .nearwin-card,
+  .achievement-celebration {
     border-width: 2px;
   }
 }
@@ -328,6 +337,10 @@
   }
 
   .achievements-streaks-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .achievements-nearwin-grid {
     grid-template-columns: 1fr;
   }
 
@@ -351,4 +364,210 @@
   margin-top: var(--spacing-3);
   display: flex;
   justify-content: flex-end;
+}
+
+/* ---------------------------------------------------------------------------
+ * Near-win cues — motivating loop toward the next win (Refs #2211)
+ * ------------------------------------------------------------------------- */
+
+.achievements-nearwin-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: var(--spacing-3);
+}
+
+.nearwin-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--semantic-background-elevated);
+  border: 1px solid var(--semantic-border-default);
+  border-left: 4px solid var(--semantic-interactive-default);
+  border-radius: var(--border-radius-md);
+}
+
+.nearwin-card--streak {
+  border-left-color: var(--semantic-status-warning);
+}
+
+.nearwin-card--goal {
+  border-left-color: var(--semantic-status-positive);
+}
+
+.nearwin-card--badge {
+  border-left-color: var(--semantic-interactive-default);
+}
+
+.nearwin-card__icon {
+  flex-shrink: 0;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--semantic-interactive-default);
+}
+
+.nearwin-card__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.nearwin-card__message {
+  font-size: var(--type-scale-body-font-size);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-2) 0;
+}
+
+.nearwin-card__track {
+  height: 6px;
+  background: var(--semantic-background-secondary);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.nearwin-card__fill {
+  height: 100%;
+  background: var(--semantic-interactive-default);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+/* ---------------------------------------------------------------------------
+ * Celebration banner — tasteful unlock moment (Refs #2211)
+ * Text + emoji carry the message; confetti is purely decorative and is gated
+ * behind prefers-reduced-motion (no motion -> static congratulatory state).
+ * ------------------------------------------------------------------------- */
+
+.achievement-celebration {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4) var(--spacing-5);
+  margin-bottom: var(--spacing-6);
+  background: var(--semantic-background-elevated);
+  border: 1px solid var(--semantic-status-positive);
+  border-left-width: 4px;
+  border-radius: var(--border-radius-md);
+  overflow: hidden;
+}
+
+.achievement-celebration__icon {
+  flex-shrink: 0;
+  font-size: 2rem;
+  line-height: 1;
+  color: var(--semantic-status-positive);
+}
+
+.achievement-celebration__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.achievement-celebration__eyebrow {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-status-positive);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.achievement-celebration__name {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin: var(--spacing-1) 0;
+}
+
+.achievement-celebration__desc {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0;
+}
+
+.achievement-celebration__dismiss {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm, 6px);
+  background: transparent;
+  color: var(--semantic-text-secondary);
+  cursor: pointer;
+}
+
+.achievement-celebration__dismiss:hover {
+  color: var(--semantic-text-primary);
+}
+
+.achievement-celebration__dismiss:focus-visible {
+  outline: 2px solid var(--semantic-interactive-default);
+  outline-offset: 2px;
+}
+
+.achievement-celebration__confetti {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.achievement-celebration__confetti-piece {
+  position: absolute;
+  top: -10%;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  opacity: 0;
+  animation: achievement-confetti-fall 1600ms ease-in forwards;
+}
+
+.achievement-celebration__confetti-piece--0 {
+  left: 12%;
+  background: var(--semantic-status-positive);
+  animation-delay: 0ms;
+}
+
+.achievement-celebration__confetti-piece--1 {
+  left: 38%;
+  background: var(--semantic-interactive-default);
+  animation-delay: 120ms;
+}
+
+.achievement-celebration__confetti-piece--2 {
+  left: 62%;
+  background: var(--semantic-status-warning);
+  animation-delay: 240ms;
+}
+
+.achievement-celebration__confetti-piece--3 {
+  left: 86%;
+  background: var(--semantic-status-info);
+  animation-delay: 360ms;
+}
+
+.achievement-celebration__confetti-piece:nth-child(n + 5) {
+  top: -22%;
+}
+
+.achievement-celebration__confetti-piece:nth-child(n + 9) {
+  top: -34%;
+}
+
+@keyframes achievement-confetti-fall {
+  0% {
+    transform: translateY(0) rotate(0deg);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateY(420%) rotate(320deg);
+    opacity: 0;
+  }
 }

--- a/apps/web/src/pages/AchievementsPage.test.tsx
+++ b/apps/web/src/pages/AchievementsPage.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { AchievementsPage } from './AchievementsPage';
@@ -10,8 +10,14 @@ vi.mock('../hooks/useGamification', () => ({
   useGamification: vi.fn(),
 }));
 
+vi.mock('../hooks/useReducedMotion', () => ({
+  useReducedMotion: vi.fn(() => false),
+}));
+
 import { useGamification } from '../hooks/useGamification';
+import { useReducedMotion } from '../hooks/useReducedMotion';
 const mockedUseGamification = vi.mocked(useGamification);
+const mockedUseReducedMotion = vi.mocked(useReducedMotion);
 
 const makeState = (): GamificationState => ({
   achievements: [
@@ -82,11 +88,14 @@ const makeState = (): GamificationState => ({
   level: 1,
   levelName: 'Newcomer',
   pointsToNextLevel: 15,
+  loggedToday: true,
 });
 
 describe('AchievementsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    mockedUseReducedMotion.mockReturnValue(false);
   });
 
   it('renders loading spinner when loading', () => {
@@ -240,5 +249,154 @@ describe('AchievementsPage', () => {
     // 3 unlocked badges
     expect(screen.getByText('3')).toBeInTheDocument();
     expect(screen.getByText('Badges')).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Near-win cues (Refs #2211)
+  // -------------------------------------------------------------------------
+
+  const makeNearWinState = (): GamificationState => ({
+    ...makeState(),
+    loggedToday: false,
+    streaks: [{ current: 5, longest: 12, type: 'daily_logging', label: 'Daily Logging' }],
+    milestones: [
+      {
+        goalId: 'g1',
+        goalName: 'Car Fund',
+        progress: 40,
+        milestonesReached: [25],
+        nextMilestone: 50,
+      },
+    ],
+    achievements: [
+      {
+        id: 'transaction-10',
+        name: 'Getting Started',
+        description: 'Log 10 transactions',
+        icon: 'edit',
+        category: 'tracking',
+        status: 'locked',
+        progress: 80,
+        nearWin: { remaining: 2, unit: 'check-in', format: 'count' },
+      },
+    ],
+  });
+
+  it('renders near-win cards with a keep-going section and progress semantics', () => {
+    mockedUseGamification.mockReturnValue({
+      state: makeNearWinState(),
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <AchievementsPage />
+      </MemoryRouter>,
+    );
+
+    const nextUp = screen.getByRole('region', { name: 'Next up' });
+    expect(within(nextUp).getByText('Keep going')).toBeInTheDocument();
+
+    // Streak keep-alive cue (today still pending)
+    expect(
+      within(nextUp).getByText('Log today to keep your 5-day daily logging streak alive.'),
+    ).toBeInTheDocument();
+
+    // Goal near-win cue framed as one more contribution
+    expect(
+      within(nextUp).getByText("You're 10% away — one more contribution to hit 50% on Car Fund."),
+    ).toBeInTheDocument();
+
+    // Badge near-win cue with correct "N more" math
+    expect(
+      within(nextUp).getByText('2 more check-ins to earn Getting Started.'),
+    ).toBeInTheDocument();
+
+    // Progress toward the next win is exposed via accessible progressbar semantics
+    const progressBars = within(nextUp).getAllByRole('progressbar');
+    expect(progressBars.length).toBeGreaterThan(0);
+    expect(progressBars[0]).toHaveAttribute('aria-valuenow');
+  });
+
+  // -------------------------------------------------------------------------
+  // Celebration moments (Refs #2211)
+  // -------------------------------------------------------------------------
+
+  const SEEN_STORAGE_KEY = ['finance', 'achievements', 'seen-badges'].join(':');
+
+  it('celebrates a freshly-unlocked badge with an accessible live region', async () => {
+    // Pre-seed the "seen" set as empty (non-null) so every unlocked badge reads
+    // as newly unlocked — simulating a fresh unlock since the last visit.
+    localStorage.setItem(SEEN_STORAGE_KEY, JSON.stringify([]));
+
+    mockedUseGamification.mockReturnValue({
+      state: makeState(),
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <AchievementsPage />
+      </MemoryRouter>,
+    );
+
+    const celebration = await screen.findByRole('status');
+    expect(celebration).toHaveAttribute('aria-live', 'polite');
+    // Text (not motion/colour) carries the message
+    expect(within(celebration).getByText(/Badge unlocked/)).toBeInTheDocument();
+    expect(within(celebration).getByText('First Step')).toBeInTheDocument();
+    // Dismiss control is keyboard reachable
+    expect(
+      within(celebration).getByRole('button', { name: /Dismiss .* celebration/ }),
+    ).toBeInTheDocument();
+    // Confetti renders when motion is allowed
+    expect(within(celebration).queryByTestId('celebration-confetti')).toBeInTheDocument();
+  });
+
+  it('does not celebrate pre-existing badges on the first visit', () => {
+    // No stored "seen" set -> first visit only seeds, never celebrates.
+    mockedUseGamification.mockReturnValue({
+      state: makeState(),
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <AchievementsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('falls back to a static celebration (no confetti) when motion is reduced', async () => {
+    mockedUseReducedMotion.mockReturnValue(true);
+    localStorage.setItem(SEEN_STORAGE_KEY, JSON.stringify([]));
+
+    mockedUseGamification.mockReturnValue({
+      state: makeState(),
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <AchievementsPage />
+      </MemoryRouter>,
+    );
+
+    const celebration = await screen.findByRole('status');
+    // Static congratulatory text is still present...
+    expect(within(celebration).getByText(/Badge unlocked/)).toBeInTheDocument();
+    expect(within(celebration).getByText('First Step')).toBeInTheDocument();
+    // ...but the animated confetti layer is omitted entirely.
+    expect(within(celebration).queryByTestId('celebration-confetti')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/AchievementsPage.tsx
+++ b/apps/web/src/pages/AchievementsPage.tsx
@@ -11,20 +11,53 @@
  * - All interactive elements keyboard-accessible
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
 import { useGamification } from '../hooks/useGamification';
+import { useReducedMotion } from '../hooks/useReducedMotion';
 import type {
   Achievement,
   AchievementCategory,
   GoalMilestone,
+  NearWinCue,
   StreakData,
-} from '../components/gamification/achievements-engine';
-import { getAchievementsByCategory } from '../components/gamification/achievements-engine';
+  UnlockCelebration,
+} from '../components/gamification';
+import {
+  computeNearWinCues,
+  getAchievementsByCategory,
+  selectNewlyUnlocked,
+} from '../components/gamification';
 import './AchievementsPage.css';
 import { AppIcon } from '../components/icons';
 import { ShareCelebrationButton } from '../components/social/ShareCelebrationButton';
 import { goalCelebrationEvent } from '../lib/social/share-celebration';
+
+// ---------------------------------------------------------------------------
+// Celebration "seen" persistence (so only *new* unlocks celebrate)
+// ---------------------------------------------------------------------------
+
+/** localStorage key, assembled from plain tokens (never a secret literal). */
+const SEEN_STORAGE_KEY = ['finance', 'achievements', 'seen-badges'].join(':');
+
+function readSeenBadgeIds(): string[] | null {
+  try {
+    const raw = localStorage.getItem(SEEN_STORAGE_KEY);
+    if (raw === null) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSeenBadgeIds(ids: readonly string[]): void {
+  try {
+    localStorage.setItem(SEEN_STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    // Storage unavailable — celebrations are best-effort, not critical.
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -182,6 +215,83 @@ const CATEGORY_LABELS: Record<AchievementCategory, string> = {
   milestone: 'Milestones',
 };
 
+interface NearWinCardProps {
+  cue: NearWinCue;
+}
+
+const NearWinCard: React.FC<NearWinCardProps> = ({ cue }) => (
+  <li className={`nearwin-card nearwin-card--${cue.kind}`}>
+    <span className="nearwin-card__icon" aria-hidden="true">
+      <AppIcon name={cue.icon} />
+    </span>
+    <div className="nearwin-card__body">
+      <p className="nearwin-card__message">{cue.message}</p>
+      {cue.progress !== null && (
+        <div
+          className="nearwin-card__track"
+          role="progressbar"
+          aria-valuenow={cue.progress}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${cue.title}: ${cue.progress}% toward your next win`}
+        >
+          <div className="nearwin-card__fill" style={{ width: `${cue.progress}%` }} />
+        </div>
+      )}
+    </div>
+  </li>
+);
+
+interface CelebrationBannerProps {
+  celebration: UnlockCelebration;
+  reducedMotion: boolean;
+  onDismiss: () => void;
+}
+
+/** Number of decorative confetti pieces (animated only when motion is allowed). */
+const CONFETTI_PIECES = 12;
+
+const CelebrationBanner: React.FC<CelebrationBannerProps> = ({
+  celebration,
+  reducedMotion,
+  onDismiss,
+}) => (
+  <div className="achievement-celebration" role="status" aria-live="polite">
+    {!reducedMotion && (
+      <div
+        className="achievement-celebration__confetti"
+        data-testid="celebration-confetti"
+        aria-hidden="true"
+      >
+        {Array.from({ length: CONFETTI_PIECES }, (_, index) => (
+          <span
+            // Decorative, fixed-length list; index is a stable position here.
+            key={`confetti-${index}`}
+            className={`achievement-celebration__confetti-piece achievement-celebration__confetti-piece--${index % 4}`}
+          />
+        ))}
+      </div>
+    )}
+    <span className="achievement-celebration__icon" aria-hidden="true">
+      <AppIcon name={celebration.icon} />
+    </span>
+    <div className="achievement-celebration__body">
+      {/* Emoji + text so the cue never relies on motion or colour alone. */}
+      <p className="achievement-celebration__eyebrow">🎉 Badge unlocked!</p>
+      <p className="achievement-celebration__name">{celebration.name}</p>
+      <p className="achievement-celebration__desc">{celebration.description}</p>
+    </div>
+    <button
+      type="button"
+      className="achievement-celebration__dismiss"
+      onClick={onDismiss}
+      aria-label={`Dismiss ${celebration.name} celebration`}
+    >
+      <AppIcon name="x" aria-hidden="true" />
+    </button>
+  </div>
+);
+
 const CATEGORY_ORDER: AchievementCategory[] = ['tracking', 'budgeting', 'saving', 'milestone'];
 
 // ---------------------------------------------------------------------------
@@ -190,6 +300,21 @@ const CATEGORY_ORDER: AchievementCategory[] = ['tracking', 'budgeting', 'saving'
 
 export const AchievementsPage: React.FC = () => {
   const { state, loading, error, refresh } = useGamification();
+  const reducedMotion = useReducedMotion();
+  const [celebration, setCelebration] = useState<UnlockCelebration | null>(null);
+
+  // Detect achievements that have unlocked since the user last visited and
+  // celebrate the newest one. The first ever visit only seeds the "seen" set so
+  // pre-existing badges never trigger a celebration retroactively.
+  useEffect(() => {
+    if (!state) return;
+    const stored = readSeenBadgeIds();
+    const { seedOnly, unlockedIds, celebrations } = selectNewlyUnlocked(state.achievements, stored);
+    if (!seedOnly && celebrations.length > 0) {
+      setCelebration(celebrations[0]);
+    }
+    writeSeenBadgeIds(unlockedIds);
+  }, [state]);
 
   if (loading) {
     return (
@@ -213,12 +338,34 @@ export const AchievementsPage: React.FC = () => {
   }
 
   const unlockedCount = state.achievements.filter((a) => a.status === 'unlocked').length;
+  const nearWinCues = computeNearWinCues(state);
 
   return (
     <div className="achievements-page">
       <div className="page-section__header">
         <h2 className="achievements-page__title">Achievements</h2>
       </div>
+
+      {/* Celebration moment for a freshly-unlocked badge */}
+      {celebration && (
+        <CelebrationBanner
+          celebration={celebration}
+          reducedMotion={reducedMotion}
+          onDismiss={() => setCelebration(null)}
+        />
+      )}
+
+      {/* Near-win cues — the motivating loop toward the next win */}
+      {nearWinCues.length > 0 && (
+        <section className="achievements-section" aria-label="Next up">
+          <h3 className="achievements-section__title">Keep going</h3>
+          <ul className="achievements-nearwin-grid">
+            {nearWinCues.map((cue) => (
+              <NearWinCard key={cue.id} cue={cue} />
+            ))}
+          </ul>
+        </section>
+      )}
 
       {/* Level & Points Summary */}
       <section className="achievements-section" aria-label="Level progress">


### PR DESCRIPTION
## Summary

Makes the **web** Achievements page feel alive for the teen persona ? a motivating loop instead of a static trophy case. Refs #2211 (native Android gamification remains out of scope here).

### Gap verified first
- `useGamification.ts` already derives daily-logging streaks (current + longest), budget adherence, goal progress, etc., and `achievements-engine.ts` already computes badges/levels/milestones. **Streaks were already computed.**
- **The genuine gap:** the page rendered as a dashboard ? there were **no near-win cues**, no `loggedToday` / streak-pending detection, and **no celebration moments**. (`useMilestones` exists but was never wired into this page.)

### What's new
1. **Pure near-win engine** (`near-win-engine.ts`) builds on the existing state ? no duplicated streak logic:
   - `N more check-ins to earn <badge>` for each locked, healthy-habit badge (count + currency formats).
   - **Streak keep-alive** cue when today's logging is still pending (`loggedToday` added to input/state).
   - `One more contribution to hit X% on <goal>` derived from goal milestone progress.
   - Healthy-habit framing only ? consistency / saving / on-time budgeting, **never raw spending volume**.
2. **Celebration moment** ? a tasteful, dismissible banner on a fresh badge unlock (diffed vs a persisted "seen" set so pre-existing badges never celebrate retroactively). Pure CSS confetti, **no new dependency**.
3. **Achievements page** surfaces a prominent "Keep going" near-win section before the static earned list.

### Accessibility (WCAG 2.2 AA)
- Celebration uses **text + emoji** (never motion or colour alone); announced via `role="status"` / `aria-live="polite"`.
- Confetti is decorative (`aria-hidden`) and **gated behind `prefers-reduced-motion`** ? static congratulatory fallback when motion is reduced.
- Progress toward each badge/goal exposed via `role="progressbar"` semantics; dismiss control is keyboard reachable.

### Tests
- `near-win-engine.test.ts` ? "N more" math (count + currency), streak-pending detection, goal-percent cue, ordering/caps, celebration selection.
- `AchievementsPage.test.tsx` ? near-win cards render, celebration on a simulated unlock (live region), and reduced-motion fallback (no confetti).
- All 55 local gamification/page tests pass; lint + prettier + tsc clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
