### PR TITLE
fix(web): clear message for unavailable passkey backend (#3111)

### DIFF
--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -32,6 +32,7 @@ import {
 import {
   authenticateWithPasskey,
   initWebAuthn,
+  isWebAuthnReady,
   isWebAuthnSupported,
   registerPasskey,
   type WebAuthnConfig,
@@ -56,7 +57,7 @@ import {
   isDemoMode,
   restoreDemoSession,
 } from './demo-auth';
-import { getPasskeyErrorMessage } from './passkey-errors';
+import { getPasskeyErrorMessage, PASSKEY_UNAVAILABLE_MESSAGE } from './passkey-errors';
 import { appendSecurityAuditEvent } from '../lib/security-audit-log';
 import { getStepUpStatus, markStepUpAuthenticated } from '../lib/session-security';
 import '../styles/auth.css';
@@ -571,6 +572,15 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         throw new Error(message);
       }
 
+      // Don't attempt a ceremony the environment can't fulfil. If WebAuthn is
+      // unsupported or the client never received backend config, surface the
+      // clear unavailable message up front instead of letting a network call
+      // fall through to a generic "Unknown error" (#3111).
+      if (!webAuthnSupported || !isWebAuthnReady()) {
+        setError(PASSKEY_UNAVAILABLE_MESSAGE);
+        throw new Error(PASSKEY_UNAVAILABLE_MESSAGE);
+      }
+
       setIsLoading(true);
 
       try {
@@ -607,7 +617,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         setIsLoading(false);
       }
     },
-    [demoModeActive, webAuthnConfig],
+    [demoModeActive, webAuthnSupported, webAuthnConfig],
   );
 
   const registerNewPasskey = useCallback(async (): Promise<void> => {

--- a/apps/web/src/auth/passkey-errors.test.ts
+++ b/apps/web/src/auth/passkey-errors.test.ts
@@ -34,4 +34,25 @@ describe('getPasskeyErrorMessage', () => {
   it('keeps specific server messages when no friendly mapping applies', () => {
     expect(getPasskeyErrorMessage(new Error('Rate limit exceeded'))).toBe('Rate limit exceeded');
   });
+
+  it('maps a generic "Unknown error" backend body to the unavailable message', () => {
+    expect(getPasskeyErrorMessage(new Error('Unknown error'))).toBe(
+      "Passkey sign-in isn't available right now — use email/password.",
+    );
+  });
+
+  it('maps unprovisioned/gateway Edge Function errors to the unavailable message', () => {
+    expect(getPasskeyErrorMessage(new Error('Edge Function error (502)'))).toBe(
+      "Passkey sign-in isn't available right now — use email/password.",
+    );
+    expect(getPasskeyErrorMessage(new Error('Function not found'))).toBe(
+      "Passkey sign-in isn't available right now — use email/password.",
+    );
+  });
+
+  it('maps an uninitialised WebAuthn client to the unavailable message', () => {
+    expect(
+      getPasskeyErrorMessage(new Error('Passkey sign-in is still initialising. Try again later.')),
+    ).toBe("Passkey sign-in isn't available right now — use email/password.");
+  });
 });

--- a/apps/web/src/auth/passkey-errors.ts
+++ b/apps/web/src/auth/passkey-errors.ts
@@ -26,6 +26,17 @@ const PASSKEY_REGISTRATION_FAILED =
 const PASSKEY_AUTHENTICATION_FAILED =
   'Passkey sign-in failed. Try again, or sign in with email and password.';
 
+/**
+ * Shown when the passkey backend is unconfigured or unavailable — e.g. the
+ * Edge Functions are not provisioned in this environment (404/501), the
+ * gateway is down (502/503), the WebAuthn client never received its config,
+ * or the server returned an opaque body that decoded to "Unknown error".
+ * Tells the user passkeys aren't an option right now and points them to the
+ * always-available email/password path instead of surfacing a dead end (#3111).
+ */
+export const PASSKEY_UNAVAILABLE_MESSAGE =
+  "Passkey sign-in isn't available right now — use email/password.";
+
 export function getPasskeyErrorMessage(
   error: unknown,
   context: PasskeyErrorContext = 'authentication',
@@ -75,12 +86,8 @@ export function getPasskeyErrorMessage(
     return 'Sign in again before setting up a passkey.';
   }
 
-  if (
-    normalizedMessage.includes('internal server error') ||
-    normalizedMessage.includes('edge function error') ||
-    normalizedMessage.includes('function not found')
-  ) {
-    return 'The passkey service is unavailable. Try again in a few minutes or sign in with email and password.';
+  if (isServiceUnavailableError(normalizedMessage)) {
+    return PASSKEY_UNAVAILABLE_MESSAGE;
   }
 
   return (
@@ -117,5 +124,27 @@ function isNoPasskeyError(normalizedMessage: string): boolean {
     normalizedMessage.includes('no credential') ||
     normalizedMessage.includes('no passkey') ||
     normalizedMessage.includes('not registered')
+  );
+}
+
+/**
+ * Detect an unconfigured or unavailable passkey backend. Covers the generic
+ * "Unknown error" the WebAuthn client emits when an unprovisioned endpoint
+ * returns a non-JSON body, the explicit "Edge Function error (NNN)" wrapper,
+ * 404/5xx gateway statuses, "function not found"/"not implemented", and the
+ * "still initialising" guard from a client that never got its config (#3111).
+ */
+function isServiceUnavailableError(normalizedMessage: string): boolean {
+  return (
+    normalizedMessage.includes('unknown error') ||
+    normalizedMessage.includes('internal server error') ||
+    normalizedMessage.includes('edge function error') ||
+    normalizedMessage.includes('function not found') ||
+    normalizedMessage.includes('not implemented') ||
+    normalizedMessage.includes('service unavailable') ||
+    normalizedMessage.includes('bad gateway') ||
+    normalizedMessage.includes('still initialising') ||
+    normalizedMessage.includes('still initializing') ||
+    /\b(?:404|500|501|502|503|504)\b/.test(normalizedMessage)
   );
 }


### PR DESCRIPTION
## Summary

Passkey sign-in showed a raw "Unknown error" on the live site when the WebAuthn Edge Functions were unprovisioned. There was no actionable guidance, and the button stayed active even when the backend could not fulfil a ceremony.

## Changes

- `getPasskeyErrorMessage` now maps unconfigured/unavailable backends (literal `Unknown error`, `Edge Function error (4xx/5xx)`, `function not found`, `not implemented`, gateway 502/503, `still initialising`) to a clear message: **"Passkey sign-in isn't available right now — use email/password."**
- `loginWithPasskey` (auth-context.tsx:549-599) now short-circuits when WebAuthn is unsupported or the client never received backend config, surfacing the same clear message instead of attempting a doomed network call.
- The passkey buttons remain gated on `webAuthnReady`, so they are only enabled once the client is initialised.
- Added unit tests for the new error mappings.

## Issues

Closes #3111

## Testing

- [x] `vitest` auth + LoginPage suites pass (43 tests)
- [x] `npm run format:check` clean
- [x] `eslint --max-warnings 0` clean
