### PR TITLE
fix(web): identify form errors and fix bulk-edit dialog and listbox semantics (#3337)

### DIFF
--- a/apps/web/src/components/forms/BulkEditToolbar.test.tsx
+++ b/apps/web/src/components/forms/BulkEditToolbar.test.tsx
@@ -5,6 +5,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { BulkEditToolbar } from './BulkEditToolbar';
 import type { BulkEditToolbarProps } from './BulkEditToolbar';
 
+// Focus-trap behaviour is unit-tested with the hook itself; mock it here so
+// these component tests do not depend on real DOM focus management.
+vi.mock('../../accessibility/aria', () => ({
+  useFocusTrap: vi.fn(),
+}));
+
 const syncMetadata = {
   createdAt: '2025-01-01T00:00:00Z',
   updatedAt: '2025-01-01T00:00:00Z',
@@ -98,7 +104,7 @@ describe('BulkEditToolbar', () => {
   it('opens category picker on click', () => {
     renderToolbar();
     fireEvent.click(screen.getByRole('button', { name: /change category/i }));
-    expect(screen.getByRole('listbox', { name: /select category/i })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /select category/i })).toBeInTheDocument();
     expect(screen.getByText('Food')).toBeInTheDocument();
     expect(screen.getByText('Transport')).toBeInTheDocument();
   });
@@ -115,6 +121,14 @@ describe('BulkEditToolbar', () => {
     renderToolbar();
     fireEvent.click(screen.getByRole('button', { name: /delete 3 selected/i }));
     expect(screen.getByText(/Delete 3 transactions\?/)).toBeInTheDocument();
+  });
+
+  it('exposes the delete confirmation as a described modal alertdialog', () => {
+    renderToolbar();
+    fireEvent.click(screen.getByRole('button', { name: /delete 3 selected/i }));
+    const dialog = screen.getByRole('alertdialog', { name: /confirm deletion/i });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-describedby', 'bulk-delete-confirm-text');
   });
 
   it('calls onBulkDelete on confirm', () => {

--- a/apps/web/src/components/forms/BulkEditToolbar.tsx
+++ b/apps/web/src/components/forms/BulkEditToolbar.tsx
@@ -17,7 +17,8 @@
  * References: issue #318
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useFocusTrap } from '../../accessibility/aria';
 import type { Category, SyncId } from '../../kmp/bridge';
 import type { BulkUpdateFields, BulkOperationResult } from '../../hooks/useBulkTransactions';
 import { AppIcon } from '../icons';
@@ -61,6 +62,28 @@ export const BulkEditToolbar: React.FC<BulkEditToolbarProps> = ({
   const [showCategoryPicker, setShowCategoryPicker] = useState(false);
   const [operationResult, setOperationResult] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const deleteTriggerRef = useRef<HTMLButtonElement>(null);
+  const confirmRef = useRef<HTMLDivElement>(null);
+  const wasConfirmingRef = useRef(false);
+
+  // Trap focus inside the destructive-delete confirmation and move focus onto
+  // it when it appears, so screen-reader users are told an alertdialog opened.
+  useFocusTrap(confirmRef, {
+    active: showDeleteConfirm,
+    restoreFocus: false,
+    initialFocusRef: confirmRef,
+    inertBackground: false,
+  });
+
+  // Return focus to the Delete trigger when the confirmation closes (e.g. via
+  // Cancel) so keyboard and screen-reader users are not stranded on <body>.
+  useEffect(() => {
+    if (wasConfirmingRef.current && !showDeleteConfirm) {
+      deleteTriggerRef.current?.focus();
+    }
+    wasConfirmingRef.current = showDeleteConfirm;
+  }, [showDeleteConfirm]);
 
   const allSelected = selectionCount === totalCount && totalCount > 0;
 
@@ -116,16 +139,10 @@ export const BulkEditToolbar: React.FC<BulkEditToolbarProps> = ({
             <AppIcon name="folder" /> Category
           </button>
           {showCategoryPicker && (
-            <div
-              className="bulk-edit-toolbar__dropdown"
-              role="listbox"
-              aria-label="Select category"
-            >
+            <div className="bulk-edit-toolbar__dropdown" role="group" aria-label="Select category">
               <button
                 type="button"
                 className="bulk-edit-toolbar__dropdown-item"
-                role="option"
-                aria-selected={false}
                 onClick={() => handleCategoryChange(null)}
               >
                 Uncategorized
@@ -135,8 +152,6 @@ export const BulkEditToolbar: React.FC<BulkEditToolbarProps> = ({
                   key={cat.id}
                   type="button"
                   className="bulk-edit-toolbar__dropdown-item"
-                  role="option"
-                  aria-selected={false}
                   onClick={() => handleCategoryChange(cat.id)}
                 >
                   {cat.name}
@@ -149,6 +164,7 @@ export const BulkEditToolbar: React.FC<BulkEditToolbarProps> = ({
         {/* Bulk delete */}
         {!showDeleteConfirm ? (
           <button
+            ref={deleteTriggerRef}
             type="button"
             className="bulk-edit-toolbar__button bulk-edit-toolbar__button--danger"
             onClick={() => setShowDeleteConfirm(true)}
@@ -158,11 +174,15 @@ export const BulkEditToolbar: React.FC<BulkEditToolbarProps> = ({
           </button>
         ) : (
           <div
+            ref={confirmRef}
             className="bulk-edit-toolbar__confirm"
             role="alertdialog"
+            aria-modal="true"
             aria-label="Confirm deletion"
+            aria-describedby="bulk-delete-confirm-text"
+            tabIndex={-1}
           >
-            <span className="bulk-edit-toolbar__confirm-text">
+            <span id="bulk-delete-confirm-text" className="bulk-edit-toolbar__confirm-text">
               Delete {selectionCount} transaction{selectionCount !== 1 ? 's' : ''}?
             </span>
             <button

--- a/apps/web/src/components/forms/QuickEntry.test.tsx
+++ b/apps/web/src/components/forms/QuickEntry.test.tsx
@@ -351,6 +351,26 @@ describe('QuickEntry', () => {
     expect(screen.getByLabelText('Description')).toHaveAttribute('aria-required', 'true');
   });
 
+  it('associates an amount validation error with only the amount field', () => {
+    renderQuickEntry();
+    fireEvent.submit(screen.getByRole('dialog').querySelector('form')!);
+    const amount = screen.getByLabelText('Amount');
+    expect(amount).toHaveAttribute('aria-invalid', 'true');
+    expect(amount).toHaveAttribute('aria-describedby', 'quick-entry-error');
+    expect(screen.getByRole('alert')).toHaveAttribute('id', 'quick-entry-error');
+    expect(screen.getByLabelText('Description')).not.toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('associates a description validation error with only the description field', () => {
+    renderQuickEntry();
+    enterIncrementalAmount('500');
+    fireEvent.submit(screen.getByRole('dialog').querySelector('form')!);
+    const description = screen.getByLabelText('Description');
+    expect(description).toHaveAttribute('aria-invalid', 'true');
+    expect(description).toHaveAttribute('aria-describedby', 'quick-entry-error');
+    expect(screen.getByLabelText('Amount')).not.toHaveAttribute('aria-invalid', 'true');
+  });
+
   it('success counter uses aria-live for screen reader updates', () => {
     renderQuickEntry();
     enterIncrementalAmount('100');

--- a/apps/web/src/components/forms/QuickEntry.tsx
+++ b/apps/web/src/components/forms/QuickEntry.tsx
@@ -151,6 +151,8 @@ export const QuickEntry: FC<QuickEntryProps> = ({
 }) => {
   const panelRef = useRef<HTMLDivElement>(null);
   const amountInputRef = useRef<HTMLInputElement>(null);
+  const descriptionRef = useRef<HTMLInputElement>(null);
+  const accountRef = useRef<HTMLSelectElement>(null);
 
   const [transactionType, setTransactionType] = useState<TransactionType>(getLastType);
   const amountInput = useAmountInput({
@@ -163,6 +165,7 @@ export const QuickEntry: FC<QuickEntryProps> = ({
   const [description, setDescription] = useState('');
   const [accountId, setAccountId] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [errorField, setErrorField] = useState<'amount' | 'description' | 'account' | null>(null);
   const [successCount, setSuccessCount] = useState(0);
   const [suggestion, setSuggestion] = useState<CategorySuggestion | null>(null);
 
@@ -178,6 +181,7 @@ export const QuickEntry: FC<QuickEntryProps> = ({
       setTransactionType(getLastType());
       setSuccessCount(0);
       setError(null);
+      setErrorField(null);
 
       const id = requestAnimationFrame(() => {
         amountInputRef.current?.focus();
@@ -225,6 +229,7 @@ export const QuickEntry: FC<QuickEntryProps> = ({
     amountInput.setSign(transactionType === 'EXPENSE' ? 'negative' : 'positive');
     setDescription('');
     setError(null);
+    setErrorField(null);
     setSuggestion(null);
     // Keep type and account for rapid re-entry
     requestAnimationFrame(() => {
@@ -239,18 +244,24 @@ export const QuickEntry: FC<QuickEntryProps> = ({
       const normalizedAmountCents = normalizeTransactionAmount(amountInput.cents, transactionType);
       if (normalizedAmountCents === 0) {
         setError('Enter a valid amount.');
+        setErrorField('amount');
+        amountInputRef.current?.focus();
         return;
       }
 
       const trimmedDescription = description.trim();
       if (!trimmedDescription) {
         setError('Enter a description.');
+        setErrorField('description');
+        descriptionRef.current?.focus();
         return;
       }
 
       const selectedAccount = accounts.find((a) => a.id === accountId);
       if (!selectedAccount) {
         setError('Select an account.');
+        setErrorField('account');
+        accountRef.current?.focus();
         return;
       }
 
@@ -304,8 +315,6 @@ export const QuickEntry: FC<QuickEntryProps> = ({
 
   if (!isOpen) return null;
 
-  const hasError = Boolean(error);
-
   return (
     <div className="quick-entry" role="presentation" onKeyDown={handleKeyDown}>
       <div className="quick-entry__backdrop" aria-hidden="true" onClick={onClose} />
@@ -336,7 +345,7 @@ export const QuickEntry: FC<QuickEntryProps> = ({
         </div>
 
         {error && (
-          <div className="form-banner-error" role="alert">
+          <div id="quick-entry-error" className="form-banner-error" role="alert">
             {error}
           </div>
         )}
@@ -369,10 +378,11 @@ export const QuickEntry: FC<QuickEntryProps> = ({
             <AmountInput
               ref={amountInputRef}
               amountInput={amountInput}
-              className={`form-input quick-entry__amount-input${hasError ? ' form-input--error' : ''}`}
+              className={`form-input quick-entry__amount-input${errorField === 'amount' ? ' form-input--error' : ''}`}
               placeholder="$0.00"
               aria-label="Amount"
-              aria-invalid={hasError}
+              aria-invalid={errorField === 'amount'}
+              aria-describedby={errorField === 'amount' ? 'quick-entry-error' : undefined}
               aria-required="true"
               autoComplete="off"
               toggleLabel="Toggle quick entry amount sign"
@@ -381,6 +391,7 @@ export const QuickEntry: FC<QuickEntryProps> = ({
 
           {/* Description */}
           <input
+            ref={descriptionRef}
             className="form-input quick-entry__description"
             type="text"
             placeholder="What was it for?"
@@ -388,9 +399,12 @@ export const QuickEntry: FC<QuickEntryProps> = ({
             onChange={(e) => {
               setDescription(e.target.value);
               setError(null);
+              setErrorField(null);
             }}
             aria-label="Description"
             aria-required="true"
+            aria-invalid={errorField === 'description'}
+            aria-describedby={errorField === 'description' ? 'quick-entry-error' : undefined}
             autoComplete="off"
           />
 
@@ -404,10 +418,13 @@ export const QuickEntry: FC<QuickEntryProps> = ({
           {/* Account selector (compact) */}
           {accounts.length > 1 && (
             <select
+              ref={accountRef}
               className="form-select quick-entry__account"
               value={accountId}
               onChange={(e) => setAccountId(e.target.value)}
               aria-label="Account"
+              aria-invalid={errorField === 'account'}
+              aria-describedby={errorField === 'account' ? 'quick-entry-error' : undefined}
             >
               {accounts.map((a) => (
                 <option key={a.id} value={a.id}>


### PR DESCRIPTION
## Summary

Fixes three form/bulk-edit operability defects found during a WCAG 2.2 AA deep-dive as a blind screen-reader + keyboard user. Each makes an interactive control's exposed role, state, or error association match its real behaviour so it is understandable and operable non-visually.

Found by persona: Jordan Blake (blind screen-reader + keyboard user)

## Changes

- **Quick-entry per-field error identification (#3344)** — `QuickEntry` rendered a single shared error banner and set `aria-invalid` on the *amount* input for **every** validation failure, so a description- or account-level error mislabelled the amount field and never linked the message to the field actually in error. Errors are now tracked per field (`amount` / `description` / `account`): `aria-invalid` is set only on the offending control, that control is linked to the banner via `aria-describedby="quick-entry-error"`, and focus moves to it so a screen-reader user lands on the field to fix (WCAG **3.3.1 Error Identification**, **1.3.1 Info and Relationships**).
- **Bulk-edit delete confirmation focus (#3337)** — the `role="alertdialog"` delete confirmation appeared without moving or trapping focus and lacked `aria-modal`, so a screen-reader user was never told a destructive confirmation opened and could not easily find Confirm/Cancel. It now sets `aria-modal="true"`, is described by its prompt (`aria-describedby`), traps focus, receives focus on open, and returns focus to the Delete trigger on cancel (WCAG **4.1.2 Name, Role, Value**, **2.4.3 Focus Order**).
- **Bulk-edit category dropdown semantics (#3345)** — the category picker advertised `role="listbox"` with `role="option"` children but implemented none of the listbox keyboard model (no arrow keys, roving tabindex, `aria-selected`, or `aria-activedescendant`), so a screen reader announced a listbox that could not be operated as one. It is now a labelled `role="group"` of plain buttons — each natively Tab-focusable and Enter/Space-activatable — so the exposed role matches the actual behaviour (WCAG **4.1.2**, **2.1.1 Keyboard**).

## Issues

Closes #3337
Closes #3344
Closes #3345

## Testing

- [x] `prettier --write` + `eslint --max-warnings 0` clean on all four files
- [x] `vitest run` — QuickEntry + BulkEditToolbar suites: **43/43 pass** (incl. 2 new per-field-error tests and a new modal-alertdialog test)
- [x] Amount-only error flags only the amount field; description-only error flags only the description field, each linked to the banner via `aria-describedby`
- [x] Delete confirmation exposes `aria-modal="true"` + `aria-describedby`
- [x] Category dropdown exposes `role="group"` (no false listbox role)

## Cross-Platform

Web-specific (ARIA roles/states, DOM focus). The underlying UX intents — identify the field in error, announce and focus destructive confirmations, and match a control's role to its behaviour — apply conceptually to iOS/Android/Windows via their native semantics and are tracked separately where the pattern exists.
