### PR TITLE
fix(web): surface clear error when auth backend is unreachable (#3066)

### DIFF
--- a/apps/web/src/auth/auth-context.test.tsx
+++ b/apps/web/src/auth/auth-context.test.tsx
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   AuthProvider,
+  SERVICE_UNAVAILABLE_MESSAGE,
   isBetaEmailAllowed,
+  isNetworkError,
+  isServiceUnavailableStatus,
   parseBetaAllowedEmails,
   useAuth,
   type AuthProviderConfig,
@@ -247,5 +250,165 @@ describe('AuthProvider refresh restoration', () => {
       expect.objectContaining({ credentials: 'include' }),
     );
     expect(onUnauthenticated).not.toHaveBeenCalled();
+  });
+});
+
+describe('backend-unreachable classification helpers', () => {
+  it('treats gateway/5xx and opaque (0) statuses as service-unavailable', () => {
+    expect(isServiceUnavailableStatus(0)).toBe(true);
+    expect(isServiceUnavailableStatus(500)).toBe(true);
+    expect(isServiceUnavailableStatus(502)).toBe(true);
+    expect(isServiceUnavailableStatus(503)).toBe(true);
+    expect(isServiceUnavailableStatus(504)).toBe(true);
+  });
+
+  it('does not treat client (4xx) or success statuses as service-unavailable', () => {
+    expect(isServiceUnavailableStatus(200)).toBe(false);
+    expect(isServiceUnavailableStatus(400)).toBe(false);
+    expect(isServiceUnavailableStatus(401)).toBe(false);
+    expect(isServiceUnavailableStatus(409)).toBe(false);
+    expect(isServiceUnavailableStatus(429)).toBe(false);
+  });
+
+  it('recognises fetch network rejections', () => {
+    expect(isNetworkError(new TypeError('Failed to fetch'))).toBe(true);
+    expect(isNetworkError(new TypeError('NetworkError when attempting to fetch resource'))).toBe(
+      true,
+    );
+    expect(isNetworkError(new Error('Load failed'))).toBe(true);
+    expect(isNetworkError(new Error('The network connection was lost'))).toBe(true);
+  });
+
+  it('does not misclassify ordinary errors as network errors', () => {
+    expect(isNetworkError(new Error('Incorrect password.'))).toBe(false);
+    expect(isNetworkError(new Error('Beta access required'))).toBe(false);
+    expect(isNetworkError('oops')).toBe(false);
+    expect(isNetworkError(undefined)).toBe(false);
+  });
+});
+
+describe('signup & login surface a clear message when the backend is unreachable (#3066)', () => {
+  const config: AuthProviderConfig = {
+    supabaseUrl: 'https://finance-test.supabase.co',
+    supabaseAnonKey: 'anon-key',
+    loginEndpoint: '/api/auth/login',
+    refreshEndpoint: '/api/auth/refresh',
+    logoutEndpoint: '/api/auth/logout',
+    signupEndpoint: '/api/auth/signup',
+  };
+
+  beforeEach(() => {
+    clearTokens();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearTokens();
+    localStorage.clear();
+  });
+
+  /** Probe that exposes the email signup/login actions plus the error state. */
+  function ActionProbe() {
+    const { signupWithEmail, loginWithEmail, isLoading, error } = useAuth();
+    return (
+      <div>
+        <span data-testid="loading-state">{isLoading ? 'loading' : 'ready'}</span>
+        <span data-testid="auth-error">{error ?? 'none'}</span>
+        <button
+          data-testid="do-signup"
+          onClick={() => {
+            void signupWithEmail('new@example.com', 'longenoughpassword').catch(() => {});
+          }}
+        >
+          signup
+        </button>
+        <button
+          data-testid="do-login"
+          onClick={() => {
+            void loginWithEmail('user@example.com', 'longenoughpassword').catch(() => {});
+          }}
+        >
+          login
+        </button>
+      </div>
+    );
+  }
+
+  /**
+   * Builds a fetch mock where the initial session-restore refresh returns
+   * 401 (anonymous) and the auth action under test resolves/rejects per
+   * `authResponse`.
+   */
+  function stubFetch(matchPath: string, authResponse: () => Promise<Response>) {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes(matchPath)) {
+        return authResponse();
+      }
+      // Initial mount refresh and anything else: no session.
+      return Promise.resolve(jsonResponse({ error: 'no session' }, 401));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  async function renderReady() {
+    render(
+      <AuthProvider config={config}>
+        <ActionProbe />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('loading-state')).toHaveTextContent('ready'));
+  }
+
+  it('shows the service-unavailable message when signup returns a 502', async () => {
+    stubFetch('/api/auth/signup', () =>
+      Promise.resolve(new Response('', { status: 502, statusText: 'Bad Gateway' })),
+    );
+    await renderReady();
+
+    fireEvent.click(screen.getByTestId('do-signup'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-error')).toHaveTextContent(SERVICE_UNAVAILABLE_MESSAGE),
+    );
+  });
+
+  it('shows the service-unavailable message when signup fetch rejects (network down)', async () => {
+    stubFetch('/api/auth/signup', () => Promise.reject(new TypeError('Failed to fetch')));
+    await renderReady();
+
+    fireEvent.click(screen.getByTestId('do-signup'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-error')).toHaveTextContent(SERVICE_UNAVAILABLE_MESSAGE),
+    );
+  });
+
+  it('shows the service-unavailable message when login returns a 502', async () => {
+    stubFetch('/api/auth/login', () =>
+      Promise.resolve(new Response('', { status: 502, statusText: 'Bad Gateway' })),
+    );
+    await renderReady();
+
+    fireEvent.click(screen.getByTestId('do-login'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-error')).toHaveTextContent(SERVICE_UNAVAILABLE_MESSAGE),
+    );
+  });
+
+  it('still shows the specific 4xx error message for a real client error', async () => {
+    stubFetch('/api/auth/login', () =>
+      Promise.resolve(jsonResponse({ error: 'Invalid login credentials' }, 400)),
+    );
+    await renderReady();
+
+    fireEvent.click(screen.getByTestId('do-login'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-error')).toHaveTextContent('Invalid login credentials'),
+    );
   });
 });

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -181,6 +181,16 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 const LAST_USER_STORAGE_KEY = 'finance.lastUser';
 export const BETA_ACCESS_REQUIRED_MESSAGE = 'Beta access required';
 
+/**
+ * User-facing message shown when the auth backend cannot be reached or
+ * responds with a gateway/5xx error (e.g. the Edge Functions container is
+ * down, so the reverse proxy returns a 502 with an empty body). Surfacing
+ * this distinct message stops a transient server outage from looking like a
+ * credential or validation failure — or, worse, failing silently (#3066).
+ */
+export const SERVICE_UNAVAILABLE_MESSAGE =
+  'The server is temporarily unavailable. Please try again in a few minutes.';
+
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
@@ -494,6 +504,9 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         });
 
         if (!response.ok) {
+          if (isServiceUnavailableStatus(response.status)) {
+            throw new Error(SERVICE_UNAVAILABLE_MESSAGE);
+          }
           const body = (await response.json().catch(() => ({}))) as {
             error?: string;
           };
@@ -519,6 +532,10 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         setIsOffline(false);
         triggerPasskeyPromptCheck();
       } catch (err) {
+        if (isNetworkError(err)) {
+          setError(SERVICE_UNAVAILABLE_MESSAGE);
+          throw new Error(SERVICE_UNAVAILABLE_MESSAGE, { cause: err });
+        }
         const message = err instanceof Error ? err.message : 'An unexpected error occurred';
         setError(message);
         throw err;
@@ -763,6 +780,9 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         }
 
         if (!response.ok) {
+          if (isServiceUnavailableStatus(response.status)) {
+            throw new Error(SERVICE_UNAVAILABLE_MESSAGE);
+          }
           throw new Error(body.error ?? 'Signup failed');
         }
 
@@ -808,6 +828,10 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         }
         return { kind: 'authenticated' };
       } catch (err) {
+        if (isNetworkError(err)) {
+          setError(SERVICE_UNAVAILABLE_MESSAGE);
+          throw new Error(SERVICE_UNAVAILABLE_MESSAGE, { cause: err });
+        }
         const message = err instanceof Error ? err.message : 'An unexpected error occurred';
         setError(message);
         throw err;
@@ -1062,6 +1086,33 @@ export function isBetaEmailAllowed(
   }
 
   return typeof email === 'string' && allowedEmails.has(email.trim().toLowerCase());
+}
+
+/**
+ * Whether an HTTP status indicates the auth backend itself failed or was
+ * unreachable, as opposed to a client/validation error. Covers gateway
+ * failures (502/503/504), other 5xx, and opaque responses (status `0`,
+ * e.g. an intercepted or blocked fetch). These map to
+ * {@link SERVICE_UNAVAILABLE_MESSAGE} so an outage never looks like a bad
+ * password or duplicate-email problem (#3066).
+ */
+export function isServiceUnavailableStatus(status: number): boolean {
+  return status === 0 || status >= 500;
+}
+
+/**
+ * Whether a thrown error indicates the network or server could not be
+ * reached. `fetch()` rejects with a `TypeError` on DNS failure, refused or
+ * reset connection, a blocked request, or while offline; the exact message
+ * wording varies across browsers, so we match a few known phrasings too.
+ */
+export function isNetworkError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    return true;
+  }
+  return (
+    error instanceof Error && /network|failed to fetch|load failed|connection/i.test(error.message)
+  );
 }
 
 function cacheLastUser(nextUser: AuthUser): void {


### PR DESCRIPTION
## Summary

Signup and login on the web app POST to the same-origin `/api/auth/*` routes, which Caddy proxies to the Supabase **auth Edge Functions**. When that backend is unreachable, the proxy returns a **502 with an empty body** (or the `fetch` rejects outright when the network is down). The client parsed the empty body as `{}`, fell through to a bare `throw new Error('Signup failed')` / `'Login failed'`, and the UI surfaced nothing useful — the failure looked completely silent. This was the user-reported symptom on `finance.jrmoulckers.com`.

This PR makes the client resilient: it classifies *backend-unreachable* conditions and shows a single clear, actionable message instead of a generic/empty one. Genuine 4xx validation errors (bad password, duplicate email, beta-gate, etc.) are unchanged.

> Note: this addresses the **client-side feedback gap only**. The production outage itself was the `edge-functions` container being down (returning 502); restarting that container is a separate operational fix.

## Changes

- `apps/web/src/auth/auth-context.tsx`
  - Add `SERVICE_UNAVAILABLE_MESSAGE` constant.
  - Add two exported, unit-testable helpers:
    - `isServiceUnavailableStatus(status)` — true for `0` (opaque/blocked) and all `>= 500` (502/503/504/etc.).
    - `isNetworkError(error)` — true for `fetch` rejections (`TypeError`, or messages matching `network|failed to fetch|load failed|connection`).
  - `signupWithEmail` and `loginWithEmail`: on a non-OK response with a service-unavailable status, and on a network-error rejection, surface `SERVICE_UNAVAILABLE_MESSAGE` (caught error attached as `cause`).
- `apps/web/src/auth/auth-context.test.tsx`
  - Unit tests for both helpers (5xx/0 → true; 4xx/2xx → false; TypeError/known phrasings → true; ordinary errors → false).
  - Integration tests: signup 502, signup network-reject, and login 502 all render `SERVICE_UNAVAILABLE_MESSAGE`; a real 400 still renders its specific message.

## Issues

Closes #3066

## Testing

- [x] `apps/web` vitest: `auth-context` (17), `SignupPage` (11), `LoginPage` (15), `auth-flows` (28) — all green
- [x] `npx eslint . --max-warnings 0` on changed files — clean
- [x] `npm run format:check` — clean