### PR TITLE
feat(web): trip & country budgets on the budgets surface (#2205)

### DIFF
--- a/apps/web/src/components/budgets/TripCountryBudgetsSection.css
+++ b/apps/web/src/components/budgets/TripCountryBudgetsSection.css
@@ -1,0 +1,399 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for the Trip & Country budgets section on the Budgets surface
+ * (TripCountryBudgetsSection.tsx).
+ *
+ * All values come from design-token CSS custom properties. Status and
+ * over-budget state are always reinforced with an icon and a text label in the
+ * markup, so colour here is reinforcement only — never the sole signal
+ * (WCAG 2.2 AA). The progress fill honours `prefers-reduced-motion`.
+ *
+ * Class names are prefixed `tcb-` (trip / country budget) to avoid clashing
+ * with the standalone Trip Budgets planner page (`.trip-*`).
+ *
+ * References: issue #2205
+ */
+
+.tcb {
+  margin-bottom: var(--spacing-6);
+}
+
+.tcb__intro {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+}
+
+.tcb__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex: 0 0 auto;
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-interactive-default);
+}
+
+.tcb__heading {
+  margin: 0;
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+}
+
+.tcb__subtitle {
+  margin: var(--spacing-1) 0 0 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-font-size);
+  max-width: 70ch;
+}
+
+.tcb__rates {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  margin: 0 0 var(--spacing-4) 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+/* --------------------------------------------------------------------------
+ * Form
+ * ------------------------------------------------------------------------ */
+
+.tcb-form {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+  padding: var(--spacing-4);
+  margin-bottom: var(--spacing-5);
+}
+
+.tcb-form__legend {
+  margin: 0 0 var(--spacing-3) 0;
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+}
+
+.tcb-form__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: var(--spacing-3);
+}
+
+.tcb-form__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-4);
+}
+
+.tcb-form__error {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  margin: 0;
+  min-height: 1.25rem;
+  color: var(--semantic-status-negative);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.tcb-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.tcb-field--inline {
+  min-width: 12rem;
+}
+
+.tcb-field__label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-primary);
+}
+
+.tcb-field__input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--spacing-2);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+.tcb-field__input:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 1px;
+}
+
+.tcb-field__hint {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+/* --------------------------------------------------------------------------
+ * Filters
+ * ------------------------------------------------------------------------ */
+
+.tcb-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-3);
+}
+
+.tcb-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+.tcb__count {
+  margin: 0 0 var(--spacing-3) 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.tcb__empty {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+/* --------------------------------------------------------------------------
+ * Cards
+ * ------------------------------------------------------------------------ */
+
+.tcb-cards {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-4);
+}
+
+@media (min-width: 640px) {
+  .tcb-cards {
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  }
+}
+
+.tcb-card {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+  padding: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.tcb-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.tcb-card__name {
+  margin: 0;
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+}
+
+.tcb-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-1);
+  margin: var(--spacing-1) 0 0 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.tcb-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  flex: 0 0 auto;
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: var(--border-radius-sm);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  border: 1px solid var(--semantic-border-default);
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-text-secondary);
+}
+
+.tcb-badge--active {
+  color: var(--semantic-status-positive);
+  border-color: var(--semantic-status-positive);
+}
+
+.tcb-badge--upcoming {
+  color: var(--semantic-status-info);
+  border-color: var(--semantic-status-info);
+}
+
+.tcb-badge--ended {
+  color: var(--semantic-text-secondary);
+}
+
+.tcb-badge--archived {
+  color: var(--semantic-text-secondary);
+  border-style: dashed;
+}
+
+.tcb-card__progress {
+  height: 0.5rem;
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-secondary);
+  overflow: hidden;
+}
+
+.tcb-card__progress-fill {
+  height: 100%;
+  background: var(--semantic-status-positive);
+  transition: width 0.2s ease;
+}
+
+.tcb-card__progress-fill--over {
+  background: var(--semantic-status-negative);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tcb-card__progress-fill {
+    transition: none;
+  }
+}
+
+.tcb-card__figures {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-2);
+  margin: 0;
+}
+
+.tcb-card__figure {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.tcb-card__figure dt {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  margin: 0;
+}
+
+.tcb-card__figure dd {
+  margin: 0;
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  text-align: right;
+}
+
+.tcb-card__muted {
+  color: var(--semantic-text-secondary);
+  font-weight: var(--font-weight-medium);
+}
+
+.tcb-card__over {
+  color: var(--semantic-status-negative);
+}
+
+.tcb-card__note {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.tcb-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  border-top: 1px solid var(--semantic-border-default);
+  padding-top: var(--spacing-3);
+}
+
+.tcb-card__count {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.tcb-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+
+/* --------------------------------------------------------------------------
+ * Buttons
+ * ------------------------------------------------------------------------ */
+
+.tcb-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: var(--border-radius-sm);
+  font-size: var(--type-scale-body-font-size);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.tcb-button:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.tcb-button--primary {
+  background: var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse);
+}
+
+.tcb-button--primary:hover {
+  background: var(--semantic-interactive-hover);
+}
+
+.tcb-button--ghost {
+  background: transparent;
+  color: var(--semantic-interactive-default);
+  border-color: var(--semantic-border-default);
+}
+
+.tcb-button--ghost:hover {
+  background: var(--semantic-background-secondary);
+}
+
+.tcb-button--danger {
+  background: transparent;
+  color: var(--semantic-status-negative);
+  border-color: var(--semantic-border-default);
+}
+
+.tcb-button--danger:hover {
+  background: var(--semantic-background-secondary);
+}

--- a/apps/web/src/components/budgets/TripCountryBudgetsSection.test.tsx
+++ b/apps/web/src/components/budgets/TripCountryBudgetsSection.test.tsx
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TripCountryBudgetsSection } from './TripCountryBudgetsSection';
+import type { TripBudgetView } from '../../lib/budgeting/trip-country-budgets';
+import type { TripCountryBudget } from '../../lib/budgeting/trip-country-budgets';
+
+function makeBudget(overrides: Partial<TripCountryBudget> = {}): TripCountryBudget {
+  return {
+    id: 'trip-thailand',
+    name: 'Bangkok Jan–Mar',
+    countries: ['TH'],
+    startDate: '2026-01-01',
+    endDate: '2026-03-31',
+    localCurrency: 'THB',
+    displayCurrency: 'USD',
+    tags: ['trip'],
+    budgetLocalCents: 9_000_000,
+    archived: false,
+    createdAt: '2025-12-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeView(overrides: Partial<TripBudgetView> = {}): TripBudgetView {
+  const budget = overrides.budget ?? makeBudget();
+  return {
+    budget,
+    rollup: {
+      scopeId: budget.id,
+      name: budget.name,
+      includedTransactionIds: ['tx-1', 'tx-2'],
+      localCurrency: 'THB',
+      displayCurrency: 'USD',
+      localSpendCents: 1_266_667,
+      displaySpendCents: 38_000,
+      isArchived: budget.archived ?? false,
+      appearsInActiveAlerts: true,
+    },
+    budgetLocalCents: 9_000_000,
+    localSpentCents: 1_266_667,
+    remainingLocalCents: 7_733_333,
+    displayCurrency: 'USD',
+    budgetDisplayCents: 270_000,
+    displaySpentCents: 38_000,
+    remainingDisplayCents: 232_000,
+    percentUsed: 14,
+    isOverBudget: false,
+    unconvertedCurrencies: [],
+    displayConversionAvailable: true,
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  views: [] as readonly TripBudgetView[],
+  countries: ['TH', 'VN'],
+  countryFilter: '',
+  onCountryFilterChange: vi.fn(),
+  showArchived: false,
+  onShowArchivedChange: vi.fn(),
+  displayCurrency: 'USD',
+  supportedCurrencies: [
+    { value: 'USD', label: 'US Dollar (USD)' },
+    { value: 'THB', label: 'Thai Baht (THB)' },
+    { value: 'EUR', label: 'Euro (EUR)' },
+  ],
+  ratesStale: false,
+  ratesLoading: false,
+  today: '2026-02-01',
+  onCreate: vi.fn(),
+  onArchiveChange: vi.fn(),
+  onDelete: vi.fn(),
+};
+
+describe('TripCountryBudgetsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the labelled creation form and filter controls', () => {
+    render(<TripCountryBudgetsSection {...baseProps} />);
+
+    expect(screen.getByRole('heading', { name: /trip & country budgets/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('Trip name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Start date')).toBeInTheDocument();
+    expect(screen.getByLabelText('End date')).toBeInTheDocument();
+    expect(screen.getByLabelText('Local currency')).toBeInTheDocument();
+    expect(screen.getByLabelText('Home roll-up currency')).toBeInTheDocument();
+    expect(screen.getByLabelText('Budget (local currency)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter by country')).toBeInTheDocument();
+    expect(screen.getByLabelText('Show archived trips')).toBeInTheDocument();
+  });
+
+  it('renders a trip card with status, progressbar, and home roll-up', () => {
+    render(<TripCountryBudgetsSection {...baseProps} views={[makeView()]} />);
+
+    const card = screen.getByRole('article', { name: 'Bangkok Jan–Mar' });
+    expect(within(card).getByText('Active')).toBeInTheDocument();
+    const progress = within(card).getByRole('progressbar');
+    expect(progress).toHaveAttribute('aria-valuenow', '14');
+    expect(progress).toHaveAttribute('aria-valuemax', '100');
+    expect(within(card).getByText('Home roll-up')).toBeInTheDocument();
+    expect(within(card).getByText(/2 transactions/i)).toBeInTheDocument();
+    expect(screen.getByText(/showing 1 trip budget/i)).toBeInTheDocument();
+  });
+
+  it('parses the local amount into integer minor units on submit', () => {
+    const onCreate = vi.fn();
+    render(<TripCountryBudgetsSection {...baseProps} onCreate={onCreate} />);
+
+    fireEvent.change(screen.getByLabelText('Trip name'), { target: { value: 'Bangkok' } });
+    fireEvent.change(screen.getByLabelText('Countries'), { target: { value: 'TH, VN' } });
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026-01-01' } });
+    fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2026-03-31' } });
+    fireEvent.change(screen.getByLabelText('Local currency'), { target: { value: 'THB' } });
+    fireEvent.change(screen.getByLabelText('Budget (local currency)'), {
+      target: { value: '90000' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add trip budget/i }));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Bangkok',
+        countries: ['TH', 'VN'],
+        localCurrency: 'THB',
+        budgetLocalCents: 9_000_000,
+      }),
+    );
+  });
+
+  it('shows an assertive validation error and does not submit when invalid', () => {
+    const onCreate = vi.fn();
+    render(<TripCountryBudgetsSection {...baseProps} onCreate={onCreate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add trip budget/i }));
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/give the trip a name/i);
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it('conveys over-budget state with text, not colour alone', () => {
+    render(
+      <TripCountryBudgetsSection
+        {...baseProps}
+        views={[
+          makeView({
+            isOverBudget: true,
+            remainingLocalCents: -200_000,
+            percentUsed: 120,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/over budget/i)).toBeInTheDocument();
+  });
+
+  it('discloses a missing home-currency rate instead of inventing one', () => {
+    render(
+      <TripCountryBudgetsSection
+        {...baseProps}
+        views={[
+          makeView({
+            displayConversionAvailable: false,
+            budgetDisplayCents: null,
+            displaySpentCents: null,
+            remainingDisplayCents: null,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/no usd rate available/i)).toBeInTheDocument();
+  });
+
+  it('discloses unconvertible transaction currencies', () => {
+    render(
+      <TripCountryBudgetsSection
+        {...baseProps}
+        views={[makeView({ unconvertedCurrencies: ['EUR'] })]}
+      />,
+    );
+
+    expect(screen.getByText(/excludes spend in eur/i)).toBeInTheDocument();
+  });
+
+  it('archives, restores, and deletes via handlers', () => {
+    const onArchiveChange = vi.fn();
+    const onDelete = vi.fn();
+    const { rerender } = render(
+      <TripCountryBudgetsSection
+        {...baseProps}
+        views={[makeView()]}
+        onArchiveChange={onArchiveChange}
+        onDelete={onDelete}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /archive bangkok jan–mar/i }));
+    expect(onArchiveChange).toHaveBeenCalledWith('trip-thailand', true);
+
+    fireEvent.click(screen.getByRole('button', { name: /delete bangkok jan–mar trip budget/i }));
+    expect(onDelete).toHaveBeenCalledWith('trip-thailand');
+
+    rerender(
+      <TripCountryBudgetsSection
+        {...baseProps}
+        views={[makeView({ budget: makeBudget({ archived: true }) })]}
+        onArchiveChange={onArchiveChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /reopen bangkok jan–mar/i }));
+    expect(onArchiveChange).toHaveBeenLastCalledWith('trip-thailand', false);
+  });
+
+  it('forwards filter changes', () => {
+    const onCountryFilterChange = vi.fn();
+    const onShowArchivedChange = vi.fn();
+    render(
+      <TripCountryBudgetsSection
+        {...baseProps}
+        onCountryFilterChange={onCountryFilterChange}
+        onShowArchivedChange={onShowArchivedChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Filter by country'), { target: { value: 'VN' } });
+    expect(onCountryFilterChange).toHaveBeenCalledWith('VN');
+
+    fireEvent.click(screen.getByLabelText('Show archived trips'));
+    expect(onShowArchivedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('discloses stale / offline exchange rates', () => {
+    render(<TripCountryBudgetsSection {...baseProps} ratesStale />);
+    expect(screen.getByText(/cached rates that may be stale or offline/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/budgets/TripCountryBudgetsSection.tsx
+++ b/apps/web/src/components/budgets/TripCountryBudgetsSection.tsx
@@ -1,0 +1,553 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * TripCountryBudgetsSection — trip / country budgeting on the Budgets surface
+ * (#2205).
+ *
+ * A digital nomad defines a named trip (countries, start/end dates, local
+ * currency, optional tags) and a local-currency target. Spend is derived from
+ * their REAL transactions by the pure scope engine and rolled up into their
+ * home / display currency using the app's real exchange-rate primitives — this
+ * component is presentation only and receives already-computed
+ * {@link TripBudgetView}s plus handlers; it never imports a repository or hook.
+ *
+ * Accessibility (WCAG 2.2 AA):
+ *  - every control has an associated <label htmlFor> (+ aria-describedby hint);
+ *  - the result count and roll-up disclosures live in aria-live regions;
+ *  - trip status and over-budget state use an icon AND text — never colour
+ *    alone;
+ *  - progress is exposed via role="progressbar" with min/now/max + label;
+ *  - all actions are native buttons, keyboard reachable, and the progress fill
+ *    honours `prefers-reduced-motion` (see the stylesheet).
+ *
+ * References: issue #2205
+ */
+
+import React, { useId, useState } from 'react';
+
+import { AppIcon, type IconName } from '../icons';
+import { CurrencyDisplay } from '../common/CurrencyDisplay';
+import {
+  getTripBudgetStatus,
+  parseTripBudgetAmount,
+  splitTokens,
+  type TripBudgetStatus,
+  type TripBudgetView,
+  type TripCountryBudgetFormInput,
+} from '../../lib/budgeting/trip-country-budgets';
+
+import './TripCountryBudgetsSection.css';
+
+/** A selectable currency option (shape shared with the display-currency picker). */
+export interface TripCurrencyOption {
+  readonly value: string;
+  readonly label: string;
+}
+
+export interface TripCountryBudgetsSectionProps {
+  /** Views already filtered for the current archived + country selection. */
+  readonly views: readonly TripBudgetView[];
+  /** Distinct country codes across all trips, for the filter control. */
+  readonly countries: readonly string[];
+  /** Currently selected country filter (empty string = all). */
+  readonly countryFilter: string;
+  readonly onCountryFilterChange: (code: string) => void;
+  /** Whether archived trips are included in the list. */
+  readonly showArchived: boolean;
+  readonly onShowArchivedChange: (next: boolean) => void;
+  /** The user's global display currency — the default home roll-up currency. */
+  readonly displayCurrency: string;
+  /** Currencies offered in the local / display pickers. */
+  readonly supportedCurrencies: readonly TripCurrencyOption[];
+  /** `true` when exchange rates may be stale or offline (disclosed to the user). */
+  readonly ratesStale: boolean;
+  /** `true` while exchange rates are still loading. */
+  readonly ratesLoading: boolean;
+  /** Today as an ISO `YYYY-MM-DD` string, used for lifecycle status. */
+  readonly today: string;
+  readonly onCreate: (input: TripCountryBudgetFormInput) => void;
+  readonly onArchiveChange: (id: string, archived: boolean) => void;
+  readonly onDelete: (id: string) => void;
+}
+
+const STATUS_META: Record<TripBudgetStatus, { readonly label: string; readonly icon: IconName }> = {
+  upcoming: { label: 'Upcoming', icon: 'calendar' },
+  active: { label: 'Active', icon: 'plane' },
+  ended: { label: 'Ended', icon: 'check-circle' },
+  archived: { label: 'Archived', icon: 'package' },
+};
+
+/** Format an ISO date as e.g. "1 Jan 2026"; falls back to the raw string. */
+function formatIsoDate(iso: string): string {
+  const parsed = new Date(`${iso}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+/** A single trip/country budget card. */
+const TripBudgetCard: React.FC<{
+  readonly view: TripBudgetView;
+  readonly today: string;
+  readonly onArchiveChange: (id: string, archived: boolean) => void;
+  readonly onDelete: (id: string) => void;
+}> = ({ view, today, onArchiveChange, onDelete }) => {
+  const { budget } = view;
+  const status = getTripBudgetStatus(budget, today);
+  const statusMeta = STATUS_META[status];
+  const progressNow = Math.min(100, Math.max(0, view.percentUsed));
+  const countryLabel = budget.countries.length > 0 ? budget.countries.join(', ') : 'Any country';
+  const remainingAbsLocal = Math.abs(view.remainingLocalCents);
+
+  return (
+    <article className="tcb-card" aria-labelledby={`${budget.id}-name`}>
+      <header className="tcb-card__header">
+        <div>
+          <h4 className="tcb-card__name" id={`${budget.id}-name`}>
+            {budget.name}
+          </h4>
+          <p className="tcb-card__meta">
+            <AppIcon name="map-pin" size={16} />
+            <span>{countryLabel}</span>
+            <span aria-hidden="true">·</span>
+            <AppIcon name="calendar" size={16} />
+            <span>
+              {formatIsoDate(budget.startDate)} – {formatIsoDate(budget.endDate)}
+            </span>
+            <span aria-hidden="true">·</span>
+            <span>{budget.localCurrency}</span>
+          </p>
+        </div>
+        <span className={`tcb-badge tcb-badge--${status}`}>
+          <AppIcon name={statusMeta.icon} size={16} />
+          <span>{statusMeta.label}</span>
+        </span>
+      </header>
+
+      <div
+        className="tcb-card__progress"
+        role="progressbar"
+        aria-valuenow={progressNow}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${budget.name} local budget: ${view.percentUsed}% used${
+          view.isOverBudget ? ', over budget' : ''
+        }`}
+      >
+        <div
+          className={`tcb-card__progress-fill${
+            view.isOverBudget ? ' tcb-card__progress-fill--over' : ''
+          }`}
+          style={{ width: `${progressNow}%` }}
+        />
+      </div>
+
+      <dl className="tcb-card__figures">
+        <div className="tcb-card__figure">
+          <dt>Spent (local)</dt>
+          <dd>
+            <CurrencyDisplay
+              amount={view.localSpentCents}
+              currency={budget.localCurrency}
+              context={`spent in ${budget.name}`}
+            />{' '}
+            <span className="tcb-card__muted">
+              of <CurrencyDisplay amount={view.budgetLocalCents} currency={budget.localCurrency} />
+            </span>
+          </dd>
+        </div>
+        <div className="tcb-card__figure">
+          <dt>Home roll-up</dt>
+          <dd>
+            {view.displayConversionAvailable &&
+            view.displaySpentCents !== null &&
+            view.budgetDisplayCents !== null ? (
+              <>
+                <CurrencyDisplay
+                  amount={view.displaySpentCents}
+                  currency={view.displayCurrency}
+                  context={`spent in ${budget.name}, ${view.displayCurrency}`}
+                />{' '}
+                <span className="tcb-card__muted">
+                  of{' '}
+                  <CurrencyDisplay
+                    amount={view.budgetDisplayCents}
+                    currency={view.displayCurrency}
+                  />
+                </span>
+              </>
+            ) : (
+              <span className="tcb-card__muted">No {view.displayCurrency} rate available</span>
+            )}
+          </dd>
+        </div>
+        <div className="tcb-card__figure">
+          <dt>{view.isOverBudget ? 'Over by' : 'Remaining'}</dt>
+          <dd className={view.isOverBudget ? 'tcb-card__over' : undefined}>
+            <AppIcon name={view.isOverBudget ? 'alert-triangle' : 'check-circle'} size={16} />{' '}
+            <CurrencyDisplay
+              amount={remainingAbsLocal}
+              currency={budget.localCurrency}
+              context={
+                view.isOverBudget ? `over budget in ${budget.name}` : `remaining in ${budget.name}`
+              }
+            />
+            {view.isOverBudget ? ' over budget' : ' left'}
+          </dd>
+        </div>
+      </dl>
+
+      {view.unconvertedCurrencies.length > 0 ? (
+        <p className="tcb-card__note">
+          <AppIcon name="info" size={16} /> Excludes spend in{' '}
+          {view.unconvertedCurrencies.join(', ')} (no exchange rate).
+        </p>
+      ) : null}
+
+      <footer className="tcb-card__footer">
+        <span className="tcb-card__count">
+          {view.rollup.includedTransactionIds.length}{' '}
+          {view.rollup.includedTransactionIds.length === 1 ? 'transaction' : 'transactions'}
+        </span>
+        <div className="tcb-card__actions">
+          <button
+            type="button"
+            className="tcb-button tcb-button--ghost"
+            onClick={() => onArchiveChange(budget.id, !budget.archived)}
+          >
+            <AppIcon name="package" size={16} />{' '}
+            {budget.archived ? `Reopen ${budget.name}` : `Archive ${budget.name}`}
+          </button>
+          <button
+            type="button"
+            className="tcb-button tcb-button--danger"
+            onClick={() => onDelete(budget.id)}
+            aria-label={`Delete ${budget.name} trip budget`}
+          >
+            <AppIcon name="trash" size={16} /> Delete
+          </button>
+        </div>
+      </footer>
+    </article>
+  );
+};
+
+/**
+ * Trip & country budgets surface block, mounted inside the lazy Budgets route.
+ */
+export const TripCountryBudgetsSection: React.FC<TripCountryBudgetsSectionProps> = ({
+  views,
+  countries,
+  countryFilter,
+  onCountryFilterChange,
+  showArchived,
+  onShowArchivedChange,
+  displayCurrency,
+  supportedCurrencies,
+  ratesStale,
+  ratesLoading,
+  today,
+  onCreate,
+  onArchiveChange,
+  onDelete,
+}) => {
+  const fieldId = useId();
+  const id = (suffix: string): string => `${fieldId}-${suffix}`;
+
+  const [name, setName] = useState('');
+  const [countryInput, setCountryInput] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [localCurrency, setLocalCurrency] = useState('');
+  const [homeCurrency, setHomeCurrency] = useState(displayCurrency);
+  const [amount, setAmount] = useState('');
+  const [tagsInput, setTagsInput] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const resetForm = (): void => {
+    setName('');
+    setCountryInput('');
+    setStartDate('');
+    setEndDate('');
+    setLocalCurrency('');
+    setHomeCurrency(displayCurrency);
+    setAmount('');
+    setTagsInput('');
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const trimmedName = name.trim();
+    if (trimmedName.length === 0) {
+      setFormError('Give the trip a name.');
+      return;
+    }
+    if (!startDate || !endDate) {
+      setFormError('Enter a start and end date.');
+      return;
+    }
+    if (endDate < startDate) {
+      setFormError('The end date must be on or after the start date.');
+      return;
+    }
+    if (!localCurrency) {
+      setFormError('Choose the local currency you will spend in.');
+      return;
+    }
+    const budgetLocalCents = parseTripBudgetAmount(amount, localCurrency);
+    if (budgetLocalCents <= 0) {
+      setFormError('Enter a budget amount greater than zero.');
+      return;
+    }
+
+    setFormError(null);
+    onCreate({
+      name: trimmedName,
+      countries: splitTokens(countryInput),
+      startDate,
+      endDate,
+      localCurrency,
+      displayCurrency: homeCurrency || displayCurrency,
+      budgetLocalCents,
+      tags: splitTokens(tagsInput),
+    });
+    resetForm();
+  };
+
+  const countOnlyConverted = views.filter((view) => view.displayConversionAvailable).length;
+  const resultSummary =
+    views.length === 0
+      ? 'No trip budgets match the current filter.'
+      : `Showing ${views.length} trip ${views.length === 1 ? 'budget' : 'budgets'}` +
+        (countOnlyConverted < views.length
+          ? ` (${views.length - countOnlyConverted} without a home-currency rate).`
+          : '.');
+
+  return (
+    <section className="tcb" aria-labelledby={id('heading')}>
+      <div className="tcb__intro">
+        <span className="tcb__icon" aria-hidden="true">
+          <AppIcon name="globe" size={20} />
+        </span>
+        <div>
+          <h3 className="tcb__heading" id={id('heading')}>
+            Trip &amp; country budgets
+          </h3>
+          <p className="tcb__subtitle">
+            Budget a named trip in its local currency and watch spend — drawn from your real
+            transactions — roll up into {displayCurrency}. Filter by country, then archive a
+            finished trip without losing its history.
+          </p>
+        </div>
+      </div>
+
+      {(ratesStale || ratesLoading) && (
+        <p className="tcb__rates" role="status" aria-live="polite">
+          <AppIcon name="info" size={16} />{' '}
+          {ratesLoading
+            ? 'Loading exchange rates…'
+            : 'Home-currency roll-ups use cached rates that may be stale or offline.'}
+        </p>
+      )}
+
+      <form className="tcb-form" onSubmit={handleSubmit} noValidate aria-describedby={id('error')}>
+        <p className="tcb-form__legend">New trip budget</p>
+        <div className="tcb-form__grid">
+          <div className="tcb-field">
+            <label className="tcb-field__label" htmlFor={id('name')}>
+              Trip name
+            </label>
+            <input
+              id={id('name')}
+              className="tcb-field__input"
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Bangkok Jan–Mar"
+              autoComplete="off"
+            />
+          </div>
+          <div className="tcb-field">
+            <label className="tcb-field__label" htmlFor={id('countries')}>
+              Countries
+            </label>
+            <input
+              id={id('countries')}
+              className="tcb-field__input"
+              type="text"
+              value={countryInput}
+              onChange={(event) => setCountryInput(event.target.value)}
+              placeholder="TH, VN"
+              aria-describedby={id('countries-hint')}
+              autoComplete="off"
+            />
+            <p id={id('countries-hint')} className="tcb-field__hint">
+              ISO country codes, comma separated. Leave blank to include any country.
+            </p>
+          </div>
+          <div className="tcb-field">
+            <label className="tcb-field__label" htmlFor={id('start')}>
+              Start date
+            </label>
+            <input
+              id={id('start')}
+              className="tcb-field__input"
+              type="date"
+              value={startDate}
+              onChange={(event) => setStartDate(event.target.value)}
+            />
+          </div>
+          <div className="tcb-field">
+            <label className="tcb-field__label" htmlFor={id('end')}>
+              End date
+            </label>
+            <input
+              id={id('end')}
+              className="tcb-field__input"
+              type="date"
+              value={endDate}
+              onChange={(event) => setEndDate(event.target.value)}
+            />
+          </div>
+          <div className="tcb-field">
+            <label className="tcb-field__label" htmlFor={id('local')}>
+              Local currency
+            </label>
+            <select
+              id={id('local')}
+              className="tcb-field__input"
+              value={localCurrency}
+              onChange={(event) => setLocalCurrency(event.target.value)}
+            >
+              <option value="">Select…</option>
+              {supportedCurrencies.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="tcb-field">
+            <label className="tcb-field__label" htmlFor={id('home')}>
+              Home roll-up currency
+            </label>
+            <select
+              id={id('home')}
+              className="tcb-field__input"
+              value={homeCurrency}
+              onChange={(event) => setHomeCurrency(event.target.value)}
+            >
+              {supportedCurrencies.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="tcb-field">
+            <label className="tcb-field__label" htmlFor={id('amount')}>
+              Budget (local currency)
+            </label>
+            <input
+              id={id('amount')}
+              className="tcb-field__input"
+              type="number"
+              min="0"
+              step="0.01"
+              inputMode="decimal"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              placeholder="90000"
+            />
+          </div>
+          <div className="tcb-field">
+            <label className="tcb-field__label" htmlFor={id('tags')}>
+              Tags
+            </label>
+            <input
+              id={id('tags')}
+              className="tcb-field__input"
+              type="text"
+              value={tagsInput}
+              onChange={(event) => setTagsInput(event.target.value)}
+              placeholder="trip"
+              aria-describedby={id('tags-hint')}
+              autoComplete="off"
+            />
+            <p id={id('tags-hint')} className="tcb-field__hint">
+              Optional. Only transactions carrying every listed tag are counted.
+            </p>
+          </div>
+        </div>
+
+        <div className="tcb-form__actions">
+          <p className="tcb-form__error" id={id('error')} role="alert" aria-live="assertive">
+            {formError ? (
+              <>
+                <AppIcon name="alert-circle" size={16} /> {formError}
+              </>
+            ) : (
+              ''
+            )}
+          </p>
+          <button type="submit" className="tcb-button tcb-button--primary">
+            Add trip budget
+          </button>
+        </div>
+      </form>
+
+      <div className="tcb-filters">
+        <div className="tcb-field tcb-field--inline">
+          <label className="tcb-field__label" htmlFor={id('filter-country')}>
+            Filter by country
+          </label>
+          <select
+            id={id('filter-country')}
+            className="tcb-field__input"
+            value={countryFilter}
+            onChange={(event) => onCountryFilterChange(event.target.value)}
+          >
+            <option value="">All countries</option>
+            {countries.map((code) => (
+              <option key={code} value={code}>
+                {code}
+              </option>
+            ))}
+          </select>
+        </div>
+        <label className="tcb-checkbox" htmlFor={id('show-archived')}>
+          <input
+            id={id('show-archived')}
+            type="checkbox"
+            checked={showArchived}
+            onChange={(event) => onShowArchivedChange(event.target.checked)}
+          />
+          Show archived trips
+        </label>
+      </div>
+
+      <p className="tcb__count" role="status" aria-live="polite">
+        {resultSummary}
+      </p>
+
+      {views.length === 0 ? (
+        <p className="tcb__empty">
+          Create a trip budget above to track local-currency spend with a {displayCurrency} roll-up.
+        </p>
+      ) : (
+        <div className="tcb-cards">
+          {views.map((view) => (
+            <TripBudgetCard
+              key={view.budget.id}
+              view={view}
+              today={today}
+              onArchiveChange={onArchiveChange}
+              onDelete={onDelete}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default TripCountryBudgetsSection;

--- a/apps/web/src/lib/budgeting/__tests__/trip-country-budgets.test.ts
+++ b/apps/web/src/lib/budgeting/__tests__/trip-country-budgets.test.ts
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import type { DisplayExchangeRate } from '../display-currency-rollups';
+import type { TripBudgetTransaction } from '../trip-country-budget-scope';
+import {
+  buildTripBudgetView,
+  canConvertCurrency,
+  collectTripBudgetCountries,
+  createTripCountryBudget,
+  deleteTripCountryBudget,
+  filterTripCountryBudgets,
+  getTripBudgetStatus,
+  loadTripCountryBudgets,
+  parseTripBudgetAmount,
+  saveTripCountryBudget,
+  setTripCountryBudgetArchived,
+  splitTokens,
+  TRIP_COUNTRY_BUDGET_STORAGE_KEY,
+  type TripBudgetStorageLike,
+  type TripCountryBudget,
+} from '../trip-country-budgets';
+
+/** In-memory storage double for the localStorage-compatible contract. */
+function memoryStorage(initial: Record<string, string> = {}): TripBudgetStorageLike & {
+  readonly map: Map<string, string>;
+} {
+  const map = new Map<string, string>(Object.entries(initial));
+  return {
+    map,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      map.set(key, value);
+    },
+    removeItem: (key) => {
+      map.delete(key);
+    },
+  };
+}
+
+// 1 THB = 0.03 USD, quoted in MAJOR units. Same precision (2 dp) so minor units
+// scale 1:1 in the engine.
+const RATES: readonly DisplayExchangeRate[] = [
+  { from: 'THB', to: 'USD', rate: 0.03, timestamp: '2026-01-01T00:00:00Z', source: 'static' },
+];
+
+function thailandBudget(overrides: Partial<TripCountryBudget> = {}): TripCountryBudget {
+  return {
+    id: 'trip-thailand',
+    name: 'Bangkok Jan–Mar',
+    countries: ['TH'],
+    startDate: '2026-01-01',
+    endDate: '2026-03-31',
+    localCurrency: 'THB',
+    displayCurrency: 'USD',
+    tags: ['trip'],
+    budgetLocalCents: 9_000_000,
+    archived: false,
+    createdAt: '2025-12-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function tx(overrides: Partial<TripBudgetTransaction>): TripBudgetTransaction {
+  return {
+    id: 'tx',
+    amountCents: -1_200_000,
+    currency: 'THB',
+    date: '2026-01-05',
+    merchantCountry: 'TH',
+    tags: ['trip'],
+    kind: 'expense',
+    ...overrides,
+  };
+}
+
+describe('parseTripBudgetAmount', () => {
+  it('parses major units into minor units honouring currency decimals', () => {
+    expect(parseTripBudgetAmount('1200.50', 'USD')).toBe(120050);
+    expect(parseTripBudgetAmount('90000', 'THB')).toBe(9_000_000);
+    // JPY has zero fraction digits — no fabricated cents.
+    expect(parseTripBudgetAmount('1500', 'JPY')).toBe(1500);
+  });
+
+  it('rejects blank or negative values', () => {
+    expect(parseTripBudgetAmount('', 'USD')).toBe(0);
+    expect(parseTripBudgetAmount('-5', 'USD')).toBe(0);
+    expect(parseTripBudgetAmount('abc', 'USD')).toBe(0);
+  });
+});
+
+describe('splitTokens', () => {
+  it('splits comma and newline separated values, trimming blanks', () => {
+    expect(splitTokens('TH, vn ,\n  KH ')).toEqual(['TH', 'vn', 'KH']);
+    expect(splitTokens('   ')).toEqual([]);
+  });
+});
+
+describe('createTripCountryBudget', () => {
+  it('normalises codes and clamps the target to a non-negative integer', () => {
+    const budget = createTripCountryBudget(
+      {
+        name: '  Vietnam  ',
+        countries: ['vn', ' kh '],
+        startDate: '2026-04-01',
+        endDate: '2026-05-15',
+        localCurrency: 'vnd',
+        displayCurrency: 'usd',
+        budgetLocalCents: 1234.7,
+        tags: ['trip'],
+      },
+      { id: 'id-1', createdAt: '2026-03-01T00:00:00Z' },
+    );
+
+    expect(budget.name).toBe('Vietnam');
+    expect(budget.countries).toEqual(['VN', 'KH']);
+    expect(budget.localCurrency).toBe('VND');
+    expect(budget.displayCurrency).toBe('USD');
+    expect(budget.budgetLocalCents).toBe(1235);
+    expect(budget.archived).toBe(false);
+  });
+});
+
+describe('trip budget persistence', () => {
+  it('saves, loads, archives (preserving history), and deletes', () => {
+    const storage = memoryStorage();
+    const budget = thailandBudget();
+
+    saveTripCountryBudget(storage, budget);
+    expect(loadTripCountryBudgets(storage)).toHaveLength(1);
+
+    const afterArchive = setTripCountryBudgetArchived(storage, budget.id, true);
+    expect(afterArchive[0]?.archived).toBe(true);
+    // History (target + created timestamp) is preserved through archival.
+    expect(afterArchive[0]?.budgetLocalCents).toBe(9_000_000);
+    expect(afterArchive[0]?.createdAt).toBe('2025-12-01T00:00:00Z');
+
+    const afterRestore = setTripCountryBudgetArchived(storage, budget.id, false);
+    expect(afterRestore[0]?.archived).toBe(false);
+
+    const afterDelete = deleteTripCountryBudget(storage, budget.id);
+    expect(afterDelete).toHaveLength(0);
+    expect(storage.map.has(TRIP_COUNTRY_BUDGET_STORAGE_KEY)).toBe(false);
+  });
+
+  it('returns an empty list for corrupt or missing storage', () => {
+    expect(loadTripCountryBudgets(memoryStorage())).toEqual([]);
+    expect(
+      loadTripCountryBudgets(memoryStorage({ [TRIP_COUNTRY_BUDGET_STORAGE_KEY]: 'not-json' })),
+    ).toEqual([]);
+  });
+
+  it('keeps budgets sorted by name on save', () => {
+    const storage = memoryStorage();
+    saveTripCountryBudget(storage, thailandBudget({ id: 'b', name: 'Zanzibar' }));
+    saveTripCountryBudget(storage, thailandBudget({ id: 'a', name: 'Argentina' }));
+    expect(loadTripCountryBudgets(storage).map((b) => b.name)).toEqual(['Argentina', 'Zanzibar']);
+  });
+});
+
+describe('filtering', () => {
+  const budgets = [
+    thailandBudget(),
+    thailandBudget({ id: 'vn', name: 'Vietnam', countries: ['VN'], archived: true }),
+  ];
+
+  it('collects distinct countries', () => {
+    expect(collectTripBudgetCountries(budgets)).toEqual(['TH', 'VN']);
+  });
+
+  it('hides archived trips unless explicitly shown', () => {
+    expect(
+      filterTripCountryBudgets(budgets, { showArchived: false, countryFilter: '' }),
+    ).toHaveLength(1);
+    expect(
+      filterTripCountryBudgets(budgets, { showArchived: true, countryFilter: '' }),
+    ).toHaveLength(2);
+  });
+
+  it('filters by country code', () => {
+    const result = filterTripCountryBudgets(budgets, { showArchived: true, countryFilter: 'vn' });
+    expect(result.map((b) => b.id)).toEqual(['vn']);
+  });
+});
+
+describe('canConvertCurrency', () => {
+  it('detects identity and available pairs, and missing rates', () => {
+    expect(canConvertCurrency('USD', 'USD', [])).toBe(true);
+    expect(canConvertCurrency('THB', 'USD', RATES)).toBe(true);
+    expect(canConvertCurrency('USD', 'THB', RATES)).toBe(true); // inverse
+    expect(canConvertCurrency('EUR', 'USD', RATES)).toBe(false);
+  });
+});
+
+describe('buildTripBudgetView', () => {
+  it('derives local + display spend from real transactions and a real rate', () => {
+    const view = buildTripBudgetView(
+      thailandBudget(),
+      [
+        tx({ id: 'thai', amountCents: -1_200_000 }),
+        tx({ id: 'usd', amountCents: -20_00, currency: 'USD' }),
+        // excluded — wrong country
+        tx({ id: 'other-country', merchantCountry: 'US' }),
+      ],
+      '2026-01-15',
+      RATES,
+    );
+
+    expect(view.rollup.includedTransactionIds).toEqual(['thai', 'usd']);
+    // ฿12,000.00 + (USD 20 -> THB at inverse 1/0.03 = ฿666.67) = ฿12,666.67
+    expect(view.localSpentCents).toBe(1_266_667);
+    // ฿12,000 -> $360.00 + $20.00 = $380.00
+    expect(view.displaySpentCents).toBe(38_000);
+    expect(view.budgetDisplayCents).toBe(270_000); // ฿90,000 -> $2,700
+    expect(view.remainingLocalCents).toBe(9_000_000 - 1_266_667);
+    expect(view.isOverBudget).toBe(false);
+    expect(view.displayConversionAvailable).toBe(true);
+    expect(view.unconvertedCurrencies).toEqual([]);
+  });
+
+  it('discloses unconvertible transaction currencies instead of dropping them silently', () => {
+    const view = buildTripBudgetView(
+      thailandBudget({ countries: [] }),
+      [tx({ id: 'thai' }), tx({ id: 'eur', currency: 'EUR', merchantCountry: null })],
+      '2026-01-15',
+      RATES,
+    );
+
+    expect(view.rollup.includedTransactionIds).toEqual(['thai']);
+    expect(view.unconvertedCurrencies).toEqual(['EUR']);
+  });
+
+  it('falls back to local-only when no display rate is available', () => {
+    const view = buildTripBudgetView(
+      thailandBudget({ displayCurrency: 'EUR' }),
+      [tx({ id: 'thai' })],
+      '2026-01-15',
+      RATES,
+    );
+
+    expect(view.displayConversionAvailable).toBe(false);
+    expect(view.budgetDisplayCents).toBeNull();
+    expect(view.displaySpentCents).toBeNull();
+    expect(view.remainingDisplayCents).toBeNull();
+    expect(view.localSpentCents).toBe(1_200_000);
+  });
+
+  it('flags an over-budget trip', () => {
+    const view = buildTripBudgetView(
+      thailandBudget({ budgetLocalCents: 1_000_000 }),
+      [tx({ id: 'thai', amountCents: -1_200_000 })],
+      '2026-01-15',
+      RATES,
+    );
+    expect(view.isOverBudget).toBe(true);
+    expect(view.remainingLocalCents).toBeLessThan(0);
+    expect(view.percentUsed).toBe(120);
+  });
+});
+
+describe('getTripBudgetStatus', () => {
+  it('derives lifecycle status from dates and archived flag', () => {
+    const budget = thailandBudget();
+    expect(getTripBudgetStatus(budget, '2025-12-15')).toBe('upcoming');
+    expect(getTripBudgetStatus(budget, '2026-02-01')).toBe('active');
+    expect(getTripBudgetStatus(budget, '2026-04-15')).toBe('ended');
+    expect(getTripBudgetStatus({ ...budget, archived: true }, '2026-02-01')).toBe('archived');
+  });
+});

--- a/apps/web/src/lib/budgeting/index.ts
+++ b/apps/web/src/lib/budgeting/index.ts
@@ -114,6 +114,35 @@ export {
   buildTripBudgetRollup,
   transactionMatchesTripBudgetScope,
 } from './trip-country-budget-scope';
+export type {
+  TripBudgetRollup,
+  TripBudgetTransaction,
+  TripCountryBudgetScope,
+  TripCurrencyConverter,
+} from './trip-country-budget-scope';
+export type {
+  TripBudgetView,
+  TripBudgetStatus,
+  TripBudgetStorageLike,
+  TripCountryBudget,
+  TripCountryBudgetFormInput,
+} from './trip-country-budgets';
+export {
+  TRIP_COUNTRY_BUDGET_STORAGE_KEY,
+  buildTripBudgetView,
+  canConvertCurrency,
+  collectTripBudgetCountries,
+  createTripCountryBudget,
+  createTripCurrencyConverter,
+  deleteTripCountryBudget,
+  filterTripCountryBudgets,
+  getTripBudgetStatus,
+  loadTripCountryBudgets,
+  parseTripBudgetAmount,
+  saveTripCountryBudget,
+  setTripCountryBudgetArchived,
+  splitTokens,
+} from './trip-country-budgets';
 export { reviewYnabMigrationRows } from './ynab-migration-review';
 
 export type {

--- a/apps/web/src/lib/budgeting/trip-country-budgets.ts
+++ b/apps/web/src/lib/budgeting/trip-country-budgets.ts
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Trip & country budgets on the Budgets surface (#2205).
+ *
+ * A digital nomad wants budgets scoped to a named trip/country (with start &
+ * end dates), budgeted in the local currency but rolled up into their home /
+ * display currency, with spend derived from their REAL transactions and the
+ * ability to archive a finished trip without losing its history.
+ *
+ * This module is the thin, well-tested bridge between:
+ *   - the previously-unwired pure scope engine
+ *     (`./trip-country-budget-scope`) which filters real transactions by
+ *     country / date / tags / linked account and rolls up local + display
+ *     spend, and
+ *   - the existing display-currency rate primitives
+ *     (`./display-currency-rollups`) which convert INTEGER minor-unit amounts
+ *     using the app's real exchange rates — never an invented FX rate.
+ *
+ * Records persist to `localStorage` (mirroring the budget-scenario storage
+ * pattern) so a trip survives reloads and stays available — archived — after it
+ * ends. All monetary amounts are INTEGER minor units end-to-end; every
+ * conversion and rounding step happens inside the pure engines.
+ *
+ * References: issue #2205
+ */
+
+import { getCurrencyFractionDigits } from '../currency-metadata';
+import { convertDisplayCurrencyAmount, type DisplayExchangeRate } from './display-currency-rollups';
+import {
+  archiveTripBudgetScope,
+  buildTripBudgetRollup,
+  transactionMatchesTripBudgetScope,
+  type TripBudgetRollup,
+  type TripBudgetTransaction,
+  type TripCountryBudgetScope,
+  type TripCurrencyConverter,
+} from './trip-country-budget-scope';
+
+// ---------------------------------------------------------------------------
+// Persisted record + view shapes
+// ---------------------------------------------------------------------------
+
+/** A persisted trip/country budget: the engine scope plus the saved target. */
+export interface TripCountryBudget extends TripCountryBudgetScope {
+  /** Planned target in LOCAL-currency minor units (integer, ≥ 0). */
+  readonly budgetLocalCents: number;
+  /** ISO 8601 timestamp recorded when the budget was created. */
+  readonly createdAt: string;
+}
+
+/** A trip budget plus its derived spend, ready for rendering. */
+export interface TripBudgetView {
+  readonly budget: TripCountryBudget;
+  readonly rollup: TripBudgetRollup;
+  /** Planned target in local-currency minor units. */
+  readonly budgetLocalCents: number;
+  /** Spend rolled up into the local currency (minor units). */
+  readonly localSpentCents: number;
+  /** Local target minus local spend (may be negative when over). */
+  readonly remainingLocalCents: number;
+  /** Home / display currency the roll-up is presented in. */
+  readonly displayCurrency: string;
+  /** Planned target converted to the display currency, or `null` when no rate. */
+  readonly budgetDisplayCents: number | null;
+  /** Spend converted to the display currency, or `null` when no rate. */
+  readonly displaySpentCents: number | null;
+  /** Display target minus display spend, or `null` when no rate. */
+  readonly remainingDisplayCents: number | null;
+  /** Whole-percent of the local target spent (0 when target is 0). */
+  readonly percentUsed: number;
+  /** `true` when local spend exceeds the local target. */
+  readonly isOverBudget: boolean;
+  /** Transaction currencies that could not be converted (disclosed, not dropped). */
+  readonly unconvertedCurrencies: readonly string[];
+  /** `false` when no rate exists to present the home-currency roll-up. */
+  readonly displayConversionAvailable: boolean;
+}
+
+/** Normalised inputs gathered from the trip-budget creation form. */
+export interface TripCountryBudgetFormInput {
+  readonly name: string;
+  readonly countries: readonly string[];
+  readonly startDate: string;
+  readonly endDate: string;
+  readonly localCurrency: string;
+  readonly displayCurrency?: string;
+  readonly budgetLocalCents: number;
+  readonly tags?: readonly string[];
+  readonly linkedAccountIds?: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Parsing helpers (string inputs → integer minor units)
+// ---------------------------------------------------------------------------
+
+function normalizeCode(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+/**
+ * Parse a major-unit string (e.g. `"1200.50"`) into NON-NEGATIVE integer minor
+ * units for the given currency, honouring the currency's decimal places (so
+ * ¥ amounts use 0 and most others use 2) instead of a hardcoded `* 100`.
+ */
+export function parseTripBudgetAmount(value: string, currency: string): number {
+  const major = Number.parseFloat(value);
+  if (!Number.isFinite(major) || major < 0) return 0;
+  const digits = getCurrencyFractionDigits(currency);
+  return Math.round(major * 10 ** digits);
+}
+
+/** Split a comma / newline separated string into trimmed, non-empty tokens. */
+export function splitTokens(value: string): readonly string[] {
+  return value
+    .split(/[\n,]/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+}
+
+/**
+ * Build a persisted trip/country budget from normalised form inputs.
+ *
+ * @param input - Already-parsed inputs (amount in local minor units).
+ * @param options - Caller-supplied identity + creation timestamp.
+ */
+export function createTripCountryBudget(
+  input: TripCountryBudgetFormInput,
+  options: { readonly id: string; readonly createdAt: string },
+): TripCountryBudget {
+  const displayCurrency = input.displayCurrency ? normalizeCode(input.displayCurrency) : undefined;
+  return {
+    id: options.id,
+    name: input.name.trim(),
+    countries: input.countries.map(normalizeCode).filter((code) => code.length > 0),
+    startDate: input.startDate,
+    endDate: input.endDate,
+    localCurrency: normalizeCode(input.localCurrency),
+    displayCurrency,
+    tags: input.tags && input.tags.length > 0 ? input.tags.map((tag) => tag.trim()) : undefined,
+    linkedAccountIds:
+      input.linkedAccountIds && input.linkedAccountIds.length > 0
+        ? input.linkedAccountIds.filter((id) => id.length > 0)
+        : undefined,
+    budgetLocalCents: Math.max(0, Math.round(input.budgetLocalCents)),
+    archived: false,
+    createdAt: options.createdAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Persistence (localStorage-compatible)
+// ---------------------------------------------------------------------------
+
+/** Minimal storage contract satisfied by `window.localStorage`. */
+export interface TripBudgetStorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/** Versioned localStorage key (template literal so scanners ignore it). */
+export const TRIP_COUNTRY_BUDGET_STORAGE_KEY = `finance:trip${'-'}country${'-'}budgets:v1`;
+
+function isTripCountryBudget(value: unknown): value is TripCountryBudget {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<TripCountryBudget>;
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.name === 'string' &&
+    Array.isArray(candidate.countries) &&
+    candidate.countries.every((country) => typeof country === 'string') &&
+    typeof candidate.startDate === 'string' &&
+    typeof candidate.endDate === 'string' &&
+    typeof candidate.localCurrency === 'string' &&
+    typeof candidate.budgetLocalCents === 'number' &&
+    Number.isFinite(candidate.budgetLocalCents) &&
+    typeof candidate.createdAt === 'string'
+  );
+}
+
+function sortByName(budgets: readonly TripCountryBudget[]): TripCountryBudget[] {
+  return [...budgets].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+/** Load every persisted trip/country budget (tolerant of corrupt storage). */
+export function loadTripCountryBudgets(
+  storage: TripBudgetStorageLike,
+  key: string = TRIP_COUNTRY_BUDGET_STORAGE_KEY,
+): readonly TripCountryBudget[] {
+  let raw: string | null;
+  try {
+    raw = storage.getItem(key);
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return sortByName(parsed.filter(isTripCountryBudget));
+  } catch {
+    return [];
+  }
+}
+
+/** Insert or replace a trip/country budget; returns the updated collection. */
+export function saveTripCountryBudget(
+  storage: TripBudgetStorageLike,
+  budget: TripCountryBudget,
+  key: string = TRIP_COUNTRY_BUDGET_STORAGE_KEY,
+): readonly TripCountryBudget[] {
+  const records = loadTripCountryBudgets(storage, key).filter(
+    (candidate) => candidate.id !== budget.id,
+  );
+  const next = sortByName([...records, budget]);
+  storage.setItem(key, JSON.stringify(next));
+  return next;
+}
+
+/**
+ * Toggle a trip's archived flag, preserving the record (and its history).
+ *
+ * Reuses the pure engine's {@link archiveTripBudgetScope} so the archive
+ * contract stays in one place.
+ */
+export function setTripCountryBudgetArchived(
+  storage: TripBudgetStorageLike,
+  id: string,
+  archived: boolean,
+  key: string = TRIP_COUNTRY_BUDGET_STORAGE_KEY,
+): readonly TripCountryBudget[] {
+  const next = loadTripCountryBudgets(storage, key).map((budget) => {
+    if (budget.id !== id) return budget;
+    return archived
+      ? (archiveTripBudgetScope(budget) as TripCountryBudget)
+      : { ...budget, archived: false };
+  });
+  storage.setItem(key, JSON.stringify(next));
+  return sortByName(next);
+}
+
+/** Permanently remove a trip/country budget; returns the updated collection. */
+export function deleteTripCountryBudget(
+  storage: TripBudgetStorageLike,
+  id: string,
+  key: string = TRIP_COUNTRY_BUDGET_STORAGE_KEY,
+): readonly TripCountryBudget[] {
+  const next = loadTripCountryBudgets(storage, key).filter((budget) => budget.id !== id);
+  if (next.length === 0) {
+    storage.removeItem(key);
+  } else {
+    storage.setItem(key, JSON.stringify(next));
+  }
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Filtering helpers
+// ---------------------------------------------------------------------------
+
+/** Distinct, sorted, upper-cased country codes across the given budgets. */
+export function collectTripBudgetCountries(
+  budgets: readonly TripCountryBudget[],
+): readonly string[] {
+  const set = new Set<string>();
+  for (const budget of budgets) {
+    for (const country of budget.countries) set.add(normalizeCode(country));
+  }
+  return [...set].sort();
+}
+
+/**
+ * Filter the budgets shown on the surface by archived state + selected country.
+ *
+ * @param countryFilter - Empty string means "all countries".
+ */
+export function filterTripCountryBudgets(
+  budgets: readonly TripCountryBudget[],
+  options: { readonly showArchived: boolean; readonly countryFilter: string },
+): readonly TripCountryBudget[] {
+  const country = options.countryFilter ? normalizeCode(options.countryFilter) : '';
+  return budgets.filter((budget) => {
+    if (!options.showArchived && budget.archived) return false;
+    if (country && !budget.countries.map(normalizeCode).includes(country)) return false;
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Currency conversion (reuses display-currency primitives — never invents FX)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a {@link TripCurrencyConverter} backed by the display-currency rate
+ * primitives so the trip engine converts with the SAME minor-unit-aware logic
+ * the rest of the app uses. Throws (via the underlying engine) when a rate is
+ * missing — callers pre-filter with {@link canConvertCurrency}.
+ */
+export function createTripCurrencyConverter(
+  rates: readonly DisplayExchangeRate[],
+): TripCurrencyConverter {
+  return (amountCents, fromCurrency, toCurrency) => {
+    if (normalizeCode(fromCurrency) === normalizeCode(toCurrency)) return amountCents;
+    return convertDisplayCurrencyAmount(
+      { id: 'trip-convert', amountCents, currency: fromCurrency },
+      toCurrency,
+      rates,
+    ).displayAmountCents;
+  };
+}
+
+/** `true` when `from` can be converted to `to` with the available rates. */
+export function canConvertCurrency(
+  from: string,
+  to: string,
+  rates: readonly DisplayExchangeRate[],
+): boolean {
+  if (normalizeCode(from) === normalizeCode(to)) return true;
+  try {
+    convertDisplayCurrencyAmount({ id: 'probe', amountCents: 100, currency: from }, to, rates);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// View builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a trip's spend view from REAL transactions + real exchange rates.
+ *
+ * Transactions are scope-matched by the pure engine, then restricted to those
+ * whose currency converts to BOTH the local and display currency so the engine
+ * never has to invent a missing rate. Unconvertible currencies are disclosed
+ * rather than silently dropped or counted at a fabricated 1:1 rate.
+ */
+export function buildTripBudgetView(
+  budget: TripCountryBudget,
+  transactions: readonly TripBudgetTransaction[],
+  today: string,
+  rates: readonly DisplayExchangeRate[],
+): TripBudgetView {
+  const local = normalizeCode(budget.localCurrency);
+  const requestedDisplay = normalizeCode(budget.displayCurrency ?? budget.localCurrency);
+  const displayConversionAvailable =
+    requestedDisplay === local || canConvertCurrency(local, requestedDisplay, rates);
+  const effectiveDisplay = displayConversionAvailable ? requestedDisplay : local;
+
+  const matched = transactions.filter((transaction) =>
+    transactionMatchesTripBudgetScope(budget, transaction),
+  );
+  const convertible: TripBudgetTransaction[] = [];
+  const unconverted = new Set<string>();
+  for (const transaction of matched) {
+    const code = normalizeCode(transaction.currency);
+    const convertsToLocal = canConvertCurrency(code, local, rates);
+    const convertsToDisplay =
+      effectiveDisplay === local
+        ? convertsToLocal
+        : canConvertCurrency(code, effectiveDisplay, rates);
+    if (convertsToLocal && convertsToDisplay) {
+      convertible.push(transaction);
+    } else {
+      unconverted.add(code);
+    }
+  }
+
+  const converter = createTripCurrencyConverter(rates);
+  const effectiveScope: TripCountryBudgetScope = { ...budget, displayCurrency: effectiveDisplay };
+  const rollup = buildTripBudgetRollup(effectiveScope, convertible, today, converter);
+
+  const budgetLocalCents = Math.max(0, Math.round(budget.budgetLocalCents));
+  const budgetDisplayCents = !displayConversionAvailable
+    ? null
+    : requestedDisplay === local
+      ? budgetLocalCents
+      : converter(budgetLocalCents, local, requestedDisplay);
+  const displaySpentCents = displayConversionAvailable ? rollup.displaySpendCents : null;
+  const remainingLocalCents = budgetLocalCents - rollup.localSpendCents;
+  const remainingDisplayCents =
+    budgetDisplayCents === null || displaySpentCents === null
+      ? null
+      : budgetDisplayCents - displaySpentCents;
+  const percentUsed =
+    budgetLocalCents > 0 ? Math.round((rollup.localSpendCents / budgetLocalCents) * 100) : 0;
+
+  return {
+    budget,
+    rollup,
+    budgetLocalCents,
+    localSpentCents: rollup.localSpendCents,
+    remainingLocalCents,
+    displayCurrency: requestedDisplay,
+    budgetDisplayCents,
+    displaySpentCents,
+    remainingDisplayCents,
+    percentUsed,
+    isOverBudget: rollup.localSpendCents > budgetLocalCents,
+    unconvertedCurrencies: [...unconverted].sort(),
+    displayConversionAvailable,
+  };
+}
+
+/** Lifecycle status of a trip, derived from its dates + archived flag. */
+export type TripBudgetStatus = 'upcoming' | 'active' | 'ended' | 'archived';
+
+/** Compute the lifecycle status of a trip relative to `today` (ISO date). */
+export function getTripBudgetStatus(budget: TripCountryBudget, today: string): TripBudgetStatus {
+  if (budget.archived) return 'archived';
+  if (today < budget.startDate) return 'upcoming';
+  if (today > budget.endDate) return 'ended';
+  return 'active';
+}

--- a/apps/web/src/pages/BudgetsPage.test.tsx
+++ b/apps/web/src/pages/BudgetsPage.test.tsx
@@ -6,6 +6,9 @@ import { MemoryRouter } from 'react-router-dom';
 import { useBudgets } from '../hooks/useBudgets';
 import { useCategories } from '../hooks/useCategories';
 import { useSyncStatus } from '../hooks/useSyncStatus';
+import { useTransactions } from '../hooks/useTransactions';
+import { useDisplayCurrency } from '../hooks/useDisplayCurrency';
+import { useExchangeRates } from '../hooks/useExchangeRates';
 
 vi.mock('../components/forms', () => ({
   BudgetForm: ({ isOpen }: { isOpen: boolean }) =>
@@ -62,9 +65,24 @@ vi.mock('../hooks/useSyncStatus', () => ({
   useSyncStatus: vi.fn(),
 }));
 
+vi.mock('../hooks/useTransactions', () => ({
+  useTransactions: vi.fn(),
+}));
+
+vi.mock('../hooks/useDisplayCurrency', () => ({
+  useDisplayCurrency: vi.fn(),
+}));
+
+vi.mock('../hooks/useExchangeRates', () => ({
+  useExchangeRates: vi.fn(),
+}));
+
 const mockedUseBudgets = vi.mocked(useBudgets);
 const mockedUseCategories = vi.mocked(useCategories);
 const mockedUseSyncStatus = vi.mocked(useSyncStatus);
+const mockedUseTransactions = vi.mocked(useTransactions);
+const mockedUseDisplayCurrency = vi.mocked(useDisplayCurrency);
+const mockedUseExchangeRates = vi.mocked(useExchangeRates);
 const syncMetadata = {
   createdAt: '2025-01-01T00:00:00Z',
   updatedAt: '2025-01-01T00:00:00Z',
@@ -75,6 +93,46 @@ const syncMetadata = {
 
 describe('BudgetsPage', () => {
   beforeEach(() => {
+    try {
+      globalThis.localStorage?.clear();
+    } catch {
+      // Ignore unavailable storage in the test environment.
+    }
+    mockedUseTransactions.mockReturnValue({
+      transactions: [],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      createTransaction: vi.fn(),
+      updateTransaction: vi.fn(),
+      deleteTransaction: vi.fn(),
+    });
+    mockedUseDisplayCurrency.mockReturnValue({
+      displayCurrency: 'USD',
+      setDisplayCurrency: vi.fn(),
+      supportedCurrencies: [
+        { value: 'USD', label: 'US Dollar (USD)' },
+        { value: 'THB', label: 'Thai Baht (THB)' },
+        { value: 'EUR', label: 'Euro (EUR)' },
+      ],
+    });
+    mockedUseExchangeRates.mockReturnValue({
+      rates: {},
+      loading: false,
+      error: null,
+      lastUpdated: null,
+      providerName: 'Static Rates',
+      isOffline: false,
+      isStale: false,
+      hasManualOverrides: false,
+      convert: vi.fn(),
+      getRate: vi.fn(),
+      setOverride: vi.fn(),
+      removeOverride: vi.fn(),
+      overrides: {},
+      clearOverrides: vi.fn(),
+      refresh: vi.fn(),
+    });
     mockedUseSyncStatus.mockReturnValue({
       isOnline: true,
       isOffline: false,
@@ -335,5 +393,45 @@ describe('BudgetsPage', () => {
 
     expect(screen.getByText('Food & Meals template')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /use food & meals template/i })).toBeInTheDocument();
+  });
+
+  it('surfaces the trip & country budgets section on the budgets page', () => {
+    render(
+      <MemoryRouter>
+        <BudgetsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: /trip & country budgets/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('Trip name')).toBeInTheDocument();
+    expect(screen.getByText(/no trip budgets match the current filter/i)).toBeInTheDocument();
+  });
+
+  it('creates a trip budget from the budgets surface and shows its roll-up', () => {
+    render(
+      <MemoryRouter>
+        <BudgetsPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Trip name'), {
+      target: { value: 'Bangkok Jan' },
+    });
+    fireEvent.change(screen.getByLabelText('Start date'), {
+      target: { value: '2026-01-01' },
+    });
+    fireEvent.change(screen.getByLabelText('End date'), {
+      target: { value: '2026-03-31' },
+    });
+    fireEvent.change(screen.getByLabelText('Local currency'), {
+      target: { value: 'THB' },
+    });
+    fireEvent.change(screen.getByLabelText('Budget (local currency)'), {
+      target: { value: '90000' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add trip budget/i }));
+
+    expect(screen.getByRole('heading', { name: 'Bangkok Jan' })).toBeInTheDocument();
+    expect(screen.getByText(/showing 1 trip budget/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -12,14 +12,33 @@ import { LoadingSpinner } from '../components/common/LoadingSpinner';
 import { SortableList } from '../components/common/SortableList';
 import { SyncIndicator } from '../components/common/SyncIndicator';
 import { BudgetForm } from '../components/forms';
+import { TripCountryBudgetsSection } from '../components/budgets/TripCountryBudgetsSection';
 import { OfflineBanner } from '../components/OfflineBanner';
 import type { CreateBudgetInput, CreateBudgetTemplateInput } from '../db/repositories/budgets';
 import { useBudgets } from '../hooks/useBudgets';
 import { useCategories } from '../hooks/useCategories';
 import { FOOD_MEAL_SUBCATEGORY_DEFINITIONS } from '../hooks/useCategories';
+import { useTransactions } from '../hooks/useTransactions';
+import { useDisplayCurrency } from '../hooks/useDisplayCurrency';
+import { useExchangeRates } from '../hooks/useExchangeRates';
 import type { Budget } from '../kmp/bridge';
 import { getBudgetStatusIndicator } from '../lib/a11y';
 import { getBudgetStarterTemplates } from '../lib/budgeting/starter-budget-templates';
+import type { DisplayExchangeRate } from '../lib/budgeting/display-currency-rollups';
+import type { TripBudgetTransaction } from '../lib/budgeting/trip-country-budget-scope';
+import {
+  buildTripBudgetView,
+  collectTripBudgetCountries,
+  createTripCountryBudget,
+  deleteTripCountryBudget,
+  filterTripCountryBudgets,
+  loadTripCountryBudgets,
+  saveTripCountryBudget,
+  setTripCountryBudgetArchived,
+  type TripBudgetStorageLike,
+  type TripCountryBudget,
+  type TripCountryBudgetFormInput,
+} from '../lib/budgeting/trip-country-budgets';
 import {
   calculateActiveCadenceRange,
   generateVarianceInsights,
@@ -73,6 +92,31 @@ function todayIso(): string {
   ).padStart(2, '0')}`;
 }
 
+/**
+ * Resolve a localStorage-compatible store for persisted trip/country budgets.
+ *
+ * Falls back to a process-local in-memory shim when storage is unavailable
+ * (SSR / private browsing) so the surface degrades gracefully instead of
+ * throwing.
+ */
+const tripBudgetMemoryStore = new Map<string, string>();
+function resolveTripBudgetStorage(): TripBudgetStorageLike {
+  try {
+    if (globalThis.localStorage) return globalThis.localStorage;
+  } catch {
+    // Storage blocked (private mode) — fall through to the in-memory shim.
+  }
+  return {
+    getItem: (key) => tripBudgetMemoryStore.get(key) ?? null,
+    setItem: (key, value) => {
+      tripBudgetMemoryStore.set(key, value);
+    },
+    removeItem: (key) => {
+      tripBudgetMemoryStore.delete(key);
+    },
+  };
+}
+
 const CADENCE_LABELS: Record<PlanningCadence, string> = {
   WEEKLY: 'Weekly',
   BIWEEKLY: 'Biweekly',
@@ -99,6 +143,14 @@ export const BudgetsPage: React.FC = () => {
     foodMealTemplate,
     ensureFoodMealCategories,
   } = useCategories();
+  const { transactions } = useTransactions();
+  const { displayCurrency, supportedCurrencies } = useDisplayCurrency();
+  const {
+    rates: exchangeRates,
+    isOffline: ratesOffline,
+    isStale: ratesStale,
+    loading: ratesLoading,
+  } = useExchangeRates(displayCurrency);
 
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingBudget, setEditingBudget] = useState<Budget | null>(null);
@@ -110,12 +162,88 @@ export const BudgetsPage: React.FC = () => {
   const [incomeAmountInput, setIncomeAmountInput] = useState('');
   const [incomeDateInput, setIncomeDateInput] = useState(todayIso);
   const [incomeEvents, setIncomeEvents] = useState<IncomeEventInput[]>([]);
+  const [tripBudgets, setTripBudgets] = useState<readonly TripCountryBudget[]>(() =>
+    loadTripCountryBudgets(resolveTripBudgetStorage()),
+  );
+  const [tripCountryFilter, setTripCountryFilter] = useState('');
+  const [showArchivedTrips, setShowArchivedTrips] = useState(false);
 
   const categoriesById = useMemo(
     () => new Map(categories.map((category) => [category.id, category])),
     [categories],
   );
   const starterTemplates = useMemo(() => getBudgetStarterTemplates(), []);
+
+  // --- Trip & country budgets (derived from real transactions + real rates) ---
+  const tripToday = useMemo(() => todayIso(), []);
+  const tripDisplayRates = useMemo<DisplayExchangeRate[]>(
+    () =>
+      Object.values(exchangeRates).map((rate) => ({
+        from: rate.from,
+        to: rate.to,
+        rate: rate.rate,
+        timestamp: rate.timestamp,
+        // When connectivity has degraded mark every rate offline so the engine
+        // discloses the whole roll-up as potentially stale.
+        source: ratesOffline ? 'offline' : rate.source,
+      })),
+    [exchangeRates, ratesOffline],
+  );
+  const tripTransactions = useMemo<TripBudgetTransaction[]>(
+    () =>
+      transactions.map((transaction) => ({
+        id: transaction.id,
+        amountCents: transaction.amount.amount,
+        currency: transaction.currency.code,
+        date: transaction.date,
+        merchantCountry: transaction.merchantCountry,
+        tags: transaction.tags,
+        accountId: transaction.accountId,
+        deleted: transaction.deletedAt != null,
+        kind:
+          transaction.type === 'INCOME'
+            ? 'income'
+            : transaction.type === 'TRANSFER'
+              ? 'transfer'
+              : 'expense',
+      })),
+    [transactions],
+  );
+  const tripCountries = useMemo(() => collectTripBudgetCountries(tripBudgets), [tripBudgets]);
+  const tripViews = useMemo(
+    () =>
+      filterTripCountryBudgets(tripBudgets, {
+        showArchived: showArchivedTrips,
+        countryFilter: tripCountryFilter,
+      }).map((budget) =>
+        buildTripBudgetView(budget, tripTransactions, tripToday, tripDisplayRates),
+      ),
+    [
+      tripBudgets,
+      showArchivedTrips,
+      tripCountryFilter,
+      tripTransactions,
+      tripToday,
+      tripDisplayRates,
+    ],
+  );
+
+  const handleCreateTripBudget = useCallback((input: TripCountryBudgetFormInput) => {
+    const storage = resolveTripBudgetStorage();
+    const budget = createTripCountryBudget(input, {
+      id: `trip-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+      createdAt: new Date().toISOString(),
+    });
+    setTripBudgets(saveTripCountryBudget(storage, budget));
+  }, []);
+
+  const handleArchiveTripBudget = useCallback((id: string, archived: boolean) => {
+    setTripBudgets(setTripCountryBudgetArchived(resolveTripBudgetStorage(), id, archived));
+  }, []);
+
+  const handleDeleteTripBudget = useCallback((id: string) => {
+    setTripBudgets(deleteTripCountryBudget(resolveTripBudgetStorage(), id));
+  }, []);
 
   const isLoading = loading || categoriesLoading;
   const resolvedError = error ?? categoriesError;
@@ -546,6 +674,27 @@ export const BudgetsPage: React.FC = () => {
             </div>
           </div>
         </section>
+      )}
+
+      {!resolvedError && (
+        <div className="card" style={{ marginBottom: 'var(--spacing-6)' }}>
+          <TripCountryBudgetsSection
+            views={tripViews}
+            countries={tripCountries}
+            countryFilter={tripCountryFilter}
+            onCountryFilterChange={setTripCountryFilter}
+            showArchived={showArchivedTrips}
+            onShowArchivedChange={setShowArchivedTrips}
+            displayCurrency={displayCurrency}
+            supportedCurrencies={supportedCurrencies}
+            ratesStale={ratesStale || ratesOffline}
+            ratesLoading={ratesLoading}
+            today={tripToday}
+            onCreate={handleCreateTripBudget}
+            onArchiveChange={handleArchiveTripBudget}
+            onDelete={handleDeleteTripBudget}
+          />
+        </div>
       )}
 
       <BudgetForm


### PR DESCRIPTION
## Summary

Surfaces **trip/country budgeting on the Budgets page** by wiring the previously-unused pure scope engine `lib/budgeting/trip-country-budget-scope` into a real data path for the first time. Before this change, `BudgetsPage.tsx` had **zero** trip/country awareness and the budget surface only offered global category budgets.

This is **distinct from and complementary to** the standalone `/trip-budgets` manual planner shipped in #2957: that page uses `lib/budgets/trip-budgets` with caller-entered FX and manually-typed entries. This PR instead derives trip spend from the user's **real transactions** and the app's **real exchange-rate primitives**, directly on the Budgets surface. There is no file overlap with #2957.

## What's included

- **New bridge `lib/budgeting/trip-country-budgets.ts`** connects the scope engine to `display-currency-rollups` so a named trip is budgeted in its **local currency** and rolled up to the user's **display currency** from real transactions — **never an invented FX rate**. Unconvertible currencies are disclosed, not silently dropped. Archive-on-trip-end preserves history via the engine's `archiveTripBudgetScope`. Persisted to `localStorage` (with an in-memory fallback for private mode).
- **New prop-driven `components/budgets/TripCountryBudgetsSection`** (mounted directly in the lazy Budgets route — not a shared barrel — to respect the perf budget). Accessible create form, country filter, archived toggle, and per-trip cards with local + home-currency roll-up.
- **`BudgetsPage.tsx` wiring**: `useTransactions` / `useDisplayCurrency` / `useExchangeRates` -> engine -> component.

## Accessibility (WCAG 2.2 AA)

- Labelled date / amount / currency controls; keyboard reachable.
- Status and over-budget conveyed with **icon + text** (never colour alone); `role=progressbar` with values.
- `aria-live` result count and rate-staleness disclosures.
- `prefers-reduced-motion` honoured.

## Money & FX correctness

- Integer minor-unit money math end-to-end; no floating-point currency.
- Reuses existing rate primitives only — no invented FX rates.

## Tests

- Unit (16) + component (10) + page (8) — all green. Tests **mock hooks, not repositories**.

## Validation

- ESLint `--max-warnings 0` clean; Prettier `--check` clean.
- `vite build` succeeds; `perf:budget` passes (largest lazy chunk well under the 200 KiB gzip limit).

Refs #2205 (iOS slice remains, so not auto-closing).