### PR TITLE
feat(ios): transaction row VoiceOver announcements (#2117)

### DIFF
--- a/apps/ios/Finance/Accessibility/TransactionItem+Accessibility.swift
+++ b/apps/ios/Finance/Accessibility/TransactionItem+Accessibility.swift
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionItem+Accessibility.swift
+// Finance
+// References: #2117
+//
+// Bridges the unified `TransactionItem` model to the shared, fully-tested
+// `TransactionAccessibility` label builder so every transaction row announces
+// amount, direction, payee, category, account, date, and status in one
+// coherent VoiceOver element.
+
+import FinanceShared
+import Foundation
+
+extension TransactionTypeUI {
+    /// Maps the visual transaction type to a spoken accessibility direction.
+    var accessibilityDirection: TransactionAccessibility.Direction {
+        switch self {
+        case .income: .income
+        case .expense: .expense
+        case .transfer: .transfer
+        }
+    }
+}
+
+extension TransactionStatusUI {
+    /// Status text announced to VoiceOver. The normal `.cleared` state is
+    /// omitted (empty) to keep announcements concise; pending, reconciled,
+    /// and voided states are surfaced because they change the meaning of the
+    /// row.
+    var accessibilityStatusDescription: String {
+        switch self {
+        case .cleared: ""
+        default: displayName
+        }
+    }
+}
+
+extension TransactionItem {
+    /// Display-ready fragments for the shared VoiceOver label builder.
+    ///
+    /// - Parameter includeAccount: Pass `false` for compact contexts (e.g. the
+    ///   Dashboard recent list) where the account name is not shown.
+    func accessibilityRowComponents(includeAccount: Bool = true) -> TransactionAccessibility.RowComponents {
+        let formatted = TransactionAccessibility.formattedAmount(
+            amountMinorUnits: amountMinorUnits,
+            currencyCode: currencyCode
+        )
+        let amountDescription = TransactionAccessibility.amountDescription(
+            direction: type.accessibilityDirection,
+            formattedAmount: formatted
+        )
+        return TransactionAccessibility.RowComponents(
+            amountDescription: amountDescription,
+            payee: payee,
+            category: category,
+            accountName: includeAccount ? accountName : "",
+            date: date.formatted(date: .abbreviated, time: .omitted),
+            statusDescription: status.accessibilityStatusDescription,
+            isRecurring: isRecurring,
+            tagNames: tags.map(\.displayName)
+        )
+    }
+
+    /// The fully composed VoiceOver label for a transaction row.
+    func accessibilityRowLabel(includeAccount: Bool = true) -> String {
+        TransactionAccessibility.rowLabel(accessibilityRowComponents(includeAccount: includeAccount))
+    }
+}
+
+// TODO(human): Validate the composed announcement on a physical device with
+// VoiceOver enabled — confirm that swiping a transaction row reads a single
+// coherent label (amount + direction, payee, category, account, date, status)
+// without the CurrencyLabel child being announced separately, that group
+// (date-section) context is preserved while swiping, and that swipe actions
+// remain reachable via the rotor. Automated unit tests cover the label-builder
+// string output but cannot exercise the live VoiceOver focus engine.
+

--- a/apps/ios/Finance/Components/TransactionRowView.swift
+++ b/apps/ios/Finance/Components/TransactionRowView.swift
@@ -31,16 +31,7 @@ struct TransactionRowView: View, Equatable {
             Spacer()
             CurrencyLabel(amountInMinorUnits: transaction.amountMinorUnits, currencyCode: transaction.currencyCode, font: .callout.bold()).contentTransition(.numericText())
         }.padding(.vertical, 2).accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabelText)
+        .accessibilityLabel(transaction.accessibilityRowLabel())
         .accessibilityHint(String(localized: "Tap to view details. Swipe for more actions."))
-    }
-
-    private var accessibilityLabelText: String {
-        var label = [transaction.payee, transaction.category, transaction.accountName].joined(separator: ", ")
-        if !transaction.tags.isEmpty {
-            let tagNames = transaction.tags.map(\.displayName).joined(separator: ", ")
-            label += ", " + String(localized: "Tags: \(tagNames)")
-        }
-        return label
     }
 }

