### PR TITLE
feat(web): scope Net Worth by business/personal workspace (#3246)

### DIFF
--- a/apps/web/src/hooks/useNetWorth.ts
+++ b/apps/web/src/hooks/useNetWorth.ts
@@ -30,6 +30,11 @@ import type {
 } from '../lib/analytics/net-worth';
 import { buildNetWorthHistorySeries } from '../lib/visualization/net-worth-history';
 import type { NetWorthSeriesPoint } from '../lib/visualization/net-worth-projection';
+import {
+  type AccountPurposeFilter,
+  selectWorkspaceAccounts,
+  selectWorkspaceTransactions,
+} from '../lib/accountPurpose';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -57,8 +62,15 @@ export interface UseNetWorthResult {
 // Hook
 // ---------------------------------------------------------------------------
 
-/** Computes net worth analytics from local account data. */
-export function useNetWorth(): UseNetWorthResult {
+/**
+ * Computes net worth analytics from local account data.
+ *
+ * @param purposeFilter - Optional business/personal workspace scope. Defaults to
+ *   `'all'`, which aggregates every account. Passing `'business'` or `'personal'`
+ *   restricts the snapshot, asset classes, milestones, and history to that
+ *   workspace so a small-business owner can separate business from personal net worth.
+ */
+export function useNetWorth(purposeFilter: AccountPurposeFilter = 'all'): UseNetWorthResult {
   const db = useDatabase();
 
   const [currentNetWorth, setCurrentNetWorth] = useState<NetWorthDataPoint | null>(null);
@@ -82,10 +94,13 @@ export function useNetWorth(): UseNetWorthResult {
       const accounts = getAllAccounts(db);
       const transactions = getAllTransactions(db);
 
-      const nw = computeCurrentNetWorth(accounts);
-      const classes = computeAssetClassBreakdown(accounts);
+      const scopedAccounts = selectWorkspaceAccounts(accounts, purposeFilter);
+      const scopedTransactions = selectWorkspaceTransactions(transactions, accounts, purposeFilter);
+
+      const nw = computeCurrentNetWorth(scopedAccounts);
+      const classes = computeAssetClassBreakdown(scopedAccounts);
       const ms = detectMilestones(nw.netWorth, nw.liabilities);
-      const series = buildNetWorthHistorySeries(accounts, transactions);
+      const series = buildNetWorthHistorySeries(scopedAccounts, scopedTransactions);
 
       setCurrentNetWorth(nw);
       setAssetClasses(classes);
@@ -96,7 +111,7 @@ export function useNetWorth(): UseNetWorthResult {
     } finally {
       setLoading(false);
     }
-  }, [db, refreshToken]);
+  }, [db, refreshToken, purposeFilter]);
 
   return { currentNetWorth, assetClasses, milestones, history, loading, error, refresh };
 }

--- a/apps/web/src/pages/NetWorthPage.test.tsx
+++ b/apps/web/src/pages/NetWorthPage.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { NetWorthPage } from './NetWorthPage';
 
 // Mock the hook
