### PR TITLE
fix(web): gate swipe tips to touch pointers (#3143)

### DIFF
--- a/apps/web/src/components/common/SwipeableRow.test.tsx
+++ b/apps/web/src/components/common/SwipeableRow.test.tsx
@@ -68,6 +68,23 @@ function renderRow(options: { leftActions?: SwipeAction[]; rightActions?: SwipeA
   };
 }
 
+/**
+ * Stub `matchMedia` so the coarse-pointer hook reports a touch device
+ * (`coarse = true`) or a mouse device (`coarse = false`).
+ */
+function stubPointer(coarse: boolean) {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: coarse && (query === '(pointer: coarse)' || query === '(hover: none)'),
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+  }));
+}
+
 describe('SwipeableRow', () => {
   const originalPointerEvent = window.PointerEvent;
 
@@ -78,6 +95,7 @@ describe('SwipeableRow', () => {
 
   afterEach(() => {
     window.PointerEvent = originalPointerEvent;
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -140,5 +158,27 @@ describe('SwipeableRow', () => {
     fireEvent.touchEnd(content);
 
     expect(rightHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps swipe and long-press guidance on touch (coarse) pointers', () => {
+    stubPointer(true);
+    const { row } = renderRow();
+
+    const hintId = row.getAttribute('aria-describedby');
+    expect(hintId).toBeTruthy();
+    const hint = document.getElementById(hintId as string);
+    expect(hint?.textContent?.trim()).toBe(
+      'Swipe horizontally or long-press to access transaction actions.',
+    );
+  });
+
+  it('drops swipe/long-press wording for fine (mouse) pointers', () => {
+    stubPointer(false);
+    const { row } = renderRow();
+
+    const hintId = row.getAttribute('aria-describedby');
+    expect(hintId).toBeTruthy();
+    const hint = document.getElementById(hintId as string);
+    expect(hint?.textContent?.trim()).toBe('Right-click to access transaction actions.');
   });
 });

--- a/apps/web/src/components/common/SwipeableRow.tsx
+++ b/apps/web/src/components/common/SwipeableRow.tsx
@@ -14,6 +14,8 @@ import React, {
   type TouchEvent as ReactTouchEvent,
 } from 'react';
 
+import { useCoarsePointer } from '../../hooks/useCoarsePointer';
+
 import './swipeable-row.css';
 
 export type SwipeActionVariant = 'default' | 'success' | 'warning' | 'danger';
@@ -98,6 +100,7 @@ export function SwipeableRow({
   const pointerCapturedRef = useRef(false);
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hintId = useId();
+  const isCoarsePointer = useCoarsePointer();
 
   const [offsetX, setOffsetX] = useState(0);
   const [openSide, setOpenSide] = useState<OpenSide>(null);
@@ -515,6 +518,12 @@ export function SwipeableRow({
 
   const contentClasses = joinClassNames('swipeable-row__content', contentClassName);
   const actionHint = contextMenuActions.length > 0 ? `${hintId}-hint` : undefined;
+  // Swipe and long-press are touch-only gestures, so advertise them only on
+  // coarse/touch pointers. Mouse users get the right-click affordance instead,
+  // avoiding guidance for gestures their device can't perform (#3143).
+  const actionHintText = isCoarsePointer
+    ? 'Swipe horizontally or long-press to access transaction actions.'
+    : 'Right-click to access transaction actions.';
 
   return (
     <div
@@ -589,7 +598,7 @@ export function SwipeableRow({
 
       {contextMenuActions.length > 0 && (
         <span id={actionHint} className="sr-only">
-          Swipe horizontally, right-click, or long-press to access transaction actions.
+          {actionHintText}
         </span>
       )}
 

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -120,6 +120,7 @@ export type {
 } from './useFormValidation';
 export { useBreakpoint } from './useBreakpoint';
 export type { UseBreakpointResult, Breakpoint } from './useBreakpoint';
+export { useCoarsePointer, prefersCoarsePointer } from './useCoarsePointer';
 export { useDeepLink, matchRoute } from './useDeepLink';
 export type { UseDeepLinkResult, RouteParams, RoutePattern } from './useDeepLink';
 export { useVirtualList } from './useVirtualList';

--- a/apps/web/src/hooks/useCoarsePointer.test.ts
+++ b/apps/web/src/hooks/useCoarsePointer.test.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { prefersCoarsePointer, useCoarsePointer } from './useCoarsePointer';
+
+// ---------------------------------------------------------------------------
+// Mock matchMedia
+// ---------------------------------------------------------------------------
+
+let mediaMatches: Record<string, boolean> = {};
+
+function createMockMatchMedia() {
+  return (query: string) => ({
+    matches: mediaMatches[query] ?? false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+  });
+}
+
+beforeEach(() => {
+  mediaMatches = {};
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// prefersCoarsePointer
+// ---------------------------------------------------------------------------
+
+describe('prefersCoarsePointer', () => {
+  it('returns false when matchMedia is unavailable', () => {
+    vi.stubGlobal('matchMedia', undefined);
+
+    expect(prefersCoarsePointer()).toBe(false);
+  });
+
+  it('returns false for a fine pointer that can hover (desktop mouse)', () => {
+    mediaMatches = { '(pointer: coarse)': false, '(hover: none)': false };
+    vi.stubGlobal('matchMedia', createMockMatchMedia());
+
+    expect(prefersCoarsePointer()).toBe(false);
+  });
+
+  it('returns true when the primary pointer is coarse', () => {
+    mediaMatches = { '(pointer: coarse)': true, '(hover: none)': false };
+    vi.stubGlobal('matchMedia', createMockMatchMedia());
+
+    expect(prefersCoarsePointer()).toBe(true);
+  });
+
+  it('returns true when the device cannot hover', () => {
+    mediaMatches = { '(pointer: coarse)': false, '(hover: none)': true };
+    vi.stubGlobal('matchMedia', createMockMatchMedia());
+
+    expect(prefersCoarsePointer()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useCoarsePointer
+// ---------------------------------------------------------------------------
+
+describe('useCoarsePointer', () => {
+  it('reports false on a fine-pointer device', () => {
+    mediaMatches = { '(pointer: coarse)': false, '(hover: none)': false };
+    vi.stubGlobal('matchMedia', createMockMatchMedia());
+
+    const { result } = renderHook(() => useCoarsePointer());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('reports true on a coarse-pointer device', () => {
+    mediaMatches = { '(pointer: coarse)': true, '(hover: none)': false };
+    vi.stubGlobal('matchMedia', createMockMatchMedia());
+
+    const { result } = renderHook(() => useCoarsePointer());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('does not throw when matchMedia is unavailable', () => {
+    vi.stubGlobal('matchMedia', undefined);
+
+    const { result } = renderHook(() => useCoarsePointer());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/useCoarsePointer.ts
+++ b/apps/web/src/hooks/useCoarsePointer.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * useCoarsePointer — detects whether the primary input is a coarse/touch pointer.
+ *
+ * Swipe and long-press gestures only exist on touch devices, so swipe-specific
+ * UI hints should be gated behind this check. Mouse + keyboard users otherwise
+ * see guidance for gestures their device cannot perform — a confusing and
+ * accessibility-unfriendly papercut.
+ *
+ * Detection mirrors the established `useReducedMotion` / `useBreakpoint`
+ * matchMedia pattern. A device is treated as coarse/touch when its primary
+ * pointer is coarse (`(pointer: coarse)`) or it has no hover-capable pointer
+ * (`(hover: none)`). A desktop with a mouse matches neither and is reported as
+ * a fine pointer.
+ *
+ * References: issue #3143
+ */
+
+import { useEffect, useState } from 'react';
+
+const COARSE_POINTER_QUERY = '(pointer: coarse)';
+const NO_HOVER_QUERY = '(hover: none)';
+
+/**
+ * Pure, non-reactive check for a coarse/touch primary pointer.
+ *
+ * SSR- and test-safe: returns `false` when `matchMedia` is unavailable.
+ *
+ * @returns `true` on touch-primary devices, `false` for mouse + keyboard.
+ */
+export function prefersCoarsePointer(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return (
+    window.matchMedia(COARSE_POINTER_QUERY).matches || window.matchMedia(NO_HOVER_QUERY).matches
+  );
+}
+
+/**
+ * Reactive hook that tracks whether the primary pointer is coarse/touch.
+ *
+ * Returns `true` on touch-primary devices and `false` for mouse + keyboard.
+ * Re-evaluates if the pointing capability changes (e.g. a tablet docked to a
+ * mouse, or a convertible laptop folding into tablet mode).
+ *
+ * @returns `true` when the primary pointer is coarse/touch.
+ */
+export function useCoarsePointer(): boolean {
+  const [coarse, setCoarse] = useState(prefersCoarsePointer);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
+    const coarsePointerMql = window.matchMedia(COARSE_POINTER_QUERY);
+    const noHoverMql = window.matchMedia(NO_HOVER_QUERY);
+
+    const update = () => {
+      setCoarse(coarsePointerMql.matches || noHoverMql.matches);
+    };
+
+    coarsePointerMql.addEventListener('change', update);
+    noHoverMql.addEventListener('change', update);
+    update();
+
+    return () => {
+      coarsePointerMql.removeEventListener('change', update);
+      noHoverMql.removeEventListener('change', update);
+    };
+  }, []);
+
+  return coarse;
+}

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -50,6 +50,7 @@ import { useAccessibility } from '../hooks/useAccessibility';
 import { useAutoCategorize } from '../hooks/useAutoCategorize';
 import { useBulkTransactions } from '../hooks/useBulkTransactions';
 import { useCategories } from '../hooks/useCategories';
+import { prefersCoarsePointer } from '../hooks/useCoarsePointer';
 import { useFontScale } from '../hooks/useFontScale';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { recordPwaMeaningfulAction } from '../hooks/useInstallPrompt';
@@ -587,6 +588,13 @@ export const TransactionsPage: React.FC = () => {
 
   useEffect(() => {
     if (transactions.length === 0 || toast === null || typeof window === 'undefined') {
+      return;
+    }
+
+    // Swipe gestures only exist on touch devices, so the swipe tip is
+    // irrelevant (and confusing) for mouse + keyboard users. Gate it behind a
+    // coarse/touch pointer check (#3143).
+    if (!prefersCoarsePointer()) {
       return;
     }
 


### PR DESCRIPTION
﻿## Summary

Swipe and long-press are touch-only gestures, but the web app advertised them to mouse + keyboard users on desktop/PC — confusing guidance for actions their device can't perform (an accessibility papercut).

This gates swipe-specific hint copy behind a coarse/touch pointer check.

## Changes

- **New util** `apps/web/src/hooks/useCoarsePointer.ts` — `useCoarsePointer()` hook + `prefersCoarsePointer()` pure helper, following the existing `useReducedMotion` / `useBreakpoint` `matchMedia` pattern. Detects `(pointer: coarse)` or `(hover: none)`; SSR/test-safe. (No existing pointer/touch util existed.)
- **TransactionsPage** — the `swipe right/left` tip toast now only shows on coarse/touch pointers.
- **SwipeableRow** — the `sr-only` actions hint now adapts: _"Swipe horizontally or long-press…"_ on touch, _"Right-click…"_ on fine (mouse) pointers.
- Exported the new hook from the `hooks` barrel.
- Tests: new `useCoarsePointer.test.ts` (7 cases) + 2 `SwipeableRow` cases asserting the adaptive copy.

## Issues

Closes #3143

## Testing

- [x] `npx vitest run` for useCoarsePointer, SwipeableRow, TransactionsPage — 39/39 pass
- [x] `npx prettier --check` on changed files — clean
- [x] `npx eslint --max-warnings 0` on changed files — clean

Scope: web only. No dependencies added.
