### PR TITLE
feat(web): suggest saved client names on the invoice form (#3271)

### DIFF
--- a/apps/web/src/pages/InvoicesPage.test.tsx
+++ b/apps/web/src/pages/InvoicesPage.test.tsx
@@ -138,4 +138,32 @@ describe('InvoicesPage', () => {
     // en-GB renders day-first ("1 Jun 2026"); the removed en-US hardcode showed "Jun 1, 2026".
     expect(screen.getByText(/Issued 1 Jun 2026/)).toBeInTheDocument();
   });
+
+  it('offers existing client names as autocomplete suggestions', () => {
+    const second: Invoice = { ...SAMPLE_INVOICE, id: 'inv-2', clientName: 'Maple & Co' };
+    mockedUseInvoices.mockReturnValue({
+      invoices: [SAMPLE_INVOICE, second],
+      pipelineGroups: [
+        { status: 'Sent', label: 'Sent', invoices: [SAMPLE_INVOICE, second], totalCents: 240_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 240_000,
+      addInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    const { container } = render(<InvoicesPage />);
+
+    const input = screen.getByPlaceholderText('Acme Studio');
+    expect(input).toHaveAttribute('list', 'invoice-client-suggestions');
+
+    const datalist = container.querySelector('#invoice-client-suggestions');
+    expect(datalist).not.toBeNull();
+    const values = Array.from(datalist!.querySelectorAll('option')).map((option) =>
+      option.getAttribute('value'),
+    );
+    expect(values).toContain('Etsy Wholesale');
+    expect(values).toContain('Maple & Co');
+  });
 });

--- a/apps/web/src/pages/InvoicesPage.tsx
+++ b/apps/web/src/pages/InvoicesPage.tsx
@@ -119,6 +119,14 @@ export const InvoicesPage: React.FC = () => {
   );
   const maxForecastCents = Math.max(...forecastBuckets.map((bucket) => bucket.totalCents), 1);
 
+  const clientSuggestions = useMemo(
+    () =>
+      Array.from(
+        new Set(invoices.map((invoice) => invoice.clientName.trim()).filter(Boolean)),
+      ).sort((a, b) => a.localeCompare(b)),
+    [invoices],
+  );
+
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const amountCents = parseAmountToCents(amount);
@@ -164,8 +172,17 @@ export const InvoicesPage: React.FC = () => {
               value={clientName}
               onChange={(event) => setClientName(event.target.value)}
               placeholder="Acme Studio"
+              list="invoice-client-suggestions"
+              autoComplete="off"
               required
             />
+            {clientSuggestions.length > 0 && (
+              <datalist id="invoice-client-suggestions">
+                {clientSuggestions.map((name) => (
+                  <option key={name} value={name} />
+                ))}
+              </datalist>
+            )}
           </label>
           <label className="invoice-form__field">
             Amount


### PR DESCRIPTION
## Summary

Priya invoices the same wholesale buyers month after month. The invoice form's **Client name** field was free text with no suggestions, so a typo (e.g. "Etsy Wholsale") silently fragments one buyer across pipeline groups and expected-income forecasts — undercounting what that client owes.

## Changes

- Derive a unique, alphabetically sorted list of existing client names from the current invoices (`clientSuggestions`, memoized).
- Render a `<datalist id="invoice-client-suggestions">` of those names and wire it to the client-name input via `list` + `autoComplete="off"`, so repeat clients autocomplete and stay grouped consistently.
- The native `<datalist>` combobox is keyboard- and screen-reader-accessible with no extra ARIA.
- Added an InvoicesPage test asserting the input exposes the `list` and the datalist offers each existing client name.

## Issues

Closes #3271

## Testing

- [x] `npx vitest run src/pages/InvoicesPage.test.tsx` — 6/6 pass
- [x] `npx prettier --check` + `npx eslint --max-warnings 0` on changed files — clean
- [ ] type-check via remote CI (local TS 5.9.3 issue)

Found by persona: Priya Sharma (etsy small-business owner)
