### PR TITLE
fix(web): make in-app high contrast theme-aware for dark themes (#3277)

### DIFF
--- a/apps/web/src/styles/accessibility.css
+++ b/apps/web/src/styles/accessibility.css
@@ -315,6 +315,14 @@ html[data-accessibility-font-size='extra-large'] {
   font-size: 20px;
 }
 
+/*
+ * In-app "High contrast" toggle and Simplified mode.
+ *
+ * The default palette below targets light themes. Dark and OLED themes get a
+ * matching high-contrast DARK palette further down so enabling high contrast
+ * strengthens separation within the user's chosen theme instead of forcing a
+ * white background over it (see issue #3277).
+ */
 body.accessibility-high-contrast,
 body.accessibility-simplified {
   --semantic-background-primary: #ffffff;
@@ -335,6 +343,37 @@ body.accessibility-simplified {
   --semantic-status-info: #1d4ed8;
   --semantic-amount-positive: #14532d;
   --semantic-amount-negative: #7f1d1d;
+}
+
+/*
+ * High-contrast DARK palette for dark and OLED themes. All foreground colors
+ * exceed WCAG AAA (7:1) contrast against the near-black surfaces, so a user who
+ * prefers a dark theme keeps it when turning on high contrast or Simplified
+ * mode. Higher specificity than the light rule above (theme attribute on <html>
+ * plus the body class) so it wins for dark themes only.
+ */
+[data-theme='dark'] body.accessibility-high-contrast,
+[data-theme='dark'] body.accessibility-simplified,
+[data-theme='dark-oled'] body.accessibility-high-contrast,
+[data-theme='dark-oled'] body.accessibility-simplified {
+  --semantic-background-primary: #000000;
+  --semantic-background-secondary: #0a0a0a;
+  --semantic-background-elevated: #141414;
+  --semantic-text-primary: #ffffff;
+  --semantic-text-secondary: #f3f4f6;
+  --semantic-text-inverse: #000000;
+  --semantic-border-default: #ffffff;
+  --semantic-border-focus: #ffffff;
+  --semantic-border-error: #fecaca;
+  --semantic-interactive-default: #93c5fd;
+  --semantic-interactive-hover: #bfdbfe;
+  --semantic-interactive-pressed: #dbeafe;
+  --semantic-status-positive: #86efac;
+  --semantic-status-negative: #fca5a5;
+  --semantic-status-warning: #fcd34d;
+  --semantic-status-info: #93c5fd;
+  --semantic-amount-positive: #86efac;
+  --semantic-amount-negative: #fca5a5;
 }
 
 body.accessibility-simplified {


### PR DESCRIPTION
## Needs Human Action: unrelated performance-budget blocker (route to @performance-engineer / @devops-engineer)

**This PR's own change is complete and correct** (ESLint & Prettier green; WCAG AAA contrast verified). It cannot self-merge because the required **Build** check fails on a pre-existing, unrelated bundle-size budget:

```
Performance budget check failed:
- assets/vendor-app-*.js gzip ~201.5 KiB exceeds lazy chunk budget (maxLazyChunkGzipBytes: 200000 = 195.3 KiB)
```

**Evidence this is not caused by this PR:** this change edits only `apps/web/src/styles/accessibility.css`. The failing asset is `vendor-app-*.js`, a **JavaScript vendor chunk** built entirely from dependencies -- a CSS edit cannot change its size. A local production build of this branch (rebased on current `main`) measures `vendor-app` at **gzip 201.54 kB**, already over the 200000-byte budget. The breach exists on `main` from accumulated feature JS and blocks every web PR built now.

**Human action needed (outside this persona's file ownership):** either raise `apps/web/performance.budget.json` -> `maxLazyChunkGzipBytes`, or code-split the `vendor-app` chunk in the Vite config. Both are owned by @performance-engineer / @devops-engineer. Once `main`'s vendor-app budget is resolved, a rebase of this branch will go green -- no further change to this CSS fix is required.

---

## Summary

The in-app **High contrast** toggle (Settings -> Accessibility) and **Simplified mode** forced a hardcoded **light** palette -- white background, black text -- regardless of the theme the user had chosen. A user on the Dark or OLED theme who turns on high contrast (or Simplified mode) was yanked to a bright white screen, which defeats the whole point of choosing a dark theme and is painful for the light-sensitive, low-vision users these controls exist to help.

## Root cause

`apps/web/src/styles/accessibility.css` -- `body.accessibility-high-contrast, body.accessibility-simplified` unconditionally set a light semantic palette (`--semantic-background-primary: #ffffff`, `--semantic-text-primary: #111111`, ...). Because the accessibility class lives on `<body>` and the theme lives on `html[data-theme]`, the overlay always won and overrode the dark/OLED palette from `themes.css`.

Note: this is the accessibility **toggle** overlay, distinct from the full `data-theme='high-contrast'` theme (which is unaffected).

## Fix

- Keep the existing light palette as the **light-theme default** (documented as such).
- Add a matching high-contrast **dark** palette scoped to `[data-theme='dark']` and `[data-theme='dark-oled']` (both the high-contrast and simplified classes). The theme-attribute-plus-body-class selector has higher specificity than the base rule, so it wins for dark themes only and leaves light themes untouched.

Enabling high contrast now **strengthens** separation within the user's chosen theme instead of replacing it.

### Contrast verification (WCAG SC 1.4.3 / 1.4.6)

Every foreground color in the new dark palette exceeds WCAG **AAA** (7:1) against the near-black surfaces (`#000000` primary, `#141414` elevated):

| Pair                                       | Ratio   |
| ------------------------------------------ | ------- |
| text-primary `#ffffff` on `#000000`        | 21.00:1 |
| text-secondary `#f3f4f6` on `#000000`      | 19.08:1 |
| text-primary on elevated `#141414`         | 18.42:1 |
| positive `#86efac` on `#000000`            | 14.96:1 |
| warning `#fcd34d` on `#000000`             | 14.56:1 |
| interactive/info `#93c5fd` on `#000000`    | 11.65:1 |
| inverse `#000000` on interactive `#93c5fd` | 11.65:1 |
| negative `#fca5a5` on `#000000`            | 11.06:1 |

Lowest pair is 11.06:1 -- comfortably above AAA.

## Changes

- `apps/web/src/styles/accessibility.css` -- documented the light default; added a scoped dark high-contrast palette for dark/OLED themes (additive, +39 lines).

## Testing

- [x] `npx prettier --check apps/web/src/styles/accessibility.css` -> clean
- [x] ESLint & Prettier CI check -> pass
- [x] Contrast ratios computed for all foreground/background pairs -> all AAA (>= 11:1)
- [x] Additive/scoped change: light themes are byte-for-byte unaffected; only dark/OLED + accessibility-high-contrast/simplified users see the new palette (previously a forced-light regression, so strictly an improvement)

## Cross-platform

CSS-only web overlay. iOS/Android/Windows manage high contrast through their native theming systems and are not affected.

## Issues

Closes #3277

Found by persona: Harold Whitfield (retiree low-vision fixed-income)
