### PR TITLE
fix(web): compute accounts net worth as assets minus liabilities (#3202)

### DIFF
--- a/apps/web/src/lib/analytics/net-worth.test.ts
+++ b/apps/web/src/lib/analytics/net-worth.test.ts
@@ -13,6 +13,7 @@ import {
   detectMilestones,
   computePeriodComparison,
   isLiabilityType,
+  netWorthContribution,
 } from './net-worth';
 import type { Account } from '../../kmp/bridge';
 
@@ -94,6 +95,53 @@ describe('computeCurrentNetWorth', () => {
     expect(nw.assets).toBe(0);
     expect(nw.liabilities).toBe(0);
     expect(nw.netWorth).toBe(0);
+  });
+});
+
+describe('netWorthContribution', () => {
+  it('returns the raw balance for asset accounts', () => {
+    expect(netWorthContribution(makeAccount({ type: 'CHECKING', balance: 956405 }))).toBe(956405);
+    expect(netWorthContribution(makeAccount({ type: 'SAVINGS', balance: 1200000 }))).toBe(1200000);
+    expect(netWorthContribution(makeAccount({ type: 'CASH', balance: 7375 }))).toBe(7375);
+    expect(netWorthContribution(makeAccount({ type: 'INVESTMENT', balance: 1250000 }))).toBe(
+      1250000,
+    );
+  });
+
+  it('subtracts liabilities stored as positive amounts owed', () => {
+    // Production convention (issue #3202): credit cards / loans store a
+    // positive balance owed, so they must reduce net worth.
+    expect(netWorthContribution(makeAccount({ type: 'CREDIT_CARD', balance: 67299 }))).toBe(-67299);
+    expect(netWorthContribution(makeAccount({ type: 'LOAN', balance: 2500000 }))).toBe(-2500000);
+  });
+
+  it('subtracts liabilities stored with a negative sign convention', () => {
+    // Mirrors computeCurrentNetWorth's Math.abs handling so both sign
+    // conventions reduce net worth by the same magnitude.
+    expect(netWorthContribution(makeAccount({ type: 'CREDIT_CARD', balance: -125000 }))).toBe(
+      -125000,
+    );
+  });
+
+  it('summing contributions equals assets minus liabilities and matches computeCurrentNetWorth', () => {
+    // Reproduces the live /accounts data from issue #3202.
+    const accounts = [
+      makeAccount({ type: 'CHECKING', balance: 956405 }), // $9,564.05
+      makeAccount({ type: 'SAVINGS', balance: 1200000 }), // $12,000.00
+      makeAccount({ type: 'CASH', balance: 7375 }), // $73.75
+      makeAccount({ type: 'CREDIT_CARD', balance: 67299 }), // $672.99 owed
+    ];
+
+    const total = accounts.reduce((sum, acct) => sum + netWorthContribution(acct), 0);
+
+    // assets 21,637.80 - liability 672.99 = 20,964.81 (what /net-worth shows).
+    expect(total).toBe(2096481);
+    expect(total).toBe(computeCurrentNetWorth(accounts).netWorth);
+
+    // The old sign-blind sum overstated by exactly 2x the liability ($22,310.79).
+    const naiveSum = accounts.reduce((sum, acct) => sum + acct.currentBalance.amount, 0);
+    expect(naiveSum).toBe(2231079);
+    expect(naiveSum - total).toBe(2 * 67299);
   });
 });
 

--- a/apps/web/src/lib/analytics/net-worth.ts
+++ b/apps/web/src/lib/analytics/net-worth.ts
@@ -97,6 +97,27 @@ export function isLiabilityType(type: AccountType): boolean {
   return ASSET_CLASS_MAP[type]?.isLiability ?? false;
 }
 
