### PR TITLE
feat(web): add per-supplier remittance breakdown (#3269)

### DIFF
--- a/apps/web/src/hooks/useRemittances.ts
+++ b/apps/web/src/hooks/useRemittances.ts
@@ -12,14 +12,20 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { summarizeRemittances } from '../lib/remittance';
-import type { CreateRemittanceInput, RemittanceRecord, RemittanceSummary } from '../lib/remittance';
+import { summarizeRemittances, summarizeByRecipient } from '../lib/remittance';
+import type {
+  CreateRemittanceInput,
+  RemittanceRecord,
+  RemittanceSummary,
+  RemittanceRecipientBreakdown,
+} from '../lib/remittance';
 
 const STORAGE_KEY = 'finance-remittances';
 
 export interface UseRemittancesResult {
   readonly remittances: readonly RemittanceRecord[];
   readonly summary: RemittanceSummary;
+  readonly recipientBreakdown: readonly RemittanceRecipientBreakdown[];
   readonly loading: boolean;
   readonly error: string | null;
   readonly refresh: () => void;
@@ -123,10 +129,12 @@ export function useRemittances(): UseRemittancesResult {
   }, []);
 
   const summary = useMemo(() => summarizeRemittances(remittances), [remittances]);
+  const recipientBreakdown = useMemo(() => summarizeByRecipient(remittances), [remittances]);
 
   return {
     remittances,
     summary,
+    recipientBreakdown,
     loading,
     error,
     refresh,

--- a/apps/web/src/lib/i18n/locales/en-US.ts
+++ b/apps/web/src/lib/i18n/locales/en-US.ts
@@ -195,6 +195,11 @@ export const EN_US_CATALOG: MessageCatalog = {
   'remittance.summary.totalCost': 'Total cost',
   'remittance.summary.destinations': 'Destinations',
   'remittance.summary.none': '—',
+  'remittance.bySupplier.title': 'By supplier',
+  'remittance.bySupplier.transfers': {
+    one: '{count} transfer',
+    other: '{count} transfers',
+  },
   'remittance.history.title': 'History',
   'remittance.history.sent': 'Sent',
   'remittance.history.fee': 'Fee',

--- a/apps/web/src/lib/i18n/locales/es-ES.ts
+++ b/apps/web/src/lib/i18n/locales/es-ES.ts
@@ -196,6 +196,11 @@ export const ES_ES_CATALOG: MessageCatalog = {
   'remittance.summary.totalCost': 'Coste total',
   'remittance.summary.destinations': 'Destinos',
   'remittance.summary.none': '—',
+  'remittance.bySupplier.title': 'Por proveedor',
+  'remittance.bySupplier.transfers': {
+    one: '{count} transferencia',
+    other: '{count} transferencias',
+  },
   'remittance.history.title': 'Historial',
   'remittance.history.sent': 'Enviado',
   'remittance.history.fee': 'Comisión',

--- a/apps/web/src/lib/remittance/index.ts
+++ b/apps/web/src/lib/remittance/index.ts
@@ -25,5 +25,5 @@ export {
   totalCostMinor,
 } from './remittance-math';
 
-export { summarizeRemittances } from './remittance-summary';
-export type { RemittanceSummary } from './remittance-summary';
+export { summarizeRemittances, summarizeByRecipient } from './remittance-summary';
+export type { RemittanceSummary, RemittanceRecipientBreakdown } from './remittance-summary';

--- a/apps/web/src/lib/remittance/remittance-summary.test.ts
+++ b/apps/web/src/lib/remittance/remittance-summary.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { summarizeRemittances } from './remittance-summary';
+import { summarizeRemittances, summarizeByRecipient } from './remittance-summary';
 import type { RemittanceRecord } from './remittance-types';
 
 function record(overrides: Partial<RemittanceRecord> = {}): RemittanceRecord {
@@ -77,5 +77,57 @@ describe('summarizeRemittances', () => {
       record({ id: 'c', recipient: { name: 'C', country: 'GT' } }),
     ]);
     expect(s.destinationCountries).toEqual(['MX', 'GT']);
+  });
+});
+
+describe('summarizeByRecipient', () => {
+  it('returns an empty list for no records', () => {
+    expect(summarizeByRecipient([])).toEqual([]);
+  });
+
+  it('groups per supplier and sorts by transfer count (desc)', () => {
+    const out = summarizeByRecipient([
+      record({ id: 'a', recipient: { name: 'Supplier A', country: 'MX' } }),
+      record({ id: 'b', recipient: { name: 'Supplier A', country: 'MX' } }),
+      record({ id: 'c', recipient: { name: 'Supplier B', country: 'GT' } }),
+    ]);
+
+    expect(out.map((r) => r.name)).toEqual(['Supplier A', 'Supplier B']);
+    expect(out[0].count).toBe(2);
+    expect(out[0].country).toBe('MX');
+    // total paid = (send + fee) per record, additive: 50500 * 2
+    expect(out[0].sentByCurrency).toEqual({ USD: 101_000 });
+    expect(out[0].receivedByCurrency).toEqual({ MXN: 1_700_000 });
+    expect(out[0].totalCostByCurrency).toEqual({ USD: 3_858 });
+    expect(out[1].count).toBe(1);
+  });
+
+  it('breaks count ties by most recent date, then name', () => {
+    const out = summarizeByRecipient([
+      record({ id: 'a', date: '2026-05-01', recipient: { name: 'Older', country: 'MX' } }),
+      record({ id: 'b', date: '2026-06-15', recipient: { name: 'Newer', country: 'MX' } }),
+    ]);
+
+    expect(out.map((r) => r.name)).toEqual(['Newer', 'Older']);
+    expect(out[0].lastDate).toBe('2026-06-15');
+  });
+
+  it('keeps a supplier paid in multiple corridors grouped per currency', () => {
+    const out = summarizeByRecipient([
+      record({ id: 'a', recipient: { name: 'Multi', country: 'MX' } }),
+      record({
+        id: 'b',
+        sourceCurrency: 'EUR',
+        destCurrency: 'INR',
+        fxRate: 90,
+        referenceRate: 91,
+        recipient: { name: 'Multi', country: 'MX' },
+      }),
+    ]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].count).toBe(2);
+    expect(Object.keys(out[0].sentByCurrency).sort()).toEqual(['EUR', 'USD']);
+    expect(Object.keys(out[0].receivedByCurrency).sort()).toEqual(['INR', 'MXN']);
   });
 });

