### PR TITLE
feat(web): link things-to-check items to their tasks (#3153)

### DIFF
--- a/apps/web/src/components/dashboard/DashboardThingsToCheckSection.test.tsx
+++ b/apps/web/src/components/dashboard/DashboardThingsToCheckSection.test.tsx
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DashboardThingsToCheckSection from './DashboardThingsToCheckSection';
+import { useTransactions } from '../../hooks';
+import { detectScamAlerts, type ScamSpendingAlert } from '../../lib/notifications';
+
+vi.mock('../../hooks', () => ({
+  useTransactions: vi.fn(),
+}));
+
+// Partial mock: control the detection output deterministically while keeping the
+// real routeUnusualSpendAlert so navigation targets are exercised end-to-end.
+vi.mock('../../lib/notifications', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/notifications')>();
+  return { ...actual, detectScamAlerts: vi.fn() };
+});
+
+const mockedUseTransactions = vi.mocked(useTransactions);
+const mockedDetectScamAlerts = vi.mocked(detectScamAlerts);
+
+const singleTransactionAlert: ScamSpendingAlert = {
+  id: 'scam-new-merchant-tx-1',
+  rule: 'new-merchant',
+  title: 'New merchant to review',
+  message: 'We noticed a $99.00 charge from "Unknown Merchant".',
+  nextStep: "If you don't recognize it, call your bank using the number on your card.",
+  severity: 'info',
+  transactionIds: ['tx-1'],
+  merchantName: 'Unknown Merchant',
+  amountCents: 9900,
+  createdAt: '2025-03-02T12:00:00Z',
+};
+
+const duplicateAlert: ScamSpendingAlert = {
+  id: 'scam-duplicate-tx-2-tx-3',
+  rule: 'possible-duplicate',
+  title: 'Check for a duplicate charge',
+  message: 'We noticed two $42.00 charges from "Repeat Store" within 24 hours.',
+  nextStep: 'If you only bought this once, contact the merchant or your bank.',
+  severity: 'warning',
+  transactionIds: ['tx-2', 'tx-3'],
+  merchantName: 'Repeat Store',
+  amountCents: 4200,
+  createdAt: '2025-03-03T12:00:00Z',
+};
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <DashboardThingsToCheckSection accounts={[]} selectedPurposeFilter="all" />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUseTransactions.mockReturnValue({
+    transactions: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    createTransaction: vi.fn(),
+    updateTransaction: vi.fn(),
+    deleteTransaction: vi.fn(),
+  });
+  mockedDetectScamAlerts.mockReturnValue([]);
+});
+
+describe('DashboardThingsToCheckSection', () => {
+  it('shows a calm empty state when there are no alerts', () => {
+    renderSection();
+
+    expect(screen.getByText('Everything looks normal.')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /review/i })).not.toBeInTheDocument();
+  });
+
+  it('links a single-transaction alert to its transaction detail page', () => {
+    mockedDetectScamAlerts.mockReturnValue([singleTransactionAlert]);
+
+    renderSection();
+
+    const reviewLink = screen.getByRole('link', {
+      name: 'Review the flagged charge from Unknown Merchant',
+    });
+    expect(reviewLink).toHaveAttribute('href', '/transactions/tx-1');
+    expect(reviewLink).toHaveTextContent('Review');
+  });
+
+  it('links a duplicate/rapid alert to the filtered transactions list', () => {
+    mockedDetectScamAlerts.mockReturnValue([duplicateAlert]);
+
+    renderSection();
+
+    const reviewLink = screen.getByRole('link', {
+      name: 'Review 2 flagged transactions: Check for a duplicate charge',
+    });
+    const href = reviewLink.getAttribute('href') ?? '';
+    expect(href.startsWith('/transactions?')).toBe(true);
+    expect(href).toContain('alertType=scam_check');
+    expect(href).toContain('rule=possible-duplicate');
+    expect(href).toContain('transactionIds=tx-2%2Ctx-3');
+  });
+
+  it('renders one review action per displayed alert', () => {
+    mockedDetectScamAlerts.mockReturnValue([singleTransactionAlert, duplicateAlert]);
+
+    renderSection();
+
+    expect(screen.getAllByRole('link', { name: /^Review/ })).toHaveLength(2);
+  });
+});

--- a/apps/web/src/components/dashboard/DashboardThingsToCheckSection.tsx
+++ b/apps/web/src/components/dashboard/DashboardThingsToCheckSection.tsx
@@ -1,13 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { useMemo, type FC } from 'react';
+import { Link } from 'react-router-dom';
 import { useTransactions } from '../../hooks';
 import type { Account } from '../../kmp/bridge';
 import {
   filterTransactionsByAccountPurpose,
   type AccountPurposeFilter,
 } from '../../lib/accountPurpose';
