### PR TITLE
fix(web): add call-to-action buttons to new-user empty states (#3402)

### DIFF
--- a/apps/web/src/__tests__/dashboard-visualizations.test.tsx
+++ b/apps/web/src/__tests__/dashboard-visualizations.test.tsx
@@ -703,6 +703,10 @@ describe('DashboardPage empty state (#1334)', () => {
     );
 
     expect(screen.getByText('No dashboard data yet')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /add your first account/i })).toHaveAttribute(
+      'href',
+      '/accounts',
+    );
   });
 
   it('shows empty state when data is null', () => {

--- a/apps/web/src/pages/BudgetsPage.test.tsx
+++ b/apps/web/src/pages/BudgetsPage.test.tsx
@@ -336,6 +336,30 @@ describe('BudgetsPage', () => {
     expect(screen.getByText('Budgets')).toBeInTheDocument();
   });
 
+  it('shows a create-budget call-to-action in the empty state (#3402)', () => {
+    mockedUseBudgets.mockReturnValue({
+      budgets: [],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      createBudget: vi.fn(),
+      createBudgetTemplate: vi.fn(),
+      updateBudget: vi.fn(),
+      deleteBudget: vi.fn(),
+      getBudgetSpendingBreakdown: vi.fn(),
+      reorderBudgets: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <BudgetsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('No budget envelopes yet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create your first budget/i })).toBeInTheDocument();
+  });
+
   it('displays budget summary labels', () => {
     render(
       <MemoryRouter>

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -731,6 +731,15 @@ export const BudgetsPage: React.FC = () => {
         <EmptyState
           title="No budget envelopes yet"
           description="Start by entering expected income above, then create budget envelopes that assign every dollar to spending, saving, or debt categories."
+          action={
+            <button
+              type="button"
+              className="form-button form-button--primary"
+              onClick={handleAddBudget}
+            >
+              Create your first budget
+            </button>
+          }
         />
       ) : (
         <>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -807,6 +807,13 @@ export const DashboardPage: React.FC = () => {
                   ? 'Add accounts, budgets, or transactions to see your financial summary here.'
                   : 'Try a different purpose filter or tag more accounts for this view.'
               }
+              action={
+                selectedPurposeFilter === 'all' ? (
+                  <Link to="/accounts" className="form-button form-button--primary">
+                    Add your first account
+                  </Link>
+                ) : undefined
+              }
             />
           ) : (
             <>

--- a/apps/web/src/pages/GoalsPage.test.tsx
+++ b/apps/web/src/pages/GoalsPage.test.tsx
@@ -364,6 +364,29 @@ describe('GoalsPage', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Goals' })).toBeTruthy();
   });
 
+  it('shows a create-goal call-to-action in the empty state (#3402)', () => {
+    mockedUseGoals.mockReturnValue({
+      goals: [],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      createGoal: vi.fn(),
+      updateGoal: vi.fn(),
+      contributeToGoal: vi.fn(),
+      deleteGoal: vi.fn(),
+      reorderGoals: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <GoalsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('No goals yet')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /create your first goal/i })).toBeTruthy();
+  });
+
   it('displays goals summary and ai suggestions', () => {
     render(
       <MemoryRouter>

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -768,6 +768,15 @@ export const GoalsPage: React.FC = () => {
             <EmptyState
               title="No goals yet"
               description="Create a savings goal to track progress toward something important."
+              action={
+                <button
+                  type="button"
+                  className="form-button form-button--primary"
+                  onClick={handleOpenForm}
+                >
+                  Create your first goal
+                </button>
+              }
             />
           ) : (
             <section aria-label="Goal list">

--- a/apps/web/src/pages/InsightsPage.test.tsx
+++ b/apps/web/src/pages/InsightsPage.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { InsightsPage } from './InsightsPage';
+import type { ReactNode } from 'react';
 import type { CategorySpending, UseInsightsResult } from '../hooks/useInsights';
 
 vi.mock('../hooks/useInsights', async () => {
@@ -213,7 +214,12 @@ vi.mock('../components/wellness', () => ({
 
 vi.mock('../components/common', () => ({
   CurrencyDisplay: ({ amount }: { amount: number }) => <span>{amount}</span>,
-  EmptyState: ({ title }: { title: string }) => <div>{title}</div>,
+  EmptyState: ({ title, action }: { title: string; action?: ReactNode }) => (
+    <div>
+      {title}
+      {action}
+    </div>
+  ),
   ErrorBanner: ({ message }: { message: string }) => <div>{message}</div>,
   LoadingSpinner: ({ label }: { label: string }) => <div aria-label={label} />,
 }));
@@ -553,6 +559,10 @@ describe('InsightsPage', () => {
     );
 
     expect(screen.getByText('No wealth insights yet')).toBeTruthy();
+    expect(screen.getByRole('link', { name: /add your first account/i })).toHaveAttribute(
+      'href',
+      '/accounts',
+    );
   });
 
   it('renders the wealth digest experience', () => {

--- a/apps/web/src/pages/InsightsPage.tsx
+++ b/apps/web/src/pages/InsightsPage.tsx
@@ -12,6 +12,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { WeeklyDigest } from '../components/insights';
 import { RecommendationsFeed } from '../components/recommendations';
 import { WellnessOverview } from '../components/wellness';
@@ -524,6 +525,11 @@ export const InsightsPage: React.FC = () => {
       <EmptyState
         title="No wealth insights yet"
         description="Add accounts, transactions, budgets, or goals to generate your personalized digest."
+        action={
+          <Link to="/accounts" className="form-button form-button--primary">
+            Add your first account
+          </Link>
+        }
       />
     );
   }


### PR DESCRIPTION
## Summary

A brand-new user's first look at the **dashboard, goals, budgets, and insights** pages was an empty state with a title and description but **no button to act on** — the app literally said "Add accounts, budgets, or transactions…" with nothing to click. The `EmptyState` component already supports an `action` prop; it just wasn't being used on these four pages.

## Changes

Wire an accessible call-to-action into each empty state, reusing each page's existing create mechanism and the shared `form-button form-button--primary` styling:

- **Goals** — "Create your first goal" opens the goal form (`handleOpenForm`).
- **Budgets** — "Create your first budget" opens the budget form (`handleAddBudget`).
- **Dashboard** — "Add your first account" links to `/accounts`, shown only for the genuine empty state (not the filtered "no matching account activity" variant).
- **Insights** — "Add your first account" links to `/accounts` so the digest has data to summarize (adds a `Link` import).

Each CTA is keyboard-focusable and has an accessible name. Adds empty-state CTA tests for all four pages; the Insights `EmptyState` test mock now forwards `action` so the CTA is assertable.

## Issues

Closes #3402

Found by persona: Maya Chen (new-grad first-job budgeter)

## Testing

- [x] `npx prettier --check` clean (Prettier 3.9.4, matching CI lockfile)
- [x] `npx eslint … --max-warnings 0` clean
- [x] `npx vitest run` — GoalsPage, BudgetsPage, InsightsPage, dashboard-visualizations suites all green (incl. 4 new empty-state CTA assertions)

## Notes

The impeccable hook flagged 5 pre-existing issues in `InsightsPage.css` (side-tab borders, layout-transition animations). These are out of scope for this change — I only touched the `.tsx` (added a `Link` import and `action` prop) — so they're intentionally left unchanged rather than silenced.
