### PR TITLE
feat(android): teen savings goal planner (#2207)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -59,6 +59,7 @@ import com.finance.android.ui.viewmodel.BudgetsViewModel
 import com.finance.android.ui.viewmodel.DashboardViewModel
 import com.finance.android.ui.viewmodel.GoalCreateViewModel
 import com.finance.android.ui.viewmodel.GoalEditViewModel
+import com.finance.android.ui.viewmodel.GoalPlannerViewModel
 import com.finance.android.ui.viewmodel.TransactionCreateViewModel
 import com.finance.android.ui.viewmodel.TransactionDetailViewModel
 import com.finance.android.ui.viewmodel.GoalsViewModel
@@ -66,6 +67,7 @@ import com.finance.android.ui.viewmodel.TransactionsViewModel
 import com.finance.core.monitoring.CrashReporter
 import com.finance.core.monitoring.MetricsCollector
 import org.koin.android.ext.koin.androidContext
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.bind
@@ -178,6 +180,8 @@ val appModule = module {
     viewModelOf(::GoalsViewModel)
     viewModelOf(::GoalCreateViewModel)
     viewModelOf(::GoalEditViewModel)
+    // Explicit definition so the default system Clock is used (not resolved from DI).
+    viewModel { GoalPlannerViewModel(get(), get()) }
     viewModelOf(::SettingsViewModel)
     viewModelOf(::StreakViewModel)
     viewModelOf(::NotificationSettingsViewModel)

--- a/apps/android/src/main/kotlin/com/finance/android/domain/goals/GoalPlanCopy.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/domain/goals/GoalPlanCopy.kt
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.domain.goals
+
+/**
+ * Builds plain-language, teen-friendly copy from a [GoalPlan].
+ *
+ * Pure and side-effect free: callers pass already-formatted money and date
+ * strings (e.g. from `CurrencyFormatter` / a date formatter) so this helper
+ * never depends on currency or locale machinery and stays unit testable.
+ *
+ * The phrasing deliberately avoids finance jargon — "Save $25/week to get your
+ * car by Aug 2027" rather than "Required periodic contribution".
+ */
+object GoalPlanCopy {
+
+    /**
+     * The hero line a teen reads first, e.g.
+     * "Save $25/week to get your Car by Aug 2027".
+     *
+     * @param perWeekFormatted Pre-formatted weekly amount (e.g. "$25").
+     * @param goalName The goal's name (e.g. "Car").
+     * @param buyByLabel Pre-formatted target/projected date (e.g. "Aug 2027"),
+     *   or `null` when there is no date yet.
+     */
+    fun headline(perWeekFormatted: String, goalName: String, buyByLabel: String?): String =
+        if (buyByLabel != null) {
+            "Save $perWeekFormatted/week to get your $goalName by $buyByLabel"
+        } else {
+            "Save $perWeekFormatted/week toward your $goalName"
+        }
+
+    /**
+     * A short pace message answering "am I on track / can I still go out?".
+     *
+     * @param pace The classified pace from [GoalPlanner].
+     * @param goalName The goal's name.
+     * @param buyByLabel Projected/target date label, when available.
+     * @param catchUpPerWeekFormatted Pre-formatted catch-up weekly amount, used
+     *   for [GoalPace.BEHIND] / [GoalPace.OVERDUE].
+     */
+    fun paceMessage(
+        pace: GoalPace,
+        goalName: String,
+        buyByLabel: String?,
+        catchUpPerWeekFormatted: String?,
+    ): String = when (pace) {
+        GoalPace.COMPLETE ->
+            "🎉 Done! You saved enough for your $goalName."
+        GoalPace.NO_DEADLINE ->
+            "Add a date or a weekly amount and we'll show your buy-by date."
+        GoalPace.AHEAD ->
+            "You're ahead of schedule" +
+                (buyByLabel?.let { " — on track for $it." } ?: ".")
+        GoalPace.ON_TRACK ->
+            "Right on track" +
+                (buyByLabel?.let { " for $it. Keep it up!" } ?: ". Keep it up!")
+        GoalPace.BEHIND ->
+            if (catchUpPerWeekFormatted != null) {
+                "A little behind — bump it to $catchUpPerWeekFormatted/week to stay on time."
+            } else {
+                "A little behind — save a bit more each week to catch up."
+            }
+        GoalPace.OVERDUE ->
+            if (catchUpPerWeekFormatted != null) {
+                "Your date has passed. Save $catchUpPerWeekFormatted to finish, or pick a new date."
+            } else {
+                "Your date has passed — pick a new one to get a fresh plan."
+            }
+    }
+
+    /**
+     * A short, motivating label for the current milestone.
+     */
+    fun milestoneLabel(milestone: GoalMilestone): String = when (milestone) {
+        GoalMilestone.STARTED -> "Just getting started"
+        GoalMilestone.QUARTER -> "25% there — nice start!"
+        GoalMilestone.HALF -> "Halfway there! 🚗"
+        GoalMilestone.THREE_QUARTER -> "75% — almost home!"
+        GoalMilestone.COMPLETE -> "Goal reached! 🎉"
+    }
+
+    /**
+     * The milestone percentage as a whole number (25/50/75/100, 0 when started).
+     */
+    fun milestonePercent(milestone: GoalMilestone): Int = when (milestone) {
+        GoalMilestone.STARTED -> 0
+        GoalMilestone.QUARTER -> 25
+        GoalMilestone.HALF -> 50
+        GoalMilestone.THREE_QUARTER -> 75
+        GoalMilestone.COMPLETE -> 100
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/domain/goals/GoalPlanPresenter.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/domain/goals/GoalPlanPresenter.kt
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.domain.goals
+
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.models.Goal
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.LocalDate
+
+/**
+ * Fully formatted, render-ready view of a goal's savings plan.
+ *
+ * Every monetary and date value is pre-formatted so the Compose / Glance layer
+ * never touches [Cents], [CurrencyFormatter], or date maths.
+ *
+ * @property goalId Stable identifier for keyed lists / navigation.
+ * @property goalName User-facing goal name.
+ * @property icon Optional emoji / icon for the goal.
+ * @property progressPercent Fraction of target reached, 0.0–1.0.
+ * @property progressPercentInt Whole-number progress (0–100).
+ * @property currentFormatted Formatted saved amount.
+ * @property targetFormatted Formatted target amount.
+ * @property remainingFormatted Formatted remaining amount.
+ * @property perWeekFormatted Suggested weekly save amount, formatted.
+ * @property perPaycheckFormatted Suggested per-paycheck save amount, formatted.
+ * @property perMonthFormatted Suggested monthly save amount, formatted.
+ * @property buyByLabel Short month/year buy-by label (e.g. "Aug 2027"), or null.
+ * @property headline Teen-friendly hero line.
+ * @property paceMessage Short on-track / catch-up message.
+ * @property milestoneLabel Motivating milestone label.
+ * @property milestonePercent Milestone checkpoint percent (0/25/50/75/100).
+ * @property pace Raw pace classification for icon / semantics selection.
+ * @property isBehind Whether the saver needs to catch up.
+ * @property isComplete Whether the goal is reached.
+ * @property catchUpPerWeekFormatted Formatted catch-up weekly amount, when behind.
+ * @property hasPlan Whether actionable per-week numbers are available.
+ */
+data class GoalPlanUi(
+    val goalId: SyncId,
+    val goalName: String,
+    val icon: String?,
+    val progressPercent: Float,
+    val progressPercentInt: Int,
+    val currentFormatted: String,
+    val targetFormatted: String,
+    val remainingFormatted: String,
+    val perWeekFormatted: String,
+    val perPaycheckFormatted: String,
+    val perMonthFormatted: String,
+    val buyByLabel: String?,
+    val headline: String,
+    val paceMessage: String,
+    val milestoneLabel: String,
+    val milestonePercent: Int,
+    val pace: GoalPace,
+    val isBehind: Boolean,
+    val isComplete: Boolean,
+    val catchUpPerWeekFormatted: String?,
+    val hasPlan: Boolean,
+)
+
+/**
+ * Turns a [Goal] into a render-ready [GoalPlanUi] by combining the pure
+ * [GoalPlanner] maths with [GoalPlanCopy] phrasing and currency/date formatting.
+ *
+ * Kept free of Android, coroutine, and ViewModel dependencies so it can be unit
+ * tested directly on the JVM.
+ */
+object GoalPlanPresenter {
+
+    private val monthAbbreviations = listOf(
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    )
+
+    /**
+     * Presents [goal] as of [today] in [currency].
+     *
+     * @param actualPerWeekCents Optional known weekly contribution to enable
+     *   ahead/behind pacing; `null` shows the required-pace plan.
+     */
+    fun present(
+        goal: Goal,
+        today: LocalDate,
+        currency: Currency,
+        actualPerWeekCents: Long? = null,
+    ): GoalPlanUi {
+        val plan = GoalPlanner.plan(
+            targetCents = goal.targetAmount.amount,
+            currentCents = goal.currentAmount.amount,
+            today = today,
+            targetDate = goal.targetDate,
+            actualPerWeekCents = actualPerWeekCents,
+        )
+
+        val buyByLabel = plan.projectedDate?.let { monthYearLabel(it) }
+        val perWeekFormatted = format(plan.perWeekCents, currency)
+        val catchUpFormatted = plan.catchUpPerWeekCents?.let { format(it, currency) }
+        val hasPlan = plan.perWeekCents > 0L && !plan.isComplete
+
+        return GoalPlanUi(
+            goalId = goal.id,
+            goalName = goal.name,
+            icon = goal.icon,
+            progressPercent = plan.run {
+                val fraction = (goal.targetAmount.amount - remainingCents).toDouble() /
+                    goal.targetAmount.amount.toDouble()
+                fraction.coerceIn(0.0, 1.0).toFloat()
+            },
+            progressPercentInt = progressPercentInt(goal),
+            currentFormatted = format(goal.currentAmount.amount, currency),
+            targetFormatted = format(goal.targetAmount.amount, currency),
+            remainingFormatted = format(plan.remainingCents, currency),
+            perWeekFormatted = perWeekFormatted,
+            perPaycheckFormatted = format(plan.perPaycheckCents, currency),
+            perMonthFormatted = format(plan.perMonthCents, currency),
+            buyByLabel = buyByLabel,
+            headline = GoalPlanCopy.headline(perWeekFormatted, goal.name, buyByLabel),
+            paceMessage = GoalPlanCopy.paceMessage(
+                pace = plan.pace,
+                goalName = goal.name,
+                buyByLabel = buyByLabel,
+                catchUpPerWeekFormatted = catchUpFormatted,
+            ),
+            milestoneLabel = GoalPlanCopy.milestoneLabel(plan.milestone),
+            milestonePercent = GoalPlanCopy.milestonePercent(plan.milestone),
+            pace = plan.pace,
+            isBehind = plan.pace == GoalPace.BEHIND || plan.pace == GoalPace.OVERDUE,
+            isComplete = plan.isComplete,
+            catchUpPerWeekFormatted = catchUpFormatted,
+            hasPlan = hasPlan,
+        )
+    }
+
+    private fun progressPercentInt(goal: Goal): Int {
+        val target = goal.targetAmount.amount
+        if (target <= 0L) return 0
+        val fraction = goal.currentAmount.amount.toDouble() / target.toDouble()
+        return (fraction.coerceIn(0.0, 1.0) * 100).toInt()
+    }
+
+    private fun format(cents: Long, currency: Currency): String =
+        CurrencyFormatter.format(Cents(cents), currency)
+
+    /** Formats a date as a short month/year label, e.g. "Aug 2027". */
+    fun monthYearLabel(date: LocalDate): String {
+        val month = monthAbbreviations[date.monthNumber - 1]
+        return "$month ${date.year}"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/domain/goals/GoalPlanner.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/domain/goals/GoalPlanner.kt
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.domain.goals
+
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.daysUntil
+import kotlinx.datetime.plus
+
+/**
+ * How a goal is tracking against its deadline (or lack of one).
+ *
+ * Used to drive teen-friendly copy and visuals — never relies on colour alone.
+ */
+enum class GoalPace {
+    /** Target amount already reached. */
+    COMPLETE,
+
+    /** No target date set, so there is nothing to pace against yet. */
+    NO_DEADLINE,
+
+    /** Saving the entered rate finishes comfortably before the deadline. */
+    AHEAD,
+
+    /** Saving the entered rate lands on/near the deadline. */
+    ON_TRACK,
+
+    /** Saving the entered rate finishes after the deadline — needs a catch-up. */
+    BEHIND,
+
+    /** The deadline is today or in the past and the goal is not met. */
+    OVERDUE,
+}
+
+/**
+ * Motivational checkpoint a goal has reached, classified from progress fraction.
+ */
+enum class GoalMilestone {
+    /** 0% up to (but not including) 25%. */
+    STARTED,
+
+    /** 25% up to (but not including) 50%. */
+    QUARTER,
+
+    /** 50% up to (but not including) 75%. */
+    HALF,
+
+    /** 75% up to (but not including) 100%. */
+    THREE_QUARTER,
+
+    /** 100% — goal reached. */
+    COMPLETE,
+}
+
+/**
+ * A deterministic savings plan for a single goal.
+ *
+ * All monetary values are in whole cents ([Long]) so callers can format them
+ * with the shared `CurrencyFormatter`. Required per-period amounts are rounded
+ * **up** so that saving the suggested amount always reaches the target on time.
+ *
+ * @property remainingCents Amount still needed to reach the target (never negative).
+ * @property perWeekCents Suggested weekly savings to hit the target by [targetDate].
+ * @property perPaycheckCents Suggested per-paycheck (biweekly) savings.
+ * @property perMonthCents Suggested monthly savings.
+ * @property weeksRemaining Whole weeks until [targetDate], or `null` when there is
+ *   no deadline and no save rate to project from.
+ * @property projectedDate The date the goal is expected to be reached. When a
+ *   deadline exists this equals [targetDate]; otherwise it is derived from the
+ *   provided save rate. `null` when neither is available.
+ * @property targetDate The user's chosen deadline, echoed for convenience.
+ * @property milestone The checkpoint currently reached.
+ * @property pace How the goal is tracking — see [GoalPace].
+ * @property catchUpPerWeekCents When [pace] is [GoalPace.BEHIND] or
+ *   [GoalPace.OVERDUE], the weekly amount required to still hit the deadline;
+ *   `null` otherwise.
+ * @property isComplete Whether the target has been reached.
+ */
+data class GoalPlan(
+    val remainingCents: Long,
+    val perWeekCents: Long,
+    val perPaycheckCents: Long,
+    val perMonthCents: Long,
+    val weeksRemaining: Int?,
+    val projectedDate: LocalDate?,
+    val targetDate: LocalDate?,
+    val milestone: GoalMilestone,
+    val pace: GoalPace,
+    val catchUpPerWeekCents: Long?,
+    val isComplete: Boolean,
+)
+
+/**
+ * Pure, deterministic goal-planning calculator.
+ *
+ * Owns the maths behind the teen savings planner: turning a target amount and
+ * deadline into a "save $X/week" figure, projecting a buy-by date from a save
+ * rate, classifying milestones, and judging behind/ahead pace. No Android,
+ * coroutine, or formatting dependencies — fully unit testable on the JVM.
+ *
+ * Period maths use fixed planning approximations so results are stable:
+ * - 7 days per week
+ * - 14 days per paycheck (biweekly)
+ * - ~30.44 days per month (365 / 12)
+ *
+ * Required per-period amounts always round **up** so the saver is never short.
+ */
+object GoalPlanner {
+
+    private const val DAYS_PER_WEEK = 7
+    private const val DAYS_PER_PAYCHECK = 14
+    private const val WEEKS_PER_YEAR = 52L
+    private const val MONTHS_PER_YEAR = 12L
+
+    /** Average days per month (365 / 12), scaled by 100 for integer division. */
+    private const val DAYS_PER_MONTH_X100 = 3044L
+
+    /** A save rate finishing this many days early or more is considered AHEAD. */
+    private const val AHEAD_MARGIN_DAYS = 7
+
+    /**
+     * Builds a full [GoalPlan] for a goal.
+     *
+     * @param targetCents Target amount in cents (must be > 0).
+     * @param currentCents Amount already saved in cents (clamped to ≥ 0).
+     * @param today The reference "now" date for all projections.
+     * @param targetDate The chosen deadline, or `null` for an open-ended goal.
+     * @param actualPerWeekCents The saver's real weekly contribution, when known.
+     *   Enables pace classification and (for open-ended goals) a projected date.
+     * @throws IllegalArgumentException if [targetCents] is not positive.
+     */
+    fun plan(
+        targetCents: Long,
+        currentCents: Long,
+        today: LocalDate,
+        targetDate: LocalDate?,
+        actualPerWeekCents: Long? = null,
+    ): GoalPlan {
+        require(targetCents > 0) { "Goal target must be positive" }
+
+        val current = currentCents.coerceAtLeast(0L)
+        val remaining = (targetCents - current).coerceAtLeast(0L)
+        val milestone = milestoneFor(current, targetCents)
+
+        if (remaining == 0L) {
+            return GoalPlan(
+                remainingCents = 0L,
+                perWeekCents = 0L,
+                perPaycheckCents = 0L,
+                perMonthCents = 0L,
+                weeksRemaining = 0,
+                projectedDate = today,
+                targetDate = targetDate,
+                milestone = GoalMilestone.COMPLETE,
+                pace = GoalPace.COMPLETE,
+                catchUpPerWeekCents = null,
+                isComplete = true,
+            )
+        }
+
+        return if (targetDate != null) {
+            planWithDeadline(remaining, today, targetDate, milestone, actualPerWeekCents)
+        } else {
+            planOpenEnded(remaining, today, milestone, actualPerWeekCents)
+        }
+    }
+
+    private fun planWithDeadline(
+        remaining: Long,
+        today: LocalDate,
+        targetDate: LocalDate,
+        milestone: GoalMilestone,
+        actualPerWeekCents: Long?,
+    ): GoalPlan {
+        val days = today.daysUntil(targetDate)
+
+        if (days <= 0) {
+            // Deadline today or already passed and goal unmet.
+            return GoalPlan(
+                remainingCents = remaining,
+                perWeekCents = remaining,
+                perPaycheckCents = remaining,
+                perMonthCents = remaining,
+                weeksRemaining = 0,
+                projectedDate = actualPerWeekCents
+                    ?.takeIf { it > 0 }
+                    ?.let { projectedDate(remaining, it, today) },
+                targetDate = targetDate,
+                milestone = milestone,
+                pace = GoalPace.OVERDUE,
+                catchUpPerWeekCents = remaining,
+                isComplete = false,
+            )
+        }
+
+        val weeks = ceilDiv(days.toLong(), DAYS_PER_WEEK.toLong())
+        val paychecks = ceilDiv(days.toLong(), DAYS_PER_PAYCHECK.toLong())
+        val months = monthsBetween(days)
+
+        val perWeek = ceilDiv(remaining, weeks)
+        val perPaycheck = ceilDiv(remaining, paychecks)
+        val perMonth = ceilDiv(remaining, months)
+
+        val (pace, catchUp, projected) = assessPace(
+            remaining = remaining,
+            today = today,
+            targetDate = targetDate,
+            requiredPerWeek = perWeek,
+            actualPerWeekCents = actualPerWeekCents,
+        )
+
+        return GoalPlan(
+            remainingCents = remaining,
+            perWeekCents = perWeek,
+            perPaycheckCents = perPaycheck,
+            perMonthCents = perMonth,
+            weeksRemaining = weeks.toInt(),
+            projectedDate = projected,
+            targetDate = targetDate,
+            milestone = milestone,
+            pace = pace,
+            catchUpPerWeekCents = catchUp,
+            isComplete = false,
+        )
+    }
+
+    private fun planOpenEnded(
+        remaining: Long,
+        today: LocalDate,
+        milestone: GoalMilestone,
+        actualPerWeekCents: Long?,
+    ): GoalPlan {
+        val rate = actualPerWeekCents?.takeIf { it > 0 }
+        if (rate == null) {
+            // No deadline and no save rate — nothing to pace against yet.
+            return GoalPlan(
+                remainingCents = remaining,
+                perWeekCents = 0L,
+                perPaycheckCents = 0L,
+                perMonthCents = 0L,
+                weeksRemaining = null,
+                projectedDate = null,
+                targetDate = null,
+                milestone = milestone,
+                pace = GoalPace.NO_DEADLINE,
+                catchUpPerWeekCents = null,
+                isComplete = false,
+            )
+        }
+
+        val weeks = ceilDiv(remaining, rate)
+        // Monthly equivalent of a weekly rate: rate * 52 / 12, rounded up.
+        val perMonth = ceilDiv(rate * WEEKS_PER_YEAR, MONTHS_PER_YEAR)
+        return GoalPlan(
+            remainingCents = remaining,
+            perWeekCents = rate,
+            perPaycheckCents = rate * 2L,
+            perMonthCents = perMonth,
+            weeksRemaining = weeks.toInt(),
+            projectedDate = projectedDate(remaining, rate, today),
+            targetDate = null,
+            milestone = milestone,
+            pace = GoalPace.ON_TRACK,
+            catchUpPerWeekCents = null,
+            isComplete = false,
+        )
+    }
+
+    /**
+     * Projects the date a goal is reached when saving [perWeekCents] each week.
+     *
+     * @return The expected completion date, or `null` if [perWeekCents] ≤ 0.
+     */
+    fun projectedDate(remainingCents: Long, perWeekCents: Long, today: LocalDate): LocalDate? {
+        if (perWeekCents <= 0L) return null
+        if (remainingCents <= 0L) return today
+        val weeks = ceilDiv(remainingCents, perWeekCents)
+        return today.plus(weeks * DAYS_PER_WEEK, DateTimeUnit.DAY)
+    }
+
+    /**
+     * The weekly amount required to reach [remainingCents] by [targetDate] from
+     * [today], rounded up. Returns [remainingCents] if the deadline is now/past.
+     */
+    fun requiredPerWeek(remainingCents: Long, today: LocalDate, targetDate: LocalDate): Long {
+        if (remainingCents <= 0L) return 0L
+        val days = today.daysUntil(targetDate)
+        if (days <= 0) return remainingCents
+        val weeks = ceilDiv(days.toLong(), DAYS_PER_WEEK.toLong())
+        return ceilDiv(remainingCents, weeks)
+    }
+
+    /**
+     * Classifies the milestone reached from saved vs. target amount.
+     */
+    fun milestoneFor(currentCents: Long, targetCents: Long): GoalMilestone {
+        if (targetCents <= 0L) return GoalMilestone.STARTED
+        val fraction = currentCents.toDouble() / targetCents.toDouble()
+        return when {
+            fraction >= 1.0 -> GoalMilestone.COMPLETE
+            fraction >= 0.75 -> GoalMilestone.THREE_QUARTER
+            fraction >= 0.50 -> GoalMilestone.HALF
+            fraction >= 0.25 -> GoalMilestone.QUARTER
+            else -> GoalMilestone.STARTED
+        }
+    }
+
+    private fun assessPace(
+        remaining: Long,
+        today: LocalDate,
+        targetDate: LocalDate,
+        requiredPerWeek: Long,
+        actualPerWeekCents: Long?,
+    ): Triple<GoalPace, Long?, LocalDate?> {
+        val rate = actualPerWeekCents?.takeIf { it > 0 }
+            ?: return Triple(GoalPace.ON_TRACK, null, targetDate)
+
+        val projected = projectedDate(remaining, rate, today) ?: targetDate
+        val slackDays = targetDate.daysUntil(projected) // > 0 means finishing late
+        return when {
+            slackDays <= -AHEAD_MARGIN_DAYS -> Triple(GoalPace.AHEAD, null, projected)
+            slackDays <= 0 -> Triple(GoalPace.ON_TRACK, null, projected)
+            else -> Triple(GoalPace.BEHIND, requiredPerWeek, projected)
+        }
+    }
+
+    /** Whole months represented by [days], using the 365/12 average, min 1. */
+    private fun monthsBetween(days: Int): Long {
+        val months = ceilDiv(days.toLong() * 100L, DAYS_PER_MONTH_X100)
+        return months.coerceAtLeast(1L)
+    }
+
+    /** Ceiling integer division for non-negative longs; [divisor] must be > 0. */
+    private fun ceilDiv(value: Long, divisor: Long): Long {
+        require(divisor > 0L) { "divisor must be positive" }
+        if (value <= 0L) return 0L
+        return (value + divisor - 1L) / divisor
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
@@ -34,6 +34,7 @@ import com.finance.android.ui.screens.BudgetEditScreen
 import com.finance.android.ui.screens.DashboardScreen
 import com.finance.android.ui.screens.GoalCreateScreen
 import com.finance.android.ui.screens.GoalEditScreen
+import com.finance.android.ui.screens.GoalPlannerScreen
 import com.finance.android.ui.screens.PlanningScreen
 import com.finance.android.ui.screens.ReceiptOcrScreen
 import com.finance.android.ui.screens.SettingsScreen
@@ -90,6 +91,9 @@ sealed class Route(val route: String) {
 
     /** Goal creation screen. */
     data object GoalCreate : Route("goal/create")
+
+    /** Teen savings goal planner — "save \$X/week, buy by [date]" (#2207). */
+    data object GoalPlanner : Route("goal/planner")
 
     /**
      * OAuth callback deep link destination.
@@ -509,6 +513,13 @@ fun FinanceNavHost(
                 onSaved = { navController.popBackStack() },
                 onBack = { navController.popBackStack() },
             )
+        }
+
+        composable(Route.GoalPlanner.route) {
+            // TODO(human): add an in-app entry point (e.g. a "See your plan"
+            //  action on a goal card) to navigate here, and decide whether the
+            //  planner becomes a top-level tab. Requires UX/product sign-off.
+            GoalPlannerScreen()
         }
 
         // ── Edit screens ────────────────────────────────────────────

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalPlannerScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalPlannerScreen.kt
@@ -1,0 +1,516 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.screens
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Flag
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.finance.android.domain.goals.GoalPace
+import com.finance.android.domain.goals.GoalPlanUi
+import com.finance.android.ui.theme.FinanceTheme
+import com.finance.android.ui.viewmodel.GoalPlannerUiState
+import com.finance.android.ui.viewmodel.GoalPlannerViewModel
+import com.finance.models.types.SyncId
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Goal Planner screen — the teen-friendly "save $X/week, buy by [date]" view (#2207).
+ *
+ * Highlights the saver's most relevant goal with a plain-language headline,
+ * weekly / paycheck / monthly save targets, a projected buy-by date, milestone
+ * checkpoints, and a catch-up message when behind pace. Pace is conveyed with
+ * both an icon and text — never colour alone — and every element exposes a
+ * TalkBack content description.
+ */
+@Composable
+fun GoalPlannerScreen(
+    modifier: Modifier = Modifier,
+    viewModel: GoalPlannerViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    GoalPlannerContent(state = state, modifier = modifier)
+}
+
+@Composable
+internal fun GoalPlannerContent(
+    state: GoalPlannerUiState,
+    modifier: Modifier = Modifier,
+) {
+    when {
+        state.isLoading -> {
+            Box(
+                modifier = modifier
+                    .fillMaxSize()
+                    .semantics { contentDescription = "Building your savings plan" },
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.semantics { contentDescription = "Loading indicator" },
+                )
+            }
+        }
+
+        state.errorMessage != null -> {
+            GoalPlannerMessage(
+                title = "Something went wrong",
+                body = state.errorMessage,
+                icon = Icons.Filled.Warning,
+                modifier = modifier,
+            )
+        }
+
+        state.plan == null || !state.hasGoal -> {
+            GoalPlannerMessage(
+                title = "No goal to plan yet",
+                body = "Create a savings goal with a target amount and date, and we'll " +
+                    "show you how much to save each week.",
+                icon = Icons.Filled.Flag,
+                modifier = modifier,
+            )
+        }
+
+        else -> GoalPlanDetail(plan = state.plan, modifier = modifier)
+    }
+}
+
+@Composable
+@Suppress("LongMethod") // Compose UI function with cohesive layout logic
+private fun GoalPlanDetail(
+    plan: GoalPlanUi,
+    modifier: Modifier = Modifier,
+) {
+    val animatedProgress by animateFloatAsState(
+        targetValue = plan.progressPercent,
+        animationSpec = tween(durationMillis = 800),
+        label = "plan-progress",
+    )
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // ── Title ───────────────────────────────────────────────────────
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (plan.icon != null) {
+                Text(
+                    text = plan.icon,
+                    style = MaterialTheme.typography.headlineMedium,
+                    modifier = Modifier.semantics { contentDescription = "Goal icon" },
+                )
+                Spacer(Modifier.width(8.dp))
+            }
+            Text(
+                text = plan.goalName,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.semantics { heading() },
+            )
+        }
+
+        // ── Hero headline ───────────────────────────────────────────────
+        ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .semantics { contentDescription = plan.headline },
+            ) {
+                Text(
+                    text = plan.headline,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.clearAndSetSemantics { },
+                )
+            }
+        }
+
+        // ── Save targets ────────────────────────────────────────────────
+        if (plan.hasPlan) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                SaveTargetCell(
+                    label = "Per week",
+                    value = plan.perWeekFormatted,
+                    modifier = Modifier.weight(1f),
+                )
+                SaveTargetCell(
+                    label = "Per paycheck",
+                    value = plan.perPaycheckFormatted,
+                    modifier = Modifier.weight(1f),
+                )
+                SaveTargetCell(
+                    label = "Per month",
+                    value = plan.perMonthFormatted,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+
+        // ── Progress + milestone ────────────────────────────────────────
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription = "${plan.progressPercentInt} percent saved. " +
+                        "${plan.currentFormatted} of ${plan.targetFormatted}. " +
+                        plan.milestoneLabel
+                },
+        ) {
+            Text(
+                text = plan.milestoneLabel,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.clearAndSetSemantics { },
+            )
+            Spacer(Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { animatedProgress },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(10.dp)
+                    .clearAndSetSemantics { },
+                strokeCap = StrokeCap.Round,
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "${plan.currentFormatted} saved",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.clearAndSetSemantics { },
+                )
+                Text(
+                    text = "${plan.remainingFormatted} to go",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.clearAndSetSemantics { },
+                )
+            }
+        }
+
+        // ── Milestone checkpoints ───────────────────────────────────────
+        MilestoneRow(reachedPercent = plan.milestonePercent)
+
+        // ── Pace / catch-up message ─────────────────────────────────────
+        PaceBanner(plan = plan)
+
+        // ── Buy-by date ─────────────────────────────────────────────────
+        if (plan.buyByLabel != null && !plan.isComplete) {
+            Text(
+                text = "🎯 Target: ${plan.buyByLabel}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.semantics {
+                    contentDescription = "Target date ${plan.buyByLabel}"
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SaveTargetCell(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.semantics {
+            contentDescription = "$label, $value"
+        },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.clearAndSetSemantics { },
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.clearAndSetSemantics { },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MilestoneRow(
+    reachedPercent: Int,
+    modifier: Modifier = Modifier,
+) {
+    val checkpoints = listOf(25, 50, 75, 100)
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "Milestones: reached $reachedPercent percent of the " +
+                    "25, 50, 75, 100 percent checkpoints"
+            },
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        checkpoints.forEach { checkpoint ->
+            val reached = reachedPercent >= checkpoint
+            Surface(
+                modifier = Modifier
+                    .weight(1f)
+                    .clearAndSetSemantics { },
+                shape = CircleShape,
+                color = if (reached) {
+                    MaterialTheme.colorScheme.primaryContainer
+                } else {
+                    MaterialTheme.colorScheme.surfaceVariant
+                },
+            ) {
+                Row(
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (reached) {
+                        Icon(
+                            imageVector = Icons.Filled.CheckCircle,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier.size(14.dp),
+                        )
+                        Spacer(Modifier.width(4.dp))
+                    }
+                    Text(
+                        text = "$checkpoint%",
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = if (reached) FontWeight.Bold else FontWeight.Normal,
+                        color = if (reached) {
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PaceBanner(
+    plan: GoalPlanUi,
+    modifier: Modifier = Modifier,
+) {
+    val container: androidx.compose.ui.graphics.Color
+    val content: androidx.compose.ui.graphics.Color
+    val icon: ImageVector
+    when (plan.pace) {
+        GoalPace.COMPLETE, GoalPace.AHEAD -> {
+            container = MaterialTheme.colorScheme.tertiaryContainer
+            content = MaterialTheme.colorScheme.onTertiaryContainer
+            icon = Icons.Filled.CheckCircle
+        }
+        GoalPace.ON_TRACK, GoalPace.NO_DEADLINE -> {
+            container = MaterialTheme.colorScheme.secondaryContainer
+            content = MaterialTheme.colorScheme.onSecondaryContainer
+            icon = Icons.Filled.Info
+        }
+        GoalPace.BEHIND, GoalPace.OVERDUE -> {
+            container = MaterialTheme.colorScheme.errorContainer
+            content = MaterialTheme.colorScheme.onErrorContainer
+            icon = Icons.Filled.Warning
+        }
+    }
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = plan.paceMessage },
+        colors = CardDefaults.cardColors(containerColor = container),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = content,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = plan.paceMessage,
+                style = MaterialTheme.typography.bodyMedium,
+                color = content,
+                modifier = Modifier.clearAndSetSemantics { },
+            )
+        }
+    }
+}
+
+@Composable
+private fun GoalPlannerMessage(
+    title: String,
+    body: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp)
+            .semantics { contentDescription = "$title. $body" },
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(56.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.clearAndSetSemantics { },
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.clearAndSetSemantics { },
+            )
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Previews
+// ═══════════════════════════════════════════════════════════════════════
+
+private fun previewPlan(
+    pace: GoalPace = GoalPace.ON_TRACK,
+    milestonePercent: Int = 50,
+    catchUp: String? = null,
+) = GoalPlanUi(
+    goalId = SyncId("preview"),
+    goalName = "Car",
+    icon = "🚗",
+    progressPercent = milestonePercent / 100f,
+    progressPercentInt = milestonePercent,
+    currentFormatted = "$2,500.00",
+    targetFormatted = "$5,000.00",
+    remainingFormatted = "$2,500.00",
+    perWeekFormatted = "$25.00",
+    perPaycheckFormatted = "$50.00",
+    perMonthFormatted = "$108.00",
+    buyByLabel = "Aug 2027",
+    headline = "Save $25.00/week to get your Car by Aug 2027",
+    paceMessage = "Right on track for Aug 2027. Keep it up!",
+    milestoneLabel = "Halfway there! 🚗",
+    milestonePercent = milestonePercent,
+    pace = pace,
+    isBehind = pace == GoalPace.BEHIND || pace == GoalPace.OVERDUE,
+    isComplete = pace == GoalPace.COMPLETE,
+    catchUpPerWeekFormatted = catchUp,
+    hasPlan = true,
+)
+
+@Suppress("UnusedPrivateMember") // Compose Preview function used by IDE
+@Preview(showBackground = true, name = "Planner – on track")
+@Preview(
+    showBackground = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+    name = "Planner – dark",
+)
+@Composable
+private fun GoalPlannerOnTrackPreview() {
+    FinanceTheme(dynamicColor = false) {
+        GoalPlannerContent(state = GoalPlannerUiState(isLoading = false, hasGoal = true, plan = previewPlan()))
+    }
+}
+
+@Suppress("UnusedPrivateMember") // Compose Preview function used by IDE
+@Preview(showBackground = true, name = "Planner – behind")
+@Composable
+private fun GoalPlannerBehindPreview() {
+    FinanceTheme(dynamicColor = false) {
+        GoalPlannerContent(
+            state = GoalPlannerUiState(
+                isLoading = false,
+                hasGoal = true,
+                plan = previewPlan(
+                    pace = GoalPace.BEHIND,
+                    milestonePercent = 25,
+                    catchUp = "$40.00",
+                ).copy(
+                    paceMessage = "A little behind — bump it to $40.00/week to stay on time.",
+                    milestoneLabel = "25% there — nice start!",
+                ),
+            ),
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember") // Compose Preview function used by IDE
+@Preview(showBackground = true, name = "Planner – empty")
+@Composable
+private fun GoalPlannerEmptyPreview() {
+    FinanceTheme(dynamicColor = false) {
+        GoalPlannerContent(state = GoalPlannerUiState(isLoading = false, hasGoal = false, plan = null))
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalPlannerViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalPlannerViewModel.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.GoalRepository
+import com.finance.android.domain.goals.GoalPlanPresenter
+import com.finance.android.domain.goals.GoalPlanUi
+import com.finance.models.Goal
+import com.finance.models.GoalStatus
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import timber.log.Timber
+
+/**
+ * UI state for the teen savings goal planner screen (#2207).
+ *
+ * @property isLoading True during the initial data load.
+ * @property errorMessage Non-null when an error prevents building a plan.
+ * @property plan The render-ready plan for the highlighted goal, or `null`.
+ * @property hasGoal Whether the household has at least one active goal.
+ */
+data class GoalPlannerUiState(
+    val isLoading: Boolean = true,
+    val errorMessage: String? = null,
+    val plan: GoalPlanUi? = null,
+    val hasGoal: Boolean = false,
+)
+
+/**
+ * ViewModel for the teen savings goal planner (#2207).
+ *
+ * Selects the saver's most relevant active goal, runs it through the pure
+ * [GoalPlanPresenter] to produce a "save $X/week … buy by [date]" plan with
+ * milestone and pace messaging, and exposes a reactive [GoalPlannerUiState].
+ *
+ * Goal selection prefers the soonest deadline (most urgent), falling back to
+ * the goal with the highest progress so the saver always sees momentum.
+ *
+ * @param householdIdProvider Provides the authenticated user's household ID.
+ * @param goalRepository Source for goal data.
+ * @param clock Injectable clock for deterministic "today" in tests.
+ */
+class GoalPlannerViewModel(
+    private val householdIdProvider: HouseholdIdProvider,
+    private val goalRepository: GoalRepository,
+    private val clock: Clock = Clock.System,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(GoalPlannerUiState())
+    val uiState: StateFlow<GoalPlannerUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    /** Reloads the highlighted goal's plan. */
+    fun refresh() = load()
+
+    private fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            loadData()
+            _uiState.update { it.copy(isLoading = false) }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught") // Multiple exception types possible
+    private suspend fun loadData() {
+        try {
+            val householdId = householdIdProvider.householdId.value ?: run {
+                Timber.w("No household ID available — skipping goal planner load")
+                _uiState.update { it.copy(plan = null, hasGoal = false, errorMessage = null) }
+                return
+            }
+
+            val goals = goalRepository.observeAll(householdId).first()
+            val today: LocalDate = clock.todayIn(TimeZone.currentSystemDefault())
+            val selected = selectTopGoal(goals)
+
+            if (selected == null) {
+                _uiState.update { it.copy(plan = null, hasGoal = false, errorMessage = null) }
+                return
+            }
+
+            // NOTE: Per-week contribution tracking is not wired yet, so pace is
+            // shown against the required plan rather than actual deposits.
+            // TODO(human): wire real weekly contribution rate once the
+            //  contributions feature lands so AHEAD/BEHIND reflects actual saving.
+            val plan = GoalPlanPresenter.present(
+                goal = selected,
+                today = today,
+                currency = selected.currency,
+            )
+
+            _uiState.update {
+                it.copy(plan = plan, hasGoal = true, errorMessage = null)
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error building goal plan")
+            _uiState.update {
+                it.copy(errorMessage = "Couldn't build your plan. Pull down to retry.")
+            }
+        }
+    }
+
+    /**
+     * Picks the goal to highlight: the soonest active deadline first, otherwise
+     * the active goal closest to completion.
+     */
+    private fun selectTopGoal(goals: List<Goal>): Goal? {
+        val active = goals.filter { it.status == GoalStatus.ACTIVE && !it.isComplete }
+        if (active.isEmpty()) return null
+        val withDeadline = active.filter { it.targetDate != null }
+        return if (withDeadline.isNotEmpty()) {
+            withDeadline.minByOrNull { it.targetDate!! }
+        } else {
+            active.maxByOrNull { it.progress }
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/widget/GoalProgressWidget.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/widget/GoalProgressWidget.kt
@@ -58,6 +58,9 @@ class GoalProgressWidget : GlanceAppWidget() {
         Timber.d("Providing glance content for GoalProgressWidget (id=%s)", id)
 
         // TODO(#1296): Read real data from repository once wired.
+        // TODO(human): wire GoalPlanPresenter output (perWeek + buy-by date) for
+        //  the top goal here once widget data access (#1242/#1296) lands so the
+        //  widget shows the same real projection as the in-app planner.
         val widgetData = WidgetGoalData(
             goalName = "No goals yet",
             currentFormatted = WidgetPrivacyFormatter.formatAmount(0),
@@ -66,6 +69,8 @@ class GoalProgressWidget : GlanceAppWidget() {
             progressPercent = 0,
             totalGoals = 0,
             lastUpdated = "Just now",
+            weeklyTargetLabel = null,
+            buyByLabel = null,
         )
 
         provideContent {
@@ -86,6 +91,8 @@ class GoalProgressWidget : GlanceAppWidget() {
  * @property progressPercent Progress percentage (0–100).
  * @property totalGoals Total number of active goals.
  * @property lastUpdated Human-readable last-update timestamp.
+ * @property weeklyTargetLabel Teen-friendly "save $X/week" label, or null.
+ * @property buyByLabel Projected buy-by month/year (e.g. "Aug 2027"), or null.
  */
 data class WidgetGoalData(
     val goalName: String,
@@ -95,6 +102,8 @@ data class WidgetGoalData(
     val progressPercent: Int,
     val totalGoals: Int,
     val lastUpdated: String,
+    val weeklyTargetLabel: String? = null,
+    val buyByLabel: String? = null,
 )
 
 /**
@@ -129,6 +138,8 @@ private fun GoalProgressContent(data: WidgetGoalData) {
                     "${data.goalName}: ${data.progressPercent}% complete. " +
                     "${data.currentFormatted} of ${data.targetFormatted}. " +
                     "${data.remainingFormatted} remaining. " +
+                    (data.weeklyTargetLabel?.let { "$it. " } ?: "") +
+                    (data.buyByLabel?.let { "On track for $it. " } ?: "") +
                     "${data.totalGoals} active goals. Tap to open Finance."
             },
     ) {
@@ -207,6 +218,25 @@ private fun GoalProgressContent(data: WidgetGoalData) {
                     fontSize = 12.sp,
                 ),
             )
+
+            // Teen-friendly projection: "Save $X/week · Car by Aug 2027"
+            if (data.weeklyTargetLabel != null) {
+                Spacer(modifier = GlanceModifier.height(4.dp))
+                val projection = buildString {
+                    append(data.weeklyTargetLabel)
+                    if (data.buyByLabel != null) {
+                        append(" · ${data.goalName} by ${data.buyByLabel}")
+                    }
+                }
+                Text(
+                    text = projection,
+                    style = TextStyle(
+                        color = GlanceTheme.colors.primary,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium,
+                    ),
+                )
+            }
 
             Spacer(modifier = GlanceModifier.defaultWeight())
 

--- a/apps/android/src/test/kotlin/com/finance/android/domain/goals/GoalPlanCopyTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/domain/goals/GoalPlanCopyTest.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.domain.goals
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [GoalPlanCopy] — teen-friendly phrasing of a goal plan (#2207).
+ */
+class GoalPlanCopyTest {
+
+    @Test
+    fun `headline matches the persona phrasing when a date is known`() {
+        assertEquals(
+            "Save \$25/week to get your Car by Aug 2027",
+            GoalPlanCopy.headline("\$25", "Car", "Aug 2027"),
+        )
+    }
+
+    @Test
+    fun `headline omits the date when none is available`() {
+        assertEquals(
+            "Save \$25/week toward your Car",
+            GoalPlanCopy.headline("\$25", "Car", null),
+        )
+    }
+
+    @Test
+    fun `behind pace message includes the catch-up amount`() {
+        val msg = GoalPlanCopy.paceMessage(
+            pace = GoalPace.BEHIND,
+            goalName = "Car",
+            buyByLabel = "Aug 2027",
+            catchUpPerWeekFormatted = "\$40",
+        )
+        assertTrue(msg.contains("\$40"), "Expected catch-up amount in: $msg")
+        assertTrue(msg.contains("behind"))
+    }
+
+    @Test
+    fun `complete pace message celebrates the goal`() {
+        val msg = GoalPlanCopy.paceMessage(GoalPace.COMPLETE, "Car", null, null)
+        assertTrue(msg.contains("Car"))
+        assertTrue(msg.contains("Done"))
+    }
+
+    @Test
+    fun `no deadline message prompts for a date or amount`() {
+        val msg = GoalPlanCopy.paceMessage(GoalPace.NO_DEADLINE, "Car", null, null)
+        assertTrue(msg.contains("date") || msg.contains("weekly"))
+    }
+
+    @Test
+    fun `milestone label and percent stay in sync`() {
+        assertEquals(0, GoalPlanCopy.milestonePercent(GoalMilestone.STARTED))
+        assertEquals(25, GoalPlanCopy.milestonePercent(GoalMilestone.QUARTER))
+        assertEquals(50, GoalPlanCopy.milestonePercent(GoalMilestone.HALF))
+        assertEquals(75, GoalPlanCopy.milestonePercent(GoalMilestone.THREE_QUARTER))
+        assertEquals(100, GoalPlanCopy.milestonePercent(GoalMilestone.COMPLETE))
+
+        assertTrue(GoalPlanCopy.milestoneLabel(GoalMilestone.HALF).contains("Halfway"))
+        assertTrue(GoalPlanCopy.milestoneLabel(GoalMilestone.COMPLETE).contains("reached"))
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/domain/goals/GoalPlanPresenterTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/domain/goals/GoalPlanPresenterTest.kt
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.domain.goals
+
+import com.finance.models.Goal
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [GoalPlanPresenter] — formatting a [Goal] into render-ready
+ * teen planner copy and numbers (#2207).
+ */
+class GoalPlanPresenterTest {
+
+    private val today = LocalDate(2026, 1, 1)
+    private val epoch = Instant.fromEpochSeconds(0)
+    private val household = SyncId("household")
+
+    private fun goal(
+        target: Long,
+        current: Long = 0,
+        targetDate: LocalDate? = null,
+        name: String = "Car",
+        icon: String? = "🚗",
+    ) = Goal(
+        id = SyncId("goal-1"),
+        householdId = household,
+        ownerId = household,
+        name = name,
+        targetAmount = Cents(target),
+        currentAmount = Cents(current),
+        currency = Currency.USD,
+        targetDate = targetDate,
+        icon = icon,
+        createdAt = epoch,
+        updatedAt = epoch,
+    )
+
+    @Test
+    fun `present formats money and builds the teen headline`() {
+        val ui = GoalPlanPresenter.present(
+            goal = goal(target = 500_000, current = 250_000, targetDate = LocalDate(2027, 8, 1)),
+            today = today,
+            currency = Currency.USD,
+        )
+
+        assertEquals("Car", ui.goalName)
+        assertEquals("🚗", ui.icon)
+        assertEquals("\$5,000.00", ui.targetFormatted)
+        assertEquals("\$2,500.00", ui.currentFormatted)
+        assertEquals("\$2,500.00", ui.remainingFormatted)
+        assertEquals("Aug 2027", ui.buyByLabel)
+        assertEquals(50, ui.progressPercentInt)
+        assertTrue(ui.headline.startsWith("Save "))
+        assertTrue(ui.headline.contains("Car"))
+        assertTrue(ui.headline.contains("Aug 2027"))
+        assertTrue(ui.hasPlan)
+        assertFalse(ui.isBehind)
+    }
+
+    @Test
+    fun `present marks a reached goal complete with no plan`() {
+        val ui = GoalPlanPresenter.present(
+            goal = goal(target = 100_000, current = 100_000),
+            today = today,
+            currency = Currency.USD,
+        )
+        assertTrue(ui.isComplete)
+        assertFalse(ui.hasPlan)
+        assertEquals(100, ui.milestonePercent)
+        assertEquals(GoalPace.COMPLETE, ui.pace)
+    }
+
+    @Test
+    fun `open-ended goal without a rate has no buy-by label`() {
+        val ui = GoalPlanPresenter.present(
+            goal = goal(target = 100_000, current = 10_000, targetDate = null),
+            today = today,
+            currency = Currency.USD,
+        )
+        assertNull(ui.buyByLabel)
+        assertEquals(GoalPace.NO_DEADLINE, ui.pace)
+        assertFalse(ui.hasPlan)
+    }
+
+    @Test
+    fun `monthYearLabel abbreviates month and keeps year`() {
+        assertEquals("Aug 2027", GoalPlanPresenter.monthYearLabel(LocalDate(2027, 8, 15)))
+        assertEquals("Jan 2026", GoalPlanPresenter.monthYearLabel(LocalDate(2026, 1, 1)))
+        assertEquals("Dec 2030", GoalPlanPresenter.monthYearLabel(LocalDate(2030, 12, 31)))
+    }
+
+    @Test
+    fun `behind plan surfaces a formatted catch-up amount`() {
+        val ui = GoalPlanPresenter.present(
+            goal = goal(target = 130_000, current = 0, targetDate = LocalDate(2026, 4, 2)),
+            today = today,
+            currency = Currency.USD,
+            actualPerWeekCents = 5_000,
+        )
+        assertTrue(ui.isBehind)
+        assertNotNull(ui.catchUpPerWeekFormatted)
+        assertTrue(ui.paceMessage.contains(ui.catchUpPerWeekFormatted!!))
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/domain/goals/GoalPlannerTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/domain/goals/GoalPlannerTest.kt
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.domain.goals
+
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [GoalPlanner] — the deterministic teen savings calculator (#2207).
+ *
+ * All dates are fixed so projections are reproducible on any machine. Required
+ * per-period amounts must round **up** so a saver following the plan is never
+ * short of the target on the deadline.
+ */
+class GoalPlannerTest {
+
+    private val today = LocalDate(2026, 1, 1)
+
+    // ── Required per-week / deadline plans ──────────────────────────────
+
+    @Test
+    fun `deadline plan computes weekly target rounded up`() {
+        // $1,300 over 13 weeks → $100/week exactly.
+        val plan = GoalPlanner.plan(
+            targetCents = 130_000,
+            currentCents = 0,
+            today = today,
+            targetDate = LocalDate(2026, 4, 2), // 91 days = 13 weeks
+        )
+
+        assertEquals(130_000, plan.remainingCents)
+        assertEquals(10_000, plan.perWeekCents)
+        assertEquals(13, plan.weeksRemaining)
+        assertEquals(LocalDate(2026, 4, 2), plan.projectedDate)
+        assertEquals(GoalPace.ON_TRACK, plan.pace)
+        assertFalse(plan.isComplete)
+        assertNull(plan.catchUpPerWeekCents)
+    }
+
+    @Test
+    fun `weekly target rounds up when not evenly divisible`() {
+        // $1,000 over 3 weeks → ceil(100000/3) = 33334 cents.
+        val plan = GoalPlanner.plan(
+            targetCents = 100_000,
+            currentCents = 0,
+            today = today,
+            targetDate = LocalDate(2026, 1, 22), // 21 days = 3 weeks
+        )
+        assertEquals(33_334, plan.perWeekCents)
+        // Saving the suggested amount for all weeks must cover the target.
+        assertTrue(plan.perWeekCents * plan.weeksRemaining!! >= plan.remainingCents)
+    }
+
+    @Test
+    fun `paycheck and monthly targets are populated and cover remaining`() {
+        val plan = GoalPlanner.plan(
+            targetCents = 130_000,
+            currentCents = 0,
+            today = today,
+            targetDate = LocalDate(2026, 4, 2),
+        )
+        assertTrue(plan.perPaycheckCents > 0)
+        assertTrue(plan.perMonthCents > 0)
+        // Per-paycheck (biweekly) should be roughly double the weekly amount.
+        assertTrue(plan.perPaycheckCents >= plan.perWeekCents)
+    }
+
+    @Test
+    fun `current savings reduce the remaining amount`() {
+        val plan = GoalPlanner.plan(
+            targetCents = 130_000,
+            currentCents = 65_000,
+            today = today,
+            targetDate = LocalDate(2026, 4, 2),
+        )
+        assertEquals(65_000, plan.remainingCents)
+        assertEquals(5_000, plan.perWeekCents) // half the remaining over 13 weeks
+        assertEquals(GoalMilestone.HALF, plan.milestone)
+    }
+
+    // ── Completion ──────────────────────────────────────────────────────
+
+    @Test
+    fun `reached goal reports complete with zero targets`() {
+        val plan = GoalPlanner.plan(
+            targetCents = 100_000,
+            currentCents = 100_000,
+            today = today,
+            targetDate = LocalDate(2026, 6, 1),
+        )
+        assertTrue(plan.isComplete)
+        assertEquals(GoalPace.COMPLETE, plan.pace)
+        assertEquals(GoalMilestone.COMPLETE, plan.milestone)
+        assertEquals(0, plan.perWeekCents)
+        assertEquals(0, plan.remainingCents)
+    }
+
+    @Test
+    fun `over-saved goal is still complete and clamps remaining to zero`() {
+        val plan = GoalPlanner.plan(
+            targetCents = 100_000,
+            currentCents = 150_000,
+            today = today,
+            targetDate = null,
+        )
+        assertTrue(plan.isComplete)
+        assertEquals(0, plan.remainingCents)
+    }
+
+    // ── Overdue ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `past deadline is overdue and needs the full remaining as catch-up`() {
+        val plan = GoalPlanner.plan(
+            targetCents = 100_000,
+            currentCents = 20_000,
+            today = today,
+            targetDate = LocalDate(2025, 12, 1), // before today
+        )
+        assertEquals(GoalPace.OVERDUE, plan.pace)
+        assertEquals(80_000, plan.remainingCents)
+        assertEquals(80_000, plan.catchUpPerWeekCents)
+        assertFalse(plan.isComplete)
+    }
+
+    // ── Pace assessment with an actual save rate ────────────────────────
+
+    @Test
+    fun `slow actual rate is classified behind with a catch-up amount`() {
+        val plan = GoalPlanner.plan(
+            targetCents = 130_000,
+            currentCents = 0,
+            today = today,
+            targetDate = LocalDate(2026, 4, 2), // needs $100/week
+            actualPerWeekCents = 5_000, // only $50/week
+        )
+        assertEquals(GoalPace.BEHIND, plan.pace)
+        assertEquals(10_000, plan.catchUpPerWeekCents)
+        assertTrue(plan.projectedDate!! > LocalDate(2026, 4, 2))
+    }
+
+    @Test
+    fun `fast actual rate is classified ahead`() {
+        val plan = GoalPlanner.plan(
+            targetCents = 130_000,
+            currentCents = 0,
+            today = today,
+            targetDate = LocalDate(2026, 4, 2),
+            actualPerWeekCents = 20_000, // $200/week
+        )
+        assertEquals(GoalPace.AHEAD, plan.pace)
+        assertNull(plan.catchUpPerWeekCents)
+        assertTrue(plan.projectedDate!! < LocalDate(2026, 4, 2))
+    }
+
+    @Test
+    fun `matching actual rate is on track`() {
+        val plan = GoalPlanner.plan(
+            targetCents = 130_000,
+            currentCents = 0,
+            today = today,
+            targetDate = LocalDate(2026, 4, 2),
+            actualPerWeekCents = 10_000, // exactly $100/week
+        )
+        assertEquals(GoalPace.ON_TRACK, plan.pace)
+        assertEquals(LocalDate(2026, 4, 2), plan.projectedDate)
+    }
+
+    // ── Open-ended goals ────────────────────────────────────────────────
+
+    @Test
+    fun `open-ended goal with a save rate projects a buy-by date`() {
+        val plan = GoalPlanner.plan(
+            targetCents = 100_000,
+            currentCents = 0,
+            today = today,
+            targetDate = null,
+            actualPerWeekCents = 25_000, // $250/week → 4 weeks
+        )
+        assertEquals(GoalPace.ON_TRACK, plan.pace)
+        assertEquals(25_000, plan.perWeekCents)
+        assertEquals(50_000, plan.perPaycheckCents)
+        assertEquals(4, plan.weeksRemaining)
+        assertEquals(LocalDate(2026, 1, 29), plan.projectedDate)
+    }
+
+    @Test
+    fun `open-ended goal without a save rate has no deadline pace`() {
+        val plan = GoalPlanner.plan(
+            targetCents = 100_000,
+            currentCents = 10_000,
+            today = today,
+            targetDate = null,
+        )
+        assertEquals(GoalPace.NO_DEADLINE, plan.pace)
+        assertNull(plan.weeksRemaining)
+        assertNull(plan.projectedDate)
+        assertEquals(0, plan.perWeekCents)
+    }
+
+    // ── Standalone helpers ──────────────────────────────────────────────
+
+    @Test
+    fun `projectedDate returns null for a non-positive rate`() {
+        assertNull(GoalPlanner.projectedDate(100_000, 0, today))
+        assertNull(GoalPlanner.projectedDate(100_000, -5, today))
+    }
+
+    @Test
+    fun `projectedDate rounds weeks up`() {
+        // $1,000 at $300/week → ceil(100000/30000) = 4 weeks → +28 days.
+        assertEquals(
+            LocalDate(2026, 1, 29),
+            GoalPlanner.projectedDate(100_000, 30_000, today),
+        )
+    }
+
+    @Test
+    fun `requiredPerWeek returns full remaining when deadline is today or past`() {
+        assertEquals(50_000, GoalPlanner.requiredPerWeek(50_000, today, today))
+        assertEquals(50_000, GoalPlanner.requiredPerWeek(50_000, today, LocalDate(2025, 1, 1)))
+    }
+
+    @Test
+    fun `milestoneFor classifies each checkpoint band`() {
+        assertEquals(GoalMilestone.STARTED, GoalPlanner.milestoneFor(0, 100))
+        assertEquals(GoalMilestone.STARTED, GoalPlanner.milestoneFor(24, 100))
+        assertEquals(GoalMilestone.QUARTER, GoalPlanner.milestoneFor(25, 100))
+        assertEquals(GoalMilestone.HALF, GoalPlanner.milestoneFor(50, 100))
+        assertEquals(GoalMilestone.THREE_QUARTER, GoalPlanner.milestoneFor(75, 100))
+        assertEquals(GoalMilestone.COMPLETE, GoalPlanner.milestoneFor(100, 100))
+        assertEquals(GoalMilestone.COMPLETE, GoalPlanner.milestoneFor(120, 100))
+    }
+
+    @Test
+    fun `non-positive target is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            GoalPlanner.plan(0, 0, today, null)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GoalPlanner.plan(-10, 0, today, null)
+        }
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/GoalPlannerViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/GoalPlannerViewModelTest.kt
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.viewmodel
+
+import com.finance.android.auth.TestHouseholdIdProvider
+import com.finance.android.data.repository.GoalRepository
+import com.finance.android.domain.goals.GoalPace
+import com.finance.models.Goal
+import com.finance.models.GoalStatus
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [GoalPlannerViewModel] (#2207).
+ *
+ * Uses a deterministic in-memory repository, a fixed [Clock], and
+ * `kotlinx-coroutines-test` to verify goal selection and plan exposure.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GoalPlannerViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val household = SyncId("household-1")
+    private val epoch = Instant.fromEpochSeconds(0)
+
+    // A clock fixed at 2026-01-01T00:00Z.
+    private val fixedClock = object : Clock {
+        override fun now(): Instant = Instant.parse("2026-01-01T00:00:00Z")
+    }
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun goal(
+        id: String,
+        name: String,
+        target: Long,
+        current: Long = 0,
+        status: GoalStatus = GoalStatus.ACTIVE,
+        targetDate: LocalDate? = null,
+    ) = Goal(
+        id = SyncId(id),
+        householdId = household,
+        ownerId = household,
+        name = name,
+        targetAmount = Cents(target),
+        currentAmount = Cents(current),
+        currency = Currency.USD,
+        status = status,
+        targetDate = targetDate,
+        createdAt = epoch,
+        updatedAt = epoch,
+    )
+
+    private class TestGoalRepository(initial: List<Goal>) : GoalRepository {
+        private val goals = MutableStateFlow(initial)
+        override fun observeAll(householdId: SyncId): Flow<List<Goal>> =
+            goals.map { list -> list.filter { it.deletedAt == null } }
+        override fun observeById(id: SyncId): Flow<Goal?> =
+            goals.map { list -> list.find { it.id == id } }
+        override suspend fun getById(id: SyncId): Goal? = goals.value.find { it.id == id }
+        override fun observeActive(householdId: SyncId): Flow<List<Goal>> =
+            goals.map { list -> list.filter { it.status == GoalStatus.ACTIVE } }
+        override suspend fun insert(entity: Goal) { goals.value = goals.value + entity }
+        override suspend fun update(entity: Goal) {
+            goals.value = goals.value.map { if (it.id == entity.id) entity else it }
+        }
+        override suspend fun updateProgress(id: SyncId, currentAmount: Cents) { /* no-op */ }
+        override suspend fun delete(id: SyncId) { /* no-op */ }
+        override suspend fun getUnsynced(householdId: SyncId): List<Goal> = emptyList()
+        override suspend fun markSynced(ids: List<SyncId>) { /* no-op */ }
+    }
+
+    private fun viewModel(goals: List<Goal>, householdId: SyncId? = household) =
+        GoalPlannerViewModel(
+            householdIdProvider = TestHouseholdIdProvider(householdId),
+            goalRepository = TestGoalRepository(goals),
+            clock = fixedClock,
+        )
+
+    @Test
+    fun `initial state is loading`() {
+        val vm = viewModel(emptyList())
+        assertTrue(vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `no active goals yields no plan`() = runTest {
+        val vm = viewModel(
+            listOf(goal("g1", "Old", target = 100_000, status = GoalStatus.COMPLETED)),
+        )
+        advanceUntilIdle()
+        val state = vm.uiState.value
+        assertFalse(state.isLoading)
+        assertFalse(state.hasGoal)
+        assertNull(state.plan)
+    }
+
+    @Test
+    fun `selects the goal with the soonest deadline`() = runTest {
+        val vm = viewModel(
+            listOf(
+                goal("g1", "Laptop", target = 200_000, targetDate = LocalDate(2027, 6, 1)),
+                goal("g2", "Car", target = 500_000, targetDate = LocalDate(2026, 9, 1)),
+            ),
+        )
+        advanceUntilIdle()
+        val plan = vm.uiState.value.plan
+        assertNotNull(plan)
+        assertEquals("Car", plan.goalName)
+        assertTrue(vm.uiState.value.hasGoal)
+        assertNotNull(plan.buyByLabel)
+    }
+
+    @Test
+    fun `falls back to highest progress when no deadlines`() = runTest {
+        val vm = viewModel(
+            listOf(
+                goal("g1", "Shoes", target = 100_000, current = 10_000),
+                goal("g2", "Phone", target = 100_000, current = 80_000),
+            ),
+        )
+        advanceUntilIdle()
+        val plan = vm.uiState.value.plan
+        assertNotNull(plan)
+        assertEquals("Phone", plan.goalName)
+        assertEquals(GoalPace.NO_DEADLINE, plan.pace)
+    }
+
+    @Test
+    fun `missing household id yields no plan without error`() = runTest {
+        val vm = viewModel(
+            listOf(goal("g1", "Car", target = 100_000)),
+            householdId = null,
+        )
+        advanceUntilIdle()
+        val state = vm.uiState.value
+        assertFalse(state.hasGoal)
+        assertNull(state.plan)
+        assertNull(state.errorMessage)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a teen-friendly **savings goal planner** for Android (#2207) that answers the persona's core question — _"save \$X/week and you can buy your car by [date]"_ — instead of just showing a percent bar.

### What's new
- **GoalPlanner** — a pure, deterministic, fully unit-tested calculator that turns a target amount + deadline into save-per-week / per-paycheck / per-month figures (rounded up so you're never short), projects a buy-by date from a save rate, classifies 25/50/75/100% milestones, and judges ahead / on-track / behind / overdue pace with a catch-up amount.
- **GoalPlanCopy** — plain-language teen phrasing (_"Save \$25/week to get your Car by Aug 2027"_), no finance jargon.
- **GoalPlanPresenter** — formats a `Goal` into render-ready strings via the shared `CurrencyFormatter`.
- **GoalPlannerViewModel + GoalPlannerScreen** — Material 3 screen showing the headline, save targets, animated progress, milestone checkpoints, pace banner, and buy-by date. Registered in Koin and added to the nav graph.
- **GoalProgressWidget** — structured to carry the same weekly-target + buy-by projection and privacy-safe semantics (placeholder data until widget repo wiring #1296/#1242 lands).

### Tests
- `GoalPlannerTest`, `GoalPlanCopyTest`, `GoalPlanPresenterTest` (JVM unit tests; all pass), plus `GoalPlannerViewModelTest` for goal selection and state.

### Accessibility
- Every interactive/informational composable has a `contentDescription`; pace is conveyed by **icon + text, never colour alone**; child elements use `clearAndSetSemantics` so TalkBack reads one coherent description per card.

## Needs Human Action
- `// TODO(human)` in `FinanceNavHost` — add an in-app entry point (e.g. a "See your plan" action on a goal card) and decide whether the planner becomes a top-level tab (UX/product sign-off).
- `// TODO(human)` in `GoalPlannerViewModel` / `GoalProgressWidget` — wire the real weekly contribution rate and widget repository data once the contributions feature and widget data access (#1242/#1296) land, so AHEAD/BEHIND reflects actual saving.
- On-device TalkBack / widget verification.

Closes #2207

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>