### PR TITLE
fix(web): harden onboarding storage + goal validation/formatting (#3406)

### DIFF
--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -583,7 +583,9 @@ describe('OnboardingPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /preview goal/i }));
 
     expect(screen.getByText(/confirm goal before saving/i)).toBeInTheDocument();
-    expect(screen.getByText(/estimated monthly contribution: \$1000/i)).toBeInTheDocument();
+    // #3408: onboarding money renders with locale thousands separators.
+    expect(screen.getByText(/save \$1,200/i)).toBeInTheDocument();
+    expect(screen.getByText(/estimated monthly contribution: \$1,000/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /save goal/i }));
     // Advance goals -> template, then skip the starter budget to reach the checklist.
@@ -592,6 +594,36 @@ describe('OnboardingPage', () => {
 
     expect(localStorage.getItem('finance-onboarding-goals')).toContain('Move fund');
     expect(screen.getByText(/1 goal saved/i)).toBeInTheDocument();
+  });
+
+  it('blocks previewing a goal until a positive target amount is entered (#3410)', () => {
+    renderWithRouter(<OnboardingPage />);
+
+    goToGoalsStep();
+    fireEvent.change(screen.getByLabelText(/target amount/i), { target: { value: '0' } });
+
+    const previewButton = screen.getByRole('button', { name: /preview goal/i });
+    expect(previewButton).toBeDisabled();
+    expect(screen.getByText(/enter a target amount greater than \$0/i)).toBeInTheDocument();
+
+    // Clicking the disabled control must not open the confirmation.
+    fireEvent.click(previewButton);
+    expect(screen.queryByText(/confirm goal before saving/i)).not.toBeInTheDocument();
+
+    // A positive amount re-enables previewing and clears the hint.
+    fireEvent.change(screen.getByLabelText(/target amount/i), { target: { value: '500' } });
+    expect(screen.getByRole('button', { name: /preview goal/i })).toBeEnabled();
+    expect(screen.queryByText(/enter a target amount greater than \$0/i)).not.toBeInTheDocument();
+  });
+
+  it('strips non-numeric characters from goal amount inputs (#3411)', () => {
+    renderWithRouter(<OnboardingPage />);
+
+    goToGoalsStep();
+    const amountInput = screen.getByLabelText(/target amount/i) as HTMLInputElement;
+    fireEvent.change(amountInput, { target: { value: '1a2b3c' } });
+
+    expect(amountInput.value).toBe('123');
   });
 
   it('lets users hide, restore, dismiss, and reopen post-onboarding setup help', () => {

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -34,6 +34,7 @@ import { useLocalOnlyMode } from '../hooks/useLocalOnlyMode';
 import { setReducedMotionPreference } from '../hooks/useReducedMotion';
 import { applyTheme, THEME_STORAGE_KEY } from '../hooks/useTheme';
 import { setSimplifiedModePreference } from '../lib/accessibility-preferences';
+import { formatCurrencyValue } from '../lib/currency';
 import { buildOnboardingProgressAnnouncement } from '../lib/a11y/onboarding-progress';
 import { getBudgetStarterTemplates } from '../lib/budgeting/starter-budget-templates';
 import {
@@ -333,6 +334,22 @@ const INCOME_TYPE_OPTIONS: Array<NewcomerChoiceOption<IncomeType>> = [
   },
 ];
 
+function safeGetItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSetItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Storage can be unavailable (private mode / disabled); values simply do not persist.
+  }
+}
+
 function readTaxIdStatus(): TaxIdStatus {
   try {
     const raw = localStorage.getItem(TAX_ID_STATUS_STORAGE_KEY);
@@ -366,6 +383,14 @@ function firstOfCurrentMonthISO(): string {
   return `${year}-${month}-01`;
 }
 
+function todayISO(): string {
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 function applyComfortPreferences(
   fontScaleValue: number,
   reducedMotion: boolean,
@@ -381,7 +406,7 @@ function applyComfortPreferences(
   setSimplifiedModePreference(simplifiedMode);
 
   const nextTheme = highContrast ? 'high-contrast' : 'system';
-  localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+  safeSetItem(THEME_STORAGE_KEY, nextTheme);
   applyTheme(nextTheme);
 }
 
@@ -396,15 +421,15 @@ function readStringArray(key: string): string[] {
 }
 
 function writeStringArray(key: string, values: string[]): void {
-  localStorage.setItem(key, JSON.stringify(values));
+  safeSetItem(key, JSON.stringify(values));
 }
 
 function readBoolean(key: string): boolean {
-  return localStorage.getItem(key) === 'true';
+  return safeGetItem(key) === 'true';
 }
 
 function writeBoolean(key: string, value: boolean): void {
-  localStorage.setItem(key, String(value));
+  safeSetItem(key, String(value));
 }
 
 function readGoals(): StoredGoal[] {
@@ -418,7 +443,7 @@ function readGoals(): StoredGoal[] {
 }
 
 function writeGoals(goals: StoredGoal[]): void {
-  localStorage.setItem(GOALS_STORAGE_KEY, JSON.stringify(goals));
+  safeSetItem(GOALS_STORAGE_KEY, JSON.stringify(goals));
 }
 
 const DEFAULT_GOAL_DRAFT: GoalDraft = {
@@ -462,18 +487,16 @@ function trackOnboardingEvent(
     return;
   }
 
+  const existing = safeGetItem(ANALYTICS_EVENTS_STORAGE_KEY);
+  let events: unknown;
   try {
-    const existing = localStorage.getItem(ANALYTICS_EVENTS_STORAGE_KEY);
-    const events = existing ? JSON.parse(existing) : [];
-    const nextEvents = Array.isArray(events) ? events : [];
-    nextEvents.push({ eventName, payload, timestamp: new Date().toISOString() });
-    localStorage.setItem(ANALYTICS_EVENTS_STORAGE_KEY, JSON.stringify(nextEvents));
+    events = existing ? JSON.parse(existing) : [];
   } catch {
-    localStorage.setItem(
-      ANALYTICS_EVENTS_STORAGE_KEY,
-      JSON.stringify([{ eventName, payload, timestamp: new Date().toISOString() }]),
-    );
+    events = [];
   }
+  const nextEvents = Array.isArray(events) ? events : [];
+  nextEvents.push({ eventName, payload, timestamp: new Date().toISOString() });
+  safeSetItem(ANALYTICS_EVENTS_STORAGE_KEY, JSON.stringify(nextEvents));
 }
 
 const FeatureRow: React.FC<{ feature: FeatureAvailability }> = ({ feature }) => (
@@ -579,6 +602,8 @@ const OnboardingPage: React.FC = () => {
   );
   const selectedStageLabels = selectedLifeStageOptions.map((option) => option.label).join(', ');
   const monthlyContribution = calculateMonthlyContribution(goalDraft);
+  const goalTargetAmount = Number(goalDraft.targetAmount) || 0;
+  const isGoalDraftValid = goalTargetAmount > 0;
   const fullySetUp = starterBudgetCreated || savedGoals.length > 0;
   const currentStepIndex = Math.max(ONBOARDING_STEP_ORDER.indexOf(step), 0);
   const totalStepCount = ONBOARDING_STEP_ORDER.length;
@@ -738,11 +763,24 @@ const OnboardingPage: React.FC = () => {
     setGoalSavedName(null);
   }, []);
 
+  const handleAmountDraftChange = useCallback(
+    (field: 'targetAmount' | 'startingBalance', value: string) => {
+      handleGoalDraftChange(field, value.replace(/[^0-9.]/g, ''));
+    },
+    [handleGoalDraftChange],
+  );
+
   const handlePreviewGoal = useCallback(() => {
+    if ((Number(goalDraft.targetAmount) || 0) <= 0) {
+      return;
+    }
     setGoalReviewVisible(true);
-  }, []);
+  }, [goalDraft.targetAmount]);
 
   const handleSaveGoal = useCallback(() => {
+    if ((Number(goalDraft.targetAmount) || 0) <= 0) {
+      return;
+    }
     const nextGoal: StoredGoal = {
       id: `goal-${Date.now()}`,
       name: goalDraft.name.trim() || 'My goal',
@@ -1855,25 +1893,31 @@ const OnboardingPage: React.FC = () => {
               <label className="onboarding__field">
                 <span>Target amount</span>
                 <input
-                  type="number"
-                  min="0"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="[0-9]*\.?[0-9]*"
                   value={goalDraft.targetAmount}
-                  onChange={(event) => handleGoalDraftChange('targetAmount', event.target.value)}
+                  onChange={(event) => handleAmountDraftChange('targetAmount', event.target.value)}
+                  aria-describedby={isGoalDraftValid ? undefined : 'onboarding-goal-amount-hint'}
                 />
               </label>
               <label className="onboarding__field">
                 <span>Starting balance</span>
                 <input
-                  type="number"
-                  min="0"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="[0-9]*\.?[0-9]*"
                   value={goalDraft.startingBalance}
-                  onChange={(event) => handleGoalDraftChange('startingBalance', event.target.value)}
+                  onChange={(event) =>
+                    handleAmountDraftChange('startingBalance', event.target.value)
+                  }
                 />
               </label>
               <label className="onboarding__field">
                 <span>Target date</span>
                 <input
                   type="date"
+                  min={todayISO()}
                   value={goalDraft.targetDate}
                   onChange={(event) => handleGoalDraftChange('targetDate', event.target.value)}
                 />
@@ -1885,6 +1929,8 @@ const OnboardingPage: React.FC = () => {
                 type="button"
                 className="onboarding__path-btn onboarding__path-btn--secondary"
                 onClick={handlePreviewGoal}
+                disabled={!isGoalDraftValid}
+                aria-describedby={isGoalDraftValid ? undefined : 'onboarding-goal-amount-hint'}
               >
                 Preview goal
               </button>
@@ -1898,14 +1944,32 @@ const OnboardingPage: React.FC = () => {
               </button>
             </div>
 
+            {!isGoalDraftValid && (
+              <p
+                id="onboarding-goal-amount-hint"
+                className="onboarding__path-description"
+                role="note"
+              >
+                Enter a target amount greater than $0 to preview and save your goal.
+              </p>
+            )}
+
             {goalReviewVisible && (
               <div className="onboarding__goal-review" role="status">
                 <h3 className="onboarding__section-title">Confirm goal before saving</h3>
                 <p>
-                  {goalDraft.name || 'My goal'}: save $
-                  {Number(goalDraft.targetAmount || 0).toFixed(0)}
+                  {goalDraft.name || 'My goal'}: save{' '}
+                  {formatCurrencyValue(Number(goalDraft.targetAmount) || 0, {
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 0,
+                  })}
                   {goalDraft.targetDate ? ` by ${goalDraft.targetDate}` : ''}. Estimated monthly
-                  contribution: ${monthlyContribution.toFixed(0)}.
+                  contribution:{' '}
+                  {formatCurrencyValue(monthlyContribution, {
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 0,
+                  })}
+                  .
                 </p>
                 <button
                   type="button"
@@ -1931,7 +1995,13 @@ const OnboardingPage: React.FC = () => {
                   {savedGoals.map((goal) => (
                     <li key={goal.id} className="onboarding__saved-goals-item" role="listitem">
                       <span>{goal.name}</span>
-                      <strong>${goal.monthlyContribution.toFixed(0)}/mo</strong>
+                      <strong>
+                        {formatCurrencyValue(goal.monthlyContribution, {
+                          minimumFractionDigits: 0,
+                          maximumFractionDigits: 0,
+                        })}
+                        /mo
+                      </strong>
                     </li>
                   ))}
                 </ul>
@@ -2006,7 +2076,12 @@ const OnboardingPage: React.FC = () => {
                   <span>
                     {category.emoji} {category.name}
                   </span>
-                  <strong>${(category.amountCents / 100).toFixed(0)}</strong>
+                  <strong>
+                    {formatCurrencyValue(category.amountCents / 100, {
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 0,
+                    })}
+                  </strong>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary

Hardens the first-run onboarding flow for a brand-new, financially-naive user (Maya persona). Fixes five related defects in `OnboardingPage.tsx`, all found while walking the empty-account setup path.

## Changes

- **#3406 — Storage crashes:** `localStorage` writes (theme, string arrays, booleans, saved goals, analytics events) were unguarded and threw in private-browsing / storage-disabled contexts, which could crash setup. Added `safeGetItem`/`safeSetItem` wrappers and routed every onboarding write through them so failures degrade gracefully. `trackOnboardingEvent` no longer double-throws.
- **#3408 — Money formatting:** goal + starter-budget amounts rendered as raw `$1000`. Now formatted via `formatCurrencyValue(..., { minimumFractionDigits: 0, maximumFractionDigits: 0 })` → `$1,000`, matching the rest of the app.
- **#3409 — Past target dates:** added `todayISO()` and `min={todayISO()}` on the target-date input.
- **#3410 — $0 / empty goal:** Preview is disabled with an accessible hint (`role="note"`, `aria-describedby`) until a positive target amount is entered; `handlePreviewGoal`/`handleSaveGoal` guard against `<= 0`.
- **#3411 — `type=number` footgun:** amount inputs switched to `type="text" inputMode="decimal"` and strip non-numeric characters on change (matches the app's `AmountInput` pattern).

## Tests

- Updated the preview assertion to expect locale-formatted `$1,200` / `$1,000`.
- Added: positive-amount gating (Preview disabled + hint until a valid amount) and non-numeric input sanitization.
- `npx vitest run src/pages/OnboardingPage.test.tsx` → **32 passed**.
- `npx prettier --check` + `npx eslint --max-warnings 0` clean on both files.

## Scope

- Web-only: `OnboardingPage.tsx` is not shared with iOS/Android/Windows (native onboarding lives in each `apps/*`). No `packages/` changes.

Found by persona: Maya Chen (new-grad first-job budgeter)

## Issues

Closes #3406
Closes #3408
Closes #3409
Closes #3410
Closes #3411
