### PR TITLE
feat(web): surface 529 college fund planner in Planning (#3386)

### DIFF
--- a/apps/web/src/pages/PlanningPage.css
+++ b/apps/web/src/pages/PlanningPage.css
@@ -1022,6 +1022,84 @@
   color: var(--semantic-text-secondary);
 }
 
+/* Education / 529 college fund planner */
+.education-planner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+}
+
+.education-announce {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.education-coverage-bar {
+  height: 12px;
+  width: 100%;
+  background: var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  overflow: hidden;
+  margin-bottom: var(--spacing-3);
+}
+
+.education-coverage-bar__fill {
+  display: block;
+  height: 100%;
+  background: var(--semantic-status-positive);
+  transition: width 0.3s ease;
+}
+
+.education-coverage-bar__fill--gap {
+  background: var(--semantic-status-warning);
+}
+
+.education-status {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin: 0 0 var(--spacing-3);
+  font-size: var(--type-scale-body-font-size);
+  font-weight: 600;
+}
+
+.education-status--ok {
+  color: var(--semantic-status-positive);
+}
+
+.education-status--gap {
+  color: var(--semantic-status-warning);
+}
+
+.education-allocation {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--spacing-4);
+  margin: 0;
+}
+
+.education-allocation__item {
+  padding: var(--spacing-4);
+  background: var(--semantic-background-elevated);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  text-align: center;
+}
+
+.education-allocation__item dt {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin-bottom: var(--spacing-1);
+}
+
+.education-allocation__item dd {
+  margin: 0;
+  font-size: var(--type-scale-title-font-size);
+  font-weight: 700;
+  color: var(--semantic-text-primary);
+}
+
 .wedding-badge--paid {
   color: var(--semantic-status-positive);
   border-color: var(--semantic-status-positive);
@@ -1196,6 +1274,7 @@
   .readiness-score__fill,
   .goal-progress__fill,
   .wedding-budget-bar__fill,
+  .education-coverage-bar__fill,
   .planning-btn,
   .scenario-item {
     transition: none;

--- a/apps/web/src/pages/PlanningPage.test.tsx
+++ b/apps/web/src/pages/PlanningPage.test.tsx
@@ -630,4 +630,33 @@ describe('PlanningPage', () => {
     expect(within(bandRow).getByText('$500.00')).toBeTruthy(); // deposit
     expect(within(bandRow).getByText('$2000.00')).toBeTruthy(); // remaining
   });
+
+  it('surfaces a College Fund tab with a live 529 funding projection', () => {
+    render(<PlanningPage />);
+    expect(screen.getByRole('tab', { name: /college fund/i })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('tab', { name: /college fund/i }));
+
+    expect(screen.getByRole('heading', { name: /college fund \(529\) planner/i })).toBeTruthy();
+    expect(screen.getByRole('progressbar', { name: /college costs/i })).toBeTruthy();
+    expect(screen.getByText('Projected cost')).toBeTruthy();
+    expect(screen.getByText('Needed / month')).toBeTruthy();
+    expect(screen.getByText('Annual tax benefit')).toBeTruthy();
+    // The default seed ($250/mo from birth) does not fully fund four years of college.
+    expect(screen.getAllByText(/short/i).length).toBeGreaterThan(0);
+  });
+
+  it('recomputes 529 coverage live when the monthly contribution changes', () => {
+    render(<PlanningPage />);
+    fireEvent.click(screen.getByRole('tab', { name: /college fund/i }));
+
+    const bar = screen.getByRole('progressbar', { name: /college costs/i });
+    // A large monthly contribution fully funds the goal and flips the status to on-track.
+    fireEvent.change(screen.getByLabelText('Monthly contribution (USD)'), {
+      target: { value: '5000' },
+    });
+
+    expect(bar).toHaveAttribute('aria-valuenow', '100');
+    expect(screen.getAllByText(/on track/i).length).toBeGreaterThan(0);
+  });
 });

--- a/apps/web/src/pages/PlanningPage.tsx
+++ b/apps/web/src/pages/PlanningPage.tsx
@@ -37,7 +37,7 @@ import type {
   SweepEvaluation,
   SweepLogEntry,
 } from '../lib/planning';
