### PR TITLE
feat(i18n): Spanish localization for Android (#2166)

### DIFF
--- a/apps/android/src/main/res/values-es/strings.xml
+++ b/apps/android/src/main/res/values-es/strings.xml
@@ -352,4 +352,70 @@
     <string name="theme_system">Seguir sistema</string>
     <string name="theme_light">Claro</string>
     <string name="theme_dark">Oscuro</string>
+
+    <!-- Widgets (#381) -->
+    <string name="widget_balance_summary_description">Muestra tu patrimonio neto, los gastos de hoy y el número de cuentas de un vistazo.</string>
+    <string name="widget_quick_transaction_description">Botones rápidos para añadir transacciones de gasto o ingreso.</string>
+    <string name="widget_balance_summary_label">Saldo de la cuenta</string>
+    <string name="widget_quick_transaction_label">Transacción rápida</string>
+    <string name="widget_budget_summary_label">Estado del presupuesto</string>
+    <string name="widget_budget_summary_description">Muestra cómo van tus presupuestos: en buen camino, en alerta y excedidos.</string>
+    <string name="widget_goal_progress_label">Progreso de la meta</string>
+    <string name="widget_goal_progress_description">Muestra el progreso hacia tu meta de ahorro principal.</string>
+    <string name="tile_quick_transaction_label">Añadir transacción</string>
+
+    <!-- Data Import/Export (Sprint 26) -->
+    <string name="import_title">Importar datos</string>
+    <string name="import_select_format">Seleccionar formato</string>
+    <string name="import_choose_file">Elegir archivo</string>
+    <string name="import_map_columns">Asignar columnas</string>
+    <string name="import_start">Iniciar importación</string>
+    <string name="import_complete">Importación completada</string>
+    <string name="export_title">Exportar datos</string>
+    <string name="export_csv">Exportar a CSV</string>
+    <string name="export_pdf">Exportar a PDF</string>
+    <string name="a11y_import_screen">Pantalla de importación de datos</string>
+
+    <!-- Conflict Resolution (Sprint 27) -->
+    <string name="conflicts_title">Conflictos de sincronización</string>
+    <string name="conflicts_keep_local">Conservar local</string>
+    <string name="conflicts_keep_remote">Conservar remoto</string>
+    <string name="conflicts_merge">Combinar</string>
+    <string name="conflicts_none">Sin conflictos de sincronización</string>
+    <string name="conflicts_resolved">Todos los conflictos resueltos</string>
+    <string name="a11y_conflict_screen">Resolución de conflictos de sincronización</string>
+
+    <!-- Cognitive Accessibility (Sprint 28) -->
+    <string name="accessibility_title">Accesibilidad</string>
+    <string name="accessibility_simplified_mode">Modo simplificado</string>
+    <string name="accessibility_large_targets">Áreas táctiles grandes</string>
+    <string name="accessibility_plain_language">Lenguaje sencillo</string>
+    <string name="accessibility_step_by_step">Guías paso a paso</string>
+    <string name="accessibility_reduced_animations">Animaciones reducidas</string>
+    <string name="accessibility_font_scale">Tamaño del texto</string>
+    <string name="a11y_accessibility_prefs">Preferencias de accesibilidad</string>
+
+    <!-- Theme Preferences (Sprint 29) -->
+    <string name="theme_title">Apariencia</string>
+    <string name="theme_mode">Tema</string>
+    <string name="theme_material_you">Material You</string>
+    <string name="theme_accent_color">Color de acento</string>
+    <string name="theme_high_contrast">Alto contraste</string>
+    <string name="theme_font_scale">Tamaño del texto</string>
+    <string name="theme_reset">Restablecer valores predeterminados</string>
+    <string name="a11y_theme_prefs">Preferencias de tema</string>
+
+    <!-- Quick Entry Widget (Sprint 30) -->
+    <string name="widget_quick_entry_label">Entrada rápida de Finance</string>
+    <string name="widget_quick_entry_description">Entrada rápida de gastos con accesos directos por categoría</string>
+    <string name="a11y_quick_entry_widget">Widget de entrada rápida de Finance</string>
+
+    <!-- Platform Parity (Sprint 33) -->
+    <!-- TODO(human): native-speaker review (es-MX/LatAm) — confirm "Faltante"
+         vs "Pendiente"/"Sin traducir" for parity_missing, and neutral tone for
+         the parity labels below. See docs/i18n/localization-guide.md. -->
+    <string name="parity_title">Paridad entre plataformas</string>
+    <string name="parity_complete">Completo</string>
+    <string name="parity_partial">Parcial</string>
+    <string name="parity_missing">Faltante</string>
 </resources>

--- a/config/i18n/README.md
+++ b/config/i18n/README.md
@@ -1,0 +1,52 @@
+# `config/i18n/` — Locale catalog source of truth
+
+This directory holds the canonical, platform-agnostic localization sources that
+feed the per-platform resource files. Localization Engineer owns these files;
+platform agents integrate them into native localization systems.
+
+## Files
+
+| File            | Purpose                                                                                |
+| --------------- | -------------------------------------------------------------------------------------- |
+| `glossary.json` | Financial-terminology glossary. Reviewed translations for money-critical terms.        |
+| `locales.json`  | Supported locales, fallback chain, and CLDR-aligned number/currency/date expectations. |
+
+## How this feeds platform resources
+
+The Android app projects these locales as string resources:
+
+```
+apps/android/src/main/res/values/strings.xml       # en-US (default / source)
+apps/android/src/main/res/values-es/strings.xml     # es
+apps/android/src/main/res/values-fr/strings.xml     # fr
+```
+
+`values/strings.xml` is the **source catalog**. Each localized
+`values-<locale>/strings.xml` must reach 100% key coverage against it for any
+locale marked `enforced: true` in `locales.json`. The shared KMP fallback strings
+live in `packages/core/src/commonMain/kotlin/com/finance/core/i18n/` and are owned
+by @kmp-engineer — coordinate there for the `Strings` expect/actual mechanism; do
+not edit it from here.
+
+> Ownership boundary: Localization Engineer provides the canonical catalog and the
+> Spanish translations. Platform agents wire `stringResource(...)` into Compose and
+> remove hardcoded Kotlin strings (see issue #2166).
+
+## Validation
+
+```powershell
+node scripts/i18n/validate-locale-catalogs.js            # all locales
+node scripts/i18n/validate-locale-catalogs.js --locale es
+```
+
+The validator checks coverage, extra/duplicate keys, and placeholder integrity
+(`%1$s`, `%d`, …) per key. Enforced locales failing any check exit non-zero;
+non-enforced locales are reported as warnings only.
+
+## Terminology rules
+
+- Financial terms MUST match `glossary.json` across every locale.
+- `doNotUse` lists capture false-friend traps (e.g. es "Balance" → use **Saldo**,
+  not "Equilibrio").
+- Currency/number/date formatting follows CLDR via the account's ISO 4217 code —
+  never hardcode symbols or separators.

--- a/config/i18n/glossary.json
+++ b/config/i18n/glossary.json
@@ -1,0 +1,105 @@
+{
+  "description": "Canonical financial-terminology glossary. Source of truth for translated financial terms across every localized surface (Android, iOS, web, shared KMP Strings). A mistranslated financial term is a correctness bug, not polish — keep these consistent across all locales.",
+  "sourceLocale": "en-US",
+  "locales": ["en-US", "es-ES", "fr-FR"],
+  "terms": [
+    {
+      "concept": "Balance",
+      "en-US": "Balance",
+      "es-ES": "Saldo",
+      "fr-FR": "Solde",
+      "notes": "Account balance (money available), not 'equilibrio'.",
+      "doNotUse": { "es-ES": ["Equilibrio", "Balance"] }
+    },
+    {
+      "concept": "Credit",
+      "en-US": "Credit",
+      "es-ES": "Abono",
+      "fr-FR": "Crédit",
+      "notes": "Inflow to an account. Disambiguate from lending (línea de crédito).",
+      "doNotUse": { "es-ES": ["Crédito (cuando significa entrada de dinero)"] }
+    },
+    {
+      "concept": "Debit",
+      "en-US": "Debit",
+      "es-ES": "Cargo",
+      "fr-FR": "Débit",
+      "notes": "Outflow from an account."
+    },
+    {
+      "concept": "Budget",
+      "en-US": "Budget",
+      "es-ES": "Presupuesto",
+      "fr-FR": "Budget",
+      "notes": "Consistent across all surfaces (budgets list, dashboard, widgets)."
+    },
+    {
+      "concept": "Account",
+      "en-US": "Account",
+      "es-ES": "Cuenta",
+      "fr-FR": "Compte"
+    },
+    {
+      "concept": "Transaction",
+      "en-US": "Transaction",
+      "es-ES": "Transacción",
+      "fr-FR": "Transaction"
+    },
+    {
+      "concept": "Expense",
+      "en-US": "Expense",
+      "es-ES": "Gasto",
+      "fr-FR": "Dépense"
+    },
+    {
+      "concept": "Income",
+      "en-US": "Income",
+      "es-ES": "Ingreso",
+      "fr-FR": "Revenu"
+    },
+    {
+      "concept": "Savings goal",
+      "en-US": "Goal",
+      "es-ES": "Meta",
+      "fr-FR": "Objectif",
+      "notes": "Savings goal. Prefer 'Meta de ahorro' where context needs clarity."
+    },
+    {
+      "concept": "Net worth",
+      "en-US": "Net worth",
+      "es-ES": "Patrimonio neto",
+      "fr-FR": "Valeur nette"
+    },
+    {
+      "concept": "Category",
+      "en-US": "Category",
+      "es-ES": "Categoría",
+      "fr-FR": "Catégorie"
+    },
+    {
+      "concept": "Amount",
+      "en-US": "Amount",
+      "es-ES": "Importe",
+      "fr-FR": "Montant",
+      "notes": "Monetary amount. 'Cantidad' is acceptable for non-monetary counts only."
+    },
+    {
+      "concept": "Over budget",
+      "en-US": "Over budget",
+      "es-ES": "Presupuesto excedido",
+      "fr-FR": "Budget dépassé"
+    },
+    {
+      "concept": "Sync",
+      "en-US": "Sync",
+      "es-ES": "Sincronización",
+      "fr-FR": "Synchronisation"
+    },
+    {
+      "concept": "Currency conversion",
+      "en-US": "Currency conversion",
+      "es-ES": "Conversión de divisa",
+      "fr-FR": "Conversion de devise"
+    }
+  ]
+}

--- a/config/i18n/locales.json
+++ b/config/i18n/locales.json
@@ -1,0 +1,65 @@
+{
+  "description": "Locale catalog metadata: supported locales, fallback chain, and CLDR-aligned formatting expectations. The Android string resources under apps/android/src/main/res/values[-<locale>]/strings.xml are the platform projection of these locales; the 'enforced' locales below must reach 100% key coverage against the default catalog (checked by scripts/i18n/validate-locale-catalogs.js).",
+  "sourceLocale": "en-US",
+  "defaultPlatformResource": "apps/android/src/main/res/values/strings.xml",
+  "locales": [
+    {
+      "id": "en-US",
+      "name": "English (United States)",
+      "androidQualifier": "values",
+      "fallback": null,
+      "enforced": true,
+      "rtl": false,
+      "formatting": {
+        "currency": {
+          "iso4217Example": "USD",
+          "pattern": "$1,234.56",
+          "decimalSeparator": ".",
+          "groupSeparator": ",",
+          "symbolPosition": "before"
+        },
+        "number": { "decimalSeparator": ".", "groupSeparator": "," },
+        "date": { "shortPattern": "M/d/yy", "firstDayOfWeek": "sunday" }
+      }
+    },
+    {
+      "id": "es-ES",
+      "name": "Spanish",
+      "androidQualifier": "values-es",
+      "fallback": "en-US",
+      "enforced": true,
+      "rtl": false,
+      "formatting": {
+        "currency": {
+          "iso4217Example": "EUR",
+          "pattern": "1.234,56 €",
+          "decimalSeparator": ",",
+          "groupSeparator": ".",
+          "symbolPosition": "after"
+        },
+        "number": { "decimalSeparator": ",", "groupSeparator": "." },
+        "date": { "shortPattern": "d/M/yy", "firstDayOfWeek": "monday" },
+        "notes": "es-US / es-MX users see USD with es number conventions ($1,234.56 grouping varies by region). Format via CLDR with the account's ISO 4217 currency — never hardcode the symbol or separators."
+      }
+    },
+    {
+      "id": "fr-FR",
+      "name": "French",
+      "androidQualifier": "values-fr",
+      "fallback": "en-US",
+      "enforced": false,
+      "rtl": false,
+      "formatting": {
+        "currency": {
+          "iso4217Example": "EUR",
+          "pattern": "1 234,56 €",
+          "decimalSeparator": ",",
+          "groupSeparator": " ",
+          "symbolPosition": "after"
+        },
+        "number": { "decimalSeparator": ",", "groupSeparator": " " },
+        "date": { "shortPattern": "dd/MM/yyyy", "firstDayOfWeek": "monday" }
+      }
+    }
+  ]
+}

--- a/docs/i18n/localization-guide.md
+++ b/docs/i18n/localization-guide.md
@@ -1,0 +1,58 @@
+# Spanish (es) localization — Android
+
+Tracking issue: [#2166](https://github.com/jrmoulckers/finance/issues/2166) —
+_"As a Spanish-preferred Android user, I need the full app localized instead of
+falling back to English."_
+
+## What this change delivers
+
+- **Complete `es` string catalog.** `apps/android/src/main/res/values-es/strings.xml`
+  now covers **all 361 keys** in the default catalog (was 312 → 49 keys were
+  falling back to English). 0 missing, 0 extra, 0 duplicate keys.
+- **Financial-terminology glossary** (`config/i18n/glossary.json`) as the reviewed
+  source of truth for money-critical terms (Saldo, Presupuesto, Abono/Cargo, …).
+- **Locale metadata** (`config/i18n/locales.json`) capturing the fallback chain and
+  CLDR number/currency/date expectations per locale.
+- **Coverage validator** (`scripts/i18n/validate-locale-catalogs.js`) that flags any
+  missing `es` key, extra/duplicate keys, and placeholder mismatches. `es` is an
+  `enforced` locale, so regressions fail the check.
+
+## Newly translated key groups (the 49 previously English-only)
+
+| Group                    | Keys                                                                                                                                                                                             |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Widgets / tiles          | `widget_balance_summary_*`, `widget_quick_transaction_*`, `widget_budget_summary_*`, `widget_goal_progress_*`, `tile_quick_transaction_label`, `widget_quick_entry_*`, `a11y_quick_entry_widget` |
+| Data import / export     | `import_*`, `export_*`, `a11y_import_screen`                                                                                                                                                     |
+| Sync conflict resolution | `conflicts_*`, `a11y_conflict_screen`                                                                                                                                                            |
+| Cognitive accessibility  | `accessibility_*`, `a11y_accessibility_prefs`                                                                                                                                                    |
+| Theme / appearance       | `theme_*`, `a11y_theme_prefs`                                                                                                                                                                    |
+| Platform parity          | `parity_*`                                                                                                                                                                                       |
+
+Terminology was kept consistent with the existing `es` catalog and the glossary:
+`Saldo` (balance), `Presupuesto` (budget), `Transacción`, `Gasto`/`Ingreso`,
+`Patrimonio neto` (net worth), `Sincronización`.
+
+## Formatting expectations (CLDR)
+
+`es` users get locale-aware number/currency/date formatting driven by the account's
+ISO 4217 currency code (never a hardcoded symbol). See `config/i18n/locales.json`.
+Note `es-US`/`es-MX` users typically transact in USD with regional separators —
+always format with locale **+** currency code, not a fixed pattern.
+
+## Scope boundary
+
+This PR is **i18n-only**: locale catalogs, glossary, docs, and the validator. The
+remaining work in #2166 — replacing hardcoded Kotlin strings with
+`stringResource(...)` in Compose screens — is owned by the Android platform agent.
+The complete `es` catalog and `a11y_*` labels here are the inputs that wiring
+depends on.
+
+## Needs Human Action
+
+- [ ] **Native-speaker review (es-MX/LatAm).** The 49 new translations target a
+      neutral Spanish. A native reviewer should confirm tone and regional fit for
+      the Mexican-immigrant persona in #2166. Items needing review are tagged
+      `// TODO(human)` inline where nuance is debatable.
+- [ ] **French (`fr`) parity.** `fr` is the same 49 keys behind and is currently a
+      non-enforced (warning-only) locale in the validator. Translate and flip
+      `enforced: true` in `config/i18n/locales.json` in a follow-up.

--- a/scripts/i18n/validate-locale-catalogs.js
+++ b/scripts/i18n/validate-locale-catalogs.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+// validate-locale-catalogs.js
+//
+// Validates locale catalogs (Android string resources) against the default
+// (source) catalog and the canonical locale metadata in config/i18n/locales.json.
+//
+// Checks performed per non-default locale:
+//   1. Coverage   — every key in the default catalog has a translation.
+//   2. Extra keys — the locale has no keys absent from the default catalog.
+//   3. Duplicates — no duplicate string names within a locale file.
+//   4. Placeholders — printf/positional placeholders match the default per key
+//      (a mismatched %1$s / %d would crash or corrupt a formatted money string).
+//
+// "enforced" locales (see config/i18n/locales.json) MUST pass all checks or the
+// script exits non-zero (CI gate). Non-enforced locales are reported as
+// informational warnings only.
+//
+// Usage:
+//   node scripts/i18n/validate-locale-catalogs.js            # all locales
+//   node scripts/i18n/validate-locale-catalogs.js --locale es
+//
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const metaPath = path.join(repoRoot, 'config', 'i18n', 'locales.json');
+
+function fail(msg) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(2);
+}
+
+if (!fs.existsSync(metaPath)) {
+  fail(`Missing locale metadata: ${metaPath}`);
+}
+
+const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+const defaultResource = path.join(repoRoot, meta.defaultPlatformResource);
+
+// Parse <string name="...">value</string> entries. Returns ordered array of
+// { name, value } so duplicate names are detectable.
+function parseStrings(file) {
+  const xml = fs.readFileSync(file, 'utf8');
+  const re = /<string\s+name="([^"]+)"[^>]*>([\s\S]*?)<\/string>/g;
+  const entries = [];
+  let m;
+  while ((m = re.exec(xml)) !== null) {
+    entries.push({ name: m[1], value: m[2] });
+  }
+  return entries;
+}
+
+// Extract a sorted multiset signature of printf/positional placeholders.
+function placeholders(value) {
+  const found = value.match(/%(?:\d+\$)?[-+ 0,(]*\d*(?:\.\d+)?[a-zA-Z]/g) || [];
+  return found.slice().sort();
+}
+
+function toMap(entries) {
+  const map = new Map();
+  for (const e of entries) {
+    if (!map.has(e.name)) map.set(e.name, e.value);
+  }
+  return map;
+}
+
+function findDuplicates(entries) {
+  const seen = new Set();
+  const dups = new Set();
+  for (const e of entries) {
+    if (seen.has(e.name)) dups.add(e.name);
+    seen.add(e.name);
+  }
+  return [...dups];
+}
+
+const localeFilter = (() => {
+  const i = process.argv.indexOf('--locale');
+  return i !== -1 ? process.argv[i + 1] : null;
+})();
+
+if (!fs.existsSync(defaultResource)) {
+  fail(`Missing default catalog: ${defaultResource}`);
+}
+
+const defaultEntries = parseStrings(defaultResource);
+const defaultMap = toMap(defaultEntries);
+const defaultKeys = [...defaultMap.keys()];
+
+console.log(`Default catalog: ${meta.defaultPlatformResource} (${defaultKeys.length} keys)`);
+
+let hardFailures = 0;
+let softWarnings = 0;
+
+for (const locale of meta.locales) {
+  if (locale.androidQualifier === 'values') continue; // default
+  const shortId = locale.id.split('-')[0];
+  if (localeFilter && localeFilter !== shortId && localeFilter !== locale.id) continue;
+
+  const file = path.join(
+    repoRoot,
+    'apps',
+    'android',
+    'src',
+    'main',
+    'res',
+    locale.androidQualifier,
+    'strings.xml',
+  );
+  const label = `${locale.id} (${locale.androidQualifier})${locale.enforced ? ' [enforced]' : ''}`;
+
+  if (!fs.existsSync(file)) {
+    const line = `  ${label}: catalog file not found at ${path.relative(repoRoot, file)}`;
+    if (locale.enforced) {
+      console.error(`FAIL${line}`);
+      hardFailures++;
+    } else {
+      console.warn(`WARN${line}`);
+      softWarnings++;
+    }
+    continue;
+  }
+
+  const entries = parseStrings(file);
+  const map = toMap(entries);
+
+  const missing = defaultKeys.filter((k) => !map.has(k));
+  const extra = [...map.keys()].filter((k) => !defaultMap.has(k));
+  const dups = findDuplicates(entries);
+  const placeholderMismatch = [];
+  for (const k of defaultKeys) {
+    if (!map.has(k)) continue;
+    const a = placeholders(defaultMap.get(k)).join('|');
+    const b = placeholders(map.get(k)).join('|');
+    if (a !== b) placeholderMismatch.push(`${k} (default:[${a}] vs ${shortId}:[${b}])`);
+  }
+
+  const problems = [];
+  if (missing.length) problems.push(`${missing.length} missing key(s)`);
+  if (extra.length) problems.push(`${extra.length} extra key(s)`);
+  if (dups.length) problems.push(`${dups.length} duplicate key(s)`);
+  if (placeholderMismatch.length)
+    problems.push(`${placeholderMismatch.length} placeholder mismatch(es)`);
+
+  const coverage = (((defaultKeys.length - missing.length) / defaultKeys.length) * 100).toFixed(1);
+
+  if (problems.length === 0) {
+    console.log(`  ${label}: OK — ${map.size} keys, 100.0% coverage`);
+    continue;
+  }
+
+  const detail = [
+    `  ${label}: ${coverage}% coverage — ${problems.join(', ')}`,
+    missing.length ? `      missing: ${missing.join(', ')}` : null,
+    extra.length ? `      extra: ${extra.join(', ')}` : null,
+    dups.length ? `      duplicate: ${dups.join(', ')}` : null,
+    placeholderMismatch.length ? `      placeholders: ${placeholderMismatch.join('; ')}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  if (locale.enforced) {
+    console.error(`FAIL\n${detail}`);
+    hardFailures++;
+  } else {
+    console.warn(`WARN (non-enforced)\n${detail}`);
+    softWarnings++;
+  }
+}
+
+console.log('');
+if (hardFailures > 0) {
+  console.error(
+    `Locale catalog validation FAILED: ${hardFailures} enforced locale(s) with problems.`,
+  );
+  process.exit(1);
+}
+console.log(
+  `Locale catalog validation passed.${softWarnings ? ` (${softWarnings} non-enforced warning(s))` : ''}`,
+);


### PR DESCRIPTION
## Summary
Completes the Spanish (es) locale catalog for Android so Spanish-preferred users no longer fall back to English. Adds the 49 previously English-only keys (312 -> 361, 100% coverage), establishes the canonical i18n source-of-truth (glossary + locale metadata), and adds a coverage validator.

## Changes (i18n-only)
- `apps/android/src/main/res/values-es/strings.xml` — +49 keys: widgets/tiles, import/export, sync conflicts, accessibility, theme, platform parity. 0 missing / 0 extra / 0 duplicate vs default catalog.
- `config/i18n/glossary.json` — financial-terminology glossary (Saldo, Presupuesto, Abono/Cargo, ...) with false-friend `doNotUse` guards.
- `config/i18n/locales.json` — supported locales, fallback chain, CLDR number/currency/date expectations.
- `config/i18n/README.md` + `docs/i18n/localization-guide.md` — catalog docs + Needs Human Action notes.
- `scripts/i18n/validate-locale-catalogs.js` — coverage + placeholder-integrity validator; `es` is enforced (CI-gating), `fr` informational.

## Verification
- `node scripts/i18n/validate-locale-catalogs.js` -> es 100% (pass), fr informational, exit 0.
- prettier + eslint clean on all new files.

## Scope boundary
i18n catalogs/glossary/docs only. Replacing hardcoded Kotlin strings with `stringResource(...)` in Compose is owned by the Android platform agent; this PR supplies the complete catalog + a11y labels that wiring depends on. `fr` parity is a documented follow-up.

Closes #2166

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>