### PR TITLE
fix(tools): classify supabase start failures instead of assuming a rate-limit (#3002)

### DIFF
--- a/docs/guides/full-stack-local.md
+++ b/docs/guides/full-stack-local.md
@@ -193,15 +193,43 @@ npm --prefix services/api run supabase:status
 
 ## Troubleshooting
 
-| Symptom                                   | Fix                                                                                                                                                                                     |
-| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Not sure the machine is ready             | Run `npm run doctor` — it checks Docker, free disk, and ports `54321`/`5173` and prints how to fix gaps.                                                                                |
-| "Demo Mode" banner on `/signup`           | `apps/web/.env.local` is missing or `VITE_SUPABASE_URL` is unset/placeholder — rerun the setup command.                                                                                 |
-| Live e2e fails: "App is in demo mode"     | Same cause — ensure the stack is up and `.env.local` exists, then rerun.                                                                                                                |
-| `npm run test:e2e:live` can't launch Edge | Use `npm run test:e2e:live:chromium -w apps/web`, or install Microsoft Edge.                                                                                                            |
-| Port 5173 or 5174 already in use          | Stop the other process, or set `LIVE_E2E_PORT` for the live suite.                                                                                                                      |
-| `supabase start` is slow / stalls         | First-run image pulls can be slow; ensure Docker is running and retry. `docker login` raises Docker Hub pull limits. `npm run dev:full` retries automatically. See `local-supabase.md`. |
-| Signup returns a non-2xx response         | Confirm the stack is healthy (`supabase:status`) and migrations applied (`supabase:reset`).                                                                                             |
+| Symptom                                                                   | Fix                                                                                                                                                                                               |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Not sure the machine is ready                                             | Run `npm run doctor` — it checks Docker, free disk, and ports `54321`/`5173` and prints how to fix gaps.                                                                                          |
+| "Demo Mode" banner on `/signup`                                           | `apps/web/.env.local` is missing or `VITE_SUPABASE_URL` is unset/placeholder — rerun the setup command.                                                                                           |
+| Live e2e fails: "App is in demo mode"                                     | Same cause — ensure the stack is up and `.env.local` exists, then rerun.                                                                                                                          |
+| `npm run test:e2e:live` can't launch Edge                                 | Use `npm run test:e2e:live:chromium -w apps/web`, or install Microsoft Edge.                                                                                                                      |
+| Port 5173 or 5174 already in use                                          | Stop the other process, or set `LIVE_E2E_PORT` for the live suite.                                                                                                                                |
+| `supabase start` is slow / stalls                                         | First-run image pulls can be slow; ensure Docker is running and retry. `docker login` raises Docker Hub pull limits. `npm run dev:full` retries automatically. See `local-supabase.md`.           |
+| `supabase start` fails with `exit 255` / `exec format error`              | Corrupt local image layers — **not** a rate-limit. Re-pull the images (see "Docker image corruption" below). `npm run dev:full` now detects this and stops with the same fix instead of retrying. |
+| `supabase start` fails with `permission denied for schema …` / `SQLSTATE` | A migration error, not an environment problem. Fix the offending migration; retrying won't help. `npm run dev:full` surfaces this instead of mislabeling it a rate-limit.                         |
+| Signup returns a non-2xx response                                         | Confirm the stack is healthy (`supabase:status`) and migrations applied (`supabase:reset`).                                                                                                       |
+
+### Docker image corruption (`exit 255` / `exec format error`)
+
+If `supabase start` aborts with `error running container: exit 255`, `exec format
+error`, or `corrupted shared library`, one or more Supabase image layers extracted
+on this machine are truncated/corrupt (often the aftermath of an earlier disk-full
+event). Retrying or `docker login` will **not** help — the affected images must be
+re-pulled. On Docker Desktop's containerd image store, `docker image prune` alone
+reclaims **0 B**, so a daemon restart is required to actually release the blobs:
+
+1. **Stop the stack:** `npm --prefix services/api run supabase:stop`
+2. **Protect known-good images** so a prune can't evict them — give each a
+   placeholder container:
+   `docker create --name keep-<n> --entrypoint /bin/true <image>`
+3. **Remove the corrupt images:** `docker rmi <image …>` (untags them; the blobs
+   linger until GC). **Never** pass `--volumes` to any prune — that would delete
+   your local database.
+4. **Force a real image GC:** `docker desktop restart` (this is the step that
+   actually frees containerd blobs; `docker image prune -af` reports 0 B).
+5. **Remove the placeholders:** `docker rm -f keep-<n>`
+6. **Re-pull fresh:** `npm run dev:full` (or `npm --prefix services/api run
+supabase:start`) pulls clean layers.
+
+`npm run doctor` prints a pointer to this section, and `npm run dev:full` now
+classifies this failure and stops immediately with these steps instead of burning
+three retries on a non-transient error.
 
 ## Known limitations
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -14,9 +14,12 @@ The seamless developer entry point. Brings up the local Supabase **edge** stack
 (auth + Postgres/RLS via Docker), wires the web app to it (writes
 `apps/web/.env.local` from `supabase status`), and launches the web app — all in
 one command. On a **fresh clone it installs dependencies first** (so the path is
-truly clone → run), runs `doctor.mjs`, retries `supabase start` on Docker Hub
-rate-limit stalls, and skips startup if the stack is already running. No global
-Supabase CLI required (uses `npx --yes supabase`).
+truly clone → run), runs `doctor.mjs`, and skips startup if the stack is already
+running. When `supabase start` fails it **classifies the cause** instead of
+assuming a rate-limit: a true registry pull limit is retried with backoff, while
+a corrupt local image (`exit 255` / `exec format error`) or a migration/SQL error
+fails fast with the specific fix. No global Supabase CLI required (uses
+`npx --yes supabase`).
 
 Dependency install is automatic and idempotent: it runs `npm install` only when
 `node_modules` is missing or when `package-lock.json` has changed since the last

