### PR TITLE
feat(windows): AI accessibility narration (#2394)

### DIFF
--- a/apps/windows/README.md
+++ b/apps/windows/README.md
@@ -215,6 +215,89 @@ trip it too until our publisher reputation builds up over time.
 
 ---
 
+## AI accessibility narration of finances (#2394)
+
+Screen-reader users get a calm, on-device spoken summary of the dashboard:
+its **states** (net worth, the most time-relevant bill, budgets, goals),
+**trends** (the net-worth trend), and **anomalies** (spending topics observed
+outside their usual range). Everything is generated locally — no model, no
+network, no I/O on the narration path — so source financial data and the
+generated summaries never leave the machine.
+
+### Where the code lives
+
+| Concern                                              | File                                      |
+| ---------------------------------------------------- | ----------------------------------------- |
+| Narration output contract (shared data model)        | `narration/NarrationContract.kt`          |
+| Deterministic money/percent/date text helpers        | `narration/NarrationText.kt`              |
+| Steady-state narrator (states, trend, goals)         | `narration/TemplateNarrationGenerator.kt` |
+| **Anomaly narrator (signals / notable deltas)**      | `narration/AnomalyNarrator.kt`            |
+| **Dashboard composer (states + trends + anomalies)** | `narration/DashboardNarrator.kt`          |
+
+`DashboardNarrator.generate(snapshot, mode)` returns a single `Narration`. Each
+`NarrationSegment` carries both visible prose (`text`) and a Narrator-friendly
+projection (`a11y.screenReaderText`, `a11y.role`, `a11y.ariaLive`,
+`a11y.headingLevel`). The UI Automation projection (#2707) maps those fields to
+native accessibility properties — this layer only generates the words, it does
+not touch the UIA surface.
+
+### Narration modes
+
+- **Concise** — the headline plus the few most material facts and the single
+  most material anomaly. No standalone uncertainty notes (hedging stays inline).
+- **Detailed** — every material fact and anomaly, with explicit
+  `uncertainty` segments appended last for any low-confidence claim.
+
+Material content is always read before confidence/uncertainty notes, so Narrator
+speaks "what's true → what's worth a look → how sure we are" in that order.
+
+### Tone & confidence rules (enforced by unit tests)
+
+- **Never alarmist.** Budgets are "fully used", not "overspent"; an anomaly is
+  "a little above its usual range", never a "spike", "alert", or "warning".
+  `NarrationText.BANNED_TERMS` is asserted absent from every generated string in
+  CI (`AnomalyNarratorTest`, `TemplateNarrationGeneratorTest`).
+- **Always hedged when unsure.** Low-confidence signals are framed as an "Early
+  signal …" with a gentle heads-up; medium confidence is "Based on recent
+  activity …"; high confidence states the fact plainly.
+
+### Accessibility test notes — Narrator
+
+Run these on a Windows machine with Narrator (`Win + Ctrl + Enter`):
+
+1. Open the dashboard. Confirm the headline is announced first as a level-2
+   heading with a `status` role, then each segment is read in document order.
+2. Toggle **concise ↔ detailed** narration mode. Confirm concise reads only the
+   headline plus a few segments, and detailed adds the goal and the trailing
+   uncertainty note(s).
+3. Confirm low-confidence content is spoken as "Early signal …" and is never
+   stated as a hard fact.
+4. Confirm no segment is announced assertively / interrupts — routine state is
+   `polite` only. Listen for any alarmist wording; there should be none.
+5. Cross-check with **Accessibility Insights for Windows** that each segment's
+   UI Automation `Name` matches its `a11y.screenReaderText`.
+
+### Accessibility test notes — keyboard-only
+
+1. Unplug / ignore the mouse. `Tab` / `Shift+Tab` through the dashboard; focus
+   order must follow reading order (headline → segments).
+2. Each narration segment must be reachable and focus-visible.
+3. The concise/detailed toggle must be operable with `Space` / `Enter` and must
+   announce its new state on change.
+4. No keyboard trap: you can always `Tab` back out of the narration region.
+
+### Needs Human Action
+
+The generator and its accessibility metadata are fully unit-tested, but the
+**live Narrator / UI Automation announcement can only be validated on Windows
+hardware** with the screen reader running — that cannot run in headless CI. A
+reviewer with a Windows device should walk the Narrator and keyboard-only
+checklists above and confirm real spoken output before this is considered
+shipped. The validation point is marked in code with `// TODO(human)` in
+`narration/DashboardNarrator.kt`.
+
+---
+
 ## Related issues
 
 - [#1899](../../../../issues/1899) — this PR: Windows build & release automation

--- a/apps/windows/src/main/kotlin/com/finance/desktop/narration/AnomalyNarrator.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/narration/AnomalyNarrator.kt
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.narration
+
+import com.finance.desktop.narration.NarrationText.capitalizeFirst
+import com.finance.desktop.narration.NarrationText.formatCents
+import com.finance.desktop.narration.NarrationText.spellCents
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.max
+
+// =============================================================================
+// AnomalyNarrator — deterministic, on-device narration of notable deltas
+// =============================================================================
+//
+// The `TemplateNarrationGenerator` (#2707) narrates steady-state dashboard facts
+// — net worth, the most time-relevant bill, budgets, the net-worth trend, and
+// goals. It deliberately does NOT speak the `signals` carried by a
+// [FinancialStateSnapshot]: those are pre-classified ANOMALIES (a spending topic
+// observed outside its usual range), and #2394 asks specifically for narration
+// of "anomalies" alongside states and trends.
+//
+// This narrator fills that gap. It is the deterministic TEMPLATE layer for
+// anomalies — no model, no network, no I/O. A [Signal] is already computed by an
+// upstream engine (observed cents plus an expected low/high band); this code
+// only turns that pre-computed delta into calm, Narrator-friendly prose.
+//
+// Design rules it upholds (mirrors `TemplateNarrationGenerator`):
+//   * Calm, non-alarmist tone (design §3, §5.4). A delta is "a little above its
+//     usual range", never a "spike", "alert", or "warning". The banned-term
+//     golden test fails the build if alarmist vocabulary leaks in.
+//   * Confidence/uncertainty is always surfaced. Low-confidence signals are
+//     hedged inline ("Early signal …") and, in detailed mode, summarised by an
+//     appended `uncertainty` segment.
+//   * Concise vs. detailed. Concise speaks only the single most material
+//     anomaly; detailed speaks them all, most-material first.
+//
+// Output is the shared [NarrationSegment] model so the UI Automation projection
+// (#2707) can map every segment to Narrator labels with no extra coupling.
+// Anomalies are emitted as [SegmentKind.INSIGHT] segments — a notable, material
+// fact rather than steady state — reusing the existing contract unchanged.
+class AnomalyNarrator {
+
+    /**
+     * Renders the anomaly [signals] into ordered [NarrationSegment]s for [mode].
+     *
+     * Only signals whose observed value falls OUTSIDE their expected band are
+     * narrated; a value inside the band is not anomalous and is skipped. The
+     * result is ordered most-material first (largest relative deviation), with a
+     * stable tie-break on [Signal.id] so output is fully reproducible.
+     *
+     * In [NarrationMode.DETAILED] a trailing `uncertainty` segment is appended
+     * when any narrated anomaly is low confidence.
+     */
+    fun generate(
+        signals: List<Signal>,
+        mode: NarrationMode,
+    ): List<NarrationSegment> {
+        val material = materialSegments(signals, mode)
+        if (mode == NarrationMode.CONCISE) return material
+        return material + uncertaintySegments(signals, material)
+    }
+
+    /** The anomaly fact segments (no uncertainty note), ordered + mode-limited. */
+    fun materialSegments(
+        signals: List<Signal>,
+        mode: NarrationMode,
+    ): List<NarrationSegment> {
+        val ranked =
+            signals
+                .mapNotNull { signal -> deviationOf(signal)?.let { signal to it } }
+                .sortedWith(
+                    compareByDescending<Pair<Signal, Deviation>> { it.second.relative }
+                        .thenBy { it.first.id },
+                )
+        val limited =
+            when (mode) {
+                NarrationMode.CONCISE -> ranked.take(CONCISE_LIMIT)
+                NarrationMode.DETAILED -> ranked
+            }
+        return limited.map { (signal, deviation) -> anomalySegment(signal, deviation) }
+    }
+
+    /** A single `uncertainty` note when any [material] anomaly is low confidence. */
+    fun uncertaintySegments(
+        signals: List<Signal>,
+        material: List<NarrationSegment>,
+    ): List<NarrationSegment> {
+        val renderedIds = material.map { it.id }.toSet()
+        val anyLow =
+            signals.any {
+                segmentId(it) in renderedIds && it.confidence.level == ConfidenceLevel.LOW
+            }
+        if (!anyLow) return emptyList()
+        val text =
+            "One note on confidence: some of these signals are based on a short " +
+                "history, so treat them as gentle heads-ups rather than firm conclusions."
+        val screenReader =
+            "One note on confidence. Some of these signals are based on a short " +
+                "history, so treat them as gentle heads-ups rather than firm conclusions."
+        return listOf(
+            NarrationSegment(
+                id = "anomaly.uncertainty",
+                kind = SegmentKind.UNCERTAINTY,
+                text = text,
+                confidence = LOW_NOTE_CONFIDENCE,
+                a11y =
+                    A11yMetadata(
+                        screenReaderText = screenReader,
+                        ariaLive = AriaLive.POLITE,
+                        role = A11yRole.NOTE,
+                        headingLevel = null,
+                    ),
+                sourceRefs = listOf("signals"),
+            ),
+        )
+    }
+
+    // -- Segment construction ----------------------------------------------
+
+    private fun anomalySegment(
+        signal: Signal,
+        deviation: Deviation,
+    ): NarrationSegment {
+        val label = topicLabel(signal.kind)
+        val position = positionPhrase(deviation)
+        val band =
+            "its usual range of ${formatCents(signal.expectedLowCents)} to " +
+                formatCents(signal.expectedHighCents)
+        val spokenBand =
+            "its usual range of ${spellCents(signal.expectedLowCents)} to " +
+                spellCents(signal.expectedHighCents)
+
+        val bodyVisible =
+            "your $label came in at ${formatCents(signal.observedCents)} this period, " +
+                "$position $band."
+        val bodySpoken =
+            "Your $label came in at ${spellCents(signal.observedCents)} this period. " +
+                "${capitalizeFirst(position)} $spokenBand."
+
+        val (text, screenReader) =
+            when (signal.confidence.level) {
+                ConfidenceLevel.LOW -> {
+                    val tail =
+                        " This is based on limited history, so it's just a gentle heads-up."
+                    val visible = "Early signal: $bodyVisible$tail"
+                    val spoken = "Early signal. $bodySpoken$tail"
+                    visible to spoken
+                }
+                ConfidenceLevel.MEDIUM -> {
+                    val visible = "Based on recent activity, $bodyVisible"
+                    val spoken = "Based on recent activity. $bodySpoken"
+                    visible to spoken
+                }
+                ConfidenceLevel.HIGH -> capitalizeFirst(bodyVisible) to bodySpoken
+            }
+
+        return NarrationSegment(
+            id = segmentId(signal),
+            kind = SegmentKind.INSIGHT,
+            text = text,
+            confidence = signal.confidence,
+            a11y =
+                A11yMetadata(
+                    screenReaderText = screenReader,
+                    ariaLive = AriaLive.POLITE,
+                    role = A11yRole.NOTE,
+                    headingLevel = null,
+                ),
+            sourceRefs = listOf("signal.${signal.id}"),
+        )
+    }
+
+    // -- Deviation + phrasing ----------------------------------------------
+
+    /** A pre-computed observed value's position relative to its expected band. */
+    private data class Deviation(
+        val above: Boolean,
+        /** Relative size of the breach (0.10 == 10% past the nearer edge). */
+        val relative: Double,
+    )
+
+    private fun deviationOf(signal: Signal): Deviation? {
+        val low = minOf(signal.expectedLowCents, signal.expectedHighCents)
+        val high = maxOf(signal.expectedLowCents, signal.expectedHighCents)
+        return when {
+            signal.observedCents > high -> {
+                val edge = max(abs(high), 1L).toDouble()
+                Deviation(above = true, relative = (signal.observedCents - high) / edge)
+            }
+            signal.observedCents < low -> {
+                val edge = max(abs(low), 1L).toDouble()
+                Deviation(above = false, relative = (low - signal.observedCents) / edge)
+            }
+            else -> null
+        }
+    }
+
+    private fun positionPhrase(deviation: Deviation): String {
+        val magnitude =
+            when {
+                deviation.relative < SLIGHT_THRESHOLD -> "a little "
+                deviation.relative < MODERATE_THRESHOLD -> ""
+                else -> "noticeably "
+            }
+        val direction = if (deviation.above) "above" else "below"
+        return "$magnitude$direction".trim()
+    }
+
+    /**
+     * Humanises a [Signal.kind] code into a calm topic noun. Direction suffixes
+     * are stripped so the prose carries the tone, not the raw classifier name:
+     * "dining_spike" -> "dining", "subscription_increase" -> "subscription
+     * increase".
+     */
+    private fun topicLabel(kind: String): String {
+        val cleaned =
+            kind.lowercase(Locale.US)
+                .removeSuffix("_spike")
+                .removeSuffix("_dip")
+                .removeSuffix("_anomaly")
+                .removeSuffix("_signal")
+        val humanised = cleaned.replace('_', ' ').trim()
+        return humanised.ifEmpty { "spending" }
+    }
+
+    private fun segmentId(signal: Signal): String = "anomaly.${signal.id}"
+
+    private companion object {
+        const val CONCISE_LIMIT = 1
+        const val SLIGHT_THRESHOLD = 0.10
+        const val MODERATE_THRESHOLD = 0.25
+
+        val LOW_NOTE_CONFIDENCE =
+            Confidence(ConfidenceLevel.LOW, 0.4, ConfidenceBasis.BLENDED)
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/narration/DashboardNarrator.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/narration/DashboardNarrator.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.narration
+
+// =============================================================================
+// DashboardNarrator — the complete on-device dashboard narration for #2394
+// =============================================================================
+//
+// A Windows screen-reader user opening the dashboard should hear ONE coherent
+// announcement that covers the three things #2394 calls out: states, trends, and
+// anomalies. This narrator composes the two deterministic template layers into
+// that single [Narration]:
+//
+//   * [TemplateNarrationGenerator] — steady-state facts (#2707): the headline,
+//     budgets needing attention, the net-worth trend, and goals.
+//   * [AnomalyNarrator] — notable deltas (signals) the template layer ignores.
+//
+// Composition is pure and reproducible (no model, no network, no I/O). The
+// ordering keeps every material fact first and every confidence/uncertainty note
+// last, so Narrator reads "here's what's true, here's what's worth a look, and
+// here's how sure we are" in that order:
+//
+//   headline
+//   → steady-state material (budgets, trend, goals)
+//   → anomaly material (most-material first)
+//   → steady-state uncertainty (e.g. a short-window net-worth trend)
+//   → anomaly uncertainty (low-confidence signals)
+//
+// The result is the shared [Narration] model, so the UI Automation projection
+// (#2707) consumes it exactly as it already consumes a template narration — this
+// class adds segments, never a new output shape.
+class DashboardNarrator(
+    private val stateGenerator: TemplateNarrationGenerator = TemplateNarrationGenerator(),
+    private val anomalyNarrator: AnomalyNarrator = AnomalyNarrator(),
+) {
+
+    // TODO(human): Validate the composed Narration on Windows hardware with
+    //  Narrator running (Win+Ctrl+Enter) and the keyboard-only flow. The text
+    //  and a11y metadata are unit-tested, but real spoken output + UI Automation
+    //  exposure can only be confirmed on-device (see apps/windows/README.md →
+    //  "AI accessibility narration of finances (#2394) → Needs Human Action").
+
+    /** Builds the full dashboard [Narration] for [snapshot] in the given [mode]. */
+    fun generate(
+        snapshot: FinancialStateSnapshot,
+        mode: NarrationMode,
+    ): Narration {
+        val base = stateGenerator.generate(snapshot, mode)
+        val (baseMaterial, baseUncertainty) =
+            base.segments.partition { it.kind != SegmentKind.UNCERTAINTY }
+
+        val anomalyMaterial = anomalyNarrator.materialSegments(snapshot.signals, mode)
+        val anomalyUncertainty =
+            if (mode == NarrationMode.DETAILED) {
+                anomalyNarrator.uncertaintySegments(snapshot.signals, anomalyMaterial)
+            } else {
+                emptyList()
+            }
+
+        val segments =
+            baseMaterial + anomalyMaterial + baseUncertainty + anomalyUncertainty
+
+        return base.copy(segments = segments)
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/narration/AnomalyNarratorTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/narration/AnomalyNarratorTest.kt
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.narration
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the deterministic [AnomalyNarrator].
+ *
+ * Signals (anomalies) are constructed in code — they are tiny, derived inputs —
+ * and the narrator runs with no model and no I/O, so every assertion is fully
+ * reproducible in CI. Coverage spans the calm phrasing ladder, confidence
+ * hedging, concise/detailed selection, ordering, and the non-alarmist tone gate.
+ */
+class AnomalyNarratorTest {
+
+    private val narrator = AnomalyNarrator()
+
+    private fun signal(
+        id: String,
+        kind: String,
+        observedCents: Long,
+        lowCents: Long,
+        highCents: Long,
+        level: ConfidenceLevel = ConfidenceLevel.HIGH,
+        basis: ConfidenceBasis = ConfidenceBasis.SAMPLE_SIZE,
+        score: Double = 0.9,
+    ): Signal =
+        Signal(
+            id = id,
+            kind = kind,
+            observedCents = observedCents,
+            expectedLowCents = lowCents,
+            expectedHighCents = highCents,
+            confidence = Confidence(level, score, basis),
+        )
+
+    @Test
+    fun `a value inside its expected band is not anomalous and is skipped`() {
+        val inRange = signal("s1", "dining", observedCents = 25000, lowCents = 20000, highCents = 30000)
+
+        val segments = narrator.generate(listOf(inRange), NarrationMode.DETAILED)
+
+        assertTrue(segments.isEmpty())
+    }
+
+    @Test
+    fun `a small breach reads as 'a little above', not alarmist`() {
+        val s = signal("dining", "dining_spike", observedCents = 31500, lowCents = 20000, highCents = 30000)
+
+        val segment = narrator.generate(listOf(s), NarrationMode.CONCISE).single()
+
+        assertEquals(SegmentKind.INSIGHT, segment.kind)
+        assertTrue(segment.text.contains("a little above its usual range"), segment.text)
+        // The classifier suffix "_spike" must never reach the prose.
+        assertFalse(segment.text.contains("spike"))
+        assertTrue(segment.text.lowercase().contains("your dining came in at"), segment.text)
+    }
+
+    @Test
+    fun `a large breach reads as 'noticeably above' and still avoids alarm`() {
+        val s = signal("groceries", "groceries", observedCents = 40000, lowCents = 20000, highCents = 30000)
+
+        val segment = narrator.generate(listOf(s), NarrationMode.DETAILED).first()
+
+        assertTrue(segment.text.contains("noticeably above its usual range"), segment.text)
+        assertNull(NarrationText.firstBannedTerm(segment.text + " " + segment.a11y.screenReaderText))
+    }
+
+    @Test
+    fun `a value below the band reads as 'below its usual range'`() {
+        val s = signal("income", "income_dip", observedCents = 10000, lowCents = 20000, highCents = 25000)
+
+        val segment = narrator.generate(listOf(s), NarrationMode.DETAILED).first()
+
+        assertTrue(segment.text.contains("below its usual range"), segment.text)
+        assertTrue(segment.text.lowercase().contains("your income came in at"), segment.text)
+    }
+
+    @Test
+    fun `low-confidence signals are hedged as an early signal and add an uncertainty note`() {
+        val s =
+            signal(
+                "subscriptions",
+                "subscription_increase",
+                observedCents = 5000,
+                lowCents = 2000,
+                highCents = 3000,
+                level = ConfidenceLevel.LOW,
+                score = 0.4,
+            )
+
+        val segments = narrator.generate(listOf(s), NarrationMode.DETAILED)
+
+        val anomaly = segments.first()
+        assertTrue(anomaly.text.startsWith("Early signal:"), anomaly.text)
+        assertTrue(anomaly.text.contains("gentle heads-up"))
+        assertTrue(anomaly.text.contains("subscription increase"))
+
+        val uncertainty = segments.last()
+        assertEquals(SegmentKind.UNCERTAINTY, uncertainty.kind)
+        assertEquals("anomaly.uncertainty", uncertainty.id)
+    }
+
+    @Test
+    fun `medium-confidence signals are framed as based on recent activity`() {
+        val s =
+            signal(
+                "fuel",
+                "fuel",
+                observedCents = 9000,
+                lowCents = 4000,
+                highCents = 6000,
+                level = ConfidenceLevel.MEDIUM,
+                score = 0.7,
+            )
+
+        val segment = narrator.generate(listOf(s), NarrationMode.DETAILED).first()
+
+        assertTrue(segment.text.startsWith("Based on recent activity,"), segment.text)
+    }
+
+    @Test
+    fun `detailed mode adds no uncertainty note when every anomaly is confident`() {
+        val s = signal("dining", "dining", observedCents = 40000, lowCents = 20000, highCents = 30000)
+
+        val segments = narrator.generate(listOf(s), NarrationMode.DETAILED)
+
+        assertTrue(segments.none { it.kind == SegmentKind.UNCERTAINTY })
+    }
+
+    @Test
+    fun `anomalies are ordered most-material first`() {
+        val small = signal("a-small", "dining", observedCents = 31500, lowCents = 20000, highCents = 30000)
+        val big = signal("z-big", "groceries", observedCents = 60000, lowCents = 20000, highCents = 30000)
+
+        val ids =
+            narrator.generate(listOf(small, big), NarrationMode.DETAILED)
+                .filter { it.kind == SegmentKind.INSIGHT }
+                .map { it.id }
+
+        assertEquals(listOf("anomaly.z-big", "anomaly.a-small"), ids)
+    }
+
+    @Test
+    fun `concise mode speaks only the single most material anomaly`() {
+        val small = signal("a-small", "dining", observedCents = 31500, lowCents = 20000, highCents = 30000)
+        val big = signal("z-big", "groceries", observedCents = 60000, lowCents = 20000, highCents = 30000)
+
+        val segments = narrator.generate(listOf(small, big), NarrationMode.CONCISE)
+
+        assertEquals(1, segments.size)
+        assertEquals("anomaly.z-big", segments.single().id)
+    }
+
+    @Test
+    fun `every segment carries non-blank screen reader text, source refs, and a polite note role`() {
+        val s =
+            signal(
+                "dining",
+                "dining",
+                observedCents = 40000,
+                lowCents = 20000,
+                highCents = 30000,
+                level = ConfidenceLevel.LOW,
+            )
+
+        val segments = narrator.generate(listOf(s), NarrationMode.DETAILED)
+
+        assertTrue(segments.isNotEmpty())
+        for (segment in segments) {
+            assertTrue(segment.a11y.screenReaderText.isNotBlank(), "blank SR for ${segment.id}")
+            assertTrue(segment.sourceRefs.isNotEmpty(), "no sourceRefs for ${segment.id}")
+            assertEquals(A11yRole.NOTE, segment.a11y.role)
+            assertEquals(AriaLive.POLITE, segment.a11y.ariaLive)
+            assertNull(segment.a11y.headingLevel)
+        }
+    }
+
+    @Test
+    fun `narration never uses banned, alarmist vocabulary across modes`() {
+        val signals =
+            listOf(
+                signal("dining", "dining_spike", 40000, 20000, 30000, ConfidenceLevel.LOW),
+                signal("income", "income_dip", 10000, 20000, 25000, ConfidenceLevel.MEDIUM),
+                signal("rent", "rent", 150000, 140000, 145000, ConfidenceLevel.HIGH),
+            )
+        for (mode in NarrationMode.entries) {
+            val segments = narrator.generate(signals, mode)
+            val combined =
+                segments.joinToString(" ") { it.text + " " + it.a11y.screenReaderText }
+            val banned = NarrationText.firstBannedTerm(combined)
+            assertNull(banned, "mode $mode leaked banned term: $banned")
+        }
+    }
+
+    @Test
+    fun `an empty signal list produces no narration`() {
+        assertTrue(narrator.generate(emptyList(), NarrationMode.DETAILED).isEmpty())
+        assertTrue(narrator.generate(emptyList(), NarrationMode.CONCISE).isEmpty())
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/narration/DashboardNarratorTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/narration/DashboardNarratorTest.kt
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.narration
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [DashboardNarrator], the composer that joins the steady-state
+ * [TemplateNarrationGenerator] output (#2707) with [AnomalyNarrator] segments
+ * into the single dashboard [Narration] required by #2394.
+ *
+ * The base snapshot is the shared §9 worked-example fixture; signals are layered
+ * on via `copy` so the composition — ordering, mode limits, and the
+ * material-before-uncertainty rule — is verified against a realistic state.
+ */
+class DashboardNarratorTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val narrator = DashboardNarrator()
+
+    private fun baseSnapshot(): FinancialStateSnapshot {
+        val text =
+            requireNotNull(
+                javaClass.getResourceAsStream(
+                    "/narration-fixtures/snapshots/02-bill-due-soon.json",
+                ),
+            ) { "missing fixture" }
+                .bufferedReader()
+                .use { it.readText() }
+        return json.decodeFromString(FinancialStateSnapshot.serializer(), text)
+    }
+
+    private fun signal(
+        id: String,
+        kind: String,
+        observedCents: Long,
+        lowCents: Long,
+        highCents: Long,
+        level: ConfidenceLevel = ConfidenceLevel.HIGH,
+    ): Signal =
+        Signal(
+            id = id,
+            kind = kind,
+            observedCents = observedCents,
+            expectedLowCents = lowCents,
+            expectedHighCents = highCents,
+            confidence = Confidence(level, 0.9, ConfidenceBasis.SAMPLE_SIZE),
+        )
+
+    @Test
+    fun `with no signals the dashboard narration matches the template narration`() {
+        val snapshot = baseSnapshot()
+
+        val dashboard = narrator.generate(snapshot, NarrationMode.DETAILED)
+        val template = TemplateNarrationGenerator().generate(snapshot, NarrationMode.DETAILED)
+
+        assertEquals(template, dashboard)
+    }
+
+    @Test
+    fun `detailed mode keeps anomaly facts ahead of every uncertainty note`() {
+        val snapshot =
+            baseSnapshot().copy(
+                signals =
+                    listOf(
+                        // Low confidence -> contributes an anomaly uncertainty note.
+                        signal("groceries", "groceries", 40000, 20000, 30000, ConfidenceLevel.LOW),
+                    ),
+            )
+
+        val dashboard = narrator.generate(snapshot, NarrationMode.DETAILED)
+        val kinds = dashboard.segments.map { it.kind }
+
+        // The fixture trend is low-confidence, so the template appends an
+        // uncertainty note; the anomaly narrator appends its own. Both must
+        // sit after all material (insight) content.
+        val lastInsight = kinds.indexOfLast { it == SegmentKind.INSIGHT }
+        val firstUncertainty = kinds.indexOfFirst { it == SegmentKind.UNCERTAINTY }
+        assertTrue(lastInsight in 0 until firstUncertainty, kinds.toString())
+
+        val ids = dashboard.segments.map { it.id }
+        assertEquals(2, ids.count { it.startsWith("anomaly") })
+        assertTrue(ids.contains("anomaly.groceries"))
+        assertTrue(ids.contains("anomaly.uncertainty"))
+        assertEquals(SegmentKind.UNCERTAINTY, dashboard.segments.last().kind)
+    }
+
+    @Test
+    fun `concise mode appends at most one calm anomaly and no uncertainty notes`() {
+        val snapshot =
+            baseSnapshot().copy(
+                signals =
+                    listOf(
+                        signal("small", "dining", 31500, 20000, 30000),
+                        signal("big", "groceries", 60000, 20000, 30000),
+                    ),
+            )
+
+        val dashboard = narrator.generate(snapshot, NarrationMode.CONCISE)
+        val ids = dashboard.segments.map { it.id }
+
+        assertEquals(1, ids.count { it.startsWith("anomaly") })
+        assertTrue(ids.contains("anomaly.big"))
+        assertTrue(dashboard.segments.none { it.kind == SegmentKind.UNCERTAINTY })
+    }
+
+    @Test
+    fun `composed narration preserves the template headline and stays non-alarmist`() {
+        val snapshot =
+            baseSnapshot().copy(
+                signals = listOf(signal("groceries", "groceries", 60000, 20000, 30000)),
+            )
+
+        val dashboard = narrator.generate(snapshot, NarrationMode.DETAILED)
+
+        assertEquals("summary", dashboard.headline.id)
+        assertTrue(dashboard.headline.text.startsWith("Your Electric bill"))
+        val combined = dashboard.plainText() + " " + dashboard.screenReaderText()
+        assertNull(NarrationText.firstBannedTerm(combined))
+    }
+}


### PR DESCRIPTION
## What & why

Closes #2394. Windows screen-reader users now get a calm, **on-device** spoken summary of the dashboard — its **states**, **trends**, and **anomalies** — so charts and trends are understandable without sight. No model, no network, no I/O on the narration path; source data and generated summaries stay on-device.

## Scope (narration generation — not the UIA projection)

The narration **output contract** and steady-state template narrator landed via #2707. This PR owns the **narration-generation** gap that #2707 left open: the contract carries pre-classified `signals` (anomalies) in the snapshot, but nothing rendered them. To avoid conflicts with #2707's UI Automation files, all changes are **new files** that reuse the existing `Narration`/`NarrationSegment` contract unchanged.

### Added (`apps/windows` only)

- `narration/AnomalyNarrator.kt` — deterministic narrator for notable deltas. Renders a `Signal` (observed vs. expected band) into calm, non-alarmist prose with confidence/uncertainty phrasing; concise (top anomaly only) vs. detailed (all + appended `uncertainty` note for low-confidence signals).
- `narration/DashboardNarrator.kt` — composes the steady-state template output with anomaly segments into one `Narration` (states + trends + anomalies), keeping all material facts before all uncertainty notes.
- Unit tests: `AnomalyNarratorTest` (12) + `DashboardNarratorTest` (4) — phrasing ladder, confidence hedging, ordering, concise/detailed limits, and a banned-term tone gate. **15/15 narration tests green.**
- `apps/windows/README.md` — Narrator + keyboard-only test notes and a `Needs Human Action` section.

## Tone & confidence

- Never alarmist: an anomaly is "a little above its usual range", never a "spike"/"alert"/"warning" (`BANNED_TERMS` asserted absent in CI).
- Always hedged when unsure: low confidence → "Early signal …"; medium → "Based on recent activity …"; high → plain statement.

## Needs Human Action

Live Narrator / UI Automation announcement can only be validated on Windows hardware with the screen reader running — not possible in headless CI. A reviewer with a Windows device should walk the Narrator + keyboard-only checklists in the README. Marked in code with `// TODO(human)` in `narration/DashboardNarrator.kt`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>