### PR TITLE
fix: repair local signup — heal stale edge runtime + stop SW caching HTML under asset URLs (#3091)

### DIFF
--- a/apps/web/src/sw/__tests__/service-worker-wasm-cache-poisoning.test.ts
+++ b/apps/web/src/sw/__tests__/service-worker-wasm-cache-poisoning.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Regression test for the SQLite-WASM cache-poisoning trap (#3091).
+ *
+ * A dev server / misconfigured host can answer an unknown
+ * `/assets/sql-wasm/*.wasm` request with `200` + the SPA shell
+ * (`index.html`) via history-API fallback. The previous `cacheFirst`
+ * cached any `response.ok`, so it would persist that HTML under the asset
+ * URL and serve it `cache-first` forever — `WebAssembly.instantiate()`
+ * then receives `<!do…` instead of the `\0asm` magic word, the data layer
+ * crashes, and a freshly signed-up user is bounced back to an empty form.
+ *
+ * `cacheFirst` must therefore (a) never write an HTML response under a
+ * static-asset URL, and (b) evict + bypass any such entry already in the
+ * cache so the cache self-heals without a CACHE_VERSION bump.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cacheFirst } from '../service-worker';
+
+interface MockCache {
+  put: ReturnType<typeof vi.fn>;
+  match: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+}
+
+const WASM_URL = 'http://localhost/assets/sql-wasm/sql-wasm-browser.wasm';
+
+let mockCache: MockCache;
+let openMock: ReturnType<typeof vi.fn>;
+let originalFetch: typeof globalThis.fetch;
+let originalCaches: CacheStorage | undefined;
+
+function htmlShellResponse(): Response {
+  return new Response('<!doctype html><html><head></head><body></body></html>', {
+    status: 200,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  });
+}
+
+function wasmResponse(): Response {
+  // `\0asm` magic word + version.
+  return new Response(new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]), {
+    status: 200,
+    headers: { 'Content-Type': 'application/wasm' },
+  });
+}
+
+beforeEach(() => {
+  mockCache = { put: vi.fn(), match: vi.fn().mockResolvedValue(undefined), delete: vi.fn() };
+  openMock = vi.fn().mockResolvedValue(mockCache);
+
+  originalFetch = globalThis.fetch;
+  originalCaches = (globalThis as { caches?: CacheStorage }).caches;
+  (globalThis as { caches: unknown }).caches = { open: openMock };
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalCaches !== undefined) {
+    (globalThis as { caches: CacheStorage }).caches = originalCaches;
+  } else {
+    delete (globalThis as { caches?: CacheStorage }).caches;
+  }
+  vi.restoreAllMocks();
+});
+
+describe('cacheFirst (SQLite-WASM cache-poisoning guard, #3091)', () => {
+  it('never caches an HTML SPA-fallback response served under a .wasm URL', async () => {
+    const html = htmlShellResponse();
+    globalThis.fetch = vi.fn().mockResolvedValue(html);
+
+    const result = await cacheFirst(new Request(WASM_URL));
+
+    // The real (broken) response still surfaces to the caller…
+    expect(result).toBe(html);
+    // …but it is never persisted, so the cache cannot be poisoned.
+    expect(mockCache.put).not.toHaveBeenCalled();
+  });
+
+  it('caches a legitimate application/wasm response under a .wasm URL', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(wasmResponse());
+
+    await cacheFirst(new Request(WASM_URL));
+
+    expect(mockCache.put).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts a previously poisoned entry and re-fetches from the network', async () => {
+    mockCache.match.mockResolvedValueOnce(htmlShellResponse());
+    const fresh = wasmResponse();
+    globalThis.fetch = vi.fn().mockResolvedValue(fresh);
+
+    const result = await cacheFirst(new Request(WASM_URL));
+
+    // Poisoned entry deleted, network hit, fresh wasm returned + re-cached.
+    expect(mockCache.delete).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(result).toBe(fresh);
+    expect(mockCache.put).toHaveBeenCalledTimes(1);
+  });
+
+  it('still serves a valid cached asset without hitting the network', async () => {
+    const cachedWasm = wasmResponse();
+    mockCache.match.mockResolvedValueOnce(cachedWasm);
+    globalThis.fetch = vi.fn();
+
+    const result = await cacheFirst(new Request(WASM_URL));
+
+    expect(result).toBe(cachedWasm);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(mockCache.delete).not.toHaveBeenCalled();
+    expect(mockCache.put).not.toHaveBeenCalled();
+  });
+
+  it('does not apply the HTML guard to non-asset URLs (scoping)', async () => {
+    const html = htmlShellResponse();
+    globalThis.fetch = vi.fn().mockResolvedValue(html);
+
+    await cacheFirst(new Request('http://localhost/offline-shell'));
+
+    // A non-asset path is outside the guard, so normal caching still applies.
+    expect(mockCache.put).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/sw/service-worker.ts
+++ b/apps/web/src/sw/service-worker.ts
@@ -624,15 +624,55 @@ async function navigationHandler(request: Request): Promise<Response> {
 }
 
 /**
+ * Detects an HTML document returned for a **static-asset** request
+ * (`.js`, `.css`, `.wasm`, fonts, images, …).
+ *
+ * A dev server or misconfigured host answers an unknown `/assets/*.wasm`
+ * path with `200` + the SPA shell (`index.html`) via history-API fallback.
+ * Caching that HTML under the asset URL "poisons" the cache: `cacheFirst`
+ * would then serve the app shell for the binary on every later load, so
+ * `WebAssembly.instantiate()` receives `<!do…` instead of the `\0asm` magic
+ * word and the SQLite-WASM data layer crashes — which bounces a freshly
+ * signed-up user back to an empty form (#3091).
+ *
+ * Such a response must never be written to — nor served from — Cache
+ * Storage. The caller still returns it to the page so the real failure
+ * surfaces; we only refuse to persist it.
+ */
+function isHtmlForStaticAsset(request: Request, response: Response): boolean {
+  let pathname: string;
+  try {
+    pathname = new URL(request.url).pathname;
+  } catch {
+    return false;
+  }
+  if (!isStaticAsset(pathname)) {
+    return false;
+  }
+  return /\btext\/html\b/i.test(response.headers.get('Content-Type') ?? '');
+}
+
+/**
  * **Cache-first**: serve from cache if available, otherwise fetch from
  * the network and cache the response for next time.
+ *
+ * Exported so regression tests can assert the cache-poisoning guard
+ * (#3091): an HTML SPA-fallback response served under a static-asset URL
+ * is never persisted, and any such entry already in the cache is evicted
+ * on read so the cache self-heals without a CACHE_VERSION bump.
  */
-async function cacheFirst(request: Request, fallbackUrl?: string): Promise<Response> {
+export async function cacheFirst(request: Request, fallbackUrl?: string): Promise<Response> {
   const cache = await caches.open(STATIC_CACHE);
 
   const cached = await cache.match(request);
   if (cached) {
-    return cached;
+    if (isHtmlForStaticAsset(request, cached)) {
+      // Evict a previously poisoned entry (HTML cached under an asset URL)
+      // and fall through to the network so the cache self-heals (#3091).
+      await cache.delete(request);
+    } else {
+      return cached;
+    }
   }
 
   if (fallbackUrl) {
@@ -644,7 +684,7 @@ async function cacheFirst(request: Request, fallbackUrl?: string): Promise<Respo
 
   try {
     const response = await fetch(request);
-    if (response.ok) {
+    if (response.ok && !isHtmlForStaticAsset(request, response)) {
       await cache.put(request, response.clone());
     }
     return response;

--- a/tools/dev-full.mjs
+++ b/tools/dev-full.mjs
@@ -11,11 +11,26 @@
 //                                                skip with --skip-install,
 //                                                force with --install
 //   1. Preflight (tools/doctor.mjs)            — skip with --skip-doctor
-//   2. supabase start (services/api)           — skipped if already running;
-//                                                retries with backoff on a true
+//   2. supabase start (services/api)           — reused only if it is genuinely
+//                                                healthy AND bound to THIS
+//                                                worktree. The Edge Functions
+//                                                runtime is probed; a "running"
+//                                                stack whose functions are dead
+//                                                (every /functions/v1/* call 503s
+//                                                — a stale/orphaned edge-runtime
+//                                                container Docker keeps "Up" but
+//                                                broken), OR a stack bound to a
+//                                                different worktree (the shared
+//                                                project_id trap), is healed by a
+//                                                forced recreate: stop → docker rm
+//                                                -f the project containers → start
+//                                                (data volumes are preserved).
+//                                                Retries with backoff on a true
 //                                                registry rate-limit, but fails
 //                                                fast (with the right fix) on a
-//                                                corrupt image or migration error
+//                                                corrupt image or migration error.
+//                                                Force a clean restart with
+//                                                --recreate.
 //   3. supabase db reset (optional)            — only with --reset
 //   4. Write apps/web/.env.local               — from `supabase status -o env`,
 //                                                so the web app leaves demo mode
@@ -26,6 +41,7 @@
 // Usage:
 //   node tools/dev-full.mjs                 # bring up stack + web app, open browser
 //   node tools/dev-full.mjs --reset         # also reset the DB (migrations + seed)
+//   node tools/dev-full.mjs --recreate      # force-recreate the stack (heal a broken/stale one)
 //   node tools/dev-full.mjs --e2e           # bring up stack, run the live e2e suite
 //   node tools/dev-full.mjs --no-open       # don't auto-open the browser
 //   node tools/dev-full.mjs --skip-install  # skip the automatic dependency install
@@ -43,12 +59,22 @@ import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { dependencyState, recordInstall, classifySupabaseStartFailure } from './lib/dev-env.mjs';
+import {
+  dependencyState,
+  recordInstall,
+  classifySupabaseStartFailure,
+  interpretEdgeProbe,
+} from './lib/dev-env.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
 const API_DIR = path.join(REPO_ROOT, 'services', 'api');
 const WEB_ENV_LOCAL = path.join(REPO_ROOT, 'apps', 'web', '.env.local');
+
+// Default local API gateway (config.toml [api] port = 54321) and the function we
+// probe to tell a healthy Edge Functions runtime from a dead one.
+const DEFAULT_API_URL = 'http://127.0.0.1:54321';
+const FUNCTIONS_PROBE_PATH = '/functions/v1/auth-signup';
 
 const args = process.argv.slice(2);
 
@@ -63,6 +89,8 @@ Usage:
 
 Options:
   --reset         Reset the database (apply all migrations + seed) before launch.
+  --recreate      Force-recreate the Supabase stack before launch (heals a stack
+                  whose Edge Functions runtime is dead OR bound to another worktree).
   --e2e           Run the live Playwright e2e suite instead of the dev server.
   --no-open       Do not auto-open the browser (dev mode only).
   --skip-doctor   Skip the preflight health check.
@@ -78,6 +106,7 @@ No global Supabase CLI needed (uses npx).`);
 
 const opts = {
   reset: args.includes('--reset'),
+  recreate: args.includes('--recreate'),
   e2e: args.includes('--e2e'),
   noOpen: args.includes('--no-open'),
   skipDoctor: args.includes('--skip-doctor'),
@@ -119,7 +148,7 @@ function resolve(cmd, cmdArgs) {
  * Run a command to completion, inheriting stdio so the user sees live output.
  * @param {string} cmd
  * @param {string[]} cmdArgs
- * @param {{cwd?:string}} [options]
+ * @param {{cwd?:string, timeoutMs?:number}} [options]
  * @returns {number} exit code
  */
 function runInherit(cmd, cmdArgs, options = {}) {
@@ -128,6 +157,7 @@ function runInherit(cmd, cmdArgs, options = {}) {
     cwd: options.cwd || REPO_ROOT,
     stdio: 'inherit',
     shell: r.viaShell,
+    timeout: options.timeoutMs,
     windowsHide: true,
   });
   if (res.error) fail(`Failed to run ${cmd}: ${res.error.message}`);
@@ -251,7 +281,7 @@ function preflight() {
   info('Preflight passed.');
 }
 
-// --- 2. Supabase start (idempotent, with rate-limit backoff) -----------------
+// --- 2. Supabase start (idempotent, with rate-limit backoff + self-heal) ------
 function isSupabaseRunning() {
   // `supabase status` exits 0 and prints "API URL" only when the stack is up.
   const res = runCapture('npx', ['--yes', 'supabase', 'status'], {
@@ -261,20 +291,270 @@ function isSupabaseRunning() {
   return res.ok && /API URL/i.test(res.stdout);
 }
 
+/**
+ * Best-effort API URL of the running stack, read from `supabase status -o env`
+ * (the same source writeEnvLocal uses). Falls back to the local default
+ * (config.toml [api] port 54321) when status can't be read.
+ * @returns {string}
+ */
+function readApiUrl() {
+  const res = runCapture('npx', ['--yes', 'supabase', 'status', '-o', 'env'], {
+    cwd: API_DIR,
+    timeoutMs: 30000,
+  });
+  if (res.ok) {
+    const m = res.stdout.match(/^\s*API_URL\s*=\s*"?(.*?)"?\s*$/m);
+    if (m && m[1]) return m[1];
+  }
+  return DEFAULT_API_URL;
+}
+
+/**
+ * Probe the Edge Functions runtime once. POSTs an intentionally-invalid body to
+ * a known auth function: a healthy runtime validates and returns 400 (no user is
+ * created — validation fails before any GoTrue call), while a dead runtime makes
+ * the gateway answer 503. The pure pass/fail interpretation lives in
+ * interpretEdgeProbe (dev-env.mjs); this only does the IO.
+ * @param {string} fnUrl
+ * @param {number} [timeoutMs]
+ * @returns {Promise<import('./lib/dev-env.mjs').EdgeHealth>}
+ */
+async function probeEdgeOnce(fnUrl, timeoutMs = 8000) {
+  if (typeof globalThis.fetch !== 'function') {
+    // Node without global fetch — skip rather than break dev:full. (engines
+    // requires Node >= 22, where fetch is always present, so this is belt-and-
+    // braces for an unusually old runtime.)
+    return { healthy: true, detail: 'probe skipped (no global fetch)' };
+  }
+  const controller = new globalThis.AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await globalThis.fetch(fnUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+      signal: controller.signal,
+    });
+    return interpretEdgeProbe({ status: res.status });
+  } catch (err) {
+    const code =
+      err && err.name === 'AbortError'
+        ? 'timeout'
+        : err?.cause?.code || err?.code || err?.message || 'request failed';
+    return interpretEdgeProbe({ errorCode: String(code) });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Poll the Edge Functions runtime until it is healthy or the attempts run out.
+ * Healthy responses return on the first attempt; the retry budget only elapses
+ * when the runtime is down or still booting.
+ * @param {string} fnUrl
+ * @param {{attempts:number, delayMs:number}} budget
+ * @returns {Promise<import('./lib/dev-env.mjs').EdgeHealth>}
+ */
+async function waitForEdgeHealth(fnUrl, { attempts, delayMs }) {
+  let last = { healthy: false, detail: 'not probed' };
+  for (let i = 1; i <= attempts; i++) {
+    last = await probeEdgeOnce(fnUrl);
+    if (last.healthy) return last;
+    if (i < attempts) await sleep(delayMs);
+  }
+  return last;
+}
+
+/**
+ * Stop the local Supabase stack so the next `supabase start` recreates its
+ * containers from scratch. Never passes --volumes (that would wipe local data —
+ * a human-gated operation); the database volume is preserved across the restart.
+ * @returns {void}
+ */
+function stopSupabase() {
+  const code = runInherit('npx', ['--yes', 'supabase', 'stop'], { cwd: API_DIR });
+  if (code !== 0) {
+    info('`supabase stop` returned a non-zero exit code — continuing to start anyway.');
+  }
+}
+
+/**
+ * The Supabase CLI project id (config.toml `project_id`). Every local container is
+ * labelled `com.supabase.cli.project=<id>` and named `supabase_<svc>_<id>`, so this
+ * is how container operations are scoped to THIS project. Falls back to the known
+ * local default if config.toml can't be read.
+ * @returns {string}
+ */
+function readSupabaseProjectId() {
+  try {
+    const toml = fs.readFileSync(path.join(API_DIR, 'supabase', 'config.toml'), 'utf8');
+    const m = toml.match(/^\s*project_id\s*=\s*"([^"]+)"/m);
+    if (m && m[1]) return m[1];
+  } catch {
+    // fall through to the default below
+  }
+  return 'finance-local';
+}
+
+/**
+ * The worktree-unique tail of this checkout's functions path, e.g.
+ *   /jrmoulckers-upgraded-robot/services/api/supabase/functions
+ * Used to tell whether the running edge-runtime container is bind-mounted to THIS
+ * worktree's functions or to a different/stale one — the shared `project_id`
+ * cross-worktree trap, where one Docker stack is shared by every worktree and the
+ * edge runtime stays bound to whichever worktree first ran `supabase start`.
+ * @returns {string}
+ */
+function functionsTailNeedle() {
+  const fnDir = path.join(API_DIR, 'supabase', 'functions').replace(/\\/g, '/').toLowerCase();
+  const base = path.basename(REPO_ROOT).toLowerCase();
+  const idx = fnDir.lastIndexOf(`/${base}/`);
+  return idx >= 0 ? fnDir.slice(idx) : `/${base}/services/api/supabase/functions`;
+}
+
+/**
+ * Inspect the edge-runtime container's functions bind-mount to see whether it
+ * points at THIS worktree. Works on stopped containers too (`docker inspect`), so
+ * it also catches a stopped stack bound to another worktree that `supabase start`
+ * would otherwise restart in place. When the container or docker is unavailable it
+ * reports `exists:false` (nothing stale to heal — `supabase start` will create it).
+ * @param {string} projectId
+ * @returns {{exists:boolean, source:string, matchesWorktree:boolean}}
+ */
+function inspectEdgeFunctionsMount(projectId) {
+  const container = `supabase_edge_runtime_${projectId}`;
+  const res = runCapture('docker', ['inspect', container], { timeoutMs: 20000 });
+  if (!res.ok) return { exists: false, source: '', matchesWorktree: true };
+  let mounts;
+  try {
+    mounts = JSON.parse(res.stdout)[0]?.Mounts ?? [];
+  } catch {
+    return { exists: false, source: '', matchesWorktree: true };
+  }
+  const fnMounts = mounts.filter(
+    (m) => /functions/i.test(m.Source || '') || /functions/i.test(m.Destination || ''),
+  );
+  // A container with no functions mount cannot be serving this worktree's functions.
+  if (fnMounts.length === 0) return { exists: true, source: '', matchesWorktree: false };
+  const needle = functionsTailNeedle();
+  const matchesWorktree = fnMounts.some((m) => {
+    const s = String(m.Source || '')
+      .replace(/\\/g, '/')
+      .toLowerCase();
+    const d = String(m.Destination || '')
+      .replace(/\\/g, '/')
+      .toLowerCase();
+    return s.includes(needle) || d.includes(needle);
+  });
+  return {
+    exists: true,
+    source: fnMounts[0].Source || fnMounts[0].Destination || '',
+    matchesWorktree,
+  };
+}
+
+/**
+ * Force-remove every container for this Supabase project (scoped by the
+ * `com.supabase.cli.project` label). This is the part of the heal that `supabase
+ * stop` alone does not reliably do across worktrees: it guarantees the stale
+ * containers are gone so the next `supabase start` recreates them — and crucially
+ * the edge-runtime functions bind-mount — bound to THIS worktree. Container removal
+ * only: named data volumes are preserved (never passes `--volumes`/`-v`), so local
+ * database state survives the heal.
+ * @param {string} projectId
+ * @returns {void}
+ */
+function forceRemoveProjectContainers(projectId) {
+  const list = runCapture(
+    'docker',
+    ['ps', '-aq', '--filter', `label=com.supabase.cli.project=${projectId}`],
+    { timeoutMs: 20000 },
+  );
+  if (!list.ok) {
+    info('Could not list Supabase containers via docker — continuing to start anyway.');
+    return;
+  }
+  const ids = list.stdout
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (ids.length === 0) return;
+  info(
+    `Force-removing ${ids.length} "${projectId}" container(s) so the stack rebinds to THIS worktree…`,
+  );
+  info('(Containers only — named data volumes are preserved; --volumes is never used.)');
+  runInherit('docker', ['rm', '-f', ...ids], { timeoutMs: 120000 });
+}
+
+/**
+ * Heal a stale / cross-worktree Supabase stack: stop it gracefully, then
+ * force-remove any container `supabase stop` left behind, so the next
+ * `supabase start` recreates the stack (and its edge-runtime functions mount) bound
+ * to THIS worktree. Data volumes are preserved throughout.
+ * @param {string} projectId
+ * @returns {void}
+ */
+function healStack(projectId) {
+  stopSupabase();
+  forceRemoveProjectContainers(projectId);
+}
+
 async function startSupabase() {
   step('Starting the local Supabase edge stack');
-  if (isSupabaseRunning()) {
-    info('Supabase is already running — reusing it.');
-    return;
+
+  const projectId = readSupabaseProjectId();
+  const fnUrl = `${readApiUrl()}${FUNCTIONS_PROBE_PATH}`;
+  const running = isSupabaseRunning();
+  // Detect a container set bound to a DIFFERENT worktree (works on stopped
+  // containers too), so the shared project_id cross-worktree trap is healed even
+  // when the stale stack looks healthy or is merely stopped.
+  const mount = inspectEdgeFunctionsMount(projectId);
+  const boundElsewhere = mount.exists && !mount.matchesWorktree;
+
+  if (opts.recreate) {
+    if (running || mount.exists) {
+      info('--recreate given — tearing the existing stack down for a clean restart…');
+      healStack(projectId);
+    }
+  } else if (running) {
+    info('Supabase is already running — checking the Edge Functions runtime…');
+    const health = await waitForEdgeHealth(fnUrl, { attempts: 4, delayMs: 2000 });
+    if (health.healthy && !boundElsewhere) {
+      info(
+        `Edge Functions runtime is healthy (probe: ${health.detail}). Reusing the running stack.`,
+      );
+      return;
+    }
+    if (boundElsewhere) {
+      info('The running edge runtime is bound to a DIFFERENT worktree, so it serves that');
+      info("worktree's functions (or none at all) — not this checkout's. Mounted path:");
+      info(`    ${mount.source || '(no functions mount)'}`);
+      info('This is the shared project_id cross-worktree trap (one Docker stack is shared by');
+      info('every worktree). Recreating the stack bound to THIS worktree now…');
+    } else {
+      info(`Edge Functions runtime is UNHEALTHY (probe: ${health.detail}).`);
+      info('A "running" stack with dead functions (every /functions/v1/* call 503s) is what a');
+      info('stale or orphaned edge-runtime container causes — and a plain container restart does');
+      info('not fix it. Recreating the stack to heal it now (your database volume is preserved)…');
+    }
+    healStack(projectId);
+  } else if (boundElsewhere) {
+    info('A stopped Supabase stack bound to a DIFFERENT worktree was found — a plain start would');
+    info('restart those (wrong) containers in place. Mounted path:');
+    info(`    ${mount.source || '(no functions mount)'}`);
+    info('Removing it so the stack rebinds to THIS worktree on start…');
+    healStack(projectId);
   }
 
   const maxAttempts = 3;
+  let started = false;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     info(`supabase start (attempt ${attempt}/${maxAttempts})…`);
     const { code, output } = await runTee('npx', ['--yes', 'supabase', 'start'], { cwd: API_DIR });
     if (code === 0 || isSupabaseRunning()) {
       info('Supabase is up.');
-      return;
+      started = true;
+      break;
     }
 
     // Work out *why* it failed instead of assuming a rate-limit. Terminal causes
@@ -306,10 +586,34 @@ async function startSupabase() {
       await sleep(backoff * 1000);
     }
   }
-  fail(
-    'Could not start Supabase after multiple attempts.',
-    'Read the output above for the real cause. Common ones: Docker not running; a Docker Hub pull limit (`docker login`); or corrupt image layers (see the "exit 255 / exec format error" section in docs/guides/full-stack-local.md).',
-  );
+
+  if (!started) {
+    fail(
+      'Could not start Supabase after multiple attempts.',
+      'Read the output above for the real cause. Common ones: Docker not running; a Docker Hub pull limit (`docker login`); or corrupt image layers (see the "exit 255 / exec format error" section in docs/guides/full-stack-local.md).',
+    );
+  }
+
+  // The stack reports "up" as soon as Kong/Postgres bind, but the Edge Functions
+  // runtime boots separately and can come up dead (the bug this guards against).
+  // Verify it actually serves a function before we wire the web app to it, so a
+  // broken runtime fails loudly here instead of silently breaking signup/login.
+  step('Verifying the Edge Functions runtime');
+  const health = await waitForEdgeHealth(fnUrl, { attempts: 20, delayMs: 3000 });
+  if (!health.healthy) {
+    fail(
+      `Supabase started but its Edge Functions runtime is not serving requests (probe: ${health.detail}).`,
+      [
+        'Every /functions/v1/* call is failing, so edge auth (signup/login) will not work.',
+        'Force-recreate the stack from scratch:',
+        '  npm run dev:full -- --recreate',
+        'If it persists, inspect the edge runtime logs:',
+        `  docker logs supabase_edge_runtime_${projectId} --tail 50`,
+        'See docs/guides/full-stack-local.md.',
+      ].join('\n'),
+    );
+  }
+  info(`Edge Functions runtime is healthy (probe: ${health.detail}).`);
 }
 
 // --- 3. Optional DB reset ----------------------------------------------------

--- a/tools/lib/dev-env.mjs
+++ b/tools/lib/dev-env.mjs
@@ -141,3 +141,50 @@ export function classifySupabaseStartFailure(output) {
 
   return { kind: 'unknown' };
 }
+
+/**
+ * HTTP statuses that mean the API gateway (Kong) has no healthy Edge Functions
+ * upstream — the runtime is down, wedged, or still booting. A 500/501 is treated
+ * as "runtime up, but the function itself errored" and is NOT a reason to
+ * recreate the stack.
+ */
+const RUNTIME_DOWN_STATUSES = new Set([502, 503, 504]);
+
+/**
+ * @typedef {{healthy: boolean, detail: string}} EdgeHealth
+ */
+
+/**
+ * Interpret a single Edge Functions health probe (pure; no IO).
+ *
+ * The local Supabase stack can be "running" (Kong + Postgres up, `supabase
+ * status` prints an API URL) while its Edge Functions runtime is dead — a stale
+ * or orphaned `supabase_edge_runtime_*` container that Docker's restart policy
+ * keeps "Up" but which fails to bootstrap any function and answers every
+ * `/functions/v1/*` call with HTTP 503. That state silently breaks edge auth
+ * (signup, login, refresh) even though the stack looks healthy, so dev-full.mjs
+ * probes a known function and heals (stop → start) when this returns unhealthy.
+ *
+ * - Healthy: the runtime booted a worker and produced a response we can read
+ *   (any status outside {502,503,504} — e.g. a 400 "email and password are
+ *   required" from auth-signup, a 401 from Kong, or even a 500 from the function
+ *   body). The function ran; the runtime is alive.
+ * - Unhealthy: a gateway 502/503/504 (the dead-runtime signature is 503) OR a
+ *   transport error (connection refused/reset, timeout) — nothing served the
+ *   request.
+ *
+ * @param {{status?: number|null, errorCode?: string|null}} [probe]
+ *   `status`: the HTTP status code if a response was received, else null.
+ *   `errorCode`: a transport error code/name (e.g. 'ECONNREFUSED', 'timeout')
+ *   when the request threw, else null.
+ * @returns {EdgeHealth}
+ */
+export function interpretEdgeProbe({ status = null, errorCode = null } = {}) {
+  if (typeof status === 'number') {
+    if (RUNTIME_DOWN_STATUSES.has(status)) {
+      return { healthy: false, detail: `HTTP ${status}` };
+    }
+    return { healthy: true, detail: `HTTP ${status}` };
+  }
+  return { healthy: false, detail: errorCode ? String(errorCode) : 'no response' };
+}


### PR DESCRIPTION
## Summary

Local signup silently failed — submitting the form just re-rendered the empty form. Root-caused to **two independent environmental defects**, both surfacing as "empty form again," and proven fixed via a live Ctrl+F5 debug session before this PR was opened.

## Layer 1 — dead/stale local edge runtime (HTTP 503)

`services/api/supabase/config.toml` pins `project_id = "finance-local"`, so **every worktree shares one Docker stack**. The edge-functions runtime stays bound to whichever worktree first ran `supabase start`. Once that worktree is removed, `auth-signup/index.ts` no longer exists at the bind-mount path, and the runtime returns `503` (`failed to determine entrypoint`) for **every** function call — including `POST /functions/v1/auth-signup`. A plain `supabase stop && start` reuses the stale container instead of rebinding.

**Fix:** `dev:full` now detects a cross-worktree mount mismatch (or a dead runtime) and force-removes the project's containers **by label** so the next `supabase start` recreates them bound to *this* worktree. Data volumes are always preserved (never `--volumes`).

## Layer 2 — service-worker cache poisoning (the WASM crash)

The signup form itself is a pre-auth route (no DB), so it renders fine. But a **successful** signup redirects to the dashboard, which loads SQLite-WASM. A stale service worker (left in the persistent Edge debug profile) had `cache-first`-cached an HTML SPA-fallback page under the `/assets/sql-wasm/*.wasm` URL, so `WebAssembly.instantiate()` received `<!do…` instead of the `\0asm` magic word → the data layer crashed → the user was bounced back to the empty form. Because it's `cache-first`, a hard reload never cleared it.

**Fix:** `cacheFirst` now never writes an HTML response under a static-asset URL, and evicts + bypasses any already-poisoned entry on read, so the cache self-heals **without** a `CACHE_VERSION` bump.

## Changes

- `tools/dev-full.mjs`, `tools/lib/dev-env.mjs` — cross-worktree mount detection + forced container recreate in the `dev:full` heal path.
- `apps/web/src/sw/service-worker.ts` — `cacheFirst` HTML-under-asset-URL guard + self-healing eviction (`cacheFirst` is now exported for testing).
- `apps/web/src/sw/__tests__/service-worker-wasm-cache-poisoning.test.ts` — regression coverage for the guard, eviction, valid-asset caching, and scoping.

## Testing

- [x] Live proof: user pressed **Ctrl+F5**, the edge runtime force-recreated and passed its health check (no 503), and after a one-time "Clear site data" (evicting the stale SW) **signup completed and landed on the dashboard**.
- [x] `apps/web` SW suite: **22/22 pass** (5 new poisoning-guard tests).
- [x] `npm run format:check` — clean (repo-wide).
- [x] `npx eslint . --max-warnings 0` — clean (repo-wide).

## Issues

Closes #3091