### PR TITLE
fix(web): real-edge email login/signup never authenticates — derive user from JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ coverage/
 # === Playwright ===
 test-results/
 playwright-report/
+playwright-report-live/
 
 # === Copilot / AI (session state is local) ===
 .copilot/session-state/

--- a/apps/web/e2e-live/full-stack-smoke.spec.ts
+++ b/apps/web/e2e-live/full-stack-smoke.spec.ts
@@ -33,6 +33,32 @@ test.describe('Live full-stack (edge) auth', () => {
     // Unique per run so repeated runs never collide on "email already registered".
     const email = `e2e+${Date.now()}@local.test`;
 
+    // Seed past the first-run GDPR consent overlay — a fixed z-index:9999 dialog
+    // that intercepts every click until consent is recorded, which otherwise
+    // makes the signup form unreachable. We deliberately do NOT set
+    // __PLAYWRIGHT_E2E__ here (unlike e2e/first-run-state.ts): that flag switches
+    // the app to its stub DB / demo auth and would defeat this test's real-edge
+    // purpose. We only pre-seed the consent + onboarding keys.
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'finance-gdpr-consent',
+        JSON.stringify({
+          categories: {
+            essential: true,
+            analytics: false,
+            error_reporting: false,
+            sync: false,
+            marketing: false,
+          },
+          timestamp: new Date().toISOString(),
+          policyVersion: '1.0.0',
+          method: 'first_run',
+          hasCompletedFirstRun: true,
+        }),
+      );
+      localStorage.setItem('finance-onboarding-complete', 'true');
+    });
+
     await page.goto('/signup');
 
     // Proof the app is wired to a real backend, not demo mode. The signup page

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -502,15 +502,17 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
 
         const data = (await response.json()) as {
           access_token: string;
-          user: { id: string; email: string; has_passkey?: boolean };
         };
 
         setAccessToken(data.access_token);
-        const allowed = await rememberAllowedUser({
-          id: data.user.id,
-          email: data.user.email,
-          hasPasskey: data.user.has_passkey ?? false,
-        });
+        // The edge auth functions return only { access_token, expires_in }; the
+        // authenticated user is derived from the JWT claims, matching the
+        // refresh/restore paths (userFromToken).
+        const loggedInUser = userFromToken(data.access_token);
+        if (!loggedInUser) {
+          throw new Error('Login succeeded but returned an invalid session token.');
+        }
+        const allowed = await rememberAllowedUser(loggedInUser);
         if (!allowed) {
           throw new Error(BETA_ACCESS_REQUIRED_MESSAGE);
         }
@@ -751,7 +753,6 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
           confirmation_required?: boolean;
           error?: string;
           access_token?: string;
-          user?: { id: string; email: string; has_passkey?: boolean };
         };
 
         if (response.status === 202) {
@@ -765,13 +766,13 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
           throw new Error(body.error ?? 'Signup failed');
         }
 
-        if (response.status === 201 && body.access_token && body.user) {
+        if (response.status === 201 && body.access_token) {
           setAccessToken(body.access_token);
-          const allowed = await rememberAllowedUser({
-            id: body.user.id,
-            email: body.user.email,
-            hasPasskey: body.user.has_passkey ?? false,
-          });
+          const signedUpUser = userFromToken(body.access_token);
+          if (!signedUpUser) {
+            throw new Error('Signup succeeded but returned an invalid session token.');
+          }
+          const allowed = await rememberAllowedUser(signedUpUser);
           if (!allowed) {
             throw new Error(BETA_ACCESS_REQUIRED_MESSAGE);
           }
@@ -792,14 +793,13 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         if (loginResponse.ok) {
           const data = (await loginResponse.json()) as {
             access_token: string;
-            user: { id: string; email: string; has_passkey?: boolean };
           };
           setAccessToken(data.access_token);
-          const allowed = await rememberAllowedUser({
-            id: data.user.id,
-            email: data.user.email,
-            hasPasskey: data.user.has_passkey ?? false,
-          });
+          const loggedInUser = userFromToken(data.access_token);
+          if (!loggedInUser) {
+            throw new Error('Signup succeeded but returned an invalid session token.');
+          }
+          const allowed = await rememberAllowedUser(loggedInUser);
           if (!allowed) {
             throw new Error(BETA_ACCESS_REQUIRED_MESSAGE);
           }

--- a/services/api/supabase/.gitignore
+++ b/services/api/supabase/.gitignore
@@ -1,0 +1,3 @@
+# Supabase CLI local state (not for version control)
+.branches/
+.temp/


### PR DESCRIPTION
## Summary

Against a **real Supabase edge backend**, web email **login and signup never authenticate** — the app silently stays on `/login` or `/signup`. This is a production auth bug (affects the deployed edge auth path, not just local e2e). Root-caused while standing up the local full-stack web e2e on edge.

## Root cause — auth response contract mismatch

`apps/web/src/auth/auth-context.tsx` parsed the auth responses expecting a `user` object (`data.user.id`, `body.user.id`), but the edge functions return **only** `{ access_token, expires_in }`:

- `services/api/supabase/functions/auth-login/index.ts` → `{ access_token, expires_in }` (200)
- `services/api/supabase/functions/auth-signup/index.ts` → `{ access_token, expires_in }` (201; `enable_confirmations = false`)

So against real edge:

- **login** — `data.user` is `undefined` → `data.user.id` throws → login fails.
- **signup** — the `&& body.user` guard is falsy → the authenticated branch is skipped; auto-login hits the same `data.user` problem → never authenticates.

The `refresh` (L694) and `restore` (L412) paths already derive the user correctly from the JWT via **`userFromToken()`** (decodes the GoTrue `sub`/`email` claims). Login/signup had simply diverged from that contract.

## Changes

- **`apps/web/src/auth/auth-context.tsx`** — derive the authenticated user from the access-token JWT via the existing module-level `userFromToken()` in all three real-edge branches (`loginWithEmail`, `signupWithEmail` 201, `signupWithEmail` auto-login), matching `refresh`/`restore`. Dropped the now-unused `user` field from the three response types. Demo-mode branches are untouched (they carry a real `result.user` from `demoLogin()`).
- **`apps/web/e2e-live/full-stack-smoke.spec.ts`** — seed past the first-run GDPR consent overlay (`finance-gdpr-consent` + `finance-onboarding-complete`) via `addInitScript` **without** `__PLAYWRIGHT_E2E__` (that flag switches to the stub DB / demo auth and would defeat the real-edge purpose), so the signup form is reachable.
- **`.gitignore` / `services/api/supabase/.gitignore`** — ignore `playwright-report-live/` and the Supabase CLI local-state dirs (`.branches/`, `.temp/`).

## Issues

Closes #3009

## Testing

- [x] **Live edge e2e green**: `npm run test:e2e:live -w apps/web` → `1 passed (8.7s)` — real signup → local Supabase GoTrue → JWT-derived user → authenticated app shell.
- [x] **Auth unit tests**: 54 passed (incl. 9 `auth-context.test.tsx`).
- [x] `npm run format:check` clean; `npx eslint . --max-warnings 0` clean.

## Notes

- Scope: `apps/web` only — no schema/backend change. The edge functions are correct; the client was wrong. The bug fails *closed* (no one is authenticated) rather than open, so it's a functional auth break, not a security bypass.
- No parallel fleet active on `apps/web`, so no coordination conflict.