### PR TITLE
fix(web): externalize inline SW-update script to satisfy deployed CSP (#3210)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -15,62 +15,15 @@
   </head>
   <body>
     <div id="root"></div>
-    <script>
-      // Auto-apply waiting service-worker updates (#2023).
-      //
-      // When a new build is deployed, the browser detects the changed
-      // /sw.js and installs a new SW which enters the "waiting" state
-      // until the old SW's clients close. Without manual intervention
-      // (clicking an "Update available" banner), users can stay pinned
-      // to the old bundle indefinitely — see the demo-mode-stuck bug
-      // from #2021 where the banner only rendered inside the
-      // authenticated layout, so users stuck on /login could never
-      // trigger the update.
-      //
-      // This inline script runs on every page load (Caddy serves
-      // /index.html with no-cache, so this is always the latest copy)
-      // and immediately tells any waiting SW to skipWaiting. It also
-      // listens for `updatefound` so newly-installed waiting SWs are
-      // activated as soon as they're ready (handles the race where the
-      // browser is still fetching /sw.js when this script runs).
-      //
-      // The reload guard prevents an infinite loop if controllerchange
-      // fires for an unrelated reason.
-      var isLighthouseAudit =
-        window.location.search.indexOf('lhci=1') !== -1 ||
-        /\bLighthouse\b/i.test(navigator.userAgent);
-      if ('serviceWorker' in navigator && !isLighthouseAudit) {
-        var reloaded = false;
-        var hadController = Boolean(navigator.serviceWorker.controller);
-        navigator.serviceWorker.addEventListener('controllerchange', function () {
-          if (!hadController) {
-            hadController = true;
-            return;
-          }
-          if (reloaded) return;
-          reloaded = true;
-          window.location.reload();
-        });
-        var activateWaiting = function (reg) {
-          if (reg && reg.waiting && navigator.serviceWorker.controller) {
-            reg.waiting.postMessage({ type: 'SKIP_WAITING' });
-          }
-        };
-        navigator.serviceWorker.getRegistration().then(function (reg) {
-          if (!reg) return;
-          activateWaiting(reg);
-          reg.addEventListener('updatefound', function () {
-            var installing = reg.installing;
-            if (!installing) return;
-            installing.addEventListener('statechange', function () {
-              if (installing.state === 'installed') {
-                activateWaiting(reg);
-              }
-            });
-          });
-        });
-      }
-    </script>
+    <!--
+      Service-worker auto-update driver (#2023), externalized for CSP (#3210).
+      Served from /sw-update.js so it complies with the deployed Content-Security-Policy
+      (`script-src 'self' 'wasm-unsafe-eval'`, no 'unsafe-inline') — an inline
+      <script> here was blocked on staging/production, leaving users pinned to
+      stale bundles after a deploy. Served no-cache via the Caddy SPA fallback,
+      so every load runs the latest copy.
+    -->
+    <script src="/sw-update.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/public/sw-update.js
+++ b/apps/web/public/sw-update.js
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+/* global window, navigator */
+
+// Auto-apply waiting service-worker updates (#2023); externalized for CSP (#3210).
+//
+// Externalized from an inline <script> in index.html so it complies with the
+// deployed Content-Security-Policy. Staging and production (deploy/Caddyfile,
+// deploy/Caddyfile.staging) serve `script-src 'self' 'wasm-unsafe-eval'` with
+// NO 'unsafe-inline', which blocked the previous inline script and left users
+// pinned to stale bundles after a deploy. As a same-origin static file it is
+// allowed by `script-src 'self'` — no CSP change required.
+//
+// Caddy serves this non-hashed /sw-update.js through the SPA fallback with
+// `Cache-Control: no-cache, must-revalidate`, so — like the no-cache
+// index.html that references it — every page load runs the latest copy.
+//
+// When a new build is deployed, the browser detects the changed /sw.js and
+// installs a new SW which enters the "waiting" state until the old SW's clients
+// close. Without manual intervention (clicking an "Update available" banner),
+// users can stay pinned to the old bundle indefinitely — see the
+// demo-mode-stuck bug from #2021 where the banner only rendered inside the
+// authenticated layout, so users stuck on /login could never trigger the
+// update.
+//
+// This script runs on every page load and immediately tells any waiting SW to
+// skipWaiting. It also listens for `updatefound` so newly-installed waiting SWs
+// are activated as soon as they're ready (handles the race where the browser is
+// still fetching /sw.js when this script runs).
+//
+// The reload guard prevents an infinite loop if controllerchange fires for an
+// unrelated reason.
+(function () {
+  var isLighthouseAudit =
+    window.location.search.indexOf('lhci=1') !== -1 || /\bLighthouse\b/i.test(navigator.userAgent);
+  if ('serviceWorker' in navigator && !isLighthouseAudit) {
+    var reloaded = false;
+    var hadController = Boolean(navigator.serviceWorker.controller);
+    navigator.serviceWorker.addEventListener('controllerchange', function () {
+      if (!hadController) {
+        hadController = true;
+        return;
+      }
+      if (reloaded) return;
+      reloaded = true;
+      window.location.reload();
+    });
+    var activateWaiting = function (reg) {
+      if (reg && reg.waiting && navigator.serviceWorker.controller) {
+        reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+      }
+    };
+    navigator.serviceWorker.getRegistration().then(function (reg) {
+      if (!reg) return;
+      activateWaiting(reg);
+      reg.addEventListener('updatefound', function () {
+        var installing = reg.installing;
+        if (!installing) return;
+        installing.addEventListener('statechange', function () {
+          if (installing.state === 'installed') {
+            activateWaiting(reg);
+          }
+        });
+      });
+    });
+  }
+})();

--- a/apps/web/src/__tests__/pwa-install.test.ts
+++ b/apps/web/src/__tests__/pwa-install.test.ts
@@ -129,6 +129,60 @@ describe('PWA meta tags in index.html (#1329)', () => {
   it('has lang attribute on html element', () => {
     expect(html).toMatch(/<html\s+lang="[^"]+"/);
   });
+
+  it('references the externalized service-worker update script (#3210)', () => {
+    // The SW auto-update driver must be an external same-origin file so it is
+    // allowed by the deployed CSP `script-src 'self'` (deploy/Caddyfile).
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const scriptSrcs = [...doc.querySelectorAll('script')].map((script) =>
+      script.getAttribute('src'),
+    );
+    expect(scriptSrcs).toContain('/sw-update.js');
+  });
+
+  it("has no inline <script> bodies so CSP script-src 'self' is satisfied (#3210)", () => {
+    // An inline <script> with executable content is blocked by the deployed
+    // CSP (no 'unsafe-inline'), which silently broke the SW auto-update. Parse
+    // the document with a real HTML parser (not a hand-rolled regex, which
+    // CodeQL flags as a bad HTML filter) and assert every <script> is an
+    // external src-based reference with an empty body. HTML comments — which
+    // may mention `<script>` — are ignored by the parser.
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const inlineScripts = [...doc.querySelectorAll('script')].filter(
+      (script) => !script.getAttribute('src') && (script.textContent ?? '').trim().length > 0,
+    );
+    expect(inlineScripts).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Externalized service-worker update script (#3210)
+// ---------------------------------------------------------------------------
+
+describe('externalized service-worker update script (#3210)', () => {
+  const swUpdatePath = resolve(__dirname, '../../public/sw-update.js');
+  let source: string;
+
+  beforeEach(() => {
+    source = readFileSync(swUpdatePath, 'utf-8');
+  });
+
+  it('is shipped as a static public asset served from the app origin', () => {
+    expect(existsSync(swUpdatePath)).toBe(true);
+  });
+
+  it('posts SKIP_WAITING to activate a waiting service worker', () => {
+    expect(source).toContain("postMessage({ type: 'SKIP_WAITING' })");
+  });
+
+  it('activates newly-installed workers via the updatefound/controllerchange handlers', () => {
+    expect(source).toContain('updatefound');
+    expect(source).toContain('controllerchange');
+  });
+
+  it('skips activation during Lighthouse audits', () => {
+    expect(source).toMatch(/Lighthouse/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/cdn/caddy-config-validator.test.ts
+++ b/apps/web/src/lib/cdn/caddy-config-validator.test.ts
@@ -162,6 +162,21 @@ describe('Security headers in Caddyfile', () => {
     expect(cspLine).not.toMatch(/(?<!wasm-)'unsafe-eval'/);
   });
 
+  it("CSP script-src does not allow 'unsafe-inline' (inline scripts are externalized — #3210)", () => {
+    // The deployed CSP intentionally omits 'unsafe-inline' from script-src.
+    // An inline <script> would be blocked — which is exactly what broke the PWA
+    // service-worker auto-update in #3210 — so scripts must be externalized to
+    // same-origin files rather than the policy loosened. Scoped to the
+    // script-src directive so the separate `style-src ... 'unsafe-inline'` is
+    // not matched.
+    const cspLine = caddyfileContent
+      .split('\n')
+      .find((line) => line.includes('Content-Security-Policy'));
+    expect(cspLine).toBeDefined();
+    const scriptSrc = cspLine?.match(/script-src([^;]*)/)?.[1] ?? '';
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+  });
+
   it('CSP allows worker-src self for service worker', () => {
     const cspLine = caddyfileContent
       .split('\n')


### PR DESCRIPTION
## Summary

The deployed **Content-Security-Policy blocks the PWA service-worker auto-update**. The #2023 SW `skipWaiting` fix lived in an **inline `<script>`** in `apps/web/index.html`, but the deployed CSP sets `script-src 'self' 'wasm-unsafe-eval'` with **no `'unsafe-inline'` and no hash**, so on staging + production the inline script was blocked. Users could stay pinned to **stale bundles** after a deploy. The dev/preview CSP (`vite.config.ts:410`) allows `'unsafe-inline'`, which masked the violation in local testing.

## Root cause (verified against origin/main)

| Location | Finding |
| --- | --- |
| `deploy/Caddyfile:58` | `script-src 'self' 'wasm-unsafe-eval'` — no `'unsafe-inline'` |
| `deploy/Caddyfile.staging:28` | `script-src 'self' 'wasm-unsafe-eval'` — no `'unsafe-inline'` |
| `apps/web/index.html:18-73` | inline `<script>` (#2023 SW auto-update) — blocked by the above |
| `apps/web/vite.config.ts:410` | dev CSP allows `'unsafe-inline'` — why it slipped through locally |

## Fix (CSP **not** loosened)

- Moved the SW-update logic verbatim into a same-origin static file **`apps/web/public/sw-update.js`** and reference it via **`<script src="/sw-update.js">`**, which `script-src 'self'` permits.
- Vite base-prefixes the reference, so it resolves on **both** deploy targets:
  - Caddy root deploy → `/sw-update.js`
  - GitHub Pages (`/finance/`) → `/finance/sw-update.js`
- Served no-cache via the Caddy SPA fallback, preserving the "always latest copy" property the inline script relied on.
- No other inline scripts exist in `index.html`. **`deploy/Caddyfile*` CSP is unchanged.**

## Verification

- `vite build` (root base) → `dist/index.html` references `/sw-update.js`; `dist/sw-update.js` emitted; **zero** inline `<script>` bodies.
- `vite build` (`PUBLIC_BASE_PATH=/finance/`) → reference correctly rewritten to `/finance/sw-update.js`.
- Web unit tests pass; repo-wide `prettier --check .` and `eslint . --max-warnings 0` both clean.

## Regression tests

- `pwa-install.test.ts`: `index.html` has no inline `<script>` bodies (CSP `script-src 'self'` compliance) and references `/sw-update.js`; `public/sw-update.js` exists + drives `SKIP_WAITING`.
- `caddy-config-validator.test.ts`: CSP `script-src` does not allow `'unsafe-inline'` (locks the invariant that forced externalization).

## Changes

- add `apps/web/public/sw-update.js` (externalized #2023 SW-update driver)
- `apps/web/index.html`: replace inline `<script>` with `<script src="/sw-update.js">`
- tests: `apps/web/src/__tests__/pwa-install.test.ts`, `apps/web/src/lib/cdn/caddy-config-validator.test.ts`

## Issues

Closes #3210

## Testing

- [x] Web unit tests pass (`vitest run` for touched suites)
- [x] `vite build` verified for root and `/finance/` base
- [x] `prettier --check .` and `eslint . --max-warnings 0` clean