### PR TITLE
fix(web): bottom-align spending-by-category chart (#3152)

### DIFF
--- a/apps/web/src/components/charts/SpendingBarChart.tsx
+++ b/apps/web/src/components/charts/SpendingBarChart.tsx
@@ -81,6 +81,7 @@ export const SpendingBarChart: FC<SpendingBarChartProps> = ({
   return (
     <div
       ref={containerRef}
+      className="spending-bar-chart"
       role="figure"
       aria-label={description}
       aria-roledescription="bar chart"
@@ -101,48 +102,50 @@ export const SpendingBarChart: FC<SpendingBarChartProps> = ({
       >
         {announcement}
       </div>
-      <ResponsiveContainer width="100%" height={height}>
-        <BarChart
-          data={data}
-          margin={{ top: 8, right: 16, bottom: 8, left: 16 }}
-          aria-labelledby={`${chartId}-title`}
-          aria-describedby={`${chartId}-desc`}
-          role="img"
-        >
-          <CartesianGrid strokeDasharray="3 3" stroke="var(--semantic-border-default, #E5E7EB)" />
-          <XAxis
-            dataKey="name"
-            tick={{ fill: 'var(--semantic-text-secondary, #6B7280)', fontSize: 12 }}
-          />
-          <YAxis
-            tickFormatter={(v: number) => formatChartCurrency(v, currency, 'en-US', maskingMode)}
-            tick={{ fill: 'var(--semantic-text-secondary, #6B7280)', fontSize: 12 }}
-            width={80}
-          />
-          <Tooltip
-            formatter={(value) =>
-              formatChartCurrency(Number(value ?? 0), currency, 'en-US', maskingMode)
-            }
-            contentStyle={{
-              background: 'var(--semantic-background-elevated, #FFFFFF)',
-              border: '1px solid var(--semantic-border-default, #E5E7EB)',
-              borderRadius: '0.375rem',
-            }}
-          />
-          <Bar dataKey="amount" isAnimationActive={!disableAnimation} animationDuration={600}>
-            {data.map((entry, index) => (
-              <Cell
-                key={entry.name}
-                fill={CHART_COLORS[index % CHART_COLORS.length]}
-                data-chart-point=""
-                tabIndex={-1}
-                role="listitem"
-                aria-label={`${entry.name}: ${formatChartCurrency(entry.amount, currency, 'en-US', maskingMode)}`}
-              />
-            ))}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
+      <div className="spending-bar-chart__plot">
+        <ResponsiveContainer width="100%" height={height}>
+          <BarChart
+            data={data}
+            margin={{ top: 8, right: 16, bottom: 8, left: 16 }}
+            aria-labelledby={`${chartId}-title`}
+            aria-describedby={`${chartId}-desc`}
+            role="img"
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--semantic-border-default, #E5E7EB)" />
+            <XAxis
+              dataKey="name"
+              tick={{ fill: 'var(--semantic-text-secondary, #6B7280)', fontSize: 12 }}
+            />
+            <YAxis
+              tickFormatter={(v: number) => formatChartCurrency(v, currency, 'en-US', maskingMode)}
+              tick={{ fill: 'var(--semantic-text-secondary, #6B7280)', fontSize: 12 }}
+              width={80}
+            />
+            <Tooltip
+              formatter={(value) =>
+                formatChartCurrency(Number(value ?? 0), currency, 'en-US', maskingMode)
+              }
+              contentStyle={{
+                background: 'var(--semantic-background-elevated, #FFFFFF)',
+                border: '1px solid var(--semantic-border-default, #E5E7EB)',
+                borderRadius: '0.375rem',
+              }}
+            />
+            <Bar dataKey="amount" isAnimationActive={!disableAnimation} animationDuration={600}>
+              {data.map((entry, index) => (
+                <Cell
+                  key={entry.name}
+                  fill={CHART_COLORS[index % CHART_COLORS.length]}
+                  data-chart-point=""
+                  tabIndex={-1}
+                  role="listitem"
+                  aria-label={`${entry.name}: ${formatChartCurrency(entry.amount, currency, 'en-US', maskingMode)}`}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -718,3 +718,25 @@
     border-width: 2px;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Spending-by-category bar chart card (#3152)
+ *
+ * In the dashboard charts row, grid cells stretch to the tallest sibling — the
+ * taller "Spending Trend" card (period selector, view toggle, and annotations
+ * sit above its plot). Lay the bar chart figure out as a flex column and push
+ * its plot to the bottom so its baseline lines up with the trend card's chart
+ * instead of floating in the vertical centre. When the cards stack at narrow
+ * widths the card is not stretched, so `margin-top: auto` is a no-op and the
+ * plot stays directly under the title.
+ * ------------------------------------------------------------------------- */
+
+.spending-bar-chart {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.spending-bar-chart__plot {
+  margin-top: auto;
+}


### PR DESCRIPTION
## Summary

In the dashboard charts row, the **Spending by category** bar chart floated — its plot sat higher than (appeared vertically centred relative to) the taller **Spending Trend** card beside it, so the two cards' chart baselines did not line up.

## Root cause

`.dashboard-charts` is a CSS grid; at >=640px the Spending Trend and Spending by category cards share a row, and grid cells stretch to the tallest sibling (`align-items: stretch`). The Spending Trend card is taller (it carries a period selector, a view-type toggle, and the avg/day + period-comparison annotations above its plot). The shorter Spending-by-category figure is `display: block`, so its title and fixed-height (320px) Recharts plot stacked from the top, leaving the extra vertical space below the plot.

## Changes

- `apps/web/src/components/charts/SpendingBarChart.tsx` — add a `spending-bar-chart` class to the `role=figure` root and wrap the `ResponsiveContainer` in a `spending-bar-chart__plot` element.
- `apps/web/src/components/dashboard/dashboard.css` — lay the figure out as a flex column (`height: 100%`) and push the plot to the bottom with `margin-top: auto`, so its baseline lines up with the taller trend card's chart. When the cards stack at narrow widths the card is not stretched, so `margin-top: auto` is a no-op and the plot stays directly under the title (no regression).

Scoped to the bar chart only — the Spending Trend and Category Share (pie) charts are untouched.

## Verification

- [x] `npm run format:check` — passes
- [x] `npx eslint . --max-warnings 0` — passes (exit 0)
- [x] `vitest run` (web) — `SpendingBarChart.test.tsx` (7) + `DashboardPage.test.tsx` (15) = 22 passed
- [x] Chart bottoms line up at desktop (2-col) and responsive (stacked) widths

## Issues

Closes #3152