### PR TITLE
fix(web): Cash Flow a11y and date formatting (#3213, #3220, #3221)

### DIFF
--- a/apps/web/src/pages/CashFlowPage.test.tsx
+++ b/apps/web/src/pages/CashFlowPage.test.tsx
@@ -144,7 +144,7 @@ describe('CashFlowPage', () => {
     expect(screen.getByText('Export CSV')).toBeInTheDocument();
   });
 
-  it('renders period selector tabs', () => {
+  it('renders period selector options', () => {
     mockUseCashFlow.mockReturnValue({
       aggregates: [{ month: '2024-01', income: 100000, expenses: 50000, netIncome: 50000 }],
       summary: {
@@ -164,8 +164,9 @@ describe('CashFlowPage', () => {
     });
 
     render(<CashFlowPage />);
-    expect(screen.getByRole('tab', { name: '6M' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: '12M' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: '24M' })).toBeInTheDocument();
+    expect(screen.getByRole('radiogroup', { name: 'Time period' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '6M' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '12M' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '24M' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/CashFlowPage.tsx
+++ b/apps/web/src/pages/CashFlowPage.tsx
@@ -47,21 +47,62 @@ function formatLocalDate(date: Date): string {
   ).padStart(2, '0')}`;
 }
 
-const PeriodSelector: React.FC<PeriodSelectorProps> = ({ value, onChange }) => (
-  <div className="analytics-period-selector" role="tablist" aria-label="Time period">
-    {PERIOD_OPTIONS.map((opt) => (
-      <button
-        key={opt}
-        role="tab"
-        aria-selected={value === opt}
-        className={`analytics-period-selector__btn ${value === opt ? 'analytics-period-selector__btn--active' : ''}`}
-        onClick={() => onChange(opt)}
-      >
-        {opt}M
-      </button>
-    ))}
-  </div>
-);
+/**
+ * Format an ISO `YYYY-MM-DD` string for display (e.g. "Mar 20, 2025").
+ *
+ * Parsed as a local date (not UTC) so the day does not shift in negative
+ * timezone offsets. Falls back to the raw string if it cannot be parsed.
+ */
+function formatDisplayDate(iso: string): string {
+  const [year, month, day] = iso.split('-').map(Number);
+  if (!year || !month || !day) {
+    return iso;
+  }
+  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+const PeriodSelector: React.FC<PeriodSelectorProps> = ({ value, onChange }) => {
+  // Roving-focus arrow-key handling for the radiogroup single-select pattern.
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex: number | null = null;
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      nextIndex = (index + 1) % PERIOD_OPTIONS.length;
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      nextIndex = (index - 1 + PERIOD_OPTIONS.length) % PERIOD_OPTIONS.length;
+    }
+    if (nextIndex === null) {
+      return;
+    }
+    event.preventDefault();
+    onChange(PERIOD_OPTIONS[nextIndex]);
+  };
+
+  return (
+    <div className="analytics-period-selector" role="radiogroup" aria-label="Time period">
+      {PERIOD_OPTIONS.map((opt, index) => {
+        const selected = value === opt;
+        return (
+          <button
+            key={opt}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            tabIndex={selected ? 0 : -1}
+            className={`analytics-period-selector__btn ${selected ? 'analytics-period-selector__btn--active' : ''}`}
+            onClick={() => onChange(opt)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
+          >
+            {opt}M
+          </button>
+        );
+      })}
+    </div>
+  );
+};
 
 interface IncomeExpenseChartProps {
   aggregates: MonthlyAggregate[];
@@ -224,9 +265,9 @@ export const CashFlowPage: React.FC = () => {
             gap: 'var(--spacing-2)',
           }}
         >
-          <h2 className="analytics-page__title" style={{ margin: 0 }}>
+          <h1 className="analytics-page__title" style={{ margin: 0 }}>
             Cash Flow
-          </h2>
+          </h1>
           <ExplainThis glossaryKey="cashFlow" buttonLabel="Explain cash flow" />
         </div>
         <div className="analytics-page__actions">
@@ -258,7 +299,7 @@ export const CashFlowPage: React.FC = () => {
           </article>
           <article className="analytics-metric-card" aria-label="Lowest projected balance">
             <p className="analytics-metric-card__label">
-              Lowest balance ({monthEndForecast.lowestBalanceDate})
+              Lowest balance ({formatDisplayDate(monthEndForecast.lowestBalanceDate)})
             </p>
             <p
               className={`analytics-metric-card__value ${


### PR DESCRIPTION
## Summary

Accessibility and formatting fixes for the **Cash Flow** analytics page, found while
testing as a freelance / irregular-income persona (Diego Ramirez).

## Changes

- **#3213** — The Cash Flow page title is now a page-level `<h1>` (was `<h2>`), restoring
  the heading hierarchy so screen readers and route-change focus get a correct document
  outline. Matches sibling analytics pages (Invoices, Business P&L, etc.).
- **#3220** — The period selector no longer uses an incomplete `role="tablist"`/`role="tab"`
  pattern (there was no `tabpanel` or `aria-controls`). It is now a proper
  `role="radiogroup"` of `role="radio"` options with `aria-checked`, roving `tabindex`, and
  arrow-key navigation.
- **#3221** — The "Lowest projected balance" date is formatted for display (e.g.
  "Mar 20, 2025") instead of a raw ISO `YYYY-MM-DD` string, matching the rest of the app.

## Issues

Closes #3213
Closes #3220
Closes #3221

## Testing

- `npx prettier --check` — clean
- `npx eslint --max-warnings 0` — clean
- `npx vitest run src/pages/CashFlowPage.test.tsx` — 5/5 pass (updated the period-selector
  test to assert the corrected `radio` role)

## Cross-Platform Scope

Web-only. The Cash Flow analytics page is a web PWA screen; iOS/Android/Windows do not
ship it.

Found by persona: Diego Ramirez (freelance-designer irregular-income)
