### PR TITLE
fix(web): unify savings-rate precision + full past-month windows (#3307)

### DIFF
--- a/apps/web/src/hooks/useInsights.ts
+++ b/apps/web/src/hooks/useInsights.ts
@@ -26,6 +26,7 @@ import {
   type CategoryDrillDown,
   type SpendingTrendInsight,
 } from '../lib/reports/reporting-beta';
+import { computeSavingsRatePercent } from '../lib/savings/savings-rate-format';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -664,10 +665,7 @@ export function useInsights(): UseInsightsResult {
         daysElapsed > 0 ? Math.round(totalSpentThisMonth / daysElapsed) : 0;
 
       const netCashFlow = totalIncomeThisMonth - totalSpentThisMonth;
-      const savingsRate =
-        totalIncomeThisMonth > 0
-          ? Math.round(((totalIncomeThisMonth - totalSpentThisMonth) / totalIncomeThisMonth) * 100)
-          : 0;
+      const savingsRate = computeSavingsRatePercent(totalIncomeThisMonth, totalSpentThisMonth);
 
       const topCategories = categorySpending.slice(0, 5);
       const recommendations = generateRecommendations(

--- a/apps/web/src/lib/dashboard/savings-rate-summary.ts
+++ b/apps/web/src/lib/dashboard/savings-rate-summary.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import { computeSavingsRatePercent } from '../savings/savings-rate-format';
+
 export interface MonthlyCashFlow {
   readonly month: string;
   readonly incomeCents: number;
@@ -29,8 +31,7 @@ function summarize(month: string, rows: readonly MonthlyCashFlow[]): SavingsRate
     incomeCents,
     expenseCents,
     savingsCents,
-    savingsRatePercent:
-      incomeCents === 0 ? 0 : Math.round((savingsCents / incomeCents) * 10000) / 100,
+    savingsRatePercent: computeSavingsRatePercent(incomeCents, expenseCents),
   };
 }
 

--- a/apps/web/src/lib/insights/helpers.ts
+++ b/apps/web/src/lib/insights/helpers.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { DigestPeriod, MetricChange, TrendDirection } from './types';
+import { computeSavingsRatePercent } from '../savings/savings-rate-format';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -71,14 +72,21 @@ function addDays(date: Date, days: number): Date {
   return new Date(date.getTime() + days * MS_PER_DAY);
 }
 
-function makeMonthWindow(baseDate: Date, dayOfMonth: number): PeriodWindow {
+/**
+ * Build a calendar-month window.
+ *
+ * @param baseDate - Any date within the target month
+ * @param endDay - Optional day-of-month to end at (for a month-to-date window).
+ *   When omitted, the window spans the **full** month (its last day). Only the
+ *   in-progress current month should be month-to-date; completed past months
+ *   must use the full month or their income/spend — and the savings rate
+ *   derived from them — is understated.
+ */
+function makeMonthWindow(baseDate: Date, endDay?: number): PeriodWindow {
   const startDate = new Date(baseDate.getFullYear(), baseDate.getMonth(), 1);
   const lastDay = new Date(baseDate.getFullYear(), baseDate.getMonth() + 1, 0).getDate();
-  const endDate = new Date(
-    baseDate.getFullYear(),
-    baseDate.getMonth(),
-    Math.min(dayOfMonth, lastDay),
-  );
+  const endDayOfMonth = endDay === undefined ? lastDay : Math.min(endDay, lastDay);
+  const endDate = new Date(baseDate.getFullYear(), baseDate.getMonth(), endDayOfMonth);
 
   return {
     label: startDate.toLocaleDateString('en-US', { month: 'short' }),
@@ -110,7 +118,8 @@ export function buildPeriodWindows(
   return Array.from({ length: count }, (_unused, index) => {
     const monthOffset = count - index - 1;
     const monthDate = new Date(now.getFullYear(), now.getMonth() - monthOffset, 1);
-    return makeMonthWindow(monthDate, dayOfMonth);
+    // Only the current month (offset 0) is month-to-date; past months are full.
+    return makeMonthWindow(monthDate, monthOffset === 0 ? dayOfMonth : undefined);
   });
 }
 
@@ -125,9 +134,5 @@ export function getMonthToDateWindows(now: Date): {
 }
 
 export function calculateRate(income: number, spending: number): number {
-  if (income <= 0) {
-    return 0;
-  }
-
-  return roundToOne(((income - spending) / income) * 100);
+  return computeSavingsRatePercent(income, spending);
 }

--- a/apps/web/src/lib/insights/savingsRate.test.ts
+++ b/apps/web/src/lib/insights/savingsRate.test.ts
@@ -87,4 +87,31 @@ describe('analyzeSavingsRate', () => {
     expect(analysis.change.direction).toBe('up');
     expect(analysis.history).toHaveLength(6);
   });
+
+  it('counts a full completed month even when a paycheck posts after today (#3308)', () => {
+    // Clock is the 6th; last month's income/spend land on the 15th and 20th.
+    const transactions = [
+      makeTransaction({
+        id: 'income-prev',
+        type: 'INCOME',
+        amount: { amount: 100_000 },
+        date: '2025-01-15',
+      }),
+      makeTransaction({
+        id: 'expense-prev',
+        type: 'EXPENSE',
+        amount: { amount: -40_000 },
+        date: '2025-01-20',
+      }),
+    ];
+
+    const analysis = analyzeSavingsRate(transactions, 'monthly', new Date('2025-02-06T12:00:00Z'));
+    const january = analysis.history.find((entry) => entry.label === 'Jan');
+
+    // A truncated Jan 1-6 window would miss both and report $0 income / 0% rate.
+    expect(january?.income).toBe(100_000);
+    expect(january?.spending).toBe(40_000);
+    expect(january?.rate).toBe(60);
+    expect(analysis.previousRate).toBe(60);
+  });
 });

--- a/apps/web/src/lib/savings/savings-rate-format.test.ts
+++ b/apps/web/src/lib/savings/savings-rate-format.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import {
+  SAVINGS_RATE_DECIMAL_PLACES,
+  computeSavingsRatePercent,
+  roundSavingsRatePercent,
+} from './savings-rate-format';
+import { calculateRate } from '../insights/helpers';
+import { buildSavingsRateDashboardSummary } from '../dashboard/savings-rate-summary';
+
+describe('roundSavingsRatePercent', () => {
+  it('rounds to a single decimal place', () => {
+    expect(SAVINGS_RATE_DECIMAL_PLACES).toBe(1);
+    expect(roundSavingsRatePercent(54.72)).toBe(54.7);
+    expect(roundSavingsRatePercent(54.75)).toBe(54.8);
+    expect(roundSavingsRatePercent(55)).toBe(55);
+  });
+});
+
+describe('computeSavingsRatePercent', () => {
+  it('computes a one-decimal rate from income and spend', () => {
+    // (100000 - 45280) / 100000 = 54.72% -> 54.7%
+    expect(computeSavingsRatePercent(100_000, 45_280)).toBe(54.7);
+  });
+
+  it('returns 0 when there is no income', () => {
+    expect(computeSavingsRatePercent(0, 100)).toBe(0);
+    expect(computeSavingsRatePercent(-50, 100)).toBe(0);
+  });
+
+  it('allows a negative rate when overspending', () => {
+    expect(computeSavingsRatePercent(100, 150)).toBe(-50);
+  });
+});
+
+describe('savings-rate precision is consistent across surfaces', () => {
+  it('insights calculateRate and the dashboard summary agree for identical income/spend', () => {
+    const incomeCents = 100_000;
+    const expenseCents = 45_280;
+
+    const insightsRate = calculateRate(incomeCents, expenseCents);
+    const dashboard = buildSavingsRateDashboardSummary(
+      [{ month: '2025-01', incomeCents, expenseCents }],
+      '2025-01',
+    );
+
+    const expected = computeSavingsRatePercent(incomeCents, expenseCents);
+    expect(insightsRate).toBe(expected);
+    expect(dashboard.current?.savingsRatePercent).toBe(expected);
+    // The regression this guards: 54.7 vs 54.72 vs 55 on different screens.
+    expect(insightsRate).toBe(dashboard.current?.savingsRatePercent);
+  });
+});

--- a/apps/web/src/lib/savings/savings-rate-format.ts
+++ b/apps/web/src/lib/savings/savings-rate-format.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Shared savings-rate percentage math and formatting.
+ *
+ * The savings rate is surfaced on the dashboard card, the `/insights` summary,
+ * and the weekly/monthly digest. Each surface used to round it differently
+ * (whole percent, one decimal, two decimals), so the same period could read as
+ * `55%`, `54.7%`, and `54.72%`. Every surface now rounds through the single
+ * convention defined here.
+ */
+
+/** Canonical display precision for savings-rate percentages, app-wide. */
+export const SAVINGS_RATE_DECIMAL_PLACES = 1;
+
+const SAVINGS_RATE_ROUNDING_FACTOR = 10 ** SAVINGS_RATE_DECIMAL_PLACES;
+
+/**
+ * Round a savings-rate percentage to the shared app-wide precision.
+ *
+ * @param value - A percentage value (e.g. `54.72`)
+ * @returns The value rounded to {@link SAVINGS_RATE_DECIMAL_PLACES} (e.g. `54.7`)
+ */
+export function roundSavingsRatePercent(value: number): number {
+  return Math.round(value * SAVINGS_RATE_ROUNDING_FACTOR) / SAVINGS_RATE_ROUNDING_FACTOR;
+}
+
+/**
+ * Compute a savings-rate percentage from income and spend, rounded to the
+ * shared app-wide precision.
+ *
+ * Works with any consistent unit (integer cents or major units) since it is a
+ * ratio. Returns `0` when there is no income (division guarded upstream).
+ *
+ * @param income - Total income for the period (income and spend in the same unit)
+ * @param spending - Total spending for the period
+ * @returns Savings rate as a percentage rounded to {@link SAVINGS_RATE_DECIMAL_PLACES}
+ */
+export function computeSavingsRatePercent(income: number, spending: number): number {
+  if (income <= 0) {
+    return 0;
+  }
+  return roundSavingsRatePercent(((income - spending) / income) * 100);
+}


### PR DESCRIPTION
## Summary

Fixes two `/insights` savings-rate defects a FIRE optimizer relies on for trustworthy trend data.

## Changes

- **Past-month window truncation (#3308):** `buildPeriodWindows` cut **every** monthly window off at today's day-of-month, so completed past months only counted their first N days. A paycheck that posts after today's date could make a prior month show `$0` income and a `0%` (or negative) savings rate. `makeMonthWindow` now spans the **full** month for completed months; only the in-progress current month stays month-to-date. The intentional MTD-vs-MTD comparison in `getMonthToDateWindows` is unchanged.
- **Inconsistent precision (#3307):** the savings rate rounded to a **whole** percent in `useInsights`, **one** decimal in the digest, and **two** decimals on the dashboard card — the same period read as `55%` / `54.7%` / `54.72%`. Added a single shared `computeSavingsRatePercent` / `roundSavingsRatePercent` helper (`apps/web/src/lib/savings/savings-rate-format.ts`, one decimal) and routed all three surfaces through it.

## Testing

- `npx vitest run` on `savings-rate-format`, `savingsRate`, and `savings-rate-summary` — 16 passed (incl. a past-month full-window regression test and a cross-surface consistency test).
- Full `src/lib/insights` + `src/lib/dashboard` suites — 58 passed (no regressions).
- `npx prettier --check` + `npx eslint --max-warnings 0` on changed files — clean.

## Issues

Closes #3307
Closes #3308

Found by persona: Sam Rivera (FIRE optimizer)
