### PR TITLE
test(web): de-flake record-erasure receipt assertion (#3206)

### DIFF
--- a/apps/web/src/lib/security/record-erasure.test.ts
+++ b/apps/web/src/lib/security/record-erasure.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   checkRetentionPolicy,
   createErasureRequest,
@@ -104,11 +104,44 @@ describe('record-erasure', () => {
     });
 
     it('does not contain actual financial data', () => {
-      const request = createErasureRequest('transaction', 'tx-123', 'cleanup');
-      const receipt = generateErasureReceipt(request);
-      // Verify no financial amounts or account numbers appear in the receipt
-      expect(receipt).not.toMatch(/\$\d+/);
-      expect(receipt).not.toMatch(/\d{4}-\d{4}-\d{4}/);
+      // The receipt embeds a random requestId (crypto.randomUUID()). A random
+      // v4 UUID lands three 4-digit groups separated by hyphens ~1.3% of the
+      // time (e.g. "1234-5678-9012"), which used to trip the account-number
+      // assertion below and fail this test on unrelated CI runs. Pin the id to
+      // a digit-group-free value so the receipt is deterministic and the
+      // assertions reflect only real record data. (#3206)
+      const fixedRequestId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+      const uuidSpy = vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(fixedRequestId);
+
+      try {
+        const request = createErasureRequest('transaction', 'tx-123', 'cleanup');
+        const receipt = generateErasureReceipt(request);
+        const parsed = JSON.parse(receipt);
+
+        // The receipt is metadata-only: it must never embed monetary amounts
+        // or account-number-formatted strings from the erased record.
+        expect(receipt).not.toMatch(/\$\d/); // no dollar amounts
+        expect(receipt).not.toMatch(/\d{4}-\d{4}-\d{4}/); // no account numbers
+
+        // Strengthen the guarantee structurally: only known-safe metadata keys
+        // may be serialized, so a future change that spills a raw record field
+        // (amount, balance, account number) fails here instead of silently
+        // leaking into the receipt.
+        const expectedKeys = [
+          'type',
+          'requestId',
+          'recordType',
+          'recordId',
+          'requestedAt',
+          'completedAt',
+          'status',
+          'cascadeActions',
+          'reason',
+        ];
+        expect(Object.keys(parsed).sort()).toEqual(expectedKeys.sort());
+      } finally {
+        uuidSpy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a flaky, non-deterministic unit test in the web app's record-erasure security module (issue #3206). The test `generateErasureReceipt > does not contain actual financial data` failed on ~1% of unrelated CI runs — most recently blocking dependabot PR #3136.

## Root cause

The test scanned the **entire serialized receipt** for an account-number pattern:

```ts
expect(receipt).not.toMatch(/\d{4}-\d{4}-\d{4}/);
```

The receipt embeds `requestId = crypto.randomUUID()`. A random v4 UUID contains three 4-digit groups separated by hyphens (e.g. `1234-5678-9012`) in **~1.3% of cases** (measured over 500k UUIDs), so the assertion matched the random UUID itself and failed non-deterministically — unrelated to the code under test.

## Fix

- **De-flake:** pin `requestId` to a deterministic, digit-group-free UUID (`aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa`) via a `crypto.randomUUID` spy (restored in `finally`), so the receipt is byte-stable and the account-number assertion reflects only real record data.
  - Note: the "obvious" seed `00000000-0000-4000-8000-000000000000` itself trips the regex (`0000-4000-8000`), so a digit-group-free seed is used instead.
- **Strengthen (do not weaken):** keep both financial-pattern assertions (no `$` amounts, no account-number format) and add a structural guarantee that the receipt serializes **only** the known-safe metadata keys. Any future change that spills a raw record field (amount, balance, account number) now fails the test instead of silently leaking into the receipt.

The security intent is preserved and hardened: the test still fails if a real dollar amount or account number appears in the receipt.

## Testing

- `apps/web` `record-erasure.test.ts`: 13/13 pass
- Looped the file **50×** with zero failures (deterministic)
- `npm run format:check` — clean
- `npx eslint apps/web --max-warnings 0` — clean

## Issues

Closes #3206
