### PR TITLE
fix(web): round Grocery Mode category select to match sibling inputs (#3195)

### DIFF
--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -653,6 +653,23 @@
   font: inherit;
 }
 
+/*
+ * A native <select> under the default `appearance: auto` ignores
+ * `border-radius`, so it painted square corners while its sibling text input
+ * (which shares the base rule above) renders rounded. Set `appearance: none`
+ * so the select honors the shared radius/border tokens, and restore an
+ * explicit chevron. Scoped to the select only — the text input must keep its
+ * native appearance. Mirrors the existing `.form-select` and
+ * `.transaction-sort__select` pattern (same chevron data-URI). (#3195)
+ */
+.grocery-mode-card__select {
+  appearance: none;
+  padding-right: 2rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 5l3 3 3-3' fill='none' stroke='%23666' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+}
+
 .grocery-mode-card__afford-input {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

On the Dashboard **Grocery Mode** card, the **Track a category** `<select>`
(`.grocery-mode-card__select`) rendered with **square** corners while its sibling
**Can I afford…?** text input (`.grocery-mode-card__afford-input`) was **rounded**
(8px / `--border-radius-md`). The two controls sit side by side, so the mismatch
looked like a visual bug.

**Root cause:** the native `<select>` shared a base rule with the text input that
set `border-radius` but never set `appearance: none`. Under the browser default
`appearance: auto`, a native select ignores `border-radius` and paints
rectangular, so the shared radius token had no effect on it.

## Changes

- `apps/web/src/components/dashboard/dashboard.css`
  - Kept the shared `.grocery-mode-card__select, .grocery-mode-card__input` base
    rule (padding / border / **radius** / background / color / font) untouched —
    the radius token was already correct, the select just wasn't honoring it.
  - Added a **select-scoped** rule immediately after the base rule that sets
    `appearance: none;`, `padding-right: 2rem;`, and an inline SVG chevron
    (`background-image` data-URI + `background-repeat` + `background-position`).
    This makes the native select honor the existing radius/border tokens instead
    of restyling anything.
  - The chevron data-URI, `background-repeat`, and `background-position` are the
    **exact** values already used by `.transaction-sort__select`
    (`transaction-filters.css`), so the arrow matches the rest of the app.
  - `appearance: none` is applied **only** to the select — the sibling text input
    keeps its native appearance.

No JSX, no design tokens, and no other selectors were changed.

## Design decision — scoped rule vs. shared `.app-select` utility

The issue suggested (strongly preferring) extracting a shared `.app-select`
utility applied to both the grocery select and `.transaction-sort__select` so the
chevron data-URI has a single source of truth. I evaluated this and chose the
**scoped** approach instead, because:

- The existing, working selects in this codebase already follow the scoped
  convention: **both** `.form-select` (`forms.css`) **and**
  `.transaction-sort__select` (`transaction-filters.css`) define their
  `appearance: none` + chevron in a **separate rule placed after their shared
  base rule**, in the same file. My change mirrors that established pattern
  exactly, so it is cascade-safe by construction (same file, later source order →
  the select-specific longhands win over the base `padding` / `background`
  shorthands).
- A global `.app-select` utility would be imported in `main.tsx`, and its source
  order relative to per-component CSS is not guaranteed. The existing component
  base rules use the `background:` and `padding:` **shorthands** (which reset
  `background-image` / `padding-right`). A globally-imported utility would race
  those shorthands and, to be robust, would force restructuring the two working,
  out-of-scope selectors (`.transaction-sort__select`, and for consistency
  `.form-select`) from `background:`→`background-color:` and re-splitting their
  padding. That meaningfully increases blast radius and regression risk on
  components not covered by this P3 issue.

**Follow-up (not in scope here):** the chevron data-URI is now duplicated in three
places — `.form-select`, `.transaction-sort__select`, and
`.grocery-mode-card__select`. A dedicated refactor could consolidate all three
into one shared select-appearance utility (single source of truth for the
chevron) as its own change, where the required edits to the two existing
selectors can be reviewed and visually verified in isolation. The shared
`.form-select` is already correctly rounded (it already sets `appearance: none`),
so no user-facing select is left square by this PR.

## Accessibility

- `.grocery-mode-card__select:focus-visible` still shows the 2px focus ring
  (unchanged).
- The high-contrast block (`@media (prefers-contrast: more)`) still thickens the
  select border to 2px (unchanged); the chevron is a separate background layer
  and stays visible.
- Chevron stroke color (`#666`) matches the app's other selects in light, dark,
  and high-contrast — no new dark-mode behavior is introduced beyond the existing
  established pattern.

## Testing

- [x] `npx prettier --check` on the changed file — clean.
- [x] `npx eslint . --max-warnings 0` — clean (exit 0, repo-wide).
- [x] Manual cascade review: the select-specific rule is placed after the shared
      base rule in the same file, so `padding-right: 2rem` and the chevron
      `background-image` win over the base `padding` / `background` shorthands
      while the shared `border-radius` now takes visible effect.
- [ ] No unit test added: a jsdom computed-style assertion does not reflect native
      `appearance`, so a unit test for this pure-CSS fix would be hollow. Existing
      dashboard/transactions unit + e2e specs are unaffected (no class/JSX
      changes; the sort select's role/text locators are untouched).

Closes #3195
