### PR TITLE
fix(api): create RLS helper functions in public schema instead of auth (#3003)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -172,9 +172,10 @@ services:
       GOTRUE_EXTERNAL_GOOGLE_SECRET: ${GOOGLE_SECRET:-}
 
       # Custom access token hook (injects household_ids into JWT)
-      # Disabled until the auth.custom_access_token_hook function is created via migrations
+      # The public.custom_access_token_hook function is created via migrations.
+      # Disabled by default; set ENABLED to 'true' and uncomment the URI to activate.
       GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED: 'false'
-      # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI: pg-functions://postgres/${POSTGRES_DB:-postgres}/auth.custom_access_token_hook
+      # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI: pg-functions://postgres/${POSTGRES_DB:-postgres}/public.custom_access_token_hook
 
       # Rate limiting
       GOTRUE_RATE_LIMIT_HEADER: X-Forwarded-For

--- a/services/api/supabase/migrations/20260306000002_rls_policies.sql
+++ b/services/api/supabase/migrations/20260306000002_rls_policies.sql
@@ -12,12 +12,12 @@
 --   - household_members: members can see co-members, only household owner can manage
 
 -- =============================================================================
--- Helper function: auth.household_ids()
+-- Helper function: public.household_ids()
 -- =============================================================================
 -- Returns an array of household IDs the current JWT user belongs to.
 -- Used in RLS policies for efficient household membership checks.
 
-CREATE OR REPLACE FUNCTION auth.household_ids()
+CREATE OR REPLACE FUNCTION public.household_ids()
 RETURNS UUID[] AS $$
     SELECT COALESCE(
         array_agg(household_id),
@@ -69,7 +69,7 @@ CREATE POLICY users_delete ON users
 
 CREATE POLICY households_select ON households
     FOR SELECT
-    USING (id = ANY(auth.household_ids()));
+    USING (id = ANY(public.household_ids()));
 
 CREATE POLICY households_insert ON households
     FOR INSERT
@@ -90,7 +90,7 @@ CREATE POLICY households_delete ON households
 
 CREATE POLICY household_members_select ON household_members
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 CREATE POLICY household_members_insert ON household_members
     FOR INSERT
@@ -139,20 +139,20 @@ CREATE POLICY household_members_delete ON household_members
 
 CREATE POLICY accounts_select ON accounts
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 CREATE POLICY accounts_insert ON accounts
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY accounts_update ON accounts
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY accounts_delete ON accounts
     FOR DELETE
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- categories — household members only
@@ -160,20 +160,20 @@ CREATE POLICY accounts_delete ON accounts
 
 CREATE POLICY categories_select ON categories
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 CREATE POLICY categories_insert ON categories
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY categories_update ON categories
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY categories_delete ON categories
     FOR DELETE
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- transactions — household members only
@@ -181,20 +181,20 @@ CREATE POLICY categories_delete ON categories
 
 CREATE POLICY transactions_select ON transactions
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 CREATE POLICY transactions_insert ON transactions
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY transactions_update ON transactions
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY transactions_delete ON transactions
     FOR DELETE
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- budgets — household members only
@@ -202,20 +202,20 @@ CREATE POLICY transactions_delete ON transactions
 
 CREATE POLICY budgets_select ON budgets
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 CREATE POLICY budgets_insert ON budgets
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY budgets_update ON budgets
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY budgets_delete ON budgets
     FOR DELETE
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- goals — household members only
@@ -223,17 +223,17 @@ CREATE POLICY budgets_delete ON budgets
 
 CREATE POLICY goals_select ON goals
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 CREATE POLICY goals_insert ON goals
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY goals_update ON goals
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY goals_delete ON goals
     FOR DELETE
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));

--- a/services/api/supabase/migrations/20260306000003_auth_config.sql
+++ b/services/api/supabase/migrations/20260306000003_auth_config.sql
@@ -18,7 +18,7 @@
 --   Auth → Providers → Google:      Enable Google Sign-In
 --                                    - Client ID + Client Secret from Google Cloud Console
 --   Auth → Hooks → Custom Access Token:
---                                    Point to auth.custom_access_token_hook
+--                                    Point to public.custom_access_token_hook
 --   Auth → URL Configuration:
 --                                    - Site URL: https://app.finance.example.com
 --                                    - Redirect URLs: com.finance.app://auth/callback,
@@ -110,7 +110,7 @@ ALTER TABLE household_invitations ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY household_invitations_select ON household_invitations
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 -- Only household owner (created_by) can create invitations
 CREATE POLICY household_invitations_insert ON household_invitations
@@ -126,8 +126,8 @@ CREATE POLICY household_invitations_insert ON household_invitations
 
 CREATE POLICY household_invitations_update ON household_invitations
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY household_invitations_delete ON household_invitations
     FOR DELETE
