### PR TITLE
fix(ci): staging smoke test reports red on healthy deploys (wrong host + health marker) (#3097)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -499,7 +499,7 @@ jobs:
       - name: Resolve staging target
         id: target
         env:
-          CONFIGURED_URL: ${{ vars.STAGING_URL || secrets.STAGING_URL || 'https://finance-staging.jrmoulckers.com' }}
+          CONFIGURED_URL: ${{ vars.STAGING_URL || secrets.STAGING_URL || 'https://finance.jrmoulckers.com' }}
         run: |
           echo "url=${CONFIGURED_URL%/}" >> "$GITHUB_OUTPUT"
 
@@ -529,7 +529,7 @@ jobs:
             local attempt http_code
             for attempt in 1 2 3 4 5; do
               http_code=$(curl -sSL -o "$HEALTH_RESPONSE" -w '%{http_code}' "$BASE_URL/health" || echo "000")
-              if [ "$http_code" = "200" ] && grep -Eqi '"status"[[:space:]]*:[[:space:]]*"healthy"|healthy' "$HEALTH_RESPONSE"; then
+              if [ "$http_code" = "200" ] && grep -Eqi '"status"[[:space:]]*:[[:space:]]*"(ok|healthy)"' "$HEALTH_RESPONSE"; then
                 return 0
               fi
               echo "Health check attempt ${attempt}/5 returned HTTP ${http_code}; retrying in 10s"
@@ -559,7 +559,7 @@ jobs:
           echo "### 🧪 Staging Smoke Tests Passed" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Homepage returned HTTP 200" >> "$GITHUB_STEP_SUMMARY"
-          echo "- /health returned healthy" >> "$GITHUB_STEP_SUMMARY"
+          echo "- /health returned ok" >> "$GITHUB_STEP_SUMMARY"
           echo "- Basic page load marker detected" >> "$GITHUB_STEP_SUMMARY"
           echo "- URL: $BASE_URL" >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Summary

The **Post-deploy Smoke Tests** job in `deploy-staging.yml` failed on every healthy staging deploy, painting successful deploys red and masking real deploy status. Two independent bugs in the `smoke-tests` job caused it.

## Root cause

1. **Wrong host.** `CONFIGURED_URL` fell back to `https://finance-staging.jrmoulckers.com`, which does not resolve (`curl: (6) Could not resolve host`). No `STAGING_URL` repo variable or secret is configured, so the smoke test always used this bad default. The real staging host — per this same workflow's deploy and summary steps (`https://finance.jrmoulckers.com`) — was never checked.
2. **Wrong health marker.** The health check grepped for `"healthy"`, but the live `/health` endpoint returns `{"status":"ok"}`, so it failed even once the host was corrected.

## Changes

- Default the smoke target to `https://finance.jrmoulckers.com` (keeping the `vars.STAGING_URL` / `secrets.STAGING_URL` override path, so a future dedicated staging host can still be set without code changes).
- Accept a `status` of `ok` **or** `healthy` in the `/health` check.
- Update the step-summary line to match (`/health returned ok`).

## Verification (live)

- `https://finance.jrmoulckers.com` -> HTTP 200, homepage contains `<title>Finance</title>`
- `https://finance.jrmoulckers.com/health` -> HTTP 200, body `{"status":"ok"}`

All three smoke checks (homepage 200, Finance marker, health ok) now pass on a healthy deploy.

## Scope / non-goals

- `.github/workflows/deploy-staging.yml` only — no deploy logic changes, no new required checks.

## Issues

Closes #3097

## Testing

- [x] `npx prettier --check .github/workflows/deploy-staging.yml` — clean
- [x] Live-verified the host, homepage marker, and `/health` body that the smoke test asserts against