-import { detectScamAlerts } from '../../lib/notifications';
+import {
+  detectScamAlerts,
+  routeUnusualSpendAlert,
+  type ScamSpendingAlert,
+  type UnusualSpendRouteTarget,
+} from '../../lib/notifications';
 import { ErrorBanner, LoadingSpinner } from '../common';
 
 export interface DashboardThingsToCheckSectionProps {
@@ -16,6 +22,21 @@ export interface DashboardThingsToCheckSectionProps {
 }
 
 const scamAlertFilters = { type: 'EXPENSE' as const };
+
+/**
+ * Build a concise, screen-reader-friendly accessible name for an alert's review
+ * action. The visible label is always "Review", so each name starts with
+ * "Review" to satisfy WCAG 2.5.3 (Label in Name) while adding the context that
+ * 2.4.4 (Link Purpose) requires.
+ */
+function buildReviewActionLabel(alert: ScamSpendingAlert, route: UnusualSpendRouteTarget): string {
+  if (route.kind === 'transaction_filter') {
+    return `Review ${alert.transactionIds.length} flagged transactions: ${alert.title}`;
+  }
+  return alert.merchantName
+    ? `Review the flagged charge from ${alert.merchantName}`
+    : `Review this flagged transaction: ${alert.title}`;
+}
 
 const DashboardThingsToCheckSection: FC<DashboardThingsToCheckSectionProps> = ({
   accounts,
@@ -36,6 +57,14 @@ const DashboardThingsToCheckSection: FC<DashboardThingsToCheckSectionProps> = ({
     () => detectScamAlerts(filteredScamAlertTransactions),
     [filteredScamAlertTransactions],
   );
+  const reviewableAlerts = useMemo(
+    () =>
+      scamAlerts.slice(0, 5).map((alert) => {
+        const route = routeUnusualSpendAlert(alert);
+        return { alert, to: route.path, actionLabel: buildReviewActionLabel(alert, route) };
+      }),
+    [scamAlerts],
+  );
 
   return (
     <section className="page-section" aria-label="Things to check">
@@ -49,7 +78,7 @@ const DashboardThingsToCheckSection: FC<DashboardThingsToCheckSectionProps> = ({
           <p className="list-item__secondary">Everything looks normal.</p>
         ) : (
           <ul className="list-group" role="list" aria-label="Scam-focused unusual spending alerts">
-            {scamAlerts.slice(0, 5).map((alert) => (
+            {reviewableAlerts.map(({ alert, to, actionLabel }) => (
               <li key={alert.id} className="list-item" role="listitem">
                 <div className="list-item__content">
                   <p className="list-item__primary">{alert.title}</p>
@@ -58,6 +87,9 @@ const DashboardThingsToCheckSection: FC<DashboardThingsToCheckSectionProps> = ({
                     <strong>NEXT STEP:</strong> {alert.nextStep}
                   </p>
                 </div>
+                <Link to={to} className="list-item__action" aria-label={actionLabel}>
+                  Review
+                </Link>
               </li>
             ))}
           </ul>

--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -804,3 +804,53 @@
 .spending-bar-chart__plot {
   margin-top: auto;
 }
+
+/* ---------------------------------------------------------------------------
+ * Things to check - per-item "Review" action link (issue #3153)
+ *
+ * Renders as a compact, right-aligned button-like link inside .list-item.
+ * Navigation target is computed per alert via routeUnusualSpendAlert.
+ * ------------------------------------------------------------------------- */
+
+.list-item__action {
+  flex-shrink: 0;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-2, 8px) var(--spacing-3, 12px);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--radius-sm, 4px);
+  background-color: var(--semantic-surface-secondary, #f3f4f6);
+  color: var(--semantic-text-primary, #111827);
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  font-weight: var(--font-weight-medium, 500);
+  white-space: nowrap;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.list-item__action:hover {
+  background-color: var(--semantic-surface-tertiary, #e5e7eb);
+}
+
+.list-item__action:focus-visible {
+  outline: 2px solid var(--semantic-focus-ring, #3b82f6);
+  outline-offset: 2px;
+}
+
+[data-theme='dark'] .list-item__action:hover {
+  background-color: var(--semantic-surface-tertiary, #374151);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .list-item__action {
+    transition: none;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .list-item__action {
+    border-width: 2px;
+  }
+}


### PR DESCRIPTION
## Summary

Each item in the dashboard **Things to check** section is now actionable. Previously every scam/unusual-spending alert was static text, so users had no way to jump from an alert to the underlying transaction(s) to verify a charge. This wires each alert to its correct destination using the existing, unit-tested `routeUnusualSpendAlert` helper.

## Changes

- `DashboardThingsToCheckSection.tsx`: add a clearly-labeled right-side **Review** `Link` to each alert item.
  - single-transaction alerts (`unusually-large`, `new-merchant`, `round-large-unfamiliar`) navigate to the transaction detail page (`/transactions/:id`)
  - duplicate / rapid-succession alerts navigate to the filtered transactions list (`/transactions?alertType=scam_check&rule=...&transactionIds=...`)
- `dashboard.css`: add `.list-item__action` button-like link styles (design tokens, hover, `:focus-visible` ring, dark theme, `prefers-reduced-motion`, `prefers-contrast`).
- New co-located `DashboardThingsToCheckSection.test.tsx` covering empty state, single-transaction routing, duplicate routing, and one action per alert.

## Accessibility

- Each action is a real `Link` (keyboard focusable, in the tab order) with a descriptive `aria-label` (e.g. "Review the flagged charge from {merchant}" / "Review {n} flagged transactions: {title}").
- Visible label is "Review" and is contained in every accessible name → satisfies WCAG 2.5.3 (Label in Name); the contextual aria-label satisfies 2.4.4 (Link Purpose).
- Visible focus indicator via `:focus-visible`; motion gated behind `prefers-reduced-motion`.

## Issues

Closes #3153

## Testing

- [x] `npx vitest run src/components/dashboard/DashboardThingsToCheckSection.test.tsx` — 4 passing
- [x] `npx prettier --check` on changed files — clean
- [x] `npx eslint --max-warnings 0` on changed `.tsx` — clean
- Note: the pre-existing `DashboardPage.test.tsx > has accessible landmarks` flake (a lazily-loaded mood-journal landmark exceeding its 3s `findByRole` timeout under a freshly-installed local toolchain) reproduces identically on `origin/main` without these changes and is unrelated to this PR. Remote CI is the source of truth.

## Merge order

13 of 17.