@@ -205,7 +205,7 @@ ALTER TABLE audit_log ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY audit_log_select ON audit_log
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()) OR user_id = auth.uid());
+    USING (household_id = ANY(public.household_ids()) OR user_id = auth.uid());
 
 -- Insert is service-role only (triggers insert via SECURITY DEFINER functions)
 -- No user-facing insert/update/delete policies — the audit log is append-only
@@ -219,9 +219,9 @@ CREATE POLICY audit_log_select ON audit_log
 -- can read them from the JWT without a table lookup on every query.
 --
 -- Configuration: Supabase Dashboard → Auth → Hooks → Custom Access Token
---                → Select: auth.custom_access_token_hook
+--                → Select: public.custom_access_token_hook
 
-CREATE OR REPLACE FUNCTION auth.custom_access_token_hook(event jsonb)
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
 STABLE
@@ -262,12 +262,12 @@ END;
 $$;
 
 -- Grant execute to the supabase_auth_admin role so the Auth service can call it
-GRANT EXECUTE ON FUNCTION auth.custom_access_token_hook(jsonb) TO supabase_auth_admin;
+GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb) TO supabase_auth_admin;
 
 -- Revoke from public for security
-REVOKE EXECUTE ON FUNCTION auth.custom_access_token_hook(jsonb) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION auth.custom_access_token_hook(jsonb) FROM anon;
-REVOKE EXECUTE ON FUNCTION auth.custom_access_token_hook(jsonb) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb) FROM authenticated;
 
 -- =============================================================================
 -- Helper: Create user with default household (used by auth-webhook Edge Function)

--- a/services/api/supabase/migrations/20260316000002_fix_invitation_rls.sql
+++ b/services/api/supabase/migrations/20260316000002_fix_invitation_rls.sql
@@ -72,5 +72,5 @@ CREATE POLICY household_invitations_accept ON household_invitations
 --
 -- CREATE POLICY household_invitations_update ON household_invitations
 --     FOR UPDATE
---     USING (household_id = ANY(auth.household_ids()))
---     WITH CHECK (household_id = ANY(auth.household_ids()));
+--     USING (household_id = ANY(public.household_ids()))
+--     WITH CHECK (household_id = ANY(public.household_ids()));

--- a/services/api/supabase/migrations/20260323000002_recurring_transactions.sql
+++ b/services/api/supabase/migrations/20260323000002_recurring_transactions.sql
@@ -8,7 +8,7 @@
 -- PL/pgSQL function that generates transaction instances from due templates.
 --
 -- Security:
---   - RLS enabled with household-scoped policies using auth.household_ids()
+--   - RLS enabled with household-scoped policies using public.household_ids()
 --   - Generation function is SECURITY DEFINER (bypasses RLS for cross-household batch)
 --   - GRANT EXECUTE only to service_role; REVOKE from PUBLIC
 --   - FOR UPDATE SKIP LOCKED prevents deadlocks during concurrent cron runs
@@ -66,20 +66,20 @@ ALTER TABLE recurring_transaction_templates ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY recurring_templates_select ON recurring_transaction_templates
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 CREATE POLICY recurring_templates_insert ON recurring_transaction_templates
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY recurring_templates_update ON recurring_transaction_templates
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY recurring_templates_delete ON recurring_transaction_templates
     FOR DELETE
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- updated_at trigger

--- a/services/api/supabase/migrations/20260324000002_performance_indexes.sql
+++ b/services/api/supabase/migrations/20260324000002_performance_indexes.sql
@@ -238,7 +238,7 @@ CREATE INDEX IF NOT EXISTS idx_categories_household
 -- User's households lookup:
 --   SELECT household_id FROM household_members
 --   WHERE user_id = $1 AND deleted_at IS NULL
--- Called by auth.household_ids() and every RLS policy check.
+-- Called by public.household_ids() and every RLS policy check.
 -- CRITICAL for RLS performance — invoked on every authenticated query.
 -- Estimated improvement: sub-millisecond lookup for the most frequent RLS check.
 CREATE INDEX IF NOT EXISTS idx_household_members_user

--- a/services/api/supabase/migrations/20260328000001_family_plan_subscriptions.sql
+++ b/services/api/supabase/migrations/20260328000001_family_plan_subscriptions.sql
@@ -98,14 +98,14 @@ ALTER TABLE family_plan_subscriptions ENABLE ROW LEVEL SECURITY;
 -- Household members can read their household's subscription
 CREATE POLICY family_plan_select ON family_plan_subscriptions
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 -- Only billing owner can create a subscription for their household
 CREATE POLICY family_plan_insert ON family_plan_subscriptions
     FOR INSERT
     WITH CHECK (
         billing_owner_id = auth.uid()
-        AND household_id = ANY(auth.household_ids())
+        AND household_id = ANY(public.household_ids())
     );
 
 -- Only billing owner can update the subscription

