### PR TITLE
fix(web): correct cash-flow EOM seed and add chart data table (#3214, #3215)

### DIFF
--- a/apps/web/src/pages/CashFlowPage.test.tsx
+++ b/apps/web/src/pages/CashFlowPage.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { CashFlowPage } from './CashFlowPage';
 
 // Mock the hook
@@ -168,5 +168,58 @@ describe('CashFlowPage', () => {
     expect(screen.getByRole('radio', { name: '6M' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: '12M' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: '24M' })).toBeInTheDocument();
+  });
+
+  // A two-month window where the multi-period cumulative net (800000) differs
+  // from the current month's net (200000), so a seeding regression is visible.
+  const twoMonthResult = {
+    aggregates: [
+      { month: '2024-01', income: 1000000, expenses: 400000, netIncome: 600000 },
+      { month: '2024-02', income: 500000, expenses: 300000, netIncome: 200000 },
+    ],
+    summary: {
+      averageMonthlyIncome: 750000,
+      averageMonthlyExpenses: 350000,
+      averageMonthlyNetIncome: 400000,
+      totalIncome: 1500000,
+      totalExpenses: 700000,
+      totalNetIncome: 800000,
+      monthCount: 2,
+    },
+    incomeSources: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    exportCsv: vi.fn(),
+  } as ReturnType<typeof useCashFlow>;
+
+  it('seeds the month-end forecast with the current month net, not the multi-period total', () => {
+    mockUseCashFlow.mockReturnValue(twoMonthResult);
+
+    render(<CashFlowPage />);
+
+    // Current month net (200000) + remaining avg income (250000) − remaining
+    // avg outflow (50000) = 400000 → $4,000.00. The old code seeded the forecast
+    // with the 2-month cumulative net (800000), which produced $10,000.00.
+    const projectedCard = screen.getByLabelText('Projected end-of-month balance');
+    expect(within(projectedCard).getByText('$4,000.00')).toBeInTheDocument();
+    expect(within(projectedCard).queryByText('$10,000.00')).not.toBeInTheDocument();
+  });
+
+  it('exposes an accessible data table alternative for the income vs. expenses chart', () => {
+    mockUseCashFlow.mockReturnValue(twoMonthResult);
+
+    render(<CashFlowPage />);
+
+    const table = screen.getByRole('table', { name: /monthly income versus expenses/i });
+    expect(within(table).getByRole('columnheader', { name: 'Income' })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Expenses' })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Net' })).toBeInTheDocument();
+
+    // The February row exposes the same figures the bars encode visually.
+    expect(within(table).getByRole('rowheader', { name: '2024-02' })).toBeInTheDocument();
+    expect(within(table).getByText('$5,000.00')).toBeInTheDocument(); // income
+    expect(within(table).getByText('$3,000.00')).toBeInTheDocument(); // expenses
+    expect(within(table).getByText('$2,000.00')).toBeInTheDocument(); // net
   });
 });

