### PR TITLE
feat(web): new-baby life-event template + fix childcare/kindergarten timeline (#3388, #3394)

### DIFF
--- a/apps/web/src/pages/PlanningPage.test.tsx
+++ b/apps/web/src/pages/PlanningPage.test.tsx
@@ -501,6 +501,17 @@ describe('PlanningPage', () => {
     expect(screen.getByText(/Projected monthly free cash flow: \$1400.00/i)).toBeTruthy();
   });
 
+  it('offers a new-baby life-event template that adds childcare costs (#3388)', () => {
+    render(<PlanningPage />);
+    fireEvent.click(screen.getByRole('tab', { name: /life events/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'New baby arrives' }));
+    fireEvent.click(screen.getByRole('button', { name: /add event/i }));
+
+    expect(screen.getByRole('heading', { name: 'New baby arrives' })).toBeTruthy();
+    expect(screen.getByText(/Adds \$1800\.00\/mo/i)).toBeTruthy();
+  });
+
   it('shows empty state on goals tab when no goals', () => {
     render(<PlanningPage />);
     fireEvent.click(screen.getByRole('tab', { name: /savings goals/i }));

--- a/apps/web/src/pages/PlanningPage.tsx
+++ b/apps/web/src/pages/PlanningPage.tsx
@@ -1086,13 +1086,18 @@ const HealthcareProjectionSection: React.FC<{ params: RetirementParams }> = ({ p
 
 const LIFE_EVENT_TEMPLATES: readonly Omit<LifeEvent, 'id'>[] = [
   {
+    name: 'New baby arrives',
+    date: defaultLifeEventDate(0),
+    monthlyCostChangeCents: 180000,
+  },
+  {
     name: 'Childcare ends',
-    date: defaultLifeEventDate(24),
+    date: defaultLifeEventDate(60),
     monthlyCostChangeCents: -120000,
   },
   {
     name: 'Child starts kindergarten',
-    date: defaultLifeEventDate(18),
+    date: defaultLifeEventDate(60),
     monthlyCostChangeCents: -80000,
   },
   {


### PR DESCRIPTION
﻿## Summary

Two family life-event planning fixes for new parents (Ada & Chidi persona):

- **#3388** Adds a **New baby arrives** life-event template that models the onset of childcare (~$1,800/mo, +180000 cents). New parents can now one-click the exact event that dominates their new budget.
- **#3394** Fixes illogical default dates in `LIFE_EVENT_TEMPLATES`: `Child starts kindergarten` defaulted to 18 months out (age ~1.5) and sat **before** `Childcare ends` (24 months). Kindergarten now defaults to ~age 5 (60 months), aligned with childcare ending, so the timeline reads chronologically and logically.

## Changes

- New `New baby arrives` template (+$1,800/mo) at month 0.
- `Child starts kindergarten` 18mo -> 60mo; `Childcare ends` 24mo -> 60mo (kindergarten start == childcare end).
- Regression test: clicking the new template fills the form and adds an event showing `Adds $1800.00/mo`.

## Issues

Closes #3388
Closes #3394

## Testing

- `npx vitest run src/pages/PlanningPage.test.tsx` -> 25 passed (incl. new template case)
- `npx eslint` on changed files -> 0 warnings; Prettier clean

Found by persona: Ada & Chidi Okafor (new-parents joint-finances)