--- a/services/api/supabase/migrations/20260328000005_report_generation.sql
+++ b/services/api/supabase/migrations/20260328000005_report_generation.sql
@@ -114,20 +114,20 @@ ALTER TABLE scheduled_reports ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY report_configs_select ON report_configs
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 CREATE POLICY report_configs_insert ON report_configs
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY report_configs_update ON report_configs
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY report_configs_delete ON report_configs
     FOR DELETE
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- RLS Policies: scheduled_reports
@@ -135,17 +135,17 @@ CREATE POLICY report_configs_delete ON report_configs
 
 CREATE POLICY scheduled_reports_select ON scheduled_reports
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 CREATE POLICY scheduled_reports_insert ON scheduled_reports
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY scheduled_reports_update ON scheduled_reports
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY scheduled_reports_delete ON scheduled_reports
     FOR DELETE
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));

--- a/services/api/supabase/migrations/20260328000007_bill_detection.sql
+++ b/services/api/supabase/migrations/20260328000007_bill_detection.sql
@@ -104,17 +104,17 @@ ALTER TABLE detected_bills ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY detected_bills_select ON detected_bills
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 CREATE POLICY detected_bills_insert ON detected_bills
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY detected_bills_update ON detected_bills
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 CREATE POLICY detected_bills_delete ON detected_bills
     FOR DELETE
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));

--- a/services/api/supabase/migrations/20260328000008_data_import_pipeline.sql
+++ b/services/api/supabase/migrations/20260328000008_data_import_pipeline.sql
@@ -92,14 +92,14 @@ ALTER TABLE import_jobs ENABLE ROW LEVEL SECURITY;
 -- Users can see import jobs in their households
 CREATE POLICY import_jobs_select ON import_jobs
     FOR SELECT
-    USING (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()));
 
 -- Users can create import jobs in their households (must be the owner)
 CREATE POLICY import_jobs_insert ON import_jobs
     FOR INSERT
     WITH CHECK (
         owner_id = auth.uid()
-        AND household_id = ANY(auth.household_ids())
+        AND household_id = ANY(public.household_ids())
     );
 
 -- Only the import creator can update their jobs

--- a/services/api/supabase/migrations/20260330000001_investment_tables.sql
+++ b/services/api/supabase/migrations/20260330000001_investment_tables.sql
@@ -1,4 +1,4 @@
-﻿-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-License-Identifier: BUSL-1.1
 
 -- Migration: 20260330000001_investment_tables
 -- Description: Create investment_portfolios, investment_holdings, price_history,
@@ -150,25 +150,25 @@ ALTER TABLE price_history ENABLE ROW LEVEL SECURITY;
 ALTER TABLE bill_reminders ENABLE ROW LEVEL SECURITY;
 ALTER TABLE report_templates ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY investment_portfolios_select ON investment_portfolios FOR SELECT USING (household_id = ANY(auth.household_ids()));
-CREATE POLICY investment_portfolios_insert ON investment_portfolios FOR INSERT WITH CHECK (owner_id = auth.uid() AND household_id = ANY(auth.household_ids()));
-CREATE POLICY investment_portfolios_update ON investment_portfolios FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
-CREATE POLICY investment_portfolios_delete ON investment_portfolios FOR DELETE USING (household_id = ANY(auth.household_ids()));
+CREATE POLICY investment_portfolios_select ON investment_portfolios FOR SELECT USING (household_id = ANY(public.household_ids()));
+CREATE POLICY investment_portfolios_insert ON investment_portfolios FOR INSERT WITH CHECK (owner_id = auth.uid() AND household_id = ANY(public.household_ids()));
+CREATE POLICY investment_portfolios_update ON investment_portfolios FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));
+CREATE POLICY investment_portfolios_delete ON investment_portfolios FOR DELETE USING (household_id = ANY(public.household_ids()));
 
-CREATE POLICY investment_holdings_select ON investment_holdings FOR SELECT USING (household_id = ANY(auth.household_ids()));
-CREATE POLICY investment_holdings_insert ON investment_holdings FOR INSERT WITH CHECK (owner_id = auth.uid() AND household_id = ANY(auth.household_ids()));
-CREATE POLICY investment_holdings_update ON investment_holdings FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
-CREATE POLICY investment_holdings_delete ON investment_holdings FOR DELETE USING (household_id = ANY(auth.household_ids()));
+CREATE POLICY investment_holdings_select ON investment_holdings FOR SELECT USING (household_id = ANY(public.household_ids()));
+CREATE POLICY investment_holdings_insert ON investment_holdings FOR INSERT WITH CHECK (owner_id = auth.uid() AND household_id = ANY(public.household_ids()));
+CREATE POLICY investment_holdings_update ON investment_holdings FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));
+CREATE POLICY investment_holdings_delete ON investment_holdings FOR DELETE USING (household_id = ANY(public.household_ids()));
 
