### PR TITLE
feat(web): let partners contribute to a goal from its detail page (#3391)

### DIFF
--- a/apps/web/src/pages/GoalDetailPage.test.tsx
+++ b/apps/web/src/pages/GoalDetailPage.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
@@ -322,5 +322,27 @@ describe('GoalDetailPage', () => {
     const backLink = screen.getByRole('link', { name: /back to goals/i });
     expect(backLink).toBeInTheDocument();
     expect(backLink).toHaveAttribute('href', '/goals');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Contribute from detail (issue #3391)
+  // ---------------------------------------------------------------------------
+
+  it('shows a Contribute action on the goal detail page', () => {
+    renderWithRoute();
+
+    expect(
+      screen.getByRole('button', { name: /contribute to emergency fund/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the contribution dialog when Contribute is clicked', () => {
+    renderWithRoute();
+
+    fireEvent.click(screen.getByRole('button', { name: /contribute to emergency fund/i }));
+
+    expect(
+      screen.getByRole('dialog', { name: /contribute to emergency fund/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/GoalDetailPage.tsx
+++ b/apps/web/src/pages/GoalDetailPage.tsx
@@ -12,12 +12,13 @@ import {
   LoadingSpinner,
 } from '../components/common';
 import { GoalForm } from '../components/forms';
-import type { CreateGoalInput } from '../db/repositories/goals';
+import type { CreateGoalInput, GoalContributionInput } from '../db/repositories/goals';
 import { useGoals } from '../hooks';
 import type { Goal } from '../kmp/bridge';
 import { getGoalStatusIndicator } from '../lib/a11y';
 import { ShareCelebrationButton } from '../components/social/ShareCelebrationButton';
 import { SharedGoalContributions } from '../components/goals/SharedGoalContributions';
+import { GoalContributionDialog } from '../components/goals/GoalContributionDialog';
 import { goalCelebrationEvent } from '../lib/social/share-celebration';
 import '../styles/pages.css';
 
@@ -43,8 +44,9 @@ export const GoalDetailPage: React.FC = () => {
 
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [deletingGoal, setDeletingGoal] = useState<Goal | null>(null);
+  const [isContributeOpen, setIsContributeOpen] = useState(false);
 
-  const { goals, loading, error, refresh, updateGoal, deleteGoal } = useGoals();
+  const { goals, loading, error, refresh, updateGoal, deleteGoal, contributeToGoal } = useGoals();
 
   const goal = id ? (goals.find((g) => g.id === id) ?? null) : null;
 
@@ -72,6 +74,17 @@ export const GoalDetailPage: React.FC = () => {
       navigate('/goals', { replace: true });
     }
   }, [deleteGoal, deletingGoal, navigate]);
+
+  const handleContributionSubmit = useCallback(
+    async (input: GoalContributionInput) => {
+      const updated = contributeToGoal(input.goalId, input);
+      if (updated === null) {
+        throw new Error('Failed to contribute to goal.');
+      }
+      setIsContributeOpen(false);
+    },
+    [contributeToGoal],
+  );
 
   if (loading) {
     return (
@@ -178,6 +191,14 @@ export const GoalDetailPage: React.FC = () => {
           {shareEvent && (
             <ShareCelebrationButton event={shareEvent} label={`Share ${goal.name} progress`} />
           )}
+          <button
+            type="button"
+            className="form-button form-button--primary"
+            onClick={() => setIsContributeOpen(true)}
+            aria-label={`Contribute to ${goal.name}`}
+          >
+            <AppIcon name="wallet" /> Contribute
+          </button>
           <button
             type="button"
             className="form-button form-button--secondary"
@@ -333,6 +354,13 @@ export const GoalDetailPage: React.FC = () => {
       </section>
 
       <SharedGoalContributions goal={goal} />
+
+      <GoalContributionDialog
+        isOpen={isContributeOpen}
+        goal={isContributeOpen ? goal : null}
+        onSubmit={handleContributionSubmit}
+        onCancel={() => setIsContributeOpen(false)}
+      />
 
       <GoalForm
         isOpen={isFormOpen}


### PR DESCRIPTION
## Summary

The goal detail page (`/goals/:id`) had **no way to add money to a goal** — contributing was only possible from the goals list. When Ada opens her house down-payment or 529 college goal to review progress, she had to navigate back to the list to fund it. This surfaces the existing `GoalContributionDialog` directly on the detail page as the primary action.

## Changes

- `apps/web/src/pages/GoalDetailPage.tsx`
  - Import `GoalContributionDialog` and the `GoalContributionInput` type; pull `contributeToGoal` from `useGoals`.
  - Add an `isContributeOpen` state and a `handleContributionSubmit` handler that mirrors the goals-list flow.
  - Add a **primary "Contribute" action** (wallet icon) in the page header, and render the contribution dialog.
- `apps/web/src/pages/GoalDetailPage.test.tsx` — regression tests: the Contribute action renders, and clicking it opens the contribution dialog.

No new business logic — reuses the existing, already-tested `GoalContributionDialog` and `contributeToGoal` hook.

## Issues

Closes #3391

## Testing

- [x] `npx vitest run src/pages/GoalDetailPage.test.tsx` — 21 passed
- [x] `npx prettier --check` on changed files — clean
- [x] `npx eslint` on changed files — 0 warnings

Found by persona: Ada &amp; Chidi Okafor (new-parents joint-finances)
