### PR TITLE
ci: unblock dependency review on mitigated jdom2 advisory (#3057)

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -108,6 +108,11 @@ jobs:
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
+          # jdom2 GHSA-2363-cqg2-863c (CVE-2021-33813, XXE) is mitigated at build time:
+          # build.gradle.kts force-resolves org.jdom:jdom2 to the patched 2.0.6.1 via
+          # resolutionStrategy. dependency-review reads the declared graph (transitive
+          # 2.0.6), not the Gradle useVersion force, so this is a false positive. See #3057.
+          allow-ghsas: GHSA-2363-cqg2-863c
           deny-licenses: GPL-3.0, AGPL-3.0
           allow-dependencies-licenses: pkg:githubactions/trufflesecurity/trufflehog
 


### PR DESCRIPTION
## Summary

The required **Dependency Review** check (the `dependency-review` job in `.github/workflows/ci-security.yml`, `actions/dependency-review-action@v5`, blocking per #2860) began failing on every newly-opened PR ? including web-only PRs that change no dependencies ? with:

```
org.jdom:jdom2@2.0.6 ? XXE Injection (high) -> GHSA-2363-cqg2-863c (CVE-2021-33813)
```

### Why this is a false positive

The repo **already force-resolves** `org.jdom:jdom2` to the patched **2.0.6.1** (the release that fixes CVE-2021-33813) at build time via a Gradle `resolutionStrategy`:

- `build.gradle.kts` (lines ~69-71): `useVersion(libs.versions.jdom2.get())` with `because("Fix CVE-2021-33813 (XXE Injection in JDOM2)")`
- `gradle/libs.versions.toml:27`: `jdom2 = "2.0.6.1"`

`dependency-review-action` reads the **declared** dependency graph (transitive `2.0.6`), not Gradle's runtime `useVersion` force, so it flags an advisory that is already mitigated. The GHSA was recently (re)published, which is why PRs that passed ~18h ago now fail. This blocked PR #3056 and the entire fleet.

### Change

Added a scoped, documented allow-list entry to the `dependency-review-action` step so this single already-mitigated advisory no longer blocks, while **keeping `fail-on-severity: high`** and every other security setting intact:

```yaml
with:
  fail-on-severity: high
  # jdom2 GHSA-2363-cqg2-863c (CVE-2021-33813, XXE) is mitigated at build time:
  # build.gradle.kts force-resolves org.jdom:jdom2 to the patched 2.0.6.1 via
  # resolutionStrategy. dependency-review reads the declared graph (transitive
  # 2.0.6), not the Gradle useVersion force, so this is a false positive. See #3057.
  allow-ghsas: GHSA-2363-cqg2-863c
  deny-licenses: GPL-3.0, AGPL-3.0
  allow-dependencies-licenses: pkg:githubactions/trufflesecurity/trufflehog
```

No Gradle files were changed ? the build-time force is present and correct.

## Validation

- YAML lint passes (`npx yaml-lint`).
- `prettier --check` passes on the file.
- For `pull_request` events the workflow runs from the PR merge commit, so this allow-list applies to **this PR own** Dependency Review run.

Closes #3057
Refs #2860
Refs #3056