-CREATE POLICY bill_reminders_select ON bill_reminders FOR SELECT USING (household_id = ANY(auth.household_ids()));
-CREATE POLICY bill_reminders_insert ON bill_reminders FOR INSERT WITH CHECK (owner_id = auth.uid() AND household_id = ANY(auth.household_ids()));
-CREATE POLICY bill_reminders_update ON bill_reminders FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
-CREATE POLICY bill_reminders_delete ON bill_reminders FOR DELETE USING (household_id = ANY(auth.household_ids()));
+CREATE POLICY bill_reminders_select ON bill_reminders FOR SELECT USING (household_id = ANY(public.household_ids()));
+CREATE POLICY bill_reminders_insert ON bill_reminders FOR INSERT WITH CHECK (owner_id = auth.uid() AND household_id = ANY(public.household_ids()));
+CREATE POLICY bill_reminders_update ON bill_reminders FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));
+CREATE POLICY bill_reminders_delete ON bill_reminders FOR DELETE USING (household_id = ANY(public.household_ids()));
 
-CREATE POLICY report_templates_select ON report_templates FOR SELECT USING (household_id = ANY(auth.household_ids()));
-CREATE POLICY report_templates_insert ON report_templates FOR INSERT WITH CHECK (owner_id = auth.uid() AND household_id = ANY(auth.household_ids()));
-CREATE POLICY report_templates_update ON report_templates FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
-CREATE POLICY report_templates_delete ON report_templates FOR DELETE USING (household_id = ANY(auth.household_ids()));
+CREATE POLICY report_templates_select ON report_templates FOR SELECT USING (household_id = ANY(public.household_ids()));
+CREATE POLICY report_templates_insert ON report_templates FOR INSERT WITH CHECK (owner_id = auth.uid() AND household_id = ANY(public.household_ids()));
+CREATE POLICY report_templates_update ON report_templates FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));
+CREATE POLICY report_templates_delete ON report_templates FOR DELETE USING (household_id = ANY(public.household_ids()));
 
 CREATE POLICY price_history_select ON price_history FOR SELECT USING (auth.uid() IS NOT NULL);
 CREATE POLICY price_history_insert ON price_history FOR INSERT WITH CHECK (false);

--- a/services/api/supabase/migrations/20260330000006_enforce_owner_id_rls.sql
+++ b/services/api/supabase/migrations/20260330000006_enforce_owner_id_rls.sql
@@ -40,16 +40,16 @@ DROP POLICY IF EXISTS accounts_insert ON accounts;
 CREATE POLICY accounts_insert ON accounts
     FOR INSERT
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
 DROP POLICY IF EXISTS accounts_update ON accounts;
 CREATE POLICY accounts_update ON accounts
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
+    USING (household_id = ANY(public.household_ids()))
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
@@ -61,16 +61,16 @@ DROP POLICY IF EXISTS categories_insert ON categories;
 CREATE POLICY categories_insert ON categories
     FOR INSERT
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
 DROP POLICY IF EXISTS categories_update ON categories;
 CREATE POLICY categories_update ON categories
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
+    USING (household_id = ANY(public.household_ids()))
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
@@ -82,16 +82,16 @@ DROP POLICY IF EXISTS transactions_insert ON transactions;
 CREATE POLICY transactions_insert ON transactions
     FOR INSERT
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
 DROP POLICY IF EXISTS transactions_update ON transactions;
 CREATE POLICY transactions_update ON transactions
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
+    USING (household_id = ANY(public.household_ids()))
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
@@ -103,16 +103,16 @@ DROP POLICY IF EXISTS budgets_insert ON budgets;
 CREATE POLICY budgets_insert ON budgets
     FOR INSERT
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
 DROP POLICY IF EXISTS budgets_update ON budgets;
 CREATE POLICY budgets_update ON budgets
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
+    USING (household_id = ANY(public.household_ids()))
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
@@ -124,16 +124,16 @@ DROP POLICY IF EXISTS goals_insert ON goals;
 CREATE POLICY goals_insert ON goals
     FOR INSERT
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
 DROP POLICY IF EXISTS goals_update ON goals;
 CREATE POLICY goals_update ON goals
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
+    USING (household_id = ANY(public.household_ids()))
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
@@ -145,16 +145,16 @@ DROP POLICY IF EXISTS recurring_templates_insert ON recurring_transaction_templa
 CREATE POLICY recurring_templates_insert ON recurring_transaction_templates
     FOR INSERT
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
 DROP POLICY IF EXISTS recurring_templates_update ON recurring_transaction_templates;
 CREATE POLICY recurring_templates_update ON recurring_transaction_templates
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
+    USING (household_id = ANY(public.household_ids()))
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
@@ -166,16 +166,16 @@ DROP POLICY IF EXISTS report_configs_insert ON report_configs;
 CREATE POLICY report_configs_insert ON report_configs
     FOR INSERT
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
 DROP POLICY IF EXISTS report_configs_update ON report_configs;
 CREATE POLICY report_configs_update ON report_configs
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
+    USING (household_id = ANY(public.household_ids()))
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
@@ -187,16 +187,16 @@ DROP POLICY IF EXISTS scheduled_reports_insert ON scheduled_reports;
 CREATE POLICY scheduled_reports_insert ON scheduled_reports
     FOR INSERT
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
 DROP POLICY IF EXISTS scheduled_reports_update ON scheduled_reports;
 CREATE POLICY scheduled_reports_update ON scheduled_reports
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
+    USING (household_id = ANY(public.household_ids()))
     WITH CHECK (
-        household_id = ANY(auth.household_ids())
+        household_id = ANY(public.household_ids())
         AND (owner_id IS NULL OR owner_id = auth.uid())
     );
 
