### PR TITLE
feat(ios): on-device transaction categorization (#2382)

### DIFF
--- a/apps/ios/Finance/Components/CategorySuggestionCard.swift
+++ b/apps/ios/Finance/Components/CategorySuggestionCard.swift
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategorySuggestionCard.swift
+// Finance
+//
+// Review surface for on-device category suggestions. Shows the suggested
+// category with its confidence and lets the user accept, override (pick another
+// category), or disable suggestions. Fully VoiceOver-accessible with Dynamic
+// Type; colours follow the CVD-safe convention used by ConfidenceIndicatorView.
+//
+// References: #2382
+
+import FinanceShared
+import SwiftUI
+
+/// A card presenting a single category suggestion and its review controls.
+///
+/// Drop this into a transaction review/create screen, passing a
+/// ``CategorySuggestionViewModel``. The card collapses to an unobtrusive note
+/// once the user has acted or when suggestions are disabled.
+struct CategorySuggestionCard: View {
+    @State var viewModel: CategorySuggestionViewModel
+
+    var body: some View {
+        Group {
+            switch viewModel.state {
+            case .suggested:
+                suggestionBody
+            case .accepted, .overridden:
+                resolvedBody
+            case .disabled:
+                disabledBody
+            }
+        }
+        .padding(16)
+        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 12))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("category_suggestion_card")
+    }
+
+    // MARK: - Suggested
+
+    @ViewBuilder
+    private var suggestionBody: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+
+            HStack(spacing: 10) {
+                Image(systemName: viewModel.selectedCategory?.icon ?? "tag")
+                    .foregroundStyle(viewModel.selectedCategory?.color ?? .accentColor)
+                    .accessibilityHidden(true)
+
+                Text(viewModel.selectedCategory?.name ?? String(localized: "Uncategorized"))
+                    .font(.headline)
+
+                Spacer()
+
+                confidenceBadge
+            }
+
+            HStack(spacing: 12) {
+                Button {
+                    viewModel.accept()
+                } label: {
+                    Label(String(localized: "Accept"), systemImage: "checkmark")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(viewModel.isFallback)
+                .accessibilityLabel(String(localized: "Accept suggested category"))
+                .accessibilityIdentifier("category_suggestion_accept")
+
+                overrideMenu
+            }
+
+            Button(role: .destructive) {
+                viewModel.disableSuggestions()
+            } label: {
+                Text(String(localized: "Turn off suggestions"))
+                    .font(.footnote)
+            }
+            .accessibilityLabel(String(localized: "Turn off category suggestions"))
+            .accessibilityIdentifier("category_suggestion_disable")
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "sparkles")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text(String(localized: "Suggested category"))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var confidenceBadge: some View {
+        HStack(spacing: 4) {
+            Image(systemName: confidenceSymbol)
+                .font(.caption)
+            Text(viewModel.confidenceText)
+                .font(.caption.monospacedDigit())
+        }
+        .foregroundStyle(confidenceColor)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(confidenceColor.opacity(0.15), in: Capsule())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(viewModel.confidenceBandLabel)
+        .accessibilityValue(viewModel.confidenceText)
+        .accessibilityIdentifier("category_suggestion_confidence")
+    }
+
+    private var overrideMenu: some View {
+        Menu {
+            ForEach(viewModel.availableCategories) { category in
+                Button {
+                    viewModel.override(to: category.id)
+                } label: {
+                    Label(category.name, systemImage: category.icon)
+                }
+            }
+        } label: {
+            Label(String(localized: "Change"), systemImage: "pencil")
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .accessibilityLabel(String(localized: "Change category"))
+        .accessibilityIdentifier("category_suggestion_override")
+    }
+
+    // MARK: - Resolved
+
+    private var resolvedBody: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                .accessibilityHidden(true)
+            Text(resolvedLabel)
+                .font(.subheadline)
+            Spacer()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(resolvedLabel)
+    }
+
+    private var resolvedLabel: String {
+        let name = viewModel.selectedCategory?.name ?? String(localized: "Uncategorized")
+        return viewModel.state == .accepted
+            ? String(localized: "Categorized as \(name)")
+            : String(localized: "Changed to \(name)")
+    }
+
+    // MARK: - Disabled
+
+    private var disabledBody: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "sparkles.slash")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text(String(localized: "Category suggestions are off"))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(String(localized: "Category suggestions are off"))
+    }
+
+    // MARK: - Confidence styling (CVD-safe)
+
+    private var confidenceColor: Color {
+        switch viewModel.suggestion?.band ?? .none {
+        case .high: .green
+        case .medium: .orange
+        case .low, .none: .red
+        }
+    }
+
+    private var confidenceSymbol: String {
+        switch viewModel.suggestion?.band ?? .none {
+        case .high: "checkmark.seal.fill"
+        case .medium: "checkmark.seal"
+        case .low: "exclamationmark.triangle"
+        case .none: "questionmark.circle"
+        }
+    }
+}

--- a/apps/ios/Finance/Services/CoreMLCategoryClassifier.swift
+++ b/apps/ios/Finance/Services/CoreMLCategoryClassifier.swift
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CoreMLCategoryClassifier.swift
+// Finance
+//
+// Concrete on-device Core ML adapter conforming to the Shared `MLCategoryClassifier`
+// seam. It loads a compiled category model from the app bundle when present and
+// classifies reduced `CategorizationFeatures` entirely on-device — no merchant,
+// memo, or amount content ever leaves the device.
+//
+// When no model asset is bundled (the current shipping state), the adapter
+// reports `isAvailable == false`, which drives the rule-engine fallback in
+// `TransactionCategorizer`. Packaging the compiled `.mlmodelc` and wiring the
+// `MLModel` feature-vector prediction is an Xcode/Core ML toolchain step.
+//
+// References: #2382
+
+import CoreML
+import FinanceShared
+import Foundation
+import os
+
+/// Core ML-backed implementation of ``MLCategoryClassifier``.
+///
+/// Thread-safe and `Sendable`: the underlying `MLModel` is loaded once at init
+/// and only read afterwards.
+final class CoreMLCategoryClassifier: MLCategoryClassifier, @unchecked Sendable {
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "CoreMLCategoryClassifier"
+    )
+
+    /// Name of the compiled model resource expected in the app bundle.
+    private let modelResourceName: String
+
+    /// The loaded model, or `nil` when no asset is bundled / load failed.
+    private let model: MLModel?
+
+    /// Whether the model and runtime are ready for inference.
+    let isAvailable: Bool
+
+    /// Loads the model from the given bundle if present.
+    init(modelResourceName: String = "TransactionCategoryClassifier", bundle: Bundle = .main) {
+        self.modelResourceName = modelResourceName
+
+        // A compiled Core ML model ships as a `.mlmodelc` directory in the
+        // bundle. When absent (current shipping state) we stay unavailable and
+        // the rule engine takes over — the feature never fails closed.
+        guard let url = bundle.url(forResource: modelResourceName, withExtension: "mlmodelc") else {
+            Self.logger.info(
+                "No Core ML category model bundled; using rule-engine fallback."
+            )
+            self.model = nil
+            self.isAvailable = false
+            return
+        }
+
+        do {
+            let configuration = MLModelConfiguration()
+            configuration.computeUnits = .all
+            let loaded = try MLModel(contentsOf: url, configuration: configuration)
+            self.model = loaded
+            self.isAvailable = true
+            Self.logger.info("Core ML category model loaded.")
+        } catch {
+            // Runtime load failure: log an aggregate, content-free error and
+            // fall back to rules.
+            Self.logger.error(
+                "Core ML model load failed: \(error.localizedDescription, privacy: .public)"
+            )
+            self.model = nil
+            self.isAvailable = false
+        }
+    }
+
+    func classify(features: CategorizationFeatures) -> CategorizationSuggestion? {
+        guard isAvailable, model != nil else { return nil }
+
+        // TODO(human): Map `features` (tokens + numeric/temporal signals) into the
+        // model's `MLFeatureProvider` input, run `model.prediction(from:)`, and
+        // translate the top label + probability into a `CategorizationSuggestion`
+        // with source `.coreML`. This requires the compiled `.mlmodelc` and its
+        // generated input/output schema, which are produced by the Xcode/Core ML
+        // toolchain and cannot be authored here. Until wired, abstain to `nil`
+        // so the deterministic rule engine drives suggestions.
+        return nil
+    }
+}

