### PR TITLE
feat(ios): debt payoff rings (#2175)

### DIFF
--- a/apps/ios/Finance/Components/DebtPayoffCard.swift
+++ b/apps/ios/Finance/Components/DebtPayoffCard.swift
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DebtPayoffCard.swift
+// Finance
+//
+// Card surface pairing a debt payoff ring with remaining balance, payoff
+// ETA, milestone messaging, and interest-saved tradeoff copy (#2175).
+
+import SwiftUI
+import FinanceShared
+
+/// A glanceable debt payoff card: ring + numbers + motivational milestone.
+///
+/// Presentational only — all math comes from the pure `DebtPayoffProgress`
+/// model. Every figure shown to a sighted user is also surfaced to VoiceOver
+/// via a combined accessibility label, so progress is never color-only.
+struct DebtPayoffCard: View {
+    let progress: DebtPayoffProgress
+
+    /// Reference "today" used to project the payoff date. Injected so previews
+    /// and tests stay deterministic.
+    var referenceDate: Date = .now
+
+    /// Hypothetical extra monthly principal used for the interest-saved hint.
+    var extraMonthlyMinorUnits: Int64 = 100_00
+
+    private var payoffDate: Date? {
+        progress.projectedPayoffDate(from: referenceDate)
+    }
+
+    private var interestSaved: Int64? {
+        progress.interestSavedByPayingExtra(extraMonthlyMinorUnits: extraMonthlyMinorUnits)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+
+            HStack(alignment: .center, spacing: 16) {
+                DebtPayoffRing(progress: progress, size: 104)
+                    .frame(width: 104, height: 104)
+                stats
+            }
+
+            milestoneFooter
+        }
+        .padding()
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(progress.name))
+        .accessibilityValue(Text(accessibilitySummary))
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "percent")
+                .font(.title3)
+                .foregroundStyle(.green)
+                .frame(width: 40, height: 40)
+                .background(Color.green.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(progress.name)
+                    .font(.headline)
+                Text(String(localized: "Student loan payoff"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+    }
+
+    // MARK: - Stats
+
+    private var stats: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            statRow(
+                label: String(localized: "Remaining"),
+                amount: progress.remainingBalanceMinorUnits
+            )
+            statRow(
+                label: String(localized: "Paid off"),
+                amount: progress.principalPaidMinorUnits
+            )
+            if let payoffDate {
+                HStack(spacing: 4) {
+                    Text(String(localized: "Debt-free")).font(.caption).foregroundStyle(.secondary)
+                    Text(payoffDate, format: .dateTime.month(.abbreviated).year())
+                        .font(.caption.bold())
+                }
+            } else if !progress.isPaidOff {
+                Text(String(localized: "Set a monthly payment to see a payoff date"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func statRow(label: String, amount: Int64) -> some View {
+        HStack {
+            Text(label).font(.caption).foregroundStyle(.secondary)
+            Spacer()
+            CurrencyLabel(
+                amountInMinorUnits: amount,
+                currencyCode: progress.currencyCode,
+                showSign: false,
+                font: .caption.bold()
+            )
+        }
+    }
+
+    // MARK: - Milestone footer
+
+    @ViewBuilder
+    private var milestoneFooter: some View {
+        if progress.isPaidOff {
+            Label(String(localized: "Paid off — ring closed!"), systemImage: "checkmark.seal.fill")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.green)
+        } else if let interestSaved, interestSaved > 0 {
+            HStack(spacing: 4) {
+                Image(systemName: "bolt.fill").font(.caption2).foregroundStyle(.orange)
+                    .accessibilityHidden(true)
+                Text(String(localized: "Pay")).font(.caption).foregroundStyle(.secondary)
+                CurrencyLabel(
+                    amountInMinorUnits: extraMonthlyMinorUnits,
+                    currencyCode: progress.currencyCode,
+                    showSign: false,
+                    font: .caption.bold()
+                )
+                Text(String(localized: "more monthly to save")).font(.caption).foregroundStyle(.secondary)
+                CurrencyLabel(
+                    amountInMinorUnits: interestSaved,
+                    currencyCode: progress.currencyCode,
+                    showSign: false,
+                    font: .caption.bold()
+                )
+                Text(String(localized: "in interest")).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Accessibility
+
+    private var accessibilitySummary: String {
+        var parts: [String] = []
+        parts.append(String(localized: "\(progress.percentComplete) percent paid off"))
+        if progress.isPaidOff {
+            parts.append(String(localized: "fully paid off"))
+        } else if let months = progress.monthsToPayoff() {
+            parts.append(String(localized: "about \(months) months until debt-free"))
+        }
+        return parts.joined(separator: ", ")
+    }
+}
+
+#Preview {
+    ScrollView {
+        VStack(spacing: 16) {
+            DebtPayoffCard(
+                progress: DebtPayoffProgress(
+                    id: "1", name: "Grad PLUS Loan",
+                    originalPrincipalMinorUnits: 40_000_00,
+                    currentBalanceMinorUnits: 18_000_00,
+                    monthlyPaymentMinorUnits: 600_00,
+                    annualInterestRateBasisPoints: 650
+                ),
+                referenceDate: Date(timeIntervalSince1970: 1_750_000_000)
+            )
+            DebtPayoffCard(
+                progress: DebtPayoffProgress(
+                    id: "2", name: "Car Loan",
+                    originalPrincipalMinorUnits: 12_000_00,
+                    currentBalanceMinorUnits: 0,
+                    monthlyPaymentMinorUnits: 300_00
+                )
+            )
+        }
+        .padding()
+    }
+}

--- a/apps/ios/Finance/Components/DebtPayoffRing.swift
+++ b/apps/ios/Finance/Components/DebtPayoffRing.swift
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DebtPayoffRing.swift
+// Finance
+//
+// Fitness-ring style visualization for debt payoff progress (#2175).
+// Conveys progress numerically to VoiceOver — never by color or shape
+// alone — and supports Dynamic Type for the centered percentage label.
+
+import SwiftUI
+import FinanceShared
+
+/// A circular "activity ring" showing how much of a debt has been paid off.
+///
+/// The ring fills clockwise as principal is knocked down. The center shows a
+/// Dynamic Type percentage; the whole control is a single accessibility
+/// element whose label and value spell the progress out numerically so it is
+/// never communicated by color/shape alone (WCAG 1.4.1).
+struct DebtPayoffRing: View {
+    let progress: DebtPayoffProgress
+    var lineWidth: CGFloat = 12
+    var size: CGFloat = 120
+    var tint: Color = .green
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var fraction: Double { progress.fractionComplete }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(tint.opacity(0.18), style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+            Circle()
+                .trim(from: 0, to: fraction)
+                .stroke(
+                    progress.isPaidOff ? Color.green : tint,
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.6), value: fraction)
+
+            VStack(spacing: 2) {
+                Text(percentText)
+                    .font(.title2.weight(.bold))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.5)
+                    .lineLimit(1)
+                if progress.isPaidOff {
+                    Image(systemName: "checkmark.seal.fill")
+                        .foregroundStyle(.green)
+                        .font(.caption)
+                } else {
+                    Text(String(localized: "paid off"))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .minimumScaleFactor(0.5)
+                        .lineLimit(1)
+                }
+            }
+            .padding(lineWidth)
+        }
+        .frame(width: size, height: size)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(accessibilityLabel))
+        .accessibilityValue(Text(accessibilityValue))
+    }
+
+    // MARK: - Text
+
+    private var percentText: String {
+        "\(progress.percentComplete)%"
+    }
+
+    private var accessibilityLabel: String {
+        String(localized: "\(progress.name) debt payoff ring")
+    }
+
+    /// Numeric, color-independent description for VoiceOver.
+    private var accessibilityValue: String {
+        if progress.isPaidOff {
+            return String(localized: "Fully paid off, 100 percent complete")
+        }
+        return String(localized: "\(progress.percentComplete) percent paid off")
+    }
+}
+
+#Preview("In progress") {
+    DebtPayoffRing(
+        progress: DebtPayoffProgress(
+            id: "1", name: "Grad PLUS Loan",
+            originalPrincipalMinorUnits: 40_000_00,
+            currentBalanceMinorUnits: 18_000_00,
+            monthlyPaymentMinorUnits: 600_00,
+            annualInterestRateBasisPoints: 650
+        )
+    )
+    .padding()
+}
+
+#Preview("Paid off") {
+    DebtPayoffRing(
+        progress: DebtPayoffProgress(
+            id: "2", name: "Car Loan",
+            originalPrincipalMinorUnits: 12_000_00,
+            currentBalanceMinorUnits: 0,
+            monthlyPaymentMinorUnits: 300_00
+        )
+    )
+    .padding()
+}

