### PR TITLE
fix(web): warn on non-amortizing payoff plans and clamp end-of-month dates (#3355, #3359)

### DIFF
--- a/apps/web/src/lib/date-utils.test.ts
+++ b/apps/web/src/lib/date-utils.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { addMonthsToIsoDate } from './date-utils';
+
+describe('addMonthsToIsoDate', () => {
+  it('adds whole months for a mid-month start date', () => {
+    expect(addMonthsToIsoDate('2025-06-15', 3)).toBe('2025-09-15');
+  });
+
+  it('rolls forward across a year boundary', () => {
+    expect(addMonthsToIsoDate('2025-11-10', 4)).toBe('2026-03-10');
+  });
+
+  it('returns the same date when adding zero months', () => {
+    expect(addMonthsToIsoDate('2025-02-28', 0)).toBe('2025-02-28');
+  });
+
+  it('clamps Jan 31 + 1 month to Feb 28 (non-leap year) instead of overflowing into March', () => {
+    expect(addMonthsToIsoDate('2025-01-31', 1)).toBe('2025-02-28');
+  });
+
+  it('clamps Jan 31 + 1 month to Feb 29 in a leap year', () => {
+    expect(addMonthsToIsoDate('2024-01-31', 1)).toBe('2024-02-29');
+  });
+
+  it('clamps Mar 31 + 1 month to Apr 30', () => {
+    expect(addMonthsToIsoDate('2025-03-31', 1)).toBe('2025-04-30');
+  });
+
+  it('keeps the day when the target month is long enough', () => {
+    expect(addMonthsToIsoDate('2025-01-30', 2)).toBe('2025-03-30');
+  });
+
+  it('handles large month counts (100-year non-amortizing horizon)', () => {
+    expect(addMonthsToIsoDate('2025-01-31', 1200)).toBe('2125-01-31');
+  });
+});

--- a/apps/web/src/lib/date-utils.ts
+++ b/apps/web/src/lib/date-utils.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Shared calendar-date helpers for the web app.
+ *
+ * Pure functions — no side effects, fully testable.
+ */
+
+/**
+ * Adds a whole number of months to an ISO `YYYY-MM-DD` date, clamping the day
+ * to the last valid day of the target month.
+ *
+ * JavaScript's native `Date.setUTCMonth` overflows end-of-month dates — e.g.
+ * `Jan 31 + 1 month` rolls forward to `Mar 3` because February has no 31st.
+ * For payoff/debt-free projections that produces a date a month too late.
+ * Clamping the day (`Jan 31 + 1 month` → `Feb 28/29`) keeps projected dates
+ * accurate for end-of-month start dates.
+ *
+ * @param todayIso - Start date as `YYYY-MM-DD` (interpreted as UTC).
+ * @param months - Whole number of months to add (may be 0 or large).
+ * @returns The resulting date as a `YYYY-MM-DD` string.
+ */
+export function addMonthsToIsoDate(todayIso: string, months: number): string {
+  const [year, month, day] = todayIso.split('-').map((value) => Number.parseInt(value, 10));
+  const startMonthIndex = Math.max(0, month - 1);
+  // Land on the first of the target month, then clamp the day to that month's
+  // last valid day so end-of-month starts never overflow into the next month.
+  const target = new Date(Date.UTC(year, startMonthIndex + months, 1));
+  const lastDayOfTargetMonth = new Date(
+    Date.UTC(target.getUTCFullYear(), target.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  target.setUTCDate(Math.min(day, lastDayOfTargetMonth));
+  return target.toISOString().slice(0, 10);
+}

--- a/apps/web/src/lib/debt-payoff-engine.test.ts
+++ b/apps/web/src/lib/debt-payoff-engine.test.ts
@@ -340,6 +340,8 @@ describe('calculateStrategyResult', () => {
     expect(result.totalMonths).toBe(0);
     expect(result.totalInterestCents).toBe(0);
     expect(result.schedules).toHaveLength(0);
+    expect(result.fullyPaidOff).toBe(true);
+    expect(result.unpaidDebtIds).toEqual([]);
   });
 
   it('avalanche targets highest rate first', () => {
@@ -358,6 +360,47 @@ describe('calculateStrategyResult', () => {
     const result = calculateStrategyResult(debts, 'avalanche', 10_000);
     expect(result.payoffOrder).toHaveLength(2);
     expect(result.totalMonths).toBeGreaterThan(0);
+    expect(result.totalMonths).toBeLessThan(1200);
+    expect(result.fullyPaidOff).toBe(true);
+    expect(result.unpaidDebtIds).toEqual([]);
+  });
+
+  it('flags a non-amortizing plan when the minimum does not cover interest', () => {
+    // $6,000 @ 24.99% APR → ~$124.95/mo interest, but the minimum is $100 and
+    // there is no extra payment, so the balance never amortizes.
+    const underwater: Debt[] = [
+      {
+        id: 'maxed-card',
+        name: 'Maxed Card',
+        balanceCents: 600_000,
+        annualRateBps: 2499,
+        minimumPaymentCents: 10_000,
+        type: 'credit_card',
+      },
+    ];
+    const result = calculateStrategyResult(underwater, 'avalanche', 0);
+    expect(result.fullyPaidOff).toBe(false);
+    expect(result.unpaidDebtIds).toEqual(['maxed-card']);
+    expect(result.payoffOrder).toHaveLength(0);
+    expect(result.totalMonths).toBe(1200);
+  });
+
+  it('clears a non-amortizing debt once the extra payment covers the shortfall', () => {
+    const underwater: Debt[] = [
+      {
+        id: 'maxed-card',
+        name: 'Maxed Card',
+        balanceCents: 600_000,
+        annualRateBps: 2499,
+        minimumPaymentCents: 10_000,
+        type: 'credit_card',
+      },
+    ];
+    // Adding $200/mo of extra payment pushes the total payment well above the
+    // monthly interest, so the debt now amortizes.
+    const result = calculateStrategyResult(underwater, 'avalanche', 20_000);
+    expect(result.fullyPaidOff).toBe(true);
+    expect(result.unpaidDebtIds).toEqual([]);
     expect(result.totalMonths).toBeLessThan(1200);
   });
 

--- a/apps/web/src/lib/debt-payoff-engine.ts
+++ b/apps/web/src/lib/debt-payoff-engine.ts
@@ -230,6 +230,8 @@ export function calculateStrategyResult(
       totalPaidCents: 0,
       totalMonths: 0,
       timelineBalanceCents: [],
+      fullyPaidOff: true,
+      unpaidDebtIds: [],
     };
   }
 
@@ -362,6 +364,16 @@ export function calculateStrategyResult(
     totalPaidCents += s.totalPaidCents;
   }
 
+  // Any debt still carrying a balance at the horizon never amortized — its
+  // payment does not cover its interest. Report these so callers can warn the
+  // user instead of rendering the capped horizon as a real payoff countdown.
+  const unpaidDebtIds: string[] = [];
+  for (const id of orderedIds) {
+    if ((balances.get(id) ?? 0) > 0) {
+      unpaidDebtIds.push(id);
+    }
+  }
+
   return {
     strategy,
     schedules,
@@ -370,6 +382,8 @@ export function calculateStrategyResult(
     totalPaidCents,
     totalMonths: month,
     timelineBalanceCents,
+    fullyPaidOff: unpaidDebtIds.length === 0,
+    unpaidDebtIds,
   };
 }
 

--- a/apps/web/src/lib/debt-student-loan-engine.ts
+++ b/apps/web/src/lib/debt-student-loan-engine.ts
@@ -35,6 +35,7 @@ import type {
   StudentLoanWhatIfScenario,
 } from './debt-types';
 import { bankersRound, calculateMonthlyInterestCents } from './debt-payoff-engine';
+import { addMonthsToIsoDate } from './date-utils';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -137,13 +138,6 @@ function getStudentLoanAggregate(loans: readonly StudentLoan[]): {
     weightedAverageRateBps:
       totalBalanceCents > 0 ? bankersRound(rateWeightedSum / totalBalanceCents) : 0,
   };
-}
-
-function addMonthsToIsoDate(todayIso: string, months: number): string {
-  const [year, month, day] = todayIso.split('-').map((value) => Number.parseInt(value, 10));
-  const date = new Date(Date.UTC(year, Math.max(0, month - 1), day));
-  date.setUTCMonth(date.getUTCMonth() + months);
-  return date.toISOString().slice(0, 10);
 }
 
 /**

--- a/apps/web/src/lib/debt-types.ts
+++ b/apps/web/src/lib/debt-types.ts
@@ -102,6 +102,19 @@ export interface StrategyResult {
   readonly totalMonths: number;
   /** Month-by-month combined remaining balance for chart display. */
   readonly timelineBalanceCents: number[];
+  /**
+   * `true` when every debt amortizes to zero within the simulation horizon.
+   * `false` when at least one debt never pays off (its payment does not cover
+   * its interest), in which case `totalMonths` is the capped horizon rather
+   * than a real payoff date and should not be shown as a countdown.
+   */
+  readonly fullyPaidOff: boolean;
+  /**
+   * Ids of debts that still carry a balance at the end of the simulation
+   * (i.e. non-amortizing debts whose payment never covers interest). Empty
+   * when `fullyPaidOff` is `true`.
+   */
+  readonly unpaidDebtIds: readonly string[];
 }
 
 /** Side-by-side strategy comparison. */

--- a/apps/web/src/lib/debt/debt-progress-rings.test.ts
+++ b/apps/web/src/lib/debt/debt-progress-rings.test.ts
@@ -19,6 +19,8 @@ const strategyResult: StrategyResult = {
   totalPaidCents: 1_025_00,
   totalMonths: 18,
   timelineBalanceCents: [],
+  fullyPaidOff: true,
+  unpaidDebtIds: [],
 };
 
 const milestones: DebtMilestoneSummary = {

--- a/apps/web/src/pages/DebtPage.css
+++ b/apps/web/src/pages/DebtPage.css
@@ -674,6 +674,34 @@
   color: var(--semantic-positive, #059669);
 }
 
+.debt-hero--warning {
+  background: linear-gradient(
+    135deg,
+    var(--semantic-negative-bg, #fee2e2),
+    var(--semantic-warning-bg, #fef3c7)
+  );
+}
+
+.debt-hero--warning h2 {
+  color: var(--semantic-negative, #b91c1c);
+}
+
+.debt-hero__underwater {
+  min-width: 190px;
+  margin: 0;
+  padding-left: var(--spacing-4, 1rem);
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-primary, #111);
+}
+
+.debt-hero__underwater li + li {
+  margin-top: var(--spacing-1, 0.25rem);
+}
+
+.debt-hero__underwater-name {
+  font-weight: var(--font-weight-bold, 700);
+}
+
 .debt-milestones {
   display: flex;
   justify-content: space-between;

--- a/apps/web/src/pages/DebtPage.test.tsx
+++ b/apps/web/src/pages/DebtPage.test.tsx
@@ -181,6 +181,42 @@ describe('DebtPage', () => {
     expect(screen.getAllByText('Personal Loan').length).toBeGreaterThan(0);
   });
 
+  it('warns instead of showing a countdown when the payment never covers interest (#3355)', () => {
+    mockUseAccountsState.accounts = [
+      buildAccount({
+        id: 'cc-maxed',
+        name: 'Maxed Card',
+        type: 'CREDIT_CARD',
+        currentBalance: { amount: -600_000 },
+      }),
+    ];
+
+    render(<DebtPage />);
+
+    // With the default 19.99% APR and 3% minimum the card amortizes, so the
+    // hero shows the debt-free countdown.
+    expect(screen.getByRole('region', { name: 'Debt-free countdown' })).toBeDefined();
+
+    // Push the APR up and the minimum payment below the monthly interest, and
+    // remove the default extra payment so nothing covers the shortfall.
+    fireEvent.change(screen.getByLabelText('Extra monthly payment ($)'), {
+      target: { value: '0' },
+    });
+    const importRegion = screen.getByRole('region', { name: 'Imported debt accounts' });
+    const cardItem = within(importRegion).getByText('Maxed Card').closest('li') as HTMLElement;
+    fireEvent.change(within(cardItem).getByLabelText('APR (%)'), { target: { value: '24.99' } });
+    fireEvent.change(within(cardItem).getByLabelText('Minimum payment ($)'), {
+      target: { value: '100' },
+    });
+
+    // The hero now warns that the plan never reaches debt-free instead of
+    // rendering a misleading "100 years to debt-free" countdown.
+    expect(screen.queryByRole('region', { name: 'Debt-free countdown' })).toBeNull();
+    const warning = screen.getByRole('region', { name: 'Payment does not cover interest' });
+    expect(within(warning).getByText('This plan never reaches debt-free')).toBeDefined();
+    expect(within(warning).getByText('Maxed Card')).toBeDefined();
+  });
+
   it('switches tabs on click', () => {
     render(<DebtPage />);
     const bnplTab = screen.getByRole('tab', { name: 'BNPL Dashboard' });

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -34,10 +34,12 @@ import {
   calculateDebtToIncomeTrend,
   calculateExtraPaymentImpactScenarios,
   calculateInterestSavedCents,
+  calculateMonthlyInterestCents,
   calculatePayoffStrategyRecommendation,
   calculateStrategyResult,
   compareStrategies,
 } from '../lib/debt-payoff-engine';
+import { addMonthsToIsoDate } from '../lib/date-utils';
 import { aggregateBnplDashboard, type BnplObligationDraft } from '../lib/debt/bnpl-aggregation';
 import {
   calculateStudentLoanDashboardSummary,
@@ -315,13 +317,6 @@ function formatMonthYear(dateIso: string): string {
   }).format(new Date(`${dateIso}T00:00:00.000Z`));
 }
 
-function addMonthsToIsoDate(todayIso: string, months: number): string {
-  const [year, month, day] = todayIso.split('-').map((value) => Number.parseInt(value, 10));
-  const date = new Date(Date.UTC(year, Math.max(0, month - 1), day));
-  date.setUTCMonth(date.getUTCMonth() + months);
-  return date.toISOString().slice(0, 10);
-}
-
 function formatCountdown(months: number): string {
   if (months <= 0) return 'Debt-free today';
   const years = Math.floor(months / 12);
@@ -331,6 +326,16 @@ function formatCountdown(months: number): string {
   if (remainingMonths > 0)
     parts.push(`${remainingMonths} month${remainingMonths === 1 ? '' : 's'}`);
   return `${parts.join(', ')} to debt-free`;
+}
+
+/**
+ * Joins debt names into a human-readable list ("A", "A and B", "A, B, and C").
+ */
+function formatDebtNameList(names: readonly string[]): string {
+  if (names.length === 0) return 'this debt';
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
 }
 
 function formatStrategyName(strategy: PayoffStrategy): string {
@@ -699,6 +704,13 @@ function PayoffPlannerPanel(): React.ReactElement {
         : null,
     [activeResult, interestSavedCents, milestones, todayIso],
   );
+  const underwaterDebts = useMemo(
+    () =>
+      activeResult && !activeResult.fullyPaidOff
+        ? debts.filter((debt) => activeResult.unpaidDebtIds.includes(debt.id))
+        : [],
+    [activeResult, debts],
+  );
 
   useEffect(() => {
     if (!hasRestoredConsolidation || debts.length === 0) return;
@@ -785,25 +797,62 @@ function PayoffPlannerPanel(): React.ReactElement {
         />
       ) : (
         <>
-          {activeResult && (
-            <section className="debt-hero" aria-label="Debt-free countdown">
-              <div>
-                <p className="debt-hero__eyebrow">Debt-Free Date</p>
-                <h2>{formatCountdown(activeResult.totalMonths)}</h2>
-                <p>
-                  Keep going. This plan points to{' '}
-                  {formatMonthYear(addMonthsToIsoDate(todayIso, activeResult.totalMonths))}.
-                </p>
-              </div>
-              <div className="debt-hero__savings" aria-live="polite">
-                <span>Interest saved</span>
-                <strong>
-                  <CurrencyDisplay amount={interestSavedCents} context="interest saved" />
-                </strong>
-                <p>Compared with making minimum payments only.</p>
-              </div>
-            </section>
-          )}
+          {activeResult &&
+            (activeResult.fullyPaidOff ? (
+              <section className="debt-hero" aria-label="Debt-free countdown">
+                <div>
+                  <p className="debt-hero__eyebrow">Debt-Free Date</p>
+                  <h2>{formatCountdown(activeResult.totalMonths)}</h2>
+                  <p>
+                    Keep going. This plan points to{' '}
+                    {formatMonthYear(addMonthsToIsoDate(todayIso, activeResult.totalMonths))}.
+                  </p>
+                </div>
+                <div className="debt-hero__savings" aria-live="polite">
+                  <span>Interest saved</span>
+                  <strong>
+                    <CurrencyDisplay amount={interestSavedCents} context="interest saved" />
+                  </strong>
+                  <p>Compared with making minimum payments only.</p>
+                </div>
+              </section>
+            ) : (
+              <section
+                className="debt-hero debt-hero--warning"
+                aria-label="Payment does not cover interest"
+              >
+                <div role="alert">
+                  <p className="debt-hero__eyebrow">Payment Too Low</p>
+                  <h2>This plan never reaches debt-free</h2>
+                  <p>
+                    Your current payment doesn&rsquo;t cover the monthly interest on{' '}
+                    {formatDebtNameList(underwaterDebts.map((debt) => debt.name))}, so the balance
+                    keeps growing instead of shrinking. Increase your monthly payment to start
+                    making real progress.
+                  </p>
+                </div>
+                <ul className="debt-hero__underwater">
+                  {underwaterDebts.map((debt) => (
+                    <li key={debt.id}>
+                      <span className="debt-hero__underwater-name">{debt.name}</span>: minimum{' '}
+                      <CurrencyDisplay
+                        amount={debt.minimumPaymentCents}
+                        context="minimum payment"
+                      />{' '}
+                      vs.{' '}
+                      <CurrencyDisplay
+                        amount={calculateMonthlyInterestCents(
+                          debt.balanceCents,
+                          debt.annualRateBps,
+                        )}
+                        context="monthly interest"
+                      />{' '}
+                      interest each month
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
 
           {debtProgressRing && <ProgressRingCard card={debtProgressRing} />}
 


### PR DESCRIPTION
﻿## Summary

Two debt-payoff-planner **correctness** fixes for tight-budget users who need numbers they can trust. Grounded in code on `origin/main`; found while bug-bashing the web app as an aggressive debt-payoff persona.

## Changes

### #3355 — Warn instead of showing `100 years to debt-free` when the payment never covers interest
- When a debt's payment is at or below its monthly interest (a real maxed-high-APR-card situation), `calculateStrategyResult` ran to its 1200-month cap and the hero rendered a misleading `100 years to debt-free` countdown with a payoff date a century out.
- `StrategyResult` now reports `fullyPaidOff` and `unpaidDebtIds`.
- `DebtPage` hero now branches: a `Payment Too Low` warning that names each under-water debt with its **minimum vs. monthly interest**, and tells the user to increase the payment — instead of a fake countdown. Region + inner `role="alert"` for the headline; conveyed via text (not colour alone).

### #3359 — Clamp end-of-month payoff dates
- `addMonthsToIsoDate` used `setUTCMonth` with no day-clamping, so `Jan 31 + 1 month` overflowed to `Mar 3` and displayed the debt-free/payoff date a month late.
- Extracted a shared, day-clamping `addMonthsToIsoDate` into `apps/web/src/lib/date-utils.ts` and reused it in `DebtPage` **and** `debt-student-loan-engine` — removing a duplicated copy of the same bug.

## Testing

- New `date-utils.test.ts` (8 cases incl. Jan 31→Feb 28/29, Mar 31→Apr 30, 100-year horizon).
- New engine tests: non-amortizing plan flags `fullyPaidOff=false` + `unpaidDebtIds`; amortizing plans stay `true`.
- New `DebtPage` test: drives a maxed card to non-amortizing and asserts the warning replaces the countdown.
- Full `apps/web` suite: **9263 passed**, 1 pre-existing unrelated failure (`DashboardPage > has accessible landmarks` — known JSDOM `navigation not implemented` flake).
- Prettier + ESLint clean.

## Issues

Closes #3355
Closes #3359

Found by persona: Marcus Johnson (aggressive debt-payoff)
