### PR TITLE
fix(web): repair recurring nightly E2E regressions (#3054)

### DIFF
--- a/apps/web/e2e/accounts.spec.ts
+++ b/apps/web/e2e/accounts.spec.ts
@@ -160,11 +160,14 @@ test.describe('Account detail page', () => {
       const breadcrumb = page.getByRole('navigation', { name: /breadcrumb/i });
       await expect(breadcrumb.getByRole('link', { name: /^accounts$/i })).toBeVisible();
 
-      // Should show edit and delete buttons
-      const editButton = page.getByRole('button', { name: /edit/i });
+      // Should show edit and delete buttons. Scope to <main> so the page-wide
+      // /edit/i regex does not also match the sidebar 'Building Credit' nav
+      // button ("Building Cr-edit-" contains "edit"), which lives in the
+      // <aside> and would otherwise trip a strict-mode violation.
+      const editButton = mainRegion.getByRole('button', { name: /edit/i });
       await expect(editButton).toBeVisible();
 
-      const deleteButton = page.getByRole('button', { name: /delete/i });
+      const deleteButton = mainRegion.getByRole('button', { name: /delete/i });
       await expect(deleteButton).toBeVisible();
 
       // Should show account details card

--- a/apps/web/e2e/responsive.spec.ts
+++ b/apps/web/e2e/responsive.spec.ts
@@ -253,7 +253,10 @@ test.describe('Tablet viewport (768px)', () => {
     const sidebar = page.locator('aside[aria-label="Main navigation"]');
 
     for (const label of ['Dashboard', 'Accounts', 'Transactions', 'Budgets', 'Goals']) {
-      const navItem = sidebar.getByRole('button', { name: label });
+      // exact: true — accessible-name matching is a case-insensitive substring
+      // match by default, so a bare 'Budgets' would also match the sibling
+      // 'Trip Budgets' nav item (#3053) and trip a strict-mode violation.
+      const navItem = sidebar.getByRole('button', { name: label, exact: true });
       await expect(navItem).toBeVisible();
     }
   });
@@ -440,15 +443,16 @@ test.describe('Cross-viewport navigation', () => {
     const sidebar = page.locator('aside[aria-label="Main navigation"]');
 
     // Navigate to Accounts via sidebar.
-    await sidebar.getByRole('button', { name: 'Accounts' }).click();
+    await sidebar.getByRole('button', { name: 'Accounts', exact: true }).click();
     await expect(page).toHaveURL(/\/accounts/);
 
-    // Navigate to Budgets.
-    await sidebar.getByRole('button', { name: 'Budgets' }).click();
+    // Navigate to Budgets. exact: true so we don't also match the sibling
+    // 'Trip Budgets' nav item (#3053) — a bare 'Budgets' is a substring match.
+    await sidebar.getByRole('button', { name: 'Budgets', exact: true }).click();
     await expect(page).toHaveURL(/\/budgets/);
 
     // Navigate to Goals.
-    await sidebar.getByRole('button', { name: 'Goals' }).click();
+    await sidebar.getByRole('button', { name: 'Goals', exact: true }).click();
     await expect(page).toHaveURL(/\/goals/);
   });
 

--- a/apps/web/e2e/transactions.spec.ts
+++ b/apps/web/e2e/transactions.spec.ts
@@ -218,11 +218,14 @@ test.describe('Transaction detail page', () => {
       // Should show Type label
       await expect(page.getByText('Type')).toBeVisible();
 
-      // Should show edit and delete buttons
-      const editButton = page.getByRole('button', { name: /edit/i });
+      // Should show edit and delete buttons. Scope to <main> so the page-wide
+      // /edit/i regex does not also match the sidebar 'Building Credit' nav
+      // button ("Building Cr-edit-" contains "edit"), which lives in the
+      // <aside> and would otherwise trip a strict-mode violation.
+      const editButton = mainRegion.getByRole('button', { name: /edit/i });
       await expect(editButton).toBeVisible();
 
-      const deleteButton = page.getByRole('button', { name: /delete/i });
+      const deleteButton = mainRegion.getByRole('button', { name: /delete/i });
       await expect(deleteButton).toBeVisible();
     } else {
       // No seed data — navigate to a fake ID and verify not-found


### PR DESCRIPTION
## Summary

The nightly web E2E matrix (`Nightly E2E`) has failed deterministically across **all** browsers (chromium, firefox, webkit, edge, mobile-chrome, mobile-safari) for a week — the same 4 Playwright tests, 4 failed / 146 passed. Newest run: `28083085265` on `5cb2c422`.

The root cause is **not** app or nav-config duplication. Two recently-merged, *legitimate* sidebar destinations now collide with overly-broad E2E locators. Verified against the actual rendered accessibility tree (Playwright error-context).

## Root cause and fix (per failure)

**1 & 2 — `responsive.spec.ts`: Budgets strict-mode violation (×2 tests).**
`aside[aria-label="Main navigation"].getByRole('button', { name: 'Budgets' })` resolved to **2 elements**. Playwright accessible-name matching with a bare string is a case-insensitive *substring* match, so the new **Trip Budgets** nav item (#3053, merged hours before the first failing nightly) also matched.
- Fix: pin the Budgets / Accounts / Goals sidebar locators to `exact: true`.

**3 & 4 — `accounts.spec.ts` / `transactions.spec.ts`: Edit strict-mode violation (×2 tests).**
The page-wide `getByRole('button', { name: /edit/i })` regex resolved to **2 elements**: the real edit button (`Edit <name>`) *and* the sidebar **Building Credit** nav button — `Building Cr`**`edit`**`` contains the substring `edit`.
- Fix: scope the edit/delete locators to the `<main>` landmark (the existing `mainRegion`), excluding the `<aside>` sidebar.

## Notes

- No assertions were weakened; all original visibility/navigation checks are preserved. Only the locators were tightened to be unambiguous.
- **No app code or accessibility attributes changed** — the navigation remains aria-labelled, and both "Trip Budgets" and "Building Credit" are correct, intentional destinations, so deduping the nav config would be wrong.
- There was **no empty-route failure** in the suite at this commit (the task brief's 3rd hypothesis did not reproduce).
- The visual-regression snapshot job is separate (nightly `web-visual-regression`, already marked for rebaseline) and is unaffected by this change.

## Verification

Full chromium E2E suite re-run locally against the CI preview build (`CI=true` + `vite preview`): **150 passed**. The only local diff is the platform-specific login visual snapshot (Linux-baselined; green on CI). The 4 target tests now all pass; the previously failing specs (`responsive`, `accounts`, `transactions`) are 44/44 green.

Closes #3054
Refs #3006
Refs #2849
Refs #2832
Refs #2830
Refs #2824
Refs #2822
