### PR TITLE
feat(web): surface subscription potential-savings total (#3371)

### DIFF
--- a/apps/web/src/hooks/useSubscriptions.ts
+++ b/apps/web/src/hooks/useSubscriptions.ts
@@ -72,6 +72,8 @@ export function useSubscriptions(): UseSubscriptionsResult {
     totalAnnualCents: 0,
     activeCount: 0,
     flaggedCount: 0,
+    flaggedMonthlyCents: 0,
+    flaggedAnnualCents: 0,
     cancelledCount: 0,
     byCategory: [],
   });

--- a/apps/web/src/lib/analytics/subscriptions.test.ts
+++ b/apps/web/src/lib/analytics/subscriptions.test.ts
@@ -233,4 +233,71 @@ describe('computeSubscriptionSummary', () => {
     expect(summary.totalMonthlyCents).toBe(0);
     expect(summary.cancelledCount).toBe(1);
   });
+
+  it('tracks flagged subscriptions as potential savings without counting them active', () => {
+    const subs = [
+      {
+        id: 'sub-1',
+        name: 'Netflix',
+        categoryId: null,
+        categoryName: 'Streaming',
+        amountCents: 1599,
+        cadence: 'monthly' as const,
+        monthlyCostCents: 1599,
+        annualCostCents: 19188,
+        transactionCount: 3,
+        lastDate: '2024-03-15',
+        status: 'active' as const,
+      },
+      {
+        id: 'sub-2',
+        name: 'Unused Gym',
+        categoryId: null,
+        categoryName: 'Fitness',
+        amountCents: 4000,
+        cadence: 'monthly' as const,
+        monthlyCostCents: 4000,
+        annualCostCents: 48000,
+        transactionCount: 3,
+        lastDate: '2024-03-15',
+        status: 'flagged' as const,
+      },
+    ];
+
+    const summary = computeSubscriptionSummary(subs);
+
+    // Flagged subs are still being paid, so they stay in the current total...
+    expect(summary.totalMonthlyCents).toBe(5599);
+    expect(summary.totalAnnualCents).toBe(67188);
+    // ...but they are NOT counted as active.
+    expect(summary.activeCount).toBe(1);
+    expect(summary.flaggedCount).toBe(1);
+    // Potential savings = the flagged monthly cost, projected annually.
+    expect(summary.flaggedMonthlyCents).toBe(4000);
+    expect(summary.flaggedAnnualCents).toBe(48000);
+  });
+
+  it('reports zero potential savings when nothing is flagged', () => {
+    const subs = [
+      {
+        id: 'sub-1',
+        name: 'Netflix',
+        categoryId: null,
+        categoryName: 'Streaming',
+        amountCents: 1599,
+        cadence: 'monthly' as const,
+        monthlyCostCents: 1599,
+        annualCostCents: 19188,
+        transactionCount: 3,
+        lastDate: '2024-03-15',
+        status: 'active' as const,
+      },
+    ];
+
+    const summary = computeSubscriptionSummary(subs);
+    expect(summary.flaggedCount).toBe(0);
+    expect(summary.flaggedMonthlyCents).toBe(0);
+    expect(summary.flaggedAnnualCents).toBe(0);
+    expect(summary.activeCount).toBe(1);
+  });
 });

