### PR TITLE
feat(ios): natural-language finance queries (#2386)

### DIFF
--- a/apps/ios/Finance/Intents/FinanceQueryIntent.swift
+++ b/apps/ios/Finance/Intents/FinanceQueryIntent.swift
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinanceQueryIntent.swift
+// Finance
+//
+// App Intent exposing on-device natural-language finance queries to Siri and
+// Shortcuts (#2386). Reuses the same deterministic ``FinanceQueryParser`` and
+// ``FinanceQueryPlanner`` as the in-app screen.
+//
+// Privacy: balances are *sensitive*. Siri will not speak a balance aloud;
+// instead the intent returns a privacy-preserving dialog directing the user to
+// open the app, where reading a balance aloud requires explicit confirmation.
+
+import AppIntents
+import Foundation
+import os
+
+struct FinanceQueryIntent: AppIntent {
+
+    static let title: LocalizedStringResource = "Ask About My Money"
+
+    static let description = IntentDescription(
+        "Ask a natural-language question about your spending, answered from local data.",
+        categoryName: "Transactions"
+    )
+
+    // MARK: - Parameters
+
+    @Parameter(
+        title: "Question",
+        description: "For example: how much did I spend on groceries this week."
+    )
+    var query: String
+
+    // MARK: - Logging
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "FinanceQueryIntent"
+    )
+
+    // MARK: - Perform
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let txnRepo = RepositoryProvider.shared.transactions
+        let acctRepo = RepositoryProvider.shared.accounts
+        let catRepo = RepositoryProvider.shared.categories
+
+        let transactions: [TransactionItem]
+        let accounts: [AccountItem]
+        let categories: [CategoryItem]
+        do {
+            async let t = txnRepo.getTransactions()
+            async let a = acctRepo.getAccounts()
+            async let c = catRepo.getCategories()
+            (transactions, accounts, categories) = try await (t, a, c)
+        } catch {
+            Self.logger.error("Query data load failed: \(error.localizedDescription, privacy: .public)")
+            throw IntentError.saveFailed
+        }
+
+        let dialog = Self.dialogText(
+            for: query,
+            transactions: transactions,
+            accounts: accounts,
+            categories: categories
+        )
+        Self.logger.info("Finance query intent answered")
+        return .result(dialog: IntentDialog(stringLiteral: dialog))
+    }
+
+    // MARK: - Pure Response Builder (testable)
+
+    /// Produces the spoken dialog string for a query without touching Siri.
+    ///
+    /// Sensitive balance questions are answered with a privacy-preserving
+    /// redirect rather than the figure itself.
+    static func dialogText(
+        for query: String,
+        transactions: [TransactionItem],
+        accounts: [AccountItem],
+        categories: [CategoryItem],
+        calendar: Calendar = .current,
+        referenceDate: Date = .now
+    ) -> String {
+        let vocabulary = FinanceQueryVocabulary(
+            categories: categories.map(\.name),
+            accounts: accounts.map(\.name),
+            merchants: Array(Set(transactions.map(\.payee))).filter { !$0.isEmpty }
+        )
+
+        let parser = FinanceQueryParser(
+            vocabulary: vocabulary,
+            calendar: calendar,
+            referenceDate: referenceDate
+        )
+
+        switch parser.parse(query) {
+        case .plan(let plan):
+            if plan.isSensitive {
+                return String(localized: "For your privacy, open Finance to view your balance.")
+            }
+            let planner = FinanceQueryPlanner(calendar: calendar)
+            let result = planner.execute(plan, transactions: transactions, accounts: accounts)
+            return result.spokenSummary
+
+        case .clarification(let clarification):
+            return clarificationPrompt(for: clarification)
+
+        case .unrecognized:
+            return String(localized: "I can only answer questions about your spending and balances right now.")
+        }
+    }
+
+    private static func clarificationPrompt(for clarification: FinanceQueryClarification) -> String {
+        switch clarification {
+        case .ambiguousDate(let phrase, _):
+            return String(localized: "Which period did you mean by \(phrase)? Try this week, this month, or this year.")
+        case .ambiguousCategory(let phrase, let options):
+            let list = options.formatted(.list(type: .or))
+            return String(localized: "Did you mean \(list) for \(phrase)?")
+        case .missingSubject:
+            return String(localized: "What would you like to know? Try a category, merchant, account, or time period.")
+        }
+    }
+}
+
+// TODO(human): Register `FinanceQueryIntent` for Siri voice invocation by
+// adding it to `FinanceShortcuts` and enabling the Siri & App Intents
+// capability in the Xcode project. Voice *dictation* of the question also
+// requires the Speech capability and microphone usage strings (see
+// FinanceQuerySpeech.swift). These steps need the Xcode project file and
+// cannot be performed from this environment.

--- a/apps/ios/Finance/Models/FinanceQuery.swift
+++ b/apps/ios/Finance/Models/FinanceQuery.swift
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinanceQuery.swift
+// Finance
+//
+// Data models for on-device natural-language finance queries (#2386).
+//
+// A spoken or typed question like *"how much did I spend on groceries this
+// week"* is interpreted entirely on-device into a deterministic
+// ``FinanceQueryPlan``. The plan is then executed by ``FinanceQueryPlanner``
+// over the local finance store to produce a ``FinanceQueryResult`` with both
+// typed and spoken variants.
+//
+// These types are intentionally free of any Speech / App Intents dependency so
+// the parser and planner remain fully unit-testable without speech hardware.
+
+import Foundation
+
+// MARK: - Date Preset
+
+/// A bounded, well-known calendar window the parser can resolve a date phrase
+/// to (e.g. *"this week"*, *"last month"*).
+enum FinanceQueryDatePreset: String, Sendable, CaseIterable, Equatable {
+    case today
+    case yesterday
+    case thisWeek
+    case lastWeek
+    case thisMonth
+    case lastMonth
+    case thisYear
+    case lastYear
+
+    /// Lower-cased phrase used inside a spoken/typed summary (e.g. "this week").
+    var phrase: String {
+        switch self {
+        case .today: String(localized: "today")
+        case .yesterday: String(localized: "yesterday")
+        case .thisWeek: String(localized: "this week")
+        case .lastWeek: String(localized: "last week")
+        case .thisMonth: String(localized: "this month")
+        case .lastMonth: String(localized: "last month")
+        case .thisYear: String(localized: "this year")
+        case .lastYear: String(localized: "last year")
+        }
+    }
+
+    /// Capitalised label for clarification chips.
+    var displayName: String {
+        switch self {
+        case .today: String(localized: "Today")
+        case .yesterday: String(localized: "Yesterday")
+        case .thisWeek: String(localized: "This Week")
+        case .lastWeek: String(localized: "Last Week")
+        case .thisMonth: String(localized: "This Month")
+        case .lastMonth: String(localized: "Last Month")
+        case .thisYear: String(localized: "This Year")
+        case .lastYear: String(localized: "Last Year")
+        }
+    }
+}
+
+// MARK: - Date Range
+
+/// A concrete half-open date interval (`start ..< end`) resolved from a phrase.
+struct FinanceQueryDateRange: Sendable, Equatable {
+    let start: Date
+    let end: Date
+    let label: String
+
+    /// Returns `true` when `date` falls within the half-open interval.
+    func contains(_ date: Date) -> Bool {
+        date >= start && date < end
+    }
+}
+
+// MARK: - Query Dimension
+
+/// The subject a spend query is grouped by.
+enum FinanceQueryDimension: Sendable, Equatable {
+    /// Spend within a resolved category (e.g. "Groceries").
+    case category(String)
+    /// Spend at a resolved merchant / payee (e.g. "Netflix").
+    case merchant(String)
+    /// Spend on a resolved account (e.g. "Travel Card").
+    case account(String)
+    /// Total spend across everything, constrained only by the date range.
+    case all
+}
+
+// MARK: - Query Kind
+
+/// The high-level question being asked.
+enum FinanceQueryKind: Sendable, Equatable {
+    /// A spend question grouped by ``FinanceQueryDimension``.
+    case spend(FinanceQueryDimension)
+    /// A balance question. Treated as **sensitive**: the result must not be
+    /// spoken aloud without explicit user confirmation.
+    case balance(account: String?)
+}
+
+// MARK: - Query Plan
+
+/// A fully-resolved, deterministic plan ready for execution by the planner.
+struct FinanceQueryPlan: Sendable, Equatable {
+    let kind: FinanceQueryKind
+    let dateRange: FinanceQueryDateRange?
+    let rawInput: String
+
+    /// Sensitive plans (balances) require explicit confirmation before their
+    /// result is spoken aloud, per privacy requirements.
+    var isSensitive: Bool {
+        if case .balance = kind { return true }
+        return false
+    }
+}
+
+// MARK: - Clarification
+
+/// A request for more information when the parser cannot deterministically
+/// resolve part of the query.
+enum FinanceQueryClarification: Sendable, Equatable {
+    /// A vague date phrase (e.g. "recently") that maps to multiple windows.
+    case ambiguousDate(phrase: String, options: [FinanceQueryDatePreset])
+    /// A vague category word (e.g. "food") that maps to multiple categories.
+    case ambiguousCategory(phrase: String, options: [String])
+    /// A spend question with no recognisable subject and no date window.
+    case missingSubject
+}
+
+// MARK: - Parse Outcome
+
+/// The result of interpreting a raw natural-language string.
+enum FinanceQueryParse: Sendable, Equatable {
+    /// A deterministic, executable plan.
+    case plan(FinanceQueryPlan)
+    /// The query is understood but needs user disambiguation.
+    case clarification(FinanceQueryClarification)
+    /// The query is not a supported finance question.
+    case unrecognized(rawInput: String)
+}
+
+// MARK: - Query Result
+
+/// The executed answer to a query, grounded in local finance data.
+///
+/// Provides both a concise ``typedSummary`` (shown on screen / returned typed)
+/// and a fuller ``spokenSummary`` (used for VoiceOver and speech synthesis).
+struct FinanceQueryResult: Sendable, Equatable {
+    let plan: FinanceQueryPlan
+    let amountMinorUnits: Int64
+    let currencyCode: String
+    let matchCount: Int
+    let typedSummary: String
+    let spokenSummary: String
+
+    /// `true` when the spoken variant must be gated behind explicit user
+    /// confirmation (sensitive balances).
+    var requiresSpokenConfirmation: Bool { plan.isSensitive }
+}
+
+// MARK: - Vocabulary
+
+/// The on-device vocabulary the parser resolves entities against.
+///
+/// Supplying the known categories, accounts, and merchants keeps
+/// interpretation deterministic and fully testable.
+struct FinanceQueryVocabulary: Sendable, Equatable {
+    let categories: [String]
+    let accounts: [String]
+    let merchants: [String]
+
+    init(categories: [String] = [], accounts: [String] = [], merchants: [String] = []) {
+        self.categories = categories
+        self.accounts = accounts
+        self.merchants = merchants
+    }
+}

