### PR TITLE
feat(tools): one-command local full-stack dev + doctor preflight (#2993)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Press F5 ("Web on edge (Microsoft Edge)") to bring up the full local edge
+  // stack and open the web app in Microsoft Edge with the debugger attached.
+  // The preLaunchTask starts Supabase + the Vite dev server (see tasks.json);
+  // VS Code waits for Vite to be ready, then launches Edge at :5173.
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Web on edge (Microsoft Edge)",
+      "type": "msedge",
+      "request": "launch",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}/apps/web",
+      "preLaunchTask": "Dev: Full Stack (web on edge)"
+    },
+    {
+      "name": "Web on edge (Chromium fallback)",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}/apps/web",
+      "preLaunchTask": "Dev: Full Stack (web on edge)"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,73 @@
+{
+  // One-click local full-stack web e2e (on edge). See docs/guides/full-stack-local.md.
+  // Run with: Terminal → Run Task… (Ctrl+Shift+P → "Tasks: Run Task").
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Dev: Full Stack (web on edge)",
+      "detail": "Preflight, start Supabase, wire apps/web/.env.local, launch the web app at :5173.",
+      "type": "shell",
+      "command": "npm run dev:full -- --no-open",
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "vite",
+        "pattern": {
+          "regexp": "^\\s*(.*)$",
+          "message": 1
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".*(Preflight|Supabase|supabase|VITE|vite).*",
+          "endsPattern": ".*(Local:.*5173|ready in \\d+).*"
+        }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "runOptions": {
+        "instanceLimit": 1
+      }
+    },
+    {
+      "label": "Doctor: Check local dev prereqs",
+      "detail": "Preflight health check (Docker, disk, ports, Supabase CLI).",
+      "type": "shell",
+      "command": "npm run doctor",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    },
+    {
+      "label": "Dev: Full Stack — reset DB",
+      "detail": "Same as Dev: Full Stack but resets the database (migrations + seed) first.",
+      "type": "shell",
+      "command": "npm run dev:full -- --reset --no-open",
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "vite",
+        "pattern": {
+          "regexp": "^\\s*(.*)$",
+          "message": 1
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".*(Preflight|Supabase|supabase|reset|VITE|vite).*",
+          "endsPattern": ".*(Local:.*5173|ready in \\d+).*"
+        }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "runOptions": {
+        "instanceLimit": 1
+      }
+    }
+  ]
+}

--- a/docs/guides/full-stack-local.md
+++ b/docs/guides/full-stack-local.md
@@ -9,6 +9,41 @@ For backend-only Supabase work (functions, migrations, Studio), see
 [`local-supabase.md`](./local-supabase.md). This guide is the web-to-edge
 end-to-end path on top of it.
 
+## Quick start (one command)
+
+On a machine with **Docker Desktop running** and dependencies installed
+(`npm install`), a single command does everything — preflight checks, start the
+Supabase edge stack, wire the web app to it, and launch the web app:
+
+```bash
+npm run dev:full
+```
+
+That runs [`tools/dev-full.mjs`](../../tools/dev-full.mjs), which:
+
+1. runs the **preflight** ([`npm run doctor`](../../tools/doctor.mjs)) — Docker
+   daemon, free disk, ports `54321`/`5173`, Supabase CLI;
+2. starts Supabase (`supabase start`, retrying on Docker Hub rate-limit stalls;
+   skipped if already running);
+3. writes `apps/web/.env.local` from `supabase status` (takes the app out of
+   demo mode);
+4. launches the web app at <http://localhost:5173> and opens your browser.
+
+Useful flags: `--reset` (reset DB first), `--e2e` (run the live e2e suite
+instead of the dev server), `--no-open`, `--skip-doctor`. Run
+`node tools/dev-full.mjs --help` for the full list.
+
+> **VS Code one-click / F5** — Open the repo in VS Code and either run the
+> **"Dev: Full Stack (web on edge)"** task (Ctrl+Shift+P → _Tasks: Run Task_) or
+> press **F5** ("Web on edge (Microsoft Edge)"). Both wrap `npm run dev:full`
+> and, for F5, attach the debugger to Edge at `:5173`.
+
+> **Not sure the machine is ready?** Run `npm run doctor` first — it reports
+> exactly what's missing (and how to fix it) without starting anything.
+
+The rest of this guide explains what `dev:full` does step by step, for when you
+want to run the pieces manually or troubleshoot.
+
 ## What "full-stack local (edge)" means here
 
 The genuinely server-wired path in the web app today is **authentication**:
@@ -40,7 +75,15 @@ A global `supabase` CLI is optional — the setup script and the `supabase:*` np
 scripts fall back to `npx --yes supabase`, which downloads and caches the CLI on
 first use.
 