--- a/apps/web/src/pages/CashFlowPage.tsx
+++ b/apps/web/src/pages/CashFlowPage.tsx
@@ -112,29 +112,60 @@ const IncomeExpenseChart: React.FC<IncomeExpenseChartProps> = ({ aggregates }) =
   const maxValue = Math.max(...aggregates.flatMap((a) => [a.income, a.expenses]), 1);
 
   return (
-    <div
-      className="analytics-bar-chart"
-      role="img"
-      aria-label="Monthly income versus expenses bar chart"
-    >
-      {aggregates.map((agg) => (
-        <div key={agg.month} className="analytics-bar-chart__group">
-          <div className="analytics-bar-chart__bars">
-            <div
-              className="analytics-bar-chart__bar analytics-bar-chart__bar--income"
-              style={{ height: `${Math.max((agg.income / maxValue) * 100, 1)}%` }}
-              title={`Income: $${(agg.income / 100).toFixed(2)}`}
-            />
-            <div
-              className="analytics-bar-chart__bar analytics-bar-chart__bar--expense"
-              style={{ height: `${Math.max((agg.expenses / maxValue) * 100, 1)}%` }}
-              title={`Expenses: $${(agg.expenses / 100).toFixed(2)}`}
-            />
+    <>
+      <div
+        className="analytics-bar-chart"
+        role="img"
+        aria-label="Monthly income versus expenses bar chart"
+      >
+        {aggregates.map((agg) => (
+          <div key={agg.month} className="analytics-bar-chart__group">
+            <div className="analytics-bar-chart__bars">
+              <div
+                className="analytics-bar-chart__bar analytics-bar-chart__bar--income"
+                style={{ height: `${Math.max((agg.income / maxValue) * 100, 1)}%` }}
+                title={`Income: $${(agg.income / 100).toFixed(2)}`}
+              />
+              <div
+                className="analytics-bar-chart__bar analytics-bar-chart__bar--expense"
+                style={{ height: `${Math.max((agg.expenses / maxValue) * 100, 1)}%` }}
+                title={`Expenses: $${(agg.expenses / 100).toFixed(2)}`}
+              />
+            </div>
+            <span className="analytics-bar-chart__label">{agg.month.slice(5)}</span>
           </div>
-          <span className="analytics-bar-chart__label">{agg.month.slice(5)}</span>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+      {/* Text alternative for the bar chart: screen-reader users get the same
+          per-month figures the sighted chart encodes with bar heights/colors. */}
+      <table className="sr-only">
+        <caption>Monthly income versus expenses</caption>
+        <thead>
+          <tr>
+            <th scope="col">Month</th>
+            <th scope="col">Income</th>
+            <th scope="col">Expenses</th>
+            <th scope="col">Net</th>
+          </tr>
+        </thead>
+        <tbody>
+          {aggregates.map((agg) => (
+            <tr key={agg.month}>
+              <th scope="row">{agg.month}</th>
+              <td>
+                <CurrencyDisplay amount={agg.income} />
+              </td>
+              <td>
+                <CurrencyDisplay amount={agg.expenses} />
+              </td>
+              <td>
+                <CurrencyDisplay amount={agg.netIncome} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
   );
 };
 
@@ -192,6 +223,10 @@ export const CashFlowPage: React.FC = () => {
     const now = new Date();
     const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
     const currentAggregate = aggregates.length > 0 ? aggregates[aggregates.length - 1] : null;
+    // Seed the forecast with the current month's net cash flow so far — not the
+    // multi-period cumulative total, which would overstate a single month's
+    // projected end position by a factor of the reporting window.
+    const currentMonthNetCents = currentAggregate?.netIncome ?? 0;
     const expectedIncomeRemaining = Math.max(
       0,
       summary.averageMonthlyIncome - (currentAggregate?.income ?? 0),
@@ -202,7 +237,7 @@ export const CashFlowPage: React.FC = () => {
     );
 
     return forecastMonthEndBalance({
-      currentBalanceCents: summary.totalNetIncome,
+      currentBalanceCents: currentMonthNetCents,
       today: formatLocalDate(now),
       monthEnd: formatLocalDate(monthEnd),
       expectedIncome:


### PR DESCRIPTION
## Summary

Two fixes to Diego's cash-flow forecasting view (`CashFlowPage`), batched because they touch the same file (AGENTS.md 4a).

## Changes

### `fix` #3215 - Projected EOM Balance seeded with the wrong number
The month-end forecast seeded `currentBalanceCents` with `summary.totalNetIncome` -- the **cumulative** net across the entire reporting window (6/12/24 months). For a freelancer looking at a 12-month window this overstated the projected end-of-month position by roughly 12x. The surrounding calculation already frames everything around the **current** month (remaining income/outflows are derived from the latest aggregate vs. the monthly average), so the seed is now the current month's net cash flow (`currentAggregate.netIncome`). The projection now lands at a sensible ~average-month net instead of a multi-month sum.

### `a11y` #3214 - Bar chart had no text alternative
The income-vs-expenses bar chart is a `role="img"` container whose per-bar figures lived only in `title` attributes, which screen readers do not reliably announce -- and the data was distinguished by bar color/height alone. Added a visually-hidden (`.sr-only`) data table (Month / Income / Expenses / Net) as a sibling of the chart, so assistive-technology users get the same figures. Satisfies the accessibility-testing skill's rule that financial charts must expose a data table or text summary and never encode values by color alone (WCAG 2.2 - 1.1.1 Non-text Content).

## Testing

- [x] `tsc -b` clean
- [x] `vitest run CashFlowPage` - 7/7 pass (2 new: forecast-seed regression + chart data-table)
- [x] `prettier --check` + `eslint --max-warnings 0` clean

## Issues

Closes #3214
Closes #3215

Found by persona: Diego Ramirez (freelance-designer irregular-income)