--- a/apps/ios/Finance/Screens/DashboardView.swift
+++ b/apps/ios/Finance/Screens/DashboardView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct DashboardView: View {
     @State private var viewModel: DashboardViewModel
+    @State private var showingAskFinance = false
     @Environment(NetworkMonitor.self) private var networkMonitor: NetworkMonitor?
 
     init(viewModel: DashboardViewModel = DashboardViewModel(
@@ -47,6 +48,19 @@ struct DashboardView: View {
                 }
             }
             .navigationTitle(String(localized: "Dashboard"))
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button { showingAskFinance = true } label: {
+                        Image(systemName: "bubble.left.and.text.bubble.right.fill")
+                    }
+                    .accessibilityIdentifier("ask_finance_button")
+                    .accessibilityLabel(String(localized: "Ask Finance"))
+                    .accessibilityHint(String(localized: "Ask a natural-language question about your money"))
+                }
+            }
+            .sheet(isPresented: $showingAskFinance) {
+                FinanceQueryView()
+            }
             .refreshable { await viewModel.loadDashboard() }
             .task { await viewModel.loadDashboard() }
             .alert(String(localized: "Error"), isPresented: Binding(

--- a/apps/ios/Finance/Screens/FinanceQueryView.swift
+++ b/apps/ios/Finance/Screens/FinanceQueryView.swift
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinanceQueryView.swift
+// Finance
+//
+// Natural-language finance query screen (#2386). Lets the user ask questions
+// like "how much did I spend on groceries this week" by typing (and, once the
+// Speech capability is wired up, by voice). Answers are grounded in local data,
+// shown typed, and can be read aloud — with explicit confirmation required
+// before speaking sensitive balances.
+
+import SwiftUI
+
+struct FinanceQueryView: View {
+    @State private var viewModel: FinanceQueryViewModel
+
+    init(viewModel: FinanceQueryViewModel = FinanceQueryViewModel(
+        transactions: RepositoryProvider.shared.transactions,
+        accounts: RepositoryProvider.shared.accounts,
+        categories: RepositoryProvider.shared.categories
+    )) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    inputSection
+                    outcomeSection
+                    examplesSection
+                }
+                .padding()
+            }
+            .navigationTitle(String(localized: "Ask Finance"))
+            .alert(
+                String(localized: "Read balance aloud?"),
+                isPresented: Binding(
+                    get: { viewModel.pendingSpokenConfirmation != nil },
+                    set: { if !$0 { viewModel.cancelSpeak() } }
+                )
+            ) {
+                Button(String(localized: "Read Aloud")) { viewModel.confirmSpeak() }
+                Button(String(localized: "Cancel"), role: .cancel) { viewModel.cancelSpeak() }
+            } message: {
+                Text(String(localized: "This will speak your balance out loud. Make sure no one is listening."))
+            }
+            .alert(String(localized: "Error"), isPresented: Binding(
+                get: { viewModel.showError },
+                set: { if !$0 { viewModel.dismissError() } }
+            )) {
+                Button(String(localized: "OK"), role: .cancel) { viewModel.dismissError() }
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+        }
+    }
+
+    // MARK: - Input
+
+    private var inputSection: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 8) {
+                TextField(
+                    String(localized: "Ask about your money…"),
+                    text: $viewModel.inputText
+                )
+                .textFieldStyle(.roundedBorder)
+                .submitLabel(.search)
+                .onSubmit { Task { await viewModel.submit() } }
+                .accessibilityLabel(String(localized: "Finance question"))
+                .accessibilityHint(String(localized: "Type a question such as how much did I spend on groceries this week"))
+
+                micButton
+            }
+
+            Button {
+                Task { await viewModel.submit() }
+            } label: {
+                Text(String(localized: "Ask"))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.inputText.trimmingCharacters(in: .whitespaces).isEmpty)
+            .accessibilityLabel(String(localized: "Ask question"))
+        }
+    }
+
+    private var micButton: some View {
+        Button {
+            // TODO(human): Wire up live dictation once the Speech capability,
+            // microphone entitlement, and usage-description Info.plist keys are
+            // added in Xcode. Until then the button is disabled.
+        } label: {
+            Image(systemName: "mic.fill")
+                .imageScale(.large)
+        }
+        .disabled(!viewModel.isSpeechInputAvailable)
+        .accessibilityLabel(String(localized: "Ask by voice"))
+        .accessibilityHint(
+            viewModel.isSpeechInputAvailable
+                ? String(localized: "Starts voice dictation")
+                : String(localized: "Voice input is not available yet")
+        )
+    }
+
+    // MARK: - Outcome
+
+    @ViewBuilder
+    private var outcomeSection: some View {
+        switch viewModel.phase {
+        case .idle:
+            EmptyView()
+        case .loading:
+            ProgressView()
+                .frame(maxWidth: .infinity)
+                .accessibilityLabel(String(localized: "Finding your answer"))
+        case .answered(let result):
+            answerCard(result)
+        case .clarifying(let clarification):
+            clarificationCard(clarification)
+        case .unrecognized:
+            unrecognizedCard
+        }
+    }
+
+    private func answerCard(_ result: FinanceQueryResult) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(result.typedSummary)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .accessibilityLabel(result.spokenSummary)
+
+            Button {
+                viewModel.requestSpeak()
+            } label: {
+                Label(
+                    result.requiresSpokenConfirmation
+                        ? String(localized: "Read aloud (confirm)")
+                        : String(localized: "Read aloud"),
+                    systemImage: "speaker.wave.2.fill"
+                )
+            }
+            .buttonStyle(.bordered)
+            .accessibilityHint(
+                result.requiresSpokenConfirmation
+                    ? String(localized: "Asks for confirmation before speaking sensitive balances")
+                    : String(localized: "Speaks the answer aloud")
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    @ViewBuilder
+    private func clarificationCard(_ clarification: FinanceQueryClarification) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            switch clarification {
+            case .ambiguousDate(let phrase, let options):
+                Text(String(localized: "Which period did you mean by \"\(phrase)\"?"))
+                    .font(.headline)
+                FlowChips(labels: options.map(\.displayName)) { index in
+                    Task { await viewModel.resolveDate(options[index]) }
+                }
+            case .ambiguousCategory(let phrase, let options):
+                Text(String(localized: "Which category did you mean by \"\(phrase)\"?"))
+                    .font(.headline)
+                FlowChips(labels: options) { index in
+                    Task { await viewModel.resolveCategory(options[index]) }
+                }
+            case .missingSubject:
+                Text(String(localized: "What would you like to know? Try a category, merchant, account, or time period."))
+                    .font(.headline)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var unrecognizedCard: some View {
+        Text(String(localized: "Sorry, I can only answer questions about your spending and balances right now."))
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    // MARK: - Examples
+
+    private var examplesSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "Try asking"))
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            ForEach(Self.examplePrompts, id: \.self) { prompt in
+                Button {
+                    viewModel.inputText = prompt
+                    Task { await viewModel.submit() }
+                } label: {
+                    Text(verbatim: "“\(prompt)”")
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "Example question: \(prompt)"))
+            }
+        }
+    }
+
+    private static let examplePrompts: [String] = [
+        String(localized: "How much did I spend on groceries this week?"),
+        String(localized: "How much did I spend at Netflix?"),
+        String(localized: "How much did I spend last month?"),
+    ]
+}
+
+// MARK: - Flow Chips
+
+/// A simple wrapping row of tappable chips used for clarification options.
+private struct FlowChips: View {
+    let labels: [String]
+    let onTap: (Int) -> Void
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack { chips }
+            VStack(alignment: .leading) { chips }
+        }
+    }
+
+    private var chips: some View {
+        ForEach(Array(labels.enumerated()), id: \.offset) { index, label in
+            Button {
+                onTap(index)
+            } label: {
+                Text(label)
+                    .font(.subheadline)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(.tint.opacity(0.15), in: Capsule())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "Choose \(label)"))
+        }
+    }
+}

