### PR TITLE
feat(web): split onboarding template step into a multi-step wizard (#3118)

### DIFF
--- a/apps/web/src/pages/OnboardingPage.css
+++ b/apps/web/src/pages/OnboardingPage.css
@@ -45,6 +45,86 @@
   line-height: 1.5;
 }
 
+/* -------------------------------------------------------------------
+ * Wizard navigation & step progress (#3118)
+ * ------------------------------------------------------------------- */
+
+.onboarding__progress {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-4);
+}
+
+.onboarding__progress-label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+  margin: 0;
+  text-align: center;
+}
+
+.onboarding__progress-track {
+  display: flex;
+  gap: var(--spacing-2);
+  justify-content: center;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.onboarding__progress-dot {
+  width: 28px;
+  height: 6px;
+  border-radius: var(--border-radius-full, 999px);
+  background-color: var(--semantic-border-default);
+  transition: background-color 0.15s ease;
+}
+
+.onboarding__progress-dot--active {
+  background-color: var(--semantic-interactive-default);
+}
+
+.onboarding__wizard-back-row {
+  margin-bottom: var(--spacing-3);
+}
+
+.onboarding__back-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1) var(--spacing-2);
+  background: transparent;
+  border: none;
+  color: var(--semantic-interactive-default);
+  font-size: var(--type-scale-body-font-size, 1rem);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  border-radius: var(--border-radius-sm, var(--border-radius-md));
+}
+
+.onboarding__back-button:hover {
+  text-decoration: underline;
+}
+
+.onboarding__back-button:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.onboarding__wizard-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-5);
+}
+
+.onboarding__wizard-nav .onboarding__path-btn {
+  flex: 1 1 200px;
+  margin-bottom: 0;
+}
+
 /* Comfort settings */
 .onboarding__preferences-card {
   padding: var(--spacing-5);
@@ -923,6 +1003,7 @@
 .onboarding--reduced-motion .onboarding__path-btn,
 .onboarding--reduced-motion .onboarding__toggle-switch,
 .onboarding--reduced-motion .onboarding__toggle-switch::after,
+.onboarding--reduced-motion .onboarding__progress-dot,
 .onboarding--reduced-motion .onboarding__preview-chip {
   transition: none;
 }
@@ -937,6 +1018,7 @@
   .onboarding__path-btn,
   .onboarding__toggle-switch,
   .onboarding__toggle-switch::after,
+  .onboarding__progress-dot,
   .onboarding__preview-chip {
     transition: none;
   }

--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -209,10 +209,20 @@ const continuePastComfortStep = () => {
   fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
 };
 
-const continueToTemplateStep = () => {
+const goToNewcomerStep = () => {
   continuePastComfortStep();
   fireEvent.click(screen.getByRole('button', { name: /start local only/i }));
   fireEvent.click(screen.getByRole('button', { name: /essential only/i }));
+};
+
+const goToGoalsStep = () => {
+  goToNewcomerStep();
+  fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+};
+
+const goToTemplateStep = () => {
+  goToGoalsStep();
+  fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
 };
 
 describe('OnboardingPage', () => {
@@ -312,14 +322,38 @@ describe('OnboardingPage', () => {
     renderWithRouter(<OnboardingPage />);
 
     expect(screen.getByRole('status', { name: /onboarding progress/i })).toHaveTextContent(
-      'Step 1 of 5: Comfort preferences. Current step.',
+      'Step 1 of 7: Comfort preferences. Current step.',
     );
 
     fireEvent.click(screen.getByRole('button', { name: /continue/i }));
 
     expect(screen.getByRole('status', { name: /onboarding progress/i })).toHaveTextContent(
-      'Step 2 of 5: Choose setup path. Current step.',
+      'Step 2 of 7: Choose setup path. Current step.',
     );
+
+    fireEvent.click(screen.getByRole('button', { name: /start local only/i }));
+    fireEvent.click(screen.getByRole('button', { name: /essential only/i }));
+
+    expect(screen.getByRole('status', { name: /onboarding progress/i })).toHaveTextContent(
+      'Step 4 of 7: Personalize your setup. Current step.',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+
+    expect(screen.getByRole('status', { name: /onboarding progress/i })).toHaveTextContent(
+      'Step 5 of 7: Set a savings goal. Current step.',
+    );
+  });
+
+  it('shows a visible step-progress indicator on each wizard step', () => {
+    renderWithRouter(<OnboardingPage />);
+
+    expect(screen.getByText('Step 1 of 7')).toBeInTheDocument();
+
+    goToNewcomerStep();
+
+    expect(screen.getByText('Step 4 of 7')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /personalize your setup/i })).toBeInTheDocument();
   });
 
   it('stores comfort preferences and lets the user skip ahead', () => {
@@ -365,17 +399,15 @@ describe('OnboardingPage', () => {
     expect(completeOnboarding).not.toHaveBeenCalled();
   });
 
-  it('starts at the education/template step for an authenticated (post-signup) visitor', () => {
+  it('starts at the deferred setup wizard for an authenticated (post-signup) visitor', () => {
     mockedUseAuth.mockReturnValue(authenticatedAuthReturn);
 
     renderWithRouter(<OnboardingPage />);
 
-    // Skips the pre-signup welcome (comfort/choose) and lands on the deferred
-    // education/template step.
-    expect(
-      screen.getByRole('heading', { name: /want a starter budget\? choose a template:/i }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /create my budget/i })).toBeInTheDocument();
+    // Skips the pre-signup welcome (comfort/choose) and lands on the first deferred
+    // setup step (#3089, #3118).
+    expect(screen.getByRole('heading', { name: /personalize your setup/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^continue$/i })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /welcome to finance/i })).not.toBeInTheDocument();
   });
 
@@ -396,12 +428,15 @@ describe('OnboardingPage', () => {
     expect(screen.getByText('Cloud Sync')).toBeInTheDocument();
   });
 
-  it('shows the starter budget template step after privacy selection', () => {
+  it('shows the starter budget template step after the deferred setup wizard', () => {
     renderWithRouter(<OnboardingPage />);
 
     continuePastComfortStep();
     fireEvent.click(screen.getByRole('button', { name: /start local only/i }));
     fireEvent.click(screen.getByRole('button', { name: /essential only/i }));
+    // newcomer -> goals -> template
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
 
     expect(
       screen.getByRole('heading', { name: /want a starter budget\? choose a template:/i }),
@@ -424,7 +459,7 @@ describe('OnboardingPage', () => {
 
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToNewcomerStep();
     fireEvent.click(screen.getByLabelText(/freelancer/i));
     fireEvent.click(screen.getByLabelText(/caregiver/i));
 
@@ -440,7 +475,7 @@ describe('OnboardingPage', () => {
   it('shows glossary explainers from onboarding coach copy', () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToNewcomerStep();
     fireEvent.click(screen.getByRole('button', { name: /what is cash flow/i }));
 
     expect(screen.getByRole('dialog', { name: /cash flow/i })).toBeInTheDocument();
@@ -454,21 +489,27 @@ describe('OnboardingPage', () => {
   it('completes financial-literacy lessons and reflects progress in the checklist', () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToNewcomerStep();
     fireEvent.click(screen.getByRole('button', { name: /yes, show me lessons/i }));
     fireEvent.click(screen.getByRole('button', { name: /concert ticket/i }));
     fireEvent.click(screen.getByRole('button', { name: /keep a small buffer/i }));
     fireEvent.click(screen.getByRole('button', { name: /monthly phone bill/i }));
-    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
 
     expect(localStorage.getItem('finance-onboarding-completed-lessons')).toContain('needs-wants');
+
+    // Lessons live on the newcomer step now; advance through goals + template and
+    // skip the starter budget to reach the completion checklist (#3118).
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+
     expect(screen.getByText(/education lessons 3\/3 complete/i)).toBeInTheDocument();
   });
 
   it('keeps financial-literacy lessons opt-in and not required to proceed', () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToNewcomerStep();
 
     // Lessons are gated behind an explicit opt-in, so the answer choices are hidden.
     expect(screen.getByRole('button', { name: /yes, show me lessons/i })).toBeInTheDocument();
@@ -482,7 +523,7 @@ describe('OnboardingPage', () => {
   it('resets the goal form and confirms the save', () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToGoalsStep();
     const goalNameInput = screen.getByLabelText(/goal name/i) as HTMLInputElement;
     fireEvent.change(goalNameInput, { target: { value: 'Move fund' } });
     fireEvent.click(screen.getByRole('button', { name: /preview goal/i }));
@@ -497,7 +538,7 @@ describe('OnboardingPage', () => {
   it('dismisses an explainer dialog with the top-right close control', () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToNewcomerStep();
     fireEvent.click(screen.getByRole('button', { name: /what is cash flow/i }));
 
     const dialog = screen.getByRole('dialog', { name: /cash flow/i });
@@ -509,13 +550,11 @@ describe('OnboardingPage', () => {
   it('deep-links the checklist "Edit guidance" link to the life-stage section', async () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToTemplateStep();
     fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
     fireEvent.click(screen.getByRole('button', { name: /edit guidance/i }));
 
-    expect(
-      screen.getByRole('heading', { name: /want a starter budget\? choose a template:/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /personalize your setup/i })).toBeInTheDocument();
     await waitFor(() =>
       expect(document.getElementById('onboarding-life-stage-guidance')).toHaveFocus(),
     );
@@ -524,13 +563,11 @@ describe('OnboardingPage', () => {
   it('deep-links the checklist "Review lessons" link to the lessons section', async () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToTemplateStep();
     fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
     fireEvent.click(screen.getByRole('button', { name: /review lessons/i }));
 
-    expect(
-      screen.getByRole('heading', { name: /want a starter budget\? choose a template:/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /personalize your setup/i })).toBeInTheDocument();
     await waitFor(() =>
       expect(document.getElementById('onboarding-financial-lessons')).toHaveFocus(),
     );
@@ -539,7 +576,7 @@ describe('OnboardingPage', () => {
   it('previews and saves an onboarding goal before checklist completion', () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToGoalsStep();
     fireEvent.change(screen.getByLabelText(/goal name/i), { target: { value: 'Move fund' } });
     fireEvent.change(screen.getByLabelText(/target amount/i), { target: { value: '1200' } });
     fireEvent.change(screen.getByLabelText(/starting balance/i), { target: { value: '200' } });
@@ -549,6 +586,8 @@ describe('OnboardingPage', () => {
     expect(screen.getByText(/estimated monthly contribution: \$1000/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /save goal/i }));
+    // Advance goals -> template, then skip the starter budget to reach the checklist.
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
     fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
 
     expect(localStorage.getItem('finance-onboarding-goals')).toContain('Move fund');
@@ -558,7 +597,7 @@ describe('OnboardingPage', () => {
   it('lets users hide, restore, dismiss, and reopen post-onboarding setup help', () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToTemplateStep();
     fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
 
     expect(screen.getByRole('region', { name: /setup progress/i })).toBeInTheDocument();
@@ -626,6 +665,9 @@ describe('OnboardingPage', () => {
     continuePastComfortStep();
     fireEvent.click(screen.getByRole('button', { name: /start local only/i }));
     fireEvent.click(screen.getByRole('button', { name: /essential only/i }));
+    // newcomer -> goals -> template, where the starter budget CTA lives (#3118)
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
     fireEvent.click(screen.getByRole('button', { name: /create my budget/i }));
 
     expect(rejectAll).toHaveBeenCalled();
@@ -641,7 +683,7 @@ describe('OnboardingPage', () => {
   it('surfaces an optional, private newcomer tax-ID and income-type step', () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToNewcomerStep();
 
     expect(
       screen.getByRole('heading', { name: /new to working or taxes in the us\?/i }),
@@ -663,7 +705,7 @@ describe('OnboardingPage', () => {
   it('tailors explainers for ITIN holders and opens the ITIN explainer dialog', () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToNewcomerStep();
 
     fireEvent.click(screen.getByRole('radio', { name: /i use an itin/i }));
     fireEvent.click(screen.getByRole('radio', { name: /1099 or contract/i }));
@@ -689,7 +731,7 @@ describe('OnboardingPage', () => {
   it('surfaces the 401(k) explainer for W-2 workers with an SSN', () => {
     renderWithRouter(<OnboardingPage />);
 
-    continueToTemplateStep();
+    goToNewcomerStep();
 
     fireEvent.click(screen.getByRole('radio', { name: /i have an ssn/i }));
     fireEvent.click(screen.getByRole('radio', { name: /w-2 job/i }));

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -60,12 +60,21 @@ const SIMPLE_MODE_FONT_SCALE_INDEX = Math.max(
   DEFAULT_FONT_SCALE_INDEX,
 );
 
-type OnboardingStep = 'comfort' | 'choose' | 'privacy' | 'template' | 'complete';
+type OnboardingStep =
+  | 'comfort'
+  | 'choose'
+  | 'privacy'
+  | 'newcomer'
+  | 'goals'
+  | 'template'
+  | 'complete';
 
 const ONBOARDING_STEP_ORDER: readonly OnboardingStep[] = [
   'comfort',
   'choose',
   'privacy',
+  'newcomer',
+  'goals',
   'template',
   'complete',
 ];
@@ -74,9 +83,16 @@ const ONBOARDING_STEP_LABELS: Record<OnboardingStep, string> = {
   comfort: 'Comfort preferences',
   choose: 'Choose setup path',
   privacy: 'Privacy preferences',
+  newcomer: 'Personalize your setup',
+  goals: 'Set a savings goal',
   template: 'Starter budget template',
   complete: 'Setup complete',
 };
+
+// The deferred education/setup sequence (#3118) that runs after the privacy step
+// for local-only users, and as the resume point for authenticated post-signup
+// visitors (#3089).
+const DEFERRED_SETUP_START_STEP: OnboardingStep = 'newcomer';
 
 type LifeStageId = 'student' | 'first-job' | 'household' | 'caregiver' | 'freelancer' | 'retiree';
 type GlossaryTermId = 'cashFlow' | 'recurringExpense' | 'savingsGoal' | 'budgetVariance';
@@ -505,8 +521,8 @@ const OnboardingPage: React.FC = () => {
   const [step, setStep] = useState<OnboardingStep>(() =>
     // Authenticated visitors have already completed signup (and saw the pre-signup
     // welcome/comfort/choose screens), so resume onboarding at the deferred
-    // education/template step rather than repeating the welcome flow (#3089).
-    isAuthenticated ? 'template' : 'comfort',
+    // education/setup sequence rather than repeating the welcome flow (#3089).
+    isAuthenticated ? DEFERRED_SETUP_START_STEP : 'comfort',
   );
   const [fontScaleValue, setFontScaleValue] = useState(DEFAULT_FONT_SCALE_INDEX);
   const [reducedMotion, setReducedMotion] = useState(false);
@@ -545,6 +561,8 @@ const OnboardingPage: React.FC = () => {
   const explainerTriggerRef = useRef<HTMLButtonElement | null>(null);
   const glossaryCloseRef = useRef<HTMLButtonElement>(null);
   const glossaryTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const stepHeadingRef = useRef<HTMLHeadingElement>(null);
+  const previousStepRef = useRef<OnboardingStep>(step);
 
   const analyticsEnabled = consent.categories.analytics;
   const newcomerGuidance = useMemo(
@@ -562,10 +580,12 @@ const OnboardingPage: React.FC = () => {
   const selectedStageLabels = selectedLifeStageOptions.map((option) => option.label).join(', ');
   const monthlyContribution = calculateMonthlyContribution(goalDraft);
   const fullySetUp = starterBudgetCreated || savedGoals.length > 0;
+  const currentStepIndex = Math.max(ONBOARDING_STEP_ORDER.indexOf(step), 0);
+  const totalStepCount = ONBOARDING_STEP_ORDER.length;
   const onboardingProgressAnnouncement = buildOnboardingProgressAnnouncement({
     stepLabel: ONBOARDING_STEP_LABELS[step],
-    stepIndex: Math.max(ONBOARDING_STEP_ORDER.indexOf(step), 0),
-    totalSteps: ONBOARDING_STEP_ORDER.length,
+    stepIndex: currentStepIndex,
+    totalSteps: totalStepCount,
     status: templateError
       ? 'error'
       : isApplyingTemplate
@@ -586,6 +606,30 @@ const OnboardingPage: React.FC = () => {
       {onboardingProgressAnnouncement}
     </p>
   );
+
+  // Visible companion to the live region above (#3118). Marked aria-hidden so the
+  // step count is announced exactly once — by the polite live region — for screen
+  // readers, while sighted users still get a persistent progress cue.
+  const stepProgressIndicator =
+    step === 'complete' ? null : (
+      <div className="onboarding__progress" aria-hidden="true">
+        <p className="onboarding__progress-label">
+          Step {currentStepIndex + 1} of {totalStepCount}
+        </p>
+        <ol className="onboarding__progress-track">
+          {ONBOARDING_STEP_ORDER.map((orderedStep, index) => (
+            <li
+              key={orderedStep}
+              className={
+                index <= currentStepIndex
+                  ? 'onboarding__progress-dot onboarding__progress-dot--active'
+                  : 'onboarding__progress-dot'
+              }
+            />
+          ))}
+        </ol>
+      </div>
+    );
 
   const onboardingClassName = [
     'onboarding',
@@ -775,7 +819,7 @@ const OnboardingPage: React.FC = () => {
     );
     enableLocalOnly();
     setTemplateError(null);
-    setStep('template');
+    setStep(DEFERRED_SETUP_START_STEP);
   }, [enableLocalOnly, recordBulkChanges, rejectAll]);
 
   const handlePrivacyAcceptAll = useCallback(() => {
@@ -791,8 +835,34 @@ const OnboardingPage: React.FC = () => {
     );
     enableLocalOnly();
     setTemplateError(null);
-    setStep('template');
+    setStep(DEFERRED_SETUP_START_STEP);
   }, [acceptAll, enableLocalOnly, recordBulkChanges]);
+
+  // Deferred-setup wizard navigation (#3118). Selections in each step persist on
+  // change, so "Skip for now" and "Continue" both simply advance; "Back" steps
+  // through the sequence in reverse.
+  const handleNewcomerAdvance = useCallback(() => {
+    setTemplateError(null);
+    setStep('goals');
+  }, []);
+
+  const handleNewcomerBack = useCallback(() => {
+    setStep('privacy');
+  }, []);
+
+  const handleGoalsAdvance = useCallback(() => {
+    setTemplateError(null);
+    setStep('template');
+  }, []);
+
+  const handleGoalsBack = useCallback(() => {
+    setStep('newcomer');
+  }, []);
+
+  const handleTemplateBack = useCallback(() => {
+    setTemplateError(null);
+    setStep('goals');
+  }, []);
 
   const handleSkipStarterBudget = useCallback(() => {
     setStarterBudgetCreated(false);
@@ -940,8 +1010,11 @@ const OnboardingPage: React.FC = () => {
     trackOnboardingEvent(analyticsEnabled, 'onboarding_lessons_opted_in');
   }, [analyticsEnabled]);
 
+  // Deep-link from the completion checklist back into the deferred-setup wizard.
+  // The guidance + lessons anchors live on the `newcomer` step (#3118), so focus
+  // and scroll there once it renders.
   useEffect(() => {
-    if (step !== 'template' || !pendingTemplateAnchor) {
+    if (step !== 'newcomer' || !pendingTemplateAnchor) {
       return;
     }
     const anchor = pendingTemplateAnchor;
@@ -956,21 +1029,108 @@ const OnboardingPage: React.FC = () => {
     return () => cancelAnimationFrame(frame);
   }, [step, pendingTemplateAnchor, reducedMotion]);
 
-  const openTemplateSection = useCallback((anchor: string) => {
+  // Move focus to the heading of each step on transition so keyboard and screen
+  // reader users land at the top of the new content (#3118). Skipped when a
+  // deep-link anchor is pending, which manages its own focus target above.
+  useEffect(() => {
+    if (previousStepRef.current === step) {
+      return;
+    }
+    previousStepRef.current = step;
+    if (pendingTemplateAnchor) {
+      return;
+    }
+    stepHeadingRef.current?.focus();
+  }, [step, pendingTemplateAnchor]);
+
+  const openNewcomerSection = useCallback((anchor: string) => {
     if (anchor === TEMPLATE_LESSONS_ANCHOR) {
       setLessonsOptedIn(true);
     }
     setPendingTemplateAnchor(anchor);
-    setStep('template');
+    setStep('newcomer');
   }, []);
+
+  // Shared glossary/explainer dialogs (#3120). Rendered on whichever wizard step
+  // exposes their triggers; only one of each can be open at a time.
+  const glossaryModal = activeGlossaryTerm ? (
+    <div
+      className="onboarding__glossary"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="onboarding-glossary-title"
+    >
+      <div className="onboarding__glossary-card">
+        <button
+          type="button"
+          className="onboarding__glossary-close"
+          aria-label="Close"
+          onClick={handleCloseGlossary}
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+        <h2 id="onboarding-glossary-title" className="onboarding__path-title">
+          {GLOSSARY_TERMS[activeGlossaryTerm].title}
+        </h2>
+        <p className="onboarding__path-description">{GLOSSARY_TERMS[activeGlossaryTerm].body}</p>
+        <button
+          ref={glossaryCloseRef}
+          type="button"
+          className="onboarding__path-btn onboarding__path-btn--primary"
+          onClick={handleCloseGlossary}
+        >
+          Got it
+        </button>
+      </div>
+    </div>
+  ) : null;
+
+  const explainerModal = activeExplainer ? (
+    <div
+      className="onboarding__glossary"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="onboarding-newcomer-explainer-title"
+    >
+      <div className="onboarding__glossary-card">
+        <button
+          type="button"
+          className="onboarding__glossary-close"
+          aria-label="Close"
+          onClick={handleCloseExplainer}
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+        <h2 id="onboarding-newcomer-explainer-title" className="onboarding__path-title">
+          {newcomerExplainers[activeExplainer].title}
+        </h2>
+        <p className="onboarding__path-description">{newcomerExplainers[activeExplainer].body}</p>
+        <h3 className="onboarding__section-title">Why it matters</h3>
+        <p className="onboarding__path-description">
+          {newcomerExplainers[activeExplainer].whyItMatters}
+        </p>
+        <button
+          ref={explainerCloseRef}
+          type="button"
+          className="onboarding__path-btn onboarding__path-btn--primary"
+          onClick={handleCloseExplainer}
+        >
+          Got it
+        </button>
+      </div>
+    </div>
+  ) : null;
 
   if (step === 'comfort') {
     return (
       <main className={onboardingClassName} aria-label="Comfort Preferences">
         {onboardingProgressLiveRegion}
         <div className="onboarding__container onboarding__container--narrow">
+          {stepProgressIndicator}
           <header className="onboarding__header">
-            <h1 className="onboarding__title">Welcome to Finance</h1>
+            <h1 className="onboarding__title" ref={stepHeadingRef} tabIndex={-1}>
+              Welcome to Finance
+            </h1>
             <h2 className="onboarding__preferences-title">Make it Yours</h2>
             <p className="onboarding__subtitle">
               Pick a few comfort settings now. You can change these any time later in Settings.
@@ -1111,8 +1271,11 @@ const OnboardingPage: React.FC = () => {
       <main className={onboardingClassName} aria-label="Get Started">
         {onboardingProgressLiveRegion}
         <div className="onboarding__container">
+          {stepProgressIndicator}
           <header className="onboarding__header">
-            <h1 className="onboarding__title">Welcome to Finance</h1>
+            <h1 className="onboarding__title" ref={stepHeadingRef} tabIndex={-1}>
+              Welcome to Finance
+            </h1>
             <p className="onboarding__subtitle">
               Your personal finance tracker. Choose how you want to get started.
             </p>
@@ -1218,8 +1381,11 @@ const OnboardingPage: React.FC = () => {
       <main className={onboardingClassName} aria-label="Privacy Preferences">
         {onboardingProgressLiveRegion}
         <div className="onboarding__container onboarding__container--narrow">
+          {stepProgressIndicator}
           <header className="onboarding__header">
-            <h1 className="onboarding__title">Privacy Preferences</h1>
+            <h1 className="onboarding__title" ref={stepHeadingRef} tabIndex={-1}>
+              Privacy Preferences
+            </h1>
             <p className="onboarding__subtitle">
               Even in local-only mode, you can choose to share anonymous usage data to help us
               improve the app. This is entirely optional.
@@ -1255,17 +1421,31 @@ const OnboardingPage: React.FC = () => {
     );
   }
 
-  if (step === 'template' && studentTemplate) {
+  if (step === 'newcomer') {
     return (
-      <main className={onboardingClassName} aria-label="Starter Budget Template">
+      <main className={onboardingClassName} aria-label="Personalize Your Setup">
         {onboardingProgressLiveRegion}
         <div className="onboarding__container onboarding__container--narrow">
+          {stepProgressIndicator}
+          {!isAuthenticated && (
+            <div className="onboarding__wizard-back-row">
+              <button
+                type="button"
+                className="onboarding__back-button"
+                onClick={handleNewcomerBack}
+              >
+                <span aria-hidden="true">←</span> Back
+              </button>
+            </div>
+          )}
           <header className="onboarding__header">
-            <h1 className="onboarding__title">Want a starter budget? Choose a template:</h1>
+            <h1 className="onboarding__title" ref={stepHeadingRef} tabIndex={-1}>
+              Personalize your setup
+            </h1>
             <p className="onboarding__subtitle">
               {selectedLifeStageOptions.length > 0
                 ? `Guidance is tailored for: ${selectedStageLabels}. You can change or skip this any time.`
-                : 'Start with optional guidance, short lessons, and a student-friendly budget you can edit any time.'}
+                : 'Optional: tailor guidance to your life stage and learn the basics. You can change or skip any of this at any time.'}
             </p>
           </header>
 
@@ -1474,46 +1654,6 @@ const OnboardingPage: React.FC = () => {
             </div>
           </section>
 
-          {templateError && (
-            <div className="onboarding__template-error" role="alert">
-              {templateError}
-            </div>
-          )}
-
-          <section className="onboarding__template-card" aria-label="Student starter budget">
-            <div className="onboarding__template-header">
-              <div>
-                <h2 className="onboarding__path-title">{studentTemplate.name}</h2>
-                <p className="onboarding__path-description">{studentTemplate.description}</p>
-              </div>
-              <span className="onboarding__template-badge">Available now</span>
-            </div>
-
-            <p className="onboarding__template-guidance">{studentTemplate.guidance}</p>
-
-            <ul className="onboarding__template-list" role="list">
-              {studentTemplate.categories.map((category) => (
-                <li key={category.name} className="onboarding__template-item" role="listitem">
-                  <span>
-                    {category.emoji} {category.name}
-                  </span>
-                  <strong>${(category.amountCents / 100).toFixed(0)}</strong>
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          <section className="onboarding__coming-soon" aria-label="More templates coming soon">
-            <h2 className="onboarding__comparison-title">More templates coming soon</h2>
-            <div className="onboarding__coming-soon-list">
-              {futureTemplates.map((template) => (
-                <span key={template.id} className="onboarding__coming-soon-chip">
-                  {template.name}
-                </span>
-              ))}
-            </div>
-          </section>
-
           <section
             id={TEMPLATE_LESSONS_ANCHOR}
             tabIndex={-1}
@@ -1635,10 +1775,51 @@ const OnboardingPage: React.FC = () => {
             )}
           </section>
 
-          <section
-            className="onboarding__template-card onboarding__stacked-section"
-            aria-label="Goal-setting wizard"
-          >
+          <div className="onboarding__wizard-nav">
+            <button
+              type="button"
+              className="onboarding__path-btn onboarding__path-btn--secondary"
+              onClick={handleNewcomerAdvance}
+            >
+              Skip for now
+            </button>
+            <button
+              type="button"
+              className="onboarding__path-btn onboarding__path-btn--primary"
+              onClick={handleNewcomerAdvance}
+            >
+              Continue
+            </button>
+          </div>
+
+          {glossaryModal}
+          {explainerModal}
+        </div>
+      </main>
+    );
+  }
+
+  if (step === 'goals') {
+    return (
+      <main className={onboardingClassName} aria-label="Set a Savings Goal">
+        {onboardingProgressLiveRegion}
+        <div className="onboarding__container onboarding__container--narrow">
+          {stepProgressIndicator}
+          <div className="onboarding__wizard-back-row">
+            <button type="button" className="onboarding__back-button" onClick={handleGoalsBack}>
+              <span aria-hidden="true">←</span> Back
+            </button>
+          </div>
+          <header className="onboarding__header">
+            <h1 className="onboarding__title" ref={stepHeadingRef} tabIndex={-1}>
+              Set a savings goal
+            </h1>
+            <p className="onboarding__subtitle">
+              Optional: add a goal and preview the monthly estimate, or skip and set goals later.
+            </p>
+          </header>
+
+          <section className="onboarding__template-card" aria-label="Goal-setting wizard">
             <div className="onboarding__template-header">
               <div>
                 <h2 className="onboarding__path-title">Goal-setting wizard</h2>
@@ -1758,6 +1939,90 @@ const OnboardingPage: React.FC = () => {
             )}
           </section>
 
+          <div className="onboarding__wizard-nav">
+            <button
+              type="button"
+              className="onboarding__path-btn onboarding__path-btn--secondary"
+              onClick={handleGoalsAdvance}
+            >
+              Skip for now
+            </button>
+            <button
+              type="button"
+              className="onboarding__path-btn onboarding__path-btn--primary"
+              onClick={handleGoalsAdvance}
+            >
+              Continue
+            </button>
+          </div>
+
+          {glossaryModal}
+        </div>
+      </main>
+    );
+  }
+
+  if (step === 'template' && studentTemplate) {
+    return (
+      <main className={onboardingClassName} aria-label="Starter Budget Template">
+        {onboardingProgressLiveRegion}
+        <div className="onboarding__container onboarding__container--narrow">
+          {stepProgressIndicator}
+          <div className="onboarding__wizard-back-row">
+            <button type="button" className="onboarding__back-button" onClick={handleTemplateBack}>
+              <span aria-hidden="true">←</span> Back
+            </button>
+          </div>
+          <header className="onboarding__header">
+            <h1 className="onboarding__title" ref={stepHeadingRef} tabIndex={-1}>
+              Want a starter budget? Choose a template:
+            </h1>
+            <p className="onboarding__subtitle">
+              Start with a student-friendly budget you can rename or adjust any time, or skip and
+              build your own later.
+            </p>
+          </header>
+
+          {templateError && (
+            <div className="onboarding__template-error" role="alert">
+              {templateError}
+            </div>
+          )}
+
+          <section className="onboarding__template-card" aria-label="Student starter budget">
+            <div className="onboarding__template-header">
+              <div>
+                <h2 className="onboarding__path-title">{studentTemplate.name}</h2>
+                <p className="onboarding__path-description">{studentTemplate.description}</p>
+              </div>
+              <span className="onboarding__template-badge">Available now</span>
+            </div>
+
+            <p className="onboarding__template-guidance">{studentTemplate.guidance}</p>
+
+            <ul className="onboarding__template-list" role="list">
+              {studentTemplate.categories.map((category) => (
+                <li key={category.name} className="onboarding__template-item" role="listitem">
+                  <span>
+                    {category.emoji} {category.name}
+                  </span>
+                  <strong>${(category.amountCents / 100).toFixed(0)}</strong>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="onboarding__coming-soon" aria-label="More templates coming soon">
+            <h2 className="onboarding__comparison-title">More templates coming soon</h2>
+            <div className="onboarding__coming-soon-list">
+              {futureTemplates.map((template) => (
+                <span key={template.id} className="onboarding__coming-soon-chip">
+                  {template.name}
+                </span>
+              ))}
+            </div>
+          </section>
+
           <div className="onboarding__template-actions">
             <p className="onboarding__template-summary">
               We will set up the {studentTemplate.name} starter budget shown above — more templates
@@ -1781,78 +2046,6 @@ const OnboardingPage: React.FC = () => {
               Skip for now
             </button>
           </div>
-
-          {activeGlossaryTerm && (
-            <div
-              className="onboarding__glossary"
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="onboarding-glossary-title"
-            >
-              <div className="onboarding__glossary-card">
-                <button
-                  type="button"
-                  className="onboarding__glossary-close"
-                  aria-label="Close"
-                  onClick={handleCloseGlossary}
-                >
-                  <span aria-hidden="true">×</span>
-                </button>
-                <h2 id="onboarding-glossary-title" className="onboarding__path-title">
-                  {GLOSSARY_TERMS[activeGlossaryTerm].title}
-                </h2>
-                <p className="onboarding__path-description">
-                  {GLOSSARY_TERMS[activeGlossaryTerm].body}
-                </p>
-                <button
-                  ref={glossaryCloseRef}
-                  type="button"
-                  className="onboarding__path-btn onboarding__path-btn--primary"
-                  onClick={handleCloseGlossary}
-                >
-                  Got it
-                </button>
-              </div>
-            </div>
-          )}
-
-          {activeExplainer && (
-            <div
-              className="onboarding__glossary"
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="onboarding-newcomer-explainer-title"
-            >
-              <div className="onboarding__glossary-card">
-                <button
-                  type="button"
-                  className="onboarding__glossary-close"
-                  aria-label="Close"
-                  onClick={handleCloseExplainer}
-                >
-                  <span aria-hidden="true">×</span>
-                </button>
-                <h2 id="onboarding-newcomer-explainer-title" className="onboarding__path-title">
-                  {newcomerExplainers[activeExplainer].title}
-                </h2>
-                <p className="onboarding__path-description">
-                  {newcomerExplainers[activeExplainer].body}
-                </p>
-                <h3 className="onboarding__section-title">Why it matters</h3>
-                <p className="onboarding__path-description">
-                  {newcomerExplainers[activeExplainer].whyItMatters}
-                </p>
-                <button
-                  ref={explainerCloseRef}
-                  type="button"
-                  className="onboarding__path-btn onboarding__path-btn--primary"
-                  onClick={handleCloseExplainer}
-                >
-                  Got it
-                </button>
-              </div>
-            </div>
-          )}
         </div>
       </main>
     );
@@ -1866,7 +2059,9 @@ const OnboardingPage: React.FC = () => {
           <div className="onboarding__complete-icon" aria-hidden="true">
             <AppIcon name="sparkles" />
           </div>
-          <h1 className="onboarding__title">You&apos;re All Set!</h1>
+          <h1 className="onboarding__title" ref={stepHeadingRef} tabIndex={-1}>
+            You&apos;re All Set!
+          </h1>
           <p className="onboarding__subtitle">
             {starterBudgetCreated
               ? 'Your finance tracker is ready, and your student starter budget is already in place.'
@@ -1961,7 +2156,7 @@ const OnboardingPage: React.FC = () => {
                   <button
                     type="button"
                     className="onboarding__link-button"
-                    onClick={() => openTemplateSection(TEMPLATE_GUIDANCE_ANCHOR)}
+                    onClick={() => openNewcomerSection(TEMPLATE_GUIDANCE_ANCHOR)}
                   >
                     Edit guidance
                   </button>
@@ -1974,7 +2169,7 @@ const OnboardingPage: React.FC = () => {
                   <button
                     type="button"
                     className="onboarding__link-button"
-                    onClick={() => openTemplateSection(TEMPLATE_LESSONS_ANCHOR)}
+                    onClick={() => openNewcomerSection(TEMPLATE_LESSONS_ANCHOR)}
                   >
                     Review lessons
                   </button>
@@ -2065,39 +2260,7 @@ const OnboardingPage: React.FC = () => {
             )}
           </section>
 
-          {activeGlossaryTerm && (
-            <div
-              className="onboarding__glossary"
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="onboarding-complete-glossary-title"
-            >
-              <div className="onboarding__glossary-card">
-                <button
-                  type="button"
-                  className="onboarding__glossary-close"
-                  aria-label="Close"
-                  onClick={handleCloseGlossary}
-                >
-                  <span aria-hidden="true">×</span>
-                </button>
-                <h2 id="onboarding-complete-glossary-title" className="onboarding__path-title">
-                  {GLOSSARY_TERMS[activeGlossaryTerm].title}
-                </h2>
-                <p className="onboarding__path-description">
-                  {GLOSSARY_TERMS[activeGlossaryTerm].body}
-                </p>
-                <button
-                  ref={glossaryCloseRef}
-                  type="button"
-                  className="onboarding__path-btn onboarding__path-btn--primary"
-                  onClick={handleCloseGlossary}
-                >
-                  Got it
-                </button>
-              </div>
-            </div>
-          )}
+          {glossaryModal}
 
           <button
             type="button"


### PR DESCRIPTION
## Summary

Splits the single giant `template` onboarding step in `apps/web/src/pages/OnboardingPage.tsx` into three discrete wizard steps — **`newcomer` → `goals` → `template`** — as proposed in #3118. Each step has its own **Continue**, **Skip for now**, and **Back** affordances, a **visible step-progress indicator**, and screen-reader **live-region announcements**. All existing per-section logic is reused; sections are simply gated behind their own step in the `OnboardingStep` state machine.

The state machine is now: `comfort | choose | privacy | newcomer | goals | template | complete` (7 steps).

## Changes

- **Step state machine**: added `newcomer` and `goals` to `OnboardingStep`, `ONBOARDING_STEP_ORDER`, and `ONBOARDING_STEP_LABELS`. Privacy acceptance and the authenticated post-signup resume point now start at `newcomer` (via a new `DEFERRED_SETUP_START_STEP` constant).
- **Section → step mapping**:
  - `newcomer`: life-stage guidance (anchor `onboarding-life-stage-guidance`) + newcomer tax-ID/income section + **opt-in** financial-literacy lessons (anchor `onboarding-financial-lessons`).
  - `goals`: the goal-setting wizard (preview/save/list).
  - `template`: student starter budget + "coming soon" + the final budget CTA.
- **Navigation handlers**: `handleNewcomerAdvance/Back`, `handleGoalsAdvance/Back`, `handleTemplateBack`. Skip and Continue both advance (matching the existing comfort-step pattern); Back steps to the previous step (newcomer Back only shows for unauthenticated users, returning to `privacy`).
- **Visible progress indicator**: `aria-hidden` "Step X of Y" + dot track on every wizard step (hidden on `complete`), companion to the existing polite live region so the count is announced exactly once.
- **Focus management**: focus moves to each step's heading (`stepHeadingRef`, `tabIndex={-1}`) on transition; skipped when a deep-link anchor is pending (which manages its own focus).
- **Shared modals**: extracted the glossary and explainer dialogs into shared `glossaryModal` / `explainerModal` consts rendered on whichever step exposes their triggers, removing three duplicated inline copies.
- **CSS**: new `onboarding__progress*`, `onboarding__wizard-back-row`, `onboarding__back-button`, and `onboarding__wizard-nav` classes (design tokens; reduced-motion aware).
- **Tests**: replaced `continueToTemplateStep()` with step-aware helpers `goToNewcomerStep` / `goToGoalsStep` / `goToTemplateStep`; updated each test to the step that owns its section; added coverage for the new step announcements and the visible indicator. All locked-in behavior assertions are preserved.

## Preserved polish (no regressions — verified by existing tests)

- **#3122** — lessons remain **opt-in** and do **not** gate `fullySetUp`/advancing (deferred, as the issue requires).
- **#3123** — per-lesson click feedback (`aria-pressed`, correct-answer highlight + checkmark, per-card "Completed ✓").
- **#3124** — goal save clears the form to defaults, shows a `role="status"` "Goal saved ✓" confirmation, and renders the running saved-goals list.
- **#3125** — final CTA reads "Create my budget" / "Creating your budget…" and the summary names the selected template.
- **#3120** — explainer/glossary modals keep the top-right X (`aria-label="Close"`), primary "Got it", Escape-to-close, and focus-return.

## E2E safety

Only one step renders at a time (early returns), so the new nav buttons ("Back", "Continue", "Skip for now") have distinct, role+name-scoped accessible names with no cross-element collisions. The onboarding e2e specs pre-seed `finance-onboarding-complete=true` and never walk the wizard, so they are unaffected.

## Testing

- `npx vitest run src/pages/OnboardingPage.test.tsx` — **30 passed**
- `npx vitest run src/lib/a11y/__tests__/onboarding-progress.test.ts` — **4 passed**
- `npm run format:check` — clean
- `npx eslint . --max-warnings 0` — clean

## Issues

Closes #3118