--- a/tools/dev-full.mjs
+++ b/tools/dev-full.mjs
@@ -12,8 +12,10 @@
 //                                                force with --install
 //   1. Preflight (tools/doctor.mjs)            — skip with --skip-doctor
 //   2. supabase start (services/api)           — skipped if already running;
-//                                                retries with backoff on the
-//                                                Docker Hub "Rate exceeded" stall
+//                                                retries with backoff on a true
+//                                                registry rate-limit, but fails
+//                                                fast (with the right fix) on a
+//                                                corrupt image or migration error
 //   3. supabase db reset (optional)            — only with --reset
 //   4. Write apps/web/.env.local               — from `supabase status -o env`,
 //                                                so the web app leaves demo mode
@@ -41,7 +43,7 @@ import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { dependencyState, recordInstall } from './lib/dev-env.mjs';
+import { dependencyState, recordInstall, classifySupabaseStartFailure } from './lib/dev-env.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -156,6 +158,61 @@ function runCapture(cmd, cmdArgs, options = {}) {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+/**
+ * Run a command, streaming its output live (like runInherit) **and** capturing a
+ * copy so the caller can inspect it — a "tee". Used for `supabase start`, whose
+ * failure cause (rate-limit vs. corrupt image vs. migration error) can only be
+ * told apart by reading the output.
+ * @param {string} cmd
+ * @param {string[]} cmdArgs
+ * @param {{cwd?:string}} [options]
+ * @returns {Promise<{code:number, output:string}>}
+ */
+function runTee(cmd, cmdArgs, options = {}) {
+  const r = resolve(cmd, cmdArgs);
+  return new Promise((done) => {
+    const child = spawn(r.command, r.args, {
+      cwd: options.cwd || REPO_ROOT,
+      shell: r.viaShell,
+      windowsHide: true,
+    });
+    let output = '';
+    const tee = (stream, sink) => {
+      if (!stream) return;
+      stream.on('data', (chunk) => {
+        sink.write(chunk);
+        output += chunk.toString();
+      });
+    };
+    tee(child.stdout, process.stdout);
+    tee(child.stderr, process.stderr);
+    child.on('error', (err) => done({ code: 1, output: `${output}\n${err.message}` }));
+    child.on('close', (code) => done({ code: code ?? 1, output }));
+  });
+}
+
+/**
+ * Remediation text for corrupt local Supabase image layers — the failure mode
+ * that masquerades as a rate-limit. Retrying never fixes it; the images have to
+ * be re-pulled fresh.
+ * @param {string} signal
+ * @returns {string}
+ */
+function dockerCorruptionRemedy(signal) {
+  return [
+    `Corrupt local Docker image layers ("${signal}") — retrying will not help; they must be re-pulled.`,
+    '  1. Stop the stack:        npm --prefix services/api run supabase:stop',
+    '  2. Remove the corrupt Supabase images with `docker rmi` (keep your data volumes —',
+    '     never pass --volumes). Tip: protect known-good images with a placeholder',
+    '     container first so a prune cannot evict them.',
+    '  3. Force a real image GC:  docker desktop restart',
+    '     (on the containerd image store, `docker image prune` alone reclaims 0 B).',
+    '  4. Re-pull fresh:          npm run dev:full',
+    '  See the "Docker image corruption (exit 255 / exec format error)" section in',
+    '  docs/guides/full-stack-local.md.',
+  ].join('\n');
+}
+
 // --- 0. Dependencies (auto-install on a fresh / stale clone) ------------------
 function ensureDependencies() {
   if (opts.skipInstall) {
@@ -214,23 +271,44 @@ async function startSupabase() {
   const maxAttempts = 3;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     info(`supabase start (attempt ${attempt}/${maxAttempts})…`);
-    const code = runInherit('npx', ['--yes', 'supabase', 'start'], { cwd: API_DIR });
+    const { code, output } = await runTee('npx', ['--yes', 'supabase', 'start'], { cwd: API_DIR });
     if (code === 0 || isSupabaseRunning()) {
       info('Supabase is up.');
       return;
     }
+
+    // Work out *why* it failed instead of assuming a rate-limit. Terminal causes
+    // (corrupt images, migration errors) are not worth retrying — fail fast with
+    // the right fix so the developer doesn't wait out three pointless retries.
+    const { kind, signal } = classifySupabaseStartFailure(output);
+
+    if (kind === 'image') {
+      fail(
+        'supabase start failed: corrupt local Docker image layers.',
+        dockerCorruptionRemedy(signal),
+      );
+    }
+    if (kind === 'migration') {
+      fail(
+        'supabase start failed while applying migrations — a database/SQL error, not a transient issue.',
+        'Find the "ERROR: … (SQLSTATE …)" line in the output above and fix that migration; retrying will not help. See docs/guides/full-stack-local.md.',
+      );
+    }
+
     if (attempt < maxAttempts) {
       const backoff = attempt * 15;
-      info(
-        `supabase start failed (often a Docker Hub "Rate exceeded" pull limit). Retrying in ${backoff}s…`,
-      );
-      info('If this keeps failing, run `docker login` to raise the pull limit.');
+      if (kind === 'rate-limit') {
+        info(`Docker registry pull limit ("${signal}"). Retrying in ${backoff}s…`);
+        info('Tip: `docker login` raises Docker Hub pull limits.');
+      } else {
+        info(`supabase start failed (cause unclear from output). Retrying in ${backoff}s…`);
+      }
       await sleep(backoff * 1000);
     }
   }
   fail(
     'Could not start Supabase after multiple attempts.',
-    'Check Docker is running and has disk/quota. Try `docker login` for Docker Hub rate limits, then re-run. See docs/guides/full-stack-local.md.',
+    'Read the output above for the real cause. Common ones: Docker not running; a Docker Hub pull limit (`docker login`); or corrupt image layers (see the "exit 255 / exec format error" section in docs/guides/full-stack-local.md).',
   );
 }
 

--- a/tools/doctor.mjs
+++ b/tools/doctor.mjs
@@ -326,6 +326,11 @@ async function main() {
     '\n  Tip: if `supabase start` stalls on "Rate exceeded", run `docker login`\n' +
       '       (anonymous Docker Hub pulls are rate-limited).',
   );
+  console.log(
+    '  Tip: if it fails with "exit 255" / "exec format error", the local image\n' +
+      '       layers are corrupt — re-pull them (see the troubleshooting section in\n' +
+      '       docs/guides/full-stack-local.md); retrying alone will not fix it.',
+  );
 
   if (ok) {
     console.log('\n  Ready. Start the full stack with:  npm run dev:full\n');

--- a/tools/lib/dev-env.mjs
+++ b/tools/lib/dev-env.mjs
@@ -78,3 +78,66 @@ export function recordInstall(repoRoot) {
     // Non-fatal: the marker is an optimization, not a correctness requirement.
   }
 }
+
+/**
+ * @typedef {'rate-limit'|'image'|'migration'|'unknown'} SupabaseFailureKind
+ * @typedef {{kind:SupabaseFailureKind, signal?:string}} SupabaseFailure
+ */
+
+/**
+ * Classify a failed `supabase start` from its combined stdout+stderr so the
+ * caller can react correctly instead of blaming everything on a Docker Hub
+ * rate-limit (the bug this fixes).
+ *
+ * Precedence is deliberate: **terminal, non-retryable** failures win over a
+ * transient rate-limit, because a cold pull can hit a rate-limit on one image
+ * (which then succeeds on retry) yet still fail fatally later — e.g. a migration
+ * error. Reporting the fatal cause is what the developer needs.
+ *
+ *  - `image`      — corrupt / unrunnable local image layers (truncated entrypoint
+ *                   scripts → ENOEXEC). Retrying never helps; the images must be
+ *                   re-pulled. Signals: `exec format error`, `corrupted` shared
+ *                   library, or `error running container: exit 255`.
+ *  - `migration`  — a database/SQL error while applying migrations (e.g.
+ *                   `permission denied for schema … (SQLSTATE 42501)`). Terminal;
+ *                   the migration itself must be fixed. Signals: `SQLSTATE`,
+ *                   `permission denied for`, `syntax error at or near`.
+ *  - `rate-limit` — a transient registry pull limit. Safe to retry with backoff.
+ *                   Signals: `Rate exceeded`, `toomanyrequests`, `Too Many
+ *                   Requests`, `pull rate limit`.
+ *  - `unknown`    — none of the above; caller may retry once but should surface
+ *                   the raw output.
+ *
+ * @param {string} output combined stdout+stderr from `supabase start`
+ * @returns {SupabaseFailure}
+ */
+export function classifySupabaseStartFailure(output) {
+  const lower = String(output || '').toLowerCase();
+  const has = (s) => lower.includes(s);
+
+  // 1. Corrupt local image layers — not fixable by retrying.
+  const imageSignals = ['exec format error', 'corrupted shared library', 'corrupted'];
+  const containerExec255 = has('error running container') && has('exit 255');
+  const imageHit = imageSignals.find(has);
+  if (imageHit || containerExec255) {
+    return { kind: 'image', signal: imageHit || 'error running container: exit 255' };
+  }
+
+  // 2. Migration / SQL error — terminal; surface the real DB error. Use
+  //    Postgres-specific phrasing so a Docker "permission denied while trying to
+  //    connect to the daemon socket" is NOT misread as a migration failure.
+  const migrationSignals = ['sqlstate', 'permission denied for', 'syntax error at or near'];
+  const migrationHit = migrationSignals.find(has);
+  if (migrationHit) {
+    return { kind: 'migration', signal: migrationHit };
+  }
+
+  // 3. Transient registry pull rate-limit — safe to retry with backoff.
+  const rateSignals = ['rate exceeded', 'toomanyrequests', 'too many requests', 'pull rate limit'];
+  const rateHit = rateSignals.find(has);
+  if (rateHit) {
+    return { kind: 'rate-limit', signal: rateHit };
+  }
+
+  return { kind: 'unknown' };
+}


### PR DESCRIPTION
## Summary

`npm run dev:full` (and the VS Code **F5** flow) wrapped `supabase start` and treated **every** failure as a Docker Hub pull rate-limit — retrying 3× with `docker login` advice no matter the real cause. That misdiagnosis cost real debugging time during onboarding when the actual failures were (a) **corrupt local Docker image layers** (truncated entrypoint scripts → `error running container: exit 255` / `exec format error`) and (b) a **migration SQL error** (`permission denied for schema auth (SQLSTATE 42501)`). Retrying helps neither.

`startSupabase()` now **classifies** the failure from the command output and acts accordingly.

## Changes

- **`tools/lib/dev-env.mjs`** — new pure, unit-testable `classifySupabaseStartFailure(output)` → `{ kind: 'image' | 'migration' | 'rate-limit' | 'unknown', signal }`. Terminal causes take precedence over a transient rate-limit (a cold pull can hit a rate-limit on one image yet still fail fatally later — the fatal cause is what gets reported).
- **`tools/dev-full.mjs`** — new `runTee()` streams `supabase start` output live **and** captures it; `startSupabase()` now:
  - **image corruption** → fail fast with the re-pull remediation (protect healthy images → `docker rmi` → `docker desktop restart` to force a containerd GC → re-pull),
  - **migration/SQL error** → fail fast, point at the real `ERROR: … (SQLSTATE …)` line,
  - **true rate-limit** → retry with backoff (unchanged),
  - **unknown** → retry, but no longer claims it's a rate-limit.
- **`tools/doctor.mjs`** — non-fatal tip pointing at the corruption remediation.
- **`docs/guides/full-stack-local.md`** — troubleshooting rows + a "Docker image corruption (`exit 255` / `exec format error`)" remediation section.
- **`tools/README.md`** — documents the smarter failure handling.

## Issues

Closes #3002

## Testing

- [x] Classifier harness — 10/10 cases pass, including **terminal-migration-beats-transient-rate-limit** and **"docker socket permission denied is NOT a migration"** (so a Docker daemon error isn't misread as SQL).
- [x] `node --check` on all three scripts.
- [x] `npm run format:check` + `npx eslint . --max-warnings 0` clean repo-wide.
- [x] `node tools/dev-full.mjs --help` renders with the new imports.

> Context: this class of failure (corrupt image layers producing `exit 255` / `exec format error`) was hit and root-caused during local full-stack bring-up; the fix makes the tooling diagnose it instead of masking it as a rate-limit. The downstream migration permission bug (`permission denied for schema auth`) is tracked + fixed separately (schema-gated, `@backend-engineer`).
