### PR TITLE
feat(android): voice transaction entry (#2383)

### DIFF
--- a/apps/android/docs/voice-transaction-entry.md
+++ b/apps/android/docs/voice-transaction-entry.md
@@ -1,0 +1,89 @@
+# Google Assistant voice transaction entry (#2383)
+
+Lets an Android commuter speak a short phrase and land in a **prefilled,
+reviewable** transaction draft. Utterance parsing runs **entirely on device**
+and works fully offline, so a draft is always created even when the Assistant
+handoff cannot complete.
+
+## Pipeline
+
+```
+Assistant / SpeechRecognizer ──▶ VoiceEntityExtractor ──▶ LocalUtteranceParser ──▶ VoiceTransactionViewModel ──▶ VoiceTransactionScreen
+   (transcript, device-only)         (interface)            (rules, deterministic)     (prompts + offline draft)      (review + confirm)
+```
+
+| Stage   | Type                                                     | Notes                                                                      |
+| ------- | -------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Capture | Assistant App Action / `SpeechRecognizer`                | Device-only transcript source (see _Needs human action_).                  |
+| Extract | `VoiceEntityExtractor` → `RuleBasedVoiceEntityExtractor` | Decoupling seam; an ML Kit entity-extraction impl drops in here unchanged. |
+| Parse   | `LocalUtteranceParser` (`UtteranceParser`)               | Maps entities to amount, merchant, category, account, note. Deterministic. |
+| Drive   | `VoiceTransactionViewModel`                              | Native prompts for missing/ambiguous fields; offline drafting.             |
+| Review  | `VoiceTransactionScreen`                                 | Explicit confirmation before any save.                                     |
+
+Everything except the speech capture is pure Kotlin and unit-tested on the JVM
+(`LocalUtteranceParserTest`, `VoiceTransactionInstrumentationTest`,
+`VoiceTransactionViewModelTest`).
+
+## Field capture
+
+| Field    | Example phrasing                                      | Required |
+| -------- | ----------------------------------------------------- | -------- |
+| Amount   | "$4.50", "12 dollars", "four dollars", "twelve bucks" | yes      |
+| Merchant | "at Starbucks", "from Chevron"                        | yes      |
+| Category | inferred ("coffee" → Dining)                          | no       |
+| Account  | "with cash", "on my visa"                             | no       |
+| Note     | "note client lunch"                                   | no       |
+
+Required fields that are absent, and any field with more than one plausible
+value, are surfaced as **native prompts** — there are **no silent defaults**.
+
+## Confirmation flow
+
+1. Transcript is parsed into a `VoiceParseResult`.
+2. Missing required fields → prompt (free entry). Ambiguous fields → prompt with
+   candidate chips.
+3. Once every prompt is resolved, the user sees the full draft and must tap
+   **Save** to confirm. Nothing is written before that explicit confirmation.
+
+## Offline-safe drafting
+
+`VoiceTransactionViewModel.onAssistantHandoffUnavailable(utterance)` parses the
+phrase locally and stashes the draft in a `VoiceDraftStore` so it can be
+reviewed later. Parsing and drafting never touch the network or the Assistant
+service.
+
+## Privacy — speech transcription & parsing boundaries
+
+- **On-device parsing.** `RuleBasedVoiceEntityExtractor` and
+  `LocalUtteranceParser` perform no network I/O. Mapping a transcript to fields
+  never leaves the phone.
+- **Transcription boundary.** When the system Google Assistant or
+  `SpeechRecognizer` performs speech-to-text, audio may be processed by Google
+  per the platform's own privacy policy. That boundary is **outside this app**;
+  we only ever receive the resulting text. The in-app microphone path should
+  prefer an on-device recognizer where available.
+- **No content logging.** Timber logs only field _names_, stage transitions, and
+  counts — never the transcript, amounts, merchant, account, or note.
+- **Privacy-safe metrics.** `VoiceTransactionInstrumentation` records success,
+  cancellation, and correction outcomes as anonymous counts gated by analytics
+  consent. No transaction content is ever recorded.
+- **Drafts.** Offline drafts live in memory by default; a durable store must be
+  encrypted (see _Needs human action_).
+
+## Needs human action
+
+The following require a physical device / emulator and Android Studio and are
+intentionally left as `// TODO(human)` markers:
+
+1. **App Actions / Assistant wiring.** Add `shortcuts.xml` with a
+   `GET_TRANSACTION`-style custom intent (or BII), register the capability, and
+   route the resulting transcript into
+   `VoiceTransactionViewModel.onUtteranceReceived(...)`. Requires an Assistant
+   test device and Play Console App Actions review.
+2. **In-app `SpeechRecognizer` capture.** Wire the microphone button to an
+   on-device `SpeechRecognizer`, requesting `RECORD_AUDIO` at point of use.
+3. **Durable, encrypted draft store.** Replace `InMemoryVoiceDraftStore` with a
+   SQLCipher-backed implementation so offline drafts survive process death.
+
+See the `// TODO(human)` markers in `VoiceAssistantEntryPoint.kt` and
+`VoiceDraftStore.kt`.

--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -50,6 +50,12 @@ import com.finance.android.ui.feedback.HapticAvailabilityChecker
 import com.finance.android.ui.theme.ThemeManager
 import com.finance.android.ui.theme.ThemePreferenceManager
 import com.finance.android.ui.tips.TipsViewModel
+import com.finance.android.ui.voice.InMemoryVoiceDraftStore
+import com.finance.android.ui.voice.LocalUtteranceParser
+import com.finance.android.ui.voice.UtteranceParser
+import com.finance.android.ui.voice.VoiceDraftStore
+import com.finance.android.ui.voice.VoiceTransactionInstrumentation
+import com.finance.android.ui.voice.VoiceTransactionViewModel
 import com.finance.android.ui.insights.InsightsViewModel
 import com.finance.android.ui.quickactions.DeterministicQuickActionRanker
 import com.finance.android.ui.quickactions.QuickActionPreferences
@@ -285,4 +291,18 @@ val appModule = module {
 
     /** Conflict resolution ViewModel (#Sprint27). */
     viewModelOf(::ConflictResolutionViewModel)
+
+    // ── Voice transaction entry (#2383) ─────────────────────────────
+
+    /** Deterministic, offline-capable utterance parser (ML Kit decoupled). */
+    single<UtteranceParser> { LocalUtteranceParser() }
+
+    /** Privacy-safe voice entry instrumentation — no transaction content. */
+    single { VoiceTransactionInstrumentation(get()) }
+
+    /** Offline-safe draft store for failed Assistant handoffs. */
+    single<VoiceDraftStore> { InMemoryVoiceDraftStore() }
+
+    /** Voice transaction review/confirmation ViewModel (#2383). */
+    viewModelOf(::VoiceTransactionViewModel)
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/voice/UtteranceParser.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/voice/UtteranceParser.kt
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.voice
+
+/**
+ * Maps a spoken utterance to a reviewable transaction draft (#2383).
+ *
+ * Kept behind an interface so the deterministic [LocalUtteranceParser] used in
+ * tests and offline drafting can be swapped for an ML-backed implementation
+ * without changing the confirmation flow or instrumentation.
+ */
+fun interface UtteranceParser {
+    /**
+     * @param utterance Raw transcript from Assistant/SpeechRecognizer.
+     *   Never logged — treat as financial content.
+     * @return A [VoiceParseResult] with the draft plus any missing/ambiguous
+     *   fields that require a native prompt before saving.
+     */
+    fun parse(utterance: String): VoiceParseResult
+}
+
+/**
+ * Deterministic, fully-offline utterance parser (#2383).
+ *
+ * Resolves the candidate entities from a [VoiceEntityExtractor] into a single
+ * [VoiceTransactionDraft]. The contract is intentionally conservative:
+ *
+ * - Required fields (amount + merchant) that are absent are reported in
+ *   [VoiceParseResult.missingFields] — never silently defaulted.
+ * - Fields with more than one plausible candidate are reported in
+ *   [VoiceParseResult.ambiguities] and left `null` in the draft so the user
+ *   disambiguates explicitly.
+ * - Optional fields (category, account, note) are filled when unambiguous and
+ *   omitted otherwise.
+ *
+ * Because both this parser and the default extractor run on-device with no I/O,
+ * drafting works even when the Assistant handoff cannot complete (offline).
+ *
+ * ## Security
+ * Never logs the transcript or any extracted value.
+ *
+ * @param extractor Entity-extraction strategy; defaults to the rule-based one.
+ */
+class LocalUtteranceParser(
+    private val extractor: VoiceEntityExtractor = RuleBasedVoiceEntityExtractor(),
+) : UtteranceParser {
+
+    override fun parse(utterance: String): VoiceParseResult {
+        val raw = utterance.trim()
+        if (raw.isBlank()) {
+            return VoiceParseResult(
+                draft = VoiceTransactionDraft(),
+                missingFields = REQUIRED_FIELDS,
+                rawUtterance = raw,
+            )
+        }
+
+        val entities = extractor.extract(raw)
+        val missing = mutableListOf<VoiceField>()
+        val ambiguities = mutableListOf<FieldAmbiguity>()
+
+        val amount = resolveSingle(
+            field = VoiceField.AMOUNT,
+            candidates = entities.amountsMinor.map { it.toString() },
+            missing = missing,
+            ambiguities = ambiguities,
+            required = true,
+        )?.toLongOrNull()
+
+        val merchant = resolveSingle(
+            field = VoiceField.MERCHANT,
+            candidates = entities.merchantCandidates,
+            missing = missing,
+            ambiguities = ambiguities,
+            required = true,
+        )
+
+        // Optional fields: fill when unambiguous, otherwise surface ambiguity
+        // but do not block (they are not in REQUIRED_FIELDS).
+        val category = resolveOptional(VoiceField.CATEGORY, entities.categoryHints, ambiguities)
+        val account = resolveOptional(VoiceField.ACCOUNT, entities.accountCandidates, ambiguities)
+
+        val draft = VoiceTransactionDraft(
+            amountMinor = amount,
+            currencyCode = entities.currencyCode,
+            merchant = merchant,
+            category = category,
+            account = account,
+            note = entities.note,
+            direction = if (entities.isIncome) VoiceDirection.INCOME else VoiceDirection.EXPENSE,
+        )
+
+        return VoiceParseResult(
+            draft = draft,
+            missingFields = missing.distinct(),
+            ambiguities = ambiguities,
+            overallConfidence = confidenceOf(draft, ambiguities),
+            rawUtterance = raw,
+        )
+    }
+
+    /**
+     * Resolves a field expected to have exactly one value.
+     *
+     * - 0 candidates and [required] → adds to [missing].
+     * - 1 candidate → returns it.
+     * - >1 distinct candidates → adds to [ambiguities] and returns null.
+     */
+    private fun resolveSingle(
+        field: VoiceField,
+        candidates: List<String>,
+        missing: MutableList<VoiceField>,
+        ambiguities: MutableList<FieldAmbiguity>,
+        required: Boolean,
+    ): String? {
+        val distinct = candidates.filter { it.isNotBlank() }.distinct()
+        return when {
+            distinct.isEmpty() -> {
+                if (required) missing.add(field)
+                null
+            }
+
+            distinct.size == 1 -> distinct.first()
+            else -> {
+                ambiguities.add(FieldAmbiguity(field, distinct))
+                null
+            }
+        }
+    }
+
+    private fun resolveOptional(
+        field: VoiceField,
+        candidates: List<String>,
+        ambiguities: MutableList<FieldAmbiguity>,
+    ): String? {
+        val distinct = candidates.filter { it.isNotBlank() }.distinct()
+        return when {
+            distinct.isEmpty() -> null
+            distinct.size == 1 -> distinct.first()
+            else -> {
+                ambiguities.add(FieldAmbiguity(field, distinct))
+                null
+            }
+        }
+    }
+
+    private fun confidenceOf(
+        draft: VoiceTransactionDraft,
+        ambiguities: List<FieldAmbiguity>,
+    ): Float {
+        val factors = listOfNotNull(
+            if (draft.amountMinor != null) 0.45f else null,
+            if (!draft.merchant.isNullOrBlank()) 0.30f else null,
+            if (!draft.category.isNullOrBlank()) 0.10f else null,
+            if (!draft.account.isNullOrBlank()) 0.10f else null,
+            if (!draft.note.isNullOrBlank()) 0.05f else null,
+        )
+        val penalty = ambiguities.size * 0.15f
+        return (factors.sum() - penalty).coerceIn(0f, 1f)
+    }
+
+    private companion object {
+        val REQUIRED_FIELDS = listOf(VoiceField.AMOUNT, VoiceField.MERCHANT)
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceAssistantEntryPoint.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceAssistantEntryPoint.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.voice
+
+/**
+ * Device-only seam between the Google Assistant / `SpeechRecognizer` and the
+ * on-device voice transaction flow (#2383).
+ *
+ * The deterministic parsing, prompting, review, and instrumentation are all
+ * unit-tested on the JVM. The pieces that genuinely require a physical device,
+ * Android Studio, and Play Console review are marked `// TODO(human)` below.
+ *
+ * ## Needs Human Action
+ *
+ * 1. App Actions / Assistant wiring — register a custom intent in
+ *    `res/xml/shortcuts.xml`, declare the capability in the manifest, and route
+ *    the transcript into [VoiceTransactionViewModel.onUtteranceReceived].
+ * 2. In-app microphone capture — wire a `SpeechRecognizer` (preferring an
+ *    on-device recognizer) and request `RECORD_AUDIO` at point of use.
+ *
+ * These cannot be validated headlessly in CI, so they are intentionally left as
+ * documented stubs rather than half-wired code.
+ */
+object VoiceAssistantEntryPoint {
+
+    /**
+     * Entry hook the App Action / mic capture should call once it has a
+     * transcript. Kept pure (no Android imports) so it stays testable.
+     *
+     * @param transcript Recognised speech. Never logged.
+     * @param viewModel The active [VoiceTransactionViewModel].
+     * @param online Whether the Assistant handoff completed successfully.
+     */
+    fun handleTranscript(
+        transcript: String,
+        viewModel: VoiceTransactionViewModel,
+        online: Boolean,
+    ) {
+        if (online) {
+            viewModel.onUtteranceReceived(
+                transcript,
+                VoiceTransactionInstrumentation.EntrySource.ASSISTANT,
+            )
+        } else {
+            viewModel.onAssistantHandoffUnavailable(transcript)
+        }
+    }
+
+    // TODO(human): Register the Assistant App Action capability.
+    //   - Add res/xml/shortcuts.xml with a custom intent (e.g. ADD_EXPENSE).
+    //   - Declare <capability> + <meta-data android:name="android.app.shortcuts">.
+    //   - In the receiving Activity, read the spoken transcript extra and call
+    //     [handleTranscript]. Requires an Assistant test device.
+
+    // TODO(human): Wire in-app SpeechRecognizer capture.
+    //   - Request RECORD_AUDIO at point of use.
+    //   - Prefer an on-device recognizer; fall back to system Assistant.
+    //   - Forward the final transcript to [handleTranscript].
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceDraftStore.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceDraftStore.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.voice
+
+/**
+ * Offline-safe storage for voice transaction drafts (#2383).
+ *
+ * When the Google Assistant handoff cannot complete (no connectivity, app not
+ * foregrounded, etc.) a parsed draft is stashed here so the user can review and
+ * save it later — drafting never depends on network or the Assistant service.
+ *
+ * The default [InMemoryVoiceDraftStore] is process-local. A durable,
+ * SQLCipher-backed implementation is wired separately.
+ */
+interface VoiceDraftStore {
+    /** Persist a pending draft for later review. */
+    fun saveDraft(draft: VoiceTransactionDraft)
+
+    /** All drafts awaiting review, oldest first. */
+    fun pendingDrafts(): List<VoiceTransactionDraft>
+
+    /** Remove a draft once it has been reviewed (saved or discarded). */
+    fun remove(draft: VoiceTransactionDraft)
+
+    /** Drop all pending drafts. */
+    fun clear()
+}
+
+/**
+ * Process-local [VoiceDraftStore] used for offline drafting and tests (#2383).
+ *
+ * NEVER logs draft contents.
+ *
+ * TODO(human): Back this with an encrypted (SQLCipher) store so offline drafts
+ * survive process death. See "## Needs Human Action" in the PR description.
+ */
+class InMemoryVoiceDraftStore : VoiceDraftStore {
+    private val drafts = mutableListOf<VoiceTransactionDraft>()
+
+    override fun saveDraft(draft: VoiceTransactionDraft) {
+        drafts.add(draft)
+    }
+
+    override fun pendingDrafts(): List<VoiceTransactionDraft> = drafts.toList()
+
+    override fun remove(draft: VoiceTransactionDraft) {
+        drafts.remove(draft)
+    }
+
+    override fun clear() {
+        drafts.clear()
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceEntityExtractor.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceEntityExtractor.kt
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.voice
+
+/**
+ * Raw entities extracted from a spoken utterance, before field resolution (#2383).
+ *
+ * This is the decoupling seam between *how* entities are detected (rules today,
+ * ML Kit entity extraction later) and *how* they are mapped to a transaction
+ * draft by [LocalUtteranceParser]. Swapping the extractor never changes the
+ * review/confirmation flow.
+ *
+ * @property amountsMinor Distinct monetary amounts found, in minor units (cents).
+ * @property currencyCode Spoken currency (ISO-4217) or null when unspecified.
+ * @property merchantCandidates Distinct merchant/payee spans, in spoken order.
+ * @property accountCandidates Distinct account spans (e.g. "checking", "visa").
+ * @property categoryHints Inferred category names, most specific first.
+ * @property isIncome True when the phrasing implies incoming money.
+ * @property note Free-form memo span, or null.
+ */
+data class VoiceEntities(
+    val amountsMinor: List<Long> = emptyList(),
+    val currencyCode: String? = null,
+    val merchantCandidates: List<String> = emptyList(),
+    val accountCandidates: List<String> = emptyList(),
+    val categoryHints: List<String> = emptyList(),
+    val isIncome: Boolean = false,
+    val note: String? = null,
+)
+
+/**
+ * Extracts candidate entities from a raw speech transcript (#2383).
+ *
+ * Implementations MUST be deterministic and run fully on-device so drafting
+ * works offline. The default [RuleBasedVoiceEntityExtractor] uses regex and
+ * keyword matching; an ML Kit entity-extraction implementation can be dropped
+ * in behind this same interface without touching the parser or UI.
+ */
+fun interface VoiceEntityExtractor {
+    /**
+     * @param utterance Raw transcript. Never logged — treat as financial content.
+     * @return Candidate entities for [LocalUtteranceParser] to resolve.
+     */
+    fun extract(utterance: String): VoiceEntities
+}
+
+/**
+ * Deterministic, fully-offline rule-based entity extractor (#2383).
+ *
+ * Supported phrasings:
+ * - Amount: "$4.50", "4.50", "4 dollars 50 cents", "12 bucks", "twenty dollars".
+ * - Merchant: "at <name>", "from <name>", "to <name>".
+ * - Account: "with/using/on/from my <account>" against a known account vocabulary.
+ * - Category: keyword inference (e.g. "coffee" → Dining, "uber" → Transport).
+ * - Note: "note <text>", "memo <text>".
+ * - Direction: income keywords ("received", "salary", "refund") imply INCOME.
+ *
+ * ## Security
+ * Never logs the transcript, amounts, or any extracted span.
+ */
+class RuleBasedVoiceEntityExtractor : VoiceEntityExtractor {
+
+    override fun extract(utterance: String): VoiceEntities {
+        if (utterance.isBlank()) return VoiceEntities()
+
+        val normalized = utterance.trim()
+        val lower = normalized.lowercase()
+
+        val amounts = extractAmounts(lower)
+        val merchants = extractMerchants(normalized)
+        val accounts = extractAccounts(lower)
+        val categories = inferCategories(lower)
+        val income = INCOME_KEYWORDS.any { lower.contains(it) }
+        val note = extractNote(normalized)
+
+        return VoiceEntities(
+            amountsMinor = amounts,
+            currencyCode = detectCurrency(lower),
+            merchantCandidates = merchants,
+            accountCandidates = accounts,
+            categoryHints = categories,
+            isIncome = income,
+            note = note,
+        )
+    }
+
+    // ── Amounts ──────────────────────────────────────────────────────────
+
+    private fun extractAmounts(lower: String): List<Long> {
+        val results = LinkedHashSet<Long>()
+        var working = lower
+
+        // "4 dollars 50 cents" / "4 dollars and 50 cents" — consume the whole span
+        // first so the inner numbers aren't re-counted by the patterns below.
+        DOLLARS_CENTS_PATTERN.findAll(lower).forEach { m ->
+            val dollars = m.groupValues[1].toLongOrNull() ?: return@forEach
+            val cents = m.groupValues[2].toLongOrNull() ?: 0L
+            results.add(dollars * 100 + cents.coerceIn(0, 99))
+        }
+        working = DOLLARS_CENTS_PATTERN.replace(working, " ")
+
+        // Currency-signalled amounts: "$4.50", "$1,234", "12 dollars", "12 bucks".
+        SIGNALLED_AMOUNT_PATTERN.findAll(working).forEach { m ->
+            val raw = (m.groupValues[1].ifBlank { m.groupValues[2] }).replace(",", "")
+            toMinorUnits(raw)?.let { results.add(it) }
+        }
+
+        // Bare decimals are unambiguous money even without a currency word: "4.50".
+        DECIMAL_AMOUNT_PATTERN.findAll(working).forEach { m ->
+            toMinorUnits(m.groupValues[1])?.let { results.add(it) }
+        }
+
+        // Spelled-out small amounts: "twenty dollars", "five bucks".
+        WORD_AMOUNT_PATTERN.findAll(working).forEach { m ->
+            NUMBER_WORDS[m.groupValues[1]]?.let { results.add(it * 100) }
+        }
+
+        return results.toList()
+    }
+
+    private fun toMinorUnits(raw: String): Long? {
+        if (raw.isBlank()) return null
+        val parts = raw.split(".")
+        val whole = parts[0].toLongOrNull() ?: return null
+        val fraction = if (parts.size > 1) {
+            parts[1].padEnd(2, '0').take(2).toLongOrNull() ?: 0L
+        } else {
+            0L
+        }
+        return whole * 100 + fraction
+    }
+
+    private fun detectCurrency(lower: String): String? = when {
+        lower.contains("dollar") || lower.contains("buck") || lower.contains("$") -> "USD"
+        lower.contains("euro") || lower.contains("€") -> "EUR"
+        lower.contains("pound") || lower.contains("£") -> "GBP"
+        else -> null
+    }
+
+    // ── Merchants ────────────────────────────────────────────────────────
+
+    private fun extractMerchants(input: String): List<String> {
+        val results = LinkedHashSet<String>()
+        MERCHANT_PATTERN.findAll(input).forEach { m ->
+            val cleaned = cleanSpan(m.groupValues[2])
+            if (cleaned.isNotBlank()) results.add(cleaned)
+        }
+        return results.toList()
+    }
+
+    private fun cleanSpan(span: String): String {
+        val words = span.trim().split(WHITESPACE)
+        val afterLeading = words.dropWhile { normalizeWord(it) in LEADING_STOP_WORDS }
+        val kept = afterLeading.takeWhile { isMerchantToken(normalizeWord(it)) }
+        return kept.joinToString(" ").trim().trimEnd('.', ',')
+    }
+
+    private fun isMerchantToken(normalized: String): Boolean {
+        if (normalized.isEmpty()) return false
+        if (normalized in TRAILING_STOP_WORDS) return false
+        if (normalized in CURRENCY_WORDS) return false
+        if (normalized in NUMBER_WORDS) return false
+        return !NUMERIC_TOKEN.matches(normalized)
+    }
+
+    private fun normalizeWord(word: String): String = word.lowercase().trim('.', ',')
+
+    // ── Accounts ─────────────────────────────────────────────────────────
+
+    private fun extractAccounts(lower: String): List<String> {
+        val results = LinkedHashSet<String>()
+        ACCOUNT_KEYWORDS.forEach { keyword ->
+            if (Regex("""\b${Regex.escape(keyword)}\b""").containsMatchIn(lower)) {
+                results.add(keyword.replaceFirstChar { it.uppercase() })
+            }
+        }
+        return results.toList()
+    }
+
+    // ── Categories ───────────────────────────────────────────────────────
+
+    private fun inferCategories(lower: String): List<String> {
+        val results = LinkedHashSet<String>()
+        CATEGORY_KEYWORDS.forEach { (keyword, category) ->
+            if (lower.contains(keyword)) results.add(category)
+        }
+        return results.toList()
+    }
+
+    // ── Note ─────────────────────────────────────────────────────────────
+
+    private fun extractNote(input: String): String? {
+        val match = NOTE_PATTERN.find(input) ?: return null
+        val note = match.groupValues[1].trim().trimEnd('.', ',')
+        return note.ifBlank { null }
+    }
+
+    private companion object {
+        val WHITESPACE = "\\s+".toRegex()
+
+        val DOLLARS_CENTS_PATTERN =
+            Regex("""(\d+)\s+dollars?(?:\s+and)?\s+(\d{1,2})\s+cents?""")
+        val SIGNALLED_AMOUNT_PATTERN =
+            Regex("""(?:[\$€£]\s?(\d{1,3}(?:,\d{3})+(?:\.\d{1,2})?|\d+(?:\.\d{1,2})?))|(?:(\d{1,3}(?:,\d{3})+(?:\.\d{1,2})?|\d+(?:\.\d{1,2})?)\s?(?:dollars?|bucks?|euros?|pounds?))""")
+        val DECIMAL_AMOUNT_PATTERN =
+            Regex("""(?<![\d.])(\d+\.\d{1,2})(?![\d])""")
+        val WORD_AMOUNT_PATTERN =
+            Regex("""\b([a-z]+)\b\s+(?:dollars?|bucks?)""")
+        val MERCHANT_PATTERN =
+            Regex("""(?:^|\s)(at|from|to)\s+([A-Za-z][A-Za-z0-9\s'&.-]{0,40})""", RegexOption.IGNORE_CASE)
+        val NOTE_PATTERN =
+            Regex("""(?:note|memo)\s+([A-Za-z0-9][A-Za-z0-9\s'&.,-]{0,60})""", RegexOption.IGNORE_CASE)
+
+        val NUMBER_WORDS = mapOf(
+            "one" to 1L, "two" to 2L, "three" to 3L, "four" to 4L, "five" to 5L,
+            "six" to 6L, "seven" to 7L, "eight" to 8L, "nine" to 9L, "ten" to 10L,
+            "eleven" to 11L, "twelve" to 12L, "thirteen" to 13L, "fourteen" to 14L,
+            "fifteen" to 15L, "sixteen" to 16L, "seventeen" to 17L, "eighteen" to 18L,
+            "nineteen" to 19L, "twenty" to 20L, "thirty" to 30L, "forty" to 40L,
+            "fifty" to 50L, "sixty" to 60L, "seventy" to 70L, "eighty" to 80L,
+            "ninety" to 90L, "hundred" to 100L,
+        )
+
+        val INCOME_KEYWORDS = setOf(
+            "received", "salary", "paycheck", "income", "refund",
+            "reimbursement", "bonus", "dividend", "got paid", "deposited",
+        )
+
+        val ACCOUNT_KEYWORDS = listOf(
+            "cash", "checking", "savings", "credit card", "debit card",
+            "visa", "mastercard", "amex", "paypal", "venmo",
+        )
+
+        val LEADING_STOP_WORDS = setOf("the", "a", "an", "my")
+
+        val NUMERIC_TOKEN = Regex("""[\$€£]?\d[\d,.]*""")
+
+        val CURRENCY_WORDS = setOf(
+            "dollar", "dollars", "buck", "bucks", "cent", "cents",
+            "euro", "euros", "pound", "pounds",
+        )
+
+        val TRAILING_STOP_WORDS = setOf(
+            "for", "on", "with", "using", "today", "yesterday", "tomorrow",
+            "note", "memo", "and", "in", "from", "at", "to",
+        )
+
+        val CATEGORY_KEYWORDS = linkedMapOf(
+            "coffee" to "Dining",
+            "starbucks" to "Dining",
+            "lunch" to "Dining",
+            "dinner" to "Dining",
+            "breakfast" to "Dining",
+            "restaurant" to "Dining",
+            "grocery" to "Groceries",
+            "groceries" to "Groceries",
+            "supermarket" to "Groceries",
+            "uber" to "Transport",
+            "lyft" to "Transport",
+            "gas" to "Transport",
+            "fuel" to "Transport",
+            "parking" to "Transport",
+            "bus" to "Transport",
+            "train" to "Transport",
+            "rent" to "Housing",
+            "mortgage" to "Housing",
+            "electric" to "Utilities",
+            "water" to "Utilities",
+            "internet" to "Utilities",
+            "phone" to "Utilities",
+            "netflix" to "Entertainment",
+            "spotify" to "Entertainment",
+            "movie" to "Entertainment",
+            "gym" to "Health",
+            "pharmacy" to "Health",
+            "doctor" to "Health",
+            "amazon" to "Shopping",
+            "target" to "Shopping",
+            "clothes" to "Shopping",
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceTransactionInstrumentation.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceTransactionInstrumentation.kt
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.voice
+
+import com.finance.core.monitoring.MetricsCollector
+
+/**
+ * Privacy-safe instrumentation for voice transaction entry (#2383).
+ *
+ * Records *only* the outcome and shape of a voice entry session — never the
+ * transcript, amounts, merchant, or any other transaction content. All events
+ * are gated by the consent check inside [MetricsCollector]; with consent off
+ * every call is a silent no-op.
+ *
+ * Tracked rates (derivable downstream from these counts):
+ * - success rate — [recordEntryCompleted] vs [recordEntryCancelled]
+ * - cancellation rate — [recordEntryCancelled]
+ * - correction rate — [recordFieldCorrected] / [recordPromptShown]
+ *
+ * @param metrics The shared anonymous metrics collector.
+ */
+class VoiceTransactionInstrumentation(
+    private val metrics: MetricsCollector,
+) {
+
+    /** A voice entry session was started (mic opened or Assistant handoff received). */
+    fun recordEntryStarted(source: EntrySource) {
+        metrics.recordFeatureUsage(
+            FEATURE,
+            mapOf("event" to "started", "source" to source.tag),
+        )
+    }
+
+    /**
+     * The parsed draft was confirmed and saved.
+     *
+     * @param fieldCount Number of populated fields (a count, not values).
+     * @param correctionCount How many fields the user edited before saving.
+     */
+    fun recordEntryCompleted(fieldCount: Int, correctionCount: Int) {
+        metrics.recordFeatureUsage(
+            FEATURE,
+            mapOf(
+                "event" to "completed",
+                "field_count" to fieldCount.coerceAtLeast(0).toString(),
+                "correction_count" to correctionCount.coerceAtLeast(0).toString(),
+            ),
+        )
+    }
+
+    /** The user abandoned the session before saving. */
+    fun recordEntryCancelled(stage: CancelStage) {
+        metrics.recordFeatureUsage(
+            FEATURE,
+            mapOf("event" to "cancelled", "stage" to stage.tag),
+        )
+    }
+
+    /** A native prompt was shown because a field was missing or ambiguous. */
+    fun recordPromptShown(field: VoiceField) {
+        metrics.recordFeatureUsage(
+            FEATURE,
+            mapOf("event" to "prompt_shown", "field" to field.name.lowercase()),
+        )
+    }
+
+    /** The user changed a parsed field during review (a correction). */
+    fun recordFieldCorrected(field: VoiceField) {
+        metrics.recordFeatureUsage(
+            FEATURE,
+            mapOf("event" to "field_corrected", "field" to field.name.lowercase()),
+        )
+    }
+
+    /** The draft was saved locally because the Assistant handoff could not complete. */
+    fun recordOfflineDraftSaved() {
+        metrics.recordFeatureUsage(
+            FEATURE,
+            mapOf("event" to "offline_draft_saved"),
+        )
+    }
+
+    /** Where the session originated. */
+    enum class EntrySource(val tag: String) {
+        ASSISTANT("assistant"),
+        IN_APP_MIC("in_app_mic"),
+        OFFLINE_DRAFT("offline_draft"),
+    }
+
+    /** The stage at which a session was cancelled. */
+    enum class CancelStage(val tag: String) {
+        LISTENING("listening"),
+        PROMPTING("prompting"),
+        REVIEW("review"),
+    }
+
+    private companion object {
+        const val FEATURE = "voice_transaction_entry"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceTransactionModels.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceTransactionModels.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.voice
+
+/**
+ * Transaction fields that a spoken utterance can populate (#2383).
+ *
+ * Used to drive native prompts when a field is missing or ambiguous so
+ * the user is always asked rather than silently defaulted.
+ */
+enum class VoiceField {
+    AMOUNT,
+    MERCHANT,
+    CATEGORY,
+    ACCOUNT,
+    NOTE,
+}
+
+/**
+ * Whether the spoken transaction moves money out (expense) or in (income).
+ */
+enum class VoiceDirection {
+    EXPENSE,
+    INCOME,
+}
+
+/**
+ * A structured, reviewable transaction draft produced from speech (#2383).
+ *
+ * Money is stored in integer minor units (cents) to avoid floating-point
+ * rounding errors in financial math. A `null` field means "not captured" —
+ * the review flow must never invent a value.
+ *
+ * @property amountMinor Amount in minor units (e.g. cents), or null if absent.
+ * @property currencyCode ISO-4217 code when spoken (e.g. "USD"), else null.
+ * @property merchant Merchant / payee name, or null if not captured.
+ * @property category Inferred category, or null if not captured.
+ * @property account Account name spoken (e.g. "checking"), or null.
+ * @property note Free-form memo, or null if not captured.
+ * @property direction Expense vs income inferred from the utterance.
+ */
+data class VoiceTransactionDraft(
+    val amountMinor: Long? = null,
+    val currencyCode: String? = null,
+    val merchant: String? = null,
+    val category: String? = null,
+    val account: String? = null,
+    val note: String? = null,
+    val direction: VoiceDirection = VoiceDirection.EXPENSE,
+) {
+    /** True when the draft has the minimum fields required to save (amount + merchant). */
+    val isComplete: Boolean
+        get() = amountMinor != null && !merchant.isNullOrBlank()
+}
+
+/**
+ * A field that the parser found multiple plausible values for (#2383).
+ *
+ * The review flow surfaces these candidates so the user disambiguates
+ * explicitly. The draft leaves the field `null` until resolved.
+ *
+ * @property field The ambiguous transaction field.
+ * @property candidates Distinct candidate values, in spoken order.
+ */
+data class FieldAmbiguity(
+    val field: VoiceField,
+    val candidates: List<String>,
+)
+
+/**
+ * Result of parsing a spoken utterance into transaction fields (#2383).
+ *
+ * @property draft The best-effort structured draft (unambiguous fields only).
+ * @property missingFields Required fields the utterance did not provide.
+ * @property ambiguities Fields with more than one plausible candidate.
+ * @property overallConfidence Heuristic confidence in [0.0, 1.0].
+ * @property rawUtterance Original transcript, retained in-memory for review.
+ *   NEVER log this — it is user financial content.
+ */
+data class VoiceParseResult(
+    val draft: VoiceTransactionDraft,
+    val missingFields: List<VoiceField> = emptyList(),
+    val ambiguities: List<FieldAmbiguity> = emptyList(),
+    val overallConfidence: Float = 0f,
+    val rawUtterance: String = "",
+) {
+    /** True when no field is missing or ambiguous — ready to review-and-save. */
+    val isReadyForReview: Boolean
+        get() = missingFields.isEmpty() && ambiguities.isEmpty() && draft.isComplete
+
+    /** Fields that still need user input via a native prompt. */
+    val fieldsNeedingPrompt: List<VoiceField>
+        get() = (missingFields + ambiguities.map { it.field }).distinct()
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceTransactionScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceTransactionScreen.kt
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.voice
+
+import java.util.Locale
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+
+/**
+ * Voice transaction review screen (#2383).
+ *
+ * Shows the parsed draft, asks native prompts for missing/ambiguous fields,
+ * and requires explicit confirmation before saving. The actual speech capture
+ * and Assistant App Action wiring are device-only and live outside this screen.
+ *
+ * @param state Current review state from [VoiceTransactionViewModel].
+ * @param onPromptResolved Called with the user's answer to the current prompt.
+ * @param onConfirm Called when the user confirms the reviewed draft.
+ * @param onCancel Called when the user abandons the session.
+ * @param onBack Navigation callback.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VoiceTransactionScreen(
+    state: VoiceEntryUiState,
+    onPromptResolved: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+    onBack: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        "Voice Transaction",
+                        modifier = Modifier.semantics {
+                            heading()
+                            contentDescription = "Voice transaction review screen"
+                        },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics { contentDescription = "Navigate back" },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+        modifier = modifier,
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            if (state.isOfflineDraft) {
+                OfflineBanner()
+            }
+
+            ConfidenceBar(state.overallConfidence)
+
+            when (val prompt = state.currentPrompt) {
+                null -> {
+                    DraftSummaryCard(state.draft)
+                    ReviewActions(
+                        canSave = state.canSave,
+                        onConfirm = onConfirm,
+                        onCancel = onCancel,
+                    )
+                }
+
+                else -> FieldPromptSection(
+                    prompt = prompt,
+                    onResolve = onPromptResolved,
+                    onCancel = onCancel,
+                )
+            }
+
+            Spacer(Modifier.height(48.dp))
+        }
+    }
+}
+
+@Composable
+private fun OfflineBanner() {
+    Text(
+        text = "Saved as an offline draft — finish reviewing it here when you're ready.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription =
+                    "This transaction was saved as an offline draft. Finish reviewing it when ready."
+            },
+    )
+}
+
+@Composable
+private fun ConfidenceBar(confidence: Float) {
+    val percent = (confidence * 100).toInt()
+    Column(
+        modifier = Modifier.semantics {
+            contentDescription = "Parse confidence $percent percent"
+        },
+    ) {
+        Text(
+            text = "Confidence: $percent%",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(4.dp))
+        LinearProgressIndicator(
+            progress = { confidence },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp),
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun FieldPromptSection(
+    prompt: FieldPrompt,
+    onResolve: (String) -> Unit,
+    onCancel: () -> Unit,
+) {
+    var typed by remember(prompt) { mutableStateOf("") }
+    val label = prompt.field.displayName()
+    val question = when (prompt.reason) {
+        PromptReason.MISSING -> "What's the $label?"
+        PromptReason.AMBIGUOUS -> "Which $label did you mean?"
+    }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.semantics { contentDescription = question },
+    ) {
+        Text(
+            text = question,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics { heading() },
+        )
+
+        if (prompt.candidates.isNotEmpty()) {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                prompt.candidates.forEach { candidate ->
+                    val display = prompt.field.formatCandidate(candidate)
+                    AssistChip(
+                        onClick = { onResolve(candidate) },
+                        label = { Text(display) },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Choose $label $display"
+                        },
+                    )
+                }
+            }
+        }
+
+        OutlinedTextField(
+            value = typed,
+            onValueChange = { typed = it },
+            label = { Text("Enter $label") },
+            singleLine = true,
+            keyboardOptions = if (prompt.field == VoiceField.AMOUNT) {
+                KeyboardOptions(keyboardType = KeyboardType.Number)
+            } else {
+                KeyboardOptions.Default
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "Enter $label manually" },
+        )
+
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Button(
+                onClick = {
+                    val value = if (prompt.field == VoiceField.AMOUNT) {
+                        typed.toMinorUnitsOrNull()?.toString().orEmpty()
+                    } else {
+                        typed.trim()
+                    }
+                    if (value.isNotBlank()) onResolve(value)
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .semantics { contentDescription = "Confirm $label" },
+            ) {
+                Icon(Icons.Filled.Check, null, Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text("Confirm")
+            }
+            OutlinedButton(
+                onClick = onCancel,
+                modifier = Modifier.semantics { contentDescription = "Cancel voice entry" },
+            ) {
+                Icon(Icons.Filled.Close, null, Modifier.size(18.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun DraftSummaryCard(draft: VoiceTransactionDraft) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = draft.accessibilitySummary() },
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = "Review your transaction",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            DraftRow("Amount", draft.amountMinor?.let { formatMinor(it, draft.currencyCode) } ?: "—")
+            DraftRow("Merchant", draft.merchant ?: "—")
+            DraftRow("Category", draft.category ?: "—")
+            DraftRow("Account", draft.account ?: "—")
+            DraftRow("Note", draft.note ?: "—")
+            DraftRow("Type", draft.direction.name.lowercase().replaceFirstChar { it.uppercase() })
+        }
+    }
+}
+
+@Composable
+private fun DraftRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = "$label: $value" },
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun ReviewActions(
+    canSave: Boolean,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        Button(
+            onClick = onConfirm,
+            enabled = canSave,
+            modifier = Modifier
+                .weight(1f)
+                .semantics {
+                    contentDescription = if (canSave) {
+                        "Save transaction"
+                    } else {
+                        "Save transaction, disabled until all fields are filled"
+                    }
+                },
+        ) {
+            Icon(Icons.Filled.Check, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text("Save")
+        }
+        OutlinedButton(
+            onClick = onCancel,
+            modifier = Modifier.semantics { contentDescription = "Discard voice transaction" },
+        ) {
+            Icon(Icons.Filled.Close, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text("Discard")
+        }
+    }
+}
+
+// ── Formatting helpers ──────────────────────────────────────────────────
+
+private fun VoiceField.displayName(): String = when (this) {
+    VoiceField.AMOUNT -> "amount"
+    VoiceField.MERCHANT -> "merchant"
+    VoiceField.CATEGORY -> "category"
+    VoiceField.ACCOUNT -> "account"
+    VoiceField.NOTE -> "note"
+}
+
+private fun VoiceField.formatCandidate(candidate: String): String =
+    if (this == VoiceField.AMOUNT) {
+        candidate.toLongOrNull()?.let { formatMinor(it, null) } ?: candidate
+    } else {
+        candidate
+    }
+
+private fun formatMinor(minor: Long, currencyCode: String?): String {
+    val major = minor / 100.0
+    val symbol = when (currencyCode) {
+        "EUR" -> "€"
+        "GBP" -> "£"
+        else -> "$"
+    }
+    return symbol + String.format(Locale.ROOT, "%.2f", major)
+}
+
+private fun String.toMinorUnitsOrNull(): Long? {
+    val cleaned = trim().removePrefix("$").removePrefix("€").removePrefix("£").replace(",", "")
+    if (cleaned.isBlank()) return null
+    val parts = cleaned.split(".")
+    val whole = parts[0].toLongOrNull() ?: return null
+    val fraction = if (parts.size > 1) parts[1].padEnd(2, '0').take(2).toLongOrNull() ?: 0L else 0L
+    return whole * 100 + fraction
+}
+
+private fun VoiceTransactionDraft.accessibilitySummary(): String = buildString {
+    append("Review transaction. ")
+    amountMinor?.let { append("Amount ${formatMinor(it, currencyCode)}. ") }
+    merchant?.let { append("Merchant $it. ") }
+    category?.let { append("Category $it. ") }
+    account?.let { append("Account $it. ") }
+    note?.let { append("Note $it. ") }
+    append("Type ${direction.name.lowercase()}.")
+}
+
+// ── Previews ────────────────────────────────────────────────────────────
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true, name = "Voice — Review")
+@Composable
+private fun VoiceReviewPreview() {
+    FinanceTheme(dynamicColor = false) {
+        VoiceTransactionScreen(
+            state = VoiceEntryUiState(
+                stage = VoiceEntryStage.REVIEW,
+                draft = VoiceTransactionDraft(
+                    amountMinor = 450,
+                    currencyCode = "USD",
+                    merchant = "Starbucks",
+                    category = "Dining",
+                ),
+                overallConfidence = 0.85f,
+            ),
+            onPromptResolved = {},
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true, name = "Voice — Prompt")
+@Composable
+private fun VoicePromptPreview() {
+    FinanceTheme(dynamicColor = false) {
+        VoiceTransactionScreen(
+            state = VoiceEntryUiState(
+                stage = VoiceEntryStage.PROMPTING,
+                draft = VoiceTransactionDraft(amountMinor = 1200),
+                pendingPrompts = listOf(
+                    FieldPrompt(
+                        field = VoiceField.MERCHANT,
+                        candidates = listOf("Chipotle", "Chevron"),
+                        reason = PromptReason.AMBIGUOUS,
+                    ),
+                ),
+                overallConfidence = 0.5f,
+            ),
+            onPromptResolved = {},
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceTransactionViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/voice/VoiceTransactionViewModel.kt
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.voice
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import timber.log.Timber
+
+/** Why a field needs a native prompt before the transaction can be saved. */
+enum class PromptReason {
+    /** The utterance did not provide a required field. */
+    MISSING,
+
+    /** The utterance provided more than one plausible value. */
+    AMBIGUOUS,
+}
+
+/**
+ * A native prompt the user must resolve before saving (#2383).
+ *
+ * @property field The field being clarified.
+ * @property candidates Disambiguation options; empty for free entry (missing).
+ * @property reason Whether the field was missing or ambiguous.
+ */
+data class FieldPrompt(
+    val field: VoiceField,
+    val candidates: List<String>,
+    val reason: PromptReason,
+)
+
+/** Stages of a single voice transaction entry session. */
+enum class VoiceEntryStage {
+    IDLE,
+    PROMPTING,
+    REVIEW,
+    SAVED,
+}
+
+/**
+ * UI state for the voice transaction review flow (#2383).
+ *
+ * @property stage Current stage of the session.
+ * @property draft The working draft assembled so far.
+ * @property pendingPrompts Outstanding prompts for missing/ambiguous fields.
+ * @property overallConfidence Heuristic parse confidence in [0.0, 1.0].
+ * @property isOfflineDraft True when this came from a failed Assistant handoff.
+ * @property correctionCount Fields the user edited during review (for metrics).
+ */
+data class VoiceEntryUiState(
+    val stage: VoiceEntryStage = VoiceEntryStage.IDLE,
+    val draft: VoiceTransactionDraft = VoiceTransactionDraft(),
+    val pendingPrompts: List<FieldPrompt> = emptyList(),
+    val overallConfidence: Float = 0f,
+    val isOfflineDraft: Boolean = false,
+    val correctionCount: Int = 0,
+) {
+    /** The prompt currently being shown, or null when none remain. */
+    val currentPrompt: FieldPrompt?
+        get() = pendingPrompts.firstOrNull()
+
+    /** True when the draft can be saved (required fields present, no prompts). */
+    val canSave: Boolean
+        get() = pendingPrompts.isEmpty() && draft.isComplete
+}
+
+/**
+ * Drives the confirmation/review flow for spoken transactions (#2383).
+ *
+ * Responsibilities:
+ * - Parse an utterance into a [VoiceTransactionDraft] via [UtteranceParser].
+ * - Surface native prompts for every missing or ambiguous field — there are
+ *   no silent defaults.
+ * - Require explicit user confirmation before any spoken transaction is saved.
+ * - Support offline-safe drafting when the Assistant handoff cannot complete.
+ * - Emit privacy-safe instrumentation (no transaction content).
+ *
+ * ## Security
+ * Logs only field *names* and stage transitions — never amounts, merchant
+ * names, the transcript, or any other transaction content.
+ *
+ * @param parser Deterministic, offline-capable utterance parser.
+ * @param instrumentation Privacy-safe outcome metrics.
+ * @param draftStore Offline-safe draft persistence.
+ */
+class VoiceTransactionViewModel(
+    private val parser: UtteranceParser,
+    private val instrumentation: VoiceTransactionInstrumentation,
+    private val draftStore: VoiceDraftStore,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(VoiceEntryUiState())
+    val uiState: StateFlow<VoiceEntryUiState> = _uiState.asStateFlow()
+
+    /**
+     * Begins a session from a transcript received in-app or via Assistant.
+     *
+     * @param utterance Raw transcript. Never logged.
+     * @param source Where the transcript came from (for metrics only).
+     */
+    fun onUtteranceReceived(
+        utterance: String,
+        source: VoiceTransactionInstrumentation.EntrySource =
+            VoiceTransactionInstrumentation.EntrySource.IN_APP_MIC,
+    ) {
+        instrumentation.recordEntryStarted(source)
+        val result = parser.parse(utterance)
+        applyParseResult(result, isOffline = false)
+    }
+
+    /**
+     * Handles a transcript when the Assistant handoff could not complete.
+     *
+     * The draft is parsed locally and stashed in [draftStore] so the user can
+     * finish it later — drafting works fully offline.
+     *
+     * @param utterance Raw transcript captured before the handoff failed.
+     */
+    fun onAssistantHandoffUnavailable(utterance: String) {
+        instrumentation.recordEntryStarted(
+            VoiceTransactionInstrumentation.EntrySource.OFFLINE_DRAFT,
+        )
+        val result = parser.parse(utterance)
+        draftStore.saveDraft(result.draft)
+        instrumentation.recordOfflineDraftSaved()
+        Timber.i("Voice handoff unavailable — draft stashed for later review")
+        applyParseResult(result, isOffline = true)
+    }
+
+    /**
+     * Resolves the current prompt with a user-supplied value.
+     *
+     * @param value The value chosen (candidate) or typed (missing field).
+     */
+    fun onPromptResolved(value: String) {
+        val state = _uiState.value
+        val prompt = state.currentPrompt ?: return
+        val updatedDraft = state.draft.withField(prompt.field, value)
+        val remaining = state.pendingPrompts.drop(1)
+
+        _uiState.update {
+            it.copy(
+                draft = updatedDraft,
+                pendingPrompts = remaining,
+                stage = if (remaining.isEmpty()) VoiceEntryStage.REVIEW else VoiceEntryStage.PROMPTING,
+            )
+        }
+        if (remaining.isNotEmpty()) {
+            instrumentation.recordPromptShown(remaining.first().field)
+        }
+        Timber.d("Prompt resolved for field=%s; remaining=%d", prompt.field.name, remaining.size)
+    }
+
+    /**
+     * Edits an already-parsed field during review (counts as a correction).
+     */
+    fun onFieldCorrected(field: VoiceField, value: String) {
+        instrumentation.recordFieldCorrected(field)
+        _uiState.update {
+            it.copy(
+                draft = it.draft.withField(field, value),
+                correctionCount = it.correctionCount + 1,
+            )
+        }
+        Timber.d("Field corrected: %s", field.name)
+    }
+
+    /**
+     * Confirms and saves the reviewed draft.
+     *
+     * Saving is blocked unless [VoiceEntryUiState.canSave] is true, guaranteeing
+     * the user reviewed every prompted field first.
+     *
+     * @param onSave Sink for the confirmed draft (e.g. transaction repository).
+     * @return true if the draft was saved, false if it was not yet complete.
+     */
+    fun onConfirmSave(onSave: (VoiceTransactionDraft) -> Unit): Boolean {
+        val state = _uiState.value
+        if (!state.canSave) return false
+
+        onSave(state.draft)
+        draftStore.remove(state.draft)
+        instrumentation.recordEntryCompleted(
+            fieldCount = state.draft.populatedFieldCount(),
+            correctionCount = state.correctionCount,
+        )
+        _uiState.update { it.copy(stage = VoiceEntryStage.SAVED) }
+        Timber.i("Voice transaction confirmed and saved")
+        return true
+    }
+
+    /** Abandons the session and records a cancellation for the given stage. */
+    fun onCancel() {
+        val stage = when (_uiState.value.stage) {
+            VoiceEntryStage.PROMPTING ->
+                VoiceTransactionInstrumentation.CancelStage.PROMPTING
+
+            else -> VoiceTransactionInstrumentation.CancelStage.REVIEW
+        }
+        instrumentation.recordEntryCancelled(stage)
+        reset()
+    }
+
+    /** Resets to the idle state. */
+    fun reset() {
+        _uiState.value = VoiceEntryUiState()
+    }
+
+    private fun applyParseResult(result: VoiceParseResult, isOffline: Boolean) {
+        val prompts = buildPrompts(result)
+        prompts.firstOrNull()?.let { instrumentation.recordPromptShown(it.field) }
+
+        _uiState.value = VoiceEntryUiState(
+            stage = if (prompts.isEmpty()) VoiceEntryStage.REVIEW else VoiceEntryStage.PROMPTING,
+            draft = result.draft,
+            pendingPrompts = prompts,
+            overallConfidence = result.overallConfidence,
+            isOfflineDraft = isOffline,
+        )
+        Timber.d(
+            "Parsed utterance: prompts=%d, confidence=%.2f, offline=%b",
+            prompts.size,
+            result.overallConfidence,
+            isOffline,
+        )
+    }
+
+    private fun buildPrompts(result: VoiceParseResult): List<FieldPrompt> {
+        val missingPrompts = result.missingFields.map {
+            FieldPrompt(field = it, candidates = emptyList(), reason = PromptReason.MISSING)
+        }
+        val ambiguousPrompts = result.ambiguities.map {
+            FieldPrompt(field = it.field, candidates = it.candidates, reason = PromptReason.AMBIGUOUS)
+        }
+        // Resolve required-missing fields first, then ambiguities.
+        return missingPrompts + ambiguousPrompts
+    }
+}
+
+/** Returns a copy with [field] set to [value], parsing amounts to minor units. */
+internal fun VoiceTransactionDraft.withField(field: VoiceField, value: String): VoiceTransactionDraft =
+    when (field) {
+        VoiceField.AMOUNT -> copy(amountMinor = value.toLongOrNull() ?: amountMinor)
+        VoiceField.MERCHANT -> copy(merchant = value)
+        VoiceField.CATEGORY -> copy(category = value)
+        VoiceField.ACCOUNT -> copy(account = value)
+        VoiceField.NOTE -> copy(note = value)
+    }
+
+/** Number of non-null/non-blank fields, used for anonymous metrics only. */
+internal fun VoiceTransactionDraft.populatedFieldCount(): Int = listOf(
+    amountMinor != null,
+    !merchant.isNullOrBlank(),
+    !category.isNullOrBlank(),
+    !account.isNullOrBlank(),
+    !note.isNullOrBlank(),
+).count { it }

--- a/apps/android/src/test/kotlin/com/finance/android/ui/voice/LocalUtteranceParserTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/voice/LocalUtteranceParserTest.kt
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.voice
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [LocalUtteranceParser] and [RuleBasedVoiceEntityExtractor] (#2383).
+ *
+ * Covers amount extraction across phrasings, merchant/category/account/note
+ * capture, income detection, missing-field reporting, and ambiguity handling.
+ * Deterministic and fully offline — no Android framework required.
+ */
+class LocalUtteranceParserTest {
+
+    private val parser = LocalUtteranceParser()
+
+    // ── Amount phrasings ─────────────────────────────────────────────────
+
+    @Test
+    fun `parses dollar sign amount`() {
+        val result = parser.parse("Coffee at Starbucks \$4.50")
+        assertEquals(450L, result.draft.amountMinor)
+        assertEquals("USD", result.draft.currencyCode)
+    }
+
+    @Test
+    fun `parses spoken dollars word`() {
+        val result = parser.parse("Lunch at Chipotle 12 dollars")
+        assertEquals(1200L, result.draft.amountMinor)
+    }
+
+    @Test
+    fun `parses dollars and cents phrasing`() {
+        val result = parser.parse("Gas at Chevron 4 dollars and 50 cents")
+        assertEquals(450L, result.draft.amountMinor)
+    }
+
+    @Test
+    fun `parses spelled out amount`() {
+        val result = parser.parse("Snack at Deli twenty dollars")
+        assertEquals(2000L, result.draft.amountMinor)
+    }
+
+    @Test
+    fun `parses bare decimal as money`() {
+        val result = parser.parse("Coffee at Cafe 3.75")
+        assertEquals(375L, result.draft.amountMinor)
+    }
+
+    @Test
+    fun `dollars and cents is not double counted`() {
+        val entities = RuleBasedVoiceEntityExtractor().extract("paid 4 dollars and 50 cents")
+        assertEquals(listOf(450L), entities.amountsMinor)
+    }
+
+    // ── Merchant ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `extracts merchant after at`() {
+        val result = parser.parse("Coffee at Starbucks \$4.50")
+        assertEquals("Starbucks", result.draft.merchant)
+    }
+
+    @Test
+    fun `extracts merchant after from dropping article`() {
+        val result = parser.parse("Bought lunch at the Deli 8 dollars")
+        assertEquals("Deli", result.draft.merchant)
+    }
+
+    // ── Category, account, note, direction ───────────────────────────────
+
+    @Test
+    fun `infers category from keyword`() {
+        val result = parser.parse("Coffee at Starbucks \$4.50")
+        assertEquals("Dining", result.draft.category)
+    }
+
+    @Test
+    fun `extracts account keyword`() {
+        val result = parser.parse("Coffee at Starbucks \$4.50 with cash")
+        assertEquals("Cash", result.draft.account)
+    }
+
+    @Test
+    fun `extracts note phrase`() {
+        val result = parser.parse("Dinner at Bistro 40 dollars note client meeting")
+        assertEquals("client meeting", result.draft.note)
+    }
+
+    @Test
+    fun `detects income direction`() {
+        val result = parser.parse("Received salary at Employer 3000 dollars")
+        assertEquals(VoiceDirection.INCOME, result.draft.direction)
+    }
+
+    @Test
+    fun `defaults to expense direction`() {
+        val result = parser.parse("Coffee at Starbucks \$4.50")
+        assertEquals(VoiceDirection.EXPENSE, result.draft.direction)
+    }
+
+    // ── Missing fields → prompts, never silent defaults ──────────────────
+
+    @Test
+    fun `reports missing merchant`() {
+        val result = parser.parse("Spent 20 dollars")
+        assertTrue(VoiceField.MERCHANT in result.missingFields)
+        assertNull(result.draft.merchant)
+        assertFalse(result.isReadyForReview)
+    }
+
+    @Test
+    fun `reports missing amount`() {
+        val result = parser.parse("Coffee at Starbucks")
+        assertTrue(VoiceField.AMOUNT in result.missingFields)
+        assertNull(result.draft.amountMinor)
+    }
+
+    @Test
+    fun `blank utterance reports both required fields missing`() {
+        val result = parser.parse("   ")
+        assertTrue(VoiceField.AMOUNT in result.missingFields)
+        assertTrue(VoiceField.MERCHANT in result.missingFields)
+        assertEquals(0f, result.overallConfidence)
+    }
+
+    // ── Ambiguity → never auto-pick ──────────────────────────────────────
+
+    @Test
+    fun `ambiguous amount is left unset and reported`() {
+        val result = parser.parse("Lunch at Cafe 20 dollars or 30 dollars")
+        val ambiguity = result.ambiguities.firstOrNull { it.field == VoiceField.AMOUNT }
+        assertTrue(ambiguity != null)
+        assertEquals(listOf("2000", "3000"), ambiguity!!.candidates)
+        assertNull(result.draft.amountMinor)
+    }
+
+    @Test
+    fun `ambiguous category is reported but does not block`() {
+        val result = parser.parse("Uber to the gym 15 dollars at Stop")
+        val ambiguity = result.ambiguities.firstOrNull { it.field == VoiceField.CATEGORY }
+        assertTrue(ambiguity != null)
+        assertNull(result.draft.category)
+        // category is optional, so it is not a missing required field
+        assertFalse(VoiceField.CATEGORY in result.missingFields)
+    }
+
+    // ── Happy path readiness ─────────────────────────────────────────────
+
+    @Test
+    fun `complete utterance is ready for review`() {
+        val result = parser.parse("Coffee at Starbucks \$4.50")
+        assertTrue(result.isReadyForReview)
+        assertTrue(result.missingFields.isEmpty())
+        assertTrue(result.ambiguities.isEmpty())
+        assertTrue(result.overallConfidence > 0.7f)
+    }
+
+    @Test
+    fun `fieldsNeedingPrompt combines missing and ambiguous`() {
+        val result = parser.parse("Spent 20 dollars or 30 dollars")
+        assertTrue(VoiceField.MERCHANT in result.fieldsNeedingPrompt)
+        assertTrue(VoiceField.AMOUNT in result.fieldsNeedingPrompt)
+    }
+
+    // ── Pluggable extractor seam ─────────────────────────────────────────
+
+    @Test
+    fun `custom extractor is used for resolution`() {
+        val stub = VoiceEntityExtractor {
+            VoiceEntities(amountsMinor = listOf(999L), merchantCandidates = listOf("StubCo"))
+        }
+        val result = LocalUtteranceParser(stub).parse("anything")
+        assertEquals(999L, result.draft.amountMinor)
+        assertEquals("StubCo", result.draft.merchant)
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/voice/VoiceTransactionInstrumentationTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/voice/VoiceTransactionInstrumentationTest.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.voice
+
+import com.finance.core.monitoring.MetricsCollector
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [VoiceTransactionInstrumentation] (#2383).
+ *
+ * Verifies that only anonymous outcome metadata is recorded — never the
+ * transcript, amounts, merchant, or any other transaction content — and that
+ * analytics consent gates every event.
+ */
+class VoiceTransactionInstrumentationTest {
+
+    private val safeKeys = setOf(
+        "feature", "event", "source", "stage", "field",
+        "field_count", "correction_count",
+    )
+
+    private fun collector(consent: Boolean) = MetricsCollector(consentProvider = { consent })
+
+    @Test
+    fun `records started event with source only`() {
+        val metrics = collector(consent = true)
+        VoiceTransactionInstrumentation(metrics)
+            .recordEntryStarted(VoiceTransactionInstrumentation.EntrySource.ASSISTANT)
+
+        val events = metrics.flushEvents()
+        assertEquals(1, events.size)
+        assertEquals("feature_usage", events[0].name)
+        assertEquals("started", events[0].properties["event"])
+        assertEquals("assistant", events[0].properties["source"])
+    }
+
+    @Test
+    fun `completed event records only counts`() {
+        val metrics = collector(consent = true)
+        VoiceTransactionInstrumentation(metrics).recordEntryCompleted(fieldCount = 4, correctionCount = 1)
+
+        val event = metrics.flushEvents().single()
+        assertEquals("4", event.properties["field_count"])
+        assertEquals("1", event.properties["correction_count"])
+    }
+
+    @Test
+    fun `all event properties use only safe anonymous keys`() {
+        val metrics = collector(consent = true)
+        val instrumentation = VoiceTransactionInstrumentation(metrics)
+
+        instrumentation.recordEntryStarted(VoiceTransactionInstrumentation.EntrySource.IN_APP_MIC)
+        instrumentation.recordPromptShown(VoiceField.AMOUNT)
+        instrumentation.recordFieldCorrected(VoiceField.MERCHANT)
+        instrumentation.recordEntryCancelled(VoiceTransactionInstrumentation.CancelStage.REVIEW)
+        instrumentation.recordEntryCompleted(fieldCount = 3, correctionCount = 0)
+        instrumentation.recordOfflineDraftSaved()
+
+        val events = metrics.flushEvents()
+        assertEquals(6, events.size)
+        events.forEach { event ->
+            event.properties.keys.forEach { key ->
+                assertTrue(key in safeKeys, "Unexpected metric key: $key")
+            }
+            // Field metrics carry only the field *name*, never a value.
+            event.properties["field"]?.let { value ->
+                assertTrue(value in setOf("amount", "merchant", "category", "account", "note"))
+            }
+        }
+    }
+
+    @Test
+    fun `no events recorded without consent`() {
+        val metrics = collector(consent = false)
+        val instrumentation = VoiceTransactionInstrumentation(metrics)
+
+        instrumentation.recordEntryStarted(VoiceTransactionInstrumentation.EntrySource.ASSISTANT)
+        instrumentation.recordEntryCompleted(fieldCount = 5, correctionCount = 2)
+
+        assertEquals(0, metrics.bufferedEventCount)
+    }
+
+    @Test
+    fun `negative counts are clamped to zero`() {
+        val metrics = collector(consent = true)
+        VoiceTransactionInstrumentation(metrics).recordEntryCompleted(fieldCount = -3, correctionCount = -1)
+
+        val event = metrics.flushEvents().single()
+        assertEquals("0", event.properties["field_count"])
+        assertEquals("0", event.properties["correction_count"])
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/voice/VoiceTransactionViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/voice/VoiceTransactionViewModelTest.kt
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.voice
+
+import com.finance.core.monitoring.MetricsCollector
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [VoiceTransactionViewModel] (#2383).
+ *
+ * Covers the confirmation/review flow, native prompting for missing and
+ * ambiguous fields (no silent defaults), correction tracking, and offline-safe
+ * drafting when the Assistant handoff cannot complete.
+ */
+class VoiceTransactionViewModelTest {
+
+    private fun newViewModel(
+        draftStore: VoiceDraftStore = InMemoryVoiceDraftStore(),
+    ): VoiceTransactionViewModel {
+        val metrics = MetricsCollector(consentProvider = { true })
+        return VoiceTransactionViewModel(
+            parser = LocalUtteranceParser(),
+            instrumentation = VoiceTransactionInstrumentation(metrics),
+            draftStore = draftStore,
+        )
+    }
+
+    @Test
+    fun `complete utterance goes straight to review and can save`() {
+        val vm = newViewModel()
+        vm.onUtteranceReceived("Coffee at Starbucks \$4.50")
+
+        val state = vm.uiState.value
+        assertEquals(VoiceEntryStage.REVIEW, state.stage)
+        assertTrue(state.canSave)
+        assertEquals(450L, state.draft.amountMinor)
+        assertEquals("Starbucks", state.draft.merchant)
+    }
+
+    @Test
+    fun `missing merchant produces a prompt that blocks saving`() {
+        val vm = newViewModel()
+        vm.onUtteranceReceived("Spent 20 dollars")
+
+        val state = vm.uiState.value
+        assertEquals(VoiceEntryStage.PROMPTING, state.stage)
+        assertEquals(VoiceField.MERCHANT, state.currentPrompt?.field)
+        assertEquals(PromptReason.MISSING, state.currentPrompt?.reason)
+        assertFalse(state.canSave)
+    }
+
+    @Test
+    fun `resolving the prompt advances to review`() {
+        val vm = newViewModel()
+        vm.onUtteranceReceived("Spent 20 dollars")
+        vm.onPromptResolved("Cafe")
+
+        val state = vm.uiState.value
+        assertEquals(VoiceEntryStage.REVIEW, state.stage)
+        assertEquals("Cafe", state.draft.merchant)
+        assertTrue(state.canSave)
+    }
+
+    @Test
+    fun `ambiguous amount prompts with candidates and never auto-picks`() {
+        val vm = newViewModel()
+        vm.onUtteranceReceived("Lunch at Cafe 20 dollars or 30 dollars")
+
+        val prompt = vm.uiState.value.currentPrompt
+        assertEquals(VoiceField.AMOUNT, prompt?.field)
+        assertEquals(PromptReason.AMBIGUOUS, prompt?.reason)
+        assertEquals(listOf("2000", "3000"), prompt?.candidates)
+        assertNull(vm.uiState.value.draft.amountMinor)
+
+        vm.onPromptResolved("3000")
+        assertEquals(3000L, vm.uiState.value.draft.amountMinor)
+    }
+
+    @Test
+    fun `confirm save emits draft and marks saved`() {
+        val vm = newViewModel()
+        vm.onUtteranceReceived("Coffee at Starbucks \$4.50")
+
+        var saved: VoiceTransactionDraft? = null
+        val result = vm.onConfirmSave { saved = it }
+
+        assertTrue(result)
+        assertEquals("Starbucks", saved?.merchant)
+        assertEquals(VoiceEntryStage.SAVED, vm.uiState.value.stage)
+    }
+
+    @Test
+    fun `confirm save is blocked while a prompt is pending`() {
+        val vm = newViewModel()
+        vm.onUtteranceReceived("Spent 20 dollars")
+
+        var saved = false
+        val result = vm.onConfirmSave { saved = true }
+
+        assertFalse(result)
+        assertFalse(saved)
+    }
+
+    @Test
+    fun `field correction updates draft and counts the correction`() {
+        val vm = newViewModel()
+        vm.onUtteranceReceived("Coffee at Starbucks \$4.50")
+        vm.onFieldCorrected(VoiceField.MERCHANT, "Blue Bottle")
+
+        assertEquals("Blue Bottle", vm.uiState.value.draft.merchant)
+        assertEquals(1, vm.uiState.value.correctionCount)
+    }
+
+    @Test
+    fun `offline handoff stashes a draft and flags offline`() {
+        val store = InMemoryVoiceDraftStore()
+        val vm = newViewModel(store)
+        vm.onAssistantHandoffUnavailable("Coffee at Starbucks \$4.50")
+
+        assertTrue(vm.uiState.value.isOfflineDraft)
+        assertEquals(1, store.pendingDrafts().size)
+        assertEquals("Starbucks", store.pendingDrafts().first().merchant)
+    }
+
+    @Test
+    fun `cancel resets to idle`() {
+        val vm = newViewModel()
+        vm.onUtteranceReceived("Coffee at Starbucks \$4.50")
+        vm.onCancel()
+
+        assertEquals(VoiceEntryStage.IDLE, vm.uiState.value.stage)
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Google Assistant voice transaction entry** (#2383): an Android commuter can speak a short phrase and land in a prefilled, **reviewable** transaction draft. All parsing is deterministic and on-device, so drafting works fully offline.

### What's included (`apps/android` only)
- **Deterministic utterance parser behind an interface.** `UtteranceParser` / `LocalUtteranceParser` map spoken phrases to amount, merchant, category, account, and note. ML Kit entity extraction is **decoupled** behind `VoiceEntityExtractor` (default `RuleBasedVoiceEntityExtractor`) — an ML-backed impl drops in without touching the flow.
- **Confirmation/review flow before any save.** `VoiceTransactionViewModel` + `VoiceTransactionScreen` require explicit confirmation; nothing is written until the user taps Save.
- **Native prompts for missing/ambiguous fields — no silent defaults.** Required fields that are absent, and any field with multiple candidates, are surfaced as prompts.
- **Offline-safe drafting.** `onAssistantHandoffUnavailable` parses locally and stashes a draft in `VoiceDraftStore` for later review.
- **Privacy-safe instrumentation.** `VoiceTransactionInstrumentation` records success / cancellation / correction outcomes as anonymous, consent-gated counts — never transcript or transaction content.
- **Privacy notes** documenting speech-transcription and local-parsing boundaries (`apps/android/docs/voice-transaction-entry.md`).
- **JVM unit tests** across phrasings and ambiguity: `LocalUtteranceParserTest`, `VoiceTransactionInstrumentationTest`, `VoiceTransactionViewModelTest`.

### Money & accessibility
- Amounts stored in integer **minor units (cents)** to avoid float rounding.
- All Composables carry `contentDescription`; Material 3 theming; Timber-only logging (field names/counts, never content).

## Needs Human Action
Device-only wiring is intentionally left as `// TODO(human)` (see `VoiceAssistantEntryPoint.kt` and the doc):
1. App Actions / Assistant capability (`shortcuts.xml` + manifest) routing the transcript into the ViewModel.
2. In-app `SpeechRecognizer` capture (on-device preferred, `RECORD_AUDIO` at point of use).
3. SQLCipher-backed durable `VoiceDraftStore` so offline drafts survive process death.

Scope kept minimal/additive (only `AppModule.kt` touched outside the new `ui/voice` package) to avoid conflicts with in-flight android PRs.

Closes #2383

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>