--- a/apps/web/src/lib/remittance/remittance-summary.ts
+++ b/apps/web/src/lib/remittance/remittance-summary.ts
@@ -34,6 +34,32 @@ export interface RemittanceSummary {
   readonly destinationCountries: readonly string[];
 }
 
+/**
+ * Per-recipient (per-supplier) rollup of a remittance history.
+ *
+ * A small-business owner who pays the same overseas suppliers every month needs
+ * to see how much has gone to *each* supplier, not just a single global total.
+ * Amounts stay grouped per currency — exactly like {@link RemittanceSummary} —
+ * so a supplier paid in more than one corridor is never naively summed across
+ * currencies.
+ */
+export interface RemittanceRecipientBreakdown {
+  /** Recipient display name (user-entered, never translated). */
+  readonly name: string;
+  /** Recipient destination country (first non-empty value seen). */
+  readonly country: string;
+  /** Number of remittances sent to this recipient. */
+  readonly count: number;
+  /** Most recent send date for this recipient (`YYYY-MM-DD`). */
+  readonly lastDate: string;
+  /** Total paid (converted principal + fee), grouped by source currency. */
+  readonly sentByCurrency: Record<string, number>;
+  /** Total received, grouped by destination currency. */
+  readonly receivedByCurrency: Record<string, number>;
+  /** Total cost (fee + FX margin), grouped by source currency. */
+  readonly totalCostByCurrency: Record<string, number>;
+}
+
 function addTo(map: Record<string, number>, key: string, amount: number): void {
   map[key] = (map[key] ?? 0) + amount;
 }
@@ -83,4 +109,74 @@ export function summarizeRemittances(records: readonly RemittanceRecord[]): Remi
     totalCostByCurrency,
     destinationCountries: countries,
   };
