### PR TITLE
feat(web): make privacy hide-amounts toggle discoverable (#3149)

### DIFF
--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -196,6 +196,20 @@ describe('AppLayout', () => {
     expect(within(header).getByRole('button', { name: 'Settings' })).toBeInTheDocument();
   });
 
+  it('renders a discoverable, labeled hide-amounts toggle in the header', () => {
+    renderLayout();
+
+    const header = screen.getByRole('banner', { name: 'App header' });
+    const toggle = within(header).getByRole('button', { name: 'Hide amounts' });
+
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    expect(toggle).toHaveAttribute('title', 'Hide amounts');
+    // The abstract circle glyph was replaced with a recognizable eye icon.
+    expect(toggle.querySelector('svg')).not.toBeNull();
+    expect(toggle.textContent).not.toContain('○');
+  });
+
   it('navigates to /settings when the header Settings button is clicked', () => {
     const onNavigate = vi.fn();
     renderLayout({ onNavigate });

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -28,6 +28,7 @@ import { LegalLinks } from '../legal/LegalLinks';
 import { Breadcrumbs, NavShortcuts } from '../navigation';
 
 import { SkipToContent } from './SkipToContent';
+import { EyeIcon, EyeOffIcon } from './navIcons';
 
 export interface AppLayoutProps {
   activePath: string;
@@ -192,7 +193,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
         label: isPrivacyMode ? 'Turn privacy mode off' : 'Turn privacy mode on',
         description: 'Mask or reveal financial amounts.',
         shortcut: 'Ctrl+Shift+P',
-        keywords: 'privacy mask sensitive amounts',
+        keywords: 'privacy mask sensitive amounts hide show balances values',
         perform: togglePrivacyMode,
       },
       {
@@ -272,19 +273,15 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
             <button
               type="button"
               className={`icon-button${isPrivacyMode ? ' icon-button--active' : ''}${isSimplified ? ' icon-button--labeled' : ''}`}
-              aria-label={isPrivacyMode ? 'Turn privacy mode off' : 'Turn privacy mode on'}
+              aria-label={isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
               aria-pressed={isPrivacyMode}
-              title="Privacy mode"
+              title={isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
               onClick={togglePrivacyMode}
             >
-              <span className="icon-button__glyph" aria-hidden="true">
-                {isPrivacyMode ? '●' : '○'}
+              {isPrivacyMode ? <EyeOffIcon /> : <EyeIcon />}
+              <span className="icon-button__label">
+                {isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
               </span>
-              {isSimplified ? (
-                <span className="icon-button__label">
-                  {isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
-                </span>
-              ) : null}
             </button>
             <NotificationCenter
               notifications={notifications}

--- a/apps/web/src/components/layout/navIcons.tsx
+++ b/apps/web/src/components/layout/navIcons.tsx
@@ -209,6 +209,22 @@ export const PrivacyIcon: FC<IconProps> = ({ className }) => (
   </Svg>
 );
 
+export const EyeIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7-10-7-10-7z" />
+    <circle cx="12" cy="12" r="3" />
+  </Svg>
+);
+
+export const EyeOffIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M9.88 9.88a3 3 0 0 0 4.24 4.24" />
+    <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />
+    <path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
+    <path d="M2 2l20 20" />
+  </Svg>
+);
+
 export const DebtIcon: FC<IconProps> = ({ className }) => (
   <Svg className={className}>
     <rect x="4" y="5" width="16" height="14" rx="2" />


### PR DESCRIPTION
## Summary

Users couldn't find how to hide monetary values on the dashboard. The capability already
exists (app-wide privacy mode), but the **global header toggle was undiscoverable**: it rendered
as an unlabeled abstract circle (`○` / `●`) with a generic `title="Privacy mode"`.

This PR makes the **existing** toggle recognizable and discoverable — no new system, no change to
the privacy state machine, keyboard shortcut, or Settings → Privacy toggle.

## Changes

- **Eye / eye-off icon** — replaced the `○`/`●` glyph with a clear, universally understood
  show/hide icon. Added `EyeIcon` and `EyeOffIcon` to the shared inline icon set
  (`navIcons.tsx`), matching the existing Lucide stroke style.
- **Clear affordance** — action-oriented `title` tooltip and accessible name
  ("Hide amounts" / "Show amounts") so the control's purpose is obvious. The visible label span
  is always rendered (shown in simplified mode via existing CSS).
- **Search discoverability** — broadened the command-palette keywords for the same action with
  `hide`, `show`, `balances`, `values`.
- **Accessibility preserved** — `aria-pressed` still reflects state; the accessible name matches
  the visible label (Label-in-Name).
- **Test** — added an `AppLayout` test asserting the header exposes a discoverable
  "Hide amounts" toggle with `aria-pressed` and a tooltip, and that the abstract glyph is gone.

Placement is unchanged: the control stays in the global header action group (rendered on every
screen), alongside the other global toggles.

## Issues

Closes #3149

## Testing

- [x] `vitest run` — `AppLayout.test.tsx` (16) + layout + WCAG audit suites: **122 passed**
- [x] `prettier --check` on changed files — clean
- [x] `eslint --max-warnings 0` on changed files — clean

## Notes for reviewers / merge

- Scope is `apps/web` only: header control + shared inline icons. No business logic touched.
- Merge order: **4 of 17**. Rebased on latest `origin/main` before push; `AppLayout.tsx` may also
  be touched by the sync-badge PR — both edits are independent (privacy button vs. sync/conflict
  badge), so a rebase keeps both.
