### PR TITLE
fix(web): clearer hidden-checklist copy (#3128)

### DIFF
--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -489,9 +489,9 @@ describe('OnboardingPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /hide checklist/i }));
 
     expect(localStorage.getItem('finance-onboarding-checklist-hidden')).toBe('true');
-    expect(screen.getByText(/fully set-up checklist hidden/i)).toBeInTheDocument();
+    expect(screen.getByText(/checklist hidden/i)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /restore setup checklist/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show checklist/i }));
     fireEvent.click(screen.getByRole('button', { name: /dismiss all coach marks/i }));
 
     expect(localStorage.getItem('finance-onboarding-coach-marks-dismissed')).toBe('true');

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -1714,15 +1714,13 @@ const OnboardingPage: React.FC = () => {
 
           {setupChecklistHidden ? (
             <section className="onboarding__checklist" aria-label="Setup checklist hidden">
-              <p className="onboarding__path-description">
-                Fully set-up checklist hidden. You can restore it from help or settings.
-              </p>
+              <p className="onboarding__path-description">Checklist hidden.</p>
               <button
                 type="button"
                 className="onboarding__path-btn onboarding__path-btn--secondary"
                 onClick={() => handleChecklistHiddenChange(false)}
               >
-                Restore setup checklist
+                Show checklist
               </button>
             </section>
           ) : (


### PR DESCRIPTION
## Summary
Reword the collapsed hidden-checklist state on the onboarding complete screen for clearer, more natural copy.

## Changes
- Subtitle: 'Fully set-up checklist hidden. You can restore it from help or settings.' -> 'Checklist hidden.'
- Button: 'Restore setup checklist' -> 'Show checklist'
- Behavior unchanged (handleChecklistHiddenChange(false))

## Issues
Closes #3128

## Testing
- [x] Prettier + ESLint clean on apps/web/src/pages/OnboardingPage.tsx