### PR TITLE
feat(web): restore scroll position on back navigation (#3151)

### DIFF
--- a/apps/web/src/components/navigation/ScrollToTop.test.tsx
+++ b/apps/web/src/components/navigation/ScrollToTop.test.tsx
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+import { ScrollToTop } from './ScrollToTop';
+
+interface TestLocation {
+  key: string;
+  pathname: string;
+  search: string;
+  hash: string;
+  state: unknown;
+}
+
+const routerState = vi.hoisted(() => ({
+  location: {
+    key: 'k1',
+    pathname: '/dashboard',
+    search: '',
+    hash: '',
+    state: null,
+  } as TestLocation,
+  navigationType: 'PUSH' as 'PUSH' | 'POP' | 'REPLACE',
+}));
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => routerState.location,
+  useNavigationType: () => routerState.navigationType,
+}));
+
+function makeLocation(key: string): TestLocation {
+  return { key, pathname: '/dashboard', search: '', hash: '', state: null };
+}
+
+let scrollX = 0;
+let scrollY = 0;
+let rafCallbacks: FrameRequestCallback[] = [];
+
+function setScroll(x: number, y: number): void {
+  scrollX = x;
+  scrollY = y;
+}
+
+function flushFrames(times = 60): void {
+  let n = 0;
+  while (rafCallbacks.length > 0 && n < times) {
+    const cb = rafCallbacks.shift();
+    cb?.(n);
+    n += 1;
+  }
+}
+
+function getScrollToSpy(): ReturnType<typeof vi.fn> {
+  return window.scrollTo as unknown as ReturnType<typeof vi.fn>;
+}
+
+describe('ScrollToTop scroll restoration (#3151)', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    rafCallbacks = [];
+    setScroll(0, 0);
+    routerState.location = makeLocation('k1');
+    routerState.navigationType = 'PUSH';
+
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+
+    vi.spyOn(window, 'scrollTo').mockImplementation(((x?: number | ScrollToOptions, y?: number) => {
+      if (typeof x === 'number') {
+        setScroll(x, y ?? 0);
+      }
+    }) as typeof window.scrollTo);
+
+    Object.defineProperty(window, 'scrollX', { configurable: true, get: () => scrollX });
+    Object.defineProperty(window, 'scrollY', { configurable: true, get: () => scrollY });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      configurable: true,
+      value: 5000,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opts out of the browser native scroll restoration on mount', () => {
+    if (!('scrollRestoration' in window.history)) {
+      return;
+    }
+    window.history.scrollRestoration = 'auto';
+    render(<ScrollToTop />);
+    expect(window.history.scrollRestoration).toBe('manual');
+  });
+
+  it('scrolls to the top on fresh (PUSH) navigation', () => {
+    routerState.navigationType = 'PUSH';
+    render(<ScrollToTop />);
+    expect(getScrollToSpy()).toHaveBeenCalledWith(0, 0);
+    expect(window.scrollY).toBe(0);
+  });
+
+  it('scrolls to the top on a POP with no saved offset', () => {
+    routerState.location = makeLocation('never-visited');
+    routerState.navigationType = 'POP';
+    render(<ScrollToTop />);
+    flushFrames();
+    expect(getScrollToSpy()).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('restores the saved scroll offset on back (POP) navigation', () => {
+    const scrollToSpy = getScrollToSpy();
+    const { rerender } = render(<ScrollToTop />);
+
+    // The visitor scrolls down on the dashboard (k1).
+    setScroll(0, 1200);
+    window.dispatchEvent(new Event('scroll'));
+    flushFrames();
+
+    // Forward navigation into a detail page (k2) resets to the top.
+    routerState.location = makeLocation('k2');
+    routerState.navigationType = 'PUSH';
+    rerender(<ScrollToTop />);
+    expect(scrollToSpy).toHaveBeenLastCalledWith(0, 0);
+
+    scrollToSpy.mockClear();
+
+    // Browser back to the dashboard (k1) restores the previous offset.
+    routerState.location = makeLocation('k1');
+    routerState.navigationType = 'POP';
+    rerender(<ScrollToTop />);
+    flushFrames();
+
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 1200);
+    expect(window.scrollY).toBe(1200);
+  });
+
+  it('keeps re-applying the offset until async content makes the page tall enough', () => {
+    const scrollToSpy = getScrollToSpy();
+    const { rerender } = render(<ScrollToTop />);
+
+    // Save a deep offset for the dashboard (k1).
+    setScroll(0, 2000);
+    window.dispatchEvent(new Event('scroll'));
+    flushFrames();
+
+    routerState.location = makeLocation('k2');
+    routerState.navigationType = 'PUSH';
+    rerender(<ScrollToTop />);
+
+    // Simulate a still-hydrating page: the document is too short to honour the
+    // offset, so the browser clamps scrollTo to the current max scroll height.
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      configurable: true,
+      value: 800,
+    });
+    scrollToSpy.mockImplementation(((x?: number | ScrollToOptions, y?: number) => {
+      if (typeof x !== 'number') {
+        return;
+      }
+      const maxY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+      setScroll(x, Math.min(y ?? 0, maxY));
+    }) as typeof window.scrollTo);
+
+    routerState.location = makeLocation('k1');
+    routerState.navigationType = 'POP';
+    rerender(<ScrollToTop />);
+
+    // While the page is short the offset cannot be reached, so the restore keeps
+    // retrying on subsequent frames instead of giving up at the top.
+    flushFrames(3);
+    expect(window.scrollY).toBe(0);
+    expect(rafCallbacks.length).toBeGreaterThan(0);
+
+    // Async content arrives and the document grows tall enough.
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      configurable: true,
+      value: 5000,
+    });
+    flushFrames();
+    expect(window.scrollY).toBe(2000);
+  });
+});

