### PR TITLE
fix(web): route onboarding back-nav into app instead of leave prompt (#3106)

### DIFF
--- a/apps/web/src/components/navigation/NavigationGuard.test.tsx
+++ b/apps/web/src/components/navigation/NavigationGuard.test.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { NavigationGuard } from './NavigationGuard';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+const mockUseAuth = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('../../auth/auth-context', () => ({ useAuth: mockUseAuth }));
+
+const EXIT_ANCHOR_KEY = '__financeExitAnchor';
+
+function dispatchExitBack() {
+  window.dispatchEvent(new PopStateEvent('popstate', { state: { [EXIT_ANCHOR_KEY]: true } }));
+}
+
+function renderGuard(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <NavigationGuard>
+        <p>app</p>
+      </NavigationGuard>
+    </MemoryRouter>,
+  );
+}
+
+describe('NavigationGuard back-from-onboarding (#3106)', () => {
+  let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    confirmSpy.mockRestore();
+  });
+
+  it('routes an unauthenticated back-press into /login instead of prompting to leave', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false });
+    renderGuard('/onboarding');
+
+    dispatchExitBack();
+
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  it('routes an authenticated back-press into /dashboard instead of prompting to leave', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    renderGuard('/onboarding');
+
+    dispatchExitBack();
+
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt to leave on a genuine exit when there is nothing unsaved', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    renderGuard('/dashboard');
+
+    dispatchExitBack();
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/navigation/NavigationGuard.tsx
+++ b/apps/web/src/components/navigation/NavigationGuard.tsx
@@ -9,11 +9,13 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
+import { useAuth } from '../../auth/auth-context';
 import {
   DEFAULT_UNSAVED_CHANGES_MESSAGE,
-  EXIT_APP_CONFIRMATION_MESSAGE,
   getActiveGuardMessage,
+  resolveBackNavigation,
 } from '../../lib/navigation/guardrails';
 import type {
   NavigationGuardContextValue,
@@ -30,11 +32,17 @@ export interface NavigationGuardProps {
 }
 
 export function NavigationGuard({ children }: NavigationGuardProps) {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const { isAuthenticated } = useAuth();
   const guardsRef = useRef(new Map<string, NavigationGuardRegistration>());
   const [activeGuards, setActiveGuards] = useState<readonly NavigationGuardRegistration[]>([]);
   const allowExitRef = useRef(false);
   const activeGuardsRef = useRef(activeGuards);
   const confirmActiveNavigationRef = useRef<(fallbackMessage?: string) => boolean>(() => true);
+  const navigateRef = useRef(navigate);
+  const pathnameRef = useRef(pathname);
+  const isAuthenticatedRef = useRef(isAuthenticated);
 
   const syncGuards = useCallback(() => {
     setActiveGuards(Array.from(guardsRef.current.values()).filter((guard) => guard.when));
@@ -65,7 +73,10 @@ export function NavigationGuard({ children }: NavigationGuardProps) {
   useEffect(() => {
     activeGuardsRef.current = activeGuards;
     confirmActiveNavigationRef.current = confirmActiveNavigation;
-  }, [activeGuards, confirmActiveNavigation]);
+    navigateRef.current = navigate;
+    pathnameRef.current = pathname;
+    isAuthenticatedRef.current = isAuthenticated;
+  }, [activeGuards, confirmActiveNavigation, isAuthenticated, navigate, pathname]);
 
   useEffect(() => {
     if (activeGuards.length === 0) {
@@ -107,18 +118,38 @@ export function NavigationGuard({ children }: NavigationGuardProps) {
       }
     };
 
+    // After consuming the exit anchor, push a fresh sentinel so the shell stays
+    // guarded against the next back press without leaving the user on the anchor.
+    const rearmExitSentinel = () => {
+      const baseState = (window.history.state ?? {}) as Record<string, unknown>;
+      window.history.pushState(
+        { ...baseState, [EXIT_SENTINEL_KEY]: true },
+        '',
+        window.location.href,
+      );
+    };
+
     const handlePopState = (event: PopStateEvent) => {
       const state = (event.state ?? {}) as Record<string, unknown>;
       if (!state[EXIT_ANCHOR_KEY] || allowExitRef.current) {
         return;
       }
 
-      const hasActiveGuards = activeGuardsRef.current.length > 0;
-      const confirmed = hasActiveGuards
-        ? confirmActiveNavigationRef.current()
-        : window.confirm(EXIT_APP_CONFIRMATION_MESSAGE);
+      const decision = resolveBackNavigation({
+        pathname: pathnameRef.current,
+        isAuthenticated: isAuthenticatedRef.current,
+        hasActiveGuards: activeGuardsRef.current.length > 0,
+      });
 
-      if (!confirmed) {
+      // Onboarding has no in-app back target: route into the app instead of
+      // prompting to leave, then re-arm the sentinel to stay guarded (#3106).
+      if (decision.kind === 'redirect') {
+        rearmExitSentinel();
+        navigateRef.current(decision.to);
+        return;
+      }
+
+      if (decision.kind === 'prompt' && !confirmActiveNavigationRef.current()) {
         window.history.forward();
         return;
       }

--- a/apps/web/src/lib/navigation/guardrails.test.ts
+++ b/apps/web/src/lib/navigation/guardrails.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  SIGNED_IN_HOME_PATH,
+  SIGNED_OUT_HOME_PATH,
+  isOnboardingPath,
+  resolveBackNavigation,
+} from './guardrails';
+
+describe('isOnboardingPath', () => {
+  it('matches the onboarding root and sub-routes', () => {
+    expect(isOnboardingPath('/onboarding')).toBe(true);
+    expect(isOnboardingPath('/onboarding/account')).toBe(true);
+  });
+
+  it('does not match other routes', () => {
+    expect(isOnboardingPath('/dashboard')).toBe(false);
+    expect(isOnboardingPath('/onboarding-extra')).toBe(false);
+  });
+});
+
+describe('resolveBackNavigation', () => {
+  it('redirects an unauthenticated back-press from onboarding to login (#3106)', () => {
+    expect(
+      resolveBackNavigation({
+        pathname: '/onboarding',
+        isAuthenticated: false,
+        hasActiveGuards: false,
+      }),
+    ).toEqual({ kind: 'redirect', to: SIGNED_OUT_HOME_PATH });
+  });
+
+  it('redirects an authenticated back-press from onboarding to dashboard (#3106)', () => {
+    expect(
+      resolveBackNavigation({
+        pathname: '/onboarding',
+        isAuthenticated: true,
+        hasActiveGuards: false,
+      }),
+    ).toEqual({ kind: 'redirect', to: SIGNED_IN_HOME_PATH });
+  });
+
+  it('never prompts to leave from onboarding even with unsaved guards', () => {
+    expect(
+      resolveBackNavigation({
+        pathname: '/onboarding',
+        isAuthenticated: false,
+        hasActiveGuards: true,
+      }),
+    ).toEqual({ kind: 'redirect', to: SIGNED_OUT_HOME_PATH });
+  });
+
+  it('only prompts on genuine exit when there are unsaved changes', () => {
+    expect(
+      resolveBackNavigation({
+        pathname: '/dashboard',
+        isAuthenticated: true,
+        hasActiveGuards: true,
+      }),
+    ).toEqual({ kind: 'prompt' });
+  });
+
+  it('exits silently on genuine exit with no unsaved changes', () => {
+    expect(
+      resolveBackNavigation({
+        pathname: '/dashboard',
+        isAuthenticated: true,
+        hasActiveGuards: false,
+      }),
+    ).toEqual({ kind: 'exit' });
+  });
+});

--- a/apps/web/src/lib/navigation/guardrails.ts
+++ b/apps/web/src/lib/navigation/guardrails.ts
@@ -13,6 +13,50 @@ export const DEFAULT_UNSAVED_CHANGES_MESSAGE =
 export const EXIT_APP_CONFIRMATION_MESSAGE =
   'Leave Finance? Your navigation history will stay local to this device.';
 
+export const ONBOARDING_PATH = '/onboarding';
+export const SIGNED_OUT_HOME_PATH = '/login';
+export const SIGNED_IN_HOME_PATH = '/dashboard';
+
+/**
+ * The action a back-navigation that reaches the app-shell exit anchor should take.
+ *
+ * - `redirect`: keep the visitor in the app and route to `to` (used for onboarding).
+ * - `prompt`: confirm before leaving because unsaved edits would be lost.
+ * - `exit`: allow the browser back navigation to leave the app shell.
+ */
+export type BackNavigationDecision =
+  | { kind: 'redirect'; to: string }
+  | { kind: 'prompt' }
+  | { kind: 'exit' };
+
+/** True when `pathname` is the onboarding flow (exact match or sub-route). */
+export function isOnboardingPath(pathname: string): boolean {
+  return pathname === ONBOARDING_PATH || pathname.startsWith(`${ONBOARDING_PATH}/`);
+}
+
+/**
+ * Decide what a back press should do when it reaches the app-shell exit anchor.
+ *
+ * Onboarding has no in-app back target, so back should route into the app
+ * (`/dashboard` when signed in, `/login` otherwise) instead of prompting to
+ * leave (#3106). Everywhere else, only prompt on a genuine exit when there are
+ * unsaved changes; with nothing to lose, the back press is allowed through.
+ */
+export function resolveBackNavigation(options: {
+  pathname: string;
+  isAuthenticated: boolean;
+  hasActiveGuards: boolean;
+}): BackNavigationDecision {
+  if (isOnboardingPath(options.pathname)) {
+    return {
+      kind: 'redirect',
+      to: options.isAuthenticated ? SIGNED_IN_HOME_PATH : SIGNED_OUT_HOME_PATH,
+    };
+  }
+
+  return options.hasActiveGuards ? { kind: 'prompt' } : { kind: 'exit' };
+}
+
 export const NAVIGATION_HISTORY_LIMIT = 12;
 export const BREADCRUMB_HISTORY_LIMIT = 4;
 export const MAX_NAVIGATION_SHORTCUTS = 9;


### PR DESCRIPTION
## Summary
Back-navigation from /onboarding after sign-in triggered the generic `Leave Finance?` app-exit prompt because onboarding has no in-app back target — the app-shell exit anchor fired instead of routing into the app.

## Changes
- Add esolveBackNavigation + isOnboardingPath helpers in `guardrails.ts` (review point :14): onboarding back routes to `/dashboard` (authenticated) or `/login` (signed out); other routes only prompt on a genuine exit with unsaved changes, otherwise exit silently.
- Wire `NavigationGuard.tsx` to `useAuth`/`useNavigate`/`useLocation`; redirect onboarding back into the app and re-arm the exit sentinel so the shell stays guarded.
- Tests: `guardrails.test.ts` (7) + `NavigationGuard.test.tsx` (3) cover redirect-by-auth-state, no-leave-prompt, and unsaved-data prompt vs silent exit.

## Issues
Closes #3106

## Testing
- [x] guardrails + NavigationGuard: 10 pass
- [x] OnboardingPage: 22 pass; TransactionForm (guard hook): 19 pass
- [x] Prettier + ESLint clean on changed files