### PR TITLE
fix(web): make the dev service worker a self-destruct kill-switch (#3068)

### DIFF
--- a/apps/web/src/sw/__tests__/service-worker-dev-kill-switch.test.ts
+++ b/apps/web/src/sw/__tests__/service-worker-dev-kill-switch.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the dev service-worker kill-switch (#3068, follow-up to #3064).
+ *
+ * On the Vite dev server the worker must not cache anything; instead it
+ * self-destructs — purging caches, unregistering itself, and reloading every
+ * open tab — so a browser that still has a stale production worker installed
+ * auto-heals out of the HMR reload loop without any manual unregister.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { IS_DEV_SERVICE_WORKER, selfDestructDevServiceWorker } from '../service-worker';
+
+interface MockWindowClient {
+  url: string;
+  navigate: ReturnType<typeof vi.fn>;
+}
+
+const selfScope = self as unknown as {
+  clients?: { claim: ReturnType<typeof vi.fn>; matchAll: ReturnType<typeof vi.fn> };
+  registration?: { unregister: ReturnType<typeof vi.fn> };
+};
+
+let originalCaches: CacheStorage | undefined;
+let originalClients: typeof selfScope.clients;
+let originalRegistration: typeof selfScope.registration;
+
+let cachesKeys: ReturnType<typeof vi.fn>;
+let cachesDelete: ReturnType<typeof vi.fn>;
+let claim: ReturnType<typeof vi.fn>;
+let matchAll: ReturnType<typeof vi.fn>;
+let unregister: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  cachesKeys = vi.fn().mockResolvedValue(['finance-static-v2', 'finance-sync-v2']);
+  cachesDelete = vi.fn().mockResolvedValue(true);
+  claim = vi.fn().mockResolvedValue(undefined);
+  matchAll = vi.fn().mockResolvedValue([]);
+  unregister = vi.fn().mockResolvedValue(true);
+
+  originalCaches = (globalThis as { caches?: CacheStorage }).caches;
+  originalClients = selfScope.clients;
+  originalRegistration = selfScope.registration;
+
+  (globalThis as { caches: unknown }).caches = { keys: cachesKeys, delete: cachesDelete };
+  selfScope.clients = { claim, matchAll };
+  selfScope.registration = { unregister };
+});
+
+afterEach(() => {
+  if (originalCaches !== undefined) {
+    (globalThis as { caches: CacheStorage }).caches = originalCaches;
+  } else {
+    delete (globalThis as { caches?: CacheStorage }).caches;
+  }
+  selfScope.clients = originalClients;
+  selfScope.registration = originalRegistration;
+  vi.restoreAllMocks();
+});
+
+describe('dev service-worker kill-switch (#3068)', () => {
+  it('is inert under the Vitest runner / production (MODE !== "development")', () => {
+    // Guards against the dev kill-switch ever activating in a production
+    // build or the test runner, which would disable caching + offline.
+    expect(IS_DEV_SERVICE_WORKER).toBe(false);
+  });
+
+  it('purges every cache, unregisters, and reloads all open tabs', async () => {
+    const tabA: MockWindowClient = {
+      url: 'http://localhost:5173/',
+      navigate: vi.fn().mockResolvedValue(undefined),
+    };
+    const tabB: MockWindowClient = {
+      url: 'http://localhost:5173/budgets',
+      navigate: vi.fn().mockResolvedValue(undefined),
+    };
+    matchAll.mockResolvedValue([tabA, tabB]);
+
+    await selfDestructDevServiceWorker();
+
+    expect(cachesDelete).toHaveBeenCalledWith('finance-static-v2');
+    expect(cachesDelete).toHaveBeenCalledWith('finance-sync-v2');
+    expect(claim).toHaveBeenCalledTimes(1);
+    expect(unregister).toHaveBeenCalledTimes(1);
+    expect(tabA.navigate).toHaveBeenCalledWith('http://localhost:5173/');
+    expect(tabB.navigate).toHaveBeenCalledWith('http://localhost:5173/budgets');
+  });
+
+  it('still unregisters when the cache purge rejects (best-effort)', async () => {
+    cachesKeys.mockRejectedValue(new Error('cache boom'));
+
+    await expect(selfDestructDevServiceWorker()).resolves.toBeUndefined();
+    expect(unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when unregister rejects', async () => {
+    unregister.mockRejectedValue(new Error('unregister boom'));
+
+    await expect(selfDestructDevServiceWorker()).resolves.toBeUndefined();
+    expect(claim).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a tab navigate rejection so cleanup completes', async () => {
+    const tab: MockWindowClient = {
+      url: 'http://localhost:5173/',
+      navigate: vi.fn().mockRejectedValue(new Error('navigate boom')),
+    };
+    matchAll.mockResolvedValue([tab]);
+
+    await expect(selfDestructDevServiceWorker()).resolves.toBeUndefined();
+    expect(tab.navigate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/sw/service-worker.ts
+++ b/apps/web/src/sw/service-worker.ts
@@ -386,10 +386,76 @@ async function storeConflicts(conflicts: SyncConflict[]): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Dev kill-switch (#3068, follow-up to #3064)
+// ---------------------------------------------------------------------------
+
+/**
+ * True only when this worker is running on the Vite **dev server** (serve
+ * mode, MODE `development`). A service worker must never control the dev
+ * server: its caching shadows Vite with a stale app shell + modules, which
+ * fights HMR / dependency re-optimization and triggers an infinite full-page
+ * reload loop. In dev the worker becomes a self-destruct kill-switch (below).
+ *
+ * Evaluates to `false` for production builds (`vite preview`, MODE
+ * `production`) and the Vitest runner (MODE `test`), where the worker behaves
+ * normally — so the dev branches are dead-code-eliminated from the production
+ * bundle.
+ */
+export const IS_DEV_SERVICE_WORKER: boolean = import.meta.env.MODE === 'development';
+
+/**
+ * Dev-only kill-switch: purge every cache this worker created, unregister the
+ * worker, and reload all controlled tabs so they reload fresh from the Vite
+ * dev server with no service worker in the way.
+ *
+ * The browser fetches the worker script out-of-band during its update check
+ * (not through the worker's own `fetch` handler), so a browser that still has
+ * a production worker installed from an earlier build picks this up on its
+ * next navigation and auto-heals — no manual `chrome://serviceworker-internals`
+ * unregister required. Best-effort: every step is guarded so a failure never
+ * leaves the worker half-alive.
+ */
+export async function selfDestructDevServiceWorker(): Promise<void> {
+  try {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((key) => caches.delete(key)));
+  } catch {
+    // best-effort: cache purge is non-fatal
+  }
+
+  // Control any open tabs so they can be reloaded, then remove the
+  // registration so future loads are no longer controlled.
+  await self.clients.claim();
+
+  try {
+    await self.registration.unregister();
+  } catch {
+    // best-effort: unregister is non-fatal
+  }
+
+  const windowClients = await self.clients.matchAll({ type: 'window' });
+  await Promise.all(
+    windowClients.map((client) =>
+      (client as WindowClient).navigate((client as WindowClient).url).catch(() => {
+        // best-effort: a controlled reload may be disallowed; the boot-time
+        // unregisterDevServiceWorkers() in main.tsx covers that case.
+      }),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Install -- pre-cache app shell
 // ---------------------------------------------------------------------------
 
 self.addEventListener('install', (event: ExtendableEvent) => {
+  if (IS_DEV_SERVICE_WORKER) {
+    // Activate immediately so the activate handler can self-destruct without
+    // waiting for old tabs to close. Skip precache entirely in dev.
+    void self.skipWaiting();
+    return;
+  }
+
   event.waitUntil(
     caches.open(STATIC_CACHE).then(async (cache) => {
       // Always precache the core app shell at the Vite public base path.
@@ -412,6 +478,11 @@ self.addEventListener('install', (event: ExtendableEvent) => {
 // ---------------------------------------------------------------------------
 
 self.addEventListener('activate', (event: ExtendableEvent) => {
+  if (IS_DEV_SERVICE_WORKER) {
+    event.waitUntil(selfDestructDevServiceWorker());
+    return;
+  }
+
   event.waitUntil(
     caches
       .keys()
@@ -428,6 +499,11 @@ self.addEventListener('activate', (event: ExtendableEvent) => {
 // ---------------------------------------------------------------------------
 
 self.addEventListener('fetch', (event: FetchEvent) => {
+  if (IS_DEV_SERVICE_WORKER) {
+    // Never intercept on the dev server — let every request hit Vite fresh.
+    return;
+  }
+
   const { request } = event;
   const url = new URL(request.url);
 


### PR DESCRIPTION
## Summary

Follow-up to #3064 (#3065). That fix stops the Vite dev server from **registering** a service worker, preventing the HMR reload-loop ("flashing") from recurring. But it can't evict a worker **already installed** in a developer's browser from a prior production build — and that's the state every developer who ever loaded a build is in.

## Root cause the merged fix couldn't reach

An already-active SW serves its own old code via the **default cache-first** strategy: `/src/main.tsx` isn't a navigation and `.tsx` isn't in `STATIC_EXTENSIONS`, so it falls through to `cache-first`. The SW returns the **old, pre-fix `main.tsx`**, so the new `unregisterDevServiceWorkers()` never runs and the loop persists until a manual `chrome://serviceworker-internals` / DevTools unregister.

## Fix — dev SW kill-switch

In MODE `development` the worker becomes a self-destruct kill-switch (gated on `import.meta.env.MODE === 'development'`, dead-code-eliminated in production):

- **`install`** → `skipWaiting()` and skip precache.
- **`activate`** → purge all caches, `clients.claim()`, `registration.unregister()`, then reload every open tab.
- **`fetch`** → never intercept; every request hits Vite fresh.

Because the browser fetches the worker script **out-of-band during its update check** (not through the worker's own `fetch` handler), an existing poisoned browser picks up the kill-switch on its next navigation — immediate in a reload loop — and auto-heals with **zero manual steps**.

## Changes

- **`apps/web/src/sw/service-worker.ts`** — add `IS_DEV_SERVICE_WORKER` + `selfDestructDevServiceWorker()`; gate `install` / `activate` / `fetch` on dev.
- **`apps/web/src/sw/__tests__/service-worker-dev-kill-switch.test.ts`** — new tests: self-destruct purges caches + unregisters + reloads tabs; best-effort error handling; and a guard that the kill-switch is inert under MODE `test` / production.

## Testing

- [x] `npx vitest run src/sw/__tests__/` — 17 passed (5 new + 4 auth-bypass + 8 register)
- [x] `npm run format:check` — clean
- [x] `npx eslint` on changed files — clean

## Production safety

`IS_DEV_SERVICE_WORKER` is `false` in production builds (`vite preview`, MODE `production`) and under Vitest (MODE `test`), so precache, cache strategies, offline, and installability are unchanged. Dead-code-eliminated from the production bundle.

## Scope

`apps/web/src/sw/service-worker.ts` + its tests only. Does not touch the DNS outage (#3063).

Closes #3068