-## 1. Install dependencies
+> Run `npm run doctor` to confirm Docker, disk, and ports are ready before you
+> start — it pinpoints anything missing without bringing the stack up.
+
+## Manual setup (step by step)
+
+The steps below are exactly what `npm run dev:full` automates. Run them by hand
+when you want finer control or are troubleshooting.
+
+### 1. Install dependencies
 
 From the repo root:
 
@@ -48,7 +91,10 @@ From the repo root:
 npm install
 ```
 
-## 2. Bring up the stack and wire the web app
+### 2. Bring up the stack and wire the web app
+
+> `npm run dev:full` does this step (and the next two) for you. The manual
+> equivalent below is useful for backend-only work or troubleshooting.
 
 This single command starts Supabase, applies all migrations + seed data, and
 writes `apps/web/.env.local` pointing the web app at the local stack:
@@ -76,7 +122,7 @@ Setting `VITE_SUPABASE_URL` to the local stack is what takes the app **out of
 demo mode** — Vite auto-loads `.env.local`, so `npm run dev` and the live e2e
 "just work" against the real edge backend.
 
-## 3. Run the web app
+### 3. Run the web app
 
 ```bash
 npm run dev -w apps/web
@@ -90,7 +136,7 @@ authenticated app.
 Inspect the round-trip in Studio (<http://localhost:54323>) or check the mailbox
 at Inbucket (<http://localhost:54324>).
 
-## 4. Run the live e2e (edge)
+### 4. Run the live e2e (edge)
 
 A real-backend Playwright smoke test drives signup through edge auth and asserts
 the app leaves the auth wall:
@@ -137,14 +183,15 @@ npm --prefix services/api run supabase:status
 
 ## Troubleshooting
 
-| Symptom                                   | Fix                                                                                                     |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| "Demo Mode" banner on `/signup`           | `apps/web/.env.local` is missing or `VITE_SUPABASE_URL` is unset/placeholder — rerun the setup command. |
-| Live e2e fails: "App is in demo mode"     | Same cause — ensure the stack is up and `.env.local` exists, then rerun.                                |
-| `npm run test:e2e:live` can't launch Edge | Use `npm run test:e2e:live:chromium -w apps/web`, or install Microsoft Edge.                            |
-| Port 5173 or 5174 already in use          | Stop the other process, or set `LIVE_E2E_PORT` for the live suite.                                      |
-| `supabase start` is slow / stalls         | First-run image pulls can be slow; ensure Docker is running and retry. See `local-supabase.md`.         |
-| Signup returns a non-2xx response         | Confirm the stack is healthy (`supabase:status`) and migrations applied (`supabase:reset`).             |
+| Symptom                                   | Fix                                                                                                                                                                                     |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Not sure the machine is ready             | Run `npm run doctor` — it checks Docker, free disk, and ports `54321`/`5173` and prints how to fix gaps.                                                                                |
+| "Demo Mode" banner on `/signup`           | `apps/web/.env.local` is missing or `VITE_SUPABASE_URL` is unset/placeholder — rerun the setup command.                                                                                 |
+| Live e2e fails: "App is in demo mode"     | Same cause — ensure the stack is up and `.env.local` exists, then rerun.                                                                                                                |
+| `npm run test:e2e:live` can't launch Edge | Use `npm run test:e2e:live:chromium -w apps/web`, or install Microsoft Edge.                                                                                                            |
+| Port 5173 or 5174 already in use          | Stop the other process, or set `LIVE_E2E_PORT` for the live suite.                                                                                                                      |
+| `supabase start` is slow / stalls         | First-run image pulls can be slow; ensure Docker is running and retry. `docker login` raises Docker Hub pull limits. `npm run dev:full` retries automatically. See `local-supabase.md`. |
+| Signup returns a non-2xx response         | Confirm the stack is healthy (`supabase:status`) and migrations applied (`supabase:reset`).                                                                                             |
 
 ## Known limitations
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "agent:issues": "node tools/agent-scripts/list-issues.js",
     "agent:pr-status": "node tools/agent-scripts/check-pr-status.js",
     "setup": "node tools/setup.js",
+    "doctor": "node tools/doctor.mjs",
+    "dev:full": "node tools/dev-full.mjs",
     "prepare": "husky",
     "changeset": "changeset",
     "version": "changeset version"

--- a/tools/README.md
+++ b/tools/README.md
@@ -8,6 +8,49 @@ This directory contains cross-platform scripts and Git hooks that support the de
 
 ## Contents
 
+### `dev-full.mjs` — One-command local full-stack web e2e (on edge)
+
+The seamless developer entry point. Brings up the local Supabase **edge** stack
+(auth + Postgres/RLS via Docker), wires the web app to it (writes
+`apps/web/.env.local` from `supabase status`), and launches the web app — all in
+one command. Runs `doctor.mjs` first, retries `supabase start` on Docker Hub
+rate-limit stalls, and skips startup if the stack is already running. No global
+Supabase CLI required (uses `npx --yes supabase`).
+
+**Usage:**
+
+```bash
+npm run dev:full                 # preflight → stack → wire web → launch web → open browser
+npm run dev:full -- --reset      # also reset the DB (migrations + seed) first
+npm run dev:full -- --e2e        # bring up stack, run the live Playwright e2e suite
+npm run dev:full -- --no-open    # don't auto-open the browser
+npm run dev:full -- --skip-doctor
+node tools/dev-full.mjs --help
+```
+
+In VS Code, the **"Dev: Full Stack (web on edge)"** task and the **F5** launch
+config (`.vscode/tasks.json` / `launch.json`) wrap this for a true one-click
+start. See [`docs/guides/full-stack-local.md`](../docs/guides/full-stack-local.md).
+
+### `doctor.mjs` — Local dev preflight / health check
+
+Verifies the host is ready for the full local stack **before** you start it,
+catching the failures that otherwise stall a cold `supabase start`: Docker
+daemon reachable (not just installed), enough free disk to extract the Supabase
+images, required ports free (54321 Supabase, 5173 Vite), and a resolvable
+Supabase CLI. Exits non-zero on a hard failure so `dev-full.mjs` and CI can gate
+on it.
+
+**Usage:**
+
+```bash
+npm run doctor                         # human-readable report
+node tools/doctor.mjs --json           # machine-readable report
+node tools/doctor.mjs --quiet          # only warnings/failures
+node tools/doctor.mjs --min-disk-gb=40 # override the recommended-disk threshold
+node tools/doctor.mjs --help
+```
+
 ### `gradle.js` — Cross-platform Gradle wrapper
 
 A Node.js script that invokes `gradlew` (Unix) or `gradlew.bat` (Windows) automatically based on the current OS. It also auto-detects JDK 21 if `JAVA_HOME` is not already set.

--- a/tools/dev-full.mjs
+++ b/tools/dev-full.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+// @ts-check
+//
+// dev-full.mjs — One command to run the Finance web app end-to-end on a real
+// local edge backend (Supabase via Docker), the way a developer would.
+//
+// Suggested npm script: "dev:full": "node tools/dev-full.mjs"
+//
+// Pipeline:
+//   1. Preflight (tools/doctor.mjs)            — skip with --skip-doctor
+//   2. supabase start (services/api)           — skipped if already running;
+//                                                retries with backoff on the
+//                                                Docker Hub "Rate exceeded" stall
+//   3. supabase db reset (optional)            — only with --reset
+//   4. Write apps/web/.env.local               — from `supabase status -o env`,
+//                                                so the web app leaves demo mode
+//   5. Launch the web app                      — `vite` dev (default) or the live
+//                                                e2e suite (--e2e)
+//   6. Open the browser at :5173               — unless --no-open / --e2e
+//
+// Usage:
+//   node tools/dev-full.mjs                 # bring up stack + web app, open browser
+//   node tools/dev-full.mjs --reset         # also reset the DB (migrations + seed)
+//   node tools/dev-full.mjs --e2e           # bring up stack, run the live e2e suite
+//   node tools/dev-full.mjs --no-open       # don't auto-open the browser
+//   node tools/dev-full.mjs --skip-doctor   # skip preflight (e.g. in CI)
+//   node tools/dev-full.mjs --help
+//
+// Everything here is cross-platform Node (Windows / macOS / Linux) and uses
+// `npx --yes supabase`, so no global Supabase CLI is required.
+
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const API_DIR = path.join(REPO_ROOT, 'services', 'api');
+const WEB_ENV_LOCAL = path.join(REPO_ROOT, 'apps', 'web', '.env.local');
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`Finance — one-command local full-stack web e2e (on edge)
+
+Brings up the local Supabase edge stack, wires the web app to it, and launches
+the web app — a single command for the full developer loop.
+
+Usage:
+  node tools/dev-full.mjs [options]
+
+Options:
+  --reset         Reset the database (apply all migrations + seed) before launch.
+  --e2e           Run the live Playwright e2e suite instead of the dev server.
+  --no-open       Do not auto-open the browser (dev mode only).
+  --skip-doctor   Skip the preflight health check.
+  -h, --help      Show this help.
+
+Requires Docker Desktop running. No global Supabase CLI needed (uses npx).`);
+  process.exit(0);
+}
+
+const opts = {
+  reset: args.includes('--reset'),
+  e2e: args.includes('--e2e'),
+  noOpen: args.includes('--no-open'),
+  skipDoctor: args.includes('--skip-doctor'),
+};
+
+const isWin = process.platform === 'win32';
+
+function step(msg) {
+  console.log(`\n\x1b[1m▶ ${msg}\x1b[0m`);
+}
+function info(msg) {
+  console.log(`  ${msg}`);
+}
+function fail(msg, fix) {
+  console.error(`\n\x1b[31m✗ ${msg}\x1b[0m`);
+  if (fix) console.error(`  → ${fix}`);
+  process.exit(1);
+}
+
+/**
+ * npm/npx are `.cmd` shims on Windows and must go through a shell; passing a
+ * single joined command string (no separate args array) avoids the DEP0190
+ * shell-args deprecation warning. `node` and other real executables run without
+ * a shell.
+ * @param {string} cmd
+ * @param {string[]} cmdArgs
+ * @returns {{viaShell:boolean, command:string, args:string[]}}
+ */
+function resolve(cmd, cmdArgs) {
+  if (cmd === 'npm' || cmd === 'npx') {
+    return { viaShell: true, command: [cmd, ...cmdArgs].join(' '), args: [] };
+  }
+  return { viaShell: false, command: cmd, args: cmdArgs };
+}
+
+/**
+ * Run a command to completion, inheriting stdio so the user sees live output.
+ * @param {string} cmd
+ * @param {string[]} cmdArgs
+ * @param {{cwd?:string}} [options]
+ * @returns {number} exit code
+ */
+function runInherit(cmd, cmdArgs, options = {}) {
+  const r = resolve(cmd, cmdArgs);
+  const res = spawnSync(r.command, r.args, {
+    cwd: options.cwd || REPO_ROOT,
+    stdio: 'inherit',
+    shell: r.viaShell,
+    windowsHide: true,
+  });
+  if (res.error) fail(`Failed to run ${cmd}: ${res.error.message}`);
+  return res.status ?? 1;
+}
+
+/**
+ * Run a command and capture stdout (used for `supabase status`).
+ * @param {string} cmd
+ * @param {string[]} cmdArgs
+ * @param {{cwd?:string, timeoutMs?:number}} [options]
+ */
+function runCapture(cmd, cmdArgs, options = {}) {
+  const r = resolve(cmd, cmdArgs);
+  const res = spawnSync(r.command, r.args, {
+    cwd: options.cwd || REPO_ROOT,
+    encoding: 'utf8',
+    timeout: options.timeoutMs ?? 60000,
+    shell: r.viaShell,
+    windowsHide: true,
+  });
+  return {
+    ok: res.status === 0 && !res.error,
+    stdout: (res.stdout || '').trim(),
+    stderr: (res.stderr || '').trim(),
+  };
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// --- 1. Preflight ------------------------------------------------------------
+function preflight() {
+  if (opts.skipDoctor) {
+    info('Skipping preflight (--skip-doctor).');
+    return;
+  }
+  step('Preflight check (tools/doctor.mjs)');
+  const code = runInherit(process.execPath, [path.join(__dirname, 'doctor.mjs'), '--quiet']);
+  if (code !== 0) {
+    fail(
+      'Preflight failed — the environment is not ready for the full stack.',
+      'Resolve the ✗ items above (run `npm run doctor` for the full report), then retry. Use --skip-doctor to bypass.',
+    );
+  }
+  info('Preflight passed.');
+}
+
+// --- 2. Supabase start (idempotent, with rate-limit backoff) -----------------
+function isSupabaseRunning() {
+  // `supabase status` exits 0 and prints "API URL" only when the stack is up.
+  const res = runCapture('npx', ['--yes', 'supabase', 'status'], {
+    cwd: API_DIR,
+    timeoutMs: 30000,
+  });
+  return res.ok && /API URL/i.test(res.stdout);
+}
+
+async function startSupabase() {
+  step('Starting the local Supabase edge stack');
+  if (isSupabaseRunning()) {
+    info('Supabase is already running — reusing it.');
+    return;
+  }
+
+  const maxAttempts = 3;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    info(`supabase start (attempt ${attempt}/${maxAttempts})…`);
+    const code = runInherit('npx', ['--yes', 'supabase', 'start'], { cwd: API_DIR });
+    if (code === 0 || isSupabaseRunning()) {
+      info('Supabase is up.');
+      return;
+    }
+    if (attempt < maxAttempts) {
+      const backoff = attempt * 15;
+      info(
+        `supabase start failed (often a Docker Hub "Rate exceeded" pull limit). Retrying in ${backoff}s…`,
+      );
+      info('If this keeps failing, run `docker login` to raise the pull limit.');
+      await sleep(backoff * 1000);
+    }
+  }
+  fail(
+    'Could not start Supabase after multiple attempts.',
+    'Check Docker is running and has disk/quota. Try `docker login` for Docker Hub rate limits, then re-run. See docs/guides/full-stack-local.md.',
+  );
+}
+
+// --- 3. Optional DB reset ----------------------------------------------------
+function resetDatabase() {
+  if (!opts.reset) return;
+  step('Resetting the database (migrations + seed)');
+  const code = runInherit('npx', ['--yes', 'supabase', 'db', 'reset'], { cwd: API_DIR });
+  if (code !== 0)
+    fail('Database reset failed.', 'Inspect the output above; ensure the stack is healthy.');
+  info('Database reset complete.');
+}
+
+// --- 4. Write apps/web/.env.local --------------------------------------------
+function writeEnvLocal() {
+  step('Wiring the web app to the local stack (apps/web/.env.local)');
+  const res = runCapture('npx', ['--yes', 'supabase', 'status', '-o', 'env'], {
+    cwd: API_DIR,
+    timeoutMs: 30000,
+  });
+  if (!res.ok) {
+    fail(
+      'Could not read `supabase status -o env`.',
+      'Ensure the stack started cleanly, then re-run `npm run dev:full`.',
+    );
+  }
+
+  /** @type {Record<string,string>} */
+  const envMap = {};
+  for (const line of res.stdout.split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*"?(.*?)"?\s*$/);
+    if (m) envMap[m[1]] = m[2];
+  }
+  const apiUrl = envMap.API_URL || 'http://localhost:54321';
+  const anonKey = envMap.ANON_KEY;
+  if (!anonKey) {
+    fail(
+      'No anon key found in `supabase status` output.',
+      'The stack may not be fully up. Re-run after it settles.',
+    );
+  }
+
+  const contents = `# Generated by tools/dev-full.mjs — local full-stack (edge) profile.
+# Points the web app at the local Supabase CLI stack so it exercises real edge
+# auth (GoTrue + auth-* edge functions + Postgres/RLS) instead of demo mode.
+# Safe to delete and regenerate: npm run dev:full
+VITE_SUPABASE_URL=${apiUrl}
+VITE_SUPABASE_ANON_KEY=${anonKey}
+VITE_FUNCTIONS_PROXY_TARGET=${apiUrl}
+`;
+  fs.writeFileSync(WEB_ENV_LOCAL, contents, 'utf8');
+  info(`Wrote ${path.relative(REPO_ROOT, WEB_ENV_LOCAL)} (VITE_SUPABASE_URL=${apiUrl}).`);
+}
+
+// --- 6. Open browser ---------------------------------------------------------
+function openBrowser(url) {
+  try {
+    if (isWin) {
+      spawn('cmd', ['/c', 'start', '""', url], { detached: true, stdio: 'ignore' }).unref();
+    } else if (process.platform === 'darwin') {
+      spawn('open', [url], { detached: true, stdio: 'ignore' }).unref();
+    } else {
+      spawn('xdg-open', [url], { detached: true, stdio: 'ignore' }).unref();
+    }
+  } catch {
+    // Opening the browser is a convenience, never fatal.
+  }
+}
+
+// --- 5. Launch web app (or live e2e) -----------------------------------------
+function launchWeb() {
+  if (opts.e2e) {
+    step('Running the live e2e suite (edge auth → authenticated app)');
+    const code = runInherit('npm', ['run', 'test:e2e:live', '-w', 'apps/web']);
+    process.exit(code);
+  }
+
+  step('Launching the web app (http://localhost:5173)');
+  info('Press Ctrl+C to stop the web app. The Supabase stack keeps running —');
+  info('stop it later with: npm --prefix services/api run supabase:stop');
+
+  const child = spawn('npm run dev -w apps/web', [], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+    shell: true,
+    windowsHide: true,
+  });
+
+  if (!opts.noOpen) {
+    // Give Vite a moment to bind the port before opening the browser.
+    setTimeout(() => openBrowser('http://localhost:5173'), 4000);
+  }
+
+  // Mirror the child's exit; forward Ctrl+C so the dev server shuts down cleanly.
+  child.on('exit', (code) => process.exit(code ?? 0));
+  const forward = () => child.kill('SIGINT');
+  process.on('SIGINT', forward);
+  process.on('SIGTERM', forward);
+}
+
+async function main() {
+  console.log('Finance — local full-stack web e2e (on edge)');
+  preflight();
+  await startSupabase();
+  resetDatabase();
+  writeEnvLocal();
+  launchWeb();
+}
+
+main().catch((err) => {
+  fail(`Unexpected error: ${err?.message || err}`);
+});

