### PR TITLE
fix(web): confirm before deleting expected income (#3217)

### DIFF
--- a/apps/web/src/pages/ExpectedIncomePage.test.tsx
+++ b/apps/web/src/pages/ExpectedIncomePage.test.tsx
@@ -91,10 +91,25 @@ describe('ExpectedIncomePage', () => {
     expect(screen.getByRole('heading', { level: 3, name: 'One-off gift' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete One-off gift' }));
+
+    const dialog = screen.getByRole('alertdialog', { name: 'Remove expected income' });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Remove' }));
+
     expect(
       screen.queryByRole('heading', { level: 3, name: 'One-off gift' }),
     ).not.toBeInTheDocument();
     expect(screen.getByText('No expected income yet')).toBeInTheDocument();
+  });
+
+  it('keeps the payment when the delete is cancelled', () => {
+    render(<ExpectedIncomePage />);
+    addPayment({ name: 'One-off gift', amount: '100.00', date: '2026-06-10' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete One-off gift' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByRole('heading', { level: 3, name: 'One-off gift' })).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
 
   it('validates the amount field', () => {

--- a/apps/web/src/pages/ExpectedIncomePage.tsx
+++ b/apps/web/src/pages/ExpectedIncomePage.tsx
@@ -17,7 +17,7 @@
 
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 
-import { EmptyState, Icon } from '../components/common';
+import { ConfirmDialog, EmptyState, Icon } from '../components/common';
 import { IconToken } from '../icons/tokens';
 import { formatCurrency } from '../lib/currency';
 import {
@@ -86,6 +86,7 @@ export function ExpectedIncomePage() {
   const [cleared, setCleared] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState('');
+  const [pendingDelete, setPendingDelete] = useState<ExpectedIncomeItem | null>(null);
 
   useEffect(() => {
     const refresh = () => setItems(loadExpectedIncomeItems());
@@ -161,9 +162,16 @@ export function ExpectedIncomePage() {
   }, []);
 
   const handleDelete = useCallback((item: ExpectedIncomeItem) => {
-    deleteExpectedIncomeItem(item.id);
-    setStatusMessage(`Removed “${item.label}”.`);
+    setPendingDelete(item);
   }, []);
+
+  const confirmDelete = useCallback(() => {
+    if (pendingDelete) {
+      deleteExpectedIncomeItem(pendingDelete.id);
+      setStatusMessage(`Removed “${pendingDelete.label}”.`);
+    }
+    setPendingDelete(null);
+  }, [pendingDelete]);
 
   return (
     <main className="expected-income" aria-labelledby="expected-income-title">
@@ -427,6 +435,19 @@ export function ExpectedIncomePage() {
           </ul>
         )}
       </section>
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== null}
+        title="Remove expected income"
+        message={
+          pendingDelete
+            ? `Remove “${pendingDelete.label}” from your expected income? This cannot be undone.`
+            : ''
+        }
+        confirmLabel="Remove"
+        onConfirm={confirmDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

The **Expected Income** page deleted a tracked payment the instant the Delete button was pressed — no confirmation, no undo. For someone tracking money that is often late (a freelancer chasing invoices, a household waiting on child support), a single mis-click silently discards a payment they were relying on to plan bills.

## Changes

- **#3217 — Delete confirmation.** `handleDelete` called `deleteExpectedIncomeItem` directly. It now opens the shared accessible `ConfirmDialog` (focus-trapped `role="alertdialog"`, Escape/backdrop cancel, `variant="danger"`) naming the payment, and only removes it on confirm. Cancelling leaves the payment untouched. This matches the confirmation pattern used elsewhere in the app and the companion Invoices fix (#3216).

## Testing

- `npx prettier --check` + `npx eslint --max-warnings 0` on both changed files — clean.
- `npx vitest run src/pages/ExpectedIncomePage.test.tsx` — **6 passed**. Updated the existing "deletes a payment" test to click through the confirm dialog and added a "keeps the payment when the delete is cancelled" test.

## Issues

Closes #3217

Found by persona: Diego Ramirez (freelance-designer irregular-income)
