### PR TITLE
fix(web): import microinteractions.css so hover/micro-interaction rules ship (#3199)

### DIFF
--- a/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
+++ b/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
@@ -210,3 +210,33 @@ describe('Offline Fallback Styles', () => {
     expect(css).toContain('prefers-color-scheme: dark');
   });
 });
+
+describe('Microinteractions CSS (WCAG 2.3.3)', () => {
+  const css = loadCss('microinteractions.css');
+  const mainTsx = readFileSync(resolve(__dirname, '../../../src/main.tsx'), 'utf-8');
+
+  // Regression guard for #3199: the stylesheet was orphaned for its entire
+  // history — present in the repo but never imported — silently nullifying the
+  // shared hover state-layer (#3161) and micro-interaction library (#313/#314).
+  it('must be imported by main.tsx so its rules reach users (#3199)', () => {
+    expect(mainTsx).toContain("import './styles/microinteractions.css'");
+  });
+
+  it('should gate motion behind prefers-reduced-motion', () => {
+    expect(css).toContain('prefers-reduced-motion: reduce');
+  });
+
+  it('should disable the decorative shake animation under reduced motion', () => {
+    const reducedMotionBlock = css.slice(css.indexOf('prefers-reduced-motion: reduce'));
+    expect(reducedMotionBlock).toContain('.shake');
+  });
+
+  it('should disable the nav-indicator slide (::after) under reduced motion', () => {
+    const reducedMotionBlock = css.slice(css.indexOf('prefers-reduced-motion: reduce'));
+    expect(reducedMotionBlock).toContain('.nav-item::after');
+  });
+
+  it('should drop shadow-based effects in prefers-contrast: more', () => {
+    expect(css).toContain('prefers-contrast: more');
+  });
+});

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -32,6 +32,7 @@ import './styles/reduced-motion.css';
 import './styles/font-scaling.css';
 import './styles/error-boundaries.css';
 import './styles/density.css';
+import './styles/microinteractions.css';
 
 const rootElement = document.getElementById('root');
 