--- a/apps/ios/Finance/Screens/DebtPayoffView.swift
+++ b/apps/ios/Finance/Screens/DebtPayoffView.swift
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DebtPayoffView.swift
+// Finance
+//
+// Dedicated debt payoff surface (#2175). Leads with a combined "all debts"
+// ring, then a card per loan — fitness-ring energy for student loan payoff.
+
+import SwiftUI
+import FinanceShared
+
+struct DebtPayoffView: View {
+    @State private var viewModel: DebtPayoffViewModel
+
+    init(viewModel: DebtPayoffViewModel = DebtPayoffViewModel()) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isLoading && viewModel.debts.isEmpty {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .accessibilityLabel(String(localized: "Loading"))
+                } else if viewModel.debts.isEmpty {
+                    EmptyStateView(
+                        systemImage: "percent",
+                        title: String(localized: "No Debts Tracked"),
+                        message: String(localized: "Add a loan account to watch your debt payoff rings close.")
+                    )
+                } else {
+                    content
+                }
+            }
+            .navigationTitle(String(localized: "Debt Payoff"))
+            .refreshable { await viewModel.loadDebts() }
+            .task { await viewModel.loadDebts() }
+            .alert(String(localized: "Error"), isPresented: Binding(
+                get: { viewModel.showError },
+                set: { if !$0 { viewModel.dismissError() } }
+            )) {
+                Button(String(localized: "Retry")) { Task { await viewModel.loadDebts() } }
+                Button(String(localized: "Dismiss"), role: .cancel) { viewModel.dismissError() }
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+        }
+    }
+
+    // MARK: - Content
+
+    private var content: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                portfolioSummary
+                LazyVStack(spacing: 16) {
+                    ForEach(viewModel.debts) { debt in
+                        DebtPayoffCard(progress: debt, referenceDate: viewModel.referenceDate)
+                    }
+                }
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Portfolio summary
+
+    private var portfolioSummary: some View {
+        let portfolio = viewModel.portfolio
+        return VStack(spacing: 12) {
+            DebtPayoffSummaryRing(portfolio: portfolio)
+                .frame(width: 160, height: 160)
+
+            HStack(spacing: 24) {
+                summaryStat(
+                    title: String(localized: "Remaining"),
+                    amount: portfolio.totalRemainingBalanceMinorUnits
+                )
+                summaryStat(
+                    title: String(localized: "Paid"),
+                    amount: portfolio.totalPrincipalPaidMinorUnits
+                )
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(String(localized: "All debts combined"))
+        .accessibilityValue(String(localized: "\(portfolio.percentComplete) percent paid off"))
+    }
+
+    private func summaryStat(title: String, amount: Int64) -> some View {
+        VStack(spacing: 2) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            CurrencyLabel(
+                amountInMinorUnits: amount,
+                currencyCode: viewModel.debts.first?.currencyCode ?? "USD",
+                showSign: false,
+                font: .headline
+            )
+        }
+    }
+
+    // TODO(human): Wire this surface to real loan accounts. The shared KMP
+    // model must expose original principal, monthly payment, and APR per loan
+    // before `DebtPayoffViewModel` can replace `SampleDebtPayoffProvider` with
+    // live data. Requires an ADR with @kmp-engineer (boundary: packages/).
+    // Validate ring fill, VoiceOver order, and Dynamic Type XXXL on device.
+}
+
+// MARK: - Summary Ring
+
+/// Combined ring for the whole debt portfolio.
+private struct DebtPayoffSummaryRing: View {
+    let portfolio: DebtPortfolioProgress
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.green.opacity(0.18), style: StrokeStyle(lineWidth: 16, lineCap: .round))
+            Circle()
+                .trim(from: 0, to: portfolio.fractionComplete)
+                .stroke(
+                    portfolio.isAllPaidOff ? Color.green : Color.green,
+                    style: StrokeStyle(lineWidth: 16, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.6), value: portfolio.fractionComplete)
+            VStack(spacing: 2) {
+                Text("\(portfolio.percentComplete)%")
+                    .font(.largeTitle.weight(.bold))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.5)
+                    .lineLimit(1)
+                Text(String(localized: "paid off"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(24)
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+#Preview {
+    DebtPayoffView(
+        viewModel: DebtPayoffViewModel(
+            provider: SampleDebtPayoffProvider(),
+            referenceDate: Date(timeIntervalSince1970: 1_750_000_000)
+        )
+    )
+}

--- a/apps/ios/Finance/ViewModels/DebtPayoffViewModel.swift
+++ b/apps/ios/Finance/ViewModels/DebtPayoffViewModel.swift
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DebtPayoffViewModel.swift
+// Finance
+//
+// ViewModel for the debt payoff surface (#2175). Loads debts from an
+// injectable provider and exposes a multi-debt rollup for the combined ring.
+
+import Observation
+import Foundation
+import FinanceShared
+import os
+
+// MARK: - Provider
+
+/// Supplies debt payoff progress data to the view model.
+///
+/// Abstracted so the screen can be driven by sample data today and wired to
+/// real loan accounts once the shared model tracks original principal and
+/// payment terms (see `## Needs Human Action`).
+protocol DebtPayoffProviding: Sendable {
+    func loadDebts() async throws -> [DebtPayoffProgress]
+}
+
+// MARK: - Sample Provider
+
+/// Deterministic sample debts for previews and as a placeholder data source.
+struct SampleDebtPayoffProvider: DebtPayoffProviding {
+    func loadDebts() async throws -> [DebtPayoffProgress] {
+        [
+            DebtPayoffProgress(
+                id: "loan-gradplus", name: "Grad PLUS Loan",
+                originalPrincipalMinorUnits: 40_000_00,
+                currentBalanceMinorUnits: 18_000_00,
+                monthlyPaymentMinorUnits: 600_00,
+                annualInterestRateBasisPoints: 650
+            ),
+            DebtPayoffProgress(
+                id: "loan-stafford", name: "Stafford Loan",
+                originalPrincipalMinorUnits: 22_500_00,
+                currentBalanceMinorUnits: 6_300_00,
+                monthlyPaymentMinorUnits: 350_00,
+                annualInterestRateBasisPoints: 480
+            ),
+            DebtPayoffProgress(
+                id: "loan-private", name: "Private Refi",
+                originalPrincipalMinorUnits: 15_000_00,
+                currentBalanceMinorUnits: 0,
+                monthlyPaymentMinorUnits: 250_00,
+                annualInterestRateBasisPoints: 540
+            ),
+        ]
+    }
+}
+
+// MARK: - ViewModel
+
+@Observable
+final class DebtPayoffViewModel {
+    private let provider: DebtPayoffProviding
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "DebtPayoffViewModel"
+    )
+
+    var debts: [DebtPayoffProgress] = []
+    var isLoading = false
+    var errorMessage: String?
+
+    /// Reference "today" for projecting payoff dates. Injectable for tests.
+    let referenceDate: Date
+
+    /// Combined progress across all debts for the headline ring.
+    var portfolio: DebtPortfolioProgress { DebtPortfolioProgress(debts: debts) }
+
+    /// Whether an error alert should be presented.
+    var showError: Bool { errorMessage != nil }
+
+    /// Clears the current error message, dismissing the alert.
+    func dismissError() { errorMessage = nil }
+
+    init(
+        provider: DebtPayoffProviding = SampleDebtPayoffProvider(),
+        referenceDate: Date = .now
+    ) {
+        self.provider = provider
+        self.referenceDate = referenceDate
+    }
+
+    func loadDebts() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            debts = try await provider.loadDebts()
+        } catch {
+            errorMessage = String(localized: "Failed to load debt payoff progress. Please try again.")
+            Self.logger.error("Debt payoff load failed: \(error.localizedDescription, privacy: .public)")
+            debts = []
+        }
+    }
+}

