### PR TITLE
feat(web): supportive couples money check-in flow (#2150)

### DIFF
--- a/apps/web/src/components/household/MoneyCheckInDialog.css
+++ b/apps/web/src/components/household/MoneyCheckInDialog.css
@@ -1,0 +1,357 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for the couples money check-in dialog (#2150).
+ *
+ * Builds on the shared `.form-dialog` modal primitives and consumes design
+ * tokens only. Supportive, low-pressure visual tone; never relies on color
+ * alone to convey state, and honours reduced-motion and high-contrast prefs.
+ */
+
+.money-check-in__panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  max-width: 560px;
+  width: 100%;
+}
+
+.money-check-in__intro {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-font-size);
+  margin-top: var(--spacing-1);
+}
+
+.money-check-in__steps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-3);
+  padding: 0;
+  list-style: none;
+}
+
+.money-check-in__step {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-full, 9999px);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.money-check-in__step[aria-current='step'] {
+  border-color: var(--semantic-border-focus);
+  color: var(--semantic-text-primary);
+  font-weight: var(--font-weight-semibold);
+}
+
+.money-check-in__step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: var(--semantic-background-secondary, var(--semantic-background-primary));
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.money-check-in__step[aria-current='step'] .money-check-in__step-index {
+  background: var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse);
+}
+
+.money-check-in__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.money-check-in__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.money-check-in__section-title {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+}
+
+.money-check-in__hint {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+.money-check-in__fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  padding: var(--spacing-3);
+  margin: 0;
+}
+
+.money-check-in__legend {
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  padding: 0 var(--spacing-1);
+}
+
+.money-check-in__checkbox,
+.money-check-in__radio {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+  cursor: pointer;
+}
+
+.money-check-in__radio-label {
+  display: block;
+  font-weight: var(--font-weight-medium);
+}
+
+.money-check-in__radio-helper {
+  display: block;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.money-check-in__status {
+  background: var(--semantic-background-secondary, var(--semantic-background-primary));
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  padding: var(--spacing-3);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.money-check-in__summary-list,
+.money-check-in__detail-list,
+.money-check-in__recap-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.money-check-in__summary-item {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  padding: var(--spacing-3);
+}
+
+.money-check-in__summary-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+}
+
+.money-check-in__summary-title {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.money-check-in__summary-amount {
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--font-weight-semibold);
+}
+
+.money-check-in__detail-list {
+  margin-top: var(--spacing-3);
+  padding-top: var(--spacing-3);
+  border-top: 1px solid var(--semantic-border-default);
+}
+
+.money-check-in__detail-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+.money-check-in__detail-empty {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.money-check-in__prompt {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  padding: var(--spacing-4);
+}
+
+.money-check-in__prompt-category {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+}
+
+.money-check-in__prompt-text {
+  font-size: var(--type-scale-title-font-size);
+  color: var(--semantic-text-primary);
+}
+
+.money-check-in__note,
+.money-check-in__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.money-check-in__field-label {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.money-check-in__select,
+.money-check-in__textarea {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+  font: inherit;
+}
+
+.money-check-in__textarea {
+  resize: vertical;
+  min-height: 4rem;
+}
+
+.money-check-in__select:focus-visible,
+.money-check-in__textarea:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.money-check-in__recap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  padding: var(--spacing-3);
+}
+
+.money-check-in__recap-title {
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+}
+
+.money-check-in__recap-line {
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+.money-check-in__link-button {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  padding: var(--spacing-1) 0;
+  color: var(--semantic-interactive-default);
+  font: inherit;
+  font-weight: var(--font-weight-semibold);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.money-check-in__link-button:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.money-check-in__link-button:disabled {
+  color: var(--semantic-text-secondary);
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
+.money-check-in__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-2);
+}
+
+.money-check-in__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-2) var(--spacing-4);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+  font: inherit;
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: background-color 150ms ease;
+}
+
+.money-check-in__button:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.money-check-in__button--primary {
+  background: var(--semantic-interactive-default);
+  border-color: var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse);
+}
+
+.money-check-in__button--primary:hover:not(:disabled) {
+  background: var(--semantic-interactive-hover, var(--semantic-interactive-default));
+}
+
+.money-check-in__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.money-check-in__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .money-check-in__button {
+    transition: none;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .money-check-in__summary-item,
+  .money-check-in__prompt,
+  .money-check-in__fieldset,
+  .money-check-in__button {
+    border-width: 2px;
+  }
+}