@@ -207,48 +207,48 @@ CREATE POLICY scheduled_reports_update ON scheduled_reports
 --
 -- -- accounts
 -- DROP POLICY IF EXISTS accounts_insert ON accounts;
--- CREATE POLICY accounts_insert ON accounts FOR INSERT WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY accounts_insert ON accounts FOR INSERT WITH CHECK (household_id = ANY(public.household_ids()));
 -- DROP POLICY IF EXISTS accounts_update ON accounts;
--- CREATE POLICY accounts_update ON accounts FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY accounts_update ON accounts FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));
 --
 -- -- categories
 -- DROP POLICY IF EXISTS categories_insert ON categories;
--- CREATE POLICY categories_insert ON categories FOR INSERT WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY categories_insert ON categories FOR INSERT WITH CHECK (household_id = ANY(public.household_ids()));
 -- DROP POLICY IF EXISTS categories_update ON categories;
--- CREATE POLICY categories_update ON categories FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY categories_update ON categories FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));
 --
 -- -- transactions
 -- DROP POLICY IF EXISTS transactions_insert ON transactions;
--- CREATE POLICY transactions_insert ON transactions FOR INSERT WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY transactions_insert ON transactions FOR INSERT WITH CHECK (household_id = ANY(public.household_ids()));
 -- DROP POLICY IF EXISTS transactions_update ON transactions;
--- CREATE POLICY transactions_update ON transactions FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY transactions_update ON transactions FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));
 --
 -- -- budgets
 -- DROP POLICY IF EXISTS budgets_insert ON budgets;
--- CREATE POLICY budgets_insert ON budgets FOR INSERT WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY budgets_insert ON budgets FOR INSERT WITH CHECK (household_id = ANY(public.household_ids()));
 -- DROP POLICY IF EXISTS budgets_update ON budgets;
--- CREATE POLICY budgets_update ON budgets FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY budgets_update ON budgets FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));
 --
 -- -- goals
 -- DROP POLICY IF EXISTS goals_insert ON goals;
--- CREATE POLICY goals_insert ON goals FOR INSERT WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY goals_insert ON goals FOR INSERT WITH CHECK (household_id = ANY(public.household_ids()));
 -- DROP POLICY IF EXISTS goals_update ON goals;
--- CREATE POLICY goals_update ON goals FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY goals_update ON goals FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));
 --
 -- -- recurring_transaction_templates
 -- DROP POLICY IF EXISTS recurring_templates_insert ON recurring_transaction_templates;
--- CREATE POLICY recurring_templates_insert ON recurring_transaction_templates FOR INSERT WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY recurring_templates_insert ON recurring_transaction_templates FOR INSERT WITH CHECK (household_id = ANY(public.household_ids()));
 -- DROP POLICY IF EXISTS recurring_templates_update ON recurring_transaction_templates;
--- CREATE POLICY recurring_templates_update ON recurring_transaction_templates FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY recurring_templates_update ON recurring_transaction_templates FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));
 --
 -- -- report_configs
 -- DROP POLICY IF EXISTS report_configs_insert ON report_configs;
--- CREATE POLICY report_configs_insert ON report_configs FOR INSERT WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY report_configs_insert ON report_configs FOR INSERT WITH CHECK (household_id = ANY(public.household_ids()));
 -- DROP POLICY IF EXISTS report_configs_update ON report_configs;
--- CREATE POLICY report_configs_update ON report_configs FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY report_configs_update ON report_configs FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));
 --
 -- -- scheduled_reports
 -- DROP POLICY IF EXISTS scheduled_reports_insert ON scheduled_reports;
