### PR TITLE
fix(web): meet WCAG 2.5.8 target size for settings checkbox (#3350)

### DIFF
--- a/apps/web/src/styles/font-scaling.css
+++ b/apps/web/src/styles/font-scaling.css
@@ -199,6 +199,14 @@ html {
   grid-column: 1;
 }
 
+/* Simplified (elder) mode: enlarge the settings checkbox to the comfortable
+   tap target promised by --accessibility-touch-target-size (56px in simplified,
+   48px otherwise). The 24px base in responsive.css already meets WCAG 2.5.8. */
+[data-accessibility-mode='simplified'] .settings-item__checkbox {
+  width: var(--accessibility-touch-target-size, 24px);
+  height: var(--accessibility-touch-target-size, 24px);
+}
+
 /* Transactions: amounts and actions wrap instead of colliding at Huge text. */
 .transaction-list-item__trailing,
 .transaction-item__actions {

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -726,8 +726,8 @@
   outline-offset: 2px;
 }
 .settings-item__checkbox {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   justify-self: end;
   accent-color: var(--semantic-interactive-default);
 }


### PR DESCRIPTION
## Summary

Fixes the settings checkbox target size to meet WCAG 2.2 SC 2.5.8 (Target Size Minimum) and wires the previously-dead `--accessibility-touch-target-size` variable so Simplified (elder) mode delivers the larger tap targets it promises.

## Changes

- **`responsive.css`** — `.settings-item__checkbox` raised from `20px` to `24px` (WCAG 2.5.8 24×24 CSS px floor). Every Settings toggle — including the Accessibility toggles themselves — used the 20px size.
- **`font-scaling.css`** — added `[data-accessibility-mode='simplified'] .settings-item__checkbox` which consumes `--accessibility-touch-target-size` (56px in Simplified, 48px otherwise). `AccessibilityContext` was already writing this variable to the root element, but no CSS read it, so the promised larger targets never materialized. It is now live.

## Issues

Closes #3350

## Testing

- [x] Prettier passes on both files (`npx prettier --check`)
- [x] CSS-only change; no ESLint/TS surface affected
- Manual: default checkbox is 24×24; enabling Simplified mode enlarges it to 56×56

## Cross-Platform

Native controls on iOS/Android/Windows follow platform minimum tap targets (44pt/48dp); this 20px control was CSS-only. `platform:web`.

## Notes

Found by persona: Harold Whitfield (retiree low-vision fixed-income). Related: #3280 (remaining dead a11y plumbing — the font-size variable path, tracked separately).