+}
+
+/**
+ * Group a remittance history by recipient so per-supplier spend is visible.
+ *
+ * Records are grouped by trimmed recipient name and re-quoted with
+ * {@link quoteRemittance} for the same rounding as the per-row display. The
+ * result is sorted by transfer count (desc), then most recent date (desc), then
+ * name — so the busiest supplier relationships surface first without ever
+ * comparing amounts across currencies.
+ */
+export function summarizeByRecipient(
+  records: readonly RemittanceRecord[],
+): RemittanceRecipientBreakdown[] {
+  const groups = new Map<
+    string,
+    {
+      name: string;
+      country: string;
+      count: number;
+      lastDate: string;
+      sentByCurrency: Record<string, number>;
+      receivedByCurrency: Record<string, number>;
+      totalCostByCurrency: Record<string, number>;
+    }
+  >();
+
+  for (const record of records) {
+    const name = record.recipient.name.trim();
+    let group = groups.get(name);
+    if (!group) {
+      group = {
+        name,
+        country: record.recipient.country.trim(),
+        count: 0,
+        lastDate: record.date,
+        sentByCurrency: {},
+        receivedByCurrency: {},
+        totalCostByCurrency: {},
+      };
+      groups.set(name, group);
+    }
+
+    const quote = quoteRemittance({
+      sendAmountMinor: record.sendAmountMinor,
+      feeMinor: record.feeMinor,
+      fxRate: record.fxRate,
+      feeModel: record.feeModel,
+      sourceCurrency: record.sourceCurrency,
+      destCurrency: record.destCurrency,
+      referenceRate: record.referenceRate ?? undefined,
+    });
+
+    group.count += 1;
+    if (record.date > group.lastDate) {
+      group.lastDate = record.date;
+    }
+    if (!group.country && record.recipient.country.trim()) {
+      group.country = record.recipient.country.trim();
+    }
+    addTo(group.sentByCurrency, record.sourceCurrency, quote.totalPaidMinor);
+    addTo(group.receivedByCurrency, record.destCurrency, quote.receivedMinor);
+    addTo(group.totalCostByCurrency, record.sourceCurrency, quote.totalCostMinor ?? quote.feeMinor);
+  }
+
+  return Array.from(groups.values()).sort((a, b) => {
+    if (a.count !== b.count) return b.count - a.count;
+    if (a.lastDate !== b.lastDate) return a.lastDate < b.lastDate ? 1 : -1;
+    return a.name.localeCompare(b.name);
+  });
 }

