### PR TITLE
fix(web): pill-style onboarding badge (#3121)

### DIFF
--- a/apps/web/src/pages/OnboardingPage.css
+++ b/apps/web/src/pages/OnboardingPage.css
@@ -515,12 +515,17 @@
 .onboarding__template-badge {
   display: inline-flex;
   align-items: center;
+  align-self: flex-start;
+  flex-shrink: 0;
+  width: auto;
+  max-width: 100%;
   padding: 0.25rem 0.625rem;
   border-radius: 999px;
   background: var(--semantic-background-secondary);
   color: var(--semantic-text-secondary);
   font-size: var(--type-scale-caption-font-size);
   font-weight: var(--font-weight-medium);
+  white-space: nowrap;
 }
 
 .onboarding__template-guidance {


### PR DESCRIPTION
## Summary
Restyle the 'Optional & private' onboarding template badge so it sizes to content instead of squishing into a circular blob.

## Changes
- `.onboarding__template-badge` in `apps/web/src/pages/OnboardingPage.css`: add `flex-shrink: 0` + `align-self: flex-start` so the flex parent no longer squeezes it; `white-space: nowrap` keeps the label on one line; `width: auto` + `max-width: 100%` keep it content-sized with overflow guard. Pill `border-radius` retained.

## Issues
Closes #3121

## Testing
- [x] Short ('Optional') and long ('Optional & private') labels render as content-sized pills
- [x] `npm run format:check` (file clean) + `npx eslint . --max-warnings 0` pass

Web-only CSS.