### PR TITLE
feat(web): plain-language explainers for budgeting, net worth & amortization (#3414, #3417, #3418)

### DIFF
--- a/apps/web/src/lib/education/glossary.test.ts
+++ b/apps/web/src/lib/education/glossary.test.ts
@@ -41,4 +41,13 @@ describe('financial glossary', () => {
   it('explains FX margin in terms of the mid-market reference rate', () => {
     expect(getGlossaryEntry('fxMargin').definition.toLowerCase()).toContain('mid-market');
   });
+
+  it('explains zero-based / envelope budgeting for a first-time budgeter (#3414)', () => {
+    expect(GLOSSARY_KEYS).toContain('zeroBasedBudget');
+    const entry = getGlossaryEntry('zeroBasedBudget');
+    expect(entry.term.toLowerCase()).toContain('zero-based');
+    // Defines the "give every dollar a job" idea without assuming prior knowledge.
+    expect(entry.definition.toLowerCase()).toContain('job');
+    expect(entry.definition.toLowerCase()).toContain('zero');
+  });
 });

--- a/apps/web/src/lib/education/glossary.ts
+++ b/apps/web/src/lib/education/glossary.ts
@@ -9,6 +9,15 @@ export const financialGlossary: Record<GlossaryKey, EducationEntry> = {
     whyItMatters:
       'A budget helps you give every dollar a job so you can avoid surprises and make progress on goals.',
   },
+  zeroBasedBudget: {
+    term: 'Zero-Based Budget',
+    definition:
+      'A zero-based (or "envelope") budget gives every dollar you expect to receive a specific job — bills, groceries, savings — until the money left to assign reaches zero.',
+    example:
+      'If $2,000 lands in your account, you might assign $1,200 to bills, $500 to groceries and gas, and $300 to savings. That leaves $0 "ready to assign" — not because it is spent, but because all of it now has a plan.',
+    whyItMatters:
+      'When every dollar has a job, "ready to assign" money is just a decision you have not made yet, so nothing quietly slips through the cracks.',
+  },
   sinkingFund: {
     term: 'Sinking Fund',
     definition:

--- a/apps/web/src/lib/education/types.ts
+++ b/apps/web/src/lib/education/types.ts
@@ -7,6 +7,7 @@ export interface EducationEntry {
 
 export const GLOSSARY_KEYS = [
   'budget',
+  'zeroBasedBudget',
   'sinkingFund',
   'emergencyFund',
   'apr',

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -558,6 +558,10 @@ export const BudgetsPage: React.FC = () => {
               <div>
                 <p className="card__title">
                   {envelopeSummary.readyToAssignCents < 0 ? 'Over-assigned' : 'Ready to assign'}
+                  <ExplainThis
+                    glossaryKey="zeroBasedBudget"
+                    buttonLabel="Explain assigning every dollar"
+                  />
                 </p>
                 <p className="card__value">
                   <CurrencyDisplay amount={Math.abs(envelopeSummary.readyToAssignCents)} colorize />

--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -632,6 +632,9 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Net Worth')).toBeInTheDocument();
     expect(screen.getByText('Spent This Month')).toBeInTheDocument();
     expect(screen.getByText('Budget Health')).toBeInTheDocument();
+    // Beginner explainers on the headline cards (#3418).
+    expect(screen.getByRole('button', { name: 'Explain net worth' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explain Spent This Month' })).toBeInTheDocument();
     expect(await screen.findByText('What needs attention now')).toBeInTheDocument();
   });
 
@@ -773,6 +776,43 @@ describe('DashboardPage', () => {
     // Back to All restores the full aggregate: 20,000 + 10,000 + 5,000 = 35,000.
     fireEvent.click(screen.getByRole('button', { name: 'All' }));
     expect(netWorthCard).toHaveTextContent('$35,000.00');
+  });
+
+  it('reassures a first-time user when net worth is negative (#3418)', () => {
+    // A brand-new grad whose debts outweigh their cash: net worth is negative.
+    mockedUseAccounts.mockReturnValue({
+      accounts: [
+        {
+          id: 'ws-negative',
+          householdId: 'household-1',
+          name: 'Everyday Checking',
+          type: 'CHECKING',
+          purpose: 'personal',
+          currency: { code: 'USD', decimalPlaces: 2 },
+          currentBalance: { amount: -3800000 },
+          isArchived: false,
+          sortOrder: 1,
+          icon: 'bank',
+          color: '#DC2626',
+          ...syncMetadata,
+        },
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      createAccount: vi.fn(),
+      updateAccount: vi.fn(),
+      deleteAccount: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
+
+    // Reassurance is text (not color-only) so a negative first number is not alarming.
+    expect(screen.getByText(/normal when you have student loans/i)).toBeInTheDocument();
   });
 
   it('scopes Safe-to-Spend income by workspace so All === Personal + Business (#3212)', async () => {

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -6,6 +6,7 @@ import type { TimePeriod, ViewType } from '../components/charts';
 import { AccountPurposeFilterControl } from '../components/accounts';
 import { RecentTransactionsCard } from '../components/transactions';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import { ExplainThis } from '../components/common/ExplainThis';
 import { OfflineBanner } from '../components/OfflineBanner';
 import {
   useAccounts,
@@ -855,16 +856,41 @@ export const DashboardPage: React.FC = () => {
                     <article className="card" aria-label="Net worth">
                       <div className="card__header">
                         <h3 className="card__title">Net Worth</h3>
+                        <ExplainThis glossaryKey="netWorth" buttonLabel="Explain net worth" />
                       </div>
                       <div className="card__value" aria-live="polite">
                         <CurrencyDisplay amount={netWorth} colorize context="net worth" />
                       </div>
+                      {netWorth < 0 ? (
+                        <p
+                          className="dashboard-card-reassurance"
+                          style={{
+                            marginTop: 'var(--spacing-1)',
+                            color: 'var(--semantic-text-secondary)',
+                          }}
+                        >
+                          A negative number is normal when you have student loans — it improves as
+                          you pay them down and build savings.
+                        </p>
+                      ) : null}
                     </article>
                   ) : null}
                   {visibleWidgetIds.has('monthly-spending') ? (
                     <article className="card" aria-label="Monthly spending">
                       <div className="card__header">
                         <h3 className="card__title">Spent This Month</h3>
+                        <ExplainThis
+                          buttonLabel="Explain Spent This Month"
+                          content={{
+                            term: 'Spent This Month',
+                            definition:
+                              'The total you have spent so far this calendar month, across the accounts shown here.',
+                            example:
+                              'If you spent $400 on groceries and $150 on gas since the 1st, this shows $550.',
+                            whyItMatters:
+                              'Watching it grow through the month helps you catch overspending early, while you can still adjust.',
+                          }}
+                        />
                       </div>
                       <div className="card__value" aria-live="polite">
                         <CurrencyDisplay amount={spentThisMonth} context="spent this month" />

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -1272,7 +1272,10 @@ function PayoffPlannerPanel(): React.ReactElement {
                     context="interest"
                   />
                 </dd>
-                <dt>Payoff months</dt>
+                <dt>
+                  Payoff months{' '}
+                  <ExplainThis glossaryKey="amortization" buttonLabel="Explain amortizing" />
+                </dt>
                 <dd>{consolidationPanelModel.payoffMonths ?? 'Not amortizing'}</dd>
                 <dt>Fees</dt>
                 <dd>
@@ -2090,7 +2093,10 @@ function StudentLoanPanel(): React.ReactElement {
                 </p>
               </article>
               <article className="student-loan-stat-card">
-                <h3>Estimated Payoff</h3>
+                <h3>
+                  Estimated Payoff{' '}
+                  <ExplainThis glossaryKey="amortization" buttonLabel="Explain amortizing" />
+                </h3>
                 <p className="student-loan-stat-card__value">
                   {summary.estimatedPayoffDate
                     ? formatMonthYear(summary.estimatedPayoffDate)
@@ -2260,7 +2266,10 @@ function StudentLoanPanel(): React.ReactElement {
                       colorize
                     />
                   </dd>
-                  <dt>Payoff-date change</dt>
+                  <dt>
+                    Payoff-date change{' '}
+                    <ExplainThis glossaryKey="amortization" buttonLabel="Explain amortizing" />
+                  </dt>
                   <dd>
                     {refinancePanelModel.payoffMonthsDifference === null
                       ? 'Not amortizing'
@@ -2409,7 +2418,10 @@ function StudentLoanPanel(): React.ReactElement {
                         context="scenario total paid"
                       />
                     </dd>
-                    <dt>Payoff time</dt>
+                    <dt>
+                      Payoff time{' '}
+                      <ExplainThis glossaryKey="amortization" buttonLabel="Explain amortizing" />
+                    </dt>
                     <dd>
                       {scenario.monthsToPayoff === null
                         ? 'Not amortizing'


### PR DESCRIPTION
## Summary

Maya (a brand-new grad in her first job) repeatedly hit finance jargon on the
Budgets, Debt, and Dashboard pages with no plain-language explanation. This
batch surfaces the app's existing `ExplainThis` education pattern in three of
those gaps, so the app stops assuming finance knowledge a first-time user
doesn't have.

## Changes

- **#3414 — Envelope / zero-based budgeting explainer (Budgets):** added a
  `zeroBasedBudget` glossary entry (`glossary.ts` + `types.ts`) and surfaced it
  via `ExplainThis` next to "Ready to assign" / "Over-assigned". Copy defines
  "assign every dollar" in one sentence, no jargon.
- **#3417 — Amortization explainer (Debt):** surfaced the existing
  `amortization` glossary entry via `ExplainThis` next to all four "Not
  amortizing" labels (payoff months, estimated payoff, payoff-date change,
  payoff time). No new copy required.
- **#3418 — Net Worth / Spent This Month explainers (Dashboard):** added
  `ExplainThis` to both headline cards (the `netWorth` glossary entry plus an
  inline "Spent This Month" explainer), and a visible text reassurance under a
  **negative** net worth ("normal when you have student loans…") so a
  first-time user's first, likely-negative number isn't alarming. Reassurance
  is text, not color-only.

All affordances are keyboard-accessible and labeled — `ExplainThis` renders a
labeled `<button>`.

## Tests

- New glossary test for the `zeroBasedBudget` entry.
- New Dashboard tests: explainer buttons present on both cards; negative-net-worth
  reassurance renders.
- Affected page suites (Budgets, Debt, Dashboard) stay green. Verified locally:
  `prettier --check` + `eslint --max-warnings 0` clean; 46 targeted tests pass.

## Out of scope / note

The impeccable design hook flagged **pre-existing** `DebtPage.css` side-tab
findings (borders ~230/235/240 + layout-transition) unrelated to this change
and left untouched.

## Issues

Closes #3414
Closes #3417
Closes #3418

Found by persona: Maya Chen (new-grad first-job budgeter)