--- a/apps/ios/Finance/ViewModels/CategorySuggestionViewModel.swift
+++ b/apps/ios/Finance/ViewModels/CategorySuggestionViewModel.swift
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategorySuggestionViewModel.swift
+// Finance
+//
+// Drives the category-suggestion review surface. It asks the on-device
+// `TransactionCategorizer` for a suggestion, exposes its confidence, and lets
+// the user accept, override, or disable suggestions. Accept/override persist a
+// correction for future personalization; every action emits aggregate,
+// content-free telemetry.
+//
+// References: #2382
+
+import FinanceShared
+import Observation
+import os
+import SwiftUI
+
+/// Outcome state of the suggestion review surface.
+enum CategoryReviewState: Equatable, Sendable {
+    case suggested
+    case accepted
+    case overridden
+    case disabled
+}
+
+@Observable
+final class CategorySuggestionViewModel {
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "CategorySuggestionViewModel"
+    )
+
+    private let input: CategorizationInput
+    private let categorizer: TransactionCategorizer
+    private let telemetry: any CategorizationTelemetryRecording
+    private let preferencesDefaults: UserDefaults?
+
+    // MARK: - State
+
+    /// Categories the user can choose from when overriding.
+    let availableCategories: [CategoryItem]
+
+    /// The current suggestion (nil only when suggestions are disabled).
+    private(set) var suggestion: CategorizationSuggestion?
+
+    /// The category id currently selected (suggested or overridden).
+    private(set) var selectedCategoryId: String
+
+    /// Current review state.
+    private(set) var state: CategoryReviewState
+
+    // MARK: - Init
+
+    init(
+        input: CategorizationInput,
+        availableCategories: [CategoryItem],
+        categorizer: TransactionCategorizer,
+        telemetry: any CategorizationTelemetryRecording,
+        preferencesDefaults: UserDefaults? = SharedConstants.sharedDefaults
+    ) {
+        self.input = input
+        self.availableCategories = availableCategories
+        self.categorizer = categorizer
+        self.telemetry = telemetry
+        self.preferencesDefaults = preferencesDefaults
+
+        guard CategorizationPreferences.isEnabled(defaults: preferencesDefaults) else {
+            self.suggestion = nil
+            self.selectedCategoryId = ""
+            self.state = .disabled
+            return
+        }
+
+        let suggestion = categorizer.categorize(input)
+        self.suggestion = suggestion
+        self.selectedCategoryId = suggestion.categoryId
+        self.state = .suggested
+
+        telemetry.recordSuggestionShown(source: suggestion.source, band: suggestion.band)
+        Self.logger.info(
+            "Suggestion shown: source \(suggestion.source.rawValue, privacy: .public), band \(suggestion.band.rawValue, privacy: .public)"
+        )
+    }
+
+    // MARK: - Derived display
+
+    /// Whether suggestions are currently enabled.
+    var isEnabled: Bool { state != .disabled }
+
+    /// Whether the current suggestion is the no-signal fallback.
+    var isFallback: Bool { suggestion?.isFallback ?? false }
+
+    /// The resolved `CategoryItem` for the selected category, if known.
+    var selectedCategory: CategoryItem? {
+        availableCategories.first { $0.id == selectedCategoryId }
+    }
+
+    /// Confidence as a whole-number percentage string (e.g. "85%").
+    var confidenceText: String {
+        guard let suggestion else { return "" }
+        return String(format: "%.0f%%", suggestion.score * 100)
+    }
+
+    /// Localised confidence band label.
+    var confidenceBandLabel: String {
+        switch suggestion?.band ?? .none {
+        case .high: String(localized: "High confidence")
+        case .medium: String(localized: "Medium confidence")
+        case .low: String(localized: "Low confidence")
+        case .none: String(localized: "No confident match")
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Accepts the current suggestion as-is and persists it for personalization.
+    func accept() {
+        guard let suggestion, state == .suggested else { return }
+        categorizer.learnCorrection(for: input, categoryId: suggestion.categoryId)
+        telemetry.recordAccepted(source: suggestion.source)
+        state = .accepted
+        Self.logger.info("Suggestion accepted: source \(suggestion.source.rawValue, privacy: .public)")
+    }
+
+    /// Overrides the suggestion with a different category and learns from it.
+    func override(to categoryId: String) {
+        guard isEnabled else { return }
+        let source = suggestion?.source ?? .fallback
+        selectedCategoryId = categoryId
+        categorizer.learnCorrection(for: input, categoryId: categoryId)
+        telemetry.recordOverridden(source: source)
+        state = .overridden
+        Self.logger.info("Suggestion overridden: source \(source.rawValue, privacy: .public)")
+    }
+
+    /// Disables category suggestions everywhere and records the choice.
+    func disableSuggestions() {
+        CategorizationPreferences.setEnabled(false, defaults: preferencesDefaults)
+        telemetry.recordDisabled()
+        suggestion = nil
+        state = .disabled
+        Self.logger.info("Category suggestions disabled by user.")
+    }
+}

--- a/apps/ios/Package.swift
+++ b/apps/ios/Package.swift
@@ -31,7 +31,10 @@ let package = Package(
         .target(
             name: "FinanceShared",
             dependencies: [],
-            path: "Shared"
+            path: "Shared",
+            exclude: [
+                "Categorization/README.md",
+            ]
         ),
 
         // MARK: - Main app

--- a/apps/ios/Shared/Categorization/CategorizationFeatureExtractor.swift
+++ b/apps/ios/Shared/Categorization/CategorizationFeatureExtractor.swift
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategorizationFeatureExtractor.swift
+// FinanceShared
+//
+// Converts a CategorizationInput into deterministic CategorizationFeatures.
+// The calendar is injectable so unit tests can pin a fixed time zone and get
+// reproducible day-of-week / hour features regardless of the host machine.
+//
+// References: #2382
+
+import Foundation
+
+/// Builds deterministic ``CategorizationFeatures`` from a ``CategorizationInput``.
+public struct CategorizationFeatureExtractor: Sendable {
+
+    /// Calendar used to derive day-of-week and hour features.
+    private let calendar: Calendar
+
+    /// Upper bounds (exclusive) in *major units* for each magnitude bucket.
+    /// Index of the first bound the absolute amount is below becomes the bucket;
+    /// amounts at or above the last bound fall into the final bucket.
+    private static let bucketBoundsMajor: [Double] = [
+        5, 20, 50, 100, 250, 500, 1_000,
+    ]
+
+    /// Creates an extractor.
+    ///
+    /// - Parameter calendar: Defaults to the current calendar. Tests should pass
+    ///   a calendar with a fixed `timeZone` for reproducibility.
+    public init(calendar: Calendar = .current) {
+        self.calendar = calendar
+    }
+
+    /// A deterministic extractor pinned to UTC, for reproducible features.
+    public static var utc: CategorizationFeatureExtractor {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        return CategorizationFeatureExtractor(calendar: calendar)
+    }
+
+    /// Extracts features for the given input.
+    public func features(for input: CategorizationInput) -> CategorizationFeatures {
+        let tokens = MerchantTokenizer.tokens(merchant: input.merchant, memo: input.memo)
+        let signature = MerchantTokenizer.signature(for: tokens)
+        let absolute = input.amountMinorUnits.magnitude
+        let absoluteSigned = Int64(min(absolute, UInt64(Int64.max)))
+
+        let components = calendar.dateComponents([.weekday, .hour], from: input.date)
+        let weekday = components.weekday ?? 1
+        let hour = components.hour ?? 0
+        let isWeekend = weekday == 1 || weekday == 7
+
+        return CategorizationFeatures(
+            tokens: tokens,
+            signature: signature,
+            absoluteAmountMinorUnits: absoluteSigned,
+            amountMagnitudeBucket: Self.magnitudeBucket(forMinorUnits: absoluteSigned),
+            dayOfWeek: weekday,
+            hour: hour,
+            isWeekend: isWeekend
+        )
+    }
+
+    /// Maps an absolute minor-unit amount to a coarse magnitude bucket (0...7).
+    public static func magnitudeBucket(forMinorUnits minorUnits: Int64) -> Int {
+        let major = Double(minorUnits) / 100.0
+        for (index, bound) in bucketBoundsMajor.enumerated() where major < bound {
+            return index
+        }
+        return bucketBoundsMajor.count
+    }
+}

--- a/apps/ios/Shared/Categorization/CategorizationModels.swift
+++ b/apps/ios/Shared/Categorization/CategorizationModels.swift
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategorizationModels.swift
+// FinanceShared
+//
+// Value types for on-device transaction categorization. These types are
+// deliberately content-light at the boundary: nothing here is ever logged or
+// emitted to telemetry. They describe the *inputs* to the categorizer, the
+// deterministic *features* derived from those inputs, and the *suggestion*
+// returned to the review surface.
+//
+// All processing that consumes these types runs entirely on-device. Merchant
+// names, memos, and amounts never leave the device.
+//
+// References: #2382
+
+import Foundation
+
+// MARK: - Categorization Input
+
+/// The raw, on-device signal used to suggest a category for a transaction.
+///
+/// Construct one of these from an imported or manually-entered transaction.
+/// The categorizer derives deterministic ``CategorizationFeatures`` from it and
+/// never persists or transmits the raw merchant/memo/amount content.
+public struct CategorizationInput: Sendable, Equatable {
+    /// Merchant or payee text (e.g. "Whole Foods Market #123").
+    public let merchant: String
+    /// Free-form memo or note attached to the transaction.
+    public let memo: String
+    /// Signed amount in minor units (cents). Sign is normalised away in features.
+    public let amountMinorUnits: Int64
+    /// ISO currency code (e.g. "USD").
+    public let currencyCode: String
+    /// Transaction date used for day-of-week / time features.
+    public let date: Date
+    /// Optional originating account identifier (opaque, never logged).
+    public let accountId: String?
+
+    public init(
+        merchant: String,
+        memo: String = "",
+        amountMinorUnits: Int64,
+        currencyCode: String = "USD",
+        date: Date = Date(),
+        accountId: String? = nil
+    ) {
+        self.merchant = merchant
+        self.memo = memo
+        self.amountMinorUnits = amountMinorUnits
+        self.currencyCode = currencyCode
+        self.date = date
+        self.accountId = accountId
+    }
+}
+
+// MARK: - Categorization Features
+
+/// Deterministic, privacy-reduced features derived from a ``CategorizationInput``.
+///
+/// Text is reduced to normalised tokens; the amount is reduced to a coarse
+/// magnitude bucket; the date is reduced to day-of-week / hour. The original
+/// content cannot be reconstructed from these features.
+public struct CategorizationFeatures: Sendable, Equatable {
+    /// Normalised, de-duplicated tokens from merchant + memo.
+    public let tokens: [String]
+    /// Stable key for personalization lookups (order-independent token digest).
+    public let signature: String
+    /// Absolute amount in minor units (sign removed).
+    public let absoluteAmountMinorUnits: Int64
+    /// Coarse magnitude bucket (0 = smallest, 7 = largest). See feature extractor.
+    public let amountMagnitudeBucket: Int
+    /// Day of week, 1 (Sunday) ... 7 (Saturday).
+    public let dayOfWeek: Int
+    /// Hour of day, 0 ... 23.
+    public let hour: Int
+    /// Whether the transaction falls on a weekend.
+    public let isWeekend: Bool
+
+    public init(
+        tokens: [String],
+        signature: String,
+        absoluteAmountMinorUnits: Int64,
+        amountMagnitudeBucket: Int,
+        dayOfWeek: Int,
+        hour: Int,
+        isWeekend: Bool
+    ) {
+        self.tokens = tokens
+        self.signature = signature
+        self.absoluteAmountMinorUnits = absoluteAmountMinorUnits
+        self.amountMagnitudeBucket = amountMagnitudeBucket
+        self.dayOfWeek = dayOfWeek
+        self.hour = hour
+        self.isWeekend = isWeekend
+    }
+}
+
+// MARK: - Suggestion Source
+
+/// Where a suggestion came from, in priority order.
+///
+/// Recorded in aggregate telemetry to monitor feature health. It carries no
+/// transaction content.
+public enum CategorizationSource: String, Sendable, Codable, CaseIterable {
+    /// A user correction previously learned on-device for this signature.
+    case personalization
+    /// The on-device Core ML classifier.
+    case coreML
+    /// The deterministic rule/keyword engine.
+    case rules
+    /// No signal — the safe default category.
+    case fallback
+}
+
+// MARK: - Confidence Band
+
+/// Coarse confidence band for display and telemetry.
+public enum CategorizationConfidenceBand: String, Sendable, Codable, CaseIterable {
+    case high
+    case medium
+    case low
+    case none
+
+    /// Maps a 0.0–1.0 score to a band.
+    public init(score: Double) {
+        switch score {
+        case 0.8...:
+            self = .high
+        case 0.5..<0.8:
+            self = .medium
+        case 0.2..<0.5:
+            self = .low
+        default:
+            self = .none
+        }
+    }
+}
+
+// MARK: - Suggestion
+
+/// A suggested category with a confidence score and provenance.
+public struct CategorizationSuggestion: Sendable, Equatable {
+    /// Identifier of the suggested category (matches the app's category ids).
+    public let categoryId: String
+    /// Confidence score in the closed range 0.0 ... 1.0.
+    public let score: Double
+    /// Where this suggestion originated.
+    public let source: CategorizationSource
+
+    public init(categoryId: String, score: Double, source: CategorizationSource) {
+        self.categoryId = categoryId
+        self.score = max(0.0, min(1.0, score))
+        self.source = source
+    }
+
+    /// Coarse confidence band derived from ``score``.
+    public var band: CategorizationConfidenceBand {
+        CategorizationConfidenceBand(score: score)
+    }
+
+    /// Whether this is the no-signal fallback suggestion.
+    public var isFallback: Bool {
+        source == .fallback
+    }
+}
+
+// MARK: - Category Suggesting
+
+/// Contract for any component that can suggest a category from features.
+///
+/// Both the rule engine and the Core ML adapter conform to this so the
+/// orchestrating ``TransactionCategorizer`` can treat them uniformly.
+public protocol CategorySuggesting: Sendable {
+    /// Returns a suggestion, or `nil` when this suggester has no opinion.
+    func suggest(
+        features: CategorizationFeatures,
+        input: CategorizationInput
+    ) -> CategorizationSuggestion?
+}

--- a/apps/ios/Shared/Categorization/CategorizationTelemetry.swift
+++ b/apps/ios/Shared/Categorization/CategorizationTelemetry.swift
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategorizationTelemetry.swift
+// FinanceShared
+//
+// Privacy-safe aggregate telemetry for the categorization feature. Records ONLY
+// counts and enum tags (source, confidence band). It never records merchant
+// names, memos, amounts, category ids, signatures, or any per-transaction
+// content. The snapshot is suitable for local feature-health dashboards.
+//
+// References: #2382
+
+import Foundation
+
+// MARK: - Snapshot
+
+/// An aggregate, content-free view of categorization feature health.
+public struct CategorizationTelemetrySnapshot: Sendable, Codable, Equatable {
+    /// Total suggestions surfaced to the user.
+    public var suggestionsShown: Int
+    /// Suggestions the user accepted as-is.
+    public var accepted: Int
+    /// Suggestions the user changed to a different category.
+    public var overridden: Int
+    /// Times the user disabled suggestions.
+    public var disabled: Int
+    /// Times the no-signal fallback was shown.
+    public var fallbackShown: Int
+    /// Suggestions shown, bucketed by source (raw value -> count).
+    public var shownBySource: [String: Int]
+    /// Suggestions shown, bucketed by confidence band (raw value -> count).
+    public var shownByBand: [String: Int]
+
+    public init(
+        suggestionsShown: Int = 0,
+        accepted: Int = 0,
+        overridden: Int = 0,
+        disabled: Int = 0,
+        fallbackShown: Int = 0,
+        shownBySource: [String: Int] = [:],
+        shownByBand: [String: Int] = [:]
+    ) {
+        self.suggestionsShown = suggestionsShown
+        self.accepted = accepted
+        self.overridden = overridden
+        self.disabled = disabled
+        self.fallbackShown = fallbackShown
+        self.shownBySource = shownBySource
+        self.shownByBand = shownByBand
+    }
+
+    /// Fraction of resolved suggestions that were accepted (0.0 ... 1.0).
+    public var acceptanceRate: Double {
+        let resolved = accepted + overridden
+        guard resolved > 0 else { return 0 }
+        return Double(accepted) / Double(resolved)
+    }
+}
+
+// MARK: - Recorder
+
+/// Records aggregate categorization events. Implementations MUST NOT persist any
+/// transaction content — only counts and enum tags.
+public protocol CategorizationTelemetryRecording: Sendable {
+    func recordSuggestionShown(source: CategorizationSource, band: CategorizationConfidenceBand)
+    func recordAccepted(source: CategorizationSource)
+    func recordOverridden(source: CategorizationSource)
+    func recordDisabled()
+    func snapshot() -> CategorizationTelemetrySnapshot
+    func reset()
+}
+
+/// In-memory recorder for previews and deterministic tests.
+public final class InMemoryCategorizationTelemetry: CategorizationTelemetryRecording, @unchecked Sendable {
+    private let lock = NSLock()
+    private var state = CategorizationTelemetrySnapshot()
+
+    public init() {}
+
+    public func recordSuggestionShown(source: CategorizationSource, band: CategorizationConfidenceBand) {
+        lock.lock(); defer { lock.unlock() }
+        state.suggestionsShown += 1
+        state.shownBySource[source.rawValue, default: 0] += 1
+        state.shownByBand[band.rawValue, default: 0] += 1
+        if source == .fallback {
+            state.fallbackShown += 1
+        }
+    }
+
+    public func recordAccepted(source: CategorizationSource) {
+        lock.lock(); defer { lock.unlock() }
+        state.accepted += 1
+    }
+
+    public func recordOverridden(source: CategorizationSource) {
+        lock.lock(); defer { lock.unlock() }
+        state.overridden += 1
+    }
+
+    public func recordDisabled() {
+        lock.lock(); defer { lock.unlock() }
+        state.disabled += 1
+    }
+
+    public func snapshot() -> CategorizationTelemetrySnapshot {
+        lock.lock(); defer { lock.unlock() }
+        return state
+    }
+
+    public func reset() {
+        lock.lock(); defer { lock.unlock() }
+        state = CategorizationTelemetrySnapshot()
+    }
+}
+
+/// UserDefaults-backed aggregate recorder for production.
+///
+/// Persists only the ``CategorizationTelemetrySnapshot`` (counts + enum tags).
+public final class AggregateCategorizationTelemetry: CategorizationTelemetryRecording, @unchecked Sendable {
+    private let lock = NSLock()
+    private let defaults: UserDefaults?
+    private let storageKey: String
+
+    public init(
+        defaults: UserDefaults? = SharedConstants.sharedDefaults,
+        storageKey: String = "finance:categorization-telemetry"
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+    }
+
+    private func load() -> CategorizationTelemetrySnapshot {
+        guard let data = defaults?.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode(CategorizationTelemetrySnapshot.self, from: data)
+        else { return CategorizationTelemetrySnapshot() }
+        return decoded
+    }
+
+    private func save(_ snapshot: CategorizationTelemetrySnapshot) {
+        guard let data = try? JSONEncoder().encode(snapshot) else { return }
+        defaults?.set(data, forKey: storageKey)
+    }
+
+    public func recordSuggestionShown(source: CategorizationSource, band: CategorizationConfidenceBand) {
+        lock.lock(); defer { lock.unlock() }
+        var snapshot = load()
+        snapshot.suggestionsShown += 1
+        snapshot.shownBySource[source.rawValue, default: 0] += 1
+        snapshot.shownByBand[band.rawValue, default: 0] += 1
+        if source == .fallback {
+            snapshot.fallbackShown += 1
+        }
+        save(snapshot)
+    }
+
+    public func recordAccepted(source: CategorizationSource) {
+        lock.lock(); defer { lock.unlock() }
+        var snapshot = load()
+        snapshot.accepted += 1
+        save(snapshot)
+    }
+
+    public func recordOverridden(source: CategorizationSource) {
+        lock.lock(); defer { lock.unlock() }
+        var snapshot = load()
+        snapshot.overridden += 1
+        save(snapshot)
+    }
+
+    public func recordDisabled() {
+        lock.lock(); defer { lock.unlock() }
+        var snapshot = load()
+        snapshot.disabled += 1
+        save(snapshot)
+    }
+
+    public func snapshot() -> CategorizationTelemetrySnapshot {
+        lock.lock(); defer { lock.unlock() }
+        return load()
+    }
+
+    public func reset() {
+        lock.lock(); defer { lock.unlock() }
+        defaults?.removeObject(forKey: storageKey)
+    }
+}

--- a/apps/ios/Shared/Categorization/CategoryCorrectionStore.swift
+++ b/apps/ios/Shared/Categorization/CategoryCorrectionStore.swift
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategoryCorrectionStore.swift
+// FinanceShared
+//
+// Persistence of user corrections for on-device personalization. Stores only a
+// mapping from a non-reversible token signature to a chosen category id — never
+// the raw merchant, memo, or amount. Backed by an injectable UserDefaults so it
+// can use the app-group suite in production and an isolated suite in tests.
+//
+// References: #2382
+
+import Foundation
+
+/// Read/write contract for learned user corrections.
+public protocol CategoryCorrectionStoring: Sendable {
+    /// Returns the category a user previously chose for this signature, if any.
+    func correctedCategory(forSignature signature: String) -> String?
+
+    /// Records (or overwrites) a correction for a signature.
+    func recordCorrection(signature: String, categoryId: String)
+
+    /// Removes a single correction.
+    func removeCorrection(forSignature signature: String)
+
+    /// Number of stored corrections (used for telemetry/diagnostics, no content).
+    var count: Int { get }
+
+    /// Clears every stored correction.
+    func clearAll()
+}
+
+/// In-memory correction store. Useful for previews and deterministic tests.
+public final class InMemoryCategoryCorrectionStore: CategoryCorrectionStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: String]
+
+    public init(seed: [String: String] = [:]) {
+        self.storage = seed
+    }
+
+    public func correctedCategory(forSignature signature: String) -> String? {
+        guard !signature.isEmpty else { return nil }
+        lock.lock(); defer { lock.unlock() }
+        return storage[signature]
+    }
+
+    public func recordCorrection(signature: String, categoryId: String) {
+        guard !signature.isEmpty else { return }
+        lock.lock(); defer { lock.unlock() }
+        storage[signature] = categoryId
+    }
+
+    public func removeCorrection(forSignature signature: String) {
+        lock.lock(); defer { lock.unlock() }
+        storage[signature] = nil
+    }
+
+    public var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return storage.count
+    }
+
+    public func clearAll() {
+        lock.lock(); defer { lock.unlock() }
+        storage.removeAll()
+    }
+}
+
+/// UserDefaults-backed correction store for production personalization.
+///
+/// Persists a single JSON dictionary `[signature: categoryId]`. When native
+/// storage is unavailable (no defaults), it degrades to an empty, no-op store so
+/// categorization still works (just without personalization).
+public final class UserDefaultsCategoryCorrectionStore: CategoryCorrectionStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private let defaults: UserDefaults?
+    private let storageKey: String
+
+    public init(
+        defaults: UserDefaults? = SharedConstants.sharedDefaults,
+        storageKey: String = "finance:categorization-corrections"
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+    }
+
+    private func load() -> [String: String] {
+        guard let data = defaults?.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([String: String].self, from: data)
+        else { return [:] }
+        return decoded
+    }
+
+    private func save(_ map: [String: String]) {
+        guard let data = try? JSONEncoder().encode(map) else { return }
+        defaults?.set(data, forKey: storageKey)
+    }
+
+    public func correctedCategory(forSignature signature: String) -> String? {
+        guard !signature.isEmpty else { return nil }
+        lock.lock(); defer { lock.unlock() }
+        return load()[signature]
+    }
+
+    public func recordCorrection(signature: String, categoryId: String) {
+        guard !signature.isEmpty else { return }
+        lock.lock(); defer { lock.unlock() }
+        var map = load()
+        map[signature] = categoryId
+        save(map)
+    }
+
+    public func removeCorrection(forSignature signature: String) {
+        lock.lock(); defer { lock.unlock() }
+        var map = load()
+        map[signature] = nil
+        save(map)
+    }
+
+    public var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return load().count
+    }
+
+    public func clearAll() {
+        lock.lock(); defer { lock.unlock() }
+        defaults?.removeObject(forKey: storageKey)
+    }
+}

