### PR TITLE
fix(web): guard invoice delete, add a11y names, surface past-due forecast (#3216)

### DIFF
--- a/apps/web/src/pages/InvoicesPage.test.tsx
+++ b/apps/web/src/pages/InvoicesPage.test.tsx
@@ -5,7 +5,9 @@
  *
  * Mocks the useInvoices hook (not localStorage) per project conventions and
  * asserts the page exposes its title as the single level-1 heading so the
- * heading hierarchy stays intact (issue #3203).
+ * heading hierarchy stays intact (issue #3203), gives per-invoice controls
+ * distinguishing accessible names (#3222), and surfaces the past-due bucket in
+ * the forecast summary (#3219).
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -90,7 +92,7 @@ describe('InvoicesPage', () => {
     });
     render(<InvoicesPage />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete invoice for Etsy Wholesale' }));
     // Deletion is gated by a confirmation dialog; nothing happens until confirmed.
     expect(deleteInvoice).not.toHaveBeenCalled();
 
@@ -165,5 +167,44 @@ describe('InvoicesPage', () => {
     );
     expect(values).toContain('Etsy Wholesale');
     expect(values).toContain('Maple & Co');
+  });
+
+  it('gives each invoice control a distinguishing accessible name (#3222)', () => {
+    mockedUseInvoices.mockReturnValue({
+      invoices: [SAMPLE_INVOICE],
+      pipelineGroups: [
+        { status: 'Sent', label: 'Sent', invoices: [SAMPLE_INVOICE], totalCents: 120_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    expect(screen.getByRole('combobox', { name: 'Status for Etsy Wholesale' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete invoice for Etsy Wholesale' }),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces the past-due bucket in the forecast summary (#3219)', () => {
+    mockedUseInvoices.mockReturnValue({
+      invoices: [],
+      pipelineGroups: [],
+      forecastBuckets: [
+        { id: 'past-due', label: 'Past due', invoices: [SAMPLE_INVOICE], totalCents: 120_000 },
+      ],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    expect(screen.getByRole('article', { name: 'Past due forecast' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/InvoicesPage.tsx
+++ b/apps/web/src/pages/InvoicesPage.tsx
@@ -70,6 +70,7 @@ const InvoiceCard: React.FC<{
       <label className="invoice-card__status-label">
         Status
         <select
+          aria-label={`Status for ${invoice.clientName}`}
           value={invoice.status}
           onChange={(event) => onStatusChange(invoice.id, event.target.value as InvoiceStatus)}
         >
@@ -80,7 +81,12 @@ const InvoiceCard: React.FC<{
           ))}
         </select>
       </label>
-      <button className="analytics-export-btn" type="button" onClick={() => onDelete(invoice)}>
+      <button
+        className="analytics-export-btn"
+        type="button"
+        aria-label={`Delete invoice for ${invoice.clientName}`}
+        onClick={() => onDelete(invoice)}
+      >
         Delete
       </button>
     </div>
@@ -245,7 +251,7 @@ export const InvoicesPage: React.FC = () => {
       <section className="analytics-section" aria-label="Expected income forecast">
         <p className="sr-only" role="status">
           Outstanding invoices total <CurrencyDisplay amount={totalOutstandingCents} />.
-          {forecastBuckets.slice(1, 3).map((bucket) => (
+          {forecastBuckets.slice(0, 3).map((bucket) => (
             <React.Fragment key={bucket.id}>
               {' '}
               {bucket.label}: <CurrencyDisplay amount={bucket.totalCents} />.
@@ -260,14 +266,20 @@ export const InvoicesPage: React.FC = () => {
               <CurrencyDisplay amount={totalOutstandingCents} />
             </p>
           </article>
-          {forecastBuckets.slice(1, 3).map((bucket) => (
+          {forecastBuckets.slice(0, 3).map((bucket) => (
             <article
               key={bucket.id}
               className="analytics-metric-card"
               aria-label={`${bucket.label} forecast`}
             >
               <p className="analytics-metric-card__label">{bucket.label}</p>
-              <p className="analytics-metric-card__value analytics-metric-card__value--positive">
+              <p
+                className={`analytics-metric-card__value ${
+                  bucket.id === 'past-due'
+                    ? 'analytics-metric-card__value--negative'
+                    : 'analytics-metric-card__value--positive'
+                }`}
+              >
                 <CurrencyDisplay amount={bucket.totalCents} />
               </p>
             </article>


### PR DESCRIPTION
## Summary

Improves accessibility and completeness of the Invoices page for freelancers tracking irregular income:

- **#3222** — Each invoice row's **status select** and **delete button** now carry a client-scoped accessible name (`Status for <client>`, `Delete invoice for <client>`). Previously every row exposed identical "Status"/"Delete" names, so screen-reader users (and automated tooling) could not tell repeated controls apart.
- **#3219** — The expected-income forecast **summary cards** and the screen-reader summary now include the **past-due bucket** (index 0), rendered with negative styling. Previously the summary sliced `[1, 3)`, hiding overdue money from the at-a-glance view even though it is the most urgent figure for a freelancer chasing late payers.

## Changes

- `InvoicesPage.tsx`: add `aria-label` to the status `<select>` and delete `<button>`; change forecast summary + sr-only slices from `slice(1, 3)` to `slice(0, 3)`; style the past-due metric card value as `--negative`.
- `InvoicesPage.test.tsx`: update the existing delete test to the new distinguishing button name; add coverage for the status control name (#3222) and the past-due forecast card (#3219).

## Note on #3216

The delete-**confirmation dialog** itself (#3216) was independently implemented on `main` by a parallel change while this PR was open. This branch was rebased to adopt that implementation; it adds the accessible name for the delete control that triggers the dialog and updates the delete test accordingly, completing the accessible-delete story. Closing #3216 here since the tracked bug (unguarded delete) is fully resolved on `main` and covered by these tests.

## Issues

Closes #3216
Closes #3219
Closes #3222

## Testing

- `npx tsc -b` -> 0 errors
- `npx eslint --max-warnings 0` (both files) -> clean
- `npx prettier --check` -> clean
- `vitest run InvoicesPage.test.tsx` -> 7/7 pass

Found by persona: Diego Ramirez (freelance-designer irregular-income)
