### PR TITLE
feat(web): allow goal withdrawals and corrections (#3393)

### DIFF
--- a/apps/web/src/components/goals/GoalContributionDialog.test.tsx
+++ b/apps/web/src/components/goals/GoalContributionDialog.test.tsx
@@ -108,4 +108,34 @@ describe('GoalContributionDialog', () => {
       });
     });
   });
+
+  it('submits a withdrawal as a negative amount', async () => {
+    const { onSubmit, onCancel } = renderDialog();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Withdraw' }));
+    fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '100.00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Withdraw' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        goalId: 'goal-1',
+        amount: { amount: -10000 },
+        note: null,
+      });
+    });
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('blocks a withdrawal larger than the saved amount', async () => {
+    const { onSubmit } = renderDialog();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Withdraw' }));
+    fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '300.00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Withdraw' }));
+
+    expect(
+      await screen.findByText('You can only withdraw up to the amount saved for this goal.'),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/goals/GoalContributionDialog.tsx
+++ b/apps/web/src/components/goals/GoalContributionDialog.tsx
@@ -42,6 +42,7 @@ export function GoalContributionDialog({
     allowNegative: false,
   });
   const [note, setNote] = useState('');
+  const [mode, setMode] = useState<'contribute' | 'withdraw'>('contribute');
   const [amountError, setAmountError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -56,6 +57,7 @@ export function GoalContributionDialog({
 
     amountInput.reset(0);
     setNote('');
+    setMode('contribute');
     setAmountError(null);
     setSubmitError(null);
     setSubmitting(false);
@@ -101,19 +103,28 @@ export function GoalContributionDialog({
       return null;
     }
 
-    const amountInMinorUnits = amountInput.cents;
-    if (amountInMinorUnits <= 0) {
-      setAmountError('Enter a positive contribution amount.');
+    const magnitude = amountInput.cents;
+    if (magnitude <= 0) {
+      setAmountError(
+        mode === 'withdraw'
+          ? 'Enter a positive amount to withdraw.'
+          : 'Enter a positive contribution amount.',
+      );
+      return null;
+    }
+
+    if (mode === 'withdraw' && magnitude > goal.currentAmount.amount) {
+      setAmountError('You can only withdraw up to the amount saved for this goal.');
       return null;
     }
 
     setAmountError(null);
     return {
       goalId: goal.id,
-      amount: { amount: amountInMinorUnits },
+      amount: { amount: mode === 'withdraw' ? -magnitude : magnitude },
       note: note.trim() || null,
     };
-  }, [amountInput.cents, goal, note]);
+  }, [amountInput.cents, goal, mode, note]);
 
   const handleSubmit = useCallback(
     async (event: FormEvent) => {
@@ -124,7 +135,10 @@ export function GoalContributionDialog({
         return;
       }
 
-      if (goal.currentAmount.amount + input.amount.amount > goal.targetAmount.amount) {
+      if (
+        input.amount.amount > 0 &&
+        goal.currentAmount.amount + input.amount.amount > goal.targetAmount.amount
+      ) {
         setPendingInput(input);
         return;
       }
@@ -161,10 +175,11 @@ export function GoalContributionDialog({
   }
 
   const hasAmountError = amountError !== null;
+  const signedPreview = mode === 'withdraw' ? -amountInput.cents : amountInput.cents;
   const projectedAmount =
     amountInput.cents <= 0
       ? goal.currentAmount.amount
-      : goal.currentAmount.amount + amountInput.cents;
+      : Math.max(0, goal.currentAmount.amount + signedPreview);
 
   return (
     <>
@@ -178,7 +193,7 @@ export function GoalContributionDialog({
           aria-labelledby={titleId}
         >
           <h2 id={titleId} className="form-dialog__title">
-            Contribute to {goal.name}
+            {mode === 'withdraw' ? 'Withdraw from' : 'Contribute to'} {goal.name}
           </h2>
 
           <div
@@ -196,7 +211,9 @@ export function GoalContributionDialog({
               </p>
             </div>
             <div>
-              <p className="card__title">After contribution</p>
+              <p className="card__title">
+                {mode === 'withdraw' ? 'After withdrawal' : 'After contribution'}
+              </p>
               <p className="card__value">
                 <CurrencyDisplay amount={projectedAmount} currency={goal.currency.code} />
               </p>
@@ -211,6 +228,38 @@ export function GoalContributionDialog({
 
           <form onSubmit={handleSubmit} noValidate>
             <div className="form-fields">
+              <fieldset className="form-radio-group form-fieldset">
+                <legend className="form-radio-group__legend">Adjustment type</legend>
+                <div className="form-radio-group__options">
+                  <label className="form-radio-option">
+                    <input
+                      type="radio"
+                      name="goal-adjustment-mode"
+                      value="contribute"
+                      checked={mode === 'contribute'}
+                      onChange={() => {
+                        setMode('contribute');
+                        setAmountError(null);
+                      }}
+                    />
+                    <span className="form-radio-option__label">Contribute</span>
+                  </label>
+                  <label className="form-radio-option">
+                    <input
+                      type="radio"
+                      name="goal-adjustment-mode"
+                      value="withdraw"
+                      checked={mode === 'withdraw'}
+                      onChange={() => {
+                        setMode('withdraw');
+                        setAmountError(null);
+                      }}
+                    />
+                    <span className="form-radio-option__label">Withdraw</span>
+                  </label>
+                </div>
+              </fieldset>
+
               <div className="form-group">
                 <label
                   htmlFor="goal-contribution-amount"
@@ -247,7 +296,7 @@ export function GoalContributionDialog({
                   value={note}
                   onChange={(event) => setNote(event.target.value)}
                   rows={3}
-                  placeholder="Optional note about this contribution"
+                  placeholder="Optional note about this adjustment"
                 />
               </div>
             </div>
@@ -267,7 +316,13 @@ export function GoalContributionDialog({
                 disabled={submitting}
                 aria-busy={submitting}
               >
-                {submitting ? 'Contributing...' : 'Submit'}
+                {submitting
+                  ? mode === 'withdraw'
+                    ? 'Withdrawing...'
+                    : 'Contributing...'
+                  : mode === 'withdraw'
+                    ? 'Withdraw'
+                    : 'Submit'}
               </button>
             </div>
           </form>

--- a/apps/web/src/db/repositories/goals.test.ts
+++ b/apps/web/src/db/repositories/goals.test.ts
@@ -572,7 +572,7 @@ describe('goals repository', () => {
       expect(goal?.status).toBe('COMPLETED');
     });
 
-    it('rejects non-positive contribution amounts', () => {
+    it('rejects a zero adjustment amount', () => {
       mockQueryOne.mockReturnValue({
         id: 'goal-1',
         household_id: 'hh-1',
@@ -594,7 +594,143 @@ describe('goals repository', () => {
 
       expect(() =>
         contributeToGoal(mockDb, 'goal-1', { goalId: 'goal-1', amount: { amount: 0 } }),
-      ).toThrow('Contribution amount must be greater than zero.');
+      ).toThrow('Adjustment amount must be a non-zero value.');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('records a withdrawal by reducing the current amount', () => {
+      mockQueryOne
+        .mockReturnValueOnce({
+          id: 'goal-1',
+          household_id: 'hh-1',
+          name: 'Goal',
+          description: null,
+          target_amount: 100000,
+          current_amount: 40000,
+          currency: 'USD',
+          target_date: null,
+          status: 'ACTIVE',
+          icon: null,
+          color: null,
+          account_id: null,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+          deleted_at: null,
+          sync_version: 1,
+          is_synced: 0,
+        })
+        .mockReturnValueOnce({
+          id: 'goal-1',
+          household_id: 'hh-1',
+          name: 'Goal',
+          description: null,
+          target_amount: 100000,
+          current_amount: 25000,
+          currency: 'USD',
+          target_date: null,
+          status: 'ACTIVE',
+          icon: null,
+          color: null,
+          account_id: null,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          deleted_at: null,
+          sync_version: 1,
+          is_synced: 0,
+        });
+
+      const goal = contributeToGoal(mockDb, 'goal-1', {
+        goalId: 'goal-1',
+        amount: { amount: -15000 },
+        note: 'Emergency withdrawal',
+      });
+
+      expect(mockExecute).toHaveBeenCalledWith(mockDb, expect.stringContaining('UPDATE goal'), [
+        25000,
+        'ACTIVE',
+        'goal-1',
+      ]);
+      expect(mockExecute).toHaveBeenCalledWith(
+        mockDb,
+        expect.stringContaining('INSERT INTO goal_progress_contribution'),
+        expect.arrayContaining([expect.any(String), 'goal-1', 'hh-1', -15000, 'USD']),
+      );
+      expect(goal?.currentAmount.amount).toBe(25000);
+    });
+
+    it('reverts a completed goal to active when a withdrawal drops below target', () => {
+      mockQueryOne
+        .mockReturnValueOnce({
+          id: 'goal-1',
+          household_id: 'hh-1',
+          name: 'Goal',
+          description: null,
+          target_amount: 100000,
+          current_amount: 105000,
+          currency: 'USD',
+          target_date: null,
+          status: 'COMPLETED',
+          icon: null,
+          color: null,
+          account_id: null,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+          deleted_at: null,
+          sync_version: 1,
+          is_synced: 0,
+        })
+        .mockReturnValueOnce({
+          id: 'goal-1',
+          household_id: 'hh-1',
+          name: 'Goal',
+          description: null,
+          target_amount: 100000,
+          current_amount: 95000,
+          currency: 'USD',
+          target_date: null,
+          status: 'ACTIVE',
+          icon: null,
+          color: null,
+          account_id: null,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          deleted_at: null,
+          sync_version: 1,
+          is_synced: 0,
+        });
+
+      const goal = contributeToGoal(mockDb, 'goal-1', {
+        goalId: 'goal-1',
+        amount: { amount: -10000 },
+      });
+
+      expect((mockExecute.mock.calls[0][2] as unknown[])[1]).toBe('ACTIVE');
+      expect(goal?.status).toBe('ACTIVE');
+    });
+
+    it('rejects a withdrawal larger than the amount saved', () => {
+      mockQueryOne.mockReturnValue({
+        id: 'goal-1',
+        household_id: 'hh-1',
+        name: 'Goal',
+        target_amount: 100000,
+        current_amount: 25000,
+        currency: 'USD',
+        target_date: null,
+        status: 'ACTIVE',
+        icon: null,
+        color: null,
+        account_id: null,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+        deleted_at: null,
+        sync_version: 1,
+        is_synced: 0,
+      });
+
+      expect(() =>
+        contributeToGoal(mockDb, 'goal-1', { goalId: 'goal-1', amount: { amount: -30000 } }),
+      ).toThrow('A withdrawal cannot exceed the amount saved for this goal.');
       expect(mockExecute).not.toHaveBeenCalled();
     });
   });

--- a/apps/web/src/db/repositories/goals.ts
+++ b/apps/web/src/db/repositories/goals.ts
@@ -237,7 +237,14 @@ export function updateGoal(db: SqliteDb, goalId: SyncId, updates: UpdateGoalInpu
   return updatedGoal;
 }
 
-/** Add a positive contribution amount to a goal's current progress. */
+/**
+ * Apply a signed adjustment to a goal's current progress.
+ *
+ * A positive amount records a contribution; a negative amount records a
+ * withdrawal or correction. A withdrawal cannot exceed the amount already
+ * saved, and a goal that drops back below its target is reverted from
+ * `COMPLETED` to `ACTIVE`.
+ */
 export function contributeToGoal(
   db: SqliteDb,
   goalId: SyncId,
@@ -248,13 +255,21 @@ export function contributeToGoal(
     return null;
   }
 
-  if (!Number.isFinite(input.amount.amount) || input.amount.amount <= 0) {
-    throw new Error('Contribution amount must be greater than zero.');
+  if (!Number.isFinite(input.amount.amount) || input.amount.amount === 0) {
+    throw new Error('Adjustment amount must be a non-zero value.');
   }
 
   const nextCurrentAmount = existingGoal.currentAmount.amount + input.amount.amount;
+  if (nextCurrentAmount < 0) {
+    throw new Error('A withdrawal cannot exceed the amount saved for this goal.');
+  }
+
   const nextStatus =
-    nextCurrentAmount >= existingGoal.targetAmount.amount ? 'COMPLETED' : existingGoal.status;
+    nextCurrentAmount >= existingGoal.targetAmount.amount
+      ? 'COMPLETED'
+      : existingGoal.status === 'COMPLETED'
+        ? 'ACTIVE'
+        : existingGoal.status;
 
   const contributionId = crypto.randomUUID();
 


### PR DESCRIPTION
## Summary

Goal contributions were **positive-only** — there was no way to record a **withdrawal or
correction**. If the Okafors pull money out of their house fund for an emergency, or
fat-finger a contribution, their only "undo" was deleting the entire goal. This adds a
signed **Contribute / Withdraw** adjustment so a goal's saved balance and history reflect
reality.

## Changes

- `apps/web/src/db/repositories/goals.ts`
  - `contributeToGoal` now applies a **signed** adjustment. A negative amount records a
    withdrawal/correction; the signed entry is written to `goal_progress_contribution` so
    history stays accurate.
  - Guards: rejects a **zero** amount; rejects a withdrawal that would exceed the amount
    saved (balance can't go negative).
  - Status recompute: a goal that drops back below its target is reverted from `COMPLETED`
    to `ACTIVE` (positive contributions still complete a goal as before).
- `apps/web/src/components/goals/GoalContributionDialog.tsx`
  - Added an accessible **Contribute / Withdraw** radio group (reuses the existing
    `form-radio-group` pattern).
  - Withdraw mode submits a negative amount, validates the magnitude is positive and does
    not exceed the saved balance, updates the "After …" projection, and relabels the title
    and submit button. The over-goal confirmation now only triggers for contributions.
- Tests:
  - `goals.test.ts` — withdrawal reduces the balance and writes a negative ledger entry;
    a completed goal reverts to active when it drops below target; over-withdrawal and
    zero-amount are rejected.
  - `GoalContributionDialog.test.tsx` — withdraw submits a negative amount; over-withdrawal
    is blocked with an inline error.

## Accessibility

- Mode toggle is a semantic `fieldset`/`legend` radio group (keyboard + screen-reader
  friendly); amount errors announced via existing `role="alert"`; no color-only signals.

## Issues

Closes #3393

Found by persona: Ada & Chidi Okafor (new-parents joint-finances)

## Testing

- [x] `npx vitest run src/db/repositories/goals.test.ts src/components/goals/GoalContributionDialog.test.tsx` — 35 passed
- [x] `npx vitest run src/pages/GoalDetailPage.test.tsx src/pages/GoalsPage.test.tsx src/hooks/__tests__/useGoals.test.ts` — 42 passed (no regressions)
- [x] `npx prettier --write` + `npx eslint --max-warnings 0` on all four changed files — clean

## Cross-Platform

Web goals only. Parity check for goal contribution/withdrawal flows on iOS/Android/Windows
tracked in the issue.
