### PR TITLE
feat(web): brokerage trade import & reconciliation (#2120)

### DIFF
--- a/apps/web/src/components/import/BrokerageImportPanel.test.tsx
+++ b/apps/web/src/components/import/BrokerageImportPanel.test.tsx
@@ -11,6 +11,11 @@ const FIDELITY_CSV = [
   '02/14/2024,YOU BOUGHT,AAPL,5,160.00,4.95,-804.95',
 ].join('\n');
 
+/** A generic export with no distinctive broker signature columns. */
+const GENERIC_CSV = ['Date,Action,Symbol,Quantity,Price', '2024-01-03,Buy,AAPL,10,150.00'].join(
+  '\n',
+);
+
 /** Drive the paste → confirm-mapping flow for a single broker export. */
 function addExport(broker: string, csv: string): void {
   fireEvent.change(screen.getByLabelText(/broker name/i), { target: { value: broker } });
@@ -32,13 +37,35 @@ describe('BrokerageImportPanel', () => {
     ).toBeInTheDocument();
   });
 
-  it('requires a broker name before loading a paste', () => {
+  it('requires a broker name before loading an unrecognized export', () => {
     render(<BrokerageImportPanel />);
+    fireEvent.change(screen.getByLabelText(/paste csv text/i), {
+      target: { value: GENERIC_CSV },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add pasted csv/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/broker name/i);
+  });
+
+  it('auto-detects a recognized broker export without a manually typed name', () => {
+    render(<BrokerageImportPanel />);
+    // No broker name typed — detection should recognize the Fidelity layout.
     fireEvent.change(screen.getByLabelText(/paste csv text/i), {
       target: { value: FIDELITY_CSV },
     });
     fireEvent.click(screen.getByRole('button', { name: /add pasted csv/i }));
-    expect(screen.getByRole('alert')).toHaveTextContent(/broker name/i);
+
+    // A status banner names the detected broker, and the mapping is pre-filled.
+    const banner = screen.getByText(/recognized a/i);
+    expect(banner).toHaveTextContent(/fidelity/i);
+    expect(screen.getByRole('combobox', { name: /trade date/i })).toHaveValue('Run Date');
+    expect(screen.getByRole('combobox', { name: /fees \/ commission/i })).toHaveValue(
+      'Commission ($)',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm .* add export/i }));
+    expect(screen.getByRole('group', { name: /reconciliation summary/i })).toHaveTextContent(
+      /Fidelity/,
+    );
   });
 
   it('shows a column-mapping confirmation with auto-detected fields', () => {

--- a/apps/web/src/components/import/BrokerageImportPanel.tsx
+++ b/apps/web/src/components/import/BrokerageImportPanel.tsx
@@ -37,19 +37,17 @@ import {
   type BrokerageColumnMapping,
   type BrokerageParseResult,
 } from '../../lib/investments/brokerage-import';
+import {
+  detectBrokerFormat,
+  KNOWN_BROKER_LABELS,
+  type DetectedBrokerFormat,
+} from '../../lib/investments/broker-formats';
 import { AppIcon, type IconName } from '../icons';
 import { FileDropZone } from './FileDropZone';
 
 import './brokerage-import-panel.css';
 
-const KNOWN_BROKERS = [
-  'Fidelity',
-  'Schwab',
-  'Robinhood',
-  'E*TRADE',
-  'Vanguard',
-  'Merrill',
-] as const;
+const KNOWN_BROKERS = KNOWN_BROKER_LABELS;
 
 const MAX_PREVIEW_ROWS = 3;
 const MAX_TRADE_ROWS = 100;
@@ -81,6 +79,8 @@ interface PendingSource {
   readonly headers: readonly string[];
   readonly previewRows: readonly string[][];
   readonly mapping: BrokerageColumnMapping;
+  /** Auto-detected broker format, when the export was recognized. */
+  readonly detected: DetectedBrokerFormat | null;
 }
 
 function formatQuantity(quantity: number): string {
@@ -104,22 +104,30 @@ export const BrokerageImportPanel: React.FC = () => {
   const loadContent = useCallback(
     (content: string) => {
       setParseError(null);
-      const broker = brokerName.trim();
-      if (!broker) {
-        setParseError('Enter the broker name before adding an export.');
-        return;
-      }
       const { headers, rows } = parseCsv(content, { hasHeader: true });
       if (headers.length === 0 || rows.length === 0) {
         setParseError('No rows found. Make sure the file is a CSV with a header row.');
         return;
       }
+      const detected = detectBrokerFormat(headers);
+      const broker = brokerName.trim() || detected?.broker || '';
+      if (!broker) {
+        setParseError(
+          'Enter the broker name before adding an export, or use a recognized broker export.',
+        );
+        return;
+      }
+      const baseMapping = suggestColumnMapping(headers);
+      const mapping: BrokerageColumnMapping = detected
+        ? { ...baseMapping, ...detected.mapping }
+        : baseMapping;
       setPending({
         broker,
         content,
         headers,
         previewRows: rows.slice(0, MAX_PREVIEW_ROWS),
-        mapping: suggestColumnMapping(headers),
+        mapping,
+        detected,
       });
     },
     [brokerName],
@@ -159,6 +167,7 @@ export const BrokerageImportPanel: React.FC = () => {
     const result = parseBrokerageCsv(pending.content, {
       broker: pending.broker,
       mapping: pending.mapping,
+      dateFormat: pending.detected?.dateFormat,
     });
     setSources((prev) => [...prev, result]);
     setPending(null);
@@ -199,10 +208,13 @@ export const BrokerageImportPanel: React.FC = () => {
         Brokerage Trade Import &amp; Reconciliation
       </h2>
       <p className="brokerage-import__intro">
-        Export a trade-confirmation CSV from each broker (Fidelity, Schwab, Robinhood and others),
-        add them one at a time, and we reconcile buys, sells and dividends into a single holdings
-        view with average cost basis. Connecting a live brokerage account is not available here —
-        all parsing happens on this device and nothing is saved automatically.
+        Export a trade-confirmation or activity CSV from each broker and add them one at a time. We
+        recognize common layouts automatically — Fidelity, Charles Schwab, Robinhood, Interactive
+        Brokers, E*TRADE and Vanguard, plus the crypto venues Coinbase and Kraken — and fill in the
+        broker name and column mapping for you, so you don&apos;t have to remap every file by hand.
+        Buys, sells and dividends are reconciled into a single holdings view with average cost
+        basis. Connecting a live brokerage account is not available here — all parsing happens on
+        this device and nothing is saved automatically.
       </p>
 
       {/* ----------------------------------------------------------------- */}
@@ -234,7 +246,7 @@ export const BrokerageImportPanel: React.FC = () => {
           accept=".csv"
           onFile={handleFile}
           inputLabel="Choose a broker trade-confirmation CSV file to import"
-          hint=".csv files up to 10 MB — set the broker name first"
+          hint=".csv files up to 10 MB — recognized broker exports fill in the name automatically"
         />
 
         <div className="brokerage-import__field">
@@ -275,6 +287,16 @@ export const BrokerageImportPanel: React.FC = () => {
             <legend className="brokerage-import__legend">
               Confirm columns for {pending.broker}
             </legend>
+            {pending.detected !== null && (
+              <p className="brokerage-import__detected" role="status">
+                <AppIcon name="check-circle" />
+                <span>
+                  Recognized a <strong>{pending.detected.broker}</strong>{' '}
+                  {pending.detected.assetClass === 'crypto' ? 'crypto' : 'brokerage'} export —
+                  broker name and columns were filled in for you. Review and adjust below if needed.
+                </span>
+              </p>
+            )}
             <p className="brokerage-import__hint">
               We matched these columns automatically. Adjust any that look wrong, then confirm.
             </p>

--- a/apps/web/src/components/import/brokerage-import-panel.css
+++ b/apps/web/src/components/import/brokerage-import-panel.css
@@ -87,6 +87,24 @@
  * Column mapping
  * ------------------------------------------------------------------------- */
 
+.brokerage-import__detected {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+  border: 1px solid var(--semantic-status-positive, var(--semantic-border-default));
+  border-radius: var(--border-radius-md);
+  color: var(--semantic-text-primary);
+  background: var(--semantic-background-secondary);
+  margin: 0 0 var(--spacing-3);
+}
+
+.brokerage-import__detected svg {
+  flex: none;
+  color: var(--semantic-status-positive, var(--semantic-text-primary));
+  margin-top: 0.1em;
+}
+
 .brokerage-import__mapping {
   border: 1px solid var(--semantic-border-default);
   border-radius: var(--border-radius-md);

--- a/apps/web/src/lib/investments/broker-formats.test.ts
+++ b/apps/web/src/lib/investments/broker-formats.test.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { BROKER_FORMATS, KNOWN_BROKER_LABELS, detectBrokerFormat } from './broker-formats';
+
+/** Pull just the header row out of a CSV string. */
+function headersOf(csv: string): string[] {
+  return csv.split('\n')[0].split(',');
+}
+
+describe('detectBrokerFormat', () => {
+  it('returns null for an empty or unrecognized header set', () => {
+    expect(detectBrokerFormat([])).toBeNull();
+    // Generic export with no distinctive signature columns.
+    expect(detectBrokerFormat(['Date', 'Action', 'Symbol', 'Quantity', 'Price'])).toBeNull();
+  });
+
+  it('detects a Fidelity trade-confirmation export and tunes the mapping', () => {
+    const headers = headersOf(
+      'Run Date,Action,Symbol,Quantity,Price ($),Commission ($),Amount ($)',
+    );
+    const detected = detectBrokerFormat(headers);
+    expect(detected).not.toBeNull();
+    expect(detected?.broker).toBe('Fidelity');
+    expect(detected?.assetClass).toBe('equities');
+    expect(detected?.dateFormat).toBe('MM/DD/YYYY');
+    expect(detected?.mapping).toMatchObject({
+      date: 'Run Date',
+      symbol: 'Symbol',
+      action: 'Action',
+      quantity: 'Quantity',
+      price: 'Price ($)',
+      fees: 'Commission ($)',
+      amount: 'Amount ($)',
+    });
+  });
+
+  it('detects a Schwab export by its "Fees & Comm" signature column', () => {
+    const headers = headersOf('Date,Action,Symbol,Description,Quantity,Price,Fees & Comm,Amount');
+    const detected = detectBrokerFormat(headers);
+    expect(detected?.broker).toBe('Charles Schwab');
+    expect(detected?.mapping.fees).toBe('Fees & Comm');
+  });
+
+  it('detects a Robinhood export by Activity Date / Instrument / Trans Code', () => {
+    const headers = headersOf(
+      'Activity Date,Process Date,Settle Date,Instrument,Description,Trans Code,Quantity,Price,Amount',
+    );
+    const detected = detectBrokerFormat(headers);
+    expect(detected?.broker).toBe('Robinhood');
+    expect(detected?.mapping).toMatchObject({
+      date: 'Activity Date',
+      symbol: 'Instrument',
+      action: 'Trans Code',
+    });
+  });
+
+  it('detects an Interactive Brokers export without assuming a date format', () => {
+    const headers = headersOf(
+      'TradeDate,Symbol,Buy/Sell,Quantity,TradePrice,IBCommission,Proceeds',
+    );
+    const detected = detectBrokerFormat(headers);
+    expect(detected?.broker).toBe('Interactive Brokers');
+    expect(detected?.dateFormat).toBeUndefined();
+    expect(detected?.mapping).toMatchObject({
+      action: 'Buy/Sell',
+      price: 'TradePrice',
+      fees: 'IBCommission',
+    });
+  });
+
+  it('detects crypto venues (Coinbase and Kraken) and labels them as crypto', () => {
+    const coinbase = detectBrokerFormat(
+      headersOf(
+        'Timestamp,Transaction Type,Asset,Quantity Transacted,Spot Price at Transaction,Subtotal,Total,Fees and/or Spread',
+      ),
+    );
+    expect(coinbase?.broker).toBe('Coinbase');
+    expect(coinbase?.assetClass).toBe('crypto');
+    expect(coinbase?.mapping).toMatchObject({
+      symbol: 'Asset',
+      quantity: 'Quantity Transacted',
+      fees: 'Fees and/or Spread',
+    });
+
+    const kraken = detectBrokerFormat(
+      headersOf('txid,ordertxid,pair,time,type,ordertype,price,cost,fee,vol,margin,misc,ledgers'),
+    );
+    expect(kraken?.broker).toBe('Kraken');
+    expect(kraken?.assetClass).toBe('crypto');
+    expect(kraken?.mapping).toMatchObject({
+      date: 'time',
+      symbol: 'pair',
+      quantity: 'vol',
+      amount: 'cost',
+    });
+  });
+
+  it('matches headers case-insensitively and ignoring surrounding whitespace', () => {
+    const detected = detectBrokerFormat([' RUN DATE ', 'action', 'SYMBOL', 'Quantity']);
+    expect(detected?.broker).toBe('Fidelity');
+    // Resolved mapping preserves the file's original header casing/spacing.
+    expect(detected?.mapping.date).toBe(' RUN DATE ');
+  });
+
+  it('prefers the more specific profile when signatures overlap', () => {
+    // Vanguard's signature (4 columns) is more specific than a 3-column match.
+    const headers = headersOf(
+      'Trade Date,Symbol,Transaction Type,Shares,Share Price,Principal Amount,Commission Fees',
+    );
+    const detected = detectBrokerFormat(headers);
+    expect(detected?.broker).toBe('Vanguard');
+    expect(detected?.confidence).toBe(4);
+  });
+
+  it('exposes a stable, non-empty catalog of known brokers', () => {
+    expect(BROKER_FORMATS.length).toBeGreaterThanOrEqual(8);
+    expect(KNOWN_BROKER_LABELS).toContain('Fidelity');
+    expect(KNOWN_BROKER_LABELS).toContain('Coinbase');
+    // Every profile must declare at least two signature columns to stay unambiguous.
+    for (const profile of BROKER_FORMATS) {
+      expect(profile.signature.length).toBeGreaterThanOrEqual(3);
+    }
+  });
+});

--- a/apps/web/src/lib/investments/broker-formats.ts
+++ b/apps/web/src/lib/investments/broker-formats.ts
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Broker-native export format detection.
+ *
+ * Active traders export trade-confirmation / activity CSVs from many brokers,
+ * each with its own column names, date conventions and asset class. The generic
+ * header-alias mapper in {@link ./brokerage-import} works, but it still asks the
+ * user to type the broker name and eyeball every column.
+ *
+ * This module recognizes the *signature* header layout of common brokerages
+ * (Fidelity, Schwab, Robinhood, Interactive Brokers, E*TRADE, Vanguard, plus the
+ * crypto venues Coinbase and Kraken) and returns the broker label, asset class,
+ * a pre-tuned {@link BrokerageColumnMapping} resolved against the file's actual
+ * headers, and the broker's typical date format. The UI uses this to auto-fill
+ * the broker name and column mapping so a trader can import file after file
+ * "without remapping every file by hand".
+ *
+ * Pure and deterministic — no I/O, no database, no floating-point money math.
+ * References: issue #2120.
+ */
+
+import type { BrokerageColumnMapping } from './brokerage-import';
+
+/** Logical fields a broker profile can map. Mirrors {@link BrokerageColumnMapping}. */
+type MappingField = keyof BrokerageColumnMapping;
+
+const MAPPING_FIELDS: readonly MappingField[] = [
+  'date',
+  'symbol',
+  'action',
+  'quantity',
+  'price',
+  'fees',
+  'amount',
+];
+
+/** Whether a broker trades listed securities or crypto assets. */
+export type BrokerAssetClass = 'equities' | 'crypto';
+
+/** A recognized broker export layout. */
+export interface BrokerFormatProfile {
+  /** Stable machine id, e.g. `"fidelity"`. */
+  readonly id: string;
+  /** Human-readable broker label, e.g. `"Fidelity"`. */
+  readonly broker: string;
+  readonly assetClass: BrokerAssetClass;
+  /**
+   * Normalized header names that must *all* be present for the profile to
+   * match. These are the distinctive columns that make the layout unambiguous.
+   */
+  readonly signature: readonly string[];
+  /**
+   * Candidate header names per logical field, in priority order. The first one
+   * actually present in the file is used. Stored in display casing.
+   */
+  readonly columns: Readonly<Record<MappingField, readonly string[]>>;
+  /** Typical date format (e.g. `"MM/DD/YYYY"`); omitted for ISO timestamps. */
+  readonly dateFormat?: string;
+}
+
+/** The outcome of a successful detection. */
+export interface DetectedBrokerFormat {
+  readonly id: string;
+  readonly broker: string;
+  readonly assetClass: BrokerAssetClass;
+  /** Column mapping resolved to the file's actual header strings. */
+  readonly mapping: Partial<BrokerageColumnMapping>;
+  readonly dateFormat?: string;
+  /** Specificity score: number of signature headers matched (higher = surer). */
+  readonly confidence: number;
+}
+
+/** Normalize a header for comparison (lower-case, collapse internal whitespace). */
+function normalizeHeader(header: string): string {
+  return header.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+/**
+ * Broker profiles, ordered most → least specific. The detector still ranks by
+ * matched-signature count, so ordering only breaks exact ties deterministically.
+ */
+export const BROKER_FORMATS: readonly BrokerFormatProfile[] = [
+  {
+    id: 'fidelity',
+    broker: 'Fidelity',
+    assetClass: 'equities',
+    signature: ['run date', 'action', 'symbol', 'quantity'],
+    columns: {
+      date: ['Run Date', 'Date'],
+      symbol: ['Symbol'],
+      action: ['Action'],
+      quantity: ['Quantity'],
+      price: ['Price ($)', 'Price'],
+      fees: ['Commission ($)', 'Fees ($)', 'Commission'],
+      amount: ['Amount ($)', 'Amount'],
+    },
+    dateFormat: 'MM/DD/YYYY',
+  },
+  {
+    id: 'schwab',
+    broker: 'Charles Schwab',
+    assetClass: 'equities',
+    signature: ['date', 'action', 'symbol', 'fees & comm'],
+    columns: {
+      date: ['Date'],
+      symbol: ['Symbol'],
+      action: ['Action'],
+      quantity: ['Quantity'],
+      price: ['Price'],
+      fees: ['Fees & Comm'],
+      amount: ['Amount'],
+    },
+    dateFormat: 'MM/DD/YYYY',
+  },
+  {
+    id: 'robinhood',
+    broker: 'Robinhood',
+    assetClass: 'equities',
+    signature: ['activity date', 'instrument', 'trans code'],
+    columns: {
+      date: ['Activity Date', 'Process Date', 'Settle Date'],
+      symbol: ['Instrument'],
+      action: ['Trans Code'],
+      quantity: ['Quantity'],
+      price: ['Price'],
+      fees: ['Fees'],
+      amount: ['Amount'],
+    },
+    dateFormat: 'MM/DD/YYYY',
+  },
+  {
+    id: 'interactive-brokers',
+    broker: 'Interactive Brokers',
+    assetClass: 'equities',
+    signature: ['symbol', 'buy/sell', 'tradeprice'],
+    columns: {
+      date: ['TradeDate', 'Date/Time', 'Date'],
+      symbol: ['Symbol'],
+      action: ['Buy/Sell'],
+      quantity: ['Quantity'],
+      price: ['TradePrice', 'T. Price', 'Price'],
+      fees: ['IBCommission', 'Comm/Fee', 'Commission'],
+      amount: ['Proceeds', 'NetCash', 'Amount'],
+    },
+  },
+  {
+    id: 'etrade',
+    broker: 'E*TRADE',
+    assetClass: 'equities',
+    signature: ['transactiondate', 'transactiontype', 'symbol'],
+    columns: {
+      date: ['TransactionDate'],
+      symbol: ['Symbol'],
+      action: ['TransactionType'],
+      quantity: ['Quantity'],
+      price: ['Price'],
+      fees: ['Commission'],
+      amount: ['Amount'],
+    },
+    dateFormat: 'MM/DD/YYYY',
+  },
+  {
+    id: 'vanguard',
+    broker: 'Vanguard',
+    assetClass: 'equities',
+    signature: ['trade date', 'transaction type', 'shares', 'share price'],
+    columns: {
+      date: ['Trade Date'],
+      symbol: ['Symbol'],
+      action: ['Transaction Type'],
+      quantity: ['Shares'],
+      price: ['Share Price'],
+      fees: ['Commission Fees'],
+      amount: ['Principal Amount', 'Net Amount'],
+    },
+    dateFormat: 'MM/DD/YYYY',
+  },
+  {
+    id: 'coinbase',
+    broker: 'Coinbase',
+    assetClass: 'crypto',
+    signature: ['timestamp', 'transaction type', 'asset', 'quantity transacted'],
+    columns: {
+      date: ['Timestamp'],
+      symbol: ['Asset'],
+      action: ['Transaction Type'],
+      quantity: ['Quantity Transacted'],
+      price: ['Spot Price at Transaction', 'Price'],
+      fees: ['Fees and/or Spread', 'Fees'],
+      amount: ['Subtotal', 'Total (inclusive of fees and/or spread)', 'Total'],
+    },
+  },
+  {
+    id: 'kraken',
+    broker: 'Kraken',
+    assetClass: 'crypto',
+    signature: ['ordertxid', 'pair', 'vol', 'price'],
+    columns: {
+      date: ['time'],
+      symbol: ['pair'],
+      action: ['type'],
+      quantity: ['vol'],
+      price: ['price'],
+      fees: ['fee'],
+      amount: ['cost'],
+    },
+  },
+];
+
+/** Resolve a profile's candidate columns against the file's actual headers. */
+function resolveMapping(
+  profile: BrokerFormatProfile,
+  headerByNorm: ReadonlyMap<string, string>,
+): Partial<BrokerageColumnMapping> {
+  const mapping: Partial<Record<MappingField, string>> = {};
+  for (const field of MAPPING_FIELDS) {
+    for (const candidate of profile.columns[field]) {
+      const actual = headerByNorm.get(normalizeHeader(candidate));
+      if (actual) {
+        mapping[field] = actual;
+        break;
+      }
+    }
+  }
+  return mapping;
+}
+
+/**
+ * Detect the broker behind a CSV from its header row.
+ *
+ * Returns the best-matching profile (most signature headers matched), with its
+ * column mapping resolved to the file's real header strings, or `null` when no
+ * known broker layout is recognized (the caller then falls back to the generic
+ * alias mapper and asks the user for a broker name).
+ */
+export function detectBrokerFormat(headers: readonly string[]): DetectedBrokerFormat | null {
+  if (headers.length === 0) return null;
+
+  const headerByNorm = new Map<string, string>();
+  for (const header of headers) {
+    const norm = normalizeHeader(header);
+    // First writer wins so duplicate-ish headers keep the leftmost column.
+    if (!headerByNorm.has(norm)) headerByNorm.set(norm, header);
+  }
+
+  let best: DetectedBrokerFormat | null = null;
+  for (const profile of BROKER_FORMATS) {
+    const allPresent = profile.signature.every((sig) => headerByNorm.has(sig));
+    if (!allPresent) continue;
+    const confidence = profile.signature.length;
+    if (best && confidence <= best.confidence) continue;
+    best = {
+      id: profile.id,
+      broker: profile.broker,
+      assetClass: profile.assetClass,
+      mapping: resolveMapping(profile, headerByNorm),
+      dateFormat: profile.dateFormat,
+      confidence,
+    };
+  }
+  return best;
+}
+
+/** Display labels for the broker datalist / docs, in presentation order. */
+export const KNOWN_BROKER_LABELS: readonly string[] = BROKER_FORMATS.map((p) => p.broker);


### PR DESCRIPTION
## Summary

Adds **broker-native export format detection** to the brokerage trade-import + cross-broker reconciliation surface, closing the last gap in #2120: a trader can now import activity from multiple brokerages **without remapping every file by hand**.

### What's new
- `apps/web/src/lib/investments/broker-formats.ts` — a pure, deterministic detector that recognizes the signature header layouts of common brokerages and returns the broker label, asset class (equities vs. crypto), a column mapping resolved to the file's actual headers, and the broker's typical date format:
  - **Equities:** Fidelity, Charles Schwab, Robinhood, Interactive Brokers, E*TRADE, Vanguard
  - **Crypto:** Coinbase, Kraken
  - Unrecognized layouts return `null` so the existing generic alias mapper + manual broker-name prompt still apply.
- Wired into `BrokerageImportPanel`: recognized exports auto-fill the broker name and pre-tune the column mapping; an accessible (icon **and** text, never colour-only) banner names the detected broker and asset class. Date format flows through to parsing.

### Accessibility (WCAG 2.2 AA)
- Detected-broker banner uses `role="status"` with an icon **plus** text label.
- All existing labelled inputs, `<fieldset>` mapping, table captions and live regions preserved.

### Tests
- `broker-formats.test.ts` — detection per broker, crypto labelling, case/whitespace tolerance, specificity ranking, null for generic/empty headers.
- `BrokerageImportPanel.test.tsx` — auto-detection with no typed broker name + pre-filled mapping; the broker-name-required path now asserted via a generic (undetected) export.
- Project-wide `tsc --noEmit` clean; changed-surface Vitest + ESLint green.

Closes #2120

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>