### PR TITLE
fix(web): distinguish TrendLineChart series without colour (#3328)

### DIFF
--- a/apps/web/src/components/charts/TrendLineChart.test.tsx
+++ b/apps/web/src/components/charts/TrendLineChart.test.tsx
@@ -105,6 +105,32 @@ describe('TrendLineChart', () => {
     expect(label).toContain('Expenses');
   });
 
+  it('renders a pattern-encoded legend so series are distinguishable without colour (WCAG 1.4.1)', () => {
+    render(<TrendLineChart data={sampleData} series={sampleSeries} />);
+    const legend = screen.getByRole('list', { name: /Trend over time legend/i });
+    expect(legend).toBeInTheDocument();
+    // Each series names its stroke pattern in text, not colour alone.
+    expect(screen.getByText('Income (solid line)')).toBeInTheDocument();
+    expect(screen.getByText('Expenses (dashed line)')).toBeInTheDocument();
+  });
+
+  it('applies a distinct stroke pattern per series line', () => {
+    render(<TrendLineChart data={sampleData} series={sampleSeries} />);
+    // The legend swatch mirrors each line: first series solid (no dasharray),
+    // second dashed.
+    const swatchLines = document.querySelectorAll('.trend-chart__legend-swatch line');
+    expect(swatchLines).toHaveLength(2);
+    expect(swatchLines[0].getAttribute('stroke-dasharray')).toBeNull();
+    expect(swatchLines[1].getAttribute('stroke-dasharray')).toBe('6 5');
+  });
+
+  it('describes each series line pattern in the chart summary', () => {
+    render(<TrendLineChart data={sampleData} series={sampleSeries} />);
+    const label = screen.getByRole('figure').getAttribute('aria-label')!;
+    expect(label).toContain('Income (solid line)');
+    expect(label).toContain('Expenses (dashed line)');
+  });
+
   it('includes a sr-only description paragraph', () => {
     render(<TrendLineChart data={sampleData} series={sampleSeries} />);
     const srOnly = document.querySelector('.sr-only');

--- a/apps/web/src/components/charts/TrendLineChart.tsx
+++ b/apps/web/src/components/charts/TrendLineChart.tsx
@@ -14,7 +14,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
 } from 'recharts';
 import { CHART_COLORS, formatChartCurrency } from './chart-palette';
@@ -24,6 +23,34 @@ import {
   useChartKeyboardNavigation,
 } from './chart-accessibility';
 import { buildChartTextSummary } from '../../lib/a11y/chart-table-audit';
+import './trend-line-chart.css';
+
+/**
+ * Per-series stroke patterns. Colour alone must never be the only way to tell
+ * two lines apart (WCAG 2.2 SC 1.4.1 Use of Color), so each series also gets a
+ * distinct dash pattern that is mirrored in the legend swatch and label. The
+ * cycle is deliberately small and high-contrast between neighbours.
+ */
+interface SeriesPattern {
+  /** SVG `strokeDasharray`; `undefined` renders a solid line. */
+  readonly dash?: string;
+  /** Human-readable pattern name, surfaced in the legend and a11y summary. */
+  readonly name: string;
+}
+
+const SERIES_PATTERNS: readonly SeriesPattern[] = [
+  { dash: undefined, name: 'solid' },
+  { dash: '6 5', name: 'dashed' },
+  { dash: '2 4', name: 'dotted' },
+  { dash: '8 4 2 4', name: 'dash-dot' },
+  { dash: '10 6', name: 'long-dashed' },
+  { dash: '1 6', name: 'fine-dotted' },
+];
+
+/** Resolve the stroke pattern for a series by its index (cycles the set). */
+function seriesPattern(index: number): SeriesPattern {
+  return SERIES_PATTERNS[index % SERIES_PATTERNS.length];
+}
 
 export interface TrendDataPoint {
   label: string;
@@ -61,13 +88,13 @@ export const TrendLineChart: FC<TrendLineChartProps> = ({
   const description = useMemo(() => {
     if (data.length === 0) return 'Line chart with no data.';
     const seriesDesc = series
-      .map((s) => {
+      .map((s, index) => {
         const values = data.map((d) =>
           typeof d[s.dataKey] === 'number' ? (d[s.dataKey] as number) : 0,
         );
         const min = Math.min(...values);
         const max = Math.max(...values);
-        return `${s.name}: range ${formatChartCurrency(min, currency)} to ${formatChartCurrency(max, currency)}`;
+        return `${s.name} (${seriesPattern(index).name} line): range ${formatChartCurrency(min, currency)} to ${formatChartCurrency(max, currency)}`;
       })
       .join('. ');
     return `Line chart "${title}" with ${data.length} data points and ${series.length} series. ${seriesDesc}.`;
@@ -158,7 +185,6 @@ export const TrendLineChart: FC<TrendLineChartProps> = ({
                   borderRadius: '0.375rem',
                 }}
               />
-              <Legend />
               {series.map((trendSeries, index) => (
                 <Line
                   key={trendSeries.dataKey}
@@ -167,6 +193,7 @@ export const TrendLineChart: FC<TrendLineChartProps> = ({
                   name={trendSeries.name}
                   stroke={CHART_COLORS[index % CHART_COLORS.length]}
                   strokeWidth={2}
+                  strokeDasharray={seriesPattern(index).dash}
                   dot={{ r: 4 }}
                   activeDot={{ r: 6 }}
                   isAnimationActive={!disableAnimation}
@@ -176,6 +203,36 @@ export const TrendLineChart: FC<TrendLineChartProps> = ({
             </LineChart>
           </ResponsiveContainer>
         </div>
+      )}
+      {data.length > 0 && (
+        <ul className="trend-chart__legend" aria-label={`${title} legend`}>
+          {series.map((trendSeries, index) => {
+            const pattern = seriesPattern(index);
+            return (
+              <li key={trendSeries.dataKey} className="trend-chart__legend-item">
+                <svg
+                  className="trend-chart__legend-swatch"
+                  width="28"
+                  height="10"
+                  viewBox="0 0 28 10"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <line
+                    x1="0"
+                    y1="5"
+                    x2="28"
+                    y2="5"
+                    stroke={CHART_COLORS[index % CHART_COLORS.length]}
+                    strokeWidth="2"
+                    strokeDasharray={pattern.dash}
+                  />
+                </svg>
+                <span>{`${trendSeries.name} (${pattern.name} line)`}</span>
+              </li>
+            );
+          })}
+        </ul>
       )}
       <div
         id={`${chartId}-live`}

--- a/apps/web/src/components/charts/trend-line-chart.css
+++ b/apps/web/src/components/charts/trend-line-chart.css
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * TrendLineChart legend — mirrors the accessible, pattern-encoded legend used
+ * by NetWorthProjectionChart so series are distinguishable without relying on
+ * colour alone (WCAG 2.2 SC 1.4.1). Swatches reproduce each line's dash
+ * pattern; labels name the pattern in text.
+ */
+
+.trend-chart__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-4, 1rem);
+  margin: var(--spacing-2, 0.5rem) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.trend-chart__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2, 0.5rem);
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-secondary, #6b7280);
+}
+
+.trend-chart__legend-swatch {
+  flex: 0 0 auto;
+}


### PR DESCRIPTION
## Summary

Fixes a WCAG 2.2 SC 1.4.1 (Use of Color) gap found while reviewing the FIRE projection chart as a FIRE optimizer. The chart's two lines ("Projected portfolio" vs "FI number") were distinguishable by colour only, with a colour-keyed legend — impossible to map legend → line under colour-vision deficiency. Fix lives in the shared `TrendLineChart`, so every consumer benefits.

## Changes

- **Per-series stroke patterns.** `TrendLineChart` now cycles a small, high-contrast set of dash patterns (solid, dashed, dotted, dash-dot, …) and applies `strokeDasharray` per line — so lines are distinguishable without colour.
- **Accessible, pattern-encoded legend.** Replaced the colour-only Recharts `<Legend />` with a custom `<ul>` legend whose SVG swatches reproduce each line's dash pattern and whose labels name the pattern in text (e.g. "Projected portfolio (solid line)"). Mirrors the sibling `NetWorthProjectionChart`.
- **A11y summary.** The chart `aria-label` / sr-only description now names each series' line pattern alongside its range.
- Added co-located `trend-line-chart.css` (token-based legend styling, matching `net-worth-projection.css`).

## Tests

- `TrendLineChart.test.tsx`: new assertions for the pattern-encoded legend, per-series dash swatches, and pattern-labelled summary.
- Verified consumers still pass: `FirePlannerPage`, `PlanningPage`, `dashboard-visualizations` — **80 tests pass**.
- `tsc -b` clean, `eslint --max-warnings 0` clean.

## Issues

Closes #3328

Found by persona: Sam Rivera (FIRE optimizer)