--- a/apps/ios/Shared/Categorization/CoreMLCategoryClassifier.swift
+++ b/apps/ios/Shared/Categorization/CoreMLCategoryClassifier.swift
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CoreMLCategoryClassifier.swift
+// FinanceShared
+//
+// Protocol seam for the on-device Core ML classifier. The Shared module stays
+// dependency-free (no CoreML import) so it builds everywhere and stays fully
+// unit-testable; the concrete Core ML-backed adapter lives in the Finance app
+// target where the compiled model is bundled.
+//
+// When no model is available this seam yields `nil`, and the orchestrating
+// ``TransactionCategorizer`` transparently falls back to the rule engine. See
+// `Shared/Categorization/README.md` for the documented fallback chain.
+//
+// References: #2382
+
+import Foundation
+
+/// Contract for an on-device machine-learning category classifier.
+///
+/// Conformers must run entirely on-device. They receive only the reduced
+/// ``CategorizationFeatures`` (tokens + coarse numeric/temporal signals), never
+/// raw merchant/memo/amount content beyond what the features already expose.
+public protocol MLCategoryClassifier: Sendable {
+    /// Whether the model and runtime are loaded and ready.
+    ///
+    /// When `false`, callers must skip ML and fall back to rules.
+    var isAvailable: Bool { get }
+
+    /// Returns a classification, or `nil` when the model abstains or is missing.
+    func classify(features: CategorizationFeatures) -> CategorizationSuggestion?
+}
+
+/// A no-op classifier used when no Core ML asset is bundled.
+///
+/// Always reports `isAvailable == false` and classifies to `nil`, which drives
+/// the rule-engine fallback. This is the default wired into
+/// ``TransactionCategorizer/makeDefault(...)``.
+public struct UnavailableMLClassifier: MLCategoryClassifier {
+    public init() {}
+
+    public var isAvailable: Bool { false }
+
+    public func classify(features: CategorizationFeatures) -> CategorizationSuggestion? {
+        nil
+    }
+}
+
+/// Wraps any ``MLCategoryClassifier`` as a ``CategorySuggesting`` so the
+/// orchestrator can treat ML and rules uniformly.
+public struct MLCategorySuggester: CategorySuggesting {
+    private let classifier: MLCategoryClassifier
+
+    public init(classifier: MLCategoryClassifier) {
+        self.classifier = classifier
+    }
+
+    public func suggest(
+        features: CategorizationFeatures,
+        input: CategorizationInput
+    ) -> CategorizationSuggestion? {
+        guard classifier.isAvailable else { return nil }
+        return classifier.classify(features: features)
+    }
+}

