### PR TITLE
feat(core): currency-aware money model for foreign spend (#2202)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/money/ForeignTransactionEntry.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/money/ForeignTransactionEntry.kt
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.money
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+/**
+ * An exchange rate quoted in **major units**: one major unit of [from] equals
+ * [rate] major units of [to] (e.g. `1 EUR = 1.085 USD`).
+ *
+ * Quoting in major units matches how users read FX rates and how rate feeds
+ * publish them. The minor-unit scale difference between currencies (e.g.
+ * JPY has 0 decimals, USD has 2) is handled by [MoneyConverter], not by the
+ * caller, so the same rate value works regardless of either currency's decimals.
+ *
+ * @property from Source currency.
+ * @property to Target currency.
+ * @property rate Major-unit multiplier (`1 from = rate to`). Must be > 0.
+ * @property asOf Timestamp the rate was observed/quoted.
+ */
+@Serializable
+data class MoneyRate(
+    val from: Currency,
+    val to: Currency,
+    val rate: Double,
+    val asOf: Instant,
+) {
+    init {
+        require(rate > 0.0) { "Exchange rate must be positive, was $rate" }
+    }
+
+    /** The inverse quote (`1 to = 1/rate from`), preserving [asOf]. */
+    val inverse: MoneyRate get() = MoneyRate(to, from, 1.0 / rate, asOf)
+}
+
+/**
+ * Pure abstraction over a source of exchange rates.
+ *
+ * Implementations live outside `commonMain` business logic (network client,
+ * on-device cache, user-supplied rate, …). The domain layer never hardcodes
+ * rates or API keys — it only depends on this interface.
+ *
+ * Implementations should return `null` when no rate is available for the
+ * requested pair/time rather than throwing, so callers can decide how to
+ * degrade (e.g. ask the user for a manual rate).
+ */
+fun interface MoneyRateProvider {
+    /**
+     * @param from Source currency.
+     * @param to Target currency.
+     * @param at Point in time the rate is needed for (entry time).
+     * @return A [MoneyRate] for `from → to`, or `null` if unavailable.
+     */
+    fun rateFor(from: Currency, to: Currency, at: Instant): MoneyRate?
+}
+
+/**
+ * Decimal-place-aware currency conversion.
+ *
+ * The critical correctness rule for foreign spend: a [Money] amount is stored
+ * in the *minor units of its own currency*, but currencies have different
+ * minor-unit scales. Converting minor units directly with a major-unit rate is
+ * only correct when both currencies share the same number of decimal places.
+ *
+ * For the general case we rescale by `10^(targetDecimals - sourceDecimals)`:
+ *
+ * ```
+ * targetMinor = round_half_even( sourceMinor * rate * 10^(targetDec - sourceDec) )
+ * ```
+ *
+ * Worked examples:
+ *  - `€100.00 → USD @ 1.085` : `10000 * 1.085 * 10^0   = 10850` → `$108.50`
+ *  - `¥1000   → USD @ 0.0067`: `1000  * 0.0067 * 10^2  = 670`   → `$6.70`
+ *  - `$6.70   → JPY @ 149.25`: `670   * 149.25 * 10^-2 ≈ 1000`  → `¥1000`
+ */
+object MoneyConverter {
+
+    /**
+     * Convert [amount] into [target] using a major-unit [rate], applying the
+     * minor-unit rescale and banker's rounding (round half to even).
+     *
+     * When [amount] is already in [target] the original amount is returned
+     * unchanged (rate is treated as the identity).
+     *
+     * @throws IllegalArgumentException when [rate] is not positive.
+     */
+    fun convert(amount: Money, target: Currency, rate: Double): Money {
+        if (amount.currency == target) return amount
+        require(rate > 0.0) { "Exchange rate must be positive, was $rate" }
+
+        val sourceDecimals = amount.currency.decimalPlaces
+        val targetDecimals = target.decimalPlaces
+        val scaleDiff = targetDecimals - sourceDecimals
+
+        val scaled = amount.cents.amount.toDouble() * rate * pow10(scaleDiff)
+        return Money(Cents(MoneyOperations.bankersRound(scaled)), target)
+    }
+
+    /**
+     * Convert [amount] using a [MoneyRate]. The rate's [MoneyRate.from] must
+     * match the amount's currency.
+     *
+     * @throws IllegalArgumentException when the rate's source currency does not
+     *   match [amount]'s currency.
+     */
+    fun convert(amount: Money, rate: MoneyRate): Money {
+        require(rate.from == amount.currency) {
+            "Rate source ${rate.from.code} does not match amount currency ${amount.currency.code}"
+        }
+        return convert(amount, rate.to, rate.rate)
+    }
+
+    private fun pow10(exponent: Int): Double {
+        var result = 1.0
+        val magnitude = kotlin.math.abs(exponent)
+        repeat(magnitude) { result *= 10.0 }
+        return if (exponent < 0) 1.0 / result else result
+    }
+}
+
+/**
+ * Source of the exchange rate captured on a foreign transaction.
+ */
+@Serializable
+enum class RateSource {
+    /** Rate obtained from a [MoneyRateProvider] (live or cached feed). */
+    PROVIDER,
+
+    /** Rate entered/overridden by the user (e.g. the rate printed on a receipt). */
+    MANUAL,
+
+    /** Both currencies were identical; no conversion was needed. */
+    NONE,
+}
+
+/**
+ * An immutable record of a transaction entered in a (possibly foreign) currency.
+ *
+ * This separates the **entered amount** — what the user actually paid in the
+ * local currency — from the **base amount** in the account/home currency, while
+ * preserving every input needed to audit or recompute the conversion: the rate,
+ * its timestamp, its source, and any explicit fee.
+ *
+ * Invariants:
+ *  - [enteredAmount] and [baseAmount] always carry their own currency.
+ *  - When [enteredAmount] is already in [baseAmount]'s currency the rate is
+ *    `1.0`, [rateSource] is [RateSource.NONE], and the two amounts match
+ *    (plus any [feeAmount]).
+ *  - [feeAmount], when present, is expressed in the base currency and is **not**
+ *    folded into [baseAmount]; it is tracked separately so totals and the FX
+ *    markup remain transparent.
+ *
+ * @property enteredAmount Amount in the currency the user actually paid in.
+ * @property baseAmount Converted amount in the account/home base currency.
+ * @property exchangeRate Major-unit rate applied (entered → base); `1.0` when same currency.
+ * @property rateTimestamp When the applied rate was observed.
+ * @property rateSource Where [exchangeRate] came from.
+ * @property feeAmount Optional explicit FX/card fee, in the base currency.
+ */
+@Serializable
+data class ForeignTransactionEntry(
+    val enteredAmount: Money,
+    val baseAmount: Money,
+    val exchangeRate: Double,
+    val rateTimestamp: Instant,
+    val rateSource: RateSource,
+    val feeAmount: Money? = null,
+) {
+    init {
+        require(exchangeRate > 0.0) { "Exchange rate must be positive, was $exchangeRate" }
+        feeAmount?.let {
+            require(it.currency == baseAmount.currency) {
+                "Fee currency ${it.currency.code} must match base currency ${baseAmount.currency.code}"
+            }
+            require(!it.isNegative()) { "Fee amount must not be negative" }
+        }
+    }
+
+    /** `true` when the entry was made directly in the base currency (no FX). */
+    val isSameCurrency: Boolean get() = enteredAmount.currency == baseAmount.currency
+
+    /**
+     * Total impact on the base currency: the converted amount plus any explicit
+     * fee. When no fee is recorded this equals [baseAmount].
+     */
+    val baseTotalWithFee: Money
+        get() = feeAmount?.let { baseAmount + it } ?: baseAmount
+}
+
+/**
+ * Builds [ForeignTransactionEntry] records from an entered [Money] amount,
+ * resolving the rate via a [MoneyRateProvider] (or an explicit manual override)
+ * and recording everything needed to reproduce the conversion.
+ *
+ * Pure and stateless — all inputs are passed explicitly so the same call always
+ * yields the same result.
+ */
+object ForeignTransactionEntryBuilder {
+
+    /**
+     * Build an entry, fetching the rate from [provider] at [at].
+     *
+     * @param entered The amount the user paid, in its local currency.
+     * @param baseCurrency The account/home currency to convert into.
+     * @param provider Rate source for `entered.currency → baseCurrency`.
+     * @param at Entry timestamp used to query and stamp the rate.
+     * @param fee Optional explicit FX/card fee, expressed in [baseCurrency].
+     * @return A populated [ForeignTransactionEntry], or `null` when [provider]
+     *   has no rate for the pair (caller may then prompt for a manual rate).
+     */
+    @Suppress("ReturnCount")
+    fun build(
+        entered: Money,
+        baseCurrency: Currency,
+        provider: MoneyRateProvider,
+        at: Instant,
+        fee: Money? = null,
+    ): ForeignTransactionEntry? {
+        if (entered.currency == baseCurrency) {
+            return sameCurrencyEntry(entered, at, fee)
+        }
+        val rate = provider.rateFor(entered.currency, baseCurrency, at) ?: return null
+        val base = MoneyConverter.convert(entered, rate)
+        return ForeignTransactionEntry(
+            enteredAmount = entered,
+            baseAmount = base,
+            exchangeRate = rate.rate,
+            rateTimestamp = rate.asOf,
+            rateSource = RateSource.PROVIDER,
+            feeAmount = fee,
+        )
+    }
+
+    /**
+     * Build an entry using a user-supplied [rate] (e.g. the rate printed on a
+     * receipt). Records [RateSource.MANUAL].
+     *
+     * @param entered The amount the user paid, in its local currency.
+     * @param baseCurrency The account/home currency to convert into.
+     * @param rate Major-unit rate (`1 entered = rate base`). Must be > 0.
+     * @param at Entry timestamp used to stamp the manual rate.
+     * @param fee Optional explicit FX/card fee, expressed in [baseCurrency].
+     */
+    fun buildWithManualRate(
+        entered: Money,
+        baseCurrency: Currency,
+        rate: Double,
+        at: Instant,
+        fee: Money? = null,
+    ): ForeignTransactionEntry {
+        require(rate > 0.0) { "Exchange rate must be positive, was $rate" }
+        if (entered.currency == baseCurrency) {
+            return sameCurrencyEntry(entered, at, fee)
+        }
+        val base = MoneyConverter.convert(entered, baseCurrency, rate)
+        return ForeignTransactionEntry(
+            enteredAmount = entered,
+            baseAmount = base,
+            exchangeRate = rate,
+            rateTimestamp = at,
+            rateSource = RateSource.MANUAL,
+            feeAmount = fee,
+        )
+    }
+
+    private fun sameCurrencyEntry(
+        entered: Money,
+        at: Instant,
+        fee: Money?,
+    ): ForeignTransactionEntry = ForeignTransactionEntry(
+        enteredAmount = entered,
+        baseAmount = entered,
+        exchangeRate = 1.0,
+        rateTimestamp = at,
+        rateSource = RateSource.NONE,
+        feeAmount = fee,
+    )
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/money/Money.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/money/Money.kt
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.money
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.serialization.Serializable
+
+/**
+ * A currency-aware monetary amount.
+ *
+ * Unlike the raw [Cents] type — which is a currency-agnostic Long count of
+ * minor units — [Money] always pairs an amount with its [Currency]. This makes
+ * it impossible to silently add USD to EUR, and it carries the per-currency
+ * minor-unit scale (2 for USD, 0 for JPY/KRW/VND, 3 for BHD/KWD/OMR) needed for
+ * correct entry, display, and conversion of foreign spend.
+ *
+ * The stored [cents] are always in the *minor units* of [currency]:
+ *  - `$12.34` → `Money(Cents(1234), USD)`
+ *  - `¥500`   → `Money(Cents(500), JPY)`   (0 decimal places)
+ *  - `1.234 BD` → `Money(Cents(1234), BHD)` (3 decimal places)
+ *
+ * All arithmetic stays in `Long` minor units — never floating point — and
+ * same-currency operations are enforced at runtime.
+ *
+ * @property cents The amount in the minor units of [currency].
+ * @property currency The ISO 4217 currency of this amount.
+ */
+@Serializable
+data class Money(
+    val cents: Cents,
+    val currency: Currency,
+) : Comparable<Money> {
+
+    /** Number of minor-unit decimal places for this money's currency. */
+    val decimalPlaces: Int get() = currency.decimalPlaces
+
+    /** Raw minor-unit amount (e.g. cents for USD). */
+    val minorUnits: Long get() = cents.amount
+
+    /** `true` when the amount is greater than zero. */
+    fun isPositive(): Boolean = cents.isPositive()
+
+    /** `true` when the amount is less than zero. */
+    fun isNegative(): Boolean = cents.isNegative()
+
+    /** `true` when the amount is exactly zero. */
+    fun isZero(): Boolean = cents.isZero()
+
+    /** Absolute value, preserving currency. */
+    fun abs(): Money = Money(cents.abs(), currency)
+
+    /** Negated amount, preserving currency. */
+    operator fun unaryMinus(): Money = Money(-cents, currency)
+
+    /**
+     * Add two amounts of the **same** currency.
+     * @throws IllegalArgumentException when currencies differ.
+     */
+    operator fun plus(other: Money): Money {
+        requireSameCurrency(other)
+        return Money(cents + other.cents, currency)
+    }
+
+    /**
+     * Subtract an amount of the **same** currency.
+     * @throws IllegalArgumentException when currencies differ.
+     */
+    operator fun minus(other: Money): Money {
+        requireSameCurrency(other)
+        return Money(cents - other.cents, currency)
+    }
+
+    /** Scale by an integer factor (e.g. quantity), preserving currency. */
+    operator fun times(factor: Int): Money = Money(cents * factor, currency)
+
+    /**
+     * Compare two amounts of the **same** currency.
+     * @throws IllegalArgumentException when currencies differ.
+     */
+    override fun compareTo(other: Money): Int {
+        requireSameCurrency(other)
+        return cents.compareTo(other.cents)
+    }
+
+    /**
+     * Render the amount as a plain, locale-neutral decimal string with the
+     * correct number of fractional digits for the currency, e.g. `"12.34"`,
+     * `"500"` (JPY), `"1.234"` (BHD). No symbol or grouping separators —
+     * presentation belongs to the formatting layer.
+     */
+    fun toPlainString(): String {
+        val negative = cents.amount < 0
+        val absMinor = if (negative) {
+            // Guard against Long.MIN_VALUE overflow on negation.
+            if (cents.amount == Long.MIN_VALUE) {
+                return "-" + buildPlain(Long.MIN_VALUE.toULong().toString())
+            }
+            -cents.amount
+        } else {
+            cents.amount
+        }
+        val body = buildPlain(absMinor.toString())
+        return if (negative) "-$body" else body
+    }
+
+    private fun buildPlain(absDigits: String): String {
+        if (decimalPlaces == 0) return absDigits
+        val padded = absDigits.padStart(decimalPlaces + 1, '0')
+        val splitAt = padded.length - decimalPlaces
+        val whole = padded.substring(0, splitAt)
+        val frac = padded.substring(splitAt)
+        return "$whole.$frac"
+    }
+
+    private fun requireSameCurrency(other: Money) {
+        require(currency == other.currency) {
+            "Currency mismatch: ${currency.code} vs ${other.currency.code}"
+        }
+    }
+
+    companion object {
+        /** Zero amount in the given currency. */
+        fun zero(currency: Currency): Money = Money(Cents.ZERO, currency)
+
+        /**
+         * Construct from a raw minor-unit amount in [currency].
+         * @param minorUnits Amount in minor units (cents, yen, fils, …).
+         */
+        fun ofMinor(minorUnits: Long, currency: Currency): Money =
+            Money(Cents(minorUnits), currency)
+
+        /**
+         * Construct from separated whole and fractional components.
+         *
+         * The [fraction] is interpreted as digits of the currency's minor unit
+         * and must be in `0 until 10^decimalPlaces`. For zero-decimal currencies
+         * (e.g. JPY) [fraction] must be `0`.
+         *
+         * Examples:
+         *  - `ofMajor(12, 34, USD)` → `$12.34`
+         *  - `ofMajor(500, 0, JPY)` → `¥500`
+         *  - `ofMajor(1, 234, BHD)` → `1.234 BD`
+         *
+         * @throws IllegalArgumentException for a negative [fraction] or one that
+         *   does not fit the currency's decimal places.
+         */
+        fun ofMajor(whole: Long, fraction: Long, currency: Currency): Money {
+            val decimals = currency.decimalPlaces
+            val scale = pow10(decimals)
+            require(fraction in 0 until maxOf(scale, 1L)) {
+                "Fraction $fraction out of range for ${currency.code} " +
+                    "($decimals decimal place(s))"
+            }
+            val sign = if (whole < 0) -1L else 1L
+            val magnitude = kotlin.math.abs(whole) * scale + fraction
+            return Money(Cents(sign * magnitude), currency)
+        }
+
+        /**
+         * Construct from a whole major-unit amount with no fractional part,
+         * e.g. `ofWholeMajor(20, USD)` → `$20.00`, `ofWholeMajor(500, JPY)` → `¥500`.
+         */
+        fun ofWholeMajor(whole: Long, currency: Currency): Money =
+            ofMajor(whole, 0, currency)
+
+        internal fun pow10(n: Int): Long {
+            var result = 1L
+            repeat(n) { result *= 10 }
+            return result
+        }
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/money/ForeignTransactionEntryTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/money/ForeignTransactionEntryTest.kt
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.money
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ForeignTransactionEntryTest {
+
+    private val usd = Currency.USD
+    private val eur = Currency.EUR
+    private val jpy = Currency.JPY
+    private val thb = Currency("THB")
+    private val mxn = Currency("MXN")
+    private val now = Instant.fromEpochSeconds(1_700_000_000L)
+
+    /** Simple in-memory rate provider for tests — no hardcoded rates in prod code. */
+    private fun providerOf(vararg rates: Pair<Pair<Currency, Currency>, Double>): MoneyRateProvider {
+        val table = rates.toMap()
+        return MoneyRateProvider { from, to, at ->
+            table[from to to]?.let { MoneyRate(from, to, it, at) }
+        }
+    }
+
+    // ── MoneyRate ───────────────────────────────────────────────────
+
+    @Test
+    fun moneyRate_rejectsNonPositive() {
+        assertFailsWith<IllegalArgumentException> { MoneyRate(eur, usd, 0.0, now) }
+        assertFailsWith<IllegalArgumentException> { MoneyRate(eur, usd, -1.0, now) }
+    }
+
+    @Test
+    fun moneyRate_inverse() {
+        val r = MoneyRate(eur, usd, 1.25, now)
+        val inv = r.inverse
+        assertEquals(usd, inv.from)
+        assertEquals(eur, inv.to)
+        assertEquals(0.8, inv.rate, 1e-9)
+        assertEquals(now, inv.asOf)
+    }
+
+    // ── MoneyConverter: same-decimal currencies ─────────────────────
+
+    @Test
+    fun convert_eurToUsd_sameDecimals() {
+        val euros = Money.ofMajor(100, 0, eur) // €100.00
+        val dollars = MoneyConverter.convert(euros, usd, 1.085)
+        assertEquals(Money.ofMinor(10850, usd), dollars) // $108.50
+    }
+
+    @Test
+    fun convert_sameCurrency_returnsUnchanged() {
+        val m = Money.ofMinor(5000, usd)
+        assertEquals(m, MoneyConverter.convert(m, usd, 999.0))
+    }
+
+    @Test
+    fun convert_rejectsNonPositiveRate() {
+        assertFailsWith<IllegalArgumentException> {
+            MoneyConverter.convert(Money.ofMinor(100, eur), usd, 0.0)
+        }
+    }
+
+    // ── MoneyConverter: cross-decimal currencies (the hard case) ────
+
+    @Test
+    fun convert_jpyToUsd_zeroToTwoDecimals() {
+        // ¥1000 at 1 JPY = 0.0067 USD → $6.70
+        val yen = Money.ofMinor(1000, jpy)
+        val dollars = MoneyConverter.convert(yen, usd, 0.0067)
+        assertEquals(Money.ofMinor(670, usd), dollars)
+    }
+
+    @Test
+    fun convert_usdToJpy_twoToZeroDecimals() {
+        // $6.70 at 1 USD = 149.25 JPY → ¥1000
+        val dollars = Money.ofMinor(670, usd)
+        val yen = MoneyConverter.convert(dollars, jpy, 149.25)
+        assertEquals(Money.ofMinor(1000, jpy), yen)
+    }
+
+    @Test
+    fun convert_thbToUsd_nomadCashWithdrawal() {
+        // ฿5000 (THB, 2 decimals stored as 500000 minor) at 1 THB = 0.0274 USD
+        val baht = Money.ofMajor(5000, 0, thb)
+        val dollars = MoneyConverter.convert(baht, usd, 0.0274)
+        // 500000 * 0.0274 = 13700 → $137.00
+        assertEquals(Money.ofMinor(13700, usd), dollars)
+    }
+
+    @Test
+    fun convert_viaMoneyRate_matchesSourceCurrency() {
+        val rate = MoneyRate(eur, usd, 1.085, now)
+        val result = MoneyConverter.convert(Money.ofMajor(100, 0, eur), rate)
+        assertEquals(Money.ofMinor(10850, usd), result)
+    }
+
+    @Test
+    fun convert_viaMoneyRate_currencyMismatch_throws() {
+        val rate = MoneyRate(eur, usd, 1.085, now)
+        assertFailsWith<IllegalArgumentException> {
+            MoneyConverter.convert(Money.ofMinor(100, mxn), rate)
+        }
+    }
+
+    // ── Banker's rounding through conversion ────────────────────────
+
+    @Test
+    fun convert_bankersRounding_halfToEven() {
+        // 1 minor unit EUR * rate → exactly .5 boundaries, same decimals (scale 1)
+        assertEquals(Cents(2L), MoneyConverter.convert(Money.ofMinor(1, eur), usd, 2.5).cents)
+        assertEquals(Cents(4L), MoneyConverter.convert(Money.ofMinor(1, eur), usd, 3.5).cents)
+        assertEquals(Cents(2L), MoneyConverter.convert(Money.ofMinor(1, eur), usd, 1.5).cents)
+    }
+
+    // ── Builder: provider path ──────────────────────────────────────
+
+    @Test
+    fun build_foreignCurrency_recordsRateAndOriginal() {
+        val provider = providerOf((eur to usd) to 1.085)
+        val entry = ForeignTransactionEntryBuilder.build(
+            entered = Money.ofMajor(100, 0, eur),
+            baseCurrency = usd,
+            provider = provider,
+            at = now,
+        )
+        assertNotNull(entry)
+        assertFalse(entry.isSameCurrency)
+        assertEquals(Money.ofMajor(100, 0, eur), entry.enteredAmount)
+        assertEquals(Money.ofMinor(10850, usd), entry.baseAmount)
+        assertEquals(1.085, entry.exchangeRate)
+        assertEquals(now, entry.rateTimestamp)
+        assertEquals(RateSource.PROVIDER, entry.rateSource)
+        assertNull(entry.feeAmount)
+    }
+
+    @Test
+    fun build_missingRate_returnsNull() {
+        val provider = providerOf() // empty
+        val entry = ForeignTransactionEntryBuilder.build(
+            entered = Money.ofMajor(100, 0, mxn),
+            baseCurrency = usd,
+            provider = provider,
+            at = now,
+        )
+        assertNull(entry)
+    }
+
+    @Test
+    fun build_sameCurrency_noConversion() {
+        val provider = providerOf() // not consulted
+        val entry = ForeignTransactionEntryBuilder.build(
+            entered = Money.ofMinor(5000, usd),
+            baseCurrency = usd,
+            provider = provider,
+            at = now,
+        )
+        assertNotNull(entry)
+        assertTrue(entry.isSameCurrency)
+        assertEquals(entry.enteredAmount, entry.baseAmount)
+        assertEquals(1.0, entry.exchangeRate)
+        assertEquals(RateSource.NONE, entry.rateSource)
+    }
+
+    @Test
+    fun build_withFee_tracksFeeSeparately() {
+        val provider = providerOf((eur to usd) to 1.10)
+        val fee = Money.ofMinor(150, usd) // $1.50 card fee
+        val entry = ForeignTransactionEntryBuilder.build(
+            entered = Money.ofMajor(100, 0, eur),
+            baseCurrency = usd,
+            provider = provider,
+            at = now,
+            fee = fee,
+        )
+        assertNotNull(entry)
+        assertEquals(Money.ofMinor(11000, usd), entry.baseAmount)
+        assertEquals(fee, entry.feeAmount)
+        // Fee is not folded into baseAmount, but reflected in the total.
+        assertEquals(Money.ofMinor(11150, usd), entry.baseTotalWithFee)
+    }
+
+    // ── Builder: manual rate path ───────────────────────────────────
+
+    @Test
+    fun buildWithManualRate_recordsManualSource() {
+        val entry = ForeignTransactionEntryBuilder.buildWithManualRate(
+            entered = Money.ofMajor(1000, 0, mxn), // MX$1000.00
+            baseCurrency = usd,
+            rate = 0.058, // receipt rate
+            at = now,
+        )
+        // 100000 minor * 0.058 = 5800 → $58.00
+        assertEquals(Money.ofMinor(5800, usd), entry.baseAmount)
+        assertEquals(RateSource.MANUAL, entry.rateSource)
+        assertEquals(0.058, entry.exchangeRate)
+    }
+
+    @Test
+    fun buildWithManualRate_sameCurrency_isNone() {
+        val entry = ForeignTransactionEntryBuilder.buildWithManualRate(
+            entered = Money.ofMinor(2500, usd),
+            baseCurrency = usd,
+            rate = 1.23,
+            at = now,
+        )
+        assertTrue(entry.isSameCurrency)
+        assertEquals(RateSource.NONE, entry.rateSource)
+        assertEquals(1.0, entry.exchangeRate)
+    }
+
+    @Test
+    fun buildWithManualRate_rejectsNonPositiveRate() {
+        assertFailsWith<IllegalArgumentException> {
+            ForeignTransactionEntryBuilder.buildWithManualRate(
+                entered = Money.ofMinor(100, eur),
+                baseCurrency = usd,
+                rate = 0.0,
+                at = now,
+            )
+        }
+    }
+
+    // ── Entry invariants ────────────────────────────────────────────
+
+    @Test
+    fun entry_feeCurrencyMustMatchBase() {
+        assertFailsWith<IllegalArgumentException> {
+            ForeignTransactionEntry(
+                enteredAmount = Money.ofMinor(10000, eur),
+                baseAmount = Money.ofMinor(10850, usd),
+                exchangeRate = 1.085,
+                rateTimestamp = now,
+                rateSource = RateSource.PROVIDER,
+                feeAmount = Money.ofMinor(100, eur), // wrong currency
+            )
+        }
+    }
+
+    @Test
+    fun entry_feeMustNotBeNegative() {
+        assertFailsWith<IllegalArgumentException> {
+            ForeignTransactionEntry(
+                enteredAmount = Money.ofMinor(10000, eur),
+                baseAmount = Money.ofMinor(10850, usd),
+                exchangeRate = 1.085,
+                rateTimestamp = now,
+                rateSource = RateSource.PROVIDER,
+                feeAmount = Money.ofMinor(-100, usd),
+            )
+        }
+    }
+
+    @Test
+    fun entry_rejectsNonPositiveRate() {
+        assertFailsWith<IllegalArgumentException> {
+            ForeignTransactionEntry(
+                enteredAmount = Money.ofMinor(10000, eur),
+                baseAmount = Money.ofMinor(10850, usd),
+                exchangeRate = 0.0,
+                rateTimestamp = now,
+                rateSource = RateSource.PROVIDER,
+            )
+        }
+    }
+
+    @Test
+    fun entry_baseTotalWithoutFee_equalsBase() {
+        val entry = ForeignTransactionEntryBuilder.buildWithManualRate(
+            entered = Money.ofMajor(100, 0, eur),
+            baseCurrency = usd,
+            rate = 1.085,
+            at = now,
+        )
+        assertEquals(entry.baseAmount, entry.baseTotalWithFee)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/money/MoneyTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/money/MoneyTest.kt
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.money
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MoneyTest {
+
+    private val jpy = Currency.JPY
+    private val usd = Currency.USD
+    private val eur = Currency.EUR
+    private val bhd = Currency("BHD") // 3 decimal places
+
+    // ── Construction ────────────────────────────────────────────────
+
+    @Test
+    fun ofMinor_storesRawMinorUnits() {
+        val m = Money.ofMinor(1234, usd)
+        assertEquals(1234L, m.minorUnits)
+        assertEquals(usd, m.currency)
+        assertEquals(2, m.decimalPlaces)
+    }
+
+    @Test
+    fun ofMajor_twoDecimalCurrency() {
+        val m = Money.ofMajor(12, 34, usd)
+        assertEquals(Cents(1234L), m.cents)
+    }
+
+    @Test
+    fun ofMajor_zeroDecimalCurrency() {
+        val m = Money.ofMajor(500, 0, jpy)
+        assertEquals(Cents(500L), m.cents)
+        assertEquals(0, m.decimalPlaces)
+    }
+
+    @Test
+    fun ofMajor_threeDecimalCurrency() {
+        val m = Money.ofMajor(1, 234, bhd)
+        assertEquals(Cents(1234L), m.cents)
+        assertEquals(3, m.decimalPlaces)
+    }
+
+    @Test
+    fun ofMajor_negativeWhole() {
+        val m = Money.ofMajor(-12, 34, usd)
+        assertEquals(Cents(-1234L), m.cents)
+    }
+
+    @Test
+    fun ofMajor_rejectsFractionOutOfRange() {
+        assertFailsWith<IllegalArgumentException> { Money.ofMajor(1, 100, usd) }
+        assertFailsWith<IllegalArgumentException> { Money.ofMajor(1, 1, jpy) }
+        assertFailsWith<IllegalArgumentException> { Money.ofMajor(1, -1, usd) }
+    }
+
+    @Test
+    fun ofWholeMajor_addsNoFraction() {
+        assertEquals(Cents(2000L), Money.ofWholeMajor(20, usd).cents)
+        assertEquals(Cents(500L), Money.ofWholeMajor(500, jpy).cents)
+    }
+
+    @Test
+    fun zero_isZeroInCurrency() {
+        val z = Money.zero(eur)
+        assertTrue(z.isZero())
+        assertEquals(eur, z.currency)
+    }
+
+    // ── Arithmetic (same currency) ──────────────────────────────────
+
+    @Test
+    fun plus_sameCurrency() {
+        val sum = Money.ofMinor(1000, usd) + Money.ofMinor(250, usd)
+        assertEquals(Money.ofMinor(1250, usd), sum)
+    }
+
+    @Test
+    fun minus_sameCurrency() {
+        val diff = Money.ofMinor(1000, usd) - Money.ofMinor(250, usd)
+        assertEquals(Money.ofMinor(750, usd), diff)
+    }
+
+    @Test
+    fun times_scalesByFactor() {
+        assertEquals(Money.ofMinor(3000, usd), Money.ofMinor(1000, usd) * 3)
+    }
+
+    @Test
+    fun unaryMinus_negates() {
+        assertEquals(Money.ofMinor(-1000, usd), -Money.ofMinor(1000, usd))
+    }
+
+    @Test
+    fun abs_returnsMagnitude() {
+        assertEquals(Money.ofMinor(1000, usd), Money.ofMinor(-1000, usd).abs())
+        assertEquals(Money.ofMinor(1000, usd), Money.ofMinor(1000, usd).abs())
+    }
+
+    // ── Arithmetic (currency mismatch) ──────────────────────────────
+
+    @Test
+    fun plus_currencyMismatch_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            Money.ofMinor(1000, usd) + Money.ofMinor(1000, eur)
+        }
+    }
+
+    @Test
+    fun minus_currencyMismatch_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            Money.ofMinor(1000, usd) - Money.ofMinor(1000, eur)
+        }
+    }
+
+    @Test
+    fun compareTo_currencyMismatch_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            Money.ofMinor(1000, usd).compareTo(Money.ofMinor(1000, eur))
+        }
+    }
+
+    // ── Comparison & predicates ─────────────────────────────────────
+
+    @Test
+    fun compareTo_sameCurrency() {
+        assertTrue(Money.ofMinor(2000, usd) > Money.ofMinor(1000, usd))
+        assertTrue(Money.ofMinor(500, usd) < Money.ofMinor(1000, usd))
+        assertEquals(0, Money.ofMinor(1000, usd).compareTo(Money.ofMinor(1000, usd)))
+    }
+
+    @Test
+    fun predicates() {
+        assertTrue(Money.ofMinor(1, usd).isPositive())
+        assertTrue(Money.ofMinor(-1, usd).isNegative())
+        assertTrue(Money.zero(usd).isZero())
+        assertFalse(Money.ofMinor(1, usd).isNegative())
+    }
+
+    // ── Plain string rendering ──────────────────────────────────────
+
+    @Test
+    fun toPlainString_twoDecimals() {
+        assertEquals("12.34", Money.ofMinor(1234, usd).toPlainString())
+        assertEquals("0.05", Money.ofMinor(5, usd).toPlainString())
+        assertEquals("0.00", Money.zero(usd).toPlainString())
+        assertEquals("-12.34", Money.ofMinor(-1234, usd).toPlainString())
+    }
+
+    @Test
+    fun toPlainString_zeroDecimals() {
+        assertEquals("500", Money.ofMinor(500, jpy).toPlainString())
+        assertEquals("-500", Money.ofMinor(-500, jpy).toPlainString())
+        assertEquals("0", Money.zero(jpy).toPlainString())
+    }
+
+    @Test
+    fun toPlainString_threeDecimals() {
+        assertEquals("1.234", Money.ofMinor(1234, bhd).toPlainString())
+        assertEquals("0.007", Money.ofMinor(7, bhd).toPlainString())
+    }
+
+    // ── Overflow safety inherited from Cents ────────────────────────
+
+    @Test
+    fun plus_overflow_throws() {
+        assertFailsWith<ArithmeticException> {
+            Money.ofMinor(Long.MAX_VALUE, usd) + Money.ofMinor(1, usd)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Shared-core (KMP `commonMain`) portion of #2202 — give the domain a **currency-aware money model** so foreign spend can be captured in the currency actually paid, with the rate and original amount preserved. No UI and no schema changes.

### What's added (`packages/core/.../money/`)

- **`Money`** — a currency-aware value type pairing `Cents` (Long minor units) with a `Currency`. Replaces USD/cents-only assumptions:
  - Minor-unit aware (`2` for USD, `0` for JPY/KRW/VND, `3` for BHD/KWD/OMR) via `Currency.decimalPlaces`.
  - Same-currency-enforced `plus`/`minus`/`compareTo` (mismatch throws), `times`, `abs`, unary minus.
  - Constructors: `ofMinor`, `ofMajor(whole, fraction)`, `ofWholeMajor`, `zero`; locale-neutral `toPlainString()`.
  - Overflow safety inherited from `Cents`.
- **`MoneyRate` / `MoneyRateProvider`** — a pure rate abstraction (`fun interface`). **No hardcoded rates or API keys**; implementations live outside the domain and return `null` when unavailable so callers can fall back to a manual rate.
- **`MoneyConverter`** — **decimal-place-aware** conversion: rescales by `10^(targetDec − sourceDec)` so cross-decimal pairs are correct (e.g. `¥1000 → $6.70`, `$6.70 → ¥1000`), with **banker's rounding** (HALF_EVEN). Same-decimal pairs (EUR↔USD) are unchanged from existing behavior.
- **`ForeignTransactionEntry`** + **`ForeignTransactionEntryBuilder`** — separates the **entered amount** (local currency) from the **base amount** (home currency) and records everything needed to audit/recompute the conversion: rate, rate timestamp, `RateSource` (`PROVIDER` / `MANUAL` / `NONE`), and an optional FX/card **fee** tracked separately (not folded into the base amount). Provider path and manual-rate path included.

### Tests (`commonTest`)

- `MoneyTest` — construction, arithmetic, currency-mismatch guards, 0/2/3-decimal `toPlainString`, overflow.
- `ForeignTransactionEntryTest` — EUR/USD, JPY (zero-decimal), THB & MXN (nomad currencies), cross-decimal conversion, banker's-rounding boundaries, fee tracking, manual vs provider rate sourcing, missing-rate → `null`, and entry invariants.

All `:packages:core:jvmTest` green; `detekt` clean.

### Design notes

- Pure/immutable, `commonMain`-only; existing `Cents`/rounding semantics preserved (`MoneyOperations.bankersRound` reused).
- Additive value types only — **no SQLDelight/schema/migration changes** (see below).

## Needs Human Action

- **iOS create flow is out of scope here** and remains a follow-up: surface a per-transaction currency picker, default currency from the selected account, and show local + USD amounts in review (`apps/ios/.../TransactionCreateView(Model).swift`, `SettingsViewModel`, `AccountEditViewModel`; add THB/MXN to supported lists). Owned by the iOS agent.
- **Persistence**: storing `ForeignTransactionEntry` (entered amount/currency, base amount, rate, timestamp, source, fee) will eventually need additive columns on the transaction schema. None are added in this PR to avoid migration risk; @kmp-engineer should design the reversible additive migration when wiring persistence.

Closes #2202

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
