### PR TITLE
fix(deploy): quote tilde in DEPLOY_PATH normalization so VM rebuild path resolves (#3092)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -395,7 +395,7 @@ jobs:
           ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
             "DEPLOY_PATH='$DEPLOY_PATH' SUPABASE_URL_B64='$SUPABASE_URL_B64' SUPABASE_ANON_KEY_B64='$SUPABASE_ANON_KEY_B64' POWERSYNC_URL_B64='$POWERSYNC_URL_B64' SENTRY_DSN_B64='$SENTRY_DSN_B64' TARGET_SHA='$TARGET_SHA' SHA_SHORT='$SHA_SHORT' bash -s" <<'DEPLOY'
             set -euo pipefail
-            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#~}" ;; esac
+            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#"~"}" ;; esac  # quote ~ for a literal strip (an unquoted ~ tilde-expands to $HOME and corrupts the path)
             export VITE_SUPABASE_URL="$(printf '%s' "$SUPABASE_URL_B64" | base64 -d)"
             export VITE_SUPABASE_ANON_KEY="$(printf '%s' "$SUPABASE_ANON_KEY_B64" | base64 -d)"
             export VITE_POWERSYNC_URL="$(printf '%s' "$POWERSYNC_URL_B64" | base64 -d)"
@@ -672,7 +672,7 @@ jobs:
           ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
             "DEPLOY_PATH='$DEPLOY_PATH' ROLLBACK_SHA='$ROLLBACK_SHA' ROLLBACK_TAG='$ROLLBACK_TAG' DEPLOY_WEB='$DEPLOY_WEB' DEPLOY_BACKEND='$DEPLOY_BACKEND' SUPABASE_URL_B64='$SUPABASE_URL_B64' SUPABASE_ANON_KEY_B64='$SUPABASE_ANON_KEY_B64' POWERSYNC_URL_B64='$POWERSYNC_URL_B64' SENTRY_DSN_B64='$SENTRY_DSN_B64' bash -s" <<'DEPLOY'
             set -euo pipefail
-            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#~}" ;; esac
+            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#"~"}" ;; esac  # quote ~ for a literal strip (an unquoted ~ tilde-expands to $HOME and corrupts the path)
             cd "$DEPLOY_PATH"
             echo "→ git fetch --force --prune --tags origin main"
             git fetch --force --prune --tags origin main

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -294,7 +294,7 @@ jobs:
           ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
             "DEPLOY_PATH='$DEPLOY_PATH' SUPABASE_URL_B64='$SUPABASE_URL_B64' SUPABASE_ANON_KEY_B64='$SUPABASE_ANON_KEY_B64' POWERSYNC_URL_B64='$POWERSYNC_URL_B64' BETA_ALLOWED_EMAILS_B64='$BETA_ALLOWED_EMAILS_B64' SENTRY_DSN_B64='$SENTRY_DSN_B64' TARGET_SHA='$TARGET_SHA' SHA_SHORT='$SHA_SHORT' bash -s" <<'DEPLOY'
             set -euo pipefail
-            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#~}" ;; esac
+            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#"~"}" ;; esac  # quote ~ for a literal strip (an unquoted ~ tilde-expands to $HOME and corrupts the path)
             export VITE_SUPABASE_URL="$(printf '%s' "$SUPABASE_URL_B64" | base64 -d)"
             export VITE_SUPABASE_ANON_KEY="$(printf '%s' "$SUPABASE_ANON_KEY_B64" | base64 -d)"
             export VITE_POWERSYNC_URL="$(printf '%s' "$POWERSYNC_URL_B64" | base64 -d)"
@@ -359,7 +359,7 @@ jobs:
           if ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
             "DEPLOY_PATH='$DEPLOY_PATH' SENTRY_DSN_B64='$SENTRY_DSN_B64' bash -s" <<'VERIFY'
             set -euo pipefail
-            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#~}" ;; esac
+            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#"~"}" ;; esac  # quote ~ for a literal strip (an unquoted ~ tilde-expands to $HOME and corrupts the path)
             cd "$DEPLOY_PATH"
             expected_dsn="$(printf '%s' "$SENTRY_DSN_B64" | base64 -d)"
             if grep -R --fixed-strings --quiet "$expected_dsn" apps/web/dist/index.html apps/web/dist/assets 2>/dev/null; then
@@ -430,7 +430,7 @@ jobs:
           ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
             "DEPLOY_PATH='$DEPLOY_PATH' TARGET_SHA='$TARGET_SHA' bash -s" <<'DEPLOY'
             set -u
-            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#~}" ;; esac
+            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#"~"}" ;; esac  # quote ~ for a literal strip (an unquoted ~ tilde-expands to $HOME and corrupts the path)
             cd "$DEPLOY_PATH" || exit 1
             echo "→ git fetch --force --prune origin main"
             git fetch --force --prune origin main || exit 1


### PR DESCRIPTION
## Summary

Fixes the broken Azure **staging** VM web deploy that left `finance.jrmoulckers.com` serving a stale bundle (the login tagline shipped in #3088 never reached the VM, even though it is live on GitHub Pages and on `main`).

Root cause is a bash **tilde-expansion bug** in the `DEPLOY_PATH` normalization line used by the SSH deploy scripts.

## Root cause

The deploy scripts normalize a leading `~` in `DEPLOY_PATH` to `$HOME`:

```bash
case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#~}" ;; esac
```

In bash, the `word` in `${param#word}` is itself **tilde-, parameter-, command- and arithmetic-expanded**. So the unquoted `~` in `${DEPLOY_PATH#~}` expands to `$HOME` (e.g. `/home/azureuser`). Since `DEPLOY_PATH` is `~/finance` (it does **not** start with `/home/azureuser`), nothing is stripped, and the result becomes:

```
${HOME}~/finance  ->  /home/azureuser~/finance
```

The next line `cd "$DEPLOY_PATH"` then fails:

```
bash: line 10: cd: /home/azureuser~/finance: No such file or directory
```

which aborts the **"Rebuild apps/web/dist on staging VM"** step — so the VM keeps serving the previously-built bundle. (`DEPLOY_PATH` is unset as a repo/env variable, so it defaults to `~/finance`, which is exactly the input that triggers the bug.)

## Fix

Quote the tilde so it is stripped **literally** instead of being tilde-expanded:

```bash
DEPLOY_PATH="${HOME}${DEPLOY_PATH#"~"}"
```

Applied to all **5** occurrences and annotated each with a short comment to prevent a "simplify the redundant quotes" regression.

## Changes

- `.github/workflows/deploy-staging.yml` — 3 occurrences (deploy, verify, rollback heredocs)
- `.github/workflows/deploy-production.yml` — 2 occurrences (deploy, rollback heredocs)

The edits live inside single-quoted heredocs (`<<'DEPLOY'` / `<<'VERIFY'`), so the literal `"~"` is passed verbatim over SSH and evaluated by the remote bash. No YAML structure changes.

## Verification

Empirically confirmed in bash (`HOME=/home/azureuser`):

| input         | before (buggy)              | after (fixed)            |
| ------------- | --------------------------- | ------------------------ |
| `~`           | `/home/azureuser`           | `/home/azureuser`        |
| `~/finance`   | `/home/azureuser~/finance`  | `/home/azureuser/finance`|
| `/abs/path`   | `/abs/path`                 | `/abs/path`              |

- `npx prettier --check` passes on both files.
- Workflow-only change; no app code touched.

## Issues

Closes #3092

## Needs Human Action (post-merge)

This change only touches workflow files, so the staging `web_changed` guard will **not** flip — the auto-deploy would skip the web rebuild. To push the fix live, after merge dispatch the staging deploy manually:

```bash
gh workflow run deploy-staging.yml --ref main
```

(Dispatching/triggering a deployment is a human-gated operation per `AGENTS.md` Category 3.) Once green, hard-refresh `finance.jrmoulckers.com` to bypass the PWA service worker.

> Note: this assumes the VM checkout actually lives at `$HOME/finance`. If it lives elsewhere, set a `DEPLOY_PATH` repo/environment **variable** to the absolute path instead — the normalization only matters for the `~` default.
