### PR TITLE
fix(web): allow adding a newborn (age 0) to a household (#3382)

### DIFF
--- a/apps/web/src/pages/HouseholdPage.test.tsx
+++ b/apps/web/src/pages/HouseholdPage.test.tsx
@@ -665,6 +665,34 @@ describe('HouseholdPage', () => {
     });
   });
 
+  it('accepts a newborn (age 0) when creating a child profile (#3382)', () => {
+    const createChildProfile = vi.fn().mockReturnValue(makeChild({ age: 0 }));
+    mockedUseHousehold.mockReturnValue(
+      mockHouseholdResult({
+        household: makeHousehold(),
+        members: [makeOwnerMember()],
+        createChildProfile,
+      }),
+    );
+
+    render(<HouseholdPage />);
+
+    fireEvent.change(screen.getByLabelText(/child name/i), { target: { value: 'Ada Jr.' } });
+    fireEvent.change(screen.getByLabelText(/^age$/i), { target: { value: '0' } });
+    fireEvent.change(screen.getByLabelText(/weekly allowance/i), { target: { value: '0' } });
+    fireEvent.change(screen.getByLabelText(/starting balance/i), { target: { value: '0' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /add child profile/i }));
+
+    expect(createChildProfile).toHaveBeenCalledWith({
+      name: 'Ada Jr.',
+      age: 0,
+      weeklyAllowance: 0,
+      allowanceDay: 'friday',
+      balance: 0,
+    });
+  });
+
   it('toggles chores and records withdrawals through the household hook', () => {
     const toggleChildChoreCompletion = vi.fn();
     const recordChildWithdrawal = vi.fn().mockReturnValue(makeChild({ balance: 9 }));

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -762,8 +762,8 @@ export function HouseholdPage() {
         return;
       }
 
-      if (!Number.isInteger(parsedAge) || parsedAge < 1) {
-        setKidError('Enter a valid age.');
+      if (!Number.isInteger(parsedAge) || parsedAge < 0) {
+        setKidError('Enter a valid age (0 for under one year).');
         return;
       }
 
@@ -2220,7 +2220,7 @@ export function HouseholdPage() {
                 id="child-age"
                 className="household-form-input"
                 type="number"
-                min="1"
+                min="0"
                 step="1"
                 value={childAge}
                 onChange={(e) => setChildAge(e.target.value)}


### PR DESCRIPTION
﻿## Summary

New parents could not add their newborn to the household Kids & Allowances section: the form rejected age 0. This fixes the validation so an infant (age 0 = under one year) is accepted.

## Changes

- `handleCreateChild` validation loosened from `parsedAge < 1` to `parsedAge < 0` (age 0 is now valid; negatives still rejected).
- Child age `<input>` `min` lowered from `1` to `0`.
- Clearer helper message: `Enter a valid age (0 for under one year).`
- Added a regression test asserting a newborn (age 0) submits through the household hook.

## Issues

Closes #3382

## Testing

- `npx vitest run src/pages/HouseholdPage.test.tsx` -> 27 passed (incl. new newborn case)
- `npx eslint` on changed files -> 0 warnings; Prettier clean

Found by persona: Ada & Chidi Okafor (new-parents joint-finances)
