### PR TITLE
docs(prompts): align prompt library with the canonical fleet workflow (#2992)

### DIFF
--- a/.github/prompts/README.md
+++ b/.github/prompts/README.md
@@ -42,7 +42,7 @@ Run 5 sprints using the sprint prompt
 1. Fetches latest main and queries open issues
 2. Categorizes issues by agent type
 3. Dispatches agents in parallel waves (1 issue per agent type per wave)
-4. Each agent: creates worktree → implements → lint/format → rebase → push → create PR → monitor CI
+4. Each agent: creates worktree → implements → lint/format → rebase → push → create PR → monitor CI → self-merge
 5. Reports results after all waves complete
 
 ---
@@ -227,6 +227,6 @@ parameters:
 ## Design Principles
 
 - **Deterministic**: Each prompt produces consistent results given the same inputs.
-- **Self-contained**: Prompts include all context needed — agents don't need to look elsewhere.
+- **Self-contained, but DRY on canonical registries**: Prompts include the concrete steps an agent needs to execute. For project facts that evolve over time — the **label → agent map** (the `sprint-planning` skill) and the **pre-push / push / merge workflow** (`.github/instructions/workflow.instructions.md`) — prompts reference the canonical source instead of duplicating it, so they can't drift out of date.
 - **Safe by default**: Prompts respect human-gated operations. Destructive actions are flagged, not executed.
 - **Observable**: Every prompt ends with a structured report so the human can verify results.

--- a/.github/prompts/fix-ci.prompt.md
+++ b/.github/prompts/fix-ci.prompt.md
@@ -56,7 +56,7 @@ Fix the CI failures on PR #<number> (branch: <branch>).
 ```bash
 cd <worktree-path-for-this-branch>
 # OR if no worktree exists:
-cd G:\\personal\\finance
+cd <path-to-main-checkout>   # the primary clone; sibling worktrees are created next to it
 git fetch origin <branch>
 git worktree add ../wt-fix-ci-<number> <branch>
 cd ../wt-fix-ci-<number>
@@ -82,7 +82,7 @@ gh run view <run-id> --log-failed
 ```bash
 npm run format
 npx eslint . --fix
-npm run ci:check
+npm run format:check && npx eslint . --max-warnings 0   # NOT ci:check — type-check fails locally
 ```
 
 ### 5. Push
@@ -93,7 +93,7 @@ git commit --amend --no-edit
 # OR: git commit -m "fix(ci): resolve <failure-type> (#<issue>)"
 git fetch origin main
 git rebase origin/main
-git push origin <branch> --force-with-lease
+$env:HUSKY = "0"; git push --no-verify --force-with-lease origin <branch>   # bypass pre-push hook; force-with-lease re-pushes the rebased branch
 ```
 
 ### 6. Verify
@@ -101,6 +101,13 @@ git push origin <branch> --force-with-lease
 ```bash
 gh pr checks <number> --watch
 ```
+
+### 7. Merge or Hand Off
+
+Once CI is green **and** the PR is `MERGEABLE` (`gh pr view <number> --json mergeable,mergeStateStatus,author`):
+
+- **Agent-authored / fleet PR** — the orchestrator self-merges in the recommended merge order: `gh pr merge <number> --squash` (`AGENTS.md` Category 2).
+- **Human-authored PR** — do **not** merge; leave it green and note that it is ready for its author.
 
 """
 )
@@ -129,5 +136,5 @@ After all fix agents complete:
 
 ```
 
-> **Note**: `--force-with-lease` is used here because we're amending commits on feature branches to fix CI. This is safe for agent-owned branches but requires human approval per project rules. If the agent cannot push, it should document the fix and flag for human push.
+> **Note**: `--force-with-lease` re-pushes the amended/rebased commits on the PR's own feature branch. Per `AGENTS.md` Category 1, force-with-lease on an agent's **own** branch (to re-push after a rebase or conflict resolution) is **auto-approved** — no human approval needed. Never use plain `git push --force`.
 ```

--- a/.github/prompts/rebase-all.prompt.md
+++ b/.github/prompts/rebase-all.prompt.md
@@ -29,7 +29,7 @@ git worktree list | grep <branch>
 cd <existing-worktree>
 
 # Otherwise create a temporary worktree:
-cd G:\personal\finance
+cd <path-to-main-checkout>   # the primary clone; sibling worktrees are created next to it
 git fetch origin <branch>
 git worktree add ../wt-rebase-<number> <branch>
 cd ../wt-rebase-<number>
@@ -47,9 +47,9 @@ git rebase origin/main
 ```bash
 npm run format
 npx eslint . --fix
-npm run ci:check
-# Only push if ci:check passes:
-git push origin <branch> --force-with-lease
+npm run format:check && npx eslint . --max-warnings 0   # NOT ci:check — type-check fails locally
+# Only push if the checks pass:
+$env:HUSKY = "0"; git push --no-verify --force-with-lease origin <branch>   # bypass pre-push hook
 ```
 
 **If rebase has conflicts:**
@@ -89,4 +89,4 @@ git worktree remove ../wt-rebase-<number>
 | ... |
 ```
 
-> **Note**: `--force-with-lease` is used because rebasing rewrites history on feature branches. This is standard practice for feature branches but requires human approval per project rules. If the push is blocked, document the rebase status and flag for human push.
+> **Note**: `--force-with-lease` is required because rebasing rewrites history on the feature branch. Per `AGENTS.md` Category 1, force-with-lease on an agent's **own** branch after a clean rebase is **auto-approved** — no human approval needed. Never use plain `git push --force`.

--- a/.github/prompts/sprint.prompt.md
+++ b/.github/prompts/sprint.prompt.md
@@ -29,20 +29,7 @@ gh pr list --state open --json number,title,headRefName,statusCheckRollup
 
 For each sprint (1 through {{ N }}):
 
-1. **Categorize unclaimed issues** by agent type using labels and file paths:
-
-   | Label / Path                   | Agent Type          |
-   | ------------------------------ | ------------------- |
-   | `platform:android`             | `android-engineer`  |
-   | `platform:ios`                 | `ios-engineer`      |
-   | `platform:web`                 | `web-engineer`      |
-   | `platform:windows`             | `windows-engineer`  |
-   | `platform:shared`, `comp:sync` | `kmp-engineer`      |
-   | `ci`, `infrastructure`         | `devops-engineer`   |
-   | `documentation`                | `docs-writer`       |
-   | `design-system`                | `design-engineer`   |
-   | `security`                     | `security-reviewer` |
-   | `business`, `product`          | `product-manager`   |
+1. **Categorize unclaimed issues** by agent type using the canonical **label → agent map** in the `sprint-planning` skill (`.github/skills/sprint-planning/SKILL.md` → "Issue-to-Agent Mapping Algorithm" → Step 2). That table is the single source of truth and covers all 24 agent types (including `compliance-specialist`, `experimentation-engineer`, `data-engineer`, and the review/business roles). For issues with no matching label, infer the owner from the files that will change (see the file-ownership table in `AGENTS.md`).
 
 2. **Select 1 issue per agent type** (up to 15 agents per wave).
 3. **Track assignments** in SQL todos to prevent double-dispatch.
@@ -67,7 +54,7 @@ Issue: #<number> — <title>
 
 ### 1. Setup Worktree
 ```bash
-cd G:\\personal\\finance
+cd <path-to-main-checkout>   # the primary clone; sibling worktrees are created next to it
 git fetch origin main
 git worktree add ../wt-<agent>-<type>/<desc>-<issue#> -b <type>/<desc>-<issue#> origin/main
 cd ../wt-<agent>-<type>/<desc>-<issue#>
@@ -83,11 +70,12 @@ npm install
 
 ### 3. Pre-Push Checklist (NEVER SKIP)
 
+Canonical checklist: `.github/instructions/workflow.instructions.md`.
+
 ```bash
-npm run format
-npx eslint . --fix
-npm run ci:check
-# If ci:check fails, fix and re-run until clean
+npm run format            # auto-fix Prettier
+npx eslint . --fix        # auto-fix ESLint
+npm run format:check && npx eslint . --max-warnings 0   # verify (NOT ci:check — type-check fails locally)
 git add -A && git commit --amend --no-edit
 ```
 
@@ -96,15 +84,19 @@ git add -A && git commit --amend --no-edit
 ```bash
 git fetch origin main
 git rebase origin/main
-git push origin <branch-name>
+$env:HUSKY = "0"; git push --no-verify origin <branch-name>   # bypass the pre-push hook (agents)
 ```
 
 ### 5. Create PR
 
 ```bash
-gh pr create --title "type(scope): description (#<issue>)" \
-  --body "## Summary\n<description>\n\n## Changes\n- <bullets>\n\nCloses #<issue>" \
-  --base main
+gh pr create --base main --title "type(scope): description (#<issue>)" --body "## Summary
+<description>
+
+## Changes
+- <bullets>
+
+Closes #<issue>"
 ```
 
 ### 6. Monitor CI
@@ -114,6 +106,18 @@ gh pr checks <pr-number> --watch
 ```
 
 If CI fails: read logs, fix locally, re-run step 3, push, repeat.
+
+### 7. Self-Merge and Clean Up
+
+Once CI is green **and** the PR is `MERGEABLE`:
+
+```bash
+gh pr view <pr-number> --json mergeable,mergeStateStatus
+gh pr merge <pr-number> --squash
+git worktree remove ../wt-<agent>-<type>/<desc>-<issue#>
+```
+
+Agents have full autonomy to merge their own PRs once the quality gate passes (`AGENTS.md` Category 2). Use `--admin` to clear a branch-protection `BLOCKED` state only after local format + lint + affected tests pass, and note the override in the PR.
 """
 )
 

