### PR TITLE
fix(web): correct capital-gains netting and disclose estimated acquisition dates in Tax Center (#3256)

### DIFF
--- a/apps/web/src/lib/investment/tax-center.test.ts
+++ b/apps/web/src/lib/investment/tax-center.test.ts
@@ -6,6 +6,7 @@ import {
   computeTaxSummary,
   detectWashSaleGuardrails,
   matchSaleLots,
+  type ClosedTaxLot,
   type TaxLot,
 } from './tax-center';
 
@@ -14,6 +15,21 @@ function lot(overrides: Partial<TaxLot> & { id: string; acquiredDate: string }):
     symbol: 'AAPL',
     shares: 10,
     costPerShare: 10000,
+    ...overrides,
+  };
+}
+
+function closed(
+  overrides: Partial<ClosedTaxLot> & { lotId: string; gainLoss: number },
+): ClosedTaxLot {
+  return {
+    symbol: 'AAPL',
+    acquiredDate: '2023-01-01',
+    soldDate: '2024-06-01',
+    shares: 10,
+    proceeds: 0,
+    costBasis: 0,
+    term: 'SHORT_TERM',
     ...overrides,
   };
 }
@@ -141,5 +157,60 @@ describe('computeTaxSummary', () => {
     expect(summary.washSaleDisallowedLoss).toBe(30000);
     expect(summary.taxableLongTermGainLoss).toBe(0);
     expect(summary.estimatedTax).toBe(0);
+  });
+
+  it('nets a long-term loss against a short-term gain before estimating tax', () => {
+    // $10,000 ST gain, $4,000 LT loss → residual $6,000 ST gain taxed at 35%.
+    const summary = computeTaxSummary(
+      [
+        closed({ lotId: 'st', term: 'SHORT_TERM', gainLoss: 1_000_000 }),
+        closed({ lotId: 'lt', term: 'LONG_TERM', gainLoss: -400_000 }),
+      ],
+      35,
+      15,
+    );
+
+    expect(summary.estimatedTax).toBe(210_000); // 6,000 * 35%, not 10,000 * 35%
+    expect(summary.netDeductibleLoss).toBe(0);
+    expect(summary.lossCarryforward).toBe(0);
+  });
+
+  it('taxes both categories independently when both are gains', () => {
+    const summary = computeTaxSummary(
+      [
+        closed({ lotId: 'st', term: 'SHORT_TERM', gainLoss: 200_000 }),
+        closed({ lotId: 'lt', term: 'LONG_TERM', gainLoss: 300_000 }),
+      ],
+      35,
+      15,
+    );
+
+    expect(summary.estimatedTax).toBe(115_000); // 2,000*35% + 3,000*15%
+    expect(summary.netDeductibleLoss).toBe(0);
+    expect(summary.lossCarryforward).toBe(0);
+  });
+
+  it('caps a net capital loss deduction at the $3,000 annual limit and carries the rest forward', () => {
+    // $2,000 ST loss + $5,000 LT loss = $7,000 net loss.
+    const summary = computeTaxSummary(
+      [
+        closed({ lotId: 'st', term: 'SHORT_TERM', gainLoss: -200_000 }),
+        closed({ lotId: 'lt', term: 'LONG_TERM', gainLoss: -500_000 }),
+      ],
+      35,
+      15,
+    );
+
+    expect(summary.estimatedTax).toBe(0);
+    expect(summary.netDeductibleLoss).toBe(300_000); // $3,000 cap
+    expect(summary.lossCarryforward).toBe(400_000); // $4,000 remainder
+  });
+
+  it('deducts a small net capital loss fully with no carryforward', () => {
+    const summary = computeTaxSummary([closed({ lotId: 'st', gainLoss: -100_000 })], 35, 15);
+
+    expect(summary.estimatedTax).toBe(0);
+    expect(summary.netDeductibleLoss).toBe(100_000); // full $1,000, under the cap
+    expect(summary.lossCarryforward).toBe(0);
   });
 });

--- a/apps/web/src/lib/investment/tax-center.ts
+++ b/apps/web/src/lib/investment/tax-center.ts
@@ -14,6 +14,13 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const WASH_SALE_WINDOW_DAYS = 30;
 const EPSILON = 1e-8;
 