@@ -160,5 +160,63 @@ describe('NetWorthPage', () => {
       screen.getByRole('region', { name: 'Net worth growth and projection' }),
     ).toBeInTheDocument();
     expect(screen.getByTestId('net-worth-projection-chart')).toBeInTheDocument();
+  });
+
+  it('renders the workspace purpose filter and defaults to all accounts', () => {
+    mockUseNetWorth.mockReturnValue({
+      currentNetWorth: {
+        label: '2024-03-15',
+        assets: 2000000,
+        liabilities: 500000,
+        netWorth: 1500000,
+      },
+      assetClasses: [],
+      milestones: [],
+      history: [],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    render(<NetWorthPage />);
+    expect(screen.getByRole('group', { name: 'Filter by account purpose' })).toBeInTheDocument();
+    expect(mockUseNetWorth).toHaveBeenCalledWith('all');
+  });
+
+  it('scopes net worth to the business workspace when selected', () => {
+    mockUseNetWorth.mockReturnValue({
+      currentNetWorth: {
+        label: '2024-03-15',
+        assets: 2000000,
+        liabilities: 500000,
+        netWorth: 1500000,
+      },
+      assetClasses: [],
+      milestones: [],
+      history: [],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    render(<NetWorthPage />);
+    fireEvent.click(screen.getByRole('button', { name: /Business/ }));
+    expect(mockUseNetWorth).toHaveBeenLastCalledWith('business');
+  });
+
+  it('keeps the workspace filter visible when the selected workspace has no balances', () => {
+    mockUseNetWorth.mockReturnValue({
+      currentNetWorth: { label: '2024-03-15', assets: 0, liabilities: 0, netWorth: 0 },
+      assetClasses: [],
+      milestones: [],
+      history: [],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    render(<NetWorthPage />);
+    expect(screen.getByText('No net worth data')).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Filter by account purpose' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/NetWorthPage.tsx
+++ b/apps/web/src/pages/NetWorthPage.tsx
@@ -13,7 +13,7 @@
  * References: issue #1578
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   CurrencyDisplay,
   EmptyState,
@@ -21,10 +21,12 @@ import {
   ExplainThis,
   LoadingSpinner,
 } from '../components/common';
+import { AccountPurposeFilterControl } from '../components/accounts';
 import { AppIcon } from '../components/icons';
 import { NetWorthProjectionChart } from '../components/charts/NetWorthProjectionChart';
 import { useNetWorth } from '../hooks/useNetWorth';
 import type { AssetClassBreakdown, NetWorthMilestone } from '../lib/analytics/net-worth';
+import type { AccountPurposeFilter } from '../lib/accountPurpose';
 import { CHART_COLORS } from '../components/charts/chart-palette';
 import './analytics.css';
 
@@ -99,8 +101,9 @@ const MilestoneList: React.FC<MilestoneListProps> = ({ milestones }) => (
 // ---------------------------------------------------------------------------
 
 export const NetWorthPage: React.FC = () => {
+  const [purposeFilter, setPurposeFilter] = useState<AccountPurposeFilter>('all');
   const { currentNetWorth, assetClasses, milestones, history, loading, error, refresh } =
-    useNetWorth();
+    useNetWorth(purposeFilter);
 
   if (loading) {
     return (
@@ -124,32 +127,43 @@ export const NetWorthPage: React.FC = () => {
   }
 
   const isEmpty = currentNetWorth.assets === 0 && currentNetWorth.liabilities === 0;
+  const workspaceLabel =
+    purposeFilter === 'business' ? 'business' : purposeFilter === 'personal' ? 'personal' : '';
+  const emptyDescription =
+    purposeFilter === 'all'
+      ? 'Your accounts have no balances yet. Update account balances to see your net worth.'
+      : `No ${workspaceLabel} accounts have balances yet. Switch workspace above or update account balances.`;
+
+  const header = (
+    <div className="analytics-page__header">
+      <div
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 'var(--spacing-2)',
+        }}
+      >
+        <h1 className="analytics-page__title" style={{ margin: 0 }}>
+          Net Worth
+        </h1>
+        <ExplainThis glossaryKey="netWorth" />
+      </div>
+      <AccountPurposeFilterControl value={purposeFilter} onChange={setPurposeFilter} />
+    </div>
+  );
 
   if (isEmpty) {
     return (
-      <EmptyState
-        title="No net worth data"
-        description="Your accounts have no balances yet. Update account balances to see your net worth."
-      />
+      <div className="analytics-page">
+        {header}
+        <EmptyState title="No net worth data" description={emptyDescription} />
+      </div>
     );
   }
 
   return (
     <div className="analytics-page">
-      <div className="analytics-page__header">
-        <div
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 'var(--spacing-2)',
-          }}
-        >
-          <h1 className="analytics-page__title" style={{ margin: 0 }}>
-            Net Worth
-          </h1>
-          <ExplainThis glossaryKey="netWorth" />
-        </div>
-      </div>
+      {header}
 
       {/* Key figures */}
       <section className="analytics-section" aria-label="Net worth summary">


### PR DESCRIPTION
## Summary

Priya Sharma keeps her Etsy business money separate from personal finances, but the **Net Worth** page aggregated every account into one number with no way to view a single workspace. The Dashboard and Transactions pages already expose a business/personal filter — this brings Net Worth to parity.

## Changes

- `useNetWorth(purposeFilter)` now accepts an optional `AccountPurposeFilter` (`'all' | 'personal' | 'business'`, default `'all'`) and scopes the snapshot, asset classes, milestones, and history using the disjoint `selectWorkspaceAccounts` / `selectWorkspaceTransactions` partition (so `All === Personal + Business + shared`, no double counting).
- `NetWorthPage` renders the shared `AccountPurposeFilterControl` in the page header.
- The filter control stays visible in the empty state (extracted `header`), so selecting a workspace with no balances doesn't strand the user — and the empty message names the selected workspace.
- Added 3 NetWorthPage tests (control renders + defaults to `all`, selecting Business re-invokes the hook, control stays visible when the workspace is empty).

## Issues

Closes #3246

## Testing

- [x] `npx vitest run src/pages/NetWorthPage.test.tsx` — 8/8 pass
- [x] `npx prettier --check` + `npx eslint --max-warnings 0` on changed files — clean
- [ ] type-check via remote CI (local TS 5.9.3 issue)

Found by persona: Priya Sharma (etsy small-business owner)
