### PR TITLE
fix(web): open a single keyboard-help dialog on '?' (#3329)

### DIFF
--- a/apps/web/src/components/common/KeyboardShortcutsModal.test.tsx
+++ b/apps/web/src/components/common/KeyboardShortcutsModal.test.tsx
@@ -131,4 +131,22 @@ describe('KeyboardShortcutsModal', () => {
     const backdrop = container.querySelector('.form-dialog__backdrop');
     expect(backdrop).toHaveAttribute('aria-hidden', 'true');
   });
+
+  it('renders appended extra shortcut categories', () => {
+    render(
+      <KeyboardShortcutsModal
+        isOpen={true}
+        onClose={vi.fn()}
+        extraCategories={[
+          {
+            title: 'Locked navigation',
+            shortcuts: [{ keys: 'Ctrl + 1', description: 'Dashboard' }],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Locked navigation')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/common/KeyboardShortcutsModal.tsx
+++ b/apps/web/src/components/common/KeyboardShortcutsModal.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useId, useRef, type KeyboardEvent } from 'react';
 
 import { useFocusTrap } from '../../accessibility/aria';
-import { SHORTCUT_CATEGORIES } from '../../hooks/useKeyboardShortcuts';
+import { SHORTCUT_CATEGORIES, type ShortcutCategory } from '../../hooks/useKeyboardShortcuts';
 
 import '../forms/forms.css';
 
@@ -11,6 +11,12 @@ export interface KeyboardShortcutsModalProps {
   isOpen: boolean;
   onClose: () => void;
   singleKeyShortcutsEnabled?: boolean;
+  /**
+   * Additional shortcut categories appended after the built-in ones. Used to
+   * fold the locked Ctrl+1..9 navigation shortcuts into this single help
+   * dialog instead of a second competing modal.
+   */
+  extraCategories?: readonly ShortcutCategory[];
 }
 
 /** Accessible help dialog listing the app's keyboard shortcuts. */
@@ -18,11 +24,16 @@ export function KeyboardShortcutsModal({
   isOpen,
   onClose,
   singleKeyShortcutsEnabled = true,
+  extraCategories,
 }: KeyboardShortcutsModalProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const titleId = useId();
   const descriptionId = useId();
+  const categories =
+    extraCategories && extraCategories.length > 0
+      ? [...SHORTCUT_CATEGORIES, ...extraCategories]
+      : SHORTCUT_CATEGORIES;
 
   useFocusTrap(panelRef, {
     active: isOpen,
@@ -91,7 +102,7 @@ export function KeyboardShortcutsModal({
             </tr>
           </thead>
           <tbody>
-            {SHORTCUT_CATEGORIES.map((category) => (
+            {categories.map((category) => (
               <React.Fragment key={category.title}>
                 <tr className="keyboard-shortcuts__category-row">
                   <th scope="rowgroup" colSpan={2}>

--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -86,6 +86,7 @@ vi.mock('./navConfig', () => ({
 vi.mock('../navigation', () => ({
   Breadcrumbs: () => null,
   NavShortcuts: () => null,
+  buildNavShortcutCategory: () => null,
 }));
 
 vi.mock('../../contexts/PrivacyModeContext', () => ({

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -25,7 +25,7 @@ import { BottomNavigation, SidebarNavigation } from './Navigation';
 import { getVisibleNavItems } from './navConfig';
 import { InstallBanner } from '../common/InstallBanner';
 import { LegalLinks } from '../legal/LegalLinks';
-import { Breadcrumbs, NavShortcuts } from '../navigation';
+import { Breadcrumbs, NavShortcuts, buildNavShortcutCategory } from '../navigation';
 
 import { SkipToContent } from './SkipToContent';
 import { EyeIcon, EyeOffIcon } from './navIcons';
@@ -104,6 +104,10 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
   // module-visibility catalogue/hook.
   const hiddenModuleIds = useHiddenModules();
   const shortcutItems = useMemo(() => getVisibleNavItems(isSimplified), [isSimplified]);
+  const navShortcutCategory = useMemo(
+    () => buildNavShortcutCategory(shortcutItems),
+    [shortcutItems],
+  );
   const { showHelp, setShowHelp, singleKeyShortcutsEnabled } = useKeyboardShortcuts({
     onNavigate,
     onNewTransaction: () => onNavigate('/transactions?new=transaction'),
@@ -394,13 +398,12 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
         isOpen={showHelp}
         onClose={closeKeyboardShortcuts}
         singleKeyShortcutsEnabled={singleKeyShortcutsEnabled}
+        extraCategories={navShortcutCategory ? [navShortcutCategory] : undefined}
       />
-      <NavShortcuts
-        isOpen={showHelp}
-        onClose={closeKeyboardShortcuts}
-        onNavigate={onNavigate}
-        items={shortcutItems}
-      />
+      {/* Headless: registers the always-on Ctrl+1..9 nav shortcuts. Its
+          reference list is folded into the single KeyboardShortcutsModal above
+          so "?" opens exactly one dialog (#3329, #3347). */}
+      <NavShortcuts onNavigate={onNavigate} items={shortcutItems} />
       <ConflictResolutionDialog isOpen={showConflicts} onClose={closeConflictDialog} />
       <FeedbackDialog isOpen={showFeedback} onClose={closeFeedbackDialog} />
     </div>

--- a/apps/web/src/components/navigation/NavShortcuts.test.tsx
+++ b/apps/web/src/components/navigation/NavShortcuts.test.tsx
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { NavShortcuts } from './NavShortcuts';
-
-vi.mock('../../accessibility/aria', () => ({
-  useFocusTrap: vi.fn(),
-}));
+import { NavShortcuts, buildNavShortcutCategory } from './NavShortcuts';
 
 const items = [
   { id: 'dashboard', label: 'Dashboard', href: '/dashboard' },
@@ -16,18 +12,15 @@ const items = [
 ] as const;
 
 describe('NavShortcuts', () => {
-  it('renders the locked shortcut order in the overlay', () => {
-    render(<NavShortcuts isOpen={true} onClose={vi.fn()} onNavigate={vi.fn()} items={items} />);
+  it('renders nothing (headless: no competing modal surface)', () => {
+    const { container } = render(<NavShortcuts onNavigate={vi.fn()} items={items} />);
 
-    expect(screen.getByRole('dialog', { name: 'Navigation shortcuts' })).toBeInTheDocument();
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
-    expect(screen.getByText('Accounts')).toBeInTheDocument();
-    expect(screen.getByText('Transactions')).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('navigates with Ctrl+digit shortcuts', () => {
     const onNavigate = vi.fn();
-    render(<NavShortcuts isOpen={false} onClose={vi.fn()} onNavigate={onNavigate} items={items} />);
+    render(<NavShortcuts onNavigate={onNavigate} items={items} />);
 
     fireEvent.keyDown(window, { key: '2', ctrlKey: true });
 
@@ -36,7 +29,7 @@ describe('NavShortcuts', () => {
 
   it('ignores Ctrl+digit shortcuts while typing in an input', () => {
     const onNavigate = vi.fn();
-    render(<NavShortcuts isOpen={false} onClose={vi.fn()} onNavigate={onNavigate} items={items} />);
+    render(<NavShortcuts onNavigate={onNavigate} items={items} />);
 
     const input = document.createElement('input');
     document.body.appendChild(input);
@@ -45,5 +38,23 @@ describe('NavShortcuts', () => {
 
     expect(onNavigate).not.toHaveBeenCalled();
     document.body.removeChild(input);
+  });
+});
+
+describe('buildNavShortcutCategory', () => {
+  it('builds a "Locked navigation" category from the nav items', () => {
+    const category = buildNavShortcutCategory(items);
+
+    expect(category).not.toBeNull();
+    expect(category?.title).toBe('Locked navigation');
+    expect(category?.shortcuts).toHaveLength(3);
+    expect(category?.shortcuts.map((shortcut) => shortcut.keys)).toContain('Ctrl + 1');
+    expect(category?.shortcuts.some((shortcut) => shortcut.description.includes('Accounts'))).toBe(
+      true,
+    );
+  });
+
+  it('returns null when there are no navigation items', () => {
+    expect(buildNavShortcutCategory([])).toBeNull();
   });
 });

--- a/apps/web/src/components/navigation/NavShortcuts.tsx
+++ b/apps/web/src/components/navigation/NavShortcuts.tsx
@@ -1,37 +1,48 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  type FC,
-  type KeyboardEvent as ReactKeyboardEvent,
-} from 'react';
+import { useEffect, useMemo, type FC } from 'react';
 
-import { useFocusTrap } from '../../accessibility/aria';
+import type { ShortcutCategory } from '../../hooks/useKeyboardShortcuts';
 import { buildNavigationShortcuts, isEditableTarget } from '../../lib/navigation/guardrails';
 import { isMuscleMemoryRoute } from '../../lib/navigation/history';
 import type { StableNavItem } from '../../lib/navigation/types';
-import '../forms/forms.css';
 
 export interface NavShortcutsProps {
-  isOpen: boolean;
-  onClose: () => void;
   onNavigate: (path: string) => void;
   items: readonly StableNavItem[];
 }
 
-export const NavShortcuts: FC<NavShortcutsProps> = ({ isOpen, onClose, onNavigate, items }) => {
-  const panelRef = useRef<HTMLDivElement>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const shortcuts = useMemo(() => buildNavigationShortcuts(items), [items]);
+/**
+ * Builds the "Locked navigation" shortcut category (Ctrl+1..9 -> primary
+ * navigation destinations) for display inside the single, consolidated
+ * keyboard-shortcuts help dialog. Returns `null` when there are no navigation
+ * shortcuts to show so callers can omit an empty section.
+ */
+export function buildNavShortcutCategory(items: readonly StableNavItem[]): ShortcutCategory | null {
+  const shortcuts = buildNavigationShortcuts(items);
+  if (shortcuts.length === 0) {
+    return null;
+  }
 
-  useFocusTrap(panelRef, {
-    active: isOpen,
-    restoreFocus: true,
-    initialFocusRef: closeButtonRef,
-  });
+  return {
+    title: 'Locked navigation',
+    shortcuts: shortcuts.map((shortcut) => ({
+      keys: `Ctrl + ${shortcut.digit}`,
+      description: `${shortcut.label}${isMuscleMemoryRoute(shortcut.path) ? ' · frequent' : ''}`,
+    })),
+  };
+}
+
+/**
+ * Registers the always-on Ctrl+1..9 locked-order navigation shortcuts.
+ *
+ * Renders nothing: the shortcut reference is surfaced in the single
+ * {@link KeyboardShortcutsModal} help dialog (via {@link buildNavShortcutCategory}),
+ * so pressing "?" opens exactly one dialog instead of two competing modal
+ * surfaces that trapped focus against each other.
+ */
+export const NavShortcuts: FC<NavShortcutsProps> = ({ onNavigate, items }) => {
+  const shortcuts = useMemo(() => buildNavigationShortcuts(items), [items]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -56,98 +67,5 @@ export const NavShortcuts: FC<NavShortcutsProps> = ({ isOpen, onClose, onNavigat
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [onNavigate, shortcuts]);
 
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [isOpen]);
-
-  const handleKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLDivElement>) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        onClose();
-      }
-    },
-    [onClose],
-  );
-
-  if (!isOpen) {
-    return null;
-  }
-
-  return (
-    <div className="form-dialog nav-shortcuts" role="presentation">
-      <div className="form-dialog__backdrop" aria-hidden="true" onClick={onClose} />
-      <div
-        ref={panelRef}
-        className="form-dialog__panel nav-shortcuts__panel"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="nav-shortcuts-title"
-        aria-describedby="nav-shortcuts-description"
-        onKeyDown={handleKeyDown}
-      >
-        <h2 id="nav-shortcuts-title" className="form-dialog__title">
-          Navigation shortcuts
-        </h2>
-        <p id="nav-shortcuts-description">
-          Ctrl+1 through Ctrl+9 always follow the locked primary navigation order.
-        </p>
-
-        <table className="keyboard-shortcuts__table">
-          <thead>
-            <tr>
-              <th scope="col">Shortcut</th>
-              <th scope="col">Destination</th>
-            </tr>
-          </thead>
-          <tbody>
-            {shortcuts.map((shortcut) => (
-              <tr key={shortcut.path}>
-                <th scope="row">
-                  <kbd className="keyboard-shortcuts__key">Ctrl</kbd>
-                  {' + '}
-                  <kbd className="keyboard-shortcuts__key">{shortcut.digit}</kbd>
-                </th>
-                <td>
-                  {shortcut.label}
-                  {isMuscleMemoryRoute(shortcut.path) ? ' · frequent' : ''}
-                </td>
-              </tr>
-            ))}
-            <tr>
-              <th scope="row">
-                <kbd className="keyboard-shortcuts__key">?</kbd>
-              </th>
-              <td>Open this overlay</td>
-            </tr>
-            <tr>
-              <th scope="row">
-                <kbd className="keyboard-shortcuts__key">Esc</kbd>
-              </th>
-              <td>Close the overlay</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <div className="form-actions keyboard-shortcuts__actions">
-          <button
-            ref={closeButtonRef}
-            type="button"
-            className="form-button form-button--secondary"
-            onClick={onClose}
-          >
-            Close
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+  return null;
 };

--- a/apps/web/src/components/navigation/index.ts
+++ b/apps/web/src/components/navigation/index.ts
@@ -13,7 +13,7 @@ export { Breadcrumb } from './Breadcrumb';
 export type { BreadcrumbProps, BreadcrumbSegment } from './Breadcrumb';
 export { Breadcrumbs } from './Breadcrumbs';
 export type { BreadcrumbsProps } from './Breadcrumbs';
-export { NavShortcuts } from './NavShortcuts';
+export { NavShortcuts, buildNavShortcutCategory } from './NavShortcuts';
 export type { NavShortcutsProps } from './NavShortcuts';
 export { NavigationGuard, NavigationGuardContext } from './NavigationGuard';
 export type { NavigationGuardProps } from './NavigationGuard';


### PR DESCRIPTION
## Summary

Pressing <kbd>?</kbd> mounted **two** `aria-modal="true"` dialogs simultaneously — `KeyboardShortcutsModal` and `NavShortcuts` were both bound to the same `showHelp` state (`AppLayout.tsx`). Two modals open at once means two competing focus traps, two backdrops, and a confusing double announcement for screen-reader users, who cannot tell which dialog owns focus.

This PR consolidates the keyboard-help experience into a **single** dialog.

## Changes

- `NavShortcuts` is now a **headless** component: it keeps only its always-on Ctrl+1–9 locked-order navigation keydown handler and renders nothing. Its redundant modal overlay is removed.
- A new `buildNavShortcutCategory(items)` helper produces a "Locked navigation" shortcut category, exported from the navigation barrel.
- `KeyboardShortcutsModal` accepts an optional `extraCategories` prop and appends them after the built-in categories, so the Ctrl+1–9 reference now lives inside the one comprehensive help dialog.
- `AppLayout` builds the nav category with `useMemo` and passes it to `KeyboardShortcutsModal`; `NavShortcuts` is mounted purely for its keydown behaviour.
- Tests updated: `NavShortcuts.test.tsx` (headless behaviour + `buildNavShortcutCategory`), `KeyboardShortcutsModal.test.tsx` (`extraCategories` render), `AppLayout.test.tsx` mock.

## Issues

Closes #3329
Closes #3347

## WCAG 2.2 AA

- **2.4.3 Focus Order (A)** — a single dialog now owns the focus trap; no competing modal.
- **4.1.2 Name, Role, Value (A)** — exactly one `aria-modal` dialog is exposed at a time, so assistive tech announces one help surface.
- **2.1.1 Keyboard (A)** — the Ctrl+1–9 navigation shortcuts remain fully operable (headless handler preserved) and are documented in the consolidated dialog (#3347).

## Testing

- [x] `npx eslint <files> --max-warnings 0` — clean
- [x] `npx prettier --write <files>` — formatted
- [x] `NavShortcuts.test.tsx`, `KeyboardShortcutsModal.test.tsx`, `AppLayout.test.tsx` — 37/37 pass
- [x] Rebased on `origin/main` before push

Found by persona: Jordan Blake (blind screen-reader + keyboard user)
