### PR TITLE
fix(web): trap and restore focus in modal dialogs (#3331)

### DIFF
--- a/apps/web/src/components/FeedbackDialog.tsx
+++ b/apps/web/src/components/FeedbackDialog.tsx
@@ -14,6 +14,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import packageJson from '../../package.json';
 import { buildFeedbackDiagnostics, submitFeedback } from '../lib/feedback';
+import { useFocusTrap } from '../accessibility/aria';
 
 const BUILD_SHA =
   import.meta.env.VITE_BUILD_SHA ??
@@ -40,7 +41,7 @@ export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose 
   const panelRef = useRef<HTMLDivElement>(null);
   const firstInputRef = useRef<HTMLInputElement>(null);
 
-  // Reset form state when dialog opens/closes
+  // Reset form state when dialog opens.
   useEffect(() => {
     if (isOpen) {
       setSubject('');
@@ -49,49 +50,23 @@ export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose 
       setSubmitted(false);
       setIsSubmitting(false);
       setError(null);
-      // Focus first input on open
-      requestAnimationFrame(() => {
-        firstInputRef.current?.focus();
-      });
     }
   }, [isOpen]);
 
-  // Focus trap
-  useEffect(() => {
-    if (!isOpen) return;
+  // Trap focus within the dialog, focus the first field on open, and restore
+  // focus to the trigger element when the dialog closes. The previous
+  // hand-rolled trap never restored focus on close (issue #3338).
+  useFocusTrap(panelRef, { active: isOpen, restoreFocus: true, initialFocusRef: firstInputRef });
 
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
+  const handlePanelKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
         onClose();
-        return;
       }
-
-      if (e.key !== 'Tab') return;
-
-      const panel = panelRef.current;
-      if (!panel) return;
-
-      const focusable = panel.querySelectorAll<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-      );
-      if (focusable.length === 0) return;
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
+    },
+    [onClose],
+  );
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -139,6 +114,7 @@ export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose 
         aria-modal="true"
         aria-labelledby="feedback-dialog-title"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={handlePanelKeyDown}
       >
         <h2 id="feedback-dialog-title" className="form-dialog__title">
           Send feedback

--- a/apps/web/src/components/common/ConflictResolutionDialog.tsx
+++ b/apps/web/src/components/common/ConflictResolutionDialog.tsx
@@ -19,6 +19,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { getUnresolvedConflicts, resolveConflict, type SyncConflict } from '../../db/sync';
+import { useFocusTrap } from '../../accessibility/aria';
 
 import '../../styles/conflict-resolution.css';
 
