### PR TITLE
fix(web): persist onboarding savings goals to the real goals store (#3405)

### DIFF
--- a/apps/web/src/db/repositories/household.ts
+++ b/apps/web/src/db/repositories/household.ts
@@ -274,6 +274,20 @@ export function getHouseholdById(db: SqliteDb, id: SyncId): Household | null {
   return row ? mapHousehold(row) : null;
 }
 
+/**
+ * Returns the id of the primary (oldest, non-deleted) household, or `null` when
+ * no household exists yet. Used to attach records created before any
+ * household-scoped entity is available — e.g. savings goals saved during
+ * onboarding, which happens before the first budget/account exists (#3405).
+ */
+export function getPrimaryHouseholdId(db: SqliteDb): SyncId | null {
+  const row = queryOne(
+    db,
+    `SELECT id FROM household WHERE deleted_at IS NULL ORDER BY created_at ASC LIMIT 1`,
+  );
+  return row ? requireString(row.id, 'household.id') : null;
+}
+
 /** Create a new household and add the creator as OWNER member. */
 export function createHousehold(db: SqliteDb, input: CreateHouseholdInput): Household {
   const id = crypto.randomUUID();

--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -19,6 +19,9 @@ import { useBudgets } from '../hooks/useBudgets';
 import { useConsent } from '../hooks/useConsent';
 import { useConsentHistory } from '../hooks/useConsentHistory';
 import { useLocalOnlyMode } from '../hooks/useLocalOnlyMode';
+import { useGoals } from '../hooks/useGoals';
+import { useDatabase } from '../db/DatabaseProvider';
+import { getPrimaryHouseholdId } from '../db/repositories/household';
 
 const createMatchMedia = (matches: boolean = false) =>
   vi.fn().mockImplementation((query: string) => ({
@@ -82,6 +85,29 @@ vi.mock('../hooks/useBudgets', () => ({
   useBudgets: vi.fn(),
 }));
 
+vi.mock('../hooks/useGoals', () => ({
+  useGoals: vi.fn(),
+}));
+
+vi.mock('../db/DatabaseProvider', async () => {
+  const actual =
+    await vi.importActual<typeof import('../db/DatabaseProvider')>('../db/DatabaseProvider');
+  return {
+    ...actual,
+    useDatabase: vi.fn(() => ({})),
+  };
+});
+
+vi.mock('../db/repositories/household', async () => {
+  const actual = await vi.importActual<typeof import('../db/repositories/household')>(
+    '../db/repositories/household',
+  );
+  return {
+    ...actual,
+    getPrimaryHouseholdId: vi.fn(() => 'household-1'),
+  };
+});
+
 // Partial mock: keep the real AuthProvider/ProtectedRoute exports (used by App/routes)
 // and only stub useAuth so OnboardingPage can be rendered without an AuthProvider and
 // the post-signup (authenticated) start step can be exercised (#3089).
@@ -99,6 +125,9 @@ const mockedUseConsent = vi.mocked(useConsent);
 const mockedUseConsentHistory = vi.mocked(useConsentHistory);
 const mockedUseBudgets = vi.mocked(useBudgets);
 const mockedUseAuth = vi.mocked(useAuth);
+const mockedUseGoals = vi.mocked(useGoals);
+const mockedUseDatabase = vi.mocked(useDatabase);
+const mockedGetPrimaryHouseholdId = vi.mocked(getPrimaryHouseholdId);
 
 const unauthenticatedAuthReturn = {
   isAuthenticated: false,
@@ -182,6 +211,20 @@ const defaultBudgetsReturn = {
   getBudgetSpendingBreakdown: vi.fn(() => []),
 };
 
+const createGoalMock = vi.fn(() => ({ id: 'goal-1' }));
+
+const defaultGoalsReturn = {
+  goals: [],
+  loading: false,
+  error: null,
+  refresh: vi.fn(),
+  createGoal: createGoalMock,
+  updateGoal: vi.fn(),
+  contributeToGoal: vi.fn(),
+  deleteGoal: vi.fn(),
+  reorderGoals: vi.fn(),
+} as unknown as ReturnType<typeof useGoals>;
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.stubGlobal('matchMedia', createMatchMedia(false));
@@ -197,6 +240,11 @@ beforeEach(() => {
   mockedUseConsentHistory.mockReturnValue(defaultConsentHistoryReturn);
   mockedUseBudgets.mockReturnValue(defaultBudgetsReturn);
   mockedUseAuth.mockReturnValue(unauthenticatedAuthReturn);
+  mockedUseGoals.mockReturnValue(defaultGoalsReturn);
+  mockedUseDatabase.mockReturnValue({} as unknown as ReturnType<typeof useDatabase>);
+  mockedGetPrimaryHouseholdId.mockReturnValue(
+    'household-1' as unknown as ReturnType<typeof getPrimaryHouseholdId>,
+  );
 });
 
 const renderWithRouter = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
@@ -592,8 +640,70 @@ describe('OnboardingPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
     fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
 
-    expect(localStorage.getItem('finance-onboarding-goals')).toContain('Move fund');
+    // #3405: the goal is migrated into the real goals store (minor units) and the
+    // onboarding-only localStorage cache is cleared once persisted.
+    expect(createGoalMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        householdId: 'household-1',
+        name: 'Move fund',
+        targetAmount: { amount: 120_000 },
+        currentAmount: { amount: 20_000 },
+      }),
+    );
+    expect(localStorage.getItem('finance-onboarding-goals')).toBe('[]');
     expect(screen.getByText(/1 goal saved/i)).toBeInTheDocument();
+  });
+
+  it('migrates onboarding goals into the real goals store when creating the starter budget (#3405)', () => {
+    mockedUseBudgets.mockReturnValue({
+      ...defaultBudgetsReturn,
+      createBudgetTemplate: vi.fn(() => [
+        { id: 'budget-1', householdId: 'household-1' },
+      ]) as unknown as typeof defaultBudgetsReturn.createBudgetTemplate,
+    });
+
+    renderWithRouter(<OnboardingPage />);
+
+    goToGoalsStep();
+    fireEvent.change(screen.getByLabelText(/goal name/i), { target: { value: 'Emergency fund' } });
+    fireEvent.change(screen.getByLabelText(/target amount/i), { target: { value: '1000' } });
+    fireEvent.change(screen.getByLabelText(/starting balance/i), { target: { value: '0' } });
+    fireEvent.click(screen.getByRole('button', { name: /preview goal/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save goal/i }));
+
+    // goals -> template, then create the starter budget (the household now exists).
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /create my budget/i }));
+
+    expect(createGoalMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        householdId: 'household-1',
+        name: 'Emergency fund',
+        targetAmount: { amount: 100_000 },
+        currentAmount: { amount: 0 },
+      }),
+    );
+    expect(localStorage.getItem('finance-onboarding-goals')).toBe('[]');
+  });
+
+  it('keeps onboarding goals in local storage when no household exists yet (#3405)', () => {
+    mockedGetPrimaryHouseholdId.mockReturnValue(
+      null as unknown as ReturnType<typeof getPrimaryHouseholdId>,
+    );
+
+    renderWithRouter(<OnboardingPage />);
+
+    goToGoalsStep();
+    fireEvent.change(screen.getByLabelText(/target amount/i), { target: { value: '750' } });
+    fireEvent.click(screen.getByRole('button', { name: /preview goal/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save goal/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+
+    // The goal must not be silently dropped: with no household to attach it to,
+    // it stays cached locally so a later completion can still migrate it.
+    expect(createGoalMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem('finance-onboarding-goals')).toContain('750');
   });
 
   it('blocks previewing a goal until a positive target amount is entered (#3410)', () => {

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -21,9 +21,12 @@ import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../auth/auth-context';
 import { AppIcon } from '../components/icons';
+import { useDatabase } from '../db/DatabaseProvider';
+import { getPrimaryHouseholdId } from '../db/repositories/household';
 import { useBudgets } from '../hooks/useBudgets';
 import { useConsent } from '../hooks/useConsent';
 import { useConsentHistory } from '../hooks/useConsentHistory';
+import { useGoals } from '../hooks/useGoals';
 import {
   DEFAULT_FONT_SCALE_PREFERENCE,
   FONT_SCALE_OPTIONS,
@@ -530,6 +533,8 @@ const OnboardingPage: React.FC = () => {
   const { acceptAll, rejectAll, consent } = useConsent();
   const { recordBulkChanges } = useConsentHistory();
   const { createBudgetTemplate } = useBudgets();
+  const { createGoal } = useGoals();
+  const db = useDatabase();
 
   const starterTemplates = useMemo(() => getBudgetStarterTemplates(), []);
   const studentTemplate = starterTemplates.find((template) => template.id === 'student') ?? null;
@@ -798,6 +803,46 @@ const OnboardingPage: React.FC = () => {
     });
   }, [analyticsEnabled, goalDraft, monthlyContribution]);
 
+  const persistOnboardingGoalsToStore = useCallback(() => {
+    // Goals captured during onboarding live only in a standalone localStorage
+    // key until now; migrate them into the real goals store so they show up on
+    // /goals just like starter budgets do (#3405). Amounts are entered in whole
+    // currency units and stored as minor units (cents) to match the goals repo.
+    // A migration failure must never block onboarding completion.
+    try {
+      const pendingGoals = readGoals();
+      if (pendingGoals.length === 0) {
+        return;
+      }
+
+      const householdId = getPrimaryHouseholdId(db);
+      if (!householdId) {
+        return;
+      }
+
+      let migratedAny = false;
+      for (const goal of pendingGoals) {
+        const created = createGoal({
+          householdId,
+          name: goal.name,
+          description: goal.goalType || null,
+          targetAmount: { amount: Math.round(goal.targetAmount * 100) },
+          currentAmount: { amount: Math.round(goal.startingBalance * 100) },
+          targetDate: goal.targetDate ? goal.targetDate : null,
+        });
+        if (created) {
+          migratedAny = true;
+        }
+      }
+
+      if (migratedAny) {
+        writeGoals([]);
+      }
+    } catch {
+      // Best-effort migration; onboarding completion continues regardless.
+    }
+  }, [createGoal, db]);
+
   const handleCoachMarksDismiss = useCallback(() => {
     setCoachMarksDismissed(true);
     writeBoolean(COACH_MARKS_STORAGE_KEY, true);
@@ -899,9 +944,10 @@ const OnboardingPage: React.FC = () => {
   const handleSkipStarterBudget = useCallback(() => {
     setStarterBudgetCreated(false);
     setTemplateError(null);
+    persistOnboardingGoalsToStore();
     completeOnboarding();
     setStep('complete');
-  }, [completeOnboarding]);
+  }, [completeOnboarding, persistOnboardingGoalsToStore]);
 
   const handleApplyStudentTemplate = useCallback(() => {
     if (!studentTemplate) {
@@ -923,6 +969,7 @@ const OnboardingPage: React.FC = () => {
       }
 
       setStarterBudgetCreated(true);
+      persistOnboardingGoalsToStore();
       completeOnboarding();
       setStep('complete');
     } catch (error) {
@@ -932,7 +979,7 @@ const OnboardingPage: React.FC = () => {
     } finally {
       setIsApplyingTemplate(false);
     }
-  }, [completeOnboarding, createBudgetTemplate, studentTemplate]);
+  }, [completeOnboarding, createBudgetTemplate, persistOnboardingGoalsToStore, studentTemplate]);
 
   const handleGoToDashboard = useCallback(() => {
     navigate('/dashboard');


### PR DESCRIPTION
## Summary

A brand-new user who set a savings goal during onboarding landed on an **empty `/goals` page** — the goal silently vanished. Goals captured in the onboarding "goals" step were written only to a standalone `finance-onboarding-goals` localStorage key and never reached the goals repository, unlike starter budgets which are persisted properly.

This is a real first-run trap for exactly the newcomer the onboarding goals step is designed for: they follow the flow, set an emergency-fund goal, finish onboarding, open Goals, and see nothing.

## Changes

- **`apps/web/src/pages/OnboardingPage.tsx`** — on onboarding completion (both the **"Create my budget"** and **"Skip for now"** paths) migrate any pending onboarding goals into the real goals store via `useGoals().createGoal`, converting the whole-currency-unit onboarding amounts to **minor units (cents)** to match the repository. The onboarding-only localStorage cache is cleared once migrated. Migration is **best-effort** (wrapped in `try/catch`) so it can never block onboarding completion, and it no-ops safely when no household exists yet (the cached goal is retained for a later pass, never dropped).
- **`apps/web/src/db/repositories/household.ts`** — new `getPrimaryHouseholdId(db)` helper returning the oldest non-deleted household id (or `null`), used to attach goals created before any household-scoped entity exists.
- **`apps/web/src/pages/OnboardingPage.test.tsx`** — updated the existing save-goal test to assert real-store persistence + cache clearing, and added focused tests for the create-budget path (cents conversion + household id) and the null-household guard (goal retained, `createGoal` not called).

## Issues

Closes #3405

Found by persona: Maya Chen (new-grad first-job budgeter)

## Testing

- [x] `npx prettier --write` clean on all 3 files
- [x] `npx eslint … --max-warnings 0` clean
- [x] `npx vitest run src/pages/OnboardingPage.test.tsx` — **34 passed** (incl. the `<App/>` render test with the new `useDatabase` mock and the 3 new/updated goal-persistence tests)
- [x] Rebased on latest `origin/main`; tests re-run green post-rebase
