### PR TITLE
feat(web): show period-over-period net worth change (#3267)

### DIFF
--- a/apps/web/src/hooks/useNetWorth.ts
+++ b/apps/web/src/hooks/useNetWorth.ts
@@ -21,12 +21,14 @@ import { getAllTransactions } from '../db/repositories/transactions';
 import {
   computeCurrentNetWorth,
   computeAssetClassBreakdown,
+  computePeriodComparison,
   detectMilestones,
 } from '../lib/analytics/net-worth';
 import type {
   NetWorthDataPoint,
   AssetClassBreakdown,
   NetWorthMilestone,
+  PeriodComparison,
 } from '../lib/analytics/net-worth';
 import { buildNetWorthHistorySeries } from '../lib/visualization/net-worth-history';
 import type { NetWorthSeriesPoint } from '../lib/visualization/net-worth-projection';
@@ -50,6 +52,11 @@ export interface UseNetWorthResult {
   milestones: NetWorthMilestone[];
   /** Trailing monthly net-worth history, oldest first (for trend + projection). */
   history: NetWorthSeriesPoint[];
+  /**
+   * Period-over-period change between the two most recent history points
+   * (typically month-over-month), or `null` when fewer than two points exist.
+   */
+  periodComparison: PeriodComparison | null;
   /** True while data is being computed. */
   loading: boolean;
   /** Human-readable error message or null. */
@@ -77,6 +84,7 @@ export function useNetWorth(purposeFilter: AccountPurposeFilter = 'all'): UseNet
   const [assetClasses, setAssetClasses] = useState<AssetClassBreakdown[]>([]);
   const [milestones, setMilestones] = useState<NetWorthMilestone[]>([]);
   const [history, setHistory] = useState<NetWorthSeriesPoint[]>([]);
+  const [periodComparison, setPeriodComparison] = useState<PeriodComparison | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState(0);
@@ -102,10 +110,23 @@ export function useNetWorth(purposeFilter: AccountPurposeFilter = 'all'): UseNet
       const ms = detectMilestones(nw.netWorth, nw.liabilities);
       const series = buildNetWorthHistorySeries(scopedAccounts, scopedTransactions);
 
+      // Period-over-period delta from the two most recent history points
+      // (oldest-first series → last two entries are prior period vs. current).
+      const comparison =
+        series.length >= 2
+          ? computePeriodComparison(
+              series[series.length - 1].netWorthCents,
+              series[series.length - 2].netWorthCents,
+              series[series.length - 1].label,
+              series[series.length - 2].label,
+            )
+          : null;
+
       setCurrentNetWorth(nw);
       setAssetClasses(classes);
       setMilestones(ms);
       setHistory(series);
+      setPeriodComparison(comparison);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to compute net worth.');
     } finally {
@@ -113,5 +134,14 @@ export function useNetWorth(purposeFilter: AccountPurposeFilter = 'all'): UseNet
     }
   }, [db, refreshToken, purposeFilter]);
 
-  return { currentNetWorth, assetClasses, milestones, history, loading, error, refresh };
+  return {
+    currentNetWorth,
+    assetClasses,
+    milestones,
+    history,
+    periodComparison,
+    loading,
+    error,
+    refresh,
+  };
 }

--- a/apps/web/src/pages/NetWorthPage.test.tsx
+++ b/apps/web/src/pages/NetWorthPage.test.tsx
@@ -29,8 +29,28 @@ vi.mock('../components/charts/NetWorthProjectionChart', () => ({
 }));
 
 import { useNetWorth } from '../hooks/useNetWorth';
+import type { UseNetWorthResult } from '../hooks/useNetWorth';
 
 const mockUseNetWorth = vi.mocked(useNetWorth);
