### PR TITLE
docs(ai): fix onboarding/navigation docs accuracy (Area 8a) (#3033)

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -89,6 +89,7 @@ Finance is developed with AI agents as first-class contributors. This means:
 │   ├── design-engineer.agent.md
 │   ├── devops-engineer.agent.md
 │   ├── docs-writer.agent.md
+│   ├── experimentation-engineer.agent.md
 │   ├── finance-domain.agent.md
 │   ├── ios-engineer.agent.md
 │   ├── kmp-engineer.agent.md
@@ -103,19 +104,25 @@ Finance is developed with AI agents as first-class contributors. This means:
 │   └── windows-engineer.agent.md
 ├── skills/                           # Reusable domain knowledge (20 skills as of 2026-06; .github/skills/ is the source of truth)
 │   ├── accessibility-testing/SKILL.md
-│   ├── dev-onboarding/SKILL.md
 │   ├── design-tokens/SKILL.md
+│   ├── dev-onboarding/SKILL.md
 │   ├── edge-sync/SKILL.md
 │   ├── financial-modeling/SKILL.md
+│   ├── fleet-orchestration/SKILL.md
+│   ├── go-to-market/SKILL.md
 │   ├── i18n-localization/SKILL.md
+│   ├── issue-management/SKILL.md
 │   ├── kmp-development/SKILL.md
 │   ├── mcp-agent-tooling/SKILL.md
+│   ├── monetization/SKILL.md
 │   ├── performance-budgets/SKILL.md
 │   ├── privacy-compliance/SKILL.md
+│   ├── project-management/SKILL.md
 │   ├── prompt-engineering/SKILL.md
 │   ├── security-review-methodology/SKILL.md
+│   ├── sprint-planning/SKILL.md
 │   ├── supabase-powersync/SKILL.md
-│   └── …                             # plus go-to-market, monetization, project-management, issue-management, sprint-planning, fleet-orchestration, ux-testing
+│   └── ux-testing/SKILL.md
 └── workflows/                        # CI/CD workflows
     └── copilot-setup-steps.yml       # CI environment for coding agent
 

--- a/docs/ai/agent-cookbook.md
+++ b/docs/ai/agent-cookbook.md
@@ -76,7 +76,11 @@ $env:HUSKY = "0" ; git push --no-verify origin feat/budget-rollover-134
 
 # 8. Create PR
 gh pr create --title "feat(core): implement budget rollover (#134)" \
-  --body "## Summary\nImplement budget rollover logic.\n\nCloses #134"
+  --body "## Summary
+
+Implement budget rollover logic.
+
+Closes #134"
 
 # 9. Monitor CI until green (remote CI is source of truth)
 gh pr checks <number>
@@ -116,7 +120,11 @@ $env:HUSKY = "0" ; git push --no-verify origin fix/auth-token-200
 
 # 7. Create PR
 gh pr create --title "fix(web): handle expired auth token gracefully (#200)" \
-  --body "## Summary\nFix expired token handling.\n\nCloses #200"
+  --body "## Summary
+
+Fix expired token handling.
+
+Closes #200"
 
 # 8. Monitor CI (remote CI is source of truth)
 gh pr checks <number>
@@ -152,7 +160,11 @@ $env:HUSKY = "0" ; git push --no-verify origin docs/api-reference-86
 
 # 6. Create PR
 gh pr create --title "docs: update API reference for sync endpoints (#86)" \
-  --body "## Summary\nUpdate API docs.\n\nCloses #86"
+  --body "## Summary
+
+Update API docs.
+
+Closes #86"
 
 # 7. Monitor CI (use the docs-only quick check locally), then self-merge once green AND MERGEABLE
 gh pr checks <number>

--- a/docs/ai/start-here.md
+++ b/docs/ai/start-here.md
@@ -56,7 +56,7 @@ These are the rules that cause the most rework when skipped:
 | Root agent guidance        | [`AGENTS.md`](../../AGENTS.md)                                             | Canonical policy for all AI tools     |
 | MCP servers                | [`.vscode/mcp.json`](../../.vscode/mcp.json) · [mcp.md](mcp.md)            | `mcp.json` (config) / `mcp.md` (docs) |
 
-> Counts drift quickly. Prefer counting the directory (or consulting the planned `ai-manifest`) over trusting a number written in prose. See the [CHANGELOG](CHANGELOG.md) for what changed and when.
+> Counts drift quickly. Prefer counting the directory (or running `npm run ai:manifest:check`, which flags any count claim that has drifted from the files) over trusting a number written in prose. See the [CHANGELOG](CHANGELOG.md) for what changed and when.
 
 ## Reference by Role
 

--- a/docs/ai/troubleshooting.md
+++ b/docs/ai/troubleshooting.md
@@ -11,6 +11,7 @@ Solutions for the most common problems AI agents encounter in the Finance monore
 - [PR Failing "Lint & Format / ESLint & Prettier" Check](#pr-failing-lint--format--eslint--prettier-check)
 - [PR Failing Type-Check](#pr-failing-type-check)
 - [Merge Conflicts After Rebase](#merge-conflicts-after-rebase)
+- [PR Behind main / "Head Branch Is Not Up To Date"](#pr-behind-main--head-branch-is-not-up-to-date)
 - [Worktree Already Exists for Branch](#worktree-already-exists-for-branch)
 - [Pre-Push Hook Blocking Push](#pre-push-hook-blocking-push)
 - [CI Check Stuck or Not Running](#ci-check-stuck-or-not-running)
@@ -132,6 +133,44 @@ npm run format:check && npx eslint . --max-warnings 0
 git add -A && git commit --amend --no-edit
 $env:HUSKY = "0" ; git push --no-verify origin <branch-name>
 ```
+
+---
+
+## PR Behind main / "Head Branch Is Not Up To Date"
+
+### Symptoms
+
+- `gh pr merge` fails with "Pull request is not mergeable" or "head branch is not up to date"
+- `gh pr view <number> --json mergeable,mergeStateStatus` shows `mergeable=UNKNOWN` or `mergeStateStatus=BEHIND`
+- CI is green, but the merge is blocked because `main` advanced after you branched
+
+### Root Cause
+
+Another PR merged into `main` after you last pushed. Your branch is now behind, and the merge requires the head to be up to date with `main` first. This is **not** a code conflict — it is a stale-base condition, and it carries the same P0 urgency as a red CI check.
+
+### Fix
+
+```powershell
+# Sync with the latest main and replay your commits on top
+git fetch origin main
+git rebase origin/main
+
+# Re-run the pre-push workflow (a rebase can surface new lint/format drift)
+npm run format
+npx eslint . --fix
+npm run format:check && npx eslint . --max-warnings 0
+
+# Re-push your OWN branch. --force-with-lease is auto-approved for this —
+# it refuses to overwrite commits you haven't already seen.
+$env:HUSKY = "0" ; git push --force-with-lease --no-verify origin <branch-name>
+
+# Re-check until green AND mergeable, then self-merge
+gh pr checks <number>
+gh pr view <number> --json mergeable,mergeStateStatus
+gh pr merge <number> --squash
+```
+
+> **Never use plain `git push --force`** — it is forbidden. `--force-with-lease` on your **own** branch after a rebase is the only auto-approved force variant. See [Restrictions](restrictions.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Area 8a of the AI capabilities audit: accuracy + enrichment pass over the `docs/ai/` **onboarding / navigation** cluster (`start-here.md`, `README.md`, `agent-cookbook.md`, `troubleshooting.md`).

## Changes

- **`README.md`** — the `.github/agents/` file-tree was annotated "24 agents" but enumerated only **23**; added the missing **`experimentation-engineer`** row. Also fully enumerated the skills tree (all **20** in alpha order) in place of "13 listed + a `…plus 7` line" (which was also out of alpha order).
- **`start-here.md`** — the `ai-manifest` is no longer "planned"; it is implemented (`tools/ai-manifest.js` + `check-ai-manifest.js` + `npm run ai:manifest:check` + a CI workflow). Point readers at the real drift-checker command.
- **`agent-cookbook.md`** — recipes 1–3 passed `--body "...\nCloses #N"`. In bash double-quotes `\n` is a literal backslash-n, so the body renders `…nCloses #N` with **no word boundary before "Closes"**, which **breaks GitHub auto-close**. Switched to real newlines so each `Closes #N` sits on its own line.
- **`troubleshooting.md`** — added a **"PR Behind main / Head Branch Is Not Up To Date"** entry: the rebase + `--force-with-lease` self-heal for the most common self-merge blocker (a stale base, distinct from a code conflict), plus its TOC link.

## Testing

- [x] `npm run format:check` clean
- [x] `npx eslint . --max-warnings 0` clean
- [x] `node tools/check-ai-manifest.js` — no drift (24 agents / 20 skills)

## Issues

Closes #3033