+/**
+ * Annual net capital loss deductible against ordinary income (IRC §1211(b)),
+ * in cents. $3,000 for single/MFJ ($1,500 MFS — not modelled here). Losses
+ * beyond this carry forward to future tax years.
+ */
+const CAPITAL_LOSS_ANNUAL_LIMIT_CENTS = 3_000_00;
+
 export type HoldingPeriodTerm = 'SHORT_TERM' | 'LONG_TERM';
 export type TaxLotMatchingMethod = 'FIFO' | 'SPECIFIC_ID';
 
@@ -23,6 +30,13 @@ export interface TaxLot {
   readonly shares: number;
   readonly costPerShare: number;
   readonly acquiredDate: LocalDate;
+  /**
+   * True when {@link acquiredDate} is an estimate (e.g. the record-creation date
+   * of an aggregate holding without recorded purchase lots) rather than a real
+   * purchase date. Consumers should disclose that holding-period (ST/LT)
+   * classification for such lots is approximate.
+   */
+  readonly acquiredDateEstimated?: boolean;
 }
 
 export interface TaxSaleInput {
@@ -74,6 +88,13 @@ export interface TaxSummary {
   readonly taxableShortTermGainLoss: number;
   readonly taxableLongTermGainLoss: number;
   readonly estimatedTax: number;
+  /**
+   * Portion of a net capital loss deductible against ordinary income this year
+   * (capped at the annual limit). Zero when the year nets to a gain.
+   */
+  readonly netDeductibleLoss: number;
+  /** Net capital loss beyond the annual deduction limit, carried to future years. */
+  readonly lossCarryforward: number;
 }
 
 export interface UnrealizedTaxLot {
@@ -241,10 +262,36 @@ export function computeTaxSummary(
     }
   }
 
+  // Net short-term and long-term against each other when one category nets to a
+  // gain and the other to a loss (IRC §1222 netting). Tax applies only to the
+  // residual gains, so a long-term loss correctly offsets a short-term gain.
+  let residualShortTerm = taxableShortTermGainLoss;
+  let residualLongTerm = taxableLongTermGainLoss;
+  if (residualShortTerm > 0 && residualLongTerm < 0) {
+    const applied = Math.min(residualShortTerm, -residualLongTerm);
+    residualShortTerm -= applied;
+    residualLongTerm += applied;
+  } else if (residualLongTerm > 0 && residualShortTerm < 0) {
+    const applied = Math.min(residualLongTerm, -residualShortTerm);
+    residualLongTerm -= applied;
+    residualShortTerm += applied;
+  }
+
   const estimatedTax = roundCents(
-    Math.max(0, taxableShortTermGainLoss) * (shortTermTaxRatePercent / 100) +
-      Math.max(0, taxableLongTermGainLoss) * (longTermTaxRatePercent / 100),
+    Math.max(0, residualShortTerm) * (shortTermTaxRatePercent / 100) +
+      Math.max(0, residualLongTerm) * (longTermTaxRatePercent / 100),
   );
+
+  // A net capital loss offsets up to the annual limit against ordinary income;
+  // any excess carries forward to future tax years.
+  const netCapitalGainLoss = residualShortTerm + residualLongTerm;
+  let netDeductibleLoss = 0;
+  let lossCarryforward = 0;
+  if (netCapitalGainLoss < 0) {
+    const totalLoss = -netCapitalGainLoss;
+    netDeductibleLoss = roundCents(Math.min(totalLoss, CAPITAL_LOSS_ANNUAL_LIMIT_CENTS));
+    lossCarryforward = roundCents(totalLoss - netDeductibleLoss);
+  }
 
   return {
     shortTermGainLoss,
@@ -254,6 +301,8 @@ export function computeTaxSummary(
     taxableShortTermGainLoss,
     taxableLongTermGainLoss,
     estimatedTax,
+    netDeductibleLoss,
+    lossCarryforward,
   };
 }
 

--- a/apps/web/src/pages/TaxCenterPage.tsx
+++ b/apps/web/src/pages/TaxCenterPage.tsx
@@ -60,6 +60,9 @@ function syntheticLot(investment: Investment): DisplayTaxLot {
     shares: investment.shares,
     costPerShare: investment.costBasisPerShare.amount,
     acquiredDate,
+    // createdAt is when the holding was added to the app, not when it was
+    // actually purchased, so the holding-period classification is an estimate.
+    acquiredDateEstimated: true,
     currentPricePerShare: investment.currentPricePerShare.amount,
     currency: investment.currency.code,
   };
@@ -131,6 +134,11 @@ export const TaxCenterPage: React.FC = () => {
       return lots.map((lot) => displayLot(investment, lot));
     });
   }, [getLots, investments]);
