### PR TITLE
fix(ci): probe /health so prod uptime monitor detects auth/API outages (#3075)

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -185,6 +185,31 @@ jobs:
             [ "$attempt" -lt "$attempts" ] && sleep "$delay_seconds"
           done
 
+          # API health probe: Caddy rewrites /health -> edge-functions /health-check.
+          # The static root returns 200 even when the edge-runtime is down, so a
+          # root-only check is blind to auth/API outages (#3075, the root cause of
+          # the silent signup failure in #3066). A 5xx or connection failure here
+          # means edge-functions is unreachable; a 4xx means it responded (a
+          # different problem) and is deliberately not treated as a health failure.
+          health_url="${url}/health"
+          health_curl_status=0
+          health_status_code=000
+          for attempt in $(seq 1 "$attempts"); do
+            health_output=$(curl --silent --show-error --location --max-time 10 --output /dev/null --write-out '%{http_code}' "$health_url" 2>&1)
+            health_curl_status=$?
+            health_status_code="${health_output: -3}"
+            if [ "$health_curl_status" -eq 0 ] && [ "$health_status_code" -ge 200 ] && [ "$health_status_code" -lt 300 ]; then
+              break
+            fi
+            [ "$attempt" -lt "$attempts" ] && sleep "$delay_seconds"
+          done
+
+          if [ "$health_curl_status" -ne 0 ] || [ "$health_status_code" -ge 500 ]; then
+            health_ok=false
+          else
+            health_ok=true
+          fi
+
           {
             echo "url=$url"
             echo "host=$host"
@@ -192,9 +217,13 @@ jobs:
             echo "resolved_ip=$resolved_ip"
             echo "status_code=$status_code"
             echo "curl_status=$curl_status"
+            echo "health_url=$health_url"
+            echo "health_status_code=$health_status_code"
+            echo "health_curl_status=$health_curl_status"
+            echo "health_ok=$health_ok"
           } >> "$GITHUB_OUTPUT"
 
-          if [ "$dns_ok" != "true" ] || [ "$curl_status" -ne 0 ] || [ "$status_code" -lt 200 ] || [ "$status_code" -ge 400 ]; then
+          if [ "$dns_ok" != "true" ] || [ "$curl_status" -ne 0 ] || [ "$status_code" -lt 200 ] || [ "$status_code" -ge 400 ] || [ "$health_ok" != "true" ]; then
             echo "failed=true" >> "$GITHUB_OUTPUT"
           else
             echo "failed=false" >> "$GITHUB_OUTPUT"
@@ -209,6 +238,10 @@ jobs:
           RESOLVED_IP: ${{ steps.check.outputs.resolved_ip }}
           STATUS_CODE: ${{ steps.check.outputs.status_code }}
           CURL_STATUS: ${{ steps.check.outputs.curl_status }}
+          API_HEALTH_URL: ${{ steps.check.outputs.health_url }}
+          API_STATUS_CODE: ${{ steps.check.outputs.health_status_code }}
+          API_CURL_STATUS: ${{ steps.check.outputs.health_curl_status }}
+          API_HEALTH_OK: ${{ steps.check.outputs.health_ok }}
         run: |
           set -euo pipefail
           gh label create uptime --repo "$GITHUB_REPOSITORY" --color D73A4A --description "Uptime monitor alerts" --force >/dev/null
@@ -218,13 +251,19 @@ jobs:
           else
             dns_line="- DNS resolution: ok (${HEALTH_HOST} -> ${RESOLVED_IP})"
           fi
+          if [ "$API_HEALTH_OK" != "true" ]; then
+            api_line="- API health (${API_HEALTH_URL}): FAILED — HTTP ${API_STATUS_CODE}, curl exit ${API_CURL_STATUS}. edge-functions is unreachable, so auth/account/feedback routes are down (the #3066 failure mode)."
+          else
+            api_line="- API health (${API_HEALTH_URL}): ok (HTTP ${API_STATUS_CODE})"
+          fi
           body=$(printf '%s\n' \
             "Automated production uptime check failed." \
             "" \
             "- URL: ${HEALTH_URL}" \
             "${dns_line}" \
-            "- HTTP status: ${STATUS_CODE}" \
+            "- Static HTTP status: ${STATUS_CODE}" \
             "- curl exit: ${CURL_STATUS}" \
+            "${api_line}" \
             "- Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             "- Checked at: $(date -u +'%Y-%m-%dT%H:%M:%SZ')")
           existing_issue=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label uptime --label infrastructure --json number --jq '.[0].number // empty')


### PR DESCRIPTION
## Summary

The production uptime monitor (`prod-uptime` in `housekeeping.yml`) only probed the **static site root**. Caddy serves that directly, so it returns **200 even when the `edge-functions` container is down**. That is exactly why the monitor stayed green through the entire silent-signup outage (#3066) while every `/api/auth/*` route was returning **502** — the monitor was blind to the API tier (#3075).

## Changes (`.github/workflows/housekeeping.yml`, `prod-uptime` job)

- **Add an API health probe**: `GET ${url}/health`, which Caddy rewrites to the `edge-functions` `/health-check` function. Same retry pattern (3× / 10s) as the existing root probe.
- **Fail the check** when `/health` returns a **5xx** or the connection fails (`curl` non-zero). A **4xx** is treated as "responded — different problem" and deliberately does *not* trip the outage alarm.
- **Surface the API status** in the auto-filed uptime issue body (new `- API health (...)` line), and relabel the existing root line as `Static HTTP status` to distinguish the two tiers.
- DNS resolution and static-root checks are unchanged.

## Why this matters

This closes the monitoring gap that let #3066 go undetected. With this in place, an `edge-functions` outage opens/updates the `uptime` + `infrastructure` issue automatically instead of failing silently.

Pairs with #3074 (which makes the container self-heal): #3074 prevents most of these outages, this PR makes sure we hear about the ones that still happen.

## Testing / validation

- [x] YAML parses; `prod-uptime` job structure intact (2 steps), `/health` probe present, `health_ok` wired into the failure condition and issue body.
- [x] `prettier --check` clean.
- [x] Beta `uptime` job untouched (verified by line-range inspection).
- [ ] End-to-end probe behavior runs only on schedule/dispatch against the live host — cannot exercise in CI.

## Issues

Closes #3075
Refs #3066