--- a/tools/doctor.mjs
+++ b/tools/doctor.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+// @ts-check
+//
+// doctor.mjs — Preflight health check for local full-stack web-on-edge dev.
+//
+// Suggested npm script: "doctor": "node tools/doctor.mjs"
+//
+// Verifies the conditions that actually break `supabase start` + `vite` — the
+// real-world failures we hit bringing the stack up on a fresh machine:
+//   - Docker daemon reachable (installed AND running, not wedged)
+//   - Enough free disk to extract the Supabase images (the #1 silent killer)
+//   - Required ports free (54321 Supabase API gateway, 5173 Vite dev server)
+//   - Supabase CLI resolvable (global or via npx)
+// It also prints the Docker Hub anonymous-pull rate-limit tip, since that is the
+// other thing that stalls a cold `supabase start`.
+//
+// Usage:
+//   node tools/doctor.mjs              # human-readable report
+//   node tools/doctor.mjs --json       # machine-readable JSON report
+//   node tools/doctor.mjs --quiet      # only print warnings/failures
+//   node tools/doctor.mjs --min-disk-gb=30   # override the recommended-disk threshold
+//   node tools/doctor.mjs --help
+//
+// Exit code: 0 when every hard check passes (warnings allowed); 1 when any hard
+// check fails. Safe to call from other scripts (dev-full.mjs runs it first).
+
+import { spawnSync } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`Finance — local full-stack dev preflight (doctor)
+
+Checks the host for everything needed to run the web app against a real local
+edge backend (Supabase via Docker) before you start it.
+
+Usage:
+  node tools/doctor.mjs [options]
+
+Options:
+  --json              Emit a JSON report instead of human-readable text.
+  --quiet             Only print warnings and failures (hide passing checks).
+  --min-disk-gb=<n>   Recommended free-disk threshold in GB (default 30; the
+                      hard-fail floor stays at 10 GB).
+  -h, --help          Show this help.
+
+Exit code: 0 if all hard checks pass, 1 otherwise.`);
+  process.exit(0);
+}
+
+const asJson = args.includes('--json');
+const quiet = args.includes('--quiet');
+const minDiskArg = args.find((a) => a.startsWith('--min-disk-gb='));
+const RECOMMENDED_DISK_GB = minDiskArg ? Number(minDiskArg.split('=')[1]) : 30;
+const CRITICAL_DISK_GB = 10; // below this, image extraction reliably fails
+
+const GB = 1024 * 1024 * 1024;
+
+/** @typedef {{name:string, level:'pass'|'warn'|'fail', detail:string, fix?:string}} Check */
+/** @type {Check[]} */
+const checks = [];
+
+/**
+ * Run a command with a hard timeout; never throws.
+ * npm/npx are `.cmd` shims on Windows and need a shell; passing them as a single
+ * joined string (rather than command + args array) avoids the DEP0190
+ * shell-args deprecation warning. Everything else runs without a shell.
+ * @param {string} cmd
+ * @param {string[]} cmdArgs
+ * @param {number} timeoutMs
+ * @returns {{ok:boolean, stdout:string, stderr:string, timedOut:boolean, code:number|null}}
+ */
+function run(cmd, cmdArgs, timeoutMs) {
+  const viaShell = cmd === 'npx' || cmd === 'npm';
+  const res = viaShell
+    ? spawnSync([cmd, ...cmdArgs].join(' '), {
+        timeout: timeoutMs,
+        encoding: 'utf8',
+        shell: true,
+        windowsHide: true,
+      })
+    : spawnSync(cmd, cmdArgs, {
+        timeout: timeoutMs,
+        encoding: 'utf8',
+        windowsHide: true,
+      });
+  return {
+    ok: res.status === 0 && !res.error,
+    stdout: (res.stdout || '').trim(),
+    stderr: (res.stderr || '').trim(),
+    timedOut: res.error?.code === 'ETIMEDOUT' || res.signal === 'SIGTERM',
+    code: res.status,
+  };
+}
+
+/**
+ * Is a TCP port already bound on localhost?
+ * @param {number} port
+ * @returns {Promise<boolean>}
+ */
+function portInUse(port) {
+  return new Promise((resolve) => {
+    const server = net
+      .createServer()
+      .once('error', (err) => {
+        resolve(/** @type {NodeJS.ErrnoException} */ (err).code === 'EADDRINUSE');
+      })
+      .once('listening', () => {
+        server.close(() => resolve(false));
+      })
+      .listen(port, '127.0.0.1');
+  });
+}
+
+/** Best-effort free bytes on the volume that holds Docker's data. */
+function freeDiskBytes() {
+  // Docker Desktop stores its VM disk under LOCALAPPDATA on Windows; on
+  // macOS/Linux the daemon root lives on the same volume as $HOME in the
+  // common case. Checking that volume is the right signal for image pulls.
+  const probe =
+    process.platform === 'win32' ? process.env.LOCALAPPDATA || os.homedir() : os.homedir();
+  try {
+    // fs.statfsSync is available on Node 18.15+ (present on this repo's Node 22+).
+    const stat = fs.statfsSync(probe);
+    return { bytes: stat.bsize * stat.bavail, volume: path.parse(probe).root || probe };
+  } catch {
+    return { bytes: null, volume: path.parse(probe).root || probe };
+  }
+}
+
+function add(name, level, detail, fix) {
+  checks.push({ name, level, detail, ...(fix ? { fix } : {}) });
+}
+
+// --- Check: Docker daemon ----------------------------------------------------
+function checkDocker() {
+  const version = run('docker', ['--version'], 8000);
+  if (!version.ok) {
+    add(
+      'Docker installed',
+      'fail',
+      'The `docker` command was not found on PATH.',
+      'Install Docker Desktop: https://www.docker.com/products/docker-desktop/',
+    );
+    return;
+  }
+  add('Docker installed', 'pass', version.stdout);
+
+  // `docker info` is what hangs when the daemon is wedged — the timeout turns
+  // that hang into a clear failure instead of a stuck preflight.
+  const info = run('docker', ['info', '--format', '{{.ServerVersion}}'], 20000);
+  if (info.ok && info.stdout) {
+    add('Docker daemon running', 'pass', `server ${info.stdout}`);
+  } else if (info.timedOut) {
+    add(
+      'Docker daemon running',
+      'fail',
+      'Docker daemon did not respond within 20s (likely starting or wedged).',
+      'Open Docker Desktop and wait for "Engine running", then retry. If it stays stuck, restart Docker Desktop.',
+    );
+  } else {
+    add(
+      'Docker daemon running',
+      'fail',
+      'Docker is installed but the daemon is not reachable.',
+      'Start Docker Desktop (or `sudo systemctl start docker` on Linux), then retry.',
+    );
+  }
+}
+
+// --- Check: free disk --------------------------------------------------------
+function checkDisk() {
+  const { bytes, volume } = freeDiskBytes();
+  if (bytes == null) {
+    add(
+      'Free disk space',
+      'warn',
+      `Could not determine free space on ${volume}.`,
+      `Ensure at least ${RECOMMENDED_DISK_GB} GB is free for the Supabase images.`,
+    );
+    return;
+  }
+  const gb = bytes / GB;
+  const human = `${gb.toFixed(1)} GB free on ${volume}`;
+  if (gb < CRITICAL_DISK_GB) {
+    add(
+      'Free disk space',
+      'fail',
+      `${human} — below the ${CRITICAL_DISK_GB} GB floor; Supabase image extraction will fail.`,
+      `Free up disk (target ≥ ${RECOMMENDED_DISK_GB} GB). Reclaim Docker space with \`docker system prune -a\` (removes unused images/containers — review first).`,
+    );
+  } else if (gb < RECOMMENDED_DISK_GB) {
+    add(
+      'Free disk space',
+      'warn',
+      `${human} — below the recommended ${RECOMMENDED_DISK_GB} GB; a cold image pull may run tight.`,
+      'Free some space or run `docker system prune` if a pull fails midway.',
+    );
+  } else {
+    add('Free disk space', 'pass', human);
+  }
+}
+
+// --- Check: ports ------------------------------------------------------------
+async function checkPorts() {
+  const ports = [
+    { port: 54321, who: 'Supabase API gateway' },
+    { port: 5173, who: 'Vite dev server' },
+  ];
+  for (const { port, who } of ports) {
+    const busy = await portInUse(port);
+    if (busy) {
+      add(
+        `Port ${port} free`,
+        'warn',
+        `Port ${port} (${who}) is already in use — the stack may already be running, or another process holds it.`,
+        `If this is a stale process, stop it. Supabase: \`npm --prefix services/api run supabase:stop\`. Vite: stop the other dev server.`,
+      );
+    } else {
+      add(`Port ${port} free`, 'pass', `${who} port is available`);
+    }
+  }
+}
+
+// --- Check: Supabase CLI -----------------------------------------------------
+function checkSupabaseCli() {
+  const global = run('supabase', ['--version'], 8000);
+  if (global.ok && global.stdout) {
+    add('Supabase CLI', 'pass', `global supabase ${global.stdout}`);
+    return;
+  }
+  // No global CLI — confirm npx can resolve a cached copy. We use --no-install
+  // so this stays fast; if absent, dev-full's `npx --yes` will fetch it.
+  const viaNpx = run('npx', ['--no-install', 'supabase', '--version'], 12000);
+  if (viaNpx.ok && viaNpx.stdout) {
+    add('Supabase CLI', 'pass', `via npx (cached): ${viaNpx.stdout}`);
+  } else {
+    add(
+      'Supabase CLI',
+      'warn',
+      'No global Supabase CLI and none cached for npx.',
+      'No action needed — `npm run dev:full` runs `npx --yes supabase`, which downloads and caches it on first use.',
+    );
+  }
+}
+
+async function main() {
+  checkDocker();
+  checkDisk();
+  await checkPorts();
+  checkSupabaseCli();
+
+  const failed = checks.filter((c) => c.level === 'fail');
+  const warned = checks.filter((c) => c.level === 'warn');
+  const ok = failed.length === 0;
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          ok,
+          summary: {
+            pass: checks.filter((c) => c.level === 'pass').length,
+            warn: warned.length,
+            fail: failed.length,
+          },
+          checks,
+          thresholds: { criticalDiskGb: CRITICAL_DISK_GB, recommendedDiskGb: RECOMMENDED_DISK_GB },
+        },
+        null,
+        2,
+      ),
+    );
+    process.exit(ok ? 0 : 1);
+  }
+
+  const icon = { pass: '✓', warn: '!', fail: '✗' };
+  console.log('\nFinance — local full-stack dev preflight (doctor)\n');
+  for (const c of checks) {
+    if (quiet && c.level === 'pass') continue;
+    console.log(`  ${icon[c.level]} ${c.name}: ${c.detail}`);
+    if (c.fix && c.level !== 'pass') console.log(`      → ${c.fix}`);
+  }
+
+  console.log(
+    `\n  ${checks.filter((c) => c.level === 'pass').length} passed, ${warned.length} warning(s), ${failed.length} failure(s)`,
+  );
+
+  // Always surface the rate-limit tip — it is the other cold-start stall and is
+  // not detectable without actually pulling.
+  console.log(
+    '\n  Tip: if `supabase start` stalls on "Rate exceeded", run `docker login`\n' +
+      '       (anonymous Docker Hub pulls are rate-limited).',
+  );
+
+  if (ok) {
+    console.log('\n  Ready. Start the full stack with:  npm run dev:full\n');
+  } else {
+    console.log('\n  Fix the ✗ failures above, then re-run:  npm run doctor\n');
+  }
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('doctor: unexpected error —', err?.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a seamless, near zero-config developer loop for running the Finance web app **end-to-end against the local Supabase edge backend** — the "develop on a capable machine with one command" experience. Builds directly on the enablement shipped in #2982.

Before this PR, the seamless path was a single `setup:windows`/`setup` script that brought up the stack but still left the developer to run the web app, manage env wiring, and debug cold-start failures (wedged Docker daemon, exhausted disk, Docker Hub pull rate limits) by hand. This PR collapses that into **one command** and adds a **preflight** that explains exactly what's wrong before anything starts.

## Changes

- **`tools/dev-full.mjs`** (`npm run dev:full`) — one-command orchestrator:
  1. preflight via `doctor.mjs`,
  2. `supabase start` in `services/api` (skips if already running; retries with backoff on the Docker Hub "Rate exceeded" stall),
  3. writes `apps/web/.env.local` from `supabase status -o env` (takes the app out of demo mode — same format the setup scripts produce),
  4. launches the web app at `http://localhost:5173` and opens the browser.
  - Flags: `--reset` (DB reset first), `--e2e` (run the live Playwright suite instead of the dev server), `--no-open`, `--skip-doctor`, `--help`.
- **`tools/doctor.mjs`** (`npm run doctor`) — preflight health check for the failures that actually stall a cold start: Docker daemon **reachable** (timeout turns a wedged daemon into a clear failure), **free disk** (hard-fail under 10 GB — the exact thing that bit us), ports `54321`/`5173` free, and a resolvable Supabase CLI. `--json`/`--quiet`/`--min-disk-gb`/`--help`; exits non-zero on hard failure so `dev:full` and CI can gate on it.
- **`.vscode/tasks.json` + `.vscode/launch.json`** — true one-click: a **"Dev: Full Stack (web on edge)"** task and an **F5** Microsoft Edge launch (Chromium fallback) that wrap `npm run dev:full`.
- **`package.json`** — adds `dev:full` and `doctor` scripts.
- **Docs** — `tools/README.md` documents both tools; `docs/guides/full-stack-local.md` now **leads with the one-command path** (`npm run dev:full`) and points at `npm run doctor`, with the manual steps reframed as "what dev:full does for you."

## Implementation notes

- Pure cross-platform Node (Windows/macOS/Linux), no new dependencies. Uses `npx --yes supabase`, so **no global Supabase CLI is required**.
- npm/npx (`.cmd` shims on Windows that require a shell under Node 20+) are invoked as a single joined command string rather than command + args, which avoids the Node `DEP0190` shell-args deprecation warning while keeping real executables (`docker`, `node`) shell-free.
- The `.env.local` writer mirrors the exact parsing/format of `services/api/scripts/setup-local.ps1`, so `dev:full` and the existing setup scripts are interchangeable.

## Testing

- `node tools/doctor.mjs` / `--json` — verified it correctly diagnoses this machine (flagged a wedged Docker daemon via the 20s timeout, and < 10 GB free disk as a hard fail; ports free; CLI warning). Exit code `1` on hard failure as designed.
- `node tools/dev-full.mjs --help`, `node tools/doctor.mjs --help` — verified.
- `node --check` on both scripts; env-parse logic unit-verified against sample `supabase status -o env` output.
- `npm run format:check` and `npx eslint . --max-warnings 0` — clean repo-wide.

> Full live `supabase start` → web e2e could not be exercised on the authoring machine (Docker disk-exhausted + rate-limited — exactly the conditions `doctor` now reports). The orchestration is runnable on any machine with a healthy Docker; the live e2e itself (`test:e2e:live`) already landed and is green in #2982.

## Issues

Closes #2993
