### PR TITLE
fix(web): report growth from a zero baseline as new, not a fixed 100% (#3364)

### DIFF
--- a/apps/web/src/components/budgets/BudgetAnalytics.test.tsx
+++ b/apps/web/src/components/budgets/BudgetAnalytics.test.tsx
@@ -85,6 +85,23 @@ describe('BudgetAnalytics', () => {
     expect(screen.getByText(/higher/)).toBeInTheDocument();
   });
 
+  it('shows a "new spending" state instead of a misleading 100% when previous spend was zero', () => {
+    render(
+      <BudgetAnalytics
+        {...defaultProps}
+        previousPeriodSpent={0}
+        currentCategorySpending={new Map([['Food', 100_000]])}
+        previousCategorySpending={new Map()}
+      />,
+    );
+    // Period comparison card reports the honest "new" copy, never "100%".
+    expect(
+      screen.getByText('New spending this period (nothing spent last period)'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/100%/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/higher than last period/)).not.toBeInTheDocument();
+  });
+
   it('displays empty state for comparison when no previous data', () => {
     render(<BudgetAnalytics {...defaultProps} previousPeriodSpent={null} />);
     expect(screen.getByText('Not enough data for comparison')).toBeInTheDocument();

--- a/apps/web/src/components/budgets/BudgetAnalytics.tsx
+++ b/apps/web/src/components/budgets/BudgetAnalytics.tsx
@@ -86,8 +86,17 @@ function HealthIndicator({ status }: { status: BudgetHealthStatus }) {
   );
 }
 
-/** Renders a directional arrow with percentage change. */
-function ComparisonArrow({ change, direction }: { change: number; direction: ChangeDirection }) {
+/** Renders a directional arrow with percentage change, or a "New" badge when
+ * there is no prior-period baseline to compute a percentage from. */
+function ComparisonArrow({
+  change,
+  direction,
+  isNew = false,
+}: {
+  change: number;
+  direction: ChangeDirection;
+  isNew?: boolean;
+}) {
   const arrowMap: Record<ChangeDirection, string> = {
     up: '↑',
     down: '↓',
@@ -96,7 +105,7 @@ function ComparisonArrow({ change, direction }: { change: number; direction: Cha
 
   return (
     <span className={`comparison-arrow comparison-arrow--${direction}`} aria-hidden="true">
-      {arrowMap[direction]} {change}%
+      {arrowMap[direction]} {isNew ? 'New' : `${change}%`}
     </span>
   );
 }
@@ -204,19 +213,30 @@ export const BudgetAnalytics: React.FC<BudgetAnalyticsProps> = ({
               <ComparisonArrow
                 change={periodComparison.change}
                 direction={periodComparison.direction}
+                isNew={periodComparison.isNew}
               />
             </p>
             <p
               className="analytics-card__detail"
-              aria-label={`Spending is ${periodComparison.change}% ${periodComparison.direction === 'down' ? 'lower' : periodComparison.direction === 'up' ? 'higher' : 'the same as'} than last period`}
+              aria-label={
+                periodComparison.isNew
+                  ? 'New spending this period; there was nothing spent last period to compare against'
+                  : `Spending is ${periodComparison.change}% ${periodComparison.direction === 'down' ? 'lower' : periodComparison.direction === 'up' ? 'higher' : 'the same as'} than last period`
+              }
             >
-              Spending is {periodComparison.change}%{' '}
-              {periodComparison.direction === 'down'
-                ? 'lower'
-                : periodComparison.direction === 'up'
-                  ? 'higher'
-                  : 'the same as'}{' '}
-              than last period
+              {periodComparison.isNew ? (
+                'New spending this period (nothing spent last period)'
+              ) : (
+                <>
+                  Spending is {periodComparison.change}%{' '}
+                  {periodComparison.direction === 'down'
+                    ? 'lower'
+                    : periodComparison.direction === 'up'
+                      ? 'higher'
+                      : 'the same as'}{' '}
+                  than last period
+                </>
+              )}
             </p>
           </>
         ) : (
@@ -264,7 +284,7 @@ function CategoryTrendsList({
             key={trend.name}
             className="category-trends__item"
             role="listitem"
-            aria-label={`${trend.name}: ${trend.change}% ${trend.direction}`}
+            aria-label={`${trend.name}: ${trend.isNew ? 'new spending this period' : `${trend.change}% ${trend.direction}`}`}
           >
             <span className="category-trends__name">{trend.name}</span>
             <div
@@ -278,7 +298,11 @@ function CategoryTrendsList({
               <div className="category-trends__bar" style={{ width: `${barPercent}%` }} />
             </div>
             <span className="category-trends__change">
-              <ComparisonArrow change={trend.change} direction={trend.direction} />{' '}
+              <ComparisonArrow
+                change={trend.change}
+                direction={trend.direction}
+                isNew={trend.isNew}
+              />{' '}
               <CurrencyDisplay amount={trend.current} currency={currency} />
             </span>
           </li>

--- a/apps/web/src/lib/budget-analytics.test.ts
+++ b/apps/web/src/lib/budget-analytics.test.ts
@@ -96,8 +96,20 @@ describe('comparePeriods', () => {
     expect(comparePeriods(0, 0)).toEqual({ change: 0, direction: 'flat' });
   });
 
-  it('returns up 100% when previous is zero and current is non-zero', () => {
-    expect(comparePeriods(500, 0)).toEqual({ change: 100, direction: 'up' });
+  it('flags growth from a zero baseline as "new" instead of a fixed 100%', () => {
+    // Previous $0 → any current spend has no percentage baseline (#3364).
+    expect(comparePeriods(500, 0)).toEqual({ change: 0, direction: 'up', isNew: true });
+    // Magnitude no longer collapses to a single 100% value.
+    expect(comparePeriods(5, 0)).toEqual({ change: 0, direction: 'up', isNew: true });
+  });
+
+  it('flags a decrease from a zero baseline as "new" (negative current)', () => {
+    expect(comparePeriods(-500, 0)).toEqual({ change: 0, direction: 'down', isNew: true });
+  });
+
+  it('does not flag isNew when the previous value is non-zero', () => {
+    expect(comparePeriods(600, 500).isNew).toBeUndefined();
+    expect(comparePeriods(0, 500)).toEqual({ change: 100, direction: 'down' });
   });
 
   it('returns down when current is less than previous', () => {
@@ -148,6 +160,9 @@ describe('buildCategoryTrends', () => {
     expect(trends).toHaveLength(1);
     expect(trends[0].previous).toBe(0);
     expect(trends[0].direction).toBe('up');
+    // No prior-period baseline → flagged as new, not a misleading 100% (#3364).
+    expect(trends[0].isNew).toBe(true);
+    expect(trends[0].change).toBe(0);
   });
 
   it('defaults to top 5', () => {

--- a/apps/web/src/lib/budget-analytics.ts
+++ b/apps/web/src/lib/budget-analytics.ts
@@ -27,6 +27,13 @@ export interface PeriodComparison {
   readonly change: number;
   /** Whether spending went up, down, or stayed flat. */
   readonly direction: ChangeDirection;
+  /**
+   * True when the previous value was zero and the current value is non-zero, so
+   * there is no baseline to compute a percentage from. In this case `change` is
+   * not meaningful (it is reported as 0); consumers should render an honest
+   * "new" state or an absolute delta rather than a misleading percentage.
+   */
+  readonly isNew?: boolean;
 }
 
 /** Spending data for a single category across two periods. */
@@ -41,6 +48,11 @@ export interface CategoryTrend {
   readonly change: number;
   /** Direction of the change. */
   readonly direction: ChangeDirection;
+  /**
+   * True when there was no spending in the previous period, so `change` has no
+   * meaningful baseline. Consumers should render a "new" state instead.
+   */
+  readonly isNew?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -134,16 +146,22 @@ export function getBudgetHealth(
 /**
  * Compare two period values and return the percentage change and direction.
  *
+ * When the previous value was zero and the current value is non-zero, growth
+ * has no meaningful percentage baseline (a jump from $0 to $500 and from $0 to
+ * $5 would both be "+100%"). Such results are flagged with `isNew` and report a
+ * `change` of 0 so callers can render an honest "new" state or an absolute
+ * delta instead of a misleading capped percentage.
+ *
  * @param current - Current period value (cents or any numeric).
  * @param previous - Previous period value (cents or any numeric).
- * @returns Object with `change` (percentage) and `direction`.
+ * @returns Object with `change` (percentage), `direction`, and optional `isNew`.
  */
 export function comparePeriods(current: number, previous: number): PeriodComparison {
   if (previous === 0 && current === 0) {
     return { change: 0, direction: 'flat' };
   }
   if (previous === 0) {
-    return { change: 100, direction: 'up' };
+    return { change: 0, direction: current > 0 ? 'up' : 'down', isNew: true };
   }
 
   const change = Math.round(((current - previous) / Math.abs(previous)) * 100);
@@ -184,6 +202,7 @@ export function buildCategoryTrends(
       previous,
       change: comparison.change,
       direction: comparison.direction,
+      ...(comparison.isNew ? { isNew: true } : {}),
     });
   }
 


### PR DESCRIPTION
﻿## Summary
`comparePeriods` in `apps/web/src/lib/budget-analytics.ts` capped **every** zero-previous change at `+100%`. A category jumping from $0 to $500 looked identical to $0 to $5, understating real changes for overspend tracking — a problem for a tight-budget debt-payoff user watching category creep.

## Changes
- `comparePeriods` now flags the zero-baseline case (`previous === 0 && current !== 0`) with `isNew: true` and reports `change: 0` instead of a misleading fixed 100%. Direction still reflects sign (up for new spend, down for a negative current).
- `PeriodComparison` and `CategoryTrend` gain an optional `isNew` flag (additive; no consumer breakage).
- `buildCategoryTrends` propagates `isNew`.
- `BudgetAnalytics` renders an honest **"New"** badge (`ComparisonArrow`) and "New spending this period (nothing spent last period)" copy plus matching aria-labels, instead of "↑ 100%" / "Spending is 100% higher than last period".
- Going **to** zero from a non-zero baseline is unchanged (a legitimate `-100%` / down).

## Tests
- Updated + added `comparePeriods` cases (`500→0` baseline, magnitude no longer collapses, negative current, non-zero previous unaffected).
- `buildCategoryTrends` asserts `isNew`/`change` for a new category.
- New `BudgetAnalytics` render test: shows the "new spending" state and never "100%".
- Full affected set green locally (42 tests across the two files).

## Issues
Closes #3364

Found by persona: Marcus Johnson (aggressive debt-payoff)
