### PR TITLE
fix(web): repair mojibake in user-visible strings (#3403)

### DIFF
--- a/apps/web/src/components/forms/GoalForm.tsx
+++ b/apps/web/src/components/forms/GoalForm.tsx
@@ -307,7 +307,7 @@ export function GoalForm({ isOpen, onCancel, onSubmit, initialData }: GoalFormPr
   const minimumTargetDate = isEditing ? undefined : tomorrowISO();
   const dialogTitle = isEditing ? 'Edit Goal' : 'Create Goal';
   const submitLabel = isEditing ? 'Update Goal' : 'Create Goal';
-  const submittingLabel = isEditing ? 'UpdatingΓÇª' : 'CreatingΓÇª';
+  const submittingLabel = isEditing ? 'Updating...' : 'Creating...';
 
   return (
     <div className="form-dialog" role="presentation" onKeyDown={handleKeyDown}>

--- a/apps/web/src/components/forms/TransactionForm.test.tsx
+++ b/apps/web/src/components/forms/TransactionForm.test.tsx
@@ -410,7 +410,7 @@ describe('TransactionForm', () => {
   it('includes additional fields in submission data', async () => {
     const { onSubmit } = renderTransactionForm();
 
-    // Fill required fields ΓÇö amount uses keyDown events with useAmountInput
+    // Fill required fields - amount uses keyDown events with useAmountInput
     const amountInput = screen.getByLabelText('Amount');
     fireEvent.keyDown(amountInput, { key: '5' });
     fireEvent.keyDown(amountInput, { key: '0' });

--- a/apps/web/src/components/goals/GoalContributionDialog.tsx
+++ b/apps/web/src/components/goals/GoalContributionDialog.tsx
@@ -267,7 +267,7 @@ export function GoalContributionDialog({
                 disabled={submitting}
                 aria-busy={submitting}
               >
-                {submitting ? 'ContributingΓÇª' : 'Submit'}
+                {submitting ? 'Contributing...' : 'Submit'}
               </button>
             </div>
           </form>
@@ -277,7 +277,7 @@ export function GoalContributionDialog({
       <ConfirmDialog
         isOpen={pendingInput !== null}
         title="Contribution exceeds goal"
-        message="This would exceed your goal ΓÇö still contribute?"
+        message="This would exceed your goal. Still contribute?"
         confirmLabel="Still Contribute"
         cancelLabel="Go Back"
         variant="warning"

--- a/apps/web/src/components/transactions/QuickEntry.tsx
+++ b/apps/web/src/components/transactions/QuickEntry.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Quick Entry ΓÇö floating action button that expands to a compact transaction form.
+ * Quick Entry - floating action button that expands to a compact transaction form.
  *
  * Provides a keyboard-first, accessible way to quickly log transactions.
  * The FAB shows a "+" icon; clicking or pressing "n" expands the form.
@@ -337,7 +337,7 @@ export const QuickEntry: React.FC<QuickEntryProps> = ({ className = '' }) => {
                 aria-busy={saving}
                 data-testid="quick-entry-save"
               >
-                {saving ? 'SavingΓÇª' : 'Save'}
+                {saving ? 'Saving...' : 'Save'}
               </button>
             </div>
           </form>

--- a/apps/web/src/components/transactions/quick-entry.css
+++ b/apps/web/src/components/transactions/quick-entry.css
@@ -1,14 +1,14 @@
 /* SPDX-License-Identifier: BUSL-1.1 */
 
 /**
- * Quick Entry ΓÇö floating action button + compact transaction form.
+ * Quick Entry - floating action button + compact transaction form.
  *
  * Uses design tokens for all visual values. Respects prefers-reduced-motion
  * and prefers-color-scheme. See tokens.css for available custom properties.
  */
 
 /* ==========================================================================
- * FAB ΓÇö Floating Action Button
+ * FAB - Floating Action Button
  * ========================================================================== */
 
 .quick-entry-fab {

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -146,7 +146,7 @@ function toExactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
 }
 
 // ---------------------------------------------------------------------------
-// Schema ΓÇö matches packages/models SQLDelight .sq files
+// Schema - matches packages/models SQLDelight .sq files
 // ---------------------------------------------------------------------------
 
 /**

--- a/apps/web/src/pages/WatchlistsPage.tsx
+++ b/apps/web/src/pages/WatchlistsPage.tsx
@@ -355,7 +355,7 @@ export const WatchlistsPage: React.FC = () => {
                 required
                 aria-required="true"
               >
-                <option value="">Select categoryΓÇª</option>
+                <option value="">Select category...</option>
                 {availableCategories.map((cat) => (
                   <option key={cat.id} value={cat.id}>
                     {cat.name}


### PR DESCRIPTION
## Summary

Repairs **mojibake** (double-encoded punctuation that renders as corrupted characters) in user-visible web strings. The affected bytes were CP850-flavored double-encodings of `…` and `—`.

## Changes

- Replace the double-encoded ellipsis with ASCII `...` in loading labels and the category placeholder: `Updating...`, `Creating...`, `Contributing...`, `Saving...`, `Select category...`.
- Reword the goal-contribution confirm message to drop a mojibake em-dash: **"This would exceed your goal. Still contribute?"**
- Fix mojibake em-dash in code/CSS comments (`QuickEntry.tsx`, `quick-entry.css`, `sqlite-wasm.ts`, `TransactionForm.test.tsx`).
- ASCII-only replacements to eliminate the corruption class (consistent with prior em-dash cleanup in #3156).

7 files, 10 insertions / 10 deletions.

## Issues

Closes #3403

## Testing

- [x] `npx prettier --check` on changed files — all clean
- [x] `npx eslint` on changed `.ts`/`.tsx` files — 0 errors / 0 warnings
- [x] Raw-byte re-scan confirms **0** remaining mojibake signatures in `apps/web/src`

## Cross-platform

Web-only: these are `apps/web` string/comment literals. Native platforms localize separately.

Found by persona: Maya Chen (new-grad first-job budgeter)
