### PR TITLE
fix(web): align FIRE projection horizon with time-to-FI + local FI date (#3286, #3310)

### DIFF
--- a/apps/web/src/lib/fire.test.ts
+++ b/apps/web/src/lib/fire.test.ts
@@ -453,4 +453,57 @@ describe('calculateFIREPlan (integration)', () => {
     });
     expect(plan.yearsToTraditionalRetirement).toBe(30);
   });
+
+  it('extends the projection horizon to the year FI is actually reached (#3286)', () => {
+    // Slow-growth inputs put FI well beyond the default 50-year display horizon
+    // but within the 100-year search horizon.
+    const plan = calculateFIREPlan({
+      currentInvestedCents: $(10_000),
+      annualSpendingCents: $(60_000),
+      annualContributionCents: $(3_000),
+      realReturnRate: 0.03,
+      swrRate: 0.04,
+      now: new Date('2020-06-15T12:00:00Z'),
+    });
+
+    expect(plan.yearsToFI.reachedFI).toBe(true);
+    expect(plan.yearsToFI.years).toBeGreaterThan(50);
+
+    // The chart must run at least to the year FI is reached so the crossover is
+    // visible and consistent with the "time to FI" headline (not capped at 50).
+    const lastPoint = plan.projection[plan.projection.length - 1];
+    expect(lastPoint.year).toBeGreaterThanOrEqual(plan.yearsToFI.years);
+    expect(lastPoint.year).toBeLessThanOrEqual(MAX_FI_SEARCH_YEARS);
+    expect(plan.projection.some((point) => point.reachedFI)).toBe(true);
+  });
+
+  it('keeps the default display horizon when FI is unreachable (#3286)', () => {
+    // Spending dwarfs contributions + growth capacity → FI is never reached.
+    const plan = calculateFIREPlan({
+      currentInvestedCents: $(1_000),
+      annualSpendingCents: $(400_000),
+      annualContributionCents: $(0),
+      realReturnRate: 0.01,
+      swrRate: 0.04,
+      now: new Date('2020-06-15T12:00:00Z'),
+    });
+
+    expect(plan.yearsToFI.reachedFI).toBe(false);
+    const lastPoint = plan.projection[plan.projection.length - 1];
+    expect(lastPoint.year).toBe(50);
+  });
+
+  it('builds the projected FI date from local calendar components (#3310)', () => {
+    const now = new Date('2020-06-15T12:00:00Z');
+    const plan = calculateFIREPlan({ ...baseInput, now });
+
+    // Independently reproduce the local add-months + local-format pipeline; the
+    // serialized FI date must match it (no UTC `toISOString` month drift).
+    const expected = new Date(now.getTime());
+    expected.setMonth(expected.getMonth() + plan.yearsToFI.totalMonths);
+    const year = expected.getFullYear();
+    const month = String(expected.getMonth() + 1).padStart(2, '0');
+    const day = String(expected.getDate()).padStart(2, '0');
+    expect(plan.fiDateIso).toBe(`${year}-${month}-${day}`);
+  });
 });

--- a/apps/web/src/lib/fire.ts
+++ b/apps/web/src/lib/fire.ts
@@ -105,9 +105,22 @@ export function monthlyRateFromAnnual(annualRate: number): number {
 // Date helpers (calendar-date math — FI date is a LocalDate, not a timestamp)
 // ---------------------------------------------------------------------------
 
-/** Format a `Date` as a `YYYY-MM-DD` calendar date string. */
+/**
+ * Format a `Date` as a `YYYY-MM-DD` calendar date string using **local** date
+ * components.
+ *
+ * The projected FI date is a wall-clock calendar date, not an instant, so it
+ * must be built ({@link addMonths} uses local `setMonth`), serialized, and
+ * parsed (`FirePlannerPage` parses `${iso}T00:00:00` as local) with a single
+ * consistent local convention. Serializing with UTC (`toISOString`) here would
+ * shift the displayed month by one near midnight in western timezones. See
+ * issue #3310.
+ */
 function toIsoDate(date: Date): string {
-  return date.toISOString().slice(0, 10);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 /** Add whole months to a date, returning a new `Date` (no mutation). */
@@ -379,11 +392,21 @@ export function calculateFIREPlan(input: FIREPlanInput): FIREPlanResult {
     yearsToTraditionalRetirement,
   });
 
+  // Extend the chart horizon to (at least) the year FI is actually reached so
+  // the portfolio/FI crossover is visible and consistent with the headline.
+  // `yearsToFI` searches up to MAX_FI_SEARCH_YEARS (100) while the projection
+  // defaults to DEFAULT_DISPLAY_HORIZON_YEARS (50); without this the chart and
+  // the "time to FI" headline disagree for 50 < years-to-FI <= 100. See #3286.
+  const projectionMaxYears = ytf.reachedFI
+    ? Math.min(MAX_FI_SEARCH_YEARS, ytf.years + DEFAULT_PROJECTION_BUFFER_YEARS)
+    : DEFAULT_DISPLAY_HORIZON_YEARS;
+
   const projection = buildFIProjection({
     currentInvestedCents: input.currentInvestedCents,
     annualContributionCents: input.annualContributionCents,
     realReturnRate: input.realReturnRate,
     fiNumberCents: fiCents,
+    maxYears: projectionMaxYears,
   });
 
   const fiDateIso = ytf.reachedFI ? toIsoDate(addMonths(now, ytf.totalMonths)) : null;


### PR DESCRIPTION
## Summary

Fixes two web-only FIRE planner bugs found while stress-testing slow-growth and month-boundary scenarios as a FIRE optimizer. Both live in `apps/web/src/lib/fire.ts`.

## Changes

- **#3286 — projection horizon vs. time-to-FI mismatch.** `buildFIProjection` defaulted to a 50-year display horizon while `yearsToFI` searches up to `MAX_FI_SEARCH_YEARS` (100). For `50 < years-to-FI <= 100` the headline reported a reach year the chart never showed (portfolio line stopped at year 50, still below the flat FI line). `calculateFIREPlan` now derives `maxYears` from the computed `yearsToFI` (`years + buffer`, capped at 100) when FI is reachable, and keeps the default 50-year horizon when it is not — so the crossover is always visible and consistent with the headline.
- **#3310 — FI date UTC/local mixing.** The projected FI date was built with local `setMonth` math but serialized with UTC `toISOString`, then re-parsed as local — shifting the displayed month by one near midnight in western timezones. `toIsoDate` now formats from **local** calendar components so build → serialize → parse share one convention.

## Tests

- `apps/web/src/lib/fire.test.ts`: added horizon tests (reachable FI beyond 50y extends the chart; unreachable keeps the 50y default) and a local FI-date regression test. **43 tests pass.**
- `tsc -b` clean, `eslint --max-warnings 0` clean.

## Issues

Closes #3286
Closes #3310

Found by persona: Sam Rivera (FIRE optimizer)
