### PR TITLE
fix(web): correct achievements net worth and daily logging streak (#3289)

### DIFF
--- a/apps/web/src/hooks/useGamification.ts
+++ b/apps/web/src/hooks/useGamification.ts
@@ -22,6 +22,8 @@ import {
   type GamificationInput,
   type GamificationState,
 } from '../components/gamification/achievements-engine';
+import { computeCurrentNetWorth } from '../lib/analytics/net-worth';
+import { computeLoggingStreak } from '../lib/gamification/logging-streak';
 
 // ---------------------------------------------------------------------------
 // Public interface
@@ -66,52 +68,15 @@ export function useGamification(): UseGamificationResult {
       const budgets = getAllBudgets(db);
       const transactions = getAllTransactions(db);
 
-      // Compute daily logging streak from transaction dates
+      // Daily logging streak. Transaction dates are stored as *local* calendar
+      // dates, so the streak anchors to the local "today"/"yesterday" and
+      // avoids the UTC off-by-one that affects evening logging in western zones.
       const txDates = new Set(transactions.map((tx) => tx.date));
-      const sortedDates = Array.from(txDates).sort().reverse();
-
-      const todayStr = new Date().toISOString().slice(0, 10);
-      const loggedToday = txDates.has(todayStr);
-
-      let dailyLoggingStreak = 0;
-      let longestDailyLoggingStreak = 0;
-
-      if (sortedDates.length > 0) {
-        // Count current streak from today backwards
-        const today = new Date();
-        const checkDate = new Date(today);
-        let currentStreak = 0;
-
-        for (let i = 0; i < 365; i++) {
-          const dateStr = checkDate.toISOString().slice(0, 10);
-          if (txDates.has(dateStr)) {
-            currentStreak++;
-          } else if (currentStreak > 0) {
-            break;
-          }
-          checkDate.setDate(checkDate.getDate() - 1);
-        }
-
-        dailyLoggingStreak = currentStreak;
-
-        // Compute longest streak
-        let tempStreak = 0;
-        for (let i = 0; i < sortedDates.length; i++) {
-          if (i === 0) {
-            tempStreak = 1;
-          } else {
-            const prev = new Date(`${sortedDates[i - 1]}T00:00:00`);
-            const curr = new Date(`${sortedDates[i]}T00:00:00`);
-            const diffDays = Math.round((prev.getTime() - curr.getTime()) / (1000 * 60 * 60 * 24));
-            if (diffDays === 1) {
-              tempStreak++;
-            } else {
-              tempStreak = 1;
-            }
-          }
-          longestDailyLoggingStreak = Math.max(longestDailyLoggingStreak, tempStreak);
-        }
-      }
+      const {
+        current: dailyLoggingStreak,
+        longest: longestDailyLoggingStreak,
+        loggedToday,
+      } = computeLoggingStreak(txDates);
 
       // Budget adherence: count budgets where spending <= budget amount
       let budgetAdherenceMonths = 0;
@@ -158,7 +123,10 @@ export function useGamification(): UseGamificationResult {
         })),
         dailyLoggingStreak,
         longestDailyLoggingStreak,
-        netWorth: accounts.reduce((sum, a) => sum + a.currentBalance.amount, 0),
+        // Net worth must subtract liabilities (credit cards, loans) rather
+        // than summing every balance as a positive asset. Reuse the canonical
+        // helper so achievement thresholds match the /net-worth screen.
+        netWorth: computeCurrentNetWorth(accounts).netWorth,
         accountCount: accounts.length,
         totalSaved,
         categoriesUsed,

--- a/apps/web/src/lib/gamification/logging-streak.test.ts
+++ b/apps/web/src/lib/gamification/logging-streak.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { computeLoggingStreak } from './logging-streak';
+import { toLocalDate } from '../insights/helpers';
+
+/** Local date key for `now` shifted by `offsetDays` (negative = past). */
+function dayKey(now: Date, offsetDays: number): string {
+  const d = new Date(now);
+  d.setDate(d.getDate() + offsetDays);
+  return toLocalDate(d);
+}
+
+describe('computeLoggingStreak', () => {
+  // Evening reference time to guard against UTC off-by-one handling.
+  const now = new Date(2024, 5, 15, 20, 30, 0);
+
+  it('returns zeros for no transactions', () => {
+    expect(computeLoggingStreak([], now)).toEqual({
+      current: 0,
+      longest: 0,
+      loggedToday: false,
+    });
+  });
+
+  it('counts a run ending today as the current streak', () => {
+    const dates = [dayKey(now, 0), dayKey(now, -1), dayKey(now, -2)];
+    const result = computeLoggingStreak(dates, now);
+    expect(result.current).toBe(3);
+    expect(result.longest).toBe(3);
+    expect(result.loggedToday).toBe(true);
+  });
+
+  it('treats yesterday as a one-day grace (streak still current, not logged today)', () => {
+    const dates = [dayKey(now, -1), dayKey(now, -2)];
+    const result = computeLoggingStreak(dates, now);
+    expect(result.current).toBe(2);
+    expect(result.loggedToday).toBe(false);
+  });
+
+  it('reports 0 current when the last activity is older than yesterday', () => {
+    const dates = [dayKey(now, -3), dayKey(now, -4), dayKey(now, -5)];
+    const result = computeLoggingStreak(dates, now);
+    expect(result.current).toBe(0);
+    expect(result.longest).toBe(3);
+    expect(result.loggedToday).toBe(false);
+  });
+
+  it('does not surface a stale 10-day run as the current streak', () => {
+    const dates = Array.from({ length: 10 }, (_v, i) => dayKey(now, -20 - i));
+    const result = computeLoggingStreak(dates, now);
+    expect(result.current).toBe(0);
+    expect(result.longest).toBe(10);
+  });
+
+  it('counts an evening-logged "today" regardless of time-of-day (no UTC drift)', () => {
+    const lateNight = new Date(2024, 5, 15, 23, 45, 0);
+    const dates = [toLocalDate(lateNight)];
+    const result = computeLoggingStreak(dates, lateNight);
+    expect(result.loggedToday).toBe(true);
+    expect(result.current).toBe(1);
+  });
+
+  it('ignores gaps when measuring the longest historical streak', () => {
+    const dates = [
+      dayKey(now, 0),
+      dayKey(now, -1),
+      // gap
+      dayKey(now, -5),
+      dayKey(now, -6),
+      dayKey(now, -7),
+      dayKey(now, -8),
+    ];
+    const result = computeLoggingStreak(dates, now);
+    expect(result.current).toBe(2);
+    expect(result.longest).toBe(4);
+  });
+});