--- a/apps/ios/Shared/Categorization/MerchantTokenizer.swift
+++ b/apps/ios/Shared/Categorization/MerchantTokenizer.swift
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// MerchantTokenizer.swift
+// FinanceShared
+//
+// Deterministic tokenizer for merchant + memo text. Pure value transform with
+// no I/O — given the same input it always produces the same tokens, which makes
+// the categorization pipeline fully unit-testable.
+//
+// The tokenizer intentionally strips store numbers, payment-network noise, and
+// generic stop words so that "WHOLE FOODS MKT #123 POS DEBIT" and
+// "Whole Foods Market" collapse to the same meaningful tokens.
+//
+// References: #2382
+
+import Foundation
+
+/// Deterministic merchant/memo tokenizer.
+public enum MerchantTokenizer {
+
+    /// Generic words and payment-network noise removed before classification.
+    private static let stopWords: Set<String> = [
+        "the", "and", "for", "inc", "llc", "ltd", "co", "corp", "company",
+        "store", "shop", "pos", "purchase", "payment", "pmt", "debit", "credit",
+        "card", "visa", "mastercard", "amex", "discover", "us", "usa", "online",
+        "recurring", "transaction", "txn", "ref", "auth", "checkcard", "ach",
+    ]
+
+    /// Minimum length for a token to be considered meaningful.
+    private static let minimumTokenLength = 2
+
+    /// Tokenizes merchant + memo into normalised, de-duplicated tokens.
+    ///
+    /// - Order is preserved (first occurrence wins) so callers that care about
+    ///   primary token can rely on `tokens.first`.
+    /// - Pure-numeric tokens (store numbers, dates) and stop words are removed.
+    public static func tokens(merchant: String, memo: String = "") -> [String] {
+        let combined = merchant + " " + memo
+        let lowered = combined.lowercased()
+
+        // Split on any non-alphanumeric character.
+        let separators = CharacterSet.alphanumerics.inverted
+        let rawTokens = lowered.components(separatedBy: separators)
+
+        var seen: Set<String> = []
+        var result: [String] = []
+
+        for token in rawTokens {
+            guard token.count >= minimumTokenLength else { continue }
+            guard !stopWords.contains(token) else { continue }
+            // Drop pure-numeric tokens (store numbers, amounts, dates).
+            guard !token.allSatisfy(\.isNumber) else { continue }
+
+            if seen.insert(token).inserted {
+                result.append(token)
+            }
+        }
+
+        return result
+    }
+
+    /// Produces a stable, order-independent signature for personalization.
+    ///
+    /// Two inputs that tokenize to the same *set* of tokens share a signature,
+    /// so a correction learned for "Starbucks #44" also applies to
+    /// "STARBUCKS STORE 91". Returns an empty string when there are no tokens.
+    public static func signature(for tokens: [String]) -> String {
+        guard !tokens.isEmpty else { return "" }
+        return Set(tokens).sorted().joined(separator: " ")
+    }
+}

