### PR TITLE
docs(ai): fix workflow & worktrees docs accuracy (Area 8b) (#3035)

### DIFF
--- a/docs/ai/ci-monitoring.md
+++ b/docs/ai/ci-monitoring.md
@@ -25,7 +25,7 @@ When a check fails:
 gh run view <run-id> --log-failed
 ```
 
-Fix locally, follow the [canonical pre-push workflow](workflow.md#-mandatory-pre-push-workflow-never-skip), push, and re-poll.
+Fix locally, follow the [canonical pre-push workflow](workflow.md#️-mandatory-pre-push-workflow-never-skip), push, and re-poll.
 
 ---
 
@@ -37,7 +37,7 @@ Local checks (`npm run ci:check`, `npm run format:check`, etc.) are useful for c
 
 TypeScript 5.9.3 rejects the `ignoreDeprecations` compiler option locally, causing `npm run type-check` (and therefore `npm run ci:check`) to fail even on clean code. Remote CI uses a compatible configuration and is not affected.
 
-**Workaround:** The [canonical pre-push workflow](workflow.md#-mandatory-pre-push-workflow-never-skip) intentionally checks only formatting and lint locally. Let remote CI handle the type-check.
+**Workaround:** The [canonical pre-push workflow](workflow.md#️-mandatory-pre-push-workflow-never-skip) intentionally checks only formatting and lint locally. Let remote CI handle the type-check.
 
 ---
 
@@ -47,7 +47,7 @@ When `gh pr checks` shows a failure:
 
 1. Read logs: `gh run view <run-id> --log-failed`
 2. Fix locally in the worktree
-3. Run the [canonical pre-push workflow](workflow.md#-mandatory-pre-push-workflow-never-skip)
+3. Run the [canonical pre-push workflow](workflow.md#️-mandatory-pre-push-workflow-never-skip)
 4. Push and re-poll `gh pr checks`
 5. Repeat until all checks are green
 

--- a/docs/ai/workflow-metrics.md
+++ b/docs/ai/workflow-metrics.md
@@ -100,7 +100,7 @@ Metrics are NOT used to evaluate individual agent "performance." They measure sy
 
 #### Q-1: Avoidable CI Failure Rate
 
-**Definition:** Percentage of CI runs that fail due to issues that `npm run ci:check` would have caught locally (formatting, lint, type errors).
+**Definition:** Percentage of CI runs that fail due to issues the pre-push checklist would have caught locally — formatting and lint (`npm run format:check && npx eslint . --max-warnings 0`). Type-check is excluded: it is unreliable locally on TS 5.9.3 (see [CI Monitoring](ci-monitoring.md)), so type failures are a remote-CI concern, not an avoidable local miss.
 
 **Measurement:** `avoidable_failures / total_ci_runs × 100`
 
@@ -282,7 +282,7 @@ Most metrics are collected passively through existing tools:
 | Pain point count      | This repo (pain-points.md) | Manual count from the document                                     |
 | Self-healing attempts | PR commit history          | Count fix commits after CI failure on the same branch              |
 
-**Automated collection:** A future improvement is a `tools/workflow-metrics.js` script that queries the GitHub API and generates a metrics report. Until then, metrics are collected manually during sprint retrospectives.
+**Automated collection:** The `tools/workflow-metrics.js` collector queries the GitHub API and generates a metrics report (Markdown + JSON). Run it with `node tools/workflow-metrics.js` (see `--help` for options such as `--days` and `--out-dir`); it is not yet wired to an npm script. Metrics it does not cover are still gathered manually during sprint retrospectives.
 
 ---
 
@@ -346,4 +346,4 @@ Define thresholds that trigger action when crossed:
 
 ---
 
-_Last updated: 2025-07-18. Maintained by `@docs-writer`._
+_Last updated: 2026-06-24. Maintained by `@docs-writer`._

--- a/docs/ai/workflow.md
+++ b/docs/ai/workflow.md
@@ -56,7 +56,7 @@ git add -A && git commit --amend --no-edit
 $env:HUSKY = "0" ; git push --no-verify origin <branch-name>
 
 # Step 6: Create PR
-gh pr create --title "type(scope): description (#N)" --body "Closes #N"
+gh pr create --base main --title "type(scope): description (#N)" --body "Closes #N"
 
 # Step 7: Monitor CI — remote CI is the source of truth
 gh pr checks <number>   # poll until all checks are green

--- a/docs/ai/worktrees.md
+++ b/docs/ai/worktrees.md
@@ -101,7 +101,7 @@ git rebase origin/main
 $env:HUSKY = "0" ; git push --no-verify origin <branch-name>
 
 # Step 7: Open PR (auto-approved, mandatory)
-gh pr create --fill --body "Closes #N"
+gh pr create --base main --fill --body "Closes #N"
 
 # Step 8: VERIFY the PR exists (catches silent gh-cli failures)
 gh pr view <branch-name> --json number
@@ -122,6 +122,7 @@ $env:HUSKY = "0" ; git push --no-verify origin feat/transactions-443
 
 # Open PR automatically
 gh pr create `
+  --base main `
   --title "feat(android): implement transaction list (#443)" `
   --body "## Summary
 ...


### PR DESCRIPTION
## Summary

Area 8b of the AI-documentation audit — the **workflow & worktrees** cluster of `docs/ai/`. Reconciles four workflow docs with the canonical pre-push checklist, the real heading anchors, and the now-existing metrics collector.

## Changes

- **`ci-monitoring.md`** — 3 pre-push cross-doc anchor links pointed at `workflow.md#-mandatory-...`, missing the U+FE0F variation selector that GitHub keeps in the rendered heading anchor, so all three 404'd. Verified the true anchor via GitHub's Markdown API and restored U+FE0F in each link.
- **`workflow-metrics.md`** — reframed the Q-1 Definition-of-Done gate from `npm run ci:check` to `format:check && eslint --max-warnings 0` (type-check is remote-only per the Known Local Issue); refreshed the "automated collection" note to describe the now-existing `tools/workflow-metrics.js` collector; bumped the Last-updated date.
- **`workflow.md`** — pre-push `gh pr create` example now passes `--base main`.
- **`worktrees.md`** — 2 `gh pr create` examples now pass `--base main`.

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean
- [x] `node tools/check-ai-manifest.js` — no drift
- [x] U+FE0F survival in `ci-monitoring.md` anchors verified post-format (byte scan)

## Issues

Closes #3035