--- a/.github/prompts/team.prompt.md
+++ b/.github/prompts/team.prompt.md
@@ -25,23 +25,7 @@ gh pr list --state open --json number,title,headRefName,statusCheckRollup
 ```
 
 - Parse the `agents` parameter into a list of agent types.
-- Map each agent type to its label/path filter:
-
-  | Agent Type             | Issue Filter                    |
-  | ---------------------- | ------------------------------- |
-  | `android-engineer`     | `platform:android`              |
-  | `ios-engineer`         | `platform:ios`                  |
-  | `web-engineer`         | `platform:web`                  |
-  | `windows-engineer`     | `platform:windows`              |
-  | `kmp-engineer`         | `platform:shared`, `comp:sync`  |
-  | `backend-engineer`     | `comp:backend`, `comp:supabase` |
-  | `devops-engineer`      | `ci`, `infrastructure`          |
-  | `docs-writer`          | `documentation`                 |
-  | `design-engineer`      | `design-system`                 |
-  | `security-reviewer`    | `security`                      |
-  | `product-manager`      | `business`, `product`           |
-  | `marketing-strategist` | `marketing`                     |
-  | `business-analyst`     | `monetization`, `pricing`       |
+- Map each requested agent type to its issue filter using the canonical **label → agent map** in the `sprint-planning` skill (`.github/skills/sprint-planning/SKILL.md` → "Issue-to-Agent Mapping Algorithm" → Step 2) — the single source of truth for all 24 agent types. Invert it (agent → its labels) to filter the backlog for each requested agent.
 
 - Filter the issue backlog to only issues matching the requested agent types.
 - Exclude issues already claimed by open PRs.
@@ -57,10 +41,10 @@ Each agent follows the identical workflow from the sprint prompt:
 
 1. **Setup worktree** from `origin/main`
 2. **Implement** the assigned issue with tests
-3. **Pre-push checklist**: `npm run format` → `npx eslint . --fix` → `npm run ci:check`
-4. **Rebase and push**: `git fetch origin main && git rebase origin/main && git push`
-5. **Create PR** with `gh pr create` and `Closes #N`
-6. **Monitor CI** until green
+3. **Pre-push checklist**: `npm run format` → `npx eslint . --fix` → `npm run format:check && npx eslint . --max-warnings 0` (NOT `ci:check` — type-check fails locally)
+4. **Rebase and push**: `git fetch origin main && git rebase origin/main`, then `$env:HUSKY = "0"; git push --no-verify origin <branch>`
+5. **Create PR** with `gh pr create --base main` and `Closes #N`
+6. **Monitor CI**, then **self-merge** (`gh pr merge <pr> --squash`) once green and `MERGEABLE`, and remove the worktree
 
 ### Phase 3: Monitor and Report
 


