### PR TITLE
feat(web): add client profitability CSV export (#3231)

### DIFF
--- a/apps/web/src/lib/reports/client-profitability.test.ts
+++ b/apps/web/src/lib/reports/client-profitability.test.ts
@@ -4,7 +4,11 @@ import { describe, expect, it } from 'vitest';
 
 import type { Transaction } from '../../kmp/bridge';
 import { Currencies } from '../../kmp/bridge';
-import { buildClientProfitabilityReport, extractClientProjectLabels } from './client-profitability';
+import {
+  buildClientProfitabilityReport,
+  exportClientProfitabilityCsv,
+  extractClientProjectLabels,
+} from './client-profitability';
 
 function transaction(overrides: Partial<Transaction>): Transaction {
   return {
@@ -168,5 +172,86 @@ describe('buildClientProfitabilityReport', () => {
     expect(report.rows).toHaveLength(2);
     expect(report.rows.map((row) => row.revenue).sort((a, b) => b - a)).toEqual([5_001, 5_000]);
     expect(report.totalRevenue).toBe(10_001);
+  });
+});
+
+describe('exportClientProfitabilityCsv', () => {
+  it('emits a header, one row per client, and a dollar-denominated totals row', () => {
+    const csv = exportClientProfitabilityCsv(
+      buildClientProfitabilityReport([
+        transaction({
+          id: 'acme-income',
+          type: 'INCOME',
+          amount: { amount: 10_000 },
+          tags: ['client:Acme'],
+        }),
+        transaction({
+          id: 'acme-cost',
+          type: 'EXPENSE',
+          amount: { amount: 2_500 },
+          tags: ['client:Acme'],
+        }),
+        transaction({
+          id: 'beta-income',
+          type: 'INCOME',
+          amount: { amount: 5_000 },
+          tags: ['client:Beta'],
+        }),
+      ]),
+    );
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe('Client / project,Revenue,Cost,Net profit,Margin %,Transactions');
+    expect(lines).toContain('Acme,100.00,25.00,75.00,75.0,2');
+    expect(lines).toContain('Beta,50.00,0.00,50.00,100.0,1');
+    // Totals land on the last row; the transaction column is blank because a
+    // split transaction must not be double counted across clients.
+    expect(lines[lines.length - 1]).toBe('All clients,150.00,25.00,125.00,83.3,');
+  });
+
+  it('quotes client/project names that contain commas or quotes', () => {
+    const csv = exportClientProfitabilityCsv(
+      buildClientProfitabilityReport([
+        transaction({
+          id: 'comma',
+          type: 'INCOME',
+          amount: { amount: 4_000 },
+          tags: ['client:Beta, LLC'],
+        }),
+        transaction({
+          id: 'quote',
+          type: 'INCOME',
+          amount: { amount: 2_000 },
+          tags: ['client:Say "Hi"'],
+        }),
+      ]),
+    );
+
+    expect(csv).toContain('"Beta, LLC",40.00,0.00,40.00,100.0,1');
+    expect(csv).toContain('"Say ""Hi""",20.00,0.00,20.00,100.0,1');
+  });
+
+  it('leaves the margin blank when a client has no revenue', () => {
+    const csv = exportClientProfitabilityCsv(
+      buildClientProfitabilityReport([
+        transaction({
+          id: 'cost-only',
+          type: 'EXPENSE',
+          amount: { amount: 3_000 },
+          tags: ['client:Gamma'],
+        }),
+      ]),
+    );
+
+    expect(csv).toContain('Gamma,0.00,30.00,-30.00,,1');
+  });
+
+  it('returns the header and an empty totals row for a report with no clients', () => {
+    const csv = exportClientProfitabilityCsv(buildClientProfitabilityReport([]));
+
+    expect(csv.split('\n')).toEqual([
+      'Client / project,Revenue,Cost,Net profit,Margin %,Transactions',
+      'All clients,0.00,0.00,0.00,,',
+    ]);
   });
 });

--- a/apps/web/src/lib/reports/client-profitability.ts
+++ b/apps/web/src/lib/reports/client-profitability.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { LocalDate, Transaction } from '../../kmp/bridge';
+import { escapeCsvField } from '../export/simple-export';
 
 export const DEFAULT_CLIENT_TAG_PREFIXES = ['client:', 'project:'] as const;
 
@@ -202,4 +203,48 @@ export function buildClientProfitabilityReport(
     leastProfitable: rows.length > 0 ? rows[rows.length - 1] : null,
     clientCount: rows.length,
   };
+}
+
+function formatCsvAmount(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+function formatCsvMargin(margin: number | null): string {
+  return margin === null || !Number.isFinite(margin) ? '' : margin.toFixed(1);
+}
+
+/**
+ * Serialize a client/project profitability report as CSV for download.
+ *
+ * Amounts are emitted in major currency units with two decimals to match the
+ * app's other CSV exports (e.g. cash flow). Client/project labels are escaped so
+ * that a comma or quote in a client name cannot break the row structure. A
+ * trailing "All clients" row carries the report totals; its transaction column
+ * is intentionally left blank because a single transaction can be split across
+ * multiple clients and must not be double counted.
+ */
+export function exportClientProfitabilityCsv(report: ClientProfitabilitySummary): string {
+  const header = 'Client / project,Revenue,Cost,Net profit,Margin %,Transactions';
+
+  const rows = report.rows.map((row) =>
+    [
+      escapeCsvField(row.client),
+      formatCsvAmount(row.revenue),
+      formatCsvAmount(row.expenses),
+      formatCsvAmount(row.netProfit),
+      formatCsvMargin(row.profitMargin),
+      String(row.transactionCount),
+    ].join(','),
+  );
+
+  const totals = [
+    escapeCsvField('All clients'),
+    formatCsvAmount(report.totalRevenue),
+    formatCsvAmount(report.totalExpenses),
+    formatCsvAmount(report.netProfit),
+    formatCsvMargin(report.profitMargin),
+    '',
+  ].join(',');
+
+  return [header, ...rows, totals].join('\n');
 }

--- a/apps/web/src/pages/ClientProfitabilityPage.css
+++ b/apps/web/src/pages/ClientProfitabilityPage.css
@@ -31,6 +31,29 @@
   max-width: 72ch;
 }
 
+.client-profitability__export-btn {
+  align-self: flex-start;
+  margin-top: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-elevated);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.client-profitability__export-btn:hover:not(:disabled) {
+  background: var(--semantic-background-secondary);
+}
+
+.client-profitability__export-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .client-profitability__card {
   background: var(--semantic-surface-primary);
   border: 1px solid var(--semantic-border-default);

--- a/apps/web/src/pages/ClientProfitabilityPage.test.tsx
+++ b/apps/web/src/pages/ClientProfitabilityPage.test.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the ClientProfitabilityPage CSV export control.
+ *
+ * Mocks the `useTransactions` hook (not repositories) per project conventions.
+ * References: issue #3231.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { Transaction, TransactionType } from '../kmp/bridge';
+import { ClientProfitabilityPage } from './ClientProfitabilityPage';
+
+vi.mock('../hooks/useTransactions', () => ({
+  useTransactions: vi.fn(),
+}));
+
+import { useTransactions } from '../hooks/useTransactions';
+
+const mockUseTransactions = vi.mocked(useTransactions);
+
+let nextId = 0;
+
+function makeTransaction(options: {
+  type: TransactionType;
+  amountCents: number;
+  tags?: readonly string[];
+}): Transaction {
+  nextId += 1;
+  return {
+    id: `txn-${nextId}`,
+    householdId: 'hh-1',
+    accountId: 'acct-1',
+    categoryId: null,
+    type: options.type,
+    status: 'CLEARED',
+    amount: { amount: options.amountCents },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    payee: null,
+    note: null,
+    date: '2024-01-05',
+    transferAccountId: null,
+    transferTransactionId: null,
+    isRecurring: false,
+    recurringRuleId: null,
+    tags: options.tags ?? [],
+    merchantAddress: null,
+    merchantCity: null,
+    merchantState: null,
+    merchantZip: null,
+    merchantCountry: null,
+    externalReferenceId: null,
+    statementDescription: null,
+    customFields: null,
+    extraNotes: null,
+    counterpartyName: null,
+    counterpartyAccountId: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  };
+}
+
+function mockResult(overrides: Partial<ReturnType<typeof useTransactions>> = {}) {
+  return {
+    transactions: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    createTransaction: vi.fn(),
+    updateTransaction: vi.fn(),
+    deleteTransaction: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useTransactions>;
+}
+
+const CLIENT_TRANSACTIONS: Transaction[] = [
+  makeTransaction({ type: 'INCOME', amountCents: 500_000, tags: ['client:Acme'] }),
+  makeTransaction({ type: 'EXPENSE', amountCents: 120_000, tags: ['client:Acme'] }),
+];
+
+const EXPORT_BUTTON = /download client profitability report as csv/i;
+
+describe('ClientProfitabilityPage CSV export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enables the Download CSV button when the report has client rows', () => {
+    mockUseTransactions.mockReturnValue(mockResult({ transactions: CLIENT_TRANSACTIONS }));
+    render(<ClientProfitabilityPage />);
+
+    expect(screen.getByRole('button', { name: EXPORT_BUTTON })).toBeEnabled();
+  });
+
+  it('disables the Download CSV button when there are no client-tagged transactions', () => {
+    mockUseTransactions.mockReturnValue(mockResult({ transactions: [] }));
+    render(<ClientProfitabilityPage />);
+
+    expect(screen.getByRole('button', { name: EXPORT_BUTTON })).toBeDisabled();
+  });
+
+  it('generates a CSV blob download when the button is clicked', async () => {
+    const user = userEvent.setup();
+    const createObjectURL = vi.fn((_blob: Blob | MediaSource) => 'blob:client-profitability');
+    const revokeObjectURL = vi.fn();
+    // jsdom does not implement the object-URL helpers; provide test doubles.
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL });
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+
+    mockUseTransactions.mockReturnValue(mockResult({ transactions: CLIENT_TRANSACTIONS }));
+    render(<ClientProfitabilityPage />);
+
+    await user.click(screen.getByRole('button', { name: EXPORT_BUTTON }));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(createObjectURL.mock.calls[0]?.[0]).toBeInstanceOf(Blob);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+
+    clickSpy.mockRestore();
+    delete (URL as unknown as Record<string, unknown>).createObjectURL;
+    delete (URL as unknown as Record<string, unknown>).revokeObjectURL;
+  });
+});

--- a/apps/web/src/pages/ClientProfitabilityPage.tsx
+++ b/apps/web/src/pages/ClientProfitabilityPage.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   Bar,
   BarChart,
@@ -16,9 +16,11 @@ import { DateInput, ErrorBanner, LoadingSpinner } from '../components/common';
 import { CHART_COLORS, formatChartCurrency } from '../components/charts/chart-palette';
 import { useTransactions } from '../hooks/useTransactions';
 import { formatCurrency } from '../lib/currency';
+import { buildDatedExportFileName } from '../lib/export/simple-export';
 import {
   DEFAULT_CLIENT_TAG_PREFIXES,
   buildClientProfitabilityReport,
+  exportClientProfitabilityCsv,
   type ClientProfitabilityRow,
 } from '../lib/reports/client-profitability';
 
@@ -77,6 +79,19 @@ export function ClientProfitabilityPage() {
     [report.rows],
   );
 
+  const handleExportCsv = useCallback(() => {
+    const csv = exportClientProfitabilityCsv(report);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = buildDatedExportFileName('client-profitability', 'csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [report]);
+
   if (loading) {
     return <LoadingSpinner label="Loading client profitability report" />;
   }
@@ -100,6 +115,15 @@ export function ClientProfitabilityPage() {
           Tag transactions with {tagExamples} to allocate real income and costs to client or project
           profit-and-loss reporting.
         </p>
+        <button
+          type="button"
+          className="client-profitability__export-btn"
+          onClick={handleExportCsv}
+          disabled={report.rows.length === 0}
+          aria-label="Download client profitability report as CSV"
+        >
+          Download CSV
+        </button>
       </header>
 
       <section className="client-profitability__card" aria-labelledby="client-filters-title">


### PR DESCRIPTION
## Summary

Adds a **Download CSV** export to the Client / Project Profitability report so freelancers (like Diego, who juggles 5-8 clients a year) can pull per-client revenue, cost, net profit, margin, and transaction counts into a spreadsheet for bookkeeping and Schedule C prep. The report already existed on-screen but had no way to get the numbers out.

## Changes

- **`lib/reports/client-profitability.ts`** - new `exportClientProfitabilityCsv(report)` that serializes the report to CSV:
  - Amounts in major units (dollars, 2 decimals) to match the app's other CSV exports (cash flow).
  - Client/project names escaped via the shared `escapeCsvField` so a comma or quote in a client name can't break the row structure.
  - Trailing **All clients** totals row; its transaction column is intentionally blank because a single split transaction is allocated across multiple clients and must not be double counted.
- **`pages/ClientProfitabilityPage.tsx`** - accessible, token-styled **Download CSV** button in the header (aria-label, disabled when the report is empty); Blob + object-URL download wired through a `useCallback` declared before the loading/error early returns (Rules of Hooks).
- **`pages/ClientProfitabilityPage.css`** - scoped `.client-profitability__export-btn` mirroring the existing `.analytics-export-btn` tokens + disabled state.
- **Tests** - unit tests for CSV formatting, comma/quote escaping, null-margin (zero-revenue) rows, and the empty-report shape; page tests for the button enabled/disabled state and the blob-download wiring.

## Issues

Closes #3231

## Testing

- [x] `tsc -b` clean
- [x] `vitest run` - 12/12 pass (lib + page)
- [x] `prettier --check` + `eslint --max-warnings 0` clean

Found by persona: Diego Ramirez (freelance-designer irregular-income)