### PR TITLE
fix(web): single-border grocery affordability input (#3142)

### DIFF
--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -602,6 +602,16 @@
   outline-offset: 2px;
 }
 
+/*
+ * The afford field draws its border and focus ring on the wrapper
+ * (`:focus-within`, above). Suppress the inner input's own outline so focus
+ * shows a single ring on the wrapper instead of a doubled box-in-a-box. Focus
+ * visibility (WCAG 2.4.7) is preserved by the wrapper's ring.
+ */
+.grocery-mode-card__afford-input .grocery-mode-card__input:focus-visible {
+  outline: none;
+}
+
 .grocery-mode-card__afford-result {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## Summary

Fixes the doubled box / nested focus ring on the dashboard **Grocery mode** card's "Can I afford…?" dollar-amount input. The field now renders as a single clean field with **one border and one focus ring**.

## Root cause

The afford field is a flex wrapper (`.grocery-mode-card__afford-input`) holding the `$` prefix and the `<input>`. The wrapper owns the visible border and a `:focus-within` focus ring; the inner `<input class="grocery-mode-card__input">` is intentionally borderless/transparent.

The shared focus rule also targeted `.grocery-mode-card__input:focus-visible`, giving the inner input its **own** 2px outline. On focus (notably keyboard focus) the inner-input outline and the wrapper `:focus-within` outline both rendered — two concentric rings = the doubled box-in-a-box.

## Changes

- `apps/web/src/components/dashboard/dashboard.css`: suppress the inner input's `:focus-visible` outline when it sits inside `.grocery-mode-card__afford-input`, so the wrapper's `:focus-within` ring is the single focus indicator. Added a clarifying comment noting focus visibility (WCAG 2.4.7) is preserved by the wrapper ring.

CSS-only, 10 lines added, scoped to the one file. No DOM/TSX or behavioral changes — the existing `GroceryModeCard` tests are unaffected.

## Accessibility

- One clearly visible 2px focus ring on the field wrapper on focus (keyboard and pointer) — WCAG 2.4.7 Focus Visible preserved.
- No change to labels, live regions, or the `$` prefix semantics.

## Testing

- [x] Prettier clean on the changed file under the CI-pinned version (`prettier@3.8.4 --check`)
- [x] Change is CSS-only; no ESLint/TS surface affected
- [x] Existing `GroceryModeCard.test.tsx` behavior unchanged (no DOM changes)

## Issues

Closes #3142

---

Merge order: 1 of 17 (dashboard bug-bash batch).
