### PR TITLE
feat(web): add bypass-block skip link to transaction results (#3348)

### DIFF
--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -506,6 +506,20 @@ describe('TransactionsPage', () => {
     expect(screen.getByRole('searchbox', { name: /search transactions/i })).toBeInTheDocument();
   });
 
+  it('offers a bypass-block skip link that targets the transaction results region (#3348)', () => {
+    render(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    );
+
+    const skipLink = screen.getByRole('link', { name: /skip to transaction results/i });
+    expect(skipLink).toHaveAttribute('href', '#transaction-results');
+
+    const resultsTarget = screen.getByRole('heading', { name: /transaction results/i });
+    expect(resultsTarget).toHaveAttribute('id', 'transaction-results');
+  });
+
   it('displays filter and sort controls', () => {
     render(
       <MemoryRouter>

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -18,6 +18,7 @@ import {
   SyncIndicator,
   useToast,
 } from '../components/common';
+import { SkipLink } from '../components/common/SkipLink';
 import { SwipeableRow } from '../components/common/SwipeableRow';
 import { CategoryConfirmation } from '../components/categorization';
 import { TransactionForm } from '../components/forms';
@@ -1352,6 +1353,8 @@ export const TransactionsPage: React.FC = () => {
             )}
           </div>
 
+          <SkipLink targetId="transaction-results" label="Skip to transaction results" />
+
           <AccountPurposeFilterControl
             value={selectedPurposeFilter}
             onChange={setSelectedPurposeFilter}
@@ -1449,6 +1452,10 @@ export const TransactionsPage: React.FC = () => {
               )}
             </div>
           </section>
+
+          <h2 id="transaction-results" className="sr-only">
+            Transaction results
+          </h2>
 
           {isLoading ? (
             <div


### PR DESCRIPTION
## Summary

Adds an in-page **bypass-block skip link** so a keyboard / screen-reader user can jump past the repeated filter, sort, and bulk-action toolbars straight to the transaction results, instead of Tabbing through every control. Found during a WCAG 2.2 AA deep-dive as a blind screen-reader + keyboard user.

Found by persona: Jordan Blake (blind screen-reader + keyboard user)

## Changes

- **Bypass blocks for repeated in-page toolbars (#3348)** — the Transactions page renders an account-purpose filter, a search box, a filter/sort control bar, a bulk-actions toolbar, and a category drop zone _before_ the transaction list. The only existing bypass was the app-shell "Skip to main content" link, which drops focus at the top of all of that. Added a `SkipLink` (reusing the existing tested, CSP-safe component) right after the page header that targets a new focusable, screen-reader-announced **`Transaction results`** heading wrapping the results region. Activating it moves focus straight to the results, and the visually-hidden heading also gives heading-navigation (rotor) users a second bypass mechanism. (WCAG **2.4.1 Bypass Blocks**, A — extends coverage to repeated in-page blocks; user story / enhancement.)

## Implementation notes

- Reuses `components/common/SkipLink` (`targetId="transaction-results"`), which manages the dynamic `tabindex` on activation and cleans it up on blur — the same pattern used for `#main-content`, so no permanent-`tabindex` / React-attribute clobbering.
- The skip target is a `sr-only` `<h2 id="transaction-results">Transaction results</h2>` — visually hidden (no layout change) but present in the a11y tree and heading outline (`h2 → h3` group headers stays valid).
- Deliberately additive and low-diff (21 insertions, 0 reindent) to minimize rebase conflicts on this high-traffic shared page.

## Issues

Closes #3348

## Testing

- [x] `prettier --write` + `eslint --max-warnings 0` clean
- [x] `vitest run src/pages/TransactionsPage.test.tsx` — **29/29 pass** (added 1 test asserting the skip link `href="#transaction-results"` and the matching results heading id)

## Cross-Platform

Web-specific (the `SkipLink` React component + in-page anchor). On iOS/Android/Windows the native rotor / heading / landmark quick-nav partially covers this; no platform duplicate filed (baseline 2.4.1 is already met natively there).
