### PR TITLE
fix(web): remove duplicate /learning route registration (#3407)

### DIFF
--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -782,16 +782,6 @@ export const AppRoutes: FC = () => (
       }
     />
     <Route
-      path="/learning"
-      element={
-        <AuthenticatedRoute>
-          <RouteBoundary name="Learning">
-            <Learning />
-          </RouteBoundary>
-        </AuthenticatedRoute>
-      }
-    />
-    <Route
       path="/privacy-dashboard"
       element={
         <AuthenticatedRoute>


### PR DESCRIPTION
## Summary

Removes a **duplicate `/learning` route** registration in the web router. The path was declared twice; React Router only matches the first, so the second block was unreachable dead code.

## Changes

- Delete the second `<Route path="/learning">` block in `apps/web/src/routes.tsx` (10 lines). The remaining single registration is unchanged.

## Issues

Closes #3407

## Testing

- [x] `npx prettier --check apps/web/src/routes.tsx` — clean
- [x] `npx eslint apps/web/src/routes.tsx --max-warnings 0` — 0 errors / 0 warnings
- [x] Verified exactly one `path="/learning"` remains

## Cross-platform

Web-only: route table is specific to the React PWA (`apps/web`). Native platforms register navigation separately.

Found by persona: Maya Chen (new-grad first-job budgeter)