@@ -48,31 +49,20 @@ export const ConflictResolutionDialog: React.FC<ConflictResolutionDialogProps> =
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isResolving, setIsResolving] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Trap focus within the dialog while it is open and actually rendered (i.e.
+  // once conflicts have loaded), restoring focus to the trigger element on
+  // close. Replaces the previous manual focus() call, which never trapped Tab.
+  useFocusTrap(dialogRef, { active: isOpen && conflicts.length > 0, restoreFocus: true });
 
   // Load conflicts when dialog opens.
   useEffect(() => {
     if (!isOpen) return;
 
-    previousFocusRef.current = document.activeElement as HTMLElement | null;
-
     void getUnresolvedConflicts().then((unresolved) => {
       setConflicts(unresolved);
       setCurrentIndex(0);
     });
-  }, [isOpen]);
-
-  // Focus management.
-  useEffect(() => {
-    if (isOpen && dialogRef.current) {
-      dialogRef.current.focus();
-    }
-
-    return () => {
-      if (!isOpen && previousFocusRef.current) {
-        previousFocusRef.current.focus();
-      }
-    };
   }, [isOpen]);
 
   // Keyboard handler.

--- a/apps/web/src/components/recommendations/RecommendationDetail.tsx
+++ b/apps/web/src/components/recommendations/RecommendationDetail.tsx
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { CurrencyDisplay } from '../common/CurrencyDisplay';
 import { AppIcon } from '../icons';
+import { useFocusTrap } from '../../accessibility/aria';
 import type { PersonalizedRecommendation } from '../../lib/recommendations';
 
 export interface RecommendationDetailProps {
@@ -52,6 +53,22 @@ export const RecommendationDetail: React.FC<RecommendationDetailProps> = ({
   recommendation,
   onClose,
 }) => {
+  const dialogRef = useRef<HTMLElement>(null);
+
+  // Trap focus within the modal while it is open and restore focus to the
+  // trigger element when it closes.
+  useFocusTrap(dialogRef, { active: recommendation !== null, restoreFocus: true });
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
   if (!recommendation) {
     return null;
   }
@@ -59,11 +76,13 @@ export const RecommendationDetail: React.FC<RecommendationDetailProps> = ({
   return (
     <div className="recommendation-detail__backdrop" role="presentation" onClick={onClose}>
       <section
+        ref={dialogRef}
         className="recommendation-detail"
         role="dialog"
         aria-modal="true"
         aria-labelledby="recommendation-detail-title"
         onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleKeyDown}
       >
         <div className="recommendation-detail__header">
           <div>

--- a/apps/web/src/components/settings/AccountDeletionModal.tsx
+++ b/apps/web/src/components/settings/AccountDeletionModal.tsx
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useFocusTrap } from '../../accessibility/aria';
 
 import { useAuth } from '../../auth/auth-context';
 import { useDatabase } from '../../db/DatabaseProvider';
@@ -143,6 +145,7 @@ export function useAccountDeletion(): {
     memberHouseholds: 0,
     pendingInvites: 0,
   });
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const openDeleteModal = useCallback(() => {
     setConfirmationText('');
@@ -157,6 +160,22 @@ export function useAccountDeletion(): {
     setConfirmationText('');
     setError(null);
   }, [completionReceipt, isDeleting]);
+
+  // Trap focus within the modal, move initial focus into it, and restore focus
+  // to the trigger element on close (issue #3331). closeDeleteModal is itself
+  // guarded so Escape cannot dismiss the modal mid-deletion or after the
+  // receipt is shown.
+  useFocusTrap(dialogRef, { active: isOpen, restoreFocus: true });
+
+  const handleDialogKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeDeleteModal();
+      }
+    },
+    [closeDeleteModal],
+  );
 
   useEffect(() => {
     if (!isOpen) return;
@@ -249,10 +268,12 @@ export function useAccountDeletion(): {
 
   const deleteModal = isOpen ? (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby="delete-account-title"
       aria-describedby="delete-account-description"
+      onKeyDown={handleDialogKeyDown}
       style={{
         position: 'fixed',
         inset: 0,


### PR DESCRIPTION
## Summary

Four modal dialogs did not correctly manage keyboard focus, breaking WCAG 2.2 **2.4.3 Focus Order**, **2.1.2 No Keyboard Trap** (Tab escaping the dialog), and **4.1.2 Name, Role, Value** for screen-reader + keyboard users. Each now adopts the shared `useFocusTrap` primitive (`apps/web/src/accessibility/aria.ts`) so that:

- opening the dialog moves focus **inside** it,
- `Tab` / `Shift+Tab` **cycle within** the dialog (background is inert),
- focus **returns to the triggering control** on close, and
- `Escape` closes the dialog.

This centralizes focus behavior on the already-tested primitive instead of four divergent hand-rolled (or missing) implementations.

## Changes

- **`settings/AccountDeletionModal.tsx`** (#3331, P1) — the destructive Delete-Account confirmation had **no** focus trap, initial focus, or restore. Added `useFocusTrap` + `Escape` (guarded so it can't dismiss mid-deletion).
- **`common/ConflictResolutionDialog.tsx`** (#3334, P2) — moved initial focus but never trapped `Tab`, so keyboard users tabbed out into the page behind the sync-conflict dialog. Replaced the manual `previousFocusRef` effect with `useFocusTrap` (activated once conflicts have loaded).
- **`FeedbackDialog.tsx`** (#3338, P2) — hand-rolled Tab trap that **never restored focus** to the trigger on close. Replaced with `useFocusTrap` (initial focus to the first field) + `Escape`.
- **`recommendations/RecommendationDetail.tsx`** (#3332, P2) — the recommendation dialog had **no** focus management. Added `useFocusTrap` + `Escape`.

## Issues

Closes #3331
Closes #3332
Closes #3334
Closes #3338

## Testing

- `npx prettier --check` + `npx eslint --max-warnings 0` on all four files — clean.
- `ConflictResolutionDialog.test.tsx` + `AccountDeletionModal.test.tsx` — **10/10 pass** (the two dialogs of the four that have test files; both now exercise `useFocusTrap` in context).
- Focus-trap/restore/initial-focus semantics themselves are covered by the existing `useFocusTrap` unit tests.

## Accessibility

- WCAG 2.4.3 (Focus Order), 2.1.2 (No Keyboard Trap), 4.1.2 (Name, Role, Value).
- Found by persona: Jordan Blake (blind screen-reader + keyboard user).

## Cross-Platform

Web-only patterns (React focus management). iOS/Android/Windows manage modal focus through their native navigation stacks and are out of scope for these issues.
