### PR TITLE
fix(web): calm neutral tone for brand-new goals instead of red (#3392)

### DIFF
--- a/apps/web/src/lib/a11y.test.ts
+++ b/apps/web/src/lib/a11y.test.ts
@@ -84,6 +84,12 @@ describe('getGoalStatusIndicator', () => {
   it('returns just started for <25%', () => {
     expect(getGoalStatusIndicator(10).label).toBe('Just started');
   });
+
+  it('uses a calm neutral tone (not negative) for a brand-new goal <25% (#3392)', () => {
+    expect(getGoalStatusIndicator(0).tone).toBe('neutral');
+    expect(getGoalStatusIndicator(10).tone).toBe('neutral');
+    expect(getGoalStatusIndicator(24).tone).toBe('neutral');
+  });
 });
 
 describe('getBudgetStatusIndicator', () => {

--- a/apps/web/src/lib/a11y.ts
+++ b/apps/web/src/lib/a11y.ts
@@ -128,13 +128,14 @@ export function getStatusIndicator(amount: number): {
  * ```ts
  * getGoalStatusIndicator(100); // { icon: 'check', label: 'Goal reached', tone: 'positive' }
  * getGoalStatusIndicator(60);  // { icon: 'target', label: 'In progress', tone: 'positive' }
- * getGoalStatusIndicator(20);  // { icon: 'target', label: 'Getting started', tone: 'warning' }
+ * getGoalStatusIndicator(30);  // { icon: 'target', label: 'Getting started', tone: 'warning' }
+ * getGoalStatusIndicator(10);  // { icon: 'target', label: 'Just started', tone: 'neutral' }
  * ```
  */
 export function getGoalStatusIndicator(percentComplete: number): {
   icon: IconName;
   label: string;
-  tone: 'positive' | 'warning' | 'negative';
+  tone: 'positive' | 'warning' | 'neutral';
 } {
   if (percentComplete >= 100) {
     return { icon: 'check', label: 'Goal reached', tone: 'positive' };
@@ -145,7 +146,9 @@ export function getGoalStatusIndicator(percentComplete: number): {
   if (percentComplete >= 25) {
     return { icon: 'target', label: 'Getting started', tone: 'warning' };
   }
-  return { icon: 'target', label: 'Just started', tone: 'negative' };
+  // A brand-new goal that is barely started is not "bad" — use a calm, neutral
+  // tone rather than an alarming negative/red one (#3392).
+  return { icon: 'target', label: 'Just started', tone: 'neutral' };
 }
 
 /**

--- a/apps/web/src/pages/GoalDetailPage.tsx
+++ b/apps/web/src/pages/GoalDetailPage.tsx
@@ -125,15 +125,6 @@ export const GoalDetailPage: React.FC = () => {
     currency: goal.currency.code,
   });
 
-  const statusTone =
-    percentComplete >= 100
-      ? 'positive'
-      : percentComplete >= 50
-        ? 'positive'
-        : percentComplete >= 25
-          ? 'warning'
-          : 'negative';
-
   const remainingAmount = Math.max(goal.targetAmount.amount - goal.currentAmount.amount, 0);
 
   const targetDate = goal.targetDate ? new Date(`${goal.targetDate}T00:00:00`) : null;
@@ -293,7 +284,7 @@ export const GoalDetailPage: React.FC = () => {
             aria-label={`${goal.name}: ${percentComplete} percent of goal reached, ${goalStatus.label}`}
           >
             <div
-              className={`progress-bar__fill progress-bar__fill--${statusTone}`}
+              className={`progress-bar__fill progress-bar__fill--${goalStatus.tone}`}
               style={{ width: `${Math.min(percentComplete, 100)}%` }}
             />
           </div>

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -787,14 +787,6 @@ export const GoalsPage: React.FC = () => {
                     0,
                   );
                   const goalStatus = getGoalStatusIndicator(percentComplete);
-                  const statusTone =
-                    percentComplete >= 100
-                      ? 'positive'
-                      : percentComplete >= 50
-                        ? 'positive'
-                        : percentComplete >= 25
-                          ? 'warning'
-                          : 'negative';
                   const targetDate = goal.targetDate
                     ? new Date(`${goal.targetDate}T00:00:00`)
                     : null;
@@ -923,7 +915,7 @@ export const GoalsPage: React.FC = () => {
                         aria-label={`${goal.name}: ${percentComplete} percent of goal reached, ${goalStatus.label}`}
                       >
                         <div
-                          className={`progress-bar__fill progress-bar__fill--${statusTone}`}
+                          className={`progress-bar__fill progress-bar__fill--${goalStatus.tone}`}
                           style={{ width: `${Math.min(percentComplete, 100)}%` }}
                         />
                       </div>

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -530,6 +530,9 @@
 .progress-bar__fill--negative {
   background: var(--semantic-status-negative);
 }
+.progress-bar__fill--neutral {
+  background: var(--semantic-interactive-default);
+}
 .progress-ring {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
﻿## Summary

A brand-new savings goal (0-24% progress) rendered its progress bar and status with a **negative/red** tone, implying something was wrong. For new parents just starting a House down-payment or 529 goal, a red bar on day one is discouraging and misleading. This uses a calm, neutral tone for the early `Just started` range.

## Changes

- `getGoalStatusIndicator` (source of truth in `lib/a11y.ts`) now returns `tone: 'neutral'` for <25% instead of `'negative'`.
- Added `.progress-bar__fill--neutral` (uses the neutral brand color).
- `GoalsPage` and `GoalDetailPage` now consume `goalStatus.tone` for the progress-bar color, removing a duplicated tone ternary in each.
- Status **label and icon** remain as non-color text alternatives (WCAG 1.4.1 — info not conveyed by color alone).

## Issues

Closes #3392

## Testing

- `npx vitest run src/lib/a11y.test.ts` -> 26 passed (incl. new neutral-tone assertions for 0/10/24%)
- `npx eslint` on changed files -> 0 warnings; Prettier clean

Found by persona: Ada & Chidi Okafor (new-parents joint-finances)
