### PR TITLE
fix(web): correct recent-transactions hover styling (#3158)

### DIFF
--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -854,3 +854,35 @@
     border-width: 2px;
   }
 }
+
+/*
+ * Recent Transactions list — accessible row hover (#3158)
+ *
+ * The shared `.list-item__link` hover painted the row with
+ * `var(--semantic-surface-secondary, #f3f4f6)`. That token is undefined at
+ * runtime, so the near-white fallback was always used, and the dark override
+ * keyed off `[data-theme='dark']` never matched OS-driven dark mode
+ * (`prefers-color-scheme`). The result was a near-white block under near-white
+ * text, failing WCAG 2.2 AA. Scoped to this list we instead:
+ *   1. give the hovered/focused row an inset, rounded bounding box that matches
+ *      the card radius, and
+ *   2. paint it with a theme-adaptive tint of the current text colour — never a
+ *      fixed near-white block — so text/background contrast stays AA in light,
+ *      dark (both entry paths), and high-contrast themes. The defined
+ *      `--semantic-background-secondary` surface is the fallback for browsers
+ *      without `color-mix()`.
+ */
+.recent-transactions__list .list-item__link {
+  width: auto;
+  flex: 1;
+  min-width: 0;
+  margin-inline: var(--spacing-2);
+  padding: var(--spacing-3) var(--spacing-2);
+  border-radius: var(--card-border-radius, var(--radius-md, 8px));
+}
+
+.recent-transactions__list .list-item__link:hover,
+.recent-transactions__list .list-item__link:focus-visible {
+  background-color: var(--semantic-background-secondary);
+  background-color: color-mix(in srgb, var(--semantic-text-primary) 6%, transparent);
+}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1005,7 +1005,7 @@ export const DashboardPage: React.FC = () => {
                     description="Transactions you add will appear here."
                   />
                 ) : (
-                  <ul className="list-group" role="list">
+                  <ul className="list-group recent-transactions__list" role="list">
                     {recentPrivacyRollup?.protectedRollup !== null &&
                       recentPrivacyRollup?.protectedRollup !== undefined && (
                         <li className="list-item" role="listitem">


### PR DESCRIPTION
## Summary

Fixes the broken hover state on the dashboard **Recent Transactions** list. Hovering a
row produced a full-bleed highlight that, in dark mode, became a **near-white block**
under near-white text — failing WCAG 2.2 AA. The fix gives the hovered/focused row an
inset, rounded bounding box that matches the card and a theme-adaptive fill that keeps
text readable in every theme.

## Root cause

The shared `.list-item__link` hover (in `apps/web/src/styles/responsive.css`) used:

```css
.list-item__link:hover {
  background-color: var(--semantic-surface-secondary, #f3f4f6);
}
[data-theme='dark'] .list-item__link:hover {
  background-color: var(--semantic-surface-secondary, #374151);
}
```

- `--semantic-surface-secondary` is **undefined at runtime** (not in `tokens.css` or the
  generated design-token output), so the literal **fallback** is always used — `#f3f4f6`
  (near-white).
- Dark mode is engaged via `@media (prefers-color-scheme: dark)` on
  `html:not([data-theme='light'])`, **not** by the `[data-theme='dark']` attribute the
  override requires. So under OS-driven dark mode the base rule wins and the near-white
  `#f3f4f6` leaks in — under near-white primary text.

Separately, `.list-item:has(> .list-item__link)` zeroes the padding and the link uses
`padding: var(--spacing-3) 0; width: 100%`, so the highlight is full-bleed with no inset.

## Changes

- `apps/web/src/pages/DashboardPage.tsx` — add a scoped `recent-transactions__list`
  class to the Recent Transactions `<ul>` (one-line, additive).
- `apps/web/src/components/dashboard/dashboard.css` — scoped rules for that list:
  - Hovered/focused row gets an **inset, rounded** box (`margin-inline`, internal
    padding, `border-radius: var(--card-border-radius, …)`) matching the card.
  - Fill uses a **theme-adaptive** tint of the current text colour
    (`color-mix(in srgb, var(--semantic-text-primary) 6%, transparent)`) — never a fixed
    near-white block. `--semantic-background-secondary` is the `color-mix`-less fallback.

The shared global list styles are left untouched, so the change is contained to this list.

## Accessibility / WCAG 2.2 AA

Contrast verified against the actual token values (dark card = `neutral-800` #1F2937):

- **Primary text** on the 6% hover tint: ~11.8:1 (AA / AAA).
- **Secondary** caption text (`neutral-400`) on the 6% hover tint: ~4.84:1 (≥ 4.5:1 AA).
- Light and high-contrast themes remain high-contrast (dark text on a light tint).
- Hover fill never approaches the text colour, so the near-white-block failure is gone in
  all dark-mode entry paths (`prefers-color-scheme` **and** `[data-theme='dark']`).

## Testing

- [x] ESLint clean — `npx eslint apps/web/src/pages/DashboardPage.tsx --max-warnings 0`
- [x] Prettier clean — `npx prettier --check` on both changed files
- [x] Unit tests pass — `vitest run src/pages/DashboardPage.test.tsx` (15/15)
- [x] Manual reasoning: WCAG contrast math above

## Issues

Closes #3158