--- a/apps/ios/Finance/Services/FinanceQueryParser.swift
+++ b/apps/ios/Finance/Services/FinanceQueryParser.swift
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinanceQueryParser.swift
+// Finance
+//
+// Deterministic, on-device natural-language parser for finance queries (#2386).
+//
+// The parser converts a raw question string into a ``FinanceQueryParse`` —
+// either an executable ``FinanceQueryPlan``, a ``FinanceQueryClarification``
+// request, or `.unrecognized`. It has **no dependency on Speech or App
+// Intents**, so it can be exhaustively unit-tested with fixtures and produces
+// identical output for identical input (a fixed `referenceDate` is injected for
+// reproducible date windows).
+
+import Foundation
+
+/// Interprets natural-language finance questions entirely on-device.
+struct FinanceQueryParser: Sendable {
+
+    let vocabulary: FinanceQueryVocabulary
+    let calendar: Calendar
+    let referenceDate: Date
+
+    /// - Parameters:
+    ///   - vocabulary:    Known categories, accounts, and merchants.
+    ///   - calendar:      Calendar used to resolve date windows (default: current).
+    ///   - referenceDate: "Now" anchor for relative dates. Injected for testing.
+    init(
+        vocabulary: FinanceQueryVocabulary,
+        calendar: Calendar = .current,
+        referenceDate: Date = .now
+    ) {
+        self.vocabulary = vocabulary
+        self.calendar = calendar
+        self.referenceDate = referenceDate
+    }
+
+    // MARK: - Keyword Sets
+
+    private static let spendKeywords = ["spend", "spent", "spending"]
+    private static let balanceKeywords = ["balance", "how much do i have", "how much money do i have"]
+    private static let ambiguousDatePhrases = ["recently", "lately", "a while ago", "these days"]
+
+    /// Vague category words that map to more than one concrete category.
+    private static let categorySynonyms: [String: [String]] = [
+        "food": ["Groceries", "Dining Out"],
+        "eating": ["Groceries", "Dining Out"],
+        "going out": ["Dining Out", "Entertainment"],
+        "fun": ["Entertainment", "Dining Out"],
+    ]
+
+    // MARK: - Public API
+
+    /// Parses `input` into a deterministic outcome.
+    ///
+    /// - Parameters:
+    ///   - input:           The raw question text.
+    ///   - dateOverride:    When set, forces the date window (used after the
+    ///                      user resolves an ambiguous date).
+    ///   - categoryOverride: When set, forces the category (used after the user
+    ///                      resolves an ambiguous category).
+    func parse(
+        _ input: String,
+        dateOverride: FinanceQueryDatePreset? = nil,
+        categoryOverride: String? = nil
+    ) -> FinanceQueryParse {
+        let normalized = input
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        guard !normalized.isEmpty else {
+            return .unrecognized(rawInput: input)
+        }
+
+        // Balance questions take priority and are flagged sensitive.
+        if Self.balanceKeywords.contains(where: { normalized.contains($0) }) {
+            let account = matchedAccount(in: normalized)
+            let plan = FinanceQueryPlan(
+                kind: .balance(account: account),
+                dateRange: nil,
+                rawInput: input
+            )
+            return .plan(plan)
+        }
+
+        // Everything else must be a spend question.
+        guard Self.spendKeywords.contains(where: { normalized.contains($0) }) else {
+            return .unrecognized(rawInput: input)
+        }
+
+        // 1. Resolve the date window (may request clarification).
+        let dateRange: FinanceQueryDateRange?
+        if let dateOverride {
+            dateRange = resolveDateRange(for: dateOverride)
+        } else {
+            switch resolveDate(in: normalized) {
+            case .resolved(let range):
+                dateRange = range
+            case .ambiguous(let phrase):
+                return .clarification(
+                    .ambiguousDate(phrase: phrase, options: [.thisWeek, .thisMonth, .thisYear])
+                )
+            case .none:
+                dateRange = nil
+            }
+        }
+
+        // 2. Resolve the spend dimension (may request clarification).
+        let dimension: FinanceQueryDimension
+        switch resolveDimension(in: normalized, categoryOverride: categoryOverride) {
+        case .resolved(let value):
+            dimension = value
+        case .ambiguousCategory(let phrase, let options):
+            return .clarification(.ambiguousCategory(phrase: phrase, options: options))
+        case .none:
+            // A bare date-range question ("how much did I spend last month")
+            // is valid; otherwise we have nothing to compute.
+            if dateRange != nil {
+                dimension = .all
+            } else {
+                return .clarification(.missingSubject)
+            }
+        }
+
+        let plan = FinanceQueryPlan(
+            kind: .spend(dimension),
+            dateRange: dateRange,
+            rawInput: input
+        )
+        return .plan(plan)
+    }
+
+    // MARK: - Date Resolution
+
+    private enum DateOutcome {
+        case resolved(FinanceQueryDateRange)
+        case ambiguous(phrase: String)
+        case none
+    }
+
+    /// Phrases checked in priority order (longest / most specific first).
+    private static let datePhrases: [(phrase: String, preset: FinanceQueryDatePreset)] = [
+        ("last week", .lastWeek),
+        ("this week", .thisWeek),
+        ("last month", .lastMonth),
+        ("this month", .thisMonth),
+        ("last year", .lastYear),
+        ("this year", .thisYear),
+        ("yesterday", .yesterday),
+        ("today", .today),
+    ]
+
+    private func resolveDate(in normalized: String) -> DateOutcome {
+        for entry in Self.datePhrases where normalized.contains(entry.phrase) {
+            if let range = resolveDateRange(for: entry.preset) {
+                return .resolved(range)
+            }
+        }
+        if let vague = Self.ambiguousDatePhrases.first(where: { normalized.contains($0) }) {
+            return .ambiguous(phrase: vague)
+        }
+        return .none
+    }
+
+    /// Builds a concrete half-open interval for a preset relative to
+    /// `referenceDate` using `calendar`.
+    func resolveDateRange(for preset: FinanceQueryDatePreset) -> FinanceQueryDateRange? {
+        let label = preset.phrase
+
+        func interval(_ component: Calendar.Component, offset: Int) -> FinanceQueryDateRange? {
+            guard
+                let anchor = calendar.date(byAdding: shiftComponent(component), value: offset, to: referenceDate),
+                let dateInterval = calendar.dateInterval(of: component, for: anchor)
+            else { return nil }
+            return FinanceQueryDateRange(start: dateInterval.start, end: dateInterval.end, label: label)
+        }
+
+        switch preset {
+        case .today: return interval(.day, offset: 0)
+        case .yesterday: return interval(.day, offset: -1)
+        case .thisWeek: return interval(.weekOfYear, offset: 0)
+        case .lastWeek: return interval(.weekOfYear, offset: -1)
+        case .thisMonth: return interval(.month, offset: 0)
+        case .lastMonth: return interval(.month, offset: -1)
+        case .thisYear: return interval(.year, offset: 0)
+        case .lastYear: return interval(.year, offset: -1)
+        }
+    }
+
+    /// Maps an interval component to the unit used when offsetting the anchor.
+    private func shiftComponent(_ component: Calendar.Component) -> Calendar.Component {
+        switch component {
+        case .weekOfYear: .weekOfYear
+        case .month: .month
+        case .year: .year
+        default: .day
+        }
+    }
+
+    // MARK: - Dimension Resolution
+
+    private enum DimensionOutcome {
+        case resolved(FinanceQueryDimension)
+        case ambiguousCategory(phrase: String, options: [String])
+        case none
+    }
+
+    private func resolveDimension(
+        in normalized: String,
+        categoryOverride: String?
+    ) -> DimensionOutcome {
+        if let categoryOverride {
+            return .resolved(.category(categoryOverride))
+        }
+
+        // 1. Merchant via an explicit "at <merchant>" preposition.
+        if let merchant = merchantAfterPreposition(in: normalized) {
+            return .resolved(.merchant(merchant))
+        }
+
+        // 2. A known account name appearing anywhere.
+        if let account = matchedAccount(in: normalized) {
+            return .resolved(.account(account))
+        }
+
+        // 3. An exact known category name appearing anywhere.
+        if let category = matchedCategory(in: normalized) {
+            return .resolved(.category(category))
+        }
+
+        // 4. A vague category synonym.
+        switch synonymCategory(in: normalized) {
+        case .resolved(let value):
+            return .resolved(.category(value))
+        case .ambiguousCategory(let phrase, let options):
+            return .ambiguousCategory(phrase: phrase, options: options)
+        case .none:
+            break
+        }
+
+        // 5. A known merchant name appearing anywhere (no preposition).
+        if let merchant = matchedMerchant(in: normalized) {
+            return .resolved(.merchant(merchant))
+        }
+
+        return .none
+    }
+
+    // MARK: - Entity Matching Helpers
+
+    private func matchedAccount(in normalized: String) -> String? {
+        vocabulary.accounts.first { normalized.contains($0.lowercased()) }
+    }
+
+    private func matchedCategory(in normalized: String) -> String? {
+        vocabulary.categories.first { normalized.contains($0.lowercased()) }
+    }
+
+    private func matchedMerchant(in normalized: String) -> String? {
+        vocabulary.merchants.first { normalized.contains($0.lowercased()) }
+    }
+
+    private func synonymCategory(in normalized: String) -> DimensionOutcome {
+        let known = Set(vocabulary.categories.map { $0.lowercased() })
+        for (word, candidates) in Self.categorySynonyms where normalized.contains(word) {
+            let present = candidates.filter { known.contains($0.lowercased()) }
+            if present.count >= 2 {
+                return .ambiguousCategory(phrase: word, options: present)
+            } else if let only = present.first {
+                return .resolved(.category(only))
+            }
+        }
+        return .none
+    }
+
+    /// Extracts and cleans the merchant token following an " at " preposition.
+    private func merchantAfterPreposition(in normalized: String) -> String? {
+        guard let atRange = normalized.range(of: " at ") else { return nil }
+        var candidate = String(normalized[atRange.upperBound...])
+
+        // Trim any trailing date phrase from the candidate.
+        for entry in Self.datePhrases where candidate.contains(entry.phrase) {
+            if let phraseRange = candidate.range(of: entry.phrase) {
+                candidate = String(candidate[..<phraseRange.lowerBound])
+            }
+        }
+        for vague in Self.ambiguousDatePhrases where candidate.contains(vague) {
+            if let phraseRange = candidate.range(of: vague) {
+                candidate = String(candidate[..<phraseRange.lowerBound])
+            }
+        }
+
+        candidate = candidate
+            .trimmingCharacters(in: CharacterSet(charactersIn: " ?.!,"))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !candidate.isEmpty else { return nil }
+
+        // Canonicalise to a known merchant when one matches.
+        if let known = vocabulary.merchants.first(where: {
+            candidate.contains($0.lowercased()) || $0.lowercased().contains(candidate)
+        }) {
+            return known
+        }
+        return candidate.capitalizedWords
+    }
+}
+
+// MARK: - String Capitalisation Helper
+
+extension String {
+    /// Capitalises the first letter of each whitespace-separated word.
+    var capitalizedWords: String {
+        split(separator: " ")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+}

--- a/apps/ios/Finance/Services/FinanceQueryPlanner.swift
+++ b/apps/ios/Finance/Services/FinanceQueryPlanner.swift
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinanceQueryPlanner.swift
+// Finance
+//
+// Executes a deterministic ``FinanceQueryPlan`` over the local finance store
+// (#2386). The planner is a pure value type operating on in-memory arrays so it
+// can be unit-tested without repositories, KMP, or speech availability.
+
+import Foundation
+
+/// Computes a grounded answer for a parsed finance query.
+struct FinanceQueryPlanner: Sendable {
+
+    let calendar: Calendar
+
+    init(calendar: Calendar = .current) {
+        self.calendar = calendar
+    }
+
+    /// Executes `plan` against the supplied local data and returns a result
+    /// with both typed and spoken summaries.
+    func execute(
+        _ plan: FinanceQueryPlan,
+        transactions: [TransactionItem],
+        accounts: [AccountItem]
+    ) -> FinanceQueryResult {
+        switch plan.kind {
+        case .spend(let dimension):
+            return executeSpend(plan, dimension: dimension, transactions: transactions)
+        case .balance(let account):
+            return executeBalance(plan, accountName: account, accounts: accounts)
+        }
+    }
+
+    // MARK: - Spend
+
+    private func executeSpend(
+        _ plan: FinanceQueryPlan,
+        dimension: FinanceQueryDimension,
+        transactions: [TransactionItem]
+    ) -> FinanceQueryResult {
+        let matches = transactions.filter { transaction in
+            guard transaction.type == .expense else { return false }
+            if let range = plan.dateRange, !range.contains(transaction.date) { return false }
+            return matchesDimension(transaction, dimension: dimension)
+        }
+
+        let total = matches.reduce(Int64(0)) { $0 + abs($1.amountMinorUnits) }
+        let currencyCode = matches.first?.currencyCode
+            ?? transactions.first?.currencyCode
+            ?? "USD"
+        let formatted = Self.formatCurrency(minorUnits: total, currencyCode: currencyCode)
+
+        let subject = subjectPhrase(for: dimension)
+        let period = periodPhrase(for: plan.dateRange)
+        let count = matches.count
+
+        let typed: String
+        let spoken: String
+
+        if count == 0 {
+            typed = String(localized: "No spending found \(subject)\(period).")
+            spoken = String(localized: "I didn't find any spending \(subject)\(period).")
+        } else {
+            let transactionWord = count == 1
+                ? String(localized: "transaction")
+                : String(localized: "transactions")
+            typed = String(localized: "\(formatted) spent \(subject)\(period).")
+            spoken = String(
+                localized: "You spent \(formatted) \(subject)\(period), across \(count) \(transactionWord)."
+            )
+        }
+
+        return FinanceQueryResult(
+            plan: plan,
+            amountMinorUnits: total,
+            currencyCode: currencyCode,
+            matchCount: count,
+            typedSummary: typed,
+            spokenSummary: spoken
+        )
+    }
+
+    private func matchesDimension(
+        _ transaction: TransactionItem,
+        dimension: FinanceQueryDimension
+    ) -> Bool {
+        switch dimension {
+        case .category(let name):
+            return transaction.category.localizedCaseInsensitiveCompare(name) == .orderedSame
+        case .merchant(let name):
+            return transaction.payee.localizedCaseInsensitiveContains(name)
+                || name.localizedCaseInsensitiveContains(transaction.payee)
+        case .account(let name):
+            return transaction.accountName.localizedCaseInsensitiveCompare(name) == .orderedSame
+                || transaction.accountName.localizedCaseInsensitiveContains(name)
+        case .all:
+            return true
+        }
+    }
+
+    // MARK: - Balance (sensitive)
+
+    private func executeBalance(
+        _ plan: FinanceQueryPlan,
+        accountName: String?,
+        accounts: [AccountItem]
+    ) -> FinanceQueryResult {
+        if let accountName,
+           let matched = accounts.first(where: {
+               $0.name.localizedCaseInsensitiveCompare(accountName) == .orderedSame
+                   || $0.name.localizedCaseInsensitiveContains(accountName)
+           }) {
+            let formatted = Self.formatCurrency(
+                minorUnits: matched.balanceMinorUnits,
+                currencyCode: matched.currencyCode
+            )
+            return FinanceQueryResult(
+                plan: plan,
+                amountMinorUnits: matched.balanceMinorUnits,
+                currencyCode: matched.currencyCode,
+                matchCount: 1,
+                typedSummary: String(localized: "\(matched.name): \(formatted)"),
+                spokenSummary: String(localized: "Your \(matched.name) balance is \(formatted).")
+            )
+        }
+
+        let total = accounts.reduce(Int64(0)) { $0 + $1.balanceMinorUnits }
+        let currencyCode = accounts.first?.currencyCode ?? "USD"
+        let formatted = Self.formatCurrency(minorUnits: total, currencyCode: currencyCode)
+        let count = accounts.count
+        let accountWord = count == 1
+            ? String(localized: "account")
+            : String(localized: "accounts")
+
+        return FinanceQueryResult(
+            plan: plan,
+            amountMinorUnits: total,
+            currencyCode: currencyCode,
+            matchCount: count,
+            typedSummary: String(localized: "Total balance: \(formatted)"),
+            spokenSummary: String(
+                localized: "Your total balance across \(count) \(accountWord) is \(formatted)."
+            )
+        )
+    }
+
+    // MARK: - Phrase Builders
+
+    private func subjectPhrase(for dimension: FinanceQueryDimension) -> String {
+        switch dimension {
+        case .category(let name): String(localized: "on \(name)")
+        case .merchant(let name): String(localized: "at \(name)")
+        case .account(let name): String(localized: "on \(name)")
+        case .all: String(localized: "in total")
+        }
+    }
+
+    private func periodPhrase(for range: FinanceQueryDateRange?) -> String {
+        guard let range else { return "" }
+        return " " + range.label
+    }
+
+    // MARK: - Currency Formatting
+
+    static func formatCurrency(minorUnits: Int64, currencyCode: String) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        let majorUnits = NSDecimalNumber(value: minorUnits)
+            .dividing(by: NSDecimalNumber(decimal: 100))
+        return formatter.string(from: majorUnits) ?? "\(currencyCode) \(minorUnits)"
+    }
+}

