### PR TITLE
chore(deps): land npm-dev group (supersedes #3137)

### DIFF
--- a/.github/agents/docs-writer.agent.md
+++ b/.github/agents/docs-writer.agent.md
@@ -88,9 +88,10 @@ graph TD
 **Authentication**: Bearer token (required)
 
 **Request Body**:
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `changes` | `Change[]` | Yes | Array of local mutations |
+
+| Field     | Type       | Required | Description              |
+| --------- | ---------- | -------- | ------------------------ |
+| `changes` | `Change[]` | Yes      | Array of local mutations |
 
 **Response**: `200 OK` with `SyncResult`
 **Errors**: `401 Unauthorized`, `429 Too Many Requests`

--- a/.github/prompts/README.md
+++ b/.github/prompts/README.md
@@ -26,9 +26,10 @@ The CLI loads the `.prompt.md` file and follows the instructions inside, substit
 Deploys N sprints across all agent types in parallel. Each sprint dispatches up to 15 agents, each working in its own worktree with full CI validation.
 
 **Parameters:**
-| Name | Default | Description |
-|------|---------|-------------|
-| `N` | `3` | Number of sprints to run |
+
+| Name | Default | Description              |
+| ---- | ------- | ------------------------ |
+| `N`  | `3`     | Number of sprints to run |
 
 **Examples:**
 
@@ -54,10 +55,11 @@ Run 5 sprints using the sprint prompt
 Deploys only specific agent types for focused work. Use when you want to run a subset of the fleet.
 
 **Parameters:**
-| Name | Default | Description |
-|----------|---------|-------------|
-| `agents` | (none) | Comma-separated agent types |
-| `N` | `2` | Number of sprints |
+
+| Name     | Default | Description                 |
+| -------- | ------- | --------------------------- |
+| `agents` | (none)  | Comma-separated agent types |
+| `N`      | `2`     | Number of sprints           |
 
 **Examples:**
 
@@ -148,9 +150,10 @@ Rebase all open PRs
 Dispatches code-review agents in parallel to review all (or selected) open PRs.
 
 **Parameters:**
-| Name | Default | Description |
-|---------|---------|-------------|
-| `scope` | `all` | `all` or comma-separated PR numbers |
+
+| Name    | Default | Description                         |
+| ------- | ------- | ----------------------------------- |
+| `scope` | `all`   | `all` or comma-separated PR numbers |
 
 **Examples:**
 
@@ -176,9 +179,10 @@ Review PRs 42, 57, 63 using the review prompt
 Prunes stale worktrees, identifies stale PRs/issues, finds duplicates, and lists merged branches.
 
 **Parameters:**
-| Name | Default | Description |
-|-------------|---------|-------------|
-| `stale-days`| `30` | Days of inactivity before flagging as stale |
+
+| Name         | Default | Description                                 |
+| ------------ | ------- | ------------------------------------------- |
+| `stale-days` | `30`    | Days of inactivity before flagging as stale |
 
 **Examples:**
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,7 +37,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.0",
+    "@playwright/test": "^1.61.1",
     "@storybook/addon-a11y": "^10.4.6",
     "@storybook/react": "^10.4.6",
     "@storybook/react-vite": "^10.4.6",
@@ -51,7 +51,7 @@
     "@vitejs/plugin-react": "5.2.0",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
-    "nanoid": "^5.1.15",
+    "nanoid": "^5.1.16",
     "source-map-js": "^1.2.1",
     "storybook": "^10.4.6",
     "typescript": "^6.0.3",

--- a/apps/web/src/auth/webauthn.ts
+++ b/apps/web/src/auth/webauthn.ts
@@ -291,11 +291,9 @@ export async function registerPasskey(
     authenticatorSelection: options.authenticatorSelection
       ? {
           authenticatorAttachment: options.authenticatorSelection.authenticatorAttachment as
-            | AuthenticatorAttachment
-            | undefined,
+            AuthenticatorAttachment | undefined,
           residentKey: options.authenticatorSelection.residentKey as
-            | ResidentKeyRequirement
-            | undefined,
+            ResidentKeyRequirement | undefined,
           requireResidentKey: options.authenticatorSelection.requireResidentKey ?? false,
           userVerification:
             (options.authenticatorSelection.userVerification as UserVerificationRequirement) ??

--- a/apps/web/src/components/DataExport.tsx
+++ b/apps/web/src/components/DataExport.tsx
@@ -39,13 +39,7 @@ import { recordThirdPartyConnectionGrant } from '../lib/third-party-permissions'
 import './data-export.css';
 
 type ExportStatus =
-  | 'idle'
-  | 'pending'
-  | 'generating'
-  | 'ready'
-  | 'delivered'
-  | 'error'
-  | 'cancelled';
+  'idle' | 'pending' | 'generating' | 'ready' | 'delivered' | 'error' | 'cancelled';
 type ExportRecord = Record<string, unknown>;
 
 interface ExportData {

--- a/apps/web/src/components/tips/tips-engine.ts
+++ b/apps/web/src/components/tips/tips-engine.ts
@@ -17,12 +17,7 @@ import { DEFAULT_LOCALE, getCurrentLocale, translate } from '../../lib/i18n';
 
 /** The context/page where a tip is relevant. */
 export type TipContext =
-  | 'dashboard'
-  | 'accounts'
-  | 'transactions'
-  | 'budgets'
-  | 'goals'
-  | 'general';
+  'dashboard' | 'accounts' | 'transactions' | 'budgets' | 'goals' | 'general';
 
 /** Severity/importance of a tip. */
 export type TipSeverity = 'info' | 'warning' | 'success' | 'critical';

--- a/apps/web/src/db/sync/powersync-client.ts
+++ b/apps/web/src/db/sync/powersync-client.ts
@@ -35,11 +35,7 @@ export interface PowerSyncConfig {
 
 /** Current PowerSync connection status. */
 export type PowerSyncConnectionStatus =
-  | 'disconnected'
-  | 'connecting'
-  | 'connected'
-  | 'syncing'
-  | 'error';
+  'disconnected' | 'connecting' | 'connected' | 'syncing' | 'error';
 
 /** Snapshot of the PowerSync sync state for the UI. */
 export interface PowerSyncStatus {

--- a/apps/web/src/hooks/householdKids.ts
+++ b/apps/web/src/hooks/householdKids.ts
@@ -4,13 +4,7 @@ import type { Category, Goal, SyncId, Transaction } from '../kmp/bridge';
 
 export type ChoreFrequency = 'daily' | 'weekly';
 export type AllowanceDay =
-  | 'sunday'
-  | 'monday'
-  | 'tuesday'
-  | 'wednesday'
-  | 'thursday'
-  | 'friday'
-  | 'saturday';
+  'sunday' | 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday';
 
 export interface Chore {
   id: string;

--- a/apps/web/src/hooks/useMutationQueue.ts
+++ b/apps/web/src/hooks/useMutationQueue.ts
@@ -6,8 +6,7 @@ import { getQueueSize } from '../db/mutation-queue';
 const QUEUE_POLL_INTERVAL_MS = 5_000;
 
 type MutationQueueMessage =
-  | { type: 'MUTATION_REPLAY_STARTED' }
-  | { type: 'MUTATION_REPLAY_FINISHED'; queueSize: number };
+  { type: 'MUTATION_REPLAY_STARTED' } | { type: 'MUTATION_REPLAY_FINISHED'; queueSize: number };
 
 /** Shape returned by {@link useMutationQueue}. */
 export interface UseMutationQueueResult {

--- a/apps/web/src/hooks/useOfflineStatus.ts
+++ b/apps/web/src/hooks/useOfflineStatus.ts
@@ -90,8 +90,7 @@ export function clearSlowNetworkDegradation(): void {
 }
 
 function getNavigatorConnection():
-  | (EventTarget & { effectiveType?: NetworkEffectiveType; saveData?: boolean })
-  | null {
+  (EventTarget & { effectiveType?: NetworkEffectiveType; saveData?: boolean }) | null {
   const nav = navigator as Navigator & {
     connection?: EventTarget & { effectiveType?: NetworkEffectiveType; saveData?: boolean };
     mozConnection?: EventTarget & { effectiveType?: NetworkEffectiveType; saveData?: boolean };

--- a/apps/web/src/hooks/useReportBuilder.ts
+++ b/apps/web/src/hooks/useReportBuilder.ts
@@ -50,15 +50,7 @@ import { useTransactions } from './useTransactions';
 // ---------------------------------------------------------------------------
 
 export type ReportFieldType =
-  | 'date'
-  | 'payee'
-  | 'amount'
-  | 'category'
-  | 'account'
-  | 'type'
-  | 'note'
-  | 'balance'
-  | 'tags';
+  'date' | 'payee' | 'amount' | 'category' | 'account' | 'type' | 'note' | 'balance' | 'tags';
 
 export interface ReportField {
   readonly id: string;
@@ -84,13 +76,7 @@ export type ReportTemplate =
   | 'custom';
 
 export type DatePreset =
-  | 'this-month'
-  | 'last-month'
-  | 'this-quarter'
-  | 'last-quarter'
-  | 'ytd'
-  | 'last-year'
-  | 'custom';
+  'this-month' | 'last-month' | 'this-quarter' | 'last-quarter' | 'ytd' | 'last-year' | 'custom';
 
 export interface ReportConfig {
   readonly name: string;

--- a/apps/web/src/kmp/bridge.ts
+++ b/apps/web/src/kmp/bridge.ts
@@ -73,25 +73,12 @@ export interface SyncMetadata {
 
 /** Maps to KMP `com.finance.models.AccountType`. */
 export type AccountType =
-  | 'CHECKING'
-  | 'SAVINGS'
-  | 'CREDIT_CARD'
-  | 'CASH'
-  | 'INVESTMENT'
-  | 'LOAN'
-  | 'OTHER';
+  'CHECKING' | 'SAVINGS' | 'CREDIT_CARD' | 'CASH' | 'INVESTMENT' | 'LOAN' | 'OTHER';
 
 export type AccountPurpose = 'personal' | 'business' | 'both';
 
 export type RetirementAccountType =
-  | 'TRADITIONAL_IRA'
-  | 'ROTH_IRA'
-  | '401K'
-  | 'ROTH_401K'
-  | '403B'
-  | 'SEP_IRA'
-  | 'HSA'
-  | 'FSA';
+  'TRADITIONAL_IRA' | 'ROTH_IRA' | '401K' | 'ROTH_401K' | '403B' | 'SEP_IRA' | 'HSA' | 'FSA';
 
 export type RetirementTaxTreatment = 'PRE_TAX' | 'ROTH' | 'AFTER_TAX' | 'EMPLOYER';
 export type HsaCoverageLevel = 'SELF_ONLY' | 'FAMILY';
@@ -421,14 +408,7 @@ export interface GoalContribution {
 
 /** Maps to KMP `com.finance.models.InvestmentType`. */
 export type InvestmentType =
-  | 'STOCK'
-  | 'BOND'
-  | 'ETF'
-  | 'MUTUAL_FUND'
-  | 'CRYPTO'
-  | 'REAL_ESTATE'
-  | 'COMMODITY'
-  | 'OTHER';
+  'STOCK' | 'BOND' | 'ETF' | 'MUTUAL_FUND' | 'CRYPTO' | 'REAL_ESTATE' | 'COMMODITY' | 'OTHER';
 
 /** Maps to KMP `com.finance.models.Investment`. */
 export interface Investment extends SyncMetadata {

--- a/apps/web/src/lib/a11y/simple-mode.ts
+++ b/apps/web/src/lib/a11y/simple-mode.ts
@@ -1,13 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 export type SimpleModeSurface =
-  | 'dashboard'
-  | 'transactions'
-  | 'budgets'
-  | 'bills'
-  | 'goals'
-  | 'reports'
-  | 'settings';
+  'dashboard' | 'transactions' | 'budgets' | 'bills' | 'goals' | 'reports' | 'settings';
 
 export interface SimpleModePlan {
   surface: SimpleModeSurface;

--- a/apps/web/src/lib/ai/duplicate-transfer-detection.ts
+++ b/apps/web/src/lib/ai/duplicate-transfer-detection.ts
@@ -19,10 +19,7 @@ export interface LearnedDetectionThreshold {
 }
 
 export type ReviewAction =
-  | 'merge-duplicate'
-  | 'link-transfer'
-  | 'keep-separate'
-  | 'ignore-suggestion';
+  'merge-duplicate' | 'link-transfer' | 'keep-separate' | 'ignore-suggestion';
 
 export interface CandidateScore {
   readonly leftId: string;

--- a/apps/web/src/lib/ai/finance-query-parser.ts
+++ b/apps/web/src/lib/ai/finance-query-parser.ts
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 export type FinanceQueryIntent =
-  | 'spend-by-category'
-  | 'spend-by-merchant'
-  | 'spend-by-account'
-  | 'net-worth'
-  | 'unknown';
+  'spend-by-category' | 'spend-by-merchant' | 'spend-by-account' | 'net-worth' | 'unknown';
 
 export interface FinanceQueryParseResult {
   readonly intent: FinanceQueryIntent;

--- a/apps/web/src/lib/ai/notificationPrioritization.ts
+++ b/apps/web/src/lib/ai/notificationPrioritization.ts
@@ -13,13 +13,7 @@ export interface SmartNotification {
   readonly status: SmartNotificationStatus;
   readonly entityId?: string;
   readonly entityType?:
-    | 'bill'
-    | 'budget'
-    | 'goal'
-    | 'account'
-    | 'transaction'
-    | 'merchant'
-    | 'category';
+    'bill' | 'budget' | 'goal' | 'account' | 'transaction' | 'merchant' | 'category';
   readonly dueDate?: string;
   readonly financialImpactCents?: number;
   readonly deduplicationKey?: string;

--- a/apps/web/src/lib/ai/savingsRuleSuggestions.ts
+++ b/apps/web/src/lib/ai/savingsRuleSuggestions.ts
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 export type SavingsRuleType =
-  | 'payday_percentage'
-  | 'monthly_surplus'
-  | 'round_up'
-  | 'spending_reduction';
+  'payday_percentage' | 'monthly_surplus' | 'round_up' | 'spending_reduction';
 export type SavingsRisk = 'low' | 'medium' | 'high';
 export type SavingsSuggestionStatus = 'suggested' | 'approved' | 'dismissed';
 

--- a/apps/web/src/lib/ai/subscriptionDetection.ts
+++ b/apps/web/src/lib/ai/subscriptionDetection.ts
@@ -42,12 +42,7 @@ export interface SubscriptionCandidate {
 export interface SubscriptionDecision {
   readonly candidateId: string;
   readonly action:
-    | 'confirm'
-    | 'rename'
-    | 'merge'
-    | 'dismiss'
-    | 'cancel'
-    | 'acknowledge-price-change';
+    'confirm' | 'rename' | 'merge' | 'dismiss' | 'cancel' | 'acknowledge-price-change';
   readonly name?: string;
   readonly mergeIntoId?: string;
   readonly effectiveDate?: string;

--- a/apps/web/src/lib/analytics/invoices.ts
+++ b/apps/web/src/lib/analytics/invoices.ts
@@ -42,11 +42,7 @@ export interface InvoicePipelineGroup {
 }
 
 export type ForecastBucketId =
-  | 'past-due'
-  | 'next-30'
-  | 'days-31-60'
-  | 'days-61-90'
-  | 'days-90-plus';
+  'past-due' | 'next-30' | 'days-31-60' | 'days-61-90' | 'days-90-plus';
 
 export interface ForecastBucket {
   readonly id: ForecastBucketId;

--- a/apps/web/src/lib/assets/defi-positions-types.ts
+++ b/apps/web/src/lib/assets/defi-positions-types.ts
@@ -27,12 +27,7 @@ import type { ChainId, LocalDate, StakingIncome } from './types';
 
 /** The kind of DeFi position, which drives reward-income classification. */
 export type DefiPositionKind =
-  | 'STAKING'
-  | 'LIQUIDITY_POOL'
-  | 'LENDING'
-  | 'BORROW'
-  | 'VAULT'
-  | 'FARM';
+  'STAKING' | 'LIQUIDITY_POOL' | 'LENDING' | 'BORROW' | 'VAULT' | 'FARM';
 
 /**
  * Lock / withdrawal state of a position.

--- a/apps/web/src/lib/assets/types.ts
+++ b/apps/web/src/lib/assets/types.ts
@@ -442,12 +442,7 @@ export interface EquityTaxImplication {
 
 /** Source of passive income. */
 export type PassiveIncomeType =
-  | 'DIVIDEND'
-  | 'INTEREST'
-  | 'RENTAL'
-  | 'ROYALTY'
-  | 'DISTRIBUTION'
-  | 'OTHER';
+  'DIVIDEND' | 'INTEREST' | 'RENTAL' | 'ROYALTY' | 'DISTRIBUTION' | 'OTHER';
 
 /** Frequency of passive income payments. */
 export type PaymentFrequency = 'MONTHLY' | 'QUARTERLY' | 'SEMI_ANNUAL' | 'ANNUAL' | 'IRREGULAR';

--- a/apps/web/src/lib/automation/types.ts
+++ b/apps/web/src/lib/automation/types.ts
@@ -45,12 +45,7 @@ export interface Transaction {
 
 /** Comparison operators for numeric conditions. */
 export type AmountOperator =
-  | 'greater_than'
-  | 'less_than'
-  | 'equal'
-  | 'greater_or_equal'
-  | 'less_or_equal'
-  | 'between';
+  'greater_than' | 'less_than' | 'equal' | 'greater_or_equal' | 'less_or_equal' | 'between';
 
 /** Pattern matching mode for string conditions. */
 export type PatternMode = 'substring' | 'regex' | 'starts_with' | 'exact';

--- a/apps/web/src/lib/banking/types.ts
+++ b/apps/web/src/lib/banking/types.ts
@@ -159,12 +159,7 @@ export interface BankAccount {
 
 /** Supported account types. */
 export type BankAccountType =
-  | 'checking'
-  | 'savings'
-  | 'credit_card'
-  | 'loan'
-  | 'investment'
-  | 'other';
+  'checking' | 'savings' | 'credit_card' | 'loan' | 'investment' | 'other';
 
 /**
  * A normalized financial transaction in integer cents.

--- a/apps/web/src/lib/budgeting/expected-income-lifecycle.ts
+++ b/apps/web/src/lib/budgeting/expected-income-lifecycle.ts
@@ -2,11 +2,7 @@
 
 export type ExpectedIncomeStatus = 'expected' | 'cleared' | 'late' | 'partial' | 'missed';
 export type ExpectedIncomeSourceType =
-  | 'child_support'
-  | 'freelance'
-  | 'reimbursement'
-  | 'tips'
-  | 'other';
+  'child_support' | 'freelance' | 'reimbursement' | 'tips' | 'other';
 
 export interface ExpectedIncomeRecord {
   readonly id: string;

--- a/apps/web/src/lib/budgeting/starter-budget-templates.ts
+++ b/apps/web/src/lib/budgeting/starter-budget-templates.ts
@@ -12,11 +12,7 @@
 import { SINGLE_PARENT_FAMILY_TEMPLATE } from './single-parent-starter-template';
 
 export type BudgetStarterTemplateId =
-  | 'student'
-  | 'food-meals'
-  | 'professional'
-  | 'family'
-  | 'retiree';
+  'student' | 'food-meals' | 'professional' | 'family' | 'retiree';
 
 export interface BudgetStarterTemplateCategory {
   readonly emoji: string;

--- a/apps/web/src/lib/cashflow/cash-runway.ts
+++ b/apps/web/src/lib/cashflow/cash-runway.ts
@@ -41,12 +41,7 @@ export type CashEventDirection = 'inflow' | 'outflow';
 
 /** How often a scheduled event repeats within the horizon. */
 export type RecurrenceFrequency =
-  | 'once'
-  | 'weekly'
-  | 'biweekly'
-  | 'monthly'
-  | 'quarterly'
-  | 'yearly';
+  'once' | 'weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'yearly';
 
 /** A scheduled cash movement, optionally recurring. */
 export interface ScheduledCashEvent {

--- a/apps/web/src/lib/coaching/supportive-family-copy.ts
+++ b/apps/web/src/lib/coaching/supportive-family-copy.ts
@@ -21,10 +21,7 @@ export type SupportiveCopyTone = 'reassuring' | 'celebratory' | 'supportive';
 
 /** Stable identifiers for each supportive copy variant. */
 export type SupportiveFamilyCopyId =
-  | 'tight-month-reframe'
-  | 'celebrate-small-win'
-  | 'family-ready'
-  | 'steady-and-supported';
+  'tight-month-reframe' | 'celebrate-small-win' | 'family-ready' | 'steady-and-supported';
 
 /** A single piece of supportive coaching copy. */
 export interface SupportiveFamilyCopy {

--- a/apps/web/src/lib/crypto/defi-positions.ts
+++ b/apps/web/src/lib/crypto/defi-positions.ts
@@ -2,12 +2,7 @@
 
 /** Manual-entry DeFi position model separate from spot holdings. References: issue #2689 */
 export type DeFiPositionType =
-  | 'staking'
-  | 'liquidity-pool'
-  | 'lending'
-  | 'borrow'
-  | 'vault'
-  | 'farm';
+  'staking' | 'liquidity-pool' | 'lending' | 'borrow' | 'vault' | 'farm';
 export type LockStatus = 'liquid' | 'locked' | 'unbonding' | 'withdrawal-pending';
 
 export interface RewardBalance {

--- a/apps/web/src/lib/crypto/provenance-resolver.ts
+++ b/apps/web/src/lib/crypto/provenance-resolver.ts
@@ -2,11 +2,7 @@
 
 /** Bridge, wrap, and self-transfer provenance resolver for crypto tax evidence. References: issue #2674 */
 export type ProvenanceClassification =
-  | 'self-transfer'
-  | 'bridge'
-  | 'wrap'
-  | 'taxable-swap'
-  | 'ambiguous';
+  'self-transfer' | 'bridge' | 'wrap' | 'taxable-swap' | 'ambiguous';
 
 export interface AssetIdentity {
   readonly canonicalAsset: string;

--- a/apps/web/src/lib/debt/credit-score-impact.ts
+++ b/apps/web/src/lib/debt/credit-score-impact.ts
@@ -15,10 +15,7 @@ import { calculateCreditUtilizationSummary } from '../debt-credit-card-engine';
 export type CreditScoreImpactDirection = 'positive' | 'neutral' | 'negative' | 'unknown';
 export type CreditScoreImpactMagnitude = 'low' | 'medium' | 'high' | 'unknown';
 export type CreditScoreFactor =
-  | 'utilization'
-  | 'payment_history'
-  | 'new_credit'
-  | 'account_age_mix';
+  'utilization' | 'payment_history' | 'new_credit' | 'account_age_mix';
 
 export interface CreditScoreScenarioInput {
   readonly cards: readonly CreditCard[];

--- a/apps/web/src/lib/debt/refinance-baseline-options.ts
+++ b/apps/web/src/lib/debt/refinance-baseline-options.ts
@@ -3,9 +3,7 @@
 import type { StudentLoan, StudentLoanDashboardSummary } from '../debt-types';
 
 export type RefinanceBaselineId =
-  | 'current_required'
-  | 'selected_payoff_strategy'
-  | 'student_loan_baseline';
+  'current_required' | 'selected_payoff_strategy' | 'student_loan_baseline';
 
 export interface RefinanceBaselineOption {
   readonly id: RefinanceBaselineId;

--- a/apps/web/src/lib/enhancements/types.ts
+++ b/apps/web/src/lib/enhancements/types.ts
@@ -235,10 +235,7 @@ export interface CategoryDropZone {
 
 /** Data categories eligible for anonymous benchmarking */
 export type PrivacyDataCategory =
-  | 'spending_by_category'
-  | 'savings_rate'
-  | 'income_bracket'
-  | 'debt_ratio';
+  'spending_by_category' | 'savings_rate' | 'income_bracket' | 'debt_ratio';
 
 /** Differential privacy configuration */
 export interface DifferentialPrivacyConfig {

--- a/apps/web/src/lib/estate/types.ts
+++ b/apps/web/src/lib/estate/types.ts
@@ -11,13 +11,7 @@ export type EstateCategoryId =
   | 'important-contacts';
 
 export type EstateFieldInputType =
-  | 'text'
-  | 'textarea'
-  | 'currency'
-  | 'select'
-  | 'email'
-  | 'tel'
-  | 'date';
+  'text' | 'textarea' | 'currency' | 'select' | 'email' | 'tel' | 'date';
 
 export interface EstateFieldOption {
   readonly value: string;

--- a/apps/web/src/lib/haptics/types.ts
+++ b/apps/web/src/lib/haptics/types.ts
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 export type HapticEventType =
-  | 'budget_warning'
-  | 'budget_critical'
-  | 'budget_exceeded'
-  | 'goal_reached'
-  | 'savings_milestone';
+  'budget_warning' | 'budget_critical' | 'budget_exceeded' | 'goal_reached' | 'savings_milestone';
 
 export type HapticPattern = readonly number[];
 

--- a/apps/web/src/lib/household-advanced/types.ts
+++ b/apps/web/src/lib/household-advanced/types.ts
@@ -34,11 +34,7 @@ export type HouseholdType = 'couple' | 'roommates' | 'family';
 
 /** Identifiers for every step in the onboarding flow. */
 export type OnboardingStepId =
-  | 'invite_partner'
-  | 'set_shared_categories'
-  | 'configure_privacy'
-  | 'set_budgets'
-  | 'review';
+  'invite_partner' | 'set_shared_categories' | 'configure_privacy' | 'set_budgets' | 'review';
 
 /** Metadata for a single onboarding step. */
 export interface OnboardingStep {

--- a/apps/web/src/lib/household/net-worth-contribution-model.ts
+++ b/apps/web/src/lib/household/net-worth-contribution-model.ts
@@ -28,28 +28,22 @@ export function buildNetWorthContributionModel(
   accounts: readonly NetWorthAccountInput[],
 ): NetWorthContributionModel {
   const rollup = buildPrivacyAwareNetWorthRollup(accounts);
-  const detailedRows = rollup.detailedAttributions.map(
-    (item): NetWorthContributionRow => ({
-      label: item.label,
-      amountCents: item.amountCents,
-      visibility: 'DETAILED',
-      ownerMemberId: item.ownerMemberId,
-      accountId: item.accountId,
-      explanation:
-        'Detailed accounts show account name and owner attribution in the shared roll-up.',
-    }),
-  );
-  const aggregateRows = rollup.aggregateAttributions.map(
-    (item): NetWorthContributionRow => ({
-      label: item.label,
-      amountCents: item.amountCents,
-      visibility: 'AGGREGATE_ONLY',
-      ownerMemberId: null,
-      accountId: null,
-      explanation:
-        'Aggregate-only accounts add to totals without exposing account names or owners.',
-    }),
-  );
+  const detailedRows = rollup.detailedAttributions.map((item): NetWorthContributionRow => ({
+    label: item.label,
+    amountCents: item.amountCents,
+    visibility: 'DETAILED',
+    ownerMemberId: item.ownerMemberId,
+    accountId: item.accountId,
+    explanation: 'Detailed accounts show account name and owner attribution in the shared roll-up.',
+  }));
+  const aggregateRows = rollup.aggregateAttributions.map((item): NetWorthContributionRow => ({
+    label: item.label,
+    amountCents: item.amountCents,
+    visibility: 'AGGREGATE_ONLY',
+    ownerMemberId: null,
+    accountId: null,
+    explanation: 'Aggregate-only accounts add to totals without exposing account names or owners.',
+  }));
   const excludedRow: NetWorthContributionRow[] =
     rollup.excludedAccountCount > 0
       ? [

--- a/apps/web/src/lib/household/spending-visibility.ts
+++ b/apps/web/src/lib/household/spending-visibility.ts
@@ -7,10 +7,7 @@
  */
 
 export type SpendingVisibilityLevel =
-  | 'PRIVATE'
-  | 'AGGREGATE_ONLY'
-  | 'SHARED_TRANSACTIONS'
-  | 'CUSTOM';
+  'PRIVATE' | 'AGGREGATE_ONLY' | 'SHARED_TRANSACTIONS' | 'CUSTOM';
 
 export interface SpendingVisibilityRule {
   readonly id: string;

--- a/apps/web/src/lib/i18n/local-currency-entry.ts
+++ b/apps/web/src/lib/i18n/local-currency-entry.ts
@@ -7,11 +7,7 @@ import {
 } from '../currency-metadata';
 
 export type LocalCurrencyAmountError =
-  | 'required'
-  | 'invalid'
-  | 'too-many-decimals'
-  | 'not-positive'
-  | 'too-large';
+  'required' | 'invalid' | 'too-many-decimals' | 'not-positive' | 'too-large';
 
 export interface LocalCurrencyAmountParseSuccess {
   readonly ok: true;
@@ -31,8 +27,7 @@ export interface LocalCurrencyAmountParseFailure {
 }
 
 export type LocalCurrencyAmountParseResult =
-  | LocalCurrencyAmountParseSuccess
-  | LocalCurrencyAmountParseFailure;
+  LocalCurrencyAmountParseSuccess | LocalCurrencyAmountParseFailure;
 
 const LOCAL_CURRENCY_AMOUNT_ERROR_IDS: Readonly<Record<LocalCurrencyAmountError, string>> = {
   required: 'transaction.localAmount.error.required',

--- a/apps/web/src/lib/import/brokerage-trade-import.ts
+++ b/apps/web/src/lib/import/brokerage-trade-import.ts
@@ -4,13 +4,7 @@ import { parseCsv } from '../csv-parser';
 import { parseCurrencyToCents, parseDate } from './csv-parser';
 
 export type BrokerageActivityKind =
-  | 'fill'
-  | 'fee'
-  | 'dividend'
-  | 'transfer'
-  | 'option_event'
-  | 'corporate_action'
-  | 'crypto_trade';
+  'fill' | 'fee' | 'dividend' | 'transfer' | 'option_event' | 'corporate_action' | 'crypto_trade';
 
 export interface BrokerageProviderMetadata {
   readonly provider: string;

--- a/apps/web/src/lib/import/import-repair.ts
+++ b/apps/web/src/lib/import/import-repair.ts
@@ -9,13 +9,7 @@ import { parseCurrencyToCents, parseDate } from './csv-parser';
 
 export type RepairSeverity = 'blocking' | 'warning' | 'info';
 export type RepairField =
-  | 'date'
-  | 'amount'
-  | 'payee'
-  | 'category'
-  | 'account'
-  | 'note'
-  | 'sourceReference';
+  'date' | 'amount' | 'payee' | 'category' | 'account' | 'note' | 'sourceReference';
 export type DuplicateRepairAction = 'skip' | 'import' | 'replace';
 
 export interface RepairIssue {

--- a/apps/web/src/lib/import/migration-importers.ts
+++ b/apps/web/src/lib/import/migration-importers.ts
@@ -13,12 +13,7 @@ import type { YnabParseResult, YnabTransaction } from './ynab-parser';
 import type { ImportResult, ParsedTransaction } from './types';
 
 export type MigrationSource =
-  | 'mint'
-  | 'ynab'
-  | 'quicken-qif'
-  | 'quicken-qfx'
-  | 'quicken-ofx'
-  | 'generic';
+  'mint' | 'ynab' | 'quicken-qif' | 'quicken-qfx' | 'quicken-ofx' | 'generic';
 
 export interface MigrationTransaction {
   readonly source: MigrationSource;

--- a/apps/web/src/lib/import/migration.ts
+++ b/apps/web/src/lib/import/migration.ts
@@ -24,11 +24,7 @@ export type ImportSessionId = string;
 
 /** Status of an import session. */
 export type ImportSessionStatus =
-  | 'pending'
-  | 'in_progress'
-  | 'completed'
-  | 'rolled_back'
-  | 'failed';
+  'pending' | 'in_progress' | 'completed' | 'rolled_back' | 'failed';
 
 /** Strategy for handling duplicates during import. */
 export type MergeStrategy = 'skip' | 'overwrite' | 'keep_both';

--- a/apps/web/src/lib/import/qif-parser.ts
+++ b/apps/web/src/lib/import/qif-parser.ts
@@ -20,14 +20,7 @@ import { bankersRound } from './utils';
 
 /** QIF account/transaction type from the !Type: header. */
 export type QifType =
-  | 'Bank'
-  | 'Cash'
-  | 'CCard'
-  | 'Invst'
-  | 'Oth A'
-  | 'Oth L'
-  | 'Memorized'
-  | string;
+  'Bank' | 'Cash' | 'CCard' | 'Invst' | 'Oth A' | 'Oth L' | 'Memorized' | string;
 
 /** A single parsed QIF record with raw field values. */
 export interface QifRecord {

--- a/apps/web/src/lib/investment/broker-reconciliation.ts
+++ b/apps/web/src/lib/investment/broker-reconciliation.ts
@@ -4,10 +4,7 @@
 export type BrokerActivityType = 'BUY' | 'SELL' | 'DIVIDEND' | 'TRANSFER' | 'FEE' | 'CASH';
 export type ReconciliationSeverity = 'info' | 'warning' | 'critical';
 export type ReconciliationIssueType =
-  | 'duplicate-activity'
-  | 'position-mismatch'
-  | 'cash-mismatch'
-  | 'possible-transfer';
+  'duplicate-activity' | 'position-mismatch' | 'cash-mismatch' | 'possible-transfer';
 
 export interface BrokerActivity {
   readonly id: string;

--- a/apps/web/src/lib/investment/cash-flow-sankey-presentation.ts
+++ b/apps/web/src/lib/investment/cash-flow-sankey-presentation.ts
@@ -10,14 +10,7 @@ import type {
 /** UI-ready, accessible presentation model for cash-flow Sankey reports (#2480). */
 
 export type CashFlowSankeyColorToken =
-  | 'income'
-  | 'expense'
-  | 'transfer'
-  | 'debt'
-  | 'savings'
-  | 'available-cash'
-  | 'surplus'
-  | 'deficit';
+  'income' | 'expense' | 'transfer' | 'debt' | 'savings' | 'available-cash' | 'surplus' | 'deficit';
 
 export interface CashFlowSankeyLegendItem {
   readonly token: CashFlowSankeyColorToken;

--- a/apps/web/src/lib/investment/market-data.ts
+++ b/apps/web/src/lib/investment/market-data.ts
@@ -3,12 +3,7 @@
 /** Market-data snapshot abstraction with deterministic stale-state semantics. References: issue #2637 */
 export type AssetKind = 'equity' | 'option' | 'crypto' | 'cash' | 'other';
 export type MarketSessionStatus =
-  | 'open'
-  | 'closed'
-  | 'pre-market'
-  | 'after-hours'
-  | '24x7'
-  | 'unknown';
+  'open' | 'closed' | 'pre-market' | 'after-hours' | '24x7' | 'unknown';
 export type QuoteFreshness = 'fresh' | 'delayed' | 'stale' | 'missing' | 'failed';
 
 export interface QuoteSnapshot {

--- a/apps/web/src/lib/investment/p2p-matching.ts
+++ b/apps/web/src/lib/investment/p2p-matching.ts
@@ -3,11 +3,7 @@
 /** Reimbursement and split-payment matching engine for P2P flows. References: issue #2643 */
 export type P2PTransactionKind = 'bank' | 'p2p-payment' | 'p2p-request' | 'manual';
 export type P2PMatchType =
-  | 'reimbursement'
-  | 'roommate-rent'
-  | 'meal-split'
-  | 'pass-through-transfer'
-  | 'ambiguous';
+  'reimbursement' | 'roommate-rent' | 'meal-split' | 'pass-through-transfer' | 'ambiguous';
 export type P2POverrideState = 'none' | 'confirmed' | 'rejected' | 'edited';
 
 export interface P2PTransaction {

--- a/apps/web/src/lib/investments/brokerage-import.ts
+++ b/apps/web/src/lib/investments/brokerage-import.ts
@@ -140,9 +140,7 @@ export interface ReconciledHolding {
 
 /** Categories of reconciliation warning. */
 export type BrokerageWarningType =
-  | 'duplicate-within-broker'
-  | 'duplicate-cross-broker'
-  | 'oversold-position';
+  'duplicate-within-broker' | 'duplicate-cross-broker' | 'oversold-position';
 
 /** A group of trades flagged as duplicates of one another. */
 export interface DuplicateGroup {

--- a/apps/web/src/lib/mileage/types.ts
+++ b/apps/web/src/lib/mileage/types.ts
@@ -3,12 +3,7 @@
 export type TripPurpose = 'business' | 'medical' | 'charity' | 'moving' | 'personal';
 export type MileageRatePurpose = Exclude<TripPurpose, 'personal'>;
 export type ExpenseCategory =
-  | 'travel'
-  | 'meals'
-  | 'equipment'
-  | 'home-office'
-  | 'professional-services'
-  | 'subscriptions';
+  'travel' | 'meals' | 'equipment' | 'home-office' | 'professional-services' | 'subscriptions';
 export type DeductionType = 'mileage' | 'business-expense';
 export type BusinessExpenseSource = 'manual' | 'rule';
 

--- a/apps/web/src/lib/milestones/types.ts
+++ b/apps/web/src/lib/milestones/types.ts
@@ -3,11 +3,7 @@
 import type { IconName } from '../../components/icons';
 
 export type MilestoneCategory =
-  | 'net-worth'
-  | 'goal-progress'
-  | 'savings-streak'
-  | 'debt-reduction'
-  | 'debt-payoff';
+  'net-worth' | 'goal-progress' | 'savings-streak' | 'debt-reduction' | 'debt-payoff';
 
 export interface GoalSnapshot {
   readonly goalId: string;

--- a/apps/web/src/lib/navigation/guardrails.ts
+++ b/apps/web/src/lib/navigation/guardrails.ts
@@ -25,9 +25,7 @@ export const SIGNED_IN_HOME_PATH = '/dashboard';
  * - `exit`: allow the browser back navigation to leave the app shell.
  */
 export type BackNavigationDecision =
-  | { kind: 'redirect'; to: string }
-  | { kind: 'prompt' }
-  | { kind: 'exit' };
+  { kind: 'redirect'; to: string } | { kind: 'prompt' } | { kind: 'exit' };
 
 /** True when `pathname` is the onboarding flow (exact match or sub-route). */
 export function isOnboardingPath(pathname: string): boolean {

--- a/apps/web/src/lib/notifications/preference-controls.ts
+++ b/apps/web/src/lib/notifications/preference-controls.ts
@@ -51,18 +51,16 @@ export function buildNotificationPreferenceViewModel(params: {
   const preferences = normalizeNotificationPreferences(params.preferences);
   const quietHoursValidation = validateQuietHours(preferences.quietHours);
   const controls = preferences.channelPreferences.flatMap((preference) =>
-    ALL_CHANNELS.map(
-      (channel): NotificationPreferenceControl => ({
-        alertType: preference.alertType,
-        channel,
-        checked: preference.channels.includes(channel),
-        disabled: !isAvailable(channel, params.availability),
-        label: `${CHANNEL_LABELS[channel]} ${preference.alertType.replaceAll('_', ' ')}`,
-        describedBy: !isAvailable(channel, params.availability)
-          ? `${CHANNEL_LABELS[channel]} delivery is not available on this device yet.`
-          : 'Press Space to toggle this delivery channel.',
-      }),
-    ),
+    ALL_CHANNELS.map((channel): NotificationPreferenceControl => ({
+      alertType: preference.alertType,
+      channel,
+      checked: preference.channels.includes(channel),
+      disabled: !isAvailable(channel, params.availability),
+      label: `${CHANNEL_LABELS[channel]} ${preference.alertType.replaceAll('_', ' ')}`,
+      describedBy: !isAvailable(channel, params.availability)
+        ? `${CHANNEL_LABELS[channel]} delivery is not available on this device yet.`
+        : 'Press Space to toggle this delivery channel.',
+    })),
   );
 
   return {

--- a/apps/web/src/lib/onboarding/first-budget-tutorial.ts
+++ b/apps/web/src/lib/onboarding/first-budget-tutorial.ts
@@ -11,11 +11,7 @@
  */
 
 export type FirstBudgetTutorialStepId =
-  | 'income'
-  | 'fixed-expenses'
-  | 'flexible-spending'
-  | 'savings'
-  | 'review';
+  'income' | 'fixed-expenses' | 'flexible-spending' | 'savings' | 'review';
 
 export type FirstBudgetCategoryKind = 'income' | 'fixed' | 'flexible' | 'savings';
 

--- a/apps/web/src/lib/perf/offline-action-coverage.ts
+++ b/apps/web/src/lib/perf/offline-action-coverage.ts
@@ -2,13 +2,7 @@
 
 export type OfflineCoverageEntity = 'account' | 'transaction' | 'budget' | 'receipt' | 'settings';
 export type OfflineCoverageOperation =
-  | 'create'
-  | 'edit'
-  | 'delete'
-  | 'categorize'
-  | 'add-note'
-  | 'upload'
-  | 'change-preference';
+  'create' | 'edit' | 'delete' | 'categorize' | 'add-note' | 'upload' | 'change-preference';
 
 export interface OfflineActionCoverageRule {
   readonly entity: OfflineCoverageEntity;

--- a/apps/web/src/lib/perf/offline-first-actions.ts
+++ b/apps/web/src/lib/perf/offline-first-actions.ts
@@ -3,12 +3,7 @@
 export type OfflineEntity = 'account' | 'transaction' | 'budget' | 'receipt' | 'settings';
 export type OfflineOperation = 'create' | 'edit' | 'delete' | 'categorize' | 'add-note' | 'view';
 export type OfflineActionStatus =
-  | 'queued'
-  | 'syncing'
-  | 'synced'
-  | 'failed'
-  | 'needs-review'
-  | 'disabled';
+  'queued' | 'syncing' | 'synced' | 'failed' | 'needs-review' | 'disabled';
 
 export interface OfflineActionRequest {
   readonly entity: OfflineEntity;

--- a/apps/web/src/lib/perf/optional-route-chunk-plan.ts
+++ b/apps/web/src/lib/perf/optional-route-chunk-plan.ts
@@ -2,13 +2,7 @@
 
 export type OptionalChunkRoute = 'dashboard' | 'transactions';
 export type OptionalChunkCategory =
-  | 'primary-shell'
-  | 'chart'
-  | 'analytics'
-  | 'tax'
-  | 'investment'
-  | 'receipt'
-  | 'education';
+  'primary-shell' | 'chart' | 'analytics' | 'tax' | 'investment' | 'receipt' | 'education';
 
 export interface RouteImportDescriptor {
   readonly route: OptionalChunkRoute;

--- a/apps/web/src/lib/perf/transaction-sync-badges.ts
+++ b/apps/web/src/lib/perf/transaction-sync-badges.ts
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 export type TransactionSyncState =
-  | 'saved-local'
-  | 'queued'
-  | 'syncing'
-  | 'failed'
-  | 'conflicted'
-  | 'synced';
+  'saved-local' | 'queued' | 'syncing' | 'failed' | 'conflicted' | 'synced';
 export type TransactionSyncTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger';
 export type TransactionSyncAction = 'retry-sync' | 'review-conflict' | null;
 

--- a/apps/web/src/lib/planning/types.ts
+++ b/apps/web/src/lib/planning/types.ts
@@ -215,11 +215,7 @@ export interface GoalMilestone {
 
 /** Types of sweep rule triggers. */
 export type SweepRuleType =
-  | 'round-up'
-  | 'percent-of-income'
-  | 'threshold'
-  | 'fixed-amount'
-  | 'date-based';
+  'round-up' | 'percent-of-income' | 'threshold' | 'fixed-amount' | 'date-based';
 
 /** A configurable sweep automation rule. */
 export interface SweepRule {

--- a/apps/web/src/lib/recommendations/types.ts
+++ b/apps/web/src/lib/recommendations/types.ts
@@ -7,12 +7,7 @@ import type { DetectedSubscription } from '../analytics/subscriptions';
 import type { EmergencyRunwayResult } from '../savings/types';
 
 export type RecommendationCategory =
-  | 'cash-flow'
-  | 'spending'
-  | 'budget'
-  | 'savings'
-  | 'emergency-fund'
-  | 'subscriptions';
+  'cash-flow' | 'spending' | 'budget' | 'savings' | 'emergency-fund' | 'subscriptions';
 
 export type RecommendationPriority = 'critical' | 'high' | 'medium' | 'low';
 

--- a/apps/web/src/lib/reports/peer-benchmarks.ts
+++ b/apps/web/src/lib/reports/peer-benchmarks.ts
@@ -2,10 +2,7 @@
 
 export type PeerBenchmarkConfidence = 'low' | 'medium' | 'high';
 export type PeerBenchmarkStatus =
-  | 'below-peer-range'
-  | 'within-peer-range'
-  | 'above-peer-range'
-  | 'no-data';
+  'below-peer-range' | 'within-peer-range' | 'above-peer-range' | 'no-data';
 
 export interface PeerBenchmarkProfile {
   readonly optedIn: boolean;

--- a/apps/web/src/lib/reports/reporting-beta.ts
+++ b/apps/web/src/lib/reports/reporting-beta.ts
@@ -89,11 +89,7 @@ export interface AnnualSummary {
 }
 
 export type AnomalyModule =
-  | 'category-spend'
-  | 'merchant-spike'
-  | 'missing-income'
-  | 'duplicates'
-  | 'net-worth';
+  'category-spend' | 'merchant-spike' | 'missing-income' | 'duplicates' | 'net-worth';
 
 export type AnomalyStatus = 'needs-review' | 'expected' | 'ignored';
 
@@ -178,17 +174,15 @@ export function buildCategoryDrillDown(
   });
 
   const rows = filtered
-    .map(
-      (tx): DrillDownTransactionRow => ({
-        id: tx.id,
-        date: tx.date,
-        payee: tx.payee ?? tx.counterpartyName ?? 'Unknown payee',
-        accountName: accountNameFor(accountsById, tx.accountId),
-        amount: tx.type === 'EXPENSE' ? Math.abs(tx.amount.amount) : tx.amount.amount,
-        tags: tx.tags,
-        note: tx.note ?? tx.extraNotes ?? '',
-      }),
-    )
+    .map((tx): DrillDownTransactionRow => ({
+      id: tx.id,
+      date: tx.date,
+      payee: tx.payee ?? tx.counterpartyName ?? 'Unknown payee',
+      accountName: accountNameFor(accountsById, tx.accountId),
+      amount: tx.type === 'EXPENSE' ? Math.abs(tx.amount.amount) : tx.amount.amount,
+      tags: tx.tags,
+      note: tx.note ?? tx.extraNotes ?? '',
+    }))
     .sort((a, b) => b.date.localeCompare(a.date));
 
   const total = rows.reduce((sum, row) => sum + row.amount, 0);

--- a/apps/web/src/lib/reports/tax-year-summary.ts
+++ b/apps/web/src/lib/reports/tax-year-summary.ts
@@ -15,11 +15,7 @@ export type TaxSummarySectionKey =
   | 'estimated-payments';
 
 export type TaxSourceType =
-  | 'transaction'
-  | 'estimated-payment'
-  | 'investment-summary'
-  | 'manual-entry'
-  | 'checklist-item';
+  'transaction' | 'estimated-payment' | 'investment-summary' | 'manual-entry' | 'checklist-item';
 export type TaxQualityFlagSeverity = 'info' | 'warning';
 
 export interface TaxSummarySourceLink {
@@ -32,10 +28,7 @@ export interface TaxYearManualEntry {
   readonly id: string;
   readonly taxYear: number;
   readonly section:
-    | 'ordinary-income'
-    | 'deductible-expenses'
-    | 'charitable-giving'
-    | 'wash-sale-addbacks';
+    'ordinary-income' | 'deductible-expenses' | 'charitable-giving' | 'wash-sale-addbacks';
   readonly amountCents: number;
   readonly label: string;
 }
@@ -331,13 +324,11 @@ export function buildTaxYearSummaryReport(params: {
     (sum, summary) => sum + summary.longTermGainLossCents,
     0,
   );
-  const investmentSourceLinks = investmentSummaries.map(
-    (summary): TaxSummarySourceLink => ({
-      type: 'investment-summary',
-      id: `investment-${summary.taxYear}`,
-      label: `${summary.taxYear} investment tax summary`,
-    }),
-  );
+  const investmentSourceLinks = investmentSummaries.map((summary): TaxSummarySourceLink => ({
+    type: 'investment-summary',
+    id: `investment-${summary.taxYear}`,
+    label: `${summary.taxYear} investment tax summary`,
+  }));
   for (const source of investmentSourceLinks) addSectionSource(sources, 'capital-gains', source);
 
   let washSaleAddbacksCents = investmentSummaries.reduce(
@@ -396,14 +387,12 @@ export function buildTaxYearSummaryReport(params: {
     'wash-sale-addbacks': washSaleAddbacksCents,
     'estimated-payments': estimatedTaxPaymentsCents,
   };
-  const sections = sectionKeys.map(
-    (key): TaxYearSummarySection => ({
-      key,
-      label: SECTION_LABELS[key],
-      amountCents: amounts[key],
-      sourceLinks: sources.get(key) ?? [],
-    }),
-  );
+  const sections = sectionKeys.map((key): TaxYearSummarySection => ({
+    key,
+    label: SECTION_LABELS[key],
+    amountCents: amounts[key],
+    sourceLinks: sources.get(key) ?? [],
+  }));
 
   return {
     taxYear: params.taxYear,

--- a/apps/web/src/lib/savings/types.ts
+++ b/apps/web/src/lib/savings/types.ts
@@ -273,11 +273,7 @@ export interface Milestone {
 
 /** Goal categories surfaced by the savings suggestion engine. */
 export type SuggestedGoalType =
-  | 'emergency-fund'
-  | 'discretionary-savings'
-  | 'big-purchase'
-  | 'retirement'
-  | 'debt-payoff';
+  'emergency-fund' | 'discretionary-savings' | 'big-purchase' | 'retirement' | 'debt-payoff';
 
 /** Contribution cadence for a suggested plan. */
 export type ContributionFrequency = 'weekly' | 'biweekly' | 'monthly';
@@ -406,11 +402,7 @@ export interface SuggestedGoalProjection {
 
 /** Nudge categories emitted by the local suggestion engine. */
 export type SavingsNudgeType =
-  | 'spending-drift'
-  | 'redirect-opportunity'
-  | 'retirement-gap'
-  | 'debt-push'
-  | 'goal-momentum';
+  'spending-drift' | 'redirect-opportunity' | 'retirement-gap' | 'debt-push' | 'goal-momentum';
 
 /** A contextual nudge built from recent spending and savings momentum. */
 export interface SavingsNudge {

--- a/apps/web/src/lib/security-audit-log.ts
+++ b/apps/web/src/lib/security-audit-log.ts
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonValue[]
-  | { readonly [key: string]: JsonValue };
+  string | number | boolean | null | JsonValue[] | { readonly [key: string]: JsonValue };
 export type AuditActionType =
   | 'data_export_generated'
   | 'account_deletion_attempted'

--- a/apps/web/src/lib/security/app-lock-settings.ts
+++ b/apps/web/src/lib/security/app-lock-settings.ts
@@ -2,10 +2,7 @@
 
 export type AppLockEvent = 'manual_lock' | 'unlock_success' | 'activity' | 'idle_check' | 'resume';
 export type AppLockAuditEvent =
-  | 'app_lock_enabled'
-  | 'app_locked'
-  | 'app_unlocked'
-  | 'app_lock_bypassed';
+  'app_lock_enabled' | 'app_locked' | 'app_unlocked' | 'app_lock_bypassed';
 export type AppLockReason = 'disabled' | 'manual' | 'idle_timeout' | 'resume' | 'unlock_success';
 
 export interface AppLockSettings {

--- a/apps/web/src/lib/security/passkey-gate.ts
+++ b/apps/web/src/lib/security/passkey-gate.ts
@@ -3,11 +3,7 @@
 /** App-lock helpers built on WebAuthn user verification/passkeys. */
 
 export type AppLockDecisionReason =
-  | 'disabled'
-  | 'manual'
-  | 'idle_timeout'
-  | 'resume'
-  | 'unsupported';
+  'disabled' | 'manual' | 'idle_timeout' | 'resume' | 'unsupported';
 export type PasskeyGateStatus = 'unlocked' | 'unsupported' | 'cancelled' | 'failed';
 
 export interface AppLockPolicy {

--- a/apps/web/src/lib/security/privacy-coverage.ts
+++ b/apps/web/src/lib/security/privacy-coverage.ts
@@ -3,13 +3,7 @@
 import type { SensitiveSurfaceCategory } from './privacy-screen';
 
 export type SensitiveSurfaceArea =
-  | 'dashboard'
-  | 'chart'
-  | 'detail'
-  | 'export'
-  | 'notification'
-  | 'search'
-  | 'navigation';
+  'dashboard' | 'chart' | 'detail' | 'export' | 'notification' | 'search' | 'navigation';
 
 export interface PrivacySurfaceCoverageItem {
   readonly id: string;

--- a/apps/web/src/lib/security/types.ts
+++ b/apps/web/src/lib/security/types.ts
@@ -129,10 +129,7 @@ export interface DeviceSession {
 
 /** Granular telemetry category. */
 export type TelemetryCategory =
-  | 'crash_reports'
-  | 'usage_analytics'
-  | 'performance_metrics'
-  | 'feature_flags';
+  'crash_reports' | 'usage_analytics' | 'performance_metrics' | 'feature_flags';
 
 /** Configuration for no-telemetry mode. */
 export interface TelemetryConfig {

--- a/apps/web/src/lib/security/webauthn-challenge.ts
+++ b/apps/web/src/lib/security/webauthn-challenge.ts
@@ -7,13 +7,7 @@ import {
 } from './passkey-gate';
 
 export type WebAuthnChallengeStatus =
-  | 'created'
-  | 'verified'
-  | 'unsupported'
-  | 'cancelled'
-  | 'failed'
-  | 'expired'
-  | 'replayed';
+  'created' | 'verified' | 'unsupported' | 'cancelled' | 'failed' | 'expired' | 'replayed';
 
 export interface WebAuthnAppLockChallenge extends PasskeyGateChallenge {
   readonly id: string;

--- a/apps/web/src/lib/session-security.ts
+++ b/apps/web/src/lib/session-security.ts
@@ -3,10 +3,7 @@
 import { appendSecurityAuditEvent } from './security-audit-log';
 
 export type RiskyAction =
-  | 'data_export'
-  | 'account_deletion'
-  | 'passkey_change'
-  | 'third_party_permission_change';
+  'data_export' | 'account_deletion' | 'passkey_change' | 'third_party_permission_change';
 
 export interface StepUpStatus {
   readonly required: boolean;

--- a/apps/web/src/lib/social/share-card-redaction.ts
+++ b/apps/web/src/lib/social/share-card-redaction.ts
@@ -1,15 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 export type ShareCardType =
-  | 'goal-milestone'
-  | 'goal-completion'
-  | 'badge-unlock'
-  | 'streak-milestone';
+  'goal-milestone' | 'goal-completion' | 'badge-unlock' | 'streak-milestone';
 export type RedactionPolicy =
-  | 'amount-hidden'
-  | 'percent-only'
-  | 'nickname-only'
-  | 'private-household';
+  'amount-hidden' | 'percent-only' | 'nickname-only' | 'private-household';
 
 export interface ShareCardPayload {
   readonly type: ShareCardType;

--- a/apps/web/src/lib/subscriptions/types.ts
+++ b/apps/web/src/lib/subscriptions/types.ts
@@ -121,11 +121,7 @@ export interface AnomalyResult {
 
 /** Phase of the cancellation workflow. */
 export type CancellationPhase =
-  | 'confirm_intent'
-  | 'check_contract'
-  | 'execute_cancellation'
-  | 'verify_cancelled'
-  | 'follow_up';
+  'confirm_intent' | 'check_contract' | 'execute_cancellation' | 'verify_cancelled' | 'follow_up';
 
 /** A single step in a guided cancellation workflow. */
 export interface CancellationStep {

--- a/apps/web/src/lib/tagging/tagging-types.ts
+++ b/apps/web/src/lib/tagging/tagging-types.ts
@@ -25,12 +25,7 @@
  * - `account` matches against `Transaction.accountId`
  */
 export type TagConditionField =
-  | 'counterpartyName'
-  | 'category'
-  | 'amount'
-  | 'account'
-  | 'description'
-  | 'type';
+  'counterpartyName' | 'category' | 'amount' | 'account' | 'description' | 'type';
 
 /**
  * Comparison operators available for tag rule conditions.

--- a/apps/web/src/lib/tax/broker-1099b-reconciliation.ts
+++ b/apps/web/src/lib/tax/broker-1099b-reconciliation.ts
@@ -39,21 +39,14 @@ export interface Broker1099BLotRow {
 
 export interface Broker1099BReconciliationDifference {
   readonly field:
-    | 'proceedsCents'
-    | 'costBasisCents'
-    | 'feesCents'
-    | 'washSaleAdjustmentCents'
-    | 'shares';
+    'proceedsCents' | 'costBasisCents' | 'feesCents' | 'washSaleAdjustmentCents' | 'shares';
   readonly appValue: number;
   readonly brokerValue: number;
   readonly variance: number;
 }
 
 export type Broker1099BReconciliationStatus =
-  | 'match'
-  | 'variance'
-  | 'missing-in-app'
-  | 'missing-in-broker';
+  'match' | 'variance' | 'missing-in-app' | 'missing-in-broker';
 
 export interface Broker1099BReconciliationRow {
   readonly key: string;

--- a/apps/web/src/lib/tax/retirement-contribution-limits.ts
+++ b/apps/web/src/lib/tax/retirement-contribution-limits.ts
@@ -15,14 +15,7 @@
 const NEAR_LIMIT_THRESHOLD = 0.9;
 
 export type RetirementAccountType =
-  | 'TRADITIONAL_IRA'
-  | 'ROTH_IRA'
-  | '401K'
-  | 'ROTH_401K'
-  | '403B'
-  | 'SEP_IRA'
-  | 'HSA'
-  | 'FSA';
+  'TRADITIONAL_IRA' | 'ROTH_IRA' | '401K' | 'ROTH_401K' | '403B' | 'SEP_IRA' | 'HSA' | 'FSA';
 
 export type RetirementTaxTreatment = 'PRE_TAX' | 'ROTH' | 'AFTER_TAX' | 'EMPLOYER';
 export type ContributionDesignation = 'EMPLOYEE' | 'EMPLOYER';

--- a/apps/web/src/lib/tax/self-employment-income.ts
+++ b/apps/web/src/lib/tax/self-employment-income.ts
@@ -15,11 +15,7 @@ export const SELF_EMPLOYMENT_FORM_TYPE_FIELD = 'tax.selfEmploymentFormType';
 
 export type SelfEmploymentFormType = '1099_NEC' | '1099_MISC' | '1099_K' | 'CASH' | 'OTHER';
 export type ExpectedTaxFormStatus =
-  | 'NOT_EXPECTED'
-  | 'EXPECTED'
-  | 'RECEIVED'
-  | 'RECONCILED'
-  | 'MISSING';
+  'NOT_EXPECTED' | 'EXPECTED' | 'RECEIVED' | 'RECONCILED' | 'MISSING';
 
 export interface SelfEmploymentIncomeRecord {
   readonly id: string;
@@ -60,10 +56,7 @@ export interface PayerIncomeSummary {
 }
 
 export type IncomeReconciliationStatus =
-  | 'MATCH'
-  | 'VARIANCE'
-  | 'MISSING_FORM'
-  | 'FORM_WITHOUT_TRANSACTIONS';
+  'MATCH' | 'VARIANCE' | 'MISSING_FORM' | 'FORM_WITHOUT_TRANSACTIONS';
 
 export interface IncomeReconciliationResult {
   readonly payerName: string;

--- a/apps/web/src/lib/tax/tax-category-ui-model.ts
+++ b/apps/web/src/lib/tax/tax-category-ui-model.ts
@@ -20,11 +20,7 @@ import {
 } from './tax-category-tagging';
 
 export type TaxTransactionFilter =
-  | 'uncategorized-for-tax'
-  | 'missing-receipt'
-  | 'review-needed'
-  | 'deductible'
-  | 'non-deductible';
+  'uncategorized-for-tax' | 'missing-receipt' | 'review-needed' | 'deductible' | 'non-deductible';
 
 export interface TaxCategoryEditModel {
   readonly transactionId: string;

--- a/apps/web/src/lib/tax/tax-document-export.ts
+++ b/apps/web/src/lib/tax/tax-document-export.ts
@@ -8,18 +8,9 @@ import type { AnnualMileageSummary } from './mileage-log';
 import type { PayerIncomeSummary } from './self-employment-income';
 
 export type TaxChecklistSection =
-  | 'INCOME'
-  | 'INVESTMENTS'
-  | 'DEDUCTIONS'
-  | 'ESTIMATED_PAYMENTS'
-  | 'DOCUMENTS';
+  'INCOME' | 'INVESTMENTS' | 'DEDUCTIONS' | 'ESTIMATED_PAYMENTS' | 'DOCUMENTS';
 export type TaxChecklistStatus =
-  | 'NOT_STARTED'
-  | 'REQUESTED'
-  | 'RECEIVED'
-  | 'REVIEWED'
-  | 'EXPORTED'
-  | 'NOT_APPLICABLE';
+  'NOT_STARTED' | 'REQUESTED' | 'RECEIVED' | 'REVIEWED' | 'EXPORTED' | 'NOT_APPLICABLE';
 
 export interface TaxChecklistItem {
   readonly id: string;

--- a/apps/web/src/lib/tax/tax-reconciliation-inputs.ts
+++ b/apps/web/src/lib/tax/tax-reconciliation-inputs.ts
@@ -9,11 +9,7 @@
 
 export type TaxReceiptStatus = 'not-required' | 'required-attached' | 'required-missing';
 export type TaxForm1099Status =
-  | 'not-expected'
-  | 'expected'
-  | 'received'
-  | 'reconciled'
-  | 'variance';
+  'not-expected' | 'expected' | 'received' | 'reconciled' | 'variance';
 export type TaxReconciliationChecklistStatus = 'open' | 'done';
 
 export interface TaxReconciliationTransactionInput {
@@ -39,13 +35,7 @@ export interface TaxForm1099Input {
   readonly taxYear: number;
   readonly payerName: string;
   readonly formType:
-    | '1099-NEC'
-    | '1099-MISC'
-    | '1099-K'
-    | '1099-INT'
-    | '1099-DIV'
-    | '1099-B'
-    | 'OTHER';
+    '1099-NEC' | '1099-MISC' | '1099-K' | '1099-INT' | '1099-DIV' | '1099-B' | 'OTHER';
   readonly expectedAmountCents?: number;
   readonly receivedAmountCents?: number;
   readonly reconciled?: boolean;

--- a/apps/web/src/lib/ui/privacy/quick-actions.ts
+++ b/apps/web/src/lib/ui/privacy/quick-actions.ts
@@ -3,10 +3,7 @@
 /** Platform quick-action registration descriptor for privacy-mode toggles. */
 export interface PrivacyQuickActionDescriptor {
   readonly platform:
-    | 'ios-control-center'
-    | 'android-quick-settings'
-    | 'web-shortcut'
-    | 'windows-secondary-tile';
+    'ios-control-center' | 'android-quick-settings' | 'web-shortcut' | 'windows-secondary-tile';
   readonly title: string;
   readonly description: string;
   readonly action: 'toggle-privacy-mode';

--- a/apps/web/src/lib/voice/types.ts
+++ b/apps/web/src/lib/voice/types.ts
@@ -7,13 +7,7 @@ export type VoiceState = 'unsupported' | 'idle' | 'starting' | 'listening' | 'pr
 export type VoiceIntent = 'expense' | 'income' | 'transfer' | 'split' | 'unknown';
 
 export type VoiceField =
-  | 'amount'
-  | 'payee'
-  | 'category'
-  | 'date'
-  | 'type'
-  | 'account'
-  | 'counterparty';
+  'amount' | 'payee' | 'category' | 'date' | 'type' | 'account' | 'counterparty';
 
 export interface VoiceFieldConfidence {
   readonly value: number;

--- a/apps/web/src/lib/web-vitals.ts
+++ b/apps/web/src/lib/web-vitals.ts
@@ -190,8 +190,7 @@ export function getNavigationTiming(): Record<string, number> | null {
   if (typeof performance === 'undefined') return null;
 
   const nav = performance.getEntriesByType('navigation')[0] as
-    | (PerformanceNavigationTiming & { startTime: number })
-    | undefined;
+    (PerformanceNavigationTiming & { startTime: number }) | undefined;
   if (!nav) return null;
 
   return {

--- a/apps/web/src/lib/wellness/types.ts
+++ b/apps/web/src/lib/wellness/types.ts
@@ -15,12 +15,7 @@
 
 /** Application status for a scholarship. */
 export type ScholarshipStatus =
-  | 'researching'
-  | 'in_progress'
-  | 'submitted'
-  | 'awarded'
-  | 'rejected'
-  | 'waitlisted';
+  'researching' | 'in_progress' | 'submitted' | 'awarded' | 'rejected' | 'waitlisted';
 
 /** A scholarship application entry. */
 export interface Scholarship {
@@ -532,10 +527,7 @@ export interface MoodCorrelationSummary {
 
 /** Stress signals shown as gentle alerts in the wellness dashboard. */
 export type StressIndicatorKind =
-  | 'declining-savings'
-  | 'debt-pressure'
-  | 'irregular-income'
-  | 'bill-crunch';
+  'declining-savings' | 'debt-pressure' | 'irregular-income' | 'bill-crunch';
 
 /** A single detected financial stress signal. */
 export interface StressIndicator {

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -61,13 +61,7 @@ const SIMPLE_MODE_FONT_SCALE_INDEX = Math.max(
 );
 
 type OnboardingStep =
-  | 'comfort'
-  | 'choose'
-  | 'privacy'
-  | 'newcomer'
-  | 'goals'
-  | 'template'
-  | 'complete';
+  'comfort' | 'choose' | 'privacy' | 'newcomer' | 'goals' | 'template' | 'complete';
 
 const ONBOARDING_STEP_ORDER: readonly OnboardingStep[] = [
   'comfort',

--- a/apps/web/src/sw/service-worker.ts
+++ b/apps/web/src/sw/service-worker.ts
@@ -806,11 +806,7 @@ function isStaticAsset(pathname: string): boolean {
 }
 
 export type FetchStrategy =
-  | 'receipt-cache-first'
-  | 'network-first'
-  | 'network-only-no-store'
-  | 'cache-first'
-  | 'navigation';
+  'receipt-cache-first' | 'network-first' | 'network-only-no-store' | 'cache-first' | 'navigation';
 
 export function getFetchStrategyForPathname(
   pathname: string,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -702,10 +702,10 @@ during setup. In production, restrict it:
 ```yaml
 # In docker-compose.yml, change:
 ports:
-  - "${POSTGRES_PORT:-5432}:5432"
+  - '${POSTGRES_PORT:-5432}:5432'
 # To bind only to localhost:
 ports:
-  - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
+  - '127.0.0.1:${POSTGRES_PORT:-5432}:5432'
 ```
 
 Or remove the `ports` directive entirely if you don't need direct access.

--- a/docs/android/play-store-submission.md
+++ b/docs/android/play-store-submission.md
@@ -108,12 +108,13 @@ Google can issue a new one without affecting existing installations.
 ```
 
 Required GitHub Secrets:
-| Secret | Description |
-|--------|-------------|
-| `FINANCE_KEYSTORE_BASE64` | Base64-encoded upload keystore |
-| `FINANCE_KEYSTORE_PASSWORD` | Keystore password |
-| `FINANCE_KEY_ALIAS` | Key alias (e.g., `finance-upload`) |
-| `FINANCE_KEY_PASSWORD` | Key password |
+
+| Secret                      | Description                        |
+| --------------------------- | ---------------------------------- |
+| `FINANCE_KEYSTORE_BASE64`   | Base64-encoded upload keystore     |
+| `FINANCE_KEYSTORE_PASSWORD` | Keystore password                  |
+| `FINANCE_KEY_ALIAS`         | Key alias (e.g., `finance-upload`) |
+| `FINANCE_KEY_PASSWORD`      | Key password                       |
 
 ---
 

--- a/docs/architecture/security-audit-v1.md
+++ b/docs/architecture/security-audit-v1.md
@@ -204,8 +204,8 @@ The codebase demonstrates **strong security architecture** — envelope encrypti
 - **Recommendation:** Replace the wildcard with explicit allowed origins:
   `	ypescript
 const ALLOWED_ORIGINS = [
-  'https://app.finance.example.com',
-  'http://localhost:5173', // dev only, behind env check
+'https://app.finance.example.com',
+'http://localhost:5173', // dev only, behind env check
 ];
 `
   The `Access-Control-Allow-Origin` header must match the request's `Origin` header or be rejected. Note: browsers will not send cookies with `credentials: 'include'` when the server responds with `*`, but the `apikey` header is still sent, allowing abuse of the Supabase anon key.

--- a/docs/audits/feature-parity-matrix.md
+++ b/docs/audits/feature-parity-matrix.md
@@ -48,6 +48,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **iOS:** `Screens/AccountsView.swift`, `AccountDetailView.swift`, `AccountEditView.swift`, `ViewModels/AccountsViewModel.swift`, `Repositories/AccountRepository.swift`
 - **Web:** `pages/AccountsPage.tsx`, `pages/AccountDetailPage.tsx`, `components/forms/AccountForm.tsx`, `hooks/useAccounts.ts`, `db/repositories/accounts.ts`
 - **Windows:** `screens/AccountsScreen.kt`, `viewmodel/AccountsViewModel.kt`, `data/repository/AccountRepository.kt`
+
 </details>
 
 <details>
@@ -57,6 +58,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **iOS:** `Screens/TransactionsView.swift`, `TransactionCreateView.swift`, `TransactionDetailView.swift`, `TransactionEditView.swift`, `ViewModels/TransactionsViewModel.swift`, `TransactionCreateViewModel.swift`
 - **Web:** `pages/TransactionsPage.tsx`, `pages/TransactionDetailPage.tsx`, `components/forms/TransactionForm.tsx`, `components/forms/QuickEntry.tsx`, `hooks/useTransactions.ts`, `hooks/useQuickEntry.ts`
 - **Windows:** `screens/TransactionsScreen.kt`, `screens/QuickAddTransactionDialog.kt`, `viewmodel/TransactionsViewModel.kt`
+
 </details>
 
 <details>
@@ -66,6 +68,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **iOS:** `Screens/BudgetsView.swift`, `BudgetCreateView.swift`, `ViewModels/BudgetsViewModel.swift`, `BudgetCreateViewModel.swift`
 - **Web:** `pages/BudgetsPage.tsx`, `pages/BudgetDetailPage.tsx`, `components/forms/BudgetForm.tsx`, `hooks/useBudgets.ts`
 - **Windows:** `screens/BudgetsScreen.kt`, `viewmodel/BudgetsViewModel.kt`, `components/BudgetRolloverToggle.kt`
+
 </details>
 
 <details>
@@ -75,6 +78,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **iOS:** `Screens/GoalsView.swift`, `GoalCreateView.swift`, `ViewModels/GoalsViewModel.swift`, `GoalCreateViewModel.swift`
 - **Web:** `pages/GoalsPage.tsx`, `pages/GoalDetailPage.tsx`, `components/forms/GoalForm.tsx`, `hooks/useGoals.ts`
 - **Windows:** `screens/GoalsScreen.kt`, `viewmodel/GoalsViewModel.kt`
+
 </details>
 
 <details>
@@ -85,6 +89,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **Web:** `components/DataExport.tsx` (with tests and Storybook), `components/gdpr/` (ConsentDialog, PrivacySettings)
 - **Windows:** `screens/gdpr/` (GdprConsentDialog, PrivacySettingsScreen) — export is GDPR-focused but lacks a standalone export ViewModel
 - **KMP Shared:** `packages/core/.../export/` (DataExportService, CsvExportSerializer, JsonExportSerializer)
+
 </details>
 
 <details>
@@ -94,6 +99,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **iOS:** `Screens/LoginView.swift`, `Screens/AuthGateView.swift`, `Screens/LockScreenView.swift`, `Security/BiometricAuthManager.swift`, `Services/SupabaseAuthClient.swift`
 - **Web:** `auth/auth-context.tsx`, `auth/webauthn.ts`, `auth/token-storage.ts`, `pages/LoginPage.tsx`, `pages/SignupPage.tsx`
 - **Windows:** `screens/auth/LoginScreen.kt`, `viewmodel/AuthViewModel.kt`, `viewmodel/LoginViewModel.kt`, `security/WindowsHelloManager.kt`, `security/CredentialManager.kt`
+
 </details>
 
 ---
@@ -120,6 +126,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **Web:** `pages/HouseholdPage.tsx` (with CSS + tests), `hooks/useHousehold.ts`
 - **Windows:** `screens/HouseholdScreen.kt`, `viewmodel/HouseholdViewModel.kt`; sidebar nav entry `Screen.Household`
 - **KMP Shared:** `packages/core/.../household/` — HouseholdManager, RbacPermissions, InvitationStateMachine, DataPartitioning, HouseholdRole
+
 </details>
 
 <details>
@@ -130,6 +137,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **Web:** ❌ No investment page, hook, or component found. `WatchlistsPage.tsx` exists but is spending watchlists, not investment tracking
 - **Windows:** `screens/InvestmentScreen.kt`, `viewmodel/InvestmentViewModel.kt`; sidebar nav entry `Screen.Investments`
 - **KMP Shared:** `packages/core/.../investment/InvestmentEngine.kt`
+
 </details>
 
 <details>
@@ -140,6 +148,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **Web:** ❌ No bill reminders page or hook. Transaction recurring support exists but no dedicated bill tracker
 - **Windows:** 🟡 `notifications/EnhancedNotificationManager.kt` and `components/RecurringPreviewPanel.kt` reference reminders, but no dedicated `BillRemindersScreen`
 - **KMP Shared:** `packages/core/.../recurring/Reminder.kt`, `RecurringTransactionEngine.kt`
+
 </details>
 
 <details>
@@ -150,6 +159,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **Web:** ✅ `hooks/useMultiCurrency.ts` — full hook with ExchangeRate types, conversion, formatting, currency totals. `components/dashboard/CurrencyDisplay.tsx`
 - **Windows:** 🟡 Settings include currency selection; no dedicated conversion UI
 - **KMP Shared:** `packages/core/.../multicurrency/MultiCurrencyEngine.kt`
+
 </details>
 
 <details>
@@ -160,6 +170,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **Web:** ✅ Full pipeline — `pages/ImportPage.tsx`, `pages/DataImportWizardPage.tsx`, `hooks/useImport.ts`, `hooks/useDataImportWizard.ts`, `components/import/` (FileDropZone, ColumnMapper, ImportPreview, ImportProgress, ImportComplete), `lib/csv-parser.ts`, `lib/csv-column-mapper.ts`, `lib/csv-import-validator.ts`, `lib/csv-duplicate-detector.ts`
 - **Windows:** `screens/ImportWizardScreen.kt`, `viewmodel/ImportWizardViewModel.kt`, `data/CsvEncodingDetector.kt`; sidebar nav entry `Screen.Import`
 - **KMP Shared:** `packages/core/.../dataimport/` — CsvParser, CsvImportParser, DataImportService, ImportData, ImportTypes
+
 </details>
 
 <details>
@@ -170,6 +181,7 @@ These features are foundational. Every platform must implement them before v2.0.
 - **Web:** ✅ `components/forms/NaturalLanguageInput.tsx` (with CSS + tests), `hooks/useNaturalLanguageInput.ts`, `lib/nlParser.ts` (with tests)
 - **Windows:** `screens/NaturalLanguageScreen.kt`, `viewmodel/NaturalLanguageViewModel.kt`, `voice/VoiceCommandManager.kt`, `VoiceCommandParser.kt`, `screens/VoiceTransactionOverlay.kt`; sidebar nav entry `Screen.QuickAdd`
 - **KMP Shared:** `packages/core/.../nlp/NaturalLanguageParser.kt`
+
 </details>
 
 ---

--- a/docs/audits/security-audit-owasp-masvs.md
+++ b/docs/audits/security-audit-owasp-masvs.md
@@ -53,10 +53,11 @@ The remaining findings are defense-in-depth improvements with no active data exp
 - **Issue:** The `CRON_SECRET` comparison uses JavaScript's `!==` operator, which short-circuits on the first differing byte. This creates a timing side-channel that could allow an attacker to brute-force the secret one character at a time. The `auth-webhook` function correctly uses `constantTimeEqual()` (line 51--63 of `auth-webhook/index.ts`), but `process-recurring` does not.
 - **MASVS:** MASVS-CRYPTO-2 (use proven cryptographic primitives correctly)
 - **Remediation:** Import or inline the `constantTimeEqual()` function from `auth-webhook/index.ts` (or extract it to `_shared/auth.ts`) and use it for the comparison:
-  `	ypescript
+
+```typescript
 const token = authHeader.replace('Bearer ', '');
 if (!constantTimeEqual(token, cronSecret)) { ... }
-`
+```
 
 ### C-2: JVM/Android SecureRandom instantiated per call --- Severity: MEDIUM
 
@@ -65,7 +66,8 @@ if (!constantTimeEqual(token, cronSecret)) { ... }
 - **Issue:** While functionally correct, repeated instantiation wastes entropy pool initialization. On Android particularly, early-boot entropy starvation is a known issue. A singleton `SecureRandom` instance would be both more performant and safer.
 - **MASVS:** MASVS-CRYPTO-1 (strong random number generation)
 - **Remediation:** Use a companion object singleton:
-  `kotlin
+
+```kotlin
 actual object PlatformSHA256 {
     private val secureRandom = java.security.SecureRandom()
     actual fun randomBytes(size: Int): ByteArray {
@@ -74,7 +76,7 @@ actual object PlatformSHA256 {
         return bytes
     }
 }
-`
+```
 
 ### C-3: JVM KeyStore uses hardcoded password --- Severity: MEDIUM
 
@@ -198,9 +200,10 @@ actual object PlatformSHA256 {
 - **Issue:** The email delivery uses `http://` (plaintext) to connect to the SMTP relay. If the relay is on a different host or traverses a network boundary, email content (including notification subjects and bodies) is transmitted unencrypted.
 - **MASVS:** MASVS-NETWORK-1 (use TLS for all network communication)
 - **Remediation:** Change to `https://` and validate the relay certificate. If the relay is localhost-only (same Deno isolate), document this as an accepted risk. Add a validation check:
-  `	ypescript
+
+```typescript
 const protocol = smtpHost === 'localhost' || smtpHost === '127.0.0.1' ? 'http' : 'https';
-`
+```
 
 ### N-2: PASS --- CORS is origin-allowlist based, never wildcard
 
@@ -255,12 +258,13 @@ const protocol = smtpHost === 'localhost' || smtpHost === '127.0.0.1' ? 'http' :
 - **Issue:** The `role` field from the request body is passed directly to the database insert (line 141) without validation against an allowlist. If the DB has a CHECK constraint this is caught, but relying solely on DB-level validation means the error message may leak schema details.
 - **MASVS:** MASVS-CODE-4 (validate all input)
 - **Remediation:** Add application-level validation:
-  `	ypescript
+
+```typescript
 const VALID_ROLES = ['member', 'admin'] as const;
 if (!VALID_ROLES.includes(role)) {
   return errorResponse(req, 'Invalid role. Must be "member" or "admin".');
 }
-`
+```
 
 ### Q-3: household-invite POST does not validate expires_in_hours --- Severity: LOW
 
@@ -268,11 +272,12 @@ if (!VALID_ROLES.includes(role)) {
 - **Issue:** `expires_in_hours` is used directly in expiry calculation (line 132) without bounds checking. A malicious request could set `expires_in_hours: 999999` (creating invitations valid for ~114 years) or `expires_in_hours: 0` (immediately expired) or negative values.
 - **MASVS:** MASVS-CODE-4 (validate all input)
 - **Remediation:**
-  `	ypescript
+
+```typescript
 const MAX_EXPIRY_HOURS = 168; // 7 days
 const MIN_EXPIRY_HOURS = 1;
 const validExpiry = Math.min(MAX_EXPIRY_HOURS, Math.max(MIN_EXPIRY_HOURS, expires_in_hours));
-`
+```
 
 ### Q-4: CSV export vulnerable to formula injection --- Severity: LOW
 
@@ -280,12 +285,13 @@ const validExpiry = Math.min(MAX_EXPIRY_HOURS, Math.max(MIN_EXPIRY_HOURS, expire
 - **Issue:** The `recordsToCsv()` function escapes commas, quotes, and newlines, but does not sanitize values starting with `=`, `+`, `-`, or `@`. If a user has entered a payee name like `=CMD('calc')`, the exported CSV could execute formulas when opened in Excel or Google Sheets (CSV injection / formula injection).
 - **MASVS:** MASVS-CODE-4 (validate and sanitize output)
 - **Remediation:** Prefix values starting with `=`, `+`, `-`, `@`, `\t`, `\r` with a single quote:
-  `	ypescript
+
+```typescript
 const FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r'];
 if (FORMULA_TRIGGERS.some(t => str.startsWith(t))) {
   return "'$`{str.replace(/"/g, '""')}";
   }
-  `
+```
 
 ### Q-5: PASS --- All Edge Functions use parameterized queries
 

--- a/docs/design/ios-wallet-transaction-capture.md
+++ b/docs/design/ios-wallet-transaction-capture.md
@@ -422,11 +422,11 @@ components independently (§6.4) rather than hashing them together.
 Given a `CapturedTransaction` and a window of existing `Transaction`s, compute a composite score
 per candidate-existing pair:
 
-| Component    | Rule                                                                                                                                           | Weight      |
+| Component | Rule | Weight |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------ | ---- |
-| **Amount**   | exact `Cents` equality → `1.0`; else within `AMOUNT_TOLERANCE_PERCENT` (10%, `SubscriptionDetector.kt:25`) → linear decay to `0.0`; else `0.0` | 0.50        |
-| **Merchant** | `MerchantNormalizer.similarity` (Sørensen–Dice), in `[0,1]`                                                                                    | 0.30        |
-| **Date**     | `                                                                                                                                              | daysBetween | `within window (default ±3 days,`INTERVAL_TOLERANCE_DAYS`, `SubscriptionDetector.kt:31`) → linear decay; outside → `0.0` | 0.20 |
+| **Amount** | exact `Cents` equality → `1.0`; else within `AMOUNT_TOLERANCE_PERCENT` (10%, `SubscriptionDetector.kt:25`) → linear decay to `0.0`; else `0.0` | 0.50 |
+| **Merchant** | `MerchantNormalizer.similarity` (Sørensen–Dice), in `[0,1]` | 0.30 |
+| **Date** | `                                                                                                                                             | daysBetween |`within window (default ±3 days,`INTERVAL_TOLERANCE_DAYS`, `SubscriptionDetector.kt:31`) → linear decay; outside → `0.0` | 0.20 |
 
 `compositeScore = 0.50·amount + 0.30·merchant + 0.20·date`.
 

--- a/docs/ops/infrastructure-standards.md
+++ b/docs/ops/infrastructure-standards.md
@@ -573,10 +573,10 @@ Secrets are scoped to GitHub Environments (`staging`, `production`). The same se
 
 ```yaml
 # In workflow YAML:
-environment: staging  # ← unlocks staging-scoped secrets
+environment: staging # ← unlocks staging-scoped secrets
 # secrets.SUPABASE_URL → staging Supabase URL
 
-environment: production  # ← unlocks production-scoped secrets
+environment: production # ← unlocks production-scoped secrets
 # secrets.SUPABASE_URL → production Supabase URL
 ```
 
@@ -969,15 +969,15 @@ Database objects outlive application code. Renaming a table requires a migration
 | Pattern | `snake_case` |
 | ------- | ------------ |
 
-| Convention      | Example                                         |
+| Convention | Example |
 | --------------- | ----------------------------------------------- | ------------------------------------------- |
-| Primary key     | `id` (UUID)                                     |
-| Foreign key     | `{referenced_table}_id`                         | `account_id`, `household_id`                |
-| Timestamps      | `created_at`, `updated_at`, `deleted_at`        |
-| Booleans        | `is_{adjective}` or `has_{noun}`                | `is_synced`, `is_rollover`, `has_passkey`   |
-| Ownership       | `owner_id` (references `auth.users`)            |
-| Sync fields     | `sync_version`, `is_synced`                     |
-| Soft delete     | `deleted_at` (nullable timestamp)               |
+| Primary key | `id` (UUID) |
+| Foreign key | `{referenced_table}_id` | `account_id`, `household_id` |
+| Timestamps | `created_at`, `updated_at`, `deleted_at` |
+| Booleans | `is_{adjective}` or `has_{noun}` | `is_synced`, `is_rollover`, `has_passkey` |
+| Ownership | `owner_id` (references `auth.users`) |
+| Sync fields | `sync_version`, `is_synced` |
+| Soft delete | `deleted_at` (nullable timestamp) |
 | Monetary values | Named descriptively, stored as `BIGINT` (cents) | `amount`, `target_amount`, `current_amount` |
 
 ### Index Naming

--- a/docs/windows/ml-balance-prediction-pipeline-plan.md
+++ b/docs/windows/ml-balance-prediction-pipeline-plan.md
@@ -114,9 +114,7 @@ is `float32[1, N]` where `N` is fixed by `feature_schema_version`.
   "reference_date": "2026-06-22", // local; never transmitted
   "horizon_days": 30, // one of the supported horizons {7, 14, 30}
   "currency": "USD",
-  "features": [
-    /* fixed-order float32 vector, length N */
-  ],
+  "features": [/* fixed-order float32 vector, length N */],
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,15 +17,15 @@
       "devDependencies": {
         "@changesets/changelog-github": "^0.7.0",
         "@changesets/cli": "^2.31.0",
-        "@commitlint/cli": "^21.0.2",
+        "@commitlint/cli": "^21.1.0",
         "@commitlint/config-conventional": "^21.0.2",
         "@eslint/js": "^10.0.1",
-        "eslint": "^10.5.0",
+        "eslint": "^10.6.0",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
-        "prettier": "^3.8.4",
-        "turbo": "^2.9.18",
-        "typescript-eslint": "^8.61.1"
+        "prettier": "^3.9.1",
+        "turbo": "^2.10.0",
+        "typescript-eslint": "^8.62.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -49,7 +49,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@playwright/test": "^1.61.0",
+        "@playwright/test": "^1.61.1",
         "@storybook/addon-a11y": "^10.4.6",
         "@storybook/react": "^10.4.6",
         "@storybook/react-vite": "^10.4.6",
@@ -63,7 +63,7 @@
         "@vitejs/plugin-react": "5.2.0",
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
-        "nanoid": "^5.1.15",
+        "nanoid": "^5.1.16",
         "source-map-js": "^1.2.1",
         "storybook": "^10.4.6",
         "typescript": "^6.0.3",
@@ -1426,15 +1426,18 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "21.0.2",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.2.0.tgz",
+      "integrity": "sha512-4GLVIhUaT3c3GBlQ0GB80/5H3xXdn/Tgw4lrsuoOQVDu2wl4Xw0GuzSar8xZKSMv4H3xaKaQXmvH91GmdyYBZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/format": "^21.0.1",
-        "@commitlint/lint": "^21.0.2",
-        "@commitlint/load": "^21.0.2",
-        "@commitlint/read": "^21.0.2",
-        "@commitlint/types": "^21.0.1",
+        "@commitlint/config-conventional": "^21.2.0",
+        "@commitlint/format": "^21.2.0",
+        "@commitlint/lint": "^21.2.0",
+        "@commitlint/load": "^21.2.0",
+        "@commitlint/read": "^21.2.0",
+        "@commitlint/types": "^21.2.0",
         "tinyexec": "^1.0.0",
         "yargs": "^18.0.0"
       },
@@ -1529,23 +1532,27 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "21.0.2",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.2.0.tgz",
+      "integrity": "sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.1",
-        "conventional-changelog-conventionalcommits": "^9.2.0"
+        "@commitlint/types": "^21.2.0",
+        "conventional-changelog-conventionalcommits": "^10.0.0"
       },
       "engines": {
         "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "21.0.1",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.2.0.tgz",
+      "integrity": "sha512-t7AzNHAKeIdo/3NRGwzpufKHsKkPHmFs/56N2Fnsh0/r0rGtnQzTxk6vnFgjaGr4hdSQKNB50/KAhR9Yk4LJKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.1",
+        "@commitlint/types": "^21.2.0",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -1553,11 +1560,13 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "21.0.1",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.2.0.tgz",
+      "integrity": "sha512-76IF9vDNS13lAzEEik9eKwzt8f9hYhWiwVXZ2AnyLCz5/f511FsEQ3pw1X3/zSQpdRLQU7i5qDMVKyXi1GWjSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.1",
+        "@commitlint/types": "^21.2.0",
         "es-toolkit": "^1.46.0"
       },
       "engines": {
@@ -1566,6 +1575,8 @@
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz",
+      "integrity": "sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1573,11 +1584,13 @@
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "21.0.1",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.2.0.tgz",
+      "integrity": "sha512-c4q64xaav2U83t7k7RyzJerBZurPer7FxUOY0RL5L/6CZijZ7K+s6HIBGIghj0ey1P2+seRX0J9XQYtDued6tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.1",
+        "@commitlint/types": "^21.2.0",
         "picocolors": "^1.1.1"
       },
       "engines": {
@@ -1585,11 +1598,13 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "21.0.2",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.2.0.tgz",
+      "integrity": "sha512-4/eB0vBN7L88O/oC4ajAEqi7j2ZfNgxl/+11RfAV9YosejZgDXhY2C9VcHnHJhOzPLoSy5P3Mg/46kqeyJfXKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.1",
+        "@commitlint/types": "^21.2.0",
         "semver": "^7.6.0"
       },
       "engines": {
@@ -1597,28 +1612,32 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "21.0.2",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.2.0.tgz",
+      "integrity": "sha512-ceO5dp9pLjEZ6y6qbq/uXWXDPykqqlTsyzoQ0NzecpisSJhK3kTy9qzQoPeJuWG/IMNdV1lO0RgmzqoAlSi1uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^21.0.2",
-        "@commitlint/parse": "^21.0.2",
-        "@commitlint/rules": "^21.0.2",
-        "@commitlint/types": "^21.0.1"
+        "@commitlint/is-ignored": "^21.2.0",
+        "@commitlint/parse": "^21.2.0",
+        "@commitlint/rules": "^21.2.0",
+        "@commitlint/types": "^21.2.0"
       },
       "engines": {
         "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "21.0.2",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.2.0.tgz",
+      "integrity": "sha512-RjlzWQqruRwIenJEfZtq7kG97co97nKoHpflE5YnF61tDLXxHPrdWImgzw6VL6MlFyaOcVlk74eBV8ZQmc3oIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^21.0.1",
+        "@commitlint/config-validator": "^21.2.0",
         "@commitlint/execute-rule": "^21.0.1",
-        "@commitlint/resolve-extends": "^21.0.1",
-        "@commitlint/types": "^21.0.1",
+        "@commitlint/resolve-extends": "^21.2.0",
+        "@commitlint/types": "^21.2.0",
         "cosmiconfig": "^9.0.1",
         "cosmiconfig-typescript-loader": "^6.1.0",
         "es-toolkit": "^1.46.0",
@@ -1630,7 +1649,9 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "21.0.2",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.2.0.tgz",
+      "integrity": "sha512-YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1638,25 +1659,29 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "21.0.2",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.2.0.tgz",
+      "integrity": "sha512-QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.1",
-        "conventional-changelog-angular": "^8.2.0",
-        "conventional-commits-parser": "^6.3.0"
+        "@commitlint/types": "^21.2.0",
+        "conventional-changelog-angular": "^9.0.0",
+        "conventional-commits-parser": "^7.0.0"
       },
       "engines": {
         "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "21.0.2",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.2.0.tgz",
+      "integrity": "sha512-ELx8Ovh/JoAw5lpvDgxc6Y0We9skf2IPI2RFN+gnYgDGjRdMSF8zeodxhZmcclLWzfUIF7hXLOa8gOlllYcvBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/top-level": "^21.0.2",
-        "@commitlint/types": "^21.0.1",
+        "@commitlint/top-level": "^21.2.0",
+        "@commitlint/types": "^21.2.0",
         "git-raw-commits": "^5.0.0",
         "tinyexec": "^1.0.0"
       },
@@ -1665,12 +1690,14 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "21.0.1",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
+      "integrity": "sha512-4O/1j51+79Wth9s/MGxt/5gs0XYLDgNlYpltQfhAvLE0itusLKs9zruxbiNg1oOkmkb9L9L4USYGjEj7n87NxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^21.0.1",
-        "@commitlint/types": "^21.0.1",
+        "@commitlint/config-validator": "^21.2.0",
+        "@commitlint/types": "^21.2.0",
         "es-toolkit": "^1.46.0",
         "global-directory": "^5.0.0",
         "resolve-from": "^5.0.0"
@@ -1680,14 +1707,16 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "21.0.2",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.2.0.tgz",
+      "integrity": "sha512-C2yXMNpiB8ETZKfx5JD8+ExgF8vTU1VQMKPSUUYwqKpw9oJWQBrlXBpdU038mj2WPjof7o9UzFpmTyBeGMZwZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^21.0.1",
-        "@commitlint/message": "^21.0.2",
+        "@commitlint/ensure": "^21.2.0",
+        "@commitlint/message": "^21.2.0",
         "@commitlint/to-lines": "^21.0.1",
-        "@commitlint/types": "^21.0.1"
+        "@commitlint/types": "^21.2.0"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -1695,6 +1724,8 @@
     },
     "node_modules/@commitlint/to-lines": {
       "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz",
+      "integrity": "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1702,7 +1733,9 @@
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "21.0.2",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.2.0.tgz",
+      "integrity": "sha512-Y5gmQ+KxzqCrBFJfLvFEPvvwD3LDiNZoTT2yeFBm96M8qhmqSzQc5DvX3rheAaAMjyIvMXOCLS/mWfdpONsjyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1713,40 +1746,27 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "21.0.1",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.2.0.tgz",
+      "integrity": "sha512-7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "conventional-commits-parser": "^6.3.0",
+        "conventional-commits-parser": "^7.0.0",
         "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=22.12.0"
       }
     },
-    "node_modules/@conventional-changelog/git-client": {
-      "version": "2.7.0",
+    "node_modules/@conventional-changelog/template": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
+      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@simple-libs/child-process-utils": "^1.0.0",
-        "@simple-libs/stream-utils": "^1.2.0",
-        "semver": "^7.5.2"
-      },
       "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "conventional-commits-filter": "^5.0.0",
-        "conventional-commits-parser": "^6.4.0"
-      },
-      "peerDependenciesMeta": {
-        "conventional-commits-filter": {
-          "optional": true
-        },
-        "conventional-commits-parser": {
-          "optional": true
-        }
+        "node": ">=22"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -4244,6 +4264,8 @@
     },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+      "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4256,12 +4278,27 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/@simple-libs/stream-utils": {
+    "node_modules/@simple-libs/child-process-utils/node_modules/@simple-libs/stream-utils": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-2.0.0.tgz",
+      "integrity": "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
@@ -4369,9 +4406,9 @@
       }
     },
     "node_modules/@turbo/darwin-64": {
-      "version": "2.9.18",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.18.tgz",
-      "integrity": "sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.3.tgz",
+      "integrity": "sha512-guuiO2kKc7yUQFU2jhWyM/BrYGD/brqb0+JvJIXTQ/QI1NlWfHZ1id50kkkOWqxmBiDc8DgW2orfY85pQIc7gw==",
       "cpu": [
         "x64"
       ],
@@ -4383,9 +4420,9 @@
       ]
     },
     "node_modules/@turbo/darwin-arm64": {
-      "version": "2.9.18",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.18.tgz",
-      "integrity": "sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.10.3.tgz",
+      "integrity": "sha512-UglEDl/r1/h5Vw6oS6cEE29Jugz2sDLxHCSupNznKatj1fDMRXFqYKFcbvm8RTFhtYPI45NxkrPNo9BqNychBg==",
       "cpu": [
         "arm64"
       ],
@@ -4397,9 +4434,9 @@
       ]
     },
     "node_modules/@turbo/linux-64": {
-      "version": "2.9.18",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.18.tgz",
-      "integrity": "sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.10.3.tgz",
+      "integrity": "sha512-KuQxaPWD7OBmwEZqO0sgijwcuXR5eMWbo7BEt2m1D2Q3RylJDj7WMcJ0Btv2VJA0QC+khzAaTAm1yWowJ0CWAw==",
       "cpu": [
         "x64"
       ],
@@ -4411,9 +4448,9 @@
       ]
     },
     "node_modules/@turbo/linux-arm64": {
-      "version": "2.9.18",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.18.tgz",
-      "integrity": "sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.10.3.tgz",
+      "integrity": "sha512-DPkIKQ+6p0sho3Cx/e/A3F+AKgXQJA+z//cHsTcyyM1YWRGSYA0UTP8NUpb4iS2tVBSniGwmjRUr73hpq8kcDg==",
       "cpu": [
         "arm64"
       ],
@@ -4425,9 +4462,9 @@
       ]
     },
     "node_modules/@turbo/windows-64": {
-      "version": "2.9.18",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.18.tgz",
-      "integrity": "sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.10.3.tgz",
+      "integrity": "sha512-8NvFAze9D4PsosZAnK3aGqHz2vLzREz9lNIxLgfE0jRchq2sZQE190cwFm7WX17yg3ftPvwCvWH3rhLbG1UHCQ==",
       "cpu": [
         "x64"
       ],
@@ -4439,9 +4476,9 @@
       ]
     },
     "node_modules/@turbo/windows-arm64": {
-      "version": "2.9.18",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.18.tgz",
-      "integrity": "sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.10.3.tgz",
+      "integrity": "sha512-AqjqV5cHbFa0YRaQ+Dyw6lSm6as4h/Uf8LcZ7VN8i+Odr23ShFD5SUvVAR1d3rZqibFVs9c0VdtXdfQfkdcs3A==",
       "cpu": [
         "arm64"
       ],
@@ -4806,17 +4843,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
-      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/type-utils": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4829,7 +4866,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.61.1",
+        "@typescript-eslint/parser": "^8.62.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -4845,16 +4882,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
-      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4870,14 +4907,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
-      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.61.1",
-        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4892,14 +4929,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
-      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1"
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4910,9 +4947,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
-      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4927,15 +4964,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
-      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4952,9 +4989,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
-      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4966,16 +5003,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
-      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.61.1",
-        "@typescript-eslint/tsconfig-utils": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4994,16 +5031,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
-      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1"
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5018,13 +5055,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
-      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/types": "8.62.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5092,6 +5129,8 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5158,11 +5197,6 @@
       "dependencies": {
         "dequal": "^2.0.3"
       }
-    },
-    "node_modules/array-ify": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -5423,6 +5457,8 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5526,15 +5562,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/compare-func": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^5.1.0"
-      }
-    },
     "node_modules/component-emitter": {
       "version": "2.0.0",
       "dev": true,
@@ -5547,40 +5574,46 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "8.3.1",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
+      "integrity": "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "compare-func": "^2.0.0"
+        "@conventional-changelog/template": "^1.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "9.3.1",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "compare-func": "^2.0.0"
+        "@conventional-changelog/template": "^1.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.0.1.tgz",
+      "integrity": "sha512-6VtskFpPsNkGVk/TY2RnV/MEdKfvCPBtQZN9x8jh9+k5RWBQ+tiaWn5UFCzTr0Dd88iKx7xghxbjBRp5uIzp3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
+        "@simple-libs/stream-utils": "^2.0.0",
+        "meow": "^14.0.0"
       },
       "bin": {
         "conventional-commits-parser": "dist/cli/index.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/convert-source-map": {
@@ -5600,7 +5633,9 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.1",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5626,6 +5661,8 @@
     },
     "node_modules/cosmiconfig-typescript-loader": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6252,17 +6289,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dot-prop": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dotenv": {
       "version": "8.6.0",
       "dev": true,
@@ -6322,6 +6348,8 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6341,6 +6369,8 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6449,9 +6479,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -6758,7 +6788,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true,
       "funding": [
         {
@@ -6969,6 +7001,9 @@
     },
     "node_modules/git-raw-commits": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
+      "integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
+      "deprecated": "Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6980,6 +7015,78 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/git-raw-commits/node_modules/@conventional-changelog/git-client": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+      "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/child-process-utils": "^1.0.0",
+        "@simple-libs/stream-utils": "^1.2.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/git-raw-commits/node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/git-raw-commits/node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob": {
@@ -7026,6 +7133,8 @@
     },
     "node_modules/global-directory": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+      "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7209,6 +7318,8 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7224,6 +7335,8 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7253,6 +7366,8 @@
     },
     "node_modules/ini": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -7283,6 +7398,8 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7414,14 +7531,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-obj": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -7638,11 +7747,15 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -7949,6 +8062,8 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8178,11 +8293,13 @@
       }
     },
     "node_modules/meow": {
-      "version": "13.2.0",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8558,6 +8675,8 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8569,6 +8688,8 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8760,9 +8881,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9749,21 +9870,21 @@
       "license": "0BSD"
     },
     "node_modules/turbo": {
-      "version": "2.9.18",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.18.tgz",
-      "integrity": "sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.10.3.tgz",
+      "integrity": "sha512-uZIqzfgtWbyqu1Tqwdd0giRnPGgL0ejbcdF8eZLJhtTTVSrOgArZGzYeXTD6XNcc7ANgdhqex11Y9bHBeyiQLQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "@turbo/darwin-64": "2.9.18",
-        "@turbo/darwin-arm64": "2.9.18",
-        "@turbo/linux-64": "2.9.18",
-        "@turbo/linux-arm64": "2.9.18",
-        "@turbo/windows-64": "2.9.18",
-        "@turbo/windows-arm64": "2.9.18"
+        "@turbo/darwin-64": "2.10.3",
+        "@turbo/darwin-arm64": "2.10.3",
+        "@turbo/linux-64": "2.10.3",
+        "@turbo/linux-arm64": "2.10.3",
+        "@turbo/windows-64": "2.10.3",
+        "@turbo/windows-arm64": "2.10.3"
       }
     },
     "node_modules/type-check": {
@@ -9790,16 +9911,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
-      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.61.1",
-        "@typescript-eslint/parser": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1"
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -97,14 +97,14 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
-    "@commitlint/cli": "^21.0.2",
+    "@commitlint/cli": "^21.1.0",
     "@commitlint/config-conventional": "^21.0.2",
     "@eslint/js": "^10.0.1",
-    "eslint": "^10.5.0",
+    "eslint": "^10.6.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",
-    "prettier": "^3.8.4",
-    "turbo": "^2.9.18",
-    "typescript-eslint": "^8.61.1"
+    "prettier": "^3.9.1",
+    "turbo": "^2.10.0",
+    "typescript-eslint": "^8.62.0"
   }
 }


### PR DESCRIPTION
## Summary

Lands the **npm-dev dependency group** (supersedes dependabot #3137) on top of current `main`, with the two fixes needed to keep CI green.

Dependabot #3137 was `CONFLICTING`/`DIRTY` with red **Build** and **ESLint & Prettier** checks. Root causes (verified):

- **Build** (`[MISSING_EXPORT] "RESET" is not exported by @griffel/core` in rolldown) was **not** a griffel desync — `@griffel/core@1.21.2` + `@griffel/react@1.7.4` are in sync on both branches. The real trigger was **vite 8.0.16 → 8.1.0**, which violates the root `overrides.vite = "8.0.16"` pin. vite 8.1.0's rolldown does stricter static-export analysis and reads `@griffel/core/src/index.js`, failing on `RESET`. **Fix: keep vite at 8.0.16** (do not bump it).
- **ESLint & Prettier** failed because the **Prettier 3.8 → 3.9** bump reformats the tree. **Fix: ran `npm run format` (prettier 3.9) and committed the result.**

## Changes

Dependency bumps (the non-formatting diff — 3 files):

- root: `@commitlint/cli` ^21.1.0, `eslint` ^10.6.0, `prettier` ^3.9.1, `turbo` ^2.10.0, `typescript-eslint` ^8.62.0
- `apps/web`: `@playwright/test` ^1.61.1, `nanoid` ^5.1.16
- `package-lock.json` regenerated with npm 10.9.4 (matching CI)

Intentionally **excluded** from the dependabot group:

- `vite` ^8.1.0 — regresses the web build (see above); kept at ^8.0.16.
- `storybook` / `@storybook/*` and `vitest` — `main` already carries newer versions than the stale dependabot branch (bumping would have been a downgrade).

Formatting / mechanical:

- Tree-wide Prettier 3.9 reformat (`npm run format`); no logic changes.
- Repaired malformed single-backtick code fences in `docs/audits/security-audit-owasp-masvs.md` (they used `` `lang … ` `` instead of triple-backtick blocks). Prettier 3.9's stricter Markdown parser was non-idempotent on those pseudo-fences (re-flowing embedded code as prose) and would fail `prettier --check` in CI. Converted to proper fenced code blocks; **code content preserved verbatim**.

## Relationship to #3137

Supersedes dependabot PR #3137 — that PR should not be merged. Leaving #3137 open for dependabot/a human to close.

## Testing

- [x] `npx prettier@3.9.4 --check .` — clean (matches CI's pinned prettier)
- [x] `eslint . --max-warnings 0` — clean
- [x] vite pinned at 8.0.16 in lockfile (build stays green)
- [x] Rebased on latest `origin/main`
