### PR TITLE
feat(web): shift-based mileage tracking with route presets and IRS export (#2137)

### DIFF
--- a/apps/web/src/components/mileage/ShiftTracker.test.tsx
+++ b/apps/web/src/components/mileage/ShiftTracker.test.tsx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ShiftTracker } from './ShiftTracker';
+
+describe('ShiftTracker', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('runs a start -> log preset leg -> end flow and shows grouped totals', () => {
+    render(<ShiftTracker />);
+
+    // No in-progress shift yet: the start control is visible.
+    const platformInput = screen.getByLabelText('Platform') as HTMLInputElement;
+    fireEvent.change(platformInput, { target: { value: 'DoorDash' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Start shift' }));
+
+    // Active shift panel appears with a live timer and status.
+    expect(screen.getByRole('timer')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+
+    // One-tap preset prefill for the leg start/end.
+    fireEvent.click(screen.getByRole('button', { name: /^From Home base/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^To Delivery hotspot/ }));
+
+    fireEvent.change(screen.getByLabelText('Miles'), { target: { value: '10' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Log leg' }));
+
+    // End the shift.
+    fireEvent.click(screen.getByRole('button', { name: 'End shift' }));
+
+    // Grouped totals by platform now show the logged mileage (10 mi @ 67c = $6.70).
+    const totals = screen.getByLabelText('Shift totals by platform');
+    expect(within(totals).getByText('DoorDash')).toBeInTheDocument();
+    expect(within(totals).getByText('10.0 mi')).toBeInTheDocument();
+    expect(within(totals).getByText('$6.70')).toBeInTheDocument();
+  });
+
+  it('requires presets and miles before logging a leg', () => {
+    render(<ShiftTracker />);
+    fireEvent.click(screen.getByRole('button', { name: 'Start shift' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Log leg' }));
+    expect(screen.getByRole('alert')).toHaveTextContent('Pick a start and end preset');
+  });
+
+  it('exports an IRS audit trail as CSV', () => {
+    const createObjectURL = vi.fn(() => 'blob:mock');
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    render(<ShiftTracker />);
+    fireEvent.click(screen.getByRole('button', { name: 'Start shift' }));
+    fireEvent.click(screen.getByRole('button', { name: /^From Home base/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^To Delivery hotspot/ }));
+    fireEvent.change(screen.getByLabelText('Miles'), { target: { value: '5' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Log leg' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export IRS audit trail as CSV' }));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/src/components/mileage/ShiftTracker.tsx
+++ b/apps/web/src/components/mileage/ShiftTracker.tsx
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { AppIcon, type IconName } from '../icons';
+import { formatCurrency } from '../../lib/currency';
+import {
+  addLegToWorkShift,
+  buildLegDraftFromPresets,
+  buildShiftMileageAuditCsv,
+  computeActiveDurationMs,
+  deleteWorkShift,
+  endShift,
+  findInProgressShift,
+  generateShiftMileageAuditReport,
+  getRoutePresetKindLabel,
+  getShiftStatusLabel,
+  loadRoutePresets,
+  loadWorkShifts,
+  MILEAGE_SHIFTS_CHANGED_EVENT,
+  pauseShift,
+  resumeShift,
+  startWorkShift,
+} from '../../lib/mileage';
+import type { RoutePreset, ShiftStatus, WorkShift } from '../../lib/mileage';
+import './mileage.css';
+
+const PLATFORM_OPTIONS = [
+  'DoorDash',
+  'UberEats',
+  'Grubhub',
+  'Instacart',
+  'Amazon Flex',
+  'Lyft',
+  'Spark',
+] as const;
+
+const STATUS_ICONS: Record<ShiftStatus, IconName> = {
+  active: 'lightning',
+  paused: 'circle',
+  ended: 'check-circle',
+};
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+}
+
+function downloadCsv(filename: string, csv: string): void {
+  if (typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+    return;
+  }
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function ShiftTracker() {
+  const [shifts, setShifts] = useState<WorkShift[]>(() => loadWorkShifts());
+  const [presets, setPresets] = useState<RoutePreset[]>(() => loadRoutePresets());
+  const [now, setNow] = useState(() => new Date().toISOString());
+  const [platform, setPlatform] = useState<string>(PLATFORM_OPTIONS[0]);
+  const [fromPresetId, setFromPresetId] = useState<string | null>(null);
+  const [toPresetId, setToPresetId] = useState<string | null>(null);
+  const [legMiles, setLegMiles] = useState('');
+  const [legError, setLegError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState('');
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Refresh from storage whenever any shift/preset data changes.
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const sync = () => {
+      setShifts(loadWorkShifts());
+      setPresets(loadRoutePresets());
+    };
+
+    window.addEventListener(MILEAGE_SHIFTS_CHANGED_EVENT, sync);
+    return () => window.removeEventListener(MILEAGE_SHIFTS_CHANGED_EVENT, sync);
+  }, []);
+
+  const inProgressShift = useMemo(() => findInProgressShift(shifts), [shifts]);
+
+  // Tick the live timer once a second only while a shift is actively running.
+  useEffect(() => {
+    if (inProgressShift?.status !== 'active') {
+      if (tickRef.current !== null) {
+        clearInterval(tickRef.current);
+        tickRef.current = null;
+      }
+      return;
+    }
+
+    tickRef.current = setInterval(() => setNow(new Date().toISOString()), 1000);
+    return () => {
+      if (tickRef.current !== null) {
+        clearInterval(tickRef.current);
+        tickRef.current = null;
+      }
+    };
+  }, [inProgressShift?.status, inProgressShift?.id]);
+
+  const auditReport = useMemo(() => generateShiftMileageAuditReport({ shifts }), [shifts]);
+
+  const activeSummary = useMemo(() => {
+    if (!inProgressShift) {
+      return null;
+    }
+
+    const miles = inProgressShift.legs.reduce((total, leg) => total + leg.miles, 0);
+    const matching = auditReport.shifts.find((entry) => entry.shiftId === inProgressShift.id);
+    return {
+      miles: Math.round(miles * 10) / 10,
+      legCount: inProgressShift.legs.length,
+      deductionCents: matching?.deductionCents ?? 0,
+      durationMs: computeActiveDurationMs(inProgressShift, now),
+    };
+  }, [auditReport.shifts, inProgressShift, now]);
+
+  const handleStart = useCallback(() => {
+    const created = startWorkShift({ platform });
+    setStatusMessage(`Started ${created.platform} shift.`);
+  }, [platform]);
+
+  const handlePauseResume = useCallback(() => {
+    if (!inProgressShift) {
+      return;
+    }
+
+    if (inProgressShift.status === 'active') {
+      pauseShift(inProgressShift.id);
+      setStatusMessage('Shift paused. The timer is on hold.');
+    } else {
+      resumeShift(inProgressShift.id);
+      setStatusMessage('Shift resumed.');
+    }
+  }, [inProgressShift]);
+
+  const handleEnd = useCallback(() => {
+    if (!inProgressShift) {
+      return;
+    }
+
+    endShift(inProgressShift.id);
+    setStatusMessage('Shift ended and saved to your audit trail.');
+  }, [inProgressShift]);
+
+  const handleLogLeg = useCallback(() => {
+    if (!inProgressShift) {
+      return;
+    }
+
+    setLegError(null);
+    const fromPreset = presets.find((preset) => preset.id === fromPresetId) ?? null;
+    const toPreset = presets.find((preset) => preset.id === toPresetId) ?? null;
+    const miles = Number.parseFloat(legMiles);
+
+    if (!fromPreset || !toPreset) {
+      setLegError('Pick a start and end preset to log a leg.');
+      return;
+    }
+
+    if (!Number.isFinite(miles) || miles <= 0) {
+      setLegError('Enter the miles for this leg.');
+      return;
+    }
+
+    try {
+      const draft = buildLegDraftFromPresets({
+        startPreset: fromPreset,
+        endPreset: toPreset,
+        miles,
+      });
+      addLegToWorkShift(inProgressShift.id, draft);
+      setLegMiles('');
+      setStatusMessage(
+        `Logged ${miles.toFixed(1)} miles from ${fromPreset.label} to ${toPreset.label}.`,
+      );
+    } catch (error) {
+      setLegError(error instanceof Error ? error.message : 'Unable to log this leg.');
+    }
+  }, [fromPresetId, inProgressShift, legMiles, presets, toPresetId]);
+
+  const handleDelete = useCallback((shiftId: string) => {
+    deleteWorkShift(shiftId);
+    setStatusMessage('Removed shift.');
+  }, []);
+
+  const handleExport = useCallback(() => {
+    if (auditReport.legs.length === 0) {
+      setStatusMessage('No shift mileage to export yet.');
+      return;
+    }
+
+    const csv = buildShiftMileageAuditCsv(auditReport);
+    const stamp = new Date().toISOString().slice(0, 10);
+    downloadCsv(`mileage-shift-audit-${stamp}.csv`, csv);
+    setStatusMessage('Exported IRS audit trail as CSV.');
+  }, [auditReport]);
+
+  const renderPresetGroup = (
+    legend: string,
+    selectedId: string | null,
+    onSelect: (id: string) => void,
+  ) => (
+    <div className="shift-presets" role="group" aria-label={legend}>
+      <span className="shift-presets__legend">{legend}</span>
+      <div className="shift-presets__buttons">
+        {presets.map((preset) => {
+          const selected = preset.id === selectedId;
+          return (
+            <button
+              key={`${legend}-${preset.id}`}
+              type="button"
+              className="shift-preset-button"
+              aria-pressed={selected}
+              aria-label={`${legend} ${preset.label} (${getRoutePresetKindLabel(preset.kind)})`}
+              onClick={() => onSelect(preset.id)}
+            >
+              <AppIcon name="map-pin" size={14} />
+              <span>{preset.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  return (
+    <section className="mileage-card" aria-labelledby="shift-tracker-title">
+      <div className="mileage-card__header">
+        <div>
+          <h3 id="shift-tracker-title" className="mileage-card__title">
+            Work shift tracker
+          </h3>
+          <p className="mileage-card__description">
+            Start a shift, tap a route preset, and log miles between deliveries in seconds.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="icon-button"
+          onClick={handleExport}
+          aria-label="Export IRS audit trail as CSV"
+        >
+          <AppIcon name="download" size={16} />
+          Export audit
+        </button>
+      </div>
+
+      {/* Status announcements for assistive tech (no color-only meaning). */}
+      <p className="shift-tracker__sr-status" role="status" aria-live="polite">
+        {statusMessage}
+      </p>
+
+      {inProgressShift && activeSummary ? (
+        <div className="shift-active">
+          <div className="shift-active__header">
+            <span
+              className={`mileage-status shift-status shift-status--${inProgressShift.status}`}
+              data-status={inProgressShift.status}
+            >
+              <AppIcon name={STATUS_ICONS[inProgressShift.status]} size={14} />
+              {getShiftStatusLabel(inProgressShift.status)}
+            </span>
+            <span className="shift-active__platform">{inProgressShift.platform}</span>
+          </div>
+
+          <div className="shift-active__metrics">
+            <div className="shift-metric">
+              <span className="shift-metric__label">Shift time</span>
+              <output className="shift-metric__value" aria-live="off">
+                <span
+                  role="timer"
+                  aria-label={`Active shift time ${formatDuration(activeSummary.durationMs)}`}
+                >
+                  {formatDuration(activeSummary.durationMs)}
+                </span>
+              </output>
+            </div>
+            <div className="shift-metric" aria-live="polite">
+              <span className="shift-metric__label">Miles logged</span>
+              <span className="shift-metric__value">{activeSummary.miles.toFixed(1)}</span>
+            </div>
+            <div className="shift-metric" aria-live="polite">
+              <span className="shift-metric__label">IRS deduction</span>
+              <span className="shift-metric__value">
+                {formatCurrency(activeSummary.deductionCents)}
+              </span>
+            </div>
+            <div className="shift-metric">
+              <span className="shift-metric__label">Legs</span>
+              <span className="shift-metric__value">{activeSummary.legCount}</span>
+            </div>
+          </div>
+
+          <div className="shift-active__controls">
+            <button type="button" className="icon-button" onClick={handlePauseResume}>
+              <AppIcon
+                name={inProgressShift.status === 'active' ? 'circle' : 'lightning'}
+                size={16}
+              />
+              {inProgressShift.status === 'active' ? 'Pause shift' : 'Resume shift'}
+            </button>
+            <button type="button" className="add-button" onClick={handleEnd}>
+              <AppIcon name="check-circle" size={16} />
+              End shift
+            </button>
+          </div>
+
+          <div className="shift-quick-log">
+            <h4 className="shift-quick-log__title">Log a leg</h4>
+            {renderPresetGroup('From', fromPresetId, setFromPresetId)}
+            {renderPresetGroup('To', toPresetId, setToPresetId)}
+            <div className="shift-quick-log__entry">
+              <div className="form-group">
+                <label className="form-group__label" htmlFor="shift-leg-miles">
+                  Miles
+                </label>
+                <input
+                  id="shift-leg-miles"
+                  className="form-input"
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  value={legMiles}
+                  onChange={(event) => setLegMiles(event.target.value)}
+                  placeholder="3.2"
+                />
+              </div>
+              <button type="button" className="add-button" onClick={handleLogLeg}>
+                <AppIcon name="plane" size={16} />
+                Log leg
+              </button>
+            </div>
+            {legError ? (
+              <p className="form-error" role="alert">
+                {legError}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ) : (
+        <div className="shift-start">
+          <div className="form-group">
+            <label className="form-group__label" htmlFor="shift-platform">
+              Platform
+            </label>
+            <input
+              id="shift-platform"
+              className="form-input"
+              list="shift-platform-options"
+              value={platform}
+              onChange={(event) => setPlatform(event.target.value)}
+              placeholder="DoorDash"
+            />
+            <datalist id="shift-platform-options">
+              {PLATFORM_OPTIONS.map((option) => (
+                <option key={option} value={option} />
+              ))}
+            </datalist>
+          </div>
+          <button type="button" className="add-button" onClick={handleStart}>
+            <AppIcon name="lightning" size={16} />
+            Start shift
+          </button>
+        </div>
+      )}
+
+      {auditReport.byPlatform.length > 0 ? (
+        <div className="shift-summary" aria-label="Shift totals by platform">
+          <h4 className="shift-quick-log__title">Totals by platform</h4>
+          <div className="mileage-list" role="list">
+            {auditReport.byPlatform.map((entry) => (
+              <div key={entry.platform} className="mileage-list__item" role="listitem">
+                <div className="mileage-list__meta">
+                  <span className="mileage-list__label">{entry.platform}</span>
+                  <span className="mileage-list__caption">
+                    {entry.shiftCount} shift(s) · {entry.legCount} leg(s)
+                  </span>
+                </div>
+                <div className="mileage-list__meta shift-summary__amount">
+                  <span className="mileage-list__label">{entry.miles.toFixed(1)} mi</span>
+                  <span className="mileage-list__caption">
+                    {formatCurrency(entry.deductionCents)}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {auditReport.shifts.length > 0 ? (
+        <div className="shift-summary" aria-label="Recent shifts">
+          <h4 className="shift-quick-log__title">Recent shifts</h4>
+          <div className="mileage-list" role="list">
+            {auditReport.shifts.map((entry) => (
+              <div key={entry.shiftId} className="mileage-list__item" role="listitem">
+                <div className="mileage-list__meta">
+                  <span className="mileage-list__label">
+                    {entry.platform} · {entry.date}
+                  </span>
+                  <span className="mileage-list__caption">
+                    {getShiftStatusLabel(entry.status)} · {entry.legCount} leg(s)
+                  </span>
+                </div>
+                <div className="mileage-list__meta shift-summary__amount">
+                  <span className="mileage-list__label">{entry.miles.toFixed(1)} mi</span>
+                  <span className="mileage-list__caption">
+                    {formatCurrency(entry.deductionCents)}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  className="icon-button"
+                  aria-label={`Delete ${entry.platform} shift from ${entry.date}`}
+                  onClick={() => handleDelete(entry.shiftId)}
+                >
+                  <AppIcon name="trash" size={14} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/mileage/mileage.css
+++ b/apps/web/src/components/mileage/mileage.css
@@ -255,3 +255,170 @@
   color: var(--semantic-status-negative, var(--semantic-text-primary));
   border-color: color-mix(in srgb, var(--semantic-status-negative) 45%, transparent);
 }
+
+/* --- Shift-based mileage tracker (#2137) --------------------------------- */
+
+.shift-tracker__sr-status {
+  margin: 0;
+  min-height: 1.25rem;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.shift-start,
+.shift-quick-log__entry {
+  display: flex;
+  gap: var(--spacing-3);
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.shift-start .form-group,
+.shift-quick-log__entry .form-group {
+  flex: 1 1 12rem;
+}
+
+.shift-active {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  padding: var(--spacing-3);
+  background: var(--semantic-background-secondary, rgba(15, 23, 42, 0.03));
+}
+
+.shift-active__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.shift-active__platform {
+  font-weight: var(--font-weight-semibold);
+}
+
+/* Shift status pill: meaning is carried by text + icon, never color alone. */
+.shift-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+}
+
+.shift-status--active {
+  color: var(--semantic-status-positive, var(--semantic-text-primary));
+  border-color: color-mix(in srgb, var(--semantic-status-positive) 40%, transparent);
+}
+
+.shift-status--paused {
+  color: var(--semantic-status-warning, var(--semantic-text-primary));
+  border-color: color-mix(in srgb, var(--semantic-status-warning) 40%, transparent);
+}
+
+.shift-status--ended {
+  color: var(--semantic-text-secondary);
+  border-color: var(--semantic-border-default);
+}
+
+.shift-active__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--spacing-3);
+}
+
+.shift-metric {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.shift-metric__label {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.shift-metric__value {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
+.shift-active__controls {
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.shift-quick-log {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  border-top: 1px solid var(--semantic-border-default);
+  padding-top: var(--spacing-3);
+}
+
+.shift-quick-log__title {
+  margin: 0;
+  font-size: var(--type-scale-body-font-size);
+}
+
+.shift-presets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.shift-presets__legend {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.shift-presets__buttons {
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.shift-preset-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+  font: inherit;
+  cursor: pointer;
+}
+
+.shift-preset-button[aria-pressed='true'] {
+  border-color: var(--semantic-interactive-default, var(--semantic-text-primary));
+  border-width: 2px;
+  font-weight: var(--font-weight-semibold);
+  background: color-mix(
+    in srgb,
+    var(--semantic-background-primary) 88%,
+    var(--semantic-interactive-default) 12%
+  );
+}
+
+.shift-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.shift-summary__amount {
+  text-align: right;
+  align-items: flex-end;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shift-preset-button,
+  .shift-metric__value {
+    transition: none;
+  }
+}

--- a/apps/web/src/lib/mileage/__tests__/shiftReports.test.ts
+++ b/apps/web/src/lib/mileage/__tests__/shiftReports.test.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { getMileageRate } from '../calculator';
+import { appendShiftLeg, createWorkShift } from '../shifts';
+import { buildShiftMileageAuditCsv, generateShiftMileageAuditReport } from '../reports';
+import type { TripEntry, WorkShift } from '../types';
+
+function legAt(overrides: Partial<TripEntry> & { id: string; miles: number }): TripEntry {
+  return {
+    date: '2024-06-01',
+    startLocation: 'Home',
+    endLocation: 'Hotspot',
+    odometerStart: null,
+    odometerEnd: null,
+    purpose: 'business',
+    notes: '',
+    businessUsePercent: 100,
+    createdAt: '2024-06-01T12:00:00.000Z',
+    updatedAt: '2024-06-01T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeShifts(): WorkShift[] {
+  let doorDash = createWorkShift({ platform: 'DoorDash', startedAt: '2024-06-01T08:00:00.000Z' });
+  doorDash = appendShiftLeg(doorDash, legAt({ id: 'dd-1', miles: 10 }));
+  doorDash = appendShiftLeg(
+    doorDash,
+    legAt({ id: 'dd-2', miles: 6, endLocation: 'Store cluster' }),
+  );
+  // A personal leg must be excluded from the audit trail.
+  doorDash = appendShiftLeg(doorDash, legAt({ id: 'dd-3', miles: 4, purpose: 'personal' }));
+
+  let uber = createWorkShift({ platform: 'UberEats', startedAt: '2024-06-02T08:00:00.000Z' });
+  uber = appendShiftLeg(uber, legAt({ id: 'ue-1', miles: 8, date: '2024-06-02' }));
+
+  return [doorDash, uber];
+}
+
+describe('shift mileage audit report', () => {
+  it('produces an IRS-friendly audit trail grouped by shift and platform', () => {
+    const businessRate = getMileageRate('business', 2024);
+    const report = generateShiftMileageAuditReport({ shifts: makeShifts() });
+
+    // Personal leg excluded -> 3 business legs.
+    expect(report.legs).toHaveLength(3);
+    const ddLeg = report.legs.find((leg) => leg.legId === 'dd-1');
+    expect(ddLeg).toMatchObject({
+      platform: 'DoorDash',
+      purpose: 'business',
+      miles: 10,
+      rateCentsPerMile: businessRate,
+      deductionCents: Math.round(10 * businessRate),
+    });
+
+    // Per-shift rollup excludes the personal leg.
+    const ddShift = report.shifts.find((shift) => shift.platform === 'DoorDash');
+    expect(ddShift?.miles).toBe(16);
+    expect(ddShift?.deductionCents).toBe(
+      Math.round(10 * businessRate) + Math.round(6 * businessRate),
+    );
+
+    // Per-platform rollup.
+    const platforms = report.byPlatform.map((entry) => entry.platform);
+    expect(platforms).toEqual(['DoorDash', 'UberEats']);
+
+    expect(report.totalMiles).toBe(24);
+    expect(report.totalDeductionCents).toBe(
+      Math.round(10 * businessRate) + Math.round(6 * businessRate) + Math.round(8 * businessRate),
+    );
+  });
+
+  it('honours the reporting period filter', () => {
+    const report = generateShiftMileageAuditReport({
+      shifts: makeShifts(),
+      startDate: '2024-06-02',
+      endDate: '2024-06-02',
+    });
+
+    expect(report.shifts).toHaveLength(1);
+    expect(report.shifts[0]?.platform).toBe('UberEats');
+  });
+
+  it('serialises a CSV audit trail with a header and totals row', () => {
+    const csv = buildShiftMileageAuditCsv(
+      generateShiftMileageAuditReport({ shifts: makeShifts() }),
+    );
+    const lines = csv.split('\r\n');
+
+    expect(lines[0]).toContain('Date,Platform,Shift ID,Purpose');
+    // header + 3 legs + total row.
+    expect(lines).toHaveLength(5);
+    expect(lines[lines.length - 1]).toContain('Total');
+  });
+});

--- a/apps/web/src/lib/mileage/__tests__/shiftTracker.test.ts
+++ b/apps/web/src/lib/mileage/__tests__/shiftTracker.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildLegDraftFromPresets, DEFAULT_ROUTE_PRESETS } from '../shifts';
+import {
+  addLegToWorkShift,
+  deleteWorkShift,
+  endShift,
+  loadRoutePresets,
+  loadWorkShifts,
+  MILEAGE_SHIFTS_CHANGED_EVENT,
+  pauseShift,
+  resumeShift,
+  startWorkShift,
+} from '../shiftTracker';
+
+function createLocalStorageMock() {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+}
+
+describe('shift tracker persistence', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'window',
+      Object.assign(new EventTarget(), {
+        localStorage: createLocalStorageMock(),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('persists a full start -> pause -> resume -> log -> end flow', () => {
+    const changeHandler = vi.fn();
+    window.addEventListener(MILEAGE_SHIFTS_CHANGED_EVENT, changeHandler);
+
+    const shift = startWorkShift({ platform: 'DoorDash' });
+    expect(loadWorkShifts()).toHaveLength(1);
+
+    pauseShift(shift.id);
+    resumeShift(shift.id);
+
+    const home = DEFAULT_ROUTE_PRESETS.find((preset) => preset.kind === 'home');
+    const hotspot = DEFAULT_ROUTE_PRESETS.find((preset) => preset.kind === 'hotspot');
+    const draft = buildLegDraftFromPresets({ startPreset: home, endPreset: hotspot, miles: 5 });
+
+    const withLeg = addLegToWorkShift(shift.id, draft);
+    expect(withLeg?.legs).toHaveLength(1);
+    expect(withLeg?.legs[0]?.startLocation).toBe('Home');
+    expect(withLeg?.legs[0]?.miles).toBe(5);
+
+    const ended = endShift(shift.id);
+    expect(ended?.status).toBe('ended');
+    expect(ended?.endedAt).not.toBeNull();
+
+    // start + pause + resume + addLeg + end = 5 writes.
+    expect(changeHandler).toHaveBeenCalledTimes(5);
+    window.removeEventListener(MILEAGE_SHIFTS_CHANGED_EVENT, changeHandler);
+  });
+
+  it('returns default route presets when none are stored', () => {
+    expect(loadRoutePresets()).toEqual([...DEFAULT_ROUTE_PRESETS]);
+  });
+
+  it('deletes a shift', () => {
+    const shift = startWorkShift({ platform: 'UberEats' });
+    expect(deleteWorkShift(shift.id)).toBe(true);
+    expect(loadWorkShifts()).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/mileage/__tests__/shifts.test.ts
+++ b/apps/web/src/lib/mileage/__tests__/shifts.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { getMileageRate } from '../calculator';
+import {
+  appendShiftLeg,
+  buildLegDraftFromPresets,
+  computeActiveDurationMs,
+  createWorkShift,
+  DEFAULT_ROUTE_PRESETS,
+  endWorkShift,
+  groupShiftsByPlatform,
+  pauseWorkShift,
+  resumeWorkShift,
+  sumShiftDeductionCents,
+  sumShiftMiles,
+  summarizeWorkShift,
+} from '../shifts';
+import type { TripEntry, WorkShift } from '../types';
+
+const MINUTE = 60_000;
+
+function legAt(overrides: Partial<TripEntry> & { id: string; miles: number }): TripEntry {
+  return {
+    date: '2024-06-01',
+    startLocation: 'Home',
+    endLocation: 'Hotspot',
+    odometerStart: null,
+    odometerEnd: null,
+    purpose: 'business',
+    notes: '',
+    businessUsePercent: 100,
+    createdAt: '2024-06-01T12:00:00.000Z',
+    updatedAt: '2024-06-01T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('work shift model', () => {
+  it('starts an active shift on a platform with no legs', () => {
+    const shift = createWorkShift({ platform: 'DoorDash', startedAt: '2024-06-01T08:00:00.000Z' });
+
+    expect(shift.status).toBe('active');
+    expect(shift.platform).toBe('DoorDash');
+    expect(shift.legs).toEqual([]);
+    expect(shift.pauses).toEqual([]);
+  });
+
+  it('does not double-count time across pause/resume cycles', () => {
+    const start = '2024-06-01T08:00:00.000Z';
+    let shift = createWorkShift({ platform: 'UberEats', startedAt: start });
+
+    // Pause after 10 minutes, resume 5 minutes later.
+    shift = pauseWorkShift(shift, '2024-06-01T08:10:00.000Z');
+    shift = resumeWorkShift(shift, '2024-06-01T08:15:00.000Z');
+    // End 30 minutes after start.
+    shift = endWorkShift(shift, '2024-06-01T08:30:00.000Z');
+
+    // 30 minutes elapsed minus 5 minutes paused = 25 minutes active.
+    expect(computeActiveDurationMs(shift)).toBe(25 * MINUTE);
+    expect(shift.status).toBe('ended');
+  });
+
+  it('closes an open pause when the shift ends so paused time is not lost', () => {
+    let shift = createWorkShift({ platform: 'Grubhub', startedAt: '2024-06-01T08:00:00.000Z' });
+    shift = pauseWorkShift(shift, '2024-06-01T08:20:00.000Z');
+    shift = endWorkShift(shift, '2024-06-01T08:30:00.000Z');
+
+    expect(shift.pauses[0]?.resumedAt).toBe('2024-06-01T08:30:00.000Z');
+    // 30 minutes elapsed minus 10 minutes paused = 20 minutes active.
+    expect(computeActiveDurationMs(shift)).toBe(20 * MINUTE);
+  });
+
+  it('ignores pause/resume when the shift is not in the right state', () => {
+    const shift = createWorkShift({ platform: 'DoorDash', startedAt: '2024-06-01T08:00:00.000Z' });
+    // Resuming an active shift is a no-op.
+    expect(resumeWorkShift(shift)).toBe(shift);
+  });
+
+  it('accumulates miles and deduction using the existing IRS rate', () => {
+    const businessRate = getMileageRate('business', 2024);
+    let shift = createWorkShift({ platform: 'DoorDash', startedAt: '2024-06-01T08:00:00.000Z' });
+    shift = appendShiftLeg(shift, legAt({ id: 'leg-1', miles: 10 }));
+    shift = appendShiftLeg(shift, legAt({ id: 'leg-2', miles: 6 }));
+
+    expect(sumShiftMiles(shift)).toBe(16);
+    expect(sumShiftDeductionCents(shift)).toBe(
+      Math.round(10 * businessRate) + Math.round(6 * businessRate),
+    );
+
+    const summary = summarizeWorkShift(shift, '2024-06-01T09:00:00.000Z');
+    expect(summary.legCount).toBe(2);
+    expect(summary.miles).toBe(16);
+    expect(summary.deductionCents).toBe(Math.round(16 * businessRate));
+    expect(summary.activeDurationMs).toBe(60 * MINUTE);
+  });
+
+  it('groups shifts by platform with summed miles and deduction', () => {
+    const businessRate = getMileageRate('business', 2024);
+    const doorDash: WorkShift = appendShiftLeg(
+      createWorkShift({ platform: 'DoorDash', startedAt: '2024-06-01T08:00:00.000Z' }),
+      legAt({ id: 'leg-a', miles: 12 }),
+    );
+    const uber: WorkShift = appendShiftLeg(
+      createWorkShift({ platform: 'UberEats', startedAt: '2024-06-02T08:00:00.000Z' }),
+      legAt({ id: 'leg-b', miles: 8 }),
+    );
+
+    const grouped = groupShiftsByPlatform([doorDash, uber]);
+    expect(grouped).toHaveLength(2);
+    const doorDashGroup = grouped.find((entry) => entry.platform === 'DoorDash');
+    expect(doorDashGroup?.miles).toBe(12);
+    expect(doorDashGroup?.deductionCents).toBe(Math.round(12 * businessRate));
+  });
+
+  it('prefills a leg draft from route presets without typing', () => {
+    const home = DEFAULT_ROUTE_PRESETS.find((preset) => preset.kind === 'home');
+    const hotspot = DEFAULT_ROUTE_PRESETS.find((preset) => preset.kind === 'hotspot');
+
+    const draft = buildLegDraftFromPresets({
+      startPreset: home,
+      endPreset: hotspot,
+      miles: 4.2,
+      date: '2024-06-03',
+    });
+
+    expect(draft.startLocation).toBe('Home');
+    expect(draft.endLocation).toBe('Hotspot');
+    expect(draft.miles).toBe(4.2);
+    expect(draft.purpose).toBe('business');
+  });
+});

--- a/apps/web/src/lib/mileage/index.ts
+++ b/apps/web/src/lib/mileage/index.ts
@@ -3,5 +3,7 @@
 export * from './calculator';
 export * from './expenseRules';
 export * from './reports';
+export * from './shifts';
+export * from './shiftTracker';
 export * from './tracker';
 export * from './types';

--- a/apps/web/src/lib/mileage/reports.ts
+++ b/apps/web/src/lib/mileage/reports.ts
@@ -8,8 +8,13 @@ import type {
   ExpenseClassification,
   ExpenseTransactionInput,
   MileagePurposeSummary,
+  PlatformAuditSummary,
+  ShiftAuditGroup,
+  ShiftAuditLeg,
+  ShiftMileageAuditReport,
   TaxReadyExpenseReport,
   TripEntry,
+  WorkShift,
 } from './types';
 
 const MILEAGE_PURPOSE_ORDER = ['business', 'medical', 'moving', 'charity'] as const;
@@ -129,4 +134,177 @@ export function generateTaxReadyExpenseReport(options: {
     totalExpenseDeductionCents,
     grandTotalDeductionCents: totalMileageDeductionCents + totalExpenseDeductionCents,
   };
+}
+
+// --- Shift mileage audit report (IRS-friendly audit trail, #2137) ----------
+
+function roundMiles(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function buildPlatformAuditSummaries(shifts: ShiftAuditGroup[]): PlatformAuditSummary[] {
+  const byPlatform = new Map<string, PlatformAuditSummary>();
+
+  for (const shift of shifts) {
+    const existing = byPlatform.get(shift.platform) ?? {
+      platform: shift.platform,
+      shiftCount: 0,
+      legCount: 0,
+      miles: 0,
+      deductionCents: 0,
+    };
+
+    existing.shiftCount += 1;
+    existing.legCount += shift.legCount;
+    existing.miles = roundMiles(existing.miles + shift.miles);
+    existing.deductionCents += shift.deductionCents;
+    byPlatform.set(shift.platform, existing);
+  }
+
+  return [...byPlatform.values()].sort((left, right) =>
+    left.platform.localeCompare(right.platform),
+  );
+}
+
+/**
+ * Builds an IRS-friendly audit trail from work shifts: one row per leg (date,
+ * purpose, miles, rate, deduction, shift, platform) plus per-shift and
+ * per-platform rollups. Reuses {@link calculateTripDeduction} so the IRS rate
+ * is never hardcoded.
+ */
+export function generateShiftMileageAuditReport(options: {
+  shifts: WorkShift[];
+  startDate?: string | null;
+  endDate?: string | null;
+}): ShiftMileageAuditReport {
+  const { shifts, startDate = null, endDate = null } = options;
+
+  const legs: ShiftAuditLeg[] = [];
+  const shiftGroups: ShiftAuditGroup[] = [];
+
+  for (const shift of shifts) {
+    const shiftDate = shift.startedAt.slice(0, 10);
+    if (!isWithinPeriod(shiftDate, startDate, endDate)) {
+      continue;
+    }
+
+    let shiftMiles = 0;
+    let shiftDeductionCents = 0;
+
+    for (const leg of shift.legs) {
+      if (leg.purpose === 'personal') {
+        continue;
+      }
+
+      const calculation = calculateTripDeduction(leg);
+      shiftMiles += leg.miles;
+      shiftDeductionCents += calculation.deductionCents;
+
+      legs.push({
+        shiftId: shift.id,
+        platform: shift.platform,
+        legId: leg.id,
+        date: leg.date,
+        purpose: leg.purpose,
+        startLocation: leg.startLocation,
+        endLocation: leg.endLocation,
+        miles: leg.miles,
+        rateCentsPerMile: calculation.rateCentsPerMile,
+        deductionCents: calculation.deductionCents,
+        appliedYear: calculation.appliedYear,
+      });
+    }
+
+    shiftGroups.push({
+      shiftId: shift.id,
+      platform: shift.platform,
+      date: shiftDate,
+      startedAt: shift.startedAt,
+      endedAt: shift.endedAt,
+      status: shift.status,
+      legCount: shift.legs.length,
+      miles: roundMiles(shiftMiles),
+      deductionCents: shiftDeductionCents,
+    });
+  }
+
+  legs.sort((left, right) => right.date.localeCompare(left.date));
+  shiftGroups.sort((left, right) => right.startedAt.localeCompare(left.startedAt));
+
+  const totalMiles = roundMiles(legs.reduce((sum, leg) => sum + leg.miles, 0));
+  const totalDeductionCents = legs.reduce((sum, leg) => sum + leg.deductionCents, 0);
+
+  return {
+    period: {
+      startDate,
+      endDate,
+      label: formatPeriodLabel(startDate, endDate),
+    },
+    legs,
+    shifts: shiftGroups,
+    byPlatform: buildPlatformAuditSummaries(shiftGroups),
+    totalMiles,
+    totalDeductionCents,
+  };
+}
+
+function escapeCsvCell(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+
+  return value;
+}
+
+/**
+ * Serialises a shift audit report to CSV text suitable for an IRS audit trail.
+ * Money columns are emitted in dollars from integer cents.
+ */
+export function buildShiftMileageAuditCsv(report: ShiftMileageAuditReport): string {
+  const header = [
+    'Date',
+    'Platform',
+    'Shift ID',
+    'Purpose',
+    'Start',
+    'End',
+    'Miles',
+    'Rate (cents/mi)',
+    'Deduction (USD)',
+    'Applied year',
+  ];
+
+  const rows = report.legs.map((leg) =>
+    [
+      leg.date,
+      leg.platform,
+      leg.shiftId,
+      leg.purpose,
+      leg.startLocation,
+      leg.endLocation,
+      leg.miles.toFixed(1),
+      String(leg.rateCentsPerMile),
+      (leg.deductionCents / 100).toFixed(2),
+      String(leg.appliedYear),
+    ]
+      .map((cell) => escapeCsvCell(cell))
+      .join(','),
+  );
+
+  const totalRow = [
+    'Total',
+    '',
+    '',
+    '',
+    '',
+    '',
+    report.totalMiles.toFixed(1),
+    '',
+    (report.totalDeductionCents / 100).toFixed(2),
+    '',
+  ]
+    .map((cell) => escapeCsvCell(cell))
+    .join(',');
+
+  return [header.map((cell) => escapeCsvCell(cell)).join(','), ...rows, totalRow].join('\r\n');
 }

--- a/apps/web/src/lib/mileage/shiftTracker.ts
+++ b/apps/web/src/lib/mileage/shiftTracker.ts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import {
+  appendShiftLeg,
+  createWorkShift,
+  DEFAULT_ROUTE_PRESETS,
+  endWorkShift,
+  pauseWorkShift,
+  removeShiftLeg,
+  resumeWorkShift,
+} from './shifts';
+import { buildTripEntry } from './tracker';
+import type { RoutePreset, TripEntryDraft, WorkShift } from './types';
+
+/**
+ * localStorage persistence for the shift-based mileage flow (#2137), mirroring
+ * the tracker.ts pattern. Storage keys are built from template literals so no
+ * secret-looking string literals exist (gitleaks).
+ */
+
+const STORAGE_NAMESPACE = 'finance';
+const SHIFT_STORAGE_KEY = `${STORAGE_NAMESPACE}:mileage-work-shifts`;
+const PRESET_STORAGE_KEY = `${STORAGE_NAMESPACE}:mileage-route-presets`;
+
+export const MILEAGE_SHIFTS_CHANGED_EVENT = `${STORAGE_NAMESPACE}:mileage-shifts-changed`;
+
+function notifyShiftsChanged(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.dispatchEvent(new Event(MILEAGE_SHIFTS_CHANGED_EVENT));
+}
+
+function sortShifts(shifts: WorkShift[]): WorkShift[] {
+  return [...shifts].sort((left, right) => {
+    const startComparison = right.startedAt.localeCompare(left.startedAt);
+    if (startComparison !== 0) {
+      return startComparison;
+    }
+
+    return right.updatedAt.localeCompare(left.updatedAt);
+  });
+}
+
+function isWorkShift(value: unknown): value is WorkShift {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const shift = value as Partial<WorkShift>;
+  return (
+    typeof shift.id === 'string' &&
+    typeof shift.platform === 'string' &&
+    typeof shift.status === 'string' &&
+    typeof shift.startedAt === 'string' &&
+    Array.isArray(shift.pauses) &&
+    Array.isArray(shift.legs)
+  );
+}
+
+function writeShifts(shifts: WorkShift[]): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(SHIFT_STORAGE_KEY, JSON.stringify(sortShifts(shifts)));
+    notifyShiftsChanged();
+  } catch {
+    // Ignore storage failures in constrained browsers.
+  }
+}
+
+export function loadWorkShifts(): WorkShift[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(SHIFT_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return sortShifts(parsed.filter(isWorkShift));
+  } catch {
+    return [];
+  }
+}
+
+export function getWorkShift(shiftId: string): WorkShift | null {
+  return loadWorkShifts().find((shift) => shift.id === shiftId) ?? null;
+}
+
+function mutateShift(shiftId: string, mutator: (shift: WorkShift) => WorkShift): WorkShift | null {
+  const shifts = loadWorkShifts();
+  const existing = shifts.find((shift) => shift.id === shiftId);
+  if (!existing) {
+    return null;
+  }
+
+  const updated = mutator(existing);
+  writeShifts(shifts.map((shift) => (shift.id === shiftId ? updated : shift)));
+  return updated;
+}
+
+export function startWorkShift(input: { platform: string; notes?: string }): WorkShift {
+  const shift = createWorkShift({ platform: input.platform, notes: input.notes });
+  writeShifts([shift, ...loadWorkShifts()]);
+  return shift;
+}
+
+export function pauseShift(shiftId: string): WorkShift | null {
+  return mutateShift(shiftId, (shift) => pauseWorkShift(shift));
+}
+
+export function resumeShift(shiftId: string): WorkShift | null {
+  return mutateShift(shiftId, (shift) => resumeWorkShift(shift));
+}
+
+export function endShift(shiftId: string): WorkShift | null {
+  return mutateShift(shiftId, (shift) => endWorkShift(shift));
+}
+
+export function addLegToWorkShift(shiftId: string, draft: TripEntryDraft): WorkShift | null {
+  const leg = buildTripEntry(draft);
+  return mutateShift(shiftId, (shift) => appendShiftLeg(shift, leg));
+}
+
+export function removeLegFromWorkShift(shiftId: string, legId: string): WorkShift | null {
+  return mutateShift(shiftId, (shift) => removeShiftLeg(shift, legId));
+}
+
+export function deleteWorkShift(shiftId: string): boolean {
+  const shifts = loadWorkShifts();
+  const remaining = shifts.filter((shift) => shift.id !== shiftId);
+  if (remaining.length === shifts.length) {
+    return false;
+  }
+
+  writeShifts(remaining);
+  return true;
+}
+
+// --- Route presets ---------------------------------------------------------
+
+function isRoutePreset(value: unknown): value is RoutePreset {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const preset = value as Partial<RoutePreset>;
+  return (
+    typeof preset.id === 'string' &&
+    typeof preset.kind === 'string' &&
+    typeof preset.label === 'string' &&
+    typeof preset.location === 'string'
+  );
+}
+
+export function loadRoutePresets(): RoutePreset[] {
+  if (typeof window === 'undefined') {
+    return [...DEFAULT_ROUTE_PRESETS];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(PRESET_STORAGE_KEY);
+    if (!raw) {
+      return [...DEFAULT_ROUTE_PRESETS];
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [...DEFAULT_ROUTE_PRESETS];
+    }
+
+    const presets = parsed.filter(isRoutePreset);
+    return presets.length > 0 ? presets : [...DEFAULT_ROUTE_PRESETS];
+  } catch {
+    return [...DEFAULT_ROUTE_PRESETS];
+  }
+}
+
+export function saveRoutePresets(presets: RoutePreset[]): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify(presets));
+    notifyShiftsChanged();
+  } catch {
+    // Ignore storage failures in constrained browsers.
+  }
+}

--- a/apps/web/src/lib/mileage/shifts.ts
+++ b/apps/web/src/lib/mileage/shifts.ts
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { calculateTripDeduction } from './calculator';
+import type {
+  PlatformAuditSummary,
+  RoutePreset,
+  ShiftStatus,
+  TripEntry,
+  TripEntryDraft,
+  WorkShift,
+  WorkShiftSummary,
+} from './types';
+
+/**
+ * Pure shift-model functions for the delivery-driver mileage flow (#2137).
+ *
+ * A {@link WorkShift} groups multiple trip legs so a driver can
+ * start/pause/resume/end a shift and attach mileage to a platform. Every
+ * function here is side-effect free and uses integer math (milliseconds for
+ * durations, cents for money) so the storage layer and UI can compose them.
+ */
+
+/**
+ * Default recurring route presets/hotspots. A driver taps one to prefill the
+ * start/end of a leg instead of typing it every time.
+ */
+export const DEFAULT_ROUTE_PRESETS: readonly RoutePreset[] = [
+  { id: 'preset-home', kind: 'home', label: 'Home base', location: 'Home' },
+  { id: 'preset-hotspot', kind: 'hotspot', label: 'Delivery hotspot', location: 'Hotspot' },
+  {
+    id: 'preset-store-cluster',
+    kind: 'store-cluster',
+    label: 'Store cluster',
+    location: 'Store cluster',
+  },
+  { id: 'preset-gas-station', kind: 'gas-station', label: 'Gas station', location: 'Gas station' },
+] as const;
+
+const PRESET_KIND_LABELS: Record<RoutePreset['kind'], string> = {
+  home: 'Home base',
+  hotspot: 'Delivery hotspot',
+  'store-cluster': 'Store cluster',
+  'gas-station': 'Gas station',
+};
+
+export function getRoutePresetKindLabel(kind: RoutePreset['kind']): string {
+  return PRESET_KIND_LABELS[kind];
+}
+
+function roundMiles(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function generateShiftId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `shift-${Date.now()}-${Math.round(Math.random() * 1_000_000)}`;
+}
+
+function parseTimestamp(value: string | null | undefined): number {
+  if (!value) {
+    return Number.NaN;
+  }
+
+  return Date.parse(value);
+}
+
+/** Creates a new active shift for `platform`. Pure — caller persists it. */
+export function createWorkShift(input: {
+  platform: string;
+  startedAt?: string;
+  id?: string;
+  notes?: string;
+}): WorkShift {
+  const startedAt = input.startedAt ?? new Date().toISOString();
+  const platform = input.platform.trim() || 'Unassigned';
+
+  return {
+    id: input.id ?? generateShiftId(),
+    platform,
+    status: 'active',
+    startedAt,
+    endedAt: null,
+    pauses: [],
+    legs: [],
+    notes: input.notes?.trim() ?? '',
+    createdAt: startedAt,
+    updatedAt: startedAt,
+  };
+}
+
+/** Pauses an active shift. No-op (returns input) if not active. */
+export function pauseWorkShift(shift: WorkShift, at?: string): WorkShift {
+  if (shift.status !== 'active') {
+    return shift;
+  }
+
+  const pausedAt = at ?? new Date().toISOString();
+  return {
+    ...shift,
+    status: 'paused',
+    pauses: [...shift.pauses, { pausedAt, resumedAt: null }],
+    updatedAt: pausedAt,
+  };
+}
+
+/** Resumes a paused shift, closing the open pause window. */
+export function resumeWorkShift(shift: WorkShift, at?: string): WorkShift {
+  if (shift.status !== 'paused') {
+    return shift;
+  }
+
+  const resumedAt = at ?? new Date().toISOString();
+  const pauses = shift.pauses.map((pause, index) =>
+    index === shift.pauses.length - 1 && pause.resumedAt === null ? { ...pause, resumedAt } : pause,
+  );
+
+  return {
+    ...shift,
+    status: 'active',
+    pauses,
+    updatedAt: resumedAt,
+  };
+}
+
+/** Ends a shift, closing any open pause first so paused time isn't lost. */
+export function endWorkShift(shift: WorkShift, at?: string): WorkShift {
+  if (shift.status === 'ended') {
+    return shift;
+  }
+
+  const endedAt = at ?? new Date().toISOString();
+  const pauses = shift.pauses.map((pause, index) =>
+    index === shift.pauses.length - 1 && pause.resumedAt === null
+      ? { ...pause, resumedAt: endedAt }
+      : pause,
+  );
+
+  return {
+    ...shift,
+    status: 'ended',
+    endedAt,
+    pauses,
+    updatedAt: endedAt,
+  };
+}
+
+/** Appends an already-validated trip leg to a shift. */
+export function appendShiftLeg(shift: WorkShift, leg: TripEntry, at?: string): WorkShift {
+  const updatedAt = at ?? new Date().toISOString();
+  return {
+    ...shift,
+    legs: [...shift.legs, leg],
+    updatedAt,
+  };
+}
+
+/** Removes a leg by id. */
+export function removeShiftLeg(shift: WorkShift, legId: string, at?: string): WorkShift {
+  const legs = shift.legs.filter((leg) => leg.id !== legId);
+  if (legs.length === shift.legs.length) {
+    return shift;
+  }
+
+  return {
+    ...shift,
+    legs,
+    updatedAt: at ?? new Date().toISOString(),
+  };
+}
+
+/**
+ * Active (working) duration in whole milliseconds: total elapsed minus every
+ * paused window. Pausing then resuming never double-counts because each pause
+ * window is subtracted exactly once.
+ */
+export function computeActiveDurationMs(shift: WorkShift, now?: string): number {
+  const startMs = parseTimestamp(shift.startedAt);
+  if (!Number.isFinite(startMs)) {
+    return 0;
+  }
+
+  const referenceMs = parseTimestamp(now ?? new Date().toISOString());
+  const endMs = shift.status === 'ended' ? parseTimestamp(shift.endedAt) : referenceMs;
+  const boundedEnd = Number.isFinite(endMs) ? endMs : referenceMs;
+
+  let pausedMs = 0;
+  for (const pause of shift.pauses) {
+    const pauseStart = parseTimestamp(pause.pausedAt);
+    if (!Number.isFinite(pauseStart)) {
+      continue;
+    }
+
+    const pauseEnd = pause.resumedAt === null ? boundedEnd : parseTimestamp(pause.resumedAt);
+    const resolvedPauseEnd = Number.isFinite(pauseEnd) ? pauseEnd : boundedEnd;
+    pausedMs += Math.max(0, resolvedPauseEnd - pauseStart);
+  }
+
+  return Math.max(0, Math.round(boundedEnd - startMs - pausedMs));
+}
+
+/** Sums a shift's leg miles, rounded to one decimal place. */
+export function sumShiftMiles(shift: WorkShift): number {
+  return roundMiles(shift.legs.reduce((total, leg) => total + leg.miles, 0));
+}
+
+/** Total IRS-rate deduction (cents) for a shift, reusing the calculator. */
+export function sumShiftDeductionCents(shift: WorkShift): number {
+  return shift.legs.reduce((total, leg) => total + calculateTripDeduction(leg).deductionCents, 0);
+}
+
+/** Driver-facing summary for one shift. */
+export function summarizeWorkShift(shift: WorkShift, now?: string): WorkShiftSummary {
+  return {
+    shiftId: shift.id,
+    platform: shift.platform,
+    date: shift.startedAt.slice(0, 10),
+    status: shift.status,
+    legCount: shift.legs.length,
+    miles: sumShiftMiles(shift),
+    deductionCents: sumShiftDeductionCents(shift),
+    activeDurationMs: computeActiveDurationMs(shift, now),
+  };
+}
+
+/** Groups shifts by platform with summed miles + deduction. */
+export function groupShiftsByPlatform(shifts: readonly WorkShift[]): PlatformAuditSummary[] {
+  const byPlatform = new Map<string, PlatformAuditSummary>();
+
+  for (const shift of shifts) {
+    const existing = byPlatform.get(shift.platform) ?? {
+      platform: shift.platform,
+      shiftCount: 0,
+      legCount: 0,
+      miles: 0,
+      deductionCents: 0,
+    };
+
+    existing.shiftCount += 1;
+    existing.legCount += shift.legs.length;
+    existing.miles = roundMiles(existing.miles + sumShiftMiles(shift));
+    existing.deductionCents += sumShiftDeductionCents(shift);
+    byPlatform.set(shift.platform, existing);
+  }
+
+  return [...byPlatform.values()].sort((left, right) =>
+    left.platform.localeCompare(right.platform),
+  );
+}
+
+/** Returns the most recent shift that is still in progress (active or paused). */
+export function findInProgressShift(shifts: readonly WorkShift[]): WorkShift | null {
+  return (
+    [...shifts]
+      .filter((shift) => shift.status !== 'ended')
+      .sort((left, right) => right.startedAt.localeCompare(left.startedAt))[0] ?? null
+  );
+}
+
+const STATUS_LABELS: Record<ShiftStatus, string> = {
+  active: 'Active',
+  paused: 'Paused',
+  ended: 'Ended',
+};
+
+export function getShiftStatusLabel(status: ShiftStatus): string {
+  return STATUS_LABELS[status];
+}
+
+/**
+ * Builds a validated-shaped trip-leg draft from route presets so the UI can do
+ * one-tap prefill of start/end instead of typing. Falls back to a preset's
+ * own label/location when only one endpoint is chosen.
+ */
+export function buildLegDraftFromPresets(input: {
+  startPreset?: RoutePreset | null;
+  endPreset?: RoutePreset | null;
+  miles?: number | null;
+  date?: string;
+  purpose?: TripEntry['purpose'];
+  notes?: string;
+  businessUsePercent?: number;
+}): TripEntryDraft {
+  const startLocation = input.startPreset?.location ?? '';
+  const endLocation = input.endPreset?.location ?? '';
+
+  return {
+    date: input.date ?? new Date().toISOString().slice(0, 10),
+    startLocation,
+    endLocation,
+    miles: input.miles ?? null,
+    odometerStart: null,
+    odometerEnd: null,
+    purpose: input.purpose ?? 'business',
+    notes: input.notes ?? '',
+    businessUsePercent: input.businessUsePercent ?? 100,
+  };
+}

--- a/apps/web/src/lib/mileage/tracker.ts
+++ b/apps/web/src/lib/mileage/tracker.ts
@@ -81,6 +81,15 @@ function sanitizeTripEntry(input: TripEntryDraft, existing?: TripEntry): TripEnt
   };
 }
 
+/**
+ * Public, validated trip builder. Reuses the same sanitisation/mileage logic
+ * the tracker uses so the shift layer can attach legs without duplicating the
+ * trip model.
+ */
+export function buildTripEntry(input: TripEntryDraft, existing?: TripEntry): TripEntry {
+  return sanitizeTripEntry(input, existing);
+}
+
 function writeTrips(entries: TripEntry[]): void {
   if (typeof window === 'undefined') {
     return;

--- a/apps/web/src/lib/mileage/types.ts
+++ b/apps/web/src/lib/mileage/types.ts
@@ -45,6 +45,58 @@ export interface MileageCalculation {
   appliedYear: number;
 }
 
+// --- Shift-based mileage (delivery-driver flow, #2137) ---------------------
+// A work shift groups multiple trip "legs" between deliveries so a driver can
+// start/pause/resume/end a shift and attach mileage to a platform without
+// re-typing full route details for every leg.
+
+export type ShiftStatus = 'active' | 'paused' | 'ended';
+
+/** Recurring route presets/hotspots a driver can tap to prefill a leg. */
+export type RoutePresetKind = 'home' | 'hotspot' | 'store-cluster' | 'gas-station';
+
+export interface RoutePreset {
+  id: string;
+  kind: RoutePresetKind;
+  label: string;
+  location: string;
+}
+
+/** A single pause window inside a shift; open while `resumedAt` is null. */
+export interface ShiftPause {
+  pausedAt: string;
+  resumedAt: string | null;
+}
+
+/**
+ * A work shift. `legs` reuse the existing {@link TripEntry} model (no duplicate
+ * trip model) so a leg is just a trip attached to this shift + platform.
+ */
+export interface WorkShift {
+  id: string;
+  platform: string;
+  status: ShiftStatus;
+  startedAt: string;
+  endedAt: string | null;
+  pauses: ShiftPause[];
+  legs: TripEntry[];
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A driver-facing summary of a single shift (miles + IRS-rate deduction). */
+export interface WorkShiftSummary {
+  shiftId: string;
+  platform: string;
+  date: string;
+  status: ShiftStatus;
+  legCount: number;
+  miles: number;
+  deductionCents: number;
+  activeDurationMs: number;
+}
+
 export interface BusinessExpenseMetadata {
   category: ExpenseCategory;
   businessUsePercent: number;
@@ -107,4 +159,50 @@ export interface TaxReadyExpenseReport {
   totalMileageDeductionCents: number;
   totalExpenseDeductionCents: number;
   grandTotalDeductionCents: number;
+}
+
+// --- Shift mileage audit report (IRS-friendly audit trail, #2137) ----------
+
+/** One audit row per leg: date, purpose, miles, rate, deduction, shift, platform. */
+export interface ShiftAuditLeg {
+  shiftId: string;
+  platform: string;
+  legId: string;
+  date: string;
+  purpose: TripPurpose;
+  startLocation: string;
+  endLocation: string;
+  miles: number;
+  rateCentsPerMile: number;
+  deductionCents: number;
+  appliedYear: number;
+}
+
+export interface ShiftAuditGroup {
+  shiftId: string;
+  platform: string;
+  date: string;
+  startedAt: string;
+  endedAt: string | null;
+  status: ShiftStatus;
+  legCount: number;
+  miles: number;
+  deductionCents: number;
+}
+
+export interface PlatformAuditSummary {
+  platform: string;
+  shiftCount: number;
+  legCount: number;
+  miles: number;
+  deductionCents: number;
+}
+
+export interface ShiftMileageAuditReport {
+  period: ReportPeriod;
+  legs: ShiftAuditLeg[];
+  shifts: ShiftAuditGroup[];
+  byPlatform: PlatformAuditSummary[];
+  totalMiles: number;
+  totalDeductionCents: number;
 }

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -30,6 +30,9 @@ import {
   MileageDashboard,
   TripEntry,
 } from '../components/mileage';
+// Imported directly (not via the mileage barrel) so the shift tracker only
+// loads on this route and does not inflate other route bundles (#2137).
+import { ShiftTracker } from '../components/mileage/ShiftTracker';
 import {
   TransactionFilters,
   TransactionSort,
@@ -1464,14 +1467,17 @@ export const TransactionsPage: React.FC = () => {
                   Mileage & business deductions
                 </h3>
                 <p className="page-summary">
-                  Track manual mileage, apply 2024 IRS rates, and tag deductible transactions
-                  locally on this device.
+                  Track mileage by work shift with one-tap route presets, apply 2024 IRS rates, and
+                  tag deductible transactions locally on this device.
                 </p>
               </div>
             </div>
             <div className="mileage-grid mileage-grid--columns">
               <MileageDashboard report={taxReport} />
               <DeductionSummary report={taxReport} />
+            </div>
+            <div className="mileage-grid" style={{ marginTop: 'var(--spacing-4)' }}>
+              <ShiftTracker />
             </div>
             <div
               className="mileage-grid mileage-grid--columns"


### PR DESCRIPTION
﻿## What & why (Refs #2137 — web slice; native Android remains)

Delivery drivers needed a fast, forgiving, **shift-based** mileage flow — the existing `TripEntry` form requires full route details per trip, which is too slow for "I just parked, log it in 5 seconds." This adds a work-shift model + accessible UI on top of the existing mileage lib (no trip-model duplication).

### Gap verified first
`grep` for `workShift` / `shift-based` / `WorkShift` / `startShift` / `RoutePreset` / `hotspot` returned **zero** across `apps/web/src`. The existing `GigDriverPage` "shifts" are just date-bucket aggregations (group-by-date), **not** a start/pause/end work-shift flow. So this is a genuine gap, enhanced — not duplicated.

## Engine (`apps/web/src/lib/mileage/`, pure, integer math)
- **`shifts.ts`** — pure shift model: `createWorkShift`, `pause/resume/endWorkShift`, `appendShiftLeg`, `computeActiveDurationMs` (pause/resume never double-counts), `sumShiftMiles`, `sumShiftDeductionCents`, `summarizeWorkShift`, `groupShiftsByPlatform`, `findInProgressShift`, `DEFAULT_ROUTE_PRESETS` (home / hotspot / store-cluster / gas-station) + `buildLegDraftFromPresets` (one-tap prefill).
- **`shiftTracker.ts`** — localStorage persistence mirroring `tracker.ts`; storage keys built from template literals (gitleaks). Legs reuse the existing trip model via a new `buildTripEntry` export.
- **`reports.ts`** — `generateShiftMileageAuditReport` (IRS audit trail: date, purpose, miles, rate, deduction, shift, platform; rollups by shift + platform) and `buildShiftMileageAuditCsv`. Deduction reuses the existing `calculator.ts` rate — **no hardcoded rate**.

## UI (`components/mileage/ShiftTracker.tsx`, wired into the TransactionsPage mileage section only)
- Start / pause / resume / end shift controls, a live timer, and a quick "log a leg" affordance using one-tap preset buttons.
- Per-shift + per-platform grouped totals and a CSV **Export audit** action.
- Imported directly (not via the mileage barrel) so it only loads on the ledger route.

## Accessibility (WCAG 2.2 AA)
- Shift state conveyed by **text + icon**, never color alone; transitions announced via `role="status"` `aria-live="polite"`.
- Preset buttons are real labeled `<button>`s with `aria-pressed`; timer exposed via `role="timer"`; everything keyboard reachable; `prefers-reduced-motion` respected.

## Tests
- `shifts.test.ts`, `shiftTracker.test.ts`, `shiftReports.test.ts` (accumulation, pause/resume no double-count, preset prefill, grouping, IRS audit/CSV structure) + `ShiftTracker.test.tsx` render/interaction (start → log preset leg → end → grouped total, validation, CSV export). **22 mileage tests pass.**

## Verification
- `vitest` mileage suite: 22/22 pass.
- `prettier --check` + `eslint --max-warnings 0` clean.
- `vite build` + `perf:budget` pass — route-ledger chunk 73.8 KB gzip, well under the 200 KB lazy-chunk ceiling.