--- a/apps/ios/Finance/Services/FinanceQuerySpeech.swift
+++ b/apps/ios/Finance/Services/FinanceQuerySpeech.swift
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinanceQuerySpeech.swift
+// Finance
+//
+// Protocol seams that decouple natural-language finance queries (#2386) from
+// the Speech framework and speech synthesis. The parser, planner, and
+// ``FinanceQueryViewModel`` depend only on these protocols, so the entire query
+// pipeline is unit-testable without microphone, Speech entitlements, or device
+// hardware.
+
+import AVFoundation
+import Foundation
+import os
+
+// MARK: - Speech Recognition Seam
+
+/// Provides spoken-input transcription for the query screen.
+///
+/// The live implementation is intentionally **not** wired up here because it
+/// requires the Speech capability, the microphone entitlement, and
+/// `NSSpeechRecognitionUsageDescription` / `NSMicrophoneUsageDescription`
+/// Info.plist keys that can only be added in Xcode.
+protocol FinanceQuerySpeechRecognizer: Sendable {
+    /// Whether transcription is currently available (authorised + capable).
+    var isAvailable: Bool { get }
+
+    /// Transcribes a single spoken utterance to text.
+    func transcribe() async throws -> String
+}
+
+/// Errors surfaced by a speech recognizer.
+enum FinanceQuerySpeechError: Error, Equatable {
+    case unavailable
+    case notAuthorized
+    case noSpeechDetected
+}
+
+/// Default recognizer used until the on-device Speech pipeline is wired up.
+///
+/// Always reports `isAvailable == false`, allowing the UI to gracefully disable
+/// the microphone affordance and fall back to typed input.
+struct UnavailableSpeechRecognizer: FinanceQuerySpeechRecognizer {
+    var isAvailable: Bool { false }
+
+    func transcribe() async throws -> String {
+        throw FinanceQuerySpeechError.unavailable
+    }
+}
+
+// TODO(human): Provide a live `FinanceQuerySpeechRecognizer` backed by
+// `SFSpeechRecognizer` + `AVAudioEngine` with on-device
+// (`requiresOnDeviceRecognition = true`) transcription. This requires Xcode
+// project changes (Speech capability, microphone entitlement, and the
+// `NSSpeechRecognitionUsageDescription` / `NSMicrophoneUsageDescription`
+// Info.plist usage strings) that cannot be made from this environment.
+
+// MARK: - Voice Output Seam
+
+/// Speaks a query answer aloud. Kept behind a protocol so tests can assert what
+/// would be spoken without invoking the audio system.
+protocol FinanceQueryVoiceOutput: Sendable {
+    /// Whether speech synthesis is available on this platform.
+    var isAvailable: Bool { get }
+
+    /// Speaks `text` aloud.
+    func speak(_ text: String)
+
+    /// Stops any in-progress utterance.
+    func stop()
+}
+
+/// Concrete voice output backed by `AVSpeechSynthesizer`.
+///
+/// Speech **synthesis** needs no special entitlement, so this is safe to ship.
+/// Callers remain responsible for gating sensitive content (balances) behind
+/// explicit confirmation before invoking ``speak(_:)``.
+final class SystemVoiceOutput: FinanceQueryVoiceOutput, @unchecked Sendable {
+    private let synthesizer = AVSpeechSynthesizer()
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "FinanceQueryVoice"
+    )
+
+    var isAvailable: Bool { true }
+
+    func speak(_ text: String) {
+        guard !text.isEmpty else { return }
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: Locale.current.identifier)
+        logger.info("Speaking query result aloud")
+        synthesizer.speak(utterance)
+    }
+
+    func stop() {
+        if synthesizer.isSpeaking {
+            synthesizer.stopSpeaking(at: .immediate)
+        }
+    }
+}
+
+/// No-op voice output for tests and previews. Records the last spoken text.
+final class SilentVoiceOutput: FinanceQueryVoiceOutput, @unchecked Sendable {
+    private(set) var spokenText: [String] = []
+    var isAvailable: Bool { true }
+
+    func speak(_ text: String) { spokenText.append(text) }
+    func stop() {}
+}

