### PR TITLE
feat(web): receipt-to-expense with COGS mapping and image attachment (#2183)

### DIFF
--- a/apps/web/src/lib/expenses/index.ts
+++ b/apps/web/src/lib/expenses/index.ts
@@ -8,3 +8,4 @@ export * from './extra-payment-sim';
 export * from './debt-interest';
 export * from './expense-separation';
 export * from './debt-settlement';
+export * from './receipt-expense-draft';

--- a/apps/web/src/lib/expenses/receipt-expense-draft.test.ts
+++ b/apps/web/src/lib/expenses/receipt-expense-draft.test.ts
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the receipt → expense draft engine (#2183).
+ *
+ * Verifies OCR-result → draft mapping, per-bucket subtotal math (exact cents),
+ * reconciliation mismatch detection, attachment handling, and serialisation to
+ * the transactions data path.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { ExtractedReceiptLineItem, ExtractedReceiptText } from '../import';
+import {
+  assignLineItemBucket,
+  attachReceiptImage,
+  buildReceiptAttachmentStorageKey,
+  classifyLineItemBucket,
+  computeBucketSubtotals,
+  computeMappedTotalCents,
+  createReceiptExpenseDraft,
+  draftToTransactionCustomFields,
+  draftToTransactionTags,
+  reconcileDraft,
+  toggleLineItemIncluded,
+  type ReceiptAttachmentRef,
+} from './receipt-expense-draft';
+
+function makeLineItem(overrides: Partial<ExtractedReceiptLineItem> = {}): ExtractedReceiptLineItem {
+  return {
+    description: 'Item',
+    total: 100,
+    quantity: null,
+    suggestedCategory: null,
+    suggestedCategoryId: null,
+    categoryAccepted: false,
+    ...overrides,
+  };
+}
+
+function makeReceipt(overrides: Partial<ExtractedReceiptText> = {}): ExtractedReceiptText {
+  return {
+    merchant: 'Restaurant Depot',
+    date: '2026-02-14',
+    total: 5000,
+    currency: 'USD',
+    lineItems: [],
+    rawText: 'RESTAURANT DEPOT\n...',
+    confidence: 82,
+    ...overrides,
+  };
+}
+
+describe('createReceiptExpenseDraft', () => {
+  it('maps an OCR result into an editable draft with integer cents', () => {
+    const receipt = makeReceipt({
+      lineItems: [
+        makeLineItem({ description: 'Chicken breast 10lb', total: 3200 }),
+        makeLineItem({ description: 'Paper cups 100ct', total: 1800 }),
+      ],
+    });
+
+    const draft = createReceiptExpenseDraft(receipt);
+
+    expect(draft.merchant).toBe('Restaurant Depot');
+    expect(draft.dateIso).toBe('2026-02-14');
+    expect(draft.totalCents).toBe(5000);
+    expect(draft.currencyCode).toBe('USD');
+    expect(draft.lineItems).toHaveLength(2);
+    expect(draft.lineItems[0]).toMatchObject({
+      description: 'Chicken breast 10lb',
+      amountCents: 3200,
+      bucket: 'COGS',
+      included: true,
+    });
+    expect(draft.lineItems[1].bucket).toBe('supplies');
+    expect(draft.attachment).toBeNull();
+  });
+
+  it('falls back to the provided date and empty merchant when OCR is missing fields', () => {
+    const receipt = makeReceipt({ merchant: null, date: null, total: null });
+    const draft = createReceiptExpenseDraft(receipt, { fallbackDateIso: '2026-06-23' });
+
+    expect(draft.merchant).toBe('');
+    expect(draft.dateIso).toBe('2026-06-23');
+    expect(draft.totalCents).toBe(0);
+  });
+
+  it('clamps negative or fractional cents to non-negative integers', () => {
+    const receipt = makeReceipt({
+      total: -50,
+      lineItems: [makeLineItem({ description: 'x', total: 12.6 })],
+    });
+    const draft = createReceiptExpenseDraft(receipt);
+    expect(draft.totalCents).toBe(0);
+    expect(draft.lineItems[0].amountCents).toBe(13);
+  });
+});
+
+describe('classifyLineItemBucket', () => {
+  it('routes ingredient keywords to COGS', () => {
+    expect(classifyLineItemBucket(makeLineItem({ description: 'Ground beef' }))).toBe('COGS');
+  });
+
+  it('routes packaging keywords to supplies', () => {
+    expect(classifyLineItemBucket(makeLineItem({ description: 'Napkin pack' }))).toBe('supplies');
+  });
+
+  it('routes bulk markers without other hints to inventory', () => {
+    expect(classifyLineItemBucket(makeLineItem({ description: 'Case of widgets' }))).toBe(
+      'inventory',
+    );
+  });
+
+  it('uses the parser category hint when no keyword matches', () => {
+    expect(
+      classifyLineItemBucket(
+        makeLineItem({ description: 'Mystery', suggestedCategory: 'Groceries' }),
+      ),
+    ).toBe('COGS');
+    expect(
+      classifyLineItemBucket(
+        makeLineItem({ description: 'Mystery', suggestedCategory: 'Household' }),
+      ),
+    ).toBe('supplies');
+  });
+
+  it('defaults to other', () => {
+    expect(classifyLineItemBucket(makeLineItem({ description: 'Unknown thing' }))).toBe('other');
+  });
+});
+
+describe('computeBucketSubtotals', () => {
+  it('sums included line items per bucket with exact cents', () => {
+    const receipt = makeReceipt({
+      total: 6000,
+      lineItems: [
+        makeLineItem({ description: 'Beef', total: 2500 }),
+        makeLineItem({ description: 'Onion', total: 500 }),
+        makeLineItem({ description: 'Cups', total: 1200 }),
+        makeLineItem({ description: 'Case widget', total: 1800 }),
+      ],
+    });
+    const draft = createReceiptExpenseDraft(receipt);
+
+    const subtotals = computeBucketSubtotals(draft);
+    expect(subtotals.COGS).toBe(3000);
+    expect(subtotals.supplies).toBe(1200);
+    expect(subtotals.inventory).toBe(1800);
+    expect(subtotals.other).toBe(0);
+  });
+
+  it('excludes line items that are toggled off', () => {
+    const receipt = makeReceipt({
+      lineItems: [
+        makeLineItem({ description: 'Beef', total: 2500 }),
+        makeLineItem({ description: 'Onion', total: 500 }),
+      ],
+    });
+    let draft = createReceiptExpenseDraft(receipt);
+    draft = toggleLineItemIncluded(draft, 1, false);
+
+    const subtotals = computeBucketSubtotals(draft);
+    expect(subtotals.COGS).toBe(2500);
+    expect(computeMappedTotalCents(draft)).toBe(2500);
+  });
+
+  it('reflects a re-assigned bucket', () => {
+    const receipt = makeReceipt({
+      lineItems: [makeLineItem({ description: 'Beef', total: 2500 })],
+    });
+    let draft = createReceiptExpenseDraft(receipt);
+    draft = assignLineItemBucket(draft, 0, 'inventory');
+
+    const subtotals = computeBucketSubtotals(draft);
+    expect(subtotals.COGS).toBe(0);
+    expect(subtotals.inventory).toBe(2500);
+  });
+});
+
+describe('reconcileDraft', () => {
+  it('reports balanced when mapped line items equal the receipt total', () => {
+    const receipt = makeReceipt({
+      total: 3000,
+      lineItems: [
+        makeLineItem({ description: 'Beef', total: 2500 }),
+        makeLineItem({ description: 'Onion', total: 500 }),
+      ],
+    });
+    const draft = createReceiptExpenseDraft(receipt);
+
+    const result = reconcileDraft(draft);
+    expect(result.mappedTotalCents).toBe(3000);
+    expect(result.receiptTotalCents).toBe(3000);
+    expect(result.differenceCents).toBe(0);
+    expect(result.isBalanced).toBe(true);
+    expect(result.status).toBe('balanced');
+  });
+
+  it('flags an under-mapped mismatch', () => {
+    const receipt = makeReceipt({
+      total: 5000,
+      lineItems: [makeLineItem({ description: 'Beef', total: 2500 })],
+    });
+    const draft = createReceiptExpenseDraft(receipt);
+
+    const result = reconcileDraft(draft);
+    expect(result.differenceCents).toBe(-2500);
+    expect(result.isBalanced).toBe(false);
+    expect(result.status).toBe('under');
+  });
+
+  it('flags an over-mapped mismatch', () => {
+    const receipt = makeReceipt({
+      total: 1000,
+      lineItems: [
+        makeLineItem({ description: 'Beef', total: 800 }),
+        makeLineItem({ description: 'Onion', total: 400 }),
+      ],
+    });
+    const draft = createReceiptExpenseDraft(receipt);
+
+    const result = reconcileDraft(draft);
+    expect(result.differenceCents).toBe(200);
+    expect(result.status).toBe('over');
+  });
+
+  it('honours a tolerance', () => {
+    const receipt = makeReceipt({
+      total: 1000,
+      lineItems: [makeLineItem({ description: 'Beef', total: 1002 })],
+    });
+    const draft = createReceiptExpenseDraft(receipt);
+
+    expect(reconcileDraft(draft, 5).status).toBe('balanced');
+    expect(reconcileDraft(draft, 0).status).toBe('over');
+  });
+
+  it('reports unmapped when no line items are included', () => {
+    const receipt = makeReceipt({ total: 1000, lineItems: [] });
+    const draft = createReceiptExpenseDraft(receipt);
+
+    const result = reconcileDraft(draft);
+    expect(result.status).toBe('unmapped');
+    expect(result.isBalanced).toBe(false);
+  });
+});
+
+describe('attachments', () => {
+  it('builds a storage key from template literals', () => {
+    expect(buildReceiptAttachmentStorageKey('abc-123', 'receipt.jpg')).toBe(
+      'receipts/abc-123/receipt.jpg',
+    );
+  });
+
+  it('falls back to a derived name when the file name is blank', () => {
+    expect(buildReceiptAttachmentStorageKey('abc-123', '  ')).toBe(
+      'receipts/abc-123/receipt-abc-123',
+    );
+  });
+
+  it('attaches and serialises the receipt image reference', () => {
+    const receipt = makeReceipt({
+      lineItems: [makeLineItem({ description: 'Beef', total: 2500 })],
+    });
+    const attachment: ReceiptAttachmentRef = {
+      url: 'blob:mock-url',
+      fileName: 'receipt.jpg',
+      mimeType: 'image/jpeg',
+      sizeBytes: 1024,
+      storageKey: buildReceiptAttachmentStorageKey('draft-1', 'receipt.jpg'),
+      altText: 'Receipt photo from Restaurant Depot',
+    };
+    const draft = attachReceiptImage(createReceiptExpenseDraft(receipt), attachment);
+
+    expect(draft.attachment).toEqual(attachment);
+
+    const fields = draftToTransactionCustomFields(draft);
+    expect(fields.receiptImageUrl).toBe('blob:mock-url');
+    expect(fields.receiptImageStorageKey).toBe('receipts/draft-1/receipt.jpg');
+    expect(fields.receiptAltText).toBe('Receipt photo from Restaurant Depot');
+    expect(fields.receiptUploadStatus).toBe('cached');
+  });
+});
+
+describe('serialisation to the transactions data path', () => {
+  it('produces bucket tags for every non-empty bucket', () => {
+    const receipt = makeReceipt({
+      lineItems: [
+        makeLineItem({ description: 'Beef', total: 2500 }),
+        makeLineItem({ description: 'Cups', total: 1000 }),
+        makeLineItem({ description: 'Case widget', total: 800 }),
+      ],
+    });
+    const draft = createReceiptExpenseDraft(receipt);
+
+    const tags = draftToTransactionTags(draft);
+    expect(tags).toContain('receipt');
+    expect(tags).toContain('pnl:cogs');
+    expect(tags).toContain('supplies');
+    expect(tags).toContain('inventory');
+  });
+
+  it('serialises included line items with their buckets and subtotals', () => {
+    const receipt = makeReceipt({
+      total: 3500,
+      lineItems: [
+        makeLineItem({ description: 'Beef', total: 2500 }),
+        makeLineItem({ description: 'Cups', total: 1000 }),
+      ],
+    });
+    const draft = createReceiptExpenseDraft(receipt);
+
+    const fields = draftToTransactionCustomFields(draft);
+    const items = JSON.parse(fields.receiptLineItems) as Array<{ bucket: string }>;
+    expect(items).toHaveLength(2);
+    expect(items[0].bucket).toBe('COGS');
+
+    const subtotals = JSON.parse(fields.receiptBucketSubtotals) as Record<string, number>;
+    expect(subtotals.COGS).toBe(2500);
+    expect(subtotals.supplies).toBe(1000);
+    expect(fields.receiptReconciliationStatus).toBe('balanced');
+    expect(fields.receiptReconciliationDifferenceCents).toBe('0');
+  });
+});

--- a/apps/web/src/lib/expenses/receipt-expense-draft.ts
+++ b/apps/web/src/lib/expenses/receipt-expense-draft.ts
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Receipt → expense draft engine (#2183).
+ *
+ * Pure, side-effect-free functions that turn an on-device OCR receipt result
+ * into an editable **expense draft** for a food-truck (or any small business)
+ * workflow. Each extracted line item can be mapped to a cost bucket from
+ * { COGS, inventory, supplies, other } so the itemised data is usable for
+ * margin / profit-and-loss math later.
+ *
+ * Money rules:
+ *   - **Every monetary value is an integer number of cents** (e.g. $12.34 →
+ *     1234). No floats are stored or returned.
+ *
+ * This module performs no I/O. The receipt image is referenced by an opaque
+ * URL/key the caller supplies (object-URL, data-URL, or an attachment-store
+ * key) — the bytes themselves are never read here.
+ */
+
+import type { ExtractedReceiptLineItem, ExtractedReceiptText } from '../import';
+
+// ── Buckets ────────────────────────────────────────────────────────────────
+
+/** The cost buckets a receipt line item can be mapped into. */
+export type CogsBucket = 'COGS' | 'inventory' | 'supplies' | 'other';
+
+/** Stable, ordered list of every bucket (drives UI controls + iteration). */
+export const COGS_BUCKETS: readonly CogsBucket[] = ['COGS', 'inventory', 'supplies', 'other'];
+
+/** Human-readable label for a bucket (screen-reader / control text). */
+export const COGS_BUCKET_LABELS: Readonly<Record<CogsBucket, string>> = {
+  COGS: 'Cost of goods (COGS)',
+  inventory: 'Inventory',
+  supplies: 'Supplies',
+  other: 'Other',
+};
+
+/**
+ * Tags applied to the saved expense for each bucket that carries a subtotal.
+ * `COGS` maps to the `pnl:cogs` marker the profit-and-loss engine already
+ * understands, so receipts feed straight into margin math. `other` carries no
+ * marker (it falls back to the default expense bucket).
+ */
+const BUCKET_TAGS: Readonly<Record<CogsBucket, string | null>> = {
+  COGS: 'pnl:cogs',
+  inventory: 'inventory',
+  supplies: 'supplies',
+  other: null,
+};
+
+// ── Draft model ──────────────────────────────────────────────────────────────
+
+/** A single, editable line item on the expense draft. */
+export interface ReceiptDraftLineItem {
+  readonly description: string;
+  /** Line amount in integer cents (always ≥ 0). */
+  readonly amountCents: number;
+  readonly quantity: number | null;
+  /** The cost bucket this line is mapped into. */
+  readonly bucket: CogsBucket;
+  /** Whether this line is included in the saved expense + reconciliation. */
+  readonly included: boolean;
+}
+
+/** Reference to the receipt image attached to the draft. */
+export interface ReceiptAttachmentRef {
+  /** Object-URL, data-URL, or remote URL the image can be displayed from. */
+  readonly url: string;
+  readonly fileName: string;
+  readonly mimeType: string;
+  readonly sizeBytes: number;
+  /** Deterministic storage key (built from template literals). */
+  readonly storageKey: string;
+  /** Accessible description for the `<img alt>` / control label. */
+  readonly altText: string;
+}
+
+/** A reviewable expense draft built from an OCR receipt result. */
+export interface ReceiptExpenseDraft {
+  readonly merchant: string;
+  /** ISO-8601 local date (YYYY-MM-DD). */
+  readonly dateIso: string;
+  /** Receipt grand total in integer cents (always ≥ 0). */
+  readonly totalCents: number;
+  readonly currencyCode: string | null;
+  readonly lineItems: readonly ReceiptDraftLineItem[];
+  readonly attachment: ReceiptAttachmentRef | null;
+  readonly rawText: string;
+  /** OCR confidence 0–100. */
+  readonly confidence: number;
+}
+
+/** Per-bucket subtotal map in integer cents. */
+export type BucketSubtotals = Readonly<Record<CogsBucket, number>>;
+
+/** Whether mapped line items add up to the receipt total. */
+export type ReconciliationStatus = 'balanced' | 'over' | 'under' | 'unmapped';
+
+/** Result of comparing mapped line items against the receipt total. */
+export interface ReconciliationResult {
+  /** Sum of included line items, integer cents. */
+  readonly mappedTotalCents: number;
+  /** Receipt grand total, integer cents. */
+  readonly receiptTotalCents: number;
+  /** mappedTotal − receiptTotal (signed, integer cents). */
+  readonly differenceCents: number;
+  /** True when |difference| ≤ tolerance. */
+  readonly isBalanced: boolean;
+  readonly status: ReconciliationStatus;
+}
+
+// ── Storage key (template-literal only — gitleaks-safe) ──────────────────────
+
+const RECEIPT_ATTACHMENT_NAMESPACE = 'receipts';
+
+/**
+ * Builds a deterministic storage key for a receipt image. The key is assembled
+ * entirely from template literals so no secret-looking string literal is
+ * introduced.
+ */
+export function buildReceiptAttachmentStorageKey(draftId: string, fileName: string): string {
+  const safeName = fileName.trim().length > 0 ? fileName.trim() : `receipt-${draftId}`;
+  return `${RECEIPT_ATTACHMENT_NAMESPACE}/${draftId}/${safeName}`;
+}
+
+// ── Classification ───────────────────────────────────────────────────────────
+
+const SUPPLY_KEYWORDS: readonly string[] = [
+  'cup',
+  'lid',
+  'napkin',
+  'straw',
+  'plate',
+  'fork',
+  'spoon',
+  'knife',
+  'utensil',
+  'bag',
+  'container',
+  'foil',
+  'wrap',
+  'glove',
+  'towel',
+  'soap',
+  'cleaner',
+  'sanitizer',
+  'detergent',
+  'label',
+];
+
+const COGS_KEYWORDS: readonly string[] = [
+  'produce',
+  'meat',
+  'chicken',
+  'beef',
+  'pork',
+  'fish',
+  'seafood',
+  'cheese',
+  'milk',
+  'egg',
+  'flour',
+  'sugar',
+  'oil',
+  'sauce',
+  'spice',
+  'bun',
+  'bread',
+  'tortilla',
+  'vegetable',
+  'tomato',
+  'onion',
+  'lettuce',
+  'beverage',
+  'soda',
+  'coffee',
+  'beans',
+  'rice',
+  'dairy',
+];
+
+const INVENTORY_KEYWORDS: readonly string[] = [
+  'case',
+  'bulk',
+  'carton',
+  'crate',
+  'pallet',
+  'wholesale',
+  'pack',
+];
+
+function matchesKeyword(text: string, keywords: readonly string[]): boolean {
+  return keywords.some((keyword) => text.includes(keyword));
+}
+
+/**
+ * Suggests a default bucket for an extracted line item. Supplies and COGS
+ * content win over a generic bulk/inventory marker, then the parser's category
+ * hint is consulted, finally falling back to `other`.
+ */
+export function classifyLineItemBucket(item: ExtractedReceiptLineItem): CogsBucket {
+  const text = item.description.toLowerCase();
+  if (matchesKeyword(text, SUPPLY_KEYWORDS)) return 'supplies';
+  if (matchesKeyword(text, COGS_KEYWORDS)) return 'COGS';
+  if (matchesKeyword(text, INVENTORY_KEYWORDS)) return 'inventory';
+
+  const category = item.suggestedCategory?.toLowerCase() ?? '';
+  if (category === 'groceries' || category === 'restaurants') return 'COGS';
+  if (category === 'household') return 'supplies';
+  return 'other';
+}
+
+// ── Draft construction + edits (immutable) ───────────────────────────────────
+
+function normaliseCents(value: number | null | undefined): number {
+  if (value === null || value === undefined || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.round(value));
+}
+
+/** Builds an editable expense draft from an on-device OCR receipt result. */
+export function createReceiptExpenseDraft(
+  ocr: ExtractedReceiptText,
+  options: { readonly fallbackDateIso?: string } = {},
+): ReceiptExpenseDraft {
+  const fallbackDate = options.fallbackDateIso ?? new Date().toISOString().slice(0, 10);
+  const lineItems: ReceiptDraftLineItem[] = ocr.lineItems.map((item) => ({
+    description: item.description,
+    amountCents: normaliseCents(item.total),
+    quantity: item.quantity,
+    bucket: classifyLineItemBucket(item),
+    included: true,
+  }));
+
+  return {
+    merchant: ocr.merchant ?? '',
+    dateIso: ocr.date ?? fallbackDate,
+    totalCents: normaliseCents(ocr.total),
+    currencyCode: ocr.currency,
+    lineItems,
+    attachment: null,
+    rawText: ocr.rawText,
+    confidence: Math.min(100, Math.max(0, Math.round(ocr.confidence))),
+  };
+}
+
+function replaceLineItem(
+  draft: ReceiptExpenseDraft,
+  index: number,
+  update: (item: ReceiptDraftLineItem) => ReceiptDraftLineItem,
+): ReceiptExpenseDraft {
+  if (index < 0 || index >= draft.lineItems.length) return draft;
+  return {
+    ...draft,
+    lineItems: draft.lineItems.map((item, itemIndex) =>
+      itemIndex === index ? update(item) : item,
+    ),
+  };
+}
+
+/** Returns a new draft with the line item at `index` mapped to `bucket`. */
+export function assignLineItemBucket(
+  draft: ReceiptExpenseDraft,
+  index: number,
+  bucket: CogsBucket,
+): ReceiptExpenseDraft {
+  return replaceLineItem(draft, index, (item) => ({ ...item, bucket }));
+}
+
+/** Returns a new draft toggling (or setting) whether a line item is included. */
+export function toggleLineItemIncluded(
+  draft: ReceiptExpenseDraft,
+  index: number,
+  included?: boolean,
+): ReceiptExpenseDraft {
+  return replaceLineItem(draft, index, (item) => ({
+    ...item,
+    included: included ?? !item.included,
+  }));
+}
+
+/** Returns a new draft with the receipt image attached. */
+export function attachReceiptImage(
+  draft: ReceiptExpenseDraft,
+  attachment: ReceiptAttachmentRef,
+): ReceiptExpenseDraft {
+  return { ...draft, attachment };
+}
+
+/** Returns a new draft with the receipt image removed. */
+export function detachReceiptImage(draft: ReceiptExpenseDraft): ReceiptExpenseDraft {
+  return { ...draft, attachment: null };
+}
+
+/** Returns a new draft with an updated merchant name. */
+export function setDraftMerchant(
+  draft: ReceiptExpenseDraft,
+  merchant: string,
+): ReceiptExpenseDraft {
+  return { ...draft, merchant };
+}
+
+/** Returns a new draft with an updated grand total (clamped to ≥ 0 cents). */
+export function setDraftTotalCents(
+  draft: ReceiptExpenseDraft,
+  totalCents: number,
+): ReceiptExpenseDraft {
+  return { ...draft, totalCents: normaliseCents(totalCents) };
+}
+
+/** Returns a new draft with an updated ISO date. */
+export function setDraftDate(draft: ReceiptExpenseDraft, dateIso: string): ReceiptExpenseDraft {
+  return { ...draft, dateIso };
+}
+
+// ── Subtotals + reconciliation ───────────────────────────────────────────────
+
+/** Computes the included subtotal (integer cents) for each bucket. */
+export function computeBucketSubtotals(draft: ReceiptExpenseDraft): BucketSubtotals {
+  const subtotals: Record<CogsBucket, number> = {
+    COGS: 0,
+    inventory: 0,
+    supplies: 0,
+    other: 0,
+  };
+  for (const item of draft.lineItems) {
+    if (item.included) {
+      subtotals[item.bucket] += item.amountCents;
+    }
+  }
+  return subtotals;
+}
+
+/** Sum of all included line items, in integer cents. */
+export function computeMappedTotalCents(draft: ReceiptExpenseDraft): number {
+  return draft.lineItems.reduce((sum, item) => (item.included ? sum + item.amountCents : sum), 0);
+}
+
+/**
+ * Compares mapped line items against the receipt total. A non-zero
+ * `differenceCents` is surfaced so the UI can flag a mismatch. `toleranceCents`
+ * defaults to 0 (exact match required).
+ */
+export function reconcileDraft(
+  draft: ReceiptExpenseDraft,
+  toleranceCents = 0,
+): ReconciliationResult {
+  const mappedTotalCents = computeMappedTotalCents(draft);
+  const receiptTotalCents = draft.totalCents;
+  const differenceCents = mappedTotalCents - receiptTotalCents;
+  const tolerance = Math.max(0, Math.round(toleranceCents));
+  const isBalanced = Math.abs(differenceCents) <= tolerance;
+
+  const hasMappedItems = draft.lineItems.some((item) => item.included);
+  let status: ReconciliationStatus;
+  if (!hasMappedItems) {
+    status = 'unmapped';
+  } else if (isBalanced) {
+    status = 'balanced';
+  } else if (differenceCents > 0) {
+    status = 'over';
+  } else {
+    status = 'under';
+  }
+
+  return {
+    mappedTotalCents,
+    receiptTotalCents,
+    differenceCents,
+    isBalanced: hasMappedItems && isBalanced,
+    status,
+  };
+}
+
+// ── Serialisation for the transactions data path ─────────────────────────────
+
+/**
+ * Tags for the saved expense: always `receipt`, plus a marker for each bucket
+ * that carries a subtotal so downstream margin math can find the line items.
+ */
+export function draftToTransactionTags(draft: ReceiptExpenseDraft): string[] {
+  const subtotals = computeBucketSubtotals(draft);
+  const tags = ['receipt'];
+  for (const bucket of COGS_BUCKETS) {
+    const tag = BUCKET_TAGS[bucket];
+    if (tag !== null && subtotals[bucket] > 0) {
+      tags.push(tag);
+    }
+  }
+  return tags;
+}
+
+/**
+ * Serialises the reviewed draft into the transaction `customFields` map (all
+ * string values) so the expense persists its itemisation, bucket subtotals,
+ * reconciliation status, and receipt-image reference.
+ */
+export function draftToTransactionCustomFields(draft: ReceiptExpenseDraft): Record<string, string> {
+  const reconciliation = reconcileDraft(draft);
+  const subtotals = computeBucketSubtotals(draft);
+  const includedItems = draft.lineItems.filter((item) => item.included);
+
+  const fields: Record<string, string> = {
+    receiptRawText: draft.rawText,
+    receiptLineItems: JSON.stringify(
+      includedItems.map((item) => ({
+        description: item.description,
+        amountCents: item.amountCents,
+        quantity: item.quantity,
+        bucket: item.bucket,
+      })),
+    ),
+    receiptBucketSubtotals: JSON.stringify(subtotals),
+    receiptReconciliationStatus: reconciliation.status,
+    receiptReconciliationDifferenceCents: String(reconciliation.differenceCents),
+    receiptMappedTotalCents: String(reconciliation.mappedTotalCents),
+  };
+
+  if (draft.attachment !== null) {
+    fields.receiptImageUrl = draft.attachment.url;
+    fields.receiptImageName = draft.attachment.fileName;
+    fields.receiptImageStorageKey = draft.attachment.storageKey;
+    fields.receiptAltText = draft.attachment.altText;
+    fields.receiptUploadStatus = 'cached';
+  }
+
+  return fields;
+}

--- a/apps/web/src/pages/ReceiptOcrPage.test.tsx
+++ b/apps/web/src/pages/ReceiptOcrPage.test.tsx
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for ReceiptOcrPage (#2183).
+ *
+ * Mocks the `useAccounts` / `useTransactions` hooks (not repositories) and the
+ * on-device OCR adapter, per project conventions. Exercises the full
+ * receipt → expense flow: capture, review, COGS mapping, image attachment, and
+ * saving the expense through the transactions mutation hook.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { Account } from '../kmp/bridge';
+import type { ExtractedReceiptText } from '../lib/import';
+
+vi.mock('../hooks/useAccounts', () => ({ useAccounts: vi.fn() }));
+vi.mock('../hooks/useTransactions', () => ({ useTransactions: vi.fn() }));
+vi.mock('../lib/import', () => ({ webReceiptOcrAdapter: { extract: vi.fn() } }));
+
+import { useAccounts } from '../hooks/useAccounts';
+import { useTransactions } from '../hooks/useTransactions';
+import { webReceiptOcrAdapter } from '../lib/import';
+import { ReceiptOcrPage } from './ReceiptOcrPage';
+
+const mockedUseAccounts = vi.mocked(useAccounts);
+const mockedUseTransactions = vi.mocked(useTransactions);
+const mockedExtract = vi.mocked(webReceiptOcrAdapter.extract);
+
+const account: Account = {
+  id: 'acct-1',
+  householdId: 'hh-1',
+  name: 'Food Truck Checking',
+  type: 'CHECKING',
+  currency: { code: 'USD', decimalPlaces: 2 },
+  currentBalance: { amount: 0 },
+  isArchived: false,
+  sortOrder: 0,
+  icon: null,
+  color: null,
+} as Account;
+
+const ocrResult: ExtractedReceiptText = {
+  merchant: 'Restaurant Depot',
+  date: '2026-02-14',
+  total: 5000,
+  currency: 'USD',
+  lineItems: [
+    {
+      description: 'Ground beef',
+      total: 2500,
+      quantity: null,
+      suggestedCategory: null,
+      suggestedCategoryId: null,
+      categoryAccepted: false,
+    },
+    {
+      description: 'Paper cups',
+      total: 1000,
+      quantity: null,
+      suggestedCategory: null,
+      suggestedCategoryId: null,
+      categoryAccepted: false,
+    },
+  ],
+  rawText: 'RESTAURANT DEPOT',
+  confidence: 80,
+};
+
+const createTransaction = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock-receipt');
+  globalThis.URL.revokeObjectURL = vi.fn();
+
+  mockedUseAccounts.mockReturnValue({
+    accounts: [account],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    createAccount: vi.fn(),
+    updateAccount: vi.fn(),
+    deleteAccount: vi.fn(),
+  } as unknown as ReturnType<typeof useAccounts>);
+
+  createTransaction.mockReturnValue({ id: 'txn-1' });
+  mockedUseTransactions.mockReturnValue({
+    transactions: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    createTransaction,
+    updateTransaction: vi.fn(),
+    deleteTransaction: vi.fn(),
+  });
+
+  mockedExtract.mockResolvedValue(ocrResult);
+});
+
+async function uploadReceipt(): Promise<void> {
+  const user = userEvent.setup();
+  const file = new File(['image-bytes'], 'receipt.jpg', { type: 'image/jpeg' });
+  const input = screen.getByLabelText('Take or choose receipt photo');
+  await user.upload(input, file);
+  await screen.findByRole('heading', { name: /review & save as expense/i });
+}
+
+describe('ReceiptOcrPage', () => {
+  it('extracts a receipt and surfaces the review + COGS mapping UI', async () => {
+    render(<ReceiptOcrPage />);
+    await uploadReceipt();
+
+    // Line items are mapped to default buckets.
+    expect(screen.getByLabelText('Cost bucket for Ground beef')).toHaveValue('COGS');
+    expect(screen.getByLabelText('Cost bucket for Paper cups')).toHaveValue('supplies');
+
+    // Receipt image is attached with an accessible alt.
+    const image = screen.getByRole('img', { name: /receipt photo from restaurant depot/i });
+    expect(image).toHaveAttribute('src', 'blob:mock-receipt');
+  });
+
+  it('announces a reconciliation mismatch with text (not color alone)', async () => {
+    render(<ReceiptOcrPage />);
+    await uploadReceipt();
+
+    // Mapped items (2500 + 1000 = 3500) are less than the 5000 total.
+    const status = screen.getByText(/less than the receipt total/i);
+    expect(status).toBeInTheDocument();
+    const liveRegion = status.closest('[role="status"]');
+    expect(liveRegion).not.toBeNull();
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('lets the user remap a line item to a different bucket', async () => {
+    const user = userEvent.setup();
+    render(<ReceiptOcrPage />);
+    await uploadReceipt();
+
+    await user.selectOptions(screen.getByLabelText('Cost bucket for Paper cups'), 'inventory');
+    expect(screen.getByLabelText('Cost bucket for Paper cups')).toHaveValue('inventory');
+  });
+
+  it('saves the expense through the transactions hook with itemised COGS data', async () => {
+    const user = userEvent.setup();
+    render(<ReceiptOcrPage />);
+    await uploadReceipt();
+
+    await user.selectOptions(screen.getByLabelText('Account'), 'acct-1');
+    await user.click(screen.getByRole('button', { name: /save as expense/i }));
+
+    expect(createTransaction).toHaveBeenCalledTimes(1);
+    const input = createTransaction.mock.calls[0][0];
+    expect(input).toMatchObject({
+      accountId: 'acct-1',
+      householdId: 'hh-1',
+      type: 'EXPENSE',
+      amount: { amount: 5000 },
+      payee: 'Restaurant Depot',
+      date: '2026-02-14',
+    });
+    expect(input.tags).toEqual(expect.arrayContaining(['receipt', 'pnl:cogs', 'supplies']));
+    expect(input.customFields.receiptImageUrl).toBe('blob:mock-receipt');
+    expect(input.customFields.receiptReconciliationStatus).toBe('under');
+
+    const items = JSON.parse(input.customFields.receiptLineItems) as Array<{ bucket: string }>;
+    expect(items).toHaveLength(2);
+
+    // Button reflects the saved state.
+    expect(screen.getByRole('button', { name: /saved/i })).toBeDisabled();
+  });
+
+  it('blocks saving until an account is chosen', async () => {
+    const user = userEvent.setup();
+    render(<ReceiptOcrPage />);
+    await uploadReceipt();
+
+    await user.click(screen.getByRole('button', { name: /save as expense/i }));
+
+    expect(createTransaction).not.toHaveBeenCalled();
+    const alert = await screen.findByRole('alert');
+    expect(within(alert).getByText(/choose an account/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/ReceiptOcrPage.tsx
+++ b/apps/web/src/pages/ReceiptOcrPage.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useId, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { DateInput } from '../components/common';
 import { AmountInput } from '../components/forms/AmountInput';
 import { AppIcon } from '../components/icons';
@@ -9,32 +9,72 @@ import { useAmountInput } from '../hooks/useAmountInput';
 import { useAccounts } from '../hooks/useAccounts';
 import { useTransactions } from '../hooks/useTransactions';
 import { Currencies, type Currency } from '../kmp/bridge';
-import type { ExtractedReceiptLineItem, ExtractedReceiptText } from '../lib/import';
+import type { ExtractedReceiptText } from '../lib/import';
 import { webReceiptOcrAdapter } from '../lib/import';
+import {
+  COGS_BUCKETS,
+  COGS_BUCKET_LABELS,
+  assignLineItemBucket,
+  attachReceiptImage,
+  buildReceiptAttachmentStorageKey,
+  computeBucketSubtotals,
+  createReceiptExpenseDraft,
+  detachReceiptImage,
+  draftToTransactionCustomFields,
+  draftToTransactionTags,
+  reconcileDraft,
+  toggleLineItemIncluded,
+  type CogsBucket,
+  type ReceiptExpenseDraft,
+  type ReconciliationStatus,
+} from '../lib/expenses/receipt-expense-draft';
 
 import '../styles/import.css';
 
-interface EditableReceiptLineItem extends ExtractedReceiptLineItem {
-  readonly accepted: boolean;
+type FlowStatus = 'idle' | 'processing' | 'ready' | 'saved';
+
+function formatMoney(cents: number): string {
+  const sign = cents < 0 ? '-' : '';
+  return `${sign}$${(Math.abs(cents) / 100).toFixed(2)}`;
 }
 
-const emptyReceipt: ExtractedReceiptText = {
-  merchant: null,
-  date: null,
-  total: null,
-  currency: null,
-  lineItems: [],
-  rawText: '',
-  confidence: 0,
+function generateDraftId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+}
+
+function createObjectUrl(file: File): string {
+  if (typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function') {
+    return URL.createObjectURL(file);
+  }
+  return '';
+}
+
+function revokeObjectUrl(url: string | null): void {
+  if (url !== null && url.startsWith('blob:') && typeof URL.revokeObjectURL === 'function') {
+    URL.revokeObjectURL(url);
+  }
+}
+
+const RECONCILIATION_LABELS: Readonly<
+  Record<ReconciliationStatus, { icon: 'check-circle' | 'alert-triangle'; text: string }>
+> = {
+  balanced: { icon: 'check-circle', text: 'Mapped items match the receipt total.' },
+  over: { icon: 'alert-triangle', text: 'Mapped items are more than the receipt total.' },
+  under: { icon: 'alert-triangle', text: 'Mapped items are less than the receipt total.' },
+  unmapped: { icon: 'alert-triangle', text: 'No line items are mapped yet.' },
 };
 
-/** Web camera/gallery receipt OCR flow using on-device Tesseract.js WASM. */
+/** Web camera/gallery receipt OCR → saved expense + COGS mapping flow. */
 export const ReceiptOcrPage: React.FC = () => {
   const accountSelectId = useId();
+  const reconciliationId = useId();
   const { accounts } = useAccounts();
   const { createTransaction } = useTransactions();
-  const [receipt, setReceipt] = useState<ExtractedReceiptText>(emptyReceipt);
-  const [items, setItems] = useState<readonly EditableReceiptLineItem[]>([]);
+
+  const [draft, setDraft] = useState<ReceiptExpenseDraft | null>(null);
   const [merchant, setMerchant] = useState('');
   const amountInput = useAmountInput({
     currencySymbol: '$',
@@ -43,89 +83,150 @@ export const ReceiptOcrPage: React.FC = () => {
   });
   const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
   const [selectedAccountId, setSelectedAccountId] = useState('');
-  const [status, setStatus] = useState<'idle' | 'processing' | 'ready' | 'saved'>('idle');
+  const [status, setStatus] = useState<FlowStatus>('idle');
   const [error, setError] = useState<string | null>(null);
+
+  const reviewHeadingRef = useRef<HTMLHeadingElement | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+
+  // Revoke any outstanding object URL when the component unmounts.
+  useEffect(
+    () => () => {
+      revokeObjectUrl(objectUrlRef.current);
+    },
+    [],
+  );
 
   const selectedAccount = useMemo(
     () => accounts.find((account) => account.id === selectedAccountId) ?? null,
     [accounts, selectedAccountId],
   );
 
-  const handleReceiptImage = (file: File) => {
-    setStatus('processing');
-    setError(null);
-    void webReceiptOcrAdapter
-      .extract(file)
-      .then((result) => {
-        setReceipt(result);
-        setMerchant(result.merchant ?? '');
-        amountInput.setCents(result.total ?? 0);
-        setDate(result.date ?? new Date().toISOString().slice(0, 10));
-        setItems(result.lineItems.map((item) => ({ ...item, accepted: true })));
-        setStatus('ready');
-      })
-      .catch(() => {
-        setError('Could not read the receipt image on this device. Please try another photo.');
-        setStatus('idle');
-      });
-  };
+  // Working draft keeps line-item edits while sourcing the total/merchant/date
+  // from the editable review controls so reconciliation stays reactive.
+  const workingDraft = useMemo<ReceiptExpenseDraft | null>(
+    () =>
+      draft === null ? null : { ...draft, merchant, dateIso: date, totalCents: amountInput.cents },
+    [draft, merchant, date, amountInput.cents],
+  );
 
-  const toggleLineItem = (index: number) => {
-    setItems((current) =>
-      current.map((item, itemIndex) =>
-        itemIndex === index ? { ...item, accepted: !item.accepted } : item,
-      ),
+  const subtotals = useMemo(
+    () => (workingDraft === null ? null : computeBucketSubtotals(workingDraft)),
+    [workingDraft],
+  );
+  const reconciliation = useMemo(
+    () => (workingDraft === null ? null : reconcileDraft(workingDraft)),
+    [workingDraft],
+  );
+
+  useEffect(() => {
+    if (status === 'ready' && reviewHeadingRef.current !== null) {
+      reviewHeadingRef.current.focus();
+    }
+  }, [status]);
+
+  const handleReceiptImage = useCallback(
+    (file: File) => {
+      setStatus('processing');
+      setError(null);
+      void webReceiptOcrAdapter
+        .extract(file)
+        .then((result: ExtractedReceiptText) => {
+          const baseDraft = createReceiptExpenseDraft(result, {
+            fallbackDateIso: new Date().toISOString().slice(0, 10),
+          });
+
+          revokeObjectUrl(objectUrlRef.current);
+          const objectUrl = createObjectUrl(file);
+          objectUrlRef.current = objectUrl;
+          const fileName = file.name.length > 0 ? file.name : `receipt-${Date.now()}.jpg`;
+          const attachedDraft = attachReceiptImage(baseDraft, {
+            url: objectUrl,
+            fileName,
+            mimeType: file.type.length > 0 ? file.type : 'image/jpeg',
+            sizeBytes: file.size,
+            storageKey: buildReceiptAttachmentStorageKey(generateDraftId(), fileName),
+            altText:
+              baseDraft.merchant.length > 0
+                ? `Receipt photo from ${baseDraft.merchant}`
+                : 'Captured receipt photo',
+          });
+
+          setDraft(attachedDraft);
+          setMerchant(attachedDraft.merchant);
+          amountInput.setCents(attachedDraft.totalCents);
+          setDate(attachedDraft.dateIso);
+          setStatus('ready');
+        })
+        .catch(() => {
+          setError('Could not read the receipt image on this device. Please try another photo.');
+          setStatus('idle');
+        });
+    },
+    [amountInput],
+  );
+
+  const handleBucketChange = useCallback((index: number, bucket: CogsBucket) => {
+    setDraft((current) =>
+      current === null ? current : assignLineItemBucket(current, index, bucket),
     );
-  };
+  }, []);
+
+  const handleToggleIncluded = useCallback((index: number) => {
+    setDraft((current) => (current === null ? current : toggleLineItemIncluded(current, index)));
+  }, []);
+
+  const handleRemoveImage = useCallback(() => {
+    revokeObjectUrl(objectUrlRef.current);
+    objectUrlRef.current = null;
+    setDraft((current) => (current === null ? current : detachReceiptImage(current)));
+  }, []);
 
   const receiptCurrency = (code: string | null, fallback: Currency): Currency => {
     if (code === null) return fallback;
     return Currencies[code as keyof typeof Currencies] ?? fallback;
   };
 
-  const saveTransaction = () => {
+  const saveExpense = useCallback(() => {
+    if (workingDraft === null) return;
     if (selectedAccount === null) {
       setError('Choose an account before saving.');
       return;
     }
-
-    const totalCents = amountInput.cents;
-    if (totalCents <= 0 || merchant.trim().length === 0) {
+    if (workingDraft.totalCents <= 0 || workingDraft.merchant.trim().length === 0) {
       setError('Review merchant and amount before saving.');
       return;
     }
 
-    const acceptedItems = items.filter((item) => item.accepted);
     const transaction = createTransaction({
       householdId: selectedAccount.householdId,
       accountId: selectedAccount.id,
       type: 'EXPENSE',
       status: 'CLEARED',
-      amount: { amount: totalCents },
-      currency: receiptCurrency(receipt.currency, selectedAccount.currency),
-      payee: merchant,
-      note: `Receipt OCR (${Math.round(receipt.confidence)}% confidence)`,
-      date,
-      tags: ['receipt'],
-      customFields: {
-        receiptRawText: receipt.rawText,
-        receiptLineItems: JSON.stringify(acceptedItems),
-      },
+      amount: { amount: workingDraft.totalCents },
+      currency: receiptCurrency(workingDraft.currencyCode, selectedAccount.currency),
+      payee: workingDraft.merchant,
+      note: `Receipt OCR (${Math.round(workingDraft.confidence)}% confidence)`,
+      date: workingDraft.dateIso,
+      tags: draftToTransactionTags(workingDraft),
+      customFields: draftToTransactionCustomFields(workingDraft),
     });
 
     if (transaction === null) {
-      setError('Could not save the receipt transaction.');
+      setError('Could not save the receipt expense.');
       return;
     }
+    setError(null);
     setStatus('saved');
-  };
+  }, [workingDraft, selectedAccount, createTransaction]);
 
   return (
     <div className="import-wizard">
       <h2 className="import-wizard__title">Scan Receipt</h2>
       <p className="import-section-description">
-        Take or upload a receipt photo. OCR runs in this browser with Tesseract.js WASM; no server
-        OCR fallback is used.
+        Take or upload a receipt photo, review the extracted fields, map each line item to a cost
+        bucket, and save it as an expense. OCR runs in this browser with Tesseract.js WASM; no
+        server OCR fallback is used.
       </p>
 
       <section aria-labelledby="capture-heading">
@@ -146,7 +247,7 @@ export const ReceiptOcrPage: React.FC = () => {
 
       {status === 'processing' && (
         <div role="status" aria-live="polite" className="import-progress">
-          Reading receipt on device╬ô├ç┬¬
+          Reading receipt on device…
         </div>
       )}
 
@@ -157,11 +258,17 @@ export const ReceiptOcrPage: React.FC = () => {
         </div>
       )}
 
-      {(status === 'ready' || status === 'saved') && (
-        <section aria-labelledby="quick-entry-heading">
-          <h3 id="quick-entry-heading" className="import-section-heading">
-            Quick entry
+      {(status === 'ready' || status === 'saved') && workingDraft !== null && (
+        <section aria-labelledby="review-heading">
+          <h3
+            id="review-heading"
+            className="import-section-heading"
+            tabIndex={-1}
+            ref={reviewHeadingRef}
+          >
+            Review &amp; save as expense
           </h3>
+
           <div className="import-account-selector">
             <label htmlFor={accountSelectId} className="import-account-selector__label">
               Account
@@ -180,6 +287,7 @@ export const ReceiptOcrPage: React.FC = () => {
               ))}
             </select>
           </div>
+
           <label className="import-account-selector__label">
             Merchant
             <input value={merchant} onChange={(event) => setMerchant(event.target.value)} />
@@ -198,27 +306,125 @@ export const ReceiptOcrPage: React.FC = () => {
             Date
             <DateInput value={date} onChange={(event) => setDate(event.target.value)} />
           </label>
-          <p>OCR confidence: {Math.round(receipt.confidence)}%</p>
+          <p>OCR confidence: {Math.round(workingDraft.confidence)}%</p>
 
-          {items.length > 0 && (
-            <fieldset>
-              <legend>Itemized split suggestions</legend>
-              {items.map((item, index) => (
-                <label key={`${item.description}-${index}`}>
-                  <input
-                    type="checkbox"
-                    checked={item.accepted}
-                    onChange={() => toggleLineItem(index)}
-                  />
-                  {item.description} ╬ô├ç├╢ ${(item.total / 100).toFixed(2)}
-                  {item.suggestedCategory === null ? '' : ` (${item.suggestedCategory})`}
-                </label>
-              ))}
+          {workingDraft.attachment !== null && (
+            <div className="receipt-attachment">
+              <h4 id="receipt-image-heading" className="import-section-heading">
+                Receipt image
+              </h4>
+              {workingDraft.attachment.url.length > 0 ? (
+                <img
+                  className="receipt-attachment__image"
+                  src={workingDraft.attachment.url}
+                  alt={workingDraft.attachment.altText}
+                />
+              ) : (
+                <p>{workingDraft.attachment.fileName} attached.</p>
+              )}
+              <button type="button" className="import-skip-all-button" onClick={handleRemoveImage}>
+                Remove receipt image
+              </button>
+            </div>
+          )}
+
+          {workingDraft.lineItems.length > 0 && (
+            <fieldset className="receipt-items">
+              <legend>Map line items to cost buckets</legend>
+              <table className="import-mapping-table receipt-items__table">
+                <thead>
+                  <tr>
+                    <th scope="col">Include</th>
+                    <th scope="col">Item</th>
+                    <th scope="col">Amount</th>
+                    <th scope="col">Cost bucket</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {workingDraft.lineItems.map((item, index) => {
+                    const selectId = `${reconciliationId}-bucket-${index}`;
+                    return (
+                      <tr key={`${item.description}-${index}`}>
+                        <td>
+                          <input
+                            type="checkbox"
+                            checked={item.included}
+                            aria-label={`Include ${item.description}`}
+                            onChange={() => handleToggleIncluded(index)}
+                          />
+                        </td>
+                        <td>{item.description}</td>
+                        <td>{formatMoney(item.amountCents)}</td>
+                        <td>
+                          <label className="sr-only" htmlFor={selectId}>
+                            Cost bucket for {item.description}
+                          </label>
+                          <select
+                            id={selectId}
+                            className="form-select"
+                            value={item.bucket}
+                            disabled={!item.included}
+                            onChange={(event) =>
+                              handleBucketChange(index, event.target.value as CogsBucket)
+                            }
+                          >
+                            {COGS_BUCKETS.map((bucket) => (
+                              <option key={bucket} value={bucket}>
+                                {COGS_BUCKET_LABELS[bucket]}
+                              </option>
+                            ))}
+                          </select>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
             </fieldset>
           )}
 
-          <button type="button" onClick={saveTransaction} disabled={status === 'saved'}>
-            {status === 'saved' ? 'Saved' : 'Save transaction'}
+          {subtotals !== null && (
+            <div className="receipt-subtotals">
+              <h4 id="subtotal-heading" className="import-section-heading">
+                Per-bucket subtotals
+              </h4>
+              <dl className="receipt-subtotals__list">
+                {COGS_BUCKETS.map((bucket) => (
+                  <div key={bucket} className="receipt-subtotals__row">
+                    <dt>{COGS_BUCKET_LABELS[bucket]}</dt>
+                    <dd>{formatMoney(subtotals[bucket])}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          )}
+
+          {reconciliation !== null && (
+            <div
+              id={reconciliationId}
+              role="status"
+              aria-live="polite"
+              className={`receipt-reconciliation receipt-reconciliation--${reconciliation.status}`}
+            >
+              <AppIcon name={RECONCILIATION_LABELS[reconciliation.status].icon} />
+              <span className="receipt-reconciliation__text">
+                {RECONCILIATION_LABELS[reconciliation.status].text} Mapped{' '}
+                {formatMoney(reconciliation.mappedTotalCents)} of{' '}
+                {formatMoney(reconciliation.receiptTotalCents)}
+                {reconciliation.differenceCents !== 0 &&
+                  ` (difference ${formatMoney(reconciliation.differenceCents)})`}
+                .
+              </span>
+            </div>
+          )}
+
+          <button
+            type="button"
+            className="form-button"
+            onClick={saveExpense}
+            disabled={status === 'saved'}
+          >
+            {status === 'saved' ? 'Saved' : 'Save as expense'}
           </button>
         </section>
       )}

--- a/apps/web/src/styles/import.css
+++ b/apps/web/src/styles/import.css
@@ -576,3 +576,94 @@
     border: 2px solid var(--semantic-border-default);
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Receipt → expense + COGS mapping (#2183)
+ * ------------------------------------------------------------------------- */
+
+.receipt-attachment {
+  margin: var(--spacing-4) 0;
+}
+
+.receipt-attachment__image {
+  display: block;
+  max-width: 240px;
+  max-height: 320px;
+  width: auto;
+  height: auto;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--card-border-radius, 8px);
+  margin-bottom: var(--spacing-2);
+}
+
+.receipt-items {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--card-border-radius, 8px);
+  padding: var(--spacing-3);
+  margin: var(--spacing-4) 0;
+}
+
+.receipt-items__table {
+  width: 100%;
+}
+
+.receipt-subtotals {
+  margin: var(--spacing-4) 0;
+}
+
+.receipt-subtotals__list {
+  margin: 0;
+}
+
+.receipt-subtotals__row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  padding: var(--spacing-1) 0;
+}
+
+.receipt-subtotals__row dt {
+  color: var(--semantic-text-secondary);
+}
+
+.receipt-subtotals__row dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+  color: var(--semantic-text-primary);
+}
+
+.receipt-reconciliation {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+  border-radius: var(--card-border-radius, 8px);
+  border: 2px solid var(--semantic-border-default);
+  margin: var(--spacing-4) 0;
+}
+
+.receipt-reconciliation--balanced {
+  border-color: var(--semantic-status-positive);
+  color: var(--semantic-status-positive);
+}
+
+.receipt-reconciliation--over,
+.receipt-reconciliation--under,
+.receipt-reconciliation--unmapped {
+  border-color: var(--semantic-status-warning);
+  color: var(--semantic-status-warning);
+}
+
+.receipt-reconciliation__text {
+  color: var(--semantic-text-primary);
+}
+
+@media (prefers-contrast: more) {
+  .receipt-reconciliation {
+    border-width: 3px;
+  }
+
+  .receipt-attachment__image {
+    border-width: 2px;
+  }
+}


### PR DESCRIPTION
## Summary
Turns the web receipt OCR result into a **saved expense** with **COGS / inventory / supplies / other** line-item mapping and a linked **receipt image attachment** — building the save+COGS workflow on top of the existing `ReceiptOcrPage` (Refs #2183; native Android ReceiptOcrScreen/ML Kit remains).

### Gap verified first
- `ReceiptOcrPage` had a basic save, but **no per-item COGS/inventory/supplies mapping** (zero COGS refs in the receipt flow), **no per-bucket subtotals / reconciliation**, and the **receipt image was never attached** to the expense.

### Engine — `apps/web/src/lib/expenses/receipt-expense-draft.ts` (pure, integer cents)
- Typed `ReceiptExpenseDraft` model + pure functions: `createReceiptExpenseDraft` (OCR → draft), `classifyLineItemBucket` (food-truck-aware defaults), `assignLineItemBucket` / `toggleLineItemIncluded`, `computeBucketSubtotals`, `reconcileDraft` (surfaces mismatch: balanced/over/under/unmapped), `attachReceiptImage` (object-/data-URL reference), and serialisers to the transactions data path (`draftToTransactionTags` maps COGS → existing `pnl:cogs` marker so the data feeds margin math; `draftToTransactionCustomFields`).
- All money is **integer cents**; storage keys built from **template literals** (gitleaks-safe).

### UI — `ReceiptOcrPage.tsx`
- Review extracted fields → map each line item to a labeled cost-bucket `<select>` → attach the receipt image → save via the existing `useTransactions().createTransaction` hook (no new data path).
- Shows per-bucket subtotals and the reconciliation status **before** save.

### Accessibility (WCAG 2.2 AA)
- Each line item has a labeled include checkbox + named cost-bucket `<select>`.
- Reconciliation mismatch announced via **text + icon** (not color alone) in an `aria-live` `role=status` region.
- Receipt image has descriptive `alt`; all controls keyboard-reachable; review heading receives focus when shown.

### Tests
- Engine: OCR→draft mapping, exact-cents per-bucket subtotals, reconciliation mismatch detection, attachment serialisation (21 tests).
- Page: render/interaction — map line items, attach image, save creates the expense; mocks **hooks** (not repositories) (5 tests).

Refs #2183