### PR TITLE
feat(ios): Today Spend / Fun Money widget (#2159)

### DIFF
--- a/apps/ios/Finance/Services/WidgetDataWriter.swift
+++ b/apps/ios/Finance/Services/WidgetDataWriter.swift
@@ -49,6 +49,25 @@ actor WidgetDataWriter {
         write(budgets, key: "widget.budgets", timelineKind: "BudgetProgressWidget")
     }
 
+    /// Computes and caches a glanceable today-spend summary, then nudges the
+    /// today-spend timeline to reload so the surface stays fresh after a
+    /// transaction save or sync.
+    ///
+    /// TODO(human): Call `writeTodaySpend(_:)` from the transaction save and
+    /// sync-completion paths (KMP `SyncManager` callback + transaction create/edit
+    /// view models) so the cache refreshes automatically. The widget cache
+    /// currently has no app-side call sites (see #2159); wiring requires the live
+    /// transaction + budget data flow which is outside this widget-only change.
+    func writeTodaySpend(_ input: TodaySpendInput) {
+        let summary = TodaySpendCalculator.summarize(input)
+        write(summary, key: "widget.todaySpend", timelineKind: "TodaySpendWidget")
+    }
+
+    /// Caches an already-computed today-spend summary (e.g. from shared logic).
+    func writeTodaySpend(summary: TodaySpendSummary) {
+        write(summary, key: "widget.todaySpend", timelineKind: "TodaySpendWidget")
+    }
+
     private func write<T: Encodable>(_ value: T, key: String, timelineKind: String) {
         guard let data = try? encoder.encode(value) else {
             logger.error("Failed to encode widget cache for \(key, privacy: .public)")

--- a/apps/ios/FinanceWidget/FinanceWidgetBundle.swift
+++ b/apps/ios/FinanceWidget/FinanceWidgetBundle.swift
@@ -13,5 +13,6 @@ struct FinanceWidgetBundle: WidgetBundle {
         BudgetProgressWidget()
         RecentTransactionsWidget()
         QuickEntryWidget()
+        TodaySpendWidget()
     }
 }

--- a/apps/ios/FinanceWidget/TodaySpendWidget.swift
+++ b/apps/ios/FinanceWidget/TodaySpendWidget.swift
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: BUSL-1.1
+// TodaySpendWidget.swift — Refs #2159
+//
+// Glance-first "Today Spend / Fun Money" widget. Reads a precomputed
+// `TodaySpendSummary` from the app-group cache (never the network), applies a
+// budget-aware refresh cadence, and surfaces staleness so the number stays
+// trustworthy. All money respects the user's widget privacy masking mode.
+
+import FinanceShared
+import SwiftUI
+import WidgetKit
+
+struct TodaySpendEntry: TimelineEntry {
+    let date: Date
+    let summary: TodaySpendSummary
+    let maskingMode: WidgetMaskingMode
+    let isStale: Bool
+}
+
+struct TodaySpendProvider: TimelineProvider {
+    func placeholder(in context: Context) -> TodaySpendEntry {
+        TodaySpendEntry(
+            date: .now,
+            summary: .placeholder,
+            maskingMode: .bucketed,
+            isStale: false
+        )
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (TodaySpendEntry) -> Void) {
+        if context.isPreview {
+            completion(placeholder(in: context))
+        } else {
+            completion(makeEntry())
+        }
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<TodaySpendEntry>) -> Void) {
+        let now = Date.now
+        let entry = makeEntry(now: now)
+        // Budget-aware cadence: refresh sooner when fun money is running low.
+        let nextRefresh = TodaySpendRefreshPolicy.nextRefreshDate(after: now, summary: entry.summary)
+        completion(Timeline(entries: [entry], policy: .after(nextRefresh)))
+    }
+
+    private func makeEntry(now: Date = .now) -> TodaySpendEntry {
+        let summary = WidgetDataProvider.readTodaySpend()
+        return TodaySpendEntry(
+            date: now,
+            summary: summary,
+            maskingMode: WidgetDataProvider.maskingMode(for: TodaySpendWidget.kind),
+            isStale: TodaySpendFreshness.isStale(updatedAt: summary.updatedAt, now: now)
+        )
+    }
+}
+
+struct TodaySpendWidget: Widget {
+    static let kind = "TodaySpendWidget"
+    let kind = TodaySpendWidget.kind
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: TodaySpendProvider()) { entry in
+            TodaySpendWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName(Text("Today Spend", comment: "Widget"))
+        .description(Text("Today's spending and the fun money you have left.", comment: "Widget description"))
+        .supportedFamilies([.systemSmall, .systemMedium])
+        .contentMarginsDisabled()
+    }
+}
+
+struct TodaySpendWidgetView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: TodaySpendEntry
+
+    var body: some View {
+        Link(destination: FinanceWidgetDeepLinks.quickEntryURL(action: nil)) {
+            switch family {
+            case .systemMedium:
+                mediumView
+            default:
+                smallView
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(accessibilityValue)
+    }
+
+    // MARK: - Small
+
+    private var smallView: some View {
+        VStack(alignment: .leading, spacing: FinanceWidgetSpacing.xs) {
+            header(title: String(localized: "Today"), icon: "calendar")
+            Text(todaySpentText)
+                .font(.system(.title2, design: .rounded, weight: .bold))
+                .monospacedDigit()
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
+            Spacer(minLength: FinanceWidgetSpacing.xxs)
+            funMoneyChip
+            staleFootnote
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .padding()
+    }
+
+    // MARK: - Medium
+
+    private var mediumView: some View {
+        HStack(alignment: .top, spacing: FinanceWidgetSpacing.md) {
+            VStack(alignment: .leading, spacing: FinanceWidgetSpacing.xs) {
+                header(title: String(localized: "Today"), icon: "calendar")
+                Text(todaySpentText)
+                    .font(.system(.title, design: .rounded, weight: .bold))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.5)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                staleFootnote
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: FinanceWidgetSpacing.xs) {
+                header(title: String(localized: "Fun money"), icon: "sparkles")
+                Text(funMoneyText)
+                    .font(.system(.title3, design: .rounded, weight: .semibold))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.5)
+                    .lineLimit(1)
+                    .foregroundStyle(funMoneyColor)
+                if entry.summary.hasDiscretionaryBudget {
+                    ProgressView(value: entry.summary.funMoneyProgress)
+                        .tint(funMoneyColor)
+                    Text(funMoneyCaption)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                } else {
+                    Text(String(localized: "Set a fun budget in Finance"))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.7)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding()
+    }
+
+    // MARK: - Components
+
+    private func header(title: String, icon: String) -> some View {
+        HStack(spacing: FinanceWidgetSpacing.xxs) {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text(title)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .accessibilityAddTraits(.isHeader)
+    }
+
+    private var funMoneyChip: some View {
+        HStack(spacing: FinanceWidgetSpacing.xxs) {
+            Image(systemName: entry.summary.isOverFunBudget ? "exclamationmark.triangle.fill" : "sparkles")
+                .font(.caption2)
+                .accessibilityHidden(true)
+            Text(funMoneyText)
+                .font(.caption.weight(.semibold))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .foregroundStyle(funMoneyColor)
+        .padding(.horizontal, FinanceWidgetSpacing.xs)
+        .padding(.vertical, FinanceWidgetSpacing.xxs)
+        .background(
+            Capsule().fill(funMoneyColor.opacity(0.14))
+        )
+    }
+
+    @ViewBuilder
+    private var staleFootnote: some View {
+        if entry.isStale {
+            Text(String(localized: "Open Finance to refresh"))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .accessibilityHidden(true)
+        }
+    }
+
+    // MARK: - Formatting
+
+    private var todaySpentText: String {
+        WidgetCurrencyFormatter.format(
+            minorUnits: entry.summary.todaySpentMinorUnits,
+            currencyCode: entry.summary.currencyCode,
+            mode: entry.maskingMode
+        )
+    }
+
+    private var funMoneyText: String {
+        guard entry.summary.hasDiscretionaryBudget else {
+            return String(localized: "—")
+        }
+        let amount = WidgetCurrencyFormatter.format(
+            minorUnits: abs(entry.summary.funMoneyRemainingMinorUnits),
+            currencyCode: entry.summary.currencyCode,
+            mode: entry.maskingMode,
+            showCents: false
+        )
+        return entry.summary.isOverFunBudget
+            ? String(localized: "\(amount) over")
+            : String(localized: "\(amount) left")
+    }
+
+    private var funMoneyCaption: String {
+        String(localized: "\(Int(entry.summary.funMoneyProgress * 100))% of fun budget used")
+    }
+
+    private var funMoneyColor: Color {
+        if entry.summary.isOverFunBudget { return FinanceWidgetColors.statusNegative }
+        if entry.summary.funMoneyProgress >= TodaySpendRefreshPolicy.lowBudgetThreshold {
+            return FinanceWidgetColors.statusWarning
+        }
+        return FinanceWidgetColors.statusPositive
+    }
+
+    // MARK: - Accessibility
+
+    private var accessibilityLabel: String {
+        String(localized: "Today's spending and fun money")
+    }
+
+    private var accessibilityValue: String {
+        let spent = WidgetCurrencyFormatter.formatForVoiceOver(
+            minorUnits: entry.summary.todaySpentMinorUnits,
+            currencyCode: entry.summary.currencyCode,
+            mode: entry.maskingMode
+        )
+        let spentPart = String(localized: "Spent \(spent) today")
+
+        guard entry.summary.hasDiscretionaryBudget else {
+            return entry.isStale
+                ? String(localized: "\(spentPart). Data may be out of date, open Finance to refresh.")
+                : spentPart
+        }
+
+        let fun = WidgetCurrencyFormatter.formatForVoiceOver(
+            minorUnits: abs(entry.summary.funMoneyRemainingMinorUnits),
+            currencyCode: entry.summary.currencyCode,
+            mode: entry.maskingMode
+        )
+        let funPart = entry.summary.isOverFunBudget
+            ? String(localized: "\(fun) over your fun budget")
+            : String(localized: "\(fun) of fun money left")
+
+        let combined = String(localized: "\(spentPart). \(funPart).")
+        return entry.isStale
+            ? String(localized: "\(combined) Data may be out of date, open Finance to refresh.")
+            : combined
+    }
+}

--- a/apps/ios/FinanceWidget/WidgetDataProvider.swift
+++ b/apps/ios/FinanceWidget/WidgetDataProvider.swift
@@ -9,6 +9,7 @@ public enum WidgetDataKeys {
     static let balance = "widget.balance"
     static let transactions = "widget.transactions"
     static let budgets = "widget.budgets"
+    static let todaySpend = "widget.todaySpend"
 }
 
 struct WidgetBalance: Codable, Sendable, Hashable {
@@ -123,6 +124,19 @@ enum WidgetDataProvider {
         )
     }
 
+    /// Reads the cached today-spend summary from the app-group cache only.
+    /// Timeline providers must never fetch from the network; a missing cache
+    /// renders the empty placeholder summary (`.distantPast` marks it stale).
+    static func readTodaySpend() -> TodaySpendSummary {
+        guard let defaults,
+              let data = defaults.data(forKey: WidgetDataKeys.todaySpend),
+              let summary = try? decoder.decode(TodaySpendSummary.self, from: data)
+        else {
+            return .empty()
+        }
+        return summary
+    }
+
     static func maskingMode(for widgetId: String) -> WidgetMaskingMode {
         let mode = WidgetPrivacySettings.maskingMode(for: widgetId, defaults: defaults)
         if mode == .bucketed {
@@ -194,6 +208,16 @@ extension WidgetBudget {
             currencyCode: "USD"
         ),
     ]
+}
+
+extension TodaySpendSummary {
+    static let placeholder = TodaySpendSummary(
+        todaySpentMinorUnits: 4_250,
+        periodDiscretionarySpentMinorUnits: 16_000,
+        discretionaryBudgetMinorUnits: 25_000,
+        currencyCode: "USD",
+        updatedAt: .now
+    )
 }
 
 enum WidgetCurrencyFormatter {

--- a/apps/ios/Shared/TodaySpendModel.swift
+++ b/apps/ios/Shared/TodaySpendModel.swift
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BUSL-1.1
+// TodaySpendModel.swift - FinanceShared - Refs #2159
+//
+// Deterministic, testable "today spend" + "fun money remaining" computation.
+// Kept free of WidgetKit/SwiftUI so it can be unit-tested in isolation and reused
+// by the main app's cache writer. All money is represented in integer minor units
+// (cents) to avoid floating-point drift; expenses are negative, income positive.
+
+import Foundation
+
+/// A single transaction as consumed by the today-spend calculator.
+///
+/// `amountMinorUnits` follows the app-wide convention: negative for outflow
+/// (spending), positive for inflow (income/refund).
+public struct TodaySpendTransaction: Sendable, Hashable, Codable {
+    public let amountMinorUnits: Int64
+    public let date: Date
+    /// Whether the transaction counts against discretionary / "fun money".
+    public let isDiscretionary: Bool
+
+    public init(amountMinorUnits: Int64, date: Date, isDiscretionary: Bool) {
+        self.amountMinorUnits = amountMinorUnits
+        self.date = date
+        self.isDiscretionary = isDiscretionary
+    }
+}
+
+/// Inputs required to derive a glanceable today-spend summary.
+public struct TodaySpendInput: Sendable {
+    public let transactions: [TodaySpendTransaction]
+    /// Discretionary ("fun money") budget for the active period, in minor units.
+    public let discretionaryBudgetMinorUnits: Int64
+    public let periodStart: Date
+    public let periodEnd: Date
+    public let currencyCode: String
+    public let referenceDate: Date
+    public let updatedAt: Date
+    public let calendar: Calendar
+
+    public init(
+        transactions: [TodaySpendTransaction],
+        discretionaryBudgetMinorUnits: Int64,
+        periodStart: Date,
+        periodEnd: Date,
+        currencyCode: String = "USD",
+        referenceDate: Date = Date(),
+        updatedAt: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        self.transactions = transactions
+        self.discretionaryBudgetMinorUnits = discretionaryBudgetMinorUnits
+        self.periodStart = periodStart
+        self.periodEnd = periodEnd
+        self.currencyCode = currencyCode
+        self.referenceDate = referenceDate
+        self.updatedAt = updatedAt
+        self.calendar = calendar
+    }
+}
+
+/// Glanceable, privacy-neutral summary suitable for caching and widget rendering.
+public struct TodaySpendSummary: Sendable, Hashable, Codable {
+    /// Total spent today (absolute value of today's outflows), minor units.
+    public let todaySpentMinorUnits: Int64
+    /// Discretionary spent across the active period, minor units.
+    public let periodDiscretionarySpentMinorUnits: Int64
+    /// Discretionary budget for the active period, minor units.
+    public let discretionaryBudgetMinorUnits: Int64
+    public let currencyCode: String
+    /// When the underlying data was last refreshed.
+    public let updatedAt: Date
+
+    public init(
+        todaySpentMinorUnits: Int64,
+        periodDiscretionarySpentMinorUnits: Int64,
+        discretionaryBudgetMinorUnits: Int64,
+        currencyCode: String,
+        updatedAt: Date
+    ) {
+        self.todaySpentMinorUnits = todaySpentMinorUnits
+        self.periodDiscretionarySpentMinorUnits = periodDiscretionarySpentMinorUnits
+        self.discretionaryBudgetMinorUnits = discretionaryBudgetMinorUnits
+        self.currencyCode = currencyCode
+        self.updatedAt = updatedAt
+    }
+
+    /// Remaining fun money for the period (may be negative when overspent).
+    public var funMoneyRemainingMinorUnits: Int64 {
+        discretionaryBudgetMinorUnits - periodDiscretionarySpentMinorUnits
+    }
+
+    /// Fraction of the discretionary budget consumed, clamped to `0...1` for gauges.
+    public var funMoneyProgress: Double {
+        guard discretionaryBudgetMinorUnits > 0 else { return 0 }
+        let raw = Double(periodDiscretionarySpentMinorUnits) / Double(discretionaryBudgetMinorUnits)
+        return min(max(raw, 0), 1)
+    }
+
+    public var isOverFunBudget: Bool {
+        funMoneyRemainingMinorUnits < 0
+    }
+
+    public var hasDiscretionaryBudget: Bool {
+        discretionaryBudgetMinorUnits > 0
+    }
+
+    /// Empty/placeholder summary used when no cache exists yet.
+    public static func empty(
+        currencyCode: String = "USD",
+        updatedAt: Date = .distantPast
+    ) -> TodaySpendSummary {
+        TodaySpendSummary(
+            todaySpentMinorUnits: 0,
+            periodDiscretionarySpentMinorUnits: 0,
+            discretionaryBudgetMinorUnits: 0,
+            currencyCode: currencyCode,
+            updatedAt: updatedAt
+        )
+    }
+}
+
+/// Pure, deterministic reducer that turns raw transactions into a summary.
+public enum TodaySpendCalculator {
+    public static func summarize(_ input: TodaySpendInput) -> TodaySpendSummary {
+        var todaySpent: Int64 = 0
+        var periodDiscretionarySpent: Int64 = 0
+
+        for transaction in input.transactions {
+            // Only outflows (negative amounts) count as spend.
+            guard transaction.amountMinorUnits < 0 else { continue }
+            let magnitude = abs(transaction.amountMinorUnits)
+
+            if input.calendar.isDate(transaction.date, inSameDayAs: input.referenceDate) {
+                todaySpent += magnitude
+            }
+
+            if transaction.isDiscretionary,
+               isDate(transaction.date, within: input.periodStart, and: input.periodEnd) {
+                periodDiscretionarySpent += magnitude
+            }
+        }
+
+        return TodaySpendSummary(
+            todaySpentMinorUnits: todaySpent,
+            periodDiscretionarySpentMinorUnits: periodDiscretionarySpent,
+            discretionaryBudgetMinorUnits: input.discretionaryBudgetMinorUnits,
+            currencyCode: input.currencyCode,
+            updatedAt: input.updatedAt
+        )
+    }
+
+    /// Inclusive range membership that tolerates a reversed start/end pair.
+    private static func isDate(_ date: Date, within start: Date, and end: Date) -> Bool {
+        let lower = min(start, end)
+        let upper = max(start, end)
+        return date >= lower && date <= upper
+    }
+}
+
+/// Freshness evaluation so widgets can communicate trustworthiness at a glance.
+public enum TodaySpendFreshness {
+    /// Cached data older than this is treated as stale and visually de-emphasised.
+    public static let defaultMaxAge: TimeInterval = 6 * 60 * 60 // 6 hours
+
+    public static func age(of updatedAt: Date, now: Date = Date()) -> TimeInterval {
+        max(now.timeIntervalSince(updatedAt), 0)
+    }
+
+    public static func isStale(
+        updatedAt: Date,
+        now: Date = Date(),
+        maxAge: TimeInterval = defaultMaxAge
+    ) -> Bool {
+        age(of: updatedAt, now: now) > maxAge
+    }
+}
+
+/// Pure refresh-cadence logic for the today-spend timeline provider.
+///
+/// The cadence tightens as discretionary budget depletes so the persona who checks
+/// "can I afford to go out tonight?" sees an up-to-date number when it matters most.
+public enum TodaySpendRefreshPolicy {
+    public static let relaxedInterval: TimeInterval = 60 * 60       // 1 hour
+    public static let tightInterval: TimeInterval = 30 * 60         // 30 minutes
+    public static let lowBudgetThreshold: Double = 0.8
+
+    public static func refreshInterval(for summary: TodaySpendSummary) -> TimeInterval {
+        if summary.isOverFunBudget { return tightInterval }
+        if summary.hasDiscretionaryBudget, summary.funMoneyProgress >= lowBudgetThreshold {
+            return tightInterval
+        }
+        return relaxedInterval
+    }
+
+    public static func nextRefreshDate(
+        after now: Date,
+        summary: TodaySpendSummary
+    ) -> Date {
+        now.addingTimeInterval(refreshInterval(for: summary))
+    }
+}

--- a/apps/ios/Tests/TodaySpendCalculatorTests.swift
+++ b/apps/ios/Tests/TodaySpendCalculatorTests.swift
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: BUSL-1.1
+// TodaySpendCalculatorTests.swift — FinanceTests — Refs #2159
+
+import XCTest
+@testable import FinanceShared
+
+final class TodaySpendCalculatorTests: XCTestCase {
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+        return calendar
+    }()
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, hour: Int = 12) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        return calendar.date(from: components)!
+    }
+
+    // MARK: - Today spend
+
+    func testTodaySpendSumsOnlyTodaysOutflows() {
+        let today = date(2026, 6, 23)
+        let input = TodaySpendInput(
+            transactions: [
+                .init(amountMinorUnits: -1_200, date: date(2026, 6, 23, hour: 9), isDiscretionary: true),
+                .init(amountMinorUnits: -3_050, date: date(2026, 6, 23, hour: 19), isDiscretionary: false),
+                .init(amountMinorUnits: -9_999, date: date(2026, 6, 22), isDiscretionary: true), // yesterday
+                .init(amountMinorUnits: 50_000, date: date(2026, 6, 23, hour: 8), isDiscretionary: false), // income
+            ],
+            discretionaryBudgetMinorUnits: 25_000,
+            periodStart: date(2026, 6, 1),
+            periodEnd: date(2026, 6, 30),
+            referenceDate: today,
+            calendar: calendar
+        )
+
+        let summary = TodaySpendCalculator.summarize(input)
+
+        XCTAssertEqual(summary.todaySpentMinorUnits, 4_250)
+    }
+
+    func testIncomeNeverCountsAsSpend() {
+        let input = TodaySpendInput(
+            transactions: [
+                .init(amountMinorUnits: 12_345, date: date(2026, 6, 23), isDiscretionary: true),
+            ],
+            discretionaryBudgetMinorUnits: 25_000,
+            periodStart: date(2026, 6, 1),
+            periodEnd: date(2026, 6, 30),
+            referenceDate: date(2026, 6, 23),
+            calendar: calendar
+        )
+
+        let summary = TodaySpendCalculator.summarize(input)
+
+        XCTAssertEqual(summary.todaySpentMinorUnits, 0)
+        XCTAssertEqual(summary.periodDiscretionarySpentMinorUnits, 0)
+    }
+
+    // MARK: - Fun money
+
+    func testFunMoneyCountsOnlyDiscretionarySpendInPeriod() {
+        let input = TodaySpendInput(
+            transactions: [
+                .init(amountMinorUnits: -5_000, date: date(2026, 6, 10), isDiscretionary: true),
+                .init(amountMinorUnits: -4_000, date: date(2026, 6, 15), isDiscretionary: true),
+                .init(amountMinorUnits: -8_000, date: date(2026, 6, 15), isDiscretionary: false), // non-discretionary
+                .init(amountMinorUnits: -7_000, date: date(2026, 5, 31), isDiscretionary: true), // before period
+            ],
+            discretionaryBudgetMinorUnits: 25_000,
+            periodStart: date(2026, 6, 1),
+            periodEnd: date(2026, 6, 30),
+            referenceDate: date(2026, 6, 23),
+            calendar: calendar
+        )
+
+        let summary = TodaySpendCalculator.summarize(input)
+
+        XCTAssertEqual(summary.periodDiscretionarySpentMinorUnits, 9_000)
+        XCTAssertEqual(summary.funMoneyRemainingMinorUnits, 16_000)
+        XCTAssertFalse(summary.isOverFunBudget)
+        XCTAssertEqual(summary.funMoneyProgress, 0.36, accuracy: 0.0001)
+    }
+
+    func testFunMoneyGoesNegativeWhenOverspent() {
+        let input = TodaySpendInput(
+            transactions: [
+                .init(amountMinorUnits: -30_000, date: date(2026, 6, 15), isDiscretionary: true),
+            ],
+            discretionaryBudgetMinorUnits: 25_000,
+            periodStart: date(2026, 6, 1),
+            periodEnd: date(2026, 6, 30),
+            referenceDate: date(2026, 6, 23),
+            calendar: calendar
+        )
+
+        let summary = TodaySpendCalculator.summarize(input)
+
+        XCTAssertEqual(summary.funMoneyRemainingMinorUnits, -5_000)
+        XCTAssertTrue(summary.isOverFunBudget)
+        XCTAssertEqual(summary.funMoneyProgress, 1.0, accuracy: 0.0001) // clamped
+    }
+
+    func testPeriodBoundsAreInclusive() {
+        let input = TodaySpendInput(
+            transactions: [
+                .init(amountMinorUnits: -1_000, date: date(2026, 6, 1, hour: 0), isDiscretionary: true),
+                .init(amountMinorUnits: -2_000, date: date(2026, 6, 30, hour: 23), isDiscretionary: true),
+            ],
+            discretionaryBudgetMinorUnits: 25_000,
+            periodStart: date(2026, 6, 1, hour: 0),
+            periodEnd: date(2026, 6, 30, hour: 23),
+            referenceDate: date(2026, 6, 23),
+            calendar: calendar
+        )
+
+        let summary = TodaySpendCalculator.summarize(input)
+
+        XCTAssertEqual(summary.periodDiscretionarySpentMinorUnits, 3_000)
+    }
+
+    func testZeroBudgetReportsNoProgressAndNoBudget() {
+        let summary = TodaySpendSummary(
+            todaySpentMinorUnits: 1_000,
+            periodDiscretionarySpentMinorUnits: 2_000,
+            discretionaryBudgetMinorUnits: 0,
+            currencyCode: "USD",
+            updatedAt: .now
+        )
+
+        XCTAssertFalse(summary.hasDiscretionaryBudget)
+        XCTAssertEqual(summary.funMoneyProgress, 0)
+    }
+
+    func testEmptySummaryIsZeroedAndStale() {
+        let summary = TodaySpendSummary.empty()
+
+        XCTAssertEqual(summary.todaySpentMinorUnits, 0)
+        XCTAssertEqual(summary.discretionaryBudgetMinorUnits, 0)
+        XCTAssertTrue(TodaySpendFreshness.isStale(updatedAt: summary.updatedAt, now: .now))
+    }
+
+    // MARK: - Determinism & Codable
+
+    func testSummaryIsDeterministicForSameInput() {
+        let makeInput = {
+            TodaySpendInput(
+                transactions: [
+                    .init(amountMinorUnits: -1_111, date: self.date(2026, 6, 23), isDiscretionary: true),
+                    .init(amountMinorUnits: -2_222, date: self.date(2026, 6, 12), isDiscretionary: true),
+                ],
+                discretionaryBudgetMinorUnits: 25_000,
+                periodStart: self.date(2026, 6, 1),
+                periodEnd: self.date(2026, 6, 30),
+                referenceDate: self.date(2026, 6, 23),
+                updatedAt: self.date(2026, 6, 23, hour: 20),
+                calendar: self.calendar
+            )
+        }
+
+        XCTAssertEqual(TodaySpendCalculator.summarize(makeInput()), TodaySpendCalculator.summarize(makeInput()))
+    }
+
+    func testSummaryRoundTripsThroughCodable() throws {
+        let summary = TodaySpendSummary.empty(currencyCode: "EUR", updatedAt: date(2026, 6, 23, hour: 18))
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let data = try encoder.encode(summary)
+        let decoded = try decoder.decode(TodaySpendSummary.self, from: data)
+
+        XCTAssertEqual(decoded, summary)
+    }
+}
+
+// MARK: - Freshness & refresh policy (timeline entry logic)
+
+final class TodaySpendTimelineTests: XCTestCase {
+    func testFreshnessUsesSixHourThresholdByDefault() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let fresh = now.addingTimeInterval(-5 * 60 * 60)
+        let stale = now.addingTimeInterval(-7 * 60 * 60)
+
+        XCTAssertFalse(TodaySpendFreshness.isStale(updatedAt: fresh, now: now))
+        XCTAssertTrue(TodaySpendFreshness.isStale(updatedAt: stale, now: now))
+    }
+
+    func testFutureTimestampIsNeverStale() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let future = now.addingTimeInterval(60 * 60)
+
+        XCTAssertEqual(TodaySpendFreshness.age(of: future, now: now), 0)
+        XCTAssertFalse(TodaySpendFreshness.isStale(updatedAt: future, now: now))
+    }
+
+    func testRelaxedCadenceWhenFunBudgetHasHeadroom() {
+        let summary = TodaySpendSummary(
+            todaySpentMinorUnits: 1_000,
+            periodDiscretionarySpentMinorUnits: 5_000,
+            discretionaryBudgetMinorUnits: 25_000,
+            currencyCode: "USD",
+            updatedAt: .now
+        )
+
+        XCTAssertEqual(
+            TodaySpendRefreshPolicy.refreshInterval(for: summary),
+            TodaySpendRefreshPolicy.relaxedInterval
+        )
+    }
+
+    func testTightCadenceWhenFunBudgetNearlyDepleted() {
+        let summary = TodaySpendSummary(
+            todaySpentMinorUnits: 1_000,
+            periodDiscretionarySpentMinorUnits: 23_000,
+            discretionaryBudgetMinorUnits: 25_000,
+            currencyCode: "USD",
+            updatedAt: .now
+        )
+
+        XCTAssertGreaterThanOrEqual(summary.funMoneyProgress, TodaySpendRefreshPolicy.lowBudgetThreshold)
+        XCTAssertEqual(
+            TodaySpendRefreshPolicy.refreshInterval(for: summary),
+            TodaySpendRefreshPolicy.tightInterval
+        )
+    }
+
+    func testTightCadenceWhenOverBudget() {
+        let summary = TodaySpendSummary(
+            todaySpentMinorUnits: 1_000,
+            periodDiscretionarySpentMinorUnits: 30_000,
+            discretionaryBudgetMinorUnits: 25_000,
+            currencyCode: "USD",
+            updatedAt: .now
+        )
+
+        XCTAssertEqual(
+            TodaySpendRefreshPolicy.refreshInterval(for: summary),
+            TodaySpendRefreshPolicy.tightInterval
+        )
+    }
+
+    func testNextRefreshDateAdvancesByInterval() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let summary = TodaySpendSummary.empty()
+
+        let next = TodaySpendRefreshPolicy.nextRefreshDate(after: now, summary: summary)
+
+        XCTAssertEqual(
+            next.timeIntervalSince(now),
+            TodaySpendRefreshPolicy.refreshInterval(for: summary),
+            accuracy: 0.5
+        )
+        XCTAssertGreaterThan(next, now)
+    }
+}

