### PR TITLE
fix(web): surface notifications + hide-amounts in desktop sidebar (#3197)

### DIFF
--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -24,6 +24,7 @@ vi.mock('../../auth/auth-context', () => ({
 
 vi.mock('../../hooks', () => ({
   useKeyboardShortcuts: vi.fn(),
+  useBreakpoint: vi.fn(),
   useNotifications: () => ({
     notifications: [],
     unreadCount: 0,
@@ -96,10 +97,20 @@ vi.mock('../../contexts/PrivacyModeContext', () => ({
   }),
 }));
 
-import { useKeyboardShortcuts } from '../../hooks';
+import { useBreakpoint, useKeyboardShortcuts } from '../../hooks';
 import { AppLayout } from './AppLayout';
 
 const mockSetShowHelp = vi.fn();
+
+/** Set the mocked breakpoint. Header quick actions render only on mobile. */
+function mockBreakpoint(kind: 'mobile' | 'tablet' | 'desktop') {
+  vi.mocked(useBreakpoint).mockReturnValue({
+    breakpoint: kind,
+    isMobile: kind === 'mobile',
+    isTablet: kind === 'tablet',
+    isDesktop: kind === 'desktop',
+  });
+}
 
 describe('AppLayout', () => {
   beforeEach(() => {
@@ -111,6 +122,7 @@ describe('AppLayout', () => {
       shortcutCategories: [],
       singleKeyShortcutsEnabled: true,
     });
+    mockBreakpoint('mobile');
     mockSetShowHelp.mockClear();
   });
 
@@ -208,6 +220,29 @@ describe('AppLayout', () => {
     // The abstract circle glyph was replaced with a recognizable eye icon.
     expect(toggle.querySelector('svg')).not.toBeNull();
     expect(toggle.textContent).not.toContain('○');
+  });
+
+  it('renders the notifications bell in the header on mobile', () => {
+    renderLayout();
+
+    const header = screen.getByRole('banner', { name: 'App header' });
+    expect(within(header).getByRole('button', { name: /notifications/i })).toBeInTheDocument();
+  });
+
+  it('relocates the hide-amounts toggle and notifications out of the header at ≥768px (#3197)', () => {
+    mockBreakpoint('desktop');
+    renderLayout();
+
+    const header = screen.getByRole('banner', { name: 'App header' });
+    // At ≥768px the header is display:none and its quick actions move to the
+    // sidebar. They must NOT be duplicated in the (hidden) header DOM, otherwise
+    // Playwright strict-mode locators match two nodes with the same name (#3197).
+    expect(within(header).queryByRole('button', { name: 'Hide amounts' })).not.toBeInTheDocument();
+    expect(
+      within(header).queryByRole('button', { name: /notifications/i }),
+    ).not.toBeInTheDocument();
+    // Non-relocated header actions stay put.
+    expect(within(header).getByRole('button', { name: 'Settings' })).toBeInTheDocument();
   });
 
   it('navigates to /settings when the header Settings button is clicked', () => {

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -8,7 +8,7 @@ import { KeyboardShortcutsModal, SyncStatusBar } from '../common';
 import { CommandPalette, type CommandPaletteAction } from '../common/CommandPalette';
 import { ConflictResolutionDialog } from '../common/ConflictResolutionDialog';
 import { NotificationCenter } from '../notifications';
-import { useKeyboardShortcuts } from '../../hooks';
+import { useBreakpoint, useKeyboardShortcuts } from '../../hooks';
 import { useAccessibility } from '../../hooks/useAccessibility';
 import { useHiddenModules } from '../../hooks/useModuleVisibility';
 import { usePrivacyMode } from '../../contexts/PrivacyModeContext';
@@ -91,6 +91,10 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
   onNotificationAction,
 }) => {
   const { isPrivacyMode, togglePrivacyMode } = usePrivacyMode();
+  // The `.app-header` is `display:none` at ≥768px, so its quick actions are
+  // rendered here only on mobile; the desktop sidebar hosts them instead. Gating
+  // by breakpoint keeps exactly one instance of each control in the DOM (#3197).
+  const { isMobile } = useBreakpoint();
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [simpleModeEnabled, setSimpleModeEnabled] = useState(getStoredSimplifiedModePreference);
   const { isSimplified } = useAccessibility();
@@ -232,6 +236,15 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
         onOpenShortcuts={openKeyboardShortcuts}
         onOpenFeedback={openFeedbackDialog}
         simpleMode={simpleModeEnabled}
+        showQuickActions={!isMobile}
+        notifications={notifications}
+        notificationUnreadCount={notificationUnreadCount}
+        onMarkNotificationAsRead={onMarkNotificationAsRead}
+        onMarkAllNotificationsAsRead={onMarkAllNotificationsAsRead}
+        onDismissNotification={onDismissNotification}
+        onNotificationAction={onNotificationAction}
+        isPrivacyMode={isPrivacyMode}
+        onTogglePrivacyMode={togglePrivacyMode}
       />
       <div className={`app-shell${isSimplified ? ' app-shell--simplified' : ''}`}>
         <SyncStatusBar />
@@ -270,27 +283,31 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
                 {isSimplified ? <span className="icon-button__label">Review alerts</span> : null}
               </button>
             )}
-            <button
-              type="button"
-              className={`icon-button${isPrivacyMode ? ' icon-button--active' : ''}${isSimplified ? ' icon-button--labeled' : ''}`}
-              aria-label={isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
-              aria-pressed={isPrivacyMode}
-              title={isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
-              onClick={togglePrivacyMode}
-            >
-              {isPrivacyMode ? <EyeOffIcon /> : <EyeIcon />}
-              <span className="icon-button__label">
-                {isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
-              </span>
-            </button>
-            <NotificationCenter
-              notifications={notifications}
-              unreadCount={notificationUnreadCount}
-              onMarkAsRead={onMarkNotificationAsRead}
-              onMarkAllAsRead={onMarkAllNotificationsAsRead}
-              onDismiss={onDismissNotification}
-              onAction={onNotificationAction}
-            />
+            {isMobile ? (
+              <>
+                <button
+                  type="button"
+                  className={`icon-button${isPrivacyMode ? ' icon-button--active' : ''}${isSimplified ? ' icon-button--labeled' : ''}`}
+                  aria-label={isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
+                  aria-pressed={isPrivacyMode}
+                  title={isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
+                  onClick={togglePrivacyMode}
+                >
+                  {isPrivacyMode ? <EyeOffIcon /> : <EyeIcon />}
+                  <span className="icon-button__label">
+                    {isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
+                  </span>
+                </button>
+                <NotificationCenter
+                  notifications={notifications}
+                  unreadCount={notificationUnreadCount}
+                  onMarkAsRead={onMarkNotificationAsRead}
+                  onMarkAllAsRead={onMarkAllNotificationsAsRead}
+                  onDismiss={onDismissNotification}
+                  onAction={onNotificationAction}
+                />
+              </>
+            ) : null}
             {!isSimplified ? (
               <button
                 type="button"

--- a/apps/web/src/components/layout/Navigation.test.tsx
+++ b/apps/web/src/components/layout/Navigation.test.tsx
@@ -245,6 +245,19 @@ describe('SidebarNavigation', () => {
     onNavigate: vi.fn(),
   };
 
+  /** Props that turn on the relocated header quick actions (#3197). */
+  const quickActionProps = {
+    ...defaultProps,
+    showQuickActions: true,
+    notifications: [],
+    notificationUnreadCount: 3,
+    onMarkNotificationAsRead: vi.fn(),
+    onMarkAllNotificationsAsRead: vi.fn(),
+    onDismissNotification: vi.fn(),
+    isPrivacyMode: false,
+    onTogglePrivacyMode: vi.fn(),
+  };
+
   it('renders the pinned destinations at the top', () => {
     render(<SidebarNavigation {...defaultProps} />);
 
@@ -452,5 +465,56 @@ describe('SidebarNavigation', () => {
 
     // Money still contains the active route; no rising edge → stays collapsed.
     expect(moneyToggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  // ─── Relocated header quick actions (#3197) ────────────────────────────────
+
+  it('does not render notifications or hide-amounts controls without showQuickActions', () => {
+    render(<SidebarNavigation {...defaultProps} />);
+
+    expect(screen.queryByRole('button', { name: /notifications/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /hide amounts/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a notifications bell with the unread count when showQuickActions is set', () => {
+    render(<SidebarNavigation {...quickActionProps} />);
+
+    const bell = screen.getByRole('button', { name: 'Notifications, 3 unread' });
+    expect(bell).toBeInTheDocument();
+    expect(bell).toHaveAttribute('aria-haspopup', 'true');
+  });
+
+  it('opens the notification panel from the sidebar bell', () => {
+    render(<SidebarNavigation {...quickActionProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Notifications, 3 unread' }));
+
+    expect(screen.getByRole('region', { name: 'Notifications' })).toBeInTheDocument();
+  });
+
+  it('renders a hide-amounts toggle with header parity when showQuickActions is set', () => {
+    render(<SidebarNavigation {...quickActionProps} />);
+
+    const toggle = screen.getByRole('button', { name: 'Hide amounts' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    expect(toggle).toHaveAttribute('title', 'Hide amounts');
+    expect(toggle.querySelector('svg')).not.toBeNull();
+  });
+
+  it('reflects active privacy mode on the sidebar hide-amounts toggle', () => {
+    render(<SidebarNavigation {...quickActionProps} isPrivacyMode />);
+
+    const toggle = screen.getByRole('button', { name: 'Show amounts' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    expect(toggle).toHaveAttribute('title', 'Show amounts');
+  });
+
+  it('calls onTogglePrivacyMode when the sidebar hide-amounts toggle is clicked', () => {
+    const onTogglePrivacyMode = vi.fn();
+    render(<SidebarNavigation {...quickActionProps} onTogglePrivacyMode={onTogglePrivacyMode} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide amounts' }));
+
+    expect(onTogglePrivacyMode).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -17,11 +17,13 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import type { AppNotification } from '../../lib/notifications';
 import { useAuth } from '../../auth/auth-context';
 import { useAccessibility } from '../../hooks/useAccessibility';
 import { useHiddenModules } from '../../hooks/useModuleVisibility';
 import { Icon } from '../common/Icon';
 import { IconToken } from '../../icons/tokens';
+import { NotificationCenter } from '../notifications';
 
 import { MoreNavSheet } from './MoreNavSheet';
 import {
@@ -35,7 +37,14 @@ import {
   type NavConfigItem,
   type NavGroup,
 } from './navConfig';
-import { ChevronDownIcon, KeyboardIcon, MoreIcon, SignOutIcon } from './navIcons';
+import {
+  ChevronDownIcon,
+  EyeIcon,
+  EyeOffIcon,
+  KeyboardIcon,
+  MoreIcon,
+  SignOutIcon,
+} from './navIcons';
 
 // ---------------------------------------------------------------------------
 // Back-compat shims for existing consumers / tests.
@@ -71,6 +80,35 @@ export interface NavigationProps {
   onOpenShortcuts?: () => void;
   onOpenFeedback?: () => void;
   simpleMode?: boolean;
+}
+
+/**
+ * Props for {@link SidebarNavigation}. Extends {@link NavigationProps} with the
+ * quick actions relocated from the app header (which is `display:none` at
+ * ≥768px). The controls are gated by `showQuickActions` so exactly one
+ * instance of each lives in the DOM per breakpoint — the header keeps them for
+ * `<768px`, the sidebar hosts them for `≥768px` — avoiding duplicate
+ * accessible-name (strict-mode) collisions (#3197).
+ */
+export interface SidebarNavigationProps extends NavigationProps {
+  /** Render the relocated header quick actions (notifications + hide-amounts). */
+  showQuickActions?: boolean;
+  /** All notifications, newest first. */
+  notifications?: readonly AppNotification[];
+  /** Number of unread notifications (drives the bell badge). */
+  notificationUnreadCount?: number;
+  /** Mark a single notification as read. */
+  onMarkNotificationAsRead?: (id: string) => void;
+  /** Mark every notification as read. */
+  onMarkAllNotificationsAsRead?: () => void;
+  /** Dismiss a single notification. */
+  onDismissNotification?: (id: string) => void;
+  /** Handle a notification's primary action (e.g. "View budget"). */
+  onNotificationAction?: (notification: AppNotification) => void;
+  /** Whether privacy mode (masked amounts) is active. */
+  isPrivacyMode?: boolean;
+  /** Toggle privacy mode. */
+  onTogglePrivacyMode?: () => void;
 }
 
 function isActive(activePath: string, href: string): boolean {
@@ -275,12 +313,21 @@ const SidebarGroup: React.FC<SidebarGroupProps> = ({
 };
 
 /** Sidebar navigation for wide viewports. */
-export const SidebarNavigation: React.FC<NavigationProps> = ({
+export const SidebarNavigation: React.FC<SidebarNavigationProps> = ({
   activePath,
   onNavigate,
   onOpenShortcuts,
   onOpenFeedback,
   simpleMode = false,
+  showQuickActions = false,
+  notifications = [],
+  notificationUnreadCount = 0,
+  onMarkNotificationAsRead = () => undefined,
+  onMarkAllNotificationsAsRead = () => undefined,
+  onDismissNotification = () => undefined,
+  onNotificationAction,
+  isPrivacyMode = false,
+  onTogglePrivacyMode = () => undefined,
 }) => {
   const { logout } = useAuth();
   const { isSimplified } = useAccessibility();
@@ -354,6 +401,37 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
 
       {/* Pinned footer — always visible without scrolling. */}
       <div className="app-sidebar__footer">
+        {/* Quick actions relocated from the header, which is hidden at ≥768px.
+            Rendered only when `showQuickActions` so the header copies (used at
+            <768px) never coexist with these in the DOM — keeping notification
+            state single-sourced and accessible names unique (#3197). */}
+        {showQuickActions ? (
+          <div className="app-sidebar__quick-actions" role="group" aria-label="Quick actions">
+            <div className="app-sidebar__notifications">
+              <NotificationCenter
+                notifications={notifications}
+                unreadCount={notificationUnreadCount}
+                onMarkAsRead={onMarkNotificationAsRead}
+                onMarkAllAsRead={onMarkAllNotificationsAsRead}
+                onDismiss={onDismissNotification}
+                onAction={onNotificationAction}
+              />
+            </div>
+            <button
+              type="button"
+              className={`icon-button${isPrivacyMode ? ' icon-button--active' : ''}`}
+              aria-label={isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
+              aria-pressed={isPrivacyMode}
+              title={isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
+              onClick={onTogglePrivacyMode}
+            >
+              {isPrivacyMode ? <EyeOffIcon /> : <EyeIcon />}
+              <span className="icon-button__label">
+                {isPrivacyMode ? 'Show amounts' : 'Hide amounts'}
+              </span>
+            </button>
+          </div>
+        ) : null}
         {onOpenShortcuts && !isSimplified ? (
           <button
             type="button"

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -3,7 +3,7 @@
 export { AppLayout } from './AppLayout';
 export type { AppLayoutProps } from './AppLayout';
 export { BottomNavigation, SidebarNavigation, NAV_ITEMS } from './Navigation';
-export type { NavigationProps, NavItem } from './Navigation';
+export type { NavigationProps, SidebarNavigationProps, NavItem } from './Navigation';
 export {
   NAV_CONFIG,
   NAV_GROUP_LABELS,

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -981,6 +981,27 @@
     padding: var(--spacing-2);
     border-top: 1px solid var(--navigation-border);
   }
+  /* Quick actions relocated from the hidden header (#3197): a compact toolbar
+     pinned above the footer links. */
+  .app-sidebar__quick-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-1);
+    padding-block: var(--spacing-1);
+  }
+  .app-sidebar__notifications {
+    position: relative;
+    display: inline-flex;
+  }
+  /* The footer sits at the bottom of the pinned sidebar, so the notification
+     panel must open upward from the bell instead of downward off-screen. */
+  .app-sidebar__notifications .notification-panel {
+    top: auto;
+    bottom: calc(100% + var(--spacing-2));
+    right: auto;
+    left: 0;
+    margin-top: 0;
+  }
   .bottom-nav {
     display: none;
   }


### PR DESCRIPTION
## Summary

Fixes a P1 desktop/tablet layout bug: at viewports ≥768px the entire `.app-header` is `display:none` (`apps/web/src/styles/responsive.css`), but its quick actions were never relocated to the desktop `.app-sidebar`. As a result:

- **Notifications were UNREACHABLE on desktop** — no route, no sidebar item, no keyboard shortcut. (The P1 core.)
- **Hide-amounts** lost its one-click discoverable control (only reachable via Settings → Privacy or a keyboard shortcut), regressing the #3149 affordance.

This PR relocates the **NotificationCenter** and the **hide-amounts privacy toggle** into the desktop sidebar footer, gated by a JS breakpoint so **exactly one instance of each control exists in the DOM per breakpoint**.

## Changes

- **`Navigation.tsx`** — `SidebarNavigation` gains an optional `SidebarNavigationProps` (notification props + `isPrivacyMode`/`onTogglePrivacyMode`, all lifted from `AppLayout`). When `showQuickActions` is set it renders a `.app-sidebar__quick-actions` group at the top of the pinned footer: the reused `NotificationCenter` (bell + unread badge) and a hide-amounts `icon-button` with full aria-pressed / aria-label / title parity with the header version.
- **`AppLayout.tsx`** — computes `isMobile` via `useBreakpoint()`. The header's `NotificationCenter` + hide-amounts toggle now render **only when `isMobile`**; the sidebar receives `showQuickActions={!isMobile}` plus the notification + privacy props. Notification unread state stays single-sourced (one `NotificationCenter` instance per breakpoint — no divergent counts).
- **`responsive.css`** — scoped `.app-sidebar__quick-actions` layout inside the existing `@media (min-width: 768px)` block, and repositions the notification panel to open **upward** from the footer bell (so it doesn't open off-screen).
- **`index.ts`** — re-exports the new `SidebarNavigationProps` type.
- **Tests** — `AppLayout.test.tsx` mocks `useBreakpoint` and adds breakpoint-gating tests (header controls on mobile; relocated out of the header at ≥768px). `Navigation.test.tsx` adds 6 tests for the sidebar quick actions (visibility gating, unread badge, panel open, hide-amounts parity, privacy reflection, toggle handler).

## Strict-mode / e2e safety

Rendering `NotificationCenter` / hide-amounts in **both** the header and the sidebar would risk Playwright strict-mode `getByRole`/`getByLabel` collisions (the header is `display:none` but `getByRole` still matches hidden nodes — the failure class that red-flagged #3176). Mitigated by breakpoint-gating so only **one** instance of each accessible name is mounted per active breakpoint. `<768px` header behavior is **unchanged**.

## Issues

Closes #3197

## Testing

- [x] `apps/web` unit tests pass — `npx vitest run` on `AppLayout.test.tsx` + `Navigation.test.tsx` (60 passed)
- [x] `npm run format:check` — all files use Prettier style
- [x] `npx eslint . --max-warnings 0` — clean (0 warnings)
- [ ] Post-merge live verification at ≥1000px on the deployed site: sidebar exposes a working notifications control (opens the center with unread count) + a hide-amounts toggle that masks amounts to bullet-dots
