### PR TITLE
fix(web): scope dashboard income to workspace so All == Personal + Business (#3212)

### DIFF
--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -775,6 +775,51 @@ describe('DashboardPage', () => {
     expect(netWorthCard).toHaveTextContent('$35,000.00');
   });
 
+  it('scopes Safe-to-Spend income by workspace so All === Personal + Business (#3212)', async () => {
+    // Default fixtures: personal account-1 has an expense this month, business
+    // account-2 has the only income this month ($4,500). Prediction adds $0.
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
+
+    const card = await screen.findByLabelText('Safe to spend this month');
+    fireEvent.click(within(card).getByRole('button', { name: /show simple breakdown/i }));
+
+    // Read the "Income" figure from the breakdown definition list.
+    const incomeText = () =>
+      (
+        within(screen.getByLabelText('Safe to spend this month')).getByText('Income')
+          .nextElementSibling?.textContent ?? ''
+      ).trim();
+    const incomeDollars = () => Number(incomeText().replace(/[^0-9.-]/g, ''));
+
+    // All: income comes from the business account only.
+    expect(incomeText()).toBe('$4,500.00');
+    const all = incomeDollars();
+
+    // Personal: no income this month → income must drop to $0 (previously it
+    // stayed at $4,500 because the card read the unscoped useDashboardData total).
+    fireEvent.click(screen.getByRole('button', { name: '🏠 Personal' }));
+    expect(incomeText()).toBe('$0.00');
+    const personal = incomeDollars();
+
+    // Business: the $4,500 income belongs here.
+    fireEvent.click(screen.getByRole('button', { name: '💼 Business' }));
+    expect(incomeText()).toBe('$4,500.00');
+    const business = incomeDollars();
+
+    // Back to All restores the aggregate.
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    expect(incomeText()).toBe('$4,500.00');
+
+    // Core invariant: All income is the exact sum of every workspace, and the
+    // reported P1 symptom (All mirroring Personal) can never recur.
+    expect(all).toBe(personal + business);
+    expect(all).toBeGreaterThan(personal);
+  });
+
   it('surfaces an RMD reminder badge when a distribution is due', () => {
     mockedUseRmdTracking.mockReturnValue({
       statuses: [

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -236,10 +236,16 @@ function isBudgetActiveInMonth(
   );
 }
 
-function getPredictedRemainingIncomeCents(prediction: PredictionSummary | null): number {
+function getPredictedRemainingIncomeCents(
+  prediction: PredictionSummary | null,
+  visibleAccountIds?: ReadonlySet<string>,
+): number {
   return (
     prediction?.accounts.reduce(
-      (sum, account) => sum + Math.max(0, account.projectedIncomeCents),
+      (sum, account) =>
+        visibleAccountIds && !visibleAccountIds.has(account.accountId)
+          ? sum
+          : sum + Math.max(0, account.projectedIncomeCents),
       0,
     ) ?? 0
   );
@@ -477,6 +483,35 @@ export const DashboardPage: React.FC = () => {
     () => new Set(filteredAccounts.map((account) => account.id)),
     [filteredAccounts],
   );
+  // Workspace-scoped monthly income and spend, derived from the same scoped
+  // transaction set as net worth. This keeps every summary figure consistent with
+  // the selected workspace so "All" is a true aggregate across workspaces
+  // (All === Personal + Business + Shared) rather than reusing the unscoped
+  // useDashboardData totals, which always cover every account.
+  const incomeThisMonth = useMemo(
+    () =>
+      filteredCurrentMonthTransactions.reduce(
+        (sum, transaction) =>
+          transaction.type === 'INCOME' ? sum + transaction.amount.amount : sum,
+        0,
+      ),
+    [filteredCurrentMonthTransactions],
+  );
+  const spentThisMonth = useMemo(
+    () =>
+      filteredCurrentMonthTransactions.reduce(
+        (sum, transaction) =>
+          transaction.type === 'EXPENSE' ? sum + Math.abs(transaction.amount.amount) : sum,
+        0,
+      ),
+    [filteredCurrentMonthTransactions],
+  );
+  // Predicted remaining income scoped to the visible workspace only, so projected
+  // income never leaks across workspaces into the "Safe to Spend" income figure.
+  const scopedPredictedIncomeCents = useMemo(
+    () => getPredictedRemainingIncomeCents(prediction, filteredAccountIds),
+    [prediction, filteredAccountIds],
+  );
   const filteredBills = useMemo(
     () =>
       selectedPurposeFilter === 'all'
@@ -507,8 +542,7 @@ export const DashboardPage: React.FC = () => {
     );
 
     return calculateSafeToSpend({
-      expectedMonthlyIncomeCents:
-        (data?.incomeThisMonth ?? 0) + getPredictedRemainingIncomeCents(prediction),
+      expectedMonthlyIncomeCents: incomeThisMonth + scopedPredictedIncomeCents,
       remainingBillsCents: getRemainingBillsDueThisMonthCents(
         filteredBills,
         currentMonthRange.startDate,
@@ -520,18 +554,18 @@ export const DashboardPage: React.FC = () => {
         spendingPace.paces,
         categoryNames,
         billCategoryIds,
-        data?.spentThisMonth ?? 0,
+        spentThisMonth,
       ),
     });
   }, [
     activeMonthlyBudgets,
     categoryNames,
     currentMonthRange,
-    data?.incomeThisMonth,
-    data?.spentThisMonth,
+    incomeThisMonth,
+    spentThisMonth,
+    scopedPredictedIncomeCents,
     filteredBills,
     filteredGoals,
-    prediction,
     spendingPace.paces,
     dashboardAsOf,
   ]);
@@ -608,15 +642,6 @@ export const DashboardPage: React.FC = () => {
   const netWorth = useMemo(
     () => filteredAccounts.reduce((sum, account) => sum + account.currentBalance.amount, 0),
     [filteredAccounts],
-  );
-  const spentThisMonth = useMemo(
-    () =>
-      filteredCurrentMonthTransactions.reduce(
-        (sum, transaction) =>
-          transaction.type === 'EXPENSE' ? sum + Math.abs(transaction.amount.amount) : sum,
-        0,
-      ),
-    [filteredCurrentMonthTransactions],
   );
   const debtSummary = useMemo(
     () =>


### PR DESCRIPTION
## Summary

On `/dashboard`, switching the workspace-scope selector (account-purpose filter: **All / Personal / Business**) did not change the **income** figure in the summary. All mirrored Personal, breaking the invariant **All income == Personal + Business**.

Prior fix #3160 scoped **net worth**, **spent this month**, and **debt** via the disjoint `selectWorkspaceAccounts` / `selectWorkspaceTransactions` helpers, but the **Safe to Spend This Month** card still read **unscoped** aggregates from `useDashboardData` (which always covers every account):

- `expectedMonthlyIncomeCents` used `data?.incomeThisMonth` (unscoped)
- the discretionary-spend fallback used `data?.spentThisMonth` (unscoped)
- predicted remaining income summed all accounts regardless of scope

So income was identical across scopes.

## Changes

- `apps/web/src/pages/DashboardPage.tsx`
  - Add a workspace-scoped `incomeThisMonth` memo computed from `filteredCurrentMonthTransactions` (sum of `INCOME`, integer cents), mirroring the existing scoped `spentThisMonth`.
  - Move the scoped `spentThisMonth` memo above `safeToSpendBreakdown` so it can feed the discretionary-spend fallback.
  - Scope predicted remaining income by the visible account ids (`getPredictedRemainingIncomeCents(prediction, filteredAccountIds)`) so projected income never leaks across workspaces.
  - Feed the scoped income + scoped predicted income into `expectedMonthlyIncomeCents`, and the scoped spend into the discretionary fallback; update dependency arrays.
- `apps/web/src/pages/DashboardPage.test.tsx`
  - New test: Safe-to-Spend **Income** is `$4,500.00` under All, `$0.00` under Personal, `$4,500.00` under Business, and asserts `All === Personal + Business` (plus `All > Personal`, guarding the P1 symptom).

## Scope note

Budget Health remains a global figure: budgets in this data model have no account/purpose association, so there is nothing to scope them by. Only account/transaction-derived summaries (net worth, spending, **income**) are workspace-scoped.

## Money math

Integer-cents summation only — no floating point. For a disjoint account partition, `All = Personal + Business + Shared` holds exactly (validated against the `financial-modeling` skill and the existing `accountPurpose.test.ts` invariants).

## Testing

- [x] `vitest run src/pages/DashboardPage.test.tsx src/lib/accountPurpose.test.ts` — 33 passed
- [x] `prettier --check` on changed files — clean
- [x] `eslint --max-warnings 0` on changed files — clean

## Issues

Closes #3212
Refs #3160