### PR TITLE
fix(web): exempt /onboarding from unauthenticated redirect to stop /login loop (#3059)

### DIFF
--- a/apps/web/src/lib/auth/pre-auth-routes.test.ts
+++ b/apps/web/src/lib/auth/pre-auth-routes.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the pre-auth / unauthenticated-safe route predicates.
+ *
+ * References: issue #3059 (fresh visitor /onboarding ⇄ /login redirect loop)
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  ONBOARDING_ROUTE,
+  PRE_AUTH_ROUTE_SET,
+  isUnauthenticatedSafeRoute,
+} from './pre-auth-routes';
+
+describe('isUnauthenticatedSafeRoute', () => {
+  it('treats the onboarding first-run route as safe (regression: #3059 loop)', () => {
+    // The whole point of #3059: a logged-out visitor parked on /onboarding must
+    // NOT be hard-redirected to /login, or App.tsx and the auth layer fight.
+    expect(isUnauthenticatedSafeRoute('/onboarding')).toBe(true);
+    expect(isUnauthenticatedSafeRoute('/onboarding/step-2')).toBe(true);
+  });
+
+  it('treats pre-auth routes (and their nested paths) as safe', () => {
+    expect(isUnauthenticatedSafeRoute('/login')).toBe(true);
+    expect(isUnauthenticatedSafeRoute('/signup')).toBe(true);
+    expect(isUnauthenticatedSafeRoute('/forgot-password')).toBe(true);
+    expect(isUnauthenticatedSafeRoute('/reset-password')).toBe(true);
+    expect(isUnauthenticatedSafeRoute('/reset-password/abc123')).toBe(true);
+    expect(isUnauthenticatedSafeRoute('/legal')).toBe(true);
+    expect(isUnauthenticatedSafeRoute('/legal/privacy')).toBe(true);
+    expect(isUnauthenticatedSafeRoute('/beta')).toBe(true);
+  });
+
+  it('treats authenticated-only app routes as NOT safe (still redirect to /login)', () => {
+    expect(isUnauthenticatedSafeRoute('/')).toBe(false);
+    expect(isUnauthenticatedSafeRoute('/dashboard')).toBe(false);
+    expect(isUnauthenticatedSafeRoute('/transactions')).toBe(false);
+    expect(isUnauthenticatedSafeRoute('/settings/security')).toBe(false);
+  });
+
+  it('does not false-match routes that merely share a string prefix', () => {
+    expect(isUnauthenticatedSafeRoute('/loginx')).toBe(false);
+    expect(isUnauthenticatedSafeRoute('/onboardingx')).toBe(false);
+    expect(isUnauthenticatedSafeRoute('/signup-promo')).toBe(false);
+  });
+});
+
+describe('PRE_AUTH_ROUTE_SET (DatabaseGate skip-list)', () => {
+  it('contains the pre-auth routes for exact-match DB-gate skipping', () => {
+    expect(PRE_AUTH_ROUTE_SET.has('/login')).toBe(true);
+    expect(PRE_AUTH_ROUTE_SET.has('/signup')).toBe(true);
+  });
+
+  it('does NOT contain onboarding — it still needs the database', () => {
+    // Onboarding is unauthenticated-safe (no forced login redirect) but is NOT
+    // a DB-skip route: it reads/writes budgets, so it keeps the DatabaseGate.
+    expect(PRE_AUTH_ROUTE_SET.has(ONBOARDING_ROUTE)).toBe(false);
+    expect(isUnauthenticatedSafeRoute(ONBOARDING_ROUTE)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/auth/pre-auth-routes.ts
+++ b/apps/web/src/lib/auth/pre-auth-routes.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Pre-authentication route definitions — single source of truth for which
+ * routes are reachable WITHOUT an authenticated session.
+ *
+ * Two related-but-distinct concepts live here and MUST be kept apart:
+ *
+ *  1. {@link PRE_AUTH_ROUTE_SET} — routes that render WITHOUT waiting for the
+ *     SQLite-WASM database (they never call `useDatabase()`), used by the
+ *     `DatabaseGate` in `main.tsx`. Matched EXACTLY, so nested paths like
+ *     `/reset-password/<token>` still wait for the DB.
+ *
+ *  2. {@link isUnauthenticatedSafeRoute} — routes that the auth bootstrap's
+ *     "session expired / not authenticated" handler must NOT hard-redirect away
+ *     from. This is a SUPERSET of the pre-auth routes that ALSO includes the
+ *     first-run {@link ONBOARDING_ROUTE} flow.
+ *
+ * Why `/onboarding` is special (#3059): `App.tsx` auto-launches unauthenticated
+ * first-run visitors into `/onboarding` (it offers local-only mode or a path to
+ * `/signup`). `/onboarding` DOES use the database (starter budgets), so it is
+ * intentionally NOT a pre-auth/DB-skip route. But it must still be exempt from
+ * the `onUnauthenticated` → `/login` hard-redirect, otherwise the auth layer and
+ * `App.tsx` fight each other: `App.tsx` sends `/login` → `/onboarding`, the auth
+ * layer sends `/onboarding` → `/login`, producing an infinite full-page reload
+ * loop. Co-locating both lists here keeps that parity from drifting again.
+ */
+
+/**
+ * Routes that render without waiting for the SQLite-WASM database.
+ *
+ * Pre-auth pages (login, signup, password reset, legal, beta) never touch the
+ * database, so gating them behind the loading `DatabaseProvider` would block
+ * rendering unnecessarily (and can time out on CI where OPFS + WASM init is
+ * slow). Keep this list in sync with `App.tsx`'s `STANDALONE_ROUTES`.
+ */
+export const PRE_AUTH_ROUTES = [
+  '/login',
+  '/signup',
+  '/forgot-password',
+  '/reset-password',
+  '/legal',
+  '/beta',
+] as const;
+
+/** Set form for O(1) EXACT-match lookups (used by the `DatabaseGate`). */
+export const PRE_AUTH_ROUTE_SET: ReadonlySet<string> = new Set(PRE_AUTH_ROUTES);
+
+/**
+ * The first-run onboarding flow. Reachable by unauthenticated visitors, but —
+ * unlike the pre-auth routes — it still uses the database, so it is tracked
+ * separately from {@link PRE_AUTH_ROUTES} (it must keep the DB gate while still
+ * being exempt from the forced-login redirect).
+ */
+export const ONBOARDING_ROUTE = '/onboarding';
+
+/** Exact path match, or a `route + '/'` prefix match for nested paths. */
+function matchesRouteOrChild(pathname: string, route: string): boolean {
+  return pathname === route || pathname.startsWith(`${route}/`);
+}
+
+/**
+ * True when `pathname` is a route a logged-out user is allowed to sit on
+ * WITHOUT being force-redirected to `/login`.
+ *
+ * Superset of {@link PRE_AUTH_ROUTES} plus the {@link ONBOARDING_ROUTE} first-run
+ * flow. Matched by exact path OR `route + '/'` prefix, so nested paths such as
+ * `/reset-password/<token>`, `/legal/privacy`, and `/onboarding/<step>` are all
+ * covered while sibling routes that merely share a string prefix (e.g.
+ * `/loginx`) are not.
+ */
+export function isUnauthenticatedSafeRoute(pathname: string): boolean {
+  if (matchesRouteOrChild(pathname, ONBOARDING_ROUTE)) {
+    return true;
+  }
+
+  return PRE_AUTH_ROUTES.some((route) => matchesRouteOrChild(pathname, route));
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter, useLocation } from 'react-router-dom';
 import { App } from './App';
 import { AuthProvider } from './auth/auth-context';
+import { PRE_AUTH_ROUTE_SET, isUnauthenticatedSafeRoute } from './lib/auth/pre-auth-routes';
 import { ErrorBoundary, ToastProvider, UpdateBanner } from './components/common';
 import { AccessibilityProvider } from './contexts/AccessibilityContext';
 import { NavigationGuard, ScrollToTop } from './components/navigation';
@@ -56,21 +57,6 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim()
     ? requiredProductionEnv('VITE_SUPABASE_ANON_KEY')
     : 'placeholder-anon-key';
 
-const PRE_AUTH_ROUTES = new Set([
-  '/login',
-  '/signup',
-  '/forgot-password',
-  '/reset-password',
-  '/legal',
-  '/beta',
-]);
-
-function isPreAuthRoute(pathname: string): boolean {
-  return Array.from(PRE_AUTH_ROUTES).some(
-    (route) => pathname === route || pathname.startsWith(`${route}/`),
-  );
-}
-
 const authConfig = {
   supabaseUrl,
   supabaseAnonKey,
@@ -83,8 +69,12 @@ const authConfig = {
     if (isLighthouseAudit()) {
       return;
     }
-    // Redirect to login when session expires or user is not authenticated.
-    if (!isPreAuthRoute(window.location.pathname)) {
+    // Redirect to login when the session expires or the user is not
+    // authenticated — UNLESS they are on a route that is valid while logged out
+    // (pre-auth pages or the first-run /onboarding flow). Without the
+    // `/onboarding` exemption this fights App.tsx's onboarding auto-launch and
+    // produces an infinite full-page reload loop (#3059).
+    if (!isUnauthenticatedSafeRoute(window.location.pathname)) {
       window.location.href = '/login';
     }
   },
@@ -179,7 +169,7 @@ if (typeof window !== 'undefined' && !isLighthouseAudit()) {
 const DatabaseGate: FC<{ children: ReactNode }> = ({ children }) => {
   const { pathname } = useLocation();
 
-  if (PRE_AUTH_ROUTES.has(pathname)) {
+  if (PRE_AUTH_ROUTE_SET.has(pathname)) {
     return children;
   }
 


### PR DESCRIPTION
## Summary

A fresh (logged-out, first-run) visitor to the web app hit an **infinite full-page reload loop** flashing between `/onboarding` and `/login`. This fixes the redirect war between two layers that disagreed about whether `/onboarding` is reachable while logged out.

## Root cause

- `apps/web/src/App.tsx` auto-launches logged-out first-run visitors into `/onboarding` (`/onboarding` is in `STANDALONE_ROUTES` + `FIRST_RUN_ALLOWED_ROUTES`).
- `apps/web/src/main.tsx`'s `authConfig.onUnauthenticated` hard-redirects (`window.location.href = '/login'`) any path **not** in its local `PRE_AUTH_ROUTES` set — and `/onboarding` was missing from that set.

The auth bootstrap fires `onUnauthenticated` on restore-failure for a logged-out visitor, so: `/login` → (App.tsx) → `/onboarding` → (onUnauthenticated, hard reload) → `/login` → … forever. The live e2e never caught it because signup happens immediately and never dwells on `/onboarding` while logged out.

## Changes

- **New** `apps/web/src/lib/auth/pre-auth-routes.ts` — single source of truth, separating two concepts that had drifted:
  - `PRE_AUTH_ROUTE_SET` — exact-match routes that skip the `DatabaseGate` (unchanged set; `/onboarding` intentionally **excluded** because it uses the database for starter budgets).
  - `isUnauthenticatedSafeRoute()` — superset (pre-auth routes **+** `/onboarding`, prefix-matched) used by the `onUnauthenticated` guard, so `/onboarding` is no longer force-redirected to `/login`.
- **`apps/web/src/main.tsx`** — imports the module, drops the local duplicate set/helper, and uses `isUnauthenticatedSafeRoute()` in the redirect guard. The existing `isLighthouseAudit()` exemption is preserved.
- **New** `apps/web/src/lib/auth/pre-auth-routes.test.ts` — regression coverage for the predicate and the DB-gate set.

## Testing

- `npx vitest run src/lib/auth/pre-auth-routes.test.ts` → 6/6 pass.
- Repo-wide `npm run format:check` and `npx eslint . --max-warnings 0` → clean.
- **Live (msedge against the local Supabase edge stack):**
  - Logged-out `/onboarding` now **stays** on `/onboarding` — never bounces to `/login`, settles (loop gone).
  - Onboarding-completed, logged-out visitor to `/dashboard` still redirects and **stays** on `/login` (protected-route guard intact).

## Issues

Closes #3059