+
+  const hasEstimatedAcquisitionDates = useMemo(
+    () => taxLots.some((lot) => lot.acquiredDateEstimated),
+    [taxLots],
+  );
 
   const activeSymbol = saleSymbol || taxLots[0]?.symbol || '';
   const activeLots = taxLots.filter((lot) => lot.symbol === activeSymbol);
@@ -538,6 +546,32 @@ export const TaxCenterPage: React.FC = () => {
                   may be disallowed.
                 </p>
               )}
+              {taxSummary.netDeductibleLoss > 0 && (
+                <p style={{ marginTop: 'var(--spacing-3)' }}>
+                  Net capital loss: {formatCurrency(taxSummary.netDeductibleLoss)} is deductible
+                  against ordinary income this year
+                  {taxSummary.lossCarryforward > 0 && (
+                    <>
+                      {' '}
+                      and {formatCurrency(taxSummary.lossCarryforward)} carries forward to future
+                      years
+                    </>
+                  )}
+                  . Assumes the $3,000 single/MFJ annual limit.
+                </p>
+              )}
+              {hasEstimatedAcquisitionDates && (
+                <p
+                  style={{
+                    marginTop: 'var(--spacing-3)',
+                    color: 'var(--semantic-text-secondary)',
+                  }}
+                >
+                  Holdings without recorded purchase lots use an estimated acquisition date (when
+                  the holding was added), so short- vs. long-term classification and the estimated
+                  tax for those are approximate. Add purchase lots for exact holding periods.
+                </p>
+              )}
             </div>
           </section>
 
@@ -708,6 +742,15 @@ export const TaxCenterPage: React.FC = () => {
                           </td>
                           <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
                             {lot.acquiredDate}
+                            {lot.acquiredDateEstimated && (
+                              <span
+                                title="Estimated acquisition date — add a purchase lot for the exact date"
+                                style={{ color: 'var(--semantic-text-secondary)' }}
+                              >
+                                {' '}
+                                (est.)
+                              </span>
+                            )}
                           </td>
                           <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
                             {lot.shares.toLocaleString()}


### PR DESCRIPTION
## Summary

Two Tax Center numbers were institutionally wrong for a HNW investor doing year-round tax-loss harvesting: holding-period classification silently trusted an unknown acquisition date, and the estimated-tax figure ignored capital-loss netting rules. This corrects both and discloses the estimate's assumptions.

Found by persona: Alexandra Petrova (HNW active investor)

## Changes

- **Estimated acquisition dates are now disclosed, not silently trusted** (`#3256`)
  - `TaxLot` gains an optional `acquiredDateEstimated` flag.
  - `TaxCenterPage` sets it on synthetic lots (those that fall back to the holding record's `createdAt` because no real acquisition date exists) and marks affected unrealized rows **"(est.)"** with a disclosure note. Short-term vs long-term classification is never presented as authoritative when the acquisition date is a guess.
- **Capital-gains estimated tax now follows IRS netting** (`#3258`)
  - `computeTaxSummary` nets short-term and long-term within each category, then cross-nets a gain in one category against a loss in the other, taxing only the residual gain at the respective rate.
  - A net capital loss is deducted against ordinary income up to the annual **$3,000** limit (`CAPITAL_LOSS_ANNUAL_LIMIT_CENTS`), with the remainder carried forward.
  - `TaxSummary` gains `netDeductibleLoss` and `lossCarryforward`; the page surfaces both.

## Correctness

- Net-within-then-cross-net matches IRS Schedule D ordering; all math is in integer cents (no float drift).
- `$3,000` annual deduction limit and loss carryforward applied per U.S. individual rules.

## Issues

Closes #3256
Closes #3258

## Testing

- [x] `npx tsc -b` clean (type-check parity with CI Deploy Preview)
- [x] `tax-center.test.ts` — 13 tests pass, incl. 4 new netting / loss-limit / carryforward cases
- [x] `npm run format:check` + `eslint --max-warnings 0` clean

## Cross-Platform

- iOS / Android / Windows: the web Tax Center uses its own TypeScript tax engine; other platforms have no equivalent surface yet, so this is `platform:web`. If/when a shared KMP tax engine lands, the netting rules here should be ported — noted in the issues.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
