### PR TITLE
fix(web): unblock web CI - BillsPage plural test + vendor-i18n chunk split (#3473, #3478)

### DIFF
--- a/apps/web/src/pages/BillsPage.test.tsx
+++ b/apps/web/src/pages/BillsPage.test.tsx
@@ -107,7 +107,7 @@ describe('BillsPage', () => {
     const summarySection = screen.getByRole('region', { name: 'Bills summary' });
     expect(within(summarySection).getByText('Upcoming')).toBeInTheDocument();
     expect(within(summarySection).getByText('Overdue')).toBeInTheDocument();
-    expect(within(summarySection).getAllByText('1 bills')).toHaveLength(2);
+    expect(within(summarySection).getAllByText('1 bill')).toHaveLength(2);
   });
 
   it('renders notification enable banner when permission is default', () => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -353,13 +353,25 @@ export default defineConfig({
               priority: 100,
             },
             {
+              // Locale catalogs (i18n message packs) are large, text-heavy, and
+              // grow with every new string. Keep them in their own shared chunk
+              // so cumulative catalog growth does not push the core shared-infra
+              // chunk (`vendor-app`) past the lazy-chunk budget (#3478). This
+              // preserves the #2983 goal of keeping db/auth/contexts unified
+              // while isolating the most separable, fastest-growing contributor.
+              name: 'vendor-i18n',
+              test: /[\\/]src[\\/]lib[\\/]i18n[\\/]/,
+              priority: 60,
+            },
+            {
               // Shared application infrastructure (SQLite-WASM data layer,
-              // repositories, auth, React contexts, i18n catalogs) is imported
-              // by nearly every route. Hoist it into one shared chunk instead
-              // of letting rolldown host it inside `route-dashboard`, which
-              // chronically inflated that chunk past the budget (#2983).
+              // repositories, auth, React contexts) is imported by nearly every
+              // route. Hoist it into one shared chunk instead of letting
+              // rolldown host it inside `route-dashboard`, which chronically
+              // inflated that chunk past the budget (#2983). Locale catalogs are
+              // split into `vendor-i18n` above (#3478).
               name: 'vendor-app',
-              test: /[\\/]src[\\/](db|auth|contexts|lib[\\/]i18n)[\\/]/,
+              test: /[\\/]src[\\/](db|auth|contexts)[\\/]/,
               priority: 50,
             },
             {


### PR DESCRIPTION
﻿## Summary

Two tiny, closely-related fixes that unblock the **required web CI checks** on `main`. Both are pre-existing failures on `origin/main` that turn checks red for **every** web PR in flight, so batching them per AGENTS.md 4a (CI unblockers).

## Changes

1. **`BillsPage.test.tsx` — correct stale plural assertion (#3473).** Commit `96454f95` (#3412, "pluralize count labels") changed `BillsPage.tsx` to render `1 bill` (singular) but left the test asserting `1 bills`. This fails `Unit Tests` shard 1 on every web PR. One-line assertion fix.
2. **`vite.config.ts` — split i18n catalogs into a `vendor-i18n` chunk (#3478).** The `vendor-app` shared-infra lazy chunk (`db|auth|contexts|lib/i18n`) grew past the 200000-byte gzip lazy-chunk budget from cumulative locale-catalog growth, turning the **required `Build` check** red. Hoisting `src/lib/i18n` into its own `vendor-i18n` chunk (priority 60) preserves the #2983 decision to keep `db/auth/contexts` unified while isolating the largest, fastest-growing, most-separable contributor.

## Verification

- `vendor-app` gzip **201.5 -> 189.1 kB** (under the 200 kB budget); new `vendor-i18n` ~12.5 kB gzip.
- `node tools/check-web-performance-budget.mjs --dist apps/web/dist --budget apps/web/performance.budget.json` -> **passes** (exit 0).
- Initial JS unchanged at 20 KiB (no first-load regression).
- `BillsPage.test.tsx` 11/11 pass locally.

## Issues

Closes #3473
Closes #3478

## Testing

- [x] `BillsPage` tests pass (`vitest run`)
- [x] Performance budget checker passes
- [x] Prettier + ESLint clean

Found by persona: Marcus Johnson (aggressive debt-payoff)