--- a/apps/ios/Shared/Categorization/README.md
+++ b/apps/ios/Shared/Categorization/README.md
@@ -1,0 +1,79 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+# On-Device Transaction Categorization (#2382)
+
+Privacy-first category suggestions for imported and manually-entered
+transactions. **All inference runs on-device.** Merchant names, memos, and
+amounts are never sent to a remote service.
+
+## Pipeline
+
+A single `TransactionCategorizer.categorize(_:)` call consults four sources in
+strict priority order and always returns one suggestion:
+
+| Priority | Source             | When it wins                                             | Confidence |
+| -------- | ------------------ | -------------------------------------------------------- | ---------- |
+| 1        | `.personalization` | A learned user correction exists for the token signature | 0.97       |
+| 2        | `.coreML`          | A bundled Core ML model is available and classifies      | model      |
+| 3        | `.rules`           | The deterministic keyword engine matches                 | ≤ 0.85     |
+| 4        | `.fallback`        | Nothing matched — safe default category                  | 0.0        |
+
+### Feature reduction
+
+`CategorizationFeatureExtractor` reduces each transaction to non-reversible
+features before any classification:
+
+- **Text** → normalised, de-duplicated tokens via `MerchantTokenizer`
+  (lowercased, punctuation stripped, store numbers / payment-network noise /
+  stop words removed).
+- **Amount** → a coarse magnitude _bucket_ (0–7); the exact amount is not used
+  for classification beyond the bucket.
+- **Date** → day-of-week, hour, and a weekend flag (calendar is injectable for
+  deterministic tests).
+
+The personalization key is an order-independent digest of the token _set_, so a
+correction learned for `STARBUCKS #44` also applies to `Starbucks Store 91`.
+
+## Core ML fallback behaviour
+
+The Shared module is dependency-free and defines the `MLCategoryClassifier`
+seam. The app target supplies the concrete adapter.
+
+- **No model bundled / runtime unavailable** → `UnavailableMLClassifier` (the
+  default) reports `isAvailable == false`; the categorizer transparently falls
+  back to the rule engine, then to the safe default. The feature never fails
+  closed and never blocks transaction entry.
+- **Model present but abstains** (`classify` returns `nil`) → same rule-engine
+  fallback.
+- **Model load failure at runtime** → the app adapter catches the error, reports
+  `isAvailable == false`, logs an aggregate (content-free) error, and the
+  rule engine takes over.
+
+The concrete Core ML adapter (`CoreMLCategoryClassifier` in
+`apps/ios/Finance/Services`) is implemented against the seam; packaging the
+compiled `.mlmodelc` and wiring `MLModel` loading is an Xcode/Core ML toolchain
+step marked `TODO(human)`. Until then it ships in the unavailable state and the
+rule engine drives every suggestion — fully functional and tested.
+
+## Persistence of corrections
+
+`UserDefaultsCategoryCorrectionStore` persists a `[signature: categoryId]`
+dictionary in the app-group suite when native storage is available. If no
+defaults are available it degrades to an empty, no-op store (categorization
+still works, just without personalization).
+
+## Telemetry (privacy-safe, aggregate only)
+
+`AggregateCategorizationTelemetry` records **counts and enum tags only** —
+`suggestionsShown`, `accepted`, `overridden`, `disabled`, `fallbackShown`, and
+breakdowns by `source` / confidence `band`. It never records merchant names,
+memos, amounts, category ids, or signatures. The snapshot supports a local
+feature-health view and an acceptance-rate metric.
+
+## Review surface
+
+`CategorySuggestionViewModel` + `CategorySuggestionCard` present the suggestion
+with its confidence and let the user **accept**, **override** (pick another
+category), or **disable** suggestions entirely
+(`CategorizationPreferences.setEnabled(false)`). Accept/override persist a
+correction for future personalization; every action emits aggregate telemetry.

--- a/apps/ios/Shared/Categorization/RuleBasedCategorySuggester.swift
+++ b/apps/ios/Shared/Categorization/RuleBasedCategorySuggester.swift
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// RuleBasedCategorySuggester.swift
+// FinanceShared
+//
+// Deterministic keyword/rule engine. This is both a standalone suggester and
+// the always-available fallback when the Core ML model is missing. It maps
+// normalised tokens to one of the app's stable category ids.
+//
+// The rule table is data, not behaviour: it is exposed for tests and can be
+// extended without touching the matching logic.
+//
+// References: #2382
+
+import Foundation
+
+/// Deterministic keyword-based category suggester.
+public struct RuleBasedCategorySuggester: CategorySuggesting {
+
+    /// A single category rule: a target category id and its trigger tokens.
+    public struct Rule: Sendable, Equatable {
+        public let categoryId: String
+        public let keywords: Set<String>
+
+        public init(categoryId: String, keywords: Set<String>) {
+            self.categoryId = categoryId
+            self.keywords = keywords
+        }
+    }
+
+    /// Ordered rules. Order is the tie-breaker when two categories match equally.
+    public let rules: [Rule]
+
+    /// Creates a suggester with the given rules (defaults to ``standardRules``).
+    public init(rules: [Rule] = RuleBasedCategorySuggester.standardRules) {
+        self.rules = rules
+    }
+
+    public func suggest(
+        features: CategorizationFeatures,
+        input: CategorizationInput
+    ) -> CategorizationSuggestion? {
+        let tokenSet = Set(features.tokens)
+        guard !tokenSet.isEmpty else { return nil }
+
+        var bestCategory: String?
+        var bestMatches = 0
+
+        for rule in rules {
+            let matches = rule.keywords.intersection(tokenSet).count
+            if matches > bestMatches {
+                bestMatches = matches
+                bestCategory = rule.categoryId
+            }
+        }
+
+        guard let category = bestCategory, bestMatches > 0 else { return nil }
+
+        // More matched keywords -> higher confidence, capped to keep the rule
+        // engine below a trained-model's ceiling.
+        let score = min(0.85, 0.55 + 0.12 * Double(bestMatches - 1) + 0.12)
+        return CategorizationSuggestion(categoryId: category, score: score, source: .rules)
+    }
+
+    /// The shipped rule table. Tokens are single, already-normalised words to
+    /// match ``MerchantTokenizer`` output (e.g. "Whole Foods" -> whole, foods).
+    public static let standardRules: [Rule] = [
+        Rule(categoryId: "groceries", keywords: [
+            "grocery", "groceries", "market", "supermarket", "whole", "foods",
+            "trader", "safeway", "kroger", "walmart", "aldi", "costco", "wegmans",
+            "publix", "heb",
+        ]),
+        Rule(categoryId: "food", keywords: [
+            "restaurant", "cafe", "coffee", "starbucks", "mcdonald", "mcdonalds",
+            "chipotle", "pizza", "grill", "diner", "bakery", "doordash", "ubereats",
+            "grubhub", "kitchen", "bistro", "taco", "burger", "deli", "sushi",
+        ]),
+        Rule(categoryId: "transport", keywords: [
+            "gas", "fuel", "shell", "chevron", "exxon", "bp", "uber", "lyft",
+            "transit", "parking", "metro", "toll", "taxi", "amtrak", "airline",
+        ]),
+        Rule(categoryId: "shopping", keywords: [
+            "amazon", "target", "best", "buy", "mall", "nike", "apparel",
+            "clothing", "ikea", "etsy", "macys", "nordstrom",
+        ]),
+        Rule(categoryId: "health", keywords: [
+            "pharmacy", "cvs", "walgreens", "medical", "doctor", "clinic",
+            "dental", "gym", "fitness", "health", "hospital", "optometry",
+        ]),
+        Rule(categoryId: "entertainment", keywords: [
+            "netflix", "spotify", "hulu", "cinema", "movie", "theater", "theatre",
+            "steam", "playstation", "xbox", "disney", "concert", "twitch",
+        ]),
+        Rule(categoryId: "bills", keywords: [
+            "electric", "electricity", "water", "internet", "comcast", "verizon",
+            "insurance", "rent", "mortgage", "utility", "utilities", "cable",
+            "wireless", "phone",
+        ]),
+    ]
+}