--- a/apps/ios/Finance/ViewModels/FinanceQueryViewModel.swift
+++ b/apps/ios/Finance/ViewModels/FinanceQueryViewModel.swift
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinanceQueryViewModel.swift
+// Finance
+//
+// Drives the natural-language finance query screen (#2386). Orchestrates the
+// deterministic parse → clarify → plan → answer pipeline and gates speaking
+// sensitive balances behind explicit user confirmation. All interpretation
+// happens on-device. Speech is injected behind protocols so the ViewModel is
+// fully unit-testable without speech availability.
+
+import Foundation
+import Observation
+import os
+
+@Observable
+final class FinanceQueryViewModel {
+
+    // MARK: - Phase
+
+    /// The current state of the query screen.
+    enum Phase: Equatable {
+        case idle
+        case loading
+        case answered(FinanceQueryResult)
+        case clarifying(FinanceQueryClarification)
+        case unrecognized
+    }
+
+    // MARK: - Observable State
+
+    var inputText = ""
+    var phase: Phase = .idle
+
+    /// When non-nil, a sensitive result is awaiting confirmation before its
+    /// spoken variant is read aloud.
+    var pendingSpokenConfirmation: FinanceQueryResult?
+
+    var errorMessage: String?
+    var showError: Bool { errorMessage != nil }
+
+    /// Whether spoken input (dictation) is available on this device.
+    var isSpeechInputAvailable: Bool { speechRecognizer.isAvailable }
+
+    // MARK: - Dependencies
+
+    private let transactions: TransactionRepository
+    private let accounts: AccountRepository
+    private let categories: CategoryRepository
+    private let voice: FinanceQueryVoiceOutput
+    private let speechRecognizer: FinanceQuerySpeechRecognizer
+    private let calendar: Calendar
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "FinanceQueryViewModel"
+    )
+
+    /// The most recent raw input, retained so clarification choices can
+    /// re-parse with an override.
+    private var lastInput = ""
+
+    // MARK: - Init
+
+    init(
+        transactions: TransactionRepository,
+        accounts: AccountRepository,
+        categories: CategoryRepository,
+        voice: FinanceQueryVoiceOutput = SystemVoiceOutput(),
+        speechRecognizer: FinanceQuerySpeechRecognizer = UnavailableSpeechRecognizer(),
+        calendar: Calendar = .current
+    ) {
+        self.transactions = transactions
+        self.accounts = accounts
+        self.categories = categories
+        self.voice = voice
+        self.speechRecognizer = speechRecognizer
+        self.calendar = calendar
+    }
+
+    // MARK: - Query Submission
+
+    /// Parses and answers the current `inputText`.
+    func submit() async {
+        await run(input: inputText)
+    }
+
+    /// Re-runs the last query forcing a resolved date window.
+    func resolveDate(_ preset: FinanceQueryDatePreset) async {
+        await run(input: lastInput, dateOverride: preset)
+    }
+
+    /// Re-runs the last query forcing a resolved category.
+    func resolveCategory(_ name: String) async {
+        await run(input: lastInput, categoryOverride: name)
+    }
+
+    private func run(
+        input: String,
+        dateOverride: FinanceQueryDatePreset? = nil,
+        categoryOverride: String? = nil
+    ) async {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            phase = .idle
+            return
+        }
+
+        lastInput = input
+        phase = .loading
+        pendingSpokenConfirmation = nil
+
+        let txns: [TransactionItem]
+        let accts: [AccountItem]
+        let cats: [CategoryItem]
+        do {
+            async let t = transactions.getTransactions()
+            async let a = accounts.getAccounts()
+            async let c = categories.getCategories()
+            (txns, accts, cats) = try await (t, a, c)
+        } catch {
+            Self.logger.error("Query data load failed: \(error.localizedDescription, privacy: .public)")
+            errorMessage = String(localized: "Couldn't load your finance data. Please try again.")
+            phase = .idle
+            return
+        }
+
+        let vocabulary = FinanceQueryVocabulary(
+            categories: cats.map(\.name),
+            accounts: accts.map(\.name),
+            merchants: Array(Set(txns.map(\.payee))).filter { !$0.isEmpty }
+        )
+
+        let parser = FinanceQueryParser(vocabulary: vocabulary, calendar: calendar)
+        let outcome = parser.parse(
+            input,
+            dateOverride: dateOverride,
+            categoryOverride: categoryOverride
+        )
+
+        switch outcome {
+        case .plan(let plan):
+            let planner = FinanceQueryPlanner(calendar: calendar)
+            let result = planner.execute(plan, transactions: txns, accounts: accts)
+            Self.logger.info("Query answered (sensitive: \(plan.isSensitive, privacy: .public))")
+            phase = .answered(result)
+
+        case .clarification(let clarification):
+            Self.logger.info("Query needs clarification")
+            phase = .clarifying(clarification)
+
+        case .unrecognized:
+            Self.logger.info("Query not recognised as a finance question")
+            phase = .unrecognized
+        }
+    }
+
+    // MARK: - Speaking
+
+    /// Requests that the current answer be read aloud.
+    ///
+    /// Sensitive results (balances) are routed through
+    /// ``pendingSpokenConfirmation`` so the View can require an explicit tap
+    /// before anything is spoken. Non-sensitive results speak immediately.
+    func requestSpeak() {
+        guard case .answered(let result) = phase else { return }
+        if result.requiresSpokenConfirmation {
+            pendingSpokenConfirmation = result
+        } else {
+            voice.speak(result.spokenSummary)
+        }
+    }
+
+    /// Confirms and speaks a pending sensitive result.
+    func confirmSpeak() {
+        guard let result = pendingSpokenConfirmation else { return }
+        Self.logger.info("User confirmed speaking sensitive balance aloud")
+        voice.speak(result.spokenSummary)
+        pendingSpokenConfirmation = nil
+    }
+
+    /// Cancels a pending sensitive spoken result without speaking it.
+    func cancelSpeak() {
+        pendingSpokenConfirmation = nil
+    }
+
+    func stopSpeaking() {
+        voice.stop()
+    }
+
+    // MARK: - Reset
+
+    func reset() {
+        inputText = ""
+        lastInput = ""
+        phase = .idle
+        pendingSpokenConfirmation = nil
+    }
+
+    func dismissError() {
+        errorMessage = nil
+    }
+}

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -408,3 +408,27 @@ planned for when the Swift Export bridge connects to the app's `KeychainManager`
 - **VoiceOver** — Every interactive element has an accessibility label
 - **Localized** — All user-facing strings go through `String(localized:)`
 - **Edge-first** — All reads/writes go to local SQLite (KMP) first; full offline support
