### PR TITLE
fix(web): keep users in-app when OAuth start is unavailable (#3109)

### DIFF
--- a/apps/web/src/auth/auth-context.test.tsx
+++ b/apps/web/src/auth/auth-context.test.tsx
@@ -6,8 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AuthProvider,
   SERVICE_UNAVAILABLE_MESSAGE,
+  OAUTH_PROVIDER_UNAVAILABLE_MESSAGE,
   isBetaEmailAllowed,
   isNetworkError,
+  isOAuthStartHealthy,
   isServiceUnavailableStatus,
   parseBetaAllowedEmails,
   useAuth,
@@ -410,5 +412,151 @@ describe('signup & login surface a clear message when the backend is unreachable
     await waitFor(() =>
       expect(screen.getByTestId('auth-error')).toHaveTextContent('Invalid login credentials'),
     );
+  });
+});
+
+describe('isOAuthStartHealthy', () => {
+  function fakeResponse(init: { type?: string; redirected?: boolean; status: number }): Response {
+    return init as unknown as Response;
+  }
+
+  it('accepts an opaque-redirect from a healthy redirect:manual probe', () => {
+    expect(isOAuthStartHealthy(fakeResponse({ type: 'opaqueredirect', status: 0 }))).toBe(true);
+  });
+
+  it('accepts an explicit 3xx redirect', () => {
+    expect(isOAuthStartHealthy(fakeResponse({ type: 'default', status: 302 }))).toBe(true);
+    expect(
+      isOAuthStartHealthy(fakeResponse({ type: 'default', redirected: true, status: 200 })),
+    ).toBe(true);
+  });
+
+  it('rejects 5xx/502/0 outages and 4xx provider errors', () => {
+    expect(isOAuthStartHealthy(fakeResponse({ type: 'default', status: 502 }))).toBe(false);
+    expect(isOAuthStartHealthy(fakeResponse({ type: 'default', status: 500 }))).toBe(false);
+    expect(isOAuthStartHealthy(fakeResponse({ type: 'default', status: 0 }))).toBe(false);
+    expect(isOAuthStartHealthy(fakeResponse({ type: 'default', status: 400 }))).toBe(false);
+  });
+});
+
+describe('loginWithOAuth keeps users in-app on a failed start (#3109)', () => {
+  const config: AuthProviderConfig = {
+    supabaseUrl: 'https://finance-test.supabase.co',
+    supabaseAnonKey: 'anon-key',
+    loginEndpoint: '/api/auth/login',
+    refreshEndpoint: '/api/auth/refresh',
+    logoutEndpoint: '/api/auth/logout',
+    signupEndpoint: '/api/auth/signup',
+  };
+
+  let assignMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    clearTokens();
+    localStorage.clear();
+    assignMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { assign: assignMock, href: 'http://localhost/login' },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearTokens();
+    localStorage.clear();
+  });
+
+  function OAuthProbe() {
+    const { loginWithOAuth, isLoading, error } = useAuth();
+    return (
+      <div>
+        <span data-testid="loading-state">{isLoading ? 'loading' : 'ready'}</span>
+        <span data-testid="auth-error">{error ?? 'none'}</span>
+        <button
+          data-testid="do-oauth"
+          onClick={() => {
+            void loginWithOAuth('google').catch(() => {});
+          }}
+        >
+          google
+        </button>
+      </div>
+    );
+  }
+
+  function stubStart(startResponse: () => Promise<Response>) {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/auth/oauth-start')) {
+        return startResponse();
+      }
+      return Promise.resolve(jsonResponse({ error: 'no session' }, 401));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  async function renderReady() {
+    render(
+      <AuthProvider config={config}>
+        <OAuthProbe />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('loading-state')).toHaveTextContent('ready'));
+  }
+
+  it('navigates to oauth-start only after a healthy pre-flight', async () => {
+    stubStart(() => Promise.resolve(new Response(null, { status: 302 })));
+    await renderReady();
+
+    fireEvent.click(screen.getByTestId('do-oauth'));
+
+    await waitFor(() =>
+      expect(assignMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/auth/oauth-start?provider=google'),
+      ),
+    );
+    expect(screen.getByTestId('auth-error')).toHaveTextContent('none');
+  });
+
+  it('keeps the user in-app with an inline error when start returns 502', async () => {
+    stubStart(() => Promise.resolve(new Response('', { status: 502, statusText: 'Bad Gateway' })));
+    await renderReady();
+
+    fireEvent.click(screen.getByTestId('do-oauth'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-error')).toHaveTextContent(SERVICE_UNAVAILABLE_MESSAGE),
+    );
+    expect(assignMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId('loading-state')).toHaveTextContent('ready');
+  });
+
+  it('keeps the user in-app with an inline error when the probe fetch rejects', async () => {
+    stubStart(() => Promise.reject(new TypeError('Failed to fetch')));
+    await renderReady();
+
+    fireEvent.click(screen.getByTestId('do-oauth'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-error')).toHaveTextContent(SERVICE_UNAVAILABLE_MESSAGE),
+    );
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it('shows the provider-unavailable message when start is 4xx (not configured)', async () => {
+    stubStart(() => Promise.resolve(jsonResponse({ error: 'Unsupported provider' }, 400)));
+    await renderReady();
+
+    fireEvent.click(screen.getByTestId('do-oauth'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-error')).toHaveTextContent(
+        OAUTH_PROVIDER_UNAVAILABLE_MESSAGE,
+      ),
+    );
+    expect(assignMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -102,7 +102,7 @@ export interface AuthActions {
   loginWithEmail: (email: string, password: string) => Promise<void>;
   /** Sign in with a registered passkey. */
   loginWithPasskey: (email?: string) => Promise<void>;
-  /** Sign in with an OAuth provider (opens popup/redirect). */
+  /** Sign in with an OAuth provider (pre-flights the start endpoint, then redirects). */
   loginWithOAuth: (provider: OAuthProvider) => Promise<void>;
   /** Register a new passkey for the current user. */
   registerNewPasskey: () => Promise<void>;
@@ -196,6 +196,16 @@ export const BETA_ACCESS_REQUIRED_MESSAGE = 'Beta access required';
  */
 export const SERVICE_UNAVAILABLE_MESSAGE =
   'The server is temporarily unavailable. Please try again in a few minutes.';
+
+/**
+ * User-facing message shown when an OAuth provider's sign-in cannot be
+ * started because the provider is not configured/enabled on the backend
+ * (e.g. the Edge Function answers 4xx for that provider). Distinct from
+ * {@link SERVICE_UNAVAILABLE_MESSAGE} so a not-yet-provisioned provider
+ * doesn't masquerade as a transient outage (#3109).
+ */
+export const OAUTH_PROVIDER_UNAVAILABLE_MESSAGE =
+  'That sign-in option is unavailable right now. Try another option or use email & password.';
 
 // ---------------------------------------------------------------------------
 // Provider
@@ -865,17 +875,45 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
 
       setIsLoading(true);
 
+      const params = new URLSearchParams({
+        provider,
+        redirect_to: '/dashboard',
+      });
+      const startUrl = `/api/auth/oauth-start?${params.toString()}`;
+
       try {
-        // Drive OAuth through our Edge Function (#1886). The function
-        // generates PKCE + state in HttpOnly cookies, redirects to
-        // Supabase, and on return sets the refresh cookie at
-        // Path=/api/auth before bouncing to /dashboard.
-        const params = new URLSearchParams({
-          provider,
-          redirect_to: '/dashboard',
+        // Pre-flight the OAuth Edge Function (#1886) before leaving the SPA.
+        // A healthy start generates PKCE + state in HttpOnly cookies and
+        // replies 302 → Supabase; with `redirect: 'manual'` that surfaces as
+        // an opaque-redirect we never follow, so the probe is side-effect
+        // free aside from throwaway cookies that the real navigation rewrites.
+        // If the function is unprovisioned/down it answers 5xx (or the proxy
+        // returns 502), so we keep the user in-app with an inline error
+        // instead of hard-redirecting them onto a raw JSON/502 page (#3109).
+        const probe = await fetch(startUrl, {
+          method: 'GET',
+          credentials: 'include',
+          redirect: 'manual',
+          headers: { Accept: 'application/json' },
         });
-        window.location.href = `/api/auth/oauth-start?${params.toString()}`;
+
+        if (isOAuthStartHealthy(probe)) {
+          window.location.assign(startUrl);
+          return;
+        }
+
+        setError(
+          isServiceUnavailableStatus(probe.status)
+            ? SERVICE_UNAVAILABLE_MESSAGE
+            : OAUTH_PROVIDER_UNAVAILABLE_MESSAGE,
+        );
+        setIsLoading(false);
       } catch (err) {
+        if (isNetworkError(err)) {
+          setError(SERVICE_UNAVAILABLE_MESSAGE);
+          setIsLoading(false);
+          return;
+        }
         const message = err instanceof Error ? err.message : `OAuth login with ${provider} failed`;
         setError(message);
         setIsLoading(false);
@@ -1112,6 +1150,23 @@ export function isBetaEmailAllowed(
  */
 export function isServiceUnavailableStatus(status: number): boolean {
   return status === 0 || status >= 500;
+}
+
+/**
+ * Whether a pre-flight probe of `/api/auth/oauth-start` indicates the Edge
+ * Function is provisioned and healthy, so the SPA can safely hand the
+ * browser off to it. A healthy start replies with a 3xx redirect to the
+ * provider; under `redirect: 'manual'` that surfaces as an `opaqueredirect`
+ * (status `0`). Anything else (4xx provider/config error, 5xx outage, or a
+ * proxy 502) means we should keep the user in-app and show an inline error
+ * rather than dump them on a raw JSON/502 page (#3109).
+ */
+export function isOAuthStartHealthy(response: Response): boolean {
+  return (
+    response.type === 'opaqueredirect' ||
+    response.redirected ||
+    (response.status >= 300 && response.status < 400)
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
OAuth sign-in (Google/GitHub `Service temporarily unavailable`, Apple 502) hard-redirected users out of the SPA to a raw JSON/error page. loginWithOAuth set `window.location.href` to `/api/auth/oauth-start` unconditionally, so a down/unprovisioned edge function left users stranded with no in-app recovery.

## Changes
- **Pre-flight the start endpoint** (pps/web/src/auth/auth-context.tsx): probe `/api/auth/oauth-start` with `redirect: 'manual'` and only `window.location.assign` when the function is healthy (302/opaque-redirect). Probe is side-effect free aside from throwaway PKCE cookies the real navigation rewrites.
- **Keep users in-app on failure**: 5xx/502/0 -> inline `SERVICE_UNAVAILABLE_MESSAGE`; 4xx (provider not configured) -> new `OAUTH_PROVIDER_UNAVAILABLE_MESSAGE`; network reject -> service-unavailable. `setIsLoading(false)` so the form stays usable.
- Added `isOAuthStartHealthy` helper + 8 tests (healthy navigates, 502/4xx/network keep user in-app).

## Backend note
The root cause also includes `oauth-start` being unprovisioned in prod. This PR is the **client** fix. Backend must still confirm the `auth-oauth-start` edge function + provider secrets are deployed (`services/api/supabase/functions/auth-oauth-start`) — tracked under platform:backend.

## Issues
Closes #3109

## Testing
- [x] Lint + format clean (`npm run format:check && npx eslint . --max-warnings 0`)
- [x] `auth-context.test.tsx` 24 passed; `LoginPage.test.tsx` 16 passed