### PR TITLE
feat(windows): crypto portfolio dashboard (#2176)

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoFormat.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoFormat.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+import kotlin.math.abs
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure presentation formatting for the crypto dashboard — Issue #2176
+//
+// Locale-stable, platform-free helpers for the "last updated" / staleness chip
+// and signed percent labels. No java.text, no Compose — unit-testable.
+// ─────────────────────────────────────────────────────────────────────────────
+
+object CryptoFormat {
+
+    /**
+     * A coarse "updated N ago" label for the freshness chip.
+     *
+     * @param deltaMs Milliseconds elapsed since the last successful update.
+     */
+    fun relativeUpdated(deltaMs: Long): String {
+        val d = abs(deltaMs)
+        return when {
+            d < 5_000L -> "Updated just now"
+            d < 60_000L -> "Updated ${d / 1_000L}s ago"
+            d < 3_600_000L -> "Updated ${d / 60_000L}m ago"
+            d < 86_400_000L -> "Updated ${d / 3_600_000L}h ago"
+            else -> "Updated ${d / 86_400_000L}d ago"
+        }
+    }
+
+    /**
+     * Signed percent with one decimal place (locale-stable), e.g. `"+2.4%"`,
+     * `"-1.8%"`, `"0.0%"`. Used so movement is conveyed in text, never by
+     * colour alone.
+     */
+    fun signedPercent(value: Double): String {
+        val rounded = (value * 10).let { kotlin.math.round(it) } / 10.0
+        val sign = when {
+            rounded > 0.0 -> "+"
+            rounded < 0.0 -> "-"
+            else -> ""
+        }
+        val magnitude = abs(rounded)
+        val whole = magnitude.toLong()
+        val tenths = (kotlin.math.round((magnitude - whole) * 10)).toLong()
+        return "$sign$whole.$tenths%"
+    }
+
+    /** A short spoken-friendly direction word for screen-reader descriptions. */
+    fun directionWord(value: Double): String = when {
+        value > 0.0 -> "up"
+        value < 0.0 -> "down"
+        else -> "flat"
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoHoldingsSource.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoHoldingsSource.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Crypto holdings source — Issue #2176
+//
+// Abstracts where the user's crypto positions come from so the live data path
+// can be swapped in without touching the ViewModel or UI.
+//
+// NOTE: The real path reads holdings from the local SQLDelight tables and tags
+// crypto accounts distinctly from traditional investments. That wiring depends
+// on the live refresh pipeline (#2702) and is deferred — see the TODO(human)
+// in CryptoDashboardViewModel. Until then [SampleCryptoHoldingsSource] supplies
+// clearly-labelled illustrative positions with NO network access.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Supplies the crypto positions to value against live prices. */
+interface CryptoHoldingsSource {
+    suspend fun holdings(): List<CryptoHolding>
+}
+
+/**
+ * Deterministic, offline holdings used until real holdings are wired (#2702).
+ * The cost-basis figures are illustrative, not financial advice.
+ */
+class SampleCryptoHoldingsSource : CryptoHoldingsSource {
+    override suspend fun holdings(): List<CryptoHolding> = listOf(
+        CryptoHolding("c-btc", "BTC", "Bitcoin", quantity = 0.4120, costBasisCents = 2_180_000L),
+        CryptoHolding("c-eth", "ETH", "Ethereum", quantity = 6.250, costBasisCents = 1_640_000L),
+        CryptoHolding("c-sol", "SOL", "Solana", quantity = 85.00, costBasisCents = 980_000L),
+        CryptoHolding("c-ada", "ADA", "Cardano", quantity = 12_500.0, costBasisCents = 720_000L),
+        CryptoHolding("c-dot", "DOT", "Polkadot", quantity = 940.0, costBasisCents = 810_000L),
+    )
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoPortfolio.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoPortfolio.kt
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+import kotlin.math.roundToLong
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure crypto portfolio aggregation model — Issue #2176
+//
+// This file is intentionally free of Compose, Koin, coroutines and platform
+// APIs so the financial maths is fully unit-testable on the JVM with no UI and
+// no network. Money is carried as Long cents; quantities (which can be highly
+// fractional for crypto) are carried as Double.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A crypto asset the user owns, independent of any live price.
+ *
+ * @param id Stable identifier for list keys.
+ * @param symbol Ticker symbol (e.g. `"BTC"`), matched against [CryptoPrice.symbol].
+ * @param name Display name (e.g. `"Bitcoin"`).
+ * @param quantity Units held; may be fractional (e.g. `0.0125` BTC).
+ * @param costBasisCents Total amount paid to acquire the position, in cents.
+ */
+data class CryptoHolding(
+    val id: String,
+    val symbol: String,
+    val name: String,
+    val quantity: Double,
+    val costBasisCents: Long,
+)
+
+/**
+ * A single holding combined with its latest price and derived metrics.
+ *
+ * @param allocationPercent Share of the priced portfolio's market value (0..100).
+ * @param change24hCents Signed value change over the trailing 24 hours, in cents.
+ * @param unrealizedPnlCents Market value minus cost basis, in cents.
+ * @param isPriceStale True when the backing quote is older than the staleness window.
+ */
+data class CryptoPosition(
+    val id: String,
+    val symbol: String,
+    val name: String,
+    val quantity: Double,
+    val priceCents: Long,
+    val marketValueCents: Long,
+    val costBasisCents: Long,
+    val allocationPercent: Double,
+    val change24hCents: Long,
+    val change24hPercent: Double,
+    val unrealizedPnlCents: Long,
+    val unrealizedPnlPercent: Double,
+    val isPriceStale: Boolean,
+    val priceAsOfEpochMs: Long,
+)
+
+/**
+ * The fully aggregated portfolio: totals plus per-asset [positions].
+ *
+ * @param missingPriceSymbols Symbols held but absent from the supplied prices.
+ * @param lastUpdatedEpochMs Newest quote timestamp across all positions (0 if none).
+ * @param oldestPriceEpochMs Oldest quote timestamp across all positions (0 if none).
+ * @param isStale True when any priced position is stale, or holdings have no prices.
+ */
+data class CryptoPortfolioSummary(
+    val totalValueCents: Long,
+    val totalCostCents: Long,
+    val totalPnlCents: Long,
+    val totalPnlPercent: Double,
+    val total24hChangeCents: Long,
+    val total24hChangePercent: Double,
+    val positions: List<CryptoPosition>,
+    val missingPriceSymbols: List<String>,
+    val lastUpdatedEpochMs: Long,
+    val oldestPriceEpochMs: Long,
+    val isStale: Boolean,
+) {
+    val hasData: Boolean get() = positions.isNotEmpty()
+
+    companion object {
+        val EMPTY = CryptoPortfolioSummary(
+            totalValueCents = 0L,
+            totalCostCents = 0L,
+            totalPnlCents = 0L,
+            totalPnlPercent = 0.0,
+            total24hChangeCents = 0L,
+            total24hChangePercent = 0.0,
+            positions = emptyList(),
+            missingPriceSymbols = emptyList(),
+            lastUpdatedEpochMs = 0L,
+            oldestPriceEpochMs = 0L,
+            isStale = false,
+        )
+    }
+}
+
+/**
+ * Pure aggregation of holdings against the latest prices.
+ *
+ * No mutable state, no platform calls — every output is a deterministic function
+ * of the inputs, which makes the financial maths straightforward to unit-test.
+ */
+object CryptoPortfolioAggregator {
+
+    /** Default window after which a quote is treated as stale (2 minutes). */
+    const val DEFAULT_STALENESS_MS: Long = 120_000L
+
+    /**
+     * Combines [holdings] with [prices] into a [CryptoPortfolioSummary].
+     *
+     * @param nowEpochMs Current time, used to evaluate per-price staleness.
+     * @param stalenessThresholdMs A quote older than this is flagged stale.
+     */
+    fun aggregate(
+        holdings: List<CryptoHolding>,
+        prices: List<CryptoPrice>,
+        nowEpochMs: Long,
+        stalenessThresholdMs: Long = DEFAULT_STALENESS_MS,
+    ): CryptoPortfolioSummary {
+        if (holdings.isEmpty()) return CryptoPortfolioSummary.EMPTY
+
+        val priceBySymbol = prices.associateBy { it.symbol.uppercase() }
+        val missing = holdings
+            .map { it.symbol.uppercase() }
+            .filter { it !in priceBySymbol }
+            .distinct()
+
+        // First pass: market values, so allocation can be a share of the whole.
+        data class Priced(val holding: CryptoHolding, val price: CryptoPrice, val valueCents: Long)
+
+        val priced = holdings.mapNotNull { holding ->
+            val price = priceBySymbol[holding.symbol.uppercase()] ?: return@mapNotNull null
+            val valueCents = (holding.quantity * price.priceCents).roundToLong()
+            Priced(holding, price, valueCents)
+        }
+
+        if (priced.isEmpty()) {
+            return CryptoPortfolioSummary.EMPTY.copy(
+                missingPriceSymbols = missing,
+                isStale = true,
+            )
+        }
+
+        val totalValue = priced.sumOf { it.valueCents }
+
+        val positions = priced.map { (holding, price, valueCents) ->
+            val priceYesterday = priceYesterdayValue(valueCents, price.change24hPercent)
+            val change24h = valueCents - priceYesterday
+            val pnl = valueCents - holding.costBasisCents
+            CryptoPosition(
+                id = holding.id,
+                symbol = holding.symbol.uppercase(),
+                name = holding.name,
+                quantity = holding.quantity,
+                priceCents = price.priceCents,
+                marketValueCents = valueCents,
+                costBasisCents = holding.costBasisCents,
+                allocationPercent = percentOf(valueCents, totalValue),
+                change24hCents = change24h,
+                change24hPercent = price.change24hPercent,
+                unrealizedPnlCents = pnl,
+                unrealizedPnlPercent = percentOf(pnl, holding.costBasisCents),
+                isPriceStale = (nowEpochMs - price.asOfEpochMs) > stalenessThresholdMs,
+                priceAsOfEpochMs = price.asOfEpochMs,
+            )
+        }.sortedByDescending { it.marketValueCents }
+
+        val totalCost = priced.sumOf { it.holding.costBasisCents }
+        val totalPnl = totalValue - totalCost
+        val total24h = positions.sumOf { it.change24hCents }
+        val totalYesterday = totalValue - total24h
+        val asOfTimes = priced.map { it.price.asOfEpochMs }
+
+        return CryptoPortfolioSummary(
+            totalValueCents = totalValue,
+            totalCostCents = totalCost,
+            totalPnlCents = totalPnl,
+            totalPnlPercent = percentOf(totalPnl, totalCost),
+            total24hChangeCents = total24h,
+            total24hChangePercent = percentOf(total24h, totalYesterday),
+            positions = positions,
+            missingPriceSymbols = missing,
+            lastUpdatedEpochMs = asOfTimes.max(),
+            oldestPriceEpochMs = asOfTimes.min(),
+            isStale = positions.any { it.isPriceStale } || missing.isNotEmpty(),
+        )
+    }
+
+    /**
+     * Reconstructs the value 24h ago from the current value and the percent move.
+     * `today = yesterday * (1 + pct/100)` so `yesterday = today / (1 + pct/100)`.
+     */
+    private fun priceYesterdayValue(valueCents: Long, change24hPercent: Double): Long {
+        val factor = 1.0 + (change24hPercent / 100.0)
+        if (factor <= 0.0) return valueCents
+        return (valueCents / factor).roundToLong()
+    }
+
+    private fun percentOf(part: Long, whole: Long): Double {
+        if (whole == 0L) return 0.0
+        return (part.toDouble() / whole.toDouble()) * 100.0
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoPriceSource.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoPriceSource.kt
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlin.math.absoluteValue
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pluggable crypto price source — Issue #2176
+//
+// The dashboard reads near-real-time prices through this interface so the
+// concrete feed can be swapped without touching aggregation or UI code.
+//
+// NOTE: A live market-data adapter is intentionally NOT wired here. The live
+// refresh pipeline (#2702) is blocked on market-data credentials. Until those
+// land, the app ships with [MockCryptoPriceSource] — a deterministic, offline
+// adapter that requires no network access and NO API keys.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A spot price for a single crypto asset, captured at a point in time.
+ *
+ * @param symbol Ticker symbol (e.g. `"BTC"`). Matched against holdings.
+ * @param priceCents Price per whole unit, in cents, to avoid float drift.
+ * @param change24hPercent Signed 24-hour move as a percent (e.g. `-3.5` = down 3.5%).
+ * @param asOfEpochMs Wall-clock time the quote was observed (epoch millis).
+ */
+data class CryptoPrice(
+    val symbol: String,
+    val priceCents: Long,
+    val change24hPercent: Double,
+    val asOfEpochMs: Long,
+)
+
+/**
+ * Source of near-real-time crypto prices.
+ *
+ * Implementations may poll an HTTP API, subscribe to a websocket, or (as in
+ * [MockCryptoPriceSource]) generate deterministic offline data. The aggregation
+ * layer ([CryptoPortfolioAggregator]) and UI depend only on this contract.
+ */
+interface CryptoPriceSource {
+    /** The human-readable name of this source, shown in diagnostics. */
+    val sourceName: String
+
+    /** Returns the latest known price for each requested [symbols] entry. */
+    suspend fun latestPrices(symbols: List<String>): List<CryptoPrice>
+}
+
+/**
+ * Deterministic, offline price source used until the live feed (#2702) is wired.
+ *
+ * Prices oscillate slightly on every call using a pure, seedable function so the
+ * dashboard's refresh and staleness behaviour can be demonstrated and tested
+ * without any network access or credentials.
+ *
+ * @param clock Supplies the current epoch-millis timestamp stamped on each quote.
+ * @param seedPrices Base price (cents) and 24h move (percent) per symbol.
+ */
+class MockCryptoPriceSource(
+    private val clock: () -> Long = { 0L },
+    private val seedPrices: Map<String, Pair<Long, Double>> = DEFAULT_SEED,
+) : CryptoPriceSource {
+
+    override val sourceName: String = "Mock (offline)"
+
+    private var tick: Long = 0L
+
+    override suspend fun latestPrices(symbols: List<String>): List<CryptoPrice> {
+        tick += 1
+        val now = clock()
+        return symbols.mapNotNull { symbol ->
+            val seed = seedPrices[symbol.uppercase()] ?: return@mapNotNull null
+            val (basePrice, baseChange) = seed
+            // Pure, bounded oscillation derived from the symbol + tick — no RNG,
+            // so repeated runs in tests and CI are fully reproducible.
+            val wobble = oscillation(symbol, tick)
+            val priceCents = (basePrice + (basePrice * wobble / 100.0)).toLong().coerceAtLeast(1L)
+            CryptoPrice(
+                symbol = symbol.uppercase(),
+                priceCents = priceCents,
+                change24hPercent = baseChange + wobble,
+                asOfEpochMs = now,
+            )
+        }
+    }
+
+    private fun oscillation(symbol: String, tick: Long): Double {
+        val phase = (symbol.sumOf { it.code } + tick * 7) % 20
+        return (phase - 10) / 10.0 // range roughly [-1.0, +0.9]
+    }
+
+    companion object {
+        /** Illustrative seed data. Replaced by the live feed under #2702. */
+        val DEFAULT_SEED: Map<String, Pair<Long, Double>> = mapOf(
+            "BTC" to (6_412_300L to 2.4),
+            "ETH" to (351_900L to -1.8),
+            "SOL" to (14_250L to 5.1),
+            "ADA" to (62L to -0.7),
+            "DOT" to (820L to 1.2),
+        )
+    }
+}
+
+/**
+ * Wraps any [CryptoPriceSource] in a polling [Flow] that re-emits prices on a
+ * fixed interval. This is the pluggable "polling adapter" the dashboard uses for
+ * near-real-time refresh while the live websocket feed (#2702) is unavailable.
+ *
+ * @param source Underlying price source to poll.
+ * @param intervalMs Delay between successive polls.
+ */
+class PollingPriceFeed(
+    private val source: CryptoPriceSource,
+    private val intervalMs: Long = 30_000L,
+) {
+    /** Emits a fresh price list immediately, then once per [intervalMs]. */
+    fun stream(symbols: List<String>): Flow<List<CryptoPrice>> = flow {
+        require(intervalMs > 0) { "intervalMs must be positive, got $intervalMs" }
+        while (true) {
+            emit(source.latestPrices(symbols))
+            delay(intervalMs.absoluteValue)
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/crypto/ResponsiveColumns.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/crypto/ResponsiveColumns.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure responsive-layout logic — Issue #2176
+//
+// Maps an available width (in dp) to a layout tier and a concrete column count
+// for the dashboard's adaptive grids. Kept free of Compose so the breakpoint
+// rules can be unit-tested directly. Values mirror docs/design/
+// responsive-breakpoints.md (tablet 640, desktop 1024, widescreen 1440).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The four responsive tiers from the Finance breakpoint system. */
+enum class LayoutTier { MOBILE, TABLET, DESKTOP, WIDESCREEN }
+
+/**
+ * Width thresholds (dp) and column rules for the crypto dashboard.
+ *
+ * The dashboard is built for ultrawide monitors: at [WIDESCREEN_MIN] and above
+ * it fans cards out into four columns so the extra horizontal space carries
+ * allocation, source breakdown, and gain/loss context side by side rather than
+ * compressing everything into a single tall scroll.
+ */
+object DashboardLayout {
+    const val TABLET_MIN: Int = 640
+    const val DESKTOP_MIN: Int = 1024
+    const val WIDESCREEN_MIN: Int = 1440
+
+    /** Returns the [LayoutTier] that owns [widthDp]. */
+    fun tierForWidth(widthDp: Int): LayoutTier = when {
+        widthDp < TABLET_MIN -> LayoutTier.MOBILE
+        widthDp < DESKTOP_MIN -> LayoutTier.TABLET
+        widthDp < WIDESCREEN_MIN -> LayoutTier.DESKTOP
+        else -> LayoutTier.WIDESCREEN
+    }
+
+    /** Number of summary-stat columns for the given [tier]. */
+    fun summaryColumns(tier: LayoutTier): Int = when (tier) {
+        LayoutTier.MOBILE -> 1
+        LayoutTier.TABLET -> 2
+        LayoutTier.DESKTOP -> 3
+        LayoutTier.WIDESCREEN -> 4
+    }
+
+    /**
+     * Number of holdings-card columns for [widthDp].
+     *
+     * Mobile stays single-column; each wider tier adds a column, with ultrawide
+     * topping out at four so very wide monitors are actually used.
+     */
+    fun holdingsColumns(widthDp: Int): Int = when (tierForWidth(widthDp)) {
+        LayoutTier.MOBILE -> 1
+        LayoutTier.TABLET -> 2
+        LayoutTier.DESKTOP -> 3
+        LayoutTier.WIDESCREEN -> 4
+    }
+
+    /**
+     * Whether the allocation panel and holdings panel sit side by side.
+     *
+     * Only desktop-class widths and above have the room; narrower tiers stack
+     * the panels vertically so nothing is truncated.
+     */
+    fun isMultiPanel(widthDp: Int): Boolean =
+        tierForWidth(widthDp) >= LayoutTier.DESKTOP
+
+    /**
+     * Fraction (0..1] of the available width given to the holdings panel when
+     * [isMultiPanel] is true; the remainder goes to the allocation/context rail.
+     * Ultrawide gives the rail a little more room than plain desktop.
+     */
+    fun holdingsPanelWeight(widthDp: Int): Float = when (tierForWidth(widthDp)) {
+        LayoutTier.WIDESCREEN -> 0.62f
+        else -> 0.66f
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/CryptoDashboardScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/CryptoDashboardScreen.kt
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.TrendingDown
+import androidx.compose.material.icons.automirrored.filled.TrendingUp
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.crypto.DashboardLayout
+import com.finance.desktop.theme.FinanceDesktopTheme
+import com.finance.desktop.viewmodel.CryptoDashboardUiState
+import com.finance.desktop.viewmodel.CryptoDashboardViewModel
+import com.finance.desktop.viewmodel.CryptoPositionUi
+
+// =============================================================================
+// Crypto Portfolio Dashboard — Issue #2176
+//
+// A responsive, ultrawide-first dashboard. Width drives the column count via the
+// pure DashboardLayout breakpoint logic, so a 1440px+ monitor fans summary stats
+// and holdings cards out side by side rather than compressing into a tall scroll.
+//
+// Accessibility: every movement is conveyed with an icon + text label and a
+// spoken contentDescription — never by colour alone. The freshness chip is a
+// polite live region so Narrator announces staleness changes.
+// =============================================================================
+
+/** Slice palette — paired with text labels so colour is never the only cue. */
+private val AllocationPalette = listOf(
+    Color(0xFF3B82F6),
+    Color(0xFF22C55E),
+    Color(0xFFF59E0B),
+    Color(0xFF8B5CF6),
+    Color(0xFF06B6D4),
+    Color(0xFFEF4444),
+)
+
+@Composable
+fun CryptoDashboardScreen(modifier: Modifier = Modifier) {
+    // Self-contained construction: the offline mock source ships today; the live
+    // adapter is injected here once #2702 (market-data credentials) lands.
+    // TODO(human): Replace with the live CryptoPriceSource + real holdings source
+    // (DI-provided) when the #2702 refresh pipeline and credentials are available.
+    val viewModel = remember { CryptoDashboardViewModel() }
+    val state by viewModel.uiState.collectAsState()
+
+    if (state.isLoading) {
+        Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(
+                modifier = Modifier.semantics { contentDescription = "Loading crypto portfolio" },
+            )
+        }
+        return
+    }
+
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        val widthDp = maxWidth.value.toInt()
+        val summaryColumns = DashboardLayout.summaryColumns(DashboardLayout.tierForWidth(widthDp))
+        val holdingsColumns = DashboardLayout.holdingsColumns(widthDp)
+        val multiPanel = DashboardLayout.isMultiPanel(widthDp)
+        val holdingsWeight = DashboardLayout.holdingsPanelWeight(widthDp)
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(FinanceDesktopTheme.spacing.xxl)
+                .semantics { contentDescription = "Crypto portfolio dashboard" },
+            verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.xxl),
+        ) {
+            DashboardHeader(state, onRefresh = viewModel::refresh)
+
+            SummaryStatsGrid(state, columns = summaryColumns)
+
+            if (multiPanel) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.xxl),
+                ) {
+                    HoldingsPanel(
+                        state = state,
+                        columns = holdingsColumns,
+                        modifier = Modifier.weight(holdingsWeight),
+                    )
+                    AllocationPanel(
+                        state = state,
+                        modifier = Modifier.weight(1f - holdingsWeight),
+                    )
+                }
+            } else {
+                HoldingsPanel(state = state, columns = holdingsColumns)
+                AllocationPanel(state = state)
+            }
+        }
+    }
+}
+
+// ─── Header + freshness ──────────────────────────────────────────────────────
+
+@Composable
+private fun DashboardHeader(state: CryptoDashboardUiState, onRefresh: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Crypto Portfolio",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics {
+                    heading()
+                    contentDescription = "Crypto Portfolio heading"
+                },
+            )
+            Text(
+                text = "Source: ${state.sourceName}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        FreshnessChip(state)
+
+        IconButton(
+            onClick = onRefresh,
+            modifier = Modifier.semantics { contentDescription = "Refresh prices" },
+        ) {
+            if (state.isRefreshing) {
+                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+            } else {
+                Icon(Icons.Filled.Refresh, contentDescription = null)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FreshnessChip(state: CryptoDashboardUiState) {
+    val description = "${state.stalenessLabel}. ${state.lastUpdatedLabel}."
+    AssistChip(
+        onClick = {},
+        enabled = false,
+        label = {
+            Column {
+                Text(state.lastUpdatedLabel, style = MaterialTheme.typography.labelMedium)
+                Text(state.stalenessLabel, style = MaterialTheme.typography.labelSmall)
+            }
+        },
+        leadingIcon = {
+            // Icon distinguishes stale vs live in addition to any colour change.
+            if (state.isStale) {
+                Icon(Icons.Filled.Warning, contentDescription = null, Modifier.size(18.dp))
+            } else {
+                Icon(Icons.Filled.Refresh, contentDescription = null, Modifier.size(18.dp))
+            }
+        },
+        colors = AssistChipDefaults.assistChipColors(
+            disabledContainerColor = if (state.isStale) {
+                MaterialTheme.colorScheme.errorContainer
+            } else {
+                MaterialTheme.colorScheme.secondaryContainer
+            },
+        ),
+        modifier = Modifier.semantics {
+            contentDescription = description
+            liveRegion = LiveRegionMode.Polite
+        },
+    )
+}
+
+// ─── Summary stats ───────────────────────────────────────────────────────────
+
+@Composable
+private fun SummaryStatsGrid(state: CryptoDashboardUiState, columns: Int) {
+    val stats = listOf(
+        Triple("Total value", state.totalValue, null),
+        Triple("24h change", "${state.total24hChange} (${state.total24hChangePercent})", state.is24hPositive),
+        Triple("Total profit / loss", "${state.totalPnl} (${state.totalPnlPercent})", state.isPnlPositive),
+        Triple("Assets held", state.positions.size.toString(), null),
+    )
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(columns),
+        modifier = Modifier.fillMaxWidth().height(((stats.size + columns - 1) / columns * 112).dp),
+        horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+        verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+        userScrollEnabled = false,
+    ) {
+        items(stats) { (label, value, positive) ->
+            SummaryStatCard(label = label, value = value, positive = positive)
+        }
+    }
+}
+
+@Composable
+private fun SummaryStatCard(label: String, value: String, positive: Boolean?) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = "$label: $value" },
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (positive != null) {
+                    DirectionIcon(positive)
+                    Spacer(Modifier.width(FinanceDesktopTheme.spacing.xs))
+                }
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = positive.toAmountColor(),
+                )
+            }
+        }
+    }
+}
+
+// ─── Holdings ────────────────────────────────────────────────────────────────
+
+@Composable
+private fun HoldingsPanel(
+    state: CryptoDashboardUiState,
+    columns: Int,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = "Holdings",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Holdings"
+            },
+        )
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(columns),
+            modifier = Modifier.fillMaxWidth().height((((state.positions.size + columns - 1) / columns) * 148).dp),
+            horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+            userScrollEnabled = false,
+        ) {
+            items(state.positions, key = { it.id }) { position ->
+                HoldingCard(position)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HoldingCard(position: CryptoPositionUi) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = position.accessibilityLabel },
+    ) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = position.symbol,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                Text(
+                    text = position.name,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                if (position.isStale) {
+                    Icon(
+                        Icons.Filled.Warning,
+                        contentDescription = "Price may be out of date",
+                        modifier = Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+            Text(
+                text = position.value,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = "${position.quantity} ${position.symbol} @ ${position.price}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                DirectionIcon(position.is24hPositive)
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.xs))
+                Text(
+                    text = "24h ${position.change24hPercent}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = position.is24hPositive.toAmountColor(),
+                )
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                Text(
+                    text = "P/L ${position.pnlPercent}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = position.isPnlPositive.toAmountColor(),
+                )
+            }
+        }
+    }
+}
+
+// ─── Allocation ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun AllocationPanel(state: CryptoDashboardUiState, modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Text(
+            text = "Allocation",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Allocation by asset"
+            },
+        )
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+        ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+                state.positions.forEachIndexed { index, position ->
+                    AllocationRow(position, AllocationPalette[index % AllocationPalette.size])
+                    if (index < state.positions.lastIndex) {
+                        Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AllocationRow(position: CryptoPositionUi, swatch: Color) {
+    Column(
+        modifier = Modifier.semantics {
+            contentDescription = "${position.name}: ${position.allocationLabel}% of portfolio"
+        },
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .clip(CircleShape)
+                    .background(swatch),
+            )
+            Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+            Text(
+                text = position.symbol,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = "${position.allocationLabel}%",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+        LinearProgressIndicator(
+            progress = { position.allocationPercent },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .clip(RoundedCornerShape(3.dp)),
+            color = swatch,
+        )
+    }
+}
+
+// ─── Shared bits ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun DirectionIcon(positive: Boolean) {
+    if (positive) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.TrendingUp,
+            contentDescription = "up",
+            modifier = Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+    } else {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.TrendingDown,
+            contentDescription = "down",
+            modifier = Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+@Composable
+private fun Boolean?.toAmountColor(): Color = when (this) {
+    true -> MaterialTheme.colorScheme.primary
+    false -> MaterialTheme.colorScheme.error
+    null -> MaterialTheme.colorScheme.onSurface
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/CryptoDashboardViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/CryptoDashboardViewModel.kt
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.viewmodel
+
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.desktop.crypto.CryptoFormat
+import com.finance.desktop.crypto.CryptoHoldingsSource
+import com.finance.desktop.crypto.CryptoPortfolioAggregator
+import com.finance.desktop.crypto.CryptoPriceSource
+import com.finance.desktop.crypto.MockCryptoPriceSource
+import com.finance.desktop.crypto.SampleCryptoHoldingsSource
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Crypto portfolio dashboard ViewModel — Issue #2176
+//
+// Mirrors the Android architecture: a StateFlow-backed holder that maps the
+// pure aggregation model (CryptoPortfolioAggregator) into display strings. The
+// price feed is injected through CryptoPriceSource so the live adapter (#2702)
+// can replace the offline mock with zero UI changes.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** UI projection of a single crypto position. */
+data class CryptoPositionUi(
+    val id: String,
+    val symbol: String,
+    val name: String,
+    val quantity: String,
+    val price: String,
+    val value: String,
+    val allocationPercent: Float,
+    val allocationLabel: String,
+    val change24h: String,
+    val change24hPercent: String,
+    val is24hPositive: Boolean,
+    val pnl: String,
+    val pnlPercent: String,
+    val isPnlPositive: Boolean,
+    val isStale: Boolean,
+    /** Full spoken description so movement is conveyed without colour. */
+    val accessibilityLabel: String,
+)
+
+data class CryptoDashboardUiState(
+    val isLoading: Boolean = true,
+    val isRefreshing: Boolean = false,
+    val totalValue: String = "",
+    val totalPnl: String = "",
+    val totalPnlPercent: String = "",
+    val isPnlPositive: Boolean = true,
+    val total24hChange: String = "",
+    val total24hChangePercent: String = "",
+    val is24hPositive: Boolean = true,
+    val positions: List<CryptoPositionUi> = emptyList(),
+    val sourceName: String = "",
+    val lastUpdatedLabel: String = "",
+    val isStale: Boolean = false,
+    val stalenessLabel: String = "",
+    val missingSymbols: List<String> = emptyList(),
+    val errorMessage: String? = null,
+)
+
+/**
+ * Loads crypto holdings, values them against the injected [priceSource], and
+ * exposes a formatted [uiState].
+ *
+ * @param holdingsSource Where positions come from (offline sample by default).
+ * @param priceSource Near-real-time prices (offline mock by default).
+ * @param clock Supplies "now" for staleness + relative-time labels.
+ * @param currency Display currency for all monetary formatting.
+ */
+class CryptoDashboardViewModel(
+    private val holdingsSource: CryptoHoldingsSource = SampleCryptoHoldingsSource(),
+    private val priceSource: CryptoPriceSource = MockCryptoPriceSource(),
+    private val clock: () -> Long = { System.currentTimeMillis() },
+    private val currency: Currency = Currency.USD,
+) : DesktopViewModel() {
+
+    private val _uiState = MutableStateFlow(CryptoDashboardUiState())
+    val uiState: StateFlow<CryptoDashboardUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    /**
+     * Re-fetches prices and re-aggregates the portfolio.
+     *
+     * TODO(human): Wire [holdingsSource] to the real SQLDelight investment
+     * tables (crypto accounts tagged separately from traditional investments)
+     * and replace [priceSource] with the live market-data adapter once the
+     * #2702 refresh pipeline and its credentials are available. See the
+     * "## Needs Human Action" section of the PR for details.
+     */
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isRefreshing = true, errorMessage = null)
+            try {
+                val holdings = holdingsSource.holdings()
+                val symbols = holdings.map { it.symbol }
+                val prices = priceSource.latestPrices(symbols)
+                val now = clock()
+                val summary = CryptoPortfolioAggregator.aggregate(
+                    holdings = holdings,
+                    prices = prices,
+                    nowEpochMs = now,
+                )
+
+                val positions = summary.positions.map { p ->
+                    val directionWord = CryptoFormat.directionWord(p.change24hPercent)
+                    val pnlWord = if (p.unrealizedPnlCents >= 0) "gain" else "loss"
+                    CryptoPositionUi(
+                        id = p.id,
+                        symbol = p.symbol,
+                        name = p.name,
+                        quantity = formatQuantity(p.quantity),
+                        price = CurrencyFormatter.format(Cents(p.priceCents), currency),
+                        value = CurrencyFormatter.format(Cents(p.marketValueCents), currency),
+                        allocationPercent = (p.allocationPercent / 100.0).toFloat(),
+                        allocationLabel = CryptoFormat.signedPercent(p.allocationPercent)
+                            .removePrefix("+"),
+                        change24h = CurrencyFormatter.format(
+                            Cents(p.change24hCents), currency, showSign = true,
+                        ),
+                        change24hPercent = CryptoFormat.signedPercent(p.change24hPercent),
+                        is24hPositive = p.change24hCents >= 0,
+                        pnl = CurrencyFormatter.format(
+                            Cents(p.unrealizedPnlCents), currency, showSign = true,
+                        ),
+                        pnlPercent = CryptoFormat.signedPercent(p.unrealizedPnlPercent),
+                        isPnlPositive = p.unrealizedPnlCents >= 0,
+                        isStale = p.isPriceStale,
+                        accessibilityLabel = buildString {
+                            append("${p.name}, ${formatQuantity(p.quantity)} ${p.symbol}, ")
+                            append("worth ${CurrencyFormatter.format(Cents(p.marketValueCents), currency)}, ")
+                            append("$directionWord ${CryptoFormat.signedPercent(p.change24hPercent).trimStart('+', '-')} ")
+                            append("over 24 hours, ")
+                            append("$pnlWord of ${CurrencyFormatter.format(Cents(p.unrealizedPnlCents).abs(), currency)}")
+                            if (p.isPriceStale) append(", price may be out of date")
+                        },
+                    )
+                }
+
+                val deltaMs = now - summary.oldestPriceEpochMs
+                _uiState.value = CryptoDashboardUiState(
+                    isLoading = false,
+                    isRefreshing = false,
+                    totalValue = CurrencyFormatter.format(Cents(summary.totalValueCents), currency),
+                    totalPnl = CurrencyFormatter.format(
+                        Cents(summary.totalPnlCents), currency, showSign = true,
+                    ),
+                    totalPnlPercent = CryptoFormat.signedPercent(summary.totalPnlPercent),
+                    isPnlPositive = summary.totalPnlCents >= 0,
+                    total24hChange = CurrencyFormatter.format(
+                        Cents(summary.total24hChangeCents), currency, showSign = true,
+                    ),
+                    total24hChangePercent = CryptoFormat.signedPercent(summary.total24hChangePercent),
+                    is24hPositive = summary.total24hChangeCents >= 0,
+                    positions = positions,
+                    sourceName = priceSource.sourceName,
+                    lastUpdatedLabel = if (summary.hasData) {
+                        CryptoFormat.relativeUpdated(deltaMs)
+                    } else {
+                        "No price data"
+                    },
+                    isStale = summary.isStale,
+                    stalenessLabel = if (summary.isStale) "Prices may be out of date" else "Live",
+                    missingSymbols = summary.missingPriceSymbols,
+                )
+            } catch (e: IllegalStateException) {
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    isRefreshing = false,
+                    errorMessage = e.message ?: "Could not refresh prices",
+                )
+            }
+        }
+    }
+
+    private fun formatQuantity(quantity: Double): String {
+        // Trim trailing zeros while keeping small fractional crypto amounts readable.
+        val rounded = (kotlin.math.round(quantity * 100_000.0) / 100_000.0)
+        val asLong = rounded.toLong()
+        return if (rounded == asLong.toDouble()) {
+            asLong.toString()
+        } else {
+            rounded.toString().trimEnd('0').trimEnd('.')
+        }
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/crypto/CryptoFormatTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/crypto/CryptoFormatTest.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for the pure presentation formatting ([CryptoFormat]).
+ *
+ * Locale-stable freshness and signed-percent labels, verified with no UI.
+ */
+class CryptoFormatTest {
+
+    @Test
+    fun `relative updated buckets elapsed time`() {
+        assertEquals("Updated just now", CryptoFormat.relativeUpdated(0L))
+        assertEquals("Updated just now", CryptoFormat.relativeUpdated(4_999L))
+        assertEquals("Updated 30s ago", CryptoFormat.relativeUpdated(30_000L))
+        assertEquals("Updated 2m ago", CryptoFormat.relativeUpdated(120_000L))
+        assertEquals("Updated 3h ago", CryptoFormat.relativeUpdated(3 * 3_600_000L))
+        assertEquals("Updated 2d ago", CryptoFormat.relativeUpdated(2 * 86_400_000L))
+    }
+
+    @Test
+    fun `signed percent renders sign and one decimal`() {
+        assertEquals("+2.4%", CryptoFormat.signedPercent(2.41))
+        assertEquals("-1.8%", CryptoFormat.signedPercent(-1.84))
+        assertEquals("0.0%", CryptoFormat.signedPercent(0.0))
+        assertEquals("+25.0%", CryptoFormat.signedPercent(25.0))
+    }
+
+    @Test
+    fun `direction word reflects sign`() {
+        assertEquals("up", CryptoFormat.directionWord(0.1))
+        assertEquals("down", CryptoFormat.directionWord(-0.1))
+        assertEquals("flat", CryptoFormat.directionWord(0.0))
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/crypto/CryptoPortfolioAggregatorTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/crypto/CryptoPortfolioAggregatorTest.kt
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the pure crypto portfolio aggregation ([CryptoPortfolioAggregator]).
+ *
+ * These run in CI with no UI and no network — they pin the value, allocation,
+ * 24h-change, P&L and staleness maths the dashboard depends on.
+ */
+class CryptoPortfolioAggregatorTest {
+
+    private val holdings = listOf(
+        CryptoHolding("btc", "BTC", "Bitcoin", quantity = 1.0, costBasisCents = 5_000_000L),
+        CryptoHolding("eth", "ETH", "Ethereum", quantity = 10.0, costBasisCents = 3_000_000L),
+    )
+
+    private fun prices(asOf: Long) = listOf(
+        CryptoPrice("BTC", priceCents = 6_000_000L, change24hPercent = 20.0, asOfEpochMs = asOf),
+        CryptoPrice("ETH", priceCents = 400_000L, change24hPercent = -10.0, asOfEpochMs = asOf),
+    )
+
+    @Test
+    fun `aggregates market value and total cost`() {
+        val summary = CryptoPortfolioAggregator.aggregate(holdings, prices(1_000L), nowEpochMs = 1_000L)
+        assertEquals(10_000_000L, summary.totalValueCents)
+        assertEquals(8_000_000L, summary.totalCostCents)
+        assertEquals(2_000_000L, summary.totalPnlCents)
+        assertEquals(25.0, summary.totalPnlPercent, 0.001)
+    }
+
+    @Test
+    fun `allocation percentages reflect market value share and sum to 100`() {
+        val summary = CryptoPortfolioAggregator.aggregate(holdings, prices(1_000L), nowEpochMs = 1_000L)
+        val btc = summary.positions.first { it.symbol == "BTC" }
+        val eth = summary.positions.first { it.symbol == "ETH" }
+        assertEquals(60.0, btc.allocationPercent, 0.001)
+        assertEquals(40.0, eth.allocationPercent, 0.001)
+        assertEquals(100.0, btc.allocationPercent + eth.allocationPercent, 0.001)
+    }
+
+    @Test
+    fun `24h change is reconstructed from the percent move`() {
+        val summary = CryptoPortfolioAggregator.aggregate(holdings, prices(1_000L), nowEpochMs = 1_000L)
+        val btc = summary.positions.first { it.symbol == "BTC" }
+        val eth = summary.positions.first { it.symbol == "ETH" }
+        // BTC up 20%: yesterday 6,000,000 / 1.2 = 5,000,000 → +1,000,000
+        assertEquals(1_000_000L, btc.change24hCents)
+        // ETH down 10%: yesterday 4,000,000 / 0.9 = 4,444,444 → -444,444
+        assertEquals(-444_444L, eth.change24hCents)
+        assertEquals(555_556L, summary.total24hChangeCents)
+    }
+
+    @Test
+    fun `positions are sorted by market value descending`() {
+        val summary = CryptoPortfolioAggregator.aggregate(holdings, prices(1_000L), nowEpochMs = 1_000L)
+        assertEquals(listOf("BTC", "ETH"), summary.positions.map { it.symbol })
+        assertEquals(1_000L, summary.lastUpdatedEpochMs)
+        assertEquals(1_000L, summary.oldestPriceEpochMs)
+    }
+
+    @Test
+    fun `per-position pnl percent uses cost basis`() {
+        val summary = CryptoPortfolioAggregator.aggregate(holdings, prices(1_000L), nowEpochMs = 1_000L)
+        val btc = summary.positions.first { it.symbol == "BTC" }
+        // value 6,000,000 - cost 5,000,000 = +1,000,000 → +20%
+        assertEquals(1_000_000L, btc.unrealizedPnlCents)
+        assertEquals(20.0, btc.unrealizedPnlPercent, 0.001)
+    }
+
+    @Test
+    fun `fresh prices are not stale`() {
+        val summary = CryptoPortfolioAggregator.aggregate(
+            holdings, prices(asOf = 1_000L), nowEpochMs = 1_000L + 30_000L,
+        )
+        assertFalse(summary.isStale)
+        assertTrue(summary.positions.none { it.isPriceStale })
+    }
+
+    @Test
+    fun `prices older than the threshold are flagged stale`() {
+        val summary = CryptoPortfolioAggregator.aggregate(
+            holdings,
+            prices(asOf = 1_000L),
+            nowEpochMs = 1_000L + 200_000L,
+            stalenessThresholdMs = 120_000L,
+        )
+        assertTrue(summary.isStale)
+        assertTrue(summary.positions.all { it.isPriceStale })
+    }
+
+    @Test
+    fun `holdings without a price are reported as missing and mark the portfolio stale`() {
+        val withExtra = holdings + CryptoHolding("doge", "DOGE", "Dogecoin", 100.0, 10_000L)
+        val summary = CryptoPortfolioAggregator.aggregate(withExtra, prices(1_000L), nowEpochMs = 1_000L)
+        assertEquals(listOf("DOGE"), summary.missingPriceSymbols)
+        assertTrue(summary.isStale)
+        // DOGE is excluded from value because it has no price.
+        assertEquals(10_000_000L, summary.totalValueCents)
+    }
+
+    @Test
+    fun `empty holdings yield the empty summary`() {
+        val summary = CryptoPortfolioAggregator.aggregate(emptyList(), prices(1_000L), nowEpochMs = 1_000L)
+        assertEquals(CryptoPortfolioSummary.EMPTY, summary)
+        assertFalse(summary.hasData)
+    }
+
+    @Test
+    fun `symbol matching is case-insensitive`() {
+        val lower = listOf(CryptoHolding("btc", "btc", "Bitcoin", 1.0, 5_000_000L))
+        val summary = CryptoPortfolioAggregator.aggregate(lower, prices(1_000L), nowEpochMs = 1_000L)
+        assertEquals(1, summary.positions.size)
+        assertEquals("BTC", summary.positions.first().symbol)
+        assertTrue(summary.missingPriceSymbols.isEmpty())
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/crypto/ResponsiveColumnsTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/crypto/ResponsiveColumnsTest.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the pure responsive-layout logic ([DashboardLayout]).
+ *
+ * These pin the breakpoint → tier → column-count mapping that drives the
+ * ultrawide adaptive grid, with no Compose involved.
+ */
+class ResponsiveColumnsTest {
+
+    @Test
+    fun `width maps to the correct tier at and around each boundary`() {
+        assertEquals(LayoutTier.MOBILE, DashboardLayout.tierForWidth(0))
+        assertEquals(LayoutTier.MOBILE, DashboardLayout.tierForWidth(639))
+        assertEquals(LayoutTier.TABLET, DashboardLayout.tierForWidth(640))
+        assertEquals(LayoutTier.TABLET, DashboardLayout.tierForWidth(1023))
+        assertEquals(LayoutTier.DESKTOP, DashboardLayout.tierForWidth(1024))
+        assertEquals(LayoutTier.DESKTOP, DashboardLayout.tierForWidth(1439))
+        assertEquals(LayoutTier.WIDESCREEN, DashboardLayout.tierForWidth(1440))
+        assertEquals(LayoutTier.WIDESCREEN, DashboardLayout.tierForWidth(3440))
+    }
+
+    @Test
+    fun `summary columns grow with the tier`() {
+        assertEquals(1, DashboardLayout.summaryColumns(LayoutTier.MOBILE))
+        assertEquals(2, DashboardLayout.summaryColumns(LayoutTier.TABLET))
+        assertEquals(3, DashboardLayout.summaryColumns(LayoutTier.DESKTOP))
+        assertEquals(4, DashboardLayout.summaryColumns(LayoutTier.WIDESCREEN))
+    }
+
+    @Test
+    fun `holdings columns use ultrawide width`() {
+        assertEquals(1, DashboardLayout.holdingsColumns(500))
+        assertEquals(2, DashboardLayout.holdingsColumns(800))
+        assertEquals(3, DashboardLayout.holdingsColumns(1200))
+        assertEquals(4, DashboardLayout.holdingsColumns(2560))
+    }
+
+    @Test
+    fun `multi-panel layout only engages at desktop width and above`() {
+        assertFalse(DashboardLayout.isMultiPanel(639))
+        assertFalse(DashboardLayout.isMultiPanel(1023))
+        assertTrue(DashboardLayout.isMultiPanel(1024))
+        assertTrue(DashboardLayout.isMultiPanel(3440))
+    }
+
+    @Test
+    fun `holdings panel weight is a valid fraction and leaves room for the rail`() {
+        listOf(1024, 1440, 2560, 3440).forEach { width ->
+            val weight = DashboardLayout.holdingsPanelWeight(width)
+            assertTrue(weight > 0f && weight < 1f, "weight out of range for $width: $weight")
+        }
+        // Ultrawide gives the context rail slightly more room than plain desktop.
+        assertTrue(
+            DashboardLayout.holdingsPanelWeight(2560) < DashboardLayout.holdingsPanelWeight(1200),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds a real-time crypto portfolio dashboard for the Windows desktop client, optimised for ultrawide monitors (#2176). Crypto is presented separately from traditional investments so volatility is visible at a glance.

### What landed (apps/windows only)
- **Pure aggregation model** (`crypto/CryptoPortfolio.kt`): holdings × latest prices → market value, allocation %, 24h change, and unrealised P&L. All money in `Long` cents, fractional quantities in `Double`, zero platform/UI deps — fully unit-tested.
- **Pluggable price source** (`crypto/CryptoPriceSource.kt`): `CryptoPriceSource` interface with a deterministic, offline `MockCryptoPriceSource` and a `PollingPriceFeed` polling adapter. **No API keys, no network** — live wiring is deferred to #2702.
- **Responsive layout logic** (`crypto/ResponsiveColumns.kt`): pure breakpoint → tier → column-count mapping (mobile/tablet/desktop/widescreen per the design-tokens breakpoints). Ultrawide (≥1440px) fans cards into 4 columns and shows holdings + allocation side by side.
- **Compose Desktop screen** (`screens/CryptoDashboardScreen.kt`): `BoxWithConstraints`-driven adaptive grid, summary stats, holdings cards, allocation bars, and a **last-updated + staleness chip** (polite live region).
- **ViewModel** (`viewmodel/CryptoDashboardViewModel.kt`): StateFlow holder mirroring the Android pattern; maps the pure model to display strings.

### Accessibility
- Every gain/loss uses an **icon + text label + spoken `contentDescription`** — never colour alone.
- Staleness shown with a warning icon and text, announced via a `LiveRegionMode.Polite` region for Narrator.
- Headings, semantics labels, and per-card descriptions throughout.

### Tests (18, all green)
- `CryptoPortfolioAggregatorTest` (10) — value, allocation sums, 24h reconstruction, P&L %, staleness, missing prices, case-insensitive symbols, empty portfolio.
- `ResponsiveColumnsTest` (5) — tier boundaries, column counts, multi-panel engagement, panel weights.
- `CryptoFormatTest` (3) — relative-time buckets, signed percent, direction words.

## Needs Human Action
Live market-data wiring is intentionally **not** included — it depends on #2702 (real-time refresh pipeline), which is blocked on market-data credentials. Marked with `// TODO(human)` in `CryptoDashboardViewModel.refresh()` and at the injection site in `CryptoDashboardScreen`. When #2702 and its credentials land, a human/follow-up should:
1. Provide a live `CryptoPriceSource` adapter (real feed) and wire real holdings from the SQLDelight investment tables (crypto tagged separately from traditional investments).
2. Register `CryptoDashboardViewModel` + sources in Koin and add a navigation entry (kept out of this PR to avoid conflicts with in-flight #2384/#2707).
3. Supply credentials via DPAPI-protected storage — never plaintext.

Closes #2176

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>