--- a/apps/ios/Shared/DebtPayoffModel.swift
+++ b/apps/ios/Shared/DebtPayoffModel.swift
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DebtPayoffModel.swift
+// FinanceShared
+//
+// Pure, dependency-free debt-payoff progress model. Powers the
+// "fitness ring" style debt payoff visuals (#2175).
+//
+// Everything here is Foundation-only and deterministic so it can be
+// fully unit tested without UI, a clock, or a repository. Monetary
+// values are always integer minor units (e.g. cents) to avoid
+// floating-point rounding drift; ratios are the only Doubles exposed.
+
+import Foundation
+
+// MARK: - Debt Payoff Progress
+
+/// Progress of a single debt toward being fully paid off.
+///
+/// Models "how much of the original principal has been knocked down"
+/// in the same spirit as closing an activity ring. All amounts are
+/// integer minor units in `currencyCode`.
+///
+/// Edge cases handled deterministically:
+/// - **Zero / negative original principal** — treated as "nothing owed",
+///   so progress is complete when the balance is also cleared.
+/// - **Overpayment** (balance below zero) — clamped; progress caps at 100%.
+/// - **Balance grew** (balance above original) — progress floors at 0%.
+/// - **Zero payment** — projection is `nil` ("never" at the current rate).
+public struct DebtPayoffProgress: Sendable, Hashable, Identifiable {
+
+    /// Stable identifier for list rendering and diffing.
+    public let id: String
+
+    /// Human-readable debt name (e.g. "Grad PLUS Loan").
+    public let name: String
+
+    /// Principal originally owed, in minor units. The "ring target".
+    public let originalPrincipalMinorUnits: Int64
+
+    /// Current outstanding balance, in minor units. Positive means still owed.
+    public let currentBalanceMinorUnits: Int64
+
+    /// Recurring monthly payment, in minor units. Drives the payoff ETA.
+    public let monthlyPaymentMinorUnits: Int64
+
+    /// Annual interest rate in basis points (1% == 100 bps). May be zero.
+    public let annualInterestRateBasisPoints: Int
+
+    /// ISO 4217 currency code for all monetary fields.
+    public let currencyCode: String
+
+    public init(
+        id: String,
+        name: String,
+        originalPrincipalMinorUnits: Int64,
+        currentBalanceMinorUnits: Int64,
+        monthlyPaymentMinorUnits: Int64,
+        annualInterestRateBasisPoints: Int = 0,
+        currencyCode: String = "USD"
+    ) {
+        self.id = id
+        self.name = name
+        self.originalPrincipalMinorUnits = originalPrincipalMinorUnits
+        self.currentBalanceMinorUnits = currentBalanceMinorUnits
+        self.monthlyPaymentMinorUnits = monthlyPaymentMinorUnits
+        self.annualInterestRateBasisPoints = annualInterestRateBasisPoints
+        self.currencyCode = currencyCode
+    }
+
+    // MARK: Balances
+
+    /// Remaining balance, clamped so overpayment never reads as negative debt.
+    public var remainingBalanceMinorUnits: Int64 {
+        max(0, currentBalanceMinorUnits)
+    }
+
+    /// Principal paid down so far, clamped to `0...originalPrincipal`.
+    public var principalPaidMinorUnits: Int64 {
+        let safeOriginal = max(0, originalPrincipalMinorUnits)
+        let paid = safeOriginal - remainingBalanceMinorUnits
+        return min(safeOriginal, max(0, paid))
+    }
+
+    // MARK: Progress
+
+    /// Fraction of the original principal paid off, clamped to `0.0...1.0`.
+    ///
+    /// When there is no original principal, progress is complete only if
+    /// the balance is also cleared (otherwise there is nothing to show, so 0).
+    public var fractionComplete: Double {
+        let safeOriginal = max(0, originalPrincipalMinorUnits)
+        guard safeOriginal > 0 else {
+            return remainingBalanceMinorUnits <= 0 ? 1.0 : 0.0
+        }
+        let ratio = Double(principalPaidMinorUnits) / Double(safeOriginal)
+        return min(1.0, max(0.0, ratio))
+    }
+
+    /// Whole-number percentage paid off, `0...100`.
+    public var percentComplete: Int {
+        Int((fractionComplete * 100).rounded())
+    }
+
+    /// Whether the debt is fully cleared.
+    public var isPaidOff: Bool {
+        remainingBalanceMinorUnits <= 0
+    }
+
+    // MARK: Projection
+
+    /// Whole months needed to reach a zero balance (principal-only view).
+    ///
+    /// Deterministic and interest-free so the headline ETA is easy to reason
+    /// about. Returns `0` when already paid off, and `nil` when the monthly
+    /// payment is zero or negative (the debt is never retired at that rate).
+    ///
+    /// - Parameter extraMonthlyMinorUnits: optional additional principal
+    ///   applied each month, used for "what if I pay more?" comparisons.
+    public func monthsToPayoff(extraMonthlyMinorUnits: Int64 = 0) -> Int? {
+        guard !isPaidOff else { return 0 }
+        let monthly = monthlyPaymentMinorUnits + extraMonthlyMinorUnits
+        guard monthly > 0 else { return nil }
+        // Ceil division on integers, never overflowing into floating point.
+        let remaining = remainingBalanceMinorUnits
+        return Int((remaining + monthly - 1) / monthly)
+    }
+
+    /// Projected payoff date measured from `referenceDate`.
+    ///
+    /// Uses a caller-supplied `calendar` so tests stay deterministic across
+    /// time zones. Returns `nil` when `monthsToPayoff` is `nil`.
+    public func projectedPayoffDate(
+        from referenceDate: Date,
+        calendar: Calendar = .current,
+        extraMonthlyMinorUnits: Int64 = 0
+    ) -> Date? {
+        guard let months = monthsToPayoff(extraMonthlyMinorUnits: extraMonthlyMinorUnits) else {
+            return nil
+        }
+        return calendar.date(byAdding: .month, value: months, to: referenceDate)
+    }
+
+    // MARK: Amortization & interest
+
+    /// Simulates month-by-month amortization including interest.
+    ///
+    /// Integer minor units throughout, with interest rounded to the nearest
+    /// minor unit each month, so results are deterministic and reproducible.
+    /// Returns `nil` when the payment cannot cover the monthly interest (the
+    /// balance would never reach zero). Capped at 1,200 months (100 years) as
+    /// a safety bound.
+    ///
+    /// - Parameter extraMonthlyMinorUnits: extra principal applied each month.
+    public func amortizationSummary(
+        extraMonthlyMinorUnits: Int64 = 0
+    ) -> DebtAmortizationSummary? {
+        guard !isPaidOff else {
+            return DebtAmortizationSummary(months: 0, totalInterestMinorUnits: 0)
+        }
+        let monthlyPayment = monthlyPaymentMinorUnits + extraMonthlyMinorUnits
+        guard monthlyPayment > 0 else { return nil }
+
+        let monthlyRate = Double(max(0, annualInterestRateBasisPoints)) / 10_000.0 / 12.0
+        var balance = remainingBalanceMinorUnits
+        var totalInterest: Int64 = 0
+        var months = 0
+        let maxMonths = 1_200
+
+        while balance > 0 && months < maxMonths {
+            let interest: Int64
+            if monthlyRate > 0 {
+                interest = Int64((Double(balance) * monthlyRate).rounded())
+            } else {
+                interest = 0
+            }
+            // If the payment cannot even cover interest, the debt never clears.
+            if monthlyPayment <= interest {
+                return nil
+            }
+            let principalPortion = monthlyPayment - interest
+            balance -= principalPortion
+            totalInterest += interest
+            months += 1
+        }
+
+        guard balance <= 0 else { return nil }
+        return DebtAmortizationSummary(months: months, totalInterestMinorUnits: totalInterest)
+    }
+
+    /// Interest saved (in minor units) by adding `extraMonthlyMinorUnits`
+    /// of principal versus the baseline payment.
+    ///
+    /// Returns `nil` if either scenario never pays off. Never negative.
+    public func interestSavedByPayingExtra(
+        extraMonthlyMinorUnits: Int64
+    ) -> Int64? {
+        guard extraMonthlyMinorUnits > 0,
+              let base = amortizationSummary(),
+              let accelerated = amortizationSummary(extraMonthlyMinorUnits: extraMonthlyMinorUnits)
+        else { return nil }
+        return max(0, base.totalInterestMinorUnits - accelerated.totalInterestMinorUnits)
+    }
+
+    // MARK: Milestones
+
+    /// Milestones already reached, ordered low to high — the "rings closed".
+    public var reachedMilestones: [DebtMilestone] {
+        DebtMilestone.allCases.filter { percentComplete >= $0.thresholdPercent }
+    }
+
+    /// The next milestone still ahead, or `nil` when fully paid off.
+    public var nextMilestone: DebtMilestone? {
+        DebtMilestone.allCases.first { percentComplete < $0.thresholdPercent }
+    }
+}
+
+// MARK: - Amortization Summary
+
+/// Result of simulating a debt's amortization to payoff.
+public struct DebtAmortizationSummary: Sendable, Hashable {
+    /// Number of whole months until the balance reaches zero.
+    public let months: Int
+    /// Total interest paid over the life of the payoff, in minor units.
+    public let totalInterestMinorUnits: Int64
+
+    public init(months: Int, totalInterestMinorUnits: Int64) {
+        self.months = months
+        self.totalInterestMinorUnits = totalInterestMinorUnits
+    }
+}
+
+// MARK: - Debt Milestone
+
+/// Reward checkpoints that make debt progress feel like closing rings.
+public enum DebtMilestone: Int, CaseIterable, Sendable, Hashable {
+    case quarter
+    case half
+    case threeQuarters
+    case paidOff
+
+    /// Percentage at which this milestone unlocks.
+    public var thresholdPercent: Int {
+        switch self {
+        case .quarter: 25
+        case .half: 50
+        case .threeQuarters: 75
+        case .paidOff: 100
+        }
+    }
+}
+
+// MARK: - Debt Portfolio Progress
+
+/// Aggregate progress across multiple debts (the multi-debt rollup).
+///
+/// Sums original principal and remaining balance, then derives a combined
+/// ring. The portfolio is only "paid off" once every debt is cleared, so the
+/// projected payoff date is the latest of the individual dates.
+public struct DebtPortfolioProgress: Sendable, Hashable {
+
+    /// The individual debts that make up the portfolio.
+    public let debts: [DebtPayoffProgress]
+
+    public init(debts: [DebtPayoffProgress]) {
+        self.debts = debts
+    }
+
+    /// Total original principal across all debts, in minor units.
+    public var totalOriginalPrincipalMinorUnits: Int64 {
+        debts.reduce(0) { $0 + max(0, $1.originalPrincipalMinorUnits) }
+    }
+
+    /// Total remaining balance across all debts, in minor units.
+    public var totalRemainingBalanceMinorUnits: Int64 {
+        debts.reduce(0) { $0 + $1.remainingBalanceMinorUnits }
+    }
+
+    /// Total principal paid across all debts, in minor units.
+    public var totalPrincipalPaidMinorUnits: Int64 {
+        debts.reduce(0) { $0 + $1.principalPaidMinorUnits }
+    }
+
+    /// Combined fraction paid off, clamped to `0.0...1.0`.
+    public var fractionComplete: Double {
+        let total = totalOriginalPrincipalMinorUnits
+        guard total > 0 else {
+            return totalRemainingBalanceMinorUnits <= 0 ? 1.0 : 0.0
+        }
+        let ratio = Double(totalPrincipalPaidMinorUnits) / Double(total)
+        return min(1.0, max(0.0, ratio))
+    }
+
+    /// Combined whole-number percentage paid off, `0...100`.
+    public var percentComplete: Int {
+        Int((fractionComplete * 100).rounded())
+    }
+
+    /// Whether every debt in the portfolio is cleared.
+    public var isAllPaidOff: Bool {
+        debts.allSatisfy(\.isPaidOff)
+    }
+
+    /// Sum of all monthly payments, in minor units.
+    public var totalMonthlyPaymentMinorUnits: Int64 {
+        debts.reduce(0) { $0 + $1.monthlyPaymentMinorUnits }
+    }
+
+    /// Latest projected payoff date across debts — when the portfolio clears.
+    ///
+    /// Returns `nil` if any unpaid debt never retires at its current rate.
+    public func projectedPayoffDate(
+        from referenceDate: Date,
+        calendar: Calendar = .current
+    ) -> Date? {
+        let unpaid = debts.filter { !$0.isPaidOff }
+        guard !unpaid.isEmpty else { return referenceDate }
+
+        var latest: Date?
+        for debt in unpaid {
+            guard let date = debt.projectedPayoffDate(from: referenceDate, calendar: calendar) else {
+                return nil
+            }
+            if let current = latest {
+                latest = max(current, date)
+            } else {
+                latest = date
+            }
+        }
+        return latest
+    }
+}

