### PR TITLE
fix(web): match customize button to workspace switcher (#3150)

### DIFF
--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -223,18 +223,23 @@
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--semantic-border-default);
-  border-radius: var(--border-radius-md);
-  background: var(--semantic-background-primary);
+  border-radius: 999px;
+  background: var(--semantic-background-secondary, #f5f5f5);
   color: var(--semantic-text-secondary);
   font: inherit;
   font-size: var(--type-scale-caption-font-size);
   font-weight: var(--font-weight-medium);
   cursor: pointer;
-  transition: background-color var(--duration-fast, 100ms) ease;
+  transition:
+    background-color var(--duration-fast, 100ms) ease,
+    color var(--duration-fast, 100ms) ease,
+    box-shadow var(--duration-fast, 100ms) ease;
 }
 
 .dashboard-customize-btn:hover {
-  background: var(--semantic-background-secondary);
+  background: var(--semantic-background-primary, #ffffff);
+  color: var(--semantic-text-primary);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
 }
 
 .dashboard-customize-btn:focus-visible {


### PR DESCRIPTION
## Summary

Restyles the dashboard **Customize workspace** button so it matches the pill/segmented account-purpose switcher (`.purpose-filter`, rendered by `AccountPurposeFilterControl`) that sits directly below it. The button was rectangular and visually mismatched against the rounded switcher.

## Changes

- `apps/web/src/components/dashboard/dashboard.css` — `.dashboard-customize-btn`:
  - **Shape/radius:** `border-radius: var(--border-radius-md)` -> `999px` (pill, mirrors `.purpose-filter`).
  - **Colors:** background `--semantic-background-primary` -> `--semantic-background-secondary` (mirrors the switcher track fill); label keeps `--semantic-text-secondary` (already matches `.purpose-filter__button`).
  - **Hover:** mirrors the switcher's selected-segment look — `--semantic-background-primary` fill, `--semantic-text-primary` text, and the same `0 1px 2px rgba(15, 23, 42, 0.12)` shadow as `.purpose-filter__button--selected`.
  - Border (`--semantic-border-default`) and `:focus-visible` outline were already aligned with the switcher — unchanged.

CSS-only, single rule block. No markup, behavior, or token changes. Theme-aware semantic tokens are reused, so light/dark/high-contrast parity is preserved.

## Issues

Closes #3150

## Testing

- [x] Changed file passes Prettier (`npx prettier --check apps/web/src/components/dashboard/dashboard.css`)
- [x] CSS-only change — no ESLint/TS surface affected
- [x] Verified the mirrored values against `.purpose-filter` / `.purpose-filter__button` / `--selected` in `apps/web/src/styles/pages.css`

> Note: repo-wide `format:check` reports pre-existing drift in ~91 unrelated files on the base branch; intentionally not touched to keep this diff tiny (dashboard.css is a hot file). Remote CI is the source of truth.