### PR TITLE
fix(web): honest FX freshness and single static rate table (#3293, #3321)

### DIFF
--- a/apps/web/src/components/dashboard/CurrencyDisplay.test.tsx
+++ b/apps/web/src/components/dashboard/CurrencyDisplay.test.tsx
@@ -82,6 +82,16 @@ describe('ExchangeRateIndicator', () => {
     expect(screen.getByText(/1 USD = 0\.9200 EUR/)).toBeInTheDocument();
   });
 
+  it('labels the rate as an approximate offline reference, not a live "updated now" quote', () => {
+    mockedHook.mockReturnValue(mockResult());
+
+    render(<ExchangeRateIndicator from="USD" to="EUR" />);
+
+    expect(screen.getByText(/approximate rate/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Updated:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Source: Static rates/)).not.toBeInTheDocument();
+  });
+
   it('shows loading state', () => {
     mockedHook.mockReturnValue(mockResult({ loading: true }));
 

--- a/apps/web/src/components/dashboard/CurrencyDisplay.tsx
+++ b/apps/web/src/components/dashboard/CurrencyDisplay.tsx
@@ -13,6 +13,7 @@ import { useCallback } from 'react';
 
 import { useMultiCurrency } from '../../hooks/useMultiCurrency';
 import type { Currency } from '../../kmp/bridge';
+import { getCurrentLocale } from '../../lib/i18n';
 
 import './CurrencyDisplay.css';
 
@@ -103,12 +104,14 @@ export function ExchangeRateIndicator({ from, to }: ExchangeRateIndicatorProps) 
           <span className="exchange-rate-indicator__rate">
             1 {from} = {rate.toFixed(4)} {to}
           </span>
+          <span className="exchange-rate-indicator__source">
+            Approximate rate — offline reference, not a live quote
+          </span>
           {lastUpdated && (
             <span className="exchange-rate-indicator__updated">
-              Updated: {new Date(lastUpdated).toLocaleString()}
+              Snapshot as of {new Date(lastUpdated).toLocaleDateString(getCurrentLocale())}
             </span>
           )}
-          <span className="exchange-rate-indicator__source">Source: Static rates</span>
         </>
       ) : (
         <span className="exchange-rate-indicator__unavailable">

--- a/apps/web/src/hooks/__tests__/useMultiCurrency.test.ts
+++ b/apps/web/src/hooks/__tests__/useMultiCurrency.test.ts
@@ -20,11 +20,15 @@ describe('useMultiCurrency', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('loads exchange rates', () => {
+  it('loads exchange rates without fabricating a freshness timestamp', () => {
     const { result } = renderHook(() => useMultiCurrency());
 
     expect(result.current.rates.length).toBeGreaterThan(0);
-    expect(result.current.lastUpdated).not.toBeNull();
+    // Static snapshot rates carry no live "as of" time, so the hook must not
+    // stamp a misleading "updated now" timestamp (#3293).
+    expect(result.current.lastUpdated).toBeNull();
+    expect(result.current.rates.every((rate) => rate.updatedAt === null)).toBe(true);
+    expect(result.current.rates.every((rate) => rate.source === 'static')).toBe(true);
   });
 
   it('converts USD to EUR', () => {

--- a/apps/web/src/hooks/useMultiCurrency.ts
+++ b/apps/web/src/hooks/useMultiCurrency.ts
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Currency } from '../kmp/bridge';
 import { Currencies } from '../kmp/bridge';
 import { formatCurrency } from '../lib/currency';
+import { STATIC_USD_RATES } from '../lib/currency/static-rates';
 import { SUPPORTED_CURRENCY_METADATA } from '../lib/currency-metadata';
 import { getCurrentLocale } from '../lib/i18n';
 
@@ -30,7 +31,11 @@ export interface ExchangeRate {
   readonly from: string;
   readonly to: string;
   readonly rate: number;
-  readonly updatedAt: string;
+  /**
+   * ISO timestamp of when the rate was fetched, or `null` for offline
+   * static-snapshot rates that have no meaningful "as of" time.
+   */
+  readonly updatedAt: string | null;
   readonly source: string;
 }
 
@@ -89,25 +94,6 @@ const SUPPORTED_CURRENCIES: Currency[] = SUPPORTED_CURRENCY_METADATA.map(
 
 const SUPPORTED_CURRENCY_CODES = new Set(SUPPORTED_CURRENCIES.map((currency) => currency.code));
 
-/**
- * Static exchange rates (USD base).
- * In production, these would be fetched from an API.
- */
-const STATIC_RATES: Record<string, number> = {
-  USD: 1.0,
-  EUR: 0.92,
-  GBP: 0.79,
-  JPY: 149.5,
-  CAD: 1.36,
-  AUD: 1.53,
-  CHF: 0.88,
-  CNY: 7.24,
-  INR: 83.12,
-  MXN: 17.15,
-  BRL: 4.97,
-  KRW: 1320.0,
-};
-
 // ---------------------------------------------------------------------------
 // Storage helpers
 // ---------------------------------------------------------------------------
@@ -131,21 +117,29 @@ function loadDefaultCurrency(): Currency {
   return Currencies.USD;
 }
 
+/**
+ * Build all cross-currency pairs from the shared static USD-base table.
+ *
+ * Rates come from the single canonical {@link STATIC_USD_RATES} snapshot
+ * (shared with `StaticRateProvider`) so there is no second table to drift.
+ * `updatedAt` is deliberately `null`: these are approximate offline
+ * reference rates, not live quotes, and stamping "now" would misrepresent
+ * them as freshly fetched.
+ */
 function buildRates(): ExchangeRate[] {
-  const now = new Date().toISOString();
   const rates: ExchangeRate[] = [];
 
-  const codes = Object.keys(STATIC_RATES);
+  const codes = Object.keys(STATIC_USD_RATES);
   for (const from of codes) {
     for (const to of codes) {
       if (from !== to) {
-        const fromRate = STATIC_RATES[from]!;
-        const toRate = STATIC_RATES[to]!;
+        const fromRate = STATIC_USD_RATES[from]!;
+        const toRate = STATIC_USD_RATES[to]!;
         rates.push({
           from,
           to,
           rate: toRate / fromRate,
-          updatedAt: now,
+          updatedAt: null,
           source: 'static',
         });
       }
@@ -179,10 +173,10 @@ export function useMultiCurrency(): UseMultiCurrencyResult {
     try {
       const builtRates = buildRates();
       setRates(builtRates);
-      const now = new Date().toISOString();
-      setLastUpdated(now);
+      // Static snapshot rates have no live "as of" time; do not fabricate one.
+      setLastUpdated(null);
       localStorage.setItem(STORAGE_KEY_RATES, JSON.stringify(builtRates));
-      localStorage.setItem(STORAGE_KEY_RATES_UPDATED, now);
+      localStorage.removeItem(STORAGE_KEY_RATES_UPDATED);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load exchange rates.');
     } finally {


### PR DESCRIPTION
## Summary

Two related honesty/correctness fixes in the web multi-currency layer, found while testing as **Wei Zhang** — a bilingual immigrant who sends CNY home monthly and watches FX rates closely. A rate widget that claims to be "Updated: now" when it is really a hardcoded offline snapshot actively misleads a rate-watcher.

## Changes

- **#3293 — misleading FX freshness.** `useMultiCurrency` stamped `updatedAt: now` on every static rate and reset `lastUpdated` to the current time on each mount. The dashboard `ExchangeRateIndicator` then rendered `Updated: <now>` + `Source: Static rates`, implying a live quote.
  - `updatedAt` / `lastUpdated` are now `null` for static snapshots (no fabricated timestamp).
  - The indicator now shows **"Approximate rate — offline reference, not a live quote"** and, only when a real snapshot date is present, a locale-formatted **"Snapshot as of &lt;date&gt;"** (via `toLocaleDateString(getCurrentLocale())`) instead of the US-locale `toLocaleString()`.
- **#3321 — duplicated static FX table.** The hook carried its own 12-currency `STATIC_RATES` map that could silently drift from the canonical ~30-currency `STATIC_USD_RATES` in `lib/currency/static-rates.ts`. The hook now derives cross-rates from that single source of truth (and gains coverage of ~18 more currencies, e.g. PHP, THB, IDR, SGD).

## Files

- `apps/web/src/hooks/useMultiCurrency.ts` — import shared `STATIC_USD_RATES`, delete local duplicate, `updatedAt`/`lastUpdated` → `null` for snapshots.
- `apps/web/src/components/dashboard/CurrencyDisplay.tsx` — honest approximate-rate label + locale-aware snapshot date.
- `apps/web/src/components/dashboard/CurrencyDisplay.test.tsx` — new assertion that the indicator is labelled approximate and no longer says "Updated:" / "Source: Static rates".

## Notes

- `ExchangeRateIndicator` / `MultiCurrencyTotals` are not yet mounted in any route (tracked separately as #3324); this hardens them so they are honest whenever they are surfaced.
- No consumer reads `ExchangeRate.updatedAt`; widening the type to `string | null` is safe.

## Testing

- [x] `npx vitest run src/components/dashboard/CurrencyDisplay.test.tsx` — 9 passed
- [x] `npx prettier --write` — clean
- [x] `npx eslint --max-warnings 0` — clean

## Issues

Closes #3293
Closes #3321

Found by persona: Wei Zhang (immigrant multi-currency remitter)
