### PR TITLE
fix(web): replace raw issue-number placeholders on Learning page (#3201)

### DIFF
--- a/apps/web/src/pages/LearningPage.test.tsx
+++ b/apps/web/src/pages/LearningPage.test.tsx
@@ -162,4 +162,12 @@ describe('LearningPage', () => {
 
     expect(screen.getByText('100% on this attempt')).toBeInTheDocument();
   });
+
+  it('never renders a raw internal issue reference as user-facing copy', () => {
+    render(<LearningPage />);
+
+    // Guards against shipping developer placeholders like "Issue #1665" /
+    // "Issue #2174" as eyebrow labels again (issue #3201).
+    expect(screen.queryAllByText(/^Issue #\d+$/)).toHaveLength(0);
+  });
 });

--- a/apps/web/src/pages/LearningPage.tsx
+++ b/apps/web/src/pages/LearningPage.tsx
@@ -89,7 +89,7 @@ export function CreditBuildingSection(): React.ReactElement {
   return (
     <section className="credit-building" aria-labelledby="credit-building-heading">
       <header className="credit-building__header">
-        <p className="credit-building__eyebrow">Issue #2174</p>
+        <p className="credit-building__eyebrow">Building credit from zero</p>
         <h2 id="credit-building-heading" className="credit-building__title">
           {content.sectionTitle}
         </h2>
@@ -316,7 +316,7 @@ export function LearningPage(): React.ReactElement {
     <main className="learning-page" aria-label="Financial literacy learning path">
       <header className="learning-page__header">
         <div>
-          <p className="learning-page__eyebrow">Issue #1665</p>
+          <p className="learning-page__eyebrow">Local-first financial education</p>
           <h1 className="learning-page__title">Personalized Financial Literacy Learning Path</h1>
           <p className="learning-page__subtitle">
             Learn budgeting, saving, debt, investing, and tax planning with a structured path that


### PR DESCRIPTION
## Summary

The Learning page (`/learning`) shipped two developer placeholder eyebrow (kicker) labels to production: **`Issue #1665`** above the page title and **`Issue #2174`** above the credit-building section. These raw internal issue references were visible to end users and stood out against the app's real eyebrow copy elsewhere.

## Changes

- `apps/web/src/pages/LearningPage.tsx`: replaced `Issue #1665` -> `Local-first financial education` (matches `LearningDashboard.tsx:51`) and `Issue #2174` -> `Building credit from zero` (matches `BuildingCreditPage.tsx:108`).
- `apps/web/src/pages/LearningPage.test.tsx`: added a recurrence-guard test asserting no rendered user-facing string matches `/^Issue #\d+$/`.

## Testing

- `npx vitest run src/pages/LearningPage.test.tsx src/pages/LearningPage.credit-building.test.tsx` -> 11 passed
- `npx prettier --check` on changed files -> clean
- `npx eslint apps/web --max-warnings 0` -> clean

## Issues

Closes #3201