### PR TITLE
fix(web): confirm before removing a household member (#3383)

### DIFF
--- a/apps/web/src/pages/HouseholdPage.test.tsx
+++ b/apps/web/src/pages/HouseholdPage.test.tsx
@@ -584,7 +584,36 @@ describe('HouseholdPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /revoke helper access for aunt maria/i }));
 
+    // The destructive action is gated behind a confirmation dialog.
+    expect(removeMember).not.toHaveBeenCalled();
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke access' }));
+
     expect(removeMember).toHaveBeenCalledWith('helper-1');
+  });
+
+  it('does not remove a member when the confirmation is cancelled', () => {
+    const removeMember = vi.fn().mockReturnValue(true);
+    mockedUseHousehold.mockReturnValue(
+      mockHouseholdResult({
+        household: makeHousehold(),
+        members: [
+          makeOwnerMember(),
+          makeOwnerMember({ id: 'partner-1', role: 'MEMBER', displayName: 'Chidi Okafor' }),
+        ],
+        removeMember,
+      }),
+    );
+
+    render(<HouseholdPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Chidi Okafor' }));
+
+    // Confirmation appears; cancelling must not remove the member.
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(removeMember).not.toHaveBeenCalled();
   });
 
   it('renders the mid-month scorecard with demo-backed pace messaging', () => {

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -15,6 +15,7 @@ import type { FormEvent } from 'react';
 import { AppIcon } from '../components/icons';
 
 import { useAuth } from '../auth/auth-context';
+import { ConfirmDialog } from '../components/common/ConfirmDialog';
 import { CurrencyDisplay } from '../components/common/CurrencyDisplay';
 import { useToast } from '../components/common/Toast';
 import {
@@ -245,6 +246,11 @@ export function HouseholdPage() {
   // -- Invite form state ---------------------------------------------------
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviteRole, setInviteRole] = useState<HouseholdRole>('MEMBER');
+  const [memberPendingRemoval, setMemberPendingRemoval] = useState<{
+    id: string;
+    name: string;
+    isViewer: boolean;
+  } | null>(null);
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [inviteSuccess, setInviteSuccess] = useState(false);
 
@@ -1903,7 +1909,13 @@ export function HouseholdPage() {
                       </select>
                       <button
                         className="household-button household-button--danger household-button--small"
-                        onClick={() => removeMember(member.id)}
+                        onClick={() =>
+                          setMemberPendingRemoval({
+                            id: member.id,
+                            name,
+                            isViewer: member.role === 'VIEWER',
+                          })
+                        }
                         aria-label={
                           member.role === 'VIEWER'
                             ? `Revoke helper access for ${name}`
@@ -3109,6 +3121,25 @@ export function HouseholdPage() {
           />
         </Suspense>
       )}
+
+      <ConfirmDialog
+        isOpen={memberPendingRemoval !== null}
+        title={memberPendingRemoval?.isViewer ? 'Revoke helper access?' : 'Remove member?'}
+        message={
+          memberPendingRemoval?.isViewer
+            ? `Revoke ${memberPendingRemoval?.name}'s read-only access to this household? They'll no longer be able to see your shared finances.`
+            : `Remove ${memberPendingRemoval?.name} from this household? They'll lose access to your shared finances, and any outstanding settle-up balances with them will be orphaned. This can't be undone.`
+        }
+        confirmLabel={memberPendingRemoval?.isViewer ? 'Revoke access' : 'Remove'}
+        variant="danger"
+        onConfirm={() => {
+          if (memberPendingRemoval) {
+            removeMember(memberPendingRemoval.id);
+          }
+          setMemberPendingRemoval(null);
+        }}
+        onCancel={() => setMemberPendingRemoval(null)}
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Removing a household member — including your partner — happened on a **single click with
no confirmation**. One accidental tap revoked a partner's access to the shared household
and orphaned their shared-expense / settle-up balances, with no undo. This is both risky
and inconsistent with the app's other destructive actions (goal delete, invoice delete),
which already confirm.

This PR gates member removal behind the app's existing accessible `ConfirmDialog`, naming
the member and the consequence before the destructive action runs.

## Changes

- `apps/web/src/pages/HouseholdPage.tsx`
  - The Remove / Revoke button now opens a confirmation instead of calling `removeMember`
    directly.
  - Added a `ConfirmDialog` (role `alertdialog`, focus-trapped) with context-aware copy:
    - **Member:** "Remove {name} from this household? They'll lose access to your shared
      finances, and any outstanding settle-up balances with them will be orphaned. This
      can't be undone." (confirm: **Remove**)
    - **Trusted helper (VIEWER):** "Revoke {name}'s read-only access…" (confirm:
      **Revoke access**)
  - `removeMember(id)` fires only on explicit confirm; cancel/Escape/backdrop dismiss safely.
- `apps/web/src/pages/HouseholdPage.test.tsx`
  - Updated the existing revoke test to assert the confirmation gate (no immediate removal,
    dialog appears, removal happens only after confirm).
  - Added a test that cancelling the confirmation does **not** remove the member.

## Accessibility

- Reuses the shared `ConfirmDialog` (`role="alertdialog"`, `aria-modal`, focus trap, focus
  restore, Escape-to-cancel) — consistent with other confirmations in the app. No new
  color-only signals.

## Issues

Closes #3383

Found by persona: Ada & Chidi Okafor (new-parents joint-finances)

## Testing

- [x] `npx vitest run src/pages/HouseholdPage.test.tsx` — 29 passed
- [x] `npx prettier --write` + `npx eslint --max-warnings 0` on both changed files — clean

## Cross-Platform

Web member-management UI only. iOS/Android/Windows household member removal should be
verified for the same confirmation pattern (tracked in the issue).
