### PR TITLE
feat(web): net-worth break-even milestones + chart zero baseline (#3366, #3367)

### DIFF
--- a/apps/web/src/components/charts/NetWorthProjectionChart.test.tsx
+++ b/apps/web/src/components/charts/NetWorthProjectionChart.test.tsx
@@ -35,7 +35,14 @@ vi.mock('recharts', async () => {
   const React = await import('react');
   const mock = (name: string) =>
     function MockComponent(props: Record<string, unknown>) {
-      return React.createElement('div', { 'data-testid': name }, props.children as never);
+      const label = props.label as { value?: unknown } | undefined;
+      const labelText =
+        label && typeof label === 'object' && 'value' in label ? String(label.value) : undefined;
+      return React.createElement(
+        'div',
+        { 'data-testid': name, 'data-label': labelText },
+        props.children as never,
+      );
     };
   return {
     ResponsiveContainer: mock('ResponsiveContainer'),
@@ -120,5 +127,19 @@ describe('NetWorthProjectionChart', () => {
   it('shows an empty state when there is no history at all', () => {
     render(<NetWorthProjectionChart history={[]} />);
     expect(screen.getByText(/Add account balances and transactions/)).toBeInTheDocument();
+  });
+
+  it('draws a labeled break-even reference line only when net worth is underwater', () => {
+    // Climbing but still-negative history crosses $0 in view.
+    const { container, rerender } = render(
+      <NetWorthProjectionChart
+        history={makeHistory([-2_600_000, -2_400_000, -2_000_000, -1_500_000])}
+      />,
+    );
+    expect(container.querySelector('[data-label="Break-even ($0)"]')).not.toBeNull();
+
+    // A purely-positive series keeps full vertical resolution — no zero line.
+    rerender(<NetWorthProjectionChart history={GROWING} />);
+    expect(container.querySelector('[data-label="Break-even ($0)"]')).toBeNull();
   });
 });

--- a/apps/web/src/components/charts/NetWorthProjectionChart.tsx
+++ b/apps/web/src/components/charts/NetWorthProjectionChart.tsx
@@ -200,6 +200,18 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
     return [...actualRows, ...projectedRows];
   }, [visible, projection]);
 
+  // Only pin the axis to $0 and draw the break-even line when the series is
+  // (or is projected to be) underwater; forcing a purely-positive chart to
+  // include zero would waste vertical resolution.
+  const crossesZero = useMemo(
+    () =>
+      chartData.some(
+        (row) =>
+          (row.actual !== null && row.actual < 0) || (row.projected !== null && row.projected < 0),
+      ),
+    [chartData],
+  );
+
   const description = useMemo(() => {
     if (visible.length === 0) return `${title}: no net worth history yet.`;
     const values = visible.map((point) => point.netWorthCents);
@@ -314,6 +326,11 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
                   tickFormatter={(value: number) => formatChartCurrency(value, currency)}
                   tick={{ fill: 'var(--semantic-text-secondary, #6B7280)', fontSize: 12 }}
                   width={80}
+                  domain={
+                    crossesZero
+                      ? [(min: number) => Math.min(0, min), (max: number) => Math.max(0, max)]
+                      : ['auto', 'auto']
+                  }
                 />
                 <Tooltip
                   formatter={(value) => formatChartCurrency(Number(value ?? 0), currency)}
@@ -331,6 +348,19 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
                     label={{
                       value: 'Now',
                       position: 'top',
+                      fill: 'var(--semantic-text-secondary, #6B7280)',
+                      fontSize: 11,
+                    }}
+                  />
+                )}
+                {crossesZero && (
+                  <ReferenceLine
+                    y={0}
+                    stroke="var(--semantic-text-secondary, #6B7280)"
+                    strokeDasharray="4 2"
+                    label={{
+                      value: 'Break-even ($0)',
+                      position: 'insideTopLeft',
                       fill: 'var(--semantic-text-secondary, #6B7280)',
                       fontSize: 11,
                     }}

--- a/apps/web/src/lib/analytics/net-worth.test.ts
+++ b/apps/web/src/lib/analytics/net-worth.test.ts
@@ -241,6 +241,41 @@ describe('detectMilestones', () => {
     // Ladder extends to at least $10M so HNW users always have a next target.
     expect(milestones.some((m) => m.label === 'First $10M')).toBe(true);
   });
+
+  it('adds a negative-side ladder for users climbing out of debt', () => {
+    // Marcus: -$26K net worth, still carrying $26K of debt.
+    const milestones = detectMilestones(-2_600_000, 2_600_000);
+
+    const past50k = milestones.find((m) => m.label === '-$50K');
+    const past25k = milestones.find((m) => m.label === '-$25K');
+    const breakEven = milestones.find((m) => m.label === 'Break-even ($0)');
+
+    // Climbed above -$50K, but not yet to -$25K or break-even.
+    expect(past50k?.reached).toBe(true);
+    expect(past25k?.reached).toBe(false);
+    expect(breakEven).toBeDefined();
+    expect(breakEven?.reached).toBe(false);
+    // The positive ladder is still present as future targets.
+    expect(milestones.some((m) => m.label === 'First $1K')).toBe(true);
+  });
+
+  it('marks break-even as reached once net worth crosses $0', () => {
+    // Just crossed into the black (+$300) but still under the first $1K rung.
+    const milestones = detectMilestones(30_000, 500_000);
+    const breakEven = milestones.find((m) => m.label === 'Break-even ($0)');
+    const first1k = milestones.find((m) => m.label === 'First $1K');
+
+    expect(breakEven?.reached).toBe(true);
+    expect(first1k?.reached).toBe(false);
+    // Debt-free stays keyed on liabilities, distinct from break-even.
+    expect(milestones.find((m) => m.label === 'Debt-free')?.reached).toBe(false);
+  });
+
+  it('omits the negative-side ladder for positive-net-worth users', () => {
+    const milestones = detectMilestones(1_500_000, 0); // $15K, out of debt
+    expect(milestones.some((m) => m.label === 'Break-even ($0)')).toBe(false);
+    expect(milestones.some((m) => m.label === '-$50K')).toBe(false);
+  });
 });
 
 describe('computePeriodComparison', () => {

--- a/apps/web/src/lib/analytics/net-worth.ts
+++ b/apps/web/src/lib/analytics/net-worth.ts
@@ -235,7 +235,31 @@ const DEFAULT_MILESTONES: Array<{ label: string; thresholdCents: number }> = [
 ];
 
 /**
+ * Negative-side milestones for users climbing out of debt toward $0 net worth.
+ *
+ * Ordered deepest-debt first so the ladder reads as an upward climb. These are
+ * only surfaced while the user is still below the first positive rung (see
+ * {@link detectMilestones}); the "Break-even ($0)" marker recognizes the single
+ * most meaningful moment of a debt-payoff journey — crossing from negative to
+ * zero net worth — which is distinct from the "Debt-free" marker (liabilities
+ * reaching zero).
+ */
+const DEBT_MILESTONES: Array<{ label: string; thresholdCents: number }> = [
+  { label: '-$100K', thresholdCents: -10_000_000 },
+  { label: '-$50K', thresholdCents: -5_000_000 },
+  { label: '-$25K', thresholdCents: -2_500_000 },
+  { label: '-$10K', thresholdCents: -1_000_000 },
+  { label: '-$5K', thresholdCents: -500_000 },
+  { label: 'Break-even ($0)', thresholdCents: 0 },
+];
+
+/**
  * Detects which milestones have been reached.
+ *
+ * Users still below the first positive milestone also receive a negative-side
+ * ladder (see {@link DEBT_MILESTONES}) so debt-payoff progress toward $0 is
+ * recognized. Higher-net-worth users are not cluttered with already-passed
+ * debt markers.
  *
  * @param currentNetWorth - Current net worth in cents
  * @param totalLiabilities - Total liabilities in cents
@@ -245,7 +269,13 @@ export function detectMilestones(
   currentNetWorth: number,
   totalLiabilities: number,
 ): NetWorthMilestone[] {
-  return DEFAULT_MILESTONES.map((m, idx) => {
+  const firstPositiveThresholdCents = DEFAULT_MILESTONES[0]?.thresholdCents ?? 0;
+  const scale =
+    currentNetWorth < firstPositiveThresholdCents
+      ? [...DEBT_MILESTONES, ...DEFAULT_MILESTONES]
+      : DEFAULT_MILESTONES;
+
+  return scale.map((m, idx) => {
     let reached: boolean;
     if (m.label === 'Debt-free') {
       reached = totalLiabilities === 0;


### PR DESCRIPTION
﻿## Summary
Recognizes the negative-to-zero climb that a debt-payoff user cares about most, and makes the ` crossing visible on the projection chart.

## Changes
- **#3366 — net-worth break-even milestones** (`apps/web/src/lib/analytics/net-worth.ts`): `detectMilestones` now prepends a negative-side ladder (`-$100K`, `-$50K`, `-$25K`, `-$10K`, `-$5K`, `Break-even ($0)`) whenever net worth is below the first positive rung. The climb toward ` is recognized/celebrated; higher-net-worth users are not cluttered with already-passed debt markers. `Break-even` (net worth >= `) is intentionally distinct from `Debt-free` (liabilities == 0).
- **#3367 — chart zero baseline** (`apps/web/src/components/charts/NetWorthProjectionChart.tsx`): draws a labeled `y=0` `ReferenceLine` ("Break-even ($0)") and pins the Y domain to include ` — but only when the series is (or is projected to be) underwater, so purely-positive charts keep full vertical resolution. Not encoded by color alone (the line is labeled).

## Issues
Closes #3366
Closes #3367

## Testing
- `net-worth.test.ts`: negative-side ladder for a -$26K user, break-even flips reached once net worth crosses $0, and the ladder is omitted for positive-net-worth users.
- `NetWorthProjectionChart.test.tsx`: break-even reference line renders only when underwater.
- Full targeted suite: 32 tests pass; lint + format clean.

Found by persona: Marcus Johnson (aggressive debt-payoff)
