### PR TITLE
fix(deploy): self-heal unhealthy containers + raise edge-functions memory (#3074)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -246,6 +246,12 @@ services:
   edge-functions:
     image: supabase/edge-runtime:v1.67.4
     restart: unless-stopped
+    # Opt in to autoheal: if the healthcheck below reports `unhealthy`, the
+    # autoheal sidecar restarts this container automatically (#3074). Without
+    # this, a wedged-but-alive edge-runtime 502s every /api/auth/* request
+    # indefinitely because `restart: unless-stopped` only fires on process exit.
+    labels:
+      autoheal: 'true'
     environment:
       SUPABASE_URL: http://rest:3000
       SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
@@ -279,7 +285,10 @@ services:
       resources:
         limits:
           cpus: '0.5'
-          memory: 256M
+          # Raised 256M -> 512M (#3074): the Deno edge-runtime hosting all auth,
+          # account, and feedback functions was OOM-prone at 256M, producing a
+          # crash-loop of 502s that read as a silent signup failure (#3066).
+          memory: 512M
         reservations:
           cpus: '0.1'
           memory: 64M
@@ -314,6 +323,9 @@ services:
   powersync:
     image: journeyapps/powersync-service:latest
     restart: unless-stopped
+    # Same incident took PowerSync down too; opt it into autoheal as well (#3074).
+    labels:
+      autoheal: 'true'
     command: ['start', '-r', 'unified']
     environment:
       POWERSYNC_CONFIG_PATH: /config/powersync.yaml
@@ -489,6 +501,45 @@ services:
     networks:
       - finance-internal
       - finance-external
+
+  # ---------------------------------------------------------------------------
+  # autoheal — restarts containers that report `unhealthy` (#3074)
+  # ---------------------------------------------------------------------------
+  # Plain Docker/Compose never acts on a failing healthcheck: it only marks the
+  # container `unhealthy` and leaves it running. `restart: unless-stopped` only
+  # fires when a process *exits*, so a wedged-but-alive edge-functions container
+  # 502s every /api/auth/* request until a human intervenes (the #3066 outage).
+  #
+  # autoheal watches the Docker event stream and restarts any container labeled
+  # `autoheal=true` that goes `unhealthy`. Only opted-in containers are touched.
+  #
+  # Security: it needs the Docker socket (host-root equivalent). It is pinned,
+  # runs with no-new-privileges, exposes no ports, and sits on the internal-only
+  # network. Hardening follow-up: front the socket with tecnativa/docker-socket-proxy.
+  autoheal:
+    image: willfarrell/autoheal:1.2.0
+    restart: unless-stopped
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: autoheal
+      AUTOHEAL_INTERVAL: '10'
+      AUTOHEAL_START_PERIOD: '30'
+      AUTOHEAL_DEFAULT_STOP_TIMEOUT: '30'
+      DOCKER_SOCK: /var/run/docker.sock
+      TZ: ${TZ:-UTC}
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    deploy:
+      resources:
+        limits:
+          cpus: '0.10'
+          memory: 32M
+        reservations:
+          cpus: '0.01'
+          memory: 8M
+    networks:
+      - finance-internal
 
 # =============================================================================
 # Volumes — persistent data


### PR DESCRIPTION
## Summary

Production `edge-functions` could stay down indefinitely after a crash, returning **502** on every `/api/auth/*`, `/api/account/*`, `/api/feedback`, and `/health` route — the root cause of the silent signup/login outage (#3066). The existing safeguards did not cover it:

- `restart: unless-stopped` only restarts on **process exit**; a wedged-but-alive container is never restarted.
- The healthcheck exists, but **plain Docker/Compose never acts on it** — it just marks the container `unhealthy`.
- The **256M** memory cap made the Deno edge-runtime OOM-prone → crash-loop of 502s.

This adds true self-healing and removes the likely OOM root cause.

## Changes (`deploy/docker-compose.yml`)

- **Add a pinned `willfarrell/autoheal:1.2.0` sidecar** that watches the Docker event stream and restarts any container reporting `unhealthy` that is labeled `autoheal=true`.
- **Label `edge-functions` and `powersync`** (both have healthchecks and both went down in the incident) with `autoheal=true`.
- **Raise `edge-functions` memory limit 256M → 512M.**

## ⚠️ Security review requested before merge

`autoheal` mounts the Docker socket (`/var/run/docker.sock`), which is **host-root-equivalent**. Mitigations applied:

- Image **pinned** to a version tag (recommend pinning to a digest during review).
- `security_opt: [no-new-privileges:true]`, **no exposed ports**, attached to the **internal-only** network (`finance-internal` is `internal: true`).
- Only restarts containers that **explicitly opt in** via `autoheal=true`.

**Hardening follow-up:** front the socket with `tecnativa/docker-socket-proxy` (read-only except container restart). Happy to do that as a fast-follow PR. Because this touches the socket on a financial app, I have **not** self-merged — please review.

## New dependency

- `willfarrell/autoheal` — widely used, single-purpose container that restarts unhealthy Docker containers. ~5MB Alpine image. Reason: Docker/Compose has no native "restart on unhealthy" behavior.

## Testing / validation

- [x] YAML parses; compose `services` resolves with `autoheal` present, both labels set, `edge-functions` memory = 512M.
- [x] `prettier --check` clean.
- [ ] **Cannot validate `docker compose config` / runtime in CI** (no Docker daemon, prod images). Verify on the host with `docker compose -f deploy/docker-compose.yml config` after merge.

## Issues

Closes #3074
Refs #3066

## Rollout note

Once merged, this only takes effect when the stack is re-deployed (`deploy-production` workflow, or `docker compose up -d` on the host). It does **not** retroactively restart the currently-down container — that still needs a one-time `docker compose up -d edge-functions` (or a `deploy-production` run).