+
+## Needs Human Action
+
+The on-device natural-language finance queries feature (#2386) is fully
+implemented and unit-tested in Swift, but the following native-toolchain steps
+require Xcode and cannot be performed from the agent environment. Each
+corresponding code site is marked with `// TODO(human)`.
+
+- **Siri & App Intents capability** — Enable the _Siri_ / App Intents capability
+  for the `FinanceApp` target and register `FinanceQueryIntent` in
+  `FinanceShortcuts` so the query can be invoked by voice.
+  (See `Finance/Intents/FinanceQueryIntent.swift`.)
+- **Speech (dictation) capability** — To enable spoken question input, add the
+  _Speech Recognition_ capability, the microphone entitlement, and the
+  `NSSpeechRecognitionUsageDescription` / `NSMicrophoneUsageDescription` keys to
+  `Info.plist`, then provide a live `FinanceQuerySpeechRecognizer` backed by
+  `SFSpeechRecognizer` + `AVAudioEngine` with on-device recognition.
+  (See `Finance/Services/FinanceQuerySpeech.swift` and the mic button in
+  `Finance/Screens/FinanceQueryView.swift`.)
+
+Until these steps are completed, the feature works via typed input, the spoken
+answer uses `AVSpeechSynthesizer` (no entitlement required), and the microphone
+affordance is disabled gracefully. Speech synthesis of sensitive balances
+remains gated behind explicit user confirmation.

--- a/apps/ios/Tests/FinanceQueryIntentTests.swift
+++ b/apps/ios/Tests/FinanceQueryIntentTests.swift
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinanceQueryIntentTests.swift
+// FinanceTests
+//
+// Tests for the pure dialog builder behind ``FinanceQueryIntent`` (#2386).
+// Verifies, in particular, that Siri never speaks a balance figure aloud —
+// sensitive balances are redirected to the in-app, confirmation-gated flow.
+
+import XCTest
+@testable import FinanceApp
+
+final class FinanceQueryIntentTests: XCTestCase {
+
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }
+
+    private static let referenceDate: Date = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar.date(from: DateComponents(year: 2024, month: 6, day: 15, hour: 12))!
+    }()
+
+    private func transactions() -> [TransactionItem] {
+        [
+            TransactionItem(
+                id: "1", payee: "Netflix", category: "Entertainment",
+                accountName: "Travel Card", amountMinorUnits: -15_00,
+                currencyCode: "USD", date: Self.referenceDate, type: .expense
+            ),
+        ]
+    }
+
+    private func accounts() -> [AccountItem] {
+        [
+            AccountItem(id: "a1", name: "Main Checking", balanceMinorUnits: 9_999_00,
+                        currencyCode: "USD", type: .checking, icon: "building.columns", isArchived: false),
+        ]
+    }
+
+    private func categories() -> [CategoryItem] {
+        [
+            CategoryItem(id: "c1", name: "Groceries", colorHex: "#38A169", icon: "cart"),
+            CategoryItem(id: "c2", name: "Dining Out", colorHex: "#DD6B20", icon: "fork.knife"),
+            CategoryItem(id: "c3", name: "Entertainment", colorHex: "#805AD5", icon: "film"),
+        ]
+    }
+
+    private func dialog(for query: String) -> String {
+        FinanceQueryIntent.dialogText(
+            for: query,
+            transactions: transactions(),
+            accounts: accounts(),
+            categories: categories(),
+            calendar: calendar,
+            referenceDate: Self.referenceDate
+        )
+    }
+
+    func testBalanceNeverSpokenAloudViaSiri() {
+        let dialog = dialog(for: "What's my balance")
+        XCTAssertFalse(dialog.contains("9,999"), "Siri must not speak the balance figure")
+        XCTAssertFalse(dialog.contains("9999"))
+        XCTAssertTrue(dialog.localizedCaseInsensitiveContains("privacy"))
+    }
+
+    func testSpendQueryReturnsSpokenSummary() {
+        let dialog = dialog(for: "How much did I spend at Netflix")
+        XCTAssertTrue(dialog.localizedCaseInsensitiveContains("spent"))
+    }
+
+    func testAmbiguousCategoryReturnsPrompt() {
+        let dialog = dialog(for: "How much did I spend on food this week")
+        XCTAssertTrue(dialog.localizedCaseInsensitiveContains("did you mean"))
+    }
+
+    func testUnrecognizedQueryReturnsFallback() {
+        let dialog = dialog(for: "What's the weather")
+        XCTAssertTrue(dialog.localizedCaseInsensitiveContains("spending"))
+    }
+}

--- a/apps/ios/Tests/FinanceQueryParserTests.swift
+++ b/apps/ios/Tests/FinanceQueryParserTests.swift
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinanceQueryParserTests.swift
+// FinanceTests
+//
+// Deterministic fixture tests for the on-device natural-language finance query
+// parser (#2386). A fixed calendar (UTC) and reference date make every date
+// window reproducible, and parsing never touches Speech or App Intents.
+
+import XCTest
+@testable import FinanceApp
+
+final class FinanceQueryParserTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// 2024-06-15 12:00 UTC (a Saturday in June).
+    private static let referenceDate: Date = {
+        var components = DateComponents()
+        components.year = 2024
+        components.month = 6
+        components.day = 15
+        components.hour = 12
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar.date(from: components)!
+    }()
+
+    private func makeParser() -> FinanceQueryParser {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let vocabulary = FinanceQueryVocabulary(
+            categories: ["Groceries", "Dining Out", "Entertainment", "Transport"],
+            accounts: ["Main Checking", "Savings", "Travel Card"],
+            merchants: ["Netflix", "Whole Foods", "Shell Gas"]
+        )
+        return FinanceQueryParser(
+            vocabulary: vocabulary,
+            calendar: calendar,
+            referenceDate: Self.referenceDate
+        )
+    }
+
+    private func plan(from outcome: FinanceQueryParse) -> FinanceQueryPlan? {
+        if case .plan(let plan) = outcome { return plan }
+        return nil
+    }
+
+    // MARK: - Spend by Category
+
+    func testSpendByCategoryResolves() {
+        let outcome = makeParser().parse("How much did I spend on groceries this week?")
+        let plan = plan(from: outcome)
+        XCTAssertEqual(plan?.kind, .spend(.category("Groceries")))
+        XCTAssertEqual(plan?.dateRange?.label, "this week")
+        XCTAssertFalse(plan?.isSensitive ?? true)
+    }
+
+    func testSpendByCategoryWithoutDate() {
+        let outcome = makeParser().parse("How much have I spent on entertainment")
+        XCTAssertEqual(plan(from: outcome)?.kind, .spend(.category("Entertainment")))
+        XCTAssertNil(plan(from: outcome)?.dateRange)
+    }
+
+    // MARK: - Spend by Merchant
+
+    func testSpendByMerchantViaPreposition() {
+        let outcome = makeParser().parse("How much did I spend at Netflix?")
+        XCTAssertEqual(plan(from: outcome)?.kind, .spend(.merchant("Netflix")))
+    }
+
+    func testSpendByMerchantStripsTrailingDate() {
+        let outcome = makeParser().parse("How much did I spend at Whole Foods last week")
+        XCTAssertEqual(plan(from: outcome)?.kind, .spend(.merchant("Whole Foods")))
+        XCTAssertEqual(plan(from: outcome)?.dateRange?.label, "last week")
+    }
+
+    // MARK: - Spend by Account
+
+    func testSpendByAccount() {
+        let outcome = makeParser().parse("How much did I spend on my Travel Card last month")
+        XCTAssertEqual(plan(from: outcome)?.kind, .spend(.account("Travel Card")))
+        XCTAssertEqual(plan(from: outcome)?.dateRange?.label, "last month")
+    }
+
+    // MARK: - Spend by Date Range Only
+
+    func testSpendByDateRangeOnly() {
+        let outcome = makeParser().parse("How much did I spend last month")
+        XCTAssertEqual(plan(from: outcome)?.kind, .spend(.all))
+        XCTAssertEqual(plan(from: outcome)?.dateRange?.label, "last month")
+    }
+
+    // MARK: - Clarifications
+
+    func testAmbiguousCategoryRequestsClarification() {
+        let outcome = makeParser().parse("How much did I spend on food this week")
+        guard case .clarification(.ambiguousCategory(let phrase, let options)) = outcome else {
+            return XCTFail("Expected ambiguousCategory clarification, got \(outcome)")
+        }
+        XCTAssertEqual(phrase, "food")
+        XCTAssertTrue(options.contains("Groceries"))
+        XCTAssertTrue(options.contains("Dining Out"))
+    }
+
+    func testAmbiguousDateRequestsClarification() {
+        let outcome = makeParser().parse("How much did I spend on groceries recently")
+        guard case .clarification(.ambiguousDate(let phrase, let options)) = outcome else {
+            return XCTFail("Expected ambiguousDate clarification, got \(outcome)")
+        }
+        XCTAssertEqual(phrase, "recently")
+        XCTAssertTrue(options.contains(.thisMonth))
+    }
+
+    func testMissingSubjectRequestsClarification() {
+        let outcome = makeParser().parse("How much did I spend")
+        XCTAssertEqual(outcome, .clarification(.missingSubject))
+    }
+
+    // MARK: - Overrides (clarification resolution)
+
+    func testCategoryOverrideResolves() {
+        let outcome = makeParser().parse(
+            "How much did I spend on food this week",
+            categoryOverride: "Groceries"
+        )
+        XCTAssertEqual(plan(from: outcome)?.kind, .spend(.category("Groceries")))
+    }
+
+    func testDateOverrideResolves() {
+        let outcome = makeParser().parse(
+            "How much did I spend on groceries recently",
+            dateOverride: .thisMonth
+        )
+        XCTAssertEqual(plan(from: outcome)?.kind, .spend(.category("Groceries")))
+        XCTAssertEqual(plan(from: outcome)?.dateRange?.label, "this month")
+    }
+
+    // MARK: - Balance (sensitive)
+
+    func testTotalBalanceIsSensitive() {
+        let outcome = makeParser().parse("What's my balance?")
+        XCTAssertEqual(plan(from: outcome)?.kind, .balance(account: nil))
+        XCTAssertTrue(plan(from: outcome)?.isSensitive ?? false)
+    }
+
+    func testSpecificAccountBalance() {
+        let outcome = makeParser().parse("What's my Savings balance")
+        XCTAssertEqual(plan(from: outcome)?.kind, .balance(account: "Savings"))
+    }
+
+    // MARK: - Unrecognized
+
+    func testUnrecognizedQuery() {
+        let outcome = makeParser().parse("What's the weather today")
+        XCTAssertEqual(outcome, .unrecognized(rawInput: "What's the weather today"))
+    }
+
+    func testEmptyInputUnrecognized() {
+        let outcome = makeParser().parse("   ")
+        XCTAssertEqual(outcome, .unrecognized(rawInput: "   "))
+    }
+
+    // MARK: - Determinism & Case Insensitivity
+
+    func testParsingIsDeterministic() {
+        let parser = makeParser()
+        let first = parser.parse("How much did I spend on groceries this week?")
+        let second = parser.parse("How much did I spend on groceries this week?")
+        XCTAssertEqual(first, second)
+    }
+
+    func testParsingIsCaseInsensitive() {
+        let outcome = makeParser().parse("HOW MUCH DID I SPEND ON GROCERIES THIS WEEK")
+        XCTAssertEqual(plan(from: outcome)?.kind, .spend(.category("Groceries")))
+    }
+
+    // MARK: - Date Window Boundaries
+
+    func testThisMonthWindowBounds() {
+        let parser = makeParser()
+        guard let range = parser.resolveDateRange(for: .thisMonth) else {
+            return XCTFail("Expected a resolved month range")
+        }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+
+        let inside = calendar.date(from: DateComponents(year: 2024, month: 6, day: 10))!
+        let before = calendar.date(from: DateComponents(year: 2024, month: 5, day: 31))!
+        let after = calendar.date(from: DateComponents(year: 2024, month: 7, day: 1))!
+
+        XCTAssertTrue(range.contains(inside))
+        XCTAssertFalse(range.contains(before))
+        XCTAssertFalse(range.contains(after))
+    }
+}

