### PR TITLE
feat(web): drag-drop reorder + themed scrollbar in customize modal (#3145)

### DIFF
--- a/apps/web/src/__tests__/dashboard-visualizations.test.tsx
+++ b/apps/web/src/__tests__/dashboard-visualizations.test.tsx
@@ -175,6 +175,7 @@ function setupDefaultMocks() {
     stopCustomizing: vi.fn(),
     toggleWidget: vi.fn(),
     moveWidget: vi.fn(),
+    reorderWidget: vi.fn(),
     resizeWidget: vi.fn(),
     resetLayout: vi.fn(),
   });

--- a/apps/web/src/components/dashboard/CustomizePanel.test.tsx
+++ b/apps/web/src/components/dashboard/CustomizePanel.test.tsx
@@ -18,11 +18,22 @@ function renderPanel(overrides = {}) {
     widgets: defaultLayout.widgets,
     onToggle: vi.fn(),
     onMove: vi.fn(),
+    onReorder: vi.fn(),
     onReset: vi.fn(),
     onClose: vi.fn(),
     ...overrides,
   };
   return { ...render(<CustomizePanel {...props} />), props };
+}
+
+/** Minimal DataTransfer stand-in for jsdom, which lacks a real implementation. */
+function mockDataTransfer() {
+  return {
+    setData: vi.fn(),
+    getData: vi.fn(),
+    effectAllowed: '',
+    dropEffect: '',
+  };
 }
 
 describe('CustomizePanel', () => {
@@ -33,6 +44,7 @@ describe('CustomizePanel', () => {
         widgets={[]}
         onToggle={vi.fn()}
         onMove={vi.fn()}
+        onReorder={vi.fn()}
         onReset={vi.fn()}
         onClose={vi.fn()}
       />,
@@ -98,6 +110,79 @@ describe('CustomizePanel', () => {
     fireEvent.click(downButtons[0]);
 
     expect(props.onMove).toHaveBeenCalledOnce();
+  });
+
+  it('announces the move via the live status region', () => {
+    renderPanel();
+
+    const downButtons = screen.getAllByLabelText(/move .+ down/i);
+    fireEvent.click(downButtons[0]);
+
+    expect(screen.getByRole('status')).toHaveTextContent(/moved to position 2 of/i);
+  });
+
+  it('renders a drag handle for each widget', () => {
+    const { container } = renderPanel();
+    const handles = container.querySelectorAll('.customize-panel__drag-handle');
+    const defaultLayout = buildDefaultLayout();
+    expect(handles.length).toBe(defaultLayout.widgets.length);
+  });
+
+  it('marks widget rows as draggable', () => {
+    const { container } = renderPanel();
+    const items = container.querySelectorAll('li.customize-panel__item');
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item).toHaveAttribute('draggable', 'true');
+    }
+  });
+
+  it('calls onReorder when a widget is dropped onto another position', () => {
+    const { props, container } = renderPanel();
+    const items = container.querySelectorAll('li.customize-panel__item');
+    const dataTransfer = mockDataTransfer();
+
+    fireEvent.dragStart(items[0], { dataTransfer });
+    fireEvent.dragEnter(items[2], { dataTransfer });
+    fireEvent.dragOver(items[2], { dataTransfer });
+    fireEvent.drop(items[2], { dataTransfer });
+
+    expect(props.onReorder).toHaveBeenCalledOnce();
+    expect(props.onReorder).toHaveBeenCalledWith(expect.any(String), 2);
+  });
+
+  it('announces the drag reorder via the live status region', () => {
+    const { container } = renderPanel();
+    const items = container.querySelectorAll('li.customize-panel__item');
+    const dataTransfer = mockDataTransfer();
+
+    fireEvent.dragStart(items[0], { dataTransfer });
+    fireEvent.drop(items[2], { dataTransfer });
+
+    expect(screen.getByRole('status')).toHaveTextContent(/moved to position 3 of/i);
+  });
+
+  it('does not call onReorder when a widget is dropped onto itself', () => {
+    const { props, container } = renderPanel();
+    const items = container.querySelectorAll('li.customize-panel__item');
+    const dataTransfer = mockDataTransfer();
+
+    fireEvent.dragStart(items[0], { dataTransfer });
+    fireEvent.drop(items[0], { dataTransfer });
+
+    expect(props.onReorder).not.toHaveBeenCalled();
+  });
+
+  it('clears the dragging state after drag end', () => {
+    const { container } = renderPanel();
+    const items = container.querySelectorAll('li.customize-panel__item');
+    const dataTransfer = mockDataTransfer();
+
+    fireEvent.dragStart(items[0], { dataTransfer });
+    expect(items[0]).toHaveClass('customize-panel__item--dragging');
+
+    fireEvent.dragEnd(items[0], { dataTransfer });
+    expect(items[0]).not.toHaveClass('customize-panel__item--dragging');
   });
 
   it('calls onReset when Reset to Defaults is clicked', () => {

--- a/apps/web/src/components/dashboard/CustomizePanel.tsx
+++ b/apps/web/src/components/dashboard/CustomizePanel.tsx
@@ -10,7 +10,7 @@
  * @module components/dashboard/CustomizePanel
  */
 
-import { useCallback, useRef, type FC, type KeyboardEvent } from 'react';
+import { useCallback, useRef, useState, type DragEvent, type FC, type KeyboardEvent } from 'react';
 
 import { useFocusTrap } from '../../accessibility/aria';
 import { WIDGET_DEFINITION_MAP, type WidgetConfig, type WidgetId } from './widget-types';
@@ -28,6 +28,8 @@ export interface CustomizePanelProps {
   onToggle: (id: WidgetId) => void;
   /** Move a widget up or down. */
   onMove: (id: WidgetId, direction: 'up' | 'down') => void;
+  /** Move a widget to an arbitrary index (drag-and-drop reordering). */
+  onReorder: (id: WidgetId, targetIndex: number) => void;
   /** Reset all widgets to default layout. */
   onReset: () => void;
   /** Close the customization panel. */
@@ -43,11 +45,70 @@ export const CustomizePanel: FC<CustomizePanelProps> = ({
   widgets,
   onToggle,
   onMove,
+  onReorder,
   onReset,
   onClose,
 }) => {
   const panelRef = useRef<HTMLDivElement>(null);
   useFocusTrap(panelRef, { active: isOpen, restoreFocus: true });
+
+  const [draggingId, setDraggingId] = useState<WidgetId | null>(null);
+  const [dragOverId, setDragOverId] = useState<WidgetId | null>(null);
+  const [statusMessage, setStatusMessage] = useState('');
+
+  const announceReorder = useCallback((label: string, position: number, total: number) => {
+    setStatusMessage(`${label} moved to position ${position} of ${total}.`);
+  }, []);
+
+  const handleMove = useCallback(
+    (id: WidgetId, direction: 'up' | 'down', index: number, label: string) => {
+      onMove(id, direction);
+      const newIndex = direction === 'up' ? index - 1 : index + 1;
+      announceReorder(label, newIndex + 1, widgets.length);
+    },
+    [onMove, announceReorder, widgets.length],
+  );
+
+  const handleDragStart = useCallback((e: DragEvent<HTMLLIElement>, id: WidgetId) => {
+    setDraggingId(id);
+    e.dataTransfer.effectAllowed = 'move';
+    // Firefox requires drag data to be set for the drag to initiate.
+    e.dataTransfer.setData('text/plain', id);
+  }, []);
+
+  const handleDragEnter = useCallback(
+    (id: WidgetId) => {
+      if (draggingId !== null && id !== draggingId) {
+        setDragOverId(id);
+      }
+    },
+    [draggingId],
+  );
+
+  const handleDragOver = useCallback((e: DragEvent<HTMLLIElement>) => {
+    // Calling preventDefault marks this element as a valid drop target.
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: DragEvent<HTMLLIElement>, targetId: WidgetId, targetIndex: number) => {
+      e.preventDefault();
+      if (draggingId !== null && draggingId !== targetId) {
+        onReorder(draggingId, targetIndex);
+        const def = WIDGET_DEFINITION_MAP.get(draggingId);
+        announceReorder(def?.label ?? 'Widget', targetIndex + 1, widgets.length);
+      }
+      setDraggingId(null);
+      setDragOverId(null);
+    },
+    [draggingId, onReorder, announceReorder, widgets.length],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggingId(null);
+    setDragOverId(null);
+  }, []);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -75,7 +136,8 @@ export const CustomizePanel: FC<CustomizePanelProps> = ({
           Customize Dashboard
         </h2>
         <p className="customize-panel__description">
-          Toggle widgets on or off and reorder them to build your ideal dashboard.
+          Toggle widgets on or off, then drag the handles — or use the arrow buttons — to reorder
+          them.
         </p>
 
         <ul className="customize-panel__list" role="list">
@@ -83,8 +145,35 @@ export const CustomizePanel: FC<CustomizePanelProps> = ({
             const def = WIDGET_DEFINITION_MAP.get(widget.id);
             if (!def) return null;
 
+            const isDragging = draggingId === widget.id;
+            const isDragOver = dragOverId === widget.id && draggingId !== widget.id;
+            const itemClass = [
+              'customize-panel__item',
+              isDragging ? 'customize-panel__item--dragging' : '',
+              isDragOver ? 'customize-panel__item--drag-over' : '',
+            ]
+              .filter(Boolean)
+              .join(' ');
+
             return (
-              <li key={widget.id} className="customize-panel__item" role="listitem">
+              <li
+                key={widget.id}
+                className={itemClass}
+                role="listitem"
+                draggable
+                onDragStart={(e) => handleDragStart(e, widget.id)}
+                onDragEnter={() => handleDragEnter(widget.id)}
+                onDragOver={handleDragOver}
+                onDrop={(e) => handleDrop(e, widget.id, index)}
+                onDragEnd={handleDragEnd}
+              >
+                <span
+                  className="customize-panel__drag-handle"
+                  aria-hidden="true"
+                  title="Drag to reorder"
+                >
+                  ⠿
+                </span>
                 <label className="customize-panel__toggle">
                   <input
                     type="checkbox"
@@ -105,7 +194,7 @@ export const CustomizePanel: FC<CustomizePanelProps> = ({
                   <button
                     type="button"
                     className="customize-panel__move-btn"
-                    onClick={() => onMove(widget.id, 'up')}
+                    onClick={() => handleMove(widget.id, 'up', index, def.label)}
                     disabled={index === 0}
                     aria-label={`Move ${def.label} up`}
                   >
@@ -114,7 +203,7 @@ export const CustomizePanel: FC<CustomizePanelProps> = ({
                   <button
                     type="button"
                     className="customize-panel__move-btn"
-                    onClick={() => onMove(widget.id, 'down')}
+                    onClick={() => handleMove(widget.id, 'down', index, def.label)}
                     disabled={index === widgets.length - 1}
                     aria-label={`Move ${def.label} down`}
                   >
@@ -125,6 +214,10 @@ export const CustomizePanel: FC<CustomizePanelProps> = ({
             );
           })}
         </ul>
+
+        <div className="sr-only" role="status" aria-live="polite">
+          {statusMessage}
+        </div>
 
         <div className="form-actions">
           <button type="button" className="form-button form-button--secondary" onClick={onReset}>

--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -276,6 +276,31 @@
   gap: var(--spacing-2);
   max-height: 400px;
   overflow-y: auto;
+  /* Themed scrollbar — Firefox / standards. */
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--semantic-border-default) 80%, transparent) transparent;
+  scrollbar-gutter: stable;
+}
+
+/* Themed scrollbar — Chromium / WebKit, scoped to the customize modal list. */
+.customize-panel__list::-webkit-scrollbar {
+  width: 10px;
+}
+
+.customize-panel__list::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: var(--border-radius-md);
+}
+
+.customize-panel__list::-webkit-scrollbar-thumb {
+  background-color: color-mix(in srgb, var(--semantic-border-default) 80%, transparent);
+  border: 2px solid transparent;
+  border-radius: var(--border-radius-md);
+  background-clip: padding-box;
+}
+
+.customize-panel__list::-webkit-scrollbar-thumb:hover {
+  background-color: var(--semantic-interactive-default);
 }
 
 .customize-panel__item {
@@ -286,6 +311,41 @@
   border: 1px solid var(--semantic-border-default);
   border-radius: var(--border-radius-md);
   background: var(--semantic-background-primary);
+  transition:
+    border-color var(--duration-fast, 100ms) ease,
+    box-shadow var(--duration-fast, 100ms) ease,
+    opacity var(--duration-fast, 100ms) ease;
+}
+
+/* Drag-and-drop reordering affordances. */
+.customize-panel__drag-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  flex-shrink: 0;
+  width: 1.25rem;
+  color: var(--semantic-text-secondary);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+
+.customize-panel__item--dragging {
+  opacity: 0.6;
+}
+
+.customize-panel__item--dragging,
+.customize-panel__item--dragging .customize-panel__drag-handle {
+  cursor: grabbing;
+}
+
+.customize-panel__item--drag-over {
+  border-color: var(--semantic-interactive-default);
+  box-shadow: inset 0 0 0 2px
+    color-mix(in srgb, var(--semantic-interactive-default) 45%, transparent);
 }
 
 .customize-panel__toggle {
@@ -384,6 +444,10 @@
 @media (prefers-reduced-motion: reduce) {
   .dashboard-customize-btn,
   .safe-to-spend-card__toggle {
+    transition: none;
+  }
+
+  .customize-panel__item {
     transition: none;
   }
 }

--- a/apps/web/src/hooks/useWidgetLayout.test.ts
+++ b/apps/web/src/hooks/useWidgetLayout.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_WIDGET_ORDER,
+  LAYOUT_STORAGE_KEY,
+  type DashboardLayout,
+} from '../components/dashboard/widget-types';
+import { useWidgetLayout } from './useWidgetLayout';
+
+function orderedIds(widgets: readonly { id: string }[]): string[] {
+  return widgets.map((w) => w.id);
+}
+
+describe('useWidgetLayout — reorderWidget', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('starts from the default widget order', () => {
+    const { result } = renderHook(() => useWidgetLayout());
+    expect(orderedIds(result.current.widgets)).toEqual([...DEFAULT_WIDGET_ORDER]);
+  });
+
+  it('moves a widget from the top to a lower position', () => {
+    const { result } = renderHook(() => useWidgetLayout());
+
+    act(() => {
+      result.current.reorderWidget('net-worth', 2);
+    });
+
+    const ids = orderedIds(result.current.widgets);
+    expect(ids[2]).toBe('net-worth');
+    expect(ids[0]).toBe('monthly-spending');
+    // Order values stay contiguous (0..n-1).
+    expect(result.current.widgets.map((w) => w.order)).toEqual(ids.map((_, i) => i));
+  });
+
+  it('moves a widget from the bottom to the top', () => {
+    const { result } = renderHook(() => useWidgetLayout());
+    const lastId = DEFAULT_WIDGET_ORDER[DEFAULT_WIDGET_ORDER.length - 1];
+
+    act(() => {
+      result.current.reorderWidget(lastId, 0);
+    });
+
+    expect(orderedIds(result.current.widgets)[0]).toBe(lastId);
+  });
+
+  it('is a no-op when dropping a widget onto its current index', () => {
+    const { result } = renderHook(() => useWidgetLayout());
+    const before = orderedIds(result.current.widgets);
+
+    act(() => {
+      result.current.reorderWidget('net-worth', 0);
+    });
+
+    expect(orderedIds(result.current.widgets)).toEqual(before);
+  });
+
+  it('clamps an out-of-range target index to the last position', () => {
+    const { result } = renderHook(() => useWidgetLayout());
+
+    act(() => {
+      result.current.reorderWidget('net-worth', 999);
+    });
+
+    const ids = orderedIds(result.current.widgets);
+    expect(ids[ids.length - 1]).toBe('net-worth');
+  });
+
+  it('ignores an unknown widget id', () => {
+    const { result } = renderHook(() => useWidgetLayout());
+    const before = orderedIds(result.current.widgets);
+
+    act(() => {
+      result.current.reorderWidget('does-not-exist' as never, 3);
+    });
+
+    expect(orderedIds(result.current.widgets)).toEqual(before);
+  });
+
+  it('persists the reordered layout to localStorage', () => {
+    const { result } = renderHook(() => useWidgetLayout());
+
+    act(() => {
+      result.current.reorderWidget('net-worth', 2);
+    });
+
+    const raw = localStorage.getItem(LAYOUT_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw as string) as DashboardLayout;
+    const sorted = [...parsed.widgets].sort((a, b) => a.order - b.order);
+    expect(sorted[2].id).toBe('net-worth');
+  });
+});

--- a/apps/web/src/hooks/useWidgetLayout.ts
+++ b/apps/web/src/hooks/useWidgetLayout.ts
@@ -78,6 +78,8 @@ export interface UseWidgetLayoutResult {
   toggleWidget: (id: WidgetId) => void;
   /** Move a widget up or down in the display order. */
   moveWidget: (id: WidgetId, direction: 'up' | 'down') => void;
+  /** Move a widget to an arbitrary position (used by drag-and-drop reordering). */
+  reorderWidget: (id: WidgetId, targetIndex: number) => void;
   /** Change the size of a widget. */
   resizeWidget: (id: WidgetId, size: WidgetSize) => void;
   /** Reset to the default layout. */
@@ -143,6 +145,29 @@ export function useWidgetLayout(): UseWidgetLayoutResult {
     [updateLayout],
   );
 
+  const reorderWidget = useCallback(
+    (id: WidgetId, targetIndex: number) => {
+      updateLayout((current) => {
+        const sorted = [...current.widgets].sort((a, b) => a.order - b.order);
+        const fromIndex = sorted.findIndex((w) => w.id === id);
+        if (fromIndex === -1) return current;
+
+        const clampedTarget = Math.max(0, Math.min(targetIndex, sorted.length - 1));
+        if (fromIndex === clampedTarget) return current;
+
+        // Remove the dragged widget and re-insert it at the target slot, then
+        // normalise every order value to its new array index.
+        const reordered = [...sorted];
+        const [moved] = reordered.splice(fromIndex, 1);
+        reordered.splice(clampedTarget, 0, moved);
+        const updatedWidgets = reordered.map((w, i) => ({ ...w, order: i }));
+
+        return { ...current, widgets: updatedWidgets };
+      });
+    },
+    [updateLayout],
+  );
+
   const resizeWidget = useCallback(
     (id: WidgetId, size: WidgetSize) => {
       updateLayout((current) => ({
@@ -167,6 +192,7 @@ export function useWidgetLayout(): UseWidgetLayoutResult {
     stopCustomizing,
     toggleWidget,
     moveWidget,
+    reorderWidget,
     resizeWidget,
     resetLayout,
   };

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1068,6 +1068,7 @@ export const DashboardPage: React.FC = () => {
           widgets={widgetLayout.widgets}
           onToggle={widgetLayout.toggleWidget}
           onMove={widgetLayout.moveWidget}
+          onReorder={widgetLayout.reorderWidget}
           onReset={widgetLayout.resetLayout}
           onClose={widgetLayout.stopCustomizing}
         />


### PR DESCRIPTION
## Summary

Adds drag-and-drop widget reordering and a theme-matched scrollbar to the Customize Dashboard modal (`apps/web/src/components/dashboard/CustomizePanel.tsx`).

## Changes

- **Drag-and-drop reorder** — widget rows are now draggable (native HTML5 drag, no new dependency). A grip handle signals draggability; dropping a row onto another position reorders it.
- **Persistence** — new `reorderWidget(id, targetIndex)` on `useWidgetLayout` reuses the existing widget-order mechanism (the `order` field in `widget-types.ts`, persisted to localStorage). Order values are re-normalised to contiguous indices after each move.
- **Keyboard accessibility** — the existing up/down buttons are retained as the keyboard path. Both drag and button reorders are announced through an `aria-live=polite` status region.
- **Themed scrollbar** — `.customize-panel__list` now sets `scrollbar-color` / `scrollbar-width` (Firefox/standards) and `::-webkit-scrollbar*` (Chromium/WebKit) using design tokens, plus `scrollbar-gutter: stable`. Adapts to dark mode, high contrast, and reduced motion.
- **Tests** — new `useWidgetLayout.test.ts` covering `reorderWidget` (move down/up, no-op, clamp, unknown id, persistence) and new `CustomizePanel` drag-and-drop + live-region cases.

## Dependencies

None added — reordering uses native HTML5 drag events.

## Issues

Closes #3145

## Testing

- [x] Lint clean (`eslint --max-warnings 0` on changed files)
- [x] Prettier clean (`prettier --check` on changed files)
- [x] Type-check passes (`tsc --noEmit` in `apps/web`)
- [x] Unit tests pass (`CustomizePanel`, `useWidgetLayout`, `dashboard-visualizations` — 66 tests)

> Merge order: 9 of 17. `dashboard.css` is shared with the customize-button restyle (order 8); rebased onto latest `origin/main` (clean, both sides preserved) before push and will rebase again before merge.