### PR TITLE
fix(web): move onboarding education to after signup (#3089)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -98,7 +98,19 @@ const STANDALONE_ROUTES: readonly string[] = [
   '/onboarding',
 ];
 
+/*
+ * Routes a visitor with incomplete onboarding is allowed to sit on WITHOUT being
+ * auto-redirected into `/onboarding`.
+ *
+ * `/login` and `/signup` are exempt so the account path can defer onboarding until
+ * AFTER signup (#3089): the onboarding "Create Account" choice navigates to `/signup`
+ * without marking onboarding complete, so the visitor must be able to reach (and stay
+ * on) the auth pages. Once authenticated, leaving an auth page for any other route
+ * re-triggers the auto-launch, which resumes onboarding at the post-signup step.
+ */
 const FIRST_RUN_ALLOWED_ROUTES: readonly string[] = [
+  '/login',
+  '/signup',
   '/forgot-password',
   '/reset-password',
   '/onboarding',

--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -14,6 +14,7 @@ import type { NavigateOptions, To } from 'react-router-dom';
 
 import { App, shouldAutoLaunchOnboarding } from '../App';
 import OnboardingPage from './OnboardingPage';
+import { useAuth } from '../auth/auth-context';
 import { useBudgets } from '../hooks/useBudgets';
 import { useConsent } from '../hooks/useConsent';
 import { useConsentHistory } from '../hooks/useConsentHistory';
@@ -81,10 +82,33 @@ vi.mock('../hooks/useBudgets', () => ({
   useBudgets: vi.fn(),
 }));
 
+// Partial mock: keep the real AuthProvider/ProtectedRoute exports (used by App/routes)
+// and only stub useAuth so OnboardingPage can be rendered without an AuthProvider and
+// the post-signup (authenticated) start step can be exercised (#3089).
+vi.mock('../auth/auth-context', async () => {
+  const actual =
+    await vi.importActual<typeof import('../auth/auth-context')>('../auth/auth-context');
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+  };
+});
+
 const mockedUseLocalOnlyMode = vi.mocked(useLocalOnlyMode);
 const mockedUseConsent = vi.mocked(useConsent);
 const mockedUseConsentHistory = vi.mocked(useConsentHistory);
 const mockedUseBudgets = vi.mocked(useBudgets);
