### PR TITLE
feat(web): label seeded demo data as sample and add a clean-slate path (#3415)

### DIFF
--- a/apps/web/src/components/common/SampleDataBanner.css
+++ b/apps/web/src/components/common/SampleDataBanner.css
@@ -1,0 +1,95 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/*
+ * SampleDataBanner styling — token-driven, CSP-compliant (no inline styles).
+ * Amber accent marks the workspace as sample data without relying on color
+ * alone: the "Sample data" text badge carries the meaning for users who cannot
+ * perceive the accent. References: issue #3415.
+ */
+
+.sample-data-banner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3, 0.75rem);
+  padding: var(--spacing-3, 0.75rem) var(--spacing-4, 1rem);
+  background-color: var(--semantic-background-elevated, #ffffff);
+  border: 1px solid var(--semantic-status-warning, #b45309);
+  border-radius: var(--radius-md, 8px);
+  color: var(--semantic-text-primary, #111827);
+}
+
+.sample-data-banner__content {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3, 0.75rem);
+  flex: 1 1 20rem;
+  min-width: 0;
+}
+
+.sample-data-banner__badge {
+  flex: none;
+  padding: 0.125rem var(--spacing-2, 0.5rem);
+  border-radius: var(--radius-sm, 4px);
+  background-color: var(--semantic-status-warning, #b45309);
+  color: var(--semantic-text-inverse, #ffffff);
+  font-size: var(--font-size-sm, 0.8125rem);
+  font-weight: var(--font-weight-semibold, 600);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.sample-data-banner__text {
+  margin: 0;
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-secondary, #4b5563);
+}
+
+.sample-data-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2, 0.5rem);
+  flex: none;
+}
+
+.sample-data-banner__button {
+  padding: var(--spacing-2, 0.5rem) var(--spacing-3, 0.75rem);
+  border-radius: var(--radius-md, 8px);
+  font-size: var(--font-size-sm, 0.875rem);
+  font-weight: var(--font-weight-medium, 500);
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.sample-data-banner__button:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+
+.sample-data-banner__button:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #2563eb);
+  outline-offset: 2px;
+}
+
+.sample-data-banner__button--primary {
+  background-color: var(--semantic-status-warning, #b45309);
+  color: var(--semantic-text-inverse, #ffffff);
+}
+
+.sample-data-banner__button--dismiss {
+  background-color: transparent;
+  color: var(--semantic-text-primary, #111827);
+  border-color: var(--semantic-border-default, #d1d5db);
+}
+
+@media (max-width: 40rem) {
+  .sample-data-banner__actions {
+    width: 100%;
+  }
+
+  .sample-data-banner__button {
+    flex: 1 1 auto;
+  }
+}

--- a/apps/web/src/components/common/SampleDataBanner.test.tsx
+++ b/apps/web/src/components/common/SampleDataBanner.test.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SampleDataBanner } from './SampleDataBanner';
+import { isSampleDataActive, requestCleanSlate } from '../../db/sampleData';
+import { wipeLocalData } from '../../storage/wipeLocalData';
+
+vi.mock('../../db/sampleData', () => ({
+  isSampleDataActive: vi.fn(),
+  requestCleanSlate: vi.fn(),
+}));
+
+vi.mock('../../storage/wipeLocalData', () => ({
+  wipeLocalData: vi.fn().mockResolvedValue([]),
+}));
+
+describe('SampleDataBanner (#3415)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(wipeLocalData).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when the workspace is not sample data', () => {
+    vi.mocked(isSampleDataActive).mockReturnValue(false);
+    const { container } = render(<SampleDataBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('labels the workspace as sample data when active', () => {
+    vi.mocked(isSampleDataActive).mockReturnValue(true);
+    render(<SampleDataBanner />);
+
+    expect(screen.getByRole('region', { name: /sample data notice/i })).toBeInTheDocument();
+    // The text badge — not color alone — carries the "sample" meaning.
+    expect(screen.getByText(/^sample data$/i)).toBeInTheDocument();
+  });
+
+  it('dismisses without wiping when the user keeps exploring', async () => {
+    vi.mocked(isSampleDataActive).mockReturnValue(true);
+    const user = userEvent.setup();
+    render(<SampleDataBanner />);
+
+    await user.click(screen.getByRole('button', { name: /keep exploring/i }));
+
+    expect(screen.queryByRole('region', { name: /sample data notice/i })).not.toBeInTheDocument();
+    expect(requestCleanSlate).not.toHaveBeenCalled();
+    expect(wipeLocalData).not.toHaveBeenCalled();
+  });
+
+  it('requests a clean slate, wipes local data, and reloads on start fresh', async () => {
+    vi.mocked(isSampleDataActive).mockReturnValue(true);
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+
+    const user = userEvent.setup();
+    render(<SampleDataBanner />);
+
+    await user.click(screen.getByRole('button', { name: /clear sample data & start fresh/i }));
+
+    await waitFor(() => {
+      expect(requestCleanSlate).toHaveBeenCalledTimes(1);
+      expect(wipeLocalData).toHaveBeenCalledTimes(1);
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/components/common/SampleDataBanner.tsx
+++ b/apps/web/src/components/common/SampleDataBanner.tsx
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * SampleDataBanner — labels the seeded demo workspace as sample data and
+ * offers a one-click path to a genuine clean slate.
+ *
+ * On first run the local database is seeded with sample accounts and
+ * transactions so a brand-new user can explore the app (see `db/seed.ts`).
+ * Without a label a first-time user cannot tell which numbers are real, and the
+ * dashboard's insights are derived from that sample data. This banner makes the
+ * sample state obvious and lets the user clear it: it requests a clean slate,
+ * wipes device-local data, and reloads into an empty workspace (no re-seed).
+ *
+ * Accessibility:
+ *   • `role="region"` with a descriptive `aria-label` so assistive technology
+ *     can identify and skip the banner.
+ *   • All controls are native buttons — keyboard-accessible and labeled.
+ *   • The clear action is disabled and announces progress while it runs.
+ *
+ * CSP-compliant — styling lives in the companion `SampleDataBanner.css`.
+ *
+ * References: issue #3415
+ */
+
+import React, { useCallback, useState } from 'react';
+
+import { isSampleDataActive, requestCleanSlate } from '../../db/sampleData';
+import { wipeLocalData } from '../../storage/wipeLocalData';
+
+import './SampleDataBanner.css';
+
+/**
+ * A banner shown while the workspace contains seeded sample data. Renders
+ * nothing once the sample data has been cleared or the banner is dismissed.
+ */
+export const SampleDataBanner: React.FC = () => {
+  const [isActive] = useState(() => isSampleDataActive());
+  const [isDismissed, setIsDismissed] = useState(false);
+  const [isClearing, setIsClearing] = useState(false);
+
+  const handleStartFresh = useCallback(async () => {
+    setIsClearing(true);
+    // Suppress the next boot's re-seed so the reload lands on an empty
+    // workspace instead of fresh sample data (#3415).
+    requestCleanSlate();
+    try {
+      await wipeLocalData();
+    } catch {
+      // A partial wipe still beats a mislabeled workspace — reload regardless
+      // so the next boot re-runs against cleared, un-seeded local data.
+    } finally {
+      if (typeof window !== 'undefined') {
+        window.location.reload();
+      }
+    }
+  }, []);
+
+  if (!isActive || isDismissed) {
+    return null;
+  }
+
+  return (
+    <aside className="sample-data-banner" role="region" aria-label="Sample data notice">
+      <div className="sample-data-banner__content">
+        <span className="sample-data-banner__badge">Sample data</span>
+        <p className="sample-data-banner__text">
+          These are example numbers so you can explore the app — they aren&rsquo;t your money yet.
+          Start fresh whenever you&rsquo;re ready to add your own.
+        </p>
+      </div>
+      <div className="sample-data-banner__actions">
+        <button
+          type="button"
+          className="sample-data-banner__button sample-data-banner__button--primary"
+          onClick={() => void handleStartFresh()}
+          disabled={isClearing}
+        >
+          {isClearing ? 'Clearing sample data…' : 'Clear sample data & start fresh'}
+        </button>
+        <button
+          type="button"
+          className="sample-data-banner__button sample-data-banner__button--dismiss"
+          onClick={() => setIsDismissed(true)}
+          disabled={isClearing}
+        >
+          Keep exploring
+        </button>
+      </div>
+    </aside>
+  );
+};
+
+export default SampleDataBanner;

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -24,6 +24,7 @@ import { getSimpleModePlan, type SimpleModeSurface } from '../../lib/a11y/simple
 import { BottomNavigation, SidebarNavigation } from './Navigation';
 import { getVisibleNavItems } from './navConfig';
 import { InstallBanner } from '../common/InstallBanner';
+import { SampleDataBanner } from '../common/SampleDataBanner';
 import { LegalLinks } from '../legal/LegalLinks';
 import { Breadcrumbs, NavShortcuts, buildNavShortcutCategory } from '../navigation';
 
@@ -389,6 +390,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
         />
       </div>
       <InstallBanner />
+      <SampleDataBanner />
       <CommandPalette
         isOpen={showCommandPalette}
         actions={commandPaletteActions}

--- a/apps/web/src/db/DatabaseProvider.tsx
+++ b/apps/web/src/db/DatabaseProvider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import { ErrorBanner, LoadingSpinner } from '../components/common';
 import { seedDatabase } from './seed';
+import { requestCleanSlate } from './sampleData';
 import { wipeLocalData } from '../storage/wipeLocalData';
 import {
   initDatabaseWithDiagnostics,
@@ -338,6 +339,9 @@ export function DatabaseProvider({ children }: DatabaseProviderProps) {
     // it re-hydrates on the next boot (#3094).
     setIsResetting(true);
     try {
+      // Ask the next boot to honor a genuine clean slate instead of re-seeding
+      // sample data, so the empty-workspace experience is reachable (#3415).
+      requestCleanSlate();
       await wipeLocalData();
     } catch (wipeError) {
       // A partial wipe is still better than a wedged state — reload regardless

--- a/apps/web/src/db/sampleData.test.ts
+++ b/apps/web/src/db/sampleData.test.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearSampleDataMarker,
+  consumeCleanSlateRequest,
+  isCleanSlateRequested,
+  isSampleDataActive,
+  markSampleDataSeeded,
+  requestCleanSlate,
+  shouldSeedSampleData,
+} from './sampleData';
+
+describe('sampleData lifecycle helpers (#3415)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('is inactive with no markers set', () => {
+    expect(isSampleDataActive()).toBe(false);
+    expect(isCleanSlateRequested()).toBe(false);
+  });
+
+  it('marks and clears the sample-data flag', () => {
+    markSampleDataSeeded();
+    expect(isSampleDataActive()).toBe(true);
+
+    clearSampleDataMarker();
+    expect(isSampleDataActive()).toBe(false);
+  });
+
+  it('records a clean-slate request', () => {
+    requestCleanSlate();
+    expect(isCleanSlateRequested()).toBe(true);
+  });
+
+  it('consumes a clean-slate request exactly once and clears the sample marker', () => {
+    markSampleDataSeeded();
+    requestCleanSlate();
+
+    // First consume honors the request and wipes both markers.
+    expect(consumeCleanSlateRequest()).toBe(true);
+    expect(isCleanSlateRequested()).toBe(false);
+    expect(isSampleDataActive()).toBe(false);
+
+    // A second consume is a no-op — the request does not linger.
+    expect(consumeCleanSlateRequest()).toBe(false);
+  });
+
+  it('skips seeding once when a clean slate was requested, then seeds again', () => {
+    requestCleanSlate();
+    // The requested clean slate suppresses this boot's seed...
+    expect(shouldSeedSampleData()).toBe(false);
+    // ...but only once — a later empty boot seeds normally.
+    expect(shouldSeedSampleData()).toBe(true);
+  });
+
+  it('seeds sample data by default', () => {
+    expect(shouldSeedSampleData()).toBe(true);
+  });
+});

--- a/apps/web/src/db/sampleData.ts
+++ b/apps/web/src/db/sampleData.ts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Sample-data lifecycle helpers.
+ *
+ * On first run the local database is seeded with clearly-labeled sample data
+ * (see `seed.ts`) so a brand-new user can explore the app before entering any
+ * real numbers. These helpers track whether the active workspace is sample
+ * data and let the user request a genuine clean slate — an empty workspace with
+ * no auto-reseed — via a durable `localStorage` marker that survives the reload
+ * that `wipeLocalData` triggers.
+ *
+ * All storage access is wrapped in try/catch so private-browsing modes (where
+ * `localStorage` can throw) degrade gracefully instead of breaking app boot.
+ *
+ * References: issue #3415
+ */
+
+const SAMPLE_DATA_ACTIVE_KEY = 'finance.sampleDataActive';
+const CLEAN_SLATE_KEY = 'finance.cleanSlate';
+
+function readFlag(key: string): boolean {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return false;
+    }
+    return localStorage.getItem(key) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writeFlag(key: string, value: boolean): void {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    if (value) {
+      localStorage.setItem(key, '1');
+    } else {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // Private mode / storage disabled — sample-data labeling is best-effort.
+  }
+}
+
+/**
+ * Whether sample-data seeding is disabled by build configuration.
+ *
+ * Defaults to enabled; set `VITE_DISABLE_SAMPLE_DATA=true` for a build whose
+ * first run should start empty (e.g. production). Guarding via env keeps
+ * first-run behavior intentional per environment (#3415).
+ */
+export function isSampleDataSeedingDisabledByEnv(): boolean {
+  try {
+    return import.meta.env?.VITE_DISABLE_SAMPLE_DATA === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** Whether the current workspace is showing seeded sample data. */
+export function isSampleDataActive(): boolean {
+  return readFlag(SAMPLE_DATA_ACTIVE_KEY);
+}
+
+/** Record that sample data has just been seeded into the local database. */
+export function markSampleDataSeeded(): void {
+  writeFlag(SAMPLE_DATA_ACTIVE_KEY, true);
+}
+
+/** Clear the sample-data marker (the workspace is no longer sample data). */
+export function clearSampleDataMarker(): void {
+  writeFlag(SAMPLE_DATA_ACTIVE_KEY, false);
+}
+
+/** Whether a clean slate has been requested and not yet consumed. */
+export function isCleanSlateRequested(): boolean {
+  return readFlag(CLEAN_SLATE_KEY);
+}
+
+/**
+ * Request a genuine clean slate on the next boot: the durable marker tells
+ * `seedDatabase` to skip re-seeding exactly once, yielding an empty workspace
+ * instead of fresh sample data. Set this immediately before wiping local data.
+ */
+export function requestCleanSlate(): void {
+  writeFlag(CLEAN_SLATE_KEY, true);
+}
+
+/**
+ * Consume a pending clean-slate request. Returns `true` (and clears both the
+ * clean-slate and sample-data markers) when the caller should skip seeding.
+ */
+export function consumeCleanSlateRequest(): boolean {
+  if (!isCleanSlateRequested()) {
+    return false;
+  }
+  writeFlag(CLEAN_SLATE_KEY, false);
+  clearSampleDataMarker();
+  return true;
+}
+
+/**
+ * Whether `seedDatabase` should seed sample data on an empty database.
+ *
+ * Returns `false` — and leaves the workspace empty — when a clean slate was
+ * requested (consumed here, so it only applies to the next boot) or when
+ * seeding is disabled for this build. Otherwise returns `true`.
+ */
+export function shouldSeedSampleData(): boolean {
+  if (consumeCleanSlateRequest()) {
+    return false;
+  }
+  if (isSampleDataSeedingDisabledByEnv()) {
+    return false;
+  }
+  return true;
+}

--- a/apps/web/src/db/seed.ts
+++ b/apps/web/src/db/seed.ts
@@ -15,6 +15,7 @@ import {
   createGoal,
   createTransaction,
 } from './repositories';
+import { markSampleDataSeeded, shouldSeedSampleData } from './sampleData';
 
 interface SeedTransactionInput {
   readonly accountId: string;
@@ -55,6 +56,13 @@ export async function seedDatabase(db: SqliteDb): Promise<void> {
   const accountCount = Number(existingAccounts?.count ?? 0);
 
   if (accountCount > 0) {
+    return;
+  }
+
+  if (!shouldSeedSampleData()) {
+    // A clean slate was requested (or seeding is disabled for this build):
+    // leave the workspace genuinely empty instead of seeding sample data so the
+    // real "empty account" experience is reachable (#3415).
     return;
   }
 
@@ -505,6 +513,9 @@ export async function seedDatabase(db: SqliteDb): Promise<void> {
     });
 
     releaseSavepoint(db, seedSavepoint);
+    // Mark the workspace as sample data so the UI can label it and offer a
+    // one-click clean slate (#3415).
+    markSampleDataSeeded();
   } catch (error) {
     try {
       rollbackToSavepoint(db, seedSavepoint);


### PR DESCRIPTION
## Summary

On first run the local database is seeded with a **"Demo User" / "Demo Household"** plus sample accounts and transactions ([`seed.ts`](../blob/main/apps/web/src/db/seed.ts)), but:

- nothing **labeled** it as sample data, so a first-time user can't tell which numbers are real, and
- there was **no path to a genuine clean slate** — the seed ran unconditionally on an empty database, and the error-gate "Reset local data" action wiped and then **re-seeded**, so the empty-account experience a brand-new user expects never appeared.

This makes the sample state obvious and gives the user a one-click path to an empty workspace.

## Changes

- **`apps/web/src/db/sampleData.ts`** (new) — localStorage-backed, private-mode-safe lifecycle helpers: mark/clear the active sample-data flag, request/consume a **durable clean-slate marker** that survives the reload `wipeLocalData` triggers, and an env guard (`VITE_DISABLE_SAMPLE_DATA`) so a build's first-run seeding is intentional.
- **`apps/web/src/db/seed.ts`** — skips seeding when a clean slate was requested or seeding is disabled for the build; marks the workspace as sample data after a successful seed.
- **`apps/web/src/db/DatabaseProvider.tsx`** — requests a clean slate before wiping, so the existing reset escape hatch yields an **empty** workspace instead of re-seeding.
- **`apps/web/src/components/common/SampleDataBanner.tsx`** (new, wired into `AppLayout`) — labels the workspace as sample data and offers **"Clear sample data & start fresh"** (request clean slate → wipe device-local data → reload into an empty workspace).

**Default first-run behavior is unchanged** (seeding stays on) — this is purely additive for existing flows.

## Accessibility

- A **"Sample data" text badge** carries the meaning (not color alone) — WCAG 1.4.1.
- Native, keyboard-accessible buttons; `role="region"` with an `aria-label`.
- Button **visible text matches accessible name** (removed a redundant `aria-label` that would have violated WCAG 2.5.3 Label in Name).

## Persona

Found by persona: Maya Chen (new-grad first-job budgeter) — she opened the app and couldn't tell the demo numbers weren't hers, and "Reset local data" never gave her the empty slate she wanted to build from scratch.

## Testing

- [x] `npx vitest run src/db/sampleData.test.ts` — 6 passed (marker lifecycle, clean-slate consume-once, env default)
- [x] `npx vitest run src/components/common/SampleDataBanner.test.tsx` — 4 passed (render/label, dismiss-without-wipe, clear→wipe→reload)
- [x] `npx vitest run src/db/__tests__/DatabaseProvider.test.tsx src/components/layout/AppLayout.test.tsx` — regression green
- [x] `npx prettier --check` + `npx eslint --max-warnings 0` on all 8 files — clean

## Platform Scope

Web-only: seeding lives in `apps/web/src/db`. Native platforms seed/onboard separately.

## Issues

Closes #3415
