### PR TITLE
fix(web): apply accessibility font size via inline root size (#3275)

### DIFF
--- a/apps/web/src/contexts/AccessibilityContext.tsx
+++ b/apps/web/src/contexts/AccessibilityContext.tsx
@@ -11,6 +11,11 @@ import {
   type ReactNode,
 } from 'react';
 
+import {
+  applyFontScalePreference,
+  getFontScaleOption,
+  getStoredFontScalePreference,
+} from '../hooks/useFontScale';
 import { useReducedMotion } from '../hooks/useReducedMotion';
 import { formatCurrencyForScreenReader } from '../lib/a11y';
 
@@ -53,6 +58,20 @@ const ROOT_FONT_SIZES: Record<AccessibilityFontSize, string> = {
   normal: '16px',
   large: '18px',
   'extra-large': '20px',
+};
+
+/**
+ * Accessibility "Font size" root sizes in CSS pixels.
+ *
+ * Mirrors {@link ROOT_FONT_SIZES} numerically so the effective root font size
+ * can be reconciled with the Display "Text size" scale (see useFontScale),
+ * which applies an inline root font-size that outranks the
+ * `html[data-accessibility-font-size]` rules in accessibility.css.
+ */
+const ACCESSIBILITY_ROOT_FONT_PIXELS: Record<AccessibilityFontSize, number> = {
+  normal: 16,
+  large: 18,
+  'extra-large': 20,
 };
 
 export const DEFAULT_ACCESSIBILITY_SETTINGS: AccessibilitySettings = {
@@ -143,6 +162,15 @@ function applyDomSettings(
     settings.accessibilityMode === 'simplified' ? '56px' : '48px',
   );
 
+  // The Display "Text size" control (useFontScale) writes an inline root
+  // font-size, which outranks the html[data-accessibility-font-size] rules in
+  // accessibility.css. Apply the accessibility font size through the same
+  // inline channel so it is not silently defeated, using the larger of the two
+  // preferences so neither control shrinks a size the user chose elsewhere.
+  const accessibilityRootPixels = ACCESSIBILITY_ROOT_FONT_PIXELS[settings.fontSize];
+  const displayRootPixels = getFontScaleOption(getStoredFontScalePreference()).basePixels;
+  root.style.fontSize = `${Math.max(accessibilityRootPixels, displayRootPixels)}px`;
+
   return () => {
     body.classList.remove(
       'accessibility-simplified',
@@ -159,6 +187,9 @@ function applyDomSettings(
     delete root.dataset.accessibilityFontSize;
     root.style.removeProperty('--accessibility-root-font-size');
     root.style.removeProperty('--accessibility-touch-target-size');
+    // Hand the inline root font-size back to the Display "Text size" preference
+    // so removing the provider does not strand the accessibility size.
+    applyFontScalePreference(getStoredFontScalePreference());
   };
 }
 

--- a/apps/web/src/hooks/useAccessibility.test.tsx
+++ b/apps/web/src/hooks/useAccessibility.test.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AccessibilityProvider } from '../contexts/AccessibilityContext';
+import { FONT_SCALE_STORAGE_KEY } from './useFontScale';
 import { useAccessibility } from './useAccessibility';
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -70,5 +71,38 @@ describe('useAccessibility', () => {
 
     expect(result.current.accessibilityMode).toBe('standard');
     expect(result.current.toggleAccessibilityMode).not.toThrow();
+  });
+
+  it('applies the accessibility font size as an inline root font-size', () => {
+    const { result } = renderHook(() => useAccessibility(), { wrapper });
+
+    act(() => {
+      result.current.setFontSize('extra-large');
+    });
+
+    expect(document.documentElement.style.fontSize).toBe('20px');
+  });
+
+  it('enlarges the root font size when simplified mode is enabled', () => {
+    const { result } = renderHook(() => useAccessibility(), { wrapper });
+
+    act(() => {
+      result.current.toggleAccessibilityMode();
+    });
+
+    expect(result.current.fontSize).toBe('extra-large');
+    expect(document.documentElement.style.fontSize).toBe('20px');
+  });
+
+  it('preserves a larger Display text-size preference over the accessibility size', () => {
+    localStorage.setItem(FONT_SCALE_STORAGE_KEY, 'huge');
+    const { result } = renderHook(() => useAccessibility(), { wrapper });
+
+    act(() => {
+      result.current.setFontSize('large');
+    });
+
+    // Display "Huge" (32px) outranks the accessibility "large" size (18px).
+    expect(document.documentElement.style.fontSize).toBe('32px');
   });
 });


