### PR TITLE
feat(android): predictive quick-actions (#2396)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -51,6 +51,12 @@ import com.finance.android.ui.theme.ThemeManager
 import com.finance.android.ui.theme.ThemePreferenceManager
 import com.finance.android.ui.tips.TipsViewModel
 import com.finance.android.ui.insights.InsightsViewModel
+import com.finance.android.ui.quickactions.DeterministicQuickActionRanker
+import com.finance.android.ui.quickactions.QuickActionPreferences
+import com.finance.android.ui.quickactions.QuickActionRanker
+import com.finance.android.ui.quickactions.QuickActionTelemetry
+import com.finance.android.ui.quickactions.QuickActionsViewModel
+import com.finance.android.ui.quickactions.TimberQuickActionTelemetry
 import com.finance.android.ui.viewmodel.ConflictResolutionViewModel
 import com.finance.android.ui.viewmodel.DataExportManager
 import com.finance.android.ui.viewmodel.DataImportViewModel
@@ -219,6 +225,20 @@ val appModule = module {
 
     // ── Insights ─────────────────────────────────────────────────────
     viewModelOf(::InsightsViewModel)
+
+    // ── Predictive Quick-Actions (#2396) ────────────────────────────
+
+    /** Deterministic on-device ranking model for quick-actions. */
+    single<QuickActionRanker> { DeterministicQuickActionRanker() }
+
+    /** On-device pin / disable / usage persistence (encrypted prefs). */
+    single { QuickActionPreferences(get()) }
+
+    /** Aggregate, non-PII usefulness telemetry. */
+    single<QuickActionTelemetry> { TimberQuickActionTelemetry() }
+
+    /** Predictive quick-actions ViewModel. */
+    viewModelOf(::QuickActionsViewModel)
 
     // ── Wave 5 ViewModels (Sprints 18-23) ───────────────────────────
 

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
@@ -268,6 +268,11 @@ fun FinanceNavHost(
                         launchSingleTop = true
                     }
                 },
+                onQuickActionNavigate = { route ->
+                    navController.navigate(route) {
+                        launchSingleTop = true
+                    }
+                },
             )
         }
 

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickAction.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickAction.kt
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickactions
+
+/**
+ * The catalogue of predictive quick-actions surfaced on the app home and via
+ * launcher shortcuts (#2396).
+ *
+ * Each entry is a stable, navigation-addressable finance task. The [route]
+ * mirrors a destination in `FinanceNavHost` so a tapped action deep-links the
+ * user straight to the relevant screen without disrupting manual navigation —
+ * the bottom bar / drawer remain the canonical way to reach every screen.
+ *
+ * The [baseWeight] is the cold-start prior used before any local usage history
+ * exists. Higher values rank earlier. These priors are intentionally tuned so a
+ * brand-new user still sees the most universally useful finance tasks first.
+ *
+ * IMPORTANT: identifiers here are **action categories only**. They never encode
+ * transaction details, amounts, payees, or categories, keeping the on-device
+ * ranking signals free of behavioural PII.
+ */
+enum class QuickActionType(
+    /** Stable analytics/persistence key — safe to log (no PII). */
+    val id: String,
+    /** Short user-facing label. */
+    val label: String,
+    /** TalkBack content description. */
+    val contentDescription: String,
+    /** `FinanceNavHost` route this action deep-links to. */
+    val route: String,
+    /** Material icon name used by the UI layer to resolve a vector. */
+    val iconName: String,
+    /** Cold-start prior; higher ranks earlier before usage history exists. */
+    val baseWeight: Double,
+) {
+    ADD_EXPENSE(
+        id = "add_expense",
+        label = "Add expense",
+        contentDescription = "Add a new expense transaction",
+        route = "transactions/create",
+        iconName = "Add",
+        baseWeight = 1.0,
+    ),
+    REVIEW_IMPORTS(
+        id = "review_imports",
+        label = "Review imports",
+        contentDescription = "Review uncategorized imported transactions",
+        route = "transactions",
+        iconName = "Inbox",
+        baseWeight = 0.7,
+    ),
+    CHECK_BILLS(
+        id = "check_bills",
+        label = "Upcoming bills",
+        contentDescription = "Check upcoming bills and reminders",
+        route = "bill-reminders",
+        iconName = "EventNote",
+        baseWeight = 0.6,
+    ),
+    ADD_INCOME(
+        id = "add_income",
+        label = "Add income",
+        contentDescription = "Record a new income transaction",
+        route = "transactions/create",
+        iconName = "AttachMoney",
+        baseWeight = 0.4,
+    ),
+    VIEW_BUDGETS(
+        id = "view_budgets",
+        label = "Budgets",
+        contentDescription = "View your budgets",
+        route = "budgets",
+        iconName = "PieChart",
+        baseWeight = 0.5,
+    ),
+    VIEW_INSIGHTS(
+        id = "view_insights",
+        label = "Insights",
+        contentDescription = "Open financial insights",
+        route = "insights",
+        iconName = "Insights",
+        baseWeight = 0.3,
+    ),
+    ;
+
+    companion object {
+        /** Lookup by stable [id]; `null` when unknown (e.g. stale persisted key). */
+        fun fromId(id: String): QuickActionType? = entries.firstOrNull { it.id == id }
+    }
+}
+
+/**
+ * A ranked quick-action ready for rendering.
+ *
+ * @property type The underlying action category.
+ * @property score The deterministic ranking score (higher = more likely).
+ * @property pinned Whether the user pinned this action (always surfaced first).
+ * @property reason A short, non-PII explanation of why it ranked where it did
+ *   (used for telemetry context and optional UI affordances).
+ */
+data class RankedQuickAction(
+    val type: QuickActionType,
+    val score: Double,
+    val pinned: Boolean,
+    val reason: RankReason,
+)
+
+/**
+ * Why an action surfaced — aggregate, non-behavioural signal categories only.
+ */
+enum class RankReason {
+    /** Surfaced from the cold-start defaults (no usage history yet). */
+    COLD_START,
+
+    /** Surfaced because the user pinned it. */
+    PINNED,
+
+    /** Boosted by recent usage of this action. */
+    RECENCY,
+
+    /** Boosted because it matches the current time-of-day bucket. */
+    TIME_OF_DAY,
+
+    /** Boosted by pending uncategorized imports. */
+    PENDING_IMPORTS,
+
+    /** Boosted by upcoming bills. */
+    UPCOMING_BILLS,
+
+    /** Surfaced from the stale-model fallback ordering. */
+    STALE_FALLBACK,
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionPreferences.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionPreferences.kt
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickactions
+
+import android.content.SharedPreferences
+
+/**
+ * On-device persistence for predictive quick-actions (#2396).
+ *
+ * Stores three kinds of local state, all keyed by the non-PII
+ * [QuickActionType.id]:
+ *
+ * - **Pinned** actions the user wants always surfaced.
+ * - **Disabled** actions the user opted out of entirely.
+ * - **Usage history** (activation count + last-used day) feeding the recency
+ *   and frequency ranking signals.
+ *
+ * Everything lives on-device in the app's (encrypted) [SharedPreferences]. No
+ * behavioural history is ever sent off-device, satisfying the on-device-only
+ * acceptance criterion. Dismissals are deliberately **not** persisted here —
+ * they are session-scoped in the ViewModel so dismissed actions can return.
+ */
+class QuickActionPreferences(
+    private val prefs: SharedPreferences,
+) {
+
+    /** Returns the set of pinned actions. */
+    fun pinned(): Set<QuickActionType> = readSet(KEY_PINNED)
+
+    /** Returns the set of disabled actions. */
+    fun disabled(): Set<QuickActionType> = readSet(KEY_DISABLED)
+
+    /** Pins ([pinned]=true) or unpins an action. */
+    fun setPinned(type: QuickActionType, pinned: Boolean) {
+        val updated = pinned().toMutableSet().apply {
+            if (pinned) add(type) else remove(type)
+        }
+        writeSet(KEY_PINNED, updated)
+    }
+
+    /** Disables an action so it is never surfaced again until re-enabled. */
+    fun setDisabled(type: QuickActionType, disabled: Boolean) {
+        val updated = disabled().toMutableSet().apply {
+            if (disabled) add(type) else remove(type)
+        }
+        writeSet(KEY_DISABLED, updated)
+        if (disabled) {
+            // A disabled action should not keep a pin.
+            setPinned(type, false)
+        }
+    }
+
+    /**
+     * Records one activation of [type] on day [epochDay] (days since epoch),
+     * incrementing its frequency counter and refreshing its recency.
+     */
+    fun recordActivation(type: QuickActionType, epochDay: Long) {
+        prefs.edit()
+            .putInt(countKey(type), readCount(type) + 1)
+            .putLong(lastDayKey(type), epochDay)
+            .apply()
+    }
+
+    /**
+     * Builds the per-action [ActionUsage] map relative to [todayEpochDay].
+     *
+     * @param todayEpochDay Current day (days since epoch) used to derive recency.
+     */
+    fun usage(todayEpochDay: Long): Map<QuickActionType, ActionUsage> =
+        QuickActionType.entries.associateWith { type ->
+            val count = readCount(type)
+            val lastDay = prefs.getLong(lastDayKey(type), Long.MIN_VALUE)
+            val recencyDays = if (lastDay == Long.MIN_VALUE) {
+                null
+            } else {
+                (todayEpochDay - lastDay).coerceAtLeast(0L).toInt()
+            }
+            ActionUsage(activationCount = count, recencyDays = recencyDays)
+        }
+
+    private fun readCount(type: QuickActionType): Int = prefs.getInt(countKey(type), 0)
+
+    private fun readSet(key: String): Set<QuickActionType> =
+        prefs.getStringSet(key, emptySet())
+            .orEmpty()
+            .mapNotNull { QuickActionType.fromId(it) }
+            .toSet()
+
+    private fun writeSet(key: String, value: Set<QuickActionType>) {
+        prefs.edit().putStringSet(key, value.map { it.id }.toSet()).apply()
+    }
+
+    private fun countKey(type: QuickActionType) = "qa_count_${type.id}"
+    private fun lastDayKey(type: QuickActionType) = "qa_lastday_${type.id}"
+
+    private companion object {
+        const val KEY_PINNED = "qa_pinned"
+        const val KEY_DISABLED = "qa_disabled"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionRanker.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionRanker.kt
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickactions
+
+/**
+ * Ranks quick-actions from on-device [QuickActionSignals] (#2396).
+ *
+ * The contract is intentionally narrow and side-effect free so the ranking
+ * model can be swapped (e.g. for an on-device TFLite model later) without
+ * touching the ViewModel or UI. The default implementation,
+ * [DeterministicQuickActionRanker], is a transparent, fully unit-tested linear
+ * model — no network, no remote inference.
+ */
+fun interface QuickActionRanker {
+    /**
+     * Produces a stable, descending-score ordering of surfaceable actions.
+     *
+     * Implementations MUST be deterministic: identical [signals] always yield
+     * identical output (including tie-break ordering).
+     */
+    fun rank(signals: QuickActionSignals): List<RankedQuickAction>
+}
+
+/**
+ * A deterministic, transparent linear ranking model.
+ *
+ * Score = base prior + recency + frequency + time-of-day + contextual signals.
+ * Pinned actions are always surfaced first; disabled and dismissed actions are
+ * excluded. The model has two well-defined fallbacks:
+ *
+ * - **Cold-start** ([QuickActionSignals.hasNoUsageHistory]): rank purely by the
+ *   per-action [QuickActionType.baseWeight] priors so new users still get a
+ *   sensible, universal ordering.
+ * - **Stale-model** ([QuickActionSignals.modelAgeMinutes] ≥
+ *   [STALE_THRESHOLD_MINUTES]): fall back to the same base-prior ordering rather
+ *   than trusting an out-of-date signal snapshot.
+ *
+ * All weights are constants below so the behaviour is auditable and testable.
+ */
+class DeterministicQuickActionRanker : QuickActionRanker {
+
+    override fun rank(signals: QuickActionSignals): List<RankedQuickAction> {
+        val candidates = QuickActionType.entries.filter { type ->
+            type !in signals.disabled && type !in signals.dismissed
+        }
+
+        val stale = signals.modelAgeMinutes?.let { it >= STALE_THRESHOLD_MINUTES } ?: false
+        val useFallback = signals.hasNoUsageHistory || stale
+        val fallbackReason = if (stale) RankReason.STALE_FALLBACK else RankReason.COLD_START
+
+        val ranked = candidates.map { type ->
+            val isPinned = type in signals.pinned
+            if (useFallback) {
+                RankedQuickAction(
+                    type = type,
+                    score = type.baseWeight + if (isPinned) PINNED_BOOST else 0.0,
+                    pinned = isPinned,
+                    reason = if (isPinned) RankReason.PINNED else fallbackReason,
+                )
+            } else {
+                score(type, signals, isPinned)
+            }
+        }
+
+        // Deterministic ordering: pinned first, then score desc, then enum
+        // ordinal as a stable tie-breaker.
+        return ranked.sortedWith(
+            compareByDescending<RankedQuickAction> { it.pinned }
+                .thenByDescending { it.score }
+                .thenBy { it.type.ordinal },
+        )
+    }
+
+    private fun score(
+        type: QuickActionType,
+        signals: QuickActionSignals,
+        isPinned: Boolean,
+    ): RankedQuickAction {
+        var score = type.baseWeight
+        var reason = if (isPinned) RankReason.PINNED else RankReason.RECENCY
+
+        val usage = signals.usage[type]
+        if (usage != null && usage.activationCount > 0) {
+            val frequency = minOf(usage.activationCount, FREQUENCY_CAP).toDouble() / FREQUENCY_CAP
+            score += frequency * FREQUENCY_WEIGHT
+            val days = usage.recencyDays
+            if (days != null) {
+                score += RECENCY_WEIGHT / (1.0 + days)
+            }
+        }
+
+        if (signals.timeBucket in preferredBuckets(type)) {
+            score += TIME_WEIGHT
+            if (!isPinned) reason = RankReason.TIME_OF_DAY
+        }
+
+        if (type == QuickActionType.REVIEW_IMPORTS && signals.pendingImportCount > 0) {
+            val ratio = minOf(signals.pendingImportCount, IMPORT_CAP).toDouble() / IMPORT_CAP
+            score += ratio * IMPORT_WEIGHT
+            if (!isPinned) reason = RankReason.PENDING_IMPORTS
+        }
+
+        if (type == QuickActionType.CHECK_BILLS && signals.upcomingBillCount > 0) {
+            val ratio = minOf(signals.upcomingBillCount, BILL_CAP).toDouble() / BILL_CAP
+            score += ratio * BILL_WEIGHT
+            if (!isPinned) reason = RankReason.UPCOMING_BILLS
+        }
+
+        if (isPinned) score += PINNED_BOOST
+
+        return RankedQuickAction(type = type, score = score, pinned = isPinned, reason = reason)
+    }
+
+    private fun preferredBuckets(type: QuickActionType): Set<TimeBucket> = when (type) {
+        QuickActionType.ADD_EXPENSE -> setOf(TimeBucket.MIDDAY, TimeBucket.EVENING)
+        QuickActionType.ADD_INCOME -> setOf(TimeBucket.MORNING)
+        QuickActionType.REVIEW_IMPORTS -> setOf(TimeBucket.MORNING, TimeBucket.EVENING)
+        QuickActionType.CHECK_BILLS -> setOf(TimeBucket.MORNING)
+        QuickActionType.VIEW_BUDGETS -> setOf(TimeBucket.EVENING)
+        QuickActionType.VIEW_INSIGHTS -> setOf(TimeBucket.EVENING)
+    }
+
+    companion object {
+        /**
+         * Snapshots older than this (minutes) trigger the stale-model fallback.
+         * Roughly one hour — short enough that time-of-day signals stay
+         * trustworthy.
+         */
+        const val STALE_THRESHOLD_MINUTES: Long = 60
+
+        /** Additive boost guaranteeing pinned actions sort first. */
+        const val PINNED_BOOST: Double = 1_000.0
+
+        private const val FREQUENCY_WEIGHT: Double = 0.6
+        private const val FREQUENCY_CAP: Int = 10
+        private const val RECENCY_WEIGHT: Double = 0.5
+        private const val TIME_WEIGHT: Double = 0.4
+        private const val IMPORT_WEIGHT: Double = 0.9
+        private const val IMPORT_CAP: Int = 5
+        private const val BILL_WEIGHT: Double = 0.8
+        private const val BILL_CAP: Int = 5
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionShortcuts.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionShortcuts.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickactions
+
+/**
+ * Bridges ranked quick-actions to Android launcher shortcuts (#2396).
+ *
+ * The ranking model is fully unit-tested on the JVM; publishing the result as
+ * **dynamic launcher shortcuts** requires real device/emulator APIs
+ * (`ShortcutManagerCompat`, deep-link `Intent`s targeting `MainActivity`) and
+ * on-device validation (long-press the launcher icon → confirm shortcuts appear
+ * and deep-link correctly). Those steps are intentionally left for a human with
+ * a device, per the issue's "native module landing spots" note.
+ *
+ * This class exposes the device-independent mapping so the human-completed
+ * publishing step has a tested, ready-made input.
+ */
+object QuickActionShortcuts {
+
+    /**
+     * Maps ranked actions to immutable shortcut descriptors (id + route),
+     * truncated to the platform's typical dynamic-shortcut budget.
+     *
+     * Pure and unit-testable — no Android imports — so the ranking-to-shortcut
+     * contract is verifiable without a device.
+     */
+    fun toDescriptors(ranked: List<RankedQuickAction>): List<ShortcutDescriptor> =
+        ranked.take(MAX_DYNAMIC_SHORTCUTS).map { action ->
+            ShortcutDescriptor(
+                id = action.type.id,
+                shortLabel = action.type.label,
+                longLabel = action.type.contentDescription,
+                route = action.type.route,
+            )
+        }
+
+    /**
+     * Publishes [descriptors] as dynamic launcher shortcuts.
+     *
+     * Device-only: must use `ShortcutManagerCompat.setDynamicShortcuts(...)`
+     * with deep-link intents and requires emulator/device validation.
+     */
+    fun publish(descriptors: List<ShortcutDescriptor>) {
+        check(descriptors.size <= MAX_DYNAMIC_SHORTCUTS) {
+            "Too many dynamic shortcuts: ${descriptors.size} > $MAX_DYNAMIC_SHORTCUTS"
+        }
+        // TODO(human): Implement on-device dynamic shortcut publishing using
+        // ShortcutManagerCompat + deep-link Intents to MainActivity, then
+        // validate by long-pressing the launcher icon on a device/emulator.
+        // See "## Needs Human Action" in the PR description.
+    }
+
+    /** Maximum dynamic shortcuts most launchers will surface. */
+    const val MAX_DYNAMIC_SHORTCUTS = 4
+}
+
+/**
+ * Device-independent description of a single launcher shortcut.
+ *
+ * @property id Stable, non-PII shortcut id (matches [QuickActionType.id]).
+ * @property shortLabel Short launcher label.
+ * @property longLabel Longer/accessible label.
+ * @property route `FinanceNavHost` route the shortcut deep-links to.
+ */
+data class ShortcutDescriptor(
+    val id: String,
+    val shortLabel: String,
+    val longLabel: String,
+    val route: String,
+)

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionSignals.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionSignals.kt
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickactions
+
+/**
+ * Coarse time-of-day buckets used as a ranking signal (#2396).
+ *
+ * Buckets are intentionally coarse so they reveal nothing precise about a
+ * user's routine — only a rough sense of when common finance tasks occur.
+ */
+enum class TimeBucket {
+    /** 05:00–10:59 — bills & planning are common. */
+    MORNING,
+
+    /** 11:00–16:59 — grocery / day-to-day spend is common. */
+    MIDDAY,
+
+    /** 17:00–21:59 — evening spend & review is common. */
+    EVENING,
+
+    /** 22:00–04:59 — low activity. */
+    NIGHT,
+
+    ;
+
+    companion object {
+        /**
+         * Maps a 24-hour clock [hour] (0–23) to a [TimeBucket].
+         * Values outside 0–23 are coerced.
+         */
+        fun fromHour(hour: Int): TimeBucket {
+            val h = ((hour % 24) + 24) % 24
+            return when (h) {
+                in 5..10 -> MORNING
+                in 11..16 -> MIDDAY
+                in 17..21 -> EVENING
+                else -> NIGHT
+            }
+        }
+    }
+}
+
+/**
+ * Per-action local usage statistics derived entirely on-device.
+ *
+ * @property activationCount How many times the user has activated this action.
+ * @property recencyDays Whole days since the action was last activated, or
+ *   `null` if it has never been activated.
+ */
+data class ActionUsage(
+    val activationCount: Int = 0,
+    val recencyDays: Int? = null,
+)
+
+/**
+ * The complete, on-device input to the [QuickActionRanker].
+ *
+ * Every field is computed locally and contains **no transaction details** —
+ * only aggregate counts and coarse time information. This is the privacy
+ * boundary required by the acceptance criteria: nothing here is suitable for,
+ * or intended to be, sent to a remote AI service.
+ *
+ * @property timeBucket Current coarse time-of-day bucket.
+ * @property usage Per-action local usage history (recency + frequency).
+ * @property pendingImportCount Number of uncategorized / pending imports
+ *   awaiting review. Boosts [QuickActionType.REVIEW_IMPORTS].
+ * @property upcomingBillCount Number of upcoming bills within the look-ahead
+ *   window. Boosts [QuickActionType.CHECK_BILLS].
+ * @property pinned Actions the user pinned (always surfaced, top of list).
+ * @property disabled Actions the user disabled (never surfaced).
+ * @property dismissed Actions dismissed for the current session (hidden now,
+ *   eligible to return later).
+ * @property modelAgeMinutes Age of the cached signal snapshot in minutes; used
+ *   for the stale-model fallback. `null` means freshly computed.
+ */
+data class QuickActionSignals(
+    val timeBucket: TimeBucket,
+    val usage: Map<QuickActionType, ActionUsage> = emptyMap(),
+    val pendingImportCount: Int = 0,
+    val upcomingBillCount: Int = 0,
+    val pinned: Set<QuickActionType> = emptySet(),
+    val disabled: Set<QuickActionType> = emptySet(),
+    val dismissed: Set<QuickActionType> = emptySet(),
+    val modelAgeMinutes: Long? = null,
+) {
+    /** True when no action has ever been activated (cold-start condition). */
+    val hasNoUsageHistory: Boolean
+        get() = usage.values.none { it.activationCount > 0 }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionTelemetry.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionTelemetry.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickactions
+
+import timber.log.Timber
+
+/**
+ * Aggregate usefulness telemetry for predictive quick-actions (#2396).
+ *
+ * The acceptance criteria require tracking how useful the predictions are
+ * **without logging transaction details**. Every method therefore accepts only
+ * a non-PII [QuickActionType] (a stable action category) plus coarse position /
+ * count integers. No amounts, payees, categories, dates, or account identifiers
+ * ever cross this boundary.
+ */
+interface QuickActionTelemetry {
+    /** Records that a set of actions was surfaced, with how many were shown. */
+    fun onSurfaced(shown: List<QuickActionType>)
+
+    /** Records that the user activated [type] shown at zero-based [position]. */
+    fun onActivated(type: QuickActionType, position: Int)
+
+    /** Records that the user dismissed [type]. */
+    fun onDismissed(type: QuickActionType)
+
+    /** Records that the user pinned ([pinned]=true) or unpinned [type]. */
+    fun onPinChanged(type: QuickActionType, pinned: Boolean)
+
+    /** Records that the user disabled [type] (opt-out). */
+    fun onDisabled(type: QuickActionType)
+}
+
+/**
+ * [QuickActionTelemetry] backed by structured Timber logging.
+ *
+ * Emits only aggregate, non-PII signals. A production build can fan these out
+ * to an opt-in metrics collector; the log statements here are deliberately free
+ * of any transaction-level data so they are safe even on shared devices.
+ */
+class TimberQuickActionTelemetry : QuickActionTelemetry {
+
+    override fun onSurfaced(shown: List<QuickActionType>) {
+        Timber.tag(TAG).d(
+            "surfaced count=%d ids=%s",
+            shown.size,
+            shown.joinToString(",") { it.id },
+        )
+    }
+
+    override fun onActivated(type: QuickActionType, position: Int) {
+        Timber.tag(TAG).d("activated id=%s position=%d", type.id, position)
+    }
+
+    override fun onDismissed(type: QuickActionType) {
+        Timber.tag(TAG).d("dismissed id=%s", type.id)
+    }
+
+    override fun onPinChanged(type: QuickActionType, pinned: Boolean) {
+        Timber.tag(TAG).d("pin_changed id=%s pinned=%b", type.id, pinned)
+    }
+
+    override fun onDisabled(type: QuickActionType) {
+        Timber.tag(TAG).d("disabled id=%s", type.id)
+    }
+
+    private companion object {
+        const val TAG = "QuickActions"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionsSection.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionsSection.kt
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickactions
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.EventNote
+import androidx.compose.material.icons.filled.Inbox
+import androidx.compose.material.icons.filled.Insights
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PieChart
+import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Predictive quick-actions section for the app home (#2396).
+ *
+ * Surfaces the user's most likely finance tasks as a horizontally scrolling row
+ * of one-tap cards. This is **additive** — it never replaces or gates the
+ * bottom-bar / drawer navigation, so manual navigation is fully preserved.
+ *
+ * Each card exposes an overflow menu to pin, dismiss, or disable the action,
+ * satisfying the user-control acceptance criterion. Every interactive element
+ * carries a [contentDescription] for TalkBack.
+ *
+ * @param onNavigate Invoked with a `FinanceNavHost` route when a card is tapped.
+ */
+@Composable
+fun QuickActionsSection(
+    onNavigate: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: QuickActionsViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    if (state.isLoading || state.actions.isEmpty()) return
+
+    QuickActionsContent(
+        actions = state.actions,
+        onActivate = { action, position ->
+            viewModel.onActivated(action, position)
+            onNavigate(action.type.route)
+        },
+        onPinToggle = { action -> viewModel.setPinned(action.type, !action.pinned) },
+        onDismiss = { action -> viewModel.dismiss(action.type) },
+        onDisable = { action -> viewModel.disable(action.type) },
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun QuickActionsContent(
+    actions: List<RankedQuickAction>,
+    onActivate: (RankedQuickAction, Int) -> Unit,
+    onPinToggle: (RankedQuickAction) -> Unit,
+    onDismiss: (RankedQuickAction) -> Unit,
+    onDisable: (RankedQuickAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "Quick actions",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Predictive quick actions section"
+            },
+        )
+        Spacer(Modifier.size(8.dp))
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(horizontal = 2.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            items(actions, key = { it.type.id }) { action ->
+                val position = actions.indexOf(action)
+                QuickActionCard(
+                    action = action,
+                    onActivate = { onActivate(action, position) },
+                    onPinToggle = { onPinToggle(action) },
+                    onDismiss = { onDismiss(action) },
+                    onDisable = { onDisable(action) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuickActionCard(
+    action: RankedQuickAction,
+    onActivate: () -> Unit,
+    onPinToggle: () -> Unit,
+    onDismiss: () -> Unit,
+    onDisable: () -> Unit,
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    val pinnedSuffix = if (action.pinned) ", pinned" else ""
+
+    ElevatedCard(
+        onClick = onActivate,
+        modifier = Modifier
+            .width(150.dp)
+            .semantics { contentDescription = action.type.contentDescription + pinnedSuffix },
+    ) {
+        Row(
+            verticalAlignment = Alignment.Top,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 12.dp, top = 8.dp, end = 4.dp),
+        ) {
+            Icon(
+                imageVector = iconFor(action.type),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(Modifier.weight(1f))
+            Box {
+                IconButton(
+                    onClick = { menuExpanded = true },
+                    modifier = Modifier.semantics {
+                        contentDescription = "More options for ${action.type.label}"
+                    },
+                ) {
+                    Icon(Icons.Filled.MoreVert, contentDescription = null)
+                }
+                QuickActionMenu(
+                    expanded = menuExpanded,
+                    pinned = action.pinned,
+                    onDismissMenu = { menuExpanded = false },
+                    onPinToggle = { menuExpanded = false; onPinToggle() },
+                    onDismiss = { menuExpanded = false; onDismiss() },
+                    onDisable = { menuExpanded = false; onDisable() },
+                )
+            }
+        }
+        Text(
+            text = action.type.label,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp),
+        )
+    }
+}
+
+@Composable
+private fun QuickActionMenu(
+    expanded: Boolean,
+    pinned: Boolean,
+    onDismissMenu: () -> Unit,
+    onPinToggle: () -> Unit,
+    onDismiss: () -> Unit,
+    onDisable: () -> Unit,
+) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismissMenu) {
+        DropdownMenuItem(
+            text = { Text(if (pinned) "Unpin" else "Pin") },
+            onClick = onPinToggle,
+            leadingIcon = {
+                Icon(
+                    Icons.Filled.PushPin,
+                    contentDescription = if (pinned) "Unpin action" else "Pin action",
+                )
+            },
+        )
+        DropdownMenuItem(
+            text = { Text("Dismiss") },
+            onClick = onDismiss,
+            leadingIcon = {
+                Icon(Icons.Filled.Close, contentDescription = "Dismiss action for now")
+            },
+        )
+        DropdownMenuItem(
+            text = { Text("Don't suggest") },
+            onClick = onDisable,
+            leadingIcon = {
+                Icon(Icons.Filled.VisibilityOff, contentDescription = "Stop suggesting this action")
+            },
+        )
+    }
+}
+
+/** Resolves the Material icon for a [QuickActionType]. */
+private fun iconFor(type: QuickActionType): ImageVector = when (type) {
+    QuickActionType.ADD_EXPENSE -> Icons.Filled.Add
+    QuickActionType.REVIEW_IMPORTS -> Icons.Filled.Inbox
+    QuickActionType.CHECK_BILLS -> Icons.Filled.EventNote
+    QuickActionType.ADD_INCOME -> Icons.Filled.AttachMoney
+    QuickActionType.VIEW_BUDGETS -> Icons.Filled.PieChart
+    QuickActionType.VIEW_INSIGHTS -> Icons.Filled.Insights
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun QuickActionsPreview() {
+    FinanceTheme {
+        QuickActionsContent(
+            actions = listOf(
+                RankedQuickAction(QuickActionType.ADD_EXPENSE, 1.4, pinned = true, RankReason.PINNED),
+                RankedQuickAction(QuickActionType.REVIEW_IMPORTS, 1.2, false, RankReason.PENDING_IMPORTS),
+                RankedQuickAction(QuickActionType.CHECK_BILLS, 0.9, false, RankReason.UPCOMING_BILLS),
+            ),
+            onActivate = { _, _ -> },
+            onPinToggle = {},
+            onDismiss = {},
+            onDisable = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionsViewModel.kt
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickactions
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.TransactionRepository
+import com.finance.models.TransactionStatus
+import com.finance.models.TransactionType
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import timber.log.Timber
+
+/**
+ * UI state for the predictive quick-actions surface (#2396).
+ *
+ * @property actions Ranked, surfaceable actions (already truncated to the
+ *   display limit). Empty while loading or when everything is disabled.
+ * @property isLoading Whether the first ranking pass is in progress.
+ */
+data class QuickActionsUiState(
+    val actions: List<RankedQuickAction> = emptyList(),
+    val isLoading: Boolean = true,
+)
+
+/**
+ * ViewModel that turns on-device signals into a ranked list of quick-actions.
+ *
+ * It computes [QuickActionSignals] entirely from local data — current time,
+ * persisted usage history, and aggregate counts of pending imports / upcoming
+ * bills derived from the transaction repository — then delegates ordering to
+ * the injected [QuickActionRanker]. No behavioural history leaves the device.
+ *
+ * User controls (dismiss / pin / disable) update either session state or
+ * [QuickActionPreferences] and re-rank immediately. Aggregate, non-PII
+ * telemetry is emitted via [QuickActionTelemetry].
+ *
+ * @param householdIdProvider Provides the authenticated household ID.
+ * @param transactionRepository Source for pending-import / upcoming-bill signals.
+ * @param ranker The (swappable) on-device ranking model.
+ * @param preferences On-device pin / disable / usage persistence.
+ * @param telemetry Aggregate usefulness telemetry sink.
+ */
+class QuickActionsViewModel(
+    private val householdIdProvider: HouseholdIdProvider,
+    private val transactionRepository: TransactionRepository,
+    private val ranker: QuickActionRanker,
+    private val preferences: QuickActionPreferences,
+    private val telemetry: QuickActionTelemetry,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(QuickActionsUiState())
+    val uiState: StateFlow<QuickActionsUiState> = _uiState.asStateFlow()
+
+    /** Actions dismissed this session — hidden now, eligible to return later. */
+    private var dismissed: Set<QuickActionType> = emptySet()
+
+    /** Cached contextual signals so re-ranks after a control tap stay cheap. */
+    private var pendingImportCount: Int = 0
+    private var upcomingBillCount: Int = 0
+
+    init {
+        refresh()
+    }
+
+    /** Recomputes signals from local data and re-ranks. */
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            loadContextualSignals()
+            rerank()
+        }
+    }
+
+    /**
+     * Handles activation of [action] at zero-based [position]. Records the
+     * activation locally (for recency / frequency) and emits telemetry. The
+     * caller is responsible for performing the actual navigation.
+     */
+    fun onActivated(action: RankedQuickAction, position: Int) {
+        preferences.recordActivation(action.type, todayEpochDay())
+        telemetry.onActivated(action.type, position)
+        rerank()
+    }
+
+    /** Dismisses [type] for the current session. */
+    fun dismiss(type: QuickActionType) {
+        dismissed = dismissed + type
+        telemetry.onDismissed(type)
+        rerank()
+    }
+
+    /** Pins or unpins [type] (persisted). */
+    fun setPinned(type: QuickActionType, pinned: Boolean) {
+        preferences.setPinned(type, pinned)
+        telemetry.onPinChanged(type, pinned)
+        rerank()
+    }
+
+    /** Disables [type] entirely (persisted opt-out). */
+    fun disable(type: QuickActionType) {
+        preferences.setDisabled(type, true)
+        telemetry.onDisabled(type)
+        rerank()
+    }
+
+    private suspend fun loadContextualSignals() {
+        val householdId = householdIdProvider.householdId.value ?: run {
+            Timber.w("No household ID — quick-action context signals default to zero")
+            pendingImportCount = 0
+            upcomingBillCount = 0
+            return
+        }
+
+        @Suppress("TooGenericExceptionCaught") // Multiple exception types possible
+        try {
+            val transactions = transactionRepository.observeAll(householdId).first()
+            // Pending imports = transactions still needing review: uncategorized
+            // or not yet cleared. Aggregate count only — no details retained.
+            pendingImportCount = transactions.count { txn ->
+                txn.categoryId == null || txn.status == TransactionStatus.PENDING
+            }
+            // Upcoming bills = recurring expense commitments.
+            upcomingBillCount = transactions
+                .filter { it.isRecurring && it.type == TransactionType.EXPENSE }
+                .mapNotNull { it.recurringRuleId }
+                .distinct()
+                .size
+            Timber.d(
+                "Quick-action signals: pendingImports=%d upcomingBills=%d",
+                pendingImportCount,
+                upcomingBillCount,
+            )
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to compute quick-action context signals")
+            pendingImportCount = 0
+            upcomingBillCount = 0
+        }
+    }
+
+    private fun rerank() {
+        val signals = QuickActionSignals(
+            timeBucket = currentTimeBucket(),
+            usage = preferences.usage(todayEpochDay()),
+            pendingImportCount = pendingImportCount,
+            upcomingBillCount = upcomingBillCount,
+            pinned = preferences.pinned(),
+            disabled = preferences.disabled(),
+            dismissed = dismissed,
+            modelAgeMinutes = null,
+        )
+
+        val ranked = ranker.rank(signals).take(MAX_VISIBLE_ACTIONS)
+        telemetry.onSurfaced(ranked.map { it.type })
+        _uiState.update { it.copy(actions = ranked, isLoading = false) }
+    }
+
+    private fun currentTimeBucket(): TimeBucket {
+        val hour = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).hour
+        return TimeBucket.fromHour(hour)
+    }
+
+    private fun todayEpochDay(): Long =
+        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date.toEpochDays().toLong()
+
+    private companion object {
+        /** Maximum number of actions surfaced at once to avoid overwhelming. */
+        const val MAX_VISIBLE_ACTIONS = 4
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/DashboardScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/DashboardScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.finance.android.ui.data.SampleData
+import com.finance.android.ui.quickactions.QuickActionsSection
 import com.finance.android.ui.theme.FinanceTheme
 import com.finance.android.ui.tips.TipsSection
 import com.finance.android.ui.viewmodel.BudgetStatusUi
@@ -84,6 +85,7 @@ fun DashboardScreen(
     onViewInsights: () -> Unit = {},
     onViewAccounts: () -> Unit = {},
     onAffordabilityCheck: () -> Unit = {},
+    onQuickActionNavigate: (String) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: DashboardViewModel = koinViewModel(),
 ) {
@@ -95,7 +97,7 @@ fun DashboardScreen(
         }
         return
     }
-    DashboardContent(state, viewModel::refresh, onAddTransaction, onViewAllTransactions, onViewInsights, onViewAccounts, onAffordabilityCheck, modifier)
+    DashboardContent(state, viewModel::refresh, onAddTransaction, onViewAllTransactions, onViewInsights, onViewAccounts, onAffordabilityCheck, onQuickActionNavigate, modifier)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -105,6 +107,7 @@ internal fun DashboardContent(
     onAddTransaction: () -> Unit, onViewAllTransactions: () -> Unit,
     onViewInsights: () -> Unit, onViewAccounts: () -> Unit,
     onAffordabilityCheck: () -> Unit = {},
+    onQuickActionNavigate: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     PullToRefreshBox(isRefreshing = state.isRefreshing, onRefresh = onRefresh,
@@ -112,6 +115,7 @@ internal fun DashboardContent(
         LazyColumn(modifier = Modifier.fillMaxSize(), contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)) {
             item(key = "net-worth") { NetWorthCard(state.netWorthFormatted, onClick = onViewAccounts) }
+            item(key = "quick-actions") { QuickActionsSection(onNavigate = onQuickActionNavigate) }
             item(key = "spending") { SpendingSummaryRow(state.todaySpendingFormatted, state.monthlySpendingFormatted) }
             item(key = "affordability") { AffordabilityCheckCard(onAffordabilityCheck) }
             item(key = "insights") { InsightsCard(onViewInsights) }

--- a/apps/android/src/test/kotlin/com/finance/android/ui/quickactions/QuickActionRankerTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/quickactions/QuickActionRankerTest.kt
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickactions
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [DeterministicQuickActionRanker] and the supporting
+ * on-device ranking primitives (#2396).
+ *
+ * Coverage:
+ * - Cold-start defaults (no usage history) order by base prior.
+ * - Stale-model fallback ignores usage and reverts to base priors.
+ * - Recency / frequency boosts move used actions up.
+ * - Time-of-day, pending-import, and upcoming-bill signals.
+ * - Pin (always first), disable (excluded), dismiss (excluded) controls.
+ * - Determinism: identical signals → identical output.
+ */
+class QuickActionRankerTest {
+
+    private val ranker = DeterministicQuickActionRanker()
+
+    // ── Cold start ──────────────────────────────────────────────────────
+
+    @Test
+    fun `cold start orders by base prior`() {
+        val signals = QuickActionSignals(timeBucket = TimeBucket.NIGHT)
+        val ranked = ranker.rank(signals)
+
+        // ADD_EXPENSE has the highest base prior, VIEW_INSIGHTS the lowest.
+        assertEquals(QuickActionType.ADD_EXPENSE, ranked.first().type)
+        assertEquals(QuickActionType.VIEW_INSIGHTS, ranked.last().type)
+        assertTrue(ranked.all { it.reason == RankReason.COLD_START })
+    }
+
+    @Test
+    fun `cold start surfaces all non-disabled actions`() {
+        val ranked = ranker.rank(QuickActionSignals(timeBucket = TimeBucket.MORNING))
+        assertEquals(QuickActionType.entries.size, ranked.size)
+    }
+
+    @Test
+    fun `cold start scores are monotonically non-increasing`() {
+        val ranked = ranker.rank(QuickActionSignals(timeBucket = TimeBucket.NIGHT))
+        for (i in 1 until ranked.size) {
+            assertTrue(ranked[i - 1].score >= ranked[i].score)
+        }
+    }
+
+    // ── Stale fallback ──────────────────────────────────────────────────
+
+    @Test
+    fun `stale model reverts to base priors despite usage`() {
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.EVENING,
+            usage = mapOf(
+                QuickActionType.VIEW_INSIGHTS to ActionUsage(activationCount = 9, recencyDays = 0),
+            ),
+            modelAgeMinutes = DeterministicQuickActionRanker.STALE_THRESHOLD_MINUTES,
+        )
+        val ranked = ranker.rank(signals)
+
+        // Despite heavy recent use of VIEW_INSIGHTS, stale fallback keeps the
+        // base-prior ordering with ADD_EXPENSE first.
+        assertEquals(QuickActionType.ADD_EXPENSE, ranked.first().type)
+        assertTrue(ranked.all { it.reason == RankReason.STALE_FALLBACK })
+    }
+
+    @Test
+    fun `fresh model below stale threshold uses live signals`() {
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.EVENING,
+            usage = mapOf(
+                QuickActionType.VIEW_INSIGHTS to ActionUsage(activationCount = 9, recencyDays = 0),
+            ),
+            modelAgeMinutes = DeterministicQuickActionRanker.STALE_THRESHOLD_MINUTES - 1,
+        )
+        val ranked = ranker.rank(signals)
+        assertFalse(ranked.all { it.reason == RankReason.STALE_FALLBACK })
+    }
+
+    // ── Recency / frequency ─────────────────────────────────────────────
+
+    @Test
+    fun `recent frequent use boosts an action above its base rank`() {
+        val coldStartRank = ranker.rank(QuickActionSignals(timeBucket = TimeBucket.NIGHT))
+            .indexOfFirst { it.type == QuickActionType.VIEW_INSIGHTS }
+
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.NIGHT,
+            usage = mapOf(
+                QuickActionType.VIEW_INSIGHTS to ActionUsage(activationCount = 10, recencyDays = 0),
+            ),
+        )
+        val boostedRank = ranker.rank(signals)
+            .indexOfFirst { it.type == QuickActionType.VIEW_INSIGHTS }
+
+        assertTrue(boostedRank < coldStartRank, "Expected VIEW_INSIGHTS to rank higher after use")
+    }
+
+    @Test
+    fun `more recent use scores higher than older use`() {
+        fun scoreFor(recencyDays: Int): Double {
+            val signals = QuickActionSignals(
+                timeBucket = TimeBucket.NIGHT,
+                usage = mapOf(
+                    QuickActionType.VIEW_BUDGETS to ActionUsage(activationCount = 3, recencyDays = recencyDays),
+                ),
+            )
+            return ranker.rank(signals).first { it.type == QuickActionType.VIEW_BUDGETS }.score
+        }
+        assertTrue(scoreFor(0) > scoreFor(30))
+    }
+
+    // ── Time of day ─────────────────────────────────────────────────────
+
+    @Test
+    fun `morning boosts bills check`() {
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.MORNING,
+            usage = mapOf(QuickActionType.ADD_EXPENSE to ActionUsage(1, 5)),
+        )
+        val checkBills = ranker.rank(signals).first { it.type == QuickActionType.CHECK_BILLS }
+        assertEquals(RankReason.TIME_OF_DAY, checkBills.reason)
+    }
+
+    // ── Contextual signals ──────────────────────────────────────────────
+
+    @Test
+    fun `pending imports boosts review imports`() {
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.NIGHT,
+            usage = mapOf(QuickActionType.ADD_EXPENSE to ActionUsage(1, 10)),
+            pendingImportCount = 5,
+        )
+        val ranked = ranker.rank(signals)
+        val review = ranked.first { it.type == QuickActionType.REVIEW_IMPORTS }
+        assertEquals(RankReason.PENDING_IMPORTS, review.reason)
+        // It should out-rank an unused INCOME action.
+        val reviewIdx = ranked.indexOfFirst { it.type == QuickActionType.REVIEW_IMPORTS }
+        val incomeIdx = ranked.indexOfFirst { it.type == QuickActionType.ADD_INCOME }
+        assertTrue(reviewIdx < incomeIdx)
+    }
+
+    @Test
+    fun `upcoming bills boosts check bills`() {
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.NIGHT,
+            usage = mapOf(QuickActionType.ADD_EXPENSE to ActionUsage(1, 10)),
+            upcomingBillCount = 4,
+        )
+        val bills = ranker.rank(signals).first { it.type == QuickActionType.CHECK_BILLS }
+        assertEquals(RankReason.UPCOMING_BILLS, bills.reason)
+    }
+
+    @Test
+    fun `zero contextual counts add no boost`() {
+        val base = ranker.rank(
+            QuickActionSignals(
+                timeBucket = TimeBucket.NIGHT,
+                usage = mapOf(QuickActionType.ADD_EXPENSE to ActionUsage(1, 10)),
+            ),
+        ).first { it.type == QuickActionType.REVIEW_IMPORTS }.score
+
+        val withZero = ranker.rank(
+            QuickActionSignals(
+                timeBucket = TimeBucket.NIGHT,
+                usage = mapOf(QuickActionType.ADD_EXPENSE to ActionUsage(1, 10)),
+                pendingImportCount = 0,
+            ),
+        ).first { it.type == QuickActionType.REVIEW_IMPORTS }.score
+
+        assertEquals(base, withZero, 0.0001)
+    }
+
+    // ── User controls ───────────────────────────────────────────────────
+
+    @Test
+    fun `pinned action is always first`() {
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.NIGHT,
+            pinned = setOf(QuickActionType.VIEW_INSIGHTS),
+        )
+        val ranked = ranker.rank(signals)
+        assertEquals(QuickActionType.VIEW_INSIGHTS, ranked.first().type)
+        assertTrue(ranked.first().pinned)
+        assertEquals(RankReason.PINNED, ranked.first().reason)
+    }
+
+    @Test
+    fun `multiple pinned actions sort before all unpinned`() {
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.NIGHT,
+            pinned = setOf(QuickActionType.VIEW_INSIGHTS, QuickActionType.VIEW_BUDGETS),
+        )
+        val ranked = ranker.rank(signals)
+        assertTrue(ranked[0].pinned)
+        assertTrue(ranked[1].pinned)
+        assertFalse(ranked[2].pinned)
+    }
+
+    @Test
+    fun `disabled action is excluded`() {
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.NIGHT,
+            disabled = setOf(QuickActionType.ADD_EXPENSE),
+        )
+        val ranked = ranker.rank(signals)
+        assertTrue(ranked.none { it.type == QuickActionType.ADD_EXPENSE })
+        assertEquals(QuickActionType.entries.size - 1, ranked.size)
+    }
+
+    @Test
+    fun `dismissed action is excluded`() {
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.NIGHT,
+            dismissed = setOf(QuickActionType.CHECK_BILLS),
+        )
+        val ranked = ranker.rank(signals)
+        assertTrue(ranked.none { it.type == QuickActionType.CHECK_BILLS })
+    }
+
+    @Test
+    fun `disabling everything yields empty list`() {
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.NIGHT,
+            disabled = QuickActionType.entries.toSet(),
+        )
+        assertTrue(ranker.rank(signals).isEmpty())
+    }
+
+    // ── Determinism ─────────────────────────────────────────────────────
+
+    @Test
+    fun `identical signals yield identical output`() {
+        val signals = QuickActionSignals(
+            timeBucket = TimeBucket.EVENING,
+            usage = mapOf(
+                QuickActionType.ADD_EXPENSE to ActionUsage(4, 1),
+                QuickActionType.VIEW_BUDGETS to ActionUsage(2, 3),
+            ),
+            pendingImportCount = 2,
+            upcomingBillCount = 1,
+        )
+        assertEquals(ranker.rank(signals), ranker.rank(signals))
+    }
+
+    // ── TimeBucket mapping ──────────────────────────────────────────────
+
+    @Test
+    fun `time bucket maps hours correctly`() {
+        assertEquals(TimeBucket.MORNING, TimeBucket.fromHour(8))
+        assertEquals(TimeBucket.MIDDAY, TimeBucket.fromHour(13))
+        assertEquals(TimeBucket.EVENING, TimeBucket.fromHour(19))
+        assertEquals(TimeBucket.NIGHT, TimeBucket.fromHour(2))
+        assertEquals(TimeBucket.NIGHT, TimeBucket.fromHour(23))
+    }
+
+    @Test
+    fun `time bucket coerces out of range hours`() {
+        assertEquals(TimeBucket.fromHour(8), TimeBucket.fromHour(32))
+        assertEquals(TimeBucket.fromHour(2), TimeBucket.fromHour(-22))
+    }
+
+    // ── Shortcut descriptors ────────────────────────────────────────────
+
+    @Test
+    fun `shortcut descriptors truncate to platform budget`() {
+        val ranked = ranker.rank(QuickActionSignals(timeBucket = TimeBucket.MORNING))
+        val descriptors = QuickActionShortcuts.toDescriptors(ranked)
+        assertEquals(QuickActionShortcuts.MAX_DYNAMIC_SHORTCUTS, descriptors.size)
+        // Descriptors carry only non-PII ids and routes.
+        assertEquals(ranked.first().type.id, descriptors.first().id)
+        assertEquals(ranked.first().type.route, descriptors.first().route)
+    }
+
+    @Test
+    fun `fromId round-trips every action`() {
+        for (type in QuickActionType.entries) {
+            assertEquals(type, QuickActionType.fromId(type.id))
+        }
+        assertEquals(null, QuickActionType.fromId("unknown_key"))
+    }
+}


### PR DESCRIPTION
## Summary
Adds predictive, context-aware quick-actions for Android power users (#2396). A deterministic, unit-tested on-device ranking model surfaces the user's most likely finance tasks (add expense, review imports, check upcoming bills, etc.) as one-tap cards on the app home — purely additive, never disrupting bottom-bar/drawer navigation.

## What's included
- **Deterministic ranking model** behind a swappable QuickActionRanker interface (DeterministicQuickActionRanker): combines recency + frequency, coarse time-of-day buckets, pending-import and upcoming-bill signals into a stable ranked list.
- **Cold-start defaults** (no usage history -> base-prior ordering) and **stale-model fallback** (snapshot older than threshold -> base priors).
- **User controls**: dismiss (session), pin (persisted, always first), and disable/opt-out (persisted) via each card's overflow menu.
- **On-device only**: all signals derive from local data; nothing behavioral leaves the device (QuickActionPreferences in encrypted SharedPreferences).
- **Aggregate telemetry** (QuickActionTelemetry / TimberQuickActionTelemetry) logs only non-PII action categories + positions — never transaction details.
- **Compose UI** (QuickActionsSection) wired into the Dashboard with full `contentDescription` for TalkBack; Koin DI wiring in `AppModule`.
- **JVM unit tests** covering ranking, cold-start, stale fallback, recency/time/context signals, and pin/dismiss/disable.

## Acceptance criteria
- [x] Local ranking model for context-aware quick-actions
- [x] Surfaced on app home without disrupting manual navigation
- [x] Dismiss / pin / disable controls
- [x] On-device signals only; no behavioral history sent remotely
- [x] Cold-start defaults + stale-model fallback
- [x] Aggregate usefulness telemetry with no transaction details

## Needs Human Action
Publishing the ranked actions as **dynamic launcher shortcuts** requires real device/emulator APIs and validation, left as `// TODO(human)` in `QuickActionShortcuts.publish(...)`:
- Implement `ShortcutManagerCompat.setDynamicShortcuts(...)` with deep-link `Intent`s to `MainActivity` using the tested `toDescriptors(...)` output.
- Validate by long-pressing the launcher icon on a device/emulator and confirming each shortcut deep-links correctly.

Closes #2396

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>