--- a/apps/web/src/components/navigation/ScrollToTop.tsx
+++ b/apps/web/src/components/navigation/ScrollToTop.tsx
@@ -1,21 +1,58 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * ScrollToTop — Resets scroll position on forward navigation (PUSH/REPLACE).
+ * ScrollToTop — app-wide scroll restoration manager.
  *
- * Preserves scroll position on browser back/forward (POP) to maintain
- * native browser behavior.
+ * Restores the previous scroll position on browser back/forward navigation
+ * (history `POP`) and scrolls to the top on fresh forward navigation
+ * (`PUSH` / `REPLACE`), so returning to a long page (dashboard, transactions)
+ * lands the visitor exactly where they left off.
  *
- * Place this component inside <BrowserRouter> to activate.
+ * Robustness — this layout scrolls the window/document (the sidebar is
+ * `position: sticky` and `.app-main` has no `overflow`), so `window.scrollTo`
+ * is correct. The naive "restore once on the next frame" approach is not:
+ *
+ *  - **`history.scrollRestoration = 'manual'`** opts out of the browser's
+ *    native restoration so it cannot race (and lose to) the manual restore.
+ *  - **Continuous, per-`location.key` capture** persists the live scroll offset
+ *    while the visitor scrolls (rAF-throttled `scroll` listener plus a
+ *    `pagehide`/`beforeunload` flush). Reading the offset only at navigation
+ *    time is unreliable: navigating from a tall page to a shorter one lets the
+ *    browser clamp `window.scrollY` before it can be saved.
+ *  - **Async-aware POP restore** re-applies the saved offset across animation
+ *    frames until the document is tall enough to honour it. Deep pages hydrate
+ *    asynchronously from SQLite-WASM, so a single `scrollTo` on the first frame
+ *    lands before the content exists and is silently clamped to 0.
+ *
+ * Place inside `<BrowserRouter>` to activate. Mounted once at the app root.
  *
  * @module components/navigation/ScrollToTop
- * References: issue #1451
+ * References: issues #1451, #3151
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import { useLocation, useNavigationType } from 'react-router-dom';
 
 import { getScrollPosition, recordScrollPosition } from '../../lib/navigation/history';