--- CREATE POLICY scheduled_reports_insert ON scheduled_reports FOR INSERT WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY scheduled_reports_insert ON scheduled_reports FOR INSERT WITH CHECK (household_id = ANY(public.household_ids()));
 -- DROP POLICY IF EXISTS scheduled_reports_update ON scheduled_reports;
--- CREATE POLICY scheduled_reports_update ON scheduled_reports FOR UPDATE USING (household_id = ANY(auth.household_ids())) WITH CHECK (household_id = ANY(auth.household_ids()));
+-- CREATE POLICY scheduled_reports_update ON scheduled_reports FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()));

--- a/services/api/supabase/migrations/down/20260306000002_rls_policies.down.sql
+++ b/services/api/supabase/migrations/down/20260306000002_rls_policies.down.sql
@@ -74,4 +74,4 @@ ALTER TABLE users              DISABLE ROW LEVEL SECURITY;
 -- =============================================================================
 -- Drop helper function
 -- =============================================================================
-DROP FUNCTION IF EXISTS auth.household_ids();
+DROP FUNCTION IF EXISTS public.household_ids();

--- a/services/api/supabase/migrations/down/20260306000003_auth_config.down.sql
+++ b/services/api/supabase/migrations/down/20260306000003_auth_config.down.sql
@@ -11,7 +11,7 @@
 -- Drop functions
 -- =============================================================================
 DROP FUNCTION IF EXISTS public.handle_new_user_signup(uuid, text, text);
-DROP FUNCTION IF EXISTS auth.custom_access_token_hook(jsonb);
+DROP FUNCTION IF EXISTS public.custom_access_token_hook(jsonb);
 
 -- =============================================================================
 -- Drop audit_log

--- a/services/api/supabase/migrations/down/20260316000002_fix_invitation_rls.down.sql
+++ b/services/api/supabase/migrations/down/20260316000002_fix_invitation_rls.down.sql
@@ -11,5 +11,5 @@ DROP POLICY IF EXISTS household_invitations_accept ON household_invitations;
 -- Restore original permissive UPDATE policy
 CREATE POLICY household_invitations_update ON household_invitations
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));

--- a/services/api/supabase/migrations/down/20260330000006_enforce_owner_id_rls.down.sql
+++ b/services/api/supabase/migrations/down/20260330000006_enforce_owner_id_rls.down.sql
@@ -40,13 +40,13 @@
 DROP POLICY IF EXISTS accounts_insert ON accounts;
 CREATE POLICY accounts_insert ON accounts
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 DROP POLICY IF EXISTS accounts_update ON accounts;
 CREATE POLICY accounts_update ON accounts
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- categories
@@ -54,13 +54,13 @@ CREATE POLICY accounts_update ON accounts
 DROP POLICY IF EXISTS categories_insert ON categories;
 CREATE POLICY categories_insert ON categories
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 DROP POLICY IF EXISTS categories_update ON categories;
 CREATE POLICY categories_update ON categories
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- transactions
@@ -68,13 +68,13 @@ CREATE POLICY categories_update ON categories
 DROP POLICY IF EXISTS transactions_insert ON transactions;
 CREATE POLICY transactions_insert ON transactions
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 DROP POLICY IF EXISTS transactions_update ON transactions;
 CREATE POLICY transactions_update ON transactions
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- budgets
@@ -82,13 +82,13 @@ CREATE POLICY transactions_update ON transactions
 DROP POLICY IF EXISTS budgets_insert ON budgets;
 CREATE POLICY budgets_insert ON budgets
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 DROP POLICY IF EXISTS budgets_update ON budgets;
 CREATE POLICY budgets_update ON budgets
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- goals
@@ -96,13 +96,13 @@ CREATE POLICY budgets_update ON budgets
 DROP POLICY IF EXISTS goals_insert ON goals;
 CREATE POLICY goals_insert ON goals
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 DROP POLICY IF EXISTS goals_update ON goals;
 CREATE POLICY goals_update ON goals
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- recurring_transaction_templates
@@ -110,13 +110,13 @@ CREATE POLICY goals_update ON goals
 DROP POLICY IF EXISTS recurring_templates_insert ON recurring_transaction_templates;
 CREATE POLICY recurring_templates_insert ON recurring_transaction_templates
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 DROP POLICY IF EXISTS recurring_templates_update ON recurring_transaction_templates;
 CREATE POLICY recurring_templates_update ON recurring_transaction_templates
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- report_configs
@@ -124,13 +124,13 @@ CREATE POLICY recurring_templates_update ON recurring_transaction_templates
 DROP POLICY IF EXISTS report_configs_insert ON report_configs;
 CREATE POLICY report_configs_insert ON report_configs
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 DROP POLICY IF EXISTS report_configs_update ON report_configs;
 CREATE POLICY report_configs_update ON report_configs
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 -- =============================================================================
 -- scheduled_reports