--- a/apps/ios/Finance/Screens/DashboardView.swift
+++ b/apps/ios/Finance/Screens/DashboardView.swift
@@ -275,7 +275,7 @@ struct DashboardView: View {
         }
         .padding(.vertical, 6)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(transaction.payee), \(transaction.category)")
+        .accessibilityLabel(transaction.accessibilityRowLabel(includeAccount: false))
     }
 }
 

--- a/apps/ios/Finance/Screens/TransactionsView.swift
+++ b/apps/ios/Finance/Screens/TransactionsView.swift
@@ -272,17 +272,8 @@ struct TransactionsView: View {
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(transactionAccessibilityLabel(transaction))
+        .accessibilityLabel(transaction.accessibilityRowLabel())
         .accessibilityHint(String(localized: "Tap to edit. Swipe for more actions."))
-    }
-
-    private func transactionAccessibilityLabel(_ transaction: TransactionItem) -> String {
-        var label = "\(transaction.payee), \(transaction.category), \(transaction.accountName)"
-        if !transaction.tags.isEmpty {
-            let tagNames = transaction.tags.map(\.displayName).joined(separator: ", ")
-            label += ", " + String(localized: "Tags: \(tagNames)")
-        }
-        return label
     }
 }
 

--- a/apps/ios/Shared/TransactionAccessibility.swift
+++ b/apps/ios/Shared/TransactionAccessibility.swift
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionAccessibility.swift
+// FinanceShared
+// References: #2117
+//
+// Builds a single, coherent VoiceOver label for a transaction row so that
+// VoiceOver users hear amount, income/expense direction, payee, category,
+// account, date, and pending/recurring status in one focused element.
+//
+// Direction (income vs expense) is always conveyed in *text* — never by
+// colour or glyph alone — so the meaning survives for users who cannot
+// perceive the red/green sign colouring.
+//
+// The assembly logic is intentionally pure (no SwiftUI, no view state) so it
+// can be unit-tested deterministically across amount signs, statuses, and
+// missing fields.
+
+import Foundation
+
+/// Namespace for transaction-row accessibility helpers shared across the
+/// main app, App Clip, and widgets.
+public enum TransactionAccessibility {
+
+    // MARK: - Direction
+
+    /// Income/expense/transfer direction, conveyed in spoken text.
+    public enum Direction: String, Sendable, Equatable {
+        case income
+        case expense
+        case transfer
+        /// Direction unknown or not applicable — the amount is announced
+        /// without a leading direction word.
+        case none
+    }
+
+    // MARK: - Components
+
+    /// Display-ready fragments for a single transaction row.
+    ///
+    /// All strings are expected to be already localised/formatted by the
+    /// caller. Empty strings are omitted from the final label so partial
+    /// data (e.g. a Dashboard row with no account name) still produces a
+    /// clean announcement.
+    public struct RowComponents: Sendable, Equatable {
+        /// Formatted amount including direction in words,
+        /// e.g. `"Expense of $42.99"`.
+        public var amountDescription: String
+        public var payee: String
+        public var category: String
+        public var accountName: String
+        /// Localised date, e.g. `"Jun 23, 2026"`.
+        public var date: String
+        /// Localised status, e.g. `"Pending"`. Empty to omit (cleared
+        /// transactions need no extra announcement).
+        public var statusDescription: String
+        public var isRecurring: Bool
+        public var tagNames: [String]
+
+        public init(
+            amountDescription: String,
+            payee: String = "",
+            category: String = "",
+            accountName: String = "",
+            date: String = "",
+            statusDescription: String = "",
+            isRecurring: Bool = false,
+            tagNames: [String] = []
+        ) {
+            self.amountDescription = amountDescription
+            self.payee = payee
+            self.category = category
+            self.accountName = accountName
+            self.date = date
+            self.statusDescription = statusDescription
+            self.isRecurring = isRecurring
+            self.tagNames = tagNames
+        }
+    }
+
+    // MARK: - Label assembly
+
+    /// Composes a single coherent VoiceOver label for a transaction row.
+    ///
+    /// The amount (with direction) is announced first because it is the most
+    /// important piece of context when auditing spending by swipe; payee,
+    /// category, account, date and status follow. Empty fragments are dropped
+    /// so missing data never produces dangling separators.
+    public static func rowLabel(_ components: RowComponents) -> String {
+        var parts: [String] = []
+
+        func append(_ value: String) {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { parts.append(trimmed) }
+        }
+
+        append(components.amountDescription)
+        append(components.payee)
+        append(components.category)
+        append(components.accountName)
+        append(components.date)
+        append(components.statusDescription)
+        if components.isRecurring {
+            parts.append(String(localized: "Recurring"))
+        }
+        let tags = components.tagNames
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        if !tags.isEmpty {
+            parts.append(String(localized: "Tags: \(tags.joined(separator: ", "))"))
+        }
+
+        return parts.joined(separator: ", ")
+    }
+
+    // MARK: - Helpers
+
+    /// Builds an amount description that names the direction in words.
+    ///
+    /// - Parameters:
+    ///   - direction: Income/expense/transfer direction.
+    ///   - formattedAmount: Already-formatted currency string, e.g. `"$42.99"`.
+    /// - Returns: e.g. `"Expense of $42.99"`, or just the amount when the
+    ///   direction is `.none`.
+    public static func amountDescription(
+        direction: Direction,
+        formattedAmount: String
+    ) -> String {
+        switch direction {
+        case .income:
+            return String(localized: "Income of \(formattedAmount)")
+        case .expense:
+            return String(localized: "Expense of \(formattedAmount)")
+        case .transfer:
+            return String(localized: "Transfer of \(formattedAmount)")
+        case .none:
+            return formattedAmount
+        }
+    }
+
+    /// Formats minor currency units into a localised currency string.
+    ///
+    /// Mirrors `CurrencyLabel`'s minor-to-major conversion and per-currency
+    /// decimal-place resolution so row announcements match the visible amount.
+    public static func formattedAmount(
+        amountMinorUnits: Int64,
+        currencyCode: String
+    ) -> String {
+        let places = decimalPlaces(for: currencyCode)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        formatter.minimumFractionDigits = places
+        formatter.maximumFractionDigits = places
+        let divisor = NSDecimalNumber(decimal: pow(10, places))
+        let amount = NSDecimalNumber(value: amountMinorUnits)
+        let majorUnits = amount.dividing(by: divisor)
+        return formatter.string(from: majorUnits) ?? "\(currencyCode) \(amountMinorUnits)"
+    }
+
+    /// Resolves the number of decimal places for a currency code.
+    public static func decimalPlaces(for currencyCode: String) -> Int {
+        switch currencyCode {
+        case "JPY", "KRW", "VND": 0
+        case "BHD", "KWD", "OMR": 3
+        default: 2
+        }
+    }
+}

