### PR TITLE
fix(web): confirm before deleting invoices and remittances (#3247) (#3249)

### DIFF
--- a/apps/web/src/lib/i18n/locales/en-US.ts
+++ b/apps/web/src/lib/i18n/locales/en-US.ts
@@ -206,4 +206,9 @@ export const EN_US_CATALOG: MessageCatalog = {
   'remittance.history.deleteAria': 'Delete remittance to {recipient} on {date}',
   'remittance.history.itemAria': '{amount} sent to {recipient} in {country} on {date}',
   'remittance.history.loading': 'Loading remittances',
+  'remittance.history.confirmDelete.title': 'Delete remittance',
+  'remittance.history.confirmDelete.message':
+    'Delete the remittance to {recipient} on {date}? This permanently removes it from your payment history and FX/fee totals.',
+  'remittance.history.confirmDelete.confirm': 'Delete remittance',
+  'remittance.history.confirmDelete.cancel': 'Cancel',
 };

--- a/apps/web/src/lib/i18n/locales/es-ES.ts
+++ b/apps/web/src/lib/i18n/locales/es-ES.ts
@@ -207,4 +207,9 @@ export const ES_ES_CATALOG: MessageCatalog = {
   'remittance.history.deleteAria': 'Eliminar la remesa a {recipient} del {date}',
   'remittance.history.itemAria': '{amount} enviado a {recipient} en {country} el {date}',
   'remittance.history.loading': 'Cargando remesas',
+  'remittance.history.confirmDelete.title': 'Eliminar remesa',
+  'remittance.history.confirmDelete.message':
+    '¿Eliminar la remesa a {recipient} del {date}? Esto la quita permanentemente de tu historial de pagos y de los totales de FX y comisiones.',
+  'remittance.history.confirmDelete.confirm': 'Eliminar remesa',
+  'remittance.history.confirmDelete.cancel': 'Cancelar',
 };

--- a/apps/web/src/pages/InvoicesPage.test.tsx
+++ b/apps/web/src/pages/InvoicesPage.test.tsx
@@ -9,15 +9,28 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import { InvoicesPage } from './InvoicesPage';
+import type { Invoice } from '../lib/analytics/invoices';
 
 vi.mock('../hooks/useInvoices', () => ({ useInvoices: vi.fn() }));
 
 import { useInvoices } from '../hooks/useInvoices';
 
 const mockedUseInvoices = vi.mocked(useInvoices);
+
+const SAMPLE_INVOICE: Invoice = {
+  id: 'inv-1',
+  clientName: 'Etsy Wholesale',
+  amountCents: 120_000,
+  issueDate: '2026-06-01',
+  paymentTerm: 'net-30',
+  status: 'Sent',
+  expectedPayDate: '2026-07-01',
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -44,5 +57,29 @@ describe('InvoicesPage', () => {
     render(<InvoicesPage />);
 
     expect(screen.getByText(/forecast when freelance income should land/i)).toBeInTheDocument();
+  });
+
+  it('confirms before deleting an invoice', () => {
+    const deleteInvoice = vi.fn();
+    mockedUseInvoices.mockReturnValue({
+      invoices: [SAMPLE_INVOICE],
+      pipelineGroups: [
+        { status: 'Sent', label: 'Sent', invoices: [SAMPLE_INVOICE], totalCents: 120_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      deleteInvoice,
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    // Deletion is gated by a confirmation dialog; nothing happens until confirmed.
+    expect(deleteInvoice).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete invoice' }));
+    expect(deleteInvoice).toHaveBeenCalledWith('inv-1');
   });
 });

--- a/apps/web/src/pages/InvoicesPage.tsx
+++ b/apps/web/src/pages/InvoicesPage.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { useMemo, useState } from 'react';
-import { CurrencyDisplay, EmptyState } from '../components/common';
+import { ConfirmDialog, CurrencyDisplay, EmptyState } from '../components/common';
 import { useInvoices } from '../hooks/useInvoices';
 import {
   computeExpectedPayDate,
@@ -54,7 +54,7 @@ const StatusBadge: React.FC<{ status: InvoiceStatus }> = ({ status }) => (
 const InvoiceCard: React.FC<{
   invoice: Invoice;
   onStatusChange: (invoiceId: string, status: InvoiceStatus) => void;
-  onDelete: (invoiceId: string) => void;
+  onDelete: (invoice: Invoice) => void;
 }> = ({ invoice, onStatusChange, onDelete }) => (
   <article className={`invoice-card invoice-card--${invoice.status.toLowerCase()}`} role="listitem">
     <div className="invoice-card__main">
@@ -84,7 +84,7 @@ const InvoiceCard: React.FC<{
           ))}
         </select>
       </label>
-      <button className="analytics-export-btn" type="button" onClick={() => onDelete(invoice.id)}>
+      <button className="analytics-export-btn" type="button" onClick={() => onDelete(invoice)}>
         Delete
       </button>
     </div>
@@ -107,6 +107,14 @@ export const InvoicesPage: React.FC = () => {
   const [paymentTerm, setPaymentTerm] = useState<InvoicePaymentTerm>('net-30');
   const [status, setStatus] = useState<InvoiceStatus>('Sent');
   const [formError, setFormError] = useState<string | null>(null);
+  const [deletingInvoice, setDeletingInvoice] = useState<Invoice | null>(null);
+
+  const handleConfirmDelete = () => {
+    if (deletingInvoice) {
+      deleteInvoice(deletingInvoice.id);
+      setDeletingInvoice(null);
+    }
+  };
 
   const expectedPayDate = useMemo(
     () => (issueDate ? computeExpectedPayDate(issueDate, paymentTerm) : todayIsoDate()),
@@ -297,7 +305,7 @@ export const InvoicesPage: React.FC = () => {
                         key={invoice.id}
                         invoice={invoice}
                         onStatusChange={updateInvoiceStatus}
-                        onDelete={deleteInvoice}
+                        onDelete={setDeletingInvoice}
                       />
                     ))}
                   </div>
@@ -307,6 +315,19 @@ export const InvoicesPage: React.FC = () => {
           </div>
         )}
       </section>
+
+      <ConfirmDialog
+        isOpen={deletingInvoice !== null}
+        title="Delete invoice"
+        message={
+          deletingInvoice
+            ? `Delete the invoice for ${deletingInvoice.clientName}? This permanently removes it from your pipeline and expected-income forecast.`
+            : ''
+        }
+        confirmLabel="Delete invoice"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setDeletingInvoice(null)}
+      />
     </div>
   );
 };

--- a/apps/web/src/pages/RemittancesPage.test.tsx
+++ b/apps/web/src/pages/RemittancesPage.test.tsx
@@ -164,7 +164,7 @@ describe('RemittancesPage', () => {
     expect(screen.getByText('Familia García')).toBeInTheDocument();
   });
 
-  it('deletes a record via the delete button', () => {
+  it('deletes a record after confirming in the dialog', () => {
     const deleteRemittance = vi.fn();
     mockUseRemittances.mockReturnValue(
       buildResult({
@@ -185,6 +185,10 @@ describe('RemittancesPage', () => {
     fireEvent.click(
       screen.getByRole('button', { name: 'Delete remittance to Familia García on Jun 1, 2026' }),
     );
+    // Deletion is gated by a confirmation dialog; nothing happens until confirmed.
+    expect(deleteRemittance).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete remittance' }));
     expect(deleteRemittance).toHaveBeenCalledWith('rem-1');
   });
 });

--- a/apps/web/src/pages/RemittancesPage.tsx
+++ b/apps/web/src/pages/RemittancesPage.tsx
@@ -27,7 +27,7 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 
-import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
+import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { useLocalePreferences } from '../hooks/useLocalePreferences';
 import { useRemittances } from '../hooks/useRemittances';
 import { formatCurrency } from '../lib/currency';
@@ -293,6 +293,15 @@ export const RemittancesPage: React.FC = () => {
       translate(id, values, locale).text,
     [locale],
   );
+
+  const [deletingRecord, setDeletingRecord] = useState<RemittanceRecord | null>(null);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (deletingRecord) {
+      deleteRemittance(deletingRecord.id);
+      setDeletingRecord(null);
+    }
+  }, [deletingRecord, deleteRemittance]);
 
   // Form state
   const [recipientName, setRecipientName] = useState('');
@@ -820,7 +829,7 @@ export const RemittancesPage: React.FC = () => {
                   record={record}
                   locale={locale}
                   t={t}
-                  onDelete={() => deleteRemittance(record.id)}
+                  onDelete={() => setDeletingRecord(record)}
                 />
               ))}
             </div>
@@ -835,6 +844,23 @@ export const RemittancesPage: React.FC = () => {
           <p className="remittance-empty__body">{t('remittance.empty.body')}</p>
         </section>
       )}
+
+      <ConfirmDialog
+        isOpen={deletingRecord !== null}
+        title={t('remittance.history.confirmDelete.title')}
+        message={
+          deletingRecord
+            ? t('remittance.history.confirmDelete.message', {
+                recipient: deletingRecord.recipient.name,
+                date: formatDate(deletingRecord.date, { locale }),
+              })
+            : ''
+        }
+        confirmLabel={t('remittance.history.confirmDelete.confirm')}
+        cancelLabel={t('remittance.history.confirmDelete.cancel')}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setDeletingRecord(null)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Deleting an invoice or a supplier remittance was immediate and irreversible — a single
misclick permanently removed the record (and its contribution to the expected-income
forecast / FX-fee totals) with no confirmation. This gates both destructive actions behind
the shared, accessible `ConfirmDialog` (`role="alertdialog"` with focus trapping), matching
the pattern already used on the Categories page.

As Priya (an Etsy small-business owner tracking wholesale invoices and monthly overseas
supplier payments), an accidental delete means losing real cash-flow history.

## Changes

- **InvoicesPage**: the per-invoice Delete button now opens a confirmation dialog that names
  the client and explains the forecast impact before removing the invoice.
- **RemittancesPage**: the per-remittance Delete button now opens a **localized** confirmation
  dialog naming the recipient and date before removing the payment.
- **i18n**: added `remittance.history.confirmDelete.{title,message,confirm,cancel}` keys to
  both `en-US` and `es-ES` catalogs (locale parity preserved).
- **Tests**: updated the remittance delete test and added an invoice delete test to assert the
  delete handler is **not** called until the user confirms.

## Issues

Closes #3247
Closes #3249

## Testing

- [x] `npx vitest run src/pages/InvoicesPage.test.tsx src/pages/RemittancesPage.test.tsx` — 12 passed
- [x] `npx vitest run src/lib/i18n` — 41 passed (locale parity intact)
- [x] `npx eslint <changed files> --max-warnings 0` — clean
- [x] `npx prettier --check <changed files>` — clean

Found by persona: Priya Sharma (etsy small-business owner)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