--- a/apps/ios/Shared/Categorization/TransactionCategorizer.swift
+++ b/apps/ios/Shared/Categorization/TransactionCategorizer.swift
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionCategorizer.swift
+// FinanceShared
+//
+// Orchestrates the on-device categorization pipeline. Given a transaction it
+// returns exactly one suggestion by consulting, in priority order:
+//
+//   1. Personalization  — a learned user correction for this token signature.
+//   2. Core ML          — the on-device classifier (if a model is bundled).
+//   3. Rules            — the deterministic keyword engine.
+//   4. Fallback         — a safe default category, never failing.
+//
+// The pipeline is pure and synchronous: no network, no disk reads beyond the
+// injected correction store. See `Shared/Categorization/README.md` for the
+// documented fallback behaviour when Core ML assets/runtime are unavailable.
+//
+// References: #2382
+
+import Foundation
+
+/// Lightweight on-device preference flag for enabling/disabling suggestions.
+public enum CategorizationPreferences {
+    public static let suggestionsEnabledKey = "finance:categorization-suggestions-enabled"
+
+    /// Whether category suggestions are enabled (default `true`).
+    public static func isEnabled(defaults: UserDefaults? = SharedConstants.sharedDefaults) -> Bool {
+        guard let defaults, defaults.object(forKey: suggestionsEnabledKey) != nil else {
+            return true
+        }
+        return defaults.bool(forKey: suggestionsEnabledKey)
+    }
+
+    /// Enables or disables category suggestions.
+    public static func setEnabled(
+        _ enabled: Bool,
+        defaults: UserDefaults? = SharedConstants.sharedDefaults
+    ) {
+        defaults?.set(enabled, forKey: suggestionsEnabledKey)
+    }
+}
+
+/// The on-device categorization orchestrator.
+public struct TransactionCategorizer: Sendable {
+
+    private let featureExtractor: CategorizationFeatureExtractor
+    private let mlClassifier: MLCategoryClassifier
+    private let ruleSuggester: CategorySuggesting
+    private let correctionStore: CategoryCorrectionStoring
+
+    /// Category id used when nothing else matches. Must always exist in the app.
+    public let fallbackCategoryId: String
+
+    /// Confidence assigned to a learned personalization match.
+    private static let personalizationScore = 0.97
+
+    public init(
+        featureExtractor: CategorizationFeatureExtractor = CategorizationFeatureExtractor(),
+        mlClassifier: MLCategoryClassifier = UnavailableMLClassifier(),
+        ruleSuggester: CategorySuggesting = RuleBasedCategorySuggester(),
+        correctionStore: CategoryCorrectionStoring,
+        fallbackCategoryId: String = "other"
+    ) {
+        self.featureExtractor = featureExtractor
+        self.mlClassifier = mlClassifier
+        self.ruleSuggester = ruleSuggester
+        self.correctionStore = correctionStore
+        self.fallbackCategoryId = fallbackCategoryId
+    }
+
+    /// Convenience factory wiring the production-style defaults.
+    public static func makeDefault(
+        mlClassifier: MLCategoryClassifier = UnavailableMLClassifier(),
+        correctionStore: CategoryCorrectionStoring = UserDefaultsCategoryCorrectionStore(),
+        fallbackCategoryId: String = "other"
+    ) -> TransactionCategorizer {
+        TransactionCategorizer(
+            mlClassifier: mlClassifier,
+            correctionStore: correctionStore,
+            fallbackCategoryId: fallbackCategoryId
+        )
+    }
+
+    /// Derives the deterministic features for an input (exposed for callers
+    /// that need the signature, e.g. to record a correction).
+    public func features(for input: CategorizationInput) -> CategorizationFeatures {
+        featureExtractor.features(for: input)
+    }
+
+    /// Returns the best suggestion for a transaction. Never throws; always
+    /// returns at least the fallback.
+    public func categorize(_ input: CategorizationInput) -> CategorizationSuggestion {
+        let features = featureExtractor.features(for: input)
+
+        // 1. Personalization — highest trust: the user already told us.
+        if let learned = correctionStore.correctedCategory(forSignature: features.signature) {
+            return CategorizationSuggestion(
+                categoryId: learned,
+                score: Self.personalizationScore,
+                source: .personalization
+            )
+        }
+
+        // 2. On-device Core ML, when available.
+        if mlClassifier.isAvailable,
+           let ml = mlClassifier.classify(features: features) {
+            return ml
+        }
+
+        // 3. Deterministic rule engine.
+        if let rule = ruleSuggester.suggest(features: features, input: input) {
+            return rule
+        }
+
+        // 4. Safe fallback — feature never fails closed.
+        return CategorizationSuggestion(
+            categoryId: fallbackCategoryId,
+            score: 0.0,
+            source: .fallback
+        )
+    }
+
+    /// Persists a user correction so future transactions with the same merchant
+    /// signature are personalised. Records only the signature, never content.
+    public func learnCorrection(for input: CategorizationInput, categoryId: String) {
+        let signature = featureExtractor.features(for: input).signature
+        correctionStore.recordCorrection(signature: signature, categoryId: categoryId)
+    }
+
+    /// Forgets a previously learned correction for an input's signature.
+    public func forgetCorrection(for input: CategorizationInput) {
+        let signature = featureExtractor.features(for: input).signature
+        correctionStore.removeCorrection(forSignature: signature)
+    }
+}

--- a/apps/ios/Tests/CategorizationFeatureExtractorTests.swift
+++ b/apps/ios/Tests/CategorizationFeatureExtractorTests.swift
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategorizationFeatureExtractorTests.swift
+// FinanceTests
+//
+// Deterministic tests for feature extraction (tokens, magnitude buckets, and
+// calendar-derived temporal features pinned to UTC).
+//
+// References: #2382
+
+import FinanceShared
+import XCTest
+
+final class CategorizationFeatureExtractorTests: XCTestCase {
+
+    // 2023-11-14T22:13:20Z — a Tuesday.
+    private let referenceDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    func testMagnitudeBuckets() {
+        XCTAssertEqual(CategorizationFeatureExtractor.magnitudeBucket(forMinorUnits: 100), 0) // $1
+        XCTAssertEqual(CategorizationFeatureExtractor.magnitudeBucket(forMinorUnits: 3_000), 2) // $30
+        XCTAssertEqual(CategorizationFeatureExtractor.magnitudeBucket(forMinorUnits: 50_000), 6) // $500
+        XCTAssertEqual(CategorizationFeatureExtractor.magnitudeBucket(forMinorUnits: 500_000), 7) // $5000
+    }
+
+    func testNegativeAmountUsesAbsoluteMagnitude() {
+        let extractor = CategorizationFeatureExtractor.utc
+        let input = CategorizationInput(
+            merchant: "Starbucks",
+            amountMinorUnits: -1_250,
+            date: referenceDate
+        )
+        let features = extractor.features(for: input)
+        XCTAssertEqual(features.absoluteAmountMinorUnits, 1_250)
+        XCTAssertEqual(features.amountMagnitudeBucket, 1) // $12.50 -> bucket 1
+    }
+
+    func testTemporalFeaturesAreDeterministicInUTC() {
+        let extractor = CategorizationFeatureExtractor.utc
+        let input = CategorizationInput(
+            merchant: "Shell",
+            amountMinorUnits: 4_000,
+            date: referenceDate
+        )
+        let features = extractor.features(for: input)
+        XCTAssertEqual(features.dayOfWeek, 3) // Tuesday (Sun = 1)
+        XCTAssertEqual(features.hour, 22)
+        XCTAssertFalse(features.isWeekend)
+    }
+
+    func testSignatureDerivedFromTokens() {
+        let extractor = CategorizationFeatureExtractor.utc
+        let input = CategorizationInput(
+            merchant: "Whole Foods Market #44",
+            amountMinorUnits: 8_000,
+            date: referenceDate
+        )
+        let features = extractor.features(for: input)
+        XCTAssertFalse(features.signature.isEmpty)
+        XCTAssertTrue(features.tokens.contains("whole"))
+        XCTAssertTrue(features.tokens.contains("foods"))
+    }
+}

--- a/apps/ios/Tests/CategorizationTelemetryTests.swift
+++ b/apps/ios/Tests/CategorizationTelemetryTests.swift
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategorizationTelemetryTests.swift
+// FinanceTests
+//
+// Tests aggregate, content-free telemetry: counts, source/band breakdowns,
+// acceptance rate, and UserDefaults persistence.
+//
+// References: #2382
+
+import FinanceShared
+import XCTest
+
+final class CategorizationTelemetryTests: XCTestCase {
+
+    func testInMemoryAggregation() {
+        let telemetry = InMemoryCategorizationTelemetry()
+
+        telemetry.recordSuggestionShown(source: .rules, band: .medium)
+        telemetry.recordSuggestionShown(source: .coreML, band: .high)
+        telemetry.recordSuggestionShown(source: .fallback, band: .none)
+        telemetry.recordAccepted(source: .rules)
+        telemetry.recordOverridden(source: .coreML)
+        telemetry.recordDisabled()
+
+        let snapshot = telemetry.snapshot()
+        XCTAssertEqual(snapshot.suggestionsShown, 3)
+        XCTAssertEqual(snapshot.accepted, 1)
+        XCTAssertEqual(snapshot.overridden, 1)
+        XCTAssertEqual(snapshot.disabled, 1)
+        XCTAssertEqual(snapshot.fallbackShown, 1)
+        XCTAssertEqual(snapshot.shownBySource["rules"], 1)
+        XCTAssertEqual(snapshot.shownBySource["coreML"], 1)
+        XCTAssertEqual(snapshot.shownByBand["high"], 1)
+    }
+
+    func testAcceptanceRate() {
+        let telemetry = InMemoryCategorizationTelemetry()
+        XCTAssertEqual(telemetry.snapshot().acceptanceRate, 0.0)
+
+        telemetry.recordAccepted(source: .rules)
+        telemetry.recordAccepted(source: .rules)
+        telemetry.recordOverridden(source: .rules)
+
+        XCTAssertEqual(telemetry.snapshot().acceptanceRate, 2.0 / 3.0, accuracy: 0.0001)
+    }
+
+    func testReset() {
+        let telemetry = InMemoryCategorizationTelemetry()
+        telemetry.recordSuggestionShown(source: .rules, band: .medium)
+        telemetry.reset()
+        XCTAssertEqual(telemetry.snapshot().suggestionsShown, 0)
+    }
+
+    func testUserDefaultsPersistsAcrossInstances() throws {
+        let suiteName = "test.categorization.telemetry.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let first = AggregateCategorizationTelemetry(defaults: defaults, storageKey: "k")
+        first.recordSuggestionShown(source: .rules, band: .medium)
+        first.recordAccepted(source: .rules)
+
+        // A fresh instance reading the same suite sees the persisted counts.
+        let second = AggregateCategorizationTelemetry(defaults: defaults, storageKey: "k")
+        let snapshot = second.snapshot()
+        XCTAssertEqual(snapshot.suggestionsShown, 1)
+        XCTAssertEqual(snapshot.accepted, 1)
+    }
+}

