### PR TITLE
fix(web): add page-level <h1> to advanced pages for heading hierarchy (#3203)

### DIFF
--- a/apps/web/src/components/dashboard/LivePnlDashboard.tsx
+++ b/apps/web/src/components/dashboard/LivePnlDashboard.tsx
@@ -231,7 +231,7 @@ export const LivePnlDashboard: React.FC<LivePnlDashboardProps> = ({
     <div className="live-pnl">
       <header className="live-pnl__header">
         <div>
-          <h2 className="live-pnl__title">Live P&amp;L &amp; Net Worth</h2>
+          <h1 className="live-pnl__title">Live P&amp;L &amp; Net Worth</h1>
           <p className="live-pnl__subtitle">
             Cross-broker intraday performance across {view.report.breakdowns.byBrokerage.length}{' '}
             brokerage{view.report.breakdowns.byBrokerage.length === 1 ? '' : 's'}.
@@ -337,7 +337,7 @@ export const LivePnlDashboard: React.FC<LivePnlDashboardProps> = ({
 
       {/* Breakdowns */}
       <section className="live-pnl__section" aria-label="Profit and loss by brokerage">
-        <h3 className="live-pnl__section-title">By Brokerage</h3>
+        <h2 className="live-pnl__section-title">By Brokerage</h2>
         <BreakdownTable
           id="pnl-by-brokerage"
           caption="Market value and intraday P&L for each brokerage."
@@ -348,7 +348,7 @@ export const LivePnlDashboard: React.FC<LivePnlDashboardProps> = ({
       </section>
 
       <section className="live-pnl__section" aria-label="Profit and loss by asset class">
-        <h3 className="live-pnl__section-title">By Asset Class</h3>
+        <h2 className="live-pnl__section-title">By Asset Class</h2>
         <BreakdownTable
           id="pnl-by-asset-class"
           caption="Market value and intraday P&L grouped by asset class, including volatile crypto."
@@ -360,7 +360,7 @@ export const LivePnlDashboard: React.FC<LivePnlDashboardProps> = ({
       </section>
 
       <section className="live-pnl__section" aria-label="Profit and loss by symbol">
-        <h3 className="live-pnl__section-title">By Symbol</h3>
+        <h2 className="live-pnl__section-title">By Symbol</h2>
         <BreakdownTable
           id="pnl-by-symbol"
           caption="Market value and intraday P&L for each holding. Stale or missing quotes are flagged."

--- a/apps/web/src/components/estate/EstateInventory.tsx
+++ b/apps/web/src/components/estate/EstateInventory.tsx
@@ -68,7 +68,7 @@ export const EstateInventory: React.FC = () => {
       <section className="estate-hero" aria-label="Estate inventory overview">
         <div>
           <p className="estate-hero__eyebrow">Local-first estate planning</p>
-          <h2 className="estate-hero__title">Estate &amp; end-of-life financial inventory</h2>
+          <h1 className="estate-hero__title">Estate &amp; end-of-life financial inventory</h1>
           <p className="estate-hero__description">
             Capture accounts, policies, property, debts, digital assets, and trusted contacts in one
             protected page that stays on this device unless you export it.

--- a/apps/web/src/pages/EstateInventoryPage.test.tsx
+++ b/apps/web/src/pages/EstateInventoryPage.test.tsx
@@ -31,6 +31,14 @@ describe('EstateInventoryPage', () => {
     expect(screen.getByText('0 of 8 categories documented')).toBeTruthy();
   });
 
+  it('exposes the page title as the single level-1 heading', () => {
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: /Estate & end-of-life financial inventory/i }),
+    ).toBeTruthy();
+  });
+
   it('creates and persists a new bank account entry', () => {
     renderPage();
 

--- a/apps/web/src/pages/FirePlannerPage.test.tsx
+++ b/apps/web/src/pages/FirePlannerPage.test.tsx
@@ -24,7 +24,7 @@ describe('FirePlannerPage', () => {
   it('renders the planner with labelled inputs', () => {
     render(<FirePlannerPage />);
 
-    expect(screen.getByRole('heading', { name: 'FIRE Planner', level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'FIRE Planner', level: 1 })).toBeInTheDocument();
     expect(screen.getByLabelText('Current invested assets')).toBeInTheDocument();
     expect(screen.getByLabelText('Annual spending in retirement')).toBeInTheDocument();
     expect(screen.getByLabelText('Annual contributions')).toBeInTheDocument();

--- a/apps/web/src/pages/FirePlannerPage.tsx
+++ b/apps/web/src/pages/FirePlannerPage.tsx
@@ -264,7 +264,7 @@ export const FirePlannerPage: React.FC = () => {
           <AppIcon name="flame" />
         </span>
         <div>
-          <h2 className="fire-page__title">FIRE Planner</h2>
+          <h1 className="fire-page__title">FIRE Planner</h1>
           <p className="fire-page__subtitle">
             Model your path to financial independence: your FI number, when you can stop working,
             and whether you have already hit Coast FI.
@@ -279,7 +279,7 @@ export const FirePlannerPage: React.FC = () => {
           aria-label="Financial independence inputs"
           onSubmit={(event) => event.preventDefault()}
         >
-          <h3 className="fire-form__legend">Your numbers</h3>
+          <h2 className="fire-form__legend">Your numbers</h2>
           <div className="fire-form__grid">
             <NumberField
               id={fid('current')}

--- a/apps/web/src/pages/InvoicesPage.test.tsx
+++ b/apps/web/src/pages/InvoicesPage.test.tsx
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for InvoicesPage.
+ *
+ * Mocks the useInvoices hook (not localStorage) per project conventions and
+ * asserts the page exposes its title as the single level-1 heading so the
+ * heading hierarchy stays intact (issue #3203).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { InvoicesPage } from './InvoicesPage';
+
+vi.mock('../hooks/useInvoices', () => ({ useInvoices: vi.fn() }));
+
+import { useInvoices } from '../hooks/useInvoices';
+
+const mockedUseInvoices = vi.mocked(useInvoices);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUseInvoices.mockReturnValue({
+    invoices: [],
+    pipelineGroups: [],
+    forecastBuckets: [],
+    totalOutstandingCents: 0,
+    addInvoice: vi.fn(),
+    updateInvoiceStatus: vi.fn(),
+    deleteInvoice: vi.fn(),
+    refresh: vi.fn(),
+  });
+});
+
+describe('InvoicesPage', () => {
+  it('exposes the page title as the single level-1 heading', () => {
+    render(<InvoicesPage />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Invoices' })).toBeInTheDocument();
+  });
+
+  it('renders the pipeline forecast subtitle', () => {
+    render(<InvoicesPage />);
+
+    expect(screen.getByText(/forecast when freelance income should land/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/InvoicesPage.tsx
+++ b/apps/web/src/pages/InvoicesPage.tsx
@@ -59,7 +59,7 @@ const InvoiceCard: React.FC<{
   <article className={`invoice-card invoice-card--${invoice.status.toLowerCase()}`} role="listitem">
     <div className="invoice-card__main">
       <div>
-        <h4 className="invoice-card__client">{invoice.clientName}</h4>
+        <h3 className="invoice-card__client">{invoice.clientName}</h3>
         <p className="invoice-card__meta">
           Issued {formatDate(invoice.issueDate)} · {PAYMENT_TERM_LABELS[invoice.paymentTerm]} ·
           expected {formatDate(invoice.expectedPayDate)}
@@ -143,7 +143,7 @@ export const InvoicesPage: React.FC = () => {
     <div className="analytics-page invoices-page">
       <div className="analytics-page__header">
         <div>
-          <h2 className="analytics-page__title">Invoices</h2>
+          <h1 className="analytics-page__title">Invoices</h1>
           <p className="invoice-subtitle">
             Track net-terms work and forecast when freelance income should land.
           </p>
@@ -225,7 +225,7 @@ export const InvoicesPage: React.FC = () => {
         aria-label="Expected income forecast"
         aria-live="polite"
       >
-        <h3 className="analytics-section__title">Expected-income forecast</h3>
+        <h2 className="analytics-section__title">Expected-income forecast</h2>
         <div className="analytics-metrics-grid">
           <article className="analytics-metric-card" aria-label="Outstanding invoice total">
             <p className="analytics-metric-card__label">Outstanding</p>
@@ -269,7 +269,7 @@ export const InvoicesPage: React.FC = () => {
       </section>
 
       <section className="analytics-section" aria-label="Invoice pipeline">
-        <h3 className="analytics-section__title">Pipeline by status</h3>
+        <h2 className="analytics-section__title">Pipeline by status</h2>
         {invoices.length === 0 ? (
           <EmptyState
             title="No invoices yet"
@@ -281,7 +281,7 @@ export const InvoicesPage: React.FC = () => {
               <article key={group.status} className="invoice-pipeline-group">
                 <div className="invoice-pipeline-group__header">
                   <div>
-                    <h4>{group.label}</h4>
+                    <h3>{group.label}</h3>
                     <p>{group.invoices.length} invoices</p>
                   </div>
                   <CurrencyDisplay amount={group.totalCents} />

--- a/apps/web/src/pages/LivePnlPage.test.tsx
+++ b/apps/web/src/pages/LivePnlPage.test.tsx
@@ -100,7 +100,9 @@ describe('LivePnlPage', () => {
       refresh: vi.fn(),
     });
     render(<LivePnlPage />);
-    expect(screen.getByRole('heading', { name: /Live P&L & Net Worth/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /Live P&L & Net Worth/i, level: 1 }),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText('Total net worth')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/RemittancesPage.test.tsx
+++ b/apps/web/src/pages/RemittancesPage.test.tsx
@@ -81,6 +81,12 @@ describe('RemittancesPage', () => {
     expect(screen.getByText('No remittances yet')).toBeInTheDocument();
   });
 
+  it('exposes the page title as the single level-1 heading', () => {
+    mockUseRemittances.mockReturnValue(buildResult());
+    render(<RemittancesPage />);
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
   it('renders a live estimate once amount and rate are entered', () => {
     mockUseRemittances.mockReturnValue(buildResult());
     render(<RemittancesPage />);

--- a/apps/web/src/pages/RemittancesPage.tsx
+++ b/apps/web/src/pages/RemittancesPage.tsx
@@ -14,8 +14,8 @@
  * money/numbers are formatted per the active locale (CLDR).
  *
  * Accessibility (WCAG 2.2 AA):
- * - Section landmarks with `aria-label`; one `<h1>`-less page heading via `<h2>`
- *   to match sibling pages, with `<h3>` sub-section headings.
+ * - Section landmarks with `aria-label`; a single page-level `<h1>` heading,
+ *   with `<h2>` sub-section headings.
  * - Every control has an associated `<label>`; required fields set
  *   `aria-required`; errors wire `aria-invalid` + `aria-describedby` to
  *   `role="alert"` messages.
@@ -114,7 +114,7 @@ const Estimate: React.FC<EstimateProps> = ({ quote, locale, t }) => (
     aria-label={t('remittance.preview.title')}
     aria-live="polite"
   >
-    <h3 className="remittance-section__title">{t('remittance.preview.title')}</h3>
+    <h2 className="remittance-section__title">{t('remittance.preview.title')}</h2>
     <dl className="remittance-estimate__grid">
       <div className="remittance-estimate__item remittance-estimate__item--hero">
         <dt>{t('remittance.preview.received')}</dt>
@@ -218,7 +218,7 @@ const HistoryItem: React.FC<HistoryItemProps> = ({ record, locale, t, onDelete }
     >
       <header className="remittance-card__header">
         <div>
-          <h4 className="remittance-card__name">{record.recipient.name}</h4>
+          <h3 className="remittance-card__name">{record.recipient.name}</h3>
           <p className="remittance-card__meta">
             {country} · {formatDate(record.date, { locale })} · {feeModelLabel}
           </p>
@@ -461,13 +461,13 @@ export const RemittancesPage: React.FC = () => {
   return (
     <div className="remittance-page">
       <header className="remittance-page__header">
-        <h2 className="remittance-page__title">{t('remittance.page.title')}</h2>
+        <h1 className="remittance-page__title">{t('remittance.page.title')}</h1>
         <p className="remittance-page__subtitle">{t('remittance.page.subtitle')}</p>
       </header>
 
       {/* Entry form */}
       <section className="remittance-section" aria-label={t('remittance.form.title')}>
-        <h3 className="remittance-section__title">{t('remittance.form.title')}</h3>
+        <h2 className="remittance-section__title">{t('remittance.form.title')}</h2>
         <form className="remittance-form" onSubmit={handleSubmit} noValidate>
           {submitError && (
             <p className="remittance-form__banner-error" role="alert">
@@ -764,7 +764,7 @@ export const RemittancesPage: React.FC = () => {
             aria-label={t('remittance.summary.title')}
             aria-live="polite"
           >
-            <h3 className="remittance-section__title">{t('remittance.summary.title')}</h3>
+            <h2 className="remittance-section__title">{t('remittance.summary.title')}</h2>
             <div className="remittance-summary-grid">
               <article className="remittance-metric" aria-label={t('remittance.summary.totalSent')}>
                 <p className="remittance-metric__label">{t('remittance.summary.totalSent')}</p>
@@ -810,9 +810,9 @@ export const RemittancesPage: React.FC = () => {
           </section>
 
           <section className="remittance-section" aria-label={t('remittance.history.title')}>
-            <h3 className="remittance-section__title">
+            <h2 className="remittance-section__title">
               {t('remittance.history.title')} ({summary.count})
-            </h3>
+            </h2>
             <div className="remittance-history" role="list">
               {remittances.map((record) => (
                 <HistoryItem
@@ -831,7 +831,7 @@ export const RemittancesPage: React.FC = () => {
           className="remittance-section remittance-empty"
           aria-label={t('remittance.empty.title')}
         >
-          <h3 className="remittance-empty__title">{t('remittance.empty.title')}</h3>
+          <h2 className="remittance-empty__title">{t('remittance.empty.title')}</h2>
           <p className="remittance-empty__body">{t('remittance.empty.body')}</p>
         </section>
       )}

--- a/apps/web/src/pages/TaxCenterPage.test.tsx
+++ b/apps/web/src/pages/TaxCenterPage.test.tsx
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for TaxCenterPage.
+ *
+ * Mocks the useInvestments / useAccounts / useTransactions hooks (not
+ * repositories) per project conventions, and wraps the page in a router since
+ * it renders a <Link> back to Investments. Asserts the page exposes its title
+ * as the single level-1 heading so the heading hierarchy stays intact
+ * (issue #3203).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { TaxCenterPage } from './TaxCenterPage';
+
+vi.mock('../hooks', () => ({
+  useInvestments: vi.fn(),
+  useAccounts: vi.fn(),
+  useTransactions: vi.fn(),
+}));
+
+import { useAccounts, useInvestments, useTransactions } from '../hooks';
+
+const mockedUseInvestments = vi.mocked(useInvestments);
+const mockedUseAccounts = vi.mocked(useAccounts);
+const mockedUseTransactions = vi.mocked(useTransactions);
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <TaxCenterPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockedUseInvestments.mockReturnValue({
+    investments: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    getLots: vi.fn(() => []),
+  } as unknown as ReturnType<typeof useInvestments>);
+
+  mockedUseAccounts.mockReturnValue({
+    accounts: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  } as unknown as ReturnType<typeof useAccounts>);
+
+  mockedUseTransactions.mockReturnValue({
+    transactions: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  } as unknown as ReturnType<typeof useTransactions>);
+});
+
+describe('TaxCenterPage', () => {
+  it('exposes the page title as the single level-1 heading', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Tax Center' })).toBeInTheDocument();
+  });
+
+  it('renders the back-to-investments link', () => {
+    renderPage();
+
+    expect(screen.getByRole('link', { name: /back to investments/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/TaxCenterPage.tsx
+++ b/apps/web/src/pages/TaxCenterPage.tsx
@@ -224,7 +224,7 @@ export const TaxCenterPage: React.FC = () => {
       </div>
 
       <div className="page-section__header" style={{ marginBottom: 'var(--spacing-6)' }}>
-        <h2
+        <h1
           style={{
             fontSize: 'var(--type-scale-headline-font-size)',
             fontWeight: 'var(--type-scale-headline-font-weight)',
@@ -232,7 +232,7 @@ export const TaxCenterPage: React.FC = () => {
           }}
         >
           Tax Center
-        </h2>
+        </h1>
         <p style={{ color: 'var(--semantic-text-secondary)', margin: 0 }}>
           Analyze lot-level realized P&amp;L, estimated taxes, and wash-sale guardrails before you
           trade.
@@ -251,14 +251,14 @@ export const TaxCenterPage: React.FC = () => {
             }}
           >
             <div>
-              <h3
+              <h2
                 style={{
                   fontWeight: 'var(--font-weight-semibold)',
                   marginBottom: 'var(--spacing-1)',
                 }}
               >
                 Retirement contribution limits
-              </h3>
+              </h2>
               <p style={{ color: 'var(--semantic-text-secondary)', margin: 0 }}>
                 Tracks transactions tagged as retirement contributions against configured IRS
                 limits.
@@ -370,14 +370,14 @@ export const TaxCenterPage: React.FC = () => {
         <>
           <section className="page-section" aria-label="Sale lot matching">
             <div className="card" style={{ marginBottom: 'var(--spacing-6)' }}>
-              <h3
+              <h2
                 style={{
                   fontWeight: 'var(--font-weight-semibold)',
                   marginBottom: 'var(--spacing-4)',
                 }}
               >
                 Sale analyzer
-              </h3>
+              </h2>
               <div
                 style={{
                   display: 'grid',
@@ -550,14 +550,14 @@ export const TaxCenterPage: React.FC = () => {
                   borderColor: 'var(--semantic-warning, #d97706)',
                 }}
               >
-                <h3
+                <h2
                   style={{
                     fontWeight: 'var(--font-weight-semibold)',
                     marginBottom: 'var(--spacing-3)',
                   }}
                 >
                   Wash-sale guardrails
-                </h3>
+                </h2>
                 {washSaleAlerts.map((alert) => (
                   <p
                     key={`${alert.closedLotId}-${alert.soldDate}`}
@@ -576,14 +576,14 @@ export const TaxCenterPage: React.FC = () => {
 
           <section className="page-section" aria-label="Closed tax lots">
             <div className="card" style={{ marginBottom: 'var(--spacing-6)' }}>
-              <h3
+              <h2
                 style={{
                   fontWeight: 'var(--font-weight-semibold)',
                   marginBottom: 'var(--spacing-4)',
                 }}
               >
                 Matched closed lots
-              </h3>
+              </h2>
               {matchResult.unmatchedShares > 0 && (
                 <p style={{ color: 'var(--semantic-negative, #dc2626)' }}>
                   {matchResult.unmatchedShares.toLocaleString()} shares could not be matched to open
@@ -659,14 +659,14 @@ export const TaxCenterPage: React.FC = () => {
 
           <section className="page-section" aria-label="Unrealized gains for open lots">
             <div className="card">
-              <h3
+              <h2
                 style={{
                   fontWeight: 'var(--font-weight-semibold)',
                   marginBottom: 'var(--spacing-4)',
                 }}
               >
                 Open lots · unrealized gains
-              </h3>
+              </h2>
               <div style={{ overflowX: 'auto' }}>
                 <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                   <thead>

--- a/apps/web/src/pages/TripBudgetsPage.test.tsx
+++ b/apps/web/src/pages/TripBudgetsPage.test.tsx
@@ -21,7 +21,7 @@ describe('TripBudgetsPage', () => {
     render(<TripBudgetsPage />);
 
     expect(
-      screen.getByRole('heading', { name: 'Trip & Country Budgets', level: 2 }),
+      screen.getByRole('heading', { name: 'Trip & Country Budgets', level: 1 }),
     ).toBeInTheDocument();
 
     expect(screen.getByLabelText('Trip name')).toBeInTheDocument();
@@ -48,7 +48,7 @@ describe('TripBudgetsPage', () => {
     render(<TripBudgetsPage />);
 
     const card = screen
-      .getByRole('heading', { name: 'Bangkok Jan–Mar', level: 4 })
+      .getByRole('heading', { name: 'Bangkok Jan–Mar', level: 3 })
       .closest('article') as HTMLElement;
 
     expect(within(card).getByText(/20,500/)).toBeInTheDocument(); // local spend
@@ -81,7 +81,7 @@ describe('TripBudgetsPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Create trip envelope' }));
 
-    expect(screen.getByRole('heading', { name: 'Lisbon Spring', level: 4 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Lisbon Spring', level: 3 })).toBeInTheDocument();
   });
 
   it('logs local-currency spend and updates the trip transaction count', () => {
@@ -94,7 +94,7 @@ describe('TripBudgetsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Add spend' }));
 
     const card = screen
-      .getByRole('heading', { name: 'Bangkok Jan–Mar', level: 4 })
+      .getByRole('heading', { name: 'Bangkok Jan–Mar', level: 3 })
       .closest('article') as HTMLElement;
     expect(within(card).getByText('3 transactions')).toBeInTheDocument();
   });
@@ -104,7 +104,7 @@ describe('TripBudgetsPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /^Archive Bangkok Jan/ }));
 
-    expect(screen.getByRole('heading', { name: 'Archived trips', level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Archived trips', level: 2 })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^Reopen Bangkok Jan/ })).toBeInTheDocument();
   });
 

--- a/apps/web/src/pages/TripBudgetsPage.tsx
+++ b/apps/web/src/pages/TripBudgetsPage.tsx
@@ -176,9 +176,9 @@ const TripCard: React.FC<TripCardProps> = ({ report, onArchive, onUnarchive }) =
     <article className="trip-card" aria-labelledby={`${report.id}-name`}>
       <header className="trip-card__header">
         <div>
-          <h4 className="trip-card__name" id={`${report.id}-name`}>
+          <h3 className="trip-card__name" id={`${report.id}-name`}>
             {report.name}
-          </h4>
+          </h3>
           <p className="trip-card__meta">
             <AppIcon name="map-pin" size={16} />
             <span>{report.country || 'Any country'}</span>
@@ -419,7 +419,7 @@ export const TripBudgetsPage: React.FC = () => {
           <AppIcon name="globe" />
         </span>
         <div>
-          <h2 className="trip-page__title">Trip &amp; Country Budgets</h2>
+          <h1 className="trip-page__title">Trip &amp; Country Budgets</h1>
           <p className="trip-page__subtitle">
             Budget a trip in its local currency, track spend inside the trip dates, and roll every
             envelope up into one home-currency view. Archive a trip when it ends. Its history stays
@@ -439,9 +439,9 @@ export const TripBudgetsPage: React.FC = () => {
 
       <div className="trip-layout">
         <section className="trip-section" aria-labelledby={fid('trips-heading')}>
-          <h3 className="trip-section__heading" id={fid('trips-heading')}>
+          <h2 className="trip-section__heading" id={fid('trips-heading')}>
             Active trips
-          </h3>
+          </h2>
           {activeReports.length === 0 ? (
             <p className="trip-empty">
               No active trips. Use the form to plan your next destination.
@@ -461,9 +461,9 @@ export const TripBudgetsPage: React.FC = () => {
 
           {archivedReports.length > 0 ? (
             <>
-              <h3 className="trip-section__heading" id={fid('archived-heading')}>
+              <h2 className="trip-section__heading" id={fid('archived-heading')}>
                 Archived trips
-              </h3>
+              </h2>
               <div className="trip-cards">
                 {archivedReports.map((report) => (
                   <TripCard
@@ -484,9 +484,9 @@ export const TripBudgetsPage: React.FC = () => {
             aria-labelledby={fid('create-heading')}
             onSubmit={handleCreateTrip}
           >
-            <h3 className="trip-form__heading" id={fid('create-heading')}>
+            <h2 className="trip-form__heading" id={fid('create-heading')}>
               Plan a new trip
-            </h3>
+            </h2>
 
             <Field id={fid('name')} label="Trip name" hint="e.g. Bangkok Jan–Mar">
               <input
@@ -612,9 +612,9 @@ export const TripBudgetsPage: React.FC = () => {
             aria-labelledby={fid('spend-heading')}
             onSubmit={handleAddSpend}
           >
-            <h3 className="trip-form__heading" id={fid('spend-heading')}>
+            <h2 className="trip-form__heading" id={fid('spend-heading')}>
               Log local-currency spend
-            </h3>
+            </h2>
 
             <Field id={fid('spend-trip')} label="Trip">
               <select
@@ -686,9 +686,9 @@ export const TripBudgetsPage: React.FC = () => {
 
       <section className="trip-section" aria-labelledby={fid('ledger-heading')}>
         <div className="trip-ledger__head">
-          <h3 className="trip-section__heading" id={fid('ledger-heading')}>
+          <h2 className="trip-section__heading" id={fid('ledger-heading')}>
             Spend ledger
-          </h3>
+          </h2>
           <Field id={fid('filter')} label="Filter by trip">
             <select
               id={fid('filter')}

--- a/apps/web/src/pages/WatchlistsPage.test.tsx
+++ b/apps/web/src/pages/WatchlistsPage.test.tsx
@@ -84,9 +84,11 @@ describe('WatchlistsPage', () => {
     });
   });
 
-  it('renders the page heading', () => {
+  it('renders the page heading as the single level-1 heading', () => {
     render(<WatchlistsPage />);
-    expect(screen.getByText('Spending Watchlists')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Spending Watchlists' }),
+    ).toBeInTheDocument();
   });
 
   it('shows empty state when no watchlists exist', () => {

--- a/apps/web/src/pages/WatchlistsPage.tsx
+++ b/apps/web/src/pages/WatchlistsPage.tsx
@@ -132,7 +132,7 @@ const WatchlistItem: React.FC<WatchlistItemProps> = ({
       </button>
       <div className="watchlist-item__content">
         <div className="watchlist-item__header">
-          <h4 className="watchlist-item__name">{watchlist.categoryName}</h4>
+          <h3 className="watchlist-item__name">{watchlist.categoryName}</h3>
           <span className="watchlist-item__period">{watchlist.period}</span>
         </div>
         <div className="watchlist-item__spending">
@@ -267,14 +267,14 @@ export const WatchlistsPage: React.FC = () => {
   return (
     <>
       <div className="page-header-with-actions">
-        <h2
+        <h1
           style={{
             fontSize: 'var(--type-scale-headline-font-size)',
             fontWeight: 'var(--type-scale-headline-font-weight)',
           }}
         >
           Spending Watchlists
-        </h2>
+        </h1>
         <button
           type="button"
           className="add-button"
@@ -288,7 +288,7 @@ export const WatchlistsPage: React.FC = () => {
       {/* Active alerts */}
       {alerts.length > 0 && (
         <section className="page-section" aria-label="Spending alerts">
-          <h3 className="page-section__title">Active Alerts</h3>
+          <h2 className="page-section__title">Active Alerts</h2>
           <div className="watchlist-alerts" role="log" aria-label="Spending alert notifications">
             {alerts.map((alert) => (
               <AlertCard key={alert.watchlist.id} alert={alert} onDismiss={dismissAlert} />
@@ -311,7 +311,7 @@ export const WatchlistsPage: React.FC = () => {
         />
       ) : (
         <section className="page-section" aria-label="Configured watchlists">
-          <h3 className="page-section__title">Your Watchlists</h3>
+          <h2 className="page-section__title">Your Watchlists</h2>
           <div className="card">
             <SortableList
               items={watchlists}
@@ -345,7 +345,7 @@ export const WatchlistsPage: React.FC = () => {
           aria-modal="true"
         >
           <form className="watchlist-form card" onSubmit={handleAddSubmit}>
-            <h3 className="watchlist-form__title">Add Watchlist</h3>
+            <h2 className="watchlist-form__title">Add Watchlist</h2>
             <div className="watchlist-form__field">
               <label htmlFor="wl-category">Category</label>
               <select

--- a/apps/web/src/pages/analytics.css
+++ b/apps/web/src/pages/analytics.css
@@ -562,7 +562,7 @@
   margin-bottom: var(--spacing-3);
 }
 
-.invoice-pipeline-group__header h4,
+.invoice-pipeline-group__header h3,
 .invoice-pipeline-group__header p {
   margin: 0;
 }

--- a/apps/web/src/styles/responsive-breakpoints.css
+++ b/apps/web/src/styles/responsive-breakpoints.css
@@ -159,7 +159,7 @@
 }
 
 .transactions-page-header h2,
-.page-header-with-actions h2 {
+.page-header-with-actions h1 {
   flex: 1;
   min-width: 0;
 }
@@ -172,7 +172,7 @@
   }
 
   .transactions-page-header h2,
-  .page-header-with-actions h2 {
+  .page-header-with-actions h1 {
     text-align: center;
   }
 }


### PR DESCRIPTION
## Summary

Several advanced web pages rendered their page title as `<h2>` (or a non-heading) with no `<h1>` inside `<main>`, breaking heading hierarchy and failing WCAG 2.2 AA **1.3.1 Info and Relationships (Level A)** and **2.4.6 Headings and Labels**.

Each affected page now has exactly one `<h1>` naming the page, and descendant section/card headings are shifted up one level so the document order is `h1 -> h2 -> h3` with no skipped levels (satisfies axe `page-has-heading-one` and `heading-order`).

## Changes

Uniform +1 heading promotion per page:

- `RemittancesPage` - title `<h2>`->`<h1>`; sections/preview/empty `<h3>`->`<h2>`; history card `<h4>`->`<h3>`; removed the misleading "h1-less pattern" doc comment.
- `InvoicesPage` - title `<h2>`->`<h1>`; sections `<h3>`->`<h2>`; group/card `<h4>`->`<h3>`.
- `TripBudgetsPage` - title `<h2>`->`<h1>`; sections `<h3>`->`<h2>`; trip card `<h4>`->`<h3>`.
- `FirePlannerPage` - title `<h2>`->`<h1>`; section `<h3>`->`<h2>`.
- `EstateInventory` - hero `<h2>`->`<h1>` (sections already `<h2>`).
- `LivePnlDashboard` - title `<h2>`->`<h1>`; breakdown sections `<h3>`->`<h2>`.
- `TaxCenterPage` - title wrapped as `<h1>` (was a non-heading styled `<h2>` block); sections `<h3>`->`<h2>`.
- `WatchlistsPage` - title `<h2>`->`<h1>`; sections `<h3>`->`<h2>`; card `<h4>`->`<h3>`.

Supporting changes:

- `analytics.css` / `responsive-breakpoints.css` - updated element-selector rules that targeted the bumped tags so styling is preserved (`.invoice-pipeline-group__header h4`->`h3`; `.page-header-with-actions h2`->`h1`).
- Tests - created `InvoicesPage.test.tsx` and `TaxCenterPage.test.tsx`; extended Remittances/Estate/LivePnl/Watchlists tests with a `getByRole('heading', { level: 1 })` assertion; fixed the level assertions in FirePlanner/TripBudgets tests to match the new hierarchy.

Page wrappers stay `<div>` because `AppLayout` already renders the global `<main id="main-content">`, so each new `<h1>` lives inside it (no nested `<main>`). `CashRunwayPage` and the core pages already followed this pattern and are unchanged.

## Issues

Closes #3203

## Testing

- [x] `npx prettier --check` on changed files - clean
- [x] `npx eslint apps/web --max-warnings 0` - clean
- [x] `npx vitest run` on the 8 affected page tests + `LivePnlDashboard` - 54 tests pass