--- a/apps/ios/Tests/WidgetRenderingTests.swift
+++ b/apps/ios/Tests/WidgetRenderingTests.swift
@@ -33,4 +33,35 @@ final class WidgetRenderingTests: XCTestCase {
         _ = QuickEntryWidgetView(entry: entry).environment(\.widgetFamily, .accessoryCircular)
         _ = QuickEntryWidgetView(entry: entry).environment(\.widgetFamily, .accessoryRectangular)
     }
+
+    func testTodaySpendViewsInstantiateForHomeScreenSizes() {
+        let entry = TodaySpendEntry(
+            date: .now,
+            summary: .placeholder,
+            maskingMode: .bucketed,
+            isStale: false
+        )
+
+        _ = TodaySpendWidgetView(entry: entry).environment(\.widgetFamily, .systemSmall)
+        _ = TodaySpendWidgetView(entry: entry).environment(\.widgetFamily, .systemMedium)
+    }
+
+    func testTodaySpendViewHandlesStaleAndOverBudgetState() {
+        let summary = TodaySpendSummary(
+            todaySpentMinorUnits: 9_900,
+            periodDiscretionarySpentMinorUnits: 30_000,
+            discretionaryBudgetMinorUnits: 25_000,
+            currencyCode: "USD",
+            updatedAt: .distantPast
+        )
+        let entry = TodaySpendEntry(
+            date: .now,
+            summary: summary,
+            maskingMode: .visible,
+            isStale: true
+        )
+
+        _ = TodaySpendWidgetView(entry: entry).environment(\.widgetFamily, .systemSmall)
+        _ = TodaySpendWidgetView(entry: entry).environment(\.widgetFamily, .systemMedium)
+    }
 }


