### PR TITLE
feat(web): beginner $1,000 starter emergency fund for zero-history users (#3419)

### DIFF
--- a/apps/web/src/lib/savings/goalSuggester.test.ts
+++ b/apps/web/src/lib/savings/goalSuggester.test.ts
@@ -291,4 +291,39 @@ describe('goalSuggester', () => {
     const purchaseSuggestion = suggestions.find((suggestion) => suggestion.type === 'big-purchase');
     expect(purchaseSuggestion?.linkedGoalId).toBe('goal-vacation');
   });
+
+  it('offers a $1,000 starter emergency fund for a zero-history user (#3419)', () => {
+    const now = new Date('2025-06-15T00:00:00Z');
+    // A brand-new user: one small checking account, no transaction history yet.
+    const newUserAccounts: Account[] = [
+      {
+        id: 'checking',
+        householdId,
+        name: 'Checking',
+        type: 'CHECKING',
+        currency,
+        currentBalance: { amount: 20_000 },
+        isArchived: false,
+        sortOrder: 1,
+        icon: 'bank',
+        color: '#2563EB',
+        ...syncMetadata,
+      },
+    ];
+
+    const snapshot = buildSavingsAnalysisSnapshot(newUserAccounts, [], [], [], now);
+    // No trailing spending, so the history-based 3–6 month target can't be derived.
+    expect(snapshot.monthlyExpensesCents).toBe(0);
+
+    const suggestions = suggestSavingsGoals(snapshot, now);
+    const starter = suggestions.find((suggestion) => suggestion.type === 'emergency-fund');
+    expect(starter).toBeDefined();
+    // The widely-recommended $1,000 starter fund, surfaced immediately.
+    expect(starter?.targetCents).toBe(100_000);
+    expect(starter?.priority).toBe('high');
+    expect(starter?.title).toContain('$1,000');
+    // Unlinked so the Goals page "Add goal" button creates it in one click.
+    expect(starter?.linkedGoalId).toBeNull();
+    expect(starter?.contributionPlan.recommendedMonthlyContributionCents).toBeGreaterThan(0);
+  });
 });

--- a/apps/web/src/lib/savings/goalSuggester.ts
+++ b/apps/web/src/lib/savings/goalSuggester.ts
@@ -32,6 +32,9 @@ const EMERGENCY_GOAL_KEYWORDS = ['emergency', 'rainy day', 'runway', 'buffer'];
 const RETIREMENT_GOAL_KEYWORDS = ['retirement', '401k', 'ira', 'roth', 'pension', 'nest egg'];
 const DEBT_GOAL_KEYWORDS = ['debt', 'payoff', 'loan', 'credit card', 'student loan'];
 const MONTHS_IN_TRAILING_AVERAGE = 3;
+// A $1,000 starter emergency fund is a widely-recommended first milestone for
+// someone who has no spending history yet to base a 3–6 month target on.
+const STARTER_EMERGENCY_FUND_CENTS = 100_000;
 
 function toIsoDate(date: Date): string {
   return date.toISOString().slice(0, 10);
@@ -393,6 +396,41 @@ export function suggestSavingsGoals(
           currentRunwayMonths < 3
             ? Math.max(Math.ceil(emergencyGapCents / 12), Math.round(availableCapacityCents * 0.45))
             : Math.max(Math.ceil(emergencyGapCents / 18), Math.round(availableCapacityCents * 0.3)),
+      }),
+    );
+  }
+
+  if (
+    snapshot.monthlyExpensesCents === 0 &&
+    snapshot.liquidSavingsCents < STARTER_EMERGENCY_FUND_CENTS
+  ) {
+    // Zero-history beginner path: with no trailing spending we can't derive a
+    // 3–6 month target, so offer the common $1,000 starter fund and a clear
+    // first step instead of telling a brand-new user to come back later.
+    const starterGapCents = Math.max(STARTER_EMERGENCY_FUND_CENTS - snapshot.liquidSavingsCents, 0);
+    const starterMonthlyCents = Math.max(
+      Math.ceil(starterGapCents / 12),
+      Math.round(availableCapacityCents * 0.3),
+    );
+
+    suggestions.push(
+      createSuggestion({
+        id: emergencyGoal?.id ?? 'suggested-emergency-fund-starter',
+        type: 'emergency-fund',
+        title: emergencyGoal?.name ?? 'Start a $1,000 emergency fund',
+        reason:
+          'A $1,000 starter fund is a common first milestone that covers most everyday surprises while you build the habit.',
+        reasoning: [
+          "You don't have enough spending history yet to calculate a 3–6 month target, so this uses the widely-recommended $1,000 starter amount.",
+          'An emergency fund keeps a surprise — a car repair or a medical copay — from going onto a high-interest credit card.',
+          "Once you've tracked a few weeks of spending, this target refines to about 3 months of your real expenses.",
+        ],
+        priority: 'high',
+        targetCents: STARTER_EMERGENCY_FUND_CENTS,
+        currentCents: snapshot.liquidSavingsCents,
+        linkedGoalId: emergencyGoal?.id ?? null,
+        monthlyCapacityCents: Math.max(availableCapacityCents, Math.ceil(starterGapCents / 12)),
+        desiredMonthlyContributionCents: starterMonthlyCents,
       }),
     );
   }


### PR DESCRIPTION
## Summary

A brand-new user with **no transaction history** got no emergency-fund guidance. The savings suggestion engine derives the emergency-fund target from trailing spending (`monthlyExpensesCents * 3`) and gated the entire suggestion on `monthlyExpensesCents > 0` ([`goalSuggester.ts`](../blob/main/apps/web/src/lib/savings/goalSuggester.ts)). So a zero-history budgeter — exactly who needs the nudge most — just saw **"No suggestions yet"** on the Goals page.

This adds a beginner **$1,000 starter emergency fund** path.

## Changes

- **`apps/web/src/lib/savings/goalSuggester.ts`**
  - New `STARTER_EMERGENCY_FUND_CENTS = 100_000` ($1,000 — the widely-recommended starter milestone).
  - New zero-history branch in `suggestSavingsGoals`: when there's no trailing spending and liquid savings are under $1,000, emit a **high-priority** `emergency-fund` suggestion with plain-language reasoning (why an emergency fund matters, and that the target refines to ~3 months of expenses once spending data accrues).
  - The existing history-based 3–6 month suggestion is **untouched** for users who do have expenses.
- **`apps/web/src/lib/savings/goalSuggester.test.ts`** — new case asserting the $1,000 starter fund (target `100_000`, priority `high`, unlinked) for a zero-history snapshot.

The suggestion is emitted **unlinked**, so the Goals page's existing "Add goal" action creates it in one click — **no Goals page change required**.

## Persona

Found by persona: Maya Chen (new-grad first-job budgeter) — she has $38k in loans, ~no savings, and has never budgeted. On day one the app gave her an empty Goals page; now it offers a concrete, achievable first milestone with an explanation.

## Testing

- [x] `npx vitest run src/lib/savings/goalSuggester.test.ts` — 2 passed (incl. new starter case)
- [x] `npx vitest run src/pages/GoalsPage.test.tsx` — 6 passed (no regression; suggestion renders through existing `SuggestedGoals` UI)
- [x] `npx prettier --check` + `npx eslint --max-warnings 0` on both files — clean

## Issues

Closes #3419