--- a/apps/ios/Tests/TransactionAccessibilityTests.swift
+++ b/apps/ios/Tests/TransactionAccessibilityTests.swift
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionAccessibilityTests.swift
+// FinanceTests
+// References: #2117
+//
+// Deterministic unit tests for the shared transaction-row VoiceOver label
+// builder. These cover amount signs/direction, every status, recurring rows,
+// tag inclusion, and missing-field handling. They assert on the *assembly*
+// logic using pre-formatted fragments so results are locale-independent.
+
+import XCTest
+@testable import FinanceApp
+@testable import FinanceShared
+
+final class TransactionAccessibilityTests: XCTestCase {
+
+    typealias TA = TransactionAccessibility
+
+    // MARK: - Direction is conveyed in text (never colour)
+
+    func testExpenseDirectionIsSpokenInWords() {
+        let desc = TA.amountDescription(direction: .expense, formattedAmount: "$42.99")
+        XCTAssertTrue(desc.contains("Expense"),
+                      "Expense direction must be conveyed in text, not colour")
+        XCTAssertTrue(desc.contains("$42.99"))
+    }
+
+    func testIncomeDirectionIsSpokenInWords() {
+        let desc = TA.amountDescription(direction: .income, formattedAmount: "$1,250.00")
+        XCTAssertTrue(desc.contains("Income"),
+                      "Income direction must be conveyed in text, not colour")
+        XCTAssertTrue(desc.contains("$1,250.00"))
+    }
+
+    func testTransferDirectionIsSpokenInWords() {
+        let desc = TA.amountDescription(direction: .transfer, formattedAmount: "$500.00")
+        XCTAssertTrue(desc.contains("Transfer"))
+        XCTAssertTrue(desc.contains("$500.00"))
+    }
+
+    func testNoneDirectionAnnouncesPlainAmount() {
+        let desc = TA.amountDescription(direction: .none, formattedAmount: "$10.00")
+        XCTAssertEqual(desc, "$10.00",
+                       "Unknown direction should announce the amount with no prefix")
+    }
+
+    // MARK: - Full label assembly
+
+    func testFullRowLabelOrderingAndContent() {
+        let components = TA.RowComponents(
+            amountDescription: "Expense of $42.99",
+            payee: "Blue Bottle Coffee",
+            category: "Dining",
+            accountName: "Checking",
+            date: "Jun 23, 2026",
+            statusDescription: "Pending",
+            isRecurring: false,
+            tagNames: ["coffee", "work"]
+        )
+        let label = TA.rowLabel(components)
+
+        XCTAssertEqual(
+            label,
+            "Expense of $42.99, Blue Bottle Coffee, Dining, Checking, Jun 23, 2026, Pending, Tags: coffee, work"
+        )
+        // Amount/direction is announced first.
+        XCTAssertTrue(label.hasPrefix("Expense of $42.99"))
+    }
+
+    func testRecurringIsAnnounced() {
+        let components = TA.RowComponents(
+            amountDescription: "Expense of $9.99",
+            payee: "Streaming",
+            category: "Entertainment",
+            isRecurring: true
+        )
+        let label = TA.rowLabel(components)
+        XCTAssertTrue(label.contains("Recurring"),
+                      "Recurring transactions must announce their recurring state")
+    }
+
+    // MARK: - Status coverage
+
+    func testEachStatusMapsToExpectedText() {
+        XCTAssertEqual(TransactionStatusUI.cleared.accessibilityStatusDescription, "",
+                       "Cleared is the normal state and should be omitted from the label")
+        XCTAssertEqual(TransactionStatusUI.pending.accessibilityStatusDescription,
+                       TransactionStatusUI.pending.displayName)
+        XCTAssertEqual(TransactionStatusUI.reconciled.accessibilityStatusDescription,
+                       TransactionStatusUI.reconciled.displayName)
+        XCTAssertEqual(TransactionStatusUI.voided.accessibilityStatusDescription,
+                       TransactionStatusUI.voided.displayName)
+    }
+
+    func testClearedStatusIsNotInLabel() {
+        let components = TA.RowComponents(
+            amountDescription: "Income of $100.00",
+            payee: "Payroll",
+            category: "Salary",
+            statusDescription: TransactionStatusUI.cleared.accessibilityStatusDescription
+        )
+        let label = TA.rowLabel(components)
+        XCTAssertEqual(label, "Income of $100.00, Payroll, Salary")
+        XCTAssertFalse(label.contains("Cleared"))
+    }
+
+    // MARK: - Missing fields are handled gracefully
+
+    func testMissingFieldsAreOmittedWithoutDanglingSeparators() {
+        let components = TA.RowComponents(
+            amountDescription: "Expense of $5.00",
+            payee: "",
+            category: "Misc",
+            accountName: "",
+            date: "",
+            statusDescription: "",
+            isRecurring: false,
+            tagNames: []
+        )
+        let label = TA.rowLabel(components)
+        XCTAssertEqual(label, "Expense of $5.00, Misc")
+        XCTAssertFalse(label.contains(", ,"), "No dangling separators for empty fields")
+        XCTAssertFalse(label.hasSuffix(", "))
+    }
+
+    func testWhitespaceOnlyFieldsAreTreatedAsMissing() {
+        let components = TA.RowComponents(
+            amountDescription: "Expense of $5.00",
+            payee: "   ",
+            category: "Misc",
+            tagNames: [" ", "valid"]
+        )
+        let label = TA.rowLabel(components)
+        XCTAssertEqual(label, "Expense of $5.00, Misc, Tags: valid")
+    }
+
+    func testEmptyTagsProduceNoTagsSegment() {
+        let components = TA.RowComponents(
+            amountDescription: "Expense of $5.00",
+            payee: "Store",
+            category: "Shopping",
+            tagNames: []
+        )
+        let label = TA.rowLabel(components)
+        XCTAssertFalse(label.contains("Tags:"))
+    }
+
+    // MARK: - TransactionItem bridge
+
+    func testTransactionItemBuildsCompleteLabel() {
+        let item = TransactionItem(
+            id: "t1",
+            payee: "Grocery Mart",
+            category: "Groceries",
+            accountName: "Checking",
+            amountMinorUnits: 5_499,
+            currencyCode: "USD",
+            date: Date(timeIntervalSince1970: 1_750_000_000),
+            type: .expense,
+            status: .pending,
+            isRecurring: true
+        )
+        let label = item.accessibilityRowLabel()
+
+        XCTAssertTrue(label.contains("Expense of"),
+                      "Direction must be spoken in words")
+        XCTAssertTrue(label.contains("Grocery Mart"))
+        XCTAssertTrue(label.contains("Groceries"))
+        XCTAssertTrue(label.contains("Checking"))
+        XCTAssertTrue(label.contains("Pending"))
+        XCTAssertTrue(label.contains("Recurring"))
+    }
+
+    func testDashboardVariantOmitsAccount() {
+        let item = TransactionItem(
+            id: "t2",
+            payee: "Cafe",
+            category: "Dining",
+            accountName: "Savings",
+            amountMinorUnits: 1_200,
+            currencyCode: "USD",
+            date: Date(timeIntervalSince1970: 1_750_000_000),
+            type: .expense,
+            status: .cleared
+        )
+        let label = item.accessibilityRowLabel(includeAccount: false)
+        XCTAssertFalse(label.contains("Savings"),
+                       "Dashboard rows do not show the account and must not announce it")
+        XCTAssertTrue(label.contains("Cafe"))
+    }
+
+    func testIncomeTransactionAnnouncesIncomeDirection() {
+        let item = TransactionItem(
+            id: "t3",
+            payee: "Payroll",
+            category: "Salary",
+            accountName: "Checking",
+            amountMinorUnits: 250_000,
+            currencyCode: "USD",
+            date: Date(timeIntervalSince1970: 1_750_000_000),
+            type: .income,
+            status: .cleared
+        )
+        let label = item.accessibilityRowLabel()
+        XCTAssertTrue(label.contains("Income of"))
+        XCTAssertFalse(label.contains("Cleared"))
+    }
+
+    // MARK: - Currency formatting helper
+
+    func testFormattedAmountDecimalPlaces() {
+        XCTAssertEqual(TA.decimalPlaces(for: "USD"), 2)
+        XCTAssertEqual(TA.decimalPlaces(for: "JPY"), 0)
+        XCTAssertEqual(TA.decimalPlaces(for: "BHD"), 3)
+    }
+
+    func testFormattedAmountProducesNonEmptyString() {
+        let formatted = TA.formattedAmount(amountMinorUnits: 125_050, currencyCode: "USD")
+        XCTAssertFalse(formatted.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
VoiceOver users now hear a single, coherent label on every transaction row combining **amount with income/expense direction in words**, payee, category, account, date, and pending/recurring **status** — instead of just payee/category.

## Changes
- Add `TransactionAccessibility` label builder to `apps/ios/Shared` (FinanceShared): pure, localizable assembly of the row label plus direction-aware amount helper. Direction is conveyed in text (Income/Expense/Transfer), never by colour or glyph alone.
- Add `TransactionItem+Accessibility` bridge mapping the model to the shared builder (Dashboard variant omits the account it does not display).
- Wire the composed label into `TransactionRowView`, `TransactionsView`, and `DashboardView` rows (keeping `accessibilityElement(children: .combine)`).
- Add deterministic unit tests covering amount signs/direction, every status, recurring, tags, and missing/whitespace fields.

Dynamic Type is preserved (no hardcoded fonts touched); `@Observable` view models unchanged.

## Needs Human Action
Device-only VoiceOver validation is marked with `// TODO(human)` in `TransactionItem+Accessibility.swift`: confirm on a physical device that each row reads one coherent label, the `CurrencyLabel` child is not announced separately, date-section group context is preserved while swiping, and swipe actions stay reachable via the rotor.

Closes #2117

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>