### PR TITLE
fix(web): manage focus in export, AI query, and consent dialogs (#3333)

### DIFF
--- a/apps/web/src/components/DataExport.tsx
+++ b/apps/web/src/components/DataExport.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDatabase } from '../db/DatabaseProvider';
+import { useFocusTrap } from '../accessibility/aria';
 import type { SqliteDb } from '../db/sqlite-wasm';
 import { getAllAccounts } from '../db/repositories/accounts';
 import { getAllTransactions } from '../db/repositories/transactions';
@@ -293,6 +294,7 @@ export const DataExport: React.FC<DataExportProps> = ({
   const [expirationWarning, setExpirationWarning] = useState(false);
   const cancelledRef = useRef(false);
   const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const confirmDialogRef = useRef<HTMLDivElement>(null);
 
   // Feature-detect Web Share with file support. We can't run the check until
   // a package exists (canShare wants a sample file), but `navigator.share`
@@ -380,6 +382,18 @@ export const DataExport: React.FC<DataExportProps> = ({
     setShowConfirmation(false);
     setStatus('cancelled');
   }, []);
+
+  useFocusTrap(confirmDialogRef, { active: showConfirmation, restoreFocus: true });
+
+  const handleConfirmKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        cancelRequest();
+      }
+    },
+    [cancelRequest],
+  );
 
   const confirmRequest = useCallback(() => {
     if (selectedDomains.length === 0) {
@@ -838,11 +852,13 @@ export const DataExport: React.FC<DataExportProps> = ({
 
       {showConfirmation && (
         <div
+          ref={confirmDialogRef}
           role="dialog"
           aria-modal="true"
           aria-labelledby="data-export-confirm-title"
           aria-describedby="data-export-confirm-body"
           className="data-export__dialog"
+          onKeyDown={handleConfirmKeyDown}
         >
           <h4 id="data-export-confirm-title" className="data-export__dialog-title">
             Request your data package

--- a/apps/web/src/components/ai/QueryEngine.tsx
+++ b/apps/web/src/components/ai/QueryEngine.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useDatabase } from '../../db/DatabaseProvider';
+import { useFocusTrap } from '../../accessibility/aria';
 import { useAccounts, useBudgets, useCategories, useGoals } from '../../hooks';
 import { executeFinancialQuery } from '../../lib/ai/executor';
 import { formatFinancialQueryResponse } from '../../lib/ai/formatter';
@@ -42,6 +43,7 @@ function createAssistantFallback(): FormattedFinancialResponse {
 
 export const QueryEngine: React.FC = () => {
   const db = useDatabase();
+  const dialogRef = useRef<HTMLElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
@@ -66,16 +68,6 @@ export const QueryEngine: React.FC = () => {
       ),
     [accounts, budgets, categories, goals],
   );
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    requestAnimationFrame(() => {
-      inputRef.current?.focus();
-    });
-  }, [isOpen]);
 
   const appendAssistantMessage = useCallback(
     (text: string, response?: FormattedFinancialResponse) => {
@@ -160,6 +152,14 @@ export const QueryEngine: React.FC = () => {
     [inputValue, runQuery],
   );
 
+  useFocusTrap(dialogRef, { active: isOpen, restoreFocus: true, initialFocusRef: inputRef });
+
+  const handleDialogKeyDown = useCallback((event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key === 'Escape') {
+      setIsOpen(false);
+    }
+  }, []);
+
   const dataLoading = categoriesLoading || accountsLoading || budgetsLoading || goalsLoading;
 
   return (
@@ -182,11 +182,13 @@ export const QueryEngine: React.FC = () => {
         >
           <div className="form-dialog__backdrop" />
           <section
+            ref={dialogRef}
             className="form-dialog__panel ai-query-engine__panel"
             role="dialog"
             aria-modal="true"
             aria-labelledby="ai-query-engine-title"
             onClick={(event) => event.stopPropagation()}
+            onKeyDown={handleDialogKeyDown}
           >
             <header className="ai-query-engine__header">
               <div>

--- a/apps/web/src/components/gdpr/ConsentDialog.tsx
+++ b/apps/web/src/components/gdpr/ConsentDialog.tsx
@@ -66,12 +66,15 @@ export const ConsentDialog: React.FC<ConsentDialogProps> = ({ onComplete }) => {
   const dialogRef = useRef<HTMLDivElement>(null);
   const firstFocusRef = useRef<HTMLButtonElement>(null);
 
-  // Focus trap: focus the dialog on mount
+  // Move focus to the primary action whenever the dialog opens or the
+  // quick-actions <-> detailed-preferences views swap. Without the showDetails
+  // dependency, clicking "Customize" (or "Back") unmounts the focused button
+  // and strands focus on <body> for keyboard and screen-reader users.
   useEffect(() => {
     if (needsConsent) {
       firstFocusRef.current?.focus();
     }
-  }, [needsConsent]);
+  }, [needsConsent, showDetails]);
 
   // Trap keyboard focus within the dialog
   useEffect(() => {


### PR DESCRIPTION
## Summary

Three more modal surfaces did not correctly manage keyboard focus for screen-reader + keyboard users, breaking WCAG 2.2 **2.4.3 Focus Order** and **4.1.2 Name, Role, Value**. Two adopt the shared `useFocusTrap` primitive; the consent dialog gets a targeted focus-move fix.

## Changes

- **`DataExport.tsx`** (#3333, P2) — the GDPR "Request your data package" confirmation dialog (`role="dialog"`) had no focus trap, initial focus, or restore. Added `useFocusTrap(active: showConfirmation)` + `Escape` → cancel. Focus now enters the dialog, `Tab`/`Shift+Tab` stay inside it, and focus returns to the trigger on close.
- **`ai/QueryEngine.tsx`** (#3336, P2) — the "Ask finance AI" dialog only moved focus to its input via `requestAnimationFrame` with no trap or restore, so `Tab` escaped into the inert page behind it. Replaced the rAF effect with `useFocusTrap(active: isOpen, initialFocusRef: inputRef)` (preserves initial focus to the query input) + `Escape` → close, restoring focus to the launcher FAB.
- **`gdpr/ConsentDialog.tsx`** (#3335, P2) — the dialog shares one `firstFocusRef` between the quick-action view and the detailed-preferences view, but the focus effect only ran on `needsConsent`. Clicking **Customize** (or **Back**) unmounted the focused button and stranded focus on `<body>`. Added `showDetails` to the effect deps so focus follows the view swap to the newly-mounted primary action. (The existing intentional "no Escape dismissal without a decision" trap is preserved.)

## Issues

Closes #3333
Closes #3336
Closes #3335

## Testing

- `npx prettier --check` + `npx eslint --max-warnings 0` on all three files — clean.
- `QueryEngine.test.tsx` + `DataExport.test.tsx` — **18/18 pass** (ConsentDialog has no test file; its change is a one-line effect-dependency fix).
- Focus-trap/restore/initial-focus semantics are covered by the existing `useFocusTrap` unit tests.

## Accessibility

- WCAG 2.4.3 (Focus Order), 4.1.2 (Name, Role, Value).
- Found by persona: Jordan Blake (blind screen-reader + keyboard user).

## Cross-Platform

Web-only React focus-management patterns. iOS/Android/Windows manage modal focus via native navigation stacks; out of scope for these issues.