--- a/apps/ios/Tests/DebtPayoffModelTests.swift
+++ b/apps/ios/Tests/DebtPayoffModelTests.swift
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DebtPayoffModelTests.swift
+// FinanceTests
+//
+// Deterministic unit tests for the pure debt-payoff model (#2175):
+// progress math, payoff projection/ETA, amortization & interest saved,
+// multi-debt rollup, and edge cases (zero balance, overpayment, zero payment).
+
+import XCTest
+import FinanceShared
+
+final class DebtPayoffModelTests: XCTestCase {
+
+    // A fixed UTC Gregorian calendar so date math is reproducible everywhere.
+    private var utcCalendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }
+
+    private func debt(
+        original: Int64,
+        current: Int64,
+        payment: Int64 = 0,
+        rateBps: Int = 0
+    ) -> DebtPayoffProgress {
+        DebtPayoffProgress(
+            id: "d", name: "Loan",
+            originalPrincipalMinorUnits: original,
+            currentBalanceMinorUnits: current,
+            monthlyPaymentMinorUnits: payment,
+            annualInterestRateBasisPoints: rateBps
+        )
+    }
+
+    // MARK: - Progress math
+
+    func testFractionCompleteHalfway() {
+        let d = debt(original: 40_000_00, current: 20_000_00)
+        XCTAssertEqual(d.fractionComplete, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(d.percentComplete, 50)
+        XCTAssertEqual(d.principalPaidMinorUnits, 20_000_00)
+        XCTAssertEqual(d.remainingBalanceMinorUnits, 20_000_00)
+        XCTAssertFalse(d.isPaidOff)
+    }
+
+    func testPercentCompleteRoundsToNearest() {
+        // 1/3 paid -> 33.33% -> rounds to 33
+        let d = debt(original: 30_000, current: 20_000)
+        XCTAssertEqual(d.percentComplete, 33)
+    }
+
+    // MARK: - Zero balance
+
+    func testZeroBalanceIsFullyPaidOff() {
+        let d = debt(original: 12_000_00, current: 0)
+        XCTAssertTrue(d.isPaidOff)
+        XCTAssertEqual(d.fractionComplete, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(d.percentComplete, 100)
+        XCTAssertEqual(d.remainingBalanceMinorUnits, 0)
+        XCTAssertEqual(d.principalPaidMinorUnits, 12_000_00)
+    }
+
+    // MARK: - Overpayment
+
+    func testOverpaymentClampsToFullyPaid() {
+        // Negative balance == paid more than owed.
+        let d = debt(original: 10_000_00, current: -500_00)
+        XCTAssertTrue(d.isPaidOff)
+        XCTAssertEqual(d.fractionComplete, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(d.percentComplete, 100)
+        XCTAssertEqual(d.remainingBalanceMinorUnits, 0)
+        XCTAssertEqual(d.principalPaidMinorUnits, 10_000_00,
+                       "Principal paid never exceeds original principal")
+    }
+
+    // MARK: - Balance grew
+
+    func testBalanceAboveOriginalFloorsAtZero() {
+        let d = debt(original: 10_000_00, current: 11_000_00)
+        XCTAssertEqual(d.fractionComplete, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(d.percentComplete, 0)
+        XCTAssertEqual(d.principalPaidMinorUnits, 0)
+        XCTAssertFalse(d.isPaidOff)
+    }
+
+    // MARK: - Zero / negative original principal
+
+    func testZeroOriginalPrincipalWithBalanceIsZeroProgress() {
+        let d = debt(original: 0, current: 5_000_00)
+        XCTAssertEqual(d.fractionComplete, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(d.percentComplete, 0)
+        XCTAssertFalse(d.isPaidOff)
+    }
+
+    func testZeroOriginalPrincipalNoBalanceIsComplete() {
+        let d = debt(original: 0, current: 0)
+        XCTAssertEqual(d.fractionComplete, 1.0, accuracy: 0.0001)
+        XCTAssertTrue(d.isPaidOff)
+    }
+
+    // MARK: - Projection (months)
+
+    func testMonthsToPayoffExactDivision() {
+        let d = debt(original: 12_000_00, current: 6_000_00, payment: 1_000_00)
+        XCTAssertEqual(d.monthsToPayoff(), 6)
+    }
+
+    func testMonthsToPayoffRoundsUp() {
+        // 6_500 / 1_000 = 6.5 -> 7 whole months
+        let d = debt(original: 12_000_00, current: 6_500_00, payment: 1_000_00)
+        XCTAssertEqual(d.monthsToPayoff(), 7)
+    }
+
+    func testMonthsToPayoffZeroWhenPaidOff() {
+        let d = debt(original: 12_000_00, current: 0, payment: 1_000_00)
+        XCTAssertEqual(d.monthsToPayoff(), 0)
+    }
+
+    func testMonthsToPayoffNilWhenZeroPayment() {
+        let d = debt(original: 12_000_00, current: 6_000_00, payment: 0)
+        XCTAssertNil(d.monthsToPayoff(),
+                     "A debt is never retired at a zero payment rate")
+    }
+
+    func testMonthsToPayoffWithExtraPayment() {
+        // 6_000 / (1_000 + 500) = 4 months
+        let d = debt(original: 12_000_00, current: 6_000_00, payment: 1_000_00)
+        XCTAssertEqual(d.monthsToPayoff(extraMonthlyMinorUnits: 500_00), 4)
+    }
+
+    // MARK: - Projection (date)
+
+    func testProjectedPayoffDateAddsMonths() {
+        let reference = Date(timeIntervalSince1970: 1_700_000_000) // 2023-11-14 UTC
+        let d = debt(original: 12_000_00, current: 6_000_00, payment: 1_000_00)
+        let projected = d.projectedPayoffDate(from: reference, calendar: utcCalendar)
+        let expected = utcCalendar.date(byAdding: .month, value: 6, to: reference)
+        XCTAssertEqual(projected, expected)
+    }
+
+    func testProjectedPayoffDateNilWhenNoPayment() {
+        let reference = Date(timeIntervalSince1970: 1_700_000_000)
+        let d = debt(original: 12_000_00, current: 6_000_00, payment: 0)
+        XCTAssertNil(d.projectedPayoffDate(from: reference, calendar: utcCalendar))
+    }
+
+    // MARK: - Amortization & interest
+
+    func testAmortizationInterestFreeMatchesPrincipalOnly() {
+        let d = debt(original: 12_000_00, current: 6_000_00, payment: 1_000_00, rateBps: 0)
+        let summary = d.amortizationSummary()
+        XCTAssertEqual(summary?.months, 6)
+        XCTAssertEqual(summary?.totalInterestMinorUnits, 0)
+    }
+
+    func testAmortizationAccruesInterest() {
+        let d = debt(original: 12_000_00, current: 6_000_00, payment: 1_000_00, rateBps: 1_200) // 12% APR
+        let summary = d.amortizationSummary()
+        XCTAssertNotNil(summary)
+        XCTAssertGreaterThan(summary!.totalInterestMinorUnits, 0,
+                             "Interest should accrue at a positive APR")
+        XCTAssertGreaterThanOrEqual(summary!.months, 6,
+                                    "Interest can only extend or hold the term")
+    }
+
+    func testAmortizationNilWhenPaymentBelowInterest() {
+        // 1% monthly interest on 100_000_00 == 1_000_00; payment under that never clears.
+        let d = debt(original: 100_000_00, current: 100_000_00, payment: 500_00, rateBps: 1_200)
+        XCTAssertNil(d.amortizationSummary())
+    }
+
+    func testAmortizationZeroMonthsWhenPaidOff() {
+        let d = debt(original: 12_000_00, current: 0, payment: 1_000_00, rateBps: 600)
+        let summary = d.amortizationSummary()
+        XCTAssertEqual(summary?.months, 0)
+        XCTAssertEqual(summary?.totalInterestMinorUnits, 0)
+    }
+
+    func testInterestSavedByPayingExtraIsPositive() {
+        let d = debt(original: 40_000_00, current: 20_000_00, payment: 500_00, rateBps: 700)
+        let saved = d.interestSavedByPayingExtra(extraMonthlyMinorUnits: 200_00)
+        XCTAssertNotNil(saved)
+        XCTAssertGreaterThan(saved!, 0,
+                             "Paying extra principal should reduce total interest")
+    }
+
+    func testInterestSavedNilForZeroExtra() {
+        let d = debt(original: 40_000_00, current: 20_000_00, payment: 500_00, rateBps: 700)
+        XCTAssertNil(d.interestSavedByPayingExtra(extraMonthlyMinorUnits: 0))
+    }
+
+    // MARK: - Milestones
+
+    func testReachedMilestones() {
+        let d = debt(original: 40_000_00, current: 12_000_00) // 70% paid
+        XCTAssertEqual(d.percentComplete, 70)
+        XCTAssertEqual(d.reachedMilestones, [.quarter, .half])
+        XCTAssertEqual(d.nextMilestone, .threeQuarters)
+    }
+
+    func testAllMilestonesReachedWhenPaidOff() {
+        let d = debt(original: 40_000_00, current: 0)
+        XCTAssertEqual(d.reachedMilestones, DebtMilestone.allCases)
+        XCTAssertNil(d.nextMilestone)
+    }
+
+    // MARK: - Portfolio rollup
+
+    func testPortfolioAggregatesProgress() {
+        let portfolio = DebtPortfolioProgress(debts: [
+            debt(original: 40_000_00, current: 20_000_00, payment: 1_000_00),
+            debt(original: 10_000_00, current: 0, payment: 500_00),
+        ])
+        // Paid: 20_000 + 10_000 = 30_000 of 50_000 = 60%
+        XCTAssertEqual(portfolio.totalOriginalPrincipalMinorUnits, 50_000_00)
+        XCTAssertEqual(portfolio.totalRemainingBalanceMinorUnits, 20_000_00)
+        XCTAssertEqual(portfolio.totalPrincipalPaidMinorUnits, 30_000_00)
+        XCTAssertEqual(portfolio.fractionComplete, 0.6, accuracy: 0.0001)
+        XCTAssertEqual(portfolio.percentComplete, 60)
+        XCTAssertFalse(portfolio.isAllPaidOff)
+        XCTAssertEqual(portfolio.totalMonthlyPaymentMinorUnits, 1_500_00)
+    }
+
+    func testPortfolioAllPaidOff() {
+        let portfolio = DebtPortfolioProgress(debts: [
+            debt(original: 40_000_00, current: 0),
+            debt(original: 10_000_00, current: -100),
+        ])
+        XCTAssertTrue(portfolio.isAllPaidOff)
+        XCTAssertEqual(portfolio.percentComplete, 100)
+    }
+
+    func testPortfolioEmptyIsComplete() {
+        let portfolio = DebtPortfolioProgress(debts: [])
+        XCTAssertTrue(portfolio.isAllPaidOff)
+        XCTAssertEqual(portfolio.fractionComplete, 1.0, accuracy: 0.0001)
+    }
+
+    func testPortfolioPayoffDateIsLatestOfDebts() {
+        let reference = Date(timeIntervalSince1970: 1_700_000_000)
+        let portfolio = DebtPortfolioProgress(debts: [
+            debt(original: 12_000_00, current: 3_000_00, payment: 1_000_00),  // 3 months
+            debt(original: 12_000_00, current: 6_000_00, payment: 1_000_00),  // 6 months
+        ])
+        let projected = portfolio.projectedPayoffDate(from: reference, calendar: utcCalendar)
+        let expected = utcCalendar.date(byAdding: .month, value: 6, to: reference)
+        XCTAssertEqual(projected, expected,
+                       "Portfolio clears only when the slowest debt is paid")
+    }
+
+    func testPortfolioPayoffDateNilWhenAnyDebtNeverClears() {
+        let reference = Date(timeIntervalSince1970: 1_700_000_000)
+        let portfolio = DebtPortfolioProgress(debts: [
+            debt(original: 12_000_00, current: 3_000_00, payment: 1_000_00),
+            debt(original: 12_000_00, current: 6_000_00, payment: 0), // never
+        ])
+        XCTAssertNil(portfolio.projectedPayoffDate(from: reference, calendar: utcCalendar))
+    }
+
+    func testPortfolioPayoffDateIsReferenceWhenAllPaid() {
+        let reference = Date(timeIntervalSince1970: 1_700_000_000)
+        let portfolio = DebtPortfolioProgress(debts: [
+            debt(original: 12_000_00, current: 0, payment: 1_000_00),
+        ])
+        XCTAssertEqual(portfolio.projectedPayoffDate(from: reference, calendar: utcCalendar), reference)
+    }
+}

--- a/apps/ios/Tests/DebtPayoffViewModelTests.swift
+++ b/apps/ios/Tests/DebtPayoffViewModelTests.swift
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DebtPayoffViewModelTests.swift
+// FinanceTests
+//
+// Tests for DebtPayoffViewModel (#2175) — loading, rollup, and error handling.
+
+import XCTest
+import FinanceShared
+@testable import FinanceApp
+
+/// Configurable stub provider for the debt payoff view model.
+final class StubDebtPayoffProvider: DebtPayoffProviding, @unchecked Sendable {
+    var debtsToReturn: [DebtPayoffProgress] = []
+    var errorToThrow: Error?
+
+    func loadDebts() async throws -> [DebtPayoffProgress] {
+        if let errorToThrow { throw errorToThrow }
+        return debtsToReturn
+    }
+}
+
+final class DebtPayoffViewModelTests: XCTestCase {
+
+    private func sampleDebts() -> [DebtPayoffProgress] {
+        [
+            DebtPayoffProgress(
+                id: "1", name: "Grad PLUS",
+                originalPrincipalMinorUnits: 40_000_00,
+                currentBalanceMinorUnits: 20_000_00,
+                monthlyPaymentMinorUnits: 1_000_00
+            ),
+            DebtPayoffProgress(
+                id: "2", name: "Car",
+                originalPrincipalMinorUnits: 10_000_00,
+                currentBalanceMinorUnits: 0,
+                monthlyPaymentMinorUnits: 500_00
+            ),
+        ]
+    }
+
+    @MainActor
+    func testLoadDebtsPopulatesList() async {
+        let provider = StubDebtPayoffProvider()
+        provider.debtsToReturn = sampleDebts()
+        let vm = DebtPayoffViewModel(provider: provider)
+
+        await vm.loadDebts()
+
+        XCTAssertEqual(vm.debts.count, 2)
+        XCTAssertFalse(vm.isLoading)
+        XCTAssertFalse(vm.showError)
+    }
+
+    @MainActor
+    func testPortfolioRollupReflectsLoadedDebts() async {
+        let provider = StubDebtPayoffProvider()
+        provider.debtsToReturn = sampleDebts()
+        let vm = DebtPayoffViewModel(provider: provider)
+
+        await vm.loadDebts()
+
+        // Paid 20_000 + 10_000 of 50_000 = 60%.
+        XCTAssertEqual(vm.portfolio.percentComplete, 60)
+        XCTAssertEqual(vm.portfolio.totalRemainingBalanceMinorUnits, 20_000_00)
+    }
+
+    @MainActor
+    func testErrorHandlingClearsDebts() async {
+        let provider = StubDebtPayoffProvider()
+        provider.errorToThrow = TestError.simulated
+        let vm = DebtPayoffViewModel(provider: provider)
+
+        await vm.loadDebts()
+
+        XCTAssertTrue(vm.debts.isEmpty)
+        XCTAssertTrue(vm.showError)
+        XCTAssertFalse(vm.isLoading)
+    }
+
+    @MainActor
+    func testDismissErrorClearsMessage() async {
+        let provider = StubDebtPayoffProvider()
+        provider.errorToThrow = TestError.simulated
+        let vm = DebtPayoffViewModel(provider: provider)
+
+        await vm.loadDebts()
+        XCTAssertTrue(vm.showError)
+
+        vm.dismissError()
+        XCTAssertFalse(vm.showError)
+    }
+
+    @MainActor
+    func testSampleProviderReturnsDebts() async {
+        let vm = DebtPayoffViewModel(provider: SampleDebtPayoffProvider())
+        await vm.loadDebts()
+        XCTAssertFalse(vm.debts.isEmpty,
+                       "Sample provider should supply placeholder debts")
+    }
+}


### PR DESCRIPTION
## Summary
Adds fitness-ring style debt payoff visuals for the student-loan persona (#2175).

- **Pure model** (pps/ios/Shared/DebtPayoffModel.swift): `DebtPayoffProgress` (principal paid vs remaining, percent complete, payoff ETA from payment rate, interest-aware amortization + interest-saved tradeoff, milestones) and `DebtPortfolioProgress` multi-debt rollup. Foundation-only, integer minor units, deterministic. Edge cases handled: zero balance, overpayment, balance growth, zero/zero-principal, zero payment.
- **Accessible SwiftUI** rings/cards (DebtPayoffRing, DebtPayoffCard, DebtPayoffView): VoiceOver conveys progress **numerically** (never color/shape alone), Dynamic Type throughout, Reduce Motion respected. `@Observable` view model with an injectable provider.
- **Deterministic tests**: `DebtPayoffModelTests` (progress/projection/amortization/rollup/edge cases) and `DebtPayoffViewModelTests` (load/rollup/error) using a fixed UTC calendar and stub provider.

Modular and additive — no edits to `DashboardView`/`GoalsView`/`AccountsView` to avoid conflicts with in-flight PRs #2386 and #2162.

## Needs Human Action
- Wire `DebtPayoffViewModel` to real loan accounts (replace `SampleDebtPayoffProvider`). The shared KMP model must expose original principal, monthly payment, and APR per loan first — requires an ADR with @kmp-engineer (`packages/` boundary). Marked in code with `// TODO(human)`.
- Device validation: ring fill, VoiceOver reading order, and Dynamic Type at XXXL.

Closes #2175

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>