+
+/**
+ * Build a complete {@link UseNetWorthResult} for the mocked hook. Tests pass
+ * only the fields they exercise; everything else defaults to an empty/neutral
+ * value so adding a new field to the hook never breaks unrelated cases.
+ */
+function makeNetWorthResult(overrides: Partial<UseNetWorthResult> = {}): UseNetWorthResult {
+  return {
+    currentNetWorth: null,
+    assetClasses: [],
+    milestones: [],
+    history: [],
+    periodComparison: null,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    ...overrides,
+  };
+}
 
 describe('NetWorthPage', () => {
   beforeEach(() => {
@@ -38,95 +58,69 @@ describe('NetWorthPage', () => {
   });
 
   it('shows loading spinner while loading', () => {
-    mockUseNetWorth.mockReturnValue({
-      currentNetWorth: null,
-      assetClasses: [],
-      milestones: [],
-      history: [],
-      loading: true,
-      error: null,
-      refresh: vi.fn(),
-    });
+    mockUseNetWorth.mockReturnValue(makeNetWorthResult({ loading: true }));
 
     render(<NetWorthPage />);
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   it('shows error banner on error', () => {
-    mockUseNetWorth.mockReturnValue({
-      currentNetWorth: null,
-      assetClasses: [],
-      milestones: [],
-      history: [],
-      loading: false,
-      error: 'Failed to load',
-      refresh: vi.fn(),
-    });
+    mockUseNetWorth.mockReturnValue(makeNetWorthResult({ error: 'Failed to load' }));
 
     render(<NetWorthPage />);
     expect(screen.getByText('Failed to load')).toBeInTheDocument();
   });
 
   it('shows empty state when no accounts', () => {
-    mockUseNetWorth.mockReturnValue({
-      currentNetWorth: null,
-      assetClasses: [],
-      milestones: [],
-      history: [],
-      loading: false,
-      error: null,
-      refresh: vi.fn(),
-    });
+    mockUseNetWorth.mockReturnValue(makeNetWorthResult());
 
     render(<NetWorthPage />);
     expect(screen.getByText('No accounts found')).toBeInTheDocument();
   });
 
   it('renders net worth data and milestones', () => {
-    mockUseNetWorth.mockReturnValue({
-      currentNetWorth: {
-        label: '2024-03-15',
-        assets: 2000000,
-        liabilities: 500000,
-        netWorth: 1500000,
-      },
-      assetClasses: [
-        {
-          className: 'Savings',
-          accountTypes: ['SAVINGS'],
-          balance: 1500000,
-          isLiability: false,
-          percent: 75,
-          accountCount: 1,
+    mockUseNetWorth.mockReturnValue(
+      makeNetWorthResult({
+        currentNetWorth: {
+          label: '2024-03-15',
+          assets: 2000000,
+          liabilities: 500000,
+          netWorth: 1500000,
         },
-        {
-          className: 'Checking',
-          accountTypes: ['CHECKING'],
-          balance: 500000,
-          isLiability: false,
-          percent: 25,
-          accountCount: 1,
-        },
-      ],
-      milestones: [
-        {
-          id: 'milestone-0',
-          label: 'First $1K',
-          thresholdCents: 100000,
-          reached: true,
-        },
-        {
-          id: 'milestone-1',
-          label: 'First $50K',
-          thresholdCents: 5000000,
-          reached: false,
-        },
-      ],
-      history: [],
-      loading: false,
-      error: null,
-      refresh: vi.fn(),
-    });
+        assetClasses: [
+          {
+            className: 'Savings',
+            accountTypes: ['SAVINGS'],
+            balance: 1500000,
+            isLiability: false,
+            percent: 75,
+            accountCount: 1,
+          },
+          {
+            className: 'Checking',
+            accountTypes: ['CHECKING'],
+            balance: 500000,
+            isLiability: false,
+            percent: 25,
+            accountCount: 1,
+          },
+        ],
+        milestones: [
+          {
+            id: 'milestone-0',
+            label: 'First $1K',
+            thresholdCents: 100000,
+            reached: true,
+          },
+          {
+            id: 'milestone-1',
+            label: 'First $50K',
+            thresholdCents: 5000000,
+            reached: false,
+          },
+        ],
+      }),
+    );
 
     render(<NetWorthPage />);
     expect(screen.getByRole('heading', { name: 'Net Worth', level: 1 })).toBeInTheDocument();
@@ -138,24 +132,21 @@ describe('NetWorthPage', () => {
   });
 
   it('renders the net worth projection section when history is available', () => {
-    mockUseNetWorth.mockReturnValue({
-      currentNetWorth: {
-        label: '2024-03-15',
-        assets: 2000000,
-        liabilities: 500000,
-        netWorth: 1500000,
-      },
-      assetClasses: [],
-      milestones: [],
-      history: [
-        { label: 'Jan', netWorthCents: 1000000, dateIso: '2024-01-31' },
-        { label: 'Feb', netWorthCents: 1250000, dateIso: '2024-02-29' },
-        { label: 'Mar', netWorthCents: 1500000, dateIso: '2024-03-15' },
-      ],
-      loading: false,
-      error: null,
-      refresh: vi.fn(),
-    });
+    mockUseNetWorth.mockReturnValue(
+      makeNetWorthResult({
+        currentNetWorth: {
+          label: '2024-03-15',
+          assets: 2000000,
+          liabilities: 500000,
+          netWorth: 1500000,
+        },
+        history: [
+          { label: 'Jan', netWorthCents: 1000000, dateIso: '2024-01-31' },
+          { label: 'Feb', netWorthCents: 1250000, dateIso: '2024-02-29' },
+          { label: 'Mar', netWorthCents: 1500000, dateIso: '2024-03-15' },
+        ],
+      }),
+    );
 
     render(<NetWorthPage />);
     expect(
@@ -164,21 +155,63 @@ describe('NetWorthPage', () => {
     expect(screen.getByTestId('net-worth-projection-chart')).toBeInTheDocument();
   });
 
+  it('renders the period-over-period change when a comparison is available', () => {
+    mockUseNetWorth.mockReturnValue(
+      makeNetWorthResult({
+        currentNetWorth: {
+          label: 'Mar',
+          assets: 2000000,
+          liabilities: 500000,
+          netWorth: 1500000,
+        },
+        history: [
+          { label: 'Feb', netWorthCents: 1250000, dateIso: '2024-02-29' },
+          { label: 'Mar', netWorthCents: 1500000, dateIso: '2024-03-15' },
+        ],
+        periodComparison: {
+          currentLabel: 'Mar',
+          previousLabel: 'Feb',
+          currentNetWorth: 1500000,
+          previousNetWorth: 1250000,
+          changeCents: 250000,
+          changePercent: 20,
+        },
+      }),
+    );
+
+    render(<NetWorthPage />);
+    expect(screen.getByText(/vs Feb/)).toBeInTheDocument();
+    expect(screen.getByText(/\(\+20%\)/)).toBeInTheDocument();
+  });
+
+  it('omits the period-over-period change when no comparison exists', () => {
+    mockUseNetWorth.mockReturnValue(
+      makeNetWorthResult({
+        currentNetWorth: {
+          label: 'Mar',
+          assets: 2000000,
+          liabilities: 500000,
+          netWorth: 1500000,
+        },
+        periodComparison: null,
+      }),
+    );
+
+    render(<NetWorthPage />);
+    expect(screen.queryByText(/ vs /)).not.toBeInTheDocument();
+  });
+
   it('renders the workspace purpose filter and defaults to all accounts', () => {
-    mockUseNetWorth.mockReturnValue({
-      currentNetWorth: {
-        label: '2024-03-15',
-        assets: 2000000,
-        liabilities: 500000,
-        netWorth: 1500000,
-      },
-      assetClasses: [],
-      milestones: [],
-      history: [],
-      loading: false,
-      error: null,
-      refresh: vi.fn(),
-    });
+    mockUseNetWorth.mockReturnValue(
+      makeNetWorthResult({
+        currentNetWorth: {
+          label: '2024-03-15',
+          assets: 2000000,
+          liabilities: 500000,
+          netWorth: 1500000,
+        },
+      }),
+    );
 
     render(<NetWorthPage />);
     expect(screen.getByRole('group', { name: 'Filter by account purpose' })).toBeInTheDocument();
@@ -186,20 +219,16 @@ describe('NetWorthPage', () => {
   });
 
   it('scopes net worth to the business workspace when selected', () => {
-    mockUseNetWorth.mockReturnValue({
-      currentNetWorth: {
-        label: '2024-03-15',
-        assets: 2000000,
-        liabilities: 500000,
-        netWorth: 1500000,
-      },
-      assetClasses: [],
-      milestones: [],
-      history: [],
-      loading: false,
-      error: null,
-      refresh: vi.fn(),
-    });
+    mockUseNetWorth.mockReturnValue(
+      makeNetWorthResult({
+        currentNetWorth: {
+          label: '2024-03-15',
+          assets: 2000000,
+          liabilities: 500000,
+          netWorth: 1500000,
+        },
+      }),
+    );
 
     render(<NetWorthPage />);
     fireEvent.click(screen.getByRole('button', { name: /Business/ }));
@@ -207,15 +236,11 @@ describe('NetWorthPage', () => {
   });
 
   it('keeps the workspace filter visible when the selected workspace has no balances', () => {
-    mockUseNetWorth.mockReturnValue({
-      currentNetWorth: { label: '2024-03-15', assets: 0, liabilities: 0, netWorth: 0 },
-      assetClasses: [],
-      milestones: [],
-      history: [],
-      loading: false,
-      error: null,
-      refresh: vi.fn(),
-    });
+    mockUseNetWorth.mockReturnValue(
+      makeNetWorthResult({
+        currentNetWorth: { label: '2024-03-15', assets: 0, liabilities: 0, netWorth: 0 },
+      }),
+    );
 
     render(<NetWorthPage />);
     expect(screen.getByText('No net worth data')).toBeInTheDocument();

--- a/apps/web/src/pages/NetWorthPage.tsx
+++ b/apps/web/src/pages/NetWorthPage.tsx
@@ -25,7 +25,11 @@ import { AccountPurposeFilterControl } from '../components/accounts';
 import { AppIcon } from '../components/icons';
 import { NetWorthProjectionChart } from '../components/charts/NetWorthProjectionChart';
 import { useNetWorth } from '../hooks/useNetWorth';
-import type { AssetClassBreakdown, NetWorthMilestone } from '../lib/analytics/net-worth';
+import type {
+  AssetClassBreakdown,
+  NetWorthMilestone,
+  PeriodComparison,
+} from '../lib/analytics/net-worth';
 import type { AccountPurposeFilter } from '../lib/accountPurpose';
 import { CHART_COLORS } from '../components/charts/chart-palette';
 import './analytics.css';
@@ -99,14 +103,63 @@ const MilestoneList: React.FC<MilestoneListProps> = ({ milestones }) => (
   </div>
 );
 
+interface NetWorthChangeIndicatorProps {
+  comparison: PeriodComparison;
+}
+
+const NET_WORTH_CHANGE_ICON = { up: '▲', down: '▼', flat: '→' } as const;
+
+/**
+ * Period-over-period net worth change (typically month-over-month).
+ *
+ * Direction is conveyed with an arrow glyph, an explicit +/− sign, and plain
+ * text ("vs {previous period}") — never colour alone (WCAG 2.2 §1.4.1). The
+ * percentage denominator uses the absolute prior value, so a recovery from a
+ * negative net worth still reads as an increase.
+ */
+const NetWorthChangeIndicator: React.FC<NetWorthChangeIndicatorProps> = ({ comparison }) => {
+  const { changeCents, changePercent, previousLabel } = comparison;
+  const direction = changeCents > 0 ? 'up' : changeCents < 0 ? 'down' : 'flat';
+
+  return (
+    <p className="analytics-metric-card__change" aria-live="polite">
+      <span className="analytics-metric-card__change-icon" aria-hidden="true">
+        {NET_WORTH_CHANGE_ICON[direction]}
+      </span>{' '}
+      <CurrencyDisplay
+        amount={changeCents}
+        colorize
+        showSign
+        context={`change versus ${previousLabel}`}
+      />
+      {direction !== 'flat' && (
+        <span className="analytics-metric-card__change-percent">
+          {' '}
+          ({changePercent > 0 ? '+' : ''}
+          {changePercent}%)
+        </span>
+      )}{' '}
+      <span className="analytics-metric-card__change-period">vs {previousLabel}</span>
+    </p>
+  );
+};
+
 // ---------------------------------------------------------------------------
 // Page component
 // ---------------------------------------------------------------------------
 
 export const NetWorthPage: React.FC = () => {
   const [purposeFilter, setPurposeFilter] = useState<AccountPurposeFilter>('all');
-  const { currentNetWorth, assetClasses, milestones, history, loading, error, refresh } =
-    useNetWorth(purposeFilter);
+  const {
+    currentNetWorth,
+    assetClasses,
+    milestones,
+    history,
+    periodComparison,
+    loading,
+    error,
+    refresh,
+  } = useNetWorth(purposeFilter);
 
   if (loading) {
     return (
@@ -191,6 +244,7 @@ export const NetWorthPage: React.FC = () => {
             >
               <CurrencyDisplay amount={currentNetWorth.netWorth} />
             </p>
+            {periodComparison && <NetWorthChangeIndicator comparison={periodComparison} />}
           </article>
           <article className="analytics-metric-card" aria-label="Total assets">
             <div


### PR DESCRIPTION
## Summary

The Net Worth page never showed how net worth moved versus the prior period. The
math already existed — `computePeriodComparison` in `net-worth.ts` — but nothing
consumed it. For an investor who tracks net worth to the dollar, "up or down, and
by how much, since last month" is the headline number, so this wires it in.

## Changes

- **`useNetWorth`** now returns `periodComparison: PeriodComparison | null`,
  computed from the two most recent history points (oldest-first series → last
  two entries). `null` when fewer than two points exist.
- **`NetWorthPage`** renders an accessible change indicator directly beneath the
  net worth value: arrow glyph (`▲`/`▼`/`→`, `aria-hidden`) + explicit `+`/`−`
  sign via `CurrencyDisplay` + `(±N%)` + `vs {previous period}`. Direction is
  conveyed by shape, sign, and text — **never colour alone** (WCAG 2.2 SC 1.4.1).
  The percentage denominator uses the absolute prior value, so a recovery from a
  negative net worth still reads as an increase.
- **`NetWorthPage.test.tsx`** refactored onto a `makeNetWorthResult` factory so
  adding a hook field no longer breaks every unrelated mock; added tests for the
  indicator rendering and for its omission when no comparison exists.

## Persona

Found by persona: Alexandra Petrova (HNW active investor)

## Issues

Closes #3267

## Testing

- [x] `npx tsc -b` clean (exit 0) — verifies the new required `periodComparison`
      field is satisfied everywhere it is constructed.
- [x] `npx vitest run src/pages/NetWorthPage.test.tsx` — 10 passed.
- [x] Prettier + ESLint clean on changed files (`--max-warnings 0`).
- [x] CI: **ESLint & Prettier ✅, Secret Detection ✅, CodeQL (java-kotlin) ✅,
      CodeQL (javascript-typescript) ✅, Required Checks Gatekeeper ✅.**

## Needs Human Action

**Blocker: the `Build` required check fails on a pre-existing, systemic
performance-budget breach that is unrelated to this PR and outside web-engineer
file ownership.**

- Failure: `assets/vendor-app-*.js gzip 196 KiB exceeds lazy chunk budget 195 KiB`
  (`maxLazyChunkGzipBytes: 200000` in `apps/web/performance.budget.json`).
- `vendor-app` is a **third-party vendor chunk** (the node_modules catch-all in
  the vite `manualChunks` config). This PR adds ~40 lines of UI to `NetWorthPage`
  (which bundles into a **route chunk**) and imports **no new dependency** — so
  it cannot and does not change `vendor-app`'s size.
- **Systemic, not local:** open PRs #3474, #3470, and #3467 fail the identical
  `Build` budget check right now. A recent merge to `main` pushed `vendor-app`
  ~700 bytes gzip over the boundary; every branch rebased onto current `main`
  inherits it.
- **Ownership:** the fix belongs to `@performance-engineer` (budget threshold in
  `performance.budget.json`) and/or `@devops-engineer` (vite `manualChunks`
  vendor splitting in `apps/web/vite.config.ts`) — both outside this web PR's
  scope. Editing them here would violate the fleet file-ownership rules.

**Recommended resolution (either):**

1. `@performance-engineer`/`@devops-engineer` trims `vendor-app` (split a heavy
   dep into its own vendor group) or bumps `maxLazyChunkGzipBytes` to reflect the
   new baseline — then this PR's `Build` re-runs green and it self-merges; **or**
2. A maintainer merges with `gh pr merge 3472 --squash --admin` (all other
   required checks are green and the code is verified: `tsc -b`, ESLint, and 10
   unit tests pass).

This PR is **MERGEABLE** (no conflicts) and green on every check it can influence.
