### PR TITLE
feat(web): give 529 college fund a target date at college age (#3390)

### DIFF
--- a/apps/web/src/pages/HouseholdPage.test.tsx
+++ b/apps/web/src/pages/HouseholdPage.test.tsx
@@ -716,6 +716,33 @@ describe('HouseholdPage', () => {
     expect(recordChildWithdrawal).toHaveBeenCalledWith({ childId: 'child-1', amount: 5 });
   });
 
+  it('gives a new 529 college fund a target date at college age (#3390)', () => {
+    const createGoal = vi.fn().mockReturnValue({ id: 'goal-college-new' });
+    const linkChildCollegeFundGoal = vi.fn().mockReturnValue(makeChild());
+    mockedUseGoals.mockReturnValue(mockGoalsResult({ createGoal }));
+    mockedUseHousehold.mockReturnValue(
+      mockHouseholdResult({
+        household: makeHousehold(),
+        members: [makeOwnerMember()],
+        children: [makeChild({ age: 3 })],
+        linkChildCollegeFundGoal,
+      }),
+    );
+
+    render(<HouseholdPage />);
+
+    fireEvent.change(screen.getByLabelText(/college fund target for/i), {
+      target: { value: '50000' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create college fund/i }));
+
+    expect(createGoal).toHaveBeenCalledTimes(1);
+    const goalArg = createGoal.mock.calls[0]![0] as { targetDate?: string };
+    expect(goalArg.targetDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const expectedYear = String(new Date().getFullYear() + (18 - 3));
+    expect(goalArg.targetDate?.startsWith(expectedYear)).toBe(true);
+  });
+
   it('displays error banner when error exists', () => {
     mockedUseHousehold.mockReturnValue(
       mockHouseholdResult({

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -908,12 +908,18 @@ export function HouseholdPage() {
         return;
       }
 
+      const yearsUntilCollege = Math.max(18 - child.age, 1);
+      const collegeStartDate = new Date();
+      collegeStartDate.setFullYear(collegeStartDate.getFullYear() + yearsUntilCollege);
+      const targetDate = collegeStartDate.toISOString().slice(0, 10);
+
       const createdGoal = goalData.createGoal({
         householdId: household.id,
         name: `${child.name} College Fund`,
         description: `Dedicated college fund for ${child.name}.`,
         targetAmount: { amount: dollarsToCents(targetAmount) },
         currentAmount: { amount: dollarsToCents(currentAmount) },
+        targetDate,
         status: 'ACTIVE',
         icon: '🎓',
         color: '#7c3aed',


### PR DESCRIPTION
## Summary

When Ada creates a 529 college fund for a child from the Household page, the goal was created with **no target date**, so the fund had no deadline and downstream pace/timeline UI had nothing to anchor to. For a new-parent couple saving toward college 15+ years out, the target date is the whole point.

This derives the college fund goal's target date from the child's age — college at 18, with a one-year minimum floor so a nearly-college-age child still gets a future date.

## Changes

- `apps/web/src/pages/HouseholdPage.tsx` — `handleCreateCollegeFund` now computes `targetDate` (YYYY-MM-DD) from `18 - child.age` years out (minimum 1 year) and passes it to `createGoal`.
- `apps/web/src/pages/HouseholdPage.test.tsx` — regression test asserting `createGoal` receives a `YYYY-MM-DD` `targetDate` for the expected college-start year (child age 3 → current year + 15).

## Issues

Closes #3390

## Testing

- [x] `npx vitest run src/pages/HouseholdPage.test.tsx` — 27 passed
- [x] `npx prettier --check` on changed files — clean
- [x] `npx eslint` on changed files — 0 warnings

Found by persona: Ada &amp; Chidi Okafor (new-parents joint-finances)
