### PR TITLE
fix(web): horizontal mood-vs-spending stats (#3144)

### DIFF
--- a/apps/web/src/components/mood/mood.css
+++ b/apps/web/src/components/mood/mood.css
@@ -243,12 +243,18 @@
   justify-items: center;
 }
 
-.mood-chart__summary,
 .mood-journal__stats,
 .mood-patterns__stats {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: var(--spacing-3);
+  margin: 0;
+}
+
+.mood-chart__summary {
+  display: flex;
+  flex-flow: row wrap;
+  gap: var(--spacing-2) var(--spacing-4);
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary

Lay out the dashboard **"Mood vs. spending"** card's **Correlation / Direction / Strength** stats as a wrapping horizontal row of compact stats instead of a vertical stack, reclaiming wasted vertical space in the card header.

## Changes

- `apps/web/src/components/mood/mood.css`: split `.mood-chart__summary` out of the shared auto-fit grid (`.mood-journal__stats` and `.mood-patterns__stats` keep the grid) and give it `display: flex; flex-flow: row wrap` with compact row/column gaps, so the three stats sit in a row and wrap gracefully on narrow widths.

## Root cause

The summary `<dl>` shared `grid-template-columns: repeat(auto-fit, minmax(120px, 1fr))`. It lives in the `.mood-chart__header` (`flex` / `space-between`) beside the title block, so its residual width frequently fell below ~240px — collapsing `auto-fit` to a single column and stacking the stats vertically.

## Note on file scope

Triage named `DashboardMoodJournalSection.tsx (+ css)`. That component only composes child mood widgets; the actual Correlation/Direction/Strength markup lives in its child `SpendingMoodChart.tsx`, styled by `mood.css`. The fix is therefore applied in `mood.css`, scoped to `.mood-chart__summary` only.

## Testing

- [x] Changed file Prettier-clean (`npx prettier --check apps/web/src/components/mood/mood.css`)
- [x] CSS-only change — ESLint does not process CSS; `.mood-journal__stats` / `.mood-patterns__stats` layout unchanged
- [ ] Visual: stats render as a horizontal row and wrap on narrow widths

## Issues

Closes #3144

---

Merge order: 7 of 17. A sibling PR (mood-over-time colors) touches the same area and merges before this one — rebased onto `origin/main` before push and again before merge, keeping both changes.