### PR DESCRIPTION
﻿## Summary

Aligns the prompt library (`.github/prompts/`) with the canonical fleet workflow now codified in `.github/instructions/workflow.instructions.md` and `AGENTS.md`. The four **fleet-action** prompts had drifted; followed verbatim, several steps would fail. `backlog`, `review`, and `cleanup` were already correct and are unchanged.

## Changes

- **`sprint` / `team`** — replaced the partial inline label->agent tables (10 and 13 of 24 agents, and mutually inconsistent) with a pointer to the canonical map in the `sprint-planning` skill ("Issue-to-Agent Mapping Algorithm" -> Step 2).
- **Pre-push checklist** — `npm run ci:check` -> `npm run format:check && npx eslint . --max-warnings 0` across `sprint`/`team`/`fix-ci`/`rebase-all` (ci:check's type-check fails locally; documented Known Local Issue). `rebase-all` no longer gates pushes on ci:check.
- **Push bypass** — added `$env:HUSKY = "0"` + `--no-verify` to every push command (the Husky pre-push hook blocks agent pushes).
- **Hardcoded path** — removed `G:\personal\finance` from `sprint`/`fix-ci`/`rebase-all`; replaced with a neutral `<path-to-main-checkout>` placeholder.
- **Stale force-push notes** — `fix-ci`/`rebase-all` notes refreshed: `--force-with-lease` on an agent's own branch is now auto-approved (AGENTS.md Category 1), not human-gated.
- **Self-merge tail** — `sprint`/`team` now end with self-merge + worktree cleanup; `fix-ci` gains a merge-or-hand-off step (only self-merges agent-authored PRs). Fixed the literal `\n` PR body in `sprint`.
- **README** — reconciled the "Self-contained" design principle to permit canonical-registry pointers (label->agent map, workflow) so prompts cannot drift again.

Docs-only; no code paths affected.

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean
- [x] `node tools/check-ai-manifest.js` — no drift (prompts are not counted, but verified roster unaffected)

Closes #2992