--- a/apps/web/src/lib/analytics/subscriptions.ts
+++ b/apps/web/src/lib/analytics/subscriptions.ts
@@ -50,14 +50,21 @@ export interface DetectedSubscription {
 
 /** Summary of all detected subscriptions. */
 export interface SubscriptionSummary {
-  /** Total monthly cost of all active subscriptions in cents. */
+  /** Total monthly cost of all non-cancelled subscriptions in cents (active + flagged). */
   totalMonthlyCents: number;
-  /** Total annual projected cost of all active subscriptions in cents. */
+  /** Total annual projected cost of all non-cancelled subscriptions in cents. */
   totalAnnualCents: number;
-  /** Count of active subscriptions. */
+  /** Count of active (non-flagged, non-cancelled) subscriptions. */
   activeCount: number;
   /** Count of subscriptions flagged as potentially unused. */
   flaggedCount: number;
+  /**
+   * Combined monthly cost of flagged subscriptions in cents — the potential
+   * savings a user would free up by cancelling everything flagged.
+   */
+  flaggedMonthlyCents: number;
+  /** Annual projection of the flagged (potential savings) monthly cost, in cents. */
+  flaggedAnnualCents: number;
   /** Count of cancelled subscriptions. */
   cancelledCount: number;
   /** Breakdown by category. */
@@ -217,6 +224,7 @@ export function computeSubscriptionSummary(
   subscriptions: DetectedSubscription[],
 ): SubscriptionSummary {
   let totalMonthlyCents = 0;
+  let flaggedMonthlyCents = 0;
   let activeCount = 0;
   let flaggedCount = 0;
   let cancelledCount = 0;
@@ -229,8 +237,15 @@ export function computeSubscriptionSummary(
       continue;
     }
 
-    if (sub.status === 'flagged') flaggedCount++;
-    activeCount++;
+    // Flagged subs are still being paid until cancelled, so they count toward
+    // the current monthly total — but they are tracked separately (not as
+    // "active") and summed as potential savings.
+    if (sub.status === 'flagged') {
+      flaggedCount++;
+      flaggedMonthlyCents += sub.monthlyCostCents;
+    } else {
+      activeCount++;
+    }
     totalMonthlyCents += sub.monthlyCostCents;
 
     const catKey = sub.categoryName;
@@ -256,6 +271,8 @@ export function computeSubscriptionSummary(
     totalAnnualCents: totalMonthlyCents * 12,
     activeCount,
     flaggedCount,
+    flaggedMonthlyCents,
+    flaggedAnnualCents: flaggedMonthlyCents * 12,
     cancelledCount,
     byCategory,
   };

--- a/apps/web/src/pages/SubscriptionsPage.test.tsx
+++ b/apps/web/src/pages/SubscriptionsPage.test.tsx
@@ -39,6 +39,8 @@ describe('SubscriptionsPage', () => {
         totalAnnualCents: 0,
         activeCount: 0,
         flaggedCount: 0,
+        flaggedMonthlyCents: 0,
+        flaggedAnnualCents: 0,
         cancelledCount: 0,
         byCategory: [],
       },
@@ -61,6 +63,8 @@ describe('SubscriptionsPage', () => {
         totalAnnualCents: 0,
         activeCount: 0,
         flaggedCount: 0,
+        flaggedMonthlyCents: 0,
+        flaggedAnnualCents: 0,
         cancelledCount: 0,
         byCategory: [],
       },
@@ -83,6 +87,8 @@ describe('SubscriptionsPage', () => {
         totalAnnualCents: 0,
         activeCount: 0,
         flaggedCount: 0,
+        flaggedMonthlyCents: 0,
+        flaggedAnnualCents: 0,
         cancelledCount: 0,
         byCategory: [],
       },
@@ -130,8 +136,10 @@ describe('SubscriptionsPage', () => {
       summary: {
         totalMonthlyCents: 2598,
         totalAnnualCents: 31176,
-        activeCount: 2,
+        activeCount: 1,
         flaggedCount: 1,
+        flaggedMonthlyCents: 999,
+        flaggedAnnualCents: 11988,
         cancelledCount: 0,
         byCategory: [
           {
@@ -155,5 +163,9 @@ describe('SubscriptionsPage', () => {
     expect(screen.getByText('Netflix')).toBeInTheDocument();
     expect(screen.getByText('Spotify')).toBeInTheDocument();
     expect(screen.getByText('All Subscriptions (2)')).toBeInTheDocument();
+    expect(screen.getByText('Potential Savings')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Potential monthly savings from cancelling flagged subscriptions'),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/SubscriptionsPage.tsx
+++ b/apps/web/src/pages/SubscriptionsPage.tsx
@@ -180,6 +180,15 @@ export const SubscriptionsPage: React.FC = () => {
             <p className="analytics-metric-card__label">Flagged</p>
             <p className="analytics-metric-card__value">{summary.flaggedCount}</p>
           </article>
+          <article
+            className="analytics-metric-card"
+            aria-label="Potential monthly savings from cancelling flagged subscriptions"
+          >
+            <p className="analytics-metric-card__label">Potential Savings</p>
+            <p className="analytics-metric-card__value analytics-metric-card__value--positive">
+              <CurrencyDisplay amount={summary.flaggedMonthlyCents} />
+            </p>
+          </article>
         </div>
       </section>
 


### PR DESCRIPTION
﻿## Summary

Marcus (aggressive debt-payoff persona) wants to see exactly how much he could free up each month by cancelling the subscriptions the app has flagged as potentially unused, so he can redirect that money to his debt snowball. The Subscriptions summary previously exposed **no savings figure** and, worse, counted every flagged subscription as `active` — so the "Active" metric overstated his committed spend and there was nothing to motivate a cut.

## Changes

- `SubscriptionSummary` gains `flaggedMonthlyCents` and `flaggedAnnualCents` (integer cents).
- `computeSubscriptionSummary` now counts flagged subs **separately** from active ones (`activeCount` excludes flagged) while still including them in `totalMonthlyCents` (you keep paying until you actually cancel), and accumulates the potential-savings totals.
- New **"Potential Savings"** metric card on `SubscriptionsPage` with a descriptive `aria-label` and positive-value styling (reusing the existing `analytics-metric-card__value--positive` token class).
- `useSubscriptions` default summary updated with the two new fields.
- Extended `subscriptions.test.ts` (flagged-savings + zero-flagged cases) and `SubscriptionsPage.test.tsx` (new card assertion + corrected active/flagged semantics).

## Issues

Closes #3371

## Testing

- `npx vitest run src/lib/analytics/subscriptions.test.ts src/pages/SubscriptionsPage.test.tsx` -> 18 passed
- Full `apps/web` suite run: only pre-existing, unrelated failures (DashboardPage a11y JSDOM flake; BillsPage "1 bills" — neither imports subscriptions, both byte-identical to origin/main)
- `npx prettier --check` + `npx eslint --max-warnings 0` on changed files -> clean

Found by persona: Marcus Johnson (aggressive debt-payoff)
