### PR TITLE
fix(web): disclose simulated prices, untracked realized P&L, and excluded currencies in Live P&L (#3243)

### DIFF
--- a/apps/web/src/components/dashboard/LivePnlDashboard.test.tsx
+++ b/apps/web/src/components/dashboard/LivePnlDashboard.test.tsx
@@ -141,4 +141,80 @@ describe('LivePnlDashboard', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('feed down');
     expect(screen.getByText('Paused')).toBeInTheDocument();
   });
+
+  it('discloses simulated prices when isSimulated is set', () => {
+    render(
+      <LivePnlDashboard
+        view={viewFor(110_00)}
+        isLive
+        isSimulated
+        onRefresh={() => {}}
+        now={nowMs}
+      />,
+    );
+    expect(screen.getByText(/simulated/i)).toBeInTheDocument();
+    expect(screen.getByText(/not real quotes/i)).toBeInTheDocument();
+  });
+
+  it('does not disclose simulation when prices come from a real feed', () => {
+    render(
+      <LivePnlDashboard
+        view={viewFor(110_00)}
+        isLive
+        isSimulated={false}
+        onRefresh={() => {}}
+        now={nowMs}
+      />,
+    );
+    expect(screen.queryByText(/not real quotes/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a "not tracked" realized card instead of a misleading $0 when realized is untracked', () => {
+    render(
+      <LivePnlDashboard
+        view={viewFor(110_00)}
+        isLive
+        realizedTracked={false}
+        onRefresh={() => {}}
+        now={nowMs}
+      />,
+    );
+    const realizedCard = screen.getByLabelText('Realized profit and loss');
+    expect(within(realizedCard).getByText(/isn't tracked yet/i)).toBeInTheDocument();
+    expect(
+      within(realizedCard).getByLabelText(/Realized profit and loss today: not tracked/i),
+    ).toBeInTheDocument();
+  });
+
+  it('discloses positions excluded for currency mismatch', () => {
+    const mixedView = buildLivePnlView({
+      positions: [
+        ...positions,
+        {
+          accountId: 'eu',
+          brokerage: 'Beta',
+          symbol: 'SAP',
+          assetClass: 'equity',
+          quantity: 5,
+          previousCloseCents: 120_00,
+          costBasisCents: 500_00,
+          currency: 'EUR',
+        },
+      ],
+      quotes: [quote(110_00)],
+      baseAccounts,
+      now: NOW,
+      currency: 'USD',
+      lastUpdated: NOW,
+    });
+    render(<LivePnlDashboard view={mixedView} isLive onRefresh={() => {}} now={nowMs} />);
+    const notice = screen.getByText(/excluded from these USD totals/i);
+    expect(notice).toBeInTheDocument();
+    expect(notice).toHaveTextContent('EUR');
+  });
+
+  it('discloses that day P&L is measured from the last saved price', () => {
+    render(<LivePnlDashboard view={viewFor(110_00)} isLive onRefresh={() => {}} now={nowMs} />);
+    expect(screen.getByText(/last saved price/i)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/dashboard/LivePnlDashboard.tsx
+++ b/apps/web/src/components/dashboard/LivePnlDashboard.tsx
@@ -37,6 +37,14 @@ export interface LivePnlDashboardProps {
   view: LivePnlView;
   /** Whether the price source is currently streaming. */
   isLive: boolean;
+  /** True when quotes are simulated (offline demo) rather than a real feed. */
+  isSimulated?: boolean;
+  /**
+   * Whether intraday realized P&L is actually sourced. When `false` the card
+   * discloses that closed-trade P&L isn't tracked yet instead of showing a
+   * misleading $0.00.
+   */
+  realizedTracked?: boolean;
   /** Last price-source error, if any. */
   error?: string | null;
   /** Invoked when the user requests an immediate refresh. */
@@ -214,6 +222,8 @@ const ASSET_CLASS_LABEL: Record<string, string> = {
 export const LivePnlDashboard: React.FC<LivePnlDashboardProps> = ({
   view,
   isLive,
+  isSimulated = false,
+  realizedTracked = true,
   error,
   onRefresh,
   now,
@@ -223,6 +233,8 @@ export const LivePnlDashboard: React.FC<LivePnlDashboardProps> = ({
   const updatedLabel =
     ageMs === null ? 'Awaiting first update' : `Updated ${formatRelativeAge(ageMs)}`;
   const { currency } = view;
+  const excludedCurrencies = view.report.excludedCurrencies;
+  const excludedCount = view.report.excludedSymbols.length;
 
   // Concise summary announced to assistive tech whenever totals change.
   const liveSummary = `${view.indicators.day.label === 'flat' ? 'No change' : `Day ${view.indicators.day.label}`} ${view.dayPnlPercent}%. ${updatedLabel}. Market data ${view.staleness.label}.`;
@@ -260,6 +272,23 @@ export const LivePnlDashboard: React.FC<LivePnlDashboardProps> = ({
       {error && (
         <p className="live-pnl__error" role="alert">
           <span aria-hidden="true">⚠</span> {error}
+        </p>
+      )}
+
+      {isSimulated && (
+        <p className="live-pnl__notice live-pnl__notice--info" role="note">
+          <span aria-hidden="true">ⓘ</span> Prices are <strong>simulated</strong> for demonstration.
+          This dashboard illustrates intraday movement without a live market-data feed — figures are
+          not real quotes.
+        </p>
+      )}
+
+      {excludedCount > 0 && (
+        <p className="live-pnl__notice live-pnl__notice--warning" role="note">
+          <span aria-hidden="true">⚠</span> {excludedCount} position
+          {excludedCount === 1 ? '' : 's'} priced in {excludedCurrencies.join(', ')}{' '}
+          {excludedCurrencies.length === 1 ? 'is' : 'are'} excluded from these {currency} totals.
+          Multi-currency roll-up is not yet converted.
         </p>
       )}
 
@@ -322,18 +351,39 @@ export const LivePnlDashboard: React.FC<LivePnlDashboardProps> = ({
 
         <article className="live-pnl__metric" aria-label="Realized profit and loss">
           <p className="live-pnl__metric-label">Realized P&amp;L (today)</p>
-          <p className="live-pnl__metric-value">
-            <PnlFigure
-              amountCents={view.realizedPnlCents}
-              indicator={view.indicators.realized}
-              currency={currency}
-              context="realized profit and loss today"
-              showTag
-            />
-          </p>
-          <p className="live-pnl__metric-sub">Closed trades booked today</p>
+          {realizedTracked ? (
+            <>
+              <p className="live-pnl__metric-value">
+                <PnlFigure
+                  amountCents={view.realizedPnlCents}
+                  indicator={view.indicators.realized}
+                  currency={currency}
+                  context="realized profit and loss today"
+                  showTag
+                />
+              </p>
+              <p className="live-pnl__metric-sub">Closed trades booked today</p>
+            </>
+          ) : (
+            <>
+              <p
+                className="live-pnl__metric-value live-pnl__metric-value--muted"
+                aria-label="Realized profit and loss today: not tracked"
+              >
+                —
+              </p>
+              <p className="live-pnl__metric-sub">
+                Intraday realized P&amp;L isn&apos;t tracked yet
+              </p>
+            </>
+          )}
         </article>
       </section>
+
+      <p className="live-pnl__footnote">
+        Today&apos;s P&amp;L is measured from each holding&apos;s last saved price, which may differ
+        from the official previous close.
+      </p>
 
       {/* Breakdowns */}
       <section className="live-pnl__section" aria-label="Profit and loss by brokerage">

--- a/apps/web/src/components/dashboard/live-pnl-dashboard.css
+++ b/apps/web/src/components/dashboard/live-pnl-dashboard.css
@@ -166,6 +166,34 @@
 }
 
 /* ---------------------------------------------------------------------------
+ * Disclosure notices (simulated data, excluded currencies)
+ * ------------------------------------------------------------------------- */
+
+.live-pnl__notice {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+  border-radius: var(--border-radius-sm);
+  border: 1px solid var(--semantic-border-default);
+  background: var(--semantic-background-elevated);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.live-pnl__notice--warning {
+  border-color: var(--semantic-status-warning);
+  color: var(--semantic-status-warning);
+}
+
+.live-pnl__footnote {
+  margin: calc(-1 * var(--spacing-4)) 0 var(--spacing-6);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+/* ---------------------------------------------------------------------------
  * Metric cards
  * ------------------------------------------------------------------------- */
 
@@ -194,6 +222,10 @@
   font-weight: var(--font-weight-semibold);
   color: var(--semantic-text-primary);
   margin: 0;
+}
+
+.live-pnl__metric-value--muted {
+  color: var(--semantic-text-secondary);
 }
 
 .live-pnl__metric-sub {

--- a/apps/web/src/hooks/useLivePnl.test.tsx
+++ b/apps/web/src/hooks/useLivePnl.test.tsx
@@ -220,4 +220,17 @@ describe('useLivePnl', () => {
     });
     expect(spy).toHaveBeenCalled();
   });
+
+  it('flags an injected (real) source as not simulated', () => {
+    const source = new ManualPriceSource({ now: () => NOW });
+    const { result } = renderHook(() => useLivePnl({ source, now: () => NOW }));
+    expect(result.current.isSimulated).toBe(false);
+  });
+
+  it('flags the default offline source as simulated', () => {
+    const { result } = renderHook(() =>
+      useLivePnl({ autoStart: false, now: () => NOW, baseCurrency: 'USD' }),
+    );
+    expect(result.current.isSimulated).toBe(true);
+  });
 });

--- a/apps/web/src/hooks/useLivePnl.ts
+++ b/apps/web/src/hooks/useLivePnl.ts
@@ -65,6 +65,12 @@ export interface UseLivePnlResult {
   error: string | null;
   /** Whether the price source is currently emitting updates. */
   isLive: boolean;
+  /**
+   * `true` when quotes come from the built-in offline price simulation rather
+   * than a real market-data feed, so the UI can disclose that figures are demo
+   * values. `false` once a real vendor source is injected.
+   */
+  isSimulated: boolean;
   /** ISO timestamp of the most recent price update, or `null`. */
   lastUpdated: string | null;
   /** Force an immediate price refresh. */
@@ -195,6 +201,11 @@ export function useLivePnl(options: UseLivePnlOptions = {}): UseLivePnlResult {
     stalenessTickMs = 5_000,
   } = options;
 
+  // The shipped web app never injects a source, so it always runs on the
+  // offline simulation. A caller (vendor adapter / test) that injects a source
+  // is treated as a real feed.
+  const isSimulated = injectedSource === undefined;
+
   const { investments, loading: investmentsLoading } = useInvestments();
   const { accounts, loading: accountsLoading } = useAccounts();
 
@@ -298,6 +309,7 @@ export function useLivePnl(options: UseLivePnlOptions = {}): UseLivePnlResult {
     loading: investmentsLoading || accountsLoading,
     error,
     isLive,
+    isSimulated,
     lastUpdated,
     refresh,
   };

--- a/apps/web/src/lib/investment/intraday-pnl.test.ts
+++ b/apps/web/src/lib/investment/intraday-pnl.test.ts
@@ -102,4 +102,75 @@ describe('computeIntradayPnl', () => {
     expect(report.staleSymbols).toEqual(['SPY-PUT']);
     expect(report.missingBasisSymbols).toEqual(['SPY-PUT']);
   });
+
+  it('reports positions excluded because their currency differs from the report currency', () => {
+    const positions: IntradayPosition[] = [
+      {
+        accountId: 'us',
+        brokerage: 'A',
+        symbol: 'VTI',
+        assetClass: 'equity',
+        quantity: 10,
+        previousCloseCents: 100_00,
+        costBasisCents: 900_00,
+        currency: 'USD',
+      },
+      {
+        accountId: 'eu',
+        brokerage: 'B',
+        symbol: 'SAP',
+        assetClass: 'equity',
+        quantity: 5,
+        previousCloseCents: 120_00,
+        costBasisCents: 500_00,
+        currency: 'EUR',
+      },
+      {
+        accountId: 'uk',
+        brokerage: 'C',
+        symbol: 'HSBA',
+        assetClass: 'equity',
+        quantity: 8,
+        previousCloseCents: 60_00,
+        costBasisCents: 400_00,
+        currency: 'GBP',
+      },
+    ];
+
+    const report = computeIntradayPnl({
+      positions,
+      quotes: [quote('VTI', 110_00)],
+      now,
+      currency: 'USD',
+    });
+
+    // Only the USD position contributes to the totals.
+    expect(report.totalMarketValueCents).toBe(1100_00);
+    // The foreign positions are surfaced so the UI can disclose them.
+    expect(report.excludedSymbols).toEqual(['HSBA', 'SAP']);
+    expect(report.excludedCurrencies).toEqual(['EUR', 'GBP']);
+  });
+
+  it('reports no exclusions when every position matches the report currency', () => {
+    const report = computeIntradayPnl({
+      positions: [
+        {
+          accountId: 'us',
+          brokerage: 'A',
+          symbol: 'VTI',
+          assetClass: 'equity',
+          quantity: 10,
+          previousCloseCents: 100_00,
+          costBasisCents: 900_00,
+          currency: 'USD',
+        },
+      ],
+      quotes: [quote('VTI', 110_00)],
+      now,
+      currency: 'USD',
+    });
+
+    expect(report.excludedSymbols).toEqual([]);
+    expect(report.excludedCurrencies).toEqual([]);
+  });
 });

--- a/apps/web/src/lib/investment/intraday-pnl.ts
+++ b/apps/web/src/lib/investment/intraday-pnl.ts
@@ -52,6 +52,10 @@ export interface IntradayPnlReport {
   readonly netWorthDeltaCents: number;
   readonly staleSymbols: readonly string[];
   readonly missingBasisSymbols: readonly string[];
+  /** Symbols dropped because their currency differs from the report currency. */
+  readonly excludedSymbols: readonly string[];
+  /** Distinct non-report currencies that were excluded from the totals. */
+  readonly excludedCurrencies: readonly string[];
   readonly breakdowns: {
     readonly byAccount: readonly PnlBreakdown[];
     readonly byBrokerage: readonly PnlBreakdown[];
@@ -115,12 +119,18 @@ export function computeIntradayPnl(input: IntradayPnlInput): IntradayPnlReport {
   const byAssetClass = new Map<string, MutableBreakdown>();
   const staleSymbols = new Set<string>();
   const missingBasisSymbols = new Set<string>();
+  const excludedSymbols = new Set<string>();
+  const excludedCurrencies = new Set<string>();
   let totalMarketValueCents = 0;
   let dayPnlCents = 0;
   let unrealizedPnlCents = 0;
 
   for (const position of input.positions) {
-    if (position.currency !== input.currency) continue;
+    if (position.currency !== input.currency) {
+      excludedSymbols.add(position.symbol.toUpperCase());
+      excludedCurrencies.add(position.currency);
+      continue;
+    }
     const symbol = position.symbol.toUpperCase();
     const quote = quotesBySymbol.get(symbol);
     if (isProblemFreshness(evaluateQuoteFreshness(quote, input.now).freshness))
@@ -180,6 +190,8 @@ export function computeIntradayPnl(input: IntradayPnlInput): IntradayPnlReport {
     netWorthDeltaCents: dayPnlCents + realizedPnlCents + cashMovementCents,
     staleSymbols: [...staleSymbols].sort(),
     missingBasisSymbols: [...missingBasisSymbols].sort(),
+    excludedSymbols: [...excludedSymbols].sort(),
+    excludedCurrencies: [...excludedCurrencies].sort(),
     breakdowns: {
       byAccount: finalize(byAccount),
       byBrokerage: finalize(byBrokerage),

--- a/apps/web/src/pages/LivePnlPage.test.tsx
+++ b/apps/web/src/pages/LivePnlPage.test.tsx
@@ -70,6 +70,7 @@ describe('LivePnlPage', () => {
       loading: true,
       error: null,
       isLive: false,
+      isSimulated: false,
       lastUpdated: null,
       refresh: vi.fn(),
     });
@@ -83,6 +84,7 @@ describe('LivePnlPage', () => {
       loading: false,
       error: null,
       isLive: false,
+      isSimulated: false,
       lastUpdated: null,
       refresh: vi.fn(),
     });
@@ -96,6 +98,7 @@ describe('LivePnlPage', () => {
       loading: false,
       error: null,
       isLive: true,
+      isSimulated: true,
       lastUpdated: NOW,
       refresh: vi.fn(),
     });

--- a/apps/web/src/pages/LivePnlPage.tsx
+++ b/apps/web/src/pages/LivePnlPage.tsx
@@ -18,7 +18,7 @@ import { LivePnlDashboard } from '../components/dashboard/LivePnlDashboard';
 import { useLivePnl } from '../hooks/useLivePnl';
 
 export const LivePnlPage: React.FC = () => {
-  const { view, loading, error, isLive, refresh } = useLivePnl();
+  const { view, loading, error, isLive, isSimulated, refresh } = useLivePnl();
 
   if (loading) {
     return (
@@ -37,7 +37,16 @@ export const LivePnlPage: React.FC = () => {
     );
   }
 
-  return <LivePnlDashboard view={view} isLive={isLive} error={error} onRefresh={refresh} />;
+  return (
+    <LivePnlDashboard
+      view={view}
+      isLive={isLive}
+      isSimulated={isSimulated}
+      realizedTracked={false}
+      error={error}
+      onRefresh={refresh}
+    />
+  );
 };
 
 export default LivePnlPage;


### PR DESCRIPTION
## Summary

Makes the Live P&L dashboard honest about what it is showing. As a high-net-worth active investor watching intraday P&L, several figures on this screen are presented as authoritative when they are not — this erodes trust in the whole dashboard. All fixes are disclosure/accuracy changes in `apps/web`.

## Changes

- **Simulated prices are now disclosed (#3243)** — the shipped web app always drives quotes from the offline `SimulatedMarketDataProvider`, yet the dashboard showed a "Live" badge with no indication the numbers are synthetic. `useLivePnl` now exposes `isSimulated` (true whenever the built-in offline simulation is in use; false once a real vendor source is injected), and the dashboard renders a clear "Prices are simulated for demonstration… figures are not real quotes" notice. Related: #2118.
- **"Realized P&L (today)" no longer shows a misleading $0.00 (#3245)** — the web hook never supplies realized events, so the card always read `$0.00` with the sub-label "Closed trades booked today," implying the user had zero closed trades rather than "not tracked." The page passes `realizedTracked={false}`; the card now discloses "Intraday realized P&L isn't tracked yet."
- **Excluded non-report-currency positions are disclosed (#3248)** — `computeIntradayPnl` silently skipped any position whose currency differed from the report currency. It now reports `excludedSymbols` / `excludedCurrencies`, and the dashboard shows "N positions priced in EUR, GBP are excluded from these USD totals. Multi-currency roll-up is not yet converted."
- **Day-P&L baseline footnote (#3250)** — the intraday baseline is each holding's last saved price, not the official previous close. Added a footnote so the "Today's P&L" figure isn't silently misread as change-since-prev-close.

## Issues

Closes #3243
Closes #3245
Closes #3248
Closes #3250

## Testing

- [x] `npx vitest run` on `intraday-pnl.test.ts`, `LivePnlDashboard.test.tsx`, `useLivePnl.test.tsx` — 26 passed
- [x] Added tests: excluded-currency reporting (engine), simulated/realized/excluded/footnote disclosures (dashboard), `isSimulated` true for default source & false for injected source (hook)
- [x] `npx eslint --max-warnings 0` on changed TS/TSX — clean
- [x] `npx prettier --check` on changed files (incl. CSS) — clean

## Accessibility

Notices use `role="note"`; the untracked realized value carries an explicit `aria-label` ("Realized profit and loss today: not tracked") so screen-reader users get the disclosure, not a bare em-dash. Direction cues remain glyph + sign + text (never colour alone).

## Cross-Platform

Web-only. The Live P&L surface, the simulated price provider, and the intraday engine wiring are web-specific. iOS/Android/Windows would need their own equivalent disclosures if/when they ship a live P&L view — verify separately (not blindly duplicated here).

Found by persona: Alexandra Petrova (HNW active investor)
