### PR TITLE
feat(ios): savings rate on dashboard (#2162)

### DIFF
--- a/apps/ios/Finance/Screens/DashboardView.swift
+++ b/apps/ios/Finance/Screens/DashboardView.swift
@@ -37,6 +37,7 @@ struct DashboardView: View {
                                 OfflineBanner()
                             }
                             netWorthCard
+                            savingsRateCard
                             spendingSummaryCard
                             budgetHealthSection
                             quickAccessSection
@@ -95,6 +96,76 @@ struct DashboardView: View {
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("net_worth_card")
         .accessibilityLabel(String(localized: "Net Worth"))
+    }
+
+    // MARK: - Savings Rate (#2162)
+
+    private var savingsRateCard: some View {
+        NavigationLink {
+            AnalyticsView(
+                transactionRepository: RepositoryProvider.shared.transactions,
+                accountRepository: RepositoryProvider.shared.accounts
+            )
+        } label: {
+            HStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "leaf.fill")
+                            .font(.subheadline)
+                            .foregroundStyle(.green)
+                            .accessibilityHidden(true)
+                        Text(String(localized: "Savings Rate"))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(viewModel.savingsRateDisplay)
+                        .font(.largeTitle.bold())
+                        .foregroundStyle(.primary)
+                        .monospacedDigit()
+                        .contentTransition(.numericText())
+                    savingsRateTrendRow
+                    Text(String(localized: "This month"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("savings_rate_card")
+        .accessibilityLabel(viewModel.savingsRateAccessibilityLabel)
+        .accessibilityHint(String(localized: "Opens savings rate history"))
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// Trend row. The direction is conveyed by both an SF Symbol *and* text —
+    /// never colour alone — to satisfy non-colour-only accessibility.
+    private var savingsRateTrendRow: some View {
+        HStack(spacing: 4) {
+            Image(systemName: viewModel.savingsRateTrendSymbol)
+                .font(.caption.weight(.bold))
+                .accessibilityHidden(true)
+            Text(viewModel.savingsRateTrendText)
+                .font(.caption)
+        }
+        .foregroundStyle(savingsRateTrendColor)
+        .accessibilityHidden(true)
+    }
+
+    private var savingsRateTrendColor: Color {
+        switch viewModel.savingsRateTrend {
+        case .improving: return .green
+        case .declining: return .orange
+        case .flat, .notEnoughData: return .secondary
+        }
     }
 
     // MARK: - Spending Summary

--- a/apps/ios/Finance/ViewModels/DashboardViewModel.swift
+++ b/apps/ios/Finance/ViewModels/DashboardViewModel.swift
@@ -13,6 +13,7 @@
 //
 // References: #414, #289
 
+import FinanceShared
 import Observation
 import os
 import SwiftUI
@@ -68,6 +69,92 @@ final class DashboardViewModel {
     /// Spending grouped by category for the current month, via Swift Export aggregator.
     private(set) var spendingByCategory: [String: Int64] = [:]
 
+    // MARK: - Savings Rate (#2162)
+    //
+    // FIRE savers optimise around savings rate, so it is a first-class
+    // dashboard metric. These values are computed from `savingsRateTransactions`
+    // — a broader, multi-month window — because a month-over-month trend needs
+    // more history than the five most-recent transactions shown elsewhere.
+
+    /// Broader transaction window used only for savings-rate math. The recent
+    /// transactions list is intentionally capped at five for the activity feed.
+    private var savingsRateTransactions: [TransactionItem] = []
+
+    /// Savings rate for the current (possibly partial) month.
+    private(set) var currentSavingsRate: SavingsRateResult = .undefined
+
+    /// Savings rate for the previous full month, used for the trend indicator.
+    private(set) var previousMonthSavingsRate: SavingsRateResult = .undefined
+
+    /// Income-weighted trailing three-month savings rate for context.
+    private(set) var trailingThreeMonthSavingsRate: SavingsRateResult = .undefined
+
+    /// Direction of the savings rate this month versus last month.
+    private(set) var savingsRateTrend: SavingsRateTrend = .notEnoughData
+
+    // MARK: - Savings Rate Presentation
+
+    /// Current savings rate as a compact string (e.g. "65%"), or an em dash
+    /// when there is no income to compute a rate.
+    var savingsRateDisplay: String {
+        guard currentSavingsRate.isDefined else { return "—" }
+        return String(format: "%.0f%%", currentSavingsRate.percent)
+    }
+
+    /// SF Symbol describing the trend direction. Always paired with text so the
+    /// indicator never relies on colour alone (accessibility requirement).
+    var savingsRateTrendSymbol: String {
+        switch savingsRateTrend {
+        case .improving: return "arrow.up.right"
+        case .declining: return "arrow.down.right"
+        case .flat: return "arrow.right"
+        case .notEnoughData: return "minus"
+        }
+    }
+
+    /// Short, localized description of the month-over-month trend.
+    var savingsRateTrendText: String {
+        switch savingsRateTrend {
+        case let .improving(delta):
+            return String(localized: "Up \(Self.formatPoints(delta)) pts vs last month")
+        case let .declining(delta):
+            return String(localized: "Down \(Self.formatPoints(delta)) pts vs last month")
+        case .flat:
+            return String(localized: "Steady vs last month")
+        case .notEnoughData:
+            return String(localized: "Not enough history yet")
+        }
+    }
+
+    /// Combined VoiceOver description of the savings-rate card.
+    var savingsRateAccessibilityLabel: String {
+        guard currentSavingsRate.isDefined else {
+            return String(localized: "Savings rate unavailable. Add income to see your rate.")
+        }
+        let rate = String(format: "%.0f", currentSavingsRate.percent)
+        switch savingsRateTrend {
+        case let .improving(delta):
+            return String(localized: "Savings rate \(rate) percent, up \(Self.formatPoints(delta)) points versus last month")
+        case let .declining(delta):
+            return String(localized: "Savings rate \(rate) percent, down \(Self.formatPoints(delta)) points versus last month")
+        case .flat:
+            return String(localized: "Savings rate \(rate) percent, steady versus last month")
+        case .notEnoughData:
+            return String(localized: "Savings rate \(rate) percent. Not enough history for a trend yet")
+        }
+    }
+
+    private static func formatPoints(_ value: Double) -> String {
+        String(format: "%.1f", value)
+    }
+
+    /// Computes the savings rate over a date range from the broad window.
+    private func savingsRateResult(from start: Date, to end: Date) -> SavingsRateResult {
+        let income = aggregator.totalIncome(transactions: savingsRateTransactions, from: start, to: end)
+        let spending = aggregator.totalSpending(transactions: savingsRateTransactions, from: start, to: end)
+        return SavingsRateCalculator.savingsRate(incomeMinorUnits: income, spendingMinorUnits: spending)
+    }
+
     /// Recomputes cached aggregation values from the current `recentTransactions`.
     ///
     /// Called once after data loads instead of on every view body evaluation.
@@ -101,6 +188,30 @@ final class DashboardViewModel {
             from: startOfMonth,
             to: endOfMonth
         )
+
+        recomputeSavingsRate(calendar: cal, startOfMonth: startOfMonth, endOfMonth: endOfMonth)
+    }
+
+    /// Recomputes the current/previous/trailing savings rates and the trend
+    /// indicator from the broad transaction window. Pure aside from the
+    /// injected aggregator, so behaviour is deterministic for a fixed dataset.
+    private func recomputeSavingsRate(calendar cal: Calendar, startOfMonth: Date, endOfMonth: Date) {
+        let startOfPrevMonth = cal.date(byAdding: .month, value: -1, to: startOfMonth) ?? startOfMonth
+        let endOfPrevMonth = cal.date(byAdding: DateComponents(day: -1), to: startOfMonth) ?? startOfMonth
+        let startOfTwoMonthsAgo = cal.date(byAdding: .month, value: -2, to: startOfMonth) ?? startOfMonth
+        let endOfTwoMonthsAgo = cal.date(byAdding: DateComponents(day: -1), to: startOfPrevMonth) ?? startOfPrevMonth
+
+        currentSavingsRate = savingsRateResult(from: startOfMonth, to: endOfMonth)
+        previousMonthSavingsRate = savingsRateResult(from: startOfPrevMonth, to: endOfPrevMonth)
+        let twoMonthsAgo = savingsRateResult(from: startOfTwoMonthsAgo, to: endOfTwoMonthsAgo)
+
+        trailingThreeMonthSavingsRate = SavingsRateCalculator.trailingAverage(
+            of: [currentSavingsRate, previousMonthSavingsRate, twoMonthsAgo]
+        )
+        savingsRateTrend = SavingsRateCalculator.trend(
+            current: currentSavingsRate,
+            previous: previousMonthSavingsRate
+        )
     }
 
     /// Formats a monetary amount using the Swift Export formatter module.
@@ -132,11 +243,13 @@ final class DashboardViewModel {
 
         do {
             // Instrumented with os_signpost for Instruments profiling (#903)
-            (accounts, recentTransactions, budgets) = try await PerformanceMonitor.shared.measure("Dashboard Load") {
+            (accounts, recentTransactions, budgets, savingsRateTransactions) = try await PerformanceMonitor.shared.measure("Dashboard Load") {
                 async let a = self.accountRepository.getAccounts()
                 async let t = self.transactionRepository.getRecentTransactions(limit: 5)
                 async let b = self.budgetRepository.getBudgets()
-                return try await (a, t, b)
+                // Broad window powers the savings-rate trend (#2162).
+                async let all = self.transactionRepository.getTransactions()
+                return try await (a, t, b, all)
             }
 
             recomputeAggregations()

--- a/apps/ios/Shared/SavingsRateCalculator.swift
+++ b/apps/ios/Shared/SavingsRateCalculator.swift
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SavingsRateCalculator.swift - FinanceShared - Refs #2162
+//
+// A pure, dependency-free savings-rate calculator for the FIRE-focused
+// dashboard. All money is expressed in integer minor units (e.g. cents) so
+// the math is exact and deterministic — no floating-point currency drift.
+//
+// "Savings rate" is the share of income that was *not* spent in a period:
+//
+//     savingsRate% = (income - spending) / income * 100
+//
+// This type is intentionally free of any UI, KMP bridge, or Foundation date
+// dependencies beyond `Date` (used only by the partial-period helper) so it
+// can be exhaustively unit-tested in isolation.
+
+import Foundation
+
+/// The outcome of a savings-rate computation for a single period.
+///
+/// `percent` is only meaningful when `isDefined` is `true`. When income is
+/// zero or negative the rate is mathematically undefined; callers should show
+/// a neutral placeholder rather than a misleading "0%".
+public struct SavingsRateResult: Sendable, Equatable {
+    /// Savings rate in percentage points (e.g. `65.0` means 65%).
+    ///
+    /// Can be negative when spending exceeds income (dissaving). Equal to `0`
+    /// — and not meaningful — when `isDefined` is `false`.
+    public let percent: Double
+
+    /// Amount kept (or, when negative, overspent) in integer minor units.
+    /// Always `income - spending`, even when the percentage is undefined.
+    public let savedMinorUnits: Int64
+
+    /// Income for the period in integer minor units.
+    public let incomeMinorUnits: Int64
+
+    /// Spending for the period in integer minor units (a positive magnitude).
+    public let spendingMinorUnits: Int64
+
+    /// `true` when income was positive and `percent` is meaningful.
+    public let isDefined: Bool
+
+    public init(
+        percent: Double,
+        savedMinorUnits: Int64,
+        incomeMinorUnits: Int64,
+        spendingMinorUnits: Int64,
+        isDefined: Bool
+    ) {
+        self.percent = percent
+        self.savedMinorUnits = savedMinorUnits
+        self.incomeMinorUnits = incomeMinorUnits
+        self.spendingMinorUnits = spendingMinorUnits
+        self.isDefined = isDefined
+    }
+
+    /// A neutral result used when there is no usable income for the period.
+    public static let undefined = SavingsRateResult(
+        percent: 0,
+        savedMinorUnits: 0,
+        incomeMinorUnits: 0,
+        spendingMinorUnits: 0,
+        isDefined: false
+    )
+}
+
+/// The direction a savings rate has moved between two periods.
+public enum SavingsRateTrend: Sendable, Equatable {
+    /// Savings rate rose by `deltaPoints` percentage points (always > 0).
+    case improving(deltaPoints: Double)
+    /// Savings rate fell by `deltaPoints` percentage points (always > 0).
+    case declining(deltaPoints: Double)
+    /// The change was within the neutral threshold; treated as steady.
+    case flat
+    /// One or both periods lacked the income needed to compute a rate.
+    case notEnoughData
+
+    /// The signed change in percentage points, or `0` for `flat` /
+    /// `notEnoughData`. Positive means improvement.
+    public var signedDeltaPoints: Double {
+        switch self {
+        case let .improving(delta): return delta
+        case let .declining(delta): return -delta
+        case .flat, .notEnoughData: return 0
+        }
+    }
+}
+
+/// Stateless savings-rate math. All members are `static` — there is nothing
+/// to instantiate.
+public enum SavingsRateCalculator {
+    /// Minimum absolute change, in percentage points, for a period-over-period
+    /// movement to count as a real trend rather than noise.
+    public static let trendThresholdPoints: Double = 0.1
+
+    /// Computes the savings rate for a single period from raw income and
+    /// spending in integer minor units.
+    ///
+    /// - Parameters:
+    ///   - incomeMinorUnits: Total income for the period (minor units).
+    ///   - spendingMinorUnits: Total spending for the period as a positive
+    ///     magnitude (minor units).
+    /// - Returns: A `SavingsRateResult`. When `incomeMinorUnits <= 0` the
+    ///   result is flagged `isDefined == false` and `percent == 0`, while
+    ///   `savedMinorUnits` still reflects `income - spending`.
+    ///
+    /// - Note: Because the rate is a *ratio*, computing it on a partial period
+    ///   (e.g. mid-month) yields a value directly comparable to a full period:
+    ///   scaling both income and spending by the same elapsed fraction leaves
+    ///   the ratio unchanged. See ``elapsedFraction(start:end:asOf:)``.
+    public static func savingsRate(
+        incomeMinorUnits: Int64,
+        spendingMinorUnits: Int64
+    ) -> SavingsRateResult {
+        // Saturating subtraction guards against Int64 overflow on absurd input
+        // while staying exact for any realistic monetary value.
+        let saved = incomeMinorUnits.subtractingReportingOverflow(spendingMinorUnits)
+        let savedMinorUnits = saved.overflow
+            ? (spendingMinorUnits > 0 ? Int64.max : Int64.min)
+            : saved.partialValue
+
+        guard incomeMinorUnits > 0 else {
+            return SavingsRateResult(
+                percent: 0,
+                savedMinorUnits: savedMinorUnits,
+                incomeMinorUnits: incomeMinorUnits,
+                spendingMinorUnits: spendingMinorUnits,
+                isDefined: false
+            )
+        }
+
+        let percent = (Double(savedMinorUnits) / Double(incomeMinorUnits)) * 100.0
+        return SavingsRateResult(
+            percent: percent,
+            savedMinorUnits: savedMinorUnits,
+            incomeMinorUnits: incomeMinorUnits,
+            spendingMinorUnits: spendingMinorUnits,
+            isDefined: true
+        )
+    }
+
+    /// Classifies the movement from a `previous` period to a `current` period.
+    ///
+    /// Returns `.notEnoughData` if either result is undefined. Changes smaller
+    /// than ``trendThresholdPoints`` are reported as `.flat`.
+    public static func trend(
+        current: SavingsRateResult,
+        previous: SavingsRateResult
+    ) -> SavingsRateTrend {
+        guard current.isDefined, previous.isDefined else { return .notEnoughData }
+        let delta = current.percent - previous.percent
+        guard abs(delta) >= trendThresholdPoints else { return .flat }
+        return delta > 0 ? .improving(deltaPoints: delta) : .declining(deltaPoints: abs(delta))
+    }
+
+    /// Pools income and spending across multiple periods to produce a single
+    /// trailing savings rate (e.g. trailing-3-month).
+    ///
+    /// Pooling the underlying minor units — rather than averaging each period's
+    /// percentage — weights every period by its income, which is the
+    /// financially correct way to summarise a savings rate across months.
+    /// Undefined periods (no income) are ignored. Returns
+    /// ``SavingsRateResult/undefined`` when there is nothing to pool.
+    public static func trailingAverage(of results: [SavingsRateResult]) -> SavingsRateResult {
+        let defined = results.filter(\.isDefined)
+        guard !defined.isEmpty else { return .undefined }
+
+        let income = defined.reduce(Int64(0)) { $0 + $1.incomeMinorUnits }
+        let spending = defined.reduce(Int64(0)) { $0 + $1.spendingMinorUnits }
+        return savingsRate(incomeMinorUnits: income, spendingMinorUnits: spending)
+    }
+
+    /// The fraction (0...1) of a date interval that has elapsed as of `asOf`.
+    ///
+    /// Useful for callers that want to know how complete the current period is
+    /// before presenting an in-progress savings rate. Clamps to `0...1` and
+    /// returns `0` for non-positive intervals.
+    public static func elapsedFraction(start: Date, end: Date, asOf: Date) -> Double {
+        let total = end.timeIntervalSince(start)
+        guard total > 0 else { return 0 }
+        let elapsed = asOf.timeIntervalSince(start)
+        return min(max(elapsed / total, 0), 1)
+    }
+}

--- a/apps/ios/Tests/SavingsRateCalculatorTests.swift
+++ b/apps/ios/Tests/SavingsRateCalculatorTests.swift
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// SavingsRateCalculatorTests.swift
+// FinanceTests
+//
+// Deterministic unit tests for the pure savings-rate calculator (#2162).
+// Covers the happy path plus the edge cases the FIRE dashboard depends on:
+// zero / negative income, overspending, zero spending, trailing pooling,
+// trend thresholds, and partial-period (elapsed-fraction) handling.
+
+import XCTest
+@testable import FinanceShared
+
+final class SavingsRateCalculatorTests: XCTestCase {
+
+    private let accuracy = 0.0001
+
+    // MARK: - savingsRate: happy path
+
+    func testTypicalFireSavingsRate() {
+        // $10,000 income, $3,500 spending -> 65% saved.
+        let result = SavingsRateCalculator.savingsRate(
+            incomeMinorUnits: 10_000_00,
+            spendingMinorUnits: 3_500_00
+        )
+
+        XCTAssertTrue(result.isDefined)
+        XCTAssertEqual(result.percent, 65.0, accuracy: accuracy)
+        XCTAssertEqual(result.savedMinorUnits, 6_500_00)
+        XCTAssertEqual(result.incomeMinorUnits, 10_000_00)
+        XCTAssertEqual(result.spendingMinorUnits, 3_500_00)
+    }
+
+    func testZeroSpendingIsHundredPercent() {
+        let result = SavingsRateCalculator.savingsRate(
+            incomeMinorUnits: 4_250_00,
+            spendingMinorUnits: 0
+        )
+
+        XCTAssertTrue(result.isDefined)
+        XCTAssertEqual(result.percent, 100.0, accuracy: accuracy)
+        XCTAssertEqual(result.savedMinorUnits, 4_250_00)
+    }
+
+    func testFractionalPercentPrecision() {
+        // 1 minor unit spent out of 3 -> 66.666...% saved.
+        let result = SavingsRateCalculator.savingsRate(
+            incomeMinorUnits: 3,
+            spendingMinorUnits: 1
+        )
+
+        XCTAssertTrue(result.isDefined)
+        XCTAssertEqual(result.percent, 200.0 / 3.0, accuracy: accuracy)
+        XCTAssertEqual(result.savedMinorUnits, 2)
+    }
+
+    // MARK: - savingsRate: edge cases
+
+    func testZeroIncomeIsUndefined() {
+        let result = SavingsRateCalculator.savingsRate(
+            incomeMinorUnits: 0,
+            spendingMinorUnits: 1_200_00
+        )
+
+        XCTAssertFalse(result.isDefined, "Rate must be undefined when there is no income")
+        XCTAssertEqual(result.percent, 0, "Undefined rate reports 0, not a misleading value")
+        XCTAssertEqual(result.savedMinorUnits, -1_200_00, "Saved still reflects income - spending")
+    }
+
+    func testNegativeIncomeIsUndefined() {
+        let result = SavingsRateCalculator.savingsRate(
+            incomeMinorUnits: -500_00,
+            spendingMinorUnits: 100_00
+        )
+
+        XCTAssertFalse(result.isDefined)
+        XCTAssertEqual(result.percent, 0)
+        XCTAssertEqual(result.savedMinorUnits, -600_00)
+    }
+
+    func testOverspendingProducesNegativeRate() {
+        // Spent $1,500 on $1,000 income -> -50% (dissaving).
+        let result = SavingsRateCalculator.savingsRate(
+            incomeMinorUnits: 1_000_00,
+            spendingMinorUnits: 1_500_00
+        )
+
+        XCTAssertTrue(result.isDefined)
+        XCTAssertEqual(result.percent, -50.0, accuracy: accuracy)
+        XCTAssertEqual(result.savedMinorUnits, -500_00)
+    }
+
+    func testBreakEvenIsZeroPercent() {
+        let result = SavingsRateCalculator.savingsRate(
+            incomeMinorUnits: 2_000_00,
+            spendingMinorUnits: 2_000_00
+        )
+
+        XCTAssertTrue(result.isDefined)
+        XCTAssertEqual(result.percent, 0.0, accuracy: accuracy)
+        XCTAssertEqual(result.savedMinorUnits, 0)
+    }
+
+    func testLargeValuesDoNotOverflow() {
+        // ~ $90 billion income, well within Int64, must stay exact.
+        let result = SavingsRateCalculator.savingsRate(
+            incomeMinorUnits: 9_000_000_000_00,
+            spendingMinorUnits: 4_500_000_000_00
+        )
+
+        XCTAssertTrue(result.isDefined)
+        XCTAssertEqual(result.percent, 50.0, accuracy: accuracy)
+        XCTAssertEqual(result.savedMinorUnits, 4_500_000_000_00)
+    }
+
+    func testUndefinedConstant() {
+        let undefined = SavingsRateResult.undefined
+        XCTAssertFalse(undefined.isDefined)
+        XCTAssertEqual(undefined.percent, 0)
+        XCTAssertEqual(undefined.savedMinorUnits, 0)
+    }
+
+    func testExtremeOverflowSaturatesWithoutCrashing() {
+        // Int64.min - 1 overflows; with positive spending the saved amount
+        // saturates to Int64.max rather than trapping.
+        let result = SavingsRateCalculator.savingsRate(incomeMinorUnits: .min, spendingMinorUnits: 1)
+
+        XCTAssertFalse(result.isDefined, "Non-positive income is undefined")
+        XCTAssertEqual(result.savedMinorUnits, .max)
+    }
+
+    // MARK: - trend
+
+    func testTrendImproving() {
+        let previous = SavingsRateCalculator.savingsRate(incomeMinorUnits: 1_000_00, spendingMinorUnits: 600_00) // 40%
+        let current = SavingsRateCalculator.savingsRate(incomeMinorUnits: 1_000_00, spendingMinorUnits: 350_00)  // 65%
+
+        let trend = SavingsRateCalculator.trend(current: current, previous: previous)
+
+        guard case let .improving(delta) = trend else {
+            return XCTFail("Expected improving trend, got \(trend)")
+        }
+        XCTAssertEqual(delta, 25.0, accuracy: accuracy)
+        XCTAssertEqual(trend.signedDeltaPoints, 25.0, accuracy: accuracy)
+    }
+
+    func testTrendDeclining() {
+        let previous = SavingsRateCalculator.savingsRate(incomeMinorUnits: 1_000_00, spendingMinorUnits: 350_00) // 65%
+        let current = SavingsRateCalculator.savingsRate(incomeMinorUnits: 1_000_00, spendingMinorUnits: 600_00)  // 40%
+
+        let trend = SavingsRateCalculator.trend(current: current, previous: previous)
+
+        guard case let .declining(delta) = trend else {
+            return XCTFail("Expected declining trend, got \(trend)")
+        }
+        XCTAssertEqual(delta, 25.0, accuracy: accuracy)
+        XCTAssertEqual(trend.signedDeltaPoints, -25.0, accuracy: accuracy)
+    }
+
+    func testTrendFlatWithinThreshold() {
+        // 0.05 point change is below the 0.1 threshold -> flat.
+        let previous = SavingsRateResult(percent: 65.00, savedMinorUnits: 0, incomeMinorUnits: 100, spendingMinorUnits: 0, isDefined: true)
+        let current = SavingsRateResult(percent: 65.05, savedMinorUnits: 0, incomeMinorUnits: 100, spendingMinorUnits: 0, isDefined: true)
+
+        XCTAssertEqual(SavingsRateCalculator.trend(current: current, previous: previous), .flat)
+    }
+
+    func testTrendNotEnoughDataWhenPreviousUndefined() {
+        let current = SavingsRateCalculator.savingsRate(incomeMinorUnits: 1_000_00, spendingMinorUnits: 350_00)
+        let previous = SavingsRateResult.undefined
+
+        XCTAssertEqual(SavingsRateCalculator.trend(current: current, previous: previous), .notEnoughData)
+        XCTAssertEqual(SavingsRateTrend.notEnoughData.signedDeltaPoints, 0)
+    }
+
+    func testTrendNotEnoughDataWhenCurrentUndefined() {
+        let previous = SavingsRateCalculator.savingsRate(incomeMinorUnits: 1_000_00, spendingMinorUnits: 350_00)
+        let current = SavingsRateResult.undefined
+
+        XCTAssertEqual(SavingsRateCalculator.trend(current: current, previous: previous), .notEnoughData)
+    }
+
+    // MARK: - trailingAverage
+
+    func testTrailingAveragePoolsIncomeAndSpending() {
+        // Three months pooled: income 3000+5000+2000 = 10000, spending 1000+1000+1000 = 3000 -> 70%.
+        let m1 = SavingsRateCalculator.savingsRate(incomeMinorUnits: 3_000_00, spendingMinorUnits: 1_000_00)
+        let m2 = SavingsRateCalculator.savingsRate(incomeMinorUnits: 5_000_00, spendingMinorUnits: 1_000_00)
+        let m3 = SavingsRateCalculator.savingsRate(incomeMinorUnits: 2_000_00, spendingMinorUnits: 1_000_00)
+
+        let pooled = SavingsRateCalculator.trailingAverage(of: [m1, m2, m3])
+
+        XCTAssertTrue(pooled.isDefined)
+        XCTAssertEqual(pooled.percent, 70.0, accuracy: accuracy)
+        XCTAssertEqual(pooled.incomeMinorUnits, 10_000_00)
+        XCTAssertEqual(pooled.spendingMinorUnits, 3_000_00)
+    }
+
+    func testTrailingAverageIgnoresUndefinedPeriods() {
+        let defined = SavingsRateCalculator.savingsRate(incomeMinorUnits: 1_000_00, spendingMinorUnits: 200_00) // 80%
+        let undefined = SavingsRateResult.undefined
+
+        let pooled = SavingsRateCalculator.trailingAverage(of: [undefined, defined, undefined])
+
+        XCTAssertTrue(pooled.isDefined)
+        XCTAssertEqual(pooled.percent, 80.0, accuracy: accuracy)
+    }
+
+    func testTrailingAverageEmptyIsUndefined() {
+        XCTAssertEqual(SavingsRateCalculator.trailingAverage(of: []), .undefined)
+        XCTAssertEqual(
+            SavingsRateCalculator.trailingAverage(of: [.undefined, .undefined]),
+            .undefined
+        )
+    }
+
+    // MARK: - elapsedFraction (partial periods)
+
+    func testElapsedFractionMidway() {
+        let start = Date(timeIntervalSince1970: 0)
+        let end = Date(timeIntervalSince1970: 100)
+        let asOf = Date(timeIntervalSince1970: 50)
+
+        XCTAssertEqual(
+            SavingsRateCalculator.elapsedFraction(start: start, end: end, asOf: asOf),
+            0.5,
+            accuracy: accuracy
+        )
+    }
+
+    func testElapsedFractionClampsBeforeStartAndAfterEnd() {
+        let start = Date(timeIntervalSince1970: 100)
+        let end = Date(timeIntervalSince1970: 200)
+
+        XCTAssertEqual(
+            SavingsRateCalculator.elapsedFraction(start: start, end: end, asOf: Date(timeIntervalSince1970: 50)),
+            0.0,
+            accuracy: accuracy
+        )
+        XCTAssertEqual(
+            SavingsRateCalculator.elapsedFraction(start: start, end: end, asOf: Date(timeIntervalSince1970: 500)),
+            1.0,
+            accuracy: accuracy
+        )
+    }
+
+    func testElapsedFractionZeroDurationIsZero() {
+        let instant = Date(timeIntervalSince1970: 100)
+        XCTAssertEqual(
+            SavingsRateCalculator.elapsedFraction(start: instant, end: instant, asOf: instant),
+            0.0,
+            accuracy: accuracy
+        )
+    }
+
+    func testPartialPeriodRateMatchesFullPeriodRate() {
+        // Scaling income and spending by the same elapsed fraction must not
+        // change the ratio — proving partial-period rates are comparable.
+        let full = SavingsRateCalculator.savingsRate(incomeMinorUnits: 6_000_00, spendingMinorUnits: 2_100_00)
+        let half = SavingsRateCalculator.savingsRate(incomeMinorUnits: 3_000_00, spendingMinorUnits: 1_050_00)
+
+        XCTAssertEqual(full.percent, half.percent, accuracy: accuracy)
+    }
+}

--- a/apps/ios/Tests/SavingsRateDashboardTests.swift
+++ b/apps/ios/Tests/SavingsRateDashboardTests.swift
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// SavingsRateDashboardTests.swift
+// FinanceTests
+//
+// Tests for the savings-rate state the dashboard surfaces (#2162). A fully
+// controlled aggregator is injected so the month-over-month trend is
+// deterministic and independent of the KMP date-filtering behaviour.
+
+import XCTest
+@testable import FinanceApp
+@testable import FinanceShared
+
+/// Aggregator stub whose income/spending are driven by injected closures keyed
+/// on the period start date, giving tests exact control over each month.
+private final class ControlledAggregator: SwiftExportAggregatorModule, @unchecked Sendable {
+    var incomeProvider: (Date) -> Int64 = { _ in 0 }
+    var spendingProvider: (Date) -> Int64 = { _ in 0 }
+
+    func netWorth(accounts: [AccountItem]) -> Int64 { 0 }
+    func totalSpending(transactions: [TransactionItem], from: Date, to: Date) -> Int64 { spendingProvider(from) }
+    func totalIncome(transactions: [TransactionItem], from: Date, to: Date) -> Int64 { incomeProvider(from) }
+    func netCashFlow(transactions: [TransactionItem], from: Date, to: Date) -> Int64 { incomeProvider(from) - spendingProvider(from) }
+    func spendingByCategory(transactions: [TransactionItem], from: Date, to: Date) -> [String: Int64] { [:] }
+    func savingsRate(transactions: [TransactionItem], from: Date, to: Date) -> Double { 0 }
+}
+
+final class SavingsRateDashboardTests: XCTestCase {
+
+    private var startOfMonth: Date {
+        let cal = Calendar.current
+        return cal.date(from: cal.dateComponents([.year, .month], from: .now)) ?? .now
+    }
+
+    @MainActor
+    private func makeVM(aggregator: ControlledAggregator) -> DashboardViewModel {
+        let accountRepo = StubAccountRepository()
+        accountRepo.accountsToReturn = SampleData.allAccounts
+        let txRepo = StubTransactionRepository()
+        txRepo.transactionsToReturn = SampleData.allTransactions
+        let budgetRepo = StubBudgetRepository()
+        budgetRepo.budgetsToReturn = SampleData.allBudgets
+
+        return DashboardViewModel(
+            accountRepository: accountRepo,
+            transactionRepository: txRepo,
+            budgetRepository: budgetRepo,
+            aggregator: aggregator
+        )
+    }
+
+    // MARK: - Current rate
+
+    @MainActor
+    func testCurrentSavingsRateComputedForThisMonth() async {
+        let start = startOfMonth
+        let agg = ControlledAggregator()
+        agg.incomeProvider = { $0 >= start ? 10_000_00 : 8_000_00 }
+        agg.spendingProvider = { $0 >= start ? 3_500_00 : 4_000_00 }
+
+        let vm = makeVM(aggregator: agg)
+        await vm.loadDashboard()
+
+        XCTAssertTrue(vm.currentSavingsRate.isDefined)
+        XCTAssertEqual(vm.currentSavingsRate.percent, 65.0, accuracy: 0.001)
+        XCTAssertEqual(vm.savingsRateDisplay, "65%")
+    }
+
+    @MainActor
+    func testImprovingTrendVsLastMonth() async {
+        let start = startOfMonth
+        let agg = ControlledAggregator()
+        // This month 65%, prior months 50% -> improving by 15 points.
+        agg.incomeProvider = { $0 >= start ? 10_000_00 : 8_000_00 }
+        agg.spendingProvider = { $0 >= start ? 3_500_00 : 4_000_00 }
+
+        let vm = makeVM(aggregator: agg)
+        await vm.loadDashboard()
+
+        guard case let .improving(delta) = vm.savingsRateTrend else {
+            return XCTFail("Expected improving trend, got \(vm.savingsRateTrend)")
+        }
+        XCTAssertEqual(delta, 15.0, accuracy: 0.001)
+        XCTAssertEqual(vm.savingsRateTrendSymbol, "arrow.up.right")
+        XCTAssertTrue(vm.savingsRateTrendText.contains("15.0"))
+    }
+
+    @MainActor
+    func testDecliningTrendVsLastMonth() async {
+        let start = startOfMonth
+        let agg = ControlledAggregator()
+        // This month 50%, prior months 65% -> declining by 15 points.
+        agg.incomeProvider = { $0 >= start ? 8_000_00 : 10_000_00 }
+        agg.spendingProvider = { $0 >= start ? 4_000_00 : 3_500_00 }
+
+        let vm = makeVM(aggregator: agg)
+        await vm.loadDashboard()
+
+        guard case let .declining(delta) = vm.savingsRateTrend else {
+            return XCTFail("Expected declining trend, got \(vm.savingsRateTrend)")
+        }
+        XCTAssertEqual(delta, 15.0, accuracy: 0.001)
+        XCTAssertEqual(vm.savingsRateTrendSymbol, "arrow.down.right")
+    }
+
+    @MainActor
+    func testTrailingThreeMonthIsIncomeWeighted() async {
+        let start = startOfMonth
+        let agg = ControlledAggregator()
+        agg.incomeProvider = { $0 >= start ? 10_000_00 : 8_000_00 }
+        agg.spendingProvider = { $0 >= start ? 3_500_00 : 4_000_00 }
+
+        let vm = makeVM(aggregator: agg)
+        await vm.loadDashboard()
+
+        // Pooled: income 10000+8000+8000 = 26000, spending 3500+4000+4000 = 11500.
+        XCTAssertTrue(vm.trailingThreeMonthSavingsRate.isDefined)
+        XCTAssertEqual(vm.trailingThreeMonthSavingsRate.percent, 14_500.0 / 26_000.0 * 100.0, accuracy: 0.01)
+    }
+
+    // MARK: - Undefined / no income
+
+    @MainActor
+    func testNoIncomeYieldsUndefinedRateAndPlaceholder() async {
+        let agg = ControlledAggregator()
+        agg.incomeProvider = { _ in 0 }
+        agg.spendingProvider = { _ in 1_200_00 }
+
+        let vm = makeVM(aggregator: agg)
+        await vm.loadDashboard()
+
+        XCTAssertFalse(vm.currentSavingsRate.isDefined)
+        XCTAssertEqual(vm.savingsRateDisplay, "—")
+        XCTAssertEqual(vm.savingsRateTrend, .notEnoughData)
+        XCTAssertEqual(vm.savingsRateTrendSymbol, "minus")
+    }
+
+    @MainActor
+    func testDefaultStateBeforeLoadIsUndefined() {
+        let agg = ControlledAggregator()
+        let vm = makeVM(aggregator: agg)
+
+        XCTAssertFalse(vm.currentSavingsRate.isDefined)
+        XCTAssertEqual(vm.savingsRateTrend, .notEnoughData)
+        XCTAssertEqual(vm.savingsRateDisplay, "—")
+    }
+
+    // MARK: - Presentation branches
+
+    @MainActor
+    func testAccessibilityLabelImproving() async {
+        let start = startOfMonth
+        let agg = ControlledAggregator()
+        agg.incomeProvider = { $0 >= start ? 10_000_00 : 8_000_00 }
+        agg.spendingProvider = { $0 >= start ? 3_500_00 : 4_000_00 }
+
+        let vm = makeVM(aggregator: agg)
+        await vm.loadDashboard()
+
+        let label = vm.savingsRateAccessibilityLabel
+        XCTAssertTrue(label.contains("65"))
+        XCTAssertTrue(label.lowercased().contains("up"))
+    }
+
+    @MainActor
+    func testDecliningTextAndAccessibility() async {
+        let start = startOfMonth
+        let agg = ControlledAggregator()
+        agg.incomeProvider = { $0 >= start ? 8_000_00 : 10_000_00 }
+        agg.spendingProvider = { $0 >= start ? 4_000_00 : 3_500_00 }
+
+        let vm = makeVM(aggregator: agg)
+        await vm.loadDashboard()
+
+        XCTAssertTrue(vm.savingsRateTrendText.lowercased().contains("down"))
+        XCTAssertTrue(vm.savingsRateAccessibilityLabel.lowercased().contains("down"))
+    }
+
+    @MainActor
+    func testFlatTrendWhenUnchanged() async {
+        let agg = ControlledAggregator()
+        // Identical income and spending across all months -> flat.
+        agg.incomeProvider = { _ in 6_000_00 }
+        agg.spendingProvider = { _ in 3_000_00 }
+
+        let vm = makeVM(aggregator: agg)
+        await vm.loadDashboard()
+
+        XCTAssertEqual(vm.savingsRateTrend, .flat)
+        XCTAssertEqual(vm.savingsRateTrendSymbol, "arrow.right")
+        XCTAssertTrue(vm.savingsRateTrendText.lowercased().contains("steady"))
+        XCTAssertTrue(vm.savingsRateAccessibilityLabel.lowercased().contains("steady"))
+        XCTAssertEqual(vm.savingsRateDisplay, "50%")
+    }
+
+    @MainActor
+    func testNotEnoughHistoryTextAndAccessibility() async {
+        let start = startOfMonth
+        let agg = ControlledAggregator()
+        // Current month has income; prior months have none -> trend undefined.
+        agg.incomeProvider = { $0 >= start ? 5_000_00 : 0 }
+        agg.spendingProvider = { $0 >= start ? 2_000_00 : 1_000_00 }
+
+        let vm = makeVM(aggregator: agg)
+        await vm.loadDashboard()
+
+        XCTAssertTrue(vm.currentSavingsRate.isDefined)
+        XCTAssertEqual(vm.savingsRateTrend, .notEnoughData)
+        XCTAssertTrue(vm.savingsRateTrendText.lowercased().contains("not enough"))
+        XCTAssertTrue(vm.savingsRateAccessibilityLabel.lowercased().contains("not enough"))
+    }
+
+    @MainActor
+    func testUndefinedAccessibilityLabelIsHelpful() async {
+        let agg = ControlledAggregator()
+        agg.incomeProvider = { _ in 0 }
+        agg.spendingProvider = { _ in 500_00 }
+
+        let vm = makeVM(aggregator: agg)
+        await vm.loadDashboard()
+
+        XCTAssertTrue(vm.savingsRateAccessibilityLabel.lowercased().contains("unavailable"))
+    }
+}


### PR DESCRIPTION
## Summary

Puts **savings rate front-and-center** on the iOS dashboard for FIRE savers (#2162). Previously `DashboardViewModel` computed a savings rate that `DashboardView` never rendered — it was only visible buried in Analytics/Insights.

### What changed
- **Pure calculator** (`apps/ios/Shared/SavingsRateCalculator.swift`): dependency-free, integer-minor-unit savings-rate math. Handles zero/negative income (`isDefined == false`), overspending (negative rate), zero spending (100%), income-weighted trailing-period pooling, a noise-thresholded period-over-period trend, and partial-period elapsed-fraction (ratios are scale-invariant, so mid-month rates are directly comparable). Saturating subtraction guards against `Int64` overflow.
- **Dashboard card** (`DashboardView`): a prominent, tappable Savings Rate card placed directly under Net Worth. Shows the current rate, a compact trend indicator (vs last month) and `This month` context, and links into Analytics for deeper history.
- **ViewModel** (`DashboardViewModel`): computes current / previous-month / trailing-3-month savings rates and the trend from a broader transaction window (the activity feed stays capped at 5). Adds localized display + VoiceOver helpers. The legacy `savingsRate` Double is preserved.

### Accessibility
- Trend direction is conveyed by an SF Symbol **and** text — never colour alone.
- Combined VoiceOver label (`savings_rate_card`) reads rate + trend; an unavailable state gives a helpful prompt.
- All user-facing strings use `String(localized:)`; Dynamic Type throughout.

### Tests
- `SavingsRateCalculatorTests` — exhaustive edge cases (zero/negative income, overspend, break-even, precision, overflow saturation, trend thresholds, trailing pooling, elapsed-fraction clamping).
- `SavingsRateDashboardTests` — deterministic VM behaviour via an injected controlled aggregator (improving/declining/flat/not-enough-data trends, undefined placeholder, all presentation + accessibility branches).

## Needs Human Action
None — no provisioning/signing or device-only steps were introduced. Build & test run on the iOS simulator in CI.

Closes #2162

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>