### PR TITLE
fix(web): add page-level h1 to Net Worth and Categories (#3252)

### DIFF
--- a/apps/web/src/pages/CategoriesPage.test.tsx
+++ b/apps/web/src/pages/CategoriesPage.test.tsx
@@ -226,7 +226,7 @@ describe('CategoriesPage', () => {
   it('renders the category list with icon and color details', () => {
     render(<CategoriesPage />);
 
-    expect(screen.getByRole('heading', { name: 'Categories' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Categories', level: 1 })).toBeInTheDocument();
     expect(screen.getByText('Food')).toBeInTheDocument();
     expect(screen.getByText('Income')).toBeInTheDocument();
     expect(screen.getByText('Utilities')).toBeInTheDocument();

--- a/apps/web/src/pages/CategoriesPage.tsx
+++ b/apps/web/src/pages/CategoriesPage.tsx
@@ -183,7 +183,7 @@ export const CategoriesPage: React.FC = () => {
 
   const pageHeader = (
     <div className="page-header">
-      <h2 className="page-heading">Categories</h2>
+      <h1 className="page-heading">Categories</h1>
       <button
         type="button"
         className="form-button form-button--primary"

--- a/apps/web/src/pages/NetWorthPage.test.tsx
+++ b/apps/web/src/pages/NetWorthPage.test.tsx
@@ -127,7 +127,7 @@ describe('NetWorthPage', () => {
     });
 
     render(<NetWorthPage />);
-    expect(screen.getByRole('heading', { name: 'Net Worth', level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Net Worth', level: 1 })).toBeInTheDocument();
     expect(screen.getByLabelText('Net worth summary')).toBeInTheDocument();
     expect(screen.getByText('Asset Class Breakdown')).toBeInTheDocument();
     expect(screen.getByText('Milestones')).toBeInTheDocument();

--- a/apps/web/src/pages/NetWorthPage.tsx
+++ b/apps/web/src/pages/NetWorthPage.tsx
@@ -144,9 +144,9 @@ export const NetWorthPage: React.FC = () => {
             gap: 'var(--spacing-2)',
           }}
         >
-          <h2 className="analytics-page__title" style={{ margin: 0 }}>
+          <h1 className="analytics-page__title" style={{ margin: 0 }}>
             Net Worth
-          </h2>
+          </h1>
           <ExplainThis glossaryKey="netWorth" />
         </div>
       </div>


### PR DESCRIPTION
## Summary

On desktop viewports (≥768px) the mobile `.app-header` — which renders the page-level
`<h1>` — is hidden by `responsive.css`. The Net Worth and Categories pages led their main
content with an `<h2>`, so on desktop these pages had **no `<h1>` at all**, leaving
screen-reader users without a document-title landmark (WCAG 2.4.6 Headings and Labels,
1.3.1 Info and Relationships).

This is a direct follow-up to #3203, which promoted the other advanced pages
(Invoices, Remittances, Tax Center, etc.) to a page-level `<h1>` but missed Net Worth and
Categories. As Priya, these are two of the pages I use most (category margins and
multi-account net worth), so they should be navigable by heading like the rest.

## Changes

- **NetWorthPage**: promote the "Net Worth" title from `<h2>` to `<h1>` (keeps the same
  `analytics-page__title` class already styled as the page headline).
- **CategoriesPage**: promote the "Categories" title from `<h2>` to `<h1>` (same
  `page-heading` class).
- **Tests**: update/strengthen both page tests to assert the title is `level: 1`.

No visual change — both classes were already styled as the headline; only the semantic
heading level changes.

## Issues

Closes #3252

## Testing

- [x] `npx vitest run src/pages/NetWorthPage.test.tsx src/pages/CategoriesPage.test.tsx` — 14 passed
- [x] `npx eslint <changed files> --max-warnings 0` — clean
- [x] `npx prettier --check <changed files>` — clean

Found by persona: Priya Sharma (etsy small-business owner)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
