### PR TITLE
fix(web): clarify mood-over-time colors (#3147)

### DIFF
--- a/apps/web/src/components/mood/MoodCalendar.test.tsx
+++ b/apps/web/src/components/mood/MoodCalendar.test.tsx
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MoodCalendar } from './MoodCalendar';
+import type { MoodJournalEntry } from '../../lib/mood';
+
+function localDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function buildEntry(
+  overrides: Partial<MoodJournalEntry> & Pick<MoodJournalEntry, 'date'>,
+): MoodJournalEntry {
+  return {
+    id: `entry-${overrides.date}`,
+    timestamp: `${overrides.date}T12:00:00Z`,
+    moodLevel: 4,
+    emotions: ['happy'],
+    note: '',
+    spending: { totalCents: 0, transactionCount: 0, categories: [] },
+    ...overrides,
+  };
+}
+
+describe('MoodCalendar', () => {
+  it('colors a day cell by its reason and documents it in a labeled key', () => {
+    const today = localDate(new Date());
+    const entry = buildEntry({ date: today, emotions: ['happy'], moodLevel: 5 });
+
+    const { container } = render(<MoodCalendar entries={[entry]} />);
+
+    const cell = screen.getByRole('gridcell', { name: /Happy reason/ });
+    expect(cell).toHaveClass('mood-reason--happy');
+    expect(cell).toHaveAccessibleName(/mood 5 out of 5/);
+
+    const key = screen.getByRole('list', { name: /what each color means/i });
+    expect(within(key).getByText('Happy')).toBeInTheDocument();
+
+    // The old ambiguous, unlabeled swatch key must be gone.
+    expect(container.querySelector('.mood-calendar__legend-chip')).toBeNull();
+  });
+
+  it('uses the first selected emotion as the reason color', () => {
+    const today = localDate(new Date());
+    const entry = buildEntry({ date: today, emotions: ['sad', 'stressed'] });
+
+    render(<MoodCalendar entries={[entry]} />);
+
+    const cell = screen.getByRole('gridcell', { name: /Sad reason/ });
+    expect(cell).toHaveClass('mood-reason--sad');
+  });
+
+  it('omits the color key when there are no check-ins', () => {
+    render(<MoodCalendar entries={[]} />);
+
+    expect(screen.queryByRole('list', { name: /what each color means/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/mood/MoodCalendar.tsx
+++ b/apps/web/src/components/mood/MoodCalendar.tsx
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useMemo } from 'react';
+import React, { useId, useMemo } from 'react';
 
-import type { MoodJournalEntry, MoodLevel } from '../../lib/mood';
+import type { EmotionTag, MoodJournalEntry, MoodLevel } from '../../lib/mood';
 import { formatDate } from '../../utils/formatDate';
+import {
+  EMOTION_VISUALS,
+  UNSPECIFIED_REASON_CLASS,
+  UNSPECIFIED_REASON_LABEL,
+  emotionVisual,
+  primaryReason,
+} from './emotionVisuals';
 
 const DAYS_TO_SHOW = 35;
 const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
@@ -60,56 +67,109 @@ export const MoodCalendar: React.FC<MoodCalendarProps> = ({ entries }) => {
       const day = new Date(today);
       day.setDate(today.getDate() - (DAYS_TO_SHOW - index - 1));
       const key = formatLocalDate(day);
+      const entry = entryByDate.get(key) ?? null;
+      const reasonTag = entry ? primaryReason(entry) : null;
+      const reasonVisual = reasonTag ? emotionVisual(reasonTag) : null;
       return {
         key,
         weekday: WEEKDAY_LABELS[day.getDay()],
-        entry: entryByDate.get(key) ?? null,
+        entry,
+        reasonTag,
+        reasonLabel: reasonVisual?.label ?? (entry ? UNSPECIFIED_REASON_LABEL : null),
+        reasonClass: reasonVisual?.className ?? (entry ? UNSPECIFIED_REASON_CLASS : null),
         isToday: index === DAYS_TO_SHOW - 1,
       };
     });
   }, [entryByDate]);
+
+  const presentReasons = useMemo(() => {
+    const seen = new Set<EmotionTag>();
+    for (const day of days) {
+      if (day.reasonTag) {
+        seen.add(day.reasonTag);
+      }
+    }
+
+    return EMOTION_VISUALS.filter((visual) => seen.has(visual.tag));
+  }, [days]);
+
+  const keyLabelId = useId();
 
   return (
     <section className="mood-calendar" aria-label="Mood calendar heatmap">
       <div className="mood-calendar__header">
         <div>
           <h4 className="mood-calendar__title">Mood over time</h4>
-          <p className="mood-calendar__subtitle">A five-week view of your daily check-ins.</p>
-        </div>
-        <div className="mood-calendar__legend" aria-hidden="true">
-          {[1, 2, 3, 4, 5].map((level) => (
-            <span
-              key={level}
-              className={`mood-calendar__legend-chip mood-calendar__legend-chip--${level}`}
-            />
-          ))}
+          <p className="mood-calendar__subtitle">
+            A five-week view of your daily check-ins. Each square is colored by what was behind that
+            day&apos;s mood.
+          </p>
         </div>
       </div>
       <div className="mood-calendar__grid" role="grid" aria-label="Mood heatmap grid">
-        {days.map((day) => (
-          <div key={day.key} className="mood-calendar__day">
-            <span className="mood-calendar__weekday" aria-hidden="true">
-              {day.weekday}
-            </span>
-            <div
-              role="gridcell"
-              className={`mood-calendar__cell${day.entry ? ` mood-calendar__cell--${day.entry.moodLevel}` : ' mood-calendar__cell--empty'}${day.isToday ? ' mood-calendar__cell--today' : ''}`}
-              aria-label={
-                day.entry
-                  ? `${formatDate(day.key)} mood ${day.entry.moodLevel} out of 5, spending ${day.entry.spending.totalCents / 100} dollars.`
-                  : `${formatDate(day.key)} no mood check-in`
-              }
-              title={
-                day.entry
-                  ? `${formatDate(day.key)} • Mood ${day.entry.moodLevel}/5 • ${day.entry.emotions.join(', ')}`
-                  : `${formatDate(day.key)} • No check-in`
-              }
-            >
-              {day.entry ? MOOD_EMOJI[day.entry.moodLevel] : '·'}
+        {days.map((day) => {
+          const cellClassName = [
+            'mood-calendar__cell',
+            day.entry ? day.reasonClass : 'mood-calendar__cell--empty',
+            day.isToday ? 'mood-calendar__cell--today' : null,
+          ]
+            .filter(Boolean)
+            .join(' ');
+
+          return (
+            <div key={day.key} className="mood-calendar__day">
+              <span className="mood-calendar__weekday" aria-hidden="true">
+                {day.weekday}
+              </span>
+              <div
+                role="gridcell"
+                className={cellClassName}
+                aria-label={
+                  day.entry
+                    ? `${formatDate(day.key)}: ${day.reasonLabel} reason, mood ${day.entry.moodLevel} out of 5, spending ${day.entry.spending.totalCents / 100} dollars.`
+                    : `${formatDate(day.key)}: no mood check-in.`
+                }
+                title={
+                  day.entry
+                    ? `${formatDate(day.key)} • Mood ${day.entry.moodLevel}/5 • ${day.entry.emotions.length > 0 ? day.entry.emotions.join(', ') : UNSPECIFIED_REASON_LABEL}`
+                    : `${formatDate(day.key)} • No check-in`
+                }
+              >
+                {day.entry ? (
+                  <>
+                    <span className="mood-calendar__cell-emoji" aria-hidden="true">
+                      {MOOD_EMOJI[day.entry.moodLevel]}
+                    </span>
+                    <span className="mood-calendar__cell-reason">{day.reasonLabel}</span>
+                  </>
+                ) : (
+                  <span className="mood-calendar__cell-empty-mark" aria-hidden="true">
+                    ·
+                  </span>
+                )}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
+      {presentReasons.length > 0 ? (
+        <div className="mood-calendar__key">
+          <p className="mood-calendar__key-label" id={keyLabelId}>
+            What each color means
+          </p>
+          <ul className="mood-calendar__legend" aria-labelledby={keyLabelId}>
+            {presentReasons.map((visual) => (
+              <li key={visual.tag} className="mood-calendar__legend-item">
+                <span
+                  className={`mood-calendar__legend-swatch ${visual.className}`}
+                  aria-hidden="true"
+                />
+                {visual.label}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
     </section>
   );
 };

--- a/apps/web/src/components/mood/emotionVisuals.ts
+++ b/apps/web/src/components/mood/emotionVisuals.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { EMOTION_TAGS, type EmotionTag, type MoodJournalEntry } from '../../lib/mood';
+
+/** Visual treatment for a single "what's behind it?" reason (emotion tag). */
+export interface EmotionVisual {
+  readonly tag: EmotionTag;
+  readonly label: string;
+  readonly className: string;
+}
+
+const EMOTION_LABELS: Record<EmotionTag, string> = {
+  stressed: 'Stressed',
+  anxious: 'Anxious',
+  happy: 'Happy',
+  sad: 'Sad',
+  bored: 'Bored',
+  excited: 'Excited',
+  frustrated: 'Frustrated',
+  content: 'Content',
+  overwhelmed: 'Overwhelmed',
+  celebratory: 'Celebratory',
+};
+
+/** Human-readable label shown when a check-in recorded no reason. */
+export const UNSPECIFIED_REASON_LABEL = 'Unspecified';
+
+/** CSS class for the neutral swatch used when no reason was recorded. */
+export const UNSPECIFIED_REASON_CLASS = 'mood-reason--unspecified';
+
+/**
+ * Resolve the color + label treatment for a single reason tag. The class name
+ * matches a `.mood-reason--<tag>` rule in `mood.css`, so the same color is used
+ * for both calendar cells and the legend swatch that documents it.
+ */
+export function emotionVisual(tag: EmotionTag): EmotionVisual {
+  return {
+    tag,
+    label: EMOTION_LABELS[tag],
+    className: `mood-reason--${tag}`,
+  };
+}
+
+/** All reason visuals in canonical order, for building a stable legend. */
+export const EMOTION_VISUALS: readonly EmotionVisual[] = EMOTION_TAGS.map(emotionVisual);
+
+/**
+ * The reason that drives a day's color: the first emotion captured for the
+ * entry. Returns `null` when the entry recorded no reason.
+ */
+export function primaryReason(entry: Pick<MoodJournalEntry, 'emotions'>): EmotionTag | null {
+  return entry.emotions[0] ?? null;
+}

--- a/apps/web/src/components/mood/mood.css
+++ b/apps/web/src/components/mood/mood.css
@@ -180,45 +180,83 @@
   color: var(--semantic-status-negative);
 }
 
-.mood-calendar__legend {
-  display: flex;
-  gap: var(--spacing-1);
-}
-
-.mood-calendar__legend-chip,
 .mood-calendar__cell {
-  width: 2rem;
-  height: 2rem;
+  min-height: 2.75rem;
+  width: 100%;
+  min-width: 0;
+  padding: var(--spacing-1);
   border-radius: var(--border-radius-sm);
-  display: inline-flex;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  border: 1px solid transparent;
+  gap: 2px;
+  text-align: center;
+  border: 1px solid color-mix(in srgb, var(--semantic-text-primary) 12%, transparent);
+  /* Fixed dark ink keeps the reason label legible on the light tints in both themes. */
+  color: #1f2937;
 }
 
-.mood-calendar__legend-chip--1,
-.mood-calendar__cell--1 {
+.mood-calendar__cell-emoji,
+.mood-calendar__cell-empty-mark {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.mood-calendar__cell-reason {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.625rem;
+  line-height: 1.2;
+  font-weight: var(--font-weight-semibold);
+}
+
+/* Reason tints: one hue per "what's behind it?" emotion. Each pairs with a
+   labeled legend swatch and visible text, so color is never the only signal. */
+.mood-reason--stressed {
   background: #fecaca;
 }
 
-.mood-calendar__legend-chip--2,
-.mood-calendar__cell--2 {
+.mood-reason--anxious {
   background: #fed7aa;
 }
 
-.mood-calendar__legend-chip--3,
-.mood-calendar__cell--3 {
-  background: #fde68a;
+.mood-reason--frustrated {
+  background: #fda4af;
 }
 
-.mood-calendar__legend-chip--4,
-.mood-calendar__cell--4 {
+.mood-reason--overwhelmed {
+  background: #ddd6fe;
+}
+
+.mood-reason--bored {
+  background: #e5e7eb;
+}
+
+.mood-reason--sad {
+  background: #bfdbfe;
+}
+
+.mood-reason--content {
+  background: #99f6e4;
+}
+
+.mood-reason--happy {
   background: #bbf7d0;
 }
 
-.mood-calendar__legend-chip--5,
-.mood-calendar__cell--5 {
-  background: #86efac;
+.mood-reason--excited {
+  background: #fde68a;
+}
+
+.mood-reason--celebratory {
+  background: #fbcfe8;
+}
+
+.mood-reason--unspecified {
+  background: #f1f5f9;
 }
 
 .mood-calendar__cell--empty {
@@ -229,6 +267,52 @@
 
 .mood-calendar__cell--today {
   border-color: var(--semantic-interactive-default);
+  box-shadow: 0 0 0 1px var(--semantic-interactive-default);
+}
+
+.mood-calendar__key {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.mood-calendar__key-label {
+  margin: 0;
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+}
+
+.mood-calendar__legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2) var(--spacing-3);
+}
+
+.mood-calendar__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.mood-calendar__legend-swatch {
+  flex: none;
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: var(--border-radius-sm);
+  border: 1px solid color-mix(in srgb, var(--semantic-text-primary) 22%, transparent);
+}
+
+@media (prefers-contrast: more) {
+  .mood-calendar__cell,
+  .mood-calendar__legend-swatch {
+    border-width: 2px;
+  }
 }
 
 .mood-calendar__grid {


### PR DESCRIPTION
## Summary

The dashboard **Mood over time** calendar showed five unlabeled, `aria-hidden` color swatches at the top-right (a red→green mood-level gradient) whose purpose was unclear, while the cell color merely duplicated the mood emoji. This recolors each day by its **"what's behind it?" reason** (emotion → color) and replaces the ambiguous key with a clearly labeled legend.

## Changes

- **`MoodCalendar.tsx`** — each day cell's background now reflects its **primary reason** (first selected emotion) instead of mood level. Removed the unlabeled top-right swatch row and added a **labeled "What each color means" legend** that lists only the reasons present in the visible 5-week window. Cells now show the mood emoji **and** a visible reason label, and the `aria-label`/`title` name the reason in text.
- **`emotionVisuals.ts`** (new) — maps each `EmotionTag` to a label + `mood-reason--<tag>` class, shared by cells and legend swatches; `primaryReason()` helper.
- **`mood.css`** — one accessible tint per reason (fixed dark ink for WCAG AA contrast in light **and** dark themes), stacked cell layout, labeled legend styling, stronger borders under `prefers-contrast: more`.
- **`MoodCalendar.test.tsx`** (new) — covers reason-based coloring, first-emotion selection, the labeled key, and the removal of the old swatch chips.

## Accessibility

- **Color is never the only signal** (WCAG 1.4.1): mood = emoji + numeric in the accessible name; reason = visible text label **+** color **+** legend text **+** `aria-label`/`title`.
- Reason text meets **WCAG AA** contrast on every tint; the previously `aria-hidden` key is now a labeled list announced to assistive tech.

## Issues

Closes #3147

## Testing

- [x] `npx vitest run src/components/mood/` — 5/5 pass (3 new + 2 existing)
- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean

## Coordination

Scoped to `apps/web/src/components/mood/` only — does **not** touch `DashboardMoodJournalSection.tsx`, so it does not collide with the in-flight "mood vs spending unstack" PR. **Merge order: 6 of 17.**