+
+/**
+ * Maximum number of animation frames to keep re-applying a restored scroll
+ * offset while async page content hydrates (~0.8s at 60fps). Bounded so a page
+ * that never grows tall enough (e.g. the saved offset is no longer reachable)
+ * cannot spin forever.
+ */
+const RESTORE_MAX_FRAMES = 50;
+
+const isBrowser = typeof window !== 'undefined';
+
+/** Largest vertical offset the document can currently be scrolled to. */
+function getMaxScrollY(): number {
+  if (!isBrowser) {
+    return 0;
+  }
+  const doc = document.documentElement;
+  return Math.max(0, doc.scrollHeight - window.innerHeight);
+}
 
 /**
  * Scrolls to the top of the page on forward navigation.
@@ -24,35 +61,97 @@ import { getScrollPosition, recordScrollPosition } from '../../lib/navigation/hi
 export const ScrollToTop: React.FC = () => {
   const location = useLocation();
   const navigationType = useNavigationType();
-  const previousKeyRef = useRef(location.key);
+  // The history key of the page currently on screen. Updated synchronously in a
+  // layout effect so scroll captures are always attributed to the right page.
+  const currentKeyRef = useRef(location.key);
 
+  // Opt out of the browser's native scroll restoration so it does not race the
+  // manual, async-aware restoration below. Restore the prior value on unmount.
   useEffect(() => {
-    recordScrollPosition(previousKeyRef.current, window.scrollX, window.scrollY);
-
-    const frame = window.requestAnimationFrame(() => {
-      if (navigationType === 'POP') {
-        const savedPosition = getScrollPosition(location.key);
-        if (savedPosition) {
-          window.scrollTo(savedPosition.x, savedPosition.y);
-          previousKeyRef.current = location.key;
-          return;
-        }
-      }
-
-      window.scrollTo(0, 0);
-      previousKeyRef.current = location.key;
-    });
-
-    const handleBeforeUnload = () => {
-      recordScrollPosition(location.key, window.scrollX, window.scrollY);
-    };
-
-    window.addEventListener('beforeunload', handleBeforeUnload);
+    if (!isBrowser || !('scrollRestoration' in window.history)) {
+      return;
+    }
+    const previous = window.history.scrollRestoration;
+    window.history.scrollRestoration = 'manual';
     return () => {
-      window.cancelAnimationFrame(frame);
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-      recordScrollPosition(location.key, window.scrollX, window.scrollY);
+      window.history.scrollRestoration = previous;
     };
+  }, []);
+
+  // Continuously persist the live scroll offset for the page on screen so the
+  // outgoing offset is captured before any navigation can clamp it.
+  useEffect(() => {
+    if (!isBrowser) {
+      return;
+    }
+    let frame = 0;
+    const persist = () => {
+      frame = 0;
+      recordScrollPosition(currentKeyRef.current, window.scrollX, window.scrollY);
+    };
+    const handleScroll = () => {
+      if (frame) {
+        return;
+      }
+      frame = window.requestAnimationFrame(persist);
+    };
+    const flush = () => {
+      recordScrollPosition(currentKeyRef.current, window.scrollX, window.scrollY);
+    };
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('pagehide', flush);
+    window.addEventListener('beforeunload', flush);
+    return () => {
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('pagehide', flush);
+      window.removeEventListener('beforeunload', flush);
+    };
+  }, []);
+
+  // On every route change, point the capture key at the new page and either
+  // restore its saved offset (POP) or reset to the top (PUSH/REPLACE). A layout
+  // effect runs before paint, so the restore happens without a flash of the top
+  // of the page.
+  useLayoutEffect(() => {
+    if (!isBrowser) {
+      return;
+    }
+    currentKeyRef.current = location.key;
+
+    let frameId = 0;
+    const cancel = () => {
+      if (frameId) {
+        window.cancelAnimationFrame(frameId);
+        frameId = 0;
+      }
+    };
+
+    if (navigationType === 'POP') {
+      const saved = getScrollPosition(location.key);
+      if (saved && (saved.x !== 0 || saved.y !== 0)) {
+        let attempts = 0;
+        const restore = () => {
+          window.scrollTo(saved.x, saved.y);
+          attempts += 1;
+          const reachedTarget = Math.abs(window.scrollY - saved.y) <= 2;
+          const documentTallEnough = getMaxScrollY() >= saved.y - 2;
+          if (attempts >= RESTORE_MAX_FRAMES || (reachedTarget && documentTallEnough)) {
+            frameId = 0;
+            return;
+          }
+          frameId = window.requestAnimationFrame(restore);
+        };
+        frameId = window.requestAnimationFrame(restore);
+        return cancel;
+      }
+    }
+
+    // Fresh navigation (or a POP with no saved offset): start at the top.
+    window.scrollTo(0, 0);
+    return cancel;
   }, [location.key, navigationType]);
 
   return null;


### PR DESCRIPTION
## Summary

Navigating **back/forward** in browser history (a history `POP`) did not restore the previous scroll position — returning to the dashboard, transactions, or any long page jumped to the top. This makes app-wide scroll restoration robust: `POP` returns to the prior scroll offset, while fresh forward navigation (`PUSH`/`REPLACE`) still starts at the top.

The window/document is the scroll container in this layout (the sidebar is `position: sticky`, `body { min-height: 100vh }`, and `.app-main` has no `overflow`), so `window.scrollTo` is correct — the surrounding logic in `ScrollToTop` was the problem.

## Root cause

The existing `ScrollToTop` attempted restoration but:

1. Left `history.scrollRestoration` at the browser default `auto`, so native restoration **raced** the manual `scrollTo` and lost on async content.
2. Restored inside a **single `requestAnimationFrame`** — deep pages (dashboard, transactions) hydrate asynchronously from SQLite-WASM, so the document was still short on the first frame and the offset was clamped to ~0.
3. **Re-read the outgoing offset after the DOM swapped**, so navigating from a tall page to a shorter one let the browser clamp `window.scrollY` before it was saved.

## Changes

- `apps/web/src/components/navigation/ScrollToTop.tsx`
  - Set `window.history.scrollRestoration = 'manual'` on mount (restore prior value on unmount).
  - Persist the **live** scroll offset per `location.key` continuously (rAF-throttled `scroll` listener + `pagehide`/`beforeunload` flush) so the outgoing offset is captured before any clamp.
  - On `POP`, re-apply the saved offset across animation frames until the document is tall enough to honour it (bounded retry, capped at 50 frames).
  - On `PUSH`/`REPLACE`, scroll to the top (now in a layout effect → no flash of the top before restore).
- `apps/web/src/components/navigation/ScrollToTop.test.tsx` (new)
  - Covers: opts out of native scroll restoration, `PUSH` → top, `POP` with no saved offset → top, `POP` → restores saved offset, and the async-content retry (keeps re-applying until the page grows tall enough).

Scope is limited to the `ScrollToTop` manager — no dashboard or other components change.

## Issues

Closes #3151

## Testing

- [x] `vitest run src/components/navigation/ScrollToTop.test.tsx` — 5/5 pass
- [x] `vitest run src/components/navigation` — 19/19 pass (no regressions)
- [x] `prettier --check .` — clean
- [x] `eslint apps/web/src/components/navigation/ScrollToTop*.tsx --max-warnings 0` — clean

> Merge order: 3 of 17.
