### PR TITLE
fix(web): cascade debt payoff surplus and roll freed minimums (#3353, #3354)

### DIFF
--- a/apps/web/src/components/debt/JointDebtPlanner.test.tsx
+++ b/apps/web/src/components/debt/JointDebtPlanner.test.tsx
@@ -50,8 +50,15 @@ describe('JointDebtPlanner', () => {
 
     const avalancheHeader = screen.getByRole('columnheader', { name: /Avalanche/ });
     expect(avalancheHeader.getAttribute('scope')).toBe('col');
-    // Avalanche is recommended for this higher-rate-vs-lower-rate mix.
-    expect(avalancheHeader.textContent).toContain('recommended');
+
+    const snowballHeader = screen.getByRole('columnheader', { name: /Snowball/ });
+    expect(snowballHeader.getAttribute('scope')).toBe('col');
+    // With freed-up minimum payments correctly rolled forward (#3354), avalanche's
+    // interest edge for this small mix ($63.56) stays under the $100 "meaningful
+    // savings" threshold and both strategies clear in the same number of months, so
+    // snowball is recommended for momentum. The badge renders on the recommended
+    // column.
+    expect(snowballHeader.textContent).toContain('recommended');
 
     const rowHeader = screen.getByRole('rowheader', { name: 'Time to debt-free' });
     expect(rowHeader.getAttribute('scope')).toBe('row');

--- a/apps/web/src/lib/debt-payoff-engine.test.ts
+++ b/apps/web/src/lib/debt-payoff-engine.test.ts
@@ -388,6 +388,43 @@ describe('calculateStrategyResult', () => {
       expect(carPaymentAfter).toBeGreaterThan(carPaymentBefore);
     }
   });
+
+  it('cascades surplus onto the next debt within the payoff month', () => {
+    // Card A clears quickly; the large extra payment overshoots its payoff,
+    // and the leftover must cascade onto Card B in the SAME month.
+    const cascadeDebts: Debt[] = [
+      {
+        id: 'a',
+        name: 'Card A',
+        balanceCents: 500_00,
+        annualRateBps: 2299,
+        minimumPaymentCents: 25_00,
+        type: 'credit_card',
+      },
+      {
+        id: 'b',
+        name: 'Card B',
+        balanceCents: 1_200_00,
+        annualRateBps: 1999,
+        minimumPaymentCents: 35_00,
+        type: 'credit_card',
+      },
+    ];
+    const result = calculateStrategyResult(cascadeDebts, 'snowball', 400_00);
+
+    // Without the same-month cascade this reported 5 months; redistributing
+    // the discarded surplus clears the plan a month earlier.
+    expect(result.totalMonths).toBe(4);
+
+    const aSchedule = result.schedules.find((s) => s.debtId === 'a')!;
+    const bSchedule = result.schedules.find((s) => s.debtId === 'b')!;
+    const aPayoffMonth = aSchedule.monthsToPayoff;
+
+    // In the month Card A is cleared, Card B receives far more than its own
+    // minimum because the unused portion of that month's payment cascaded.
+    const bPaymentInPayoffMonth = bSchedule.entries[aPayoffMonth - 1]?.paymentCents ?? 0;
+    expect(bPaymentInPayoffMonth).toBeGreaterThan(35_00);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/debt-payoff-engine.ts
+++ b/apps/web/src/lib/debt-payoff-engine.ts
@@ -206,9 +206,10 @@ export function calculateSnowballOrder(debts: readonly Debt[]): string[] {
 /**
  * Simulates a full multi-debt payoff using the given strategy and extra payment.
  *
- * Extra payment is allocated to the target debt (per strategy ordering).
- * When a debt is paid off, its minimum payment rolls into the extra amount
- * for the next target.
+ * Extra payment is allocated to debts in strategy order. When a debt is
+ * cleared, its minimum rolls into the pool for the next target, and any
+ * money left over in a debt's payoff month cascades onto the next debt in
+ * the same month (a true snowball, with no wasted surplus).
  *
  * @param debts - All debts to include.
  * @param strategy - 'avalanche' or 'snowball'.
@@ -262,32 +263,54 @@ export function calculateStrategyResult(
 
     month++;
 
-    // Find current target debt (first unpaid in order)
-    let targetId: string | null = null;
-    for (const id of orderedIds) {
-      if ((balances.get(id) ?? 0) > 0) {
-        targetId = id;
-        break;
-      }
-    }
+    // Determine this month's interest and each debt's own minimum payment.
+    // Any money beyond a debt's own minimum — the user's extra payment, the
+    // minimums freed by debts cleared in earlier months, and the unused part
+    // of a minimum that over-covers a nearly-paid debt — joins a shared pool
+    // that cascades to debts in strategy order within THIS month.
+    const monthInterest = new Map<string, number>();
+    const monthPayment = new Map<string, number>();
+    let pool = safeExtra + freedUpPayment;
 
-    // Process each debt
     for (const id of orderedIds) {
       const balance = balances.get(id) ?? 0;
       if (balance <= 0) continue;
 
       const debt = debtMap.get(id)!;
       const interestCents = calculateMonthlyInterestCents(balance, debt.annualRateBps);
+      monthInterest.set(id, interestCents);
 
-      // Calculate payment: minimum + extra (if this is the target debt)
-      let payment = debt.minimumPaymentCents;
-      if (id === targetId) {
-        payment += safeExtra + freedUpPayment;
-      }
+      const payoffCents = balance + interestCents;
+      const minPaymentCents = Math.min(debt.minimumPaymentCents, payoffCents);
+      monthPayment.set(id, minPaymentCents);
+      // If the minimum over-covers this debt, the surplus cascades too.
+      pool += debt.minimumPaymentCents - minPaymentCents;
+    }
 
-      // Cap payment at balance + interest
-      payment = Math.min(payment, balance + interestCents);
+    // Cascade the pool across debts in strategy order. When a debt is fully
+    // covered, the leftover immediately flows to the next target this month.
+    for (const id of orderedIds) {
+      if (pool <= 0) break;
+      const balance = balances.get(id) ?? 0;
+      if (balance <= 0) continue;
 
+      const interestCents = monthInterest.get(id) ?? 0;
+      const payoffCents = balance + interestCents;
+      const alreadyCents = monthPayment.get(id) ?? 0;
+      const roomCents = Math.max(0, payoffCents - alreadyCents);
+      const appliedCents = Math.min(pool, roomCents);
+      monthPayment.set(id, alreadyCents + appliedCents);
+      pool -= appliedCents;
+    }
+
+    // Commit payments, update balances, record schedules, and detect payoffs.
+    for (const id of orderedIds) {
+      const balance = balances.get(id) ?? 0;
+      if (balance <= 0) continue;
+
+      const debt = debtMap.get(id)!;
+      const interestCents = monthInterest.get(id) ?? 0;
+      const payment = monthPayment.get(id) ?? 0;
       const principalCents = Math.max(0, payment - interestCents);
       const newBalance = Math.max(0, balance - principalCents);
       balances.set(id, newBalance);
@@ -303,11 +326,10 @@ export function calculateStrategyResult(
         remainingBalanceCents: newBalance,
       });
 
-      // If debt just got paid off
+      // If debt just got paid off, free its minimum for future months.
       if (newBalance <= 0 && balance > 0) {
         payoffMonths.set(id, month);
         payoffOrder.push(id);
-        // Free up this debt's minimum for the next target
         freedUpPayment += debt.minimumPaymentCents;
       }
     }

--- a/apps/web/src/lib/debt/shared-payoff-rules.test.ts
+++ b/apps/web/src/lib/debt/shared-payoff-rules.test.ts
@@ -21,4 +21,18 @@ describe('shared debt payoff rules', () => {
     expect(extra.monthsToPayoff).toBeLessThan(base.monthsToPayoff);
     expect(extra.goalCashFlowFreedCents).toBe(395_00);
   });
+
+  it('rolls freed minimum payments into the next debt (snowball)', () => {
+    // Three debts, +$100/mo. As each debt clears, its minimum must roll into
+    // the next target. Verified against a hand-run snowball: without rolling
+    // this is 27 months / $937.85 interest; rolling clears in 19 / $738.41.
+    const threeDebts = [
+      { id: 'card1', balanceCents: 2000_00, annualRateBps: 2299, minimumPaymentCents: 60_00 },
+      { id: 'card2', balanceCents: 1200_00, annualRateBps: 1899, minimumPaymentCents: 40_00 },
+      { id: 'loan', balanceCents: 800_00, annualRateBps: 999, minimumPaymentCents: 50_00 },
+    ];
+    const rolled = calculateSharedPayoff(threeDebts, 'snowball', 100_00);
+    expect(rolled.monthsToPayoff).toBe(19);
+    expect(rolled.totalInterestCents).toBe(73841);
+  });
 });

--- a/apps/web/src/lib/debt/shared-payoff-rules.ts
+++ b/apps/web/src/lib/debt/shared-payoff-rules.ts
@@ -42,20 +42,60 @@ export function calculateSharedPayoff(
   customOrder: readonly string[] = [],
 ): SharedPayoffResult {
   const balances = new Map(debts.map((debt) => [debt.id, debt.balanceCents]));
+  const debtById = new Map(debts.map((debt) => [debt.id, debt]));
   const order = orderDebts(debts, strategy, customOrder);
+  const safeExtra = Math.max(0, extraPaymentCents);
   let totalInterestCents = 0;
   let monthsToPayoff = 0;
+  let freedUpPaymentCents = 0;
 
   while ([...balances.values()].some((balance) => balance > 0) && monthsToPayoff < 600) {
     monthsToPayoff += 1;
-    const activeTarget = order.find((id) => (balances.get(id) ?? 0) > 0);
-    for (const debt of debts) {
-      const balance = balances.get(debt.id) ?? 0;
+
+    // Accrue interest and pay each debt's own minimum first. The extra
+    // payment, minimums freed by debts cleared in earlier months, and any
+    // surplus of an over-covering minimum form a pool that snowballs onto
+    // debts in strategy order within this month.
+    const monthInterest = new Map<string, number>();
+    const monthPayment = new Map<string, number>();
+    let pool = safeExtra + freedUpPaymentCents;
+
+    for (const id of order) {
+      const balance = balances.get(id) ?? 0;
       if (balance <= 0) continue;
+      const debt = debtById.get(id)!;
       const interest = monthlyInterest(balance, debt.annualRateBps);
       totalInterestCents += interest;
-      const payment = debt.minimumPaymentCents + (debt.id === activeTarget ? extraPaymentCents : 0);
-      balances.set(debt.id, Math.max(0, balance + interest - payment));
+      monthInterest.set(id, interest);
+      const payoff = balance + interest;
+      const minPayment = Math.min(debt.minimumPaymentCents, payoff);
+      monthPayment.set(id, minPayment);
+      pool += debt.minimumPaymentCents - minPayment;
+    }
+
+    for (const id of order) {
+      if (pool <= 0) break;
+      const balance = balances.get(id) ?? 0;
+      if (balance <= 0) continue;
+      const payoff = balance + (monthInterest.get(id) ?? 0);
+      const already = monthPayment.get(id) ?? 0;
+      const room = Math.max(0, payoff - already);
+      const applied = Math.min(pool, room);
+      monthPayment.set(id, already + applied);
+      pool -= applied;
+    }
+
+    for (const id of order) {
+      const balance = balances.get(id) ?? 0;
+      if (balance <= 0) continue;
+      const interest = monthInterest.get(id) ?? 0;
+      const payment = monthPayment.get(id) ?? 0;
+      const newBalance = Math.max(0, balance + interest - payment);
+      balances.set(id, newBalance);
+      // When a debt is cleared, roll its minimum into future months.
+      if (newBalance <= 0 && balance > 0) {
+        freedUpPaymentCents += debtById.get(id)!.minimumPaymentCents;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Two debt-payoff calculation bugs that make a snowball/avalanche plan look slower and more expensive than it really is — exactly the numbers an aggressive debt-payoff user relies on to stay motivated.

### Bug 1 — single-user engine discards mid-month surplus (#3353)

`calculateStrategyResult` capped each month's target payment at that debt's own payoff amount and threw away the surplus. When a debt cleared mid-month, the leftover (extra + freed minimums beyond the payoff figure) was **not** redistributed to the next debt until the following month.

### Bug 2 — joint planner never rolls freed minimums (#3354)

`calculateSharedPayoff` (the couples/joint planner) applied `minimum + extra` to the active target every month but **never** added the minimums freed by already-paid-off debts. The snowball did not snowball.

## Changes

- **`debt-payoff-engine.ts`** — `calculateStrategyResult` now uses a two-pass monthly allocation: pay each debt's own minimum first, then cascade a shared pool (user extra + freed minimums + surplus of an over-covering minimum) across debts in strategy order **within the same month**.
- **`shared-payoff-rules.ts`** — `calculateSharedPayoff` now accumulates a `freedUpPaymentCents` pool and applies the same two-pass cascade, so cleared debts roll their minimum forward.
- Tests: engine surplus cascade (`$500` + `$1,200`, +`$400` extra → **4 months**, was 5) and joint rolling (three debts, +`$100` → **19 months / $738.41**, was 27 / $937.85).

## Issues

Closes #3353
Closes #3354

## Testing

- [x] `vitest run` on both suites — 53 passed (2 new)
- [x] `prettier --check` + `eslint --max-warnings 0` on all changed files — clean
- [x] Numbers cross-checked with a standalone Node replica of both corrected algorithms

Return shapes are unchanged, so all existing consumers (`joint-debt-planner.ts`, DebtPage) keep working — the only difference is faster/cheaper (correct) projections.

Found by persona: Marcus Johnson (aggressive debt-payoff)
