### PR TITLE
docs(ai): reconcile contradictions in global AI guidance (copilot-instructions.md + AGENTS.md) (#2999)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,20 +2,33 @@
 
 You are working in the Finance monorepo — a multi-platform, native-first financial tracking application.
 
-## Human Approval Required (CRITICAL)
+## Operation Approval Policy
 
-The following operations require EXPLICIT human approval. NEVER perform these autonomously:
+Agent operations fall into two buckets. The **mandatory, auto-approved** workflow steps must run without asking; the **human-gated** operations must stop and wait for explicit approval. (`AGENTS.md` §"Human-Gated Operations" Categories 1–8 is the canonical, full-detail version of these rules.)
 
-- **Git remote operations** — **MUST push own feature branches** (`git push origin <feature-branch>`) — this is mandatory and auto-approved, never ask for permission; **MUST** `git fetch origin main` and `git rebase origin/main` on own feature branch as pre-push hygiene; no pushing to `main`/`master`/release branches; no plain `git push --force` (forbidden entirely); `git push --force-with-lease` is auto-approved **only** to re-push the agent's **own** feature branch after a rebase/conflict resolution (never on shared/integration branches or a branch the agent does not own); no `pull`/`remote`/`merge` from remote
-- **PR/review operations** — **Full autonomy on agent-authored PRs.** **MUST create PRs** with linked issues and detailed descriptions, and agents MAY **merge, close, approve/dismiss reviews, and request reviewers** on PRs they authored — all auto-approved, never ask for permission. The only hard gate is the **quality gate**: merge only after CI is green AND the PR is `MERGEABLE` (see `AGENTS.md` §"Category 2"). Acting on PRs an agent did **not** author (approving/merging another author's PR) still requires human direction.
-- **Remote platform mutations** — No issue close/reopen/delete; no repo settings/releases/deployments. Label edits ARE allowed for routine triage, EXCEPT gating/lifecycle labels (`blocked`, `breaking-change`, `security`, `stale`, and any `wontfix`/`duplicate`/`invalid`/`do-not-merge` style label) which remain human-only. See `AGENTS.md` §"Category 3" for the full rule.
-- **Outside project boundary** — No file access outside the repository root; no system config changes; no global package installs
+### Auto-approved (mandatory — never ask for permission)
+
+These are required steps of the normal workflow. **Stopping to ask permission for any of them is a workflow violation:**
+
+- **Push your own feature branch** — `git push origin <feature-branch>`, plus the pre-push hygiene `git fetch origin main` and `git rebase origin/main`. `git push --force-with-lease` is auto-approved **only** to re-push your **own** branch after a rebase/conflict resolution.
+- **Create PRs** — `gh pr create --base main` with a linked issue (`Closes #N`) and a detailed description, immediately after the first push.
+- **Drive and merge your own PR** — monitor `gh pr checks`, fix failures, and **merge your own PR** with `gh pr merge <N> --squash` once the quality gate passes (CI green AND `MERGEABLE`). You MAY also approve/request-changes, request reviewers, dismiss reviews, and close/reopen PRs you authored. See `AGENTS.md` §"Category 2".
+- **Routine issue/PR labels** — add/remove triage labels (priority, platform, component, effort, phase, sprint, feature-area).
+
+### Human approval required (gated)
+
+**STOP, explain what you need and why, and wait for explicit human approval** before any of these:
+
+- **Risky git remote ops** — pushing to `main`/`master`/release branches; plain `git push --force` (forbidden entirely); `--force-with-lease` on a shared/integration branch or one you don't own; `pull`/`remote`/`merge` from remote
+- **Acting on a PR you did NOT author** — merging, approving, closing, or dismissing reviews on another author's PR
+- **Remote platform mutations** — issue close/reopen/delete; repo settings/releases/deployments; gating/lifecycle labels (`blocked`, `breaking-change`, `security`, `stale`, and any `wontfix`/`duplicate`/`invalid`/`do-not-merge` style label). See `AGENTS.md` §"Category 3"
+- **Outside project boundary** — file access outside the repository root; system config changes; global package installs
 - **Destructive file operations** — See detailed rules below
 - **Package publishing** — See detailed rules below
 - **Secret/credential access** — See detailed rules below
 - **Database destructive ops** — See detailed rules below
 
-If you need to perform any of these, STOP, explain what you need and why, and wait for human approval.
+If you need to perform any gated operation, STOP, explain what you need and why, and wait for human approval.
 
 ### Destructive File Operations — Detailed Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ Finance is a multi-platform, native-first financial tracking application for per
 - `apps/` — Platform-specific applications (iOS, Android, Web, Windows)
 - `packages/` — Shared libraries (core logic, data models, sync engine)
 - `services/` — Backend services (consolidated API)
+- `config/` — Cross-cutting configuration (e.g., detekt, feature flags)
+- `build-logic/` — Gradle convention plugins and shared build configuration
 - `docs/` — Project documentation (AI workflow, architecture, design)
 - `tools/` — Development tooling and scripts
 - `.github/` — GitHub configuration, Copilot agents, skills, instructions
@@ -67,7 +69,7 @@ All work in this repository follows an issue-first, feature-branch + worktree wo
 2. **Always use a git worktree** for agent work — never commit directly in the main worktree or on `main`.
    - Naming: `wt-[agent-type]-[type/description-issue#]` (e.g., `wt-android-feat-transactions-443`)
    - **Scan first**: run `git worktree list` — if a worktree for this issue already exists, resume it
-   - Main worktree (`finance-human/`) is reserved for human work
+   - Main worktree (`finance/`) is reserved for human work
 3. **Commit messages must include issue references** in the format `type(scope): description (#N)`.
 4. **Push automatically** — `git push origin <branch>` is auto-approved.
 5. **Open a PR automatically** with `gh pr create --base main` — **always target `main`** (never a long-lived feature branch) and include `Closes #N` for resolved issues. See the **Branch & Merge Policy** in `docs/ai/fleet-operations.md` (the canonical rules).
@@ -171,7 +173,7 @@ The following operations MUST NEVER be performed by AI agents without explicit h
 > ⚠️ **MANDATORY — READ THIS CAREFULLY**
 >
 > Pushing feature branches and creating PRs is **NOT optional** and does **NOT require human approval**.
-> Agents **MUST** complete the full workflow: commit → `npm run ci:check` → push → create PR → monitor CI checks.
+> Agents **MUST** complete the full workflow: commit → pre-push lint & format check (`npm run format:check && npx eslint . --max-warnings 0`) → push → create PR → monitor CI checks.
 > **Stopping at a local commit and asking for permission to push is a workflow violation.**
 > A task is **INCOMPLETE** if it ends with only a local commit. Push and PR creation are auto-approved.
 
@@ -392,7 +394,7 @@ When multiple agents work in parallel, they MUST follow these rules to avoid con
 2. **Shared config files** (`gradle/libs.versions.toml`, `settings.gradle.kts`, `package.json`, `turbo.json`) must be edited by only one agent per fleet run — assign ownership to `@kmp-engineer` (Gradle) or `@devops-engineer` (Node/CI).
 3. **Agents announce intent** — when starting a fleet task, the orchestrator should note which files each agent will touch in the issue or PR description.
 4. **Schema changes are serialized** — only `@backend-engineer` writes Supabase migrations; only `@kmp-engineer` writes SQLDelight `.sq` files. Both must be in sync (a single coordinated sprint task, not two independent ones).
-5. **After parallel work, the last agent to commit runs** `npm run ci:check` **before pushing** to catch any integration issues.
+5. **After parallel work, the last agent to commit runs** the pre-push checklist (`npm run format:check && npx eslint . --max-warnings 0`) **before pushing** to catch any integration issues.
 
 ### Fleet CI Monitoring & Self-Healing
 
@@ -407,7 +409,7 @@ After opening a PR, each fleet agent monitors its own CI status until all checks
 3. If CI fails: read logs with `gh run view <run-id> --log-failed`
 4. If merge conflicts (carry same P0 weight as red CI): trigger the **Merge Conflict Protocol** in `.github/instructions/workflow.instructions.md` — rebase, auto-resolve lockfiles/generated files, escalate semantic conflicts with `## Needs Human Action`
 5. Fix locally in the worktree
-6. Run `npm run ci:check` to confirm the fix before pushing
+6. Run `npm run format:check && npx eslint . --max-warnings 0` to confirm the fix before pushing
 7. Commit and push the fix (use `--force-with-lease` if the fix was a rebase) — restart the cycle
 8. **Once the quality gate is green, merge the PR** with `gh pr merge <number> --squash` (auto-approved). In a fleet, the orchestrator merges sub-agent PRs in the recommended merge order to avoid cross-PR conflict churn.
 


### PR DESCRIPTION
﻿## Summary

`.github/copilot-instructions.md` and `AGENTS.md` are the two always-on governance docs — both are injected into **every** agent''s context, so a contradiction between (or within) them directly causes the workflow violations they''re meant to prevent. This audit (Area 4 of the AI-capabilities review) reconciles four issues. **Docs-only.**

## Changes

- **`copilot-instructions.md` — fix the self-contradicting opener (HIGH).** The first section was headed `## Human Approval Required (CRITICAL)` → *"NEVER perform these autonomously"*, yet its first two bullets were git-push and PR-create/self-merge, which are **mandatory and auto-approved**. Restructured into **`## Operation Approval Policy`** with two labeled subsections — *"Auto-approved (mandatory — never ask)"* and *"Human approval required (gated)"* — mirroring `AGENTS.md` Categories 1–2, plus a pointer to the canonical Category 1–8 rules.
- **`AGENTS.md` — fix the internal `ci:check` contradiction (MED).** Three spots (the Category 1 callout, the fleet coordination protocol, and the self-healing cycle) told agents to run `npm run ci:check` as the pre-push gate — contradicting the same file''s pre-push checklist and the documented *Known Local Issue* that `ci:check`''s type-check fails locally. Aligned all three to `npm run format:check && npx eslint . --max-warnings 0`.
- **`AGENTS.md` — factual fix (LOW).** The human main worktree was called `finance-human/`; everywhere else (and reality) it is `finance/`.
- **`AGENTS.md` — enrichment (LOW).** Added the `config/` and `build-logic/` rows to Repository Layout (both have instruction files and named owners).

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean
- [x] `node tools/check-ai-manifest.js` — no drift (24 agents, 20 skills)

Closes #2999
