### PR TITLE
feat(web): shared wedding budget workspace (#2145)

### DIFF
--- a/apps/web/src/lib/planning/wedding-planner-rules.test.ts
+++ b/apps/web/src/lib/planning/wedding-planner-rules.test.ts
@@ -1,7 +1,48 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { describe, expect, it } from 'vitest';
-import { buildWeddingPlanSummary } from './wedding-planner-rules';
+import {
+  buildWeddingPlanSummary,
+  buildWeddingVendorBreakdown,
+  classifyDueUrgency,
+  computeVendorEstimateCents,
+  listUpcomingInstallments,
+  type WeddingVendorPlan,
+} from './wedding-planner-rules';
+
+const SCENARIO_VENDORS: readonly WeddingVendorPlan[] = [
+  {
+    id: 'venue',
+    name: 'Venue',
+    contractedCents: 14000_00,
+    paidCents: 4000_00,
+    nextDueDate: '2026-07-07',
+  },
+  {
+    id: 'catering',
+    name: 'Catering',
+    contractedCents: 3000_00,
+    paidCents: 1000_00,
+    nextDueDate: '2026-08-07',
+    perGuestCents: 85_00,
+  },
+  {
+    id: 'rentals',
+    name: 'Rentals',
+    contractedCents: 1000_00,
+    paidCents: 0,
+    nextDueDate: '2026-07-22',
+    perGuestCents: 30_00,
+  },
+  {
+    id: 'invitations',
+    name: 'Invitations',
+    contractedCents: 200_00,
+    paidCents: 575_00,
+    nextDueDate: null,
+    perGuestCents: 5_00,
+  },
+];
 
 describe('wedding planner shared rules', () => {
   it('calculates remaining balance, guest-sensitive estimates, and upcoming dues for a $35k scenario', () => {
@@ -38,5 +79,66 @@ describe('wedding planner shared rules', () => {
     expect(summary.remainingBalanceCents).toBe(22000_00);
     expect(summary.overBudgetCents).toBe(0);
     expect(summary.upcomingDue.map((item) => item.vendorId)).toEqual(['catering', 'venue']);
+  });
+
+  it('recomputes per-guest line items and remaining balances exactly to the cent when the guest count changes', () => {
+    const at75 = buildWeddingVendorBreakdown(SCENARIO_VENDORS, 75);
+    const at100 = buildWeddingVendorBreakdown(SCENARIO_VENDORS, 100);
+
+    const catering75 = at75.find((vendor) => vendor.id === 'catering');
+    const catering100 = at100.find((vendor) => vendor.id === 'catering');
+
+    // 3000_00 base + 85_00 * 75 guests = 9375_00; deposit 1000_00 leaves 8375_00.
+    expect(catering75?.estimatedTotalCents).toBe(9375_00);
+    expect(catering75?.remainingCents).toBe(8375_00);
+    // 3000_00 base + 85_00 * 100 guests = 11500_00; deposit 1000_00 leaves 10500_00.
+    expect(catering100?.estimatedTotalCents).toBe(11500_00);
+    expect(catering100?.remainingCents).toBe(10500_00);
+
+    // The breakdown total + total deposits must reconcile exactly with estimate − paid.
+    const sumEstimate = at75.reduce((sum, vendor) => sum + vendor.estimatedTotalCents, 0);
+    const sumPaid = at75.reduce((sum, vendor) => sum + vendor.paidCents, 0);
+    const sumRemaining = at75.reduce((sum, vendor) => sum + vendor.remainingCents, 0);
+    expect(sumRemaining).toBe(sumEstimate - sumPaid);
+  });
+
+  it('flags a vendor as paid in full once deposits cover the estimate and never reports negative remaining', () => {
+    const breakdown = buildWeddingVendorBreakdown(SCENARIO_VENDORS, 75);
+    const invitations = breakdown.find((vendor) => vendor.id === 'invitations');
+
+    // 200_00 base + 5_00 * 75 = 575_00, fully covered by the 575_00 deposit.
+    expect(invitations?.estimatedTotalCents).toBe(575_00);
+    expect(invitations?.remainingCents).toBe(0);
+    expect(invitations?.paidInFull).toBe(true);
+    expect(breakdown.every((vendor) => vendor.remainingCents >= 0)).toBe(true);
+  });
+
+  it('computes a single vendor estimate with floored, non-negative guest counts', () => {
+    const catering = SCENARIO_VENDORS[1];
+    expect(computeVendorEstimateCents(catering, 80.9)).toBe(3000_00 + 85_00 * 80);
+    expect(computeVendorEstimateCents(catering, -5)).toBe(3000_00);
+  });
+
+  it('orders upcoming installments by due date and tags urgency relative to today', () => {
+    const today = '2026-07-01';
+    const installments = listUpcomingInstallments(SCENARIO_VENDORS, 75, today);
+
+    // Sorted ascending by due date; invitations excluded (no due date / paid in full).
+    expect(installments.map((item) => item.vendorId)).toEqual(['venue', 'rentals', 'catering']);
+    expect(installments.map((item) => item.urgency)).toEqual([
+      'due-soon', // venue 2026-07-07 (6 days out)
+      'due-soon', // rentals 2026-07-22 (21 days out)
+      'upcoming', // catering 2026-08-07 (37 days out)
+    ]);
+    // Venue: 14000_00 estimate − 4000_00 deposit = 10000_00 remaining.
+    expect(installments[0].amountCents).toBe(10000_00);
+    expect(installments[0].daysUntilDue).toBe(6);
+  });
+
+  it('classifies overdue, due-soon, and later installments distinctly', () => {
+    expect(classifyDueUrgency('2026-06-15', '2026-07-01')).toBe('overdue');
+    expect(classifyDueUrgency('2026-07-10', '2026-07-01')).toBe('due-soon');
+    expect(classifyDueUrgency('2026-07-31', '2026-07-01')).toBe('due-soon');
+    expect(classifyDueUrgency('2026-09-01', '2026-07-01')).toBe('upcoming');
   });
 });

--- a/apps/web/src/lib/planning/wedding-planner-rules.ts
+++ b/apps/web/src/lib/planning/wedding-planner-rules.ts
@@ -24,7 +24,123 @@ export interface WeddingPlanSummary {
   readonly overBudgetCents: number;
 }
 
+/** Per-vendor breakdown after applying the current guest count. */
+export interface WeddingVendorBreakdown {
+  readonly id: string;
+  readonly name: string;
+  /** Contracted base plus per-guest scaling at the supplied guest count. */
+  readonly estimatedTotalCents: number;
+  readonly paidCents: number;
+  readonly remainingCents: number;
+  /** Per-guest contribution in cents (0 when the vendor is a flat fee). */
+  readonly perGuestCents: number;
+  /** True when this vendor scales with the guest count (catering, rentals, invitations…). */
+  readonly guestSensitive: boolean;
+  readonly nextDueDate: string | null;
+  /** True once deposits cover the full estimate. */
+  readonly paidInFull: boolean;
+}
+
+/** Urgency classification for an installment, surfaced with text + icon (never colour alone). */
+export type WeddingDueUrgency = 'overdue' | 'due-soon' | 'upcoming';
+
+export interface WeddingUpcomingInstallment extends WeddingInstallmentSummary {
+  readonly urgency: WeddingDueUrgency;
+  readonly daysUntilDue: number;
+}
+
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DUE_SOON_DAYS = 30;
+
+/** Clamp a guest count to a non-negative whole number. */
+function normalizeGuestCount(guestCount: number): number {
+  return Math.max(0, Math.floor(guestCount));
+}
+
+/**
+ * Estimate a single vendor's total in integer cents, scaling per-guest line items
+ * (catering, rentals, invitations) by the current guest count.
+ */
+export function computeVendorEstimateCents(vendor: WeddingVendorPlan, guestCount: number): number {
+  return vendor.contractedCents + (vendor.perGuestCents ?? 0) * normalizeGuestCount(guestCount);
+}
+
+/**
+ * Build a per-vendor breakdown (estimate, deposit paid, remaining balance) for the
+ * current guest count. All money stays in integer cents.
+ */
+export function buildWeddingVendorBreakdown(
+  vendors: readonly WeddingVendorPlan[],
+  guestCount: number,
+): WeddingVendorBreakdown[] {
+  return vendors.map((vendor) => {
+    const estimatedTotalCents = computeVendorEstimateCents(vendor, guestCount);
+    const paidCents = Math.max(0, vendor.paidCents);
+    const remainingCents = Math.max(0, estimatedTotalCents - paidCents);
+    const perGuestCents = vendor.perGuestCents ?? 0;
+
+    return {
+      id: vendor.id,
+      name: vendor.name,
+      estimatedTotalCents,
+      paidCents,
+      remainingCents,
+      perGuestCents,
+      guestSensitive: perGuestCents > 0,
+      nextDueDate: vendor.nextDueDate,
+      paidInFull: remainingCents === 0,
+    };
+  });
+}
+
+/**
+ * Classify how urgent an installment is relative to `today` so the UI can convey it
+ * with text + icon rather than colour alone.
+ */
+export function classifyDueUrgency(
+  dueDate: string,
+  today: string,
+  soonWithinDays = DUE_SOON_DAYS,
+): WeddingDueUrgency {
+  const days = Math.floor((Date.parse(dueDate) - Date.parse(today)) / MS_PER_DAY);
+  if (days < 0) return 'overdue';
+  if (days <= soonWithinDays) return 'due-soon';
+  return 'upcoming';
+}
+
+/**
+ * List every vendor installment that still has a balance and a due date, sorted by due
+ * date ascending (overdue first) and tagged with an urgency level and day count.
+ */
+export function listUpcomingInstallments(
+  vendors: readonly WeddingVendorPlan[],
+  guestCount: number,
+  today: string,
+): WeddingUpcomingInstallment[] {
+  const todayMs = Date.parse(today);
+
+  return vendors
+    .filter((vendor): vendor is WeddingVendorPlan & { nextDueDate: string } =>
+      Boolean(vendor.nextDueDate),
+    )
+    .map((vendor) => {
+      const amountCents = Math.max(
+        0,
+        computeVendorEstimateCents(vendor, guestCount) - Math.max(0, vendor.paidCents),
+      );
+
+      return {
+        vendorId: vendor.id,
+        vendorName: vendor.name,
+        dueDate: vendor.nextDueDate,
+        amountCents,
+        urgency: classifyDueUrgency(vendor.nextDueDate, today),
+        daysUntilDue: Math.floor((Date.parse(vendor.nextDueDate) - todayMs) / MS_PER_DAY),
+      };
+    })
+    .filter((item) => item.amountCents > 0)
+    .sort((a, b) => a.dueDate.localeCompare(b.dueDate));
+}
 
 export function buildWeddingPlanSummary(
   vendors: readonly WeddingVendorPlan[],

--- a/apps/web/src/pages/PlanningPage.css
+++ b/apps/web/src/pages/PlanningPage.css
@@ -937,6 +937,216 @@
   margin-bottom: var(--spacing-4);
 }
 
+/* Wedding workspace (#2145) */
+.wedding-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-items: end;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+}
+
+.wedding-announce {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.wedding-budget-bar {
+  height: 12px;
+  width: 100%;
+  background: var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  overflow: hidden;
+  margin-bottom: var(--spacing-3);
+}
+
+.wedding-budget-bar__fill {
+  display: block;
+  height: 100%;
+  background: var(--semantic-status-positive);
+  transition: width 0.3s ease;
+}
+
+.wedding-budget-bar__fill--over {
+  background: var(--semantic-status-negative);
+}
+
+.wedding-status {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin: 0 0 var(--spacing-3);
+  font-size: var(--type-scale-body-font-size);
+  font-weight: 600;
+}
+
+.wedding-status--ok {
+  color: var(--semantic-status-positive);
+}
+
+.wedding-status--over {
+  color: var(--semantic-status-negative);
+}
+
+.wedding-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--semantic-border-default);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+}
+
+.wedding-badge--overdue,
+.wedding-badge--paid,
+.wedding-badge--due-soon,
+.wedding-badge--upcoming {
+  border-width: 1px;
+  border-style: solid;
+}
+
+.wedding-badge--overdue {
+  color: var(--semantic-status-negative);
+  border-color: var(--semantic-status-negative);
+}
+
+.wedding-badge--due-soon {
+  color: var(--semantic-status-warning);
+  border-color: var(--semantic-status-warning);
+}
+
+.wedding-badge--upcoming {
+  color: var(--semantic-text-secondary);
+}
+
+.wedding-badge--paid {
+  color: var(--semantic-status-positive);
+  border-color: var(--semantic-status-positive);
+}
+
+.wedding-due-list,
+.wedding-vendor-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.wedding-due-item {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+}
+
+.wedding-due-item__main {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.wedding-due-item__name {
+  font-weight: 600;
+  color: var(--semantic-text-primary);
+}
+
+.wedding-due-item__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.wedding-due-item__amount {
+  font-weight: 700;
+  color: var(--semantic-text-primary);
+}
+
+.wedding-due-item__date {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.wedding-vendor {
+  padding: var(--spacing-4);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+}
+
+.wedding-vendor__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+}
+
+.wedding-vendor__name {
+  font-weight: 600;
+  color: var(--semantic-text-primary);
+}
+
+.wedding-vendor__per-guest {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.wedding-vendor__figures {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: var(--spacing-2);
+  margin: 0 0 var(--spacing-3);
+}
+
+.wedding-vendor__figure {
+  display: grid;
+  gap: var(--spacing-1);
+}
+
+.wedding-vendor__figure dt {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.wedding-vendor__figure dd {
+  margin: 0;
+  font-weight: 700;
+  color: var(--semantic-text-primary);
+}
+
+.wedding-vendor__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.wedding-vendor__due {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.wedding-vendor__due-date {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
 /* Responsive */
 @media (max-width: 480px) {
   .planning-page {
@@ -975,8 +1185,9 @@
     padding-top: var(--spacing-6);
   }
 
-  .life-event {
-    min-width: 220px;
+  .wedding-controls,
+  .wedding-vendor__figures {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -984,6 +1195,7 @@
 @media (prefers-reduced-motion: reduce) {
   .readiness-score__fill,
   .goal-progress__fill,
+  .wedding-budget-bar__fill,
   .planning-btn,
   .scenario-item {
     transition: none;
@@ -994,7 +1206,10 @@
 @media (prefers-contrast: more) {
   .planning-card,
   .sweep-rule,
-  .scenario-item {
+  .scenario-item,
+  .wedding-vendor,
+  .wedding-due-item,
+  .wedding-badge {
     border-width: 2px;
   }
 

--- a/apps/web/src/pages/PlanningPage.test.tsx
+++ b/apps/web/src/pages/PlanningPage.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import React from 'react';
 import {
   PlanningPage,
@@ -566,5 +566,57 @@ describe('PlanningPage', () => {
     expect(screen.getByText('Required RMD')).toBeTruthy();
     expect(screen.getByText('$37735.85')).toBeTruthy();
     expect(screen.getByRole('alert')).toHaveTextContent(/rmd reminder/i);
+  });
+
+  it('surfaces a wedding workspace tab with the budgeted-vs-actual summary', () => {
+    render(<PlanningPage />);
+    expect(screen.getByRole('tab', { name: /wedding/i })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('tab', { name: /wedding/i }));
+
+    expect(screen.getByRole('heading', { name: /wedding budget workspace/i })).toBeTruthy();
+    expect(screen.getByLabelText(/guest count/i)).toHaveValue(75);
+    // Default seed is within the $35,000 budget at 75 guests ($34,700 estimated).
+    expect(screen.getByText('$34700.00')).toBeTruthy();
+    expect(screen.getByText(/within your/i)).toBeTruthy();
+  });
+
+  it('recomputes guest-scaled totals live and reflects vendor deposits', () => {
+    render(<PlanningPage />);
+    fireEvent.click(screen.getByRole('tab', { name: /wedding/i }));
+
+    const guestInput = screen.getByLabelText(/guest count/i);
+    const vendorList = screen.getByRole('list', { name: /wedding vendors/i });
+    const cateringRow = within(vendorList).getByText('Catering').closest('li') as HTMLElement;
+
+    // At 75 guests: catering = $3,000 base + $85 * 75 = $9,375; $1,000 deposit leaves $8,375.
+    expect(within(cateringRow).getByText('$9375.00')).toBeTruthy();
+    expect(within(cateringRow).getByText('$1000.00')).toBeTruthy();
+    expect(within(cateringRow).getByText('$8375.00')).toBeTruthy();
+
+    // Growing the guest list recomputes per-guest estimates and trips the over-budget state.
+    fireEvent.change(guestInput, { target: { value: '100' } });
+
+    expect(screen.getByText('$37700.00')).toBeTruthy();
+    expect(screen.getByText(/over budget by/i)).toBeTruthy();
+    // Catering at 100 guests: $3,000 + $85 * 100 = $11,500; $1,000 deposit leaves $10,500.
+    expect(within(cateringRow).getByText('$11500.00')).toBeTruthy();
+    expect(within(cateringRow).getByText('$10500.00')).toBeTruthy();
+  });
+
+  it('lets a couple add a wedding vendor with its deposit and due date', () => {
+    render(<PlanningPage />);
+    fireEvent.click(screen.getByRole('tab', { name: /wedding/i }));
+
+    fireEvent.change(screen.getByLabelText(/vendor name/i), { target: { value: 'Live band' } });
+    fireEvent.change(screen.getByLabelText(/budgeted \(usd\)/i), { target: { value: '2500' } });
+    fireEvent.change(screen.getByLabelText(/deposit paid/i), { target: { value: '500' } });
+    fireEvent.click(screen.getByRole('button', { name: /add vendor/i }));
+
+    const vendorList = screen.getByRole('list', { name: /wedding vendors/i });
+    const bandRow = within(vendorList).getByText('Live band').closest('li') as HTMLElement;
+    expect(within(bandRow).getByText('$2500.00')).toBeTruthy(); // estimate
+    expect(within(bandRow).getByText('$500.00')).toBeTruthy(); // deposit
+    expect(within(bandRow).getByText('$2000.00')).toBeTruthy(); // remaining
   });
 });

--- a/apps/web/src/pages/PlanningPage.tsx
+++ b/apps/web/src/pages/PlanningPage.tsx
@@ -38,6 +38,14 @@ import type {
   SweepLogEntry,
 } from '../lib/planning';
 import { projectRetirementHealthcareCosts } from '../lib/planning';
+import {
+  buildWeddingPlanSummary,
+  buildWeddingVendorBreakdown,
+  classifyDueUrgency,
+  listUpcomingInstallments,
+  type WeddingDueUrgency,
+  type WeddingVendorPlan,
+} from '../lib/planning/wedding-planner-rules';
 import './PlanningPage.css';
 import { AppIcon, type IconName } from '../components/icons';
 import { TrendLineChart } from '../components/charts';
@@ -46,11 +54,12 @@ import { TrendLineChart } from '../components/charts';
 // Types
 // ---------------------------------------------------------------------------
 
-type PlanningTab = 'scenarios' | 'life-events' | 'retirement' | 'goals' | 'sweep';
+type PlanningTab = 'scenarios' | 'life-events' | 'wedding' | 'retirement' | 'goals' | 'sweep';
 
 const TAB_CONFIG: { id: PlanningTab; label: string; icon: IconName }[] = [
   { id: 'scenarios', label: 'What-If Modeler', icon: 'sparkles' },
   { id: 'life-events', label: 'Life Events', icon: 'calendar' },
+  { id: 'wedding', label: 'Wedding', icon: 'gift' },
   { id: 'retirement', label: 'Retirement', icon: 'leaf' },
   { id: 'goals', label: 'Savings Goals', icon: 'target' },
   { id: 'sweep', label: 'Automations', icon: 'lightning' },
@@ -234,6 +243,172 @@ export function buildReallocationGuidance(
   amounts[0] += freedCents - amounts.reduce((sum, amount) => sum + amount, 0);
 
   return labels.map((label, index) => ({ label, amountCents: amounts[index] ?? 0 }));
+}
+
+// ---------------------------------------------------------------------------
+// Wedding workspace helpers (#2145)
+// ---------------------------------------------------------------------------
+
+const WEDDING_STORAGE_KEY = `finance:wedding-workspace`;
+const WEDDING_DEFAULT_BUDGET_CENTS = 35000_00;
+const WEDDING_DEFAULT_GUEST_COUNT = 75;
+
+export interface WeddingWorkspaceState {
+  readonly vendors: WeddingVendorPlan[];
+  readonly guestCount: number;
+  readonly budgetCents: number;
+}
+
+const WEDDING_URGENCY_META: Record<WeddingDueUrgency, { label: string; icon: IconName }> = {
+  overdue: { label: 'Overdue', icon: 'alert-triangle' },
+  'due-soon': { label: 'Due soon', icon: 'bell' },
+  upcoming: { label: 'Upcoming', icon: 'calendar' },
+};
+
+/** Return an ISO `YYYY-MM-DD` date offset from `now` by `daysFromNow` days. */
+export function weddingDateFromNow(daysFromNow: number, now = new Date()): string {
+  const date = new Date(now);
+  date.setDate(date.getDate() + daysFromNow);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** Today as an ISO `YYYY-MM-DD` date (local time), used as the urgency anchor. */
+export function weddingTodayIso(now = new Date()): string {
+  return weddingDateFromNow(0, now);
+}
+
+/** Format an ISO date for display without UTC timezone drift. */
+export function formatWeddingDate(iso: string): string {
+  const [year, month, day] = iso.split('-').map(Number);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return iso;
+  }
+  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+/** Human-readable relative-day label for an installment. */
+export function weddingDueDayLabel(daysUntilDue: number): string {
+  if (daysUntilDue < 0) {
+    const overdue = Math.abs(daysUntilDue);
+    return `${overdue} day${overdue === 1 ? '' : 's'} overdue`;
+  }
+  if (daysUntilDue === 0) {
+    return 'Due today';
+  }
+  return `Due in ${daysUntilDue} day${daysUntilDue === 1 ? '' : 's'}`;
+}
+
+/** Seed vendors for a ~$35k wedding six months out (within budget at 75 guests). */
+export function defaultWeddingVendors(): WeddingVendorPlan[] {
+  return [
+    {
+      id: 'venue',
+      name: 'Venue & reception hall',
+      contractedCents: 14000_00,
+      paidCents: 4000_00,
+      nextDueDate: weddingDateFromNow(14),
+    },
+    {
+      id: 'catering',
+      name: 'Catering',
+      contractedCents: 3000_00,
+      paidCents: 1000_00,
+      nextDueDate: weddingDateFromNow(45),
+      perGuestCents: 85_00,
+    },
+    {
+      id: 'photography',
+      name: 'Photography & video',
+      contractedCents: 4500_00,
+      paidCents: 1500_00,
+      nextDueDate: weddingDateFromNow(90),
+    },
+    {
+      id: 'rentals',
+      name: 'Rentals (tables, chairs, linens)',
+      contractedCents: 1000_00,
+      paidCents: 0,
+      nextDueDate: weddingDateFromNow(60),
+      perGuestCents: 30_00,
+    },
+    {
+      id: 'invitations',
+      name: 'Invitations & stationery',
+      contractedCents: 200_00,
+      paidCents: 200_00,
+      nextDueDate: null,
+      perGuestCents: 5_00,
+    },
+    {
+      id: 'florals',
+      name: 'Florals & décor',
+      contractedCents: 3000_00,
+      paidCents: 500_00,
+      nextDueDate: weddingDateFromNow(30),
+    },
+  ];
+}
+
+function isWeddingVendorPlan(value: unknown): value is WeddingVendorPlan {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const vendor = value as Record<string, unknown>;
+  return (
+    typeof vendor.id === 'string' &&
+    typeof vendor.name === 'string' &&
+    Number.isFinite(vendor.contractedCents) &&
+    Number.isFinite(vendor.paidCents) &&
+    (vendor.nextDueDate === null || typeof vendor.nextDueDate === 'string') &&
+    (vendor.perGuestCents === undefined || Number.isFinite(vendor.perGuestCents))
+  );
+}
+
+function defaultWeddingState(): WeddingWorkspaceState {
+  return {
+    vendors: defaultWeddingVendors(),
+    guestCount: WEDDING_DEFAULT_GUEST_COUNT,
+    budgetCents: WEDDING_DEFAULT_BUDGET_CENTS,
+  };
+}
+
+export function loadWeddingState(): WeddingWorkspaceState {
+  try {
+    const raw = localStorage.getItem(WEDDING_STORAGE_KEY);
+    if (!raw) {
+      return defaultWeddingState();
+    }
+    const parsed = JSON.parse(raw) as Partial<WeddingWorkspaceState>;
+    const vendors = Array.isArray(parsed.vendors)
+      ? parsed.vendors.filter(isWeddingVendorPlan)
+      : defaultWeddingVendors();
+    return {
+      vendors: vendors.length > 0 ? vendors : defaultWeddingVendors(),
+      guestCount: Number.isFinite(parsed.guestCount)
+        ? Math.max(0, Math.floor(parsed.guestCount as number))
+        : WEDDING_DEFAULT_GUEST_COUNT,
+      budgetCents: Number.isFinite(parsed.budgetCents)
+        ? Math.max(0, Math.round(parsed.budgetCents as number))
+        : WEDDING_DEFAULT_BUDGET_CENTS,
+    };
+  } catch {
+    return defaultWeddingState();
+  }
+}
+
+export function saveWeddingState(state: WeddingWorkspaceState): void {
+  try {
+    localStorage.setItem(WEDDING_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Local storage can be unavailable or full; keep the in-memory workspace usable.
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1592,6 +1767,407 @@ const SweepPanel: React.FC = () => {
 };
 
 // ---------------------------------------------------------------------------
+// Wedding workspace panel (#2145)
+// ---------------------------------------------------------------------------
+
+/** Parse a dollar string into integer cents, or null when it is not a finite number. */
+function weddingDollarsToCents(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  const dollars = Number(trimmed);
+  if (!Number.isFinite(dollars)) {
+    return null;
+  }
+  return Math.round(dollars * 100);
+}
+
+/** Inline progress bar for estimated spend against the budget ceiling. */
+const WeddingBudgetBar: React.FC<{ estimatedCents: number; budgetCents: number }> = ({
+  estimatedCents,
+  budgetCents,
+}) => {
+  const ratio = budgetCents > 0 ? Math.min(1, estimatedCents / budgetCents) : 1;
+  const over = estimatedCents > budgetCents;
+  return (
+    <div
+      className="wedding-budget-bar"
+      role="progressbar"
+      aria-valuenow={Math.round(estimatedCents / 100)}
+      aria-valuemin={0}
+      aria-valuemax={Math.round(budgetCents / 100)}
+      aria-label={`Estimated spend ${formatCurrency(estimatedCents)} of ${formatCurrency(
+        budgetCents,
+      )} budget`}
+    >
+      <span
+        className={`wedding-budget-bar__fill ${over ? 'wedding-budget-bar__fill--over' : ''}`}
+        style={{ width: `${ratio * 100}%` }}
+      />
+    </div>
+  );
+};
+
+/** Text + icon badge that conveys installment urgency without relying on colour alone. */
+const WeddingDueBadge: React.FC<{ urgency: WeddingDueUrgency }> = ({ urgency }) => {
+  const meta = WEDDING_URGENCY_META[urgency];
+  return (
+    <span className={`wedding-badge wedding-badge--${urgency}`}>
+      <AppIcon name={meta.icon} />
+      <span>{meta.label}</span>
+    </span>
+  );
+};
+
+/** Shared wedding budget workspace: vendors, deposits, guest-scaled estimates, due dates. */
+const WeddingWorkspacePanel: React.FC = () => {
+  const [state, setState] = useState<WeddingWorkspaceState>(loadWeddingState);
+  const { vendors, guestCount, budgetCents } = state;
+
+  const [name, setName] = useState('');
+  const [budgeted, setBudgeted] = useState('');
+  const [deposit, setDeposit] = useState('');
+  const [perGuest, setPerGuest] = useState('');
+  const [dueDate, setDueDate] = useState('');
+
+  const today = useMemo(() => weddingTodayIso(), []);
+
+  useEffect(() => {
+    saveWeddingState(state);
+  }, [state]);
+
+  const breakdown = useMemo(
+    () => buildWeddingVendorBreakdown(vendors, guestCount),
+    [vendors, guestCount],
+  );
+  const summary = useMemo(
+    () => buildWeddingPlanSummary(vendors, guestCount, budgetCents, today),
+    [vendors, guestCount, budgetCents, today],
+  );
+  const upcoming = useMemo(
+    () => listUpcomingInstallments(vendors, guestCount, today),
+    [vendors, guestCount, today],
+  );
+
+  const handleGuestCountChange = useCallback((value: string) => {
+    const next = Number(value);
+    setState((prev) => ({
+      ...prev,
+      guestCount: Number.isFinite(next) ? Math.max(0, Math.floor(next)) : 0,
+    }));
+  }, []);
+
+  const handleBudgetChange = useCallback((value: string) => {
+    const cents = weddingDollarsToCents(value);
+    setState((prev) => ({ ...prev, budgetCents: cents !== null ? Math.max(0, cents) : 0 }));
+  }, []);
+
+  const handleAddVendor = useCallback(() => {
+    const trimmedName = name.trim();
+    const budgetedCents = weddingDollarsToCents(budgeted);
+    if (!trimmedName || budgetedCents === null) {
+      return;
+    }
+    const depositCents = weddingDollarsToCents(deposit) ?? 0;
+    const perGuestCents = weddingDollarsToCents(perGuest);
+
+    const vendor: WeddingVendorPlan = {
+      id: `wedding-vendor-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      name: trimmedName,
+      contractedCents: Math.max(0, budgetedCents),
+      paidCents: Math.max(0, depositCents),
+      nextDueDate: dueDate || null,
+      ...(perGuestCents && perGuestCents > 0 ? { perGuestCents } : {}),
+    };
+
+    setState((prev) => ({ ...prev, vendors: [...prev.vendors, vendor] }));
+    setName('');
+    setBudgeted('');
+    setDeposit('');
+    setPerGuest('');
+    setDueDate('');
+  }, [budgeted, deposit, dueDate, name, perGuest]);
+
+  const handleRemoveVendor = useCallback((id: string) => {
+    setState((prev) => ({ ...prev, vendors: prev.vendors.filter((vendor) => vendor.id !== id) }));
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setState(defaultWeddingState());
+  }, []);
+
+  const headroomCents = Math.max(0, budgetCents - summary.estimatedTotalCents);
+  const summaryAnnouncement = `Estimated wedding total ${formatCurrency(
+    summary.estimatedTotalCents,
+  )} for ${guestCount} guest${guestCount === 1 ? '' : 's'}. ${formatCurrency(
+    summary.paidCents,
+  )} paid in deposits, ${formatCurrency(summary.remainingBalanceCents)} remaining.`;
+
+  return (
+    <div className="wedding-workspace">
+      <section className="planning-card" aria-labelledby="wedding-intro-title">
+        <h3 id="wedding-intro-title" className="planning-card__title">
+          Wedding budget workspace
+        </h3>
+        <p className="planning-card__description">
+          Track vendors, deposits paid, and upcoming installment due dates for your big day.
+          Catering, rentals, and invitations scale with the guest count, so totals update live as
+          your list grows.
+        </p>
+
+        <div className="wedding-controls" aria-label="Wedding plan controls">
+          <label className="life-events-field">
+            Guest count
+            <input
+              className="form-input"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              step={1}
+              value={guestCount}
+              onChange={(e) => handleGuestCountChange(e.target.value)}
+            />
+          </label>
+          <label className="life-events-field">
+            Total budget (USD)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="100"
+              value={(budgetCents / 100).toString()}
+              onChange={(e) => handleBudgetChange(e.target.value)}
+            />
+          </label>
+          <button
+            className="planning-btn planning-btn--small"
+            type="button"
+            onClick={handleReset}
+            aria-label="Reset wedding workspace to the sample plan"
+          >
+            <AppIcon name="refresh" /> Reset sample
+          </button>
+        </div>
+
+        <p className="wedding-announce" aria-live="polite">
+          {summaryAnnouncement}
+        </p>
+      </section>
+
+      {/* Budgeted-vs-actual summary */}
+      <section className="planning-card" aria-labelledby="wedding-summary-title">
+        <h3 id="wedding-summary-title" className="planning-card__title">
+          Budgeted vs. actual
+        </h3>
+
+        <WeddingBudgetBar estimatedCents={summary.estimatedTotalCents} budgetCents={budgetCents} />
+
+        {summary.overBudgetCents > 0 ? (
+          <p className="wedding-status wedding-status--over" role="status">
+            <AppIcon name="alert-triangle" />
+            <span>
+              Over budget by {formatCurrency(summary.overBudgetCents)} — trim a vendor or your guest
+              list to get back on track.
+            </span>
+          </p>
+        ) : (
+          <p className="wedding-status wedding-status--ok" role="status">
+            <AppIcon name="check-circle" />
+            <span>
+              Within your {formatCurrency(budgetCents)} budget with {formatCurrency(headroomCents)}{' '}
+              of headroom.
+            </span>
+          </p>
+        )}
+
+        <div className="planning-metrics" aria-label="Wedding budget summary">
+          <article className="planning-metric" aria-label="Estimated total">
+            <p className="planning-metric__label">Estimated total</p>
+            <p className="planning-metric__value">{formatCurrency(summary.estimatedTotalCents)}</p>
+          </article>
+          <article className="planning-metric" aria-label="Deposits paid">
+            <p className="planning-metric__label">Deposits paid</p>
+            <p className="planning-metric__value">{formatCurrency(summary.paidCents)}</p>
+          </article>
+          <article className="planning-metric" aria-label="Remaining balance">
+            <p className="planning-metric__label">Remaining</p>
+            <p className="planning-metric__value">
+              {formatCurrency(summary.remainingBalanceCents)}
+            </p>
+          </article>
+        </div>
+      </section>
+
+      {/* Upcoming installments */}
+      <section className="planning-card" aria-labelledby="wedding-due-title">
+        <h3 id="wedding-due-title" className="planning-card__title">
+          Upcoming installments
+        </h3>
+        {upcoming.length === 0 ? (
+          <p className="planning-card__description">
+            No outstanding installments with a due date. Add a vendor below to schedule the next
+            payment.
+          </p>
+        ) : (
+          <ul className="wedding-due-list" role="list" aria-label="Upcoming installments">
+            {upcoming.map((item) => (
+              <li key={item.vendorId} className="wedding-due-item" role="listitem">
+                <div className="wedding-due-item__main">
+                  <span className="wedding-due-item__name">{item.vendorName}</span>
+                  <WeddingDueBadge urgency={item.urgency} />
+                </div>
+                <div className="wedding-due-item__meta">
+                  <span className="wedding-due-item__amount">
+                    {formatCurrency(item.amountCents)}
+                  </span>
+                  <span className="wedding-due-item__date">
+                    {formatWeddingDate(item.dueDate)} · {weddingDueDayLabel(item.daysUntilDue)}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Vendor list */}
+      <section className="planning-card" aria-labelledby="wedding-vendors-title">
+        <h3 id="wedding-vendors-title" className="planning-card__title">
+          Vendors &amp; line items
+        </h3>
+        <ul className="wedding-vendor-list" role="list" aria-label="Wedding vendors">
+          {breakdown.map((vendor) => {
+            const urgency =
+              vendor.nextDueDate !== null ? classifyDueUrgency(vendor.nextDueDate, today) : null;
+            return (
+              <li key={vendor.id} className="wedding-vendor" role="listitem">
+                <div className="wedding-vendor__header">
+                  <span className="wedding-vendor__name">{vendor.name}</span>
+                  {vendor.guestSensitive && (
+                    <span className="wedding-vendor__per-guest">
+                      <AppIcon name="account" /> {formatCurrency(vendor.perGuestCents)}/guest
+                    </span>
+                  )}
+                </div>
+
+                <dl className="wedding-vendor__figures">
+                  <div className="wedding-vendor__figure">
+                    <dt>Estimated</dt>
+                    <dd>{formatCurrency(vendor.estimatedTotalCents)}</dd>
+                  </div>
+                  <div className="wedding-vendor__figure">
+                    <dt>Deposit paid</dt>
+                    <dd>{formatCurrency(vendor.paidCents)}</dd>
+                  </div>
+                  <div className="wedding-vendor__figure">
+                    <dt>Remaining</dt>
+                    <dd>{formatCurrency(vendor.remainingCents)}</dd>
+                  </div>
+                </dl>
+
+                <div className="wedding-vendor__footer">
+                  {vendor.paidInFull ? (
+                    <span className="wedding-badge wedding-badge--paid">
+                      <AppIcon name="check-circle" />
+                      <span>Paid in full</span>
+                    </span>
+                  ) : vendor.nextDueDate !== null && urgency !== null ? (
+                    <span className="wedding-vendor__due">
+                      <WeddingDueBadge urgency={urgency} />
+                      <span className="wedding-vendor__due-date">
+                        Next installment {formatWeddingDate(vendor.nextDueDate)}
+                      </span>
+                    </span>
+                  ) : (
+                    <span className="wedding-vendor__due-date">No installment scheduled</span>
+                  )}
+                  <button
+                    className="planning-btn planning-btn--small planning-btn--danger"
+                    type="button"
+                    onClick={() => handleRemoveVendor(vendor.id)}
+                    aria-label={`Remove ${vendor.name}`}
+                  >
+                    Remove
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+
+        <div className="life-events-form" aria-label="Add wedding vendor">
+          <label className="life-events-field">
+            Vendor name
+            <input
+              className="form-input"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="DJ / band"
+            />
+          </label>
+          <label className="life-events-field">
+            Budgeted (USD)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              value={budgeted}
+              onChange={(e) => setBudgeted(e.target.value)}
+              placeholder="2500"
+            />
+          </label>
+          <label className="life-events-field">
+            Deposit paid (USD)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              value={deposit}
+              onChange={(e) => setDeposit(e.target.value)}
+              placeholder="500"
+            />
+          </label>
+          <label className="life-events-field">
+            Per-guest cost (USD)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              value={perGuest}
+              onChange={(e) => setPerGuest(e.target.value)}
+              placeholder="0"
+            />
+          </label>
+          <label className="life-events-field">
+            Next installment due
+            <input
+              className="form-input"
+              type="date"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+            />
+          </label>
+          <button
+            className="planning-btn planning-btn--primary"
+            type="button"
+            onClick={handleAddVendor}
+            disabled={!name.trim() || weddingDollarsToCents(budgeted) === null}
+          >
+            Add Vendor
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Main page component
 // ---------------------------------------------------------------------------
 
@@ -1631,6 +2207,7 @@ export const PlanningPage: React.FC = () => {
       >
         {activeTab === 'scenarios' && <ScenariosPanel />}
         {activeTab === 'life-events' && <LifeEventsPanel />}
+        {activeTab === 'wedding' && <WeddingWorkspacePanel />}
         {activeTab === 'retirement' && <RetirementPanel />}
         {activeTab === 'goals' && <GoalsPanel />}
         {activeTab === 'sweep' && <SweepPanel />}


### PR DESCRIPTION
﻿## Summary
Surfaces the existing-but-unwired `apps/web/src/lib/planning/wedding-planner-rules.ts` engine on the **Planning** page as a dedicated, accessible **Wedding workspace** for an engaged couple planning a ~$35k wedding ~6 months out.

**Gap verified:** the wedding rules engine + its unit test already existed under `apps/web/src/lib/planning/`, but a grep of `apps/web/src/pages` returned zero references — no page surfaced a wedding workspace. This PR closes that gap (native Android `PlanningScreen` remains; this is the web slice).

## Changes
- **Engine (`wedding-planner-rules.ts`, integer cents only):** added `buildWeddingVendorBreakdown` (per-vendor estimate / deposit paid / remaining + `paidInFull`), `computeVendorEstimateCents` (floored, non-negative guest scaling), `classifyDueUrgency` (`overdue` / `due-soon` / `upcoming`) and `listUpcomingInstallments` (sorted, urgency-tagged, day counts). Existing `buildWeddingPlanSummary` untouched.
- **PlanningPage:** new **Wedding** tab + `WeddingWorkspacePanel` — guest-count input that live-recomputes per-guest estimates (catering / rentals / invitations), budgeted-vs-actual summary with remaining + over-budget state, vendor list with deposit/remaining/next-installment, sorted upcoming installments, and add/remove vendor. Local-storage persisted (mirrors the LifeEvents panel pattern; no repository imports).
- **CSS:** token-only styles; reduced-motion and high-contrast handling extended.

## Accessibility (WCAG 2.2 AA)
- Due-date urgency and over-budget state conveyed with **text + icon, never colour alone**.
- Guest-count is a labelled control; recomputed totals announced via `aria-live="polite"`.
- Budget progress exposed with `role="progressbar"` + aria-value*; all controls keyboard reachable; `prefers-reduced-motion` respected.

## Testing
- `vitest` engine tests: exact-cent deposit/remaining reconciliation, guest-count recompute, paid-in-full, upcoming-due ordering + urgency classification.
- `vitest` render/interaction tests: Wedding tab renders, default within-budget summary, guest-count change recomputes totals + trips over-budget, vendor deposit reflected in remaining, add-vendor flow. **30/30 pass.**
- Local gate green: `prettier --check` + `eslint --max-warnings 0` clean on all changed files.

Refs #2145
