### PR TITLE
fix(web): validate remittance send/receive currencies differ (#3259)

### DIFF
--- a/apps/web/src/lib/i18n/locales/en-US.ts
+++ b/apps/web/src/lib/i18n/locales/en-US.ts
@@ -152,6 +152,7 @@ export const EN_US_CATALOG: MessageCatalog = {
   'remittance.form.date.required': 'Enter the date you sent the money.',
   'remittance.form.sourceCurrency.label': 'You send (currency)',
   'remittance.form.destCurrency.label': 'They receive (currency)',
+  'remittance.form.destCurrency.sameCurrency': 'Choose a different currency from the one you send.',
   'remittance.form.sendAmount.label': 'Amount you send',
   'remittance.form.sendAmount.required': 'Enter the amount you send.',
   'remittance.form.sendAmount.invalid': 'Enter a valid amount greater than zero.',

--- a/apps/web/src/lib/i18n/locales/es-ES.ts
+++ b/apps/web/src/lib/i18n/locales/es-ES.ts
@@ -152,6 +152,7 @@ export const ES_ES_CATALOG: MessageCatalog = {
   'remittance.form.date.required': 'Introduce la fecha en que enviaste el dinero.',
   'remittance.form.sourceCurrency.label': 'Tú envías (moneda)',
   'remittance.form.destCurrency.label': 'Reciben (moneda)',
+  'remittance.form.destCurrency.sameCurrency': 'Elige una moneda diferente a la que envías.',
   'remittance.form.sendAmount.label': 'Importe que envías',
   'remittance.form.sendAmount.required': 'Introduce el importe que envías.',
   'remittance.form.sendAmount.invalid': 'Introduce un importe válido mayor que cero.',

--- a/apps/web/src/pages/RemittancesPage.test.tsx
+++ b/apps/web/src/pages/RemittancesPage.test.tsx
@@ -191,4 +191,26 @@ describe('RemittancesPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete remittance' }));
     expect(deleteRemittance).toHaveBeenCalledWith('rem-1');
   });
+
+  it('blocks submission when the send and receive currencies match', () => {
+    const createRemittance = vi.fn();
+    mockUseRemittances.mockReturnValue(buildResult({ createRemittance }));
+    render(<RemittancesPage />);
+
+    fireEvent.change(screen.getByLabelText(/Recipient name/), {
+      target: { value: 'Familia García' },
+    });
+    fireEvent.change(screen.getByLabelText(/Date sent/), { target: { value: '2026-06-01' } });
+    fireEvent.change(screen.getByLabelText(/Amount you send/), { target: { value: '500' } });
+    fireEvent.change(screen.getByLabelText(/Exchange rate/), { target: { value: '17' } });
+    // Force the destination currency to match the source (USD) — not a real FX transfer.
+    fireEvent.change(screen.getByLabelText(/They receive/), { target: { value: 'USD' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record remittance' }));
+
+    expect(createRemittance).not.toHaveBeenCalled();
+    expect(
+      screen.getByText('Choose a different currency from the one you send.'),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/RemittancesPage.tsx
+++ b/apps/web/src/pages/RemittancesPage.tsx
@@ -389,6 +389,9 @@ export const RemittancesPage: React.FC = () => {
     ) {
       next.referenceRate = t('remittance.form.referenceRate.invalid');
     }
+    if (sourceCurrency === destCurrency) {
+      next.destCurrency = t('remittance.form.destCurrency.sameCurrency');
+    }
     return next;
   }, [
     recipientName,
@@ -398,6 +401,8 @@ export const RemittancesPage: React.FC = () => {
     fee,
     fxRate,
     referenceRate,
+    sourceCurrency,
+    destCurrency,
     parsedSendMinor,
     parsedFeeMinor,
     parsedFx,
@@ -604,6 +609,12 @@ export const RemittancesPage: React.FC = () => {
                 className="remittance-field__input"
                 value={destCurrency}
                 onChange={(e) => setDestCurrency(e.target.value)}
+                aria-invalid={Boolean(errors.destCurrency)}
+                aria-describedby={describedBy(
+                  'remit-dest-currency',
+                  Boolean(errors.destCurrency),
+                  false,
+                )}
               >
                 {CURRENCY_OPTIONS.map((currency) => (
                   <option key={currency.code} value={currency.code}>
@@ -611,6 +622,11 @@ export const RemittancesPage: React.FC = () => {
                   </option>
                 ))}
               </select>
+              {errors.destCurrency && (
+                <p id="remit-dest-currency-error" className="remittance-field__error" role="alert">
+                  {errors.destCurrency}
+                </p>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

The remittance entry form allowed selecting the **same** currency for both "You send" and "They receive". For a cross-border supplier payment (Priya pays INR suppliers from a USD account) that's never valid — it implies a 1.0 FX rate and isn't a real remittance.

## Changes

- **Validation.** `validate()` now blocks submission when `sourceCurrency === destCurrency`, keyed on `destCurrency`.
- **Accessible error.** The destination-currency `<select>` gains `aria-invalid` + `aria-describedby` and a `role="alert"` error message, matching the existing field pattern (`sendAmount`, `fee`, `fxRate`).
- **i18n.** Added `remittance.form.destCurrency.sameCurrency` to `en-US` and `es-ES` (locale parity check passes).
- **Test.** Added a RemittancesPage case asserting a same-currency form is blocked and the error is shown.

## Testing

- `npx vitest run src/pages/RemittancesPage.test.tsx src/lib/i18n` — 17 files / 52 tests passed (new same-currency test + i18n parity).
- `eslint --max-warnings 0` + `prettier --check` clean on all changed files.

## Issues

Closes #3259

Found by persona: Priya Sharma (etsy small-business owner)
