### PR TITLE
fix(web): allow legal routes during first run (#3119)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -111,6 +111,10 @@ const STANDALONE_ROUTES: readonly string[] = [
  * `/legal` is exempt (prefix match covers `/legal/privacy`, `/legal/terms`,
  * `/legal/ccpa`) so pre-onboarding visitors can read the legal documents linked from
  * the auth footers — bouncing them to `/onboarding` would be a compliance problem (#3110).
+ *
+ * The bare `/privacy`, `/terms`, and `/ccpa` aliases are also exempt: the GDPR consent
+ * modal links to `/privacy`, and bouncing that link to onboarding blocked the privacy
+ * notice during first run (#3119).
  */
 const FIRST_RUN_ALLOWED_ROUTES: readonly string[] = [
   '/login',
@@ -118,6 +122,9 @@ const FIRST_RUN_ALLOWED_ROUTES: readonly string[] = [
   '/forgot-password',
   '/reset-password',
   '/legal',
+  '/privacy',
+  '/terms',
+  '/ccpa',
   '/onboarding',
 ];
 

--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -273,6 +273,14 @@ describe('OnboardingPage', () => {
     expect(shouldAutoLaunchOnboarding('/legal/ccpa', false)).toBe(false);
   });
 
+  it('lets a first-run visitor reach the bare legal aliases linked from the consent modal (#3119)', () => {
+    // The GDPR consent modal links to /privacy directly; that alias and its
+    // siblings must be exempt so the privacy notice is reachable pre-onboarding.
+    expect(shouldAutoLaunchOnboarding('/privacy', false)).toBe(false);
+    expect(shouldAutoLaunchOnboarding('/terms', false)).toBe(false);
+    expect(shouldAutoLaunchOnboarding('/ccpa', false)).toBe(false);
+  });
+
   it('stores Huge text preferences from the comfort step', () => {
     renderWithRouter(<OnboardingPage />);
 


### PR DESCRIPTION
## Summary
The GDPR 'Your Privacy Matters' consent modal links its Privacy Policy to `/privacy`, but `/privacy`/`/terms`/`/ccpa` were missing from `FIRST_RUN_ALLOWED_ROUTES`, so first-run visitors were bounced to `/onboarding` instead of the privacy notice.

## Changes
- Add `/privacy`, `/terms`, `/ccpa` to `FIRST_RUN_ALLOWED_ROUTES` in `apps/web/src/App.tsx` (`/legal` already present)
- Update the route-comment to document the consent-modal aliases
- Add a first-run test for the bare legal aliases in `OnboardingPage.test.tsx`

## Issues
Closes #3119

## Testing
- [x] OnboardingPage legal-route tests pass
- [x] `npm run format:check` + `eslint --max-warnings 0` clean