--- a/apps/web/src/styles/microinteractions.css
+++ b/apps/web/src/styles/microinteractions.css
@@ -222,7 +222,11 @@ input[type='radio']:active {
    Accessibility overrides
    ========================================================================== */
 
-/* Reduced motion: strip all micro-interaction transitions/animations */
+/* Reduced motion: strip all micro-interaction transitions/animations.
+   Every animated/transitioned selector above is listed here so this file
+   self-gates motion for reduced-motion users — it does not rely solely on the
+   global `*` safety net in tokens.css / accessibility.css. Pseudo-elements
+   (nav indicator) and the decorative shake are included explicitly. */
 @media (prefers-reduced-motion: reduce) {
   .btn,
   .form-button,
@@ -240,12 +244,16 @@ input[type='radio']:active {
   select,
   textarea,
   .nav-item,
+  .nav-item::after,
   .sidebar-nav__link,
+  .sidebar-nav__link::after,
   .bottom-nav__link,
   .card,
   [class*='card'],
   input[type='checkbox'],
-  input[type='radio'] {
+  input[type='radio'],
+  .shake,
+  .confirm-dialog__confirm--danger:active {
     transition: none !important;
     animation: none !important;
   }
@@ -253,7 +261,9 @@ input[type='radio']:active {
   .btn:active:not(:disabled),
   .form-button:active:not(:disabled),
   button[type='submit']:active:not(:disabled),
-  button[type='button']:active:not(:disabled) {
+  button[type='button']:active:not(:disabled),
+  input[type='checkbox']:active,
+  input[type='radio']:active {
     transform: none !important;
   }
 


### PR DESCRIPTION
## Summary

`apps/web/src/styles/microinteractions.css` was **orphaned since it was created** — present in the repo but never imported by `main.tsx`, so none of its rules ever reached users. This silently nullified two merged efforts:

- **#3161 (part 1)** — the shared `button` / `[role="button"]:hover` translucent "state layer".
- **#313 / #314** — the micro-interaction library (card hover-lift, checkbox/radio bounce, button press, form-focus, nav-indicator slide).

## Investigation → decision: wire it up (this is **not** dead code)

I verified the state before touching anything:

- **Never imported**: `git log -S "microinteractions.css" -- apps/web/src/main.tsx` returns nothing — `main.tsx` never imported it in its entire history. Grep finds **zero** JS/TS imports; the only references are two comments (its own header + a `reduced-motion.css:33` `@see`).
- **Intentional, merged work**: created by `90e838c5` (#313/#314); hover state-layer added by `9631a2ea` (#3161). Deleting it would discard deliberate, reviewed design work → the correct fix is to **wire it up**, not remove it.
- **Tokens resolve** (so it renders smoothly, not degraded): `--easing-out` / `--easing-default` come from `packages/design-tokens/tokens/primitive/motion.json`, `--shadow-md` from `shadows.json`; `--hover-state-layer` and `--animation-easing-bounce` have inline fallbacks.
- **a11y-safe**: the file has its own `@media (prefers-reduced-motion: reduce)` and `@media (prefers-contrast: more)` blocks, backstopped by the global `*, *::before, *::after` reduced-motion nets in `tokens.css:66` and `accessibility.css:208`.

## Changes

1. **`apps/web/src/main.tsx`** — add the missing `import './styles/microinteractions.css';`, grouped with the other global style imports.
2. **`apps/web/src/styles/microinteractions.css`** — a11y hardening only: make the file's **own** reduced-motion block self-contained. Three motions were previously neutralized *only* by the global `*` safety net, not the file's own block:
   - `.nav-item::after` / `.sidebar-nav__link::after` transform-slide → added to `transition: none`.
   - `.shake` / `.confirm-dialog__confirm--danger:active` `micro-shake` → added to `animation: none`.
   - checkbox/radio `:active` `scale(0.85)` → added to `transform: none` (the button equivalent was already reset — this restores consistency).
   - **No change to the non-reduced-motion visual experience.**
3. **`apps/web/src/accessibility/__tests__/wcag-audit.test.ts`** — new `Microinteractions CSS (WCAG 2.3.3)` block:
   - **Regression guard**: asserts `main.tsx` imports the stylesheet, so this "silent no-op trap" can't recur.
   - Asserts the reduced-motion block gates the shake + nav-indicator, and that `prefers-contrast: more` is handled.

## ⚠️ Site-wide visual effect — please eyeball before merge

This stylesheet has **never run in production**, so wiring it in introduces several hover/press affordances **globally, at once**. All are ≤80ms, token-driven, and fully disabled under `prefers-reduced-motion`:

- Consistent hover "state layer" on every `button` / `[role="button"]` (a translucent gradient layered over the element's existing background-color — colored buttons keep their color).
- Card hover-lift `translateY(-2px)` + `--shadow-md` on `.card` **and** `[class*="card"]` (broad attribute match — worth a glance for unintended card-like elements).
- Button press `scale(0.97)`, checkbox/radio press bounce, form-field focus shadow, nav-indicator underline slide.

Dashboard toggles that already define explicit hovers (`dashboard.css`) should be unaffected — the state layer uses `background-image` and sits on top of their `background-color` — but worth a quick confirm.

## Notes / deliberately left unchanged

- **`reduced-motion.css:33` `@see` comment** — the issue flagged it as "stale," but once the file is imported the reference is *accurate*, so I kept it.
- **Design tokens** — untouched (owned by `@design-engineer`); all referenced tokens already resolve.
- **Bounce easing** (`cubic-bezier(0.34, 1.56, 0.64, 1)` on the checkbox/radio bounce, `microinteractions.css:185`) — pre-existing intentional design from #313/#314, named in the issue as the intended "checkbox/radio bounce," token-driven and reduced-motion-safe. Faithfully wiring it up is not the place to redesign the curve; flagging it here in case design wants to revisit it separately.

## Testing

- `npx vitest run src/accessibility/__tests__/wcag-audit.test.ts` → **40 passed** (incl. 5 new, incl. the #3199 import guard).
- `npx prettier --check` on all 3 files → clean.
- `npx eslint --max-warnings 0` on the TS files → clean.

## Issues

Closes #3199
