### PR TITLE
fix(web): clearer onboarding checklist title (#3126)

### DIFF
--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -519,9 +519,7 @@ describe('OnboardingPage', () => {
     continueToTemplateStep();
     fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
 
-    expect(
-      screen.getByRole('region', { name: /fully set-up progress checklist/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /setup progress/i })).toBeInTheDocument();
     expect(screen.getByRole('region', { name: /first-run coach marks/i })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /hide checklist/i }));

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -1755,10 +1755,10 @@ const OnboardingPage: React.FC = () => {
               </button>
             </section>
           ) : (
-            <section className="onboarding__checklist" aria-label="Fully set-up progress checklist">
+            <section className="onboarding__checklist" aria-label="Setup progress">
               <div className="onboarding__template-header">
                 <div>
-                  <h2 className="onboarding__path-title">Fully set-up progress checklist</h2>
+                  <h2 className="onboarding__path-title">Setup progress</h2>
                   <p className="onboarding__path-description">
                     Beta activation is complete when privacy is reviewed, setup has a first budget
                     or goal, and at least one confidence task is done.


### PR DESCRIPTION
## Summary
Renames the awkward onboarding complete-screen checklist title 'Fully set-up progress checklist' to plain 'Setup progress'. Updates the matching section aria-label; status badge unchanged.

## Changes
- apps/web/src/pages/OnboardingPage.tsx: h2 title + aria-label -> 'Setup progress'

## Issues
Closes #3126

## Testing
- [x] Prettier clean on changed file
- [ ] CI