+/**
+ * Computes a single account's signed contribution to net worth, in cents.
+ *
+ * Assets contribute their balance directly; liabilities (credit cards, loans)
+ * contribute the negative of their absolute balance so they always *reduce*
+ * net worth — regardless of whether the stored balance uses a positive
+ * amount-owed convention or a negative sign convention. This is the
+ * per-account form of {@link computeCurrentNetWorth}: summing the contribution
+ * of every non-archived account yields the same `netWorth` value.
+ *
+ * @param account - Account (or minimal `type` + `currentBalance` shape)
+ * @returns Signed cents — positive for assets, negative for liabilities
+ */
+export function netWorthContribution(account: {
+  readonly type: AccountType;
+  readonly currentBalance: { readonly amount: number };
+}): number {
+  const balance = account.currentBalance.amount;
+  return isLiabilityType(account.type) ? -Math.abs(balance) : balance;
+}
+
 // ---------------------------------------------------------------------------
 // Core calculations
 // ---------------------------------------------------------------------------

--- a/apps/web/src/pages/AccountsPage.test.tsx
+++ b/apps/web/src/pages/AccountsPage.test.tsx
@@ -7,6 +7,7 @@ import { PrivacyModeProvider } from '../contexts/PrivacyModeContext';
 import { useAccounts } from '../hooks';
 import { evaluatePrivacyScreenCoverage } from '../lib/security/privacy-screen';
 import { auditPrivacySurfaceCoverage, privacySurface } from '../lib/security/privacy-coverage';
