### PR TITLE
feat(web): joint debt payoff planner for couples (#2153)

### DIFF
--- a/apps/web/src/components/debt/JointDebtPlanner.css
+++ b/apps/web/src/components/debt/JointDebtPlanner.css
@@ -1,0 +1,317 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for JointDebtPlanner (#2153).
+ *
+ * Uses design tokens from theme/tokens.css with safe fallbacks (mirrors the
+ * convention in DebtPage.css). Ownership state never relies on colour alone —
+ * each value pairs an icon glyph with its text label. Motion is disabled under
+ * prefers-reduced-motion.
+ */
+
+.joint-debt {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-5, 1.25rem);
+}
+
+.joint-debt__header h2 {
+  font-size: var(--font-size-xl, 1.25rem);
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-text-primary, #111);
+  margin: 0 0 var(--spacing-2, 0.5rem);
+}
+
+.joint-debt__subtitle {
+  color: var(--semantic-text-secondary, #666);
+  font-size: var(--font-size-sm, 0.875rem);
+  margin: 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * Forms / controls
+ * ------------------------------------------------------------------------ */
+
+.joint-debt__partners,
+.joint-debt__strategy {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-4, 1rem);
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-radius: var(--radius-md, 0.5rem);
+  padding: var(--spacing-3, 0.75rem) var(--spacing-4, 1rem);
+}
+
+.joint-debt__partners legend,
+.joint-debt__strategy legend {
+  font-size: var(--font-size-sm, 0.875rem);
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--semantic-text-secondary, #666);
+  padding: 0 var(--spacing-2, 0.5rem);
+}
+
+.joint-debt__strategy label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2, 0.5rem);
+  font-size: var(--font-size-sm, 0.875rem);
+}
+
+.joint-debt__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-4, 1rem);
+  align-items: flex-end;
+}
+
+.joint-debt__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1, 0.25rem);
+  font-size: var(--font-size-sm, 0.875rem);
+}
+
+.joint-debt__field label {
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--semantic-text-secondary, #666);
+}
+
+.joint-debt__field input,
+.joint-debt__field select,
+.joint-debt__ownership select {
+  padding: var(--spacing-2, 0.5rem);
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--semantic-background-primary, #fff);
+  color: var(--semantic-text-primary, #111);
+  font-size: var(--font-size-sm, 0.875rem);
+  min-height: 2.25rem;
+}
+
+.joint-debt__mode label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2, 0.5rem);
+  color: var(--semantic-text-primary, #111);
+}
+
+/* ---------------------------------------------------------------------------
+ * Recommendation card
+ * ------------------------------------------------------------------------ */
+
+.joint-debt__recommendation {
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-left: 4px solid var(--semantic-info, #2563eb);
+  border-radius: var(--radius-lg, 0.75rem);
+  background: var(--semantic-info-bg, #eff6ff);
+  padding: var(--spacing-4, 1rem);
+}
+
+.joint-debt__recommendation--balanced {
+  border-left-color: var(--semantic-warning, #d97706);
+  background: var(--semantic-warning-bg, #fef3c7);
+}
+
+.joint-debt__recommendation h3 {
+  font-size: var(--font-size-lg, 1.125rem);
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-text-primary, #111);
+  margin: 0 0 var(--spacing-2, 0.5rem);
+}
+
+.joint-debt__rec-headline {
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--semantic-text-primary, #111);
+  margin: 0 0 var(--spacing-2, 0.5rem);
+}
+
+.joint-debt__rec-list {
+  margin: 0;
+  padding-left: var(--spacing-5, 1.25rem);
+  color: var(--semantic-text-secondary, #444);
+  font-size: var(--font-size-sm, 0.875rem);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1, 0.25rem);
+}
+
+/* ---------------------------------------------------------------------------
+ * Sections + tables
+ * ------------------------------------------------------------------------ */
+
+.joint-debt__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3, 0.75rem);
+}
+
+.joint-debt__section h3 {
+  font-size: var(--font-size-lg, 1.125rem);
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-text-primary, #111);
+  margin: 0;
+}
+
+.joint-debt__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm, 0.875rem);
+}
+
+.joint-debt__caption {
+  caption-side: top;
+  text-align: left;
+  color: var(--semantic-text-secondary, #666);
+  margin-bottom: var(--spacing-2, 0.5rem);
+}
+
+.joint-debt__table th,
+.joint-debt__table td {
+  text-align: left;
+  padding: var(--spacing-2, 0.5rem) var(--spacing-3, 0.75rem);
+  border-bottom: 1px solid var(--semantic-border, #e5e7eb);
+  vertical-align: middle;
+}
+
+.joint-debt__table thead th {
+  color: var(--semantic-text-secondary, #666);
+  font-weight: var(--font-weight-medium, 500);
+  border-bottom: 2px solid var(--semantic-border, #e5e7eb);
+}
+
+.joint-debt__table tbody th[scope='row'] {
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--semantic-text-primary, #111);
+}
+
+.joint-debt__badge {
+  font-size: var(--font-size-xs, 0.75rem);
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-positive, #047857);
+}
+
+.joint-debt__ownership {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2, 0.5rem);
+}
+
+.joint-debt__ownership-icon {
+  font-size: var(--font-size-sm, 0.875rem);
+  line-height: 1;
+}
+
+.joint-debt__hint {
+  color: var(--semantic-text-secondary, #666);
+  font-size: var(--font-size-sm, 0.875rem);
+  margin: 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * Ownership summary
+ * ------------------------------------------------------------------------ */
+
+.joint-debt__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--spacing-3, 0.75rem);
+  margin: 0;
+}
+
+.joint-debt__summary div {
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-radius: var(--radius-md, 0.5rem);
+  padding: var(--spacing-3, 0.75rem);
+  background: var(--semantic-background-secondary, #f9fafb);
+}
+
+.joint-debt__summary dt {
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--semantic-text-secondary, #666);
+  margin-bottom: var(--spacing-1, 0.25rem);
+}
+
+.joint-debt__summary dd {
+  margin: 0;
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-text-primary, #111);
+}
+
+/* ---------------------------------------------------------------------------
+ * Goals editor
+ * ------------------------------------------------------------------------ */
+
+.joint-debt__goals-editor h4 {
+  font-size: var(--font-size-base, 1rem);
+  font-weight: var(--font-weight-medium, 500);
+  margin: var(--spacing-3, 0.75rem) 0 var(--spacing-2, 0.5rem);
+  color: var(--semantic-text-primary, #111);
+}
+
+.joint-debt__goal-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3, 0.75rem);
+}
+
+.joint-debt__goal {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--spacing-3, 0.75rem);
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-radius: var(--radius-md, 0.5rem);
+  padding: var(--spacing-3, 0.75rem);
+}
+
+.joint-debt__add,
+.joint-debt__remove {
+  align-self: flex-end;
+  padding: var(--spacing-2, 0.5rem) var(--spacing-3, 0.75rem);
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--semantic-background-primary, #fff);
+  color: var(--semantic-text-primary, #111);
+  font-size: var(--font-size-sm, 0.875rem);
+  cursor: pointer;
+  min-height: 2.25rem;
+}
+
+.joint-debt__add {
+  margin-top: var(--spacing-3, 0.75rem);
+  align-self: flex-start;
+}
+
+.joint-debt__add:hover,
+.joint-debt__remove:hover {
+  background: var(--semantic-background-secondary, #f3f4f6);
+}
+
+.joint-debt__footnote {
+  color: var(--semantic-text-secondary, #666);
+  font-size: var(--font-size-xs, 0.75rem);
+  margin: 0;
+}
+
+/* Visually hidden but available to assistive tech (WCAG 1.3.1). */
+.joint-debt__visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .joint-debt__add,
+  .joint-debt__remove {
+    transition: none;
+  }
+}

--- a/apps/web/src/components/debt/JointDebtPlanner.test.tsx
+++ b/apps/web/src/components/debt/JointDebtPlanner.test.tsx
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Render tests for the JointDebtPlanner component (#2153).
+ *
+ * Verifies the accessible ownership table, the avalanche/snowball comparison
+ * across both partners' debts, ownership assignment, the goal-impact view, and
+ * the recommendation-mode toggle. Data arrives via props (no repository mocks).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { JointDebtPlanner } from './JointDebtPlanner';
+import type { Debt } from '../../lib/debt-types';
+
+const TODAY = '2025-01-01';
+
+const debts: Debt[] = [
+  {
+    id: 'card',
+    name: 'Rewards Card',
+    balanceCents: 300_000,
+    originalBalanceCents: 400_000,
+    annualRateBps: 1999,
+    minimumPaymentCents: 12_000,
+    type: 'credit_card',
+  },
+  {
+    id: 'loan',
+    name: 'Car Loan',
+    balanceCents: 100_000,
+    originalBalanceCents: 150_000,
+    annualRateBps: 500,
+    minimumPaymentCents: 7_500,
+    type: 'auto_loan',
+  },
+];
+
+describe('JointDebtPlanner', () => {
+  it('renders an empty state when there are no debts', () => {
+    render(<JointDebtPlanner debts={[]} todayIso={TODAY} />);
+    expect(screen.getByText('No debts to plan together')).toBeDefined();
+  });
+
+  it('renders a comparison table with scoped headers for both strategies', () => {
+    render(<JointDebtPlanner debts={debts} todayIso={TODAY} />);
+
+    expect(screen.getByRole('heading', { name: 'Joint Debt Payoff' })).toBeDefined();
+
+    const avalancheHeader = screen.getByRole('columnheader', { name: /Avalanche/ });
+    expect(avalancheHeader.getAttribute('scope')).toBe('col');
+    // Avalanche is recommended for this higher-rate-vs-lower-rate mix.
+    expect(avalancheHeader.textContent).toContain('recommended');
+
+    const rowHeader = screen.getByRole('rowheader', { name: 'Time to debt-free' });
+    expect(rowHeader.getAttribute('scope')).toBe('row');
+  });
+
+  it('exposes ownership and partner assignment for each debt', () => {
+    render(<JointDebtPlanner debts={debts} todayIso={TODAY} />);
+
+    const treatment = screen.getByLabelText('Treatment of Rewards Card') as HTMLSelectElement;
+    expect(treatment.value).toBe('shared');
+
+    fireEvent.change(treatment, { target: { value: 'jointly-funded' } });
+    expect((screen.getByLabelText('Treatment of Rewards Card') as HTMLSelectElement).value).toBe(
+      'jointly-funded',
+    );
+
+    const owner = screen.getByLabelText('Owner of Car Loan') as HTMLSelectElement;
+    fireEvent.change(owner, { target: { value: 'partner-b' } });
+    expect((screen.getByLabelText('Owner of Car Loan') as HTMLSelectElement).value).toBe(
+      'partner-b',
+    );
+  });
+
+  it('announces a recommendation through an aria-live region', () => {
+    render(<JointDebtPlanner debts={debts} todayIso={TODAY} />);
+    const status = screen.getByRole('status');
+    expect(status.getAttribute('aria-live')).toBe('polite');
+    expect(status.textContent).toContain('method');
+  });
+
+  it('shows the goal-impact trade-off for the default goals', () => {
+    render(<JointDebtPlanner debts={debts} todayIso={TODAY} />);
+    expect(screen.getByRole('rowheader', { name: 'Wedding fund' })).toBeDefined();
+    expect(screen.getByRole('rowheader', { name: 'Home down payment' })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: 'Debt-first delay' })).toBeDefined();
+  });
+
+  it('collapses detail tables in recommendation mode but keeps the recommendation', () => {
+    render(<JointDebtPlanner debts={debts} todayIso={TODAY} />);
+    const toggle = screen.getByLabelText(/Recommendation mode/);
+    fireEvent.click(toggle);
+
+    // Detail tables are hidden...
+    expect(screen.queryByRole('columnheader', { name: /Avalanche/ })).toBeNull();
+    expect(screen.queryByRole('rowheader', { name: 'Wedding fund' })).toBeNull();
+    // ...but the recommendation card stays.
+    expect(screen.getByRole('status').textContent).toContain('method');
+  });
+
+  it('lets a couple add and remove a goal', () => {
+    render(<JointDebtPlanner debts={debts} todayIso={TODAY} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Add goal' }));
+    expect(screen.getByRole('rowheader', { name: 'New goal' })).toBeDefined();
+
+    const removeButtons = screen.getAllByRole('button', { name: /Remove/ });
+    fireEvent.click(removeButtons[0]);
+    // The first original goal is gone from the impact table.
+    expect(screen.queryByRole('rowheader', { name: 'Wedding fund' })).toBeNull();
+  });
+
+  it('recomputes the comparison when the extra payment changes', () => {
+    render(<JointDebtPlanner debts={debts} todayIso={TODAY} />);
+    const extra = screen.getByLabelText('Extra payment each month ($)');
+    fireEvent.change(extra, { target: { value: '500' } });
+    const caption = screen.getByText(/Both strategies paid with an extra/);
+    expect(caption.textContent).toContain('$500');
+  });
+});

--- a/apps/web/src/components/debt/JointDebtPlanner.tsx
+++ b/apps/web/src/components/debt/JointDebtPlanner.tsx
@@ -1,0 +1,592 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * JointDebtPlanner — a joint debt payoff planner for engaged/married couples
+ * (#2153).
+ *
+ * Surfaces the partner-ownership dimension that the solo payoff planner lacks:
+ *  - mark each debt as personal / shared / jointly-funded and assign a partner;
+ *  - compare avalanche vs. snowball across BOTH partners' debts;
+ *  - see how an extra debt payment delays other couple goals (wedding fund,
+ *    home down payment, ...);
+ *  - flip on a simpler "recommendation mode" decision aid.
+ *
+ * All financial maths lives in the pure engines (`shared-payoff-rules.ts` for
+ * payoff and `joint-debt-planner.ts` for the couple/ownership layer). This
+ * component is presentational and accessible; debts arrive via props (never a
+ * direct repository import).
+ *
+ * Accessibility:
+ *  - comparison/impact tables use <caption> and scoped <th> headers;
+ *  - ownership state is conveyed with text + icon, never colour alone;
+ *  - the recommendation announces via an aria-live region;
+ *  - every control is labelled and keyboard reachable;
+ *  - motion is disabled under prefers-reduced-motion (see CSS).
+ */
+
+import React, { useCallback, useId, useMemo, useState } from 'react';
+import { EmptyState } from '../common';
+import type { Debt } from '../../lib/debt-types';
+import { formatUsdCents } from '../../lib/debt/payoff';
+import {
+  compareJointStrategies,
+  ownershipLabel,
+  projectGoalImpacts,
+  recommendForCouple,
+  selectStrategyResult,
+  summarizeOwnership,
+  type CoupleGoal,
+  type CoupleStrategy,
+  type DebtOwnership,
+  type JointDebtInput,
+  type PartnerId,
+} from '../../lib/debt/joint-debt-planner';
+import './JointDebtPlanner.css';
+
+export interface JointDebtPlannerProps {
+  /** Both partners' debts to plan across. */
+  readonly debts: readonly Debt[];
+  /** Anchor date (YYYY-MM-DD) for projections. Defaults to today. */
+  readonly todayIso?: string;
+}
+
+interface OwnershipAssignment {
+  readonly owner: PartnerId;
+  readonly ownership: DebtOwnership;
+}
+
+interface GoalFormState {
+  readonly id: string;
+  readonly name: string;
+  readonly target: string;
+  readonly saved: string;
+  readonly monthly: string;
+}
+
+const OWNERSHIP_OPTIONS: readonly DebtOwnership[] = ['personal', 'shared', 'jointly-funded'];
+
+/** Text + icon, never colour alone (WCAG 1.4.1). */
+const OWNERSHIP_ICONS: Record<DebtOwnership, string> = {
+  personal: '●',
+  shared: '◑',
+  'jointly-funded': '◇',
+};
+
+const DEFAULT_GOALS: readonly GoalFormState[] = [
+  { id: 'wedding', name: 'Wedding fund', target: '20000', saved: '2000', monthly: '300' },
+  { id: 'home', name: 'Home down payment', target: '40000', saved: '5000', monthly: '400' },
+];
+
+function parseCurrencyToCents(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed * 100) : 0;
+}
+
+function parseExtraCents(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed * 100) : 0;
+}
+
+function formatMonths(months: number): string {
+  if (months > 600) return 'beyond 50 years';
+  if (months <= 0) return 'now';
+  const years = Math.floor(months / 12);
+  const remaining = months % 12;
+  const parts: string[] = [];
+  if (years > 0) parts.push(`${years} yr${years === 1 ? '' : 's'}`);
+  if (remaining > 0) parts.push(`${remaining} mo${remaining === 1 ? '' : 's'}`);
+  return parts.join(' ') || '0 mos';
+}
+
+function createGoalId(): string {
+  return `goal-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function JointDebtPlanner({ debts, todayIso }: JointDebtPlannerProps): React.ReactElement {
+  const baseId = useId();
+  const [partnerAName, setPartnerAName] = useState('Partner A');
+  const [partnerBName, setPartnerBName] = useState('Partner B');
+  const [assignments, setAssignments] = useState<Record<string, OwnershipAssignment>>({});
+  const [extraPayment, setExtraPayment] = useState('150');
+  const [activeStrategy, setActiveStrategy] = useState<CoupleStrategy>('avalanche');
+  const [simpleMode, setSimpleMode] = useState(false);
+  const [goals, setGoals] = useState<readonly GoalFormState[]>(DEFAULT_GOALS);
+
+  const planDebts = useMemo(() => debts.filter((debt) => debt.balanceCents > 0), [debts]);
+
+  const assignmentFor = useCallback(
+    (debt: Debt): OwnershipAssignment =>
+      assignments[debt.id] ?? { owner: 'partner-a', ownership: 'shared' },
+    [assignments],
+  );
+
+  const jointDebts = useMemo<JointDebtInput[]>(
+    () =>
+      planDebts.map((debt) => {
+        const assignment = assignmentFor(debt);
+        return {
+          id: debt.id,
+          name: debt.name,
+          balanceCents: debt.balanceCents,
+          annualRateBps: debt.annualRateBps,
+          minimumPaymentCents: debt.minimumPaymentCents,
+          owner: assignment.owner,
+          ownership: assignment.ownership,
+        };
+      }),
+    [planDebts, assignmentFor],
+  );
+
+  const extraCents = parseExtraCents(extraPayment);
+
+  const ownershipSummary = useMemo(() => summarizeOwnership(jointDebts), [jointDebts]);
+  const comparison = useMemo(
+    () => (jointDebts.length > 0 ? compareJointStrategies(jointDebts, extraCents) : null),
+    [jointDebts, extraCents],
+  );
+
+  const coupleGoals = useMemo<CoupleGoal[]>(
+    () =>
+      goals.map((goal) => ({
+        id: goal.id,
+        name: goal.name.trim() || 'Goal',
+        targetCents: parseCurrencyToCents(goal.target),
+        savedCents: parseCurrencyToCents(goal.saved),
+        monthlyContributionCents: parseCurrencyToCents(goal.monthly),
+      })),
+    [goals],
+  );
+
+  const activeResult = comparison ? selectStrategyResult(comparison, activeStrategy) : null;
+  const goalImpacts = useMemo(
+    () => (activeResult ? projectGoalImpacts(activeResult, coupleGoals, extraCents) : []),
+    [activeResult, coupleGoals, extraCents],
+  );
+
+  const recommendation = useMemo(
+    () => (comparison ? recommendForCouple(comparison, goalImpacts) : null),
+    [comparison, goalImpacts],
+  );
+
+  const handleAssignmentChange = useCallback((debt: Debt, patch: Partial<OwnershipAssignment>) => {
+    setAssignments((current) => {
+      const existing = current[debt.id] ?? { owner: 'partner-a', ownership: 'shared' };
+      return { ...current, [debt.id]: { ...existing, ...patch } };
+    });
+  }, []);
+
+  const handleGoalChange = useCallback(
+    (id: string, field: keyof Omit<GoalFormState, 'id'>, value: string) => {
+      setGoals((current) =>
+        current.map((goal) => (goal.id === id ? { ...goal, [field]: value } : goal)),
+      );
+    },
+    [],
+  );
+
+  const handleAddGoal = useCallback(() => {
+    setGoals((current) => [
+      ...current,
+      { id: createGoalId(), name: 'New goal', target: '10000', saved: '0', monthly: '200' },
+    ]);
+  }, []);
+
+  const handleRemoveGoal = useCallback((id: string) => {
+    setGoals((current) => current.filter((goal) => goal.id !== id));
+  }, []);
+
+  const titleId = `${baseId}-title`;
+  const extraId = `${baseId}-extra`;
+  const recId = `${baseId}-recommendation`;
+
+  if (planDebts.length === 0) {
+    return (
+      <EmptyState
+        title="No debts to plan together"
+        description="Add both partners' debts or connect debt accounts to compare avalanche vs. snowball across your household and see how extra payments affect your shared goals."
+      />
+    );
+  }
+
+  return (
+    <section className="joint-debt" aria-labelledby={titleId}>
+      <header className="joint-debt__header">
+        <h2 id={titleId}>Joint Debt Payoff</h2>
+        <p className="joint-debt__subtitle">
+          Plan payoff across both partners&rsquo; debts, label who owns what, and see how extra
+          payments trade off against your shared goals.
+        </p>
+      </header>
+
+      <fieldset className="joint-debt__partners">
+        <legend>Partner names</legend>
+        <div className="joint-debt__field">
+          <label htmlFor={`${baseId}-partner-a`}>Partner A name</label>
+          <input
+            id={`${baseId}-partner-a`}
+            type="text"
+            value={partnerAName}
+            onChange={(event) => setPartnerAName(event.target.value)}
+          />
+        </div>
+        <div className="joint-debt__field">
+          <label htmlFor={`${baseId}-partner-b`}>Partner B name</label>
+          <input
+            id={`${baseId}-partner-b`}
+            type="text"
+            value={partnerBName}
+            onChange={(event) => setPartnerBName(event.target.value)}
+          />
+        </div>
+      </fieldset>
+
+      <div className="joint-debt__controls">
+        <div className="joint-debt__field">
+          <label htmlFor={extraId}>Extra payment each month ($)</label>
+          <input
+            id={extraId}
+            type="number"
+            min="0"
+            step="0.01"
+            inputMode="decimal"
+            value={extraPayment}
+            onChange={(event) => setExtraPayment(event.target.value)}
+          />
+        </div>
+        <div className="joint-debt__field joint-debt__mode">
+          <label htmlFor={`${baseId}-mode`}>
+            <input
+              id={`${baseId}-mode`}
+              type="checkbox"
+              checked={simpleMode}
+              onChange={(event) => setSimpleMode(event.target.checked)}
+            />
+            Recommendation mode (just tell us what to do)
+          </label>
+        </div>
+      </div>
+
+      {recommendation && (
+        <section
+          className={`joint-debt__recommendation joint-debt__recommendation--${recommendation.focus}`}
+          aria-labelledby={`${recId}-title`}
+        >
+          <h3 id={`${recId}-title`}>Our recommendation for you</h3>
+          <div id={recId} role="status" aria-live="polite" className="joint-debt__rec-body">
+            <p className="joint-debt__rec-headline">{recommendation.headline}</p>
+            <ul className="joint-debt__rec-list">
+              {recommendation.rationale.map((line, index) => (
+                <li key={index}>{line}</li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      )}
+
+      {!simpleMode && (
+        <>
+          <section className="joint-debt__section" aria-labelledby={`${baseId}-ownership-title`}>
+            <h3 id={`${baseId}-ownership-title`}>Whose debt is whose?</h3>
+            <table className="joint-debt__table">
+              <caption className="joint-debt__caption">
+                Assign each debt to a partner and mark how the couple treats it.
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Debt</th>
+                  <th scope="col">Balance</th>
+                  <th scope="col">Owner</th>
+                  <th scope="col">Treatment</th>
+                </tr>
+              </thead>
+              <tbody>
+                {planDebts.map((debt) => {
+                  const assignment = assignmentFor(debt);
+                  return (
+                    <tr key={debt.id}>
+                      <th scope="row">{debt.name}</th>
+                      <td>{formatUsdCents(debt.balanceCents)}</td>
+                      <td>
+                        <label
+                          className="joint-debt__visually-hidden"
+                          htmlFor={`${baseId}-owner-${debt.id}`}
+                        >
+                          Owner of {debt.name}
+                        </label>
+                        <select
+                          id={`${baseId}-owner-${debt.id}`}
+                          value={assignment.owner}
+                          onChange={(event) =>
+                            handleAssignmentChange(debt, {
+                              owner: event.target.value as PartnerId,
+                            })
+                          }
+                        >
+                          <option value="partner-a">{partnerAName}</option>
+                          <option value="partner-b">{partnerBName}</option>
+                        </select>
+                      </td>
+                      <td>
+                        <label
+                          className="joint-debt__visually-hidden"
+                          htmlFor={`${baseId}-ownership-${debt.id}`}
+                        >
+                          Treatment of {debt.name}
+                        </label>
+                        <span className="joint-debt__ownership">
+                          <span aria-hidden="true" className="joint-debt__ownership-icon">
+                            {OWNERSHIP_ICONS[assignment.ownership]}
+                          </span>
+                          <select
+                            id={`${baseId}-ownership-${debt.id}`}
+                            value={assignment.ownership}
+                            onChange={(event) =>
+                              handleAssignmentChange(debt, {
+                                ownership: event.target.value as DebtOwnership,
+                              })
+                            }
+                          >
+                            {OWNERSHIP_OPTIONS.map((option) => (
+                              <option key={option} value={option}>
+                                {ownershipLabel(option)}
+                              </option>
+                            ))}
+                          </select>
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+
+            <dl className="joint-debt__summary">
+              <div>
+                <dt>
+                  <span aria-hidden="true">{OWNERSHIP_ICONS.personal}</span> Personal
+                </dt>
+                <dd>{formatUsdCents(ownershipSummary.personalBalanceCents)}</dd>
+              </div>
+              <div>
+                <dt>
+                  <span aria-hidden="true">{OWNERSHIP_ICONS.shared}</span> Shared
+                </dt>
+                <dd>{formatUsdCents(ownershipSummary.sharedBalanceCents)}</dd>
+              </div>
+              <div>
+                <dt>
+                  <span aria-hidden="true">{OWNERSHIP_ICONS['jointly-funded']}</span> Jointly funded
+                </dt>
+                <dd>{formatUsdCents(ownershipSummary.jointlyFundedBalanceCents)}</dd>
+              </div>
+              <div>
+                <dt>{partnerAName} total</dt>
+                <dd>{formatUsdCents(ownershipSummary.partnerABalanceCents)}</dd>
+              </div>
+              <div>
+                <dt>{partnerBName} total</dt>
+                <dd>{formatUsdCents(ownershipSummary.partnerBBalanceCents)}</dd>
+              </div>
+            </dl>
+          </section>
+
+          {comparison && (
+            <section className="joint-debt__section" aria-labelledby={`${baseId}-compare-title`}>
+              <h3 id={`${baseId}-compare-title`}>Avalanche vs. snowball — your combined debts</h3>
+              <table className="joint-debt__table">
+                <caption className="joint-debt__caption">
+                  Both strategies paid with an extra {formatUsdCents(extraCents)} per month across
+                  both partners&rsquo; debts.
+                </caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Metric</th>
+                    <th scope="col">
+                      Avalanche
+                      {comparison.recommendedStrategy === 'avalanche' ? (
+                        <span className="joint-debt__badge"> (recommended)</span>
+                      ) : null}
+                    </th>
+                    <th scope="col">
+                      Snowball
+                      {comparison.recommendedStrategy === 'snowball' ? (
+                        <span className="joint-debt__badge"> (recommended)</span>
+                      ) : null}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Time to debt-free</th>
+                    <td>{formatMonths(comparison.avalanche.monthsToPayoff)}</td>
+                    <td>{formatMonths(comparison.snowball.monthsToPayoff)}</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Total interest paid</th>
+                    <td>{formatUsdCents(comparison.avalanche.totalInterestCents)}</td>
+                    <td>{formatUsdCents(comparison.snowball.totalInterestCents)}</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Cash flow freed at payoff</th>
+                    <td>{formatUsdCents(comparison.avalanche.goalCashFlowFreedCents)}</td>
+                    <td>{formatUsdCents(comparison.snowball.goalCashFlowFreedCents)}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <p className="joint-debt__hint">
+                Avalanche saves about {formatUsdCents(comparison.interestDifferenceCents)} in
+                interest versus snowball.
+              </p>
+
+              <fieldset className="joint-debt__strategy">
+                <legend>Plan goal impact using</legend>
+                <label>
+                  <input
+                    type="radio"
+                    name={`${baseId}-strategy`}
+                    value="avalanche"
+                    checked={activeStrategy === 'avalanche'}
+                    onChange={() => setActiveStrategy('avalanche')}
+                  />
+                  Avalanche
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name={`${baseId}-strategy`}
+                    value="snowball"
+                    checked={activeStrategy === 'snowball'}
+                    onChange={() => setActiveStrategy('snowball')}
+                  />
+                  Snowball
+                </label>
+              </fieldset>
+            </section>
+          )}
+
+          <section className="joint-debt__section" aria-labelledby={`${baseId}-goals-title`}>
+            <h3 id={`${baseId}-goals-title`}>How extra payments affect your other goals</h3>
+            <p className="joint-debt__hint">
+              Compare funding each goal when the extra payment goes to debt first versus straight to
+              the goal.
+            </p>
+
+            <table className="joint-debt__table">
+              <caption className="joint-debt__caption">
+                Months to fund each goal, by where the extra payment goes.
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Goal</th>
+                  <th scope="col">Remaining</th>
+                  <th scope="col">Extra to debt first</th>
+                  <th scope="col">Extra to goal first</th>
+                  <th scope="col">Debt-first delay</th>
+                </tr>
+              </thead>
+              <tbody>
+                {goalImpacts.map((impact) => (
+                  <tr key={impact.goalId}>
+                    <th scope="row">{impact.name}</th>
+                    <td>{formatUsdCents(impact.remainingCents)}</td>
+                    <td>
+                      {impact.reachable ? formatMonths(impact.monthsWithDebtFocus) : 'over 50 yrs'}
+                    </td>
+                    <td>
+                      {impact.reachable ? formatMonths(impact.monthsWithGoalFocus) : 'over 50 yrs'}
+                    </td>
+                    <td>
+                      {impact.monthsDelta > 0
+                        ? `+${impact.monthsDelta} mo${impact.monthsDelta === 1 ? '' : 's'}`
+                        : 'no delay'}
+                    </td>
+                  </tr>
+                ))}
+                {goalImpacts.length === 0 && (
+                  <tr>
+                    <td colSpan={5}>Add a goal below to see the trade-off.</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+
+            <div className="joint-debt__goals-editor">
+              <h4>Edit your goals</h4>
+              <ul className="joint-debt__goal-list">
+                {goals.map((goal) => (
+                  <li key={goal.id} className="joint-debt__goal">
+                    <div className="joint-debt__field">
+                      <label htmlFor={`${baseId}-goal-name-${goal.id}`}>Goal name</label>
+                      <input
+                        id={`${baseId}-goal-name-${goal.id}`}
+                        type="text"
+                        value={goal.name}
+                        onChange={(event) => handleGoalChange(goal.id, 'name', event.target.value)}
+                      />
+                    </div>
+                    <div className="joint-debt__field">
+                      <label htmlFor={`${baseId}-goal-target-${goal.id}`}>Target ($)</label>
+                      <input
+                        id={`${baseId}-goal-target-${goal.id}`}
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        inputMode="decimal"
+                        value={goal.target}
+                        onChange={(event) =>
+                          handleGoalChange(goal.id, 'target', event.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="joint-debt__field">
+                      <label htmlFor={`${baseId}-goal-saved-${goal.id}`}>Saved so far ($)</label>
+                      <input
+                        id={`${baseId}-goal-saved-${goal.id}`}
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        inputMode="decimal"
+                        value={goal.saved}
+                        onChange={(event) => handleGoalChange(goal.id, 'saved', event.target.value)}
+                      />
+                    </div>
+                    <div className="joint-debt__field">
+                      <label htmlFor={`${baseId}-goal-monthly-${goal.id}`}>Monthly ($)</label>
+                      <input
+                        id={`${baseId}-goal-monthly-${goal.id}`}
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        inputMode="decimal"
+                        value={goal.monthly}
+                        onChange={(event) =>
+                          handleGoalChange(goal.id, 'monthly', event.target.value)
+                        }
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      className="joint-debt__remove"
+                      onClick={() => handleRemoveGoal(goal.id)}
+                    >
+                      Remove
+                      <span className="joint-debt__visually-hidden"> {goal.name}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <button type="button" className="joint-debt__add" onClick={handleAddGoal}>
+                Add goal
+              </button>
+            </div>
+          </section>
+        </>
+      )}
+
+      <p className="joint-debt__footnote">
+        Projections anchor on {todayIso ?? 'today'} and assume steady payments. Goal savings grow
+        linearly; debt payoff and interest come from the shared payoff engine.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/lib/debt/joint-debt-planner.test.ts
+++ b/apps/web/src/lib/debt/joint-debt-planner.test.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import {
+  GOAL_DELAY_CONCERN_MONTHS,
+  compareJointStrategies,
+  ownershipLabel,
+  projectGoalImpact,
+  projectGoalImpacts,
+  recommendForCouple,
+  selectStrategyResult,
+  summarizeOwnership,
+  type CoupleGoal,
+  type JointDebtInput,
+} from './joint-debt-planner';
+
+const debts: JointDebtInput[] = [
+  {
+    id: 'card',
+    name: 'Rewards Card',
+    balanceCents: 3000_00,
+    annualRateBps: 1999,
+    minimumPaymentCents: 120_00,
+    ownership: 'personal',
+    owner: 'partner-a',
+  },
+  {
+    id: 'loan',
+    name: 'Car Loan',
+    balanceCents: 1000_00,
+    annualRateBps: 500,
+    minimumPaymentCents: 75_00,
+    ownership: 'shared',
+    owner: 'partner-b',
+  },
+  {
+    id: 'medical',
+    name: 'Medical Bill',
+    balanceCents: 500_00,
+    annualRateBps: 0,
+    minimumPaymentCents: 25_00,
+    ownership: 'jointly-funded',
+    owner: 'partner-a',
+  },
+];
+
+describe('summarizeOwnership', () => {
+  it('rolls up balances by ownership and partner', () => {
+    const summary = summarizeOwnership(debts);
+    expect(summary.totalBalanceCents).toBe(4500_00);
+    expect(summary.personalBalanceCents).toBe(3000_00);
+    expect(summary.sharedBalanceCents).toBe(1000_00);
+    expect(summary.jointlyFundedBalanceCents).toBe(500_00);
+    expect(summary.partnerABalanceCents).toBe(3500_00);
+    expect(summary.partnerBBalanceCents).toBe(1000_00);
+    expect(summary.counts).toEqual({ personal: 1, shared: 1, 'jointly-funded': 1 });
+  });
+
+  it('handles an empty debt list', () => {
+    const summary = summarizeOwnership([]);
+    expect(summary.totalBalanceCents).toBe(0);
+    expect(summary.counts).toEqual({ personal: 0, shared: 0, 'jointly-funded': 0 });
+  });
+});
+
+describe('ownershipLabel', () => {
+  it('returns text labels for every ownership value', () => {
+    expect(ownershipLabel('personal')).toBe('Personal');
+    expect(ownershipLabel('shared')).toBe('Shared');
+    expect(ownershipLabel('jointly-funded')).toBe('Jointly funded');
+  });
+});
+
+describe('compareJointStrategies', () => {
+  it('recommends avalanche when interest savings are material', () => {
+    const comparison = compareJointStrategies(debts, 200_00);
+    expect(comparison.interestDifferenceCents).toBeGreaterThanOrEqual(0);
+    // Avalanche never pays more interest than snowball.
+    expect(comparison.avalanche.totalInterestCents).toBeLessThanOrEqual(
+      comparison.snowball.totalInterestCents,
+    );
+    expect(comparison.recommendedStrategy).toBe('avalanche');
+  });
+
+  it('recommends snowball when the two strategies are near-equal', () => {
+    const evenDebts: JointDebtInput[] = [
+      {
+        id: 'a',
+        name: 'A',
+        balanceCents: 1000_00,
+        annualRateBps: 1000,
+        minimumPaymentCents: 50_00,
+        ownership: 'shared',
+        owner: 'partner-a',
+      },
+      {
+        id: 'b',
+        name: 'B',
+        balanceCents: 1000_00,
+        annualRateBps: 1000,
+        minimumPaymentCents: 50_00,
+        ownership: 'shared',
+        owner: 'partner-b',
+      },
+    ];
+    const comparison = compareJointStrategies(evenDebts, 100_00);
+    expect(comparison.interestDifferenceCents).toBe(0);
+    expect(comparison.recommendedStrategy).toBe('snowball');
+  });
+
+  it('selectStrategyResult returns the matching result', () => {
+    const comparison = compareJointStrategies(debts, 100_00);
+    expect(selectStrategyResult(comparison, 'avalanche')).toBe(comparison.avalanche);
+    expect(selectStrategyResult(comparison, 'snowball')).toBe(comparison.snowball);
+  });
+
+  it('clamps negative extra payments to zero', () => {
+    const negative = compareJointStrategies(debts, -500_00);
+    const zero = compareJointStrategies(debts, 0);
+    expect(negative.avalanche.monthsToPayoff).toBe(zero.avalanche.monthsToPayoff);
+  });
+});
+
+describe('projectGoalImpact', () => {
+  const goal: CoupleGoal = {
+    id: 'wedding',
+    name: 'Wedding',
+    targetCents: 20_000_00,
+    savedCents: 2_000_00,
+    monthlyContributionCents: 300_00,
+  };
+
+  it('funds the goal no sooner when the extra payment goes to debt first', () => {
+    const comparison = compareJointStrategies(debts, 300_00);
+    const result = selectStrategyResult(comparison, comparison.recommendedStrategy);
+    const impact = projectGoalImpact(result, goal, 300_00);
+    expect(impact.monthsWithDebtFocus).toBeGreaterThanOrEqual(impact.monthsWithGoalFocus);
+    expect(impact.monthsDelta).toBe(impact.monthsWithDebtFocus - impact.monthsWithGoalFocus);
+    expect(impact.remainingCents).toBe(18_000_00);
+    expect(impact.reachable).toBe(true);
+  });
+
+  it('reports zero months when the goal is already funded', () => {
+    const comparison = compareJointStrategies(debts, 100_00);
+    const result = selectStrategyResult(comparison, 'avalanche');
+    const funded: CoupleGoal = { ...goal, savedCents: goal.targetCents };
+    const impact = projectGoalImpact(result, funded, 100_00);
+    expect(impact.monthsWithDebtFocus).toBe(0);
+    expect(impact.monthsWithGoalFocus).toBe(0);
+    expect(impact.monthsDelta).toBe(0);
+  });
+
+  it('projects every goal via projectGoalImpacts', () => {
+    const comparison = compareJointStrategies(debts, 100_00);
+    const result = selectStrategyResult(comparison, 'avalanche');
+    const impacts = projectGoalImpacts(
+      result,
+      [goal, { ...goal, id: 'home', name: 'Home' }],
+      100_00,
+    );
+    expect(impacts).toHaveLength(2);
+    expect(impacts[0]?.goalId).toBe('wedding');
+    expect(impacts[1]?.goalId).toBe('home');
+  });
+});
+
+describe('recommendForCouple', () => {
+  it('recommends avalanche and a debt focus when goals stay on track', () => {
+    const comparison = compareJointStrategies(debts, 200_00);
+    const rec = recommendForCouple(comparison, []);
+    expect(rec.strategy).toBe('avalanche');
+    expect(rec.focus).toBe('debt');
+    expect(rec.headline).toContain('avalanche');
+    expect(rec.headline.toLowerCase()).toContain('focus the extra payment on debt');
+    expect(rec.rationale.length).toBeGreaterThan(0);
+  });
+
+  it('recommends a balanced focus when a goal is delayed past the concern threshold', () => {
+    const comparison = compareJointStrategies(debts, 200_00);
+    const impacts = [
+      {
+        goalId: 'wedding',
+        name: 'Wedding',
+        remainingCents: 10_000_00,
+        monthsWithDebtFocus: 24 + GOAL_DELAY_CONCERN_MONTHS,
+        monthsWithGoalFocus: 24,
+        monthsDelta: GOAL_DELAY_CONCERN_MONTHS,
+        reachable: true,
+      },
+    ];
+    const rec = recommendForCouple(comparison, impacts);
+    expect(rec.focus).toBe('balanced');
+    expect(rec.headline.toLowerCase()).toContain('split the extra payment');
+    expect(rec.rationale.some((line) => line.includes('Wedding'))).toBe(true);
+  });
+});

--- a/apps/web/src/lib/debt/joint-debt-planner.ts
+++ b/apps/web/src/lib/debt/joint-debt-planner.ts
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Joint debt payoff planner for couples (#2153).
+ *
+ * Builds on the shared payoff engine (`shared-payoff-rules.ts`) without
+ * duplicating any payoff/interest maths. This module adds the missing
+ * *partner-ownership* dimension:
+ *
+ *  - mark each debt as `personal`, `shared`, or `jointly-funded`;
+ *  - compare avalanche vs. snowball across BOTH partners' debts;
+ *  - project how an extra debt payment delays other couple goals
+ *    (wedding fund, home down payment, ...);
+ *  - produce a plain-language "recommendation mode" decision aid.
+ *
+ * All money is in integer minor units (cents). No interest maths is invented
+ * here — debt projections come straight from `calculateSharedPayoff`. Goal
+ * savings are modelled as simple linear accumulation (no invented growth/APY).
+ */
+
+import {
+  calculateSharedPayoff,
+  type SharedDebtInput,
+  type SharedPayoffResult,
+  type SharedPayoffStrategy,
+} from './shared-payoff-rules';
+import { formatUsdCents } from './payoff';
+
+// ---------------------------------------------------------------------------
+// Ownership + partner dimension
+// ---------------------------------------------------------------------------
+
+/** Who is responsible for / funds a debt. */
+export type DebtOwnership = 'personal' | 'shared' | 'jointly-funded';
+
+/** Which partner a personal debt belongs to. */
+export type PartnerId = 'partner-a' | 'partner-b';
+
+/** A debt enriched with the couple ownership dimension. */
+export interface JointDebtInput extends SharedDebtInput {
+  readonly name: string;
+  /** How the couple treats this balance. */
+  readonly ownership: DebtOwnership;
+  /** Which partner originated / primarily holds the balance. */
+  readonly owner: PartnerId;
+}
+
+/** Strategy comparison limited to the two well-known couple strategies. */
+export type CoupleStrategy = Extract<SharedPayoffStrategy, 'avalanche' | 'snowball'>;
+
+const MONTH_HORIZON = 600;
+
+/** Avalanche must beat snowball by at least this much interest to be recommended. */
+export const MEANINGFUL_INTEREST_SAVINGS_CENTS = 100_00;
+
+/** A goal delayed by at least this many months is flagged as a real trade-off. */
+export const GOAL_DELAY_CONCERN_MONTHS = 6;
+
+const OWNERSHIP_LABELS: Record<DebtOwnership, string> = {
+  personal: 'Personal',
+  shared: 'Shared',
+  'jointly-funded': 'Jointly funded',
+};
+
+/** Human-readable label for an ownership value (text, never colour-only). */
+export function ownershipLabel(ownership: DebtOwnership): string {
+  return OWNERSHIP_LABELS[ownership];
+}
+
+const STRATEGY_LABELS: Record<CoupleStrategy, string> = {
+  avalanche: 'avalanche',
+  snowball: 'snowball',
+};
+
+function toSharedDebtInput(debt: JointDebtInput): SharedDebtInput {
+  return {
+    id: debt.id,
+    balanceCents: debt.balanceCents,
+    annualRateBps: debt.annualRateBps,
+    minimumPaymentCents: debt.minimumPaymentCents,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Ownership summary
+// ---------------------------------------------------------------------------
+
+export interface OwnershipSummary {
+  readonly personalBalanceCents: number;
+  readonly sharedBalanceCents: number;
+  readonly jointlyFundedBalanceCents: number;
+  readonly totalBalanceCents: number;
+  readonly partnerABalanceCents: number;
+  readonly partnerBBalanceCents: number;
+  readonly counts: Record<DebtOwnership, number>;
+}
+
+/** Roll up balances by ownership category and by partner. */
+export function summarizeOwnership(debts: readonly JointDebtInput[]): OwnershipSummary {
+  const summary = {
+    personalBalanceCents: 0,
+    sharedBalanceCents: 0,
+    jointlyFundedBalanceCents: 0,
+    totalBalanceCents: 0,
+    partnerABalanceCents: 0,
+    partnerBBalanceCents: 0,
+    counts: { personal: 0, shared: 0, 'jointly-funded': 0 } as Record<DebtOwnership, number>,
+  };
+
+  for (const debt of debts) {
+    summary.totalBalanceCents += debt.balanceCents;
+    summary.counts[debt.ownership] += 1;
+    if (debt.ownership === 'personal') summary.personalBalanceCents += debt.balanceCents;
+    else if (debt.ownership === 'shared') summary.sharedBalanceCents += debt.balanceCents;
+    else summary.jointlyFundedBalanceCents += debt.balanceCents;
+
+    if (debt.owner === 'partner-a') summary.partnerABalanceCents += debt.balanceCents;
+    else summary.partnerBBalanceCents += debt.balanceCents;
+  }
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// Strategy comparison across BOTH partners' debts
+// ---------------------------------------------------------------------------
+
+export interface JointStrategyComparison {
+  readonly avalanche: SharedPayoffResult;
+  readonly snowball: SharedPayoffResult;
+  /** snowball interest minus avalanche interest (>= 0; avalanche never pays more). */
+  readonly interestDifferenceCents: number;
+  /** snowball months minus avalanche months. */
+  readonly monthsDifference: number;
+  readonly recommendedStrategy: CoupleStrategy;
+}
+
+/**
+ * Run avalanche and snowball across the couple's combined debts and report the
+ * recommended strategy. Avalanche is recommended when its interest savings are
+ * material or it is meaningfully faster; otherwise snowball wins for momentum.
+ */
+export function compareJointStrategies(
+  debts: readonly JointDebtInput[],
+  extraPaymentCents: number,
+): JointStrategyComparison {
+  const inputs = debts.map(toSharedDebtInput);
+  const safeExtra = Math.max(0, Math.round(extraPaymentCents));
+  const avalanche = calculateSharedPayoff(inputs, 'avalanche', safeExtra);
+  const snowball = calculateSharedPayoff(inputs, 'snowball', safeExtra);
+  const interestDifferenceCents = snowball.totalInterestCents - avalanche.totalInterestCents;
+  const monthsDifference = snowball.monthsToPayoff - avalanche.monthsToPayoff;
+  const avalancheWins =
+    interestDifferenceCents >= MEANINGFUL_INTEREST_SAVINGS_CENTS || monthsDifference > 1;
+  return {
+    avalanche,
+    snowball,
+    interestDifferenceCents,
+    monthsDifference,
+    recommendedStrategy: avalancheWins ? 'avalanche' : 'snowball',
+  };
+}
+
+/** Pick the matching result out of a comparison. */
+export function selectStrategyResult(
+  comparison: JointStrategyComparison,
+  strategy: CoupleStrategy,
+): SharedPayoffResult {
+  return strategy === 'avalanche' ? comparison.avalanche : comparison.snowball;
+}
+
+// ---------------------------------------------------------------------------
+// Goal impact of extra debt payments
+// ---------------------------------------------------------------------------
+
+export interface CoupleGoal {
+  readonly id: string;
+  readonly name: string;
+  /** Total amount the couple wants to save, in cents. */
+  readonly targetCents: number;
+  /** Amount already saved, in cents. */
+  readonly savedCents: number;
+  /** Monthly contribution made independently of the extra debt payment, in cents. */
+  readonly monthlyContributionCents: number;
+}
+
+export interface GoalImpact {
+  readonly goalId: string;
+  readonly name: string;
+  readonly remainingCents: number;
+  /** Months to fund the goal when the extra payment goes to debt first. */
+  readonly monthsWithDebtFocus: number;
+  /** Months to fund the goal when the extra payment goes straight to the goal. */
+  readonly monthsWithGoalFocus: number;
+  /** monthsWithDebtFocus - monthsWithGoalFocus (>= 0 — debt focus never funds sooner). */
+  readonly monthsDelta: number;
+  /** True when both scenarios fund the goal inside the projection horizon. */
+  readonly reachable: boolean;
+}
+
+/**
+ * Months to accumulate `remainingCents`. Contributes `phaseOneCents` per month
+ * up to and including `switchMonth`, then `phaseTwoCents` thereafter. Returns a
+ * value greater than the horizon when the goal cannot be funded in time.
+ */
+function monthsToAccumulate(
+  remainingCents: number,
+  phaseOneCents: number,
+  switchMonth: number,
+  phaseTwoCents: number,
+): number {
+  if (remainingCents <= 0) return 0;
+  let accumulated = 0;
+  for (let month = 1; month <= MONTH_HORIZON; month += 1) {
+    accumulated += month <= switchMonth ? phaseOneCents : phaseTwoCents;
+    if (accumulated >= remainingCents) return month;
+  }
+  return MONTH_HORIZON + 1;
+}
+
+/**
+ * Project how directing the *discretionary extra* payment at debt (vs. straight
+ * at the goal) changes the time to fund a single couple goal.
+ *
+ * The lever modelled is the extra payment only — minimum payments are paid in
+ * both scenarios regardless, so they are held constant and excluded. This keeps
+ * the comparison apples-to-apples and one-directional (focusing the extra on
+ * debt never funds the goal sooner):
+ *
+ *  - Goal-first: the goal grows by `monthlyContribution + extra` every month.
+ *  - Debt-first: the goal grows by `monthlyContribution` until the debts are
+ *    paid (`activeResult.monthsToPayoff`); after that the freed-up extra
+ *    redirects to the goal (`monthlyContribution + extra`).
+ *
+ * No interest/growth maths is invented for the goal — savings accumulate
+ * linearly in integer cents.
+ */
+export function projectGoalImpact(
+  activeResult: SharedPayoffResult,
+  goal: CoupleGoal,
+  extraPaymentCents: number,
+): GoalImpact {
+  const remainingCents = Math.max(0, goal.targetCents - goal.savedCents);
+  const safeExtra = Math.max(0, Math.round(extraPaymentCents));
+  const base = Math.max(0, goal.monthlyContributionCents);
+  const payoffMonths = activeResult.monthsToPayoff;
+
+  const monthsWithDebtFocus = monthsToAccumulate(
+    remainingCents,
+    base,
+    payoffMonths,
+    base + safeExtra,
+  );
+  const monthsWithGoalFocus = monthsToAccumulate(
+    remainingCents,
+    base + safeExtra,
+    MONTH_HORIZON,
+    base + safeExtra,
+  );
+
+  const reachable = monthsWithDebtFocus <= MONTH_HORIZON && monthsWithGoalFocus <= MONTH_HORIZON;
+  return {
+    goalId: goal.id,
+    name: goal.name,
+    remainingCents,
+    monthsWithDebtFocus,
+    monthsWithGoalFocus,
+    monthsDelta: Math.max(0, monthsWithDebtFocus - monthsWithGoalFocus),
+    reachable,
+  };
+}
+
+/** Project the goal impact for every goal against the active strategy result. */
+export function projectGoalImpacts(
+  activeResult: SharedPayoffResult,
+  goals: readonly CoupleGoal[],
+  extraPaymentCents: number,
+): readonly GoalImpact[] {
+  return goals.map((goal) => projectGoalImpact(activeResult, goal, extraPaymentCents));
+}
+
+// ---------------------------------------------------------------------------
+// Couples recommendation mode (simpler decision aid)
+// ---------------------------------------------------------------------------
+
+export type CoupleFocus = 'debt' | 'balanced';
+
+export interface CoupleRecommendation {
+  /** One-line plain-language recommendation. */
+  readonly headline: string;
+  readonly strategy: CoupleStrategy;
+  readonly focus: CoupleFocus;
+  /** Supporting bullet points, already formatted for display. */
+  readonly rationale: readonly string[];
+}
+
+/**
+ * Turn the strategy comparison and goal impacts into a single, plain-language
+ * recommendation for a couple. Pure and deterministic so it is unit-testable
+ * and safe to announce through an aria-live region.
+ */
+export function recommendForCouple(
+  comparison: JointStrategyComparison,
+  impacts: readonly GoalImpact[],
+): CoupleRecommendation {
+  const strategy = comparison.recommendedStrategy;
+  const rationale: string[] = [];
+
+  if (strategy === 'avalanche') {
+    rationale.push(
+      `Avalanche clears the highest-rate balances first, saving about ${formatUsdCents(
+        comparison.interestDifferenceCents,
+      )} in interest versus snowball.`,
+    );
+  } else {
+    rationale.push(
+      'Snowball clears the smallest balances first for quick, motivating wins — the interest difference here is small.',
+    );
+  }
+
+  const mostDelayed = [...impacts]
+    .filter((impact) => impact.reachable && impact.remainingCents > 0)
+    .sort((a, b) => b.monthsDelta - a.monthsDelta)[0];
+
+  let focus: CoupleFocus;
+  if (mostDelayed && mostDelayed.monthsDelta >= GOAL_DELAY_CONCERN_MONTHS) {
+    focus = 'balanced';
+    rationale.push(
+      `Putting every extra dollar on debt delays your ${mostDelayed.name} fund by about ${mostDelayed.monthsDelta} months. Consider splitting the extra payment so debt and savings both move forward.`,
+    );
+  } else {
+    focus = 'debt';
+    rationale.push(
+      'Your savings goals stay on track, so directing the extra payment at debt is a safe call.',
+    );
+  }
+
+  const headline =
+    focus === 'balanced'
+      ? `Use the ${STRATEGY_LABELS[strategy]} method and split the extra payment between debt and savings.`
+      : `Use the ${STRATEGY_LABELS[strategy]} method and focus the extra payment on debt.`;
+
+  return { headline, strategy, focus, rationale };
+}

--- a/apps/web/src/pages/DebtPage.test.tsx
+++ b/apps/web/src/pages/DebtPage.test.tsx
@@ -131,10 +131,11 @@ describe('DebtPage', () => {
     expect(screen.getByText('Debt Management')).toBeDefined();
   });
 
-  it('renders all five tabs', () => {
+  it('renders all six tabs', () => {
     render(<DebtPage />);
     expect(screen.getByText('Payoff Planner')).toBeDefined();
     expect(screen.getByText('Payoff Rings')).toBeDefined();
+    expect(screen.getByText('Joint Debt')).toBeDefined();
     expect(screen.getByText('BNPL Dashboard')).toBeDefined();
     expect(screen.getByText('Student Loans')).toBeDefined();
     expect(screen.getByText('Credit Cards')).toBeDefined();
@@ -329,13 +330,49 @@ describe('DebtPage', () => {
     expect(screen.getByText('No credit cards')).toBeDefined();
   });
 
+  it('shows the Joint Debt empty state when no debts exist', () => {
+    render(<DebtPage />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Joint Debt' }));
+    expect(screen.getByText('No debts to plan together')).toBeDefined();
+  });
+
+  it('builds a joint payoff comparison from both partners debts', () => {
+    mockUseAccountsState.accounts = [
+      buildAccount({
+        id: 'cc-joint',
+        name: 'Rewards Card',
+        type: 'CREDIT_CARD',
+        currentBalance: { amount: -300_000 },
+      }),
+      buildAccount({
+        id: 'loan-joint',
+        name: 'Car Loan',
+        type: 'LOAN',
+        currentBalance: { amount: -100_000 },
+      }),
+    ];
+    render(<DebtPage />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Joint Debt' }));
+
+    expect(screen.getByRole('heading', { name: 'Joint Debt Payoff' })).toBeDefined();
+    // Comparison table is present with both strategies as column headers.
+    expect(screen.getByRole('columnheader', { name: /Avalanche/ })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: /Snowball/ })).toBeDefined();
+    // Ownership selection appears for each debt.
+    expect(screen.getByLabelText('Owner of Rewards Card')).toBeDefined();
+    expect(screen.getByLabelText('Treatment of Car Loan')).toBeDefined();
+    // Recommendation announces via a live region.
+    const status = screen.getByRole('status');
+    expect(status.textContent).toBeTruthy();
+  });
+
   it('has proper ARIA tab structure', () => {
     render(<DebtPage />);
     const tablist = screen.getByRole('tablist');
     expect(tablist).toBeDefined();
 
     const tabs = screen.getAllByRole('tab');
-    expect(tabs).toHaveLength(5);
+    expect(tabs).toHaveLength(6);
 
     const tabpanel = screen.getByRole('tabpanel');
     expect(tabpanel).toBeDefined();

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -85,16 +85,20 @@ import type { Account } from '../kmp/bridge';
 // Imported directly (not via a shared barrel) so it stays code-split into the
 // lazy Debt page chunk and does not inflate other route bundles (#2175).
 import { DebtPayoffRings } from '../components/debt/DebtPayoffRings';
+// Imported directly (not via a shared barrel) for the same code-splitting
+// reason — keeps the joint-debt planner inside the lazy Debt chunk (#2153).
+import { JointDebtPlanner } from '../components/debt/JointDebtPlanner';
 
 // ---------------------------------------------------------------------------
 // Tab types
 // ---------------------------------------------------------------------------
 
-type DebtTab = 'payoff' | 'payoff-rings' | 'bnpl' | 'student-loans' | 'credit-cards';
+type DebtTab = 'payoff' | 'payoff-rings' | 'joint' | 'bnpl' | 'student-loans' | 'credit-cards';
 
 const TAB_LABELS: Record<DebtTab, string> = {
   payoff: 'Payoff Planner',
   'payoff-rings': 'Payoff Rings',
+  joint: 'Joint Debt',
   bnpl: 'BNPL Dashboard',
   'student-loans': 'Student Loans',
   'credit-cards': 'Credit Cards',
@@ -466,6 +470,7 @@ export function DebtPage(): React.ReactElement {
       >
         {activeTab === 'payoff' && <PayoffPlannerPanel />}
         {activeTab === 'payoff-rings' && <PayoffRingsPanel />}
+        {activeTab === 'joint' && <JointDebtPanel />}
         {activeTab === 'bnpl' && <BnplDashboardPanel />}
         {activeTab === 'student-loans' && <StudentLoanPanel />}
         {activeTab === 'credit-cards' && <CreditCardPanel />}
@@ -494,6 +499,29 @@ function PayoffRingsPanel(): React.ReactElement {
     [accounts],
   );
   return <DebtPayoffRings debts={debts} todayIso={todayIso} />;
+}
+
+// ---------------------------------------------------------------------------
+// Joint Debt panel (#2153)
+// ---------------------------------------------------------------------------
+
+/**
+ * Couples' joint debt payoff surface. Derives both partners' debts from the
+ * household's debt accounts and hands them to the accessible JointDebtPlanner,
+ * which adds the partner-ownership dimension, an avalanche/snowball comparison
+ * across the combined debts, a goal-impact view, and a recommendation mode.
+ */
+function JointDebtPanel(): React.ReactElement {
+  const { accounts } = useAccounts();
+  const todayIso = useMemo(() => new Date().toISOString().slice(0, 10), []);
+  const debts = useMemo(
+    () =>
+      accounts
+        .map(accountToDebt)
+        .filter((debt): debt is Debt => debt !== null && debt.balanceCents > 0),
+    [accounts],
+  );
+  return <JointDebtPlanner debts={debts} todayIso={todayIso} />;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the joint-debt gap for engaged/married couples (#2153). The web `DebtPage` already had a *solo* payoff planner and an **orphaned** `shared-payoff-rules.ts` engine that nothing imported. This PR surfaces the missing **partner-ownership** dimension on a new **Joint Debt** tab, building on that existing engine (no duplicated payoff/interest math).

### What's new
- **New engine** `apps/web/src/lib/debt/joint-debt-planner.ts` — wraps `calculateSharedPayoff` to add ownership (`personal` / `shared` / `jointly-funded`), a partner dimension, an avalanche-vs-snowball comparison across **both** partners' debts, a goal-impact projection, and a plain-language couples recommendation. Integer-minor-unit (cents) money math; no invented interest.
- **New component** `apps/web/src/components/debt/JointDebtPlanner.tsx` (+ CSS) — imported **directly** into the lazy `DebtPage` chunk (not via a shared barrel) so it doesn't inflate other routes.
- **DebtPage** gains a *Joint Debt* tab wired to a thin `JointDebtPanel` that pulls debts via the `useAccounts` hook.

### Accessibility (WCAG 2.2 AA)
- Comparison/impact tables use `<caption>` + scoped `<th scope=col|row>` headers.
- Ownership state is text + icon (`●` / `◑` / `◇`), never colour alone.
- The recommendation announces through an `aria-live=polite` `role=status` region.
- All controls are labelled and keyboard reachable; motion respects `prefers-reduced-motion`.

### Verification
- `vitest` — new unit tests (engine) + component tests + updated DebtPage tests pass (36 in the touched files). Tests mock the `useAccounts` hook, not repositories.
- `prettier --check` and `eslint --max-warnings 0` clean on changed files; `tsc --noEmit` reports 0 errors.
- `vite build` + `perf:budget` pass (lazy-chunk gzip budget respected).

Refs #2153 (Android slice remains open, so not `Closes`).