### PR TITLE
feat(web): live cross-broker P&L & net-worth (#2124)

### DIFF
--- a/apps/web/src/components/dashboard/LivePnlDashboard.test.tsx
+++ b/apps/web/src/components/dashboard/LivePnlDashboard.test.tsx
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for LivePnlDashboard.
+ *
+ * Verifies live-update rendering (re-render reflects new prices) and that
+ * gain/loss is never conveyed by colour alone (glyph + sign + text label).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { LivePnlDashboard } from './LivePnlDashboard';
+import { buildLivePnlView } from '../../lib/investment';
+import type { BaseAccountBalance, IntradayPosition, QuoteSnapshot } from '../../lib/investment';
+
+const NOW = '2026-01-02T15:00:00.000Z';
+const nowMs = () => new Date(NOW).getTime();
+
+const positions: IntradayPosition[] = [
+  {
+    accountId: 'acct-a',
+    brokerage: 'Alpha',
+    symbol: 'VTI',
+    assetClass: 'equity',
+    quantity: 10,
+    previousCloseCents: 100_00,
+    costBasisCents: 900_00,
+    currency: 'USD',
+  },
+];
+
+const baseAccounts: BaseAccountBalance[] = [
+  {
+    accountId: 'cash-1',
+    label: 'Checking',
+    assetClass: 'cash',
+    balanceCents: 2000_00,
+    currency: 'USD',
+  },
+];
+
+function quote(priceCents: number, asOf = '2026-01-02T14:59:50.000Z'): QuoteSnapshot {
+  return {
+    symbol: 'VTI',
+    assetKind: 'equity',
+    priceCents,
+    currency: 'USD',
+    asOf,
+    source: 'manual',
+    marketSession: 'open',
+  };
+}
+
+function viewFor(priceCents: number, lastUpdated = NOW) {
+  return buildLivePnlView({
+    positions,
+    quotes: [quote(priceCents)],
+    baseAccounts,
+    now: NOW,
+    currency: 'USD',
+    lastUpdated,
+  });
+}
+
+describe('LivePnlDashboard', () => {
+  it('renders headline metrics and cross-broker breakdown tables', () => {
+    render(<LivePnlDashboard view={viewFor(110_00)} isLive onRefresh={() => {}} now={nowMs} />);
+
+    expect(screen.getByRole('heading', { name: /Live P&L & Net Worth/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('Total net worth')).toBeInTheDocument();
+    expect(screen.getByLabelText("Today's profit and loss")).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'By Brokerage' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'By Asset Class' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'By Symbol' })).toBeInTheDocument();
+    // Table semantics with scoped headers.
+    expect(screen.getAllByRole('columnheader', { name: 'Day P&L' }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('rowheader', { name: /Alpha/ })).toBeInTheDocument();
+  });
+
+  it('conveys gain/loss with text + glyph, not colour alone', () => {
+    const { container } = render(
+      <LivePnlDashboard view={viewFor(110_00)} isLive onRefresh={() => {}} now={nowMs} />,
+    );
+    // Direction text tag is present on the headline figures.
+    expect(screen.getAllByText('gain').length).toBeGreaterThan(0);
+    // Shape glyph rendered as redundant cue.
+    expect(container.textContent).toContain('▲');
+    // Accessible direction label exists.
+    expect(screen.getByLabelText("today's profit and loss: up")).toBeInTheDocument();
+  });
+
+  it('updates rendered P&L when a new view (live price) arrives', () => {
+    const { rerender } = render(
+      <LivePnlDashboard view={viewFor(110_00)} isLive onRefresh={() => {}} now={nowMs} />,
+    );
+    const dayCard = screen.getByLabelText("Today's profit and loss");
+    expect(within(dayCard).getByText('gain')).toBeInTheDocument();
+
+    // Price drops below previous close → loss.
+    rerender(<LivePnlDashboard view={viewFor(95_00)} isLive onRefresh={() => {}} now={nowMs} />);
+    expect(within(dayCard).getByText('loss')).toBeInTheDocument();
+  });
+
+  it('shows the freshness status and last-updated time', () => {
+    render(<LivePnlDashboard view={viewFor(110_00)} isLive onRefresh={() => {}} now={nowMs} />);
+    expect(screen.getByRole('status', { name: /Market data status: Live/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/Updated/i).length).toBeGreaterThan(0);
+    expect(screen.getByText('Streaming')).toBeInTheDocument();
+  });
+
+  it('flags stale symbols in the breakdown table', () => {
+    const staleView = buildLivePnlView({
+      positions,
+      quotes: [quote(110_00, '2026-01-02T12:00:00.000Z')], // hours old → stale
+      baseAccounts,
+      now: NOW,
+      currency: 'USD',
+      lastUpdated: NOW,
+    });
+    render(<LivePnlDashboard view={staleView} isLive onRefresh={() => {}} now={nowMs} />);
+    expect(screen.getByText(/⚠ stale/)).toBeInTheDocument();
+  });
+
+  it('invokes onRefresh when the refresh button is pressed', () => {
+    const onRefresh = vi.fn();
+    render(<LivePnlDashboard view={viewFor(110_00)} isLive onRefresh={onRefresh} now={nowMs} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh now' }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an error alert and a paused indicator when not live', () => {
+    render(
+      <LivePnlDashboard
+        view={viewFor(110_00)}
+        isLive={false}
+        error="feed down"
+        onRefresh={() => {}}
+        now={nowMs}
+      />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('feed down');
+    expect(screen.getByText('Paused')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/LivePnlDashboard.tsx
+++ b/apps/web/src/components/dashboard/LivePnlDashboard.tsx
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * LivePnlDashboard — presentational view for live cross-broker P&L + net worth.
+ *
+ * Pure/props-driven so it can be unit-tested without a database or price
+ * source. The page wires it to {@link useLivePnl}.
+ *
+ * Accessibility:
+ * - Gain/loss is conveyed by a shape glyph (▲ / ▼ / ◆), an explicit sign, and a
+ *   text label — never colour alone (WCAG 2.2 AA, 1.4.1 Use of Color).
+ * - Breakdown data uses real `<table>` semantics with scoped headers.
+ * - A polite live region announces refreshed totals so screen-reader users
+ *   following an intraday session hear updates without losing focus.
+ * - The freshness badge exposes its meaning via text + `aria-label`.
+ *
+ * References: issue #2124
+ */
+
+import React from 'react';
+import { CurrencyDisplay } from '../common';
+import { formatRelativeAge } from '../../lib/investment';
+import type {
+  LivePnlView,
+  PnlBreakdown,
+  PnlIndicator,
+  StalenessSummary,
+} from '../../lib/investment';
+import './live-pnl-dashboard.css';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface LivePnlDashboardProps {
+  /** The computed live view model. */
+  view: LivePnlView;
+  /** Whether the price source is currently streaming. */
+  isLive: boolean;
+  /** Last price-source error, if any. */
+  error?: string | null;
+  /** Invoked when the user requests an immediate refresh. */
+  onRefresh: () => void;
+  /** Override "now" for deterministic relative-time rendering (tests). */
+  now?: () => number;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface PnlFigureProps {
+  amountCents: number;
+  indicator: PnlIndicator;
+  currency: string;
+  context: string;
+  /** Show the lowercase direction tag (gain/loss/flat) after the amount. */
+  showTag?: boolean;
+}
+
+/**
+ * Renders a P&L amount with redundant direction cues: a shape glyph, an
+ * explicit +/− sign on the value, an optional text tag, and (supplementary)
+ * colour. The accessible label spells out the direction and amount.
+ */
+const PnlFigure: React.FC<PnlFigureProps> = ({
+  amountCents,
+  indicator,
+  currency,
+  context,
+  showTag = false,
+}) => {
+  const directionWord =
+    indicator.direction === 'gain' ? 'up' : indicator.direction === 'loss' ? 'down' : 'unchanged';
+  return (
+    <span
+      className={`live-pnl__figure live-pnl__figure--${indicator.direction}`}
+      aria-label={`${context}: ${directionWord}`}
+    >
+      <span className="live-pnl__figure-glyph" aria-hidden="true">
+        {indicator.arrow}
+      </span>
+      <CurrencyDisplay amount={amountCents} currency={currency} showSign context={context} />
+      {showTag && (
+        <span className="live-pnl__figure-tag" aria-hidden="true">
+          {indicator.label}
+        </span>
+      )}
+    </span>
+  );
+};
+
+const TONE_GLYPH: Record<StalenessSummary['tone'], string> = {
+  live: '●',
+  delayed: '◐',
+  stale: '◑',
+  critical: '▲',
+  empty: '○',
+};
+
+interface FreshnessBadgeProps {
+  staleness: StalenessSummary;
+}
+
+const FreshnessBadge: React.FC<FreshnessBadgeProps> = ({ staleness }) => (
+  <span
+    className={`live-pnl__badge live-pnl__badge--${staleness.tone}`}
+    role="status"
+    aria-label={`Market data status: ${staleness.label}. ${staleness.description}`}
+    title={staleness.description}
+  >
+    <span className="live-pnl__badge-glyph" aria-hidden="true">
+      {TONE_GLYPH[staleness.tone]}
+    </span>
+    {staleness.label}
+  </span>
+);
+
+interface BreakdownTableProps {
+  id: string;
+  caption: string;
+  columnLabel: string;
+  rows: readonly PnlBreakdown[];
+  currency: string;
+  staleKeys?: readonly string[];
+  /** Resolve a display label for each row key (default: identity). */
+  labelFor?: (key: string) => string;
+}
+
+const BreakdownTable: React.FC<BreakdownTableProps> = ({
+  id,
+  caption,
+  columnLabel,
+  rows,
+  currency,
+  staleKeys = [],
+  labelFor = (key) => key,
+}) => {
+  if (rows.length === 0) return null;
+  const staleSet = new Set(staleKeys.map((key) => key.toUpperCase()));
+  return (
+    <div className="live-pnl__table-wrap">
+      <table className="live-pnl__table" aria-describedby={`${id}-caption`}>
+        <caption id={`${id}-caption`}>{caption}</caption>
+        <thead>
+          <tr>
+            <th scope="col">{columnLabel}</th>
+            <th scope="col">Market value</th>
+            <th scope="col">Day P&amp;L</th>
+            <th scope="col">Unrealized P&amp;L</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const isStale = staleSet.has(row.key.toUpperCase());
+            return (
+              <tr key={row.key}>
+                <th scope="row">
+                  {labelFor(row.key)}
+                  {isStale && (
+                    <span className="live-pnl__stale-flag" title="Quote is stale or missing">
+                      {' '}
+                      ⚠ stale
+                    </span>
+                  )}
+                </th>
+                <td>
+                  <CurrencyDisplay amount={row.marketValueCents} currency={currency} />
+                </td>
+                <td>
+                  <PnlFigure
+                    amountCents={row.dayPnlCents}
+                    indicator={pnlIndicatorFor(row.dayPnlCents)}
+                    currency={currency}
+                    context={`${labelFor(row.key)} day P&L`}
+                  />
+                </td>
+                <td>
+                  <PnlFigure
+                    amountCents={row.unrealizedPnlCents}
+                    indicator={pnlIndicatorFor(row.unrealizedPnlCents)}
+                    currency={currency}
+                    context={`${labelFor(row.key)} unrealized P&L`}
+                  />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+/** Local lightweight indicator (avoids importing the engine for a tiny calc). */
+function pnlIndicatorFor(cents: number): PnlIndicator {
+  if (cents > 0) return { direction: 'gain', sign: '+', arrow: '▲', label: 'gain' };
+  if (cents < 0) return { direction: 'loss', sign: '−', arrow: '▼', label: 'loss' };
+  return { direction: 'flat', sign: '', arrow: '◆', label: 'flat' };
+}
+
+const ASSET_CLASS_LABEL: Record<string, string> = {
+  equity: 'Equities',
+  option: 'Options',
+  crypto: 'Crypto',
+  cash: 'Cash',
+  other: 'Other',
+};
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export const LivePnlDashboard: React.FC<LivePnlDashboardProps> = ({
+  view,
+  isLive,
+  error,
+  onRefresh,
+  now,
+}) => {
+  const nowMs = now ? now() : Date.now();
+  const ageMs = view.lastUpdated ? Math.max(0, nowMs - new Date(view.lastUpdated).getTime()) : null;
+  const updatedLabel =
+    ageMs === null ? 'Awaiting first update' : `Updated ${formatRelativeAge(ageMs)}`;
+  const { currency } = view;
+
+  // Concise summary announced to assistive tech whenever totals change.
+  const liveSummary = `${view.indicators.day.label === 'flat' ? 'No change' : `Day ${view.indicators.day.label}`} ${view.dayPnlPercent}%. ${updatedLabel}. Market data ${view.staleness.label}.`;
+
+  return (
+    <div className="live-pnl">
+      <header className="live-pnl__header">
+        <div>
+          <h2 className="live-pnl__title">Live P&amp;L &amp; Net Worth</h2>
+          <p className="live-pnl__subtitle">
+            Cross-broker intraday performance across {view.report.breakdowns.byBrokerage.length}{' '}
+            brokerage{view.report.breakdowns.byBrokerage.length === 1 ? '' : 's'}.
+          </p>
+        </div>
+      </header>
+
+      {/* Live status / controls */}
+      <div className="live-pnl__statusbar">
+        <div className="live-pnl__status-group">
+          <FreshnessBadge staleness={view.staleness} />
+          <span className="live-pnl__updated">{updatedLabel}</span>
+        </div>
+        <div className="live-pnl__status-group live-pnl__status-group--end">
+          <span
+            className={`live-pnl__pulse ${isLive ? '' : 'live-pnl__pulse--paused'}`}
+            aria-hidden="true"
+          />
+          <span className="live-pnl__updated">{isLive ? 'Streaming' : 'Paused'}</span>
+          <button type="button" className="live-pnl__refresh" onClick={onRefresh}>
+            Refresh now
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <p className="live-pnl__error" role="alert">
+          <span aria-hidden="true">⚠</span> {error}
+        </p>
+      )}
+
+      {/* Polite live region — announces refreshed totals without stealing focus */}
+      <p className="sr-only" role="status" aria-live="polite">
+        {liveSummary}
+      </p>
+
+      {/* Headline metrics */}
+      <section className="live-pnl__metrics" aria-label="Live performance summary">
+        <article className="live-pnl__metric" aria-label="Total net worth">
+          <p className="live-pnl__metric-label">Total Net Worth</p>
+          <p className="live-pnl__metric-value">
+            <CurrencyDisplay
+              amount={view.totalNetWorthCents}
+              currency={currency}
+              context="total net worth"
+            />
+          </p>
+          <p className="live-pnl__metric-sub">
+            <CurrencyDisplay
+              amount={view.investedValueCents}
+              currency={currency}
+              context="invested value"
+            />{' '}
+            invested
+          </p>
+        </article>
+
+        <article className="live-pnl__metric" aria-label="Today's profit and loss">
+          <p className="live-pnl__metric-label">Today&apos;s P&amp;L</p>
+          <p className="live-pnl__metric-value">
+            <PnlFigure
+              amountCents={view.dayPnlCents}
+              indicator={view.indicators.day}
+              currency={currency}
+              context="today's profit and loss"
+              showTag
+            />
+          </p>
+          <p className="live-pnl__metric-sub">
+            {view.dayPnlPercent >= 0 ? '+' : '−'}
+            {Math.abs(view.dayPnlPercent)}% of start-of-day net worth
+          </p>
+        </article>
+
+        <article className="live-pnl__metric" aria-label="Unrealized profit and loss">
+          <p className="live-pnl__metric-label">Unrealized P&amp;L</p>
+          <p className="live-pnl__metric-value">
+            <PnlFigure
+              amountCents={view.unrealizedPnlCents}
+              indicator={view.indicators.unrealized}
+              currency={currency}
+              context="unrealized profit and loss"
+              showTag
+            />
+          </p>
+          <p className="live-pnl__metric-sub">Open positions vs. cost basis</p>
+        </article>
+
+        <article className="live-pnl__metric" aria-label="Realized profit and loss">
+          <p className="live-pnl__metric-label">Realized P&amp;L (today)</p>
+          <p className="live-pnl__metric-value">
+            <PnlFigure
+              amountCents={view.realizedPnlCents}
+              indicator={view.indicators.realized}
+              currency={currency}
+              context="realized profit and loss today"
+              showTag
+            />
+          </p>
+          <p className="live-pnl__metric-sub">Closed trades booked today</p>
+        </article>
+      </section>
+
+      {/* Breakdowns */}
+      <section className="live-pnl__section" aria-label="Profit and loss by brokerage">
+        <h3 className="live-pnl__section-title">By Brokerage</h3>
+        <BreakdownTable
+          id="pnl-by-brokerage"
+          caption="Market value and intraday P&L for each brokerage."
+          columnLabel="Brokerage"
+          rows={view.report.breakdowns.byBrokerage}
+          currency={currency}
+        />
+      </section>
+
+      <section className="live-pnl__section" aria-label="Profit and loss by asset class">
+        <h3 className="live-pnl__section-title">By Asset Class</h3>
+        <BreakdownTable
+          id="pnl-by-asset-class"
+          caption="Market value and intraday P&L grouped by asset class, including volatile crypto."
+          columnLabel="Asset class"
+          rows={view.report.breakdowns.byAssetClass}
+          currency={currency}
+          labelFor={(key) => ASSET_CLASS_LABEL[key] ?? key}
+        />
+      </section>
+
+      <section className="live-pnl__section" aria-label="Profit and loss by symbol">
+        <h3 className="live-pnl__section-title">By Symbol</h3>
+        <BreakdownTable
+          id="pnl-by-symbol"
+          caption="Market value and intraday P&L for each holding. Stale or missing quotes are flagged."
+          columnLabel="Symbol"
+          rows={view.report.breakdowns.bySymbol}
+          currency={currency}
+          staleKeys={[...view.staleness.staleSymbols, ...view.staleness.missingSymbols]}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default LivePnlDashboard;

--- a/apps/web/src/components/dashboard/live-pnl-dashboard.css
+++ b/apps/web/src/components/dashboard/live-pnl-dashboard.css
@@ -1,0 +1,336 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Live cross-broker P&L dashboard styles.
+ *
+ * All visual values use design-token CSS custom properties. Direction is never
+ * conveyed by colour alone — glyphs and text labels carry the meaning and the
+ * colour classes only reinforce it.
+ *
+ * References: issue #2124
+ */
+
+.live-pnl {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.live-pnl__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+}
+
+.live-pnl__title {
+  font-size: var(--type-scale-headline-font-size);
+  font-weight: var(--type-scale-headline-font-weight);
+  color: var(--semantic-text-primary);
+  margin: 0;
+}
+
+.live-pnl__subtitle {
+  margin: var(--spacing-1) 0 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+/* ---------------------------------------------------------------------------
+ * Status bar (freshness + last updated + controls)
+ * ------------------------------------------------------------------------- */
+
+.live-pnl__statusbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  margin-bottom: var(--spacing-5);
+  background: var(--semantic-background-elevated);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+}
+
+.live-pnl__status-group {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.live-pnl__status-group--end {
+  margin-left: auto;
+}
+
+.live-pnl__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: 999px;
+  border: 1px solid var(--semantic-border-default);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+}
+
+.live-pnl__badge-glyph {
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+.live-pnl__badge--live {
+  color: var(--semantic-status-positive);
+  border-color: var(--semantic-status-positive);
+}
+
+.live-pnl__badge--delayed {
+  color: var(--semantic-status-warning);
+  border-color: var(--semantic-status-warning);
+}
+
+.live-pnl__badge--stale,
+.live-pnl__badge--critical {
+  color: var(--semantic-status-negative);
+  border-color: var(--semantic-status-negative);
+}
+
+.live-pnl__badge--empty {
+  color: var(--semantic-text-secondary);
+}
+
+.live-pnl__updated {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.live-pnl__pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--semantic-status-positive);
+  animation: live-pnl-pulse 2s ease-in-out infinite;
+}
+
+.live-pnl__pulse--paused {
+  background: var(--semantic-text-secondary);
+  animation: none;
+}
+
+@keyframes live-pnl-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.live-pnl__refresh {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.live-pnl__refresh:hover {
+  background: var(--semantic-background-secondary);
+}
+
+.live-pnl__refresh:focus-visible {
+  outline: 2px solid var(--semantic-interactive-default);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Error banner
+ * ------------------------------------------------------------------------- */
+
+.live-pnl__error {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+  border-radius: var(--border-radius-sm);
+  border: 1px solid var(--semantic-status-warning);
+  color: var(--semantic-status-warning);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+/* ---------------------------------------------------------------------------
+ * Metric cards
+ * ------------------------------------------------------------------------- */
+
+.live-pnl__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+}
+
+.live-pnl__metric {
+  padding: var(--spacing-4);
+  background: var(--semantic-background-elevated);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+}
+
+.live-pnl__metric-label {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-1);
+}
+
+.live-pnl__metric-value {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin: 0;
+}
+
+.live-pnl__metric-sub {
+  margin: var(--spacing-1) 0 0;
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+/* ---------------------------------------------------------------------------
+ * P&L figure (glyph + sign + value + label — never colour alone)
+ * ------------------------------------------------------------------------- */
+
+.live-pnl__figure {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--spacing-1);
+}
+
+.live-pnl__figure-glyph {
+  font-size: 0.8em;
+  line-height: 1;
+}
+
+.live-pnl__figure-tag {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.live-pnl__figure--gain {
+  color: var(--semantic-status-positive);
+}
+
+.live-pnl__figure--loss {
+  color: var(--semantic-status-negative);
+}
+
+.live-pnl__figure--flat {
+  color: var(--semantic-text-secondary);
+}
+
+/* ---------------------------------------------------------------------------
+ * Breakdown tables
+ * ------------------------------------------------------------------------- */
+
+.live-pnl__section {
+  margin-bottom: var(--spacing-6);
+}
+
+.live-pnl__section-title {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+  margin-bottom: var(--spacing-3);
+}
+
+.live-pnl__table-wrap {
+  overflow-x: auto;
+}
+
+.live-pnl__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--type-scale-body-font-size);
+}
+
+.live-pnl__table caption {
+  text-align: left;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  margin-bottom: var(--spacing-2);
+}
+
+.live-pnl__table th,
+.live-pnl__table td {
+  padding: var(--spacing-2) var(--spacing-3);
+  text-align: right;
+  border-bottom: 1px solid var(--semantic-border-default);
+  white-space: nowrap;
+}
+
+.live-pnl__table th[scope='col'] {
+  color: var(--semantic-text-secondary);
+  font-weight: var(--font-weight-medium);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.live-pnl__table th[scope='row'],
+.live-pnl__table td:first-child {
+  text-align: left;
+}
+
+.live-pnl__table tbody tr:hover {
+  background: var(--semantic-background-secondary);
+}
+
+.live-pnl__stale-flag {
+  margin-left: var(--spacing-1);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-status-warning);
+}
+
+/* ---------------------------------------------------------------------------
+ * Reduced motion
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .live-pnl__pulse {
+    animation: none;
+  }
+  .live-pnl__refresh {
+    transition: none;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * High contrast
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-contrast: more) {
+  .live-pnl__metric,
+  .live-pnl__statusbar,
+  .live-pnl__badge {
+    border-width: 2px;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Mobile
+ * ------------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .live-pnl__metrics {
+    grid-template-columns: 1fr 1fr;
+  }
+  .live-pnl__status-group--end {
+    margin-left: 0;
+  }
+}

--- a/apps/web/src/components/layout/navConfig.tsx
+++ b/apps/web/src/components/layout/navConfig.tsx
@@ -154,6 +154,15 @@ export const NAV_CONFIG: readonly NavConfigItem[] = ensureStableNavOrder([
     description: 'Holdings, performance and watchlists.',
   },
   {
+    id: 'live-pnl',
+    label: 'Live P&L',
+    href: '/live-pnl',
+    icon: <Icon name={IconToken.INVESTMENT} />,
+    group: 'money',
+    mobilePriority: 16,
+    description: 'Real-time cross-broker P&L and net worth for active trading.',
+  },
+  {
     id: 'tax-center',
     label: 'Tax Center',
     href: '/investments/tax',

--- a/apps/web/src/hooks/useLivePnl.test.tsx
+++ b/apps/web/src/hooks/useLivePnl.test.tsx
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for useLivePnl.
+ *
+ * Mocks the data hooks (useInvestments / useAccounts) per project conventions
+ * and injects a ManualPriceSource so live updates are deterministic.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildBaseAccountBalances,
+  buildLivePositions,
+  buildQuoteRequests,
+  buildSimulatedSeeds,
+  useLivePnl,
+} from './useLivePnl';
+import { ManualPriceSource } from '../lib/investment';
+import type { QuoteSnapshot } from '../lib/investment';
+import type { Account, Investment } from '../kmp/bridge';
+
+vi.mock('./useInvestments', () => ({ useInvestments: vi.fn() }));
+vi.mock('./useAccounts', () => ({ useAccounts: vi.fn() }));
+
+import { useInvestments } from './useInvestments';
+import { useAccounts } from './useAccounts';
+
+const meta = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+} as const;
+
+const USD = { code: 'USD', decimalPlaces: 2 };
+
+function makeInvestment(
+  partial: Partial<Investment> & Pick<Investment, 'symbol' | 'shares'>,
+): Investment {
+  return {
+    id: `inv-${partial.symbol}`,
+    householdId: 'hh-1',
+    accountId: 'acct-a',
+    name: partial.symbol ?? '',
+    type: 'STOCK',
+    costBasisPerShare: { amount: 90_00 },
+    currentPricePerShare: { amount: 100_00 },
+    currency: USD,
+    lastPriceUpdate: null,
+    ...meta,
+    ...partial,
+  } as Investment;
+}
+
+function makeAccount(partial: Partial<Account> & Pick<Account, 'id' | 'name' | 'type'>): Account {
+  return {
+    householdId: 'hh-1',
+    purpose: undefined,
+    currency: USD,
+    currentBalance: { amount: 0 },
+    isArchived: false,
+    sortOrder: 0,
+    icon: null,
+    color: null,
+    ...meta,
+    ...partial,
+  } as Account;
+}
+
+const investments: Investment[] = [
+  makeInvestment({ symbol: 'VTI', shares: 10, type: 'ETF', accountId: 'acct-a' }),
+  makeInvestment({
+    symbol: 'BTC',
+    shares: 0.5,
+    type: 'CRYPTO',
+    accountId: 'acct-b',
+    currentPricePerShare: { amount: 40000_00 },
+    costBasisPerShare: { amount: 30000_00 },
+  }),
+];
+
+const accounts: Account[] = [
+  makeAccount({ id: 'acct-a', name: 'Alpha Brokerage', type: 'INVESTMENT' }),
+  makeAccount({ id: 'acct-b', name: 'Beta Crypto', type: 'INVESTMENT' }),
+  makeAccount({
+    id: 'cash-1',
+    name: 'Checking',
+    type: 'CHECKING',
+    currentBalance: { amount: 5000_00 },
+  }),
+];
+
+const mockUseInvestments = vi.mocked(useInvestments);
+const mockUseAccounts = vi.mocked(useAccounts);
+
+function setData(invs: Investment[], accts: Account[], loading = false): void {
+  mockUseInvestments.mockReturnValue({ investments: invs, loading } as never);
+  mockUseAccounts.mockReturnValue({ accounts: accts, loading } as never);
+}
+
+const NOW = '2026-01-02T15:00:00.000Z';
+
+function quote(
+  symbol: string,
+  priceCents: number,
+  assetKind: QuoteSnapshot['assetKind'] = 'equity',
+): QuoteSnapshot {
+  return {
+    symbol,
+    assetKind,
+    priceCents,
+    currency: 'USD',
+    asOf: NOW,
+    source: 'manual',
+    marketSession: assetKind === 'crypto' ? '24x7' : 'open',
+  };
+}
+
+describe('useLivePnl mapping helpers', () => {
+  it('maps investments to positions with resolved brokerage labels', () => {
+    const positions = buildLivePositions(investments, accounts);
+    expect(positions[0]).toMatchObject({
+      symbol: 'VTI',
+      brokerage: 'Alpha Brokerage',
+      assetClass: 'equity',
+      quantity: 10,
+      previousCloseCents: 100_00,
+      costBasisCents: 900_00,
+    });
+    expect(positions[1].assetClass).toBe('crypto');
+    expect(positions[1].brokerage).toBe('Beta Crypto');
+  });
+
+  it('builds de-duplicated quote requests', () => {
+    const dupes = [...investments, makeInvestment({ symbol: 'vti', shares: 1, type: 'ETF' })];
+    const requests = buildQuoteRequests(dupes);
+    expect(requests).toHaveLength(2);
+  });
+
+  it('seeds the simulator from stored prices with higher crypto volatility', () => {
+    const seeds = buildSimulatedSeeds(investments);
+    const btc = seeds.find((s) => s.symbol === 'BTC');
+    expect(btc?.basePriceCents).toBe(40000_00);
+    expect(btc?.marketSession).toBe('24x7');
+    expect(btc?.volatilityBps ?? 0).toBeGreaterThan(
+      seeds.find((s) => s.symbol === 'VTI')?.volatilityBps ?? 0,
+    );
+  });
+
+  it('excludes investment accounts from base net-worth balances', () => {
+    const base = buildBaseAccountBalances(accounts, 'USD');
+    expect(base).toHaveLength(1);
+    expect(base[0]).toMatchObject({
+      accountId: 'cash-1',
+      assetClass: 'cash',
+      balanceCents: 5000_00,
+    });
+  });
+});
+
+describe('useLivePnl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setData(investments, accounts);
+  });
+
+  it('recomputes the view as live prices arrive (live update)', () => {
+    const source = new ManualPriceSource({ now: () => NOW });
+    const { result } = renderHook(() =>
+      useLivePnl({ source, now: () => NOW, baseCurrency: 'USD' }),
+    );
+
+    // Before any quote, prices fall back to previous close → day P&L is flat.
+    expect(result.current.view).not.toBeNull();
+    expect(result.current.view?.dayPnlCents).toBe(0);
+    expect(result.current.isLive).toBe(true);
+
+    // A live tick raises VTI by $10/share → +$100 day P&L.
+    act(() => {
+      source.emit([quote('VTI', 110_00), quote('BTC', 40000_00, 'crypto')]);
+    });
+
+    expect(result.current.view?.dayPnlCents).toBe(100_00);
+    expect(result.current.view?.indicators.day.direction).toBe('gain');
+    expect(result.current.lastUpdated).toBe(NOW);
+
+    // A subsequent tick lowers VTI below previous close → loss.
+    act(() => {
+      source.emit([quote('VTI', 95_00), quote('BTC', 40000_00, 'crypto')]);
+    });
+    expect(result.current.view?.dayPnlCents).toBe(-50_00);
+    expect(result.current.view?.indicators.day.direction).toBe('loss');
+  });
+
+  it('surfaces source errors', () => {
+    const source = new ManualPriceSource({ now: () => NOW });
+    const { result } = renderHook(() => useLivePnl({ source, now: () => NOW }));
+    act(() => {
+      source.emit([], NOW, 'feed unavailable');
+    });
+    expect(result.current.error).toBe('feed unavailable');
+  });
+
+  it('returns null view when there are no positions or base accounts', () => {
+    setData([], []);
+    const source = new ManualPriceSource({ now: () => NOW });
+    const { result } = renderHook(() => useLivePnl({ source, now: () => NOW }));
+    expect(result.current.view).toBeNull();
+  });
+
+  it('refresh delegates to the source', async () => {
+    const source = new ManualPriceSource({ now: () => NOW });
+    const spy = vi.spyOn(source, 'refreshNow');
+    const { result } = renderHook(() => useLivePnl({ source, now: () => NOW }));
+    await act(async () => {
+      result.current.refresh();
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useLivePnl.ts
+++ b/apps/web/src/hooks/useLivePnl.ts
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook powering the live cross-broker P&L + net-worth dashboard.
+ *
+ * Data access stays hooks-only: positions come from {@link useInvestments} and
+ * balances from {@link useAccounts}. The hook subscribes to a pluggable
+ * {@link PriceSource} (default: an offline {@link SimulatedMarketDataProvider}
+ * polled on an interval — no network, no API keys) and recomputes a
+ * {@link LivePnlView} every time fresh quotes arrive or a staleness tick fires.
+ *
+ * A caller may inject its own `source` (e.g. a vendor websocket adapter, or a
+ * {@link ManualPriceSource} in tests) without changing the data path.
+ *
+ * References: issue #2124
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAccounts } from './useAccounts';
+import { useInvestments } from './useInvestments';
+import {
+  buildLivePnlView,
+  PollingPriceSource,
+  SimulatedMarketDataProvider,
+} from '../lib/investment';
+import type {
+  BaseAccountBalance,
+  LivePnlView,
+  PnlAssetClass,
+  PriceSource,
+  PriceUpdate,
+  QuoteRequest,
+  QuoteSnapshot,
+  SimulatedSeed,
+} from '../lib/investment';
+import type { Account, Investment, InvestmentType } from '../kmp/bridge';
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+/** Options for {@link useLivePnl}. */
+export interface UseLivePnlOptions {
+  /** Inject a custom price source (default: polled offline simulation). */
+  readonly source?: PriceSource;
+  /** Poll cadence for the default source, in ms (default: 15s). */
+  readonly intervalMs?: number;
+  /** Start the source automatically on mount (default: true). */
+  readonly autoStart?: boolean;
+  /** Reporting currency (default: `'USD'`). */
+  readonly baseCurrency?: string;
+  /** Clock injection for deterministic tests. */
+  readonly now?: () => string;
+  /** Staleness re-evaluation cadence, in ms (default: 5s). */
+  readonly stalenessTickMs?: number;
+}
+
+/** Shape returned by {@link useLivePnl}. */
+export interface UseLivePnlResult {
+  /** The computed live view, or `null` when there is nothing to show. */
+  view: LivePnlView | null;
+  /** `true` while underlying investment/account data is loading. */
+  loading: boolean;
+  /** Last price-source error message, or `null`. */
+  error: string | null;
+  /** Whether the price source is currently emitting updates. */
+  isLive: boolean;
+  /** ISO timestamp of the most recent price update, or `null`. */
+  lastUpdated: string | null;
+  /** Force an immediate price refresh. */
+  refresh: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Mapping helpers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+const INVESTMENT_PNL_CLASS: Record<InvestmentType, PnlAssetClass> = {
+  STOCK: 'equity',
+  ETF: 'equity',
+  MUTUAL_FUND: 'equity',
+  BOND: 'other',
+  CRYPTO: 'crypto',
+  REAL_ESTATE: 'other',
+  COMMODITY: 'other',
+  OTHER: 'other',
+};
+
+const INVESTMENT_QUOTE_KIND: Record<InvestmentType, QuoteRequest['assetKind']> = {
+  STOCK: 'equity',
+  ETF: 'equity',
+  MUTUAL_FUND: 'equity',
+  BOND: 'other',
+  CRYPTO: 'crypto',
+  REAL_ESTATE: 'other',
+  COMMODITY: 'other',
+  OTHER: 'other',
+};
+
+/**
+ * Investment-type accounts are valued from live positions, so their stored
+ * balance is excluded from the "base" (non-market) net-worth roll-up to avoid
+ * double-counting.
+ */
+function isInvestmentAccount(type: Account['type']): boolean {
+  return type === 'INVESTMENT';
+}
+
+/** Build intraday positions from investments, resolving the brokerage label. */
+export function buildLivePositions(
+  investments: readonly Investment[],
+  accounts: readonly Account[],
+) {
+  const accountsById = new Map(accounts.map((account) => [account.id, account]));
+  return investments.map((inv) => {
+    const account = inv.accountId ? accountsById.get(inv.accountId) : undefined;
+    const priceCents = inv.currentPricePerShare.amount;
+    return {
+      accountId: inv.accountId ?? 'unassigned',
+      brokerage: account?.name ?? 'Unassigned',
+      symbol: inv.symbol,
+      assetClass: INVESTMENT_PNL_CLASS[inv.type],
+      quantity: inv.shares,
+      // Stored current price is the intraday baseline; live quotes drive change.
+      previousCloseCents: priceCents,
+      costBasisCents: Math.round(inv.shares * inv.costBasisPerShare.amount),
+      currency: inv.currency.code,
+    };
+  });
+}
+
+/** Build de-duplicated quote requests for the tracked symbols. */
+export function buildQuoteRequests(investments: readonly Investment[]): QuoteRequest[] {
+  const seen = new Map<string, QuoteRequest>();
+  for (const inv of investments) {
+    const symbol = inv.symbol.toUpperCase();
+    if (!seen.has(symbol)) {
+      seen.set(symbol, { symbol: inv.symbol, assetKind: INVESTMENT_QUOTE_KIND[inv.type] });
+    }
+  }
+  return [...seen.values()];
+}
+
+/** Build simulated price seeds from stored current prices. */
+export function buildSimulatedSeeds(investments: readonly Investment[]): SimulatedSeed[] {
+  const seen = new Map<string, SimulatedSeed>();
+  for (const inv of investments) {
+    const symbol = inv.symbol.toUpperCase();
+    if (seen.has(symbol)) continue;
+    const isCrypto = inv.type === 'CRYPTO';
+    seen.set(symbol, {
+      symbol: inv.symbol,
+      assetKind: INVESTMENT_QUOTE_KIND[inv.type],
+      basePriceCents: inv.currentPricePerShare.amount,
+      currency: inv.currency.code,
+      marketSession: isCrypto ? '24x7' : 'open',
+      // Crypto is more volatile than equities in the simulation.
+      volatilityBps: isCrypto ? 150 : 50,
+    });
+  }
+  return [...seen.values()];
+}
+
+/** Build base (non-market) account balances that complete total net worth. */
+export function buildBaseAccountBalances(
+  accounts: readonly Account[],
+  currency: string,
+): BaseAccountBalance[] {
+  return accounts
+    .filter((account) => !account.isArchived && !isInvestmentAccount(account.type))
+    .filter((account) => account.currency.code === currency)
+    .map((account) => ({
+      accountId: account.id,
+      label: account.name,
+      assetClass:
+        account.type === 'CASH' || account.type === 'CHECKING' || account.type === 'SAVINGS'
+          ? 'cash'
+          : 'other',
+      balanceCents: account.currentBalance.amount,
+      currency: account.currency.code,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/** Live cross-broker P&L + net-worth view derived from local data + quotes. */
+export function useLivePnl(options: UseLivePnlOptions = {}): UseLivePnlResult {
+  const {
+    source: injectedSource,
+    intervalMs = 15_000,
+    autoStart = true,
+    baseCurrency = 'USD',
+    stalenessTickMs = 5_000,
+  } = options;
+
+  const { investments, loading: investmentsLoading } = useInvestments();
+  const { accounts, loading: accountsLoading } = useAccounts();
+
+  const nowFn = useMemo(() => options.now ?? (() => new Date().toISOString()), [options.now]);
+
+  const positions = useMemo(
+    () => buildLivePositions(investments, accounts),
+    [investments, accounts],
+  );
+  const baseAccounts = useMemo(
+    () => buildBaseAccountBalances(accounts, baseCurrency),
+    [accounts, baseCurrency],
+  );
+  const requests = useMemo(() => buildQuoteRequests(investments), [investments]);
+  const seeds = useMemo(() => buildSimulatedSeeds(investments), [investments]);
+
+  // Stable signature so the default source is only recreated when symbols change.
+  const requestSignature = useMemo(
+    () =>
+      requests
+        .map((request) => request.symbol.toUpperCase())
+        .sort()
+        .join(','),
+    [requests],
+  );
+
+  const [quotes, setQuotes] = useState<ReadonlyMap<string, QuoteSnapshot>>(new Map());
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLive, setIsLive] = useState(false);
+  const [nowTick, setNowTick] = useState(() => nowFn());
+
+  const activeSourceRef = useRef<PriceSource | null>(null);
+
+  const handleUpdate = useCallback(
+    (update: PriceUpdate) => {
+      setError(update.error ?? null);
+      if (update.quotes.length > 0) {
+        setQuotes((prev) => {
+          const next = new Map(prev);
+          for (const quote of update.quotes) next.set(quote.symbol.toUpperCase(), quote);
+          return next;
+        });
+      }
+      setLastUpdated(update.receivedAt);
+      setNowTick(nowFn());
+    },
+    [nowFn],
+  );
+
+  // Re-evaluate staleness on a slow tick even when no new quotes arrive.
+  useEffect(() => {
+    const id = setInterval(() => setNowTick(nowFn()), Math.max(1_000, stalenessTickMs));
+    return () => clearInterval(id);
+  }, [nowFn, stalenessTickMs]);
+
+  // Subscribe to (and, for the default source, own the lifecycle of) the source.
+  useEffect(() => {
+    const ownsSource = !injectedSource;
+    const source =
+      injectedSource ??
+      new PollingPriceSource(new SimulatedMarketDataProvider(seeds, { now: nowFn }), requests, {
+        intervalMs,
+        now: nowFn,
+      });
+    activeSourceRef.current = source;
+    const unsubscribe = source.subscribe(handleUpdate);
+    if (autoStart) {
+      source.start();
+      setIsLive(true);
+    }
+    return () => {
+      unsubscribe();
+      if (ownsSource) source.stop();
+      setIsLive(false);
+      if (activeSourceRef.current === source) activeSourceRef.current = null;
+    };
+    // `requestSignature` captures symbol-set changes so the default source is
+    // only recreated when the tracked symbols change (seeds/requests are read
+    // fresh inside the effect at that point).
+  }, [injectedSource, requestSignature, intervalMs, autoStart, handleUpdate, nowFn]);
+
+  const refresh = useCallback(() => {
+    void activeSourceRef.current?.refreshNow();
+  }, []);
+
+  const view = useMemo<LivePnlView | null>(() => {
+    if (positions.length === 0 && baseAccounts.length === 0) return null;
+    return buildLivePnlView({
+      positions,
+      quotes: [...quotes.values()],
+      baseAccounts,
+      now: nowTick,
+      currency: baseCurrency,
+      lastUpdated,
+    });
+  }, [positions, baseAccounts, quotes, nowTick, baseCurrency, lastUpdated]);
+
+  return {
+    view,
+    loading: investmentsLoading || accountsLoading,
+    error,
+    isLive,
+    lastUpdated,
+    refresh,
+  };
+}

--- a/apps/web/src/hooks/useRouteAnnouncer.ts
+++ b/apps/web/src/hooks/useRouteAnnouncer.ts
@@ -29,6 +29,7 @@ const ROUTE_TITLES: Record<string, string> = {
   '/insights': 'Insights',
   '/household': 'Household',
   '/investments': 'Investments',
+  '/live-pnl': 'Live P&L',
   '/bills': 'Bills',
   '/report-builder': 'Report Builder',
   '/achievements': 'Achievements',

--- a/apps/web/src/lib/investment/index.ts
+++ b/apps/web/src/lib/investment/index.ts
@@ -296,6 +296,56 @@ export type {
   DefiValuationStatus,
 } from './defi-position-presentation';
 
+// #2637, #2638, #2124 — Live cross-broker market data, intraday P&L, and price sources
+export {
+  DEFAULT_FRESHNESS_POLICY,
+  evaluateQuoteFreshness,
+  ManualMarketDataProvider,
+} from './market-data';
+export type {
+  AssetKind,
+  EvaluatedQuote,
+  FreshnessPolicy,
+  MarketDataProvider,
+  MarketSessionStatus,
+  QuoteFreshness,
+  QuoteRequest,
+  QuoteSnapshot,
+} from './market-data';
+
+export { computeIntradayPnl } from './intraday-pnl';
+export type {
+  CashMovement,
+  IntradayPnlInput,
+  IntradayPnlReport,
+  IntradayPosition,
+  PnlAssetClass,
+  PnlBreakdown,
+  RealizedPnlEvent,
+} from './intraday-pnl';
+
+export { ManualPriceSource, PollingPriceSource, SimulatedMarketDataProvider } from './price-source';
+export type {
+  PollingPriceSourceOptions,
+  PriceListener,
+  PriceSource,
+  PriceUpdate,
+  SimulatedProviderOptions,
+  SimulatedSeed,
+  TimerApi,
+} from './price-source';
+
+export { buildLivePnlView, formatRelativeAge, pnlIndicator } from './live-pnl';
+export type {
+  BaseAccountBalance,
+  LivePnlView,
+  LivePnlViewInput,
+  PnlDirection,
+  PnlIndicator,
+  StalenessSummary,
+  StalenessTone,
+} from './live-pnl';
+
 // Types
 export type {
   PortfolioHolding,

--- a/apps/web/src/lib/investment/live-pnl.test.ts
+++ b/apps/web/src/lib/investment/live-pnl.test.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { buildLivePnlView, formatRelativeAge, pnlIndicator } from './live-pnl';
+import type { BaseAccountBalance } from './live-pnl';
+import type { IntradayPosition } from './intraday-pnl';
+import type { QuoteSnapshot } from './market-data';
+
+const NOW = '2026-01-02T15:00:00.000Z';
+
+function quote(
+  symbol: string,
+  priceCents: number,
+  asOf = '2026-01-02T14:59:40.000Z',
+  assetKind: QuoteSnapshot['assetKind'] = 'equity',
+  marketSession: QuoteSnapshot['marketSession'] = 'open',
+): QuoteSnapshot {
+  return { symbol, assetKind, priceCents, currency: 'USD', asOf, source: 'manual', marketSession };
+}
+
+const positions: IntradayPosition[] = [
+  {
+    accountId: 'acct-a',
+    brokerage: 'Alpha',
+    symbol: 'VTI',
+    assetClass: 'equity',
+    quantity: 10,
+    previousCloseCents: 100_00, // prev close $100
+    costBasisCents: 900_00, // basis $900
+    currency: 'USD',
+  },
+  {
+    accountId: 'acct-b',
+    brokerage: 'Beta',
+    symbol: 'BTC',
+    assetClass: 'crypto',
+    quantity: 0.1,
+    previousCloseCents: 40000_00,
+    costBasisCents: 3500_00,
+    currency: 'USD',
+  },
+];
+
+const quotes: QuoteSnapshot[] = [
+  quote('VTI', 110_00), // +$10/share → +$100 day, value $1100
+  quote('BTC', 41000_00, '2026-01-02T14:59:50.000Z', 'crypto', '24x7'), // +$1000/coin → +$100 day, value $4100
+];
+
+const baseAccounts: BaseAccountBalance[] = [
+  {
+    accountId: 'cash-1',
+    label: 'Checking',
+    assetClass: 'cash',
+    balanceCents: 2000_00,
+    currency: 'USD',
+  },
+  {
+    accountId: 'loan-1',
+    label: 'Margin loan',
+    assetClass: 'other',
+    balanceCents: -500_00,
+    currency: 'USD',
+  },
+];
+
+describe('pnlIndicator', () => {
+  it('encodes direction with redundant non-colour cues', () => {
+    expect(pnlIndicator(150)).toEqual({ direction: 'gain', sign: '+', arrow: '▲', label: 'gain' });
+    expect(pnlIndicator(-150)).toEqual({ direction: 'loss', sign: '−', arrow: '▼', label: 'loss' });
+    expect(pnlIndicator(0)).toEqual({ direction: 'flat', sign: '', arrow: '◆', label: 'flat' });
+  });
+});
+
+describe('formatRelativeAge', () => {
+  it('formats common buckets', () => {
+    expect(formatRelativeAge(2_000)).toBe('just now');
+    expect(formatRelativeAge(45_000)).toBe('45s ago');
+    expect(formatRelativeAge(3 * 60_000)).toBe('3m ago');
+    expect(formatRelativeAge(2 * 60 * 60_000)).toBe('2h ago');
+    expect(formatRelativeAge(-1)).toBe('unknown');
+  });
+});
+
+describe('buildLivePnlView', () => {
+  it('aggregates market value, day/unrealized P&L and total net worth', () => {
+    const view = buildLivePnlView({ positions, quotes, baseAccounts, now: NOW, currency: 'USD' });
+
+    expect(view.investedValueCents).toBe(5200_00); // 1100 + 4100
+    expect(view.dayPnlCents).toBe(200_00); // 100 + 100
+    // unrealized: (1100-900) + (4100-3500) = 200 + 600
+    expect(view.unrealizedPnlCents).toBe(800_00);
+    // base net worth: 2000 - 500 = 1500
+    expect(view.baseNetWorthCents).toBe(1500_00);
+    // total: 5200 + 1500 = 6700
+    expect(view.totalNetWorthCents).toBe(6700_00);
+    // previous = total - dayPnl = 6700 - 200 = 6500
+    expect(view.previousNetWorthCents).toBe(6500_00);
+    expect(view.dayPnlPercent).toBeCloseTo((200_00 / 6500_00) * 100, 1);
+    expect(view.indicators.day.direction).toBe('gain');
+  });
+
+  it('classifies staleness as live when all quotes are fresh', () => {
+    const view = buildLivePnlView({ positions, quotes, baseAccounts, now: NOW, currency: 'USD' });
+    expect(view.staleness.tone).toBe('live');
+    expect(view.staleness.evaluatedCount).toBe(2);
+    expect(view.staleness.freshCount).toBe(2);
+    expect(view.staleness.staleSymbols).toEqual([]);
+  });
+
+  it('flags missing quotes as critical and lists the symbol', () => {
+    const view = buildLivePnlView({
+      positions,
+      quotes: [quote('VTI', 110_00)], // BTC quote missing
+      baseAccounts,
+      now: NOW,
+      currency: 'USD',
+    });
+    expect(view.staleness.tone).toBe('critical');
+    expect(view.staleness.missingCount).toBe(1);
+    expect(view.staleness.missingSymbols).toEqual(['BTC']);
+    expect(view.staleness.worst).toBe('missing');
+  });
+
+  it('marks stale tone when a quote exceeds the freshness policy', () => {
+    const view = buildLivePnlView({
+      positions: [positions[0]],
+      quotes: [quote('VTI', 110_00, '2026-01-02T13:00:00.000Z')], // 2h old, open market → stale
+      now: NOW,
+      currency: 'USD',
+    });
+    expect(view.staleness.tone).toBe('stale');
+    expect(view.staleness.staleSymbols).toEqual(['VTI']);
+  });
+
+  it('carries lastUpdated through and reports empty tone with no positions', () => {
+    const view = buildLivePnlView({
+      positions: [],
+      quotes: [],
+      baseAccounts,
+      now: NOW,
+      currency: 'USD',
+      lastUpdated: NOW,
+    });
+    expect(view.lastUpdated).toBe(NOW);
+    expect(view.staleness.tone).toBe('empty');
+    expect(view.totalNetWorthCents).toBe(1500_00);
+  });
+
+  it('includes realized P&L in the report and indicators', () => {
+    const view = buildLivePnlView({
+      positions,
+      quotes,
+      baseAccounts,
+      realizedEvents: [
+        {
+          accountId: 'acct-a',
+          brokerage: 'Alpha',
+          symbol: 'AAPL',
+          realizedPnlCents: -75_00,
+          currency: 'USD',
+        },
+      ],
+      now: NOW,
+      currency: 'USD',
+    });
+    expect(view.realizedPnlCents).toBe(-75_00);
+    expect(view.indicators.realized.direction).toBe('loss');
+  });
+
+  it('rolls up cross-broker breakdowns', () => {
+    const view = buildLivePnlView({ positions, quotes, baseAccounts, now: NOW, currency: 'USD' });
+    const byBrokerage = view.report.breakdowns.byBrokerage;
+    expect(byBrokerage.map((r) => r.key).sort()).toEqual(['Alpha', 'Beta']);
+    expect(byBrokerage.find((r) => r.key === 'Alpha')?.dayPnlCents).toBe(100_00);
+    expect(byBrokerage.find((r) => r.key === 'Beta')?.dayPnlCents).toBe(100_00);
+    expect(view.report.breakdowns.byAssetClass.map((r) => r.key).sort()).toEqual([
+      'crypto',
+      'equity',
+    ]);
+  });
+});

--- a/apps/web/src/lib/investment/live-pnl.ts
+++ b/apps/web/src/lib/investment/live-pnl.ts
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Live cross-broker P&L + net-worth aggregation engine.
+ *
+ * Composes the intraday P&L engine ({@link computeIntradayPnl}) with the
+ * non-market account balances that complete a trader's total net worth, then
+ * derives the presentation-layer facts a live dashboard needs:
+ *
+ * - Total net worth = invested market value + base (cash/other) balances.
+ * - Today's day P&L, unrealized P&L, realized P&L and a day-change percentage.
+ * - A {@link StalenessSummary} describing how current the underlying quotes are
+ *   (live / delayed / stale / attention) so volatile assets never make the
+ *   net-worth view silently misleading.
+ * - {@link PnlIndicator}s that encode direction with a glyph **and** text label
+ *   (never colour alone) for WCAG 2.2 AA non-text-contrast compliance.
+ *
+ * This module is pure and deterministic given its inputs, which keeps the math
+ * unit-testable independent of React or any price source.
+ *
+ * References: issue #2124
+ */
+
+import { computeIntradayPnl } from './intraday-pnl';
+import type {
+  CashMovement,
+  IntradayPnlReport,
+  IntradayPosition,
+  RealizedPnlEvent,
+} from './intraday-pnl';
+import { DEFAULT_FRESHNESS_POLICY, evaluateQuoteFreshness } from './market-data';
+import type { FreshnessPolicy, QuoteFreshness, QuoteSnapshot } from './market-data';
+
+// ---------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------
+
+/** A non-market account balance that contributes to total net worth. */
+export interface BaseAccountBalance {
+  readonly accountId: string;
+  readonly label: string;
+  /** Cash-like vs. other (real estate, vehicles, etc.). */
+  readonly assetClass: 'cash' | 'other';
+  /** Signed balance in cents — negative values represent liabilities. */
+  readonly balanceCents: number;
+  readonly currency: string;
+}
+
+/** Input to {@link buildLivePnlView}. */
+export interface LivePnlViewInput {
+  readonly positions: readonly IntradayPosition[];
+  readonly quotes: readonly QuoteSnapshot[];
+  /** Non-market balances (cash, savings, property, liabilities). */
+  readonly baseAccounts?: readonly BaseAccountBalance[];
+  readonly realizedEvents?: readonly RealizedPnlEvent[];
+  readonly cashMovements?: readonly CashMovement[];
+  /** ISO-8601 evaluation time (drives staleness). */
+  readonly now: string;
+  /** Reporting currency; positions/quotes in other currencies are ignored. */
+  readonly currency: string;
+  /** ISO-8601 timestamp of the most recent price update, if any. */
+  readonly lastUpdated?: string | null;
+  /** Override the freshness policy used for staleness classification. */
+  readonly freshnessPolicy?: FreshnessPolicy;
+}
+
+// ---------------------------------------------------------------------------
+// Presentation primitives (non-colour-only cues)
+// ---------------------------------------------------------------------------
+
+/** Direction of a P&L figure. */
+export type PnlDirection = 'gain' | 'loss' | 'flat';
+
+/**
+ * A redundant, accessible encoding of a P&L figure's direction.
+ *
+ * Combines a shape glyph (`arrow`), an explicit `sign`, and a text `label` so
+ * gain/loss is conveyed by more than colour alone.
+ */
+export interface PnlIndicator {
+  readonly direction: PnlDirection;
+  /** `'+'`, `'−'` (U+2212 minus), or `''` when flat. */
+  readonly sign: '+' | '−' | '';
+  /** Distinct shape per direction: up / down / diamond (flat). */
+  readonly arrow: '▲' | '▼' | '◆';
+  /** Human-readable label: `'gain'`, `'loss'`, or `'flat'`. */
+  readonly label: PnlDirection;
+}
+
+/** Overall freshness tone for the dashboard's status badge. */
+export type StalenessTone = 'live' | 'delayed' | 'stale' | 'critical' | 'empty';
+
+/** Aggregate description of how current the underlying quotes are. */
+export interface StalenessSummary {
+  readonly tone: StalenessTone;
+  /** Most severe per-symbol freshness, or `'none'` when nothing was evaluated. */
+  readonly worst: QuoteFreshness | 'none';
+  /** Short status label, e.g. `'Live'`, `'Delayed'`, `'Stale'`. */
+  readonly label: string;
+  /** Longer human description suitable for a tooltip / SR text. */
+  readonly description: string;
+  readonly evaluatedCount: number;
+  readonly freshCount: number;
+  readonly delayedCount: number;
+  readonly staleCount: number;
+  readonly missingCount: number;
+  readonly failedCount: number;
+  readonly staleSymbols: readonly string[];
+  readonly missingSymbols: readonly string[];
+  readonly failedSymbols: readonly string[];
+  /** Age in ms of the oldest evaluated quote (0 when none/all missing). */
+  readonly oldestQuoteAgeMs: number;
+}
+
+/** Output of {@link buildLivePnlView}. */
+export interface LivePnlView {
+  readonly report: IntradayPnlReport;
+  readonly currency: string;
+  /** Net worth from non-market accounts (cash, property, liabilities). */
+  readonly baseNetWorthCents: number;
+  /** Current market value of all positions. */
+  readonly investedValueCents: number;
+  /** base + invested. */
+  readonly totalNetWorthCents: number;
+  /** Approx. start-of-day net worth (total − day P&L). */
+  readonly previousNetWorthCents: number;
+  readonly dayPnlCents: number;
+  /** Day P&L as a percentage of previous net worth (0 when undefined). */
+  readonly dayPnlPercent: number;
+  readonly unrealizedPnlCents: number;
+  readonly realizedPnlCents: number;
+  readonly staleness: StalenessSummary;
+  readonly lastUpdated: string | null;
+  readonly indicators: {
+    readonly day: PnlIndicator;
+    readonly unrealized: PnlIndicator;
+    readonly realized: PnlIndicator;
+    readonly netWorth: PnlIndicator;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build an accessible direction indicator from a signed cents figure. */
+export function pnlIndicator(cents: number): PnlIndicator {
+  if (cents > 0) return { direction: 'gain', sign: '+', arrow: '▲', label: 'gain' };
+  if (cents < 0) return { direction: 'loss', sign: '−', arrow: '▼', label: 'loss' };
+  return { direction: 'flat', sign: '', arrow: '◆', label: 'flat' };
+}
+
+const SEVERITY: Record<QuoteFreshness, number> = {
+  fresh: 0,
+  delayed: 1,
+  stale: 2,
+  missing: 3,
+  failed: 4,
+};
+
+function toneFor(summary: {
+  evaluatedCount: number;
+  delayedCount: number;
+  staleCount: number;
+  missingCount: number;
+  failedCount: number;
+}): StalenessTone {
+  if (summary.evaluatedCount === 0) return 'empty';
+  if (summary.failedCount > 0 || summary.missingCount > 0) return 'critical';
+  if (summary.staleCount > 0) return 'stale';
+  if (summary.delayedCount > 0) return 'delayed';
+  return 'live';
+}
+
+const TONE_LABEL: Record<StalenessTone, string> = {
+  live: 'Live',
+  delayed: 'Delayed',
+  stale: 'Stale',
+  critical: 'Attention needed',
+  empty: 'No market data',
+};
+
+function describeStaleness(
+  tone: StalenessTone,
+  counts: { delayedCount: number; staleCount: number; missingCount: number; failedCount: number },
+): string {
+  switch (tone) {
+    case 'live':
+      return 'All quotes are current within the freshness policy.';
+    case 'delayed':
+      return `${counts.delayedCount} quote(s) are delayed but still usable.`;
+    case 'stale':
+      return `${counts.staleCount} quote(s) exceed the freshness policy — values may be out of date.`;
+    case 'critical':
+      return `${counts.missingCount} missing and ${counts.failedCount} failed quote(s); some positions use the last known or previous-close price.`;
+    case 'empty':
+      return 'No positions with live quotes are being tracked.';
+  }
+}
+
+/**
+ * Format a quote/update age in milliseconds as a compact relative string,
+ * e.g. `"just now"`, `"45s ago"`, `"3m ago"`, `"2h ago"`.
+ */
+export function formatRelativeAge(ageMs: number): string {
+  if (!Number.isFinite(ageMs) || ageMs < 0) return 'unknown';
+  const seconds = Math.floor(ageMs / 1000);
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function summarizeStaleness(input: LivePnlViewInput): StalenessSummary {
+  const policy = input.freshnessPolicy ?? DEFAULT_FRESHNESS_POLICY;
+  const quotesBySymbol = new Map(input.quotes.map((quote) => [quote.symbol.toUpperCase(), quote]));
+
+  // Evaluate each distinct, in-currency position symbol exactly once.
+  const seen = new Set<string>();
+  let freshCount = 0;
+  let delayedCount = 0;
+  let staleCount = 0;
+  let missingCount = 0;
+  let failedCount = 0;
+  let oldestQuoteAgeMs = 0;
+  let worstSeverity = -1;
+  let worst: QuoteFreshness | 'none' = 'none';
+  const staleSymbols: string[] = [];
+  const missingSymbols: string[] = [];
+  const failedSymbols: string[] = [];
+
+  for (const position of input.positions) {
+    if (position.currency !== input.currency) continue;
+    if (position.assetClass === 'cash') continue;
+    const symbol = position.symbol.toUpperCase();
+    if (seen.has(symbol)) continue;
+    seen.add(symbol);
+
+    const evaluated = evaluateQuoteFreshness(quotesBySymbol.get(symbol), input.now, policy);
+    const freshness = evaluated.freshness;
+    if (evaluated.ageMs > oldestQuoteAgeMs) oldestQuoteAgeMs = evaluated.ageMs;
+    if (SEVERITY[freshness] > worstSeverity) {
+      worstSeverity = SEVERITY[freshness];
+      worst = freshness;
+    }
+    switch (freshness) {
+      case 'fresh':
+        freshCount += 1;
+        break;
+      case 'delayed':
+        delayedCount += 1;
+        break;
+      case 'stale':
+        staleCount += 1;
+        staleSymbols.push(symbol);
+        break;
+      case 'missing':
+        missingCount += 1;
+        missingSymbols.push(symbol);
+        break;
+      case 'failed':
+        failedCount += 1;
+        failedSymbols.push(symbol);
+        break;
+    }
+  }
+
+  const evaluatedCount = seen.size;
+  const counts = { delayedCount, staleCount, missingCount, failedCount };
+  const tone = toneFor({ evaluatedCount, ...counts });
+
+  return {
+    tone,
+    worst,
+    label: TONE_LABEL[tone],
+    description: describeStaleness(tone, counts),
+    evaluatedCount,
+    freshCount,
+    delayedCount,
+    staleCount,
+    missingCount,
+    failedCount,
+    staleSymbols: staleSymbols.sort(),
+    missingSymbols: missingSymbols.sort(),
+    failedSymbols: failedSymbols.sort(),
+    oldestQuoteAgeMs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the complete live P&L + net-worth view model from positions, the
+ * latest quotes, and non-market account balances.
+ */
+export function buildLivePnlView(input: LivePnlViewInput): LivePnlView {
+  const report = computeIntradayPnl({
+    positions: input.positions,
+    quotes: input.quotes,
+    realizedEvents: input.realizedEvents,
+    cashMovements: input.cashMovements,
+    now: input.now,
+    currency: input.currency,
+  });
+
+  const baseNetWorthCents = (input.baseAccounts ?? [])
+    .filter((account) => account.currency === input.currency)
+    .reduce((sum, account) => sum + account.balanceCents, 0);
+
+  const investedValueCents = report.totalMarketValueCents;
+  const totalNetWorthCents = baseNetWorthCents + investedValueCents;
+  const dayPnlCents = report.dayPnlCents;
+  const previousNetWorthCents = totalNetWorthCents - dayPnlCents;
+  const dayPnlPercent =
+    previousNetWorthCents !== 0
+      ? Math.round((dayPnlCents / Math.abs(previousNetWorthCents)) * 10000) / 100
+      : 0;
+
+  return {
+    report,
+    currency: input.currency,
+    baseNetWorthCents,
+    investedValueCents,
+    totalNetWorthCents,
+    previousNetWorthCents,
+    dayPnlCents,
+    dayPnlPercent,
+    unrealizedPnlCents: report.unrealizedPnlCents,
+    realizedPnlCents: report.realizedPnlCents,
+    staleness: summarizeStaleness(input),
+    lastUpdated: input.lastUpdated ?? null,
+    indicators: {
+      day: pnlIndicator(dayPnlCents),
+      unrealized: pnlIndicator(report.unrealizedPnlCents),
+      realized: pnlIndicator(report.realizedPnlCents),
+      netWorth: pnlIndicator(dayPnlCents),
+    },
+  };
+}

--- a/apps/web/src/lib/investment/price-source.test.ts
+++ b/apps/web/src/lib/investment/price-source.test.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ManualPriceSource, PollingPriceSource, SimulatedMarketDataProvider } from './price-source';
+import type { TimerApi } from './price-source';
+import { ManualMarketDataProvider } from './market-data';
+import type { QuoteRequest, QuoteSnapshot } from './market-data';
+
+const NOW = '2026-01-02T15:00:00.000Z';
+
+function snapshot(symbol: string, priceCents: number): QuoteSnapshot {
+  return {
+    symbol,
+    assetKind: 'equity',
+    priceCents,
+    currency: 'USD',
+    asOf: NOW,
+    source: 'manual',
+    marketSession: 'open',
+  };
+}
+
+const REQUESTS: QuoteRequest[] = [{ symbol: 'VTI', assetKind: 'equity' }];
+
+describe('ManualPriceSource', () => {
+  it('delivers pushed quotes to subscribers and reports running state', () => {
+    const source = new ManualPriceSource({ now: () => NOW });
+    const updates: number[] = [];
+    const unsubscribe = source.subscribe((u) => updates.push(u.quotes.length));
+
+    expect(source.running).toBe(false);
+    source.start();
+    expect(source.running).toBe(true);
+
+    source.emit([snapshot('VTI', 100_00)]);
+    source.emit([snapshot('VTI', 101_00)]);
+    expect(updates).toEqual([1, 1]);
+
+    unsubscribe();
+    source.emit([snapshot('VTI', 102_00)]);
+    expect(updates).toEqual([1, 1]); // no further deliveries after unsubscribe
+  });
+
+  it('propagates an error flag on a failed update', () => {
+    const source = new ManualPriceSource({ now: () => NOW });
+    let lastError: string | undefined;
+    source.subscribe((u) => {
+      lastError = u.error;
+    });
+    source.emit([], NOW, 'feed down');
+    expect(lastError).toBe('feed down');
+  });
+});
+
+describe('PollingPriceSource', () => {
+  let intervalHandler: (() => void) | null = null;
+  let timers: TimerApi;
+  let cleared: boolean;
+
+  beforeEach(() => {
+    intervalHandler = null;
+    cleared = false;
+    timers = {
+      setInterval: (handler) => {
+        intervalHandler = handler;
+        return 1;
+      },
+      clearInterval: () => {
+        cleared = true;
+      },
+    };
+  });
+
+  it('emits an immediate snapshot on start and again on each interval tick', async () => {
+    const provider = new ManualMarketDataProvider([snapshot('VTI', 100_00)]);
+    const source = new PollingPriceSource(provider, REQUESTS, {
+      intervalMs: 1000,
+      now: () => NOW,
+      timers,
+    });
+    const updates: QuoteSnapshot[][] = [];
+    source.subscribe((u) => updates.push([...u.quotes]));
+
+    source.start();
+    expect(source.running).toBe(true);
+    await vi.waitFor(() => expect(updates).toHaveLength(1));
+    expect(updates[0][0]?.priceCents).toBe(100_00);
+
+    // Simulate an interval tick.
+    intervalHandler?.();
+    await vi.waitFor(() => expect(updates).toHaveLength(2));
+
+    source.stop();
+    expect(source.running).toBe(false);
+    expect(cleared).toBe(true);
+  });
+
+  it('surfaces provider failures as an error update instead of throwing', async () => {
+    const failing = {
+      id: 'boom',
+      source: 'boom',
+      getSnapshots: () => Promise.reject(new Error('network down')),
+    };
+    const source = new PollingPriceSource(failing, REQUESTS, {
+      intervalMs: 1000,
+      now: () => NOW,
+      timers,
+    });
+    let captured: string | undefined;
+    source.subscribe((u) => {
+      captured = u.error;
+    });
+    await source.refreshNow();
+    expect(captured).toBe('network down');
+  });
+
+  it('start is idempotent', () => {
+    const provider = new ManualMarketDataProvider([snapshot('VTI', 100_00)]);
+    const setInterval = vi.fn(() => 1);
+    const source = new PollingPriceSource(provider, REQUESTS, {
+      intervalMs: 1000,
+      now: () => NOW,
+      timers: { setInterval, clearInterval: () => {} },
+    });
+    source.start();
+    source.start();
+    expect(setInterval).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SimulatedMarketDataProvider', () => {
+  const seeds = [
+    {
+      symbol: 'VTI',
+      assetKind: 'equity' as const,
+      basePriceCents: 100_00,
+      currency: 'USD',
+      volatilityBps: 50,
+    },
+  ];
+
+  it('is deterministic for a given seed', async () => {
+    const a = new SimulatedMarketDataProvider(seeds, { seed: 42, now: () => NOW });
+    const b = new SimulatedMarketDataProvider(seeds, { seed: 42, now: () => NOW });
+    const qa = await a.getSnapshots(REQUESTS);
+    const qb = await b.getSnapshots(REQUESTS);
+    expect(qa[0].priceCents).toBe(qb[0].priceCents);
+  });
+
+  it('keeps simulated prices within the volatility band of the seed', async () => {
+    const provider = new SimulatedMarketDataProvider(seeds, { seed: 7, now: () => NOW });
+    for (let i = 0; i < 50; i += 1) {
+      const [quote] = await provider.getSnapshots(REQUESTS);
+      // 50 bps = 0.5% max move from base.
+      expect(quote.priceCents).toBeGreaterThanOrEqual(Math.floor(100_00 * 0.995) - 1);
+      expect(quote.priceCents).toBeLessThanOrEqual(Math.ceil(100_00 * 1.005) + 1);
+      expect(quote.asOf).toBe(NOW);
+    }
+  });
+
+  it('ignores symbols without a seed', async () => {
+    const provider = new SimulatedMarketDataProvider(seeds, { seed: 1, now: () => NOW });
+    const quotes = await provider.getSnapshots([{ symbol: 'UNKNOWN', assetKind: 'equity' }]);
+    expect(quotes).toHaveLength(0);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/apps/web/src/lib/investment/price-source.ts
+++ b/apps/web/src/lib/investment/price-source.ts
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Pluggable live price-update source abstraction.
+ *
+ * A {@link PriceSource} delivers near-real-time quote snapshots to one or more
+ * listeners. It is deliberately decoupled from any specific market-data vendor:
+ * callers wire concrete providers (polling, websocket, manual/mock, simulated)
+ * behind the same interface so the live P&L dashboard never depends on a single
+ * upstream or hard-coded API key.
+ *
+ * Adapters in this module:
+ * - {@link PollingPriceSource} — polls any {@link MarketDataProvider} on a fixed
+ *   interval (timers are injectable for deterministic tests).
+ * - {@link ManualPriceSource} — test/demo source whose updates are pushed
+ *   imperatively via {@link ManualPriceSource.emit}.
+ * - {@link SimulatedMarketDataProvider} — offline provider that jitters seeded
+ *   prices so the dashboard can demonstrate live movement without a network
+ *   call or secret. **No external API keys are ever read here.**
+ *
+ * References: issue #2124
+ */
+
+import type { AssetKind, MarketDataProvider, QuoteRequest, QuoteSnapshot } from './market-data';
+
+// ---------------------------------------------------------------------------
+// Core interface
+// ---------------------------------------------------------------------------
+
+/** A batch of quotes delivered by a {@link PriceSource}. */
+export interface PriceUpdate {
+  /** Quotes contained in this update (may be empty on a failed poll). */
+  readonly quotes: readonly QuoteSnapshot[];
+  /** ISO-8601 timestamp the update was received by the client. */
+  readonly receivedAt: string;
+  /** Identifier of the originating source/provider. */
+  readonly source: string;
+  /** Set when the underlying fetch failed; `quotes` will usually be empty. */
+  readonly error?: string;
+}
+
+/** Listener invoked for every {@link PriceUpdate}. */
+export type PriceListener = (update: PriceUpdate) => void;
+
+/**
+ * A source of live price updates.
+ *
+ * Implementations must be safe to {@link start}/{@link stop} repeatedly and to
+ * notify zero or more subscribers. `start` is idempotent.
+ */
+export interface PriceSource {
+  /** Stable identifier for diagnostics. */
+  readonly id: string;
+  /** Whether the source is currently emitting updates. */
+  readonly running: boolean;
+  /**
+   * Register a listener.
+   * @returns An unsubscribe function that removes the listener.
+   */
+  subscribe(listener: PriceListener): () => void;
+  /** Begin emitting updates (idempotent). */
+  start(): void;
+  /** Stop emitting updates and release any timers/connections. */
+  stop(): void;
+  /** Force an immediate refresh outside the normal cadence. */
+  refreshNow(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Timer injection (deterministic tests)
+// ---------------------------------------------------------------------------
+
+/** Minimal timer surface so polling can be driven by fake timers in tests. */
+export interface TimerApi {
+  setInterval(handler: () => void, ms: number): unknown;
+  clearInterval(handle: unknown): void;
+}
+
+const DEFAULT_TIMERS: TimerApi = {
+  setInterval: (handler, ms) => setInterval(handler, ms),
+  clearInterval: (handle) => clearInterval(handle as ReturnType<typeof setInterval>),
+};
+
+// ---------------------------------------------------------------------------
+// Polling adapter
+// ---------------------------------------------------------------------------
+
+/** Options for {@link PollingPriceSource}. */
+export interface PollingPriceSourceOptions {
+  /** Poll cadence in milliseconds (default: 15s). */
+  readonly intervalMs?: number;
+  /** Clock used for `receivedAt` timestamps (default: `Date.now`). */
+  readonly now?: () => string;
+  /** Injectable timer API (default: global timers). */
+  readonly timers?: TimerApi;
+  /** Override the source id. */
+  readonly id?: string;
+}
+
+/**
+ * Polls a {@link MarketDataProvider} on a fixed interval and fans the results
+ * out to subscribers. Network/provider errors are surfaced as a
+ * {@link PriceUpdate} with an `error` rather than thrown, so the UI can degrade
+ * gracefully and show a stale-data indicator.
+ */
+export class PollingPriceSource implements PriceSource {
+  readonly id: string;
+  private readonly provider: MarketDataProvider;
+  private readonly requests: readonly QuoteRequest[];
+  private readonly intervalMs: number;
+  private readonly now: () => string;
+  private readonly timers: TimerApi;
+  private readonly listeners = new Set<PriceListener>();
+  private handle: unknown = null;
+  private active = false;
+
+  constructor(
+    provider: MarketDataProvider,
+    requests: readonly QuoteRequest[],
+    options: PollingPriceSourceOptions = {},
+  ) {
+    this.provider = provider;
+    this.requests = requests;
+    this.intervalMs = Math.max(250, options.intervalMs ?? 15_000);
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.timers = options.timers ?? DEFAULT_TIMERS;
+    this.id = options.id ?? `polling:${provider.id}`;
+  }
+
+  get running(): boolean {
+    return this.active;
+  }
+
+  subscribe(listener: PriceListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  start(): void {
+    if (this.active) return;
+    this.active = true;
+    // Emit an immediate snapshot so the UI is not blank for a full interval.
+    void this.poll();
+    this.handle = this.timers.setInterval(() => {
+      void this.poll();
+    }, this.intervalMs);
+  }
+
+  stop(): void {
+    if (!this.active) return;
+    this.active = false;
+    if (this.handle !== null) {
+      this.timers.clearInterval(this.handle);
+      this.handle = null;
+    }
+  }
+
+  async refreshNow(): Promise<void> {
+    await this.poll();
+  }
+
+  private async poll(): Promise<void> {
+    const receivedAt = this.now();
+    try {
+      const quotes = await this.provider.getSnapshots(this.requests, receivedAt);
+      this.emit({ quotes, receivedAt, source: this.provider.source });
+    } catch (err) {
+      this.emit({
+        quotes: [],
+        receivedAt,
+        source: this.provider.source,
+        error: err instanceof Error ? err.message : 'Price update failed.',
+      });
+    }
+  }
+
+  private emit(update: PriceUpdate): void {
+    // Copy to tolerate unsubscribe during iteration.
+    for (const listener of [...this.listeners]) listener(update);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Manual adapter (tests / demos)
+// ---------------------------------------------------------------------------
+
+/**
+ * A source whose updates are pushed imperatively. Useful for component tests
+ * and scripted demos where deterministic, on-demand price changes are needed.
+ */
+export class ManualPriceSource implements PriceSource {
+  readonly id: string;
+  private readonly listeners = new Set<PriceListener>();
+  private readonly now: () => string;
+  private active = false;
+
+  constructor(options: { id?: string; now?: () => string } = {}) {
+    this.id = options.id ?? 'manual-price-source';
+    this.now = options.now ?? (() => new Date().toISOString());
+  }
+
+  get running(): boolean {
+    return this.active;
+  }
+
+  subscribe(listener: PriceListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  start(): void {
+    this.active = true;
+  }
+
+  stop(): void {
+    this.active = false;
+  }
+
+  async refreshNow(): Promise<void> {
+    // No-op: updates are pushed via emit().
+  }
+
+  /** Push a price update to all subscribers. */
+  emit(quotes: readonly QuoteSnapshot[], receivedAt: string = this.now(), error?: string): void {
+    const update: PriceUpdate = { quotes, receivedAt, source: this.id, error };
+    for (const listener of [...this.listeners]) listener(update);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Simulated provider (offline live-movement demo, no secrets)
+// ---------------------------------------------------------------------------
+
+/** Seed describing the baseline price for a simulated symbol. */
+export interface SimulatedSeed {
+  readonly symbol: string;
+  readonly assetKind: AssetKind;
+  readonly basePriceCents: number;
+  readonly currency: string;
+  /** Market session label applied to emitted snapshots (default: `'open'`). */
+  readonly marketSession?: QuoteSnapshot['marketSession'];
+  /** Per-tick volatility in basis points (default: 50 = 0.5%). */
+  readonly volatilityBps?: number;
+}
+
+/** Options for {@link SimulatedMarketDataProvider}. */
+export interface SimulatedProviderOptions {
+  /** Deterministic RNG seed (default: derived from a fixed constant). */
+  readonly seed?: number;
+  /** Clock used for `asOf` timestamps (default: `Date.now`). */
+  readonly now?: () => string;
+}
+
+/** Deterministic 32-bit PRNG (mulberry32) — self-contained, no dependencies. */
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * An offline {@link MarketDataProvider} that jitters seeded prices using a
+ * deterministic PRNG. Lets the live dashboard demonstrate intraday movement
+ * with zero network access and **no API keys**. Real deployments swap this for
+ * a vendor-backed provider behind the same interface.
+ */
+export class SimulatedMarketDataProvider implements MarketDataProvider {
+  readonly id = 'simulated-market-data';
+  readonly source = 'simulated';
+  private readonly seeds: ReadonlyMap<string, SimulatedSeed>;
+  private readonly rng: () => number;
+  private readonly now: () => string;
+
+  constructor(seeds: readonly SimulatedSeed[], options: SimulatedProviderOptions = {}) {
+    this.seeds = new Map(seeds.map((seed) => [seed.symbol.toUpperCase(), seed]));
+    this.rng = mulberry32(options.seed ?? 0x9e3779b9);
+    this.now = options.now ?? (() => new Date().toISOString());
+  }
+
+  async getSnapshots(
+    requests: readonly QuoteRequest[],
+    now: string = this.now(),
+  ): Promise<readonly QuoteSnapshot[]> {
+    return requests.flatMap((request) => {
+      const seed = this.seeds.get(request.symbol.toUpperCase());
+      if (!seed) return [];
+      const volatility = (seed.volatilityBps ?? 50) / 10_000;
+      const drift = (this.rng() * 2 - 1) * volatility;
+      const priceCents = Math.max(1, Math.round(seed.basePriceCents * (1 + drift)));
+      const snapshot: QuoteSnapshot = {
+        symbol: seed.symbol,
+        assetKind: seed.assetKind,
+        priceCents,
+        currency: seed.currency,
+        asOf: now,
+        source: this.source,
+        latencyMs: Math.round(this.rng() * 40),
+        marketSession: seed.marketSession ?? 'open',
+      };
+      return [snapshot];
+    });
+  }
+}

--- a/apps/web/src/pages/LivePnlPage.test.tsx
+++ b/apps/web/src/pages/LivePnlPage.test.tsx
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for LivePnlPage. Mocks the useLivePnl hook (not repositories) per
+ * project conventions.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LivePnlPage } from './LivePnlPage';
+import { buildLivePnlView } from '../lib/investment';
+import type { BaseAccountBalance, IntradayPosition, QuoteSnapshot } from '../lib/investment';
+
+vi.mock('../hooks/useLivePnl', () => ({ useLivePnl: vi.fn() }));
+
+import { useLivePnl } from '../hooks/useLivePnl';
+
+const mockUseLivePnl = vi.mocked(useLivePnl);
+
+const NOW = '2026-01-02T15:00:00.000Z';
+
+const positions: IntradayPosition[] = [
+  {
+    accountId: 'acct-a',
+    brokerage: 'Alpha',
+    symbol: 'VTI',
+    assetClass: 'equity',
+    quantity: 10,
+    previousCloseCents: 100_00,
+    costBasisCents: 900_00,
+    currency: 'USD',
+  },
+];
+const baseAccounts: BaseAccountBalance[] = [
+  {
+    accountId: 'cash-1',
+    label: 'Checking',
+    assetClass: 'cash',
+    balanceCents: 2000_00,
+    currency: 'USD',
+  },
+];
+const quote: QuoteSnapshot = {
+  symbol: 'VTI',
+  assetKind: 'equity',
+  priceCents: 110_00,
+  currency: 'USD',
+  asOf: NOW,
+  source: 'manual',
+  marketSession: 'open',
+};
+
+const sampleView = buildLivePnlView({
+  positions,
+  quotes: [quote],
+  baseAccounts,
+  now: NOW,
+  currency: 'USD',
+  lastUpdated: NOW,
+});
+
+describe('LivePnlPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a loading spinner while data loads', () => {
+    mockUseLivePnl.mockReturnValue({
+      view: null,
+      loading: true,
+      error: null,
+      isLive: false,
+      lastUpdated: null,
+      refresh: vi.fn(),
+    });
+    render(<LivePnlPage />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no positions', () => {
+    mockUseLivePnl.mockReturnValue({
+      view: null,
+      loading: false,
+      error: null,
+      isLive: false,
+      lastUpdated: null,
+      refresh: vi.fn(),
+    });
+    render(<LivePnlPage />);
+    expect(screen.getByText('No positions to track')).toBeInTheDocument();
+  });
+
+  it('renders the dashboard when a view is available', () => {
+    mockUseLivePnl.mockReturnValue({
+      view: sampleView,
+      loading: false,
+      error: null,
+      isLive: true,
+      lastUpdated: NOW,
+      refresh: vi.fn(),
+    });
+    render(<LivePnlPage />);
+    expect(screen.getByRole('heading', { name: /Live P&L & Net Worth/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('Total net worth')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/LivePnlPage.tsx
+++ b/apps/web/src/pages/LivePnlPage.tsx
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * LivePnlPage — live cross-broker P&L and net-worth dashboard for active
+ * traders. Designed to sit on a second monitor during market hours: it answers
+ * "what changed right now?" across every brokerage, account, asset class, and
+ * symbol, with explicit freshness/staleness indicators for volatile assets.
+ *
+ * Data flows through {@link useLivePnl} (hooks-only); this page only handles
+ * loading / empty / populated states and renders {@link LivePnlDashboard}.
+ *
+ * References: issue #2124
+ */
+
+import React from 'react';
+import { EmptyState, LoadingSpinner } from '../components/common';
+import { LivePnlDashboard } from '../components/dashboard/LivePnlDashboard';
+import { useLivePnl } from '../hooks/useLivePnl';
+
+export const LivePnlPage: React.FC = () => {
+  const { view, loading, error, isLive, refresh } = useLivePnl();
+
+  if (loading) {
+    return (
+      <div className="live-pnl" style={{ paddingTop: 'var(--spacing-8)', textAlign: 'center' }}>
+        <LoadingSpinner label="Loading live P&L data" />
+      </div>
+    );
+  }
+
+  if (!view) {
+    return (
+      <EmptyState
+        title="No positions to track"
+        description="Add investment holdings or brokerage accounts to see live cross-broker P&L and net worth during the trading day."
+      />
+    );
+  }
+
+  return <LivePnlDashboard view={view} isLive={isLive} error={error} onRefresh={refresh} />;
+};
+
+export default LivePnlPage;

--- a/apps/web/src/pages/index.ts
+++ b/apps/web/src/pages/index.ts
@@ -21,6 +21,7 @@ export { SignupPage } from './SignupPage';
 export { WatchlistsPage } from './WatchlistsPage';
 export { DataImportWizardPage } from './DataImportWizardPage';
 export { InvestmentsPage } from './InvestmentsPage';
+export { LivePnlPage } from './LivePnlPage';
 export { InvestmentDetailPage } from './InvestmentDetailPage';
 export { TaxCenterPage } from './TaxCenterPage';
 export { BillsPage } from './BillsPage';

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -58,6 +58,7 @@ const ClientProfitability = lazy(() => import('./pages/ClientProfitabilityPage')
 const BusinessPnl = lazy(() => import('./pages/BusinessPnlPage'));
 const GigDriver = lazy(() => import('./pages/GigDriverPage'));
 const Investments = lazy(() => import('./pages/InvestmentsPage'));
+const LivePnl = lazy(() => import('./pages/LivePnlPage'));
 const InvestmentDetail = lazy(() => import('./pages/InvestmentDetailPage'));
 const TaxCenter = lazy(() => import('./pages/TaxCenterPage'));
 const Bills = lazy(() => import('./pages/BillsPage'));
@@ -565,6 +566,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Investments">
             <Investments />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/live-pnl"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Live P&L">
+            <LivePnl />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Summary
Adds a live cross-broker P&L and net-worth dashboard for active traders (#2124). Answers "what changed right now?" across every brokerage, account, asset class, and symbol during market hours, with explicit freshness/staleness indicators for volatile assets like crypto.

## What's included
- **Pluggable price-update source** (lib/investment/price-source.ts): a `PriceSource` interface plus a `PollingPriceSource` adapter (injectable timers), a `ManualPriceSource` for tests/demos, and an offline `SimulatedMarketDataProvider` that jitters seeded prices. **No external API keys are read or hard-coded** — real deployments swap in a vendor provider behind the same interface.
- **Live P&L + net-worth aggregation engine** (`lib/investment/live-pnl.ts`): composes the existing intraday P&L engine with non-market account balances to produce total net worth, day/unrealized/realized P&L, a day-change %, and a `StalenessSummary` (live / delayed / stale / attention). Pure and deterministic.
- **`useLivePnl` hook**: hooks-only data access (`useInvestments` + `useAccounts`), subscribes to a price source, and recomputes the view as quotes arrive or a staleness tick fires. Source is injectable.
- **`LivePnlDashboard` + `LivePnlPage`** at `/live-pnl`: headline metrics, cross-broker/account/asset-class/symbol breakdown tables, last-updated + staleness badges, refresh control, and a polite live region. Wired into nav + route announcer.

## Accessibility (WCAG 2.2 AA)
- Gain/loss is conveyed by a shape glyph (▲ / ▼ / ◆) **and** an explicit sign **and** a text label — never colour alone (1.4.1 Use of Color).
- Real `<table>` semantics with scoped headers; section landmarks; status/alert roles; `prefers-reduced-motion` and `prefers-contrast` handling.

## Testing
- Unit tests for the P&L math, net-worth aggregation, and staleness classification (`live-pnl.test.ts`).
- Unit tests for the price-source adapters incl. deterministic simulation and polling via injected timers (`price-source.test.ts`).
- Hook test proving the view recomputes as live prices arrive (`useLivePnl.test.tsx`).
- Component test for live-update rendering + non-colour cues (`LivePnlDashboard.test.tsx`) and page state tests.
- 35 new tests pass; `tsc --noEmit` clean; layout/navigation suites still green.

Closes #2124

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>