### PR TITLE
a11y(web): single main landmark + calm live region on learning/credit pages (#3404)

### DIFF
--- a/apps/web/src/pages/BuildingCreditPage.test.tsx
+++ b/apps/web/src/pages/BuildingCreditPage.test.tsx
@@ -3,24 +3,46 @@
 /**
  * Tests for BuildingCreditPage.
  *
- * Covers: accessible structure (landmark, headings, labeled inputs), the
+ * Covers: accessible structure (headings, labeled inputs, debounced status), the
  * lessons content, and the secured-card utilization tracker reacting to
  * balance/limit input with the correct classification and guidance.
  *
  * References: issue #2174
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 import { BuildingCreditPage } from './BuildingCreditPage';
 
 describe('BuildingCreditPage', () => {
-  it('renders an accessible main landmark and page heading', () => {
+  it('defers the main landmark to AppLayout and renders an h2 page heading (#3404)', () => {
     render(<BuildingCreditPage />);
 
-    expect(screen.getByRole('main', { name: 'Building credit' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 1, name: 'Building credit' })).toBeInTheDocument();
+    // AppLayout owns the single <main> and <h1>; the page must not duplicate them.
+    expect(screen.queryByRole('main')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Building credit' })).toBeInTheDocument();
+  });
+
+  it('announces a debounced, concise utilization summary (#3413)', () => {
+    vi.useFakeTimers();
+    try {
+      render(<BuildingCreditPage />);
+      fireEvent.change(screen.getByLabelText('Current balance'), { target: { value: '300' } });
+      fireEvent.change(screen.getByLabelText('Credit limit'), { target: { value: '1000' } });
+
+      const status = screen.getByRole('status');
+      // Nothing is announced until the debounce settles, so a screen reader does
+      // not re-read the entire result block on every keystroke.
+      expect(status).toHaveTextContent('');
+
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+      expect(status).toHaveTextContent(/of credit limit used/i);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('labels every tracker input for assistive technology', () => {

--- a/apps/web/src/pages/BuildingCreditPage.tsx
+++ b/apps/web/src/pages/BuildingCreditPage.tsx
@@ -18,7 +18,7 @@
  * References: issue #2174
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Icon } from '../components/common';
 import { IconToken } from '../icons/tokens';
@@ -102,13 +102,22 @@ export function BuildingCreditPage() {
     : NO_LIMIT_DETAIL;
   const showPayDown = hasLimit && utilization.payDownToTargetCents > 0;
 
+  // Announce a concise, debounced summary instead of re-reading the whole
+  // result block on every keystroke (#3413, WCAG 2.2 4.1.3 Status Messages).
+  const [announcedSummary, setAnnouncedSummary] = useState('');
+  useEffect(() => {
+    const summary = hasLimit ? `${meterValueText}. ${utilization.levelLabel}.` : '';
+    const timeout = window.setTimeout(() => setAnnouncedSummary(summary), 600);
+    return () => window.clearTimeout(timeout);
+  }, [hasLimit, meterValueText, utilization.levelLabel]);
+
   return (
-    <main className="building-credit" aria-labelledby="building-credit-title">
+    <div className="building-credit">
       <header className="building-credit__header">
         <p className="building-credit__eyebrow">Building credit from zero</p>
-        <h1 id="building-credit-title" className="building-credit__title">
+        <h2 id="building-credit-title" className="building-credit__title">
           Building credit
-        </h1>
+        </h2>
         <p className="building-credit__description">{PAGE_DESCRIPTION}</p>
       </header>
 
@@ -182,7 +191,10 @@ export function BuildingCreditPage() {
           </div>
         </div>
 
-        <div className={resultClassName} role="status">
+        <div className={resultClassName}>
+          <p className="sr-only" role="status">
+            {announcedSummary}
+          </p>
           <div className="building-credit__result-heading">
             <Icon name={statusIcon} className="building-credit__result-icon" aria-hidden="true" />
             <p className="building-credit__result-headline">{utilization.headline}</p>
@@ -282,7 +294,7 @@ export function BuildingCreditPage() {
           ))}
         </ul>
       </section>
-    </main>
+    </div>
   );
 }
 

--- a/apps/web/src/pages/LearningPage.tsx
+++ b/apps/web/src/pages/LearningPage.tsx
@@ -313,11 +313,11 @@ export function LearningPage(): React.ReactElement {
   };
 
   return (
-    <main className="learning-page" aria-label="Financial literacy learning path">
+    <div className="learning-page">
       <header className="learning-page__header">
         <div>
           <p className="learning-page__eyebrow">Local-first financial education</p>
-          <h1 className="learning-page__title">Personalized Financial Literacy Learning Path</h1>
+          <h2 className="learning-page__title">Personalized Financial Literacy Learning Path</h2>
           <p className="learning-page__subtitle">
             Learn budgeting, saving, debt, investing, and tax planning with a structured path that
             stays entirely on-device.
@@ -360,7 +360,7 @@ export function LearningPage(): React.ReactElement {
       )}
 
       <CreditBuildingSection />
-    </main>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes broken assistive-technology structure on the two beginner-facing pages a brand-new user (Maya persona) actually visits: `/learning` and `/building-credit`.

## Changes

- **#3404 — Nested `<main>` + duplicate `<h1>`:** both pages rendered their own `<main>` and `<h1>` while already rendering *inside* `AppLayout`, which unconditionally provides the single `<main id="main-content">` and the page `<h1>`. That created a nested `main` landmark (invalid — one per page) and two `<h1>`s, breaking landmark/heading navigation (WCAG 2.2 § 1.3.1). Both pages now use a plain wrapper `<div>` and an `<h2>`, matching the established Dashboard/Goals pattern and deferring the single `main`/`h1` to `AppLayout`.
- **#3413 — Chatty live region:** the building-credit result block was one large `role="status"` that recomputed on every keystroke, so a screen reader re-read the whole result continuously while typing (WCAG 2.2 § 4.1.3). Replaced with a concise, **debounced (600 ms)** visually-hidden (`sr-only`) polite status region; the visible block updates silently.

## Tests

- `BuildingCreditPage.test.tsx`: asserts no page-level `main`, page heading is `h2`, and the debounced status announces only after input settles (fake timers).
- `LearningPage.test.tsx`: unchanged — its heading assertion matches by name at any level.
- `npx vitest run` on both suites → **12 passed**. Prettier + ESLint clean.

## Scope

- Web-only: DOM landmarks / ARIA live regions are an `apps/web` concern; native platforms use their own announcement APIs. No `packages/` changes.
- Pre-existing `impeccable` CSS findings (side-tab borders, layout-property animation) in `LearningPage.css` / `BuildingCreditPage.css` are unrelated to this a11y-structure change and left unchanged.

Found by persona: Maya Chen (new-grad first-job budgeter)

## Issues

Closes #3404
Closes #3413
