### PR TITLE
fix(web): translate a11y currency labels and glossary popover chrome (#3304, #3309)

### DIFF
--- a/apps/web/src/components/common/CurrencyDisplay.tsx
+++ b/apps/web/src/components/common/CurrencyDisplay.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 
 import { formatCurrencyForScreenReader } from '../../lib/a11y';
+import { translate } from '../../lib/i18n';
 import { useEffectiveMaskingMode, useIsPrivacyModeActive } from '../../contexts/PrivacyModeContext';
 import { useLocalePreferences } from '../../hooks/useLocalePreferences';
 import { getCurrencyFractionDigits } from '../../lib/currency-metadata';
@@ -87,7 +88,8 @@ export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({
       ? displaySettings.negativeFormat === 'parentheses'
         ? `(${formattedAbsolute})`
         : displaySettings.negativeFormat === 'color-only'
-          ? `Negative ${formattedAbsolute}`
+          ? translate('currency.display.negativeCue', { amount: formattedAbsolute }, resolvedLocale)
+              .text
           : formattedBase
       : formattedBase;
 
@@ -107,7 +109,7 @@ export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({
   // "negative" prefix and optional context so screen readers convey
   // sign and meaning regardless of visual negative format.
   const label = isPrivacyMode
-    ? 'Amount hidden'
+    ? translate('currency.display.amountHidden', {}, resolvedLocale).text
     : (ariaLabel ?? formatCurrencyForScreenReader(amount, currency, context, resolvedLocale));
 
   return (

--- a/apps/web/src/components/common/ExplainThis.tsx
+++ b/apps/web/src/components/common/ExplainThis.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import { useFocusTrap } from '../../accessibility/aria';
+import { useLocalePreferences } from '../../hooks/useLocalePreferences';
+import { translate } from '../../lib/i18n';
 import {
   getContextualTip,
   getGlossaryEntry,
@@ -46,6 +48,7 @@ export function ExplainThis(props: ExplainThisProps) {
   const popoverId = useId();
   const titleId = useId();
   const definitionId = useId();
+  const { locale } = useLocalePreferences();
 
   const entry = useMemo(() => {
     if ('glossaryKey' in props && props.glossaryKey) {
@@ -131,7 +134,8 @@ export function ExplainThis(props: ExplainThisProps) {
     };
   }, [closePopover, interactionMode, isOpen]);
 
-  const buttonAriaLabel = props.buttonLabel ?? `Explain ${entry.term}`;
+  const buttonAriaLabel =
+    props.buttonLabel ?? translate('education.explain.trigger', { term: entry.term }, locale).text;
   const wrapperClassName = ['explain-this', props.className].filter(Boolean).join(' ');
 
   return (
@@ -169,7 +173,7 @@ export function ExplainThis(props: ExplainThisProps) {
               ref={closeButtonRef}
               type="button"
               className="explain-this__close"
-              aria-label={`Close explanation for ${entry.term}`}
+              aria-label={translate('education.explain.close', { term: entry.term }, locale).text}
               onClick={closePopover}
             >
               <AppIcon name="x" size={14} />
@@ -181,12 +185,16 @@ export function ExplainThis(props: ExplainThisProps) {
           </p>
 
           <div className="explain-this__section">
-            <span className="explain-this__section-label">Example</span>
+            <span className="explain-this__section-label">
+              {translate('education.explain.example', {}, locale).text}
+            </span>
             <p>{entry.example}</p>
           </div>
 
           <div className="explain-this__section explain-this__section--accent">
-            <span className="explain-this__section-label">Why it matters</span>
+            <span className="explain-this__section-label">
+              {translate('education.explain.whyItMatters', {}, locale).text}
+            </span>
             <p>{entry.whyItMatters}</p>
           </div>
         </div>

--- a/apps/web/src/lib/a11y.ts
+++ b/apps/web/src/lib/a11y.ts
@@ -15,6 +15,7 @@ import type { IconName } from '../components/icons';
  */
 
 import { formatCurrency } from './currency';
+import { translate } from './i18n';
 
 // ---------------------------------------------------------------------------
 // Currency formatting for screen readers
@@ -55,9 +56,13 @@ export function formatCurrencyForScreenReader(
 ): string {
   const isNegative = amountInCents < 0;
   const formatted = formatCurrency(Math.abs(amountInCents), { currency, locale });
-  const base = isNegative ? `negative ${formatted}` : formatted;
+  const base = isNegative
+    ? translate('a11y.currency.negative', { amount: formatted }, locale).text
+    : formatted;
 
-  return context ? `${base}, ${context}` : base;
+  return context
+    ? translate('a11y.currency.withContext', { label: base, context }, locale).text
+    : base;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/currency.ts
+++ b/apps/web/src/lib/currency.ts
@@ -17,7 +17,7 @@
  * References: issue #1351
  */
 
-import { getCurrentLocale } from './i18n';
+import { getCurrentLocale, translate } from './i18n';
 import { minorUnitFactor } from './currency-metadata';
 import { formatAmount, MaskingMode } from './ui/privacy';
 
@@ -169,7 +169,11 @@ export function formatCurrencyLabel(
   options: FormatCurrencyOptions = {},
 ): string {
   if (amountInCents < 0) {
-    return `negative ${formatCurrency(Math.abs(amountInCents), options)}`;
+    return translate(
+      'a11y.currency.negative',
+      { amount: formatCurrency(Math.abs(amountInCents), options) },
+      options.locale,
+    ).text;
   }
   return formatCurrency(amountInCents, options);
 }

--- a/apps/web/src/lib/i18n.test.ts
+++ b/apps/web/src/lib/i18n.test.ts
@@ -58,3 +58,42 @@ describe('i18n locale preferences', () => {
     });
   });
 });
+
+describe('accessible currency & glossary label i18n (#3304, #3309)', () => {
+  it('translates the screen-reader negative prefix per locale with the amount placeholder', () => {
+    expect(translate('a11y.currency.negative', { amount: '$12.34' }, 'en-US').text).toBe(
+      'negative $12.34',
+    );
+    expect(translate('a11y.currency.negative', { amount: '12,34 €' }, 'es-ES')).toEqual({
+      text: 'negativo 12,34 €',
+      translated: true,
+    });
+    expect(translate('a11y.currency.negative', { amount: '¥88' }, 'zh-Hans')).toEqual({
+      text: '负¥88',
+      translated: true,
+    });
+  });
+
+  it('translates the visible color-only negative cue and the masked-amount label', () => {
+    expect(translate('currency.display.negativeCue', { amount: '$5.00' }, 'en-US').text).toBe(
+      'Negative $5.00',
+    );
+    expect(translate('currency.display.amountHidden', {}, 'zh-Hans')).toEqual({
+      text: '金额已隐藏',
+      translated: true,
+    });
+  });
+
+  it('translates the "Explain this" glossary popover chrome for bilingual readers', () => {
+    expect(translate('education.explain.trigger', { term: 'APR' }, 'en-US').text).toBe(
+      'Explain APR',
+    );
+    expect(translate('education.explain.example', {}, 'zh-Hans').text).toBe('示例');
+    expect(translate('education.explain.whyItMatters', {}, 'es-ES').text).toBe(
+      'Por qué es importante',
+    );
+    expect(translate('education.explain.close', { term: 'escrow' }, 'zh-Hans').text).toBe(
+      '关闭escrow的解释',
+    );
+  });
+});

--- a/apps/web/src/lib/i18n/locales/en-US.ts
+++ b/apps/web/src/lib/i18n/locales/en-US.ts
@@ -3,6 +3,16 @@
 import type { MessageCatalog } from '../catalog-loader';
 
 export const EN_US_CATALOG: MessageCatalog = {
+  // Accessible currency labels (screen-reader + visible color-only negative cue).
+  'a11y.currency.negative': 'negative {amount}',
+  'a11y.currency.withContext': '{label}, {context}',
+  'currency.display.negativeCue': 'Negative {amount}',
+  'currency.display.amountHidden': 'Amount hidden',
+  // "Explain this" glossary popover chrome.
+  'education.explain.trigger': 'Explain {term}',
+  'education.explain.close': 'Close explanation for {term}',
+  'education.explain.example': 'Example',
+  'education.explain.whyItMatters': 'Why it matters',
   'settings.language': 'Language',
   'settings.timeZone': 'Home time zone',
   'settings.languageDescription': 'Detected from your browser; change it anytime.',

--- a/apps/web/src/lib/i18n/locales/es-ES.ts
+++ b/apps/web/src/lib/i18n/locales/es-ES.ts
@@ -3,6 +3,16 @@
 import type { MessageCatalog } from '../catalog-loader';
 
 export const ES_ES_CATALOG: MessageCatalog = {
+  // Etiquetas accesibles de moneda (lector de pantalla + señal visible de negativo).
+  'a11y.currency.negative': 'negativo {amount}',
+  'a11y.currency.withContext': '{label}, {context}',
+  'currency.display.negativeCue': 'Negativo {amount}',
+  'currency.display.amountHidden': 'Importe oculto',
+  // Ventana emergente del glosario "Explicar esto".
+  'education.explain.trigger': 'Explicar {term}',
+  'education.explain.close': 'Cerrar la explicación de {term}',
+  'education.explain.example': 'Ejemplo',
+  'education.explain.whyItMatters': 'Por qué es importante',
   'settings.language': 'Idioma',
   'settings.timeZone': 'Zona horaria de casa',
   'settings.languageDescription': 'Detectado desde tu navegador; puedes cambiarlo cuando quieras.',

--- a/apps/web/src/lib/i18n/locales/zh-Hans.ts
+++ b/apps/web/src/lib/i18n/locales/zh-Hans.ts
@@ -16,6 +16,16 @@ import type { MessageCatalog } from '../catalog-loader';
  * References: issue #3311
  */
 export const ZH_HANS_CATALOG: MessageCatalog = {
+  // 无障碍货币标签（屏幕阅读器 + 仅颜色负数的可见提示）。
+  'a11y.currency.negative': '负{amount}',
+  'a11y.currency.withContext': '{label}，{context}',
+  'currency.display.negativeCue': '负{amount}',
+  'currency.display.amountHidden': '金额已隐藏',
+  // “解释”术语弹窗界面文字。
+  'education.explain.trigger': '解释{term}',
+  'education.explain.close': '关闭{term}的解释',
+  'education.explain.example': '示例',
+  'education.explain.whyItMatters': '为什么重要',
   'settings.language': '语言',
   'settings.timeZone': '家乡时区',
   'settings.languageDescription': '根据你的浏览器检测；可随时更改。',


### PR DESCRIPTION
## Summary

Bilingual users (like immigrant remitters who bank across two languages) still hit hardcoded English in two accessibility-critical spots:

1. the **screen-reader currency label** always prepended the English word "negative", and
2. the **"Explain this" financial-glossary popover** rendered its chrome ("Explain", "Close explanation for", "Example", "Why it matters") in English regardless of locale.

This routes those strings through the i18n catalog and ships real translations for the three shipped locales.

## Changes

- **a11y (#3304):** `formatCurrencyForScreenReader` (`lib/a11y.ts`) and `formatCurrencyLabel` (`lib/currency.ts`) now build the negative label via `translate('a11y.currency.negative' / 'a11y.currency.withContext', …, locale)` instead of a hardcoded `` `negative ${…}` `` prefix.
- **a11y (#3304):** `components/common/CurrencyDisplay.tsx` routes the visible color-only `Negative {amount}` cue and the privacy-mode `Amount hidden` accessible label through `translate(…, resolvedLocale)`.
- **glossary (#3309):** `components/common/ExplainThis.tsx` routes the trigger aria-label, close aria-label, and the "Example" / "Why it matters" section labels through `translate()`, keyed off `useLocalePreferences()` so the popover re-renders on locale switch.
- **catalogs:** adds the new keys to `en-US` (source of truth), `es-ES`, and `zh-Hans` so the labels are actually localized (not just an en-US fallback). zh-Hans is the immigrant-remitter persona's own locale.
- **tests:** adds `i18n.test.ts` cases asserting per-locale resolution and `{amount}` / `{term}` placeholder interpolation for en-US, es-ES, and zh-Hans.

en-US behavior is unchanged (the default catalog text matches the previous literals), so existing a11y/currency/ExplainThis assertions still pass.

## Issues

Closes #3304
Closes #3309

Found by persona: Wei Zhang (immigrant multi-currency remitter)

## Testing

- [x] Affected unit suites green locally: `a11y.test.ts`, `currency.test.ts`, `common/CurrencyDisplay.test.tsx`, `common/ExplainThis.test.tsx`, `i18n.test.ts` + `lib/i18n/**` (130 tests passing).
- [x] `prettier --check` + `eslint --max-warnings 0` clean on all 8 changed files.
- [x] en-US label output byte-identical to prior behavior (no visual regression for the default locale).

## Cross-Platform

- **Scope:** `platform:web`. These are TypeScript web-component + web-i18n-catalog strings (`apps/web/src/**`). The underlying "hardcode English UI labels" pattern exists independently on other platforms, but the fix here is web-catalog-specific; no shared (`packages/`) code changes.
