### PR TITLE
fix(web): make low-vision CSS theme-aware and reflow-safe (#3276, #3279, #3299)

### DIFF
--- a/apps/web/src/components/common/converted-total-indicator.css
+++ b/apps/web/src/components/common/converted-total-indicator.css
@@ -23,7 +23,7 @@
 }
 
 .converted-total-indicator__text {
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .converted-total-indicator__stale {

--- a/apps/web/src/components/estate/estate-inventory.css
+++ b/apps/web/src/components/estate/estate-inventory.css
@@ -56,7 +56,7 @@
 .estate-export__highlights > div {
   padding: var(--spacing-4);
   border-radius: var(--border-radius-md);
-  background: rgba(255, 255, 255, 0.72);
+  background: var(--semantic-background-elevated);
   border: 1px solid var(--semantic-border-default);
 }
 
@@ -195,7 +195,7 @@
   min-width: 2rem;
   padding: 0 var(--spacing-2);
   border-radius: 999px;
-  background: rgba(0, 0, 0, 0.08);
+  background: var(--semantic-background-secondary);
   color: inherit;
   font-size: var(--type-scale-caption-font-size);
 }
@@ -389,7 +389,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.72);
+  background: var(--semantic-background-elevated);
   font-weight: var(--font-weight-semibold);
 }
 

--- a/apps/web/src/styles/navigation-chrome.css
+++ b/apps/web/src/styles/navigation-chrome.css
@@ -28,7 +28,7 @@
 .app-sidebar__group-heading {
   margin: 0;
   padding: 0;
-  font-size: 11px;
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
   font-weight: var(--font-weight-semibold, 600);
 }
 
@@ -43,7 +43,7 @@
   cursor: pointer;
   color: var(--semantic-text-secondary, var(--navigation-text));
   font: inherit;
-  font-size: 11px;
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
   font-weight: var(--font-weight-semibold, 600);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -286,7 +286,7 @@
 .more-sheet__group-heading {
   margin: 0 0 var(--spacing-2);
   padding: 0 var(--spacing-2);
-  font-size: 11px;
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
   font-weight: var(--font-weight-semibold, 600);
   letter-spacing: 0.08em;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary

Three small, low-risk CSS fixes that improve legibility for low-vision users (found while testing at 200% zoom and in Dark/OLED themes).

## Changes

- **Estate dark-mode contrast (#3276)** — `estate-inventory.css`: the summary stat tiles, category count badges, and checklist status circles used hardcoded `rgba(255,255,255,0.72)` / `rgba(0,0,0,0.08)` backgrounds that became light-on-light (or dark-on-dark) in Dark/OLED themes. Swapped to theme-aware semantic tokens (`--semantic-background-elevated` / `--semantic-background-secondary`).
- **Nav text scaling (#3279)** — `navigation-chrome.css`: sidebar and More-sheet group headings used a fixed `font-size: 11px` that ignored the Text size preference. Converted to `var(--type-scale-caption-font-size, 0.75rem)` so they scale with the root font size.
- **Converted-total reflow (#3299)** — `converted-total-indicator.css`: replaced `white-space: nowrap` with `overflow-wrap: anywhere` so the converted total wraps instead of overflowing at 200% zoom / 320px width (WCAG 1.4.10 Reflow).

## Issues

Closes #3276
Closes #3279
Closes #3299

## Testing

- [x] Prettier passes on all three files (`npx prettier --check`)
- [x] CSS-only change; no ESLint/TS surface affected
- [x] Tokens verified defined across light/dark/OLED themes
- Manual: verify estate tiles legible in Dark/OLED, nav headings grow with Text size, converted total wraps at 200% zoom

## Notes

Found by persona: Harold Whitfield (retiree low-vision fixed-income). Purely presentational token/unit swaps — no behavior or logic changes.
