### PR TITLE
fix(core,web): rescale minor units in FX conversion (#3460)

### DIFF
--- a/apps/web/src/hooks/__tests__/useMultiCurrency.test.ts
+++ b/apps/web/src/hooks/__tests__/useMultiCurrency.test.ts
@@ -40,6 +40,33 @@ describe('useMultiCurrency', () => {
     expect(converted).toBe(9200);
   });
 
+  it('rescales minor units when converting to a zero-decimal currency (#3460)', () => {
+    const { result } = renderHook(() => useMultiCurrency());
+
+    // $100.00 = 10000 US cents (2 decimals). At 149.5 JPY/USD that is ¥14,950,
+    // and JPY has 0 decimal places, so the minor-unit value is 14950 — NOT the
+    // unscaled 1,495,000 that the pre-#3460 code produced.
+    const converted = result.current.convert(10000, Currencies.USD, Currencies.JPY);
+    expect(converted).toBe(14950);
+  });
+
+  it('round-trips USD -> JPY -> USD without a power-of-ten error (#3460)', () => {
+    const { result } = renderHook(() => useMultiCurrency());
+
+    const jpy = result.current.convert(10000, Currencies.USD, Currencies.JPY);
+    expect(jpy).toBe(14950);
+
+    const backToUsd = result.current.convert(jpy, Currencies.JPY, Currencies.USD);
+    expect(backToUsd).toBe(10000);
+  });
+
+  it('leaves same-scale USD <-> EUR conversion unchanged (#3460 no regression)', () => {
+    const { result } = renderHook(() => useMultiCurrency());
+
+    // Both currencies use 2 decimals, so the rescale factor is 1.
+    expect(result.current.convert(10000, Currencies.USD, Currencies.EUR)).toBe(9200);
+  });
+
   it('returns same amount when converting to same currency', () => {
     const { result } = renderHook(() => useMultiCurrency());
 
@@ -116,6 +143,24 @@ describe('useMultiCurrency', () => {
     expect(eurTotal?.totalCents).toBe(5000);
     // EUR converted to USD: 5000 / 0.92 ≈ 5435
     expect(eurTotal?.convertedCents).toBeGreaterThan(5000);
+  });
+
+  it('calculates a correct converted grand total including a zero-decimal JPY item (#3460)', () => {
+    const { result } = renderHook(() => useMultiCurrency());
+
+    // Default display currency is USD. $100.00 plus ¥14,950 (which is $100.00)
+    // must convert to a $200.00 grand total — 20000 US cents — not a value
+    // inflated ~100x by the missing minor-unit rescale.
+    const totals = result.current.calculateMultiCurrencyTotal([
+      { amountCents: 10000, currency: Currencies.USD },
+      { amountCents: 14950, currency: Currencies.JPY },
+    ]);
+
+    const jpyTotal = totals.find((t) => t.currency.code === 'JPY');
+    expect(jpyTotal?.convertedCents).toBe(10000);
+
+    const grandTotalCents = totals.reduce((sum, t) => sum + t.convertedCents, 0);
+    expect(grandTotalCents).toBe(20000);
   });
 
   it('falls back to USD when an unsupported default currency is stored', () => {

--- a/apps/web/src/hooks/useMultiCurrency.ts
+++ b/apps/web/src/hooks/useMultiCurrency.ts
@@ -212,7 +212,13 @@ export function useMultiCurrency(): UseMultiCurrencyResult {
       const rate = getRate(from.code, to.code);
       if (rate === null) return amountCents;
 
-      return Math.round(amountCents * rate);
+      // `amountCents` is in the source currency's minor units, but the rate
+      // converts *major* units (e.g. 1 USD = 149.5 JPY). Rescale by the
+      // minor-unit delta so converting to/from currencies with a different
+      // number of decimal places — notably the zero-decimal JPY/KRW — is not
+      // off by a power of ten (#3460).
+      const scaleFactor = Math.pow(10, to.decimalPlaces - from.decimalPlaces);
+      return Math.round(amountCents * rate * scaleFactor);
     },
     [getRate],
   );

--- a/packages/core/src/commonMain/kotlin/com/finance/core/currency/CurrencyConverter.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/currency/CurrencyConverter.kt
@@ -5,6 +5,7 @@ package com.finance.core.currency
 import com.finance.models.types.Cents
 import com.finance.models.types.Currency
 import com.finance.core.money.MoneyOperations
+import kotlin.math.pow
 
 /**
  * Converts monetary amounts between currencies using exchange rates.
@@ -22,7 +23,13 @@ class CurrencyConverter(
         val rate = rateProvider.getRate(from, to)
             ?: throw CurrencyConversionException("No exchange rate available for ${from.code} -> ${to.code}")
 
-        val converted = MoneyOperations.multiply(amount, rate.rate)
+        // `amount` is in the source currency's minor units, but `rate` converts
+        // *major* units (e.g. 1 USD = 149.5 JPY). Rescale by the minor-unit
+        // delta (10^(toDecimals - fromDecimals)) so converting to/from
+        // zero-decimal currencies like JPY/KRW is not off by a power of ten
+        // (#3460). Banker's rounding is still applied by MoneyOperations.multiply.
+        val scaleFactor = 10.0.pow(to.decimalPlaces - from.decimalPlaces)
+        val converted = MoneyOperations.multiply(amount, rate.rate * scaleFactor)
         return ConversionResult(
             originalAmount = amount,
             convertedAmount = converted,

--- a/packages/core/src/commonTest/kotlin/com/finance/core/currency/CurrencyConverterTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/currency/CurrencyConverterTest.kt
@@ -90,9 +90,11 @@ class CurrencyConverterTest {
         val rate = ExchangeRate(Currency.USD, Currency.JPY, 149.50, timestamp)
         val converter = CurrencyConverter(FakeRateProvider(mapOf((Currency.USD to Currency.JPY) to rate)))
 
-        // $100.00 = 10000 cents. 10000 * 149.50 = 1,495,000
+        // $100.00 = 10000 US cents (2 decimals). At 149.50 JPY/USD that is
+        // ¥14,950, and JPY has 0 decimal places, so the minor-unit result is
+        // 14950 — NOT the unscaled 1,495,000 (off by 100x before #3460).
         val result = converter.convert(Cents(10000), Currency.USD, Currency.JPY)
-        assertEquals(Cents(1495000), result.convertedAmount)
+        assertEquals(Cents(14950), result.convertedAmount)
     }
 
     @Test
@@ -100,10 +102,71 @@ class CurrencyConverterTest {
         val rate = ExchangeRate(Currency.JPY, Currency.USD, 0.0067, timestamp)
         val converter = CurrencyConverter(FakeRateProvider(mapOf((Currency.JPY to Currency.USD) to rate)))
 
-        // ¥10,000 = 10000 (JPY has 0 decimal places, so 10000 "cents" = ¥10,000)
-        // 10000 * 0.0067 = 67.0
+        // ¥10,000 = 10000 (JPY has 0 decimal places, so 10000 minor units = ¥10,000).
+        // ¥10,000 * 0.0067 USD/JPY = $67.00, and USD has 2 decimals, so the
+        // minor-unit result is 6700 US cents — NOT 67 (off by 100x before #3460).
         val result = converter.convert(Cents(10000), Currency.JPY, Currency.USD)
-        assertEquals(Cents(67), result.convertedAmount)
+        assertEquals(Cents(6700), result.convertedAmount)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Minor-unit rescale (#3460) — converting across currencies with a
+    // different number of decimal places must not be off by a power of ten
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun convert_usdJpy_roundTrip_rescalesMinorUnits() = runTest {
+        val toJpy = ExchangeRate(Currency.USD, Currency.JPY, 149.5, timestamp)
+        val toUsd = ExchangeRate(Currency.JPY, Currency.USD, 1.0 / 149.5, timestamp)
+        val converter = CurrencyConverter(
+            FakeRateProvider(
+                mapOf(
+                    (Currency.USD to Currency.JPY) to toJpy,
+                    (Currency.JPY to Currency.USD) to toUsd,
+                ),
+            ),
+        )
+
+        // $100.00 (10000 US cents) -> ¥14,950 (JPY has 0 decimals -> 14950)
+        val jpy = converter.convert(Cents(10000), Currency.USD, Currency.JPY)
+        assertEquals(Cents(14950), jpy.convertedAmount)
+
+        // ...and back again round-trips cleanly to $100.00.
+        val backToUsd = converter.convert(jpy.convertedAmount, Currency.JPY, Currency.USD)
+        assertEquals(Cents(10000), backToUsd.convertedAmount)
+    }
+
+    @Test
+    fun convert_usdKrw_roundTrip_rescalesMinorUnits() = runTest {
+        val krw = Currency("KRW") // 0 decimal places, like JPY
+        val toKrw = ExchangeRate(Currency.USD, krw, 1320.0, timestamp)
+        val toUsd = ExchangeRate(krw, Currency.USD, 1.0 / 1320.0, timestamp)
+        val converter = CurrencyConverter(
+            FakeRateProvider(
+                mapOf(
+                    (Currency.USD to krw) to toKrw,
+                    (krw to Currency.USD) to toUsd,
+                ),
+            ),
+        )
+
+        // $100.00 (10000 US cents) -> ₩132,000 (KRW has 0 decimals -> 132000)
+        val won = converter.convert(Cents(10000), Currency.USD, krw)
+        assertEquals(Cents(132000), won.convertedAmount)
+
+        val backToUsd = converter.convert(won.convertedAmount, krw, Currency.USD)
+        assertEquals(Cents(10000), backToUsd.convertedAmount)
+    }
+
+    @Test
+    fun convert_usdToEur_sameScale_noRegression() = runTest {
+        // Both USD and EUR use 2 decimals, so the rescale factor is 1 and the
+        // result is identical to a plain rate multiply (regression guard).
+        val rate = ExchangeRate(Currency.USD, Currency.EUR, 0.92, timestamp)
+        val converter = CurrencyConverter(FakeRateProvider(mapOf((Currency.USD to Currency.EUR) to rate)))
+
+        val result = converter.convert(Cents(10000), Currency.USD, Currency.EUR)
+        assertEquals(Cents(9200), result.convertedAmount)
     }
 
     // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Fixes a P1 money bug (#3460): multi-currency conversion multiplied a raw minor-unit (cents) amount by the exchange rate **without rescaling for currencies that use a different number of decimal places**. Converting to/from zero-decimal currencies (JPY, KRW — both `decimalPlaces: 0`) was off by ~100×, e.g. `$100.00` rendered as `¥1,495,000` instead of `¥14,950`.

**Root cause:** `amountMinor` is in the *source* currency's minor units, but the exchange rate converts *major* units (1 USD = 149.5 JPY), so `amountMinor * rate` is only correct when both currencies share the same minor-unit scale. Display/formatting was already scale-aware; only the conversion step was not.

**Fix — rescale by the minor-unit delta during conversion:**

`resultMinor = round(amountMinor * rate * 10^(toDecimals − fromDecimals))`

Both independent code paths in the issue are fixed in this single PR.

## Changes

### Web (`apps/web`)

- `src/hooks/useMultiCurrency.ts` — `convert()` now multiplies by `Math.pow(10, to.decimalPlaces - from.decimalPlaces)`.
- `src/hooks/__tests__/useMultiCurrency.test.ts` — added `convert(10000, USD, JPY) === 14950`; round-trip `convert(14950, JPY, USD) === 10000`; USD↔EUR unchanged (no regression); and a `calculateMultiCurrencyTotal` case with a JPY item asserting the converted grand total ($200.00 → 20000 cents).

### Shared / KMP (`packages/core`)

- `.../currency/CurrencyConverter.kt` — `convert()` folds `10.0.pow(to.decimalPlaces - from.decimalPlaces)` into the multiply factor; banker's rounding is preserved via `MoneyOperations.multiply`.
- `.../currency/CurrencyConverterTest.kt` — corrected two existing tests that encoded the bug (USD→JPY `1495000` → `14950`; JPY→USD `67` → `6700`), and added USD↔JPY and USD↔KRW round-trip tests plus a USD↔EUR same-scale no-regression test.

## Verification

- [x] Web unit tests pass locally (`vitest run src/hooks/__tests__/useMultiCurrency.test.ts` — 17 passed).
- [x] Prettier + ESLint clean on changed files; repo-wide `format:check` green.
- [x] KMP tests (`:packages:core:jvmTest`) run in the **CI — Shared** workflow, which covers `CurrencyConverterTest`.
- Expected behaviour: `$100.00 USD → ¥14,950` and back to `$100.00`; `$100.00 USD → ₩132,000` and back.

## Issues

Closes #3460

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
