### PR TITLE
feat(tools): auto-install deps in dev:full / F5 (#2998)

### DIFF
--- a/docs/guides/full-stack-local.md
+++ b/docs/guides/full-stack-local.md
@@ -9,10 +9,10 @@ For backend-only Supabase work (functions, migrations, Studio), see
 [`local-supabase.md`](./local-supabase.md). This guide is the web-to-edge
 end-to-end path on top of it.
 
-## Quick start (one command)
+## Quick start (clone → run)
 
-On a machine with **Docker Desktop running** and dependencies installed
-(`npm install`), a single command does everything — preflight checks, start the
+On a machine with **Docker Desktop running**, a single command does everything —
+**install dependencies** (on a fresh clone), run preflight checks, start the
 Supabase edge stack, wire the web app to it, and launch the web app:
 
 ```bash
@@ -21,22 +21,28 @@ npm run dev:full
 
 That runs [`tools/dev-full.mjs`](../../tools/dev-full.mjs), which:
 
-1. runs the **preflight** ([`npm run doctor`](../../tools/doctor.mjs)) — Docker
+1. **installs dependencies** (`npm install`) if `node_modules` is missing or
+   `package-lock.json` changed since the last install — so a fresh clone needs no
+   manual `npm install`;
+2. runs the **preflight** ([`npm run doctor`](../../tools/doctor.mjs)) — Docker
    daemon, free disk, ports `54321`/`5173`, Supabase CLI;
-2. starts Supabase (`supabase start`, retrying on Docker Hub rate-limit stalls;
+3. starts Supabase (`supabase start`, retrying on Docker Hub rate-limit stalls;
    skipped if already running);
-3. writes `apps/web/.env.local` from `supabase status` (takes the app out of
+4. writes `apps/web/.env.local` from `supabase status` (takes the app out of
    demo mode);
-4. launches the web app at <http://localhost:5173> and opens your browser.
+5. launches the web app at <http://localhost:5173> and opens your browser.
 
 Useful flags: `--reset` (reset DB first), `--e2e` (run the live e2e suite
-instead of the dev server), `--no-open`, `--skip-doctor`. Run
+instead of the dev server), `--no-open`, `--skip-install` (skip the auto
+dependency install), `--install` (force a reinstall), `--skip-doctor`. Run
 `node tools/dev-full.mjs --help` for the full list.
 
 > **VS Code one-click / F5** — Open the repo in VS Code and either run the
 > **"Dev: Full Stack (web on edge)"** task (Ctrl+Shift+P → _Tasks: Run Task_) or
-> press **F5** ("Web on edge (Microsoft Edge)"). Both wrap `npm run dev:full`
-> and, for F5, attach the debugger to Edge at `:5173`.
+> press **F5** ("Web on edge (Microsoft Edge)"). Both wrap `npm run dev:full`,
+> so on a **fresh clone, F5 installs dependencies, brings up the stack, and
+> launches the app** with no manual `npm install`; F5 also attaches the debugger
+> to Edge at `:5173`.
 
 > **Not sure the machine is ready?** Run `npm run doctor` first — it reports
 > exactly what's missing (and how to fix it) without starting anything.
@@ -84,6 +90,10 @@ The steps below are exactly what `npm run dev:full` automates. Run them by hand
 when you want finer control or are troubleshooting.
 
 ### 1. Install dependencies
+
+> `npm run dev:full` (and VS Code **F5**) installs dependencies automatically on
+> a fresh clone, so this step is optional when you use the one-command path. Run
+> it by hand only if you want to install without bringing up the stack.
 
 From the repo root:
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -13,33 +13,44 @@ This directory contains cross-platform scripts and Git hooks that support the de
 The seamless developer entry point. Brings up the local Supabase **edge** stack
 (auth + Postgres/RLS via Docker), wires the web app to it (writes
 `apps/web/.env.local` from `supabase status`), and launches the web app — all in
-one command. Runs `doctor.mjs` first, retries `supabase start` on Docker Hub
+one command. On a **fresh clone it installs dependencies first** (so the path is
+truly clone → run), runs `doctor.mjs`, retries `supabase start` on Docker Hub
 rate-limit stalls, and skips startup if the stack is already running. No global
 Supabase CLI required (uses `npx --yes supabase`).
+
+Dependency install is automatic and idempotent: it runs `npm install` only when
+`node_modules` is missing or when `package-lock.json` has changed since the last
+install (tracked by a content hash in `node_modules/.dev-full-install`, so a
+plain `git checkout` does not trigger a redundant reinstall).
 
 **Usage:**
 
 ```bash
-npm run dev:full                 # preflight → stack → wire web → launch web → open browser
+npm run dev:full                 # install deps if needed → preflight → stack → wire web → launch + open browser
 npm run dev:full -- --reset      # also reset the DB (migrations + seed) first
 npm run dev:full -- --e2e        # bring up stack, run the live Playwright e2e suite
 npm run dev:full -- --no-open    # don't auto-open the browser
+npm run dev:full -- --skip-install   # skip the automatic dependency install
+npm run dev:full -- --install        # force a dependency (re)install
 npm run dev:full -- --skip-doctor
 node tools/dev-full.mjs --help
 ```
 
 In VS Code, the **"Dev: Full Stack (web on edge)"** task and the **F5** launch
 config (`.vscode/tasks.json` / `launch.json`) wrap this for a true one-click
-start. See [`docs/guides/full-stack-local.md`](../docs/guides/full-stack-local.md).
+start — on a fresh clone, **F5 installs dependencies, brings up the stack, and
+launches the app** with no manual `npm install`. See
+[`docs/guides/full-stack-local.md`](../docs/guides/full-stack-local.md).
 
 ### `doctor.mjs` — Local dev preflight / health check
 
 Verifies the host is ready for the full local stack **before** you start it,
 catching the failures that otherwise stall a cold `supabase start`: Docker
 daemon reachable (not just installed), enough free disk to extract the Supabase
-images, required ports free (54321 Supabase, 5173 Vite), and a resolvable
-Supabase CLI. Exits non-zero on a hard failure so `dev-full.mjs` and CI can gate
-on it.
+images, required ports free (54321 Supabase, 5173 Vite), a resolvable Supabase
+CLI, and whether dependencies are installed (warns on a fresh/stale clone —
+non-fatal, since `dev:full`/F5 install automatically). Exits non-zero on a hard
+failure so `dev-full.mjs` and CI can gate on it.
 
 **Usage:**
 

--- a/tools/dev-full.mjs
+++ b/tools/dev-full.mjs
@@ -7,6 +7,9 @@
 // Suggested npm script: "dev:full": "node tools/dev-full.mjs"
 //
 // Pipeline:
+//   0. Install dependencies (npm install)      — on a fresh/stale clone only;
+//                                                skip with --skip-install,
+//                                                force with --install
 //   1. Preflight (tools/doctor.mjs)            — skip with --skip-doctor
 //   2. supabase start (services/api)           — skipped if already running;
 //                                                retries with backoff on the
@@ -23,16 +26,22 @@
 //   node tools/dev-full.mjs --reset         # also reset the DB (migrations + seed)
 //   node tools/dev-full.mjs --e2e           # bring up stack, run the live e2e suite
 //   node tools/dev-full.mjs --no-open       # don't auto-open the browser
+//   node tools/dev-full.mjs --skip-install  # skip the automatic dependency install
+//   node tools/dev-full.mjs --install       # force a dependency (re)install
 //   node tools/dev-full.mjs --skip-doctor   # skip preflight (e.g. in CI)
 //   node tools/dev-full.mjs --help
 //
 // Everything here is cross-platform Node (Windows / macOS / Linux) and uses
-// `npx --yes supabase`, so no global Supabase CLI is required.
+// `npx --yes supabase`, so no global Supabase CLI is required. A fresh clone
+// needs no manual `npm install` — step 0 handles it, so VS Code F5 is truly
+// clone-to-run.
 
 import { spawn, spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
 import path from 'node:path';
+
+import { dependencyState, recordInstall } from './lib/dev-env.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -55,9 +64,13 @@ Options:
   --e2e           Run the live Playwright e2e suite instead of the dev server.
   --no-open       Do not auto-open the browser (dev mode only).
   --skip-doctor   Skip the preflight health check.
+  --skip-install  Skip the automatic dependency install.
+  --install       Force a dependency install even if it looks up to date.
   -h, --help      Show this help.
 
-Requires Docker Desktop running. No global Supabase CLI needed (uses npx).`);
+On a fresh clone this installs dependencies automatically (so VS Code F5 works
+clone-to-run with no manual npm install). Requires Docker Desktop running.
+No global Supabase CLI needed (uses npx).`);
   process.exit(0);
 }
 
@@ -66,6 +79,8 @@ const opts = {
   e2e: args.includes('--e2e'),
   noOpen: args.includes('--no-open'),
   skipDoctor: args.includes('--skip-doctor'),
+  skipInstall: args.includes('--skip-install'),
+  install: args.includes('--install'),
 };
 
 const isWin = process.platform === 'win32';
@@ -140,6 +155,27 @@ function runCapture(cmd, cmdArgs, options = {}) {
 }
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// --- 0. Dependencies (auto-install on a fresh / stale clone) ------------------
+function ensureDependencies() {
+  if (opts.skipInstall) {
+    info('Skipping dependency install (--skip-install).');
+    return;
+  }
+  const { state, reason } = dependencyState(REPO_ROOT);
+  if (state === 'ok' && !opts.install) {
+    info('Dependencies present.');
+    return;
+  }
+  step('Installing dependencies (npm install)');
+  info(`${opts.install ? 'Forced by --install' : reason} — running npm install…`);
+  const code = runInherit('npm', ['install']);
+  if (code !== 0) {
+    fail('npm install failed.', 'Fix the errors above, then re-run `npm run dev:full`.');
+  }
+  recordInstall(REPO_ROOT);
+  info('Dependencies installed.');
+}
 
 // --- 1. Preflight ------------------------------------------------------------
 function preflight() {
@@ -297,6 +333,7 @@ function launchWeb() {
 
 async function main() {
   console.log('Finance — local full-stack web e2e (on edge)');
+  ensureDependencies();
   preflight();
   await startSupabase();
   resetDatabase();

--- a/tools/doctor.mjs
+++ b/tools/doctor.mjs
@@ -25,10 +25,15 @@
 // check fails. Safe to call from other scripts (dev-full.mjs runs it first).
 
 import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import net from 'node:net';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+
+import { dependencyState } from './lib/dev-env.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 const args = process.argv.slice(2);
 
@@ -248,11 +253,36 @@ function checkSupabaseCli() {
   }
 }
 
+// --- Check: dependencies installed -------------------------------------------
+function checkDependencies() {
+  const { state, reason } = dependencyState(REPO_ROOT);
+  if (state === 'missing') {
+    add(
+      'Dependencies installed',
+      'warn',
+      reason || 'node_modules is missing (fresh clone).',
+      'Run `npm install`. `npm run dev:full` and VS Code F5 do this automatically on first run.',
+    );
+    return;
+  }
+  if (state === 'stale') {
+    add(
+      'Dependencies installed',
+      'warn',
+      reason || 'dependencies may be stale.',
+      'Run `npm install` (or `npm run dev:full`, which reinstalls automatically when the lockfile changes).',
+    );
+    return;
+  }
+  add('Dependencies installed', 'pass', 'node_modules present');
+}
+
 async function main() {
   checkDocker();
   checkDisk();
   await checkPorts();
   checkSupabaseCli();
+  checkDependencies();
 
   const failed = checks.filter((c) => c.level === 'fail');
   const warned = checks.filter((c) => c.level === 'warn');

--- a/tools/lib/dev-env.mjs
+++ b/tools/lib/dev-env.mjs
@@ -1,0 +1,80 @@
+// @ts-check
+//
+// dev-env.mjs — shared helpers for the local dev tooling (dev-full.mjs + doctor.mjs).
+//
+// Detects whether workspace dependencies need (re)installing. Uses a content
+// hash of package-lock.json rather than file mtimes, because git does not
+// preserve mtimes — a plain `git checkout`/`reset` would otherwise look like a
+// dependency change and trigger spurious reinstalls.
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MARKER = '.dev-full-install'; // written under node_modules/ (gitignored)
+
+/**
+ * SHA-1 of the repo's package-lock.json, or null if it doesn't exist.
+ * @param {string} repoRoot
+ * @returns {string|null}
+ */
+export function lockfileHash(repoRoot) {
+  const lock = path.join(repoRoot, 'package-lock.json');
+  if (!fs.existsSync(lock)) return null;
+  return crypto.createHash('sha1').update(fs.readFileSync(lock)).digest('hex');
+}
+
+/**
+ * Absolute path of the install marker that records the lockfile hash of the
+ * last install performed by dev-full.mjs.
+ * @param {string} repoRoot
+ */
+export function installMarkerPath(repoRoot) {
+  return path.join(repoRoot, 'node_modules', MARKER);
+}
+
+/**
+ * Classify the dependency state of the workspace.
+ * - `missing`: no node_modules (fresh clone) — install required.
+ * - `stale`:   node_modules exists and was installed by this tool, but the
+ *              lockfile has since changed — reinstall recommended.
+ * - `ok`:      node_modules exists and is current (or was installed by a plain
+ *              `npm install` with no marker — we trust it and don't reinstall).
+ * @param {string} repoRoot
+ * @returns {{state:'missing'|'stale'|'ok', reason?:string}}
+ */
+export function dependencyState(repoRoot) {
+  const modules = path.join(repoRoot, 'node_modules');
+  if (!fs.existsSync(modules)) {
+    return { state: 'missing', reason: 'node_modules is missing (fresh clone)' };
+  }
+  const marker = installMarkerPath(repoRoot);
+  let recorded;
+  try {
+    recorded = fs.existsSync(marker) ? fs.readFileSync(marker, 'utf8').trim() : '';
+  } catch {
+    recorded = '';
+  }
+  // No marker → dependencies were installed outside this tool (e.g. a prior
+  // `npm install`). Trust them rather than forcing a redundant reinstall.
+  if (!recorded) return { state: 'ok' };
+
+  const current = lockfileHash(repoRoot);
+  if (current && recorded !== current) {
+    return { state: 'stale', reason: 'package-lock.json changed since the last install' };
+  }
+  return { state: 'ok' };
+}
+
+/**
+ * Record the current lockfile hash after a successful install. Best-effort.
+ * @param {string} repoRoot
+ */
+export function recordInstall(repoRoot) {
+  try {
+    const hash = lockfileHash(repoRoot);
+    if (hash) fs.writeFileSync(installMarkerPath(repoRoot), hash);
+  } catch {
+    // Non-fatal: the marker is an optimization, not a correctness requirement.
+  }
+}


### PR DESCRIPTION
## Summary

Makes the one-command (`npm run dev:full`) and VS Code **F5** path a true
**clone → run**: dependencies are installed automatically on a fresh or stale
clone before the stack comes up, so a brand-new box no longer needs a manual
`npm install` first. This closes the last gap in the zero-to-one-command DX
shipped in #2995.

## Changes

- **`tools/lib/dev-env.mjs` (new)** — shared dependency-state helper used by
  both `dev-full.mjs` and `doctor.mjs`. Classifies the workspace as
  `missing` / `stale` / `ok` using a **SHA-1 content hash** of
  `package-lock.json` recorded in `node_modules/.dev-full-install` (gitignored).
  Content hashing is used instead of file mtimes because **git does not preserve
  mtimes** — a plain `git checkout`/`reset` restamps the lockfile and would
  otherwise look like a dependency change, triggering spurious reinstalls. A
  checkout with **no marker** (e.g. deps installed by a prior plain
  `npm install`) is trusted as `ok`, so existing checkouts are never reinstalled
  needlessly.
- **`tools/dev-full.mjs`** — new `ensureDependencies()` step runs first in the
  pipeline (before preflight). Adds `--skip-install` and `--install` flags.
- **`tools/doctor.mjs`** — new non-fatal **Dependencies** check (warns on a
  fresh/stale clone with a fix hint; passes otherwise). It does not hard-fail,
  since `dev:full`/F5 install automatically.
- **Docs** — `tools/README.md` and `docs/guides/full-stack-local.md` document
  the clone → F5 behavior and the new flags.

## Behavior

| State     | Trigger                                            | dev:full action | doctor |
| --------- | -------------------------------------------------- | --------------- | ------ |
| `missing` | no `node_modules` (fresh clone)                    | `npm install`   | warn   |
| `stale`   | lockfile hash changed since last tool install      | `npm install`   | warn   |
| `ok`      | current, or installed outside the tool (no marker) | skip            | pass   |

`--skip-install` bypasses the step; `--install` forces a reinstall.

## Issues

Closes #2998

## Testing

- [x] `node --check` on all three scripts
- [x] `dependencyState()` validated across missing → ok → stale → ok transitions (temp-dir harness)
- [x] `node tools/doctor.mjs` shows the Dependencies check (passes on a populated checkout; no false "stale")
- [x] `node tools/dev-full.mjs --help` renders the new flags
- [x] `npm run format:check` clean repo-wide
- [x] `npx eslint . --max-warnings 0` clean repo-wide

Bootstrap-safe: all three scripts import only Node built-ins, so they run on a
fresh clone before `node_modules` exists (`npm run` + `node` need no deps), then
`dev:full` installs deps itself.