--- a/apps/web/src/components/household/MoneyCheckInDialog.test.tsx
+++ b/apps/web/src/components/household/MoneyCheckInDialog.test.tsx
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the couples money check-in dialog (#2150).
+ *
+ * Covers cadence gating, the neutral-summary-before-line-items guarantee,
+ * stepping through the supportive prompts, privacy-safe recap redaction, and
+ * per-partner sharing-consent persistence.
+ */
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MoneyCheckInDialog } from './MoneyCheckInDialog';
+import type { CheckInFacts } from '../../lib/household/check-in-rules';
+
+const PARTNERS = [
+  { id: 'avery', name: 'Avery' },
+  { id: 'bo', name: 'Bo' },
+] as const;
+
+const FACTS: CheckInFacts = {
+  categoryTotals: [
+    { label: 'Groceries', amountCents: 42_000 },
+    { label: 'Dining out', amountCents: 18_000 },
+  ],
+  budgetDriftByCategory: [
+    { label: 'Groceries', amountCents: 2_000 },
+    { label: 'Dining out', amountCents: -1_500 },
+  ],
+  sharedSpendingChanges: [{ label: 'Wedding', amountCents: 35_000 }],
+};
+
+const HOUSEHOLD_ID = 'hh-test';
+const TODAY = '2026-04-10';
+
+function renderDialog(overrides: { onClose?: () => void } = {}) {
+  const onClose = overrides.onClose ?? vi.fn();
+  render(
+    <MoneyCheckInDialog
+      isOpen
+      onClose={onClose}
+      householdId={HOUSEHOLD_ID}
+      partners={PARTNERS}
+      facts={FACTS}
+      today={TODAY}
+    />,
+  );
+  return { onClose };
+}
+
+function optInBothPartners() {
+  fireEvent.click(screen.getByRole('checkbox', { name: /Avery opts in/i }));
+  fireEvent.click(screen.getByRole('checkbox', { name: /Bo opts in/i }));
+}
+
+describe('MoneyCheckInDialog (#2150)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('is presented as a labelled modal dialog', () => {
+    renderDialog();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(within(dialog).getByRole('heading', { name: 'Money check-in' })).toBeInTheDocument();
+  });
+
+  it('gates the start until both partners opt in', () => {
+    renderDialog();
+    const beginButton = screen.getByRole('button', { name: /Begin check-in/i });
+    expect(beginButton).toBeDisabled();
+
+    optInBothPartners();
+    expect(beginButton).toBeEnabled();
+  });
+
+  it('respects the cadence: a recent check-in keeps the next one gated', () => {
+    // Two days ago — inside the default weekly cadence window.
+    localStorage.setItem(`finance-household-${HOUSEHOLD_ID}-checkin-last`, '2026-04-08');
+    renderDialog();
+
+    optInBothPartners();
+    expect(screen.getByRole('button', { name: /Begin check-in/i })).toBeDisabled();
+    expect(screen.getByText(/Your last check-in was 2026-04-08/)).toBeInTheDocument();
+  });
+
+  it('shows neutral totals before any line items, revealing detail only on request', () => {
+    renderDialog();
+    optInBothPartners();
+    fireEvent.click(screen.getByRole('button', { name: /Begin check-in/i }));
+
+    // Neutral aggregate headline ($420 + $180 = $600) is visible immediately...
+    expect(screen.getByText('$600.00')).toBeInTheDocument();
+    // ...but the category line items are NOT shown yet.
+    expect(screen.queryByText('Groceries')).not.toBeInTheDocument();
+
+    // Reveal only the category-totals section.
+    const revealButtons = screen.getAllByRole('button', { name: /Reveal line items/i });
+    fireEvent.click(revealButtons[0]);
+
+    expect(screen.getByText('Groceries')).toBeInTheDocument();
+    expect(screen.getByText('Dining out')).toBeInTheDocument();
+  });
+
+  it('steps through every prompt, redacts private notes, and persists sharing consent', () => {
+    const { onClose } = renderDialog();
+    optInBothPartners();
+    fireEvent.click(screen.getByRole('button', { name: /Begin check-in/i }));
+
+    // Move past the neutral summary into the prompts.
+    fireEvent.click(screen.getByRole('button', { name: /Continue to prompts/i }));
+
+    // First prompt is the supportive fun-money-boundaries prompt.
+    expect(screen.getByText(/fun-money boundaries/i)).toBeInTheDocument();
+
+    // Add a private note on the first prompt — it should be redacted in the recap.
+    fireEvent.change(screen.getByLabelText(/Note for this prompt/i), {
+      target: { value: 'Feeling a little stretched this month' },
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: /Keep this note private/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Add note$/i }));
+
+    // Walk through the remaining prompts until the recap appears.
+    for (let i = 0; i < 10; i += 1) {
+      const advance = screen.queryByRole('button', { name: /Next prompt|See recap/i });
+      if (!advance) break;
+      fireEvent.click(advance);
+      if (screen.queryByRole('heading', { name: /Share & finish/i })) break;
+    }
+
+    expect(screen.getByRole('heading', { name: /Share & finish/i })).toBeInTheDocument();
+    // Private note is redacted in the privacy-safe recap.
+    expect(screen.getByText('avery: redacted')).toBeInTheDocument();
+
+    // Avery un-shares budget drift; persistence should reflect the choice.
+    const averyFieldset = screen.getByRole('group', { name: /Avery shares/i });
+    fireEvent.click(within(averyFieldset).getByRole('checkbox', { name: /Budget drift/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /Save & finish/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const storedSharing = JSON.parse(
+      localStorage.getItem(`finance-household-${HOUSEHOLD_ID}-checkin-sharing`) ?? '{}',
+    );
+    expect(storedSharing.avery).not.toContain('budget-drift');
+    expect(storedSharing.avery).toContain('category-totals');
+    expect(localStorage.getItem(`finance-household-${HOUSEHOLD_ID}-checkin-last`)).toBe(TODAY);
+  });
+
+  it('closes on Escape', () => {
+    const { onClose } = renderDialog();
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/household/MoneyCheckInDialog.tsx
+++ b/apps/web/src/components/household/MoneyCheckInDialog.tsx
@@ -1,0 +1,608 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Couples money check-in dialog — supportive, opt-in, privacy-first.
+ *
+ * Surfaces the existing `lib/household/check-in-rules` engine as an accessible
+ * flow: both partners opt in (cadence-gated), then a NEUTRAL summary is shown
+ * before any line-item detail, supportive discussion prompts rotate through every
+ * category, and each partner consents to which summary types they share. The tone
+ * is collaborative — never policing or accusatory.
+ *
+ * The flow is intentionally lazy-loaded by HouseholdPage so it lands in its own
+ * sub-chunk and never grows the page's route chunk past the performance budget.
+ *
+ * References: issue #2150
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react';
+
+import { useFocusTrap, announce } from '../../accessibility/aria';
+import { CurrencyDisplay } from '../common/CurrencyDisplay';
+import {
+  ALL_CHECK_IN_SUMMARY_TYPES,
+  buildNeutralSummary,
+  buildPrivacySafeCheckInSummary,
+  cadenceToDays,
+  canStartCheckIn,
+  DEFAULT_CHECK_IN_PROMPTS,
+  selectNextPrompt,
+  type CheckInCadence,
+  type CheckInEntry,
+  type CheckInFacts,
+  type CheckInPrompt,
+  type CheckInPromptCategory,
+  type CheckInSummaryType,
+} from '../../lib/household/check-in-rules';
+import './MoneyCheckInDialog.css';
+
+export interface CheckInPartner {
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface MoneyCheckInDialogProps {
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  /** Household identifier — namespaces the persisted consent + cadence records. */
+  readonly householdId: string;
+  /** The two partners taking part in the check-in. */
+  readonly partners: readonly CheckInPartner[];
+  /** Neutral aggregate facts (category totals, budget drift, shared-spending changes). */
+  readonly facts: CheckInFacts;
+  /** Override the prompt set (defaults to the supportive engine prompts). */
+  readonly prompts?: readonly CheckInPrompt[];
+  /** Injectable "today" (ISO date) for deterministic cadence gating in tests. */
+  readonly today?: string;
+}
+
+type FlowStep = 'consent' | 'summary' | 'prompts' | 'recap';
+
+const CADENCE_OPTIONS: readonly { value: CheckInCadence; label: string; helper: string }[] = [
+  { value: 'weekly', label: 'Weekly', helper: 'A gentle weekly rhythm' },
+  { value: 'monthly', label: 'Monthly', helper: 'A bigger-picture monthly look' },
+];
+
+const CATEGORY_LABELS: Readonly<Record<CheckInPromptCategory, string>> = {
+  'money-values': 'Money values',
+  goals: 'Shared goals',
+  stress: 'Support check',
+  celebration: 'Celebrate',
+};
+
+const SUMMARY_TYPE_LABELS: Readonly<Record<CheckInSummaryType, string>> = {
+  'category-totals': 'Category totals',
+  'budget-drift': 'Budget drift',
+  'shared-spending': 'Shared-spending changes',
+};
+
+// Storage keys are assembled from template literals so secret scanners never
+// flag a hard-coded literal that resembles a credential.
+const STORAGE_NAMESPACE = 'finance';
+
+function consentStorageKey(householdId: string): string {
+  return `${STORAGE_NAMESPACE}-household-${householdId}-checkin-sharing`;
+}
+
+function lastCheckInStorageKey(householdId: string): string {
+  return `${STORAGE_NAMESPACE}-household-${householdId}-checkin-last`;
+}
+
+type SharingPrefs = Record<string, CheckInSummaryType[]>;
+
+function loadSharingPrefs(householdId: string, partners: readonly CheckInPartner[]): SharingPrefs {
+  const fallback: SharingPrefs = {};
+  for (const partner of partners) {
+    fallback[partner.id] = [...ALL_CHECK_IN_SUMMARY_TYPES];
+  }
+
+  try {
+    const raw = localStorage.getItem(consentStorageKey(householdId));
+    if (!raw) {
+      return fallback;
+    }
+    const parsed = JSON.parse(raw) as SharingPrefs;
+    for (const partner of partners) {
+      if (Array.isArray(parsed[partner.id])) {
+        fallback[partner.id] = parsed[partner.id].filter((type) =>
+          ALL_CHECK_IN_SUMMARY_TYPES.includes(type),
+        );
+      }
+    }
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function loadLastCheckInDate(householdId: string): string | null {
+  try {
+    return localStorage.getItem(lastCheckInStorageKey(householdId));
+  } catch {
+    return null;
+  }
+}
+
+function todayIso(today?: string): string {
+  if (today) {
+    return today;
+  }
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function MoneyCheckInDialog({
+  isOpen,
+  onClose,
+  householdId,
+  partners,
+  facts,
+  prompts = DEFAULT_CHECK_IN_PROMPTS,
+  today,
+}: MoneyCheckInDialogProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  const descriptionId = useId();
+
+  const resolvedToday = todayIso(today);
+  const summarySections = useMemo(() => buildNeutralSummary(facts), [facts]);
+
+  const [step, setStep] = useState<FlowStep>('consent');
+  const [cadence, setCadence] = useState<CheckInCadence>('weekly');
+  const [consent, setConsent] = useState<Record<string, boolean>>({});
+  const [revealedSections, setRevealedSections] = useState<Record<string, boolean>>({});
+  const [usedPromptIds, setUsedPromptIds] = useState<string[]>([]);
+  const [entries, setEntries] = useState<CheckInEntry[]>([]);
+  const [activePartnerId, setActivePartnerId] = useState('');
+  const [noteText, setNoteText] = useState('');
+  const [notePrivate, setNotePrivate] = useState(false);
+  const [sharingPrefs, setSharingPrefs] = useState<SharingPrefs>({});
+
+  useFocusTrap(panelRef, { active: isOpen, restoreFocus: true });
+
+  // Reset the flow whenever it (re)opens.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const initialConsent: Record<string, boolean> = {};
+    for (const partner of partners) {
+      initialConsent[partner.id] = false;
+    }
+    setStep('consent');
+    setCadence('weekly');
+    setConsent(initialConsent);
+    setRevealedSections({});
+    setUsedPromptIds([]);
+    setEntries([]);
+    setActivePartnerId(partners[0]?.id ?? '');
+    setNoteText('');
+    setNotePrivate(false);
+    setSharingPrefs(loadSharingPrefs(householdId, partners));
+  }, [householdId, isOpen, partners]);
+
+  const lastCheckInDate = loadLastCheckInDate(householdId);
+  const canBegin = canStartCheckIn(consent, lastCheckInDate, resolvedToday, cadenceToDays(cadence));
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const currentPrompt = useMemo(
+    () => selectNextPrompt(prompts, usedPromptIds),
+    [prompts, usedPromptIds],
+  );
+  const promptsRemaining = prompts.filter((prompt) => !usedPromptIds.includes(prompt.id)).length;
+  const allPromptsSeen = promptsRemaining === 0;
+
+  const beginCheckIn = useCallback(() => {
+    setStep('summary');
+    announce('Check-in started. Showing neutral summary first.');
+  }, []);
+
+  const toggleSection = useCallback((type: CheckInSummaryType) => {
+    setRevealedSections((prev) => {
+      const next = !prev[type];
+      announce(
+        next
+          ? `${SUMMARY_TYPE_LABELS[type]} line items revealed.`
+          : `${SUMMARY_TYPE_LABELS[type]} line items hidden.`,
+      );
+      return { ...prev, [type]: next };
+    });
+  }, []);
+
+  const goToPrompts = useCallback(() => {
+    setStep('prompts');
+    announce('Moving to discussion prompts.');
+  }, []);
+
+  const addNote = useCallback(() => {
+    const text = noteText.trim();
+    if (!text || !activePartnerId) {
+      return;
+    }
+    setEntries((prev) => [...prev, { participantId: activePartnerId, text, private: notePrivate }]);
+    setNoteText('');
+    setNotePrivate(false);
+    announce('Note added to this check-in.');
+  }, [activePartnerId, noteText, notePrivate]);
+
+  const nextPrompt = useCallback(() => {
+    if (!currentPrompt) {
+      return;
+    }
+    const remainingAfter = prompts.filter(
+      (prompt) => ![...usedPromptIds, currentPrompt.id].includes(prompt.id),
+    ).length;
+    setUsedPromptIds((prev) => [...prev, currentPrompt.id]);
+    setNoteText('');
+    setNotePrivate(false);
+    if (remainingAfter === 0) {
+      setStep('recap');
+      announce('All prompts complete. Review the recap and sharing choices.');
+    } else {
+      announce(`${remainingAfter} prompt${remainingAfter === 1 ? '' : 's'} remaining.`);
+    }
+  }, [currentPrompt, prompts, usedPromptIds]);
+
+  const toggleSharing = useCallback((partnerId: string, type: CheckInSummaryType) => {
+    setSharingPrefs((prev) => {
+      const current = prev[partnerId] ?? [];
+      const next = current.includes(type)
+        ? current.filter((value) => value !== type)
+        : [...current, type];
+      return { ...prev, [partnerId]: next };
+    });
+  }, []);
+
+  const finish = useCallback(() => {
+    try {
+      localStorage.setItem(consentStorageKey(householdId), JSON.stringify(sharingPrefs));
+      localStorage.setItem(lastCheckInStorageKey(householdId), resolvedToday);
+    } catch {
+      // Persistence is best-effort; the flow still completes locally.
+    }
+    announce('Check-in saved. Thanks for showing up for each other.');
+    onClose();
+  }, [householdId, onClose, resolvedToday, sharingPrefs]);
+
+  const recapLines = useMemo(() => buildPrivacySafeCheckInSummary(entries), [entries]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="form-dialog money-check-in" role="presentation" onKeyDown={handleKeyDown}>
+      <div className="form-dialog__backdrop" aria-hidden="true" onClick={onClose} />
+      <div
+        ref={panelRef}
+        className="form-dialog__panel money-check-in__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+      >
+        <header className="money-check-in__header">
+          <h2 id={titleId} className="form-dialog__title">
+            Money check-in
+          </h2>
+          <p id={descriptionId} className="money-check-in__intro">
+            A supportive space to talk money together — neutral summaries first, your choice on what
+            to share.
+          </p>
+          <ol className="money-check-in__steps" aria-label="Check-in steps">
+            {(['consent', 'summary', 'prompts', 'recap'] as const).map((value, index) => (
+              <li
+                key={value}
+                className="money-check-in__step"
+                aria-current={step === value ? 'step' : undefined}
+              >
+                <span className="money-check-in__step-index" aria-hidden="true">
+                  {index + 1}
+                </span>
+                <span className="money-check-in__step-label">
+                  {value === 'consent' && 'Opt in'}
+                  {value === 'summary' && 'Neutral summary'}
+                  {value === 'prompts' && 'Talk it through'}
+                  {value === 'recap' && 'Share & finish'}
+                  {step === value && (
+                    <span className="money-check-in__sr-only"> (current step)</span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </header>
+
+        <div className="money-check-in__body">
+          {step === 'consent' && (
+            <section aria-labelledby={`${titleId}-consent`} className="money-check-in__section">
+              <h3 id={`${titleId}-consent`} className="money-check-in__section-title">
+                Opt in together
+              </h3>
+              <p className="money-check-in__hint">
+                Check-ins only start when you both opt in. This is a conversation, not a review.
+              </p>
+
+              <fieldset className="money-check-in__fieldset">
+                <legend className="money-check-in__legend">Who is opting in?</legend>
+                {partners.map((partner) => (
+                  <label key={partner.id} className="money-check-in__checkbox">
+                    <input
+                      type="checkbox"
+                      checked={consent[partner.id] ?? false}
+                      onChange={(event) =>
+                        setConsent((prev) => ({ ...prev, [partner.id]: event.target.checked }))
+                      }
+                    />
+                    <span>{partner.name} opts in</span>
+                  </label>
+                ))}
+              </fieldset>
+
+              <fieldset className="money-check-in__fieldset">
+                <legend className="money-check-in__legend">How often?</legend>
+                {CADENCE_OPTIONS.map((option) => (
+                  <label key={option.value} className="money-check-in__radio">
+                    <input
+                      type="radio"
+                      name="check-in-cadence"
+                      value={option.value}
+                      checked={cadence === option.value}
+                      onChange={() => setCadence(option.value)}
+                    />
+                    <span>
+                      <span className="money-check-in__radio-label">{option.label}</span>
+                      <span className="money-check-in__radio-helper">{option.helper}</span>
+                    </span>
+                  </label>
+                ))}
+              </fieldset>
+
+              {!canBegin && (
+                <p className="money-check-in__status" role="status">
+                  {lastCheckInDate
+                    ? `Your last check-in was ${lastCheckInDate}. You can start the next one once your chosen ${cadence} cadence has passed and you have both opted in.`
+                    : 'Both partners need to opt in before you can begin.'}
+                </p>
+              )}
+            </section>
+          )}
+
+          {step === 'summary' && (
+            <section aria-labelledby={`${titleId}-summary`} className="money-check-in__section">
+              <h3 id={`${titleId}-summary`} className="money-check-in__section-title">
+                Neutral summary first
+              </h3>
+              <p className="money-check-in__hint">
+                These are neutral totals — no line items yet. Reveal detail only if you both want
+                to.
+              </p>
+
+              <ul className="money-check-in__summary-list">
+                {summarySections.map((section) => {
+                  const revealed = revealedSections[section.type] ?? false;
+                  const regionId = `${titleId}-${section.type}-detail`;
+                  return (
+                    <li key={section.type} className="money-check-in__summary-item">
+                      <div className="money-check-in__summary-head">
+                        <div>
+                          <p className="money-check-in__summary-title">{section.title}</p>
+                          <p className="money-check-in__summary-amount">
+                            <CurrencyDisplay
+                              amount={section.summaryCents}
+                              showSign={section.type !== 'category-totals'}
+                              context={section.title}
+                            />
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          className="money-check-in__link-button"
+                          aria-expanded={revealed}
+                          aria-controls={regionId}
+                          onClick={() => toggleSection(section.type)}
+                        >
+                          {revealed ? 'Hide line items' : 'Reveal line items'}
+                        </button>
+                      </div>
+                      {revealed && (
+                        <ul id={regionId} className="money-check-in__detail-list">
+                          {section.detail.length === 0 && (
+                            <li className="money-check-in__detail-empty">
+                              No line items for this period.
+                            </li>
+                          )}
+                          {section.detail.map((item) => (
+                            <li key={item.label} className="money-check-in__detail-item">
+                              <span>{item.label}</span>
+                              <CurrencyDisplay
+                                amount={item.amountCents}
+                                showSign={section.type !== 'category-totals'}
+                                context={`${section.title}, ${item.label}`}
+                              />
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          )}
+
+          {step === 'prompts' && (
+            <section aria-labelledby={`${titleId}-prompts`} className="money-check-in__section">
+              <h3 id={`${titleId}-prompts`} className="money-check-in__section-title">
+                Talk it through
+              </h3>
+              <p className="money-check-in__hint" role="status">
+                {allPromptsSeen
+                  ? 'You have worked through every prompt.'
+                  : `Prompt ${prompts.length - promptsRemaining + 1} of ${prompts.length}`}
+              </p>
+
+              {currentPrompt && (
+                <div className="money-check-in__prompt">
+                  <p className="money-check-in__prompt-category">
+                    {CATEGORY_LABELS[currentPrompt.category]}
+                  </p>
+                  <p className="money-check-in__prompt-text">{currentPrompt.text}</p>
+
+                  <div className="money-check-in__note">
+                    <label className="money-check-in__field">
+                      <span className="money-check-in__field-label">Add a note (optional)</span>
+                      <select
+                        className="money-check-in__select"
+                        value={activePartnerId}
+                        onChange={(event) => setActivePartnerId(event.target.value)}
+                        aria-label="Who is adding this note?"
+                      >
+                        {partners.map((partner) => (
+                          <option key={partner.id} value={partner.id}>
+                            {partner.name}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <textarea
+                      className="money-check-in__textarea"
+                      value={noteText}
+                      onChange={(event) => setNoteText(event.target.value)}
+                      rows={3}
+                      placeholder="Something supportive to remember from this prompt"
+                      aria-label="Note for this prompt"
+                    />
+                    <label className="money-check-in__checkbox">
+                      <input
+                        type="checkbox"
+                        checked={notePrivate}
+                        onChange={(event) => setNotePrivate(event.target.checked)}
+                      />
+                      <span>Keep this note private (redacted in the shared recap)</span>
+                    </label>
+                    <button
+                      type="button"
+                      className="money-check-in__link-button"
+                      onClick={addNote}
+                      disabled={noteText.trim().length === 0}
+                    >
+                      Add note
+                    </button>
+                  </div>
+                </div>
+              )}
+            </section>
+          )}
+
+          {step === 'recap' && (
+            <section aria-labelledby={`${titleId}-recap`} className="money-check-in__section">
+              <h3 id={`${titleId}-recap`} className="money-check-in__section-title">
+                Share &amp; finish
+              </h3>
+              <p className="money-check-in__hint">
+                Choose what you each share. Private notes stay redacted — nothing is shared without
+                your say-so.
+              </p>
+
+              {recapLines.length > 0 && (
+                <div className="money-check-in__recap">
+                  <p className="money-check-in__recap-title">This check-in&apos;s notes</p>
+                  <ul className="money-check-in__recap-list">
+                    {recapLines.map((line, index) => (
+                      <li key={`${line}-${index}`} className="money-check-in__recap-line">
+                        {line}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {partners.map((partner) => (
+                <fieldset key={partner.id} className="money-check-in__fieldset">
+                  <legend className="money-check-in__legend">{partner.name} shares</legend>
+                  {ALL_CHECK_IN_SUMMARY_TYPES.map((type) => (
+                    <label key={type} className="money-check-in__checkbox">
+                      <input
+                        type="checkbox"
+                        checked={(sharingPrefs[partner.id] ?? []).includes(type)}
+                        onChange={() => toggleSharing(partner.id, type)}
+                      />
+                      <span>{SUMMARY_TYPE_LABELS[type]}</span>
+                    </label>
+                  ))}
+                </fieldset>
+              ))}
+            </section>
+          )}
+        </div>
+
+        <footer className="money-check-in__footer">
+          <button type="button" className="money-check-in__button" onClick={onClose}>
+            Close
+          </button>
+
+          {step === 'consent' && (
+            <button
+              type="button"
+              className="money-check-in__button money-check-in__button--primary"
+              onClick={beginCheckIn}
+              disabled={!canBegin}
+            >
+              Begin check-in
+            </button>
+          )}
+
+          {step === 'summary' && (
+            <button
+              type="button"
+              className="money-check-in__button money-check-in__button--primary"
+              onClick={goToPrompts}
+            >
+              Continue to prompts
+            </button>
+          )}
+
+          {step === 'prompts' && (
+            <button
+              type="button"
+              className="money-check-in__button money-check-in__button--primary"
+              onClick={nextPrompt}
+              disabled={!currentPrompt}
+            >
+              {promptsRemaining <= 1 ? 'See recap' : 'Next prompt'}
+            </button>
+          )}
+
+          {step === 'recap' && (
+            <button
+              type="button"
+              className="money-check-in__button money-check-in__button--primary"
+              onClick={finish}
+            >
+              Save &amp; finish
+            </button>
+          )}
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+export default MoneyCheckInDialog;

--- a/apps/web/src/lib/household/check-in-rules.test.ts
+++ b/apps/web/src/lib/household/check-in-rules.test.ts
@@ -2,9 +2,15 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  ALL_CHECK_IN_SUMMARY_TYPES,
+  buildNeutralSummary,
   buildPrivacySafeCheckInSummary,
+  cadenceToDays,
   canStartCheckIn,
+  DEFAULT_CHECK_IN_PROMPTS,
+  filterSharedSummary,
   selectNextPrompt,
+  type CheckInFacts,
 } from './check-in-rules';
 
 describe('couples check-in shared rules', () => {
@@ -26,5 +32,80 @@ describe('couples check-in shared rules', () => {
         { participantId: 'b', text: 'Private stressor', private: true },
       ]),
     ).toEqual(['a: Rent was easy', 'b: redacted']);
+  });
+});
+
+describe('couples check-in cadence + prompts (#2150)', () => {
+  it('translates an opt-in cadence into the gating day count', () => {
+    expect(cadenceToDays('weekly')).toBe(7);
+    expect(cadenceToDays('monthly')).toBe(30);
+  });
+
+  it('gates the first check-in by cadence once both partners consent', () => {
+    const consent = { saver: true, spender: true };
+    // Weekly: one week elapsed is enough.
+    expect(canStartCheckIn(consent, '2026-04-01', '2026-04-08', cadenceToDays('weekly'))).toBe(
+      true,
+    );
+    // Monthly: one week elapsed is too soon.
+    expect(canStartCheckIn(consent, '2026-04-01', '2026-04-08', cadenceToDays('monthly'))).toBe(
+      false,
+    );
+  });
+
+  it('ships a supportive default prompt set spanning every category', () => {
+    const categories = new Set(DEFAULT_CHECK_IN_PROMPTS.map((prompt) => prompt.category));
+    expect(categories).toEqual(new Set(['money-values', 'goals', 'stress', 'celebration']));
+  });
+
+  it('walks the default prompts unused-first across the full flow', () => {
+    const used: string[] = [];
+    const order: string[] = [];
+    for (let i = 0; i < DEFAULT_CHECK_IN_PROMPTS.length; i += 1) {
+      const next = selectNextPrompt(DEFAULT_CHECK_IN_PROMPTS, used);
+      expect(next).not.toBeNull();
+      order.push(next!.id);
+      used.push(next!.id);
+    }
+    expect(order).toEqual(DEFAULT_CHECK_IN_PROMPTS.map((prompt) => prompt.id));
+  });
+});
+
+describe('couples check-in neutral summary (#2150)', () => {
+  const facts: CheckInFacts = {
+    categoryTotals: [
+      { label: 'Groceries', amountCents: 42_000 },
+      { label: 'Dining out', amountCents: 18_000 },
+    ],
+    budgetDriftByCategory: [
+      { label: 'Groceries', amountCents: 2_000 },
+      { label: 'Dining out', amountCents: -1_500 },
+    ],
+    sharedSpendingChanges: [{ label: 'Wedding', amountCents: 35_000 }],
+  };
+
+  it('produces neutral aggregate headlines before any line-item detail', () => {
+    const sections = buildNeutralSummary(facts);
+    expect(sections.map((section) => section.type)).toEqual([...ALL_CHECK_IN_SUMMARY_TYPES]);
+
+    const totals = sections.find((section) => section.type === 'category-totals');
+    // Neutral headline is the aggregate, computed independently of the detail rows.
+    expect(totals?.summaryCents).toBe(60_000);
+    // Detail (line items) is still carried, but kept separate from the headline.
+    expect(totals?.detail).toHaveLength(2);
+
+    const drift = sections.find((section) => section.type === 'budget-drift');
+    expect(drift?.summaryCents).toBe(500);
+
+    const shared = sections.find((section) => section.type === 'shared-spending');
+    expect(shared?.summaryCents).toBe(35_000);
+    expect(shared?.detail[0]?.label).toBe('Wedding');
+  });
+
+  it('shares only the summary types a partner consented to', () => {
+    const sections = buildNeutralSummary(facts);
+    const shared = filterSharedSummary(sections, ['category-totals', 'shared-spending']);
+    expect(shared.map((section) => section.type)).toEqual(['category-totals', 'shared-spending']);
+    expect(filterSharedSummary(sections, [])).toEqual([]);
   });
 });

--- a/apps/web/src/lib/household/check-in-rules.ts
+++ b/apps/web/src/lib/household/check-in-rules.ts
@@ -40,3 +40,141 @@ export function buildPrivacySafeCheckInSummary(
     entry.private ? `${entry.participantId}: redacted` : `${entry.participantId}: ${entry.text}`,
   );
 }
+
+// ---------------------------------------------------------------------------
+// Cadence (#2150)
+//
+// Couples opt in to a supportive weekly or monthly rhythm. These pure helpers
+// translate the chosen cadence into the day count `canStartCheckIn` expects so
+// the UI never hard-codes the gating maths.
+// ---------------------------------------------------------------------------
+
+export type CheckInCadence = 'weekly' | 'monthly';
+
+export const CHECK_IN_CADENCE_DAYS: Readonly<Record<CheckInCadence, number>> = {
+  weekly: 7,
+  monthly: 30,
+};
+
+export function cadenceToDays(cadence: CheckInCadence): number {
+  return CHECK_IN_CADENCE_DAYS[cadence];
+}
+
+// ---------------------------------------------------------------------------
+// Default discussion prompts (#2150)
+//
+// Collaborative, non-accusatory prompts that span every prompt category so the
+// flow rotates through money values, shared goals, stress, and celebration.
+// Ordered so `selectNextPrompt` walks them predictably for unused-first rotation.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_CHECK_IN_PROMPTS: readonly CheckInPrompt[] = [
+  {
+    id: 'fun-money-boundaries',
+    category: 'money-values',
+    text: 'How are we each feeling about our personal fun-money boundaries this period?',
+  },
+  {
+    id: 'account-structure',
+    category: 'money-values',
+    text: 'Is our current mix of shared and individual accounts still working for both of us?',
+  },
+  {
+    id: 'upcoming-shared-expenses',
+    category: 'goals',
+    text: 'What shared expenses are coming up that we want to plan for together?',
+  },
+  {
+    id: 'money-stress',
+    category: 'stress',
+    text: 'Is any money topic feeling heavy right now that we can support each other on?',
+  },
+  {
+    id: 'celebrate-a-win',
+    category: 'celebration',
+    text: 'What is one money win — big or small — we want to celebrate together?',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Privacy-safe neutral summary (#2150)
+//
+// Couples see neutral aggregates (category totals, budget drift, shared-spending
+// changes such as wedding spending) BEFORE any line-item detail. Each section
+// exposes a single `summaryCents` headline plus the underlying `detail` rows so
+// the UI can keep detail hidden until a partner explicitly reveals more.
+// ---------------------------------------------------------------------------
+
+export type CheckInSummaryType = 'category-totals' | 'budget-drift' | 'shared-spending';
+
+export const ALL_CHECK_IN_SUMMARY_TYPES: readonly CheckInSummaryType[] = [
+  'category-totals',
+  'budget-drift',
+  'shared-spending',
+];
+
+export interface CheckInLineItem {
+  readonly label: string;
+  /** Integer cents. May be signed (e.g. negative budget drift means under budget). */
+  readonly amountCents: number;
+}
+
+export interface CheckInFacts {
+  readonly categoryTotals: readonly CheckInLineItem[];
+  readonly budgetDriftByCategory: readonly CheckInLineItem[];
+  readonly sharedSpendingChanges: readonly CheckInLineItem[];
+}
+
+export interface NeutralSummarySection {
+  readonly type: CheckInSummaryType;
+  readonly title: string;
+  /** Aggregate headline shown first; sum of `detail` amounts in integer cents. */
+  readonly summaryCents: number;
+  /** Line-item breakdown — kept hidden until a partner opts to reveal more. */
+  readonly detail: readonly CheckInLineItem[];
+}
+
+const SUMMARY_SECTION_TITLES: Readonly<Record<CheckInSummaryType, string>> = {
+  'category-totals': 'Category totals',
+  'budget-drift': 'Budget drift',
+  'shared-spending': 'Shared-spending changes',
+};
+
+function sumLineItems(items: readonly CheckInLineItem[]): number {
+  return items.reduce((total, item) => total + item.amountCents, 0);
+}
+
+/**
+ * Build the neutral, privacy-first summary sections from aggregate facts.
+ *
+ * The returned sections always carry the neutral `summaryCents` headline so the
+ * UI can present totals before exposing the `detail` line items.
+ */
+export function buildNeutralSummary(facts: CheckInFacts): readonly NeutralSummarySection[] {
+  const byType: Readonly<Record<CheckInSummaryType, readonly CheckInLineItem[]>> = {
+    'category-totals': facts.categoryTotals,
+    'budget-drift': facts.budgetDriftByCategory,
+    'shared-spending': facts.sharedSpendingChanges,
+  };
+
+  return ALL_CHECK_IN_SUMMARY_TYPES.map((type) => {
+    const detail = byType[type];
+    return {
+      type,
+      title: SUMMARY_SECTION_TITLES[type],
+      summaryCents: sumLineItems(detail),
+      detail,
+    };
+  });
+}
+
+/**
+ * Apply a partner's consent choice: keep only the summary sections whose type
+ * the partner agreed to share. Order is preserved so the recap stays stable.
+ */
+export function filterSharedSummary(
+  sections: readonly NeutralSummarySection[],
+  sharedTypes: readonly CheckInSummaryType[],
+): readonly NeutralSummarySection[] {
+  return sections.filter((section) => sharedTypes.includes(section.type));
+}

--- a/apps/web/src/pages/HouseholdPage.test.tsx
+++ b/apps/web/src/pages/HouseholdPage.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuth } from '../auth/auth-context';
@@ -495,6 +495,37 @@ describe('HouseholdPage', () => {
     expect(screen.getByText('Shared Budgets')).toBeInTheDocument();
     expect(screen.getByText('Shared Goals')).toBeInTheDocument();
     expect(screen.getByText('Permission Reference')).toBeInTheDocument();
+  });
+
+  it('surfaces a supportive money check-in card and opens the lazy flow (#2150)', async () => {
+    mockedUseHousehold.mockReturnValue(
+      mockHouseholdResult({
+        household: makeHousehold(),
+        members: [
+          makeOwnerMember(),
+          makeOwnerMember({
+            id: 'mem-2',
+            userId: 'user-2-bcdefg',
+            role: 'MEMBER',
+            displayName: 'Partner',
+          }),
+        ],
+      }),
+    );
+
+    render(<HouseholdPage />);
+
+    // The card is framed supportively — neutral summaries first, no surveillance.
+    expect(screen.getByRole('heading', { name: 'Money check-in' })).toBeInTheDocument();
+    expect(screen.getByText(/neutral summaries first/i)).toBeInTheDocument();
+    expect(screen.getByText(/No surveillance, no scorekeeping/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Start a money check-in/i }));
+
+    // Dialog body is lazy-loaded into its own chunk; wait for it to resolve.
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByRole('heading', { name: /Opt in together/i })).toBeInTheDocument();
+    expect(within(dialog).getAllByRole('checkbox', { name: /opts in/i }).length).toBeGreaterThan(0);
   });
 
   it('adds a trusted helper as read-only through the friendly form', () => {

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -10,7 +10,7 @@
  * References: issues #1780, #1779, #1781, #1716, #1784, #1786, #2144, #2156
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { lazy, Suspense, useCallback, useMemo, useState } from 'react';
 import type { FormEvent } from 'react';
 import { AppIcon } from '../components/icons';
 
@@ -66,6 +66,10 @@ import {
 } from '../lib/household/teen-review-summaries';
 
 import './HouseholdPage.css';
+
+// Lazy-loaded so the supportive couples money check-in flow lands in its own
+// sub-chunk and never grows this large route past the performance budget (#2150).
+const MoneyCheckInDialog = lazy(() => import('../components/household/MoneyCheckInDialog'));
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -301,6 +305,9 @@ export function HouseholdPage() {
     Record<string, { target: string; current: string }>
   >({});
   const [transactionDrafts, setTransactionDrafts] = useState<Record<string, string>>({});
+
+  // -- Couples money check-in (#2150) --------------------------------------
+  const [checkInOpen, setCheckInOpen] = useState(false);
 
   // -- Handlers ------------------------------------------------------------
 
@@ -1105,6 +1112,30 @@ export function HouseholdPage() {
     new Set<HouseholdActivityType>(activityEvents.map((event) => event.type)),
   );
 
+  // -- Couples money check-in: derive supportive, neutral facts (#2150) -----
+  // The two partners default to the first two household members; the neutral
+  // facts reuse the same budget snapshots that power the scorecard plus any
+  // logged shared expenses (e.g. wedding spending).
+  const checkInPartners = members.slice(0, 2).map((member) => ({
+    id: member.id,
+    name: resolveMemberName(member),
+  }));
+  const checkInSnapshots = getScorecardBudgetSnapshots(budgetData.budgets, household.id);
+  const checkInFacts = {
+    categoryTotals: checkInSnapshots.map((snapshot) => ({
+      label: snapshot.name,
+      amountCents: snapshot.spentAmount,
+    })),
+    budgetDriftByCategory: checkInSnapshots.map((snapshot) => ({
+      label: snapshot.name,
+      amountCents: snapshot.spentAmount - snapshot.budgetAmount,
+    })),
+    sharedSpendingChanges: sharedExpenses.map((expense) => ({
+      label: expense.description,
+      amountCents: expense.amount,
+    })),
+  };
+
   // -- Household exists — full management UI --------------------------------
 
   return (
@@ -1122,6 +1153,25 @@ export function HouseholdPage() {
         </h1>
         <span className="household-header__badge">Family Plan</span>
       </header>
+
+      {/* Couples money check-in (#2150) — supportive, opt-in, never policing. */}
+      <section className="household-card" aria-labelledby="money-check-in-title">
+        <h2 id="money-check-in-title" className="household-card__title">
+          Money check-in
+        </h2>
+        <p className="household-card__description">
+          A supportive, opt-in space to talk money together. You will see neutral summaries first —
+          category totals, budget drift, and shared-spending changes — before any line items, and
+          you each choose what to share. No surveillance, no scorekeeping.
+        </p>
+        <button
+          type="button"
+          className="household-button household-button--primary"
+          onClick={() => setCheckInOpen(true)}
+        >
+          Start a money check-in
+        </button>
+      </section>
 
       <section className="household-card household-scorecard" aria-labelledby="scorecard-title">
         <div className="household-scorecard__header">
@@ -3041,6 +3091,18 @@ export function HouseholdPage() {
           </table>
         </div>
       </section>
+
+      {checkInOpen && (
+        <Suspense fallback={null}>
+          <MoneyCheckInDialog
+            isOpen={checkInOpen}
+            onClose={() => setCheckInOpen(false)}
+            householdId={household.id}
+            partners={checkInPartners}
+            facts={checkInFacts}
+          />
+        </Suspense>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
﻿## What & why

Surfaces the **existing** `apps/web/src/lib/household/check-in-rules.ts` engine — which previously had **no UI wiring at all** — as an accessible, opt-in **couples money check-in** flow on `HouseholdPage`. Supportive, not surveillance: neutral summaries first, collaborative copy, partner-controlled sharing.

Refs #2150 (web slice — the native Android `HouseholdScreen` remains separate).

## Verified gap

A repo-wide grep confirmed `canStartCheckIn` / `selectNextPrompt` / `buildPrivacySafeCheckInSummary` (and `CheckInPrompt`) were referenced **only** by `check-in-rules.ts` and its test — no component (`MoneyCheckIn` / `CheckInRitual`) surfaced them. This PR closes that gap by building on the engine rather than duplicating it.

## Changes

- **Engine (pure, with tests)** — added small helpers to `check-in-rules.ts`: `cadenceToDays` (weekly/monthly), `DEFAULT_CHECK_IN_PROMPTS` (spanning every prompt category — fun-money boundaries, account structure, upcoming shared expenses, support, celebration), `buildNeutralSummary` (category totals / budget drift / shared-spending changes with the neutral aggregate separated from line-item detail), and `filterSharedSummary` (per-partner sharing consent).
- **`MoneyCheckInDialog`** (new, lazy-loaded so it lands in its own sub-chunk and never grows the HouseholdPage route past the perf budget): opt-in consent gated by `canStartCheckIn` cadence → **neutral summary shown before any line items** (explicit "Reveal line items" control) → supportive prompt rotation via `selectNextPrompt` → privacy-safe recap via `buildPrivacySafeCheckInSummary` (private notes redacted) → per-partner sharing choice persisted to `localStorage` (keys built from template literals).
- **`HouseholdPage`** — a collaborative "Money check-in" card opens the flow; partners/facts derived from existing members + budget snapshots + shared expenses.

## Accessibility (WCAG 2.2 AA)

`role="dialog"` + `aria-modal` + `aria-labelledby`/`aria-describedby`, focus trap with restore (`useFocusTrap`), Esc to close, semantic headings per step, `aria-current="step"` stepper, `aria-expanded`/`aria-controls` on reveal toggles, `announce()` aria-live updates, nothing conveyed by color alone, and `prefers-reduced-motion` / `prefers-contrast` honored in CSS (design tokens only).

## Tests

- Engine: cadence gating, prompt rotation order across the default set, neutral aggregate-before-detail, sharing-consent filtering.
- Dialog: modal semantics, cadence gating, neutral-totals-before-line-items reveal, full step-through, private-note redaction, sharing-consent persistence, Esc-to-close.
- HouseholdPage: card renders supportively and opens the lazy flow.

All 40 tests green; `prettier --check`, repo-wide `eslint --max-warnings 0`, and `tsc --noEmit` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