-import { projectRetirementHealthcareCosts } from '../lib/planning';
+import { analyzeEducationFund, projectRetirementHealthcareCosts } from '../lib/planning';
 import {
   buildWeddingPlanSummary,
   buildWeddingVendorBreakdown,
@@ -54,13 +54,15 @@ import { TrendLineChart } from '../components/charts';
 // Types
 // ---------------------------------------------------------------------------
 
-type PlanningTab = 'scenarios' | 'life-events' | 'wedding' | 'retirement' | 'goals' | 'sweep';
+type PlanningTab =
+  'scenarios' | 'life-events' | 'wedding' | 'retirement' | 'education' | 'goals' | 'sweep';
 
 const TAB_CONFIG: { id: PlanningTab; label: string; icon: IconName }[] = [
   { id: 'scenarios', label: 'What-If Modeler', icon: 'sparkles' },
   { id: 'life-events', label: 'Life Events', icon: 'calendar' },
   { id: 'wedding', label: 'Wedding', icon: 'gift' },
   { id: 'retirement', label: 'Retirement', icon: 'leaf' },
+  { id: 'education', label: 'College Fund', icon: 'medal' },
   { id: 'goals', label: 'Savings Goals', icon: 'target' },
   { id: 'sweep', label: 'Automations', icon: 'lightning' },
 ];
@@ -2173,6 +2175,249 @@ const WeddingWorkspacePanel: React.FC = () => {
 };
 
 // ---------------------------------------------------------------------------
+// Education / 529 college fund planner
+// ---------------------------------------------------------------------------
+
+/** Age at which college is assumed to begin. */
+const EDUCATION_START_AGE = 18;
+/** Assumed annual tuition inflation (5.00%). */
+const EDUCATION_TUITION_INFLATION_BPS = 500;
+/** Assumed annual investment return (6.00%). */
+const EDUCATION_ANNUAL_RETURN_BPS = 600;
+/** Assumed state income tax rate for 529 benefit estimate (5.00%). */
+const EDUCATION_STATE_TAX_BPS = 500;
+
+/**
+ * Parse a dollar string into non-negative integer cents.
+ *
+ * @param value - The raw input value in dollars
+ * @returns The value in cents, floored at 0
+ */
+function educationDollarsToCents(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0;
+  }
+  return Math.round(parsed * 100);
+}
+
+/**
+ * Education / 529 college fund planner panel.
+ *
+ * Surfaces the shared `analyzeEducationFund` engine so a family can project
+ * college costs and check whether their 529 savings are on track. Results
+ * update live as the inputs change.
+ */
+const EducationPanel: React.FC = () => {
+  const [childAge, setChildAge] = useState('0');
+  const [annualTuition, setAnnualTuition] = useState('22000');
+  const [educationYears, setEducationYears] = useState('4');
+  const [currentBalance, setCurrentBalance] = useState('0');
+  const [monthlyContribution, setMonthlyContribution] = useState('250');
+
+  const beneficiaryAge = Math.max(0, Math.min(17, Math.floor(Number(childAge) || 0)));
+
+  const result = useMemo(
+    () =>
+      analyzeEducationFund({
+        beneficiaryAge,
+        educationStartAge: EDUCATION_START_AGE,
+        educationYears: Math.max(1, Math.floor(Number(educationYears) || 1)),
+        currentAnnualTuitionCents: educationDollarsToCents(annualTuition),
+        tuitionInflationBps: EDUCATION_TUITION_INFLATION_BPS,
+        currentBalanceCents: educationDollarsToCents(currentBalance),
+        monthlyContributionCents: educationDollarsToCents(monthlyContribution),
+        annualReturnBps: EDUCATION_ANNUAL_RETURN_BPS,
+        stateTaxRateBps: EDUCATION_STATE_TAX_BPS,
+      }),
+    [beneficiaryAge, educationYears, annualTuition, currentBalance, monthlyContribution],
+  );
+
+  const coveragePercent = Math.max(0, Math.min(100, Math.round(result.coverageRatioBps / 100)));
+  const fullyFunded = result.fundingGapCents <= 0;
+  const yearsToStart = Math.max(0, EDUCATION_START_AGE - beneficiaryAge);
+
+  const announcement = fullyFunded
+    ? `On track: projected savings of ${formatCurrency(
+        result.projectedBalanceCents,
+      )} cover the estimated ${formatCurrency(result.totalProjectedCostCents)} cost of college.`
+    : `Projected shortfall of ${formatCurrency(
+        result.fundingGapCents,
+      )}. Contributing ${formatCurrency(
+        result.requiredMonthlyContributionCents,
+      )} per month would fully fund the goal.`;
+
+  return (
+    <div className="education-planner">
+      <section className="planning-card" aria-labelledby="education-intro-title">
+        <h3 id="education-intro-title" className="planning-card__title">
+          College fund (529) planner
+        </h3>
+        <p className="planning-card__description">
+          Project your child&apos;s college costs and see whether your 529 savings are on track.
+          Assumes college starts at age {EDUCATION_START_AGE},{' '}
+          {EDUCATION_TUITION_INFLATION_BPS / 100}% annual tuition inflation, and a{' '}
+          {EDUCATION_ANNUAL_RETURN_BPS / 100}% expected return.
+        </p>
+        <div className="life-events-form" aria-label="Education fund inputs">
+          <label className="life-events-field">
+            Child&apos;s current age (years)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              max={17}
+              step={1}
+              value={childAge}
+              onChange={(e) => setChildAge(e.target.value)}
+            />
+          </label>
+          <label className="life-events-field">
+            Current annual tuition (USD)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="500"
+              value={annualTuition}
+              onChange={(e) => setAnnualTuition(e.target.value)}
+            />
+          </label>
+          <label className="life-events-field">
+            Years of college
+            <input
+              className="form-input"
+              type="number"
+              inputMode="numeric"
+              min={1}
+              max={8}
+              step={1}
+              value={educationYears}
+              onChange={(e) => setEducationYears(e.target.value)}
+            />
+          </label>
+          <label className="life-events-field">
+            Current 529 balance (USD)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="100"
+              value={currentBalance}
+              onChange={(e) => setCurrentBalance(e.target.value)}
+            />
+          </label>
+          <label className="life-events-field">
+            Monthly contribution (USD)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="25"
+              value={monthlyContribution}
+              onChange={(e) => setMonthlyContribution(e.target.value)}
+            />
+          </label>
+        </div>
+        <p className="education-announce" aria-live="polite">
+          {announcement}
+        </p>
+      </section>
+
+      <section className="planning-card" aria-labelledby="education-projection-title">
+        <h3 id="education-projection-title" className="planning-card__title">
+          Funding projection
+        </h3>
+        <div
+          className="education-coverage-bar"
+          role="progressbar"
+          aria-valuenow={coveragePercent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Projected 529 savings cover ${coveragePercent}% of estimated college costs`}
+        >
+          <span
+            className={`education-coverage-bar__fill ${
+              fullyFunded ? '' : 'education-coverage-bar__fill--gap'
+            }`}
+            style={{ width: `${coveragePercent}%` }}
+          />
+        </div>
+        <p
+          className={`education-status ${
+            fullyFunded ? 'education-status--ok' : 'education-status--gap'
+          }`}
+          role="status"
+        >
+          <AppIcon name={fullyFunded ? 'check-circle' : 'alert-triangle'} />
+          <span>
+            {coveragePercent}% funded —{' '}
+            {fullyFunded ? 'on track' : `${formatCurrency(result.fundingGapCents)} short`}
+          </span>
+        </p>
+        <div className="planning-metrics" aria-label="Education funding summary">
+          <article className="planning-metric" aria-label="Projected total cost of college">
+            <p className="planning-metric__label">Projected cost</p>
+            <p className="planning-metric__value">
+              {formatCurrency(result.totalProjectedCostCents)}
+            </p>
+          </article>
+          <article className="planning-metric" aria-label="Projected 529 balance at college start">
+            <p className="planning-metric__label">Projected savings</p>
+            <p className="planning-metric__value">{formatCurrency(result.projectedBalanceCents)}</p>
+          </article>
+          <article className="planning-metric" aria-label={fullyFunded ? 'Surplus' : 'Shortfall'}>
+            <p className="planning-metric__label">{fullyFunded ? 'Surplus' : 'Shortfall'}</p>
+            <p className="planning-metric__value">{formatCurrency(result.fundingGapCents)}</p>
+          </article>
+          <article
+            className="planning-metric"
+            aria-label="Monthly contribution needed to fully fund"
+          >
+            <p className="planning-metric__label">Needed / month</p>
+            <p className="planning-metric__value">
+              {formatCurrency(result.requiredMonthlyContributionCents)}
+            </p>
+          </article>
+          <article className="planning-metric" aria-label="Estimated annual state tax benefit">
+            <p className="planning-metric__label">Annual tax benefit</p>
+            <p className="planning-metric__value">{formatCurrency(result.annualTaxBenefitCents)}</p>
+          </article>
+        </div>
+      </section>
+
+      <section className="planning-card" aria-labelledby="education-allocation-title">
+        <h3 id="education-allocation-title" className="planning-card__title">
+          Suggested allocation
+        </h3>
+        <p className="planning-card__description">
+          {yearsToStart} year{yearsToStart === 1 ? '' : 's'} until college.{' '}
+          {result.suggestedAllocation.description}.
+        </p>
+        <dl className="education-allocation">
+          <div className="education-allocation__item">
+            <dt>Equities</dt>
+            <dd>{result.suggestedAllocation.equityPercent}%</dd>
+          </div>
+          <div className="education-allocation__item">
+            <dt>Bonds</dt>
+            <dd>{result.suggestedAllocation.bondPercent}%</dd>
+          </div>
+          <div className="education-allocation__item">
+            <dt>Cash</dt>
+            <dd>{result.suggestedAllocation.cashPercent}%</dd>
+          </div>
+        </dl>
+      </section>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Main page component
 // ---------------------------------------------------------------------------
 
@@ -2214,6 +2459,7 @@ export const PlanningPage: React.FC = () => {
         {activeTab === 'life-events' && <LifeEventsPanel />}
         {activeTab === 'wedding' && <WeddingWorkspacePanel />}
         {activeTab === 'retirement' && <RetirementPanel />}
+        {activeTab === 'education' && <EducationPanel />}
         {activeTab === 'goals' && <GoalsPanel />}
         {activeTab === 'sweep' && <SweepPanel />}
       </div>


### PR DESCRIPTION
﻿## Summary

The app ships a complete, unit-tested **529 / education fund planner** (`analyzeEducationFund`)
but it was never surfaced in the Planning UI — a couple saving for college couldn't use the one
feature built for exactly that. This adds a **College Fund** tab to `/planning` that drives the
existing engine, so the Okafors can project their child's college costs and see whether their 529
savings are on track.

## Changes

- `apps/web/src/pages/PlanningPage.tsx`
  - Added a `'education'` tab (`College Fund`) to `PlanningTab` and `TAB_CONFIG`.
  - New `EducationPanel` component wires the shared `analyzeEducationFund` engine to live inputs:
    child's current age, current annual tuition, years of college, current 529 balance, and monthly
    contribution. (Assumptions — college at 18, 5% tuition inflation, 6% return, 5% state tax — are
    stated in the panel.)
  - Surfaces projected cost, projected savings, funding gap/surplus, required monthly contribution,
    estimated annual tax benefit, an age-based suggested allocation, and a coverage progress bar.
- `apps/web/src/pages/PlanningPage.css`
  - Added `education-*` styles that reuse existing design tokens and mirror the established
    progress-bar/metric patterns. The coverage-bar fill is added to the existing
    `prefers-reduced-motion` rule.
- `apps/web/src/pages/PlanningPage.test.tsx`
  - Two tests: the tab renders a live projection with the expected metrics, and coverage recomputes
    live to 100% / "on track" when the monthly contribution is raised.

No changes to the shared engine or its math — this is purely UI surfacing.

## Accessibility

- Tab uses the existing `tablist`/`tab`/`tabpanel` ARIA wiring.
- Coverage bar is a `role="progressbar"` with `aria-valuenow/min/max` and a descriptive
  `aria-label`; funding status uses `role="status"` plus an icon (not color alone).
- Live announcement region (`aria-live="polite"`) summarizes on-track vs. shortfall.
- Inputs are native number fields with associated `<label>`s; the fill transition respects
  `prefers-reduced-motion`.

## Issues

Closes #3386

Found by persona: Ada & Chidi Okafor (new-parents joint-finances)

## Testing

- [x] `npx vitest run src/pages/PlanningPage.test.tsx` — 27 passed (25 existing + 2 new)
- [x] `npx prettier --write` + `npx eslint --max-warnings 0` on the changed TS files — clean

## Cross-Platform

Web planning UI only. The shared `analyzeEducationFund` engine can back the same feature on
iOS/Android/Windows; that parity work is noted in the issue.

