### PR TITLE
fix(web): localize invoice/runway dates, pluralize counts, scope forecast live region (#3255)

### DIFF
--- a/apps/web/src/pages/CashRunwayPage.tsx
+++ b/apps/web/src/pages/CashRunwayPage.tsx
@@ -25,6 +25,7 @@ import { IconToken } from '../icons/tokens';
 import { useAccounts } from '../hooks/useAccounts';
 import { useBills } from '../hooks/useBills';
 import { useInvoices } from '../hooks/useInvoices';
+import { useLocalePreferences } from '../hooks/useLocalePreferences';
 import { useReducedMotion } from '../hooks/useReducedMotion';
 import { formatCurrency } from '../lib/currency';
 import {
@@ -33,6 +34,7 @@ import {
   type RecurrenceFrequency,
   type ScheduledCashEvent,
 } from '../lib/cashflow/cash-runway';
+import { formatDate } from '../utils/formatDate';
 import type { Account, BillFrequency } from '../kmp/bridge';
 
 import './CashRunwayPage.css';
@@ -55,15 +57,6 @@ const BILL_FREQUENCY_TO_RECURRENCE: Record<BillFrequency, RecurrenceFrequency> =
   YEARLY: 'yearly',
 };
 
-/** Format a `YYYY-MM-DD` date for display, e.g. "Jan 15, 2025". */
-function formatDate(isoDate: string): string {
-  const parsed = new Date(`${isoDate}T00:00:00`);
-  if (Number.isNaN(parsed.getTime())) {
-    return isoDate;
-  }
-  return parsed.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-}
-
 /** Clamp a past date forward to today so overdue items count as imminent. */
 function notBefore(isoDate: string, today: string): string {
   return isoDate < today ? today : isoDate;
@@ -74,6 +67,7 @@ export function CashRunwayPage() {
 
   const today = useMemo(() => todayIsoDate(), []);
   const reducedMotion = useReducedMotion();
+  const { locale } = useLocalePreferences();
 
   const { accounts, loading: accountsLoading } = useAccounts();
   const { bills } = useBills();
@@ -130,8 +124,8 @@ export function CashRunwayPage() {
   const isShortfall = forecast.status === 'shortfall';
   const statusIcon = isShortfall ? IconToken.WARNING : IconToken.SUCCESS;
   const statusHeadline = isShortfall
-    ? `Projected cash shortfall on ${formatDate(forecast.shortfallDate ?? forecast.startDate)}`
-    : `Cash stays positive through ${formatDate(forecast.endDate)}`;
+    ? `Projected cash shortfall on ${formatDate(forecast.shortfallDate ?? forecast.startDate, { locale })}`
+    : `Cash stays positive through ${formatDate(forecast.endDate, { locale })}`;
   const statusDetail = isShortfall
     ? forecast.runwayDays === 0
       ? 'Your cash is already below zero. Bring in revenue or defer outflows now.'
@@ -207,7 +201,7 @@ export function CashRunwayPage() {
                 <dt className="cash-runway__metric-label">Runway</dt>
                 <dd className="cash-runway__metric-value">
                   {isShortfall
-                    ? formatDate(forecast.shortfallDate ?? forecast.startDate)
+                    ? formatDate(forecast.shortfallDate ?? forecast.startDate, { locale })
                     : 'No shortfall'}
                 </dd>
               </div>
@@ -220,7 +214,7 @@ export function CashRunwayPage() {
                 >
                   {formatCurrency(forecast.minBalanceCents)}
                   <span className="cash-runway__metric-sub">
-                    on {formatDate(forecast.minBalanceDate)}
+                    on {formatDate(forecast.minBalanceDate, { locale })}
                   </span>
                 </dd>
               </div>
@@ -255,7 +249,7 @@ export function CashRunwayPage() {
             </h2>
             <p className="cash-runway__timeline-intro">
               Starting cash of {formatCurrency(forecast.startingCashCents)} on{' '}
-              {formatDate(forecast.startDate)}
+              {formatDate(forecast.startDate, { locale })}
               {forecast.timeline.length === 0
                 ? ' with no scheduled events in this horizon.'
                 : ', then each day with a scheduled inflow or outflow:'}
@@ -272,7 +266,9 @@ export function CashRunwayPage() {
                   return (
                     <li key={point.date} className="cash-runway__day">
                       <div className="cash-runway__day-head">
-                        <span className="cash-runway__day-date">{formatDate(point.date)}</span>
+                        <span className="cash-runway__day-date">
+                          {formatDate(point.date, { locale })}
+                        </span>
                         <span
                           className={`cash-runway__day-balance${
                             negative ? ' cash-runway__day-balance--negative' : ''

--- a/apps/web/src/pages/InvoicesPage.test.tsx
+++ b/apps/web/src/pages/InvoicesPage.test.tsx
@@ -15,10 +15,24 @@ import { InvoicesPage } from './InvoicesPage';
 import type { Invoice } from '../lib/analytics/invoices';
 
 vi.mock('../hooks/useInvoices', () => ({ useInvoices: vi.fn() }));
+vi.mock('../hooks/useLocalePreferences', () => ({ useLocalePreferences: vi.fn() }));
 
 import { useInvoices } from '../hooks/useInvoices';
+import { useLocalePreferences } from '../hooks/useLocalePreferences';
 
 const mockedUseInvoices = vi.mocked(useInvoices);
+const mockedUseLocalePreferences = vi.mocked(useLocalePreferences);
+
+function mockLocale(locale: string): void {
+  mockedUseLocalePreferences.mockReturnValue({
+    locale,
+    timeZone: 'UTC',
+    supportedLocales: [],
+    timeZoneOptions: [],
+    setLocale: vi.fn(),
+    setTimeZone: vi.fn(),
+  });
+}
 
 const SAMPLE_INVOICE: Invoice = {
   id: 'inv-1',
@@ -34,6 +48,7 @@ const SAMPLE_INVOICE: Invoice = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockLocale('en-US');
   mockedUseInvoices.mockReturnValue({
     invoices: [],
     pipelineGroups: [],
@@ -81,5 +96,46 @@ describe('InvoicesPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete invoice' }));
     expect(deleteInvoice).toHaveBeenCalledWith('inv-1');
+  });
+
+  it('pluralizes the invoice count per pipeline group', () => {
+    const second: Invoice = { ...SAMPLE_INVOICE, id: 'inv-2' };
+    mockedUseInvoices.mockReturnValue({
+      invoices: [SAMPLE_INVOICE, second],
+      pipelineGroups: [
+        { status: 'Sent', label: 'Sent', invoices: [SAMPLE_INVOICE], totalCents: 120_000 },
+        { status: 'Paid', label: 'Paid', invoices: [SAMPLE_INVOICE, second], totalCents: 240_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    expect(screen.getByText('1 invoice')).toBeInTheDocument();
+    expect(screen.getByText('2 invoices')).toBeInTheDocument();
+  });
+
+  it('formats invoice dates using the active locale', () => {
+    mockLocale('en-GB');
+    mockedUseInvoices.mockReturnValue({
+      invoices: [SAMPLE_INVOICE],
+      pipelineGroups: [
+        { status: 'Sent', label: 'Sent', invoices: [SAMPLE_INVOICE], totalCents: 120_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    // en-GB renders day-first ("1 Jun 2026"); the removed en-US hardcode showed "Jun 1, 2026".
+    expect(screen.getByText(/Issued 1 Jun 2026/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/InvoicesPage.tsx
+++ b/apps/web/src/pages/InvoicesPage.tsx
@@ -12,6 +12,7 @@
 import React, { useMemo, useState } from 'react';
 import { ConfirmDialog, CurrencyDisplay, EmptyState } from '../components/common';
 import { useInvoices } from '../hooks/useInvoices';
+import { useLocalePreferences } from '../hooks/useLocalePreferences';
 import {
   computeExpectedPayDate,
   PAYMENT_TERM_LABELS,
@@ -21,6 +22,7 @@ import {
   type InvoicePaymentTerm,
   type InvoiceStatus,
 } from '../lib/analytics/invoices';
+import { formatDate } from '../utils/formatDate';
 import './analytics.css';
 
 function todayIsoDate(): string {
@@ -37,14 +39,6 @@ function parseAmountToCents(value: string): number | null {
   return Math.round(amount * 100);
 }
 
-function formatDate(date: string): string {
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(new Date(`${date}T00:00:00`));
-}
-
 const StatusBadge: React.FC<{ status: InvoiceStatus }> = ({ status }) => (
   <span className={`invoice-status-badge invoice-status-badge--${status.toLowerCase()}`}>
     {status}
@@ -53,16 +47,18 @@ const StatusBadge: React.FC<{ status: InvoiceStatus }> = ({ status }) => (
 
 const InvoiceCard: React.FC<{
   invoice: Invoice;
+  locale: string;
   onStatusChange: (invoiceId: string, status: InvoiceStatus) => void;
   onDelete: (invoice: Invoice) => void;
-}> = ({ invoice, onStatusChange, onDelete }) => (
+}> = ({ invoice, locale, onStatusChange, onDelete }) => (
   <article className={`invoice-card invoice-card--${invoice.status.toLowerCase()}`} role="listitem">
     <div className="invoice-card__main">
       <div>
         <h3 className="invoice-card__client">{invoice.clientName}</h3>
         <p className="invoice-card__meta">
-          Issued {formatDate(invoice.issueDate)} · {PAYMENT_TERM_LABELS[invoice.paymentTerm]} ·
-          expected {formatDate(invoice.expectedPayDate)}
+          Issued {formatDate(invoice.issueDate, { locale })} ·{' '}
+          {PAYMENT_TERM_LABELS[invoice.paymentTerm]} · expected{' '}
+          {formatDate(invoice.expectedPayDate, { locale })}
         </p>
       </div>
       <div className="invoice-card__amount">
@@ -101,6 +97,7 @@ export const InvoicesPage: React.FC = () => {
     updateInvoiceStatus,
     deleteInvoice,
   } = useInvoices();
+  const { locale } = useLocalePreferences();
   const [clientName, setClientName] = useState('');
   const [amount, setAmount] = useState('');
   const [issueDate, setIssueDate] = useState(todayIsoDate);
@@ -219,7 +216,7 @@ export const InvoicesPage: React.FC = () => {
             </select>
           </label>
           <div className="invoice-form__preview" aria-live="polite">
-            Expected pay date: <strong>{formatDate(expectedPayDate)}</strong>
+            Expected pay date: <strong>{formatDate(expectedPayDate, { locale })}</strong>
           </div>
           {formError && <p className="invoice-form__error">{formError}</p>}
           <button className="analytics-export-btn invoice-form__submit" type="submit">
@@ -228,11 +225,16 @@ export const InvoicesPage: React.FC = () => {
         </form>
       </section>
 
-      <section
-        className="analytics-section"
-        aria-label="Expected income forecast"
-        aria-live="polite"
-      >
+      <section className="analytics-section" aria-label="Expected income forecast">
+        <p className="sr-only" role="status">
+          Outstanding invoices total <CurrencyDisplay amount={totalOutstandingCents} />.
+          {forecastBuckets.slice(1, 3).map((bucket) => (
+            <React.Fragment key={bucket.id}>
+              {' '}
+              {bucket.label}: <CurrencyDisplay amount={bucket.totalCents} />.
+            </React.Fragment>
+          ))}
+        </p>
         <h2 className="analytics-section__title">Expected-income forecast</h2>
         <div className="analytics-metrics-grid">
           <article className="analytics-metric-card" aria-label="Outstanding invoice total">
@@ -290,7 +292,9 @@ export const InvoicesPage: React.FC = () => {
                 <div className="invoice-pipeline-group__header">
                   <div>
                     <h3>{group.label}</h3>
-                    <p>{group.invoices.length} invoices</p>
+                    <p>
+                      {group.invoices.length} {group.invoices.length === 1 ? 'invoice' : 'invoices'}
+                    </p>
                   </div>
                   <CurrencyDisplay amount={group.totalCents} />
                 </div>
@@ -304,6 +308,7 @@ export const InvoicesPage: React.FC = () => {
                       <InvoiceCard
                         key={invoice.id}
                         invoice={invoice}
+                        locale={locale}
                         onStatusChange={updateInvoiceStatus}
                         onDelete={setDeletingInvoice}
                       />


### PR DESCRIPTION
## Summary

Batch B (Invoices & Cash Runway i18n + a11y polish) for Priya's small-business workflow. Three small, related fixes on the same two pages, batched per AGENTS.md §4a.

## Changes

- **#3255 — Localized dates.** `InvoicesPage` and `CashRunwayPage` hardcoded `en-US` date formatting. Both now route dates through the shared locale-aware `utils/formatDate` helper, driven by `useLocalePreferences` — matching the existing Remittances page behavior. A UK/German user now sees `1 Jun 2026`, not `Jun 1, 2026`.
- **#3257 — Pluralization.** The invoice pipeline rendered "1 invoices". Now "1 invoice" / "N invoices".
- **#3253 — Scoped live region.** The expected-income forecast wrapped the entire `<section>` (heading + every metric card + the full forecast list) in `aria-live="polite"`, so screen readers re-announced the whole region on any change. Replaced with a focused visually-hidden `role="status"` summary of just the headline figures (outstanding + near-term buckets).

## Testing

- `npx vitest run src/pages/InvoicesPage.test.tsx` — 5 passed (added locale-aware-date and pluralization cases).
- `npx vitest run src/lib/cashflow/cash-runway.test.ts` — engine tests unaffected.
- `eslint --max-warnings 0` + `prettier --check` clean on all changed files.

## Issues

Closes #3255
Closes #3257
Closes #3253

Found by persona: Priya Sharma (etsy small-business owner)
