### PR TITLE
ci(deps): revert in-workflow Gradle dep-graph submission (#3100)

### DIFF
--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -50,13 +50,6 @@ jobs:
     name: Lint & Test (KMP)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # contents: write is required only so the push-to-main run can submit the
-    # force-resolved Gradle dependency graph (see the Set up Gradle step). It is
-    # scoped to this single job; checks/pull-requests:write preserve the test reporter.
-    permissions:
-      contents: write
-      checks: write
-      pull-requests: write
 
     steps:
       - name: Checkout
@@ -77,11 +70,7 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-          # On push to main, submit the force-resolved dependency graph so Dependabot
-          # sees the patched transitive versions from build.gradle.kts resolutionStrategy.
-          # PRs (and non-main) only generate — no submit — so contents:write is never
-          # exercised on untrusted runs.
-          dependency-graph: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'generate-and-submit' || 'generate' }}
+          dependency-graph: generate
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0


### PR DESCRIPTION
## Summary

Reverts PR #3102. Keeps GitHub's **Automatic Dependency Submission** enabled as the broad, whole-monorepo dependency-graph source rather than replacing it with a narrow packages-only in-workflow submission.

## Why revert

Follow-up investigation found the repo's **current dependency graph contains 0 maven nodes** — only 837 npm packages (from `package-lock.json`), 34 GitHub Actions, and 1 gem. The Gradle snapshot expired, so the 45 Maven alerts are **orphaned legacy alerts**, not live graph findings.

#3102's in-workflow submit only covered the 3 KMP packages (`core`/`models`/`sync`). Relying on it as the sole Gradle source would shrink coverage for app-module deps (android/windows) — trading noisy-but-broad coverage for narrow-but-blind coverage, i.e. risking **false negatives** on a financial app. Not worth the `contents: write` escalation. Auto-submission stays on; the 45 false positives (real builds force patched versions) will be **dismissed** separately.

## Changes

- `.github/workflows/ci-shared.yml`: restore `dependency-graph: generate`; drop the job-scoped `contents: write` block.

## Testing

- [x] `npx prettier --check` clean
- [x] Restores file to pre-#3102 baseline

Refs #3100