### PR TITLE
fix(web): generate design tokens in vite + quiet dev task problem matcher (#3072)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,8 +29,12 @@
       "isBackground": true,
       "problemMatcher": {
         "owner": "vite",
+        // Sentinel regexp that never matches: the dev server streams
+        // human-readable status lines (URLs, box art, tips), not diagnostics.
+        // This stops VS Code surfacing every line as a Problem while the
+        // background begin/end patterns below still drive F5 ready-detection.
         "pattern": {
-          "regexp": "^\\s*(.*)$",
+          "regexp": "^__finance_no_problem__(.*)$",
           "message": 1
         },
         "background": {
@@ -68,8 +72,12 @@
       "isBackground": true,
       "problemMatcher": {
         "owner": "vite",
+        // Sentinel regexp that never matches: the dev server streams
+        // human-readable status lines (URLs, box art, tips), not diagnostics.
+        // This stops VS Code surfacing every line as a Problem while the
+        // background begin/end patterns below still drive F5 ready-detection.
         "pattern": {
-          "regexp": "^\\s*(.*)$",
+          "regexp": "^__finance_no_problem__(.*)$",
           "message": 1
         },
         "background": {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { resolve } from 'node:path';
 
 import react from '@vitejs/plugin-react';
@@ -8,6 +17,81 @@ import { defineConfig, type Connect, type Plugin, type ResolvedConfig } from 'vi
 
 import { getRouteChunkName } from './src/lib/perf/route-chunks';
 import { applyBaseToWebManifest, type WebManifest } from './src/lib/pwa/manifest-base';
+
+/**
+ * Vite plugin that generates the design-token CSS before the dev server or a
+ * production build starts.
+ *
+ * `src/theme/tokens.css` `@import`s four generated stylesheets from
+ * `packages/design-tokens/build/web/`. Those files are produced by Style
+ * Dictionary (`npm run build:tokens`) and are gitignored, so a fresh clone — or
+ * a tree after `npm run clean` — has none, and Vite's PostCSS aborts with
+ * `ENOENT ... tokens.css`. This plugin runs the generator at `buildStart` when
+ * the outputs are missing or older than their token sources, making `vite`,
+ * `vite build`, and Storybook clone-to-run with no manual token build.
+ */
+function ensureDesignTokens(): Plugin {
+  const tokensRoot = resolve(__dirname, '../../packages/design-tokens');
+  const configScript = resolve(tokensRoot, 'config/style-dictionary.config.mjs');
+  const sourceDir = resolve(tokensRoot, 'tokens');
+  const outputs = [
+    'tokens.css',
+    'tokens-dark.css',
+    'tokens-dark-oled.css',
+    'tokens-high-contrast.css',
+  ].map((file) => resolve(tokensRoot, 'build/web', file));
+
+  const mtimeOf = (path: string): number => {
+    try {
+      return statSync(path).mtimeMs;
+    } catch {
+      return 0;
+    }
+  };
+
+  const tokensNeedBuild = (): boolean => {
+    // Any missing output forces a (re)generation.
+    if (outputs.some((path) => !existsSync(path))) return true;
+    // Otherwise regenerate only when a token source or the generator config is
+    // newer than the oldest generated output, so editing a token and restarting
+    // the dev server picks up the change.
+    const sourceFiles = readdirSync(sourceDir, { recursive: true }).map((rel) =>
+      resolve(sourceDir, rel.toString()),
+    );
+    const newestSource = [configScript, ...sourceFiles].reduce(
+      (newest, path) => Math.max(newest, mtimeOf(path)),
+      0,
+    );
+    const oldestOutput = outputs.reduce(
+      (oldest, path) => Math.min(oldest, mtimeOf(path)),
+      Infinity,
+    );
+    return newestSource > oldestOutput;
+  };
+
+  return {
+    name: 'ensure-design-tokens',
+    // Generate before any CSS module is transformed so the @imports resolve.
+    enforce: 'pre',
+    buildStart() {
+      if (!existsSync(configScript)) {
+        this.warn('design-tokens generator not found — skipping token generation.');
+        return;
+      }
+      if (!tokensNeedBuild()) return;
+      const result = spawnSync(process.execPath, [configScript], {
+        cwd: tokensRoot,
+        stdio: 'inherit',
+      });
+      if (result.status !== 0) {
+        this.error(
+          'Failed to generate design tokens (packages/design-tokens). ' +
+            'Run `npm run build:tokens` and retry.',
+        );
+      }
+    },
+  };
+}
 
 /**
  * Vite plugin that copies sql.js WASM binaries to the public assets directory.
@@ -198,6 +282,7 @@ export default defineConfig({
   // PUBLIC_BASE_PATH=/finance/. import.meta.env.BASE_URL reflects this at runtime.
   base: process.env.PUBLIC_BASE_PATH ?? '/',
   plugins: [
+    ensureDesignTokens(),
     react(),
     copySqlJsWasm(),
     swPrecacheManifest(),


### PR DESCRIPTION
## Summary

Running the web app locally (VS Code F5 → **Dev: Full Stack** → `npm run dev:full`) aborted with a Vite PostCSS error:

```
[postcss] ENOENT: no such file or directory, open '.../packages/design-tokens/build/web/tokens.css'
```

Two distinct root causes, one user-visible failure:

1. **Missing generated token CSS.** `apps/web/src/theme/tokens.css` `@import`s four stylesheets from `packages/design-tokens/build/web/`. Those are generated by Style Dictionary (`npm run build:tokens`) and are **gitignored** (`.gitignore` → `build/`), so a fresh clone — or a tree after `npm run clean` — has none. Nothing in the F5 path (`launch.json` → `Dev: Full Stack` → `dev:full` → `tools/dev-full.mjs` → `vite`) generated them, so PostCSS hit a non-existent file. (`apps/web` doesn't declare `@finance/design-tokens` as a dependency, so Turborepo's `^build` ordering didn't cover it either.)
2. **Noisy VS Code "Problems".** Both `Dev: Full Stack` background tasks used a catch-all problem matcher (`"regexp": "^\\s*(.*)$"`) with no file/severity capture, so VS Code flagged **every** dev-server status line (URLs, box-art, tips) as a severity-8 error — dozens of false positives.

## Changes

- **`apps/web/vite.config.ts`** — add an `ensureDesignTokens()` Vite plugin that runs the Style Dictionary build at `buildStart` when the web token CSS is missing or older than its token sources/config. Makes `vite`, `vite build`, and Storybook clone-to-run with no manual token build. Mirrors the existing `copySqlJsWasm()` `buildStart` pattern already in this file; registered first (`enforce: 'pre'`) so the `@import`s resolve before any CSS is transformed.
- **`.vscode/tasks.json`** — replace the catch-all `problemMatcher` regexp on both `Dev: Full Stack` tasks with a sentinel that never matches, so the dev server's status output no longer pollutes the Problems panel. The `background` begin/end patterns are unchanged, so F5 ready-detection still works. Added a comment explaining why.

## Why a Vite plugin (not just docs / a script)

The fix has to live in the path everything already uses. A plugin covers dev server, prod build, and Storybook uniformly, self-heals on `clean`, and regenerates when a token source changes — no new step for contributors to remember and no generated output committed to the repo.

## Testing

- [x] `npm run build:tokens` generates all four web CSS files (exit 0).
- [x] Fresh worktree with **no** `packages/design-tokens/build/` → ran the exact generator the plugin invokes → all four files produced (exit 0), reproducing the fresh-clone scenario.
- [x] End-to-end (in prior verification): renamed `tokens.css` away → started `vite` → plugin auto-regenerated tokens, server became ready, `/src/theme/tokens.css` served HTTP 200 with the expected `--semantic-*` variables.
- [x] `npx prettier --write` (both files) and `npx eslint apps/web/vite.config.ts --max-warnings 0` → clean (exit 0).
- [x] Generated `build/` stays gitignored — only the 2 source files are in the diff.

## Notes

- No generated token outputs are committed (gitignored; `tokens.instructions.md` forbids hand-editing generated files).
- Remote CI is the source of truth for type-check (known local TS tooling issue).

Closes #3072
