### PR TITLE
fix(web): make social-login e2e assertion deterministic (#3183)

### DIFF
--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -17,37 +17,25 @@ test('login page renders', async ({ page }) => {
   await expect(page.getByLabel(/password/i)).toBeVisible();
 });
 
-test('passkey-primary layout keeps social sign-in reachable (#3178)', async ({
-  page,
-}, testInfo) => {
-  // Forcing a platform authenticator is only reliable on Chromium, matching the
-  // visual-regression project scoping.
-  test.skip(
-    testInfo.project.name !== 'chromium',
-    'Platform-authenticator stubbing is exercised on the Chromium project only.',
-  );
-
-  // Simulate a returning user whose browser has a saved passkey, so the login
-  // page renders the biometric-first layout that collapses the email form.
-  await page.addInitScript(() => {
-    if (typeof window.PublicKeyCredential !== 'undefined') {
-      window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = () =>
-        Promise.resolve(true);
-    }
-    localStorage.setItem('finance:preferred-auth-method', 'passkey');
-    localStorage.setItem('finance:has-registered-passkey', 'true');
-  });
-
+test('keeps social sign-in outside the collapsible email form (#3178)', async ({ page }) => {
   await page.goto('/login');
 
-  // Social sign-in must be reachable WITHOUT expanding the email disclosure.
-  await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Sign in with GitHub' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Sign in with Apple' })).toBeVisible();
+  // Social sign-in renders in its own section that is a sibling of — not a
+  // descendant of — the email <form>. This is the regression invariant: a
+  // passkey-primary user's email form collapses (hidden), so the OAuth buttons
+  // must live outside it to stay reachable. Asserting the structure directly is
+  // deterministic and needs no WebAuthn/platform-authenticator stubbing (the
+  // passkey-primary collapse path is covered by the LoginPage unit tests).
+  const oauthSection = page.locator('.auth-oauth-section');
+  await expect(oauthSection.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
+  await expect(oauthSection.getByRole('button', { name: 'Sign in with GitHub' })).toBeVisible();
+  await expect(oauthSection.getByRole('button', { name: 'Sign in with Apple' })).toBeVisible();
 
-  // The email field stays collapsed in the passkey-primary layout — proving the
-  // social buttons are no longer gated behind the hidden form (#3178).
-  await expect(page.getByLabel('Email', { exact: true })).toBeHidden();
+  // None of the social buttons may be nested inside the collapsible email form.
+  const emailForm = page.locator('form#login-email-form');
+  await expect(emailForm.getByRole('button', { name: 'Sign in with Google' })).toHaveCount(0);
+  await expect(emailForm.getByRole('button', { name: 'Sign in with GitHub' })).toHaveCount(0);
+  await expect(emailForm.getByRole('button', { name: 'Sign in with Apple' })).toHaveCount(0);
 });
 
 test('signup page renders', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fast-follow to #3178 / PR #3181. That PR added an e2e test that tried to force the **passkey-primary** login layout by stubbing `PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable` and seeding localStorage, then asserting the email field was hidden. In the headless `vite preview` build the full `passkeyPrimary` precondition chain can't be reliably forced, so the form never collapsed and the assertion timed out.

That test only runs in the **`E2E Desktop Matrix (chromium)`** job, which executes on `main` but is skipped on PRs — so the failure surfaced only after #3181 merged, turning `main` red and blocking the production auto-deploy to finance.jrmoulckers.com.

## Changes

- **`apps/web/e2e/auth.spec.ts`** — Replaced the WebAuthn-dependent assertion with a deterministic DOM-structure assertion that encodes the real regression invariant: the Google/GitHub/Apple buttons render in the `.auth-oauth-section` sibling, **outside** `form#login-email-form`, so they stay reachable when a passkey-primary user's email form collapses. Removed the chromium-only `test.skip` (the structural assertion is browser-agnostic, so it now runs across the full desktop matrix). No WebAuthn/platform-authenticator stubbing required.

## Why this is the right fix

- The regression is a **UI-structure** problem (OAuth buttons trapped inside a collapsible form). Asserting the structure directly is deterministic and fails if anyone moves the OAuth group back inside the form.
- The passkey-primary collapse behaviour remains fully covered by `apps/web/src/pages/LoginPage.test.tsx`, which controls all inputs via mocks (and passes).

## Testing

- [x] Ran locally against the Vite dev server: `npx playwright test e2e/auth.spec.ts -g "keeps social sign-in outside" --project=chromium` → **1 passed**
- [x] `npx prettier --check` and `npx eslint --max-warnings 0` clean on the changed file
- [x] Assertion uses only role/structure locators (no browser-specific APIs); sibling `login page renders` test already passes in firefox/webkit/edge

## Issues

Closes #3183
Refs #3178
