### PR TITLE
fix(web): gate oauth-start on provider-enabled + collapse email disclosure + inline auth error (#3188, #3189, #3190)

### DIFF
--- a/apps/web/src/auth/auth-context.test.tsx
+++ b/apps/web/src/auth/auth-context.test.tsx
@@ -559,4 +559,24 @@ describe('loginWithOAuth keeps users in-app on a failed start (#3109)', () => {
     );
     expect(assignMock).not.toHaveBeenCalled();
   });
+
+  it('degrades gracefully in-app when a supported-but-disabled provider is rejected (#3188)', async () => {
+    // A statically-supported provider that GoTrue has NOT enabled now answers
+    // the pre-flight probe with a 400 (auth-oauth-start gates on the provider
+    // actually being enabled). The probe is non-healthy, so we keep the user
+    // in-app with the graceful "option unavailable" message and never hand off
+    // to a raw GoTrue "provider is not enabled" page.
+    stubStart(() => Promise.resolve(jsonResponse({ error: 'Provider not enabled' }, 400)));
+    await renderReady();
+
+    fireEvent.click(screen.getByTestId('do-oauth'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-error')).toHaveTextContent(
+        OAUTH_PROVIDER_UNAVAILABLE_MESSAGE,
+      ),
+    );
+    expect(assignMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId('loading-state')).toHaveTextContent('ready');
+  });
 });

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -191,7 +191,7 @@ describe('LoginPage', () => {
       );
     });
 