@@ -138,10 +138,10 @@ CREATE POLICY report_configs_update ON report_configs
 DROP POLICY IF EXISTS scheduled_reports_insert ON scheduled_reports;
 CREATE POLICY scheduled_reports_insert ON scheduled_reports
     FOR INSERT
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    WITH CHECK (household_id = ANY(public.household_ids()));
 
 DROP POLICY IF EXISTS scheduled_reports_update ON scheduled_reports;
 CREATE POLICY scheduled_reports_update ON scheduled_reports
     FOR UPDATE
-    USING (household_id = ANY(auth.household_ids()))
-    WITH CHECK (household_id = ANY(auth.household_ids()));
+    USING (household_id = ANY(public.household_ids()))
+    WITH CHECK (household_id = ANY(public.household_ids()));

--- a/services/api/supabase/tests/README.md
+++ b/services/api/supabase/tests/README.md
@@ -49,7 +49,7 @@ npm run test:sync-contract
 | ------- | ----------------------------------------------------------------- |
 | Test 1  | All sync-rules tables exist with expected columns                 |
 | Test 2  | RLS is enabled on all user-data tables                            |
-| Test 3  | `auth.household_ids()` function exists                            |
+| Test 3  | `public.household_ids()` function exists                          |
 | Test 4  | `custom_access_token_hook` exists with correct signature          |
 | Test 5  | `sync_version` and `is_synced` columns on synced tables           |
 | Test 6  | Soft-deleted rows are filtered out                                |

--- a/services/api/supabase/tests/db-optimization.test.sql
+++ b/services/api/supabase/tests/db-optimization.test.sql
@@ -149,7 +149,7 @@ END $$;
 -- Test 4: Category and household member indexes exist
 -- =============================================================================
 -- Category indexes support the parent/child tree structure.
--- Household member indexes are critical for RLS performance (auth.household_ids).
+-- Household member indexes are critical for RLS performance (public.household_ids).
 
 DO $$
 DECLARE

--- a/services/api/supabase/tests/rls-verification.sql
+++ b/services/api/supabase/tests/rls-verification.sql
@@ -118,24 +118,24 @@ BEGIN
     RAISE NOTICE '';
     RAISE NOTICE '--- Security Function Verification ---';
 
-    -- auth.household_ids()
+    -- public.household_ids()
     SELECT count(*) INTO fn_count
     FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'auth' AND p.proname = 'household_ids';
+    WHERE n.nspname = 'public' AND p.proname = 'household_ids';
     IF fn_count > 0 THEN
-        RAISE NOTICE '  ✅ auth.household_ids() exists';
+        RAISE NOTICE '  ✅ public.household_ids() exists';
     ELSE
-        RAISE WARNING '  ❌ auth.household_ids() MISSING';
+        RAISE WARNING '  ❌ public.household_ids() MISSING';
     END IF;
 
-    -- auth.custom_access_token_hook()
+    -- public.custom_access_token_hook()
     SELECT count(*) INTO fn_count
     FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'auth' AND p.proname = 'custom_access_token_hook';
+    WHERE n.nspname = 'public' AND p.proname = 'custom_access_token_hook';
     IF fn_count > 0 THEN
-        RAISE NOTICE '  ✅ auth.custom_access_token_hook() exists';
+        RAISE NOTICE '  ✅ public.custom_access_token_hook() exists';
     ELSE
-        RAISE WARNING '  ❌ auth.custom_access_token_hook() MISSING';
+        RAISE WARNING '  ❌ public.custom_access_token_hook() MISSING';
     END IF;
 
     -- public.check_rate_limit()

--- a/services/api/supabase/tests/sync-integration.test.sql
+++ b/services/api/supabase/tests/sync-integration.test.sql
@@ -134,7 +134,7 @@ END $$;
 -- =============================================================================
 -- Test 3: Verify household_ids() function exists and returns correct results
 -- =============================================================================
--- The auth.household_ids() function is the backbone of household-based RLS.
+-- The public.household_ids() function is the backbone of household-based RLS.
 -- We test it by directly querying household_members for a known seed user.
 
 DO $$
@@ -145,15 +145,15 @@ BEGIN
         SELECT 1
         FROM pg_proc p
         JOIN pg_namespace n ON n.oid = p.pronamespace
-        WHERE n.nspname = 'auth'
+        WHERE n.nspname = 'public'
           AND p.proname = 'household_ids'
     ) INTO fn_exists;
 
     IF NOT fn_exists THEN
-        RAISE EXCEPTION 'FAIL Test 3: auth.household_ids() function does not exist';
+        RAISE EXCEPTION 'FAIL Test 3: public.household_ids() function does not exist';
     END IF;
 
