### PR TITLE
fix(web): consolidate redundant sync status badges (#3141)

### DIFF
--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -74,9 +74,6 @@ vi.mock('../components/common/LoadingSpinner', () => ({
     </div>
   ),
 }));
-vi.mock('../components/common/SyncIndicator', () => ({
-  SyncIndicator: () => <span>Synced</span>,
-}));
 vi.mock('../components/OfflineBanner', () => ({
   OfflineBanner: () => null,
 }));

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -4,13 +4,7 @@ import React, { Suspense, useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { TimePeriod, ViewType } from '../components/charts';
 import { AccountPurposeFilterControl } from '../components/accounts';
-import {
-  CurrencyDisplay,
-  EmptyState,
-  ErrorBanner,
-  LoadingSpinner,
-  SyncIndicator,
-} from '../components/common';
+import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
 import { OfflineBanner } from '../components/OfflineBanner';
 import {
   useAccounts,
@@ -776,7 +770,6 @@ export const DashboardPage: React.FC = () => {
             <span aria-hidden="true">{rmdDueCount}</span>
           </Link>
         )}
-        <SyncIndicator />
       </div>
       <button
         type="button"


### PR DESCRIPTION
## Summary

The dashboard rendered **two redundant sync-status indicators** at once:

- The global **`SyncStatusBar`** ("All synced", richest state set) from `AppLayout`, shown on every page.
- A redundant **`SyncIndicator`** ("Synced") mounted in the dashboard header.

This consolidates to a **single canonical** indicator by removing the redundant `SyncIndicator` from the dashboard. The global `SyncStatusBar` — which already renders on the dashboard and carries the richer states (synced / pending / syncing / error / offline / conflict) plus Sync-now / Retry actions — becomes the one source of truth, with consistent wording and style.

## Changes

- Remove `<SyncIndicator />` and its import from `apps/web/src/pages/DashboardPage.tsx`.
- Remove the now-unused `SyncIndicator` mock from `apps/web/src/pages/DashboardPage.test.tsx`.

Net diff: **1 insertion, 11 deletions** across 2 files — intentionally minimal, since `DashboardPage.tsx`/`AppLayout.tsx` are touched by other in-flight PRs.

## Root cause

`SyncStatusBar` (mounted globally in `AppLayout`) and `SyncIndicator` (mounted in `DashboardPage`) both render a sync pill, so the dashboard showed the same state twice with inconsistent wording/style. The richer `SyncStatusBar` is kept; the simpler `SyncIndicator` is removed from the dashboard.

> The original report named `SyncStatusPanel.tsx`; that component is actually dead code (never mounted). The visible redundant pill was `SyncIndicator`. Removing the dead `SyncStatusPanel` and the `SyncIndicator` usages on Budgets/Transactions are intentionally **out of scope** here to keep the diff minimal.

## Testing

- [x] `npx prettier --check` on changed files — clean
- [x] `npx eslint --fix` on changed files — clean (0 problems)
- [x] Repo-wide `npm run format:check` — passes
- [x] `DashboardPage.test.tsx` — 14/15 pass; the 1 failure (`has accessible landmarks`) is a **pre-existing** environmental timeout on a lazily-loaded mood-journal landmark, reproduced on `main` without these changes (unrelated to sync).

## Issues

Closes #3141

---

Merge order: 5 of 17.