### PR DESCRIPTION
## Summary

The Accessibility **Font size** control (Settings -> Accessibility) and **Simplified mode** never actually enlarged text. Both wrote only a `data-accessibility-font-size` attribute plus the `--accessibility-root-font-size` CSS variable, relying on the `html[data-accessibility-font-size='...']` rules in `accessibility.css` to resize the root. But the Display **Text size** control (`useFontScale`) writes an **inline** `style.fontSize` on `<html>` at bootstrap (`main.tsx:45`), and an inline style outranks any attribute-selector rule. So for every user whose Display size was at the default, choosing a larger accessibility font size -- or turning on Simplified mode -- did nothing.

For a low-vision user this is the single most important control silently failing.

## Root cause

- `apps/web/src/hooks/useFontScale.ts:94` -- `applyFontScalePreference` sets `document.documentElement.style.fontSize` inline (applied at bootstrap in `main.tsx:45`, always present).
- `apps/web/src/contexts/AccessibilityContext.tsx` -- `applyDomSettings` set only the attribute + `--accessibility-root-font-size` var.
- `apps/web/src/styles/accessibility.css:306-316` -- `html[data-accessibility-font-size]` font-size rules are defeated by the inline style (higher specificity/priority), so the accessibility size and the Simplified `extra-large` preset were inert.

## Fix

`AccessibilityContext` now applies the accessibility font size through the **same inline channel** that actually wins, reconciled with the Display preference:

- Adds `ACCESSIBILITY_ROOT_FONT_PIXELS` (normal 16 / large 18 / extra-large 20).
- In `applyDomSettings`, sets `root.style.fontSize` to `max(accessibilityPixels, displayPixels)` -- the accessibility size now takes effect, and a larger Display size is never shrunk.
- On provider cleanup, hands the inline root size back to the Display preference (`applyFontScalePreference(getStoredFontScalePreference())`) so unmount does not strand the accessibility size.

Taking the **max** means the two redundant text-size controls compose predictably instead of fighting: whichever the user set larger wins.

## Changes

- `apps/web/src/contexts/AccessibilityContext.tsx` -- inline `max()` root font-size write + cleanup restore; new pixel map; imports from `useFontScale`.
- `apps/web/src/hooks/useAccessibility.test.tsx` -- 3 regression tests: accessibility `extra-large` -> `20px`; Simplified mode -> `20px`; Display `huge` preserved over accessibility `large` -> `32px`.

## Testing

- [x] `npx vitest run src/hooks/useAccessibility.test.tsx src/hooks/useFontScale.test.ts` -> 11/11 pass (3 new; no `useFontScale` regression)
- [x] `npx vitest run src/pages/OnboardingPage.test.tsx` -> 30/30 pass (Display `%` path unaffected)
- [x] `npx eslint <files> --max-warnings 0` -> exit 0
- [x] `npx prettier --check <files>` -> clean

## Follow-up (not in this PR)

The app has three overlapping text-size entry points (Display Text size, Accessibility Font size, Simplified preset). This PR makes them all functional and mutually consistent via `max()`, but consolidating them into a single control remains a product decision -- tracked in the discussion on #3275.

## Issues

Closes #3275

Found by persona: Harold Whitfield (retiree low-vision fixed-income)
