### PR TITLE
ci(deps): submit force-resolved Gradle dependency graph on main (#3100)

### DIFF
--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -50,6 +50,13 @@ jobs:
     name: Lint & Test (KMP)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # contents: write is required only so the push-to-main run can submit the
+    # force-resolved Gradle dependency graph (see the Set up Gradle step). It is
+    # scoped to this single job; checks/pull-requests:write preserve the test reporter.
+    permissions:
+      contents: write
+      checks: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -70,7 +77,11 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-          dependency-graph: generate
+          # On push to main, submit the force-resolved dependency graph so Dependabot
+          # sees the patched transitive versions from build.gradle.kts resolutionStrategy.
+          # PRs (and non-main) only generate — no submit — so contents:write is never
+          # exercised on untrusted runs.
+          dependency-graph: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'generate-and-submit' || 'generate' }}
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0


### PR DESCRIPTION
## Summary

On push to `main`, the KMP build (`ci-shared.yml`) now runs `gradle/actions/setup-gradle` with **`generate-and-submit`** instead of `generate`, so the **force-resolved** dependency graph is submitted to GitHub's Dependency Graph API. This lets Dependabot see the **patched** transitive versions that `build.gradle.kts`'s `resolutionStrategy.eachDependency` forces produce — which is required for the ~45 code-remediated Maven alerts to auto-close.

## Why the Maven alerts haven't been closing

The `build.gradle.kts` forces correctly patch the **shipped app runtime** (e.g. Ktor → `netty 4.1.135.Final`). The app is secure. But the repo's **Automatic Dependency Submission** (a repo *setting*, not a workflow file — runs as the `submit-gradle` check) submits a graph that **ignores those forces** and includes build-time / plugin-classpath versions:

| Package | Force in `build.gradle.kts` / catalog | Versions in the submitted SBOM |
| --- | --- | --- |
| jose4j | **0.9.6** | `0.7.0` + `0.9.5` — **0.9.6 is absent entirely** |
| bouncycastle | **1.84** | `1.77` + `1.84` |
| netty | **4.1.135.Final** | `4.1.93.Final` (via `io.grpc:grpc-netty@1.57.0`) + `4.1.135.Final` |

`grpc` is **not declared** anywhere in the repo — it is pulled by a Gradle plugin's classpath, which `allprojects { configurations.all }` does not cover. Those un-forced version nodes are what keep the alerts open.

## The change

- `.github/workflows/ci-shared.yml`:
  - `dependency-graph: generate` → `${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'generate-and-submit' || 'generate' }}` — **main-guarded**: submits only on push to `main`; PRs stay `generate`-only (no submit).
  - Added a **job-scoped** `permissions:` block granting `contents: write` (required by the Dependency Submission API) plus the existing `checks: write` / `pull-requests: write` the test reporter uses. `contents: write` is never exercised on PR/untrusted runs because the submit only happens on `main`.

## ⚠️ Needs Human Action (after merge) — repo setting toggle

The in-workflow submission alone is **not sufficient**: it uses a different *correlator* than the Automatic Dependency Submission, so both snapshots coexist and the vulnerable nodes persist. To actually close the alerts, the noisy auto-submission must be turned off so only this clean, force-resolved graph remains:

1. Go to **Settings → Code security → Automatic dependency submission** and **disable** it.
2. Let this PR merge so the `main` build submits the clean graph once (it fires only on push to `main`, so it can't be verified pre-merge).
3. Confirm the Dependabot alert count drops on the next `main` build (the un-forced `netty 4.1.93` / `jose4j 0.7.0` / `bcprov 1.77` nodes should disappear).

I can't change a repo setting (admin/gated), so step 1 is yours.

## Follow-up (not in this PR)

`ci-security.yml`'s `allow-ghsas: GHSA-2363-cqg2-863c` (jdom2) is left in place. Whether it can be removed depends on the post-merge graph — track as a follow-up under #3100 once the above is verified.

## Testing

- [x] YAML parses (`js-yaml` load) — `permissions` and the `dependency-graph` expression resolve correctly
- [x] `npm run format:check` — clean (Prettier checks YAML)
- [x] `npx eslint . --max-warnings 0` — clean
- [ ] Post-merge: `main` build submits the resolved graph; alert count drops once auto-submission is disabled

Closes #3100
Refs #3099