+import type { Account } from '../kmp/bridge';
 import { AccountsPage } from './AccountsPage';
 
 vi.mock('../hooks', () => ({
@@ -45,6 +46,32 @@ const syncMetadata = {
   syncVersion: 1,
   isSynced: true,
 };
+
+/** Builds a minimal Account for net-worth rendering assertions. */
+function makeMockAccount(overrides: {
+  id: string;
+  name: string;
+  type: Account['type'];
+  balance: number;
+  purpose?: Account['purpose'];
+  currency?: Account['currency'];
+  isArchived?: boolean;
+}): Account {
+  return {
+    id: overrides.id,
+    householdId: 'household-1',
+    name: overrides.name,
+    type: overrides.type,
+    currency: overrides.currency ?? { code: 'USD', decimalPlaces: 2 },
+    currentBalance: { amount: overrides.balance },
+    purpose: overrides.purpose ?? 'personal',
+    isArchived: overrides.isArchived ?? false,
+    sortOrder: 0,
+    icon: null,
+    color: null,
+    ...syncMetadata,
+  } as Account;
+}
 
 describe('AccountsPage', () => {
   beforeEach(() => {
@@ -157,6 +184,105 @@ describe('AccountsPage', () => {
       </MemoryRouter>,
     );
     expect(screen.getByText(/net worth/i)).toBeInTheDocument();
+  });
+
+  it('computes net worth as assets minus liabilities within one workspace (issue #3202)', () => {
+    // Live /accounts data from the bug report: three assets + one positive
+    // credit-card balance, all in the same workspace. The top-level "Net worth"
+    // total and the single workspace subtotal must both equal assets - liability.
+    mockedUseAccounts.mockReturnValue({
+      accounts: [
+        makeMockAccount({ id: 'a-checking', name: 'Checking', type: 'CHECKING', balance: 956405 }),
+        makeMockAccount({ id: 'a-savings', name: 'Savings', type: 'SAVINGS', balance: 1200000 }),
+        makeMockAccount({ id: 'a-cash', name: 'Cash', type: 'CASH', balance: 7375 }),
+        makeMockAccount({
+          id: 'a-card',
+          name: 'Credit Card',
+          type: 'CREDIT_CARD',
+          balance: 67299,
+        }),
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      createAccount: vi.fn(),
+      updateAccount: vi.fn(),
+      deleteAccount: vi.fn(),
+    });
+
+    render(
+      <PrivacyModeProvider initialValue={false}>
+        <MemoryRouter>
+          <AccountsPage />
+        </MemoryRouter>
+      </PrivacyModeProvider>,
+    );
+
+    // 9,564.05 + 12,000.00 + 73.75 - 672.99 = $20,964.81 (matches /net-worth).
+    // Appears for the top-level total and the single workspace subtotal.
+    expect(screen.getAllByText('$20,964.81').length).toBeGreaterThanOrEqual(2);
+    // The old sign-blind sum ($22,310.79 = assets + liability) must never appear.
+    expect(screen.queryByText('$22,310.79')).not.toBeInTheDocument();
+  });
+
+  it('nets liabilities across workspaces while keeping per-workspace subtotals correct', () => {
+    // Assets in Personal, the credit card in Business — verifies the top-level
+    // aggregate nets across workspaces and each subtotal is liability-aware.
+    mockedUseAccounts.mockReturnValue({
+      accounts: [
+        makeMockAccount({
+          id: 'a-checking',
+          name: 'Checking',
+          type: 'CHECKING',
+          balance: 956405,
+          purpose: 'personal',
+        }),
+        makeMockAccount({
+          id: 'a-savings',
+          name: 'Savings',
+          type: 'SAVINGS',
+          balance: 1200000,
+          purpose: 'personal',
+        }),
+        makeMockAccount({
+          id: 'a-cash',
+          name: 'Cash',
+          type: 'CASH',
+          balance: 7375,
+          purpose: 'personal',
+        }),
+        makeMockAccount({
+          id: 'a-card',
+          name: 'Credit Card',
+          type: 'CREDIT_CARD',
+          balance: 67299,
+          purpose: 'business',
+        }),
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      createAccount: vi.fn(),
+      updateAccount: vi.fn(),
+      deleteAccount: vi.fn(),
+    });
+
+    render(
+      <PrivacyModeProvider initialValue={false}>
+        <MemoryRouter>
+          <AccountsPage />
+        </MemoryRouter>
+      </PrivacyModeProvider>,
+    );
+
+    // Top-level net worth still nets to $20,964.81.
+    expect(screen.getByText('$20,964.81')).toBeInTheDocument();
+    // Personal subtotal = 9,564.05 + 12,000.00 + 73.75 = $21,637.80 (assets only).
+    expect(screen.getByText('$21,637.80')).toBeInTheDocument();
+    // Business subtotal is the lone credit card, shown as a negative contribution.
+    expect(screen.getByText('-$672.99')).toBeInTheDocument();
+    // The inflated figure must never appear anywhere on the page.
+    expect(screen.queryByText('$22,310.79')).not.toBeInTheDocument();
   });
 
   it('shows multi-currency indicator when accounts have different currencies', async () => {

--- a/apps/web/src/pages/AccountsPage.tsx
+++ b/apps/web/src/pages/AccountsPage.tsx
@@ -21,6 +21,7 @@ import {
   ACCOUNT_PURPOSE_ORDER,
   normalizeAccountPurpose,
 } from '../lib/accountPurpose';
+import { netWorthContribution } from '../lib/analytics/net-worth';
 import { formatAmount, MaskingMode } from '../lib/ui/privacy';
 import '../styles/pages.css';
 
@@ -48,9 +49,18 @@ const ACCOUNT_TYPE_ORDER: AccountType[] = [
  * Renders a multi-currency total display.
  * If all accounts share the same currency, shows a single CurrencyDisplay.
  * If mixed, shows per-currency breakdown with a "(multiple currencies)" indicator.
+ *
+ * The total is a **net worth** figure: liability accounts (credit cards, loans)
+ * subtract from the total via {@link netWorthContribution} rather than being
+ * summed sign-blind. This keeps the Accounts page consistent with the
+ * dedicated Net Worth page (see `lib/analytics/net-worth.ts`).
  */
 const MultiCurrencyTotal: React.FC<{
-  accounts: ReadonlyArray<{ currentBalance: { amount: number }; currency: { code: string } }>;
+  accounts: ReadonlyArray<{
+    type: AccountType;
+    currentBalance: { amount: number };
+    currency: { code: string };
+  }>;
   colorize?: boolean;
 }> = ({ accounts, colorize = false }) => {
   const maskingMode = useEffectiveMaskingMode();
@@ -62,14 +72,14 @@ const MultiCurrencyTotal: React.FC<{
 
   if (!isMixed) {
     const singleCurrency = getSingleCurrency(currencyItems);
-    const total = accounts.reduce((sum, acc) => sum + acc.currentBalance.amount, 0);
+    const total = accounts.reduce((sum, acc) => sum + netWorthContribution(acc), 0);
     return (
       <CurrencyDisplay amount={total} currency={singleCurrency ?? 'USD'} colorize={colorize} />
     );
   }
 
   const amounts = accounts.map((acc) => ({
-    amount: acc.currentBalance.amount,
+    amount: netWorthContribution(acc),
     currency: acc.currency.code,
   }));
   const groups = groupByCurrency(amounts);
@@ -132,14 +142,13 @@ export const AccountsPage: React.FC = () => {
     try {
       let total = 0;
       for (const account of accounts) {
+        // Liabilities subtract from the converted net-worth total, matching
+        // the single-currency path and the Net Worth page.
+        const contribution = netWorthContribution(account);
         if (account.currency.code === 'USD') {
-          total += account.currentBalance.amount;
+          total += contribution;
         } else {
-          const converted = await convert(
-            account.currentBalance.amount,
-            account.currency.code,
-            'USD',
-          );
+          const converted = await convert(contribution, account.currency.code, 'USD');
           total += converted;
         }
       }


### PR DESCRIPTION
## Summary

The **/accounts** page "Net worth" total (and every per-workspace subtotal)
summed all account balances **sign-blind**, adding credit-card / loan
liabilities instead of subtracting them. This overstated net worth by **2x
total liabilities** and disagreed with the dedicated **/net-worth** page.

Live evidence (same account set):

| Page | "Net worth" |
| --- | --- |
| /accounts (before) | `,310.79` ❌ |
| /net-worth | `,964.81` ✅ |
| /accounts (after this PR) | `,964.81` ✅ |

Assets `,564.05 + ,000.00 + .75 = ,637.80` minus the `.99`
credit-card liability = `,964.81`. The old code added the `.99`,
overshooting by `2 x .99 = ,345.98`.

## Root cause

`MultiCurrencyTotal` in `apps/web/src/pages/AccountsPage.tsx` reduced with
`sum + acc.currentBalance.amount` and its prop type did not even include the
account `type`, so it could not distinguish an asset from a liability.

## Fix

- Added `netWorthContribution(account)` to
  `apps/web/src/lib/analytics/net-worth.ts` next to the existing
  `isLiabilityType` / `computeCurrentNetWorth` (the source of truth used by
  /net-worth). It returns the raw balance for assets and `-Math.abs(balance)`
  for liabilities, so summing every account's contribution yields the same
  `netWorth` as `computeCurrentNetWorth`.
- `MultiCurrencyTotal` now takes `type` and uses `netWorthContribution` in
  both the single-currency and mixed-currency (`groupByCurrency`) paths.
- The converted "≈ USD" net-worth total (`computeConvertedTotal`) also uses
  `netWorthContribution` so multi-currency net worth is liability-aware too.

### Sign convention (verified)

Liabilities are stored as **positive amounts-owed** in production (the live
credit card was `+.99`). `computeCurrentNetWorth` handles this with
`liabilities += Math.abs(balance)`; `netWorthContribution` mirrors it with
`-Math.abs(balance)`, which is correct for **both** positive- and
negative-stored liabilities — guaranteeing parity with /net-worth.

### Note on per-workspace subtotals (scope)

/accounts groups accounts by **workspace purpose** (personal / business /
both), **not** by account type, so a single group routinely mixes assets and
liabilities. The per-workspace subtotals were therefore affected by the same
bug and are fixed by the same change — required for internal consistency (the
top-level total must equal the sum of the workspace subtotals). The individual
account rows still show each account's own balance unchanged.

## Testing

- `apps/web/src/lib/analytics/net-worth.test.ts` — new `netWorthContribution`
  suite: asserts liabilities subtract (positive **and** negative sign
  conventions) and that summing contributions equals both
  `assets - liabilities` and `computeCurrentNetWorth(...).netWorth` for the
  issue's exact data (`,964.81`), documenting the old `,310.79` bug.
- `apps/web/src/pages/AccountsPage.test.tsx` — new component tests render the
  page with a positive credit-card balance mixed with assets and assert the
  net worth is `,964.81` (never the inflated `,310.79`), both within a
  single workspace and split across workspaces (asset subtotal `,637.80`,
  liability subtotal `-.99`).
- `npx vitest run` on both files: **26 passed**.
- `prettier --check` + `eslint --max-warnings 0` clean; `tsc --noEmit` for
  `apps/web` reports **0 errors**.

Closes #3202