--- a/apps/ios/Tests/FinanceQueryPlannerTests.swift
+++ b/apps/ios/Tests/FinanceQueryPlannerTests.swift
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinanceQueryPlannerTests.swift
+// FinanceTests
+//
+// Tests for ``FinanceQueryPlanner`` execution over an in-memory local store
+// (#2386). All amounts are asserted in minor units to avoid locale-dependent
+// currency-formatting flakiness.
+
+import XCTest
+@testable import FinanceApp
+
+final class FinanceQueryPlannerTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        calendar.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
+    }
+
+    private func makeTransactions() -> [TransactionItem] {
+        [
+            TransactionItem(
+                id: "1", payee: "Whole Foods", category: "Groceries",
+                accountName: "Main Checking", amountMinorUnits: -50_00,
+                currencyCode: "USD", date: date(2024, 6, 10), type: .expense
+            ),
+            TransactionItem(
+                id: "2", payee: "Trader Joe's", category: "Groceries",
+                accountName: "Main Checking", amountMinorUnits: -30_00,
+                currencyCode: "USD", date: date(2024, 6, 12), type: .expense
+            ),
+            TransactionItem(
+                id: "3", payee: "Netflix", category: "Entertainment",
+                accountName: "Travel Card", amountMinorUnits: -15_00,
+                currencyCode: "USD", date: date(2024, 6, 5), type: .expense
+            ),
+            // Outside June — should be excluded from "this month".
+            TransactionItem(
+                id: "4", payee: "Whole Foods", category: "Groceries",
+                accountName: "Main Checking", amountMinorUnits: -99_00,
+                currencyCode: "USD", date: date(2024, 5, 20), type: .expense
+            ),
+            // Income — should never count toward spend.
+            TransactionItem(
+                id: "5", payee: "Payroll", category: "Income",
+                accountName: "Main Checking", amountMinorUnits: 4_000_00,
+                currencyCode: "USD", date: date(2024, 6, 1), type: .income
+            ),
+        ]
+    }
+
+    private func makeAccounts() -> [AccountItem] {
+        [
+            AccountItem(id: "a1", name: "Main Checking", balanceMinorUnits: 1_200_00,
+                        currencyCode: "USD", type: .checking, icon: "building.columns", isArchived: false),
+            AccountItem(id: "a2", name: "Savings", balanceMinorUnits: 5_000_00,
+                        currencyCode: "USD", type: .savings, icon: "banknote", isArchived: false),
+        ]
+    }
+
+    private func juneRange() -> FinanceQueryDateRange {
+        let interval = calendar.dateInterval(of: .month, for: date(2024, 6, 15))!
+        return FinanceQueryDateRange(start: interval.start, end: interval.end, label: "this month")
+    }
+
+    // MARK: - Spend by Category
+
+    func testSpendByCategoryWithDateRange() {
+        let plan = FinanceQueryPlan(
+            kind: .spend(.category("Groceries")),
+            dateRange: juneRange(),
+            rawInput: "groceries this month"
+        )
+        let result = FinanceQueryPlanner(calendar: calendar)
+            .execute(plan, transactions: makeTransactions(), accounts: [])
+
+        // 50 + 30 (June groceries); the May 99 is excluded.
+        XCTAssertEqual(result.amountMinorUnits, 80_00)
+        XCTAssertEqual(result.matchCount, 2)
+        XCTAssertFalse(result.requiresSpokenConfirmation)
+        XCTAssertFalse(result.typedSummary.isEmpty)
+        XCTAssertFalse(result.spokenSummary.isEmpty)
+    }
+
+    func testSpendByCategoryAllTime() {
+        let plan = FinanceQueryPlan(
+            kind: .spend(.category("Groceries")),
+            dateRange: nil,
+            rawInput: "groceries"
+        )
+        let result = FinanceQueryPlanner(calendar: calendar)
+            .execute(plan, transactions: makeTransactions(), accounts: [])
+
+        // 50 + 30 + 99 across all time.
+        XCTAssertEqual(result.amountMinorUnits, 179_00)
+        XCTAssertEqual(result.matchCount, 3)
+    }
+
+    // MARK: - Spend by Merchant
+
+    func testSpendByMerchant() {
+        let plan = FinanceQueryPlan(
+            kind: .spend(.merchant("Netflix")),
+            dateRange: nil,
+            rawInput: "at netflix"
+        )
+        let result = FinanceQueryPlanner(calendar: calendar)
+            .execute(plan, transactions: makeTransactions(), accounts: [])
+        XCTAssertEqual(result.amountMinorUnits, 15_00)
+        XCTAssertEqual(result.matchCount, 1)
+    }
+
+    // MARK: - Spend by Account
+
+    func testSpendByAccount() {
+        let plan = FinanceQueryPlan(
+            kind: .spend(.account("Main Checking")),
+            dateRange: juneRange(),
+            rawInput: "main checking this month"
+        )
+        let result = FinanceQueryPlanner(calendar: calendar)
+            .execute(plan, transactions: makeTransactions(), accounts: [])
+        // June expenses on Main Checking: 50 + 30 (income excluded).
+        XCTAssertEqual(result.amountMinorUnits, 80_00)
+        XCTAssertEqual(result.matchCount, 2)
+    }
+
+    // MARK: - Date-Range Total
+
+    func testTotalSpendForDateRange() {
+        let plan = FinanceQueryPlan(
+            kind: .spend(.all),
+            dateRange: juneRange(),
+            rawInput: "last month"
+        )
+        let result = FinanceQueryPlanner(calendar: calendar)
+            .execute(plan, transactions: makeTransactions(), accounts: [])
+        // All June expenses: 50 + 30 + 15.
+        XCTAssertEqual(result.amountMinorUnits, 95_00)
+        XCTAssertEqual(result.matchCount, 3)
+    }
+
+    // MARK: - No Matches
+
+    func testNoMatchesProducesZeroResult() {
+        let plan = FinanceQueryPlan(
+            kind: .spend(.category("Transport")),
+            dateRange: nil,
+            rawInput: "transport"
+        )
+        let result = FinanceQueryPlanner(calendar: calendar)
+            .execute(plan, transactions: makeTransactions(), accounts: [])
+        XCTAssertEqual(result.amountMinorUnits, 0)
+        XCTAssertEqual(result.matchCount, 0)
+        XCTAssertFalse(result.typedSummary.isEmpty)
+    }
+
+    // MARK: - Balance (sensitive)
+
+    func testTotalBalanceIsSensitive() {
+        let plan = FinanceQueryPlan(
+            kind: .balance(account: nil),
+            dateRange: nil,
+            rawInput: "balance"
+        )
+        let result = FinanceQueryPlanner(calendar: calendar)
+            .execute(plan, transactions: [], accounts: makeAccounts())
+        XCTAssertEqual(result.amountMinorUnits, 6_200_00)
+        XCTAssertEqual(result.matchCount, 2)
+        XCTAssertTrue(result.requiresSpokenConfirmation)
+    }
+
+    func testSpecificAccountBalance() {
+        let plan = FinanceQueryPlan(
+            kind: .balance(account: "Savings"),
+            dateRange: nil,
+            rawInput: "savings balance"
+        )
+        let result = FinanceQueryPlanner(calendar: calendar)
+            .execute(plan, transactions: [], accounts: makeAccounts())
+        XCTAssertEqual(result.amountMinorUnits, 5_000_00)
+        XCTAssertEqual(result.matchCount, 1)
+        XCTAssertTrue(result.requiresSpokenConfirmation)
+    }
+}

