### PR TITLE
feat(web): code-split route-ledger/route-dashboard chunks (#2983)

### DIFF
--- a/apps/web/performance.budget.json
+++ b/apps/web/performance.budget.json
@@ -21,7 +21,7 @@
   ],
   "bundle": {
     "initialJsGzipBytes": 184320,
-    "maxLazyChunkGzipBytes": 217000,
+    "maxLazyChunkGzipBytes": 200000,
     "maxSpeculativeJsGzipBytes": 460800
   },
   "waivers": []

--- a/apps/web/src/lib/__tests__/performance-budget.test.ts
+++ b/apps/web/src/lib/__tests__/performance-budget.test.ts
@@ -153,11 +153,15 @@ describe('Route Code Splitting', () => {
 // ---------------------------------------------------------------------------
 
 describe('Vite Build Configuration', () => {
-  it('should define manual chunks for vendor splitting', async () => {
+  it('should define advanced chunks for vendor splitting', async () => {
     const configPath = resolve(__dirname, '../../../vite.config.ts');
     const configContent = readFileSync(configPath, 'utf-8');
 
-    expect(configContent).toContain('manualChunks');
+    // We use rolldown's `advancedChunks` (not rollup's `manualChunks`) because
+    // manualChunks is ignored for modules reached only through dynamic route
+    // chunks, which let recharts/shared infra inflate route-ledger and
+    // route-dashboard past the budget (#2983).
+    expect(configContent).toContain('advancedChunks');
     expect(configContent).toContain('vendor-react');
     expect(configContent).toContain('vendor-charts');
     expect(configContent).toContain('vendor-sqlite');

--- a/apps/web/src/pages/BudgetDetailPage.test.tsx
+++ b/apps/web/src/pages/BudgetDetailPage.test.tsx
@@ -28,7 +28,7 @@ vi.mock('../components/forms', () => ({
   BudgetForm: () => null,
 }));
 
-vi.mock('../components/charts', () => ({
+vi.mock('../components/charts/BudgetDonutChart', () => ({
   BudgetDonutChart: ({ title }: { title: string }) => <div>{title}</div>,
 }));
 
@@ -301,12 +301,14 @@ describe('BudgetDetailPage', () => {
     expect(progressBar).toHaveAttribute('aria-valuemax', '100');
   });
 
-  it('shows the weekly meal budget target and food breakdown for food budgets', () => {
+  it('shows the weekly meal budget target and food breakdown for food budgets', async () => {
     renderWithRoute();
 
     expect(screen.getByText('Weekly Meal Budget')).toBeInTheDocument();
     expect(screen.getByText('$138.57')).toBeInTheDocument();
-    expect(screen.getByText('Subcategory spending')).toBeInTheDocument();
+    // The donut chart is lazy-loaded (recharts is code-split); wait for the
+    // Suspense boundary to resolve before asserting on its title (#2983).
+    expect(await screen.findByText('Subcategory spending')).toBeInTheDocument();
     expect(screen.getByText(/Groceries/i)).toBeInTheDocument();
     expect(screen.getByText(/Dining Out/i)).toBeInTheDocument();
   });

--- a/apps/web/src/pages/BudgetDetailPage.tsx
+++ b/apps/web/src/pages/BudgetDetailPage.tsx
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { Suspense, useCallback, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { AppIcon, type IconName } from '../components/icons';
 
-import { BudgetDonutChart } from '../components/charts';
 import { ConfirmDialog } from '../components/common/ConfirmDialog';
 import { CurrencyDisplay } from '../components/common/CurrencyDisplay';
 import { ErrorBanner } from '../components/common/ErrorBanner';
@@ -19,6 +18,25 @@ import type { Budget } from '../kmp/bridge';
 import { getBudgetStatusIndicator } from '../lib/a11y';
 import { calculateRolloverLedger, generateVarianceInsights } from '../lib/budgeting-beta';
 import '../styles/pages.css';
+
+/*
+ * Recharts is a heavy visualization dependency (recharts + redux-toolkit +
+ * immer + decimal.js-light ≈ 290 KB raw). The donut chart is a secondary,
+ * conditionally-rendered breakdown that is not above the fold, so we load it
+ * as its own async chunk to keep the `route-ledger` bundle lean (#2983).
+ */
+const BudgetDonutChart = React.lazy(() =>
+  import('../components/charts/BudgetDonutChart').then((module) => ({
+    default: module.BudgetDonutChart,
+  })),
+);
+
+/** Accessible, non-focus-trapping placeholder shown while the chart chunk loads. */
+const ChartFallback = ({ label }: { readonly label: string }) => (
+  <div className="card" role="status" aria-live="polite" style={{ minHeight: 260 }}>
+    <LoadingSpinner size={24} label={label} />
+  </div>
+);
 
 const PERIOD_LABELS: Record<string, string> = {
   WEEKLY: 'Weekly',
@@ -490,16 +508,18 @@ export const BudgetDetailPage: React.FC = () => {
             </div>
             <div>
               {foodBudgetBreakdown.length > 0 ? (
-                <BudgetDonutChart
-                  data={foodBudgetBreakdown.map((entry) => ({
-                    name: entry.categoryName,
-                    value: entry.spentAmount.amount,
-                  }))}
-                  currency={budget.currency.code}
-                  height={260}
-                  title="Subcategory spending"
-                  centerLabel={`${foodBudgetBreakdown.length} groups`}
-                />
+                <Suspense fallback={<ChartFallback label="Loading subcategory chart" />}>
+                  <BudgetDonutChart
+                    data={foodBudgetBreakdown.map((entry) => ({
+                      name: entry.categoryName,
+                      value: entry.spentAmount.amount,
+                    }))}
+                    currency={budget.currency.code}
+                    height={260}
+                    title="Subcategory spending"
+                    centerLabel={`${foodBudgetBreakdown.length} groups`}
+                  />
+                </Suspense>
               ) : (
                 <div>
                   <p className="card__title">Subcategory spending</p>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -240,32 +240,48 @@ export default defineConfig({
           chunkInfo.name === 'sw' ? 'sw.js' : 'assets/[name]-[hash].js',
         chunkFileNames: 'assets/[name]-[hash].js',
         assetFileNames: 'assets/[name]-[hash][extname]',
-        manualChunks(id) {
-          // React core (react + react-dom + react-router-dom)
-          if (
-            id.includes('node_modules/react-dom') ||
-            id.includes('node_modules/react-router-dom') ||
-            id.includes('node_modules/react/')
-          ) {
-            return 'vendor-react';
-          }
-
-          // Charting libraries (recharts + d3)
-          if (id.includes('node_modules/recharts') || id.includes('node_modules/d3')) {
-            return 'vendor-charts';
-          }
-
-          // SQLite WASM (wa-sqlite + sql.js)
-          if (id.includes('node_modules/wa-sqlite') || id.includes('node_modules/sql.js')) {
-            return 'vendor-sqlite';
-          }
-
-          // Validation (zod)
-          if (id.includes('node_modules/zod')) {
-            return 'vendor-zod';
-          }
-
-          return getRouteChunkName(id) ?? undefined;
+        advancedChunks: {
+          groups: [
+            {
+              name: 'vendor-react',
+              test: /node_modules[\\/](react|react-dom|react-router|react-router-dom|scheduler)[\\/]/,
+              priority: 100,
+            },
+            {
+              name: 'vendor-charts',
+              test: /node_modules[\\/](recharts|d3-[^\\/]+|d3|@reduxjs[\\/]toolkit|redux|immer|reselect|decimal\.js-light|victory-vendor)[\\/]/,
+              priority: 100,
+            },
+            {
+              name: 'vendor-sqlite',
+              test: /node_modules[\\/](wa-sqlite|sql\.js)[\\/]/,
+              priority: 100,
+            },
+            {
+              name: 'vendor-zod',
+              test: /node_modules[\\/]zod[\\/]/,
+              priority: 100,
+            },
+            {
+              name: 'vendor-ocr',
+              test: /node_modules[\\/]tesseract\.js[\\/]/,
+              priority: 100,
+            },
+            {
+              // Shared application infrastructure (SQLite-WASM data layer,
+              // repositories, auth, React contexts, i18n catalogs) is imported
+              // by nearly every route. Hoist it into one shared chunk instead
+              // of letting rolldown host it inside `route-dashboard`, which
+              // chronically inflated that chunk past the budget (#2983).
+              name: 'vendor-app',
+              test: /[\\/]src[\\/](db|auth|contexts|lib[\\/]i18n)[\\/]/,
+              priority: 50,
+            },
+            {
+              name: (id: string) => getRouteChunkName(id) ?? undefined,
+              priority: 10,
+            },
+          ],
         },
       },
     },


### PR DESCRIPTION
## Summary

`route-ledger` and `route-dashboard` chronically exceeded the gzip lazy-chunk budget enforced by `tools/check-web-performance-budget.mjs`. PR #2975 band-aided it by raising `maxLazyChunkGzipBytes` 215000 → 217000. This PR genuinely **reduces** both chunks via code-splitting and **lowers the budget to 200000** to lock in the win.

Closes #2983.

## Root cause

1. **route-ledger** was bloated by **recharts** (recharts + `@reduxjs/toolkit` + `immer` + `decimal.js-light`, ~290 KB raw), dragged in by `BudgetDetailPage`'s static barrel import `{ BudgetDonutChart } from '../components/charts'` (the barrel re-exports every chart, defeating tree-shaking).
2. **route-dashboard** was the de-facto host that rolldown chose for shared application infrastructure (SQLite-WASM data layer, repositories, auth, React contexts, i18n) — and every other route chunk imported `route-dashboard`.
3. The existing `rollupOptions.output.manualChunks` **does not work across dynamic boundaries** in rolldown: modules reached only through dynamic route chunks are placed/duplicated into route chunks regardless of `manualChunks`. The correct rolldown API is `advancedChunks`, which honors grouping across dynamic boundaries.

## Changes

- **`BudgetDetailPage.tsx`** — the secondary, below-the-fold subcategory **donut chart is now `React.lazy` + `<Suspense>`** with an accessible, non-focus-trapping fallback (`role=status`, `aria-live=polite`). Recharts is now its own async chunk, loaded only when the food breakdown is shown.
- **`vite.config.ts`** — replaced `manualChunks` with rolldown **`advancedChunks` groups**: `vendor-react`, `vendor-charts`, `vendor-sqlite`, `vendor-zod`, `vendor-ocr` (priority 100), and a new **`vendor-app`** group (priority 50) that hoists the shared data/auth/contexts/i18n foundation into one shared chunk instead of inflating `route-dashboard`. The existing route mapping (`getRouteChunkName`) runs at priority 10.
- **`performance.budget.json`** — `maxLazyChunkGzipBytes` **217000 → 200000**.
- **`BudgetDetailPage.test.tsx`** — mock now targets `../components/charts/BudgetDonutChart`; the food-breakdown test awaits the lazy Suspense boundary (`await screen.findByText('Subcategory spending')`). 18/18 pass.

## Before → after (gzip, measured with the enforcer's own `gzipSync`)

| Chunk | Before | After |
| --- | ---: | ---: |
| `route-ledger` | 215,753 B | **68,614 B** (−68%) |
| `route-dashboard` | 214,958 B | **7,533 B** (−96%) |

New shared chunks (loaded once across all routes): `vendor-app` **191,322 B** (binding constraint), `vendor-charts` 128,936 B, `vendor-react` 73,722 B.

**Budget:** `maxLazyChunkGzipBytes` 217000 → **200000**. The two issue-named route chunks now have huge headroom; the binding chunk is the shared `vendor-app` foundation at 191,322 B (~4.3% headroom under 200000). That ~191 KB foundation is inherent — it is the data/auth/i18n layer loaded once for the whole app — so 200000 is the smallest round budget that passes with comfortable headroom while still landing 15000 below the original 215000 ceiling. `tools/check-web-performance-budget.mjs` passes locally.

## Accessibility

- Suspense fallback uses `role=status` + `aria-live=polite` so screen readers announce the loading state; it does not trap focus (WCAG 2.2 AA preserved).
- No functional regression — the same `BudgetDonutChart` renders; only its load timing changes.

## Verification

- `vite build` + `node tools/check-web-performance-budget.mjs` → **Performance budgets passed**.
- `vitest run` for `BudgetDetailPage`, `BudgetsPage`, and `lib/perf` (route-chunks / lighthouse-route-budgets / web-vitals) → 72/72 pass.
- Prettier + ESLint clean on changed files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>