### PR TITLE
feat(web): high-risk week + one-off kid expenses in bill calendar (#2196)

### DIFF
--- a/apps/web/src/components/bills/BillCalendarView.test.tsx
+++ b/apps/web/src/components/bills/BillCalendarView.test.tsx
@@ -99,6 +99,45 @@ describe('BillCalendarView', () => {
     expect(screen.getAllByText(/Short by/).length).toBeGreaterThan(0);
   });
 
+  it('flags a high-risk week when bills exceed the paycheck', () => {
+    seedSchedule('40'); // $40 income, well under the bill
+    const bills = [makeBill({ name: 'Rent', dueDate: isoOffset(3), amount: { amount: 120000 } })];
+
+    render(<BillCalendarView bills={bills} />);
+
+    expect(screen.getAllByText('High-risk week').length).toBeGreaterThan(0);
+  });
+
+  it('surfaces one-time (kid) expenses with a distinct badge and explainer', () => {
+    seedSchedule('2000');
+    const bills = [
+      makeBill({
+        name: 'Soccer signup',
+        dueDate: isoOffset(4),
+        frequency: 'ONE_TIME',
+        amount: { amount: 8500 },
+      }),
+    ];
+
+    render(<BillCalendarView bills={bills} />);
+
+    // A "One-time" tag is rendered next to the bill name.
+    expect(screen.getAllByText(/One-time/i).length).toBeGreaterThan(0);
+    // The schedule form explains where one-off kid expenses appear.
+    expect(screen.getByText(/school fees, birthdays/i)).toBeInTheDocument();
+  });
+
+  it('announces high-risk weeks in the live summary region', () => {
+    seedSchedule('40');
+    const bills = [makeBill({ name: 'Rent', dueDate: isoOffset(3), amount: { amount: 120000 } })];
+
+    const { container } = render(<BillCalendarView bills={bills} />);
+
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).not.toBeNull();
+    expect(liveRegion?.textContent ?? '').toMatch(/high-risk/i);
+  });
+
   it('prompts for income before computing coverage', () => {
     seedSchedule(''); // no income provided
     const bills = [makeBill({ name: 'Water', dueDate: isoOffset(3), amount: { amount: 4000 } })];

--- a/apps/web/src/components/bills/BillCalendarView.tsx
+++ b/apps/web/src/components/bills/BillCalendarView.tsx
@@ -25,8 +25,13 @@ import { CurrencyDisplay } from '../common';
 import { AppIcon } from '../icons';
 import {
   buildBillCalendar,
+  classifyPeriodRisk,
   DEFAULT_PERIODS_TO_SHOW,
+  oneTimeDueCents,
+  oneTimeOccurrences,
   PAYDAY_CADENCE_LABELS,
+  PERIOD_RISK_LABELS,
+  summarizeCalendarRisk,
   type PayPeriod,
   type PaydayCadence,
 } from '../../lib/bills/bill-calendar';
@@ -159,6 +164,24 @@ function CoverageStatus({
   );
 }
 
+/** High-risk-week badge shown with an icon + text (never colour alone). */
+function RiskBadge({
+  period,
+  incomeProvided,
+}: {
+  period: PayPeriod;
+  incomeProvided: boolean;
+}): React.ReactElement | null {
+  const risk = classifyPeriodRisk(period, incomeProvided);
+  if (risk !== 'shortfall' && risk !== 'tight') return null;
+  return (
+    <span className={`bill-risk-badge bill-risk-badge--${risk}`}>
+      <AppIcon name={risk === 'shortfall' ? 'flame' : 'alert-triangle'} />
+      {risk === 'shortfall' ? 'High-risk week' : 'Tight week'}
+    </span>
+  );
+}
+
 /** A single pay-period card. */
 function PayPeriodCard({
   period,
@@ -168,11 +191,21 @@ function PayPeriodCard({
   incomeProvided: boolean;
 }): React.ReactElement {
   const headingId = `pay-period-${period.index}`;
+  const risk = classifyPeriodRisk(period, incomeProvided);
+  const oneTimeBills = oneTimeOccurrences(period);
+  const accessibleStatus =
+    risk === 'unknown' ? 'pay period' : `pay period — ${PERIOD_RISK_LABELS[risk]}`;
   return (
-    <article className="card" aria-labelledby={headingId}>
-      <h4 id={headingId} style={{ margin: 0, fontWeight: 'var(--font-weight-semibold)' }}>
-        <AppIcon name="wallet" /> Payday {formatDate(period.paydayDate)}
-      </h4>
+    <article
+      className="card"
+      aria-label={`Payday ${formatDate(period.paydayDate)}, ${accessibleStatus}`}
+    >
+      <div className="bill-period-card__header">
+        <h4 id={headingId} style={{ margin: 0, fontWeight: 'var(--font-weight-semibold)' }}>
+          <AppIcon name="wallet" /> Payday {formatDate(period.paydayDate)}
+        </h4>
+        <RiskBadge period={period} incomeProvided={incomeProvided} />
+      </div>
       <p
         style={{ ...captionStyle, marginTop: 'var(--spacing-1)', marginBottom: 'var(--spacing-3)' }}
       >
@@ -199,6 +232,17 @@ function PayPeriodCard({
         <CoverageStatus period={period} incomeProvided={incomeProvided} />
       </div>
 
+      {oneTimeBills.length > 0 && (
+        <p className="bill-period-card__onetime" style={captionStyle}>
+          <AppIcon name="gift" /> Includes {oneTimeBills.length} one-time{' '}
+          {oneTimeBills.length === 1 ? 'expense' : 'expenses'} ·{' '}
+          <CurrencyDisplay
+            amount={oneTimeDueCents(period)}
+            context="one-time expenses this period"
+          />
+        </p>
+      )}
+
       {period.bills.length === 0 ? (
         <p style={captionStyle}>No bills due before this payday.</p>
       ) : (
@@ -217,6 +261,14 @@ function PayPeriodCard({
             >
               <span style={{ minWidth: 0 }}>
                 <span style={{ fontWeight: 'var(--font-weight-medium)' }}>{bill.name}</span>
+                {bill.frequency === 'ONE_TIME' && (
+                  <>
+                    {' '}
+                    <span className="bill-onetime-badge">
+                      <AppIcon name="gift" /> One-time
+                    </span>
+                  </>
+                )}
                 <br />
                 <span style={captionStyle}>
                   {bill.payee} · Due {formatDate(bill.dueDate)}
@@ -272,6 +324,11 @@ export const BillCalendarView: React.FC<BillCalendarViewProps> = ({ bills }) => 
   const anchorId = `${fieldIdPrefix}-anchor`;
   const incomeId = `${fieldIdPrefix}-income`;
 
+  const riskSummary = useMemo(
+    () => summarizeCalendarRisk(calendar, incomeProvided),
+    [calendar, incomeProvided],
+  );
+
   return (
     <section aria-label="Bills by pay period">
       <form
@@ -285,7 +342,9 @@ export const BillCalendarView: React.FC<BillCalendarViewProps> = ({ bills }) => 
             Your payday schedule
           </legend>
           <p style={{ ...captionStyle, marginTop: 'var(--spacing-1)' }}>
-            Tell us your pay cycle to see which bills fall in each pay period.
+            Tell us your pay cycle to see which bills fall in each pay period. One-time expenses —
+            school fees, birthdays, sports signups — appear here too when you add them as a One-Time
+            bill.
           </p>
 
           <div
@@ -374,8 +433,32 @@ export const BillCalendarView: React.FC<BillCalendarViewProps> = ({ bills }) => 
       <p aria-live="polite" style={{ ...captionStyle, marginBottom: 'var(--spacing-3)' }}>
         Next {calendar.periods.length} pay periods ·{' '}
         <CurrencyDisplay amount={calendar.totalDueCents} context="total bills due" /> in bills
-        {incomeProvided && (
-          <> · {calendar.totalCoverageCents >= 0 ? 'covered overall' : 'shortfall overall'}</>
+        {incomeProvided &&
+          (riskSummary.highRiskPeriodCount > 0 ? (
+            <>
+              {' '}
+              · <AppIcon name="flame" /> {riskSummary.highRiskPeriodCount} high-risk{' '}
+              {riskSummary.highRiskPeriodCount === 1 ? 'week' : 'weeks'} before payday
+              {riskSummary.firstShortfallPaydayDate !== null && (
+                <>
+                  {' '}
+                  — first shortfall on the {formatDate(riskSummary.firstShortfallPaydayDate)} payday
+                </>
+              )}
+            </>
+          ) : (
+            <>
+              {' '}
+              · <AppIcon name="check-circle" /> on track across every payday
+            </>
+          ))}
+        {riskSummary.oneTimeCount > 0 && (
+          <>
+            {' '}
+            · <AppIcon name="gift" /> {riskSummary.oneTimeCount} one-time{' '}
+            {riskSummary.oneTimeCount === 1 ? 'expense' : 'expenses'} (
+            <CurrencyDisplay amount={riskSummary.oneTimeDueCents} context="one-time expenses" />)
+          </>
         )}
       </p>
 

--- a/apps/web/src/lib/bills/bill-calendar.test.ts
+++ b/apps/web/src/lib/bills/bill-calendar.test.ts
@@ -3,8 +3,14 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildBillCalendar,
+  classifyPeriodRisk,
   expandBillOccurrences,
   generatePaydays,
+  isHighRiskPeriod,
+  oneTimeDueCents,
+  oneTimeOccurrences,
+  summarizeCalendarRisk,
+  type PayPeriod,
   type PaydaySchedule,
 } from './bill-calendar';
 import type { Bill, BillFrequency, BillStatus } from '../../kmp/bridge';
@@ -326,5 +332,119 @@ describe('buildBillCalendar', () => {
     expect(calendar.periods).toHaveLength(3);
     expect(calendar.totalDueCents).toBe(0);
     expect(calendar.periods.every((p) => p.covered)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Risk classification + one-time (kid) expenses
+// ---------------------------------------------------------------------------
+
+describe('classifyPeriodRisk', () => {
+  const biweekly: PaydaySchedule = {
+    cadence: 'BIWEEKLY',
+    anchorDate: '2025-01-03',
+    expectedIncomeCents: 200_000,
+  };
+
+  function periodFor(amountCents: number): PayPeriod {
+    const calendar = buildBillCalendar({
+      bills: [makeBill({ amountCents, dueDate: '2025-01-20', frequency: 'ONE_TIME' })],
+      schedule: biweekly,
+      fromDate: '2025-01-20',
+      periodsToShow: 1,
+    });
+    return calendar.periods[0];
+  }
+
+  it('returns unknown when no income is provided', () => {
+    expect(classifyPeriodRisk(periodFor(50_000), false)).toBe('unknown');
+  });
+
+  it('returns shortfall when bills exceed expected income', () => {
+    expect(classifyPeriodRisk(periodFor(220_000), true)).toBe('shortfall');
+    expect(isHighRiskPeriod(periodFor(220_000), true)).toBe(true);
+  });
+
+  it('returns tight when the leftover buffer is under the threshold', () => {
+    // 200000 income, 10% ratio -> tight when coverage < 20000.
+    expect(classifyPeriodRisk(periodFor(185_000), true)).toBe('tight'); // 15000 left
+    expect(isHighRiskPeriod(periodFor(185_000), true)).toBe(true);
+  });
+
+  it('returns covered with a comfortable buffer and is not high-risk', () => {
+    expect(classifyPeriodRisk(periodFor(50_000), true)).toBe('covered');
+    expect(isHighRiskPeriod(periodFor(50_000), true)).toBe(false);
+  });
+});
+
+describe('one-time expenses and calendar risk summary', () => {
+  const biweekly: PaydaySchedule = {
+    cadence: 'BIWEEKLY',
+    anchorDate: '2025-01-03',
+    expectedIncomeCents: 200_000,
+  };
+
+  it('isolates one-time occurrences and sums them in integer cents', () => {
+    const bills = [
+      makeBill({ name: 'Rent', amountCents: 120_000, dueDate: '2025-01-20', frequency: 'MONTHLY' }),
+      makeBill({
+        name: 'Soccer signup',
+        amountCents: 8_500,
+        dueDate: '2025-01-22',
+        frequency: 'ONE_TIME',
+      }),
+      makeBill({
+        name: 'Birthday party',
+        amountCents: 6_000,
+        dueDate: '2025-01-24',
+        frequency: 'ONE_TIME',
+      }),
+    ];
+    const calendar = buildBillCalendar({
+      bills,
+      schedule: biweekly,
+      fromDate: '2025-01-20',
+      periodsToShow: 1,
+    });
+    const period = calendar.periods[0];
+    expect(oneTimeOccurrences(period).map((b) => b.name)).toEqual([
+      'Soccer signup',
+      'Birthday party',
+    ]);
+    expect(oneTimeDueCents(period)).toBe(14_500);
+  });
+
+  it('summarises high-risk periods, the first shortfall, and one-time totals', () => {
+    const bills = [
+      // Period 0 [01-17, 01-31): shortfall (240k > 200k)
+      makeBill({ amountCents: 180_000, dueDate: '2025-01-20', frequency: 'ONE_TIME' }),
+      makeBill({
+        name: 'Field trip',
+        amountCents: 60_000,
+        dueDate: '2025-01-22',
+        frequency: 'ONE_TIME',
+      }),
+      // Period 1 [01-31, 02-14): comfortably covered
+      makeBill({ amountCents: 5_000, dueDate: '2025-02-01', frequency: 'ONE_TIME' }),
+    ];
+    const calendar = buildBillCalendar({
+      bills,
+      schedule: biweekly,
+      fromDate: '2025-01-20',
+      periodsToShow: 2,
+    });
+
+    const withIncome = summarizeCalendarRisk(calendar, true);
+    expect(withIncome.highRiskPeriodCount).toBe(1);
+    expect(withIncome.shortfallPeriodCount).toBe(1);
+    expect(withIncome.firstShortfallPaydayDate).toBe('2025-01-17');
+    expect(withIncome.oneTimeCount).toBe(3);
+    expect(withIncome.oneTimeDueCents).toBe(245_000);
+
+    const withoutIncome = summarizeCalendarRisk(calendar, false);
+    expect(withoutIncome.highRiskPeriodCount).toBe(0);
+    expect(withoutIncome.firstShortfallPaydayDate).toBeNull();
+    // One-time totals are independent of income being known.
+    expect(withoutIncome.oneTimeCount).toBe(3);
   });
 });

--- a/apps/web/src/lib/bills/bill-calendar.ts
+++ b/apps/web/src/lib/bills/bill-calendar.ts
@@ -421,3 +421,116 @@ export function buildBillCalendar(options: BuildBillCalendarOptions): BillCalend
     totalCoverageCents: totalIncomeCents - totalDueCents,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Risk classification (high-risk pay periods) and one-time expenses
+// ---------------------------------------------------------------------------
+
+/**
+ * Risk level for a single pay period, judged against the expected income.
+ *  - `unknown`  – no income entered yet, so coverage cannot be assessed.
+ *  - `shortfall`– bills due before the next payday exceed expected income.
+ *  - `tight`    – covered, but the leftover buffer is a thin slice of income.
+ *  - `covered`  – comfortably covered.
+ *
+ * Both `shortfall` and `tight` are treated as "high-risk" so single parents see
+ * the weeks where money is dangerously close to running out before payday.
+ */
+export type PeriodRisk = 'covered' | 'tight' | 'shortfall' | 'unknown';
+
+/**
+ * Share of expected income that, when the leftover buffer falls below it, marks
+ * a pay period as financially "tight" (high-risk-adjacent). For example, with a
+ * 10% ratio a $2,000 paycheck is tight when under $200 is left after bills.
+ */
+export const TIGHT_COVERAGE_RATIO = 0.1;
+
+/** Plain-language labels for each {@link PeriodRisk}, safe for screen readers. */
+export const PERIOD_RISK_LABELS: Record<PeriodRisk, string> = {
+  covered: 'On track',
+  tight: 'Tight — little left after bills',
+  shortfall: 'High-risk — bills exceed this paycheck',
+  unknown: 'Add income to assess risk',
+};
+
+/** Classify how risky a pay period is, given whether income was supplied. */
+export function classifyPeriodRisk(period: PayPeriod, incomeProvided: boolean): PeriodRisk {
+  if (!incomeProvided || period.expectedIncomeCents <= 0) return 'unknown';
+  if (period.coverageCents < 0) return 'shortfall';
+  if (period.coverageCents < Math.round(period.expectedIncomeCents * TIGHT_COVERAGE_RATIO)) {
+    return 'tight';
+  }
+  return 'covered';
+}
+
+/**
+ * A pay period is "high-risk" when bills outpace — or come dangerously close to
+ * outpacing — the income landing on that payday.
+ */
+export function isHighRiskPeriod(period: PayPeriod, incomeProvided: boolean): boolean {
+  const risk = classifyPeriodRisk(period, incomeProvided);
+  return risk === 'shortfall' || risk === 'tight';
+}
+
+/**
+ * One-time (non-recurring) bill occurrences due in a period. These are the
+ * one-off "kid expenses" — school fees, birthdays, sports signups — planned
+ * alongside recurring bills rather than tracked separately.
+ */
+export function oneTimeOccurrences(period: PayPeriod): readonly BillOccurrence[] {
+  return period.bills.filter((bill) => bill.frequency === 'ONE_TIME');
+}
+
+/** Total of one-time expenses due in a period, in integer cents. */
+export function oneTimeDueCents(period: PayPeriod): number {
+  return oneTimeOccurrences(period).reduce((sum, bill) => sum + bill.amountCents, 0);
+}
+
+/** Calendar-wide risk + one-off-expense summary for the at-a-glance banner. */
+export interface CalendarRiskSummary {
+  /** Number of pay periods flagged high-risk (shortfall or tight). */
+  readonly highRiskPeriodCount: number;
+  /** Number of pay periods with an outright shortfall. */
+  readonly shortfallPeriodCount: number;
+  /** Payday of the first period that runs short, or `null` if none. */
+  readonly firstShortfallPaydayDate: LocalDate | null;
+  /** Total one-time (non-recurring) expenses across the horizon, in cents. */
+  readonly oneTimeDueCents: number;
+  /** Count of one-time expense occurrences across the horizon. */
+  readonly oneTimeCount: number;
+}
+
+/** Summarise risk and one-off expenses across an entire {@link BillCalendar}. */
+export function summarizeCalendarRisk(
+  calendar: BillCalendar,
+  incomeProvided: boolean,
+): CalendarRiskSummary {
+  let highRiskPeriodCount = 0;
+  let shortfallPeriodCount = 0;
+  let firstShortfallPaydayDate: LocalDate | null = null;
+  let totalOneTimeCents = 0;
+  let oneTimeCount = 0;
+
+  for (const period of calendar.periods) {
+    const risk = classifyPeriodRisk(period, incomeProvided);
+    if (risk === 'shortfall' || risk === 'tight') highRiskPeriodCount += 1;
+    if (risk === 'shortfall') {
+      shortfallPeriodCount += 1;
+      if (firstShortfallPaydayDate === null) firstShortfallPaydayDate = period.paydayDate;
+    }
+    for (const bill of period.bills) {
+      if (bill.frequency === 'ONE_TIME') {
+        totalOneTimeCents += bill.amountCents;
+        oneTimeCount += 1;
+      }
+    }
+  }
+
+  return {
+    highRiskPeriodCount,
+    shortfallPeriodCount,
+    firstShortfallPaydayDate,
+    oneTimeDueCents: totalOneTimeCents,
+    oneTimeCount,
+  };
+}

--- a/apps/web/src/pages/BillsPage.css
+++ b/apps/web/src/pages/BillsPage.css
@@ -104,3 +104,69 @@
     min-height: 44px;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Payday calendar — high-risk week + one-time (kid) expense affordances
+ *
+ * Risk and one-time states are always paired with an icon AND text in the
+ * markup, so meaning never relies on colour alone (WCAG 1.4.1). The border +
+ * background here are supplementary. No transitions/animations are introduced,
+ * so prefers-reduced-motion (handled globally in tokens.css) is respected.
+ * ------------------------------------------------------------------------- */
+
+.bill-period-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.bill-risk-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: var(--radius-sm, 4px);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold, 600);
+  border: 1px solid currentColor;
+  white-space: nowrap;
+}
+
+.bill-risk-badge--shortfall {
+  color: var(--semantic-negative, #b91c1c);
+  background-color: var(--semantic-negative-bg, #fee2e2);
+}
+
+.bill-risk-badge--tight {
+  color: var(--semantic-warning, #92400e);
+  background-color: var(--semantic-warning-bg, #fef3c7);
+}
+
+.bill-onetime-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: 0 var(--spacing-1);
+  border-radius: var(--radius-sm, 4px);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--semantic-text-secondary);
+  border: 1px solid var(--semantic-border, #d1d5db);
+  white-space: nowrap;
+}
+
+.bill-period-card__onetime {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+@media (forced-colors: active) {
+  .bill-risk-badge,
+  .bill-onetime-badge {
+    border: 1px solid CanvasText;
+  }
+}

--- a/apps/web/src/pages/CreateBillPage.tsx
+++ b/apps/web/src/pages/CreateBillPage.tsx
@@ -283,6 +283,7 @@ export const CreateBillPage: React.FC = () => {
               value={frequency}
               onChange={(e) => setFrequency(e.target.value as BillFrequency)}
               disabled={submitting}
+              aria-describedby="bill-frequency-hint"
             >
               <option value="ONE_TIME">One-Time</option>
               <option value="WEEKLY">Weekly</option>
@@ -291,6 +292,17 @@ export const CreateBillPage: React.FC = () => {
               <option value="QUARTERLY">Quarterly</option>
               <option value="YEARLY">Yearly</option>
             </select>
+            <p
+              id="bill-frequency-hint"
+              style={{
+                marginTop: 'var(--spacing-1)',
+                fontSize: 'var(--type-scale-caption-font-size)',
+                color: 'var(--semantic-text-secondary)',
+              }}
+            >
+              Choose One-Time for one-off costs like school fees, birthdays, or sports signups —
+              they line up against your paydays in the bill calendar too.
+            </p>
           </div>
 
           {/* Auto-Pay */}


### PR DESCRIPTION
## Summary

The payday-aligned bill calendar core (pay-period timeline, payday/expected-income markers, "due before next paycheck" totals) shipped in #2969 (merged). This PR closes the two remaining desires from #2196 that the merged version did not surface:

1. **"High-risk week" highlighting** ? each pay period is classified against expected income and flagged when money is dangerously tight before the next paycheck.
2. **One-off kid expenses as first-class planning** ? non-recurring costs (school fees, birthdays, sports signups) are surfaced distinctly in the same planning view rather than being indistinguishable from recurring bills.

Builds on the existing `lib/bills/bill-calendar` engine and `BillCalendarView` (imported directly into the lazy `BillsPage` ? no shared barrel, no new dependencies).

## What changed

- **lib/bills/bill-calendar.ts** (pure, deterministic, integer-cent):
  - `classifyPeriodRisk` / `isHighRiskPeriod` with a tight-buffer threshold (`TIGHT_COVERAGE_RATIO`) returning `covered` | `tight` | `shortfall` | `unknown`, plus `PERIOD_RISK_LABELS`.
  - `oneTimeOccurrences` / `oneTimeDueCents` to isolate one-off expenses.
  - `summarizeCalendarRisk` for the at-a-glance banner (high-risk count, first shortfall payday, one-time totals).
- **components/bills/BillCalendarView.tsx**: per-period High-risk week / Tight week badge (icon + text), distinct One-time tag and per-period one-off total, and an enriched `aria-live` summary announcing high-risk weeks and one-off expenses.
- **pages/CreateBillPage.tsx**: helper text under Frequency explaining one-off kid costs land in the payday calendar (`aria-describedby`).
- **pages/BillsPage.css**: token-based badge styles with `forced-colors` support; no motion introduced.

## Accessibility (WCAG 2.2 AA)

- Risk states conveyed by text + icon, never colour alone (1.4.1).
- Accessible period names include risk status; `aria-live="polite"` summary announces due-before-payday risk.
- Reduced-motion respected globally (no animation added); `forced-colors` handled.

## Testing & gates

- bill-calendar.test.ts: +6 unit tests (24 total) for risk classification and one-off summaries.
- BillCalendarView.test.tsx: +3 component tests (8 total) ? high-risk badge, one-time badge/explainer, live-region announcement. Tests use props (no repository imports).
- prettier --check, eslint . --max-warnings 0, tsc --noEmit, web build, and perf:budget all pass locally (BillsPage route-planning chunk ~76 KB gzip, well under the 200 KB lazy-chunk budget).

Refs #2196 (iOS slice remains, so not Closes).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
