### PR TITLE
fix(web): login wrong-credentials submit flash (residual of #3108)

### DIFF
--- a/apps/web/src/auth/auth-context.test.tsx
+++ b/apps/web/src/auth/auth-context.test.tsx
@@ -413,6 +413,38 @@ describe('signup & login surface a clear message when the backend is unreachable
       expect(screen.getByTestId('auth-error')).toHaveTextContent('Invalid login credentials'),
     );
   });
+
+  it('keeps a prior error visible while a retry request is in flight (#3192)', async () => {
+    // The login endpoint fails the first time (surfacing an error) and then
+    // hangs on the retry so we can observe state while the request is pending.
+    let loginAttempts = 0;
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/auth/login')) {
+        loginAttempts += 1;
+        if (loginAttempts === 1) {
+          return Promise.resolve(jsonResponse({ error: 'Invalid login credentials' }, 400));
+        }
+        // Second attempt never resolves: the request stays in flight.
+        return new Promise<Response>(() => {});
+      }
+      return Promise.resolve(jsonResponse({ error: 'no session' }, 401));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await renderReady();
+
+    // First attempt fails and the banner appears.
+    fireEvent.click(screen.getByTestId('do-login'));
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-error')).toHaveTextContent('Invalid login credentials'),
+    );
+
+    // Retry: the request is in flight (loading) and the prior error is NOT
+    // eagerly cleared — it must stay put until the new result resolves (#3192).
+    fireEvent.click(screen.getByTestId('do-login'));
+    await waitFor(() => expect(screen.getByTestId('loading-state')).toHaveTextContent('loading'));
+    expect(screen.getByTestId('auth-error')).toHaveTextContent('Invalid login credentials');
+  });
 });
 
 describe('isOAuthStartHealthy', () => {

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -499,7 +499,11 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
 
   const loginWithEmail = useCallback(
     async (email: string, password: string): Promise<void> => {
-      setError(null);
+      // Intentionally do NOT clear the error here. On a retry the prior banner
+      // must stay put until the new result arrives — an eager clear unmounts it
+      // (form jumps up) and the fast failure remounts it (form jumps down),
+      // which is the residual submit flash from #3108 that #3192 closes. The
+      // error is cleared on the success paths below and overwritten on failure.
       setIsLoading(true);
 
       try {
@@ -515,6 +519,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
             throw new Error(BETA_ACCESS_REQUIRED_MESSAGE);
           }
           setIsOffline(false);
+          setError(null);
           triggerPasskeyPromptCheck();
           return;
         }
@@ -553,6 +558,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
           throw new Error(BETA_ACCESS_REQUIRED_MESSAGE);
         }
         setIsOffline(false);
+        setError(null);
         triggerPasskeyPromptCheck();
       } catch (err) {
         if (isNetworkError(err)) {

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -333,4 +333,35 @@ describe('LoginPage', () => {
       expect((screen.getByLabelText('Password') as HTMLInputElement).value).toBe('badpassword1');
     });
   });
+
+  describe('error region reserves space & announces (#3192)', () => {
+    it('keeps the aria-live region mounted (reserving space) when there is no error', () => {
+      authState.error = null;
+      const { container } = renderLoginPage();
+
+      const region = container.querySelector('.auth-error-region');
+      // The region is always present so its reserved min-height stops the form
+      // from shifting on the first failed submit, and the polite live region
+      // stays available for screen-reader announcements.
+      expect(region).toBeInTheDocument();
+      expect(region).toHaveAttribute('aria-live', 'polite');
+      expect(region).toHaveAttribute('aria-atomic', 'true');
+      // No banner content while there is no error, but the region persists.
+      expect(container.querySelector('.auth-error')).toBeNull();
+    });
+
+    it('mounts the error banner inside that same live region without remounting it', () => {
+      authState.error = 'Incorrect email or password';
+      const { container } = renderLoginPage();
+
+      const region = container.querySelector('.auth-error-region');
+      expect(region).toBeInTheDocument();
+      expect(region).toHaveAttribute('aria-live', 'polite');
+      expect(region).toHaveAttribute('aria-atomic', 'true');
+
+      const banner = region?.querySelector('.auth-error');
+      expect(banner).not.toBeNull();
+      expect(screen.getByText('Incorrect email or password')).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -271,11 +271,7 @@ export const LoginPage: React.FC = () => {
           politely via the live region; we no longer steal visual focus to a
           top-of-card box on every error (#3190).
         */}
-        <div
-          className={`auth-error-region${error ? ' auth-error-region--filled' : ''}`}
-          aria-live="polite"
-          aria-atomic="true"
-        >
+        <div className="auth-error-region" aria-live="polite" aria-atomic="true">
           {error && (
             <div id={authErrorId} className="auth-error">
               <svg

--- a/apps/web/src/styles/auth.css
+++ b/apps/web/src/styles/auth.css
@@ -160,16 +160,23 @@
 /* ─── Error / status banners ─────────────────────────────────────────────── */
 
 /*
- * Reserve vertical space for the auth error so a failed sign-in renders the
- * message inline without a layout shift / flash (#3108). The region is always
- * present (and announces politely); the styled box only appears once filled.
+ * Reserve a stable block of vertical space for the auth error so mounting or
+ * unmounting the inline banner never shifts the sibling form — the residual
+ * submit flash that #3192 closes on top of #3108. `min-height` holds exactly
+ * one compact banner (one line of caption text + the box's vertical padding),
+ * expressed with the same tokens the banner uses so it tracks the cognitive /
+ * high-contrast / accessibility type-scale overrides. The margin is constant
+ * (never toggled) so the reserved footprint is identical whether or not an
+ * error is present, keeping cumulative layout shift at zero. The region is
+ * always rendered and announces politely via aria-live; the styled box only
+ * appears once there is a message.
  */
 .auth-error-region {
+  min-height: calc(
+    var(--type-scale-caption-line-height, 1.5) * var(--type-scale-caption-font-size, 0.875rem) +
+      var(--spacing-2) * 2
+  );
   margin-bottom: var(--spacing-4);
-}
-
-.auth-error-region:not(.auth-error-region--filled) {
-  margin-bottom: 0;
 }
 
 /*
@@ -187,6 +194,7 @@
   background: var(--color-red-50, #fef2f2);
   color: var(--semantic-status-negative);
   font-size: var(--type-scale-caption-font-size, 0.875rem);
+  line-height: var(--type-scale-caption-line-height, 1.5);
   text-align: start;
 }
 


### PR DESCRIPTION
## Summary

Fixes the residual web-only login-page submit flash that remained after #3108. Submitting **wrong** credentials still caused a brief layout shift — the form condensed/jumped and the spinner flickered before the "Incorrect email or password" banner settled, most visible on a retry. This closes that with two complementary web-only changes; no shared/native code is touched.

## Root cause

1. **`.auth-error-region` reserved no real height.** It only toggled `margin-bottom`, despite the comment claiming it prevented shift. Mounting the compact `.auth-error` banner pushed the sibling `<form>` down.
2. **The error was cleared mid-request.** `loginWithEmail` called `setError(null)` at the very start, so on a retry the visible banner unmounted instantly (form jumps up) and the fast `400` immediately remounted it (form jumps down) — that up-then-down is the flash.

## Changes

- **`apps/web/src/styles/auth.css`** — `.auth-error-region` now reserves a stable `min-height` sized to exactly one compact banner (one line of caption text + the box's vertical padding), expressed with the same `--type-scale-caption-*` / `--spacing-2` tokens the banner uses so it tracks cognitive / high-contrast / accessibility type-scale overrides. The margin is now constant (removed the `:not(--filled)` toggle) so the reserved footprint is identical with or without an error → **CLS 0**. Added a deterministic `line-height` on `.auth-error` so the rendered banner height matches the reserved height. `aria-live="polite"` + `aria-atomic` are unchanged.
- **`apps/web/src/auth/auth-context.tsx`** — removed the eager `setError(null)` at the top of `loginWithEmail`. The error is now cleared only on the **success** paths (demo + real) and overwritten on failure, so a retry keeps the prior message stable until the new result arrives. A successful login still clears any prior error.
- **`apps/web/src/pages/LoginPage.tsx`** — dropped the now-dead `auth-error-region--filled` modifier (the region wrapper stays unconditionally rendered inside the live region).
- **Tests** — `LoginPage.test.tsx`: the aria-live region stays mounted (reserving space) both with and without an error, and the banner mounts inside that same region. `auth-context.test.tsx`: `loginWithEmail` no longer clears a prior error while a retry request is in flight.

## Non-regressions

- Keeps #3189 (disclosure `display:none`), #3190 (compact inline error banner), #3178 (social buttons outside hidden form) intact.
- No e2e/backend-timing tests added. Out of scope of #3187 (OAuth provider enablement) — no secrets/Supabase/OAuth config touched.

## Issues

Closes #3192

## Testing

- [x] `apps/web` unit tests pass (`LoginPage.test.tsx` + `auth-context.test.tsx`, 46 tests)
- [x] `npx prettier --check` clean on changed files
- [x] `npx eslint apps/web --max-warnings 0` clean
- [x] First wrong-creds submit: banner appears with no downward form shift
- [x] Retry wrong-creds submit: banner stays put, text updates in place
- [x] Successful login clears any prior error
- [x] aria-live region still announces (a11y intact)
