### PR TITLE
fix(edge-functions): dispatch to user workers + add SUPABASE_ANON_KEY (#3081)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -265,6 +265,10 @@ services:
       # through to a silent 202 no-op (#3066, #3079).
       SUPABASE_URL: https://${DOMAIN}
       SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
+      # auth-* functions (signup/login/refresh/logout/password-reset) send this
+      # as the GoTrue `apikey` header and require it via validateEnv; without it
+      # signup fails env validation even once the main service dispatches (#3081).
+      SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_DB_URL: postgres://supabase_admin:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
       JWT_SECRET: ${JWT_SECRET}
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}

--- a/services/api/supabase/functions/main/index.ts
+++ b/services/api/supabase/functions/main/index.ts
@@ -1,29 +1,102 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Edge Functions — Main Service Entry Point
+ * Edge Functions - Main Service Entry Point (`--main-service`).
  *
- * Required by supabase/edge-runtime as the `--main-service` handler.
- * Provides a minimal health-check responder and routes requests.
+ * supabase/edge-runtime boots this module as the main worker, and it is the
+ * router for EVERY request: it derives the target function from the request
+ * path, spawns (or reuses) a per-function user worker via
+ * `EdgeRuntime.userWorkers.create`, and forwards the request to it. Without
+ * this dispatch the runtime answers 404 for every function path, which is why
+ * signup/login/account endpoints were unreachable (#3081).
  *
- * Uses native Deno.serve() — no URL imports needed at boot time.
+ * Path handling (see deploy/Caddyfile):
+ *   /                       -> runtime liveness  ({ status: 'ok' })
+ *   /health-check           -> runtime liveness  ({ status: 'ok' })  (Caddy /health)
+ *   /_internal/health       -> runtime liveness  ({ message: 'ok' })
+ *   /functions/v1/<fn>/...  -> user worker <fn>   (/api/* facade rewrite, prefix kept)
+ *   /<fn>/...               -> user worker <fn>   (/functions/v1/* route, prefix stripped)
  *
- * Issues: #1246
+ * Functions are mounted read-only at /home/deno/functions/<fn>
+ * (deploy/docker-compose.yml). Each function calls `Deno.serve(handler)` when
+ * run as a worker entry point (`if (import.meta.main)`), so the worker serves
+ * it directly. The main worker's env is forwarded to every function so they
+ * can read SUPABASE_URL / SUPABASE_ANON_KEY / JWT_SECRET etc.
+ *
+ * Issues: #1246 (stub introduced), #3081 (dispatch restored)
  */
 
-Deno.serve((_req: Request): Response => {
-  const url = new URL(_req.url);
+/** Minimal shape of the edge-runtime user-worker API used here (v1.67.4). */
+declare const EdgeRuntime: {
+  userWorkers: {
+    create(options: {
+      servicePath: string;
+      memoryLimitMb?: number;
+      workerTimeoutMs?: number;
+      noModuleCache?: boolean;
+      importMapPath?: string | null;
+      envVars?: string[][];
+    }): Promise<{ fetch(request: Request): Promise<Response> }>;
+  };
+};
 
-  // Health check for the edge-runtime itself
-  if (url.pathname === '/health-check' || url.pathname === '/') {
-    return new Response(JSON.stringify({ status: 'ok' }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    });
+const FUNCTIONS_ROOT = '/home/deno/functions';
+const FUNCTIONS_PREFIX = '/functions/v1';
+const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
+
+function json(body: Record<string, unknown>, status: number): Response {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+/**
+ * Resolve the function name from a request path, tolerating both the
+ * `/functions/v1/<fn>` facade form and the prefix-stripped `/<fn>` form.
+ * Returns null when no function segment is present (e.g. `/`).
+ */
+function resolveFunctionName(pathname: string): string | null {
+  const path = pathname.startsWith(`${FUNCTIONS_PREFIX}/`)
+    ? pathname.slice(FUNCTIONS_PREFIX.length)
+    : pathname;
+  const segment = path.split('/')[1];
+  return segment && segment.length > 0 ? segment : null;
+}
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  const { pathname } = new URL(req.url);
+
+  // Liveness probes are kept dependency-free so /health never blocks on a
+  // function cold start.
+  if (pathname === '/' || pathname === '/health-check') {
+    return json({ status: 'ok' }, 200);
+  }
+  if (pathname === '/_internal/health') {
+    return json({ message: 'ok' }, 200);
   }
 
-  return new Response(JSON.stringify({ error: 'Not found' }), {
-    status: 404,
-    headers: { 'Content-Type': 'application/json' },
-  });
+  const serviceName = resolveFunctionName(pathname);
+  if (!serviceName) {
+    return json({ error: 'Not found' }, 404);
+  }
+
+  try {
+    const worker = await EdgeRuntime.userWorkers.create({
+      servicePath: `${FUNCTIONS_ROOT}/${serviceName}`,
+      memoryLimitMb: 256,
+      workerTimeoutMs: 5 * 60 * 1000,
+      noModuleCache: false,
+      importMapPath: null,
+      envVars: Object.entries(Deno.env.toObject()),
+    });
+    return await worker.fetch(req);
+  } catch (err) {
+    console.error(`main: dispatch failed for "${serviceName}":`, err);
+    const message = err instanceof Error ? err.message : String(err);
+    // A missing function directory surfaces as a filesystem error; treat that
+    // as 404, and any other worker failure as a 502 from the function layer.
+    const missing = /not found|no such file|os error 2/i.test(message);
+    return json(
+      { error: missing ? 'Not found' : 'Function invocation failed' },
+      missing ? 404 : 502,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

Final fix for the silent signup outage. After #3079 restored edge-functions startup and `SUPABASE_URL` routing, `/health` returned 200 but `/api/auth/signup` still returned `404 {"error":"Not found"}`. Root cause: the edge-runtime `--main-service` handler (`services/api/supabase/functions/main/index.ts`) was a stub that only answered `/` and `/health-check` and 404'd everything else. It never spawned user workers, so **no edge function was ever reachable** in any environment.

## Changes

- **`services/api/supabase/functions/main/index.ts`** ? rewrite the stub into a real dispatcher (the canonical supabase/edge-runtime `main` pattern for v1.67.4): derive the function name from the request path and forward to a per-function user worker via `EdgeRuntime.userWorkers.create({ servicePath, envVars, ... })`. Normalizes both the `/functions/v1/<fn>` fa?ade form (the `/api/*` Caddy rewrite keeps the prefix) and the prefix-stripped `/<fn>` form (the `/functions/v1/*` route strips it). Keeps `/`, `/health-check`, and `/_internal/health` as dependency-free liveness so `/health` stays cheap. Forwards container env to each worker.
- **`deploy/docker-compose.yml`** ? add `SUPABASE_ANON_KEY: \` to the edge-functions `environment`. `auth-signup`/`auth-login`/`auth-refresh`/`auth-logout`/password-reset require it via `validateEnv` and use it as the GoTrue `apikey` header; without it signup fails env validation even once dispatch works.

## Why this is safe

- Every production function uses relative + fully-qualified remote imports (no bare specifiers), so `importMapPath: null` is correct for all of them ? no import map needed.
- Each function already calls `Deno.serve(handler)` under `if (import.meta.main)`, so it serves itself when run as a worker entry point. No function code changes required.
- Liveness paths are preserved, so the `/health` = 200 restored by #3079 is unaffected.

## Issues

Closes #3081

## Testing

- [x] `prettier --check` clean (both files)
- [x] `eslint --max-warnings 0` clean (`main/index.ts`)
- [x] `docker-compose.yml` parses; `SUPABASE_ANON_KEY=\`, `depends_on.rest=service_started` confirmed
- [ ] Post-deploy live check: `POST /api/auth/signup` returns 201/202 (not 404); `/health` stays 200

## Note

This PR spans `services/api/` (backend) and `deploy/` (devops) because both changes are required together for signup to work end-to-end.
