### PR TITLE
fix(web): rename coach marks to quick tips (#3129)

### DIFF
--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -520,7 +520,7 @@ describe('OnboardingPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
 
     expect(screen.getByRole('region', { name: /setup progress/i })).toBeInTheDocument();
-    expect(screen.getByRole('region', { name: /first-run coach marks/i })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /quick tips/i })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /hide checklist/i }));
 
@@ -528,12 +528,12 @@ describe('OnboardingPage', () => {
     expect(screen.getByText(/checklist hidden/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /show checklist/i }));
-    fireEvent.click(screen.getByRole('button', { name: /dismiss all coach marks/i }));
+    fireEvent.click(screen.getByRole('button', { name: /hide tips/i }));
 
     expect(localStorage.getItem('finance-onboarding-coach-marks-dismissed')).toBe('true');
-    expect(screen.getByRole('button', { name: /reopen coach marks/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /show tips/i })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /reopen coach marks/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show tips/i }));
 
     expect(localStorage.getItem('finance-onboarding-coach-marks-dismissed')).toBe('false');
     expect(screen.getByText(/budget categories are planning buckets/i)).toBeInTheDocument();

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -1838,10 +1838,10 @@ const OnboardingPage: React.FC = () => {
             </section>
           )}
 
-          <section className="onboarding__coachmarks" aria-label="First-run coach marks">
+          <section className="onboarding__coachmarks" aria-label="Quick tips">
             <div className="onboarding__template-header">
               <div>
-                <h2 className="onboarding__path-title">First-run coach marks</h2>
+                <h2 className="onboarding__path-title">Quick tips</h2>
                 <p className="onboarding__path-description">
                   Plain-language tips for dashboard, budget, transactions, and goals. Dismiss once
                   or reopen later from help.
@@ -1854,7 +1854,7 @@ const OnboardingPage: React.FC = () => {
                 className="onboarding__path-btn onboarding__path-btn--secondary"
                 onClick={handleCoachMarksRestore}
               >
-                Reopen coach marks
+                Show tips
               </button>
             ) : (
               <>
@@ -1892,7 +1892,7 @@ const OnboardingPage: React.FC = () => {
                     className="onboarding__path-btn onboarding__path-btn--secondary"
                     onClick={handleCoachMarksDismiss}
                   >
-                    Dismiss all coach marks
+                    Hide tips
                   </button>
                 </div>
               </>


### PR DESCRIPTION
## Summary
Renames the jargon `First-run coach marks` onboarding section to plain language (`Quick tips`) on the web app.

## Changes
- Section `aria-label` and `h2` title: `First-run coach marks` -> `Quick tips`
- Button `Reopen coach marks` -> `Show tips`
- Button `Dismiss all coach marks` -> `Hide tips`
- Updated OnboardingPage tests for the new labels

## Issues
Closes #3129

## Testing
- [x] OnboardingPage.test.tsx (23 passed)
- [x] prettier --check + eslint --max-warnings 0 on changed files