### PR TITLE
fix(web): aggregate All workspace as sum of all workspaces (#3160)

### DIFF
--- a/apps/web/src/lib/accountPurpose.test.ts
+++ b/apps/web/src/lib/accountPurpose.test.ts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import type { AccountPurpose } from '../kmp/bridge';
+import {
+  filterAccountsByPurpose,
+  filterTransactionsByAccountPurpose,
+  matchesAccountPurposeFilter,
+  matchesWorkspaceSelection,
+  selectWorkspaceAccounts,
+  selectWorkspaceTransactions,
+  type AccountPurposeFilter,
+} from './accountPurpose';
+
+interface TestAccount {
+  readonly id: string;
+  readonly purpose?: AccountPurpose;
+  readonly currentBalance: { readonly amount: number };
+}
+
+interface TestTransaction {
+  readonly id: string;
+  readonly accountId: string;
+  readonly amount: { readonly amount: number };
+}
+
+// Balances in integer cents — disjoint personal + business, no shared accounts.
+const personalChecking: TestAccount = {
+  id: 'p1',
+  purpose: 'personal',
+  currentBalance: { amount: 2_475_000 },
+};
+const personalSavings: TestAccount = {
+  id: 'p2',
+  purpose: 'personal',
+  currentBalance: { amount: 800_000 },
+};
+const businessChecking: TestAccount = {
+  id: 'b1',
+  purpose: 'business',
+  currentBalance: { amount: 1_250_000 },
+};
+const untagged: TestAccount = { id: 'u1', currentBalance: { amount: 100_000 } };
+const sharedCard: TestAccount = { id: 's1', purpose: 'both', currentBalance: { amount: 500_000 } };
+
+function sumBalances(accounts: readonly TestAccount[]): number {
+  return accounts.reduce((sum, account) => sum + account.currentBalance.amount, 0);
+}
+
+function netWorthForFilter(accounts: readonly TestAccount[], filter: AccountPurposeFilter): number {
+  return sumBalances(selectWorkspaceAccounts(accounts, filter));
+}
+
+describe('matchesWorkspaceSelection (disjoint partition)', () => {
+  it('matches every account under the "all" workspace', () => {
+    for (const purpose of ['personal', 'business', 'both', null, undefined] as const) {
+      expect(matchesWorkspaceSelection(purpose, 'all')).toBe(true);
+    }
+  });
+
+  it('treats personal as personal-only and untagged as personal', () => {
+    expect(matchesWorkspaceSelection('personal', 'personal')).toBe(true);
+    expect(matchesWorkspaceSelection(null, 'personal')).toBe(true);
+    expect(matchesWorkspaceSelection(undefined, 'personal')).toBe(true);
+    expect(matchesWorkspaceSelection('business', 'personal')).toBe(false);
+    expect(matchesWorkspaceSelection('both', 'personal')).toBe(false);
+  });
+
+  it('treats business as business-only', () => {
+    expect(matchesWorkspaceSelection('business', 'business')).toBe(true);
+    expect(matchesWorkspaceSelection('personal', 'business')).toBe(false);
+    expect(matchesWorkspaceSelection('both', 'business')).toBe(false);
+  });
+
+  it('keeps shared (both) accounts out of personal and business so they roll up only into all', () => {
+    expect(matchesWorkspaceSelection('both', 'personal')).toBe(false);
+    expect(matchesWorkspaceSelection('both', 'business')).toBe(false);
+    expect(matchesWorkspaceSelection('both', 'all')).toBe(true);
+  });
+});
+
+describe('selectWorkspaceAccounts', () => {
+  it('returns all accounts for the "all" filter', () => {
+    const accounts = [personalChecking, businessChecking, sharedCard, untagged];
+    expect(selectWorkspaceAccounts(accounts, 'all')).toHaveLength(4);
+  });
+
+  it('partitions disjoint personal and business accounts', () => {
+    const accounts = [personalChecking, personalSavings, businessChecking, untagged];
+    expect(selectWorkspaceAccounts(accounts, 'personal').map((a) => a.id)).toEqual([
+      'p1',
+      'p2',
+      'u1',
+    ]);
+    expect(selectWorkspaceAccounts(accounts, 'business').map((a) => a.id)).toEqual(['b1']);
+  });
+});
+
+describe('All workspace aggregation — All === Personal + Business', () => {
+  it('aggregates the "all" net worth as the exact sum of every workspace (disjoint data)', () => {
+    const accounts = [personalChecking, personalSavings, businessChecking, untagged];
+
+    const all = netWorthForFilter(accounts, 'all');
+    const personal = netWorthForFilter(accounts, 'personal');
+    const business = netWorthForFilter(accounts, 'business');
+
+    // Exact integer-cents equality: no double counting, no rounding drift.
+    expect(all).toBe(personal + business);
+    expect(all).toBe(2_475_000 + 800_000 + 1_250_000 + 100_000);
+  });
+
+  it('never lets "All" merely mirror a single workspace when other workspaces have value', () => {
+    const accounts = [personalChecking, businessChecking];
+
+    const all = netWorthForFilter(accounts, 'all');
+    const personal = netWorthForFilter(accounts, 'personal');
+
+    // Reported P1 symptom: switching All<->Personal showed no change.
+    expect(all).not.toBe(personal);
+    expect(all).toBeGreaterThan(personal);
+  });
+
+  it('counts shared (both) accounts once, only under All: All === Personal + Business + Shared', () => {
+    const accounts = [personalChecking, businessChecking, sharedCard];
+
+    const all = netWorthForFilter(accounts, 'all');
+    const personal = netWorthForFilter(accounts, 'personal');
+    const business = netWorthForFilter(accounts, 'business');
+    const shared = sharedCard.currentBalance.amount;
+
+    expect(all).toBe(personal + business + shared);
+    // Shared balance is excluded from the per-workspace subsets (no double count).
+    expect(personal).toBe(2_475_000);
+    expect(business).toBe(1_250_000);
+  });
+
+  it('reproduces and fixes the personal + shared (no business-only) case where All used to mirror Personal', () => {
+    // User has only personal + shared accounts and no business-only account.
+    const accounts = [personalChecking, sharedCard];
+
+    const all = netWorthForFilter(accounts, 'all');
+    const personal = netWorthForFilter(accounts, 'personal');
+    const business = netWorthForFilter(accounts, 'business');
+
+    expect(personal).toBe(2_475_000);
+    expect(business).toBe(0);
+    expect(all).toBe(2_975_000);
+    // The shared card is now visible only in the aggregate, so All > Personal.
+    expect(all).toBeGreaterThan(personal);
+  });
+});
+
+describe('selectWorkspaceTransactions', () => {
+  const accounts = [personalChecking, businessChecking, sharedCard];
+  const transactions: TestTransaction[] = [
+    { id: 't-personal', accountId: 'p1', amount: { amount: 5_000 } },
+    { id: 't-business', accountId: 'b1', amount: { amount: 9_000 } },
+    { id: 't-shared', accountId: 's1', amount: { amount: 3_000 } },
+  ];
+
+  it('returns every transaction for the "all" filter', () => {
+    expect(selectWorkspaceTransactions(transactions, accounts, 'all')).toHaveLength(3);
+  });
+
+  it('scopes transactions to the disjoint workspace and excludes shared-account activity', () => {
+    expect(
+      selectWorkspaceTransactions(transactions, accounts, 'personal').map((t) => t.id),
+    ).toEqual(['t-personal']);
+    expect(
+      selectWorkspaceTransactions(transactions, accounts, 'business').map((t) => t.id),
+    ).toEqual(['t-business']);
+  });
+
+  it('keeps the spend total partitioned so All === Personal + Business + Shared', () => {
+    const spend = (filter: AccountPurposeFilter) =>
+      selectWorkspaceTransactions(transactions, accounts, filter).reduce(
+        (sum, t) => sum + t.amount.amount,
+        0,
+      );
+
+    expect(spend('all')).toBe(spend('personal') + spend('business') + 3_000);
+  });
+});
+
+describe('matchesAccountPurposeFilter (inclusive visibility) remains unchanged', () => {
+  // Regression guard: the inclusive filter still surfaces shared (both) accounts
+  // under both personal and business for browsing on Transactions/Accounts pages.
+  it('keeps shared accounts visible under both personal and business', () => {
+    expect(matchesAccountPurposeFilter('both', 'personal')).toBe(true);
+    expect(matchesAccountPurposeFilter('both', 'business')).toBe(true);
+  });
+
+  it('still differs from the disjoint partition for shared accounts', () => {
+    const accounts = [personalChecking, businessChecking, sharedCard];
+    // Inclusive personal view shows the shared card; the disjoint partition does not.
+    expect(filterAccountsByPurpose(accounts, 'personal').map((a) => a.id)).toContain('s1');
+    expect(selectWorkspaceAccounts(accounts, 'personal').map((a) => a.id)).not.toContain('s1');
+  });
+
+  it('keeps transaction visibility inclusive for shared accounts', () => {
+    const accounts = [personalChecking, sharedCard];
+    const transactions: TestTransaction[] = [
+      { id: 't-shared', accountId: 's1', amount: { amount: 1 } },
+    ];
+    expect(filterTransactionsByAccountPurpose(transactions, accounts, 'personal')).toHaveLength(1);
+    expect(selectWorkspaceTransactions(transactions, accounts, 'personal')).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/accountPurpose.ts
+++ b/apps/web/src/lib/accountPurpose.ts
@@ -96,3 +96,59 @@ export function filterTransactionsByAccountPurpose<T extends Pick<Transaction, '
   const visibleAccountIds = getScopedAccountIds(accounts, filter);
   return transactions.filter((transaction) => visibleAccountIds.has(transaction.accountId));
 }
+
+/**
+ * Strict, disjoint workspace partition used for dashboard AGGREGATION.
+ *
+ * Unlike {@link matchesAccountPurposeFilter} — which is *inclusive* so a `both`
+ * account surfaces under both the personal and business views while browsing —
+ * this predicate assigns every account to exactly one workspace:
+ *
+ * - `personal` filter -> purpose `personal` (and untagged, which normalizes to
+ *   `personal`)
+ * - `business` filter -> purpose `business`
+ * - `both` accounts -> a distinct shared workspace that rolls up only into `all`
+ *
+ * Treating the workspaces as a partition guarantees the `all` aggregate equals
+ * the sum of every workspace (personal + business + shared) with no double
+ * counting, so `All === Personal + Business` whenever there are no shared
+ * (`both`) accounts. This is what the dashboard needs so that "All" is a true
+ * sum across workspaces and never merely mirrors a single one.
+ */
+export function matchesWorkspaceSelection(
+  purpose: string | null | undefined,
+  filter: AccountPurposeFilter,
+): boolean {
+  if (filter === 'all') {
+    return true;
+  }
+
+  return normalizeAccountPurpose(purpose) === filter;
+}
+
+export function selectWorkspaceAccounts<T extends { readonly purpose?: AccountPurpose | null }>(
+  accounts: readonly T[],
+  filter: AccountPurposeFilter,
+): T[] {
+  return accounts.filter((account) => matchesWorkspaceSelection(account.purpose, filter));
+}
+
+export function selectWorkspaceAccountIds(
+  accounts: readonly Pick<Account, 'id' | 'purpose'>[],
+  filter: AccountPurposeFilter,
+): Set<SyncId> {
+  return new Set(selectWorkspaceAccounts(accounts, filter).map((account) => account.id));
+}
+
+export function selectWorkspaceTransactions<T extends Pick<Transaction, 'accountId'>>(
+  transactions: readonly T[],
+  accounts: readonly Pick<Account, 'id' | 'purpose'>[],
+  filter: AccountPurposeFilter,
+): T[] {
+  if (filter === 'all') {
+    return [...transactions];
+  }
+
+  const visibleAccountIds = selectWorkspaceAccountIds(accounts, filter);
+  return transactions.filter((transaction) => visibleAccountIds.has(transaction.accountId));
+}

--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -697,6 +697,84 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Client Retainer')).toBeInTheDocument();
   });
 
+  it('aggregates the All workspace net worth as the sum of every workspace (#3160)', () => {
+    // Personal $20,000 + Business $10,000 + shared "Both" $5,000.
+    mockedUseAccounts.mockReturnValue({
+      accounts: [
+        {
+          id: 'ws-personal',
+          householdId: 'household-1',
+          name: 'Personal Checking',
+          type: 'CHECKING',
+          purpose: 'personal',
+          currency: { code: 'USD', decimalPlaces: 2 },
+          currentBalance: { amount: 2000000 },
+          isArchived: false,
+          sortOrder: 1,
+          icon: 'bank',
+          color: '#2563EB',
+          ...syncMetadata,
+        },
+        {
+          id: 'ws-business',
+          householdId: 'household-1',
+          name: 'Business Checking',
+          type: 'CHECKING',
+          purpose: 'business',
+          currency: { code: 'USD', decimalPlaces: 2 },
+          currentBalance: { amount: 1000000 },
+          isArchived: false,
+          sortOrder: 2,
+          icon: 'bank',
+          color: '#059669',
+          ...syncMetadata,
+        },
+        {
+          id: 'ws-both',
+          householdId: 'household-1',
+          name: 'Shared Card',
+          type: 'CHECKING',
+          purpose: 'both',
+          currency: { code: 'USD', decimalPlaces: 2 },
+          currentBalance: { amount: 500000 },
+          isArchived: false,
+          sortOrder: 3,
+          icon: 'credit-card',
+          color: '#DC2626',
+          ...syncMetadata,
+        },
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      createAccount: vi.fn(),
+      updateAccount: vi.fn(),
+      deleteAccount: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
+
+    const netWorthCard = screen.getByLabelText('Net worth');
+
+    // All = personal + business + shared = $35,000.00 (never mirrors one workspace).
+    expect(netWorthCard).toHaveTextContent('$35,000.00');
+
+    fireEvent.click(screen.getByRole('button', { name: '🏠 Personal' }));
+    expect(netWorthCard).toHaveTextContent('$20,000.00');
+    expect(netWorthCard).not.toHaveTextContent('$35,000.00');
+
+    fireEvent.click(screen.getByRole('button', { name: '💼 Business' }));
+    expect(netWorthCard).toHaveTextContent('$10,000.00');
+
+    // Back to All restores the full aggregate: 20,000 + 10,000 + 5,000 = 35,000.
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    expect(netWorthCard).toHaveTextContent('$35,000.00');
+  });
+
   it('surfaces an RMD reminder badge when a distribution is due', () => {
     mockedUseRmdTracking.mockReturnValue({
       statuses: [

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -24,8 +24,8 @@ import type { BudgetWithSpending } from '../db/repositories/budgets';
 import type { Bill, Goal, Transaction } from '../kmp/bridge';
 import { getBudgetStatusIndicator } from '../lib/a11y';
 import {
-  filterAccountsByPurpose,
-  filterTransactionsByAccountPurpose,
+  selectWorkspaceAccounts,
+  selectWorkspaceTransactions,
   type AccountPurposeFilter,
 } from '../lib/accountPurpose';
 import { isLiabilityType } from '../lib/analytics/net-worth';
@@ -450,40 +450,30 @@ export const DashboardPage: React.FC = () => {
     [categories],
   );
   const filteredChartTransactions = useMemo(
-    () => filterTransactionsByAccountPurpose(chartTransactions, accounts, selectedPurposeFilter),
+    () => selectWorkspaceTransactions(chartTransactions, accounts, selectedPurposeFilter),
     [chartTransactions, accounts, selectedPurposeFilter],
   );
   const filteredPrevTransactions = useMemo(
-    () => filterTransactionsByAccountPurpose(prevTransactions, accounts, selectedPurposeFilter),
+    () => selectWorkspaceTransactions(prevTransactions, accounts, selectedPurposeFilter),
     [prevTransactions, accounts, selectedPurposeFilter],
   );
   const filteredCurrentMonthTransactions = useMemo(
-    () =>
-      filterTransactionsByAccountPurpose(currentMonthTransactions, accounts, selectedPurposeFilter),
+    () => selectWorkspaceTransactions(currentMonthTransactions, accounts, selectedPurposeFilter),
     [currentMonthTransactions, accounts, selectedPurposeFilter],
   );
   const filteredPreviousMonthTransactions = useMemo(
-    () =>
-      filterTransactionsByAccountPurpose(
-        previousMonthTransactions,
-        accounts,
-        selectedPurposeFilter,
-      ),
+    () => selectWorkspaceTransactions(previousMonthTransactions, accounts, selectedPurposeFilter),
     [previousMonthTransactions, accounts, selectedPurposeFilter],
   );
   const filteredRecentTransactions = useMemo(
     () =>
       data === null
         ? []
-        : filterTransactionsByAccountPurpose(
-            data.recentTransactions,
-            accounts,
-            selectedPurposeFilter,
-          ),
+        : selectWorkspaceTransactions(data.recentTransactions, accounts, selectedPurposeFilter),
     [data, accounts, selectedPurposeFilter],
   );
   const filteredAccounts = useMemo(
-    () => filterAccountsByPurpose(accounts, selectedPurposeFilter),
+    () => selectWorkspaceAccounts(accounts, selectedPurposeFilter),
     [accounts, selectedPurposeFilter],
   );
   const chartCurrency =


### PR DESCRIPTION
## Summary

Fixes a P1 financial-correctness bug on the dashboard **workspace switcher** (account-purpose filter: **All / Personal / Business**). Switching **All vs Personal** showed **no value change** while **Personal vs Business** did. `All` is meant to be the **sum/aggregate across all workspaces**, so it must be greater-than-or-equal to any single workspace and never merely mirror one.

Merge order: **16 of 17** (DashboardPage.tsx is hot — rebased before push; will rebase again right before merge).

## Root cause

`apps/web/src/lib/accountPurpose.ts` `matchesAccountPurposeFilter` is **inclusive**: Personal matches `personal` **or** `both`; Business matches `business` **or** `both`. Shared (`both`) accounts are counted in **both** subsets. `DashboardPage.tsx` derives its summary figures (net worth, spent this month, debt) from this filter, so:

1. `All != Personal + Business` whenever shared (`both`) accounts exist (double counting), and
2. with personal + shared accounts but **no business-only account**, the Personal subset already contains every account `All` contains -> **All mirrors Personal** (the reported symptom).

## Changes

- `accountPurpose.ts`: add a **disjoint workspace partition** used for dashboard aggregation:
  - `matchesWorkspaceSelection` / `selectWorkspaceAccounts` / `selectWorkspaceAccountIds` / `selectWorkspaceTransactions`.
  - `personal` -> purpose `personal` (untagged normalizes to personal); `business` -> `business`; `both` -> shared workspace that rolls up **only** into `all`.
- `DashboardPage.tsx`: wire the `filtered*` memos (accounts + chart/prev/current-month/previous-month/recent transactions) to the disjoint helpers. Net worth, spent-this-month, and debt now aggregate as a true partition.
- The existing inclusive `matchesAccountPurposeFilter` is **retained** for non-dashboard visibility (Transactions/Accounts pages) — no behavior change there.

Guarantees: `All = Personal + Business + Shared` (no double counting), and `All == Personal + Business` when there are no shared accounts. `All` is always >= each workspace and never mirrors a single one when others have value.

## Needs Decision

The fix is scoped to **dashboard aggregation**. Two follow-up questions for product/design:

1. Should shared (`both`) accounts surface **only under All** on the dashboard (current fix), or also appear under Personal/Business there? The most defensible `All = sum` behavior is implemented; shared accounts roll up into `All`.
2. Should the **Transactions/Accounts** pages and the dashboard **scam-alert** visibility (`DashboardThingsToCheckSection`) adopt the same disjoint model for consistency? Left inclusive for now to keep blast radius minimal and avoid changing browsing/visibility semantics.

These do not block the correctness fix (`All` now aggregates either way).

## Testing

- [x] NEW `apps/web/src/lib/accountPurpose.test.ts` (16 tests): proves `All == Personal + Business` in exact integer cents, shared-account handling (`All == Personal + Business + Shared`), reproduces & fixes the personal+shared mirror case, and regression-guards that the inclusive filter is unchanged.
- [x] `DashboardPage.test.tsx`: new UI test asserts the net-worth headline aggregates (All `\,000.00` = Personal `\,000` + Business `\,000` + shared `\,000`) and that Personal/Business exclude the shared account.
- [x] `npm run format:check` (repo-wide) + `eslint --max-warnings 0` on changed files: clean.
- Note: pre-existing `has accessible landmarks` test is environmentally flaky locally (lazy-import timeout); confirmed it fails identically on un-changed `main` and is unrelated to this change.

Closes #3160