### PR TITLE
fix(web): parse and format money by active locale, not hardcoded en-US (#3326, #3302)

### DIFF
--- a/apps/web/src/hooks/useAmountInput.test.ts
+++ b/apps/web/src/hooks/useAmountInput.test.ts
@@ -20,6 +20,13 @@ describe('useAmountInput', () => {
     expect(formatCentsDisplay(1234567)).toBe('$12,345.67');
   });
 
+  it('honors the active locale for grouping and decimal separators (#3302)', () => {
+    // de-DE uses "." for grouping and "," for the decimal separator.
+    expect(formatCentsDisplay(1234567, '$', 2, 'de-DE')).toBe('$12.345,67');
+    // en-US keeps the familiar grouping.
+    expect(formatCentsDisplay(1234567, '$', 2, 'en-US')).toBe('$12,345.67');
+  });
+
   it('parses text input into cents', () => {
     expect(parseAmountInput('$12.34')).toBe(1234);
   });

--- a/apps/web/src/hooks/useAmountInput.ts
+++ b/apps/web/src/hooks/useAmountInput.ts
@@ -15,6 +15,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { getCurrentLocale } from '../lib/i18n';
+
 const DEFAULT_MAX_CENTS = 99_999_999;
 const PASS_THROUGH_KEYS = new Set([
   'Tab',
@@ -132,16 +134,22 @@ export function parseAmountInput(
 
 /**
  * Format cents as a currency display string.
+ *
+ * Grouping and decimal separators follow the active locale (issue #3302) so a
+ * `,`-decimal locale sees "1.234,56" rather than a hardcoded US "1,234.56".
+ * `currencySymbol` is caller-supplied because this hook is symbol-based; pass
+ * the account/display currency's symbol rather than relying on the `$` default.
  */
 export function formatCentsDisplay(
   cents: number,
   currencySymbol: string = '$',
   decimalPlaces: number = 2,
+  locale: string = getCurrentLocale(),
 ): string {
   const signPrefix = cents < 0 ? '-' : '';
   const value = Math.abs(cents) / Math.pow(10, decimalPlaces);
 
-  return `${signPrefix}${currencySymbol}${value.toLocaleString('en-US', {
+  return `${signPrefix}${currencySymbol}${value.toLocaleString(locale, {
     minimumFractionDigits: decimalPlaces,
     maximumFractionDigits: decimalPlaces,
   })}`;

--- a/apps/web/src/lib/i18n/local-currency-entry.test.ts
+++ b/apps/web/src/lib/i18n/local-currency-entry.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   getLocalCurrencyAmountPlaceholder,
   getLocalCurrencyAmountStep,
+  normalizeNumberInput,
   parseLocalCurrencyAmountInput,
 } from './local-currency-entry';
 
@@ -45,5 +46,16 @@ describe('local-currency-entry', () => {
     expect(getLocalCurrencyAmountStep('JPY')).toBe('1');
     expect(getLocalCurrencyAmountPlaceholder('USD')).toBe('0.00');
     expect(getLocalCurrencyAmountStep('BHD')).toBe('0.001');
+  });
+
+  it('normalizes both dot- and comma-decimal input to a canonical dot form (#3326)', () => {
+    // Comma-decimal locales ("1.234,56") must not silently drop the fraction.
+    expect(normalizeNumberInput('1.234,56', 2)).toBe('1234.56');
+    expect(normalizeNumberInput('7,24', 2)).toBe('7.24');
+    // Dot-decimal / US-grouped input is preserved.
+    expect(normalizeNumberInput('1,234.56', 2)).toBe('1234.56');
+    expect(normalizeNumberInput('500', 2)).toBe('500');
+    // A comma with more trailing digits than the currency allows is grouping.
+    expect(normalizeNumberInput('1,320', 0)).toBe('1320');
   });
 });

--- a/apps/web/src/lib/i18n/local-currency-entry.ts
+++ b/apps/web/src/lib/i18n/local-currency-entry.ts
@@ -57,7 +57,18 @@ function failure(
   };
 }
 
-function normalizeNumberInput(input: string, decimalPlaces: number): string {
+/**
+ * Normalize a locale-entered decimal string to a canonical `.`-decimal form.
+ *
+ * Handles both `.`-decimal ("1,234.56") and `,`-decimal ("1.234,56") locales by
+ * treating the last-occurring separator as the decimal point and stripping the
+ * other as a grouping separator. When only a comma is present, `decimalPlaces`
+ * disambiguates a decimal comma ("7,24") from a grouping comma ("1,320").
+ *
+ * Exported so currency amount and FX-rate inputs can share one locale-aware
+ * parser instead of re-implementing `.`-only `parseFloat` (issue #3326).
+ */
+export function normalizeNumberInput(input: string, decimalPlaces: number): string {
   const compact = input.trim().replace(/[\s_]/g, '');
   const lastDot = compact.lastIndexOf('.');
   const lastComma = compact.lastIndexOf(',');

--- a/apps/web/src/pages/RemittancesPage.tsx
+++ b/apps/web/src/pages/RemittancesPage.tsx
@@ -32,8 +32,13 @@ import { useLocalePreferences } from '../hooks/useLocalePreferences';
 import { useRemittances } from '../hooks/useRemittances';
 import { formatCurrency } from '../lib/currency';
 import { formatCurrencyGroup } from '../lib/currency-utils';
-import { SUPPORTED_CURRENCY_METADATA, minorUnitFactor } from '../lib/currency-metadata';
+import {
+  SUPPORTED_CURRENCY_METADATA,
+  getCurrencyFractionDigits,
+  minorUnitFactor,
+} from '../lib/currency-metadata';
 import { translate } from '../lib/i18n';
+import { normalizeNumberInput } from '../lib/i18n/local-currency-entry';
 import { quoteRemittance } from '../lib/remittance';
 import type { RemittanceFeeModel, RemittanceQuote, RemittanceRecord } from '../lib/remittance';
 import { formatDate } from '../utils/formatDate';
@@ -47,14 +52,19 @@ function today(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+// FX rates carry more fractional precision than currency amounts; format/entry
+// allow up to 6 decimals (see `formatRate`).
+const RATE_MAX_DECIMALS = 6;
+
 function toMinor(value: string, currency: string): number {
-  const num = Number.parseFloat(value);
+  const normalized = normalizeNumberInput(value, getCurrencyFractionDigits(currency));
+  const num = Number.parseFloat(normalized);
   if (!Number.isFinite(num)) return Number.NaN;
   return Math.round(num * minorUnitFactor(currency));
 }
 
 function parseRate(value: string): number {
-  return Number.parseFloat(value);
+  return Number.parseFloat(normalizeNumberInput(value, RATE_MAX_DECIMALS));
 }
 
 function formatRate(rate: number, locale: string): string {


### PR DESCRIPTION
﻿## Summary

Two money I/O primitives on the web app assumed a US (en-US) locale, which breaks the experience for a bilingual USD/CNY remitter (persona: Wei Zhang) who enters and reads amounts in a comma-decimal locale.

## Changes

- **Remittance parsing (#3326):** RemittancesPage 	oMinor/parseRate used dot-only Number.parseFloat, so a comma-decimal entry like `1.234,56` silently dropped its fraction — producing the wrong send amount on a page whose whole purpose is money accuracy. They now route through the shared, locale-aware `normalizeNumberInput` (now exported from `lib/i18n/local-currency-entry`) before parsing the amount, fee, FX rate, and reference rate. Amounts disambiguate decimal-vs-grouping using the currency's fraction digits; rates use up to 6 decimals.
- **Amount display (#3302):** `formatCentsDisplay` grouped/decimal-separated with a hardcoded `'en-US'`; it now honors `getCurrentLocale()` (with an explicit `locale` param for deterministic tests), so comma-decimal locales see `1.234,56` instead of `1,234.56`. The `currencySymbol` remains caller-supplied (the hook is symbol-based); callers should pass the account/display currency symbol rather than the `$` default.

## Tests

- `local-currency-entry.test.ts`: `normalizeNumberInput` handles dot- and comma-decimal input, US/de grouping, and the grouping-comma edge case.
- `useAmountInput.test.ts`: `formatCentsDisplay` honors de-DE vs en-US separators.
- All affected suites pass locally (25 tests): `local-currency-entry`, `useAmountInput`, `RemittancesPage`.

## Issues

Closes #3326
Closes #3302

Found by persona: Wei Zhang (immigrant multi-currency remitter)
