### PR TITLE
fix(web): show social sign-in for passkey-primary users (#3178)

### DIFF
--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -17,6 +17,39 @@ test('login page renders', async ({ page }) => {
   await expect(page.getByLabel(/password/i)).toBeVisible();
 });
 
+test('passkey-primary layout keeps social sign-in reachable (#3178)', async ({
+  page,
+}, testInfo) => {
+  // Forcing a platform authenticator is only reliable on Chromium, matching the
+  // visual-regression project scoping.
+  test.skip(
+    testInfo.project.name !== 'chromium',
+    'Platform-authenticator stubbing is exercised on the Chromium project only.',
+  );
+
+  // Simulate a returning user whose browser has a saved passkey, so the login
+  // page renders the biometric-first layout that collapses the email form.
+  await page.addInitScript(() => {
+    if (typeof window.PublicKeyCredential !== 'undefined') {
+      window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = () =>
+        Promise.resolve(true);
+    }
+    localStorage.setItem('finance:preferred-auth-method', 'passkey');
+    localStorage.setItem('finance:has-registered-passkey', 'true');
+  });
+
+  await page.goto('/login');
+
+  // Social sign-in must be reachable WITHOUT expanding the email disclosure.
+  await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Sign in with GitHub' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Sign in with Apple' })).toBeVisible();
+
+  // The email field stays collapsed in the passkey-primary layout — proving the
+  // social buttons are no longer gated behind the hidden form (#3178).
+  await expect(page.getByLabel('Email', { exact: true })).toBeHidden();
+});
+
 test('signup page renders', async ({ page }) => {
   await page.goto('/signup');
   // The signup page has the brand heading "Finance" and tagline "Create your account"

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -195,7 +195,9 @@ describe('LoginPage', () => {
       const { container } = renderLoginPage();
 
       await waitFor(() =>
-        expect(screen.getByRole('button', { name: /use email & password/i })).toBeInTheDocument(),
+        expect(
+          screen.getByRole('button', { name: /sign in with email instead/i }),
+        ).toBeInTheDocument(),
       );
 
       // Form is hidden when biometric is primary and the disclosure is collapsed.
@@ -204,20 +206,39 @@ describe('LoginPage', () => {
       expect(form).toHaveAttribute('hidden');
     });
 
+    it('keeps social sign-in visible while the email form is collapsed (#3178)', async () => {
+      const { container } = renderLoginPage();
+
+      // Wait for the biometric-first layout to activate (async platform check).
+      await screen.findByRole('button', { name: /sign in with biometrics/i });
+
+      // The email/password form is collapsed (hidden)...
+      const form = container.querySelector('#login-email-form');
+      expect(form).toHaveAttribute('hidden');
+
+      // ...yet the social sign-in buttons remain visible, because they no longer
+      // live inside the hidden form (the bug this fixes).
+      expect(screen.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
+      expect(screen.getByRole('button', { name: 'Sign in with GitHub' })).toBeVisible();
+      expect(screen.getByRole('button', { name: 'Sign in with Apple' })).toBeVisible();
+    });
+
     it('expands the email/password form when the disclosure is clicked', async () => {
       const { default: userEvent } = await import('@testing-library/user-event');
       const user = userEvent.setup();
 
       const { container } = renderLoginPage();
 
-      const disclosure = await screen.findByRole('button', { name: /use email & password/i });
+      const disclosure = await screen.findByRole('button', {
+        name: /sign in with email instead/i,
+      });
       await user.click(disclosure);
 
       const form = container.querySelector('#login-email-form');
       expect(form).not.toBeNull();
       expect(form).not.toHaveAttribute('hidden');
       // Toggle re-labelled
-      expect(screen.getByRole('button', { name: /hide email & password/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /hide email sign-in/i })).toBeInTheDocument();
     });
 
     it('records preferred=passkey after a successful biometric sign-in', async () => {

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -277,7 +277,7 @@ export const LoginPage: React.FC = () => {
               aria-expanded={emailFormVisible}
               aria-controls="login-email-form"
             >
-              {emailFormVisible ? 'Hide email & password' : 'Use email & password'}
+              {emailFormVisible ? 'Hide email sign-in' : 'Sign in with email instead'}
             </button>
           </div>
         )}
@@ -400,84 +400,89 @@ export const LoginPage: React.FC = () => {
                 </button>
               </>
             ) : null}
-
-            <div className="auth-divider" aria-hidden="true">
-              <span className="auth-divider__text">or continue with</span>
-            </div>
-
-            <div className="auth-oauth-buttons" role="group" aria-label="Social login options">
-              <button
-                type="button"
-                className="form-button form-button--secondary auth-oauth-button"
-                onClick={() => {
-                  void loginWithOAuth('google');
-                }}
-                disabled={isBusy}
-                aria-label="Sign in with Google"
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
-                  <path
-                    fill="#4285F4"
-                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                  />
-                  <path
-                    fill="#34A853"
-                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                  />
-                  <path
-                    fill="#FBBC05"
-                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                  />
-                  <path
-                    fill="#EA4335"
-                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                  />
-                </svg>
-                Google
-              </button>
-              <button
-                type="button"
-                className="form-button form-button--secondary auth-oauth-button"
-                onClick={() => {
-                  void loginWithOAuth('github');
-                }}
-                disabled={isBusy}
-                aria-label="Sign in with GitHub"
-              >
-                <svg
-                  width="18"
-                  height="18"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
-                </svg>
-                GitHub
-              </button>
-              <button
-                type="button"
-                className="form-button form-button--secondary auth-oauth-button"
-                onClick={() => {
-                  void loginWithOAuth('apple');
-                }}
-                disabled={isBusy}
-                aria-label="Sign in with Apple"
-              >
-                <svg
-                  width="18"
-                  height="18"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
-                </svg>
-                Apple
-              </button>
-            </div>
           </div>
         </form>
+
+        {/* Social sign-in lives OUTSIDE the collapsible email form so it stays
+            reachable for passkey-primary users without expanding the email
+            disclosure (#3178). */}
+        <div className="auth-actions auth-oauth-section">
+          <div className="auth-divider" aria-hidden="true">
+            <span className="auth-divider__text">or continue with</span>
+          </div>
+
+          <div className="auth-oauth-buttons" role="group" aria-label="Social login options">
+            <button
+              type="button"
+              className="form-button form-button--secondary auth-oauth-button"
+              onClick={() => {
+                void loginWithOAuth('google');
+              }}
+              disabled={isBusy}
+              aria-label="Sign in with Google"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  fill="#4285F4"
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                />
+                <path
+                  fill="#34A853"
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                />
+                <path
+                  fill="#FBBC05"
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                />
+                <path
+                  fill="#EA4335"
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                />
+              </svg>
+              Google
+            </button>
+            <button
+              type="button"
+              className="form-button form-button--secondary auth-oauth-button"
+              onClick={() => {
+                void loginWithOAuth('github');
+              }}
+              disabled={isBusy}
+              aria-label="Sign in with GitHub"
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+              </svg>
+              GitHub
+            </button>
+            <button
+              type="button"
+              className="form-button form-button--secondary auth-oauth-button"
+              onClick={() => {
+                void loginWithOAuth('apple');
+              }}
+              disabled={isBusy}
+              aria-label="Sign in with Apple"
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+              </svg>
+              Apple
+            </button>
+          </div>
+        </div>
 
         <p className="auth-footer">
           Don&apos;t have an account?{' '}

--- a/apps/web/src/styles/auth.css
+++ b/apps/web/src/styles/auth.css
@@ -202,7 +202,20 @@
   color: var(--semantic-text-secondary);
 }
 
-/* ─── Disclosure: "Use email & password" under biometric CTA (#1983) ────── */
+/* ─── Social sign-in section (moved outside the collapsible form, #3178) ──── */
+
+/*
+ * The OAuth button group renders as a sibling of the email <form> so social
+ * sign-in stays visible for passkey-primary users even when the email form is
+ * collapsed. The top margin replaces the flex `gap` it previously inherited
+ * from `.auth-actions` inside the form, keeping the non-passkey-primary layout
+ * pixel-identical.
+ */
+.auth-oauth-section {
+  margin-top: var(--spacing-4);
+}
+
+/* ─── Disclosure: email sign-in toggle under biometric CTA (#1983) ───────── */
 
 .auth-disclosure {
   display: inline-block;


### PR DESCRIPTION
## Summary

On the web login page, returning users with a saved passkey (`passkeyPrimary === true`) saw the page collapse to a **Sign in with biometrics** button plus a disclosure toggle. The Google / GitHub / Apple OAuth buttons were nested **inside** the email `<form>`, which is `hidden` when the email form is collapsed — so social sign-in was completely invisible and only reachable by clicking the mislabeled **Use email & password** disclosure.

This PR moves social sign-in out of the collapsible form so it is always visible, and relabels the disclosure to describe only the email form.

Found during a live bug-bash of finance.jrmoulckers.com.

## Changes

- **`apps/web/src/pages/LoginPage.tsx`** — Moved the OAuth button group and its "or continue with" divider out of the `<form hidden={!emailFormVisible}>` into a sibling `<div className="auth-actions auth-oauth-section">`. The email/password fields, submit button, and the non-passkey-primary secondary passkey button stay inside the collapsible form. Relabeled the disclosure from "Use email & password" / "Hide email & password" to **"Sign in with email instead"** / **"Hide email sign-in"** now that social sign-in is no longer gated behind it.
- **`apps/web/src/styles/auth.css`** — Added `.auth-oauth-section { margin-top: var(--spacing-4); }`. This replaces the flex `gap` the OAuth group previously inherited inside `.auth-actions`, keeping the non-passkey-primary layout pixel-identical (verified against the existing visual-regression baseline: `2 × spacing-4` above the "or continue with" divider in both the old and new markup, since `.auth-card` is a block container whose siblings' margins collapse).
- **`apps/web/src/pages/LoginPage.test.tsx`** — Updated the disclosure-label assertions and added a regression test that the Google / GitHub / Apple buttons are visible while the email form is collapsed (`hidden`) in the passkey-primary layout.
- **`apps/web/e2e/auth.spec.ts`** — Added a Chromium-scoped e2e test that stubs platform-authenticator availability + the saved-passkey preference, then asserts the social buttons are visible (role/name-scoped locators) while the email field is hidden.

## Behavior notes

- **Non-passkey-primary layout is unchanged** — the OAuth section renders in the same position with identical spacing.
- **Demo mode is unaffected** — the relocated OAuth section renders unconditionally, exactly as it did before (OAuth buttons already rendered in demo mode because the form was visible there). No new gating was added, so nothing regresses.
- The OAuth buttons are `type="button"` with `onClick` handlers — they never submitted the form, so relocating them has zero functional impact.

## Testing

- [x] `apps/web` unit suite — **9082 / 9083 pass**. All 18 `LoginPage.test.tsx` tests green, including the new #3178 test. The single failure is a pre-existing, unrelated `DashboardPage` lazy-load **timeout** flake under heavy local CPU contention (the test depends on a dynamic import resolving within 3s; `import` alone took 25s locally). It does not import `LoginPage` or `auth.css`.
- [x] `npx prettier --check` clean on all changed files
- [x] `npx eslint . --max-warnings 0` — clean (exit 0)
- [x] e2e regression test added (Chromium-scoped, strict role/name locators)

## Issues

Closes #3178