### PR DESCRIPTION
## Summary
Adds a glance-first **Today Spend / Fun Money** Home Screen widget (small + medium) so the persona can answer "can I afford to go out tonight?" without opening the app.

### What's included
- **Deterministic computation** ( + "" + Shared/TodaySpendModel.swift + "" + ): pure, WidgetKit-free  + "" + TodaySpendCalculator + "" +  that reduces raw transactions (integer minor units) into a  + "" + TodaySpendSummary + "" +  — today's spend, period discretionary spend, and fun-money-remaining (can go negative). Income never counts as spend; period bounds are inclusive.
- **Freshness + refresh policy**:  + "" + TodaySpendFreshness + "" +  (6h staleness threshold) and  + "" + TodaySpendRefreshPolicy + "" +  (budget-aware cadence — tightens to 30m as fun money depletes / goes over).
- **Widget** ( + "" + FinanceWidget/TodaySpendWidget.swift + "" + ):  + "" + TimelineProvider + "" +  reading app-group cache only (never network),  + "" + .after + "" +  policy from the refresh planner, glanceable small/medium views with a fun-money chip + progress, staleness footnote, and full VoiceOver labels/values.
- **Privacy**: all money respects the user's  + "" + WidgetMaskingMode + "" +  (bucketed by default), preserving Lock Screen masking semantics.
- **Cache wiring**:  + "" + WidgetDataWriter.writeTodaySpend(_:) + "" +  computes + caches the summary and reloads the timeline.
- **Tests**: computation, fun-money/over-budget, inclusive bounds, Codable round-trip, determinism, freshness, and refresh-cadence logic, plus widget view instantiation across families/states.

### Needs Human Action
-  + "" + WidgetDataWriter.writeTodaySpend(_:) + "" +  is marked  + "" + // TODO(human) + "" + : it must be called from the live transaction-save and sync-completion paths (KMP  + "" + SyncManager + "" +  + transaction create/edit view models). The widget cache has no app-side call sites today (noted in the issue); wiring requires the live transaction + budget data flow, which is outside this widget-only change.

Closes #2159

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>