### PR TITLE
fix(api): make remaining local migrations apply cleanly via Supabase CLI

### DIFF
--- a/services/api/supabase/migrations/20260324000003_automated_maintenance.sql
+++ b/services/api/supabase/migrations/20260324000003_automated_maintenance.sql
@@ -18,8 +18,11 @@
 --   - Functions use SET search_path = public to prevent search_path injection
 --
 -- Note: cleanup_expired_rate_limits replaces the version from 20260323000003
--- with an hours-based interface (was seconds-based). The signature (INTEGER)
--- is identical, so CREATE OR REPLACE succeeds.
+-- with an hours-based interface (was seconds-based). Although the argument
+-- type is unchanged (INTEGER), the parameter is renamed
+-- (p_retention_seconds -> retention_hours), which CREATE OR REPLACE cannot do
+-- (ERROR 42P13: cannot change name of input parameter). The old function is
+-- therefore dropped first, then recreated.
 
 -- =============================================================================
 -- 1. cleanup_expired_rate_limits(retention_hours INTEGER DEFAULT 2)
@@ -33,7 +36,12 @@
 -- used by data-export / account-deletion / sync-health-report).
 --
 -- Replaces: cleanup_expired_rate_limits(p_retention_seconds) from migration
--- 20260323000003_rate_limits.sql — same signature (INTEGER), new semantics.
+-- 20260323000003_rate_limits.sql — same argument type (INTEGER), renamed
+-- parameter and new semantics.
+
+-- Drop the old (p_retention_seconds) version first: CREATE OR REPLACE cannot
+-- rename an existing function's parameters.
+DROP FUNCTION IF EXISTS public.cleanup_expired_rate_limits(integer);
 
 CREATE OR REPLACE FUNCTION public.cleanup_expired_rate_limits(
     retention_hours INTEGER DEFAULT 2
@@ -288,7 +296,7 @@ REVOKE EXECUTE ON FUNCTION public.run_all_maintenance() FROM anon;
 -- To verify scheduled jobs after migration:
 --   SELECT * FROM cron.job ORDER BY jobid;
 
-DO $$
+DO $maint$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
         -- Hourly: clean up expired rate limit windows (fast, <10ms typical)
@@ -316,7 +324,7 @@ BEGIN
     ELSE
         RAISE NOTICE 'pg_cron not available — skipping cron schedule. Use Edge Functions or external scheduler.';
     END IF;
-END $$;
+END $maint$;
 
 
 -- =============================================================================

--- a/services/api/supabase/migrations/20260330000005_audit_log_retention.sql
+++ b/services/api/supabase/migrations/20260330000005_audit_log_retention.sql
@@ -118,7 +118,7 @@ REVOKE EXECUTE ON FUNCTION public.run_all_maintenance() FROM anon;
 -- run_all_maintenance() at 3 AM also calls it, but the dedicated weekly
 -- job ensures catch-up if daily runs miss rows due to the 10k batch limit.
 
-DO $$
+DO $maint$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
         PERFORM cron.schedule(
@@ -131,7 +131,7 @@ BEGIN
     ELSE
         RAISE NOTICE 'pg_cron not available — skipping audit log cron schedule.';
     END IF;
-END $$;
+END $maint$;
 
 
 -- =============================================================================

--- a/services/api/supabase/migrations/20260330000007_transaction_pagination_index.sql
+++ b/services/api/supabase/migrations/20260330000007_transaction_pagination_index.sql
@@ -7,6 +7,12 @@
 -- Supports efficient keyset pagination by (date, id) and (created_at, id).
 -- These indexes enable cursor-based queries without OFFSET, providing
 -- consistent O(log n) performance regardless of page depth.
+--
+-- IMPORTANT: Do NOT use CREATE INDEX CONCURRENTLY here. The Supabase migration
+-- runner applies each file inside a transaction/pipeline, and CONCURRENTLY
+-- cannot run in that context (SQLSTATE 25001). This matches the established
+-- convention in 20260324000002_performance_indexes.sql. All statements use
+-- IF NOT EXISTS for idempotency.
 
 -- =============================================================================
 -- Up
@@ -14,18 +20,18 @@
 
 -- Primary pagination index: date descending with id tiebreaker.
 -- Used by the transactions-list Edge Function for default sorting.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_pagination_date
+CREATE INDEX IF NOT EXISTS idx_transactions_pagination_date
     ON transactions (date DESC, id DESC)
     WHERE deleted_at IS NULL;
 
 -- Secondary pagination index: created_at descending with id tiebreaker.
 -- Used when sorting by creation time.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_pagination_created_at
+CREATE INDEX IF NOT EXISTS idx_transactions_pagination_created_at
     ON transactions (created_at DESC, id DESC)
     WHERE deleted_at IS NULL;
 
 -- Tertiary pagination index: amount_cents descending with id tiebreaker.
 -- Used when sorting by amount.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_pagination_amount
+CREATE INDEX IF NOT EXISTS idx_transactions_pagination_amount
     ON transactions (amount_cents DESC, id DESC)
     WHERE deleted_at IS NULL;

--- a/services/api/supabase/migrations/20260331000002_add_mood_tag_to_transactions.sql
+++ b/services/api/supabase/migrations/20260331000002_add_mood_tag_to_transactions.sql
@@ -5,7 +5,7 @@
 -- Issues: #1874
 
 ALTER TABLE transactions
-    ADD COLUMN mood_tag TEXT NULL;
+    ADD COLUMN IF NOT EXISTS mood_tag TEXT NULL;
 
 COMMENT ON COLUMN transactions.mood_tag IS
     'Optional single emoji mood tag for user-owned transaction entry; excluded from household and visibility sharing surfaces.';

--- a/services/api/supabase/migrations/down/20260324000003_automated_maintenance.down.sql
+++ b/services/api/supabase/migrations/down/20260324000003_automated_maintenance.down.sql
@@ -28,6 +28,9 @@ DROP FUNCTION IF EXISTS public.cleanup_expired_webauthn_challenges(INTEGER);
 -- =============================================================================
 -- Restore original cleanup_expired_rate_limits with seconds-based interface
 -- =============================================================================
+-- Drop the hours-based version first: CREATE OR REPLACE cannot rename an
+-- existing function's parameters (retention_hours -> p_retention_seconds).
+DROP FUNCTION IF EXISTS public.cleanup_expired_rate_limits(integer);
 CREATE OR REPLACE FUNCTION public.cleanup_expired_rate_limits(
     p_retention_seconds INTEGER DEFAULT 7200
 )


### PR DESCRIPTION
## Summary

Follow-up to #3003. After the auth-schema helper functions were relocated to `public`, `supabase start` / `supabase db reset` progressed past migrations 2-3 but hit a **chain** of additional migration-application bugs. Because the Supabase CLI runs a full `DockerRemoveAll` teardown on any migration error, each bug masked the next — they could only be found and fixed serially by repeatedly running `supabase start`. This PR fixes the remaining blockers so the **entire** local stack comes up.

All four are **pre-existing bugs on `main`**, unmasked by #3003. They affect only **local** application via the Supabase CLI migration runner (each file is applied inside a transaction/pipeline); runtime behavior is unaffected.

## Bugs fixed (in application order)

| # | SQLSTATE | Migration | Root cause | Fix |
|---|----------|-----------|------------|-----|
| 1 | `42P13` | `20260324000003_automated_maintenance.sql` (+ down) | `CREATE OR REPLACE FUNCTION public.cleanup_expired_rate_limits(retention_hours INTEGER)` renames the parameter of the earlier `(p_retention_seconds INTEGER)` version; Postgres forbids renaming a parameter via `CREATE OR REPLACE` even when the type is unchanged | `DROP FUNCTION IF EXISTS public.cleanup_expired_rate_limits(integer);` before the recreate (mirrored in the down migration) |
| 2 | `42601` | `20260324000003`, `20260330000005_audit_log_retention.sql` | Anonymous `DO $$ ... END $$;` blocks contain inner `cron.schedule(..., $$SELECT ...$$)` literals that reuse the `$$` tag, closing the outer block early | Retag the outer block uniquely: `DO $maint$ ... END $maint$;` |
| 3 | `25001` | `20260330000007_transaction_pagination_index.sql` | `CREATE INDEX CONCURRENTLY` cannot run inside the CLI migration transaction/pipeline | Remove `CONCURRENTLY` -> plain `CREATE INDEX IF NOT EXISTS`, matching the repo convention documented in `20260324000002_performance_indexes.sql` (line 17) |
| 4 | `42701` | `20260331000002_add_mood_tag_to_transactions.sql` | `transactions.mood_tag` is already defined in the initial schema (`20260306000001_initial_schema.sql:164`), so the plain `ADD COLUMN` collides | `ADD COLUMN IF NOT EXISTS` (idempotent; matches the `20260331000004` privacy-trio pattern) |

## Verification (local, empirical)

From `services/api`, `npx supabase start` now brings the **entire** stack up:

- All **49** migrations applied — no `permission denied`, no `42P13` / `42601` / `25001` / `42701`, **no teardown**.
- Post-start DB introspection confirms `public.household_ids`, `public.custom_access_token_hook`, and `public.cleanup_expired_rate_limits` all resolve in `public` (none left in `auth`).
- `supabase stop` clean.

A proactive sweep (`$$\w` across all migrations; `CONCURRENTLY` across up + down) confirms no further instances of bugs 2-3 remain.

## Scope

Migrations only (`services/api/supabase/migrations`). No `tools/` changes (owned by a separate PR), no docs.

## Down-migration parity

The only affected down migration (`down/20260324000003`) gets the mirror-image `DROP FUNCTION` fix; Reverse Migration Coverage applies.

## Testing

- [x] `npx supabase start` brings the full stack up locally (49/49 migrations, no teardown)
- [x] Helper functions verified resolvable in `public`
- [ ] Remote CI (ESLint & Prettier, Reverse Migration Coverage, Semantic PR Title) green on push

Closes #3007