-    RAISE NOTICE 'PASS Test 3: auth.household_ids() function exists';
+    RAISE NOTICE 'PASS Test 3: public.household_ids() function exists';
 END $$;
 
 -- =============================================================================
@@ -171,21 +171,21 @@ BEGIN
         SELECT 1
         FROM pg_proc p
         JOIN pg_namespace n ON n.oid = p.pronamespace
-        WHERE n.nspname = 'auth'
+        WHERE n.nspname = 'public'
           AND p.proname = 'custom_access_token_hook'
           AND pg_get_function_arguments(p.oid) = 'event jsonb'
           AND pg_get_function_result(p.oid) = 'jsonb'
     ) INTO hook_exists;
 
     IF NOT hook_exists THEN
-        RAISE EXCEPTION 'FAIL Test 4: auth.custom_access_token_hook(jsonb) does not exist';
+        RAISE EXCEPTION 'FAIL Test 4: public.custom_access_token_hook(jsonb) does not exist';
     END IF;
 
     -- Verify SECURITY DEFINER
     SELECT p.prosecdef INTO is_definer
     FROM pg_proc p
     JOIN pg_namespace n ON n.oid = p.pronamespace
-    WHERE n.nspname = 'auth'
+    WHERE n.nspname = 'public'
       AND p.proname = 'custom_access_token_hook';
 
     IF NOT is_definer THEN


### PR DESCRIPTION
## Summary

`supabase start` / `supabase db reset` applies all repo migrations as the non-superuser `postgres` role. Two migrations created `SECURITY DEFINER` helper functions **in the `auth` schema**, which is owned by `supabase_auth_admin`. `postgres` lacks `CREATE` on `auth`, so these statements failed hard:

```
ERROR: permission denied for schema auth (SQLSTATE 42501)
```

On any migration error the CLI runs `DockerRemoveAll` and tears the whole stack down, so the local full-stack could **never** finish starting. (This was previously masked behind a now-resolved Docker image-corruption issue.)

## Root cause

- `migrations/20260306000002_rls_policies.sql` — `CREATE OR REPLACE FUNCTION auth.household_ids()`
- `migrations/20260306000003_auth_config.sql` — `CREATE OR REPLACE FUNCTION auth.custom_access_token_hook(event jsonb)`

## Fix

Relocate both helpers to the **`public`** schema — the Supabase-recommended pattern (never create your own objects in `auth`). `SECURITY DEFINER` is preserved; `public.household_ids()` still reads `household_members` / `auth.uid()`, both resolvable from `public`.

- `auth.household_ids()` → `public.household_ids()`
- `auth.custom_access_token_hook()` → `public.custom_access_token_hook()`
- Updated **all** references in up + down migrations (RLS policy predicates, `GRANT`/`REVOKE`, `DROP`) — 175 qualified-name occurrences across 16 migration files.
- Updated SQL test files, including the `pg_namespace.nspname = 'auth'` existence checks in `rls-verification.sql` and `sync-integration.test.sql` (a plain qualified-name find/replace does **not** catch these split-form checks).
- Updated the disabled GoTrue custom-access-token hook URI/comment in `deploy/docker-compose.yml` to point at `public.custom_access_token_hook` (the parent session referenced this as `services/api/docker-compose.yml:175/177`; the actual hook config lives in `deploy/docker-compose.yml`).

`auth.uid()` / `auth.jwt()` references are intentionally left untouched (those are Supabase built-ins in `auth`).

## Verification

`cd services/api && npx supabase start` now applies migrations **`20260306000002` and `20260306000003` cleanly** — the `permission denied for schema auth` error and the stack teardown it caused are gone.

> **⚠️ Note — a second, unrelated migration blocker was discovered during verification.** The parent session's premise that this was the *sole* remaining blocker was incomplete: migration `20260324000003_automated_maintenance.sql` then fails with `cannot change name of input parameter "p_retention_seconds"` (SQLSTATE 42P13) — a `CREATE OR REPLACE FUNCTION` that renames an existing function's parameter (`p_retention_seconds` → `retention_hours`). That is a distinct root cause and is fixed in a **separate issue + PR** (schema work is never batched). Full end-to-end `supabase start` stack-up is verified there, once both land.

## Scope notes

- This is intentionally a focused, schema-only PR.
- Documentation references to the old `auth.*`-qualified names (security audits, threat models, RLS reviews, `services/api/README.md`) are **deliberately deferred** to a separate docs PR to keep this change surgical and reviewable.
- Local ESLint could not run in this fresh worktree (`package-lock.json` is out of sync with `package.json` — a pre-existing condition unrelated to this change), but the diff contains **zero** JS/TS; `prettier --check` (covering the YAML/MD/SQL touched here) passes. Remote CI runs the authoritative lint.

Closes #3003