--- a/apps/web/src/pages/RemittancesPage.test.tsx
+++ b/apps/web/src/pages/RemittancesPage.test.tsx
@@ -33,6 +33,7 @@ function buildResult(overrides: Partial<ReturnType<typeof useRemittances>> = {})
   return {
     remittances: [],
     summary: EMPTY_SUMMARY,
+    recipientBreakdown: [],
     loading: false,
     error: null,
     refresh: vi.fn(),
@@ -85,6 +86,37 @@ describe('RemittancesPage', () => {
     mockUseRemittances.mockReturnValue(buildResult());
     render(<RemittancesPage />);
     expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('renders a per-supplier breakdown when records exist', () => {
+    mockUseRemittances.mockReturnValue(
+      buildResult({
+        remittances: [SAMPLE_RECORD],
+        summary: {
+          count: 1,
+          sentByCurrency: { USD: 50_500 },
+          feesByCurrency: { USD: 500 },
+          receivedByCurrency: { MXN: 850_000 },
+          totalCostByCurrency: { USD: 1_929 },
+          destinationCountries: ['MX'],
+        },
+        recipientBreakdown: [
+          {
+            name: 'Mumbai Textiles',
+            country: 'IN',
+            count: 3,
+            lastDate: '2026-06-01',
+            sentByCurrency: { USD: 151_500 },
+            receivedByCurrency: { INR: 12_600_000 },
+            totalCostByCurrency: { USD: 5_787 },
+          },
+        ],
+      }),
+    );
+    render(<RemittancesPage />);
+
+    expect(screen.getByRole('region', { name: 'By supplier' })).toBeInTheDocument();
+    expect(screen.getByText(/Mumbai Textiles/)).toBeInTheDocument();
   });
 
   it('renders a live estimate once amount and rate are entered', () => {

--- a/apps/web/src/pages/RemittancesPage.tsx
+++ b/apps/web/src/pages/RemittancesPage.tsx
@@ -295,8 +295,16 @@ const HistoryItem: React.FC<HistoryItemProps> = ({ record, locale, t, onDelete }
 
 export const RemittancesPage: React.FC = () => {
   const { locale } = useLocalePreferences();
-  const { remittances, summary, loading, error, refresh, createRemittance, deleteRemittance } =
-    useRemittances();
+  const {
+    remittances,
+    summary,
+    recipientBreakdown,
+    loading,
+    error,
+    refresh,
+    createRemittance,
+    deleteRemittance,
+  } = useRemittances();
 
   const t = useCallback(
     (id: string, values: Record<string, string | number> = {}) =>
@@ -843,6 +851,30 @@ export const RemittancesPage: React.FC = () => {
               </article>
             </div>
           </section>
+
+          {recipientBreakdown.length > 0 && (
+            <section className="remittance-section" aria-label={t('remittance.bySupplier.title')}>
+              <h2 className="remittance-section__title">{t('remittance.bySupplier.title')}</h2>
+              <div className="remittance-summary-grid" role="list">
+                {recipientBreakdown.map((recipient) => (
+                  <article key={recipient.name} className="remittance-metric" role="listitem">
+                    <p className="remittance-metric__label">
+                      {recipient.name}
+                      {recipient.country ? ` · ${formatCountry(recipient.country, locale)}` : ''}
+                    </p>
+                    <p className="remittance-metric__value">
+                      {formatCurrencyGroup(recipient.sentByCurrency, locale)}
+                    </p>
+                    <p className="remittance-metric__label">
+                      {t('remittance.bySupplier.transfers', { count: recipient.count })} ·{' '}
+                      {t('remittance.summary.totalCost')}:{' '}
+                      {formatCurrencyGroup(recipient.totalCostByCurrency, locale)}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            </section>
+          )}
 
           <section className="remittance-section" aria-label={t('remittance.history.title')}>
             <h2 className="remittance-section__title">


### PR DESCRIPTION
## Summary

The Remittances page only rolled spending up **by currency**, so Priya — who pays the same two overseas fabric suppliers in India every month — could not see how much has gone to **each supplier**, or which relationship is her biggest cost. This adds a currency-safe per-supplier breakdown.

## Changes

- **`summarizeByRecipient()`** (`lib/remittance/remittance-summary.ts`) — groups a remittance history by trimmed recipient name, re-quotes each transfer with the existing `quoteRemittance` (so rounding matches the per-row display), and keeps **per-currency** `sent`/`received`/`totalCost` maps. It never sums minor units across currencies, and sorts by transfer count (desc) → most recent date (desc) → name, so the busiest supplier relationships surface first without comparing amounts across currencies.
- **`useRemittances`** exposes a memoized `recipientBreakdown`.
- **`RemittancesPage`** renders a **"By supplier"** region (`role="list"`) between the currency summary and the history list, showing each supplier's total sent, transfer count (pluralized), and total cost.
- **i18n**: `remittance.bySupplier.title` + `remittance.bySupplier.transfers` (plural `{one, other}`) added to **both** `en-US` and `es-ES`.

## Currency safety

Follows the same discipline as `summarizeRemittances`: all amounts stay grouped per currency via `formatCurrencyGroup`; a supplier paid in more than one corridor is shown per-currency, never naively added together.

## Accessibility

- The new section is a labelled `region` (`aria-label="By supplier"`) with an `<h2>` and a `role="list"` / `role="listitem"` structure.
- Transfer counts are pluralized through the i18n catalog (no "1 transfers").

## Issues

Closes #3269

## Testing

- [x] `summarizeByRecipient` unit tests: empty input, grouping + count/date sort, multi-corridor currency safety (4 new tests).
- [x] `RemittancesPage` render test: the "By supplier" region + supplier name appear when records exist.
- [x] Full web suite green locally: 18 files / 64 tests pass.
- [x] `prettier --check` + `eslint --max-warnings 0` clean on all changed files.

Found by persona: Priya Sharma (etsy small-business owner)
