### PR TITLE
feat(android): quick cash entry (#2180)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -27,6 +27,7 @@ import com.finance.android.receipt.ReceiptImageRetentionStore
 import com.finance.android.receipt.ReceiptTextRecognizer
 import com.finance.android.receipt.UnavailableReceiptImageCapture
 import com.finance.android.ui.receipt.ReceiptScanViewModel
+import com.finance.android.ui.quickcash.QuickCashEntryViewModel
 import com.finance.android.notifications.NotificationContentBuilder
 import com.finance.android.notifications.NotificationDispatcher
 import com.finance.android.notifications.NotificationPreferences
@@ -225,6 +226,18 @@ val appModule = module {
 
     /** On-device receipt scanning to transaction draft (#2388). */
     viewModelOf(::ReceiptScanViewModel)
+
+    /** True quick cash entry — 1–2 tap cash expense capture (#2180). */
+    // Explicit definition so the default system Clock is used (not resolved from DI).
+    viewModel {
+        QuickCashEntryViewModel(
+            householdIdProvider = get(),
+            transactionRepository = get(),
+            accountRepository = get(),
+            categoryRepository = get(),
+            prefs = get(),
+        )
+    }
 
     // ── Tips ─────────────────────────────────────────────────────────
     viewModelOf(::TipsViewModel)

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickcash/QuickCashEntry.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickcash/QuickCashEntry.kt
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickcash
+
+import com.finance.models.Account
+import com.finance.models.AccountType
+import com.finance.models.Category
+import com.finance.models.Transaction
+import com.finance.models.TransactionStatus
+import com.finance.models.TransactionType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+
+/**
+ * Deterministic, framework-free logic for the **true quick cash entry** flow (#2180).
+ *
+ * A cash-first user must be able to log a small expense in 1–2 taps: type an amount and
+ * (optionally) pick a category/note, with the account defaulting to a cash wallet. All of
+ * the rules that decide *what gets saved* live here as pure functions so they can be
+ * exhaustively unit-tested on the JVM without Android, Compose, or Koin.
+ *
+ * Nothing in this file performs I/O or touches Android APIs — the ViewModel wires these
+ * pure helpers to repositories and the Compose surface.
+ */
+object QuickCashEntry {
+
+    /**
+     * Upper sanity bound for a single quick cash entry: `$1,000,000.00`.
+     *
+     * Quick entry is meant for small, fast purchases. Anything above this is almost
+     * certainly a typo (or grouping-separator confusion) and is rejected so the user
+     * does not silently record a wildly wrong amount.
+     */
+    const val MAX_AMOUNT_CENTS: Long = 1_000_000_00L
+
+    /** Maximum length of the optional note, mirroring the full transaction wizard. */
+    const val MAX_NOTE_LENGTH: Int = 1000
+
+    /** Tag applied to transactions created via quick cash entry, for later analytics. */
+    const val QUICK_CASH_TAG = "quick-cash"
+
+    /**
+     * Parses free-form amount input into integer cents, deterministically.
+     *
+     * Designed for fast numpad entry, so a **single** separator is always treated as the
+     * decimal point. This keeps the common case predictable and locale-tolerant for `es`
+     * users who type a comma decimal (`12,50`):
+     * - All characters except digits, `.` and `,` are stripped (currency symbols, spaces,
+     *   letters).
+     * - When **both** separators appear (e.g. a pasted, grouped number) the one that
+     *   occurs **last** is the decimal separator and the other is treated as grouping and
+     *   removed: `1.234,56` (es) and `1,234.56` (en) both parse to `123456`.
+     * - When **one** separator appears it is the decimal separator: `12.999` → `1299`,
+     *   `1234,56` → `123456`.
+     * - The fractional part is truncated to two digits.
+     *
+     * Overflowing or empty/garbage input yields a value that fails [validate]
+     * (`0` for empty, [Long.MAX_VALUE] for overflow), so the UI can surface a clear error
+     * rather than crashing or silently wrapping.
+     *
+     * @param raw the user-entered text.
+     * @return the amount as a non-negative number of cents.
+     */
+    fun parseAmountToCents(raw: String): Long {
+        val filtered = raw.filter { it.isDigit() || it == '.' || it == ',' }
+        if (filtered.isEmpty()) return 0L
+
+        val hasDot = filtered.contains('.')
+        val hasComma = filtered.contains(',')
+
+        val normalized: String = when {
+            hasDot && hasComma -> {
+                val decimalSep = if (filtered.lastIndexOf('.') > filtered.lastIndexOf(',')) '.' else ','
+                val grouping = if (decimalSep == '.') ',' else '.'
+                filtered.replace(grouping.toString(), "").replace(decimalSep, '.')
+            }
+
+            // A single comma is the decimal separator (es-style input).
+            hasComma -> filtered.replace(',', '.')
+
+            // A single (or no) dot is already the decimal separator.
+            else -> filtered
+        }
+
+        val dotParts = normalized.split('.')
+        val wholeStr: String
+        val fracStr: String
+        if (dotParts.size == 1) {
+            wholeStr = dotParts[0]
+            fracStr = "00"
+        } else {
+            wholeStr = dotParts.dropLast(1).joinToString("")
+            fracStr = dotParts.last().take(2).padEnd(2, '0')
+        }
+
+        val whole = wholeStr.ifEmpty { "0" }.toLongOrNull()
+        val frac = fracStr.ifEmpty { "0" }.toLongOrNull() ?: 0L
+        // Clamp overflow to MAX (so validation rejects it) instead of throwing.
+        return when {
+            whole == null -> Long.MAX_VALUE
+            whole > (Long.MAX_VALUE - frac) / 100L -> Long.MAX_VALUE
+            else -> whole * 100L + frac
+        }
+    }
+
+    /**
+     * Picks the cash wallet that a quick entry should default to.
+     *
+     * Preference order: the user's explicitly chosen [preferredAccountId] (if it still
+     * exists and is usable) → the lowest-sorted [AccountType.CASH] account → the
+     * lowest-sorted remaining account. Archived and deleted accounts are never chosen.
+     *
+     * @return the default account, or `null` when the household has no usable account.
+     */
+    fun selectDefaultCashAccount(
+        accounts: List<Account>,
+        preferredAccountId: SyncId? = null,
+    ): Account? {
+        val usable = accounts.filter { it.deletedAt == null && !it.isArchived }
+        preferredAccountId?.let { pid ->
+            usable.find { it.id == pid }?.let { return it }
+        }
+        return usable.filter { it.type == AccountType.CASH }.minByOrNull { it.sortOrder }
+            ?: usable.minByOrNull { it.sortOrder }
+    }
+
+    /**
+     * Picks the expense category a quick entry should default to. Income categories are
+     * excluded because quick cash entry only records expenses. Category is optional, so
+     * this may legitimately return `null`.
+     *
+     * Preference order: the user's [preferredCategoryId] (if still valid) → the
+     * lowest-sorted expense category.
+     */
+    fun selectDefaultCategory(
+        categories: List<Category>,
+        preferredCategoryId: SyncId? = null,
+    ): Category? {
+        val usable = categories.filter { it.deletedAt == null && !it.isIncome }
+        preferredCategoryId?.let { pid ->
+            usable.find { it.id == pid }?.let { return it }
+        }
+        return usable.minByOrNull { it.sortOrder }
+    }
+
+    /**
+     * Validates a [QuickCashDraft], returning every failed rule (empty when valid).
+     * Returning a list keeps validation deterministic and lets the UI show all problems
+     * at once rather than one-at-a-time.
+     */
+    fun validate(draft: QuickCashDraft): List<QuickCashError> = buildList {
+        if (draft.amountCents <= 0L) add(QuickCashError.INVALID_AMOUNT)
+        if (draft.amountCents > MAX_AMOUNT_CENTS) add(QuickCashError.AMOUNT_TOO_LARGE)
+        if (draft.accountId == null) add(QuickCashError.NO_ACCOUNT)
+        if (draft.note.length > MAX_NOTE_LENGTH) add(QuickCashError.NOTE_TOO_LONG)
+    }
+
+    /**
+     * Builds the [Transaction] to persist from a *validated* [draft]. Quick cash entries
+     * are always cleared expenses, so the amount is stored as negative cents and the
+     * payee is left null (cash purchases rarely have a meaningful payee).
+     *
+     * @throws IllegalArgumentException if [draft] is not valid — callers must call
+     *   [validate] first.
+     */
+    fun buildTransaction(
+        draft: QuickCashDraft,
+        householdId: SyncId,
+        date: LocalDate,
+        now: Instant,
+        idSuffix: Long = now.toEpochMilliseconds(),
+    ): Transaction {
+        require(validate(draft).isEmpty()) { "Cannot build a transaction from an invalid draft" }
+        val accountId = requireNotNull(draft.accountId) { "Account is required" }
+        return Transaction(
+            id = SyncId("txn-cash-$idSuffix"),
+            householdId = householdId,
+            ownerId = householdId,
+            accountId = accountId,
+            categoryId = draft.categoryId,
+            type = TransactionType.EXPENSE,
+            status = TransactionStatus.CLEARED,
+            amount = Cents(-draft.amountCents),
+            currency = draft.currency,
+            payee = null,
+            note = draft.note.trim().ifBlank { null },
+            date = date,
+            tags = listOf(QUICK_CASH_TAG),
+            createdAt = now,
+            updatedAt = now,
+            isSynced = false,
+        )
+    }
+}
+
+/**
+ * Immutable snapshot of everything needed to persist a quick cash expense.
+ *
+ * @property amountCents amount in positive cents (sign is applied at build time).
+ * @property note optional free-form note.
+ * @property categoryId optional expense category.
+ * @property accountId the cash wallet/account to record against; `null` is invalid.
+ * @property currency the account currency (defaults to USD).
+ */
+data class QuickCashDraft(
+    val amountCents: Long = 0L,
+    val note: String = "",
+    val categoryId: SyncId? = null,
+    val accountId: SyncId? = null,
+    val currency: Currency = Currency.USD,
+)
+
+/** Deterministic validation failures for a [QuickCashDraft]. */
+enum class QuickCashError {
+    /** Amount is zero or unparseable. */
+    INVALID_AMOUNT,
+
+    /** Amount exceeds [QuickCashEntry.MAX_AMOUNT_CENTS]. */
+    AMOUNT_TOO_LARGE,
+
+    /** No cash account is available/selected to record against. */
+    NO_ACCOUNT,
+
+    /** Note exceeds [QuickCashEntry.MAX_NOTE_LENGTH]. */
+    NOTE_TOO_LONG,
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickcash/QuickCashEntrySheet.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickcash/QuickCashEntrySheet.kt
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickcash
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Payments
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Minimum touch target per Material accessibility guidance. Quick entry is used on the go,
+ * so every interactive element stays at least this tall/wide for reliable tapping and
+ * Switch Access traversal.
+ */
+private val MinTouchTarget = 48.dp
+
+/**
+ * Modal bottom sheet for **true quick cash entry** (#2180).
+ *
+ * Presents the fastest possible path to record a cash expense: amount field, optional
+ * one-tap category chips, optional note, and a single Save button. The account defaults to
+ * the user's cash wallet (resolved in [QuickCashEntryViewModel]). On save the sheet
+ * dismisses and reports back via [onSaved].
+ *
+ * Localization note: user-facing copy is currently English literals. Extracting these into
+ * localized string resources is owned by the in-flight i18n work — see the matching
+ * `// TODO(human)` markers and the PR "Needs Human Action" section.
+ *
+ * @param onDismiss invoked when the user dismisses the sheet without saving.
+ * @param onSaved invoked after a successful save (the entry has been persisted).
+ * @param viewModel injected quick cash entry ViewModel.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun QuickCashEntrySheet(
+    onDismiss: () -> Unit,
+    onSaved: () -> Unit,
+    viewModel: QuickCashEntryViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    // Dismiss the sheet once the entry has been saved.
+    LaunchedEffect(state.isSaved) {
+        if (state.isSaved) onSaved()
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        QuickCashEntryContent(
+            state = state,
+            onAmountChange = viewModel::updateAmount,
+            onNoteChange = viewModel::updateNote,
+            onSelectCategory = viewModel::selectCategory,
+            onSelectAccount = viewModel::selectAccount,
+            onSave = viewModel::save,
+        )
+    }
+}
+
+/**
+ * Stateless content of the quick cash entry sheet. Hoisted out of [QuickCashEntrySheet] so
+ * it can be previewed and snapshot-tested without Koin or a live ViewModel.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun QuickCashEntryContent(
+    state: QuickCashUiState,
+    onAmountChange: (String) -> Unit,
+    onNoteChange: (String) -> Unit,
+    onSelectCategory: (com.finance.models.types.SyncId?) -> Unit,
+    onSelectAccount: (com.finance.models.types.SyncId) -> Unit,
+    onSave: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .imePadding()
+            .navigationBarsPadding()
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = "Quick cash expense",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics { heading() },
+        )
+
+        // ── Amount ───────────────────────────────────────────────────────
+        OutlinedTextField(
+            value = state.amountText,
+            onValueChange = onAmountChange,
+            label = { Text("Amount") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+            supportingText = {
+                if (state.formattedAmount.isNotEmpty()) {
+                    Text(state.formattedAmount)
+                }
+            },
+            isError = state.errors.any {
+                it == QuickCashError.INVALID_AMOUNT || it == QuickCashError.AMOUNT_TOO_LARGE
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = MinTouchTarget)
+                .semantics {
+                    contentDescription = "Cash expense amount in dollars"
+                },
+        )
+
+        // ── Account (cash-first) ─────────────────────────────────────────
+        QuickCashChipRow(
+            title = "Account",
+            items = state.cashAccounts.map { it.id to it.name },
+            selectedId = state.selectedAccountId,
+            selectedSemanticsSuffix = "selected account",
+            onClick = onSelectAccount,
+        )
+
+        // ── Category (optional) ──────────────────────────────────────────
+        QuickCashChipRow(
+            title = "Category (optional)",
+            items = state.categories.map { it.id to it.name },
+            selectedId = state.selectedCategoryId,
+            selectedSemanticsSuffix = "selected category",
+            onClick = onSelectCategory,
+        )
+
+        // ── Note (optional) ──────────────────────────────────────────────
+        OutlinedTextField(
+            value = state.note,
+            onValueChange = onNoteChange,
+            label = { Text("Note (optional)") },
+            singleLine = true,
+            isError = state.errors.contains(QuickCashError.NOTE_TOO_LONG),
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = MinTouchTarget)
+                .semantics { contentDescription = "Optional note for this cash expense" },
+        )
+
+        // ── Errors (announced for TalkBack) ──────────────────────────────
+        val errorText = state.errors.joinToString("\n", transform = ::errorMessage)
+        if (errorText.isNotEmpty()) {
+            Text(
+                text = errorText,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+            )
+        }
+
+        // ── Save ─────────────────────────────────────────────────────────
+        Button(
+            onClick = onSave,
+            enabled = state.canSave,
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = MinTouchTarget)
+                .semantics { contentDescription = "Save cash expense" },
+        ) {
+            Icon(Icons.Filled.Payments, contentDescription = null)
+            Spacer(Modifier.padding(horizontal = 4.dp))
+            Text("Save cash expense")
+        }
+    }
+}
+
+/**
+ * A titled, wrapping row of single-select [FilterChip]s with large touch targets and
+ * TalkBack-friendly semantics. Renders nothing when [items] is empty.
+ *
+ * @param items list of `(id, displayName)` pairs.
+ * @param selectedId the currently selected id, if any.
+ * @param selectedSemanticsSuffix appended to the selected chip's content description.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun QuickCashChipRow(
+    title: String,
+    items: List<Pair<com.finance.models.types.SyncId, String>>,
+    selectedId: com.finance.models.types.SyncId?,
+    selectedSemanticsSuffix: String,
+    onClick: (com.finance.models.types.SyncId) -> Unit,
+) {
+    if (items.isEmpty()) return
+    Text(
+        text = title,
+        style = MaterialTheme.typography.labelLarge,
+        modifier = Modifier.semantics { heading() },
+    )
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        items.forEach { (id, name) ->
+            val selected = id == selectedId
+            FilterChip(
+                selected = selected,
+                onClick = { onClick(id) },
+                label = { Text(name) },
+                leadingIcon = if (selected) {
+                    { Icon(Icons.Filled.Check, contentDescription = null) }
+                } else {
+                    null
+                },
+                modifier = Modifier
+                    .sizeIn(minHeight = MinTouchTarget)
+                    .semantics {
+                        contentDescription = if (selected) "$name, $selectedSemanticsSuffix" else name
+                    },
+            )
+        }
+    }
+}
+
+/**
+ * Maps a [QuickCashError] to a user-facing message.
+ *
+ * TODO(human): Replace these English literals with localized string resources (es-ES, etc.)
+ * once the i18n resource keys are finalized by the localization work in flight (#2166).
+ */
+private fun errorMessage(error: QuickCashError): String = when (error) {
+    QuickCashError.INVALID_AMOUNT -> "Enter an amount greater than zero"
+    QuickCashError.AMOUNT_TOO_LARGE -> "That amount looks too large for quick entry"
+    QuickCashError.NO_ACCOUNT -> "Add a cash account to record this expense"
+    QuickCashError.NOTE_TOO_LONG -> "Note is too long"
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Preview(showBackground = true)
+@Composable
+private fun QuickCashEntryContentPreview() {
+    FinanceTheme {
+        QuickCashEntryContent(
+            state = QuickCashUiState(
+                amountText = "12.50",
+                formattedAmount = "$12.50",
+            ),
+            onAmountChange = {},
+            onNoteChange = {},
+            onSelectCategory = {},
+            onSelectAccount = {},
+            onSave = {},
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickcash/QuickCashEntryViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickcash/QuickCashEntryViewModel.kt
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickcash
+
+import android.content.SharedPreferences
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.AccountRepository
+import com.finance.android.data.repository.CategoryRepository
+import com.finance.android.data.repository.TransactionRepository
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.models.Account
+import com.finance.models.Category
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import timber.log.Timber
+
+/**
+ * Immutable UI state for the quick cash entry surface.
+ *
+ * @property amountText the raw text shown in the amount field.
+ * @property formattedAmount the parsed amount rendered with the account currency.
+ * @property note optional note text.
+ * @property cashAccounts cash-first list of accounts the user can record against.
+ * @property selectedAccountId the account the entry will be saved to.
+ * @property selectedAccountName display name of [selectedAccountId].
+ * @property categories optional expense categories (income excluded).
+ * @property selectedCategoryId optional chosen category.
+ * @property errors deterministic validation failures, surfaced for accessibility.
+ * @property isSaving true while the insert is in flight.
+ * @property isSaved true once the entry has been persisted (UI dismisses on this).
+ */
+data class QuickCashUiState(
+    val amountText: String = "",
+    val formattedAmount: String = "",
+    val note: String = "",
+    val cashAccounts: List<Account> = emptyList(),
+    val selectedAccountId: SyncId? = null,
+    val selectedAccountName: String = "",
+    val categories: List<Category> = emptyList(),
+    val selectedCategoryId: SyncId? = null,
+    val errors: List<QuickCashError> = emptyList(),
+    val isSaving: Boolean = false,
+    val isSaved: Boolean = false,
+) {
+    /** True when the current input is savable — drives the Save button enabled state. */
+    val canSave: Boolean
+        get() = !isSaving && selectedAccountId != null && amountText.isNotBlank()
+}
+
+/**
+ * ViewModel for **true quick cash entry** (#2180).
+ *
+ * Unlike [com.finance.android.ui.viewmodel.TransactionCreateViewModel] (a 3-step wizard),
+ * this drives a single, low-friction surface: the amount defaults to focus, the account
+ * defaults to the user's cash wallet, and [save] persists the expense in one tap. All
+ * decision logic is delegated to [QuickCashEntry] so it stays deterministic and unit
+ * tested; this class only wires those helpers to repositories and reactive state.
+ *
+ * @param householdIdProvider provides the authenticated household scope.
+ * @param transactionRepository persistence target for the new expense.
+ * @param accountRepository source of the cash-first account list.
+ * @param categoryRepository source of optional expense categories.
+ * @param prefs optional store for the user's remembered default account/category.
+ * @param clock injectable clock; defaults to the system clock for production.
+ */
+class QuickCashEntryViewModel(
+    private val householdIdProvider: HouseholdIdProvider,
+    private val transactionRepository: TransactionRepository,
+    private val accountRepository: AccountRepository,
+    private val categoryRepository: CategoryRepository,
+    private val prefs: SharedPreferences? = null,
+    private val clock: Clock = Clock.System,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(QuickCashUiState())
+    val uiState: StateFlow<QuickCashUiState> = _uiState.asStateFlow()
+
+    private var accountMap: Map<SyncId, Account> = emptyMap()
+    private var categoryMap: Map<SyncId, Category> = emptyMap()
+
+    init {
+        viewModelScope.launch {
+            val householdId = householdIdProvider.householdId.value ?: run {
+                Timber.w("No household ID available — skipping quick cash entry init")
+                return@launch
+            }
+            val accounts = accountRepository.observeAll(householdId).first()
+            val categories = categoryRepository.observeAll(householdId).first()
+            accountMap = accounts.associateBy { it.id }
+            categoryMap = categories.associateBy { it.id }
+
+            val preferredAccountId = prefs?.getString(PREF_DEFAULT_ACCOUNT, null)?.let(::SyncId)
+            val preferredCategoryId = prefs?.getString(PREF_DEFAULT_CATEGORY, null)?.let(::SyncId)
+            val defaultAccount = QuickCashEntry.selectDefaultCashAccount(accounts, preferredAccountId)
+            val defaultCategory = QuickCashEntry.selectDefaultCategory(categories, preferredCategoryId)
+            val cashFirst = accounts
+                .filter { it.deletedAt == null && !it.isArchived }
+                .sortedWith(compareByDescending<Account> { it.type == com.finance.models.AccountType.CASH }
+                    .thenBy { it.sortOrder })
+
+            _uiState.update {
+                it.copy(
+                    cashAccounts = cashFirst,
+                    selectedAccountId = defaultAccount?.id,
+                    selectedAccountName = defaultAccount?.name.orEmpty(),
+                    categories = categories.filter { c -> c.deletedAt == null && !c.isIncome },
+                    selectedCategoryId = defaultCategory?.id,
+                )
+            }
+        }
+    }
+
+    /** Updates the amount text and recomputes the formatted preview. */
+    fun updateAmount(text: String) {
+        val cents = QuickCashEntry.parseAmountToCents(text)
+        val currency = currentCurrency()
+        _uiState.update {
+            it.copy(
+                amountText = text,
+                formattedAmount = if (cents in 1..QuickCashEntry.MAX_AMOUNT_CENTS) {
+                    CurrencyFormatter.format(Cents(cents), currency)
+                } else {
+                    ""
+                },
+                errors = emptyList(),
+            )
+        }
+    }
+
+    /** Updates the optional note. */
+    fun updateNote(note: String) {
+        _uiState.update { it.copy(note = note, errors = emptyList()) }
+    }
+
+    /** Selects the cash account the entry will be recorded against. */
+    fun selectAccount(id: SyncId) {
+        _uiState.update {
+            it.copy(
+                selectedAccountId = id,
+                selectedAccountName = accountMap[id]?.name.orEmpty(),
+                errors = emptyList(),
+            )
+        }
+        // Recompute formatted amount in case the account currency changed.
+        updateAmount(_uiState.value.amountText)
+    }
+
+    /** Toggles the optional category. Selecting the active category clears it. */
+    fun selectCategory(id: SyncId?) {
+        _uiState.update { current ->
+            current.copy(
+                selectedCategoryId = if (id != null && current.selectedCategoryId == id) null else id,
+                errors = emptyList(),
+            )
+        }
+    }
+
+    /** Builds a [QuickCashDraft] from the current state. */
+    private fun draft(): QuickCashDraft = with(_uiState.value) {
+        QuickCashDraft(
+            amountCents = QuickCashEntry.parseAmountToCents(amountText),
+            note = note,
+            categoryId = selectedCategoryId,
+            accountId = selectedAccountId,
+            currency = currentCurrency(),
+        )
+    }
+
+    /**
+     * Validates and persists the quick cash expense. On success, remembers the chosen
+     * account/category as defaults for next time and sets [QuickCashUiState.isSaved].
+     */
+    fun save() {
+        val draft = draft()
+        val errors = QuickCashEntry.validate(draft)
+        if (errors.isNotEmpty()) {
+            _uiState.update { it.copy(errors = errors) }
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, errors = emptyList()) }
+            val householdId = householdIdProvider.householdId.value ?: run {
+                Timber.w("No household ID available — cannot save quick cash entry")
+                _uiState.update { it.copy(isSaving = false, errors = listOf(QuickCashError.NO_ACCOUNT)) }
+                return@launch
+            }
+            val now = clock.now()
+            val date = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
+            val transaction = QuickCashEntry.buildTransaction(draft, householdId, date, now)
+            transactionRepository.insert(transaction)
+            rememberDefaults(draft)
+            _uiState.update { it.copy(isSaving = false, isSaved = true) }
+        }
+    }
+
+    private fun rememberDefaults(draft: QuickCashDraft) {
+        val editor = prefs?.edit() ?: return
+        draft.accountId?.let { editor.putString(PREF_DEFAULT_ACCOUNT, it.value) }
+        if (draft.categoryId != null) {
+            editor.putString(PREF_DEFAULT_CATEGORY, draft.categoryId.value)
+        } else {
+            editor.remove(PREF_DEFAULT_CATEGORY)
+        }
+        editor.apply()
+    }
+
+    private fun currentCurrency() =
+        _uiState.value.selectedAccountId?.let { accountMap[it]?.currency }
+            ?: com.finance.models.types.Currency.USD
+
+    private companion object {
+        const val PREF_DEFAULT_ACCOUNT = "quickcash.defaultAccountId"
+        const val PREF_DEFAULT_CATEGORY = "quickcash.defaultCategoryId"
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/quickcash/QuickCashEntryTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/quickcash/QuickCashEntryTest.kt
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickcash
+
+import com.finance.models.Account
+import com.finance.models.AccountType
+import com.finance.models.Category
+import com.finance.models.TransactionType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [QuickCashEntry] — the deterministic logic behind true quick cash entry (#2180).
+ *
+ * Covers locale-tolerant amount parsing, cash-first default account selection, optional
+ * expense category defaulting, validation rules, and transaction building.
+ */
+class QuickCashEntryTest {
+
+    private val now = Clock.System.now()
+    private val householdId = SyncId("household-1")
+    private val date = LocalDate(2026, 6, 23)
+
+    private fun account(
+        id: String,
+        name: String,
+        type: AccountType = AccountType.CHECKING,
+        sortOrder: Int = 0,
+        archived: Boolean = false,
+    ) = Account(
+        id = SyncId(id),
+        householdId = householdId,
+        ownerId = householdId,
+        name = name,
+        type = type,
+        currency = Currency.USD,
+        currentBalance = Cents(0L),
+        isArchived = archived,
+        sortOrder = sortOrder,
+        createdAt = now,
+        updatedAt = now,
+    )
+
+    private fun category(
+        id: String,
+        name: String,
+        isIncome: Boolean = false,
+        sortOrder: Int = 0,
+    ) = Category(
+        id = SyncId(id),
+        householdId = householdId,
+        ownerId = householdId,
+        name = name,
+        isIncome = isIncome,
+        sortOrder = sortOrder,
+        createdAt = now,
+        updatedAt = now,
+    )
+
+    // ── Amount parsing ──────────────────────────────────────────────────
+
+    @Test
+    fun `parses whole dollars`() {
+        assertEquals(500L, QuickCashEntry.parseAmountToCents("5"))
+        assertEquals(10_000L, QuickCashEntry.parseAmountToCents("100"))
+    }
+
+    @Test
+    fun `parses dollars and cents`() {
+        assertEquals(1250L, QuickCashEntry.parseAmountToCents("12.50"))
+        assertEquals(99L, QuickCashEntry.parseAmountToCents("0.99"))
+    }
+
+    @Test
+    fun `truncates fractional digits beyond two`() {
+        assertEquals(1299L, QuickCashEntry.parseAmountToCents("12.999"))
+    }
+
+    @Test
+    fun `strips currency symbols and whitespace`() {
+        assertEquals(1250L, QuickCashEntry.parseAmountToCents("$ 12.50"))
+        assertEquals(1250L, QuickCashEntry.parseAmountToCents("12.50 USD"))
+    }
+
+    @Test
+    fun `parses spanish-style comma decimal`() {
+        assertEquals(123456L, QuickCashEntry.parseAmountToCents("1234,56"))
+    }
+
+    @Test
+    fun `parses spanish-style grouping with comma decimal`() {
+        // es: 1.234,56 -> 1234.56
+        assertEquals(123456L, QuickCashEntry.parseAmountToCents("1.234,56"))
+    }
+
+    @Test
+    fun `parses english-style grouping with dot decimal`() {
+        // en: 1,234.56 -> 1234.56
+        assertEquals(123456L, QuickCashEntry.parseAmountToCents("1,234.56"))
+    }
+
+    @Test
+    fun `treats single dot as decimal separator`() {
+        // 1.234 -> 1.23 (truncated to two fractional digits)
+        assertEquals(123L, QuickCashEntry.parseAmountToCents("1.234"))
+    }
+
+    @Test
+    fun `treats single comma as decimal separator`() {
+        // 1,000 (es decimal) -> 1.00
+        assertEquals(100L, QuickCashEntry.parseAmountToCents("1,000"))
+    }
+
+    @Test
+    fun `empty or garbage input parses to zero`() {
+        assertEquals(0L, QuickCashEntry.parseAmountToCents(""))
+        assertEquals(0L, QuickCashEntry.parseAmountToCents("abc"))
+    }
+
+    @Test
+    fun `overflowing input clamps to max long so validation rejects it`() {
+        val parsed = QuickCashEntry.parseAmountToCents("999999999999999999999")
+        assertEquals(Long.MAX_VALUE, parsed)
+        assertTrue(
+            QuickCashError.AMOUNT_TOO_LARGE in
+                QuickCashEntry.validate(QuickCashDraft(amountCents = parsed, accountId = SyncId("a"))),
+        )
+    }
+
+    // ── Default account selection ───────────────────────────────────────
+
+    @Test
+    fun `prefers cash account when present`() {
+        val accounts = listOf(
+            account("acc-checking", "Checking", AccountType.CHECKING, sortOrder = 0),
+            account("acc-cash", "Wallet", AccountType.CASH, sortOrder = 5),
+        )
+        assertEquals(SyncId("acc-cash"), QuickCashEntry.selectDefaultCashAccount(accounts)?.id)
+    }
+
+    @Test
+    fun `falls back to lowest sorted account when no cash account`() {
+        val accounts = listOf(
+            account("acc-b", "B", AccountType.CHECKING, sortOrder = 2),
+            account("acc-a", "A", AccountType.SAVINGS, sortOrder = 1),
+        )
+        assertEquals(SyncId("acc-a"), QuickCashEntry.selectDefaultCashAccount(accounts)?.id)
+    }
+
+    @Test
+    fun `honors a valid preferred account over the cash default`() {
+        val accounts = listOf(
+            account("acc-cash", "Wallet", AccountType.CASH),
+            account("acc-checking", "Checking", AccountType.CHECKING),
+        )
+        assertEquals(
+            SyncId("acc-checking"),
+            QuickCashEntry.selectDefaultCashAccount(accounts, SyncId("acc-checking"))?.id,
+        )
+    }
+
+    @Test
+    fun `ignores archived accounts`() {
+        val accounts = listOf(
+            account("acc-cash", "Old Wallet", AccountType.CASH, archived = true),
+            account("acc-checking", "Checking", AccountType.CHECKING),
+        )
+        assertEquals(SyncId("acc-checking"), QuickCashEntry.selectDefaultCashAccount(accounts)?.id)
+    }
+
+    @Test
+    fun `returns null when there are no usable accounts`() {
+        assertNull(QuickCashEntry.selectDefaultCashAccount(emptyList()))
+    }
+
+    // ── Default category selection ──────────────────────────────────────
+
+    @Test
+    fun `default category excludes income categories`() {
+        val categories = listOf(
+            category("cat-salary", "Salary", isIncome = true, sortOrder = 0),
+            category("cat-food", "Food", isIncome = false, sortOrder = 1),
+        )
+        assertEquals(SyncId("cat-food"), QuickCashEntry.selectDefaultCategory(categories)?.id)
+    }
+
+    @Test
+    fun `default category can be null when none exist`() {
+        assertNull(QuickCashEntry.selectDefaultCategory(emptyList()))
+    }
+
+    // ── Validation ──────────────────────────────────────────────────────
+
+    @Test
+    fun `valid draft has no errors`() {
+        val draft = QuickCashDraft(amountCents = 1250L, accountId = SyncId("acc-cash"))
+        assertTrue(QuickCashEntry.validate(draft).isEmpty())
+    }
+
+    @Test
+    fun `zero amount is invalid`() {
+        val draft = QuickCashDraft(amountCents = 0L, accountId = SyncId("acc-cash"))
+        assertTrue(QuickCashError.INVALID_AMOUNT in QuickCashEntry.validate(draft))
+    }
+
+    @Test
+    fun `missing account is invalid`() {
+        val draft = QuickCashDraft(amountCents = 1250L, accountId = null)
+        assertTrue(QuickCashError.NO_ACCOUNT in QuickCashEntry.validate(draft))
+    }
+
+    @Test
+    fun `over-long note is invalid`() {
+        val draft = QuickCashDraft(
+            amountCents = 1250L,
+            accountId = SyncId("acc-cash"),
+            note = "x".repeat(QuickCashEntry.MAX_NOTE_LENGTH + 1),
+        )
+        assertTrue(QuickCashError.NOTE_TOO_LONG in QuickCashEntry.validate(draft))
+    }
+
+    // ── Transaction building ────────────────────────────────────────────
+
+    @Test
+    fun `builds a cleared negative expense tagged as quick cash`() {
+        val draft = QuickCashDraft(
+            amountCents = 1250L,
+            accountId = SyncId("acc-cash"),
+            categoryId = SyncId("cat-food"),
+            note = "  Coffee  ",
+        )
+        val txn = QuickCashEntry.buildTransaction(draft, householdId, date, now, idSuffix = 42L)
+
+        assertEquals(SyncId("txn-cash-42"), txn.id)
+        assertEquals(TransactionType.EXPENSE, txn.type)
+        assertEquals(Cents(-1250L), txn.amount)
+        assertEquals(SyncId("acc-cash"), txn.accountId)
+        assertEquals(SyncId("cat-food"), txn.categoryId)
+        assertEquals("Coffee", txn.note)
+        assertNull(txn.payee)
+        assertEquals(date, txn.date)
+        assertTrue(QuickCashEntry.QUICK_CASH_TAG in txn.tags)
+    }
+
+    @Test
+    fun `blank note becomes null`() {
+        val draft = QuickCashDraft(amountCents = 500L, accountId = SyncId("acc-cash"), note = "   ")
+        val txn = QuickCashEntry.buildTransaction(draft, householdId, date, now)
+        assertNull(txn.note)
+    }
+
+    @Test
+    fun `building from an invalid draft throws`() {
+        val invalid = QuickCashDraft(amountCents = 0L, accountId = null)
+        assertFailsWith<IllegalArgumentException> {
+            QuickCashEntry.buildTransaction(invalid, householdId, date, now)
+        }
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/quickcash/QuickCashEntryViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/quickcash/QuickCashEntryViewModelTest.kt
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.quickcash
+
+import com.finance.android.auth.TestHouseholdIdProvider
+import com.finance.android.data.repository.AccountRepository
+import com.finance.android.data.repository.CategoryRepository
+import com.finance.android.data.repository.TransactionRepository
+import com.finance.models.Account
+import com.finance.models.AccountType
+import com.finance.models.Category
+import com.finance.models.Transaction
+import com.finance.models.TransactionType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [QuickCashEntryViewModel].
+ *
+ * Verifies cash-first default selection on init, formatted-amount preview, validation
+ * surfacing, and one-tap save via a deterministic in-memory repository (no mocking).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class QuickCashEntryViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val now = Clock.System.now()
+    private val householdId = SyncId("household-1")
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun account(
+        id: String,
+        name: String,
+        type: AccountType = AccountType.CHECKING,
+        sortOrder: Int = 0,
+    ) = Account(
+        id = SyncId(id),
+        householdId = householdId,
+        ownerId = householdId,
+        name = name,
+        type = type,
+        currency = Currency.USD,
+        currentBalance = Cents(0L),
+        sortOrder = sortOrder,
+        createdAt = now,
+        updatedAt = now,
+    )
+
+    private fun category(id: String, name: String, isIncome: Boolean = false) = Category(
+        id = SyncId(id),
+        householdId = householdId,
+        ownerId = householdId,
+        name = name,
+        isIncome = isIncome,
+        createdAt = now,
+        updatedAt = now,
+    )
+
+    private class TestAccountRepository(initial: List<Account>) : AccountRepository {
+        private val accounts = MutableStateFlow(initial)
+        override fun observeAll(householdId: SyncId): Flow<List<Account>> =
+            accounts.map { list -> list.filter { it.deletedAt == null } }
+        override fun observeById(id: SyncId): Flow<Account?> =
+            accounts.map { list -> list.find { it.id == id } }
+        override suspend fun getById(id: SyncId): Account? = accounts.value.find { it.id == id }
+        override fun observeActive(householdId: SyncId): Flow<List<Account>> =
+            accounts.map { list -> list.filter { !it.isArchived } }
+        override suspend fun updateBalance(id: SyncId, newBalance: Cents) { /* no-op */ }
+        override suspend fun archive(id: SyncId) { /* no-op */ }
+        override suspend fun insert(entity: Account) { accounts.value = accounts.value + entity }
+        override suspend fun update(entity: Account) { /* no-op */ }
+        override suspend fun delete(id: SyncId) { /* no-op */ }
+        override suspend fun getUnsynced(householdId: SyncId): List<Account> = emptyList()
+        override suspend fun markSynced(ids: List<SyncId>) { /* no-op */ }
+    }
+
+    private class TestCategoryRepository(initial: List<Category>) : CategoryRepository {
+        private val categories = MutableStateFlow(initial)
+        override fun observeAll(householdId: SyncId): Flow<List<Category>> =
+            categories.map { list -> list.filter { it.deletedAt == null } }
+        override fun observeById(id: SyncId): Flow<Category?> =
+            categories.map { list -> list.find { it.id == id } }
+        override suspend fun getById(id: SyncId): Category? = categories.value.find { it.id == id }
+        override fun observeByParent(parentId: SyncId?): Flow<List<Category>> =
+            categories.map { list -> list.filter { it.parentId == parentId } }
+        override fun observeIncome(householdId: SyncId): Flow<List<Category>> =
+            categories.map { list -> list.filter { it.isIncome } }
+        override fun observeExpense(householdId: SyncId): Flow<List<Category>> =
+            categories.map { list -> list.filter { !it.isIncome } }
+        override suspend fun insert(entity: Category) { categories.value = categories.value + entity }
+        override suspend fun update(entity: Category) { /* no-op */ }
+        override suspend fun delete(id: SyncId) { /* no-op */ }
+        override suspend fun getUnsynced(householdId: SyncId): List<Category> = emptyList()
+        override suspend fun markSynced(ids: List<SyncId>) { /* no-op */ }
+    }
+
+    private class TestTransactionRepository : TransactionRepository {
+        private val transactions = MutableStateFlow<List<Transaction>>(emptyList())
+        var lastInserted: Transaction? = null
+            private set
+        override fun observeAll(householdId: SyncId): Flow<List<Transaction>> = transactions
+        override fun observeById(id: SyncId): Flow<Transaction?> =
+            transactions.map { list -> list.find { it.id == id } }
+        override suspend fun getById(id: SyncId): Transaction? = transactions.value.find { it.id == id }
+        override fun observeByAccount(accountId: SyncId): Flow<List<Transaction>> =
+            transactions.map { list -> list.filter { it.accountId == accountId } }
+        override fun observeByCategory(categoryId: SyncId): Flow<List<Transaction>> =
+            transactions.map { list -> list.filter { it.categoryId == categoryId } }
+        override fun observeByDateRange(householdId: SyncId, start: LocalDate, end: LocalDate): Flow<List<Transaction>> =
+            transactions.map { list -> list.filter { it.date in start..end } }
+        override suspend fun getByDateRange(householdId: SyncId, start: LocalDate, end: LocalDate): List<Transaction> =
+            transactions.value.filter { it.date in start..end }
+        override suspend fun insert(entity: Transaction) {
+            lastInserted = entity
+            transactions.value = transactions.value + entity
+        }
+        override suspend fun update(entity: Transaction) { /* no-op */ }
+        override suspend fun delete(id: SyncId) { /* no-op */ }
+        override suspend fun getUnsynced(householdId: SyncId): List<Transaction> = emptyList()
+        override suspend fun markSynced(ids: List<SyncId>) { /* no-op */ }
+    }
+
+    private fun viewModel(
+        accounts: List<Account> = listOf(
+            account("acc-checking", "Checking", AccountType.CHECKING, sortOrder = 0),
+            account("acc-cash", "Wallet", AccountType.CASH, sortOrder = 1),
+        ),
+        categories: List<Category> = listOf(
+            category("cat-food", "Food"),
+            category("cat-salary", "Salary", isIncome = true),
+        ),
+        txnRepo: TestTransactionRepository = TestTransactionRepository(),
+    ) = QuickCashEntryViewModel(
+        householdIdProvider = TestHouseholdIdProvider(householdId),
+        transactionRepository = txnRepo,
+        accountRepository = TestAccountRepository(accounts),
+        categoryRepository = TestCategoryRepository(categories),
+        prefs = null,
+    )
+
+    @Test
+    fun `init defaults to cash account and excludes income categories`() = runTest(testDispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+        val state = vm.uiState.value
+        assertEquals(SyncId("acc-cash"), state.selectedAccountId)
+        assertEquals("Wallet", state.selectedAccountName)
+        assertTrue(state.categories.none { it.isIncome })
+        assertEquals(SyncId("cat-food"), state.selectedCategoryId)
+    }
+
+    @Test
+    fun `cash account is listed first`() = runTest(testDispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+        assertEquals(SyncId("acc-cash"), vm.uiState.value.cashAccounts.first().id)
+    }
+
+    @Test
+    fun `updating amount produces a formatted preview`() = runTest(testDispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.updateAmount("12.50")
+        assertEquals("$12.50", vm.uiState.value.formattedAmount)
+    }
+
+    @Test
+    fun `saving with zero amount surfaces a validation error and does not insert`() =
+        runTest(testDispatcher) {
+            val txnRepo = TestTransactionRepository()
+            val vm = viewModel(txnRepo = txnRepo)
+            advanceUntilIdle()
+            vm.save()
+            advanceUntilIdle()
+            assertTrue(QuickCashError.INVALID_AMOUNT in vm.uiState.value.errors)
+            assertNull(txnRepo.lastInserted)
+            assertFalse(vm.uiState.value.isSaved)
+        }
+
+    @Test
+    fun `one-tap save inserts a negative cash expense`() = runTest(testDispatcher) {
+        val txnRepo = TestTransactionRepository()
+        val vm = viewModel(txnRepo = txnRepo)
+        advanceUntilIdle()
+        vm.updateAmount("7.25")
+        vm.save()
+        advanceUntilIdle()
+
+        val inserted = txnRepo.lastInserted
+        assertTrue(inserted != null)
+        assertEquals(TransactionType.EXPENSE, inserted.type)
+        assertEquals(Cents(-725L), inserted.amount)
+        assertEquals(SyncId("acc-cash"), inserted.accountId)
+        assertTrue(QuickCashEntry.QUICK_CASH_TAG in inserted.tags)
+        assertTrue(vm.uiState.value.isSaved)
+    }
+
+    @Test
+    fun `selecting an already-selected category clears it`() = runTest(testDispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+        val current = vm.uiState.value.selectedCategoryId
+        assertTrue(current != null)
+        vm.selectCategory(current)
+        assertNull(vm.uiState.value.selectedCategoryId)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a **true quick cash entry** path for cash-first Android users (#2180): a minimal, fast cash-expense capture that saves in 1–2 taps instead of the 3-step transaction wizard.

## What's included
- **Deterministic, unit-tested logic** (QuickCashEntry): locale-tolerant amount parsing (en 1,234.56 / es 1.234,56 / single-separator decimal), cash-first default account selection, optional expense-category defaulting, validation (amount > 0, sane max, account required, note length), and transaction building (cleared negative expense tagged quick-cash).
- **QuickCashEntryViewModel**: wires the pure logic to repositories, defaults the account to the user's cash wallet, remembers the chosen account/category, and saves in one tap. Injected via Koin (explicit definition so the system `Clock` default is used).
- **QuickCashEntrySheet** Compose bottom sheet: amount field with live formatted preview, one-tap account/category chips, optional note, single Save button. TalkBack `contentDescription` + headings + polite live-region errors, and >=48dp touch targets throughout.
- **Tests**: `QuickCashEntryTest` (parsing/defaults/validation/build) and `QuickCashEntryViewModelTest` (init defaults, formatted preview, validation surfacing, one-tap save) using deterministic in-memory repositories.

## Conflict-avoidance
Self-contained new package `ui/quickcash/`; the only edit to shared files is one additive Koin registration in `AppModule.kt`. No nav/screen lines shared with #2396/#2383, and no `build.gradle.kts` or string-resource edits (avoids #2166).

## Needs Human Action
- `// TODO(human)` in `QuickCashEntrySheet.kt`: extract user-facing copy into localized string resources (es-ES, etc.) once the i18n keys land (#2166).
- Device-only wiring (widget/shortcut deep-link into this sheet, and hosting it from navigation) is intentionally deferred to avoid colliding with in-flight android PRs; hook the sheet up where the quick-actions/nav work settles.

Closes #2180

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>