### PR TITLE
fix(web): add data-table text alternative to pie and donut charts (#3346)

### DIFF
--- a/apps/web/src/components/charts/BudgetDonutChart.test.tsx
+++ b/apps/web/src/components/charts/BudgetDonutChart.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { BudgetDonutChart, type BudgetSlice } from './BudgetDonutChart';
 
@@ -113,5 +113,19 @@ describe('BudgetDonutChart', () => {
       'aria-live',
       'polite',
     );
+  });
+
+  it('renders a screen-reader data-table alternative listing each allocation', () => {
+    render(<BudgetDonutChart data={sampleData} />);
+    const table = screen.getByRole('table', { name: /budget breakdown data table/i });
+    expect(within(table).getByRole('rowheader', { name: 'Housing' })).toBeInTheDocument();
+    expect(within(table).getByRole('rowheader', { name: 'Groceries' })).toBeInTheDocument();
+    expect(within(table).getByRole('rowheader', { name: 'Savings' })).toBeInTheDocument();
+    expect(within(table).getByText('54.5%')).toBeInTheDocument();
+  });
+
+  it('omits the data table when there is no data', () => {
+    render(<BudgetDonutChart data={[]} />);
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/charts/BudgetDonutChart.tsx
+++ b/apps/web/src/components/charts/BudgetDonutChart.tsx
@@ -7,6 +7,7 @@
 import { type FC, useCallback, useId, useMemo, useRef, useState } from 'react';
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Label } from 'recharts';
 import { CHART_COLORS, buildChartDescription, formatChartCurrency } from './chart-palette';
+import { AccessibleChartDataTable } from './chart-accessibility';
 import { useArrowKeyNavigation } from '../../accessibility/aria';
 
 export interface BudgetSlice {
@@ -62,6 +63,21 @@ export const BudgetDonutChart: FC<BudgetDonutChartProps> = ({
       [pointAnnouncements],
     ),
   });
+
+  const tableRows = useMemo(
+    () =>
+      data.map((entry, index) => {
+        const percent = total > 0 ? ((entry.value / total) * 100).toFixed(1) : '0.0';
+        const formattedValue = formatChartCurrency(entry.value, currency);
+        return {
+          id: `${chartId}-row-${index}`,
+          rowHeader: entry.name,
+          cells: [formattedValue, `${percent}%`],
+          ariaLabel: `${entry.name}: ${formattedValue} (${percent}%)`,
+        };
+      }),
+    [chartId, currency, data, total],
+  );
 
   return (
     <div
@@ -137,6 +153,18 @@ export const BudgetDonutChart: FC<BudgetDonutChartProps> = ({
           />
         </PieChart>
       </ResponsiveContainer>
+      {data.length > 0 && (
+        <AccessibleChartDataTable
+          captionId={`${chartId}-table-caption`}
+          title={title}
+          rowHeaderLabel="Category"
+          columns={[
+            { key: 'amount', header: 'Amount' },
+            { key: 'share', header: 'Share' },
+          ]}
+          rows={tableRows}
+        />
+      )}
     </div>
   );
 };

--- a/apps/web/src/components/charts/CategoryPieChart.test.tsx
+++ b/apps/web/src/components/charts/CategoryPieChart.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { CategoryPieChart, type CategorySlice } from './CategoryPieChart';
 
@@ -126,5 +126,20 @@ describe('CategoryPieChart', () => {
     expect(screen.getByRole('status', { name: /chart point announcement/i })).toHaveTextContent(
       'Food: $450 (56.3%)',
     );
+  });
+
+  it('renders a screen-reader data-table alternative listing each category', () => {
+    render(<CategoryPieChart data={sampleData} />);
+    const table = screen.getByRole('table', { name: /spending by category data table/i });
+    expect(within(table).getByRole('rowheader', { name: 'Food' })).toBeInTheDocument();
+    expect(within(table).getByRole('rowheader', { name: 'Transport' })).toBeInTheDocument();
+    expect(within(table).getByRole('rowheader', { name: 'Entertainment' })).toBeInTheDocument();
+    expect(within(table).getByText('$450')).toBeInTheDocument();
+    expect(within(table).getByText('56.3%')).toBeInTheDocument();
+  });
+
+  it('omits the data table when there is no data', () => {
+    render(<CategoryPieChart data={[]} />);
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/charts/CategoryPieChart.tsx
+++ b/apps/web/src/components/charts/CategoryPieChart.tsx
@@ -11,6 +11,7 @@
 import { type FC, useCallback, useEffect, useId, useRef, useState } from 'react';
 import * as d3 from 'd3';
 import { CHART_COLORS, buildChartDescription, formatChartCurrency } from './chart-palette';
+import { AccessibleChartDataTable } from './chart-accessibility';
 import { useEffectiveMaskingMode } from '../../contexts/PrivacyModeContext';
 
 export interface CategorySlice {
@@ -131,6 +132,17 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
     chartSlices[next].focus();
   }, []);
 
+  const tableRows = data.map((slice, i) => {
+    const percent = total > 0 ? ((slice.value / total) * 100).toFixed(1) : '0.0';
+    const formattedValue = formatChartCurrency(slice.value, currency, 'en-US', maskingMode);
+    return {
+      id: `${chartId}-row-${i}`,
+      rowHeader: slice.name,
+      cells: [formattedValue, `${percent}%`],
+      ariaLabel: `${slice.name}: ${formattedValue} (${percent}%)`,
+    };
+  });
+
   return (
     <div ref={containerRef} role="figure" aria-label={description} aria-roledescription="pie chart">
       <h3 id={`${chartId}-title`} className="chart-title">
@@ -178,6 +190,18 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
           })}
         </ul>
       </div>
+      {data.length > 0 && (
+        <AccessibleChartDataTable
+          captionId={`${chartId}-table-caption`}
+          title={title}
+          rowHeaderLabel="Category"
+          columns={[
+            { key: 'amount', header: 'Amount' },
+            { key: 'share', header: 'Share' },
+          ]}
+          rows={tableRows}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Adds a screen-reader data-table text alternative to the two remaining chart types that lacked one, so every chart in the app offers the same tabular alternative. Found during a WCAG 2.2 AA deep-dive as a blind screen-reader + keyboard user.

Found by persona: Jordan Blake (blind screen-reader + keyboard user)

## Changes

- **Consistent chart text alternatives (#3346)** — the line, area, and projection charts (`SpendingTrendChart`, `NetWorthProjectionChart`, `TrendLineChart`) render an `AccessibleChartDataTable` so a screen-reader user can read exact values, but `CategoryPieChart` and `BudgetDonutChart` exposed only a visual legend plus a summary sentence — there was no equivalent table to read each category's exact amount and share. Both charts now render the same `sr-only` `AccessibleChartDataTable` (from `chart-accessibility.tsx`) with one row per category (**Category → Amount → Share**), mirroring the line-chart implementation. The table is omitted when there is no data. (WCAG **1.1.1 Non-text Content** — user story: consistency across all chart types.)

## Issues

Closes #3346

## Testing

- [x] `prettier --write` + `eslint --max-warnings 0` clean (incl. the `finance/no-money-template-interpolation` rule)
- [x] `vitest run` — CategoryPieChart + BudgetDonutChart suites: **22/22 pass** (incl. 4 new data-table tests)
- [x] Pie table lists Food/Transport/Entertainment with amount + share; donut table lists Housing/Groceries/Savings with amount + share
- [x] No table is rendered for empty data

## Cross-Platform

Web-specific (the `AccessibleChartDataTable` React component). The intent — a text alternative for every chart — is tracked on iOS via #2113 (VoiceOver chart text alternatives); the Cash Flow bar chart gap is tracked separately in #3214.
