### PR TITLE
fix(web): make transactions page search filter the register (#3200)

### DIFF
--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -541,6 +541,78 @@ describe('TransactionsPage', () => {
     expect(screen.getByText('Monthly Salary')).toBeInTheDocument();
   });
 
+  it('filters the register live by free-text search and restores on clear (#3200)', () => {
+    render(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    );
+
+    // All transactions are visible before searching.
+    expect(screen.getByText('Grocery Store')).toBeInTheDocument();
+    expect(screen.getByText('Monthly Salary')).toBeInTheDocument();
+    expect(screen.getByText('Electric Bill')).toBeInTheDocument();
+
+    const searchBox = screen.getByRole('searchbox', { name: /search transactions/i });
+
+    // Typing a payee substring narrows the rendered register immediately, even
+    // though the mocked data hook returns every row regardless of its filters.
+    fireEvent.change(searchBox, { target: { value: 'Grocery' } });
+
+    expect(screen.getByText('Grocery Store')).toBeInTheDocument();
+    expect(screen.queryByText('Monthly Salary')).not.toBeInTheDocument();
+    expect(screen.queryByText('Electric Bill')).not.toBeInTheDocument();
+
+    // Clearing the search restores the full list.
+    fireEvent.change(searchBox, { target: { value: '' } });
+
+    expect(screen.getByText('Grocery Store')).toBeInTheDocument();
+    expect(screen.getByText('Monthly Salary')).toBeInTheDocument();
+    expect(screen.getByText('Electric Bill')).toBeInTheDocument();
+  });
+
+  it('matches free-text search against transaction tags (#3200)', () => {
+    render(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    );
+
+    // "groceries" is only present as a tag on the Grocery Store transaction.
+    fireEvent.change(screen.getByRole('searchbox', { name: /search transactions/i }), {
+      target: { value: 'groceries' },
+    });
+
+    expect(screen.getByText('Grocery Store')).toBeInTheDocument();
+    expect(screen.queryByText('Monthly Salary')).not.toBeInTheDocument();
+    expect(screen.queryByText('Electric Bill')).not.toBeInTheDocument();
+  });
+
+  it('composes free-text search with the account-purpose filter (#3200)', () => {
+    render(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    );
+
+    // Scope to business accounts: only the salary (account-2) remains.
+    fireEvent.click(screen.getByRole('button', { name: '💼 Business' }));
+    expect(screen.getByText('Monthly Salary')).toBeInTheDocument();
+    expect(screen.queryByText('Grocery Store')).not.toBeInTheDocument();
+
+    const searchBox = screen.getByRole('searchbox', { name: /search transactions/i });
+
+    // A search matching only a personal-account transaction yields no rows,
+    // proving purpose + search compose with AND semantics.
+    fireEvent.change(searchBox, { target: { value: 'Grocery' } });
+    expect(screen.queryByText('Monthly Salary')).not.toBeInTheDocument();
+    expect(screen.queryByText('Grocery Store')).not.toBeInTheDocument();
+
+    // A search matching the in-scope transaction keeps it visible.
+    fireEvent.change(searchBox, { target: { value: 'Salary' } });
+    expect(screen.getByText('Monthly Salary')).toBeInTheDocument();
+  });
+
   it('displays edit and delete actions for each transaction', () => {
     render(
       <MemoryRouter>

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -77,7 +77,11 @@ import {
 } from '../lib/accountPurpose';
 import { chooseLargeTextReflow } from '../lib/a11y/large-text-reflow';
 import { getTransactionLocalDay } from '../lib/transactions/local-timestamp';
-import { applyAdvancedFilters, sortTransactions } from '../lib/transactions/filter-sort';
+import {
+  applyAdvancedFilters,
+  matchesTransactionQuery,
+  sortTransactions,
+} from '../lib/transactions/filter-sort';
 
 // Lazy-loaded so the quick-add affordance (dialog, presets, persistence helper)
 // lands in its own async chunk and stays out of the saturated ledger route chunk.
@@ -312,14 +316,17 @@ export const TransactionsPage: React.FC = () => {
   const advancedFilters = useMemo(() => filtersFromParams(searchParams), [searchParams]);
   const sortConfig = useMemo(() => sortFromParams(searchParams), [searchParams]);
 
-  // Build hook filters from URL params + search query
+  // Build hook filters from the URL date params. Free-text search is applied
+  // client-side in the `transactions` memo below (alongside the purpose filter,
+  // advanced filters, and sort) so the register narrows live as the user types.
+  // The underlying live-query hook does not re-run when only the search term
+  // changes, so keeping search out of the DB query is what makes it work (#3200).
   const hookFilters = useMemo(
     () => ({
-      searchTerm: query.trim() || undefined,
       startDate: advancedFilters.startDate || undefined,
       endDate: advancedFilters.endDate || undefined,
     }),
-    [query, advancedFilters.startDate, advancedFilters.endDate],
+    [advancedFilters.startDate, advancedFilters.endDate],
   );
 
   const {
@@ -374,6 +381,12 @@ export const TransactionsPage: React.FC = () => {
     () => new Map(accounts.map((account) => [account.id, account.name])),
     [accounts],
   );
+  // Free-text search context so matches can resolve category and account names,
+  // mirroring the repository's SQL search fields (#3200 / #3155).
+  const searchContext = useMemo(
+    () => ({ categoryNames, accountNames }),
+    [categoryNames, accountNames],
+  );
   const visibleFilterAccounts = useMemo(
     () => filterAccountsByPurpose(accounts, selectedPurposeFilter),
     [accounts, selectedPurposeFilter],
@@ -415,19 +428,26 @@ export const TransactionsPage: React.FC = () => {
     [categoryNames, learnFromFeedback],
   );
 
-  // Apply purpose filter, advanced local filters, then sort
+  // Apply the purpose filter, free-text search, advanced local filters, then
+  // sort. All narrowing happens client-side here so the register updates live
+  // as the user types in the search box or adjusts controls (#3200).
   const transactions = useMemo(() => {
     const purposeFiltered = filterTransactionsByAccountPurpose(
       rawTransactions,
       accounts,
       selectedPurposeFilter,
     );
-    const filtered = applyAdvancedFilters(purposeFiltered, advancedFilters);
+    const searched = purposeFiltered.filter((transaction) =>
+      matchesTransactionQuery(transaction, query, searchContext),
+    );
+    const filtered = applyAdvancedFilters(searched, advancedFilters);
     return sortTransactions(filtered, sortConfig, categoryNames);
   }, [
     rawTransactions,
     accounts,
     selectedPurposeFilter,
+    query,
+    searchContext,
     advancedFilters,
     sortConfig,
     categoryNames,


### PR DESCRIPTION
## Summary

The free-text **Search** box on the `/transactions` page did not filter the
transaction register. Typing a merchant/description substring had no effect on
the rendered rows, while sort, the account-purpose filter, and advanced filters
all worked.

## Root cause

The search term flowed correctly from the input into
`useTransactions(hookFilters)` via `hookFilters.searchTerm`. The bug is in the
data layer: `useTransactions` runs through `useLiveQuery`, which intentionally
captures its `queryFn` in a ref (to keep `runQuery` stable and avoid an earlier
render-loop/hang regression). Its load effect only re-runs on **mount**, when
the bound **param values** change, or on a **data-change event** — never when
_only_ the `queryFn` (which encodes the search term) changes. So the live query
kept returning rows computed for the previous search term.

This is why search was the _only_ dead filter: purpose, advanced filters, and
sort are all applied **client-side** in the page's `transactions` `useMemo`,
whereas free-text search was the one filter applied inside the DB query. The
dashboard `RecentTransactionsCard` search works precisely because it already
filters client-side via `matchesTransactionQuery`.

## Fix

Apply free-text search **client-side**, consistent with how every other filter
on the page already works and mirroring the working `RecentTransactionsCard`
path:

- Filter `rawTransactions` through the shared `matchesTransactionQuery` helper
  inside the existing `transactions` `useMemo` (order: purpose → search →
  advanced filters → sort), with a `searchContext` so matches resolve category
  and account names — the same fields the repository's SQL search covers.
- Drop `searchTerm` from the DB `hookFilters` so all narrowing lives in one
  place and there is no divergence between the SQL search and the client
  predicate.

No financial/money math is touched — this is purely UI/data-layer filtering.

> Note (out of scope): the same `useLiveQuery` limitation means DB-level
> **date-range** bounds passed via `hookFilters` also only take effect on the
> next data-change event rather than immediately. That is a separate latent
> issue from #3200 and is left for a follow-up; this PR keeps the change
> focused on free-text search.

## Changes

- `apps/web/src/pages/TransactionsPage.tsx`
  - Import `matchesTransactionQuery`.
  - Remove `searchTerm` from `hookFilters` (keep date bounds).
  - Add a memoized `searchContext` ({ categoryNames, accountNames }).
  - Apply `matchesTransactionQuery` in the `transactions` `useMemo`.
- `apps/web/src/pages/TransactionsPage.test.tsx`
  - Add regression tests: typing narrows the register live, tag matches work,
    clearing restores the full list, and search composes with the
    account-purpose filter (AND semantics).

## Testing

- [x] `apps/web` — `TransactionsPage.test.tsx` (28 passed, incl. 3 new #3200 tests)
- [x] Related suites green: `useTransactions`, `filter-sort`,
      `RecentTransactionsCard`, `useLiveQuery` (45 passed)
- [x] `npx tsc --noEmit` in `apps/web` — clean
- [x] `prettier --check` + `eslint --max-warnings 0` on changed files — clean

## Issues

Closes #3200