-    it('collapses the email/password form behind a disclosure', async () => {
+    it('collapses the email/password form behind a disclosure (#3189)', async () => {
       const { container } = renderLoginPage();
 
       await waitFor(() =>
@@ -200,10 +200,16 @@ describe('LoginPage', () => {
         ).toBeInTheDocument(),
       );
 
-      // Form is hidden when biometric is primary and the disclosure is collapsed.
+      // The `hidden` attribute must actually collapse the form. `.auth-form`
+      // sets `display: flex`, so `auth.css` adds a `.auth-form[hidden]` override
+      // (#3189); jest-dom honours the `hidden` attribute directly, so the form
+      // and its fields report as not visible while collapsed.
       const form = container.querySelector('#login-email-form');
       expect(form).not.toBeNull();
       expect(form).toHaveAttribute('hidden');
+      expect(form).not.toBeVisible();
+      expect(screen.getByLabelText('Email')).not.toBeVisible();
+      expect(screen.getByLabelText('Password')).not.toBeVisible();
     });
 
     it('keeps social sign-in visible while the email form is collapsed (#3178)', async () => {

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -95,7 +95,6 @@ export const LoginPage: React.FC = () => {
 
   const emailInputRef = useRef<HTMLInputElement>(null);
   const passwordInputRef = useRef<HTMLInputElement>(null);
-  const errorRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -138,12 +137,6 @@ export const LoginPage: React.FC = () => {
       cancelled = true;
     };
   }, [webAuthnSupported]);
-
-  useEffect(() => {
-    if (error) {
-      errorRef.current?.focus();
-    }
-  }, [error]);
 
   const handleEmailLogin = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -235,18 +228,6 @@ export const LoginPage: React.FC = () => {
           </div>
         )}
 
-        <div
-          className={`auth-error-region${error ? ' auth-error-region--filled' : ''}`}
-          aria-live="polite"
-          aria-atomic="true"
-        >
-          {error && (
-            <div ref={errorRef} id={authErrorId} className="auth-error" tabIndex={-1}>
-              {error}
-            </div>
-          )}
-        </div>
-
         {/* ── Passkey-first layout: biometric primary when preferred (#1983) ── */}
         {/* Passkey UI is suppressed in demo mode (#2011) because the demo
             build ships with a placeholder Supabase URL and no backend
@@ -281,6 +262,43 @@ export const LoginPage: React.FC = () => {
             </button>
           </div>
         )}
+
+        {/*
+          The sign-in error is a direct child of the card — NOT inside the
+          collapsible email form — so passkey- and OAuth-failure messages stay
+          visible when the email form is collapsed for passkey-primary users
+          (#1983). It sits adjacent to the sign-in controls and is announced
+          politely via the live region; we no longer steal visual focus to a
+          top-of-card box on every error (#3190).
+        */}
+        <div
+          className={`auth-error-region${error ? ' auth-error-region--filled' : ''}`}
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {error && (
+            <div id={authErrorId} className="auth-error">
+              <svg
+                className="auth-error__icon"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M12 9v4m0 4h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              <span className="auth-error__text">{error}</span>
+            </div>
+          )}
+        </div>
 
         <form
           id="login-email-form"

--- a/apps/web/src/styles/auth.css
+++ b/apps/web/src/styles/auth.css
@@ -59,6 +59,16 @@
   gap: var(--spacing-4);
 }
 
+/*
+ * The email/password form collapses behind the "Sign in with email instead"
+ * disclosure for passkey-primary users (#1983). Without this rule the
+ * `.auth-form { display: flex }` above wins over the UA `[hidden]` rule, so the
+ * form never actually hides and the toggle appears to do nothing (#3189).
+ */
+.auth-form[hidden] {
+  display: none;
+}
+
 .auth-actions {
   display: flex;
   flex-direction: column;
@@ -162,13 +172,31 @@
   margin-bottom: 0;
 }
 
+/*
+ * Compact, left-aligned inline alert (#3190). Presented as contextual feedback
+ * next to the sign-in controls — a leading warning icon on a tinted background —
+ * rather than a full-width centred box that reads like a focused button. The
+ * parent `.auth-error-region` still announces politely.
+ */
 .auth-error {
-  padding: var(--spacing-3);
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
   border-radius: var(--border-radius-md);
   background: var(--color-red-50, #fef2f2);
   color: var(--semantic-status-negative);
-  font-size: var(--type-scale-body-font-size, 1rem);
-  text-align: center;
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  text-align: start;
+}
+
+.auth-error__icon {
+  flex: 0 0 auto;
+  margin-top: 0.1em;
+}
+
+.auth-error__text {
+  margin: 0;
 }
 
 .auth-info {

--- a/services/api/supabase/functions/_shared/supabase-auth.test.ts
+++ b/services/api/supabase/functions/_shared/supabase-auth.test.ts
@@ -9,11 +9,16 @@
  * exercised by the per-function integration tests with fetch mocks.
  */
 
-import { assert, assertEquals } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from 'https://deno.land/std@0.208.0/testing/asserts.ts';
 
 import {
   SUPPORTED_PROVIDERS,
   buildAuthorizeUrl,
+  fetchProviderEnabled,
   generatePkceMaterial,
   isSupportedProvider,
   requestPasswordRecovery,
@@ -184,6 +189,87 @@ Deno.test(
     });
   },
 );
+
+// ---------------------------------------------------------------------------
+// fetchProviderEnabled (#3188)
+// ---------------------------------------------------------------------------
+
+Deno.test('fetchProviderEnabled — "enabled" when the external flag is true', async () => {
+  await withRecoveryEnv(async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (input) => {
+        assertStringIncludes(String(input), '/auth/v1/settings');
+        return Promise.resolve(
+          new Response(JSON.stringify({ external: { google: true, github: false } }), {
+            status: 200,
+          }),
+        );
+      };
+      assertEquals(await fetchProviderEnabled('google'), 'enabled');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+Deno.test(
+  'fetchProviderEnabled — "disabled" when the external flag is false or absent',
+  async () => {
+    await withRecoveryEnv(async () => {
+      const originalFetch = globalThis.fetch;
+      try {
+        globalThis.fetch = () =>
+          Promise.resolve(
+            new Response(JSON.stringify({ external: { google: true, github: false } }), {
+              status: 200,
+            }),
+          );
+        assertEquals(await fetchProviderEnabled('github'), 'disabled'); // explicit false
+        assertEquals(await fetchProviderEnabled('apple'), 'disabled'); // key absent
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  },
+);
+
+Deno.test('fetchProviderEnabled — "unknown" on a non-2xx settings response', async () => {
+  await withRecoveryEnv(async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = () => Promise.resolve(new Response('nope', { status: 500 }));
+      assertEquals(await fetchProviderEnabled('google'), 'unknown');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+Deno.test('fetchProviderEnabled — "unknown" when the settings fetch rejects', async () => {
+  await withRecoveryEnv(async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = () => Promise.reject(new TypeError('network down'));
+      assertEquals(await fetchProviderEnabled('google'), 'unknown');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+Deno.test('fetchProviderEnabled — "unknown" when the settings body is not JSON', async () => {
+  await withRecoveryEnv(async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = () =>
+        Promise.resolve(new Response('<html>not json</html>', { status: 200 }));
+      assertEquals(await fetchProviderEnabled('google'), 'unknown');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/services/api/supabase/functions/_shared/supabase-auth.ts
+++ b/services/api/supabase/functions/_shared/supabase-auth.ts
@@ -242,6 +242,61 @@ export function buildAuthorizeUrl(
   return `${authUrl()}/authorize?${params.toString()}`;
 }
 
+/**
+ * Shape of the public GoTrue settings document served at
+ * `{SUPABASE_URL}/auth/v1/settings`. The `external` map exposes a per-provider
+ * boolean indicating whether that social provider is enabled on the backend.
+ */
+export interface GoTrueSettings {
+  external?: Record<string, boolean>;
+}
+
+/**
+ * Classified result of checking whether a provider is enabled on the backend:
+ *
+ * - `enabled`  — GoTrue reports the provider's `external` flag as `true`.
+ * - `disabled` — settings were read and the provider is absent/`false`.
+ * - `unknown`  — settings could not be read (network error or non-2xx); callers
+ *   should degrade as "backend temporarily unavailable" rather than guess.
+ */
+export type ProviderEnabledResult = 'enabled' | 'disabled' | 'unknown';
+
+/**
+ * Query GoTrue's public settings document to determine whether `provider` is
+ * actually enabled on the backend.
+ *
+ * A provider can be statically supported (google/github/apple) yet not enabled
+ * in GoTrue. Without this check, `auth-oauth-start` would 302 the browser to
+ * `/authorize` and the user would land on a raw
+ * `validation_failed: provider is not enabled` JSON page (#3188). Reading
+ * `/auth/v1/settings` auto-tracks whatever gets enabled later with no manual env
+ * sync. On any read failure we return `unknown` so the caller can surface a
+ * graceful in-app message instead of hard-redirecting onto a raw page.
+ */
+export async function fetchProviderEnabled(provider: AuthProvider): Promise<ProviderEnabledResult> {
+  const url = `${authUrl()}/settings`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'GET',
+      headers: { apikey: requireEnv('SUPABASE_ANON_KEY') },
+    });
+  } catch {
+    return 'unknown';
+  }
+
+  if (!response.ok) return 'unknown';
+
+  let settings: GoTrueSettings;
+  try {
+    settings = (await response.json()) as GoTrueSettings;
+  } catch {
+    return 'unknown';
+  }
+
+  return settings.external?.[provider] === true ? 'enabled' : 'disabled';
+}
+
 /** Outcome of a password-recovery request to Supabase Auth (GoTrue). */
 export interface PasswordRecoveryResult {
   /**

--- a/services/api/supabase/functions/auth-oauth-start/index.test.ts
+++ b/services/api/supabase/functions/auth-oauth-start/index.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Handler tests for auth-oauth-start provider-enablement gating (#3188).
+ *
+ * A statically-supported provider (google/github/apple) that is NOT enabled in
+ * GoTrue must fail fast with a 4xx/5xx JSON response instead of 302-ing the
+ * browser to `/authorize`, where GoTrue would render a raw
+ * "provider is not enabled" page. The SPA's pre-flight probe then keeps the
+ * user in-app with a graceful message.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+
+import { handler } from './index.ts';
+
+const ENV_KEYS = [
+  'SUPABASE_URL',
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'SUPABASE_ANON_KEY',
+  'OAUTH_REDIRECT_BASE',
+] as const;
+
+type TestFetch = (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;
+
+Deno.test('auth-oauth-start — enabled provider generates a 302 to GoTrue authorize', async () => {
+  const calls: string[] = [];
+  await withOAuthStartRuntime(
+    (input) => {
+      calls.push(String(input));
+      return settingsResponse({ google: true });
+    },
+    async () => {
+      const res = await handler(startRequest('google'));
+
+      assertEquals(res.status, 302);
+      const location = res.headers.get('Location') ?? '';
+      assertStringIncludes(location, '/auth/v1/authorize');
+      assertStringIncludes(location, 'provider=google');
+      assertStringIncludes(res.headers.get('Set-Cookie') ?? '', 'finance_pkce=');
+      // The only upstream call is the settings probe (buildAuthorizeUrl is pure).
+      assertEquals(calls.length, 1);
+      assertStringIncludes(calls[0], '/auth/v1/settings');
+    },
+  );
+});
+
+Deno.test(
+  'auth-oauth-start — disabled provider returns 400 and never redirects (#3188)',
+  async () => {
+    await withOAuthStartRuntime(
+      () => settingsResponse({ google: false }),
+      async () => {
+        const res = await handler(startRequest('google'));
+
+        assertEquals(res.status, 400);
+        assertEquals(await res.json(), { error: 'Provider not enabled' });
+        assertEquals(res.headers.get('Location'), null);
+        assertEquals(res.headers.get('Set-Cookie'), null);
+      },
+    );
+  },
+);
+
+Deno.test(
+  'auth-oauth-start — a provider absent from the external map is disabled (#3188)',
+  async () => {
+    await withOAuthStartRuntime(
+      () => settingsResponse({ github: true }),
+      async () => {
+        const res = await handler(startRequest('google'));
+
+        assertEquals(res.status, 400);
+        assertEquals(res.headers.get('Location'), null);
+      },
+    );
+  },
+);
+
+Deno.test(
+  'auth-oauth-start — unreadable settings returns 503, never a raw page (#3188)',
+  async () => {
+    await withOAuthStartRuntime(
+      () => new Response('upstream down', { status: 502 }),
+      async () => {
+        const res = await handler(startRequest('google'));
+
+        assertEquals(res.status, 503);
+        assertEquals(res.headers.get('Retry-After'), '60');
+        assertEquals(await res.json(), { error: 'Service temporarily unavailable' });
+        assertEquals(res.headers.get('Location'), null);
+      },
+    );
+  },
+);
+
+Deno.test('auth-oauth-start — a settings fetch rejection returns 503 (#3188)', async () => {
+  await withOAuthStartRuntime(
+    () => {
+      throw new TypeError('fetch failed');
+    },
+    async () => {
+      const res = await handler(startRequest('google'));
+
+      assertEquals(res.status, 503);
+      assertEquals(res.headers.get('Location'), null);
+    },
+  );
+});
+
+Deno.test(
+  'auth-oauth-start — unsupported provider returns 400 without probing settings',
+  async () => {
+    let settingsCalls = 0;
+    await withOAuthStartRuntime(
+      () => {
+        settingsCalls++;
+        return settingsResponse({ google: true });
+      },
+      async () => {
+        const res = await handler(startRequest('facebook'));
+
+        assertEquals(res.status, 400);
+        assertEquals(await res.json(), { error: 'Unsupported provider' });
+        assertEquals(settingsCalls, 0);
+      },
+    );
+  },
+);
+
+function startRequest(provider: string): Request {
+  return new Request(
+    `https://finance.example.test/api/auth/oauth-start?provider=${provider}&redirect_to=/dashboard`,
+    { method: 'GET', headers: { 'x-forwarded-proto': 'https' } },
+  );
+}
+
+function settingsResponse(external: Record<string, boolean>): Response {
+  return new Response(JSON.stringify({ external }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function withOAuthStartRuntime(
+  fetchImpl: TestFetch,
+  run: () => Promise<void>,
+): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  const originalEnv = new Map<(typeof ENV_KEYS)[number], string | undefined>();
+  for (const key of ENV_KEYS) originalEnv.set(key, Deno.env.get(key));
+
+  Deno.env.set('SUPABASE_URL', 'https://project-ref.supabase.co');
+  Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
+  Deno.env.set('SUPABASE_ANON_KEY', 'anon-key');
+  Deno.env.set('OAUTH_REDIRECT_BASE', 'https://finance.example.test');
+  globalThis.fetch = fetchImpl as typeof fetch;
+
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+    for (const key of ENV_KEYS) {
+      const value = originalEnv.get(key);
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  }
+}

--- a/services/api/supabase/functions/auth-oauth-start/index.ts
+++ b/services/api/supabase/functions/auth-oauth-start/index.ts
@@ -19,6 +19,7 @@ import { requireEnv, validateEnv } from '../_shared/env.ts';
 import { COOKIE_PKCE, COOKIE_POST_LOGIN, buildSetCookie } from '../_shared/cookie.ts';
 import {
   buildAuthorizeUrl,
+  fetchProviderEnabled,
   generatePkceMaterial,
   isSupportedProvider,
 } from '../_shared/supabase-auth.ts';
@@ -43,6 +44,27 @@ export const handler = async (req: Request): Promise<Response> => {
     return new Response(JSON.stringify({ error: 'Unsupported provider' }), {
       status: 400,
       headers: { ...NO_STORE, 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Statically supported ≠ actually enabled on GoTrue. Verify the provider is
+  // enabled BEFORE issuing a 302 — otherwise the browser follows the redirect
+  // to GoTrue's `/authorize` and lands on a raw "provider is not enabled" JSON
+  // page (#3188). A disabled provider answers 400 (the SPA shows the graceful
+  // in-app "that option is unavailable" message); an unreadable settings
+  // document answers 503 (the SPA shows the "temporarily unavailable" message).
+  // Neither ever hard-redirects the user onto a raw page.
+  const providerEnabled = await fetchProviderEnabled(provider);
+  if (providerEnabled === 'disabled') {
+    return new Response(JSON.stringify({ error: 'Provider not enabled' }), {
+      status: 400,
+      headers: { ...NO_STORE, 'Content-Type': 'application/json' },
+    });
+  }
+  if (providerEnabled === 'unknown') {
+    return new Response(JSON.stringify({ error: 'Service temporarily unavailable' }), {
+      status: 503,
+      headers: { ...NO_STORE, 'Content-Type': 'application/json', 'Retry-After': '60' },
     });
   }
 

--- a/services/api/supabase/functions/deno.json
+++ b/services/api/supabase/functions/deno.json
@@ -10,6 +10,7 @@
       "health-check/**/*.test.ts",
       "auth-webhook/**/*.test.ts",
       "auth-refresh/**/*.test.ts",
+      "auth-oauth-start/**/*.test.ts",
       "passkey-register/**/*.test.ts",
       "passkey-authenticate/**/*.test.ts",
       "household-invite/**/*.test.ts",


### PR DESCRIPTION
## Summary

Fixes **three related login-page issues** found during the finance.jrmoulckers.com bug-bash. All three touch `apps/web/src/pages/LoginPage.tsx` and/or `apps/web/src/styles/auth.css`, so they ship as **one PR** by a single owner (sequential edits, no parallel work).

## Changes

### #3189 (P2) — email disclosure collapsed nothing

- `.auth-form { display: flex }` was overriding the UA `[hidden] { display: none }` rule, so the **"Sign in with email instead" / "Hide email sign-in"** toggle flipped `aria-expanded` but never actually collapsed the form.
- **Fix:** add `.auth-form[hidden] { display: none; }` to `auth.css`.
- OAuth buttons live in a **sibling** `.auth-oauth-section` (outside the collapsible form) and stay visible — no regression to #3178.

### #3188 (P2) — disabled OAuth provider dumped the user on a raw GoTrue JSON page

- `auth-oauth-start` issued a `302` for any statically-**supported** provider (google/github/apple) regardless of whether GoTrue actually had it **enabled**. The SPA's `redirect:'manual'` pre-flight probe saw the `302` → "healthy" → navigated → GoTrue `/authorize` returned a raw `400 validation_failed: provider is not enabled` JSON page. The probe was blind to the downstream rejection because `redirect:'manual'` never follows the hop.
- **Fix (backend only):** `auth-oauth-start` now verifies the provider is enabled **before** it `302`s, by reading GoTrue's public `GET {SUPABASE_URL}/auth/v1/settings` (its `external` map exposes per-provider booleans):
  - **disabled** → `400` JSON → the existing probe treats it as non-healthy → in-app **`OAUTH_PROVIDER_UNAVAILABLE_MESSAGE`**.
  - **settings unreadable** (network error / non-2xx / non-JSON) → `503` JSON → in-app **`SERVICE_UNAVAILABLE_MESSAGE`**.
  - **enabled** → unchanged `302` PKCE flow.
- The browser is **never** hard-redirected onto a raw page. Reading `/auth/v1/settings` auto-tracks whatever gets enabled later (#3187) with no manual env sync.
- **No frontend logic change was needed** — `loginWithOAuth` / `isOAuthStartHealthy` / `isServiceUnavailableStatus` already map `4xx → provider-unavailable` and `5xx → service-unavailable` with no navigation. The bug was purely the edge function `302`-ing for disabled-but-supported providers.
- Social buttons stay **visible** (respects #3178). **No secrets touched and no providers enabled** — that is human-gated #3187; this PR only makes the flow degrade gracefully.

### #3190 (P3) — auth error was a focused, centered box at the top of the card

- The error rendered as a full-width, `text-align:center` red box at the **top** of the card (above the biometric button and fields) and **stole focus** to a `tabIndex=-1` div on every error — it read like a focused button far from the Sign in action.
- **Fix (CSS):** restyle `.auth-error` as a **compact, left-aligned inline alert** (smaller padding, `text-align:start`, a leading warning icon) so it reads as contextual feedback.
- **Fix (TSX):** **reposition** the error region to sit directly **above the sign-in form**, and **drop the `errorRef.current?.focus()` focus-steal** — while **keeping** the `aria-live="polite"` + `aria-atomic="true"` announcement so screen-reader UX is preserved. Field-validation errors already move focus to the first invalid field.

## Testing

- [x] `apps/web` unit suite green — `LoginPage.test.tsx` (18) + `auth-context.test.tsx` (25) pass, including the strengthened #3189 collapse assertion (`form` + email/password labels `not.toBeVisible()`) and the new #3188 disabled-provider path (probe non-healthy → in-app message, no navigation).
- [x] Full `apps/web` vitest run: **9087 passed** (the single flake was `DashboardPage > has accessible landmarks` timing out under two concurrent suites; it passes 16/16 in isolation — unrelated to this change, which doesn't touch dashboard code).
- [x] Backend Deno tests added (run in CI): 5 `fetchProviderEnabled` unit tests + 6 `auth-oauth-start` handler tests (enabled→302 w/ `finance_pkce` cookie + single settings probe; disabled→400; absent-flag→400; unreadable→503 + `Retry-After`; fetch-reject→503; unsupported→400 without probing). `auth-oauth-start/**/*.test.ts` added to `deno.json` `test.include` so the new handler test runs in CI.
- [x] `npm run format:check` ✓ and `npx eslint . --max-warnings 0` ✓.
- [x] **E2E locator safety (#3176):** grepped `apps/web/e2e/**` — no specs reference `.auth-error`, the disclosure text, or the OAuth error text; `.auth-oauth-section` and `form#login-email-form` are preserved, and new elements stay addressable by role + accessible name.

## Design notes

- **The error region is a card-level child, not inside the collapsible `<form>`.** Passkey- and OAuth-failure paths set the same shared `error` and their buttons live outside the form, so nesting the error inside the form would hide failures when the email form is collapsed for passkey-primary users. This matches the WCAG error-summary pattern (error adjacent to the controls).
- **Extra upstream call:** each `oauth-start` invocation now makes one `GET /auth/v1/settings` probe before redirecting. This is a cheap, cache-friendly public endpoint and is the cost of guaranteeing no raw page.

## Needs Decision

I deliberately **kept the social buttons visible** even when a provider is disabled (a click now surfaces the graceful in-app message instead of a raw page), per the issue author's stated preference. The alternative — **hiding** a social button entirely when its provider isn't enabled (e.g. via a small `GET /api/auth/providers` capability endpoint the SPA reads at render time) — would avoid the dead-click entirely but is a larger UX/product change. Flagging for a product call; not implemented here.

Closes #3188
Closes #3189
Closes #3190
