### PR TITLE
feat(web): link a savings goal to a funding account (#3380)

### DIFF
--- a/apps/web/src/components/forms/GoalForm.test.tsx
+++ b/apps/web/src/components/forms/GoalForm.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDatabase } from '../../db/DatabaseProvider';
 import { queryOne } from '../../db/sqlite-wasm';
+import { useAccounts } from '../../hooks/useAccounts';
 import { GoalForm, type GoalFormProps } from './GoalForm';
 
 vi.mock('../../accessibility/aria', () => ({
@@ -18,8 +19,13 @@ vi.mock('../../db/sqlite-wasm', () => ({
   queryOne: vi.fn(),
 }));
 
+vi.mock('../../hooks/useAccounts', () => ({
+  useAccounts: vi.fn(),
+}));
+
 const mockedUseDatabase = vi.mocked(useDatabase);
 const mockedQueryOne = vi.mocked(queryOne);
+const mockedUseAccounts = vi.mocked(useAccounts);
 const mockDb = {};
 
 function renderGoalForm(overrides: Partial<GoalFormProps> = {}) {
@@ -37,6 +43,19 @@ describe('GoalForm', () => {
     vi.setSystemTime(new Date('2025-06-15T12:00:00Z'));
     mockedUseDatabase.mockReturnValue(mockDb as never);
     mockedQueryOne.mockReturnValue({ id: 'household-1' } as never);
+    mockedUseAccounts.mockReturnValue({
+      accounts: [
+        { id: 'acct-1', name: 'Joint Checking', isArchived: false },
+        { id: 'acct-2', name: 'Personal Savings', isArchived: false },
+        { id: 'acct-3', name: 'Closed Card', isArchived: true },
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      createAccount: vi.fn(),
+      updateAccount: vi.fn(),
+      deleteAccount: vi.fn(),
+    } as never);
   });
 
   afterEach(() => {
@@ -52,6 +71,7 @@ describe('GoalForm', () => {
     expect(screen.getByLabelText('Target Amount')).toBeInTheDocument();
     expect(screen.getByLabelText('Current Amount')).toHaveValue('');
     expect(screen.getByLabelText('Target Date')).toHaveAttribute('min', '2025-06-16');
+    expect(screen.getByLabelText('Funding Account')).toBeInTheDocument();
     expect(screen.getByLabelText('Description')).toBeInTheDocument();
   });
 
@@ -89,8 +109,26 @@ describe('GoalForm', () => {
       targetAmount: { amount: 100025 },
       currentAmount: { amount: 25010 },
       targetDate: '2025-07-01',
+      accountId: null,
       status: 'ACTIVE',
     });
+  });
+
+  it('excludes archived accounts and links the selected funding account', async () => {
+    const { onSubmit } = renderGoalForm();
+
+    expect(screen.queryByRole('option', { name: 'Closed Card' })).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'House Down Payment' } });
+    fireEvent.change(screen.getByLabelText('Target Amount'), { target: { value: '20000' } });
+    fireEvent.change(screen.getByLabelText('Funding Account'), { target: { value: 'acct-1' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create Goal' }));
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'House Down Payment', accountId: 'acct-1' }),
+    );
   });
 
   it('prefills the description when editing an existing goal', () => {

--- a/apps/web/src/components/forms/GoalForm.tsx
+++ b/apps/web/src/components/forms/GoalForm.tsx
@@ -5,7 +5,7 @@
  *
  * Renders a modal dialog with fields for creating or editing a savings goal:
  * name (required), target amount (required), current amount (defaults to zero),
- * target date (optional), and description (optional).
+ * target date (optional), funding account (optional), and description (optional).
  *
  * Validates input client-side with accessible error messages using
  * `aria-invalid` and `aria-describedby`. The household ID is resolved from the
@@ -34,6 +34,7 @@ import { useDatabase } from '../../db/DatabaseProvider';
 import type { CreateGoalInput } from '../../db/repositories/goals';
 import { queryOne, type Row } from '../../db/sqlite-wasm';
 import { useAmountInput } from '../../hooks/useAmountInput';
+import { useAccounts } from '../../hooks/useAccounts';
 import { useNavigationGuard } from '../../hooks/useNavigationGuard';
 import type { Goal, GoalStatus, SyncId } from '../../kmp/bridge';
 import { goalSchema } from '../../lib/validation';
@@ -160,18 +161,21 @@ export function GoalForm({ isOpen, onCancel, onSubmit, initialData }: GoalFormPr
     allowNegative: false,
   });
   const [targetDate, setTargetDate] = useState('');
+  const [accountId, setAccountId] = useState('');
   const [description, setDescription] = useState('');
   const [errors, setErrors] = useState<FormErrors>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const db = useDatabase();
+  const { accounts } = useAccounts();
   const initialValues = useMemo(
     () => ({
       name: initialData?.name ?? '',
       targetAmount: initialData?.targetAmount.amount ?? 0,
       currentAmount: initialData?.currentAmount.amount ?? 0,
       targetDate: initialData?.targetDate ?? '',
+      accountId: initialData?.accountId ?? '',
       description: initialData?.description ?? '',
     }),
     [initialData],
@@ -182,6 +186,7 @@ export function GoalForm({ isOpen, onCancel, onSubmit, initialData }: GoalFormPr
       targetAmountInput.cents !== initialValues.targetAmount ||
       currentAmountInput.cents !== initialValues.currentAmount ||
       targetDate !== initialValues.targetDate ||
+      accountId !== initialValues.accountId ||
       description !== initialValues.description);
   const { confirmNavigation } = useNavigationGuard({
     when: isDirty,
@@ -208,6 +213,7 @@ export function GoalForm({ isOpen, onCancel, onSubmit, initialData }: GoalFormPr
     targetAmountInput.setCents(initialValues.targetAmount);
     currentAmountInput.setCents(initialValues.currentAmount);
     setTargetDate(initialValues.targetDate);
+    setAccountId(initialValues.accountId);
     setDescription(initialValues.description);
     setErrors({});
     setSubmitting(false);
@@ -262,6 +268,7 @@ export function GoalForm({ isOpen, onCancel, onSubmit, initialData }: GoalFormPr
         targetAmount: { amount: targetAmountInput.cents },
         currentAmount: { amount: currentAmountInput.cents },
         targetDate: targetDate || null,
+        accountId: accountId || null,
         status: initialData?.status ?? DEFAULT_GOAL_STATUS,
       };
 
@@ -287,6 +294,7 @@ export function GoalForm({ isOpen, onCancel, onSubmit, initialData }: GoalFormPr
       currentAmountInput.cents,
       db,
       description,
+      accountId,
       initialData,
       isEditing,
       name,
@@ -418,6 +426,27 @@ export function GoalForm({ isOpen, onCancel, onSubmit, initialData }: GoalFormPr
                   {errors.targetDate}
                 </span>
               )}
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="goal-account" className="form-group__label">
+                Funding Account
+              </label>
+              <select
+                id="goal-account"
+                className="form-select"
+                value={accountId}
+                onChange={(event) => setAccountId(event.target.value)}
+              >
+                <option value="">No linked account</option>
+                {accounts
+                  .filter((account) => !account.isArchived)
+                  .map((account) => (
+                    <option key={account.id} value={account.id}>
+                      {account.name}
+                    </option>
+                  ))}
+              </select>
             </div>
 
             <div className="form-group">


### PR DESCRIPTION
## Summary

Adds an optional **Funding Account** field to the savings-goal form so a goal can be
linked to the account that funds it. New parents like Ada & Chidi can now point their
**House Down Payment** goal at their joint savings account and their **529 College Fund**
goal at the account they actually contribute from — instead of tracking goals that float
free of any account.

The data layer already supported this (`CreateGoalInput.accountId` and the goals
repository persist `account_id`); the web form was the only missing piece.

## Changes

- `apps/web/src/components/forms/GoalForm.tsx`
  - Added an accessible `<select id="goal-account">` **Funding Account** field (label +
    `form-select` styling) rendered between Target Date and Description.
  - Lists non-archived accounts via the `useAccounts()` hook; defaults to
    **"No linked account"** (value `''`).
  - Wired `accountId` through form state, `initialValues`, the dirty check, the reset
    effect, and the `CreateGoalInput` payload (`accountId: accountId || null`) so editing a
    goal prefills its linked account and clearing it unlinks.
  - Updated the component JSDoc to list the new field.
- `apps/web/src/components/forms/GoalForm.test.tsx`
  - Mocked `useAccounts` (mock the hook, not the repository — per web-engineer guidance).
  - Updated the exact-payload assertion to include `accountId: null`.
  - Added coverage that archived accounts are excluded and that selecting an account passes
    `accountId` in the submitted payload.

## Accessibility

- Native `<label htmlFor>` + `<select>` pairing; keyboard-operable; no color-only meaning.
- Matches the existing form-field pattern (`form-group`, `form-group__label`, `form-select`).

## Issues

Closes #3380

Found by persona: Ada & Chidi Okafor (new-parents joint-finances)

## Testing

- [x] `npx vitest run src/components/forms/GoalForm.test.tsx` — 7 passed
- [x] `npx vitest run src/pages/GoalsPage.test.tsx src/pages/GoalDetailPage.test.tsx` — 26 passed
- [x] `npx prettier --write` + `npx eslint --max-warnings 0` on both changed files — clean
