### PR TITLE
fix(web): pluralize singular count labels (#3412)

### DIFF
--- a/apps/web/src/lib/ui/pluralize.test.ts
+++ b/apps/web/src/lib/ui/pluralize.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { formatCount, pluralize } from './pluralize';
+
+describe('pluralize', () => {
+  it('returns the singular form for a count of 1', () => {
+    expect(pluralize(1, 'day')).toBe('day');
+    expect(pluralize(1, 'bill')).toBe('bill');
+  });
+
+  it('returns the plural form for 0 and counts greater than 1', () => {
+    expect(pluralize(0, 'day')).toBe('days');
+    expect(pluralize(2, 'day')).toBe('days');
+    expect(pluralize(12, 'month')).toBe('months');
+  });
+
+  it('treats a count of -1 as singular', () => {
+    expect(pluralize(-1, 'month')).toBe('month');
+    expect(pluralize(-3, 'month')).toBe('months');
+  });
+
+  it('supports irregular explicit plurals', () => {
+    expect(pluralize(1, 'entry', 'entries')).toBe('entry');
+    expect(pluralize(4, 'entry', 'entries')).toBe('entries');
+  });
+});
+
+describe('formatCount', () => {
+  it('combines the count with the pluralized noun', () => {
+    expect(formatCount(1, 'day')).toBe('1 day');
+    expect(formatCount(3, 'day')).toBe('3 days');
+    expect(formatCount(0, 'transaction')).toBe('0 transactions');
+  });
+});

--- a/apps/web/src/lib/ui/pluralize.ts
+++ b/apps/web/src/lib/ui/pluralize.ts
@@ -1,0 +1,39 @@
+/**
+ * Lightweight English pluralization helpers for short, non-localized UI count
+ * labels (e.g. "1 day left", "3 bills"). For fully localized, catalog-driven
+ * copy use the i18n message catalog (`lib/i18n`) with `Intl.PluralRules`
+ * instead; these helpers exist for the many internal count strings that are
+ * currently hardcoded in English.
+ */
+
+/**
+ * Return the singular or plural form of a noun for a given count.
+ *
+ * Uses the common English rule where the plural is the singular plus "s".
+ * Pass an explicit `plural` for irregular nouns. A count of exactly one
+ * (in either direction) is treated as singular.
+ *
+ * @param count - The quantity the noun describes.
+ * @param singular - The singular form of the noun (e.g. "day").
+ * @param plural - Optional explicit plural form (defaults to `singular + "s"`).
+ * @returns The singular form when `|count|` is 1, otherwise the plural form.
+ */
+export function pluralize(
+  count: number,
+  singular: string,
+  plural: string = `${singular}s`,
+): string {
+  return Math.abs(count) === 1 ? singular : plural;
+}
+
+/**
+ * Format a count together with its correctly pluralized noun.
+ *
+ * @param count - The quantity to display.
+ * @param singular - The singular form of the noun (e.g. "day").
+ * @param plural - Optional explicit plural form (defaults to `singular + "s"`).
+ * @returns A string such as "1 day" or "3 days".
+ */
+export function formatCount(count: number, singular: string, plural?: string): string {
+  return `${count} ${pluralize(count, singular, plural)}`;
+}

--- a/apps/web/src/pages/AccountDetailPage.tsx
+++ b/apps/web/src/pages/AccountDetailPage.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { AppIcon } from '../components/icons';
+import { pluralize } from '../lib/ui/pluralize';
 
 import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { AccountDeleteDialog, AccountPurposeBadge } from '../components/accounts';
@@ -315,7 +316,7 @@ export const AccountDetailPage: React.FC = () => {
             <p className="page-muted-text">
               {reconciliationLoading
                 ? 'Loading reconciliation status…'
-                : `${unclearedTransactionCount} transactions uncleared`}
+                : `${unclearedTransactionCount} ${pluralize(unclearedTransactionCount, 'transaction')} uncleared`}
             </p>
           </div>
           <button type="button" className="form-button" onClick={handleStartReconciliation}>

--- a/apps/web/src/pages/BillsPage.tsx
+++ b/apps/web/src/pages/BillsPage.tsx
@@ -9,6 +9,7 @@
 
 import React, { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { pluralize } from '../lib/ui/pluralize';
 import {
   ConfirmDialog,
   CurrencyDisplay,
@@ -223,7 +224,7 @@ export const BillsPage: React.FC = () => {
                 <div className="bills-summary__metric">
                   <p className="card__title">Upcoming</p>
                   <p className="card__value" aria-live="polite">
-                    {summary.upcomingCount} bills
+                    {summary.upcomingCount} {pluralize(summary.upcomingCount, 'bill')}
                   </p>
                   <p
                     style={{
@@ -243,7 +244,7 @@ export const BillsPage: React.FC = () => {
                         summary.overdueCount > 0 ? 'var(--semantic-negative, #dc2626)' : 'inherit',
                     }}
                   >
-                    {summary.overdueCount} bills
+                    {summary.overdueCount} {pluralize(summary.overdueCount, 'bill')}
                   </p>
                   <p
                     style={{

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -14,6 +14,7 @@
 
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { CurrencyDisplay, EmptyState } from '../components/common';
+import { pluralize } from '../lib/ui/pluralize';
 import { ExplainThis } from '../components/common/ExplainThis';
 import { useAccounts } from '../hooks/useAccounts';
 import './DebtPage.css';
@@ -1331,7 +1332,8 @@ function PayoffPlannerPanel(): React.ReactElement {
                   <p>{recommendation.snowballMotivationNote}</p>
                   <p>
                     Minimum-only baseline for {formatStrategyName(activeStrategy)}:{' '}
-                    {minimumOnlyResult?.totalMonths ?? 0} months and{' '}
+                    {minimumOnlyResult?.totalMonths ?? 0}{' '}
+                    {pluralize(minimumOnlyResult?.totalMonths ?? 0, 'month')} and{' '}
                     <CurrencyDisplay
                       amount={minimumOnlyResult?.totalInterestCents ?? 0}
                       context="minimum only interest"
@@ -1551,7 +1553,7 @@ function StrategyCard({
           <ol>
             {result.schedules.map((s) => (
               <li key={s.debtId}>
-                {s.debtName}: {s.monthsToPayoff} months
+                {s.debtName}: {s.monthsToPayoff} {pluralize(s.monthsToPayoff, 'month')}
               </li>
             ))}
           </ol>
@@ -2262,7 +2264,7 @@ function StudentLoanPanel(): React.ReactElement {
                   <dd>
                     {refinancePanelModel.payoffMonthsDifference === null
                       ? 'Not amortizing'
-                      : `${refinancePanelModel.payoffMonthsDifference} months`}
+                      : `${refinancePanelModel.payoffMonthsDifference} ${pluralize(refinancePanelModel.payoffMonthsDifference, 'month')}`}
                   </dd>
                   <dt>Break-even month</dt>
                   <dd>{refinancePanelModel.breakEvenMonth ?? 'No break-even'}</dd>
@@ -2411,7 +2413,7 @@ function StudentLoanPanel(): React.ReactElement {
                     <dd>
                       {scenario.monthsToPayoff === null
                         ? 'Not amortizing'
-                        : `${scenario.monthsToPayoff} months`}
+                        : `${scenario.monthsToPayoff} ${pluralize(scenario.monthsToPayoff, 'month')}`}
                     </dd>
                     <dt>Forgiven</dt>
                     <dd>

--- a/apps/web/src/pages/GoalDetailPage.tsx
+++ b/apps/web/src/pages/GoalDetailPage.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { AppIcon, type IconName } from '../components/icons';
+import { pluralize } from '../lib/ui/pluralize';
 
 import {
   ConfirmDialog,
@@ -233,7 +234,11 @@ export const GoalDetailPage: React.FC = () => {
             <div>
               <dt className="card__title">Time Remaining</dt>
               <dd>
-                {daysLeft > 0 ? `${daysLeft} days left` : daysLeft === 0 ? 'Due today' : 'Past due'}
+                {daysLeft > 0
+                  ? `${daysLeft} ${pluralize(daysLeft, 'day')} left`
+                  : daysLeft === 0
+                    ? 'Due today'
+                    : 'Past due'}
               </dd>
             </div>
           )}
@@ -325,7 +330,7 @@ export const GoalDetailPage: React.FC = () => {
               {daysLeft === null
                 ? 'No due date'
                 : daysLeft > 0
-                  ? `${daysLeft} days left`
+                  ? `${daysLeft} ${pluralize(daysLeft, 'day')} left`
                   : 'Past due'}
             </span>
           </div>

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -14,6 +14,7 @@ import {
 import { GoalContributionDialog } from '../components/goals/GoalContributionDialog';
 import { SharedGoalBadge } from '../components/goals/SharedGoalContributions';
 import { GoalForm } from '../components/forms';
+import { pluralize } from '../lib/ui/pluralize';
 import { AppIcon, type IconName } from '../components/icons';
 import {
   ContributionPlanner,
@@ -955,7 +956,7 @@ export const GoalsPage: React.FC = () => {
                           {daysLeft === null
                             ? 'No due date'
                             : daysLeft > 0
-                              ? `${daysLeft} days left`
+                              ? `${daysLeft} ${pluralize(daysLeft, 'day')} left`
                               : 'Past due'}
                         </span>
                       </div>


### PR DESCRIPTION
## Summary

Fixes hardcoded plural nouns in UI count labels so a count of **1** no longer renders as "1 days left", "1 bills", "1 months", or "1 transactions uncleared".

## Changes

- Add a small shared `pluralize(count, singular, plural?)` helper (+ `formatCount`) in `apps/web/src/lib/ui/pluralize.ts` with unit tests. It treats `|count| === 1` as singular; heavyweight localized copy still belongs in the i18n catalog.
- Apply it to genuinely unguarded sites:
  - Goal countdown: `GoalsPage` (list) and `GoalDetailPage` (two spots) — "1 day left".
  - Bill summary counts: `BillsPage` upcoming/overdue — "1 bill".
  - Uncleared count: `AccountDetailPage` — "1 transaction uncleared".
  - Debt month totals: `DebtPage` (baseline, payoff order, refinance, scenario) — "1 month".
- **Left untouched:** `BillsPage` relative-due strings (`Due tomorrow`, `1 day overdue`) are already guarded by explicit singular branches, and `DebtPage.css` side-tab styles are pre-existing and out of scope.

## Issues

Closes #3412

## Testing

- [x] `npx prettier --check` — clean
- [x] `npx eslint --max-warnings 0` — 0/0
- [x] `vitest run pluralize.test.ts` — 5 passing (singular, plural, negative, irregular, formatCount)

## Cross-platform

Web-only: these are `apps/web` string labels. Native platforms format counts separately.

Found by persona: Maya Chen (new-grad first-job budgeter)