--- a/apps/ios/Tests/CategorySuggestionViewModelTests.swift
+++ b/apps/ios/Tests/CategorySuggestionViewModelTests.swift
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategorySuggestionViewModelTests.swift
+// FinanceTests
+//
+// Tests the review-surface view model: showing a suggestion, accept, override,
+// disable, and the disabled-at-init path. Uses isolated UserDefaults and an
+// in-memory telemetry recorder for determinism.
+//
+// References: #2382
+
+import FinanceShared
+import XCTest
+@testable import FinanceApp
+
+final class CategorySuggestionViewModelTests: XCTestCase {
+
+    private let categories: [CategoryItem] = [
+        CategoryItem(id: "food", name: "Food", colorHex: "#38A169", icon: "fork.knife"),
+        CategoryItem(id: "groceries", name: "Groceries", colorHex: "#3182CE", icon: "cart"),
+        CategoryItem(id: "bills", name: "Bills", colorHex: "#805AD5", icon: "doc.text"),
+        CategoryItem(id: "other", name: "Other", colorHex: "#718096", icon: "ellipsis"),
+    ]
+
+    private func makeInput(merchant: String) -> CategorizationInput {
+        CategorizationInput(
+            merchant: merchant,
+            amountMinorUnits: 1_500,
+            date: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
+    private func makeContext() -> (TransactionCategorizer, InMemoryCategorizationTelemetry, UserDefaults, String) {
+        let store = InMemoryCategoryCorrectionStore()
+        let categorizer = TransactionCategorizer(
+            featureExtractor: .utc,
+            correctionStore: store,
+            fallbackCategoryId: "other"
+        )
+        let telemetry = InMemoryCategorizationTelemetry()
+        let suiteName = "test.categorization.vm.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return (categorizer, telemetry, defaults, suiteName)
+    }
+
+    @MainActor
+    func testShowsSuggestionAndRecordsTelemetry() {
+        let (categorizer, telemetry, defaults, suiteName) = makeContext()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let vm = CategorySuggestionViewModel(
+            input: makeInput(merchant: "Starbucks"),
+            availableCategories: categories,
+            categorizer: categorizer,
+            telemetry: telemetry,
+            preferencesDefaults: defaults
+        )
+
+        XCTAssertEqual(vm.state, .suggested)
+        XCTAssertEqual(vm.selectedCategoryId, "food")
+        XCTAssertEqual(vm.selectedCategory?.name, "Food")
+        XCTAssertFalse(vm.confidenceText.isEmpty)
+        XCTAssertFalse(vm.isFallback)
+        XCTAssertEqual(telemetry.snapshot().suggestionsShown, 1)
+    }
+
+    @MainActor
+    func testAcceptPersistsCorrectionAndRecords() {
+        let (categorizer, telemetry, defaults, suiteName) = makeContext()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let input = makeInput(merchant: "Starbucks")
+
+        let vm = CategorySuggestionViewModel(
+            input: input,
+            availableCategories: categories,
+            categorizer: categorizer,
+            telemetry: telemetry,
+            preferencesDefaults: defaults
+        )
+        vm.accept()
+
+        XCTAssertEqual(vm.state, .accepted)
+        XCTAssertEqual(telemetry.snapshot().accepted, 1)
+        // The acceptance is learned for future personalization.
+        XCTAssertEqual(categorizer.categorize(input).source, .personalization)
+    }
+
+    @MainActor
+    func testOverrideChangesSelectionAndRecords() {
+        let (categorizer, telemetry, defaults, suiteName) = makeContext()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let input = makeInput(merchant: "Starbucks")
+
+        let vm = CategorySuggestionViewModel(
+            input: input,
+            availableCategories: categories,
+            categorizer: categorizer,
+            telemetry: telemetry,
+            preferencesDefaults: defaults
+        )
+        vm.override(to: "bills")
+
+        XCTAssertEqual(vm.state, .overridden)
+        XCTAssertEqual(vm.selectedCategoryId, "bills")
+        XCTAssertEqual(vm.selectedCategory?.name, "Bills")
+        XCTAssertEqual(telemetry.snapshot().overridden, 1)
+        XCTAssertEqual(categorizer.categorize(input).categoryId, "bills")
+    }
+
+    @MainActor
+    func testDisableTurnsOffAndPersistsPreference() {
+        let (categorizer, telemetry, defaults, suiteName) = makeContext()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let vm = CategorySuggestionViewModel(
+            input: makeInput(merchant: "Starbucks"),
+            availableCategories: categories,
+            categorizer: categorizer,
+            telemetry: telemetry,
+            preferencesDefaults: defaults
+        )
+        vm.disableSuggestions()
+
+        XCTAssertEqual(vm.state, .disabled)
+        XCTAssertNil(vm.suggestion)
+        XCTAssertFalse(vm.isEnabled)
+        XCTAssertEqual(telemetry.snapshot().disabled, 1)
+        XCTAssertFalse(CategorizationPreferences.isEnabled(defaults: defaults))
+    }
+
+    @MainActor
+    func testInitRespectsDisabledPreference() {
+        let (categorizer, telemetry, defaults, suiteName) = makeContext()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        CategorizationPreferences.setEnabled(false, defaults: defaults)
+
+        let vm = CategorySuggestionViewModel(
+            input: makeInput(merchant: "Starbucks"),
+            availableCategories: categories,
+            categorizer: categorizer,
+            telemetry: telemetry,
+            preferencesDefaults: defaults
+        )
+
+        XCTAssertEqual(vm.state, .disabled)
+        XCTAssertNil(vm.suggestion)
+        XCTAssertEqual(telemetry.snapshot().suggestionsShown, 0)
+    }
+
+    @MainActor
+    func testUnknownMerchantIsFallback() {
+        let (categorizer, telemetry, defaults, suiteName) = makeContext()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let vm = CategorySuggestionViewModel(
+            input: makeInput(merchant: "Zxqw"),
+            availableCategories: categories,
+            categorizer: categorizer,
+            telemetry: telemetry,
+            preferencesDefaults: defaults
+        )
+
+        XCTAssertTrue(vm.isFallback)
+        XCTAssertEqual(vm.selectedCategoryId, "other")
+        XCTAssertEqual(telemetry.snapshot().fallbackShown, 1)
+    }
+}

--- a/apps/ios/Tests/MerchantTokenizerTests.swift
+++ b/apps/ios/Tests/MerchantTokenizerTests.swift
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// MerchantTokenizerTests.swift
+// FinanceTests
+//
+// Deterministic tests for the merchant/memo tokenizer.
+//
+// References: #2382
+
+import FinanceShared
+import XCTest
+
+final class MerchantTokenizerTests: XCTestCase {
+
+    func testStripsNoiseAndStoreNumbers() {
+        let tokens = MerchantTokenizer.tokens(merchant: "WHOLE FOODS MKT #123 POS DEBIT")
+        XCTAssertTrue(tokens.contains("whole"))
+        XCTAssertTrue(tokens.contains("foods"))
+        XCTAssertFalse(tokens.contains("pos"), "Payment-network noise should be removed")
+        XCTAssertFalse(tokens.contains("debit"), "Payment-network noise should be removed")
+        XCTAssertFalse(tokens.contains("123"), "Pure-numeric store numbers should be removed")
+    }
+
+    func testLowercasesAndDeduplicates() {
+        let tokens = MerchantTokenizer.tokens(merchant: "Coffee COFFEE coffee")
+        XCTAssertEqual(tokens, ["coffee"])
+    }
+
+    func testCombinesMerchantAndMemo() {
+        let tokens = MerchantTokenizer.tokens(merchant: "Amazon", memo: "Marketplace order")
+        XCTAssertTrue(tokens.contains("amazon"))
+        XCTAssertTrue(tokens.contains("marketplace"))
+        XCTAssertTrue(tokens.contains("order"))
+    }
+
+    func testRemovesShortTokens() {
+        let tokens = MerchantTokenizer.tokens(merchant: "A B Target")
+        XCTAssertEqual(tokens, ["target"])
+    }
+
+    func testEmptyInputProducesNoTokens() {
+        XCTAssertTrue(MerchantTokenizer.tokens(merchant: "   #  42 ").isEmpty)
+    }
+
+    func testSignatureIsOrderIndependent() {
+        let a = MerchantTokenizer.signature(for: ["whole", "foods"])
+        let b = MerchantTokenizer.signature(for: ["foods", "whole"])
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a, "foods whole")
+    }
+
+    func testSignatureEmptyForNoTokens() {
+        XCTAssertEqual(MerchantTokenizer.signature(for: []), "")
+    }
+
+    func testDeterministicAcrossCalls() {
+        let first = MerchantTokenizer.tokens(merchant: "Shell Gas Station 4471")
+        let second = MerchantTokenizer.tokens(merchant: "Shell Gas Station 4471")
+        XCTAssertEqual(first, second)
+    }
+}

--- a/apps/ios/Tests/TransactionCategorizerTests.swift
+++ b/apps/ios/Tests/TransactionCategorizerTests.swift
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionCategorizerTests.swift
+// FinanceTests
+//
+// Deterministic tests for the rule engine and the priority-ordered
+// categorization pipeline (personalization > Core ML > rules > fallback).
+//
+// References: #2382
+
+import FinanceShared
+import XCTest
+
+// MARK: - Stub ML Classifier
+
+private struct StubMLClassifier: MLCategoryClassifier {
+    var available: Bool
+    var result: CategorizationSuggestion?
+
+    var isAvailable: Bool { available }
+
+    func classify(features: CategorizationFeatures) -> CategorizationSuggestion? {
+        result
+    }
+}
+
+final class TransactionCategorizerTests: XCTestCase {
+
+    private func makeInput(merchant: String, memo: String = "") -> CategorizationInput {
+        CategorizationInput(
+            merchant: merchant,
+            memo: memo,
+            amountMinorUnits: 4_200,
+            date: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
+    private func makeCategorizer(
+        ml: MLCategoryClassifier = UnavailableMLClassifier(),
+        store: CategoryCorrectionStoring = InMemoryCategoryCorrectionStore()
+    ) -> TransactionCategorizer {
+        TransactionCategorizer(
+            featureExtractor: .utc,
+            mlClassifier: ml,
+            ruleSuggester: RuleBasedCategorySuggester(),
+            correctionStore: store,
+            fallbackCategoryId: "other"
+        )
+    }
+
+    // MARK: - Rules
+
+    func testRulesMatchKnownMerchants() {
+        let categorizer = makeCategorizer()
+
+        XCTAssertEqual(categorizer.categorize(makeInput(merchant: "Starbucks")).categoryId, "food")
+        XCTAssertEqual(categorizer.categorize(makeInput(merchant: "Whole Foods Market")).categoryId, "groceries")
+        XCTAssertEqual(categorizer.categorize(makeInput(merchant: "Shell Gas Station")).categoryId, "transport")
+        XCTAssertEqual(categorizer.categorize(makeInput(merchant: "Netflix")).categoryId, "entertainment")
+    }
+
+    func testRuleSourceAndConfidence() {
+        let categorizer = makeCategorizer()
+        let suggestion = categorizer.categorize(makeInput(merchant: "Whole Foods Market"))
+        XCTAssertEqual(suggestion.source, .rules)
+        XCTAssertGreaterThan(suggestion.score, 0.5)
+        XCTAssertLessThanOrEqual(suggestion.score, 0.85)
+    }
+
+    func testUnknownMerchantFallsBack() {
+        let categorizer = makeCategorizer()
+        let suggestion = categorizer.categorize(makeInput(merchant: "Zxqw"))
+        XCTAssertEqual(suggestion.source, .fallback)
+        XCTAssertEqual(suggestion.categoryId, "other")
+        XCTAssertEqual(suggestion.score, 0.0)
+        XCTAssertTrue(suggestion.isFallback)
+    }
+
+    // MARK: - Priority
+
+    func testCoreMLWinsOverRulesWhenAvailable() {
+        let mlSuggestion = CategorizationSuggestion(categoryId: "shopping", score: 0.9, source: .coreML)
+        let categorizer = makeCategorizer(ml: StubMLClassifier(available: true, result: mlSuggestion))
+        // "Starbucks" would be food by rules, but ML overrides.
+        let suggestion = categorizer.categorize(makeInput(merchant: "Starbucks"))
+        XCTAssertEqual(suggestion.source, .coreML)
+        XCTAssertEqual(suggestion.categoryId, "shopping")
+    }
+
+    func testUnavailableMLFallsThroughToRules() {
+        let categorizer = makeCategorizer(ml: StubMLClassifier(available: false, result: nil))
+        let suggestion = categorizer.categorize(makeInput(merchant: "Starbucks"))
+        XCTAssertEqual(suggestion.source, .rules)
+    }
+
+    func testMLAbstainFallsThroughToRules() {
+        let categorizer = makeCategorizer(ml: StubMLClassifier(available: true, result: nil))
+        let suggestion = categorizer.categorize(makeInput(merchant: "Starbucks"))
+        XCTAssertEqual(suggestion.source, .rules)
+    }
+
+    func testPersonalizationWinsOverEverything() {
+        let store = InMemoryCategoryCorrectionStore()
+        let mlSuggestion = CategorizationSuggestion(categoryId: "shopping", score: 0.95, source: .coreML)
+        let categorizer = makeCategorizer(
+            ml: StubMLClassifier(available: true, result: mlSuggestion),
+            store: store
+        )
+        let input = makeInput(merchant: "Starbucks")
+        categorizer.learnCorrection(for: input, categoryId: "bills")
+
+        let suggestion = categorizer.categorize(input)
+        XCTAssertEqual(suggestion.source, .personalization)
+        XCTAssertEqual(suggestion.categoryId, "bills")
+        XCTAssertGreaterThan(suggestion.score, 0.9)
+    }
+
+    // MARK: - Personalization persistence
+
+    func testLearnedCorrectionAppliesToSameSignature() {
+        let store = InMemoryCategoryCorrectionStore()
+        let categorizer = makeCategorizer(store: store)
+
+        let learnInput = makeInput(merchant: "Starbucks #44")
+        categorizer.learnCorrection(for: learnInput, categoryId: "food")
+
+        // Different store number, same token signature -> personalised.
+        let recallInput = makeInput(merchant: "STARBUCKS STORE 91")
+        let suggestion = categorizer.categorize(recallInput)
+        XCTAssertEqual(suggestion.source, .personalization)
+        XCTAssertEqual(suggestion.categoryId, "food")
+    }
+
+    func testForgetCorrectionRevertsToRules() {
+        let store = InMemoryCategoryCorrectionStore()
+        let categorizer = makeCategorizer(store: store)
+        let input = makeInput(merchant: "Starbucks")
+
+        categorizer.learnCorrection(for: input, categoryId: "bills")
+        XCTAssertEqual(categorizer.categorize(input).source, .personalization)
+
+        categorizer.forgetCorrection(for: input)
+        XCTAssertEqual(categorizer.categorize(input).source, .rules)
+    }
+
+    // MARK: - Confidence bands
+
+    func testConfidenceBandMapping() {
+        XCTAssertEqual(CategorizationConfidenceBand(score: 0.95), .high)
+        XCTAssertEqual(CategorizationConfidenceBand(score: 0.65), .medium)
+        XCTAssertEqual(CategorizationConfidenceBand(score: 0.35), .low)
+        XCTAssertEqual(CategorizationConfidenceBand(score: 0.0), .none)
+    }
+}


### PR DESCRIPTION
## Summary

On-device transaction categorization for imported and manually-entered transactions. **All inference runs on-device** — merchant names, memos, and amounts never leave the device.

### Engine (`apps/ios/Shared/Categorization`, FinanceShared, dependency-free + fully testable)
- `MerchantTokenizer` — deterministic merchant/memo tokenization (lowercase, punctuation/store-number/payment-noise/stop-word stripping) + order-independent personalization signature.
- `CategorizationFeatureExtractor` — reduces input to tokens, a coarse amount magnitude bucket, and calendar-derived day/hour features (injectable calendar; UTC variant for deterministic tests).
- `RuleBasedCategorySuggester` — deterministic keyword engine mapping to the app's stable category ids; doubles as the always-available fallback.
- `MLCategoryClassifier` seam + `UnavailableMLClassifier` — Core ML adapter behind a protocol so Shared stays dependency-free.
- `TransactionCategorizer` — priority pipeline: **personalization > Core ML > rules > fallback**, never fails closed.

### Review surface (`apps/ios/Finance`)
- `CategorySuggestionViewModel` (`@Observable`) + `CategorySuggestionCard` (SwiftUI) showing confidence and **accept / override / disable**. VoiceOver labels, Dynamic Type, CVD-safe colours.
- `CoreMLCategoryClassifier` concrete adapter (loads a bundled `.mlmodelc` when present; ships unavailable → rule-engine fallback).

### Persistence & privacy
- `UserDefaultsCategoryCorrectionStore` persists `[signature: categoryId]` corrections (app-group), degrades to no-op when native storage is unavailable.
- `AggregateCategorizationTelemetry` records **counts + enum tags only** (source, confidence band, accept/override/disable/fallback) — never merchant/memo/amount/category content.
- Documented Core ML fallback behaviour in `Shared/Categorization/README.md`.

### Tests (`apps/ios/Tests`, deterministic)
Tokenizer, feature extractor, rule engine + pipeline priority, telemetry aggregation/persistence, and the review view model (accept/override/disable/disabled-init/fallback).

## Needs Human Action
- `CoreMLCategoryClassifier.classify` is marked `TODO(human)`: mapping `CategorizationFeatures` into the model's `MLFeatureProvider` and translating predictions requires a compiled `.mlmodelc` and its generated schema (Xcode/Core ML toolchain). Until bundled, the adapter reports unavailable and the deterministic rule engine drives every suggestion — fully functional and CI-green.

Closes #2382

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>