### PR TITLE
feat(web): ship the professional / early-career starter budget template (#3416)

### DIFF
--- a/apps/web/src/lib/budgeting/starter-budget-templates.test.ts
+++ b/apps/web/src/lib/budgeting/starter-budget-templates.test.ts
@@ -49,7 +49,7 @@ describe('starter budget templates', () => {
     expect(calculateStarterTemplateTotal('food-meals')).toBe(70_000);
   });
 
-  it('keeps future starter templates visible but unavailable while family is available', () => {
+  it('exposes the professional template as available while retiree stays coming soon', () => {
     const templateIds = getBudgetStarterTemplates().map((template) => template.id);
 
     expect(templateIds).toEqual(['student', 'food-meals', 'family', 'professional', 'retiree']);
@@ -57,7 +57,27 @@ describe('starter budget templates', () => {
       'student',
       'food-meals',
       'family',
+      'professional',
     ]);
+
+    const retiree = getBudgetStarterTemplateById('retiree');
+    expect(retiree?.isAvailable).toBe(false);
+    expect(retiree?.availabilityLabel).toBe('Coming soon');
+  });
+
+  it('includes a professional starter template with an emergency fund and student loan payment', () => {
+    const professionalTemplate = getBudgetStarterTemplateById('professional');
+
+    expect(professionalTemplate).not.toBeNull();
+    expect(professionalTemplate?.isAvailable).toBe(true);
+    expect(professionalTemplate?.availabilityLabel).toBeUndefined();
+
+    const categoryNames = professionalTemplate?.categories.map((category) => category.name) ?? [];
+    expect(categoryNames).toContain('Emergency Fund');
+    expect(categoryNames).toContain('Student Loan Payment');
+    expect(categoryNames).toContain('Rent/Housing');
+
+    expect(calculateStarterTemplateTotal('professional')).toBe(308_000);
   });
 
   it('shares the student income guidance copy', () => {

--- a/apps/web/src/lib/budgeting/starter-budget-templates.ts
+++ b/apps/web/src/lib/budgeting/starter-budget-templates.ts
@@ -167,16 +167,83 @@ const FOOD_MEALS_TEMPLATE: BudgetStarterTemplate = {
   ],
 };
 
+const PROFESSIONAL_TEMPLATE: BudgetStarterTemplate = {
+  id: 'professional',
+  name: 'Professional',
+  description:
+    'A starter budget for a steady entry-level paycheck: rent, groceries, commute, a student-loan payment, an emergency fund, and savings.',
+  guidance:
+    'Starting points for a steady early-career paycheck. Adjust to your take-home pay - a common split is needs ~50%, wants ~30%, savings & debt ~20%.',
+  isAvailable: true,
+  categories: [
+    { emoji: '🏠', name: 'Rent/Housing', amountCents: 120_000, icon: 'home', color: '#7C3AED' },
+    {
+      emoji: '🍽️',
+      name: 'Food & Groceries',
+      amountCents: 40_000,
+      icon: 'utensils',
+      color: '#16A34A',
+    },
+    {
+      emoji: '🚇',
+      name: 'Commute & Transport',
+      amountCents: 15_000,
+      icon: 'car',
+      color: '#2563EB',
+    },
+    {
+      emoji: '💡',
+      name: 'Utilities',
+      amountCents: 12_000,
+      icon: 'wallet',
+      color: '#0EA5E9',
+    },
+    {
+      emoji: '🎓',
+      name: 'Student Loan Payment',
+      amountCents: 30_000,
+      icon: 'package',
+      color: '#F59E0B',
+    },
+    {
+      emoji: '🛟',
+      name: 'Emergency Fund',
+      amountCents: 30_000,
+      icon: 'wallet',
+      color: '#0284C7',
+    },
+    {
+      emoji: '📈',
+      name: 'Retirement & Savings',
+      amountCents: 25_000,
+      icon: 'wallet',
+      color: '#059669',
+    },
+    {
+      emoji: '📱',
+      name: 'Phone & Subscriptions',
+      amountCents: 8_000,
+      icon: 'wallet',
+      color: '#6366F1',
+    },
+    {
+      emoji: '💊',
+      name: 'Health & Wellness',
+      amountCents: 8_000,
+      icon: 'heart-pulse',
+      color: '#EF4444',
+    },
+    {
+      emoji: '🎉',
+      name: 'Fun & Social',
+      amountCents: 20_000,
+      icon: 'film',
+      color: '#DB2777',
+    },
+  ],
+};
+
 const COMING_SOON_TEMPLATES: readonly BudgetStarterTemplate[] = [
-  {
-    id: 'professional',
-    name: 'Professional',
-    description: 'Built for early-career budgets with commuting and career growth costs.',
-    guidance: 'Coming soon',
-    categories: [],
-    isAvailable: false,
-    availabilityLabel: 'Coming soon',
-  },
   {
     id: 'retiree',
     name: 'Retiree',
@@ -192,6 +259,7 @@ const STARTER_BUDGET_TEMPLATES: readonly BudgetStarterTemplate[] = [
   STUDENT_TEMPLATE,
   FOOD_MEALS_TEMPLATE,
   SINGLE_PARENT_FAMILY_TEMPLATE,
+  PROFESSIONAL_TEMPLATE,
   ...COMING_SOON_TEMPLATES,
 ] as const;
 


### PR DESCRIPTION
## Summary

Ships the **Professional** starter budget template, which until now was an empty `Coming soon` placeholder. Maya (a brand-new grad on her first salaried paycheck) does not fit the Student template, and the option that looked made for her was disabled — so she had nothing to start from.

The template is aimed at a steady entry-level paycheck and is deliberately loan-and-savings aware, which is exactly what an early-career budgeter needs.

## Changes

- Add `PROFESSIONAL_TEMPLATE` (`isAvailable: true`) in `apps/web/src/lib/budgeting/starter-budget-templates.ts` with 10 categories totalling **$3,080** (308,000 cents):
  - Rent/Housing, Food & Groceries, Commute & Transport, Utilities, **Student Loan Payment**, **Emergency Fund**, Retirement & Savings, Phone & Subscriptions, Health & Wellness, Fun & Social.
  - Guidance nudges a ~50% needs / 30% wants / 20% savings & debt split.
- Remove the empty `professional` entry from `COMING_SOON_TEMPLATES` so only **Retiree** remains labelled "Coming soon".
- Insert `PROFESSIONAL_TEMPLATE` into `STARTER_BUDGET_TEMPLATES` preserving the existing id order (`student, food-meals, family, professional, retiree`).
- Reuse only icon tokens already shipped by existing templates (`home, utensils, car, wallet, package, heart-pulse, film`) — no new icon vocabulary.

Because `BudgetForm` reads `template.isAvailable` at runtime, the Professional template now renders as a **selectable, non-disabled** option in the budget-creation template picker, and it drops out of onboarding's "more templates coming soon" list automatically.

> Note: onboarding's dedicated starter-budget step still auto-applies the Student template (it hard-codes `studentTemplate`). Turning that step into a multi-template picker is a separate UX change that overlaps other in-flight onboarding work, so it is intentionally out of scope here — this PR ships the template and makes it selectable everywhere starter templates are offered.

## Issues

Closes #3416

Found by persona: Maya Chen (new-grad first-job budgeter)

## Testing

- [x] `npx prettier --write` + `npx eslint --max-warnings 0` clean on both changed files
- [x] `npx vitest run` — `starter-budget-templates.test.ts`, `single-parent-starter-template.test.ts`, `BudgetForm.test.tsx` (14 tests pass)
- Added a focused test asserting the Professional template is available, includes Emergency Fund + Student Loan Payment, and totals 308,000 cents; updated the availability-list test to include `professional`.

## Platform scope

Web-only. The starter-template data lives in `apps/web`; iOS/Android/Windows do not consume this TypeScript module.
