### PR TITLE
ci(housekeeping): add production DNS + HTTPS uptime monitor (#3067)

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -133,3 +133,103 @@ jobs:
           else
             gh issue create --repo "$GITHUB_REPOSITORY" --title "Beta uptime check failing" --label uptime --label beta --body "$body"
           fi
+
+  prod-uptime:
+    name: Check production web uptime
+    if: >-
+      (github.event_name == 'schedule' && github.event.schedule == '*/15 * * * *') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.task == 'all' || inputs.task == 'uptime'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Probe production DNS + HTTPS with retries
+        id: check
+        env:
+          PRODUCTION_URL: ${{ vars.PRODUCTION_URL }}
+        run: |
+          set +e
+          if [ -n "${PRODUCTION_URL:-}" ]; then
+            if [[ "$PRODUCTION_URL" == http://* || "$PRODUCTION_URL" == https://* ]]; then
+              url="${PRODUCTION_URL%/}"
+            else
+              url="https://${PRODUCTION_URL%/}"
+            fi
+          else
+            url="https://finance.jrmoulckers.com"
+          fi
+          host="${url#*://}"
+          host="${host%%/*}"
+          host="${host%%:*}"
+
+          # DNS resolution check — catches NXDOMAIN, the #3063 failure mode the
+          # beta-only monitor never saw (a missing Cloudflare record).
+          resolved_ip="$(getent hosts "$host" | awk '{ print $1; exit }')"
+          if [ -n "$resolved_ip" ]; then
+            dns_ok=true
+          else
+            dns_ok=false
+          fi
+
+          # HTTPS reachability check with retries.
+          attempts=3
+          delay_seconds=10
+          curl_status=0
+          status_code=000
+          for attempt in $(seq 1 "$attempts"); do
+            curl_output=$(curl --silent --show-error --location --max-time 10 --output /dev/null --write-out '%{http_code}' "$url" 2>&1)
+            curl_status=$?
+            status_code="${curl_output: -3}"
+            if [ "$curl_status" -eq 0 ] && [ "$status_code" -ge 200 ] && [ "$status_code" -lt 400 ]; then
+              break
+            fi
+            [ "$attempt" -lt "$attempts" ] && sleep "$delay_seconds"
+          done
+
+          {
+            echo "url=$url"
+            echo "host=$host"
+            echo "dns_ok=$dns_ok"
+            echo "resolved_ip=$resolved_ip"
+            echo "status_code=$status_code"
+            echo "curl_status=$curl_status"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$dns_ok" != "true" ] || [ "$curl_status" -ne 0 ] || [ "$status_code" -lt 200 ] || [ "$status_code" -ge 400 ]; then
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "failed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Open or update production uptime issue
+        if: steps.check.outputs.failed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEALTH_URL: ${{ steps.check.outputs.url }}
+          HEALTH_HOST: ${{ steps.check.outputs.host }}
+          DNS_OK: ${{ steps.check.outputs.dns_ok }}
+          RESOLVED_IP: ${{ steps.check.outputs.resolved_ip }}
+          STATUS_CODE: ${{ steps.check.outputs.status_code }}
+          CURL_STATUS: ${{ steps.check.outputs.curl_status }}
+        run: |
+          set -euo pipefail
+          gh label create uptime --repo "$GITHUB_REPOSITORY" --color D73A4A --description "Uptime monitor alerts" --force >/dev/null
+          gh label create infrastructure --repo "$GITHUB_REPOSITORY" --color BFDADC --description "Infrastructure setup and configuration" --force >/dev/null
+          if [ "$DNS_OK" != "true" ]; then
+            dns_line="- DNS resolution: FAILED — no A record for ${HEALTH_HOST} (NXDOMAIN). Check the Cloudflare DNS record."
+          else
+            dns_line="- DNS resolution: ok (${HEALTH_HOST} -> ${RESOLVED_IP})"
+          fi
+          body=$(printf '%s\n' \
+            "Automated production uptime check failed." \
+            "" \
+            "- URL: ${HEALTH_URL}" \
+            "${dns_line}" \
+            "- HTTP status: ${STATUS_CODE}" \
+            "- curl exit: ${CURL_STATUS}" \
+            "- Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            "- Checked at: $(date -u +'%Y-%m-%dT%H:%M:%SZ')")
+          existing_issue=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label uptime --label infrastructure --json number --jq '.[0].number // empty')
+          if [ -n "$existing_issue" ]; then
+            gh issue comment "$existing_issue" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "Production uptime check failing" --label uptime --label infrastructure --body "$body"
+          fi


### PR DESCRIPTION
## Summary

The existing `uptime` job in `housekeeping.yml` only probes the **beta/staging** URL
(`BETA_UPTIME_URL`, default Vercel). When production `finance.jrmoulckers.com` went fully
dark with a DNS **NXDOMAIN** (#3063), no automated check fired and the outage had to be
reported manually. This adds a dedicated **production** uptime monitor so a recurrence is
caught automatically.

## Changes

- Add a `prod-uptime` job to `.github/workflows/housekeeping.yml`, running on the existing
  `*/15 * * * *` schedule plus manual `workflow_dispatch`.
- **DNS resolution check** (`getent hosts`) that explicitly catches NXDOMAIN — the exact
  failure mode of #3063 — and reports it distinctly from an HTTP error.
- **HTTPS reachability check** (3 retries, expects a 2xx/3xx response).
- On failure, opens or updates a single **deduplicated** issue labeled `uptime` +
  `infrastructure` so repeated runs don't spam the tracker.
- Targets `vars.PRODUCTION_URL` (default `https://finance.jrmoulckers.com`). Runs on
  GitHub-hosted infra, independent of the Azure VM / Cloudflare path it monitors.

## Why

`#3063` was a production-only DNS outage that our automation could not have detected: the
only scheduled probe watches the beta deployment, which stayed up. Monitoring production
from GitHub's runners closes that gap with no new infrastructure.

## Testing

- `node` YAML parse confirms valid structure and that the `prod-uptime` job is recognized.
- `npx prettier --check .github/workflows/housekeeping.yml` passes.
- Job logic mirrors the existing `uptime` job (same dedup pattern and label scheme); the
  workflow already grants `issues: write`, so no permission change is needed.

## Issues

Closes #3067
Refs #3063