--- a/apps/ios/Tests/FinanceQueryViewModelTests.swift
+++ b/apps/ios/Tests/FinanceQueryViewModelTests.swift
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinanceQueryViewModelTests.swift
+// FinanceTests
+//
+// Tests for ``FinanceQueryViewModel`` orchestration (#2386): the parse →
+// clarify → answer pipeline and, crucially, the requirement that sensitive
+// balances are not spoken aloud without explicit confirmation. Speech is
+// injected via ``SilentVoiceOutput`` so nothing is actually spoken.
+
+import XCTest
+@testable import FinanceApp
+
+@MainActor
+final class FinanceQueryViewModelTests: XCTestCase {
+
+    // MARK: - Builders
+
+    private func makeViewModel(
+        transactions: [TransactionItem] = [],
+        accounts: [AccountItem] = [],
+        categories: [CategoryItem] = [],
+        transactionError: Error? = nil
+    ) -> (FinanceQueryViewModel, SilentVoiceOutput) {
+        let txnStub = StubTransactionRepository()
+        txnStub.transactionsToReturn = transactions
+        txnStub.errorToThrow = transactionError
+
+        let acctStub = StubAccountRepository()
+        acctStub.accountsToReturn = accounts
+
+        let catStub = StubCategoryRepository()
+        catStub.categoriesToReturn = categories
+
+        let voice = SilentVoiceOutput()
+        let viewModel = FinanceQueryViewModel(
+            transactions: txnStub,
+            accounts: acctStub,
+            categories: catStub,
+            voice: voice,
+            speechRecognizer: UnavailableSpeechRecognizer()
+        )
+        return (viewModel, voice)
+    }
+
+    private func sampleTransactions() -> [TransactionItem] {
+        [
+            TransactionItem(
+                id: "1", payee: "Netflix", category: "Entertainment",
+                accountName: "Travel Card", amountMinorUnits: -15_00,
+                currencyCode: "USD", date: .now, type: .expense
+            ),
+            TransactionItem(
+                id: "2", payee: "Whole Foods", category: "Groceries",
+                accountName: "Main Checking", amountMinorUnits: -40_00,
+                currencyCode: "USD", date: .now, type: .expense
+            ),
+        ]
+    }
+
+    private func sampleCategories() -> [CategoryItem] {
+        [
+            CategoryItem(id: "c1", name: "Groceries", colorHex: "#38A169", icon: "cart"),
+            CategoryItem(id: "c2", name: "Dining Out", colorHex: "#DD6B20", icon: "fork.knife"),
+        ]
+    }
+
+    private func sampleAccounts() -> [AccountItem] {
+        [
+            AccountItem(id: "a1", name: "Main Checking", balanceMinorUnits: 1_200_00,
+                        currencyCode: "USD", type: .checking, icon: "building.columns", isArchived: false),
+        ]
+    }
+
+    // MARK: - Spend Query (non-sensitive speaks immediately)
+
+    func testSpendQueryAnswersAndSpeaksImmediately() async {
+        let (viewModel, voice) = makeViewModel(
+            transactions: sampleTransactions(),
+            accounts: sampleAccounts(),
+            categories: sampleCategories()
+        )
+        viewModel.inputText = "How much did I spend at Netflix"
+        await viewModel.submit()
+
+        guard case .answered(let result) = viewModel.phase else {
+            return XCTFail("Expected answered phase, got \(viewModel.phase)")
+        }
+        XCTAssertFalse(result.requiresSpokenConfirmation)
+
+        viewModel.requestSpeak()
+        XCTAssertNil(viewModel.pendingSpokenConfirmation)
+        XCTAssertEqual(voice.spokenText.count, 1, "Non-sensitive answers speak immediately")
+    }
+
+    // MARK: - Balance Query (sensitive requires confirmation)
+
+    func testBalanceQueryRequiresConfirmationBeforeSpeaking() async {
+        let (viewModel, voice) = makeViewModel(accounts: sampleAccounts())
+        viewModel.inputText = "What's my balance"
+        await viewModel.submit()
+
+        guard case .answered(let result) = viewModel.phase else {
+            return XCTFail("Expected answered phase, got \(viewModel.phase)")
+        }
+        XCTAssertTrue(result.requiresSpokenConfirmation)
+
+        // Requesting speak must NOT speak yet — it should stage a confirmation.
+        viewModel.requestSpeak()
+        XCTAssertNotNil(viewModel.pendingSpokenConfirmation)
+        XCTAssertTrue(voice.spokenText.isEmpty, "Sensitive balance must not be spoken without confirmation")
+
+        // Confirming finally speaks it.
+        viewModel.confirmSpeak()
+        XCTAssertNil(viewModel.pendingSpokenConfirmation)
+        XCTAssertEqual(voice.spokenText.count, 1)
+    }
+
+    func testCancelSpeakDoesNotSpeakBalance() async {
+        let (viewModel, voice) = makeViewModel(accounts: sampleAccounts())
+        viewModel.inputText = "What's my balance"
+        await viewModel.submit()
+
+        viewModel.requestSpeak()
+        XCTAssertNotNil(viewModel.pendingSpokenConfirmation)
+
+        viewModel.cancelSpeak()
+        XCTAssertNil(viewModel.pendingSpokenConfirmation)
+        XCTAssertTrue(voice.spokenText.isEmpty, "Cancelling must never speak the balance")
+    }
+
+    // MARK: - Clarification Flow
+
+    func testAmbiguousCategoryEntersClarificationThenResolves() async {
+        let (viewModel, _) = makeViewModel(
+            transactions: sampleTransactions(),
+            accounts: sampleAccounts(),
+            categories: sampleCategories()
+        )
+        viewModel.inputText = "How much did I spend on food this week"
+        await viewModel.submit()
+
+        guard case .clarifying(.ambiguousCategory(let phrase, let options)) = viewModel.phase else {
+            return XCTFail("Expected ambiguousCategory clarification, got \(viewModel.phase)")
+        }
+        XCTAssertEqual(phrase, "food")
+        XCTAssertTrue(options.contains("Groceries"))
+
+        await viewModel.resolveCategory("Groceries")
+        guard case .answered(let result) = viewModel.phase else {
+            return XCTFail("Expected answered phase after resolution, got \(viewModel.phase)")
+        }
+        XCTAssertEqual(result.plan.kind, .spend(.category("Groceries")))
+    }
+
+    // MARK: - Unrecognized
+
+    func testUnrecognizedQuery() async {
+        let (viewModel, _) = makeViewModel()
+        viewModel.inputText = "What's the weather today"
+        await viewModel.submit()
+        XCTAssertEqual(viewModel.phase, .unrecognized)
+    }
+
+    // MARK: - Empty Input
+
+    func testEmptyInputStaysIdle() async {
+        let (viewModel, _) = makeViewModel()
+        viewModel.inputText = "   "
+        await viewModel.submit()
+        XCTAssertEqual(viewModel.phase, .idle)
+    }
+
+    // MARK: - Error Handling
+
+    func testDataLoadFailureSurfacesError() async {
+        let (viewModel, _) = makeViewModel(transactionError: TestError.simulated)
+        viewModel.inputText = "How much did I spend at Netflix"
+        await viewModel.submit()
+
+        XCTAssertTrue(viewModel.showError)
+        XCTAssertEqual(viewModel.phase, .idle)
+    }
+
+    // MARK: - Reset
+
+    func testResetClearsState() async {
+        let (viewModel, _) = makeViewModel(accounts: sampleAccounts())
+        viewModel.inputText = "What's my balance"
+        await viewModel.submit()
+        viewModel.requestSpeak()
+
+        viewModel.reset()
+        XCTAssertEqual(viewModel.phase, .idle)
+        XCTAssertTrue(viewModel.inputText.isEmpty)
+        XCTAssertNil(viewModel.pendingSpokenConfirmation)
+    }
+
+    // MARK: - Speech Availability
+
+    func testSpeechInputUnavailableByDefault() {
+        let (viewModel, _) = makeViewModel()
+        XCTAssertFalse(viewModel.isSpeechInputAvailable)
+    }
+}


### PR DESCRIPTION
## Summary

Adds on-device, natural-language finance queries for iPhone (#2386). Users can ask questions like *"how much did I spend on groceries this week"* and get a concise, private answer grounded in local finance data — typed on screen and optionally spoken aloud.

Interpretation is fully on-device and deterministic. Siri/App Intents and the Speech framework are decoupled behind protocols so the parser/planner are exhaustively unit-tested without speech availability.

## What's included
- **Deterministic parser** (`FinanceQueryParser`) — first intent set: spend by **category**, **merchant**, **account**, and **date range**, plus balance queries. Injectable `referenceDate`/`Calendar` for reproducible date windows.
- **Ambiguity & clarification** — vague dates ("recently") and vague categories ("food") return a `FinanceQueryClarification` the UI resolves with chips; overrides re-run the same code path.
- **Query planner** (`FinanceQueryPlanner`) — pure execution over the local store producing **typed + spoken** result variants.
- **Sensitive-balance gating** — balances are never spoken without explicit confirmation in-app; the Siri intent redirects balances to the app rather than speaking the figure.
- **Speech decoupled** — `FinanceQuerySpeechRecognizer` / `FinanceQueryVoiceOutput` protocols; `AVSpeechSynthesizer`-backed voice output (no entitlement); live dictation left as a documented stub.
- **UI** — `FinanceQueryView` (`@Observable` VM, Dynamic Type, VoiceOver labels) surfaced via an "Ask Finance" toolbar action on the Dashboard.
- **App Intent** — `FinanceQueryIntent` reusing the same parser/planner.
- **Tests** — parser fixtures, planner execution, ViewModel orchestration (incl. confirmation gating), and the Siri privacy redirect.

## Needs Human Action (Xcode-only)
- Enable Siri & App Intents capability and register `FinanceQueryIntent` in `FinanceShortcuts`.
- Add Speech capability + microphone entitlement + `NSSpeechRecognitionUsageDescription` / `NSMicrophoneUsageDescription`, then provide a live `FinanceQuerySpeechRecognizer`.

Each site is marked `// TODO(human)`; details in `apps/ios/README.md` -> "Needs Human Action".

Closes #2386

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>