### PR TITLE
feat(web): add remittance and exchange-rate terms to the financial glossary (#3316)

### DIFF
--- a/apps/web/src/lib/education/glossary.test.ts
+++ b/apps/web/src/lib/education/glossary.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the plain-language financial glossary, including the cross-border
+ * remittance and exchange-rate terms a bilingual remitter needs.
+ *
+ * References: issue #3316
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { financialGlossary, getGlossaryEntry } from './glossary';
+import { GLOSSARY_KEYS } from './types';
+
+describe('financial glossary', () => {
+  it('defines a complete, well-formed entry for every glossary key', () => {
+    for (const key of GLOSSARY_KEYS) {
+      const entry = financialGlossary[key];
+      expect(entry, key).toBeDefined();
+      expect(entry.term.length).toBeGreaterThan(0);
+      expect(entry.definition.length).toBeGreaterThan(0);
+      expect(entry.example.length).toBeGreaterThan(0);
+      expect(entry.whyItMatters.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('covers the remittance and FX terms an immigrant remitter needs (#3316)', () => {
+    const remittanceTerms = [
+      'exchangeRate',
+      'midMarketRate',
+      'fxMargin',
+      'remittance',
+      'wireTransfer',
+    ] as const;
+    for (const key of remittanceTerms) {
+      expect(GLOSSARY_KEYS).toContain(key);
+      expect(getGlossaryEntry(key).term.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('explains FX margin in terms of the mid-market reference rate', () => {
+    expect(getGlossaryEntry('fxMargin').definition.toLowerCase()).toContain('mid-market');
+  });
+});

--- a/apps/web/src/lib/education/glossary.ts
+++ b/apps/web/src/lib/education/glossary.ts
@@ -161,6 +161,50 @@ export const financialGlossary: Record<GlossaryKey, EducationEntry> = {
     whyItMatters:
       'Diversification can lower risk and make your results less dependent on one company, sector, or market move.',
   },
+  exchangeRate: {
+    term: 'Exchange Rate',
+    definition:
+      'An exchange rate is how much one currency is worth in another currency at a given moment.',
+    example:
+      'If the US dollar to Chinese yuan exchange rate is 7.2, then $1 is worth about ¥7.2, so $500 is worth about ¥3,600.',
+    whyItMatters:
+      'The rate decides how much your family actually receives, and it moves from day to day, so the same amount sent can arrive as more or less.',
+  },
+  midMarketRate: {
+    term: 'Mid-Market Rate',
+    definition:
+      'The mid-market rate is the "real" exchange rate banks use with each other, halfway between the buy and sell price, before any markup is added.',
+    example:
+      'If the mid-market rate is ¥7.20 per dollar but a transfer service offers you ¥7.05, the difference is the markup you are paying.',
+    whyItMatters:
+      'It is the fair reference point to compare against, so you can see how much a provider is really charging beyond any stated fee.',
+  },
+  fxMargin: {
+    term: 'FX Margin',
+    definition:
+      'The FX margin, or exchange-rate markup, is the gap between the mid-market rate and the rate a provider gives you. It is a hidden cost on top of any upfront fee.',
+    example:
+      'A service advertising "no fee" but paying ¥7.05 when the mid-market rate is ¥7.20 is still charging about 2% through the margin.',
+    whyItMatters:
+      'Two transfers with the same fee can cost very different amounts once the margin is included, so comparing the rate matters as much as comparing the fee.',
+  },
+  remittance: {
+    term: 'Remittance',
+    definition:
+      'A remittance is money you send to family or friends in another country, usually on a regular basis.',
+    example: 'Sending part of each paycheck home to parents abroad is a remittance.',
+    whyItMatters:
+      'Tracking each remittance with its fee and exchange rate shows the true monthly cost of supporting people back home and helps you pick cheaper ways to send.',
+  },
+  wireTransfer: {
+    term: 'Wire Transfer',
+    definition:
+      'A wire transfer is a way to move money electronically between banks, often across countries using networks identified by SWIFT or IBAN codes.',
+    example:
+      'An international wire might cost a flat fee of $15 to $45 and take one to three business days to arrive.',
+    whyItMatters:
+      'Wires are reliable for larger amounts but can carry higher flat fees than app-based transfers, so the best choice depends on how much you send.',
+  },
 };
 
 export function getGlossaryEntry(key: GlossaryKey): EducationEntry {

--- a/apps/web/src/lib/education/types.ts
+++ b/apps/web/src/lib/education/types.ts
@@ -26,6 +26,11 @@ export const GLOSSARY_KEYS = [
   'dollarCostAveraging',
   'expenseRatio',
   'diversification',
+  'exchangeRate',
+  'fxMargin',
+  'midMarketRate',
+  'remittance',
+  'wireTransfer',
 ] as const;
 
 export type GlossaryKey = (typeof GLOSSARY_KEYS)[number];


### PR DESCRIPTION
﻿## Summary

The in-app financial glossary and newcomer explainers covered US payroll and investing terms but nothing about **sending money abroad** — the single most frequent action for persona Wei Zhang, who remits USD→CNY to family every month. Terms she actually struggles with were absent.

## Changes

- Adds five plain-language, advice-free glossary entries (`lib/education/glossary.ts` + `GLOSSARY_KEYS` in `types.ts`):
  - **Exchange Rate** — what a rate is and why the received amount moves day to day.
  - **Mid-Market Rate** — the fair reference rate before markup.
  - **FX Margin** — the hidden markup vs mid-market, distinct from an upfront fee.
  - **Remittance** — money sent to family abroad.
  - **Wire Transfer** — bank-to-bank international transfer (SWIFT/IBAN).
- These become available anywhere the existing `getGlossaryEntry` / `ExplainThis` mechanism is used.

## Tests

- New `glossary.test.ts`: asserts every `GLOSSARY_KEYS` entry is complete and the new remittance/FX terms are present; verifies FX margin references the mid-market rate.
- Existing `newcomer-explainers.test.ts` unchanged and still passing (the US-tax explainer set is intentionally left as-is).

## Follow-up

Surfacing these via `ExplainThis` on the Remittances page is a natural next step (tracked under the same issue); kept out of this PR to keep it focused and avoid overlap with the in-flight remittance parsing PR.

## Issues

Closes #3316

Found by persona: Wei Zhang (immigrant multi-currency remitter)