--- a/apps/web/src/lib/gamification/logging-streak.ts
+++ b/apps/web/src/lib/gamification/logging-streak.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Pure daily-logging-streak calculation for gamification.
+ *
+ * Transaction dates are stored as *local* calendar dates (`YYYY-MM-DD`, see
+ * {@link toLocalDate}). Streak math must therefore use the same local
+ * convention rather than UTC `toISOString`, which is off-by-one for evening
+ * logging in negative-UTC timezones.
+ *
+ * The *current* streak only counts when the run reaches today or yesterday (a
+ * one-day grace period). If the most recent activity is older than yesterday,
+ * the streak is considered broken and reported as 0 — a stale historical run
+ * is never surfaced as the current streak.
+ *
+ * References: issues #3292, #3295
+ */
+
+import { toLocalDate } from '../insights/helpers';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Result of {@link computeLoggingStreak}. */
+export interface LoggingStreak {
+  /** Consecutive days ending today/yesterday; 0 when the streak is broken. */
+  readonly current: number;
+  /** Longest consecutive run anywhere in the history. */
+  readonly longest: number;
+  /** Whether a transaction exists for the local "today". */
+  readonly loggedToday: boolean;
+}
+
+/**
+ * Computes the current and longest daily-logging streaks from a set of local
+ * transaction dates.
+ *
+ * @param dates - Iterable of local `YYYY-MM-DD` date strings (deduped internally)
+ * @param now - The reference "now" (injectable for deterministic tests)
+ * @returns Current streak, longest streak, and whether today has activity
+ */
+export function computeLoggingStreak(
+  dates: Iterable<string>,
+  now: Date = new Date(),
+): LoggingStreak {
+  const dateSet = dates instanceof Set ? (dates as Set<string>) : new Set(dates);
+
+  const today = new Date(now);
+  const loggedToday = dateSet.has(toLocalDate(today));
+
+  if (dateSet.size === 0) {
+    return { current: 0, longest: 0, loggedToday };
+  }
+
+  // Current streak, anchored to today or (as a grace) yesterday.
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  let current = 0;
+  if (loggedToday || dateSet.has(toLocalDate(yesterday))) {
+    const cursor = loggedToday ? new Date(today) : new Date(yesterday);
+    while (dateSet.has(toLocalDate(cursor))) {
+      current++;
+      cursor.setDate(cursor.getDate() - 1);
+    }
+  }
+
+  // Longest streak across the full sorted history.
+  const sorted = Array.from(dateSet).sort();
+  let longest = 0;
+  let run = 0;
+  let prev: Date | null = null;
+  for (const key of sorted) {
+    const day = new Date(`${key}T00:00:00`);
+    if (prev) {
+      const diffDays = Math.round((day.getTime() - prev.getTime()) / MS_PER_DAY);
+      run = diffDays === 1 ? run + 1 : 1;
+    } else {
+      run = 1;
+    }
+    longest = Math.max(longest, run);
+    prev = day;
+  }
+
+  return { current, longest, loggedToday };
+}


### PR DESCRIPTION
## Summary

Fixes three FIRE-relevant achievements/net-worth bugs found by persona **Sam Rivera (FIRE optimizer)**. All changes are web-only (`apps/web`).

## Changes

- **Net worth (#3289):** `useGamification` summed all account balances as positive assets, counting credit-card/loan balances as wealth. It now uses the canonical `computeCurrentNetWorth` helper (subtracts liabilities, excludes archived accounts) so net-worth achievements match the `/net-worth` screen.
- **Streak anchor (#3292):** extracted a pure `computeLoggingStreak` helper that only reports a _current_ streak when the run reaches today or yesterday (a one-day grace). A logging streak that ended weeks ago is no longer shown as the current streak.
- **Streak dates (#3295):** streak / "logged today" now use local calendar dates (`toLocalDate`) instead of UTC `toISOString`, fixing the off-by-one that dropped evening logs in negative-UTC timezones.
- Added `logging-streak.test.ts` (7 deterministic cases with injected `now`).

## Issues

Closes #3289
Closes #3292
Closes #3295

## Testing

- [x] `vitest run` — `logging-streak` (7) + `achievements-engine` / `AchievementsPage` / `net-worth` (52) all pass
- [x] Prettier + ESLint (`--max-warnings 0`) clean on changed files

Found by persona: Sam Rivera (FIRE optimizer)
