### PR TITLE
test(web): tighten e2e locators colliding with new dashboard UI (#3176)

### DIFF
--- a/apps/web/e2e/dashboard.spec.ts
+++ b/apps/web/e2e/dashboard.spec.ts
@@ -153,7 +153,13 @@ test.describe('Dashboard page', () => {
 
     if (hasSummary) {
       // The "Recent Transactions" section always renders when data is present.
-      const recentSection = authenticatedPage.getByLabel('Recent transactions');
+      // Scope to the region role: the card now also contains a search input
+      // with aria-label="Search recent transactions" (#3175), so a substring
+      // getByLabel('Recent transactions') would match both the section and the
+      // input and trip a strict-mode violation.
+      const recentSection = authenticatedPage.getByRole('region', {
+        name: 'Recent Transactions',
+      });
       await expect(recentSection).toBeVisible();
 
       const sectionHeading = recentSection.getByRole('heading', {

--- a/apps/web/e2e/transactions.spec.ts
+++ b/apps/web/e2e/transactions.spec.ts
@@ -212,11 +212,14 @@ test.describe('Transaction detail page', () => {
       const detailsCard = page.locator('article[aria-label="Transaction details"]');
       await expect(detailsCard).toBeVisible();
 
-      // Should show Amount label
-      await expect(page.getByText('Amount')).toBeVisible();
+      // Should show Amount label. Scope to the details card and match exactly:
+      // the shared app header now has a "Hide amounts" privacy toggle (#3172)
+      // on every page, so a substring getByText('Amount') would also match the
+      // toggle and trip a strict-mode violation.
+      await expect(detailsCard.getByText('Amount', { exact: true })).toBeVisible();
 
-      // Should show Type label
-      await expect(page.getByText('Type')).toBeVisible();
+      // Should show Type label (scoped + exact for the same reason).
+      await expect(detailsCard.getByText('Type', { exact: true })).toBeVisible();
 
       // Should show edit and delete buttons. Scope to <main> so the page-wide
       // /edit/i regex does not also match the sidebar 'Building Credit' nav


### PR DESCRIPTION
## Summary

Web CI **E2E Desktop Matrix** went red on `main` (HEAD `e4cf6c8f`) after today's
dashboard batch. Because `deploy-staging.yml` gates the real **Deploy Web (Azure VM)**
job on Web CI being green, finance.jrmoulckers.com stopped receiving merged fixes — a P0
deploy blocker (#3176).

Root cause: two newly added UI elements collide with loose Playwright locators, producing
strict-mode violations. The product behavior is correct — only the E2E locators were too
loose. This is a **test-only** change under `apps/web/e2e/**`.

## Changes

- **`dashboard.spec.ts`** — the searchable recent-transactions card (#3175) adds an
  `<input aria-label="Search recent transactions">`. The substring matcher
  `getByLabel('Recent transactions')` resolved to **2** elements (the section region +
  the input). Switched to `getByRole('region', { name: 'Recent Transactions' })`, which
  targets only the section.
- **`transactions.spec.ts`** — the discoverable "Hide amounts" privacy toggle (#3172)
  now lives in the **shared app header on every page**. The substring matcher
  `getByText('Amount')` resolved to **2** elements (the `<dt>Amount</dt>` detail label +
  the toggle). Scoped the `Amount`/`Type` assertions to the transaction details card and
  matched with `{ exact: true }`.

## Why only these two

I pulled the failing run (`gh run view 28395230131 --log-failed`). Across the matrix there
are exactly **two** unique strict-mode violations — `getByLabel('Recent transactions')`
and `getByText('Amount')` — and they are the only **deterministic, multi-browser** hard
failures (recent-transactions fails in all 4 desktop browsers, amount in 3). The remaining
annotated tests were **webkit-only** `page.goto … interrupted by navigation to /login`
auth-restore races that pass on retry in the other browsers (reported as flaky); no
auth/routing code changed in the batch. Removing the two deterministic failures (each
retried with trace capture) should also relieve the retry/trace pressure that tipped those
webkit races over. I'm watching the full matrix and will follow up if any webkit race still
hard-fails after this lands.

## Testing

- [x] `npm run format:check` — the two changed files pass (only an untracked local cache file is flagged)
- [x] `npx eslint . --max-warnings 0` — clean
- [ ] Playwright E2E — validated via remote CI (no local browsers/dev server)

## Issues

Closes #3176