+const mockedUseAuth = vi.mocked(useAuth);
+
+const unauthenticatedAuthReturn = {
+  isAuthenticated: false,
+  isLoading: false,
+} as unknown as ReturnType<typeof useAuth>;
+
+const authenticatedAuthReturn = {
+  isAuthenticated: true,
+  isLoading: false,
+} as unknown as ReturnType<typeof useAuth>;
 
 const defaultLocalOnlyReturn = {
   isLocalOnly: false,
@@ -172,6 +196,7 @@ beforeEach(() => {
   mockedUseConsent.mockReturnValue(defaultConsentReturn);
   mockedUseConsentHistory.mockReturnValue(defaultConsentHistoryReturn);
   mockedUseBudgets.mockReturnValue(defaultBudgetsReturn);
+  mockedUseAuth.mockReturnValue(unauthenticatedAuthReturn);
 });
 
 const renderWithRouter = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
@@ -229,6 +254,14 @@ describe('OnboardingPage', () => {
     expect(shouldAutoLaunchOnboarding('/dashboard', true)).toBe(false);
     expect(shouldAutoLaunchOnboarding('/onboarding', false)).toBe(false);
     expect(shouldAutoLaunchOnboarding('/dashboard', false)).toBe(true);
+  });
+
+  it('lets a first-run visitor reach the auth pages so signup precedes onboarding', () => {
+    // /login and /signup are exempt so the account path can defer onboarding until
+    // after signup; only after authenticating and leaving these pages does the app
+    // resume onboarding (#3089).
+    expect(shouldAutoLaunchOnboarding('/signup', false)).toBe(false);
+    expect(shouldAutoLaunchOnboarding('/login', false)).toBe(false);
   });
 
   it('stores Huge text preferences from the comfort step', () => {
@@ -297,13 +330,36 @@ describe('OnboardingPage', () => {
     expect(screen.getByRole('heading', { name: /create account/i })).toBeInTheDocument();
   });
 
-  it('navigates to signup when Create Account is clicked', () => {
+  it('navigates to signup without completing onboarding when Create Account is clicked', () => {
+    const completeOnboarding = vi.fn();
+    mockedUseLocalOnlyMode.mockReturnValue({
+      ...defaultLocalOnlyReturn,
+      completeOnboarding,
+    });
+
     renderWithRouter(<OnboardingPage />);
     skipComfortStep();
 
     fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 
     expect(mockNavigate).toHaveBeenCalledWith('/signup');
+    // Onboarding stays incomplete so the education/template content runs AFTER
+    // signup, when the app re-launches onboarding for the authenticated user (#3089).
+    expect(completeOnboarding).not.toHaveBeenCalled();
+  });
+
+  it('starts at the education/template step for an authenticated (post-signup) visitor', () => {
+    mockedUseAuth.mockReturnValue(authenticatedAuthReturn);
+
+    renderWithRouter(<OnboardingPage />);
+
+    // Skips the pre-signup welcome (comfort/choose) and lands on the deferred
+    // education/template step.
+    expect(
+      screen.getByRole('heading', { name: /want a starter budget\? choose a template:/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /use student template/i })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /welcome to finance/i })).not.toBeInTheDocument();
   });
 
   it('shows privacy preferences step when Local Only is clicked', () => {

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -1,18 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * OnboardingPage — local-only onboarding path.
+ * OnboardingPage — first-run onboarding for the web app.
  *
- * Offers accessible comfort settings first, then two clear paths:
- *   1. Local Only — no account, no sync, all data stays on device
- *   2. Create Account — sign up for cloud sync and sharing
+ * Before signup it offers a genuine welcome/get-started experience:
+ *   1. Comfort settings (accessibility — no account details)
+ *   2. A path choice: Local Only vs Create Account
  *
- * References: issue #1621, #2148
+ * The financial-education and starter-budget-template content is deferred until
+ * AFTER signup for the account path (#3089): "Create Account" navigates to
+ * `/signup` without completing onboarding, and once the user is authenticated the
+ * app re-launches onboarding starting at the template/education step. Local-only
+ * users (who decline signup) see that content right after the privacy step.
+ *
+ * References: issue #1621, #2148, #3089
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { useAuth } from '../auth/auth-context';
 import { AppIcon } from '../components/icons';
 import { useBudgets } from '../hooks/useBudgets';
 import { useConsent } from '../hooks/useConsent';
@@ -475,6 +482,7 @@ const FeatureRow: React.FC<{ feature: FeatureAvailability }> = ({ feature }) => 
 
 const OnboardingPage: React.FC = () => {
   const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
   const { features, enableLocalOnly, completeOnboarding } = useLocalOnlyMode();
   const { acceptAll, rejectAll, consent } = useConsent();
   const { recordBulkChanges } = useConsentHistory();
@@ -484,7 +492,12 @@ const OnboardingPage: React.FC = () => {
   const studentTemplate = starterTemplates.find((template) => template.id === 'student') ?? null;
   const futureTemplates = starterTemplates.filter((template) => template.isAvailable === false);
 
-  const [step, setStep] = useState<OnboardingStep>('comfort');
+  const [step, setStep] = useState<OnboardingStep>(() =>
+    // Authenticated visitors have already completed signup (and saw the pre-signup
+    // welcome/comfort/choose screens), so resume onboarding at the deferred
+    // education/template step rather than repeating the welcome flow (#3089).
+    isAuthenticated ? 'template' : 'comfort',
+  );
   const [fontScaleValue, setFontScaleValue] = useState(DEFAULT_FONT_SCALE_INDEX);
   const [reducedMotion, setReducedMotion] = useState(false);
   const [simplifiedMode, setSimplifiedMode] = useState(false);
@@ -731,9 +744,12 @@ const OnboardingPage: React.FC = () => {
   }, []);
 
   const handleCreateAccount = useCallback(() => {
-    completeOnboarding();
+    // Defer onboarding completion until AFTER signup (#3089). Onboarding stays
+    // incomplete so that, once the user is authenticated, the app re-launches
+    // onboarding at the education/template step. `/signup` is exempt from the
+    // first-run auto-redirect (see FIRST_RUN_ALLOWED_ROUTES in App.tsx).
     navigate('/signup');
-  }, [completeOnboarding, navigate]);
+  }, [navigate]);
 
   const handlePrivacyAcceptEssential = useCallback(() => {
     rejectAll();
@@ -1657,12 +1673,22 @@ const OnboardingPage: React.FC = () => {
           <p className="onboarding__subtitle">
             {starterBudgetCreated
               ? 'Your finance tracker is ready, and your student starter budget is already in place.'
-              : 'Your finance tracker is ready. All data is stored locally on this device.'}
+              : isAuthenticated
+                ? 'Your finance tracker is ready and synced to your account.'
+                : 'Your finance tracker is ready. All data is stored locally on this device.'}
           </p>
           <div className="onboarding__complete-details">
-            <p className="onboarding__complete-item">
-              <AppIcon name="lock" /> <strong>Local-only mode</strong> — no data leaves your browser
-            </p>
+            {isAuthenticated ? (
+              <p className="onboarding__complete-item">
+                <AppIcon name="cloud" /> <strong>Synced to your account</strong> — your data is
+                backed up and available on every device
+              </p>
+            ) : (
+              <p className="onboarding__complete-item">
+                <AppIcon name="lock" /> <strong>Local-only mode</strong> — no data leaves your
+                browser
+              </p>
+            )}
             {starterBudgetCreated && (
               <p className="onboarding__complete-item">
                 <AppIcon name="wallet" /> <strong>Starter budget added</strong> — realistic student
@@ -1673,10 +1699,17 @@ const OnboardingPage: React.FC = () => {
               <AppIcon name="database" /> <strong>SQLite storage</strong> — fast, reliable,
               offline-first
             </p>
-            <p className="onboarding__complete-item">
-              <AppIcon name="refresh" /> <strong>Upgrade anytime</strong> — create an account later
-              to enable sync
-            </p>
+            {isAuthenticated ? (
+              <p className="onboarding__complete-item">
+                <AppIcon name="check" /> <strong>Account active</strong> — sign in anywhere to pick
+                up where you left off
+              </p>
+            ) : (
+              <p className="onboarding__complete-item">
+                <AppIcon name="refresh" /> <strong>Upgrade anytime</strong> — create an account
+                later to enable sync
+              </p>
+            )}
           </div>
 
           {setupChecklistHidden ? (


### PR DESCRIPTION
## Summary

The web first-run flow previously walked **unauthenticated** visitors through privacy consent, starter-budget templates, and financial-education content **before** they signed up. The account path also called `completeOnboarding()` on "Create Account", so account users skipped that content entirely.

This moves the education/template content to **after signup** for the account path, while keeping a genuine welcome/get-started experience (accessibility comfort settings + path choice) before signup.

## Changes

- **`App.tsx`** — add `/login` and `/signup` to `FIRST_RUN_ALLOWED_ROUTES` so an incomplete-onboarding visitor can reach the auth pages instead of being bounced into `/onboarding`. After authenticating and leaving the auth page, the existing auto-launch resumes onboarding.
- **`OnboardingPage.tsx`** — read `useAuth().isAuthenticated`; authenticated (post-signup) visitors start at the `template`/education step; "Create Account" navigates to `/signup` **without** completing onboarding; the completion-step copy branches for account (synced) vs local-only.
- **`OnboardingPage.test.tsx`** — partial-mock `useAuth`; assert Create Account no longer completes onboarding; assert authenticated visitors start at the education/template step; cover the new `/login` + `/signup` auto-launch exemptions.

## Resulting flow

- **Before signup:** `comfort` (accessibility welcome — no account details) → `choose` (Local Only vs Create Account).
- **Account path:** `choose → Create Account → /signup → (after auth) onboarding resumes at template/education → complete → dashboard`.
- **Local-only path:** unchanged (`comfort → choose → privacy → template → complete`).

## Issues

Closes #3089

## Testing

- [x] `npx vitest run src/pages/OnboardingPage.test.tsx src/pages/SignupPage.test.tsx` — 33 passed
- [x] `npm run format:check` — clean
- [x] `npx eslint` on changed files with `--max-warnings 0` — clean
- [ ] Type-check via remote CI (local type-check is a known-unreliable issue)