### PR TITLE
fix(web): allow legal pages pre-onboarding (#3110)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -107,12 +107,17 @@ const STANDALONE_ROUTES: readonly string[] = [
  * without marking onboarding complete, so the visitor must be able to reach (and stay
  * on) the auth pages. Once authenticated, leaving an auth page for any other route
  * re-triggers the auto-launch, which resumes onboarding at the post-signup step.
+ *
+ * `/legal` is exempt (prefix match covers `/legal/privacy`, `/legal/terms`,
+ * `/legal/ccpa`) so pre-onboarding visitors can read the legal documents linked from
+ * the auth footers — bouncing them to `/onboarding` would be a compliance problem (#3110).
  */
 const FIRST_RUN_ALLOWED_ROUTES: readonly string[] = [
   '/login',
   '/signup',
   '/forgot-password',
   '/reset-password',
+  '/legal',
   '/onboarding',
 ];
 

--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -264,6 +264,15 @@ describe('OnboardingPage', () => {
     expect(shouldAutoLaunchOnboarding('/login', false)).toBe(false);
   });
 
+  it('lets a first-run visitor reach the legal pages linked from the auth footers (#3110)', () => {
+    // Legal/Privacy/Terms/CCPA links must be reachable pre-onboarding for compliance;
+    // bouncing visitors to /onboarding would hide them. Prefix match covers the docs.
+    expect(shouldAutoLaunchOnboarding('/legal', false)).toBe(false);
+    expect(shouldAutoLaunchOnboarding('/legal/privacy', false)).toBe(false);
+    expect(shouldAutoLaunchOnboarding('/legal/terms', false)).toBe(false);
+    expect(shouldAutoLaunchOnboarding('/legal/ccpa', false)).toBe(false);
+  });
+
   it('stores Huge text preferences from the comfort step', () => {
     renderWithRouter(<OnboardingPage />);
 


### PR DESCRIPTION
## Summary
Fixes #3110. Pre-onboarding visitors clicking **Legal/Privacy/Terms/CCPA** footer links on `/login` were bounced to `/onboarding` — a compliance problem since they could never read the legal docs.

## Changes
- Add `/legal` to `FIRST_RUN_ALLOWED_ROUTES` in `apps/web/src/App.tsx` (prefix match covers `/legal/privacy`, `/legal/terms`, `/legal/ccpa`).
- Add a regression test asserting legal routes do not auto-launch onboarding pre-onboarding.

## Issues
Closes #3110

## Testing
- [x] `vitest` OnboardingPage auto-launch + legal regression tests pass
- [x] ESLint clean on changed files