### PR TITLE
fix(web): deep-link onboarding checklist review links (#3127)

### DIFF
--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import type { NavigateOptions, To } from 'react-router-dom';
 
@@ -454,6 +454,36 @@ describe('OnboardingPage', () => {
 
     expect(localStorage.getItem('finance-onboarding-completed-lessons')).toContain('needs-wants');
     expect(screen.getByText(/education lessons 3\/3 complete/i)).toBeInTheDocument();
+  });
+
+  it('deep-links the checklist "Edit guidance" link to the life-stage section', async () => {
+    renderWithRouter(<OnboardingPage />);
+
+    continueToTemplateStep();
+    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit guidance/i }));
+
+    expect(
+      screen.getByRole('heading', { name: /want a starter budget\? choose a template:/i }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(document.getElementById('onboarding-life-stage-guidance')).toHaveFocus(),
+    );
+  });
+
+  it('deep-links the checklist "Review lessons" link to the lessons section', async () => {
+    renderWithRouter(<OnboardingPage />);
+
+    continueToTemplateStep();
+    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+    fireEvent.click(screen.getByRole('button', { name: /review lessons/i }));
+
+    expect(
+      screen.getByRole('heading', { name: /want a starter budget\? choose a template:/i }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(document.getElementById('onboarding-financial-lessons')).toHaveFocus(),
+    );
   });
 
   it('previews and saves an onboarding goal before checklist completion', () => {

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -114,6 +114,8 @@ type Lesson = {
 
 const LIFE_STAGE_STORAGE_KEY = 'finance-onboarding-life-stages';
 const LESSONS_STORAGE_KEY = 'finance-onboarding-completed-lessons';
+const TEMPLATE_GUIDANCE_ANCHOR = 'onboarding-life-stage-guidance';
+const TEMPLATE_LESSONS_ANCHOR = 'onboarding-financial-lessons';
 const GOALS_STORAGE_KEY = 'finance-onboarding-goals';
 const COACH_MARKS_STORAGE_KEY = 'finance-onboarding-coach-marks-dismissed';
 const CHECKLIST_HIDDEN_STORAGE_KEY = 'finance-onboarding-checklist-hidden';
@@ -512,6 +514,7 @@ const OnboardingPage: React.FC = () => {
     readStringArray(LESSONS_STORAGE_KEY),
   );
   const [lessonFeedback, setLessonFeedback] = useState<Record<string, string>>({});
+  const [pendingTemplateAnchor, setPendingTemplateAnchor] = useState<string | null>(null);
   const [activeGlossaryTerm, setActiveGlossaryTerm] = useState<GlossaryTermId | null>(null);
   const [coachMarksDismissed, setCoachMarksDismissed] = useState(() =>
     readBoolean(COACH_MARKS_STORAGE_KEY),
@@ -890,6 +893,27 @@ const OnboardingPage: React.FC = () => {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [activeExplainer, handleCloseExplainer]);
 
+  useEffect(() => {
+    if (step !== 'template' || !pendingTemplateAnchor) {
+      return;
+    }
+    const anchor = pendingTemplateAnchor;
+    const frame = requestAnimationFrame(() => {
+      const target = document.getElementById(anchor);
+      if (target) {
+        target.scrollIntoView?.({ behavior: reducedMotion ? 'auto' : 'smooth', block: 'start' });
+        target.focus({ preventScroll: true });
+      }
+      setPendingTemplateAnchor(null);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [step, pendingTemplateAnchor, reducedMotion]);
+
+  const openTemplateSection = useCallback((anchor: string) => {
+    setPendingTemplateAnchor(anchor);
+    setStep('template');
+  }, []);
+
   if (step === 'comfort') {
     return (
       <main className={onboardingClassName} aria-label="Comfort Preferences">
@@ -1195,7 +1219,12 @@ const OnboardingPage: React.FC = () => {
             </p>
           </header>
 
-          <section className="onboarding__template-card" aria-label="Life-stage tailored setup">
+          <section
+            id={TEMPLATE_GUIDANCE_ANCHOR}
+            tabIndex={-1}
+            className="onboarding__template-card"
+            aria-label="Life-stage tailored setup"
+          >
             <div className="onboarding__template-header">
               <div>
                 <h2 className="onboarding__path-title">Tailor setup to your life stage</h2>
@@ -1436,6 +1465,8 @@ const OnboardingPage: React.FC = () => {
           </section>
 
           <section
+            id={TEMPLATE_LESSONS_ANCHOR}
+            tabIndex={-1}
             className="onboarding__template-card onboarding__stacked-section"
             aria-label="Financial literacy lessons"
           >
@@ -1764,7 +1795,7 @@ const OnboardingPage: React.FC = () => {
                   <button
                     type="button"
                     className="onboarding__link-button"
-                    onClick={() => setStep('template')}
+                    onClick={() => openTemplateSection(TEMPLATE_GUIDANCE_ANCHOR)}
                   >
                     Edit guidance
                   </button>
@@ -1777,7 +1808,7 @@ const OnboardingPage: React.FC = () => {
                   <button
                     type="button"
                     className="onboarding__link-button"
-                    onClick={() => setStep('template')}
+                    onClick={() => openTemplateSection(TEMPLATE_LESSONS_ANCHOR)}
                   >
                     Review lessons
                   </button>


### PR DESCRIPTION
## Summary
Fixes the onboarding complete checklist deep-links. 'Edit guidance' and 'Review lessons' both called setStep('template') and dropped users at the top of the generic template step.

## Changes
- Added stable anchor ids + tabIndex on the life-stage guidance and financial-lessons sections
- Added a pendingTemplateAnchor scroll effect (respects reduced motion) that scrolls/focuses the named section after the step switches
- Wired each checklist link to its own anchor via openTemplateSection
- Tests for both deep links

Closes #3127