### PR TITLE
feat(web): surface the home down payment planner in Planning (#3387)

### DIFF
--- a/apps/web/src/pages/PlanningPage.css
+++ b/apps/web/src/pages/PlanningPage.css
@@ -1100,6 +1100,66 @@
   color: var(--semantic-text-primary);
 }
 
+.home-planner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+}
+
+.home-announce {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.home-coverage-bar {
+  height: 12px;
+  width: 100%;
+  background: var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  overflow: hidden;
+  margin-bottom: var(--spacing-3);
+}
+
+.home-coverage-bar__fill {
+  display: block;
+  height: 100%;
+  background: var(--semantic-status-positive);
+  transition: width 0.3s ease;
+}
+
+.home-coverage-bar__fill--gap {
+  background: var(--semantic-status-warning);
+}
+
+.home-status {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin: 0 0 var(--spacing-3);
+  font-size: var(--type-scale-body-font-size);
+  font-weight: 600;
+}
+
+.home-guideline {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin: var(--spacing-3) 0 0;
+  font-size: var(--type-scale-body-font-size);
+  font-weight: 500;
+}
+
+.home-status--ok,
+.home-guideline--ok {
+  color: var(--semantic-status-positive);
+}
+
+.home-status--gap,
+.home-guideline--warn {
+  color: var(--semantic-status-warning);
+}
+
 .wedding-badge--paid {
   color: var(--semantic-status-positive);
   border-color: var(--semantic-status-positive);
@@ -1275,6 +1335,7 @@
   .goal-progress__fill,
   .wedding-budget-bar__fill,
   .education-coverage-bar__fill,
+  .home-coverage-bar__fill,
   .planning-btn,
   .scenario-item {
     transition: none;

--- a/apps/web/src/pages/PlanningPage.test.tsx
+++ b/apps/web/src/pages/PlanningPage.test.tsx
@@ -659,4 +659,34 @@ describe('PlanningPage', () => {
     expect(bar).toHaveAttribute('aria-valuenow', '100');
     expect(screen.getAllByText(/on track/i).length).toBeGreaterThan(0);
   });
+
+  it('surfaces a Down Payment tab with a live home-purchase projection', () => {
+    render(<PlanningPage />);
+    expect(screen.getByRole('tab', { name: /down payment/i })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('tab', { name: /down payment/i }));
+
+    expect(screen.getByRole('heading', { name: /home down payment planner/i })).toBeTruthy();
+    expect(screen.getByRole('progressbar', { name: /cash needed to close/i })).toBeTruthy();
+    expect(screen.getByText('Down payment')).toBeTruthy();
+    expect(screen.getByText('Closing costs')).toBeTruthy();
+    expect(screen.getByText('Total cash needed')).toBeTruthy();
+    expect(screen.getByText('PMI required')).toBeTruthy();
+    // The default seed ($0 saved) leaves a gap toward the cash needed to close.
+    expect(screen.getAllByText(/to go|short/i).length).toBeGreaterThan(0);
+  });
+
+  it('recomputes the down-payment coverage live when current savings change', () => {
+    render(<PlanningPage />);
+    fireEvent.click(screen.getByRole('tab', { name: /down payment/i }));
+
+    const bar = screen.getByRole('progressbar', { name: /cash needed to close/i });
+    // $150k covers a 20% down payment ($80k) plus 3% closing ($12k) on a $400k home.
+    fireEvent.change(screen.getByLabelText('Current savings (USD)'), {
+      target: { value: '150000' },
+    });
+
+    expect(bar).toHaveAttribute('aria-valuenow', '100');
+    expect(screen.getAllByText(/ready to close/i).length).toBeGreaterThan(0);
+  });
 });

--- a/apps/web/src/pages/PlanningPage.tsx
+++ b/apps/web/src/pages/PlanningPage.tsx
@@ -37,7 +37,11 @@ import type {
   SweepEvaluation,
   SweepLogEntry,
 } from '../lib/planning';
-import { analyzeEducationFund, projectRetirementHealthcareCosts } from '../lib/planning';
+import {
+  analyzeEducationFund,
+  analyzeHomePurchase,
+  projectRetirementHealthcareCosts,
+} from '../lib/planning';
 import {
   buildWeddingPlanSummary,
   buildWeddingVendorBreakdown,
@@ -55,7 +59,7 @@ import { TrendLineChart } from '../components/charts';
 // ---------------------------------------------------------------------------
 
 type PlanningTab =
-  'scenarios' | 'life-events' | 'wedding' | 'retirement' | 'education' | 'goals' | 'sweep';
+  'scenarios' | 'life-events' | 'wedding' | 'retirement' | 'education' | 'home' | 'goals' | 'sweep';
 
 const TAB_CONFIG: { id: PlanningTab; label: string; icon: IconName }[] = [
   { id: 'scenarios', label: 'What-If Modeler', icon: 'sparkles' },
@@ -63,6 +67,7 @@ const TAB_CONFIG: { id: PlanningTab; label: string; icon: IconName }[] = [
   { id: 'wedding', label: 'Wedding', icon: 'gift' },
   { id: 'retirement', label: 'Retirement', icon: 'leaf' },
   { id: 'education', label: 'College Fund', icon: 'medal' },
+  { id: 'home', label: 'Down Payment', icon: 'home' },
   { id: 'goals', label: 'Savings Goals', icon: 'target' },
   { id: 'sweep', label: 'Automations', icon: 'lightning' },
 ];
@@ -2418,6 +2423,308 @@ const EducationPanel: React.FC = () => {
 };
 
 // ---------------------------------------------------------------------------
+// Home down payment planner
+// ---------------------------------------------------------------------------
+
+/** Assumed mortgage APR (7.00%) for the affordability estimate. */
+const HOME_MORTGAGE_RATE_BPS = 700;
+/** Assumed mortgage term in years. */
+const HOME_LOAN_TERM_YEARS = 30;
+/** Assumed annual property tax rate (1.20% of home price). */
+const HOME_PROPERTY_TAX_BPS = 120;
+/** Assumed annual homeowner's insurance ($1,800). */
+const HOME_ANNUAL_INSURANCE_CENTS = 180000;
+/** Assumed closing costs (3.00% of home price). */
+const HOME_CLOSING_COST_BPS = 300;
+/** Front-end DTI guideline ceiling (28.00%). */
+const HOME_DTI_GUIDELINE_BPS = 2800;
+
+/**
+ * Parse a dollar string into non-negative integer cents.
+ *
+ * @param value - The raw input value in dollars
+ * @returns The value in cents, floored at 0
+ */
+function homeDollarsToCents(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0;
+  }
+  return Math.round(parsed * 100);
+}
+
+/**
+ * Home down payment planner panel.
+ *
+ * Surfaces the shared `analyzeHomePurchase` engine so a couple saving for a
+ * house can see the down payment and closing costs they need, whether their
+ * savings are on pace, and a rough monthly-payment / affordability estimate.
+ * Results update live as the inputs change.
+ */
+const DownPaymentPanel: React.FC = () => {
+  const [homePrice, setHomePrice] = useState('400000');
+  const [downPaymentPercent, setDownPaymentPercent] = useState('20');
+  const [currentSavings, setCurrentSavings] = useState('0');
+  const [monthlySavings, setMonthlySavings] = useState('1500');
+  const [yearsToPurchase, setYearsToPurchase] = useState('3');
+  const [annualIncome, setAnnualIncome] = useState('120000');
+
+  const years = Math.max(0, Math.min(30, Math.floor(Number(yearsToPurchase) || 0)));
+  const downPaymentBps = Math.max(
+    0,
+    Math.min(10000, Math.round((Number(downPaymentPercent) || 0) * 100)),
+  );
+
+  const targetDate = useMemo(() => {
+    const now = new Date();
+    return new Date(now.getFullYear() + years, now.getMonth(), 1).toISOString().slice(0, 10);
+  }, [years]);
+
+  const result = useMemo(
+    () =>
+      analyzeHomePurchase({
+        homePriceCents: homeDollarsToCents(homePrice),
+        currentSavingsCents: homeDollarsToCents(currentSavings),
+        monthlySavingsCents: homeDollarsToCents(monthlySavings),
+        targetDate,
+        mortgageRateBps: HOME_MORTGAGE_RATE_BPS,
+        loanTermYears: HOME_LOAN_TERM_YEARS,
+        propertyTaxRateBps: HOME_PROPERTY_TAX_BPS,
+        annualInsuranceCents: HOME_ANNUAL_INSURANCE_CENTS,
+        annualIncomeCents: homeDollarsToCents(annualIncome),
+        existingMonthlyDebtCents: 0,
+        downPaymentBps,
+        closingCostBps: HOME_CLOSING_COST_BPS,
+      }),
+    [homePrice, currentSavings, monthlySavings, targetDate, annualIncome, downPaymentBps],
+  );
+
+  const currentSavingsCents = homeDollarsToCents(currentSavings);
+  const savedPercent =
+    result.totalCashNeededCents > 0
+      ? Math.max(
+          0,
+          Math.min(100, Math.round((currentSavingsCents / result.totalCashNeededCents) * 100)),
+        )
+      : 100;
+  const fullyFunded = result.savingsGapCents <= 0;
+  const frontEndDtiPercent = (result.frontEndDtiBps / 100).toFixed(1);
+  const withinDtiGuideline = result.frontEndDtiBps <= HOME_DTI_GUIDELINE_BPS;
+
+  let announcement: string;
+  if (fullyFunded) {
+    announcement = `On track: your ${formatCurrency(
+      currentSavingsCents,
+    )} covers the ${formatCurrency(
+      result.totalCashNeededCents,
+    )} needed for the down payment and closing costs.`;
+  } else if (result.requiredMonthlySavingsCents !== null) {
+    announcement = `You're ${formatCurrency(result.savingsGapCents)} short. Saving ${formatCurrency(
+      result.requiredMonthlySavingsCents,
+    )} per month reaches your goal in about ${years} year${years === 1 ? '' : 's'}.`;
+  } else {
+    announcement = `You're ${formatCurrency(
+      result.savingsGapCents,
+    )} short of the cash needed to close.`;
+  }
+
+  return (
+    <div className="home-planner">
+      <section className="planning-card" aria-labelledby="home-intro-title">
+        <h3 id="home-intro-title" className="planning-card__title">
+          Home down payment planner
+        </h3>
+        <p className="planning-card__description">
+          See the down payment and closing costs you need for a home, and whether your savings are
+          on pace. Assumes a {HOME_MORTGAGE_RATE_BPS / 100}% mortgage over {HOME_LOAN_TERM_YEARS}{' '}
+          years, {HOME_PROPERTY_TAX_BPS / 100}% property tax, and {HOME_CLOSING_COST_BPS / 100}%
+          closing costs.
+        </p>
+        <div className="life-events-form" aria-label="Down payment inputs">
+          <label className="life-events-field">
+            Target home price (USD)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="5000"
+              value={homePrice}
+              onChange={(e) => setHomePrice(e.target.value)}
+            />
+          </label>
+          <label className="life-events-field">
+            Down payment (%)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              max={100}
+              step="1"
+              value={downPaymentPercent}
+              onChange={(e) => setDownPaymentPercent(e.target.value)}
+            />
+          </label>
+          <label className="life-events-field">
+            Current savings (USD)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="500"
+              value={currentSavings}
+              onChange={(e) => setCurrentSavings(e.target.value)}
+            />
+          </label>
+          <label className="life-events-field">
+            Monthly savings (USD)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="50"
+              value={monthlySavings}
+              onChange={(e) => setMonthlySavings(e.target.value)}
+            />
+          </label>
+          <label className="life-events-field">
+            Years until purchase
+            <input
+              className="form-input"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              max={30}
+              step={1}
+              value={yearsToPurchase}
+              onChange={(e) => setYearsToPurchase(e.target.value)}
+            />
+          </label>
+          <label className="life-events-field">
+            Combined annual income (USD)
+            <input
+              className="form-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="1000"
+              value={annualIncome}
+              onChange={(e) => setAnnualIncome(e.target.value)}
+            />
+          </label>
+        </div>
+        <p className="home-announce" aria-live="polite">
+          {announcement}
+        </p>
+      </section>
+
+      <section className="planning-card" aria-labelledby="home-projection-title">
+        <h3 id="home-projection-title" className="planning-card__title">
+          Cash needed to close
+        </h3>
+        <div
+          className="home-coverage-bar"
+          role="progressbar"
+          aria-valuenow={savedPercent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Current savings cover ${savedPercent}% of the cash needed to close`}
+        >
+          <span
+            className={`home-coverage-bar__fill ${fullyFunded ? '' : 'home-coverage-bar__fill--gap'}`}
+            style={{ width: `${savedPercent}%` }}
+          />
+        </div>
+        <p
+          className={`home-status ${fullyFunded ? 'home-status--ok' : 'home-status--gap'}`}
+          role="status"
+        >
+          <AppIcon name={fullyFunded ? 'check-circle' : 'alert-triangle'} />
+          <span>
+            {savedPercent}% saved —{' '}
+            {fullyFunded ? 'ready to close' : `${formatCurrency(result.savingsGapCents)} to go`}
+          </span>
+        </p>
+        <div className="planning-metrics" aria-label="Down payment summary">
+          <article className="planning-metric" aria-label="Down payment needed">
+            <p className="planning-metric__label">Down payment</p>
+            <p className="planning-metric__value">{formatCurrency(result.downPaymentCents)}</p>
+          </article>
+          <article className="planning-metric" aria-label="Estimated closing costs">
+            <p className="planning-metric__label">Closing costs</p>
+            <p className="planning-metric__value">{formatCurrency(result.closingCostsCents)}</p>
+          </article>
+          <article className="planning-metric" aria-label="Total cash needed to close">
+            <p className="planning-metric__label">Total cash needed</p>
+            <p className="planning-metric__value">{formatCurrency(result.totalCashNeededCents)}</p>
+          </article>
+          <article
+            className="planning-metric"
+            aria-label={fullyFunded ? 'Savings surplus' : 'Still to save'}
+          >
+            <p className="planning-metric__label">{fullyFunded ? 'Surplus' : 'Still to save'}</p>
+            <p className="planning-metric__value">{formatCurrency(result.savingsGapCents)}</p>
+          </article>
+          <article
+            className="planning-metric"
+            aria-label="Monthly savings needed to hit the target date"
+          >
+            <p className="planning-metric__label">Needed / month</p>
+            <p className="planning-metric__value">
+              {result.requiredMonthlySavingsCents !== null
+                ? formatCurrency(result.requiredMonthlySavingsCents)
+                : '—'}
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section className="planning-card" aria-labelledby="home-affordability-title">
+        <h3 id="home-affordability-title" className="planning-card__title">
+          Monthly cost &amp; affordability
+        </h3>
+        <div className="planning-metrics" aria-label="Affordability summary">
+          <article className="planning-metric" aria-label="Estimated total monthly housing cost">
+            <p className="planning-metric__label">Est. monthly housing</p>
+            <p className="planning-metric__value">
+              {formatCurrency(result.totalMonthlyHousingCents)}
+            </p>
+          </article>
+          <article className="planning-metric" aria-label="Front-end debt-to-income ratio">
+            <p className="planning-metric__label">Housing DTI</p>
+            <p className="planning-metric__value">{frontEndDtiPercent}%</p>
+          </article>
+          <article
+            className="planning-metric"
+            aria-label="Whether private mortgage insurance is required"
+          >
+            <p className="planning-metric__label">PMI required</p>
+            <p className="planning-metric__value">{result.pmiRequired ? 'Yes' : 'No'}</p>
+          </article>
+        </div>
+        <p
+          className={`home-guideline ${
+            withinDtiGuideline ? 'home-guideline--ok' : 'home-guideline--warn'
+          }`}
+          role="status"
+        >
+          <AppIcon name={withinDtiGuideline ? 'check-circle' : 'alert-triangle'} />
+          <span>
+            {withinDtiGuideline
+              ? `Housing costs are ${frontEndDtiPercent}% of income — within the 28% guideline.`
+              : `Housing costs are ${frontEndDtiPercent}% of income — above the 28% guideline.`}
+            {result.pmiRequired ? ' A down payment of 20% or more avoids PMI.' : ''}
+          </span>
+        </p>
+      </section>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Main page component
 // ---------------------------------------------------------------------------
 
@@ -2460,6 +2767,7 @@ export const PlanningPage: React.FC = () => {
         {activeTab === 'wedding' && <WeddingWorkspacePanel />}
         {activeTab === 'retirement' && <RetirementPanel />}
         {activeTab === 'education' && <EducationPanel />}
+        {activeTab === 'home' && <DownPaymentPanel />}
         {activeTab === 'goals' && <GoalsPanel />}
         {activeTab === 'sweep' && <SweepPanel />}
       </div>


### PR DESCRIPTION
﻿## Summary

Surfaces the app's built-but-unused **Home Down Payment planner**
(`apps/web/src/lib/planning/life-events/home-purchase.ts`) as a new **Down Payment** tab on
`/planning`. Saving for a house down payment is a headline use case for a couple merging finances,
but the dedicated engine had no UI entry point — the planning tabs were scenarios, life-events,
wedding, retirement, College Fund, goals, and sweep, with nothing for a home purchase.

Direct sibling of the 529 College Fund tab (#3386) — same pattern, reusing the shared engine.

## Changes

- **`PlanningPage.tsx`**: new `'home'` tab (`Down Payment`, `home` icon) rendering a `DownPaymentPanel`
  that drives the shared `analyzeHomePurchase` engine. Inputs: target home price, down payment %,
  current savings, monthly savings, years until purchase, combined annual income. Live outputs:
  down payment, closing costs, total cash needed, a savings-coverage `progressbar`, "needed / month"
  to hit the target date, and a monthly-cost / affordability card (estimated monthly housing,
  front-end DTI vs. the 28% guideline, PMI-required flag).
- **`PlanningPage.css`**: `home-*` styles (design tokens only), coverage-bar fill added to the
  existing `prefers-reduced-motion` rule.
- **`PlanningPage.test.tsx`**: 2 tests (tab renders a live projection; coverage recomputes to 100% /
  "ready to close" when savings cover the cash needed).

## Accessibility

- Coverage bar is a `role="progressbar"` with `aria-valuenow/min/max` and a descriptive `aria-label`.
- Live announcement (`aria-live="polite"`) and DTI/PMI guidance use text + icon, never color alone.
- `transition: width` on the fill is gated behind `prefers-reduced-motion: reduce` (consistent with
  the 4 existing planning progress bars).

## Issues

Closes #3387

Found by persona: Ada & Chidi Okafor (new-parents joint-finances)

## Testing

- [x] `npx vitest run src/pages/PlanningPage.test.tsx` — 29 passed (27 existing + 2 new)
- [x] `prettier@3.9.4 --check` + `eslint --max-warnings 0` on the changed files — clean
- [x] `tsc -b` — no errors

## Cross-Platform

Web planning UI only. The shared `analyzeHomePurchase` engine can back the same feature on
iOS/Android/Windows; that parity work is noted in the issue.
