### PR TITLE
feat(web): add business P&L CSV export (#3230)

### DIFF
--- a/apps/web/src/lib/business/profit-and-loss.test.ts
+++ b/apps/web/src/lib/business/profit-and-loss.test.ts
@@ -8,6 +8,7 @@ import {
   buildProfitAndLoss,
   classifyTransaction,
   compilePnlTagSets,
+  exportBusinessPnlCsv,
   formatMarginPercent,
   marginBasisPoints,
   periodKey,
@@ -471,5 +472,60 @@ describe('DEFAULT_PNL_TAGS', () => {
     expect(DEFAULT_PNL_TAGS.cogs).toContain('cogs');
     expect(DEFAULT_PNL_TAGS.labor).toContain('payroll');
     expect(DEFAULT_PNL_TAGS.overhead).toContain('opex');
+  });
+});
+
+describe('exportBusinessPnlCsv', () => {
+  it('emits a header, one row per period, and an All periods totals row', () => {
+    const csv = exportBusinessPnlCsv(
+      buildProfitAndLoss([
+        makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 100_000 }),
+        makeTransaction({
+          date: '2024-01-06',
+          type: 'EXPENSE',
+          amountCents: 30_000,
+          tags: ['cogs'],
+        }),
+        makeTransaction({
+          date: '2024-01-07',
+          type: 'EXPENSE',
+          amountCents: 20_000,
+          tags: ['labor'],
+        }),
+        makeTransaction({ date: '2024-01-08', type: 'EXPENSE', amountCents: 10_000 }),
+        makeTransaction({ date: '2024-02-05', type: 'INCOME', amountCents: 50_000 }),
+      ]),
+    );
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe(
+      'Period,Revenue,COGS,Gross profit,Gross margin %,Labor,Overhead,Operating expenses,Net profit,Net margin %,Transactions',
+    );
+    expect(lines).toContain(
+      'Jan 2024,1000.00,300.00,700.00,70.0,200.00,100.00,300.00,400.00,40.0,4',
+    );
+    expect(lines).toContain('Feb 2024,500.00,0.00,500.00,100.0,0.00,0.00,0.00,500.00,100.0,1');
+    expect(lines[lines.length - 1]).toBe(
+      'All periods,1500.00,300.00,1200.00,80.0,200.00,100.00,300.00,900.00,60.0,5',
+    );
+  });
+
+  it('leaves both margins blank for a period with no revenue', () => {
+    const csv = exportBusinessPnlCsv(
+      buildProfitAndLoss([
+        makeTransaction({ date: '2024-03-05', type: 'EXPENSE', amountCents: 5_000 }),
+      ]),
+    );
+
+    expect(csv).toContain('Mar 2024,0.00,0.00,0.00,,0.00,50.00,50.00,-50.00,,1');
+  });
+
+  it('returns the header and an empty totals row for an empty statement', () => {
+    const csv = exportBusinessPnlCsv(buildProfitAndLoss([]));
+
+    expect(csv.split('\n')).toEqual([
+      'Period,Revenue,COGS,Gross profit,Gross margin %,Labor,Overhead,Operating expenses,Net profit,Net margin %,Transactions',
+      'All periods,0.00,0.00,0.00,,0.00,0.00,0.00,0.00,,0',
+    ]);
   });
 });

--- a/apps/web/src/lib/business/profit-and-loss.ts
+++ b/apps/web/src/lib/business/profit-and-loss.ts
@@ -40,6 +40,7 @@
  */
 
 import type { LocalDate, Transaction } from '../../kmp/bridge';
+import { escapeCsvField } from '../export/simple-export';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -408,4 +409,52 @@ export function buildProfitAndLoss(
     periods,
     totals: finalizeBucket(combined),
   };
+}
+
+// ---------------------------------------------------------------------------
+// CSV export
+// ---------------------------------------------------------------------------
+
+/** Format an integer cent amount as major currency units with two decimals. */
+function formatCsvAmount(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+/** Format a basis-point margin as a plain percentage, or blank when N/A. */
+function formatCsvMargin(bps: number | null): string {
+  return bps === null || !Number.isFinite(bps) ? '' : (bps / 100).toFixed(1);
+}
+
+const PNL_CSV_HEADER =
+  'Period,Revenue,COGS,Gross profit,Gross margin %,Labor,Overhead,Operating expenses,Net profit,Net margin %,Transactions';
+
+function pnlCsvRow(label: string, totals: PnlTotals): string {
+  return [
+    escapeCsvField(label),
+    formatCsvAmount(totals.revenueCents),
+    formatCsvAmount(totals.cogsCents),
+    formatCsvAmount(totals.grossProfitCents),
+    formatCsvMargin(totals.grossMarginBps),
+    formatCsvAmount(totals.laborCents),
+    formatCsvAmount(totals.overheadCents),
+    formatCsvAmount(totals.operatingExpensesCents),
+    formatCsvAmount(totals.netProfitCents),
+    formatCsvMargin(totals.netMarginBps),
+    String(totals.transactionCount),
+  ].join(',');
+}
+
+/**
+ * Serialize a profit-and-loss statement as CSV for handing to an accountant.
+ *
+ * Emits one row per reporting period followed by an "All periods" totals row.
+ * Amounts are major currency units with two decimals; margins are plain
+ * percentages (blank when revenue is zero and the margin is N/A). The totals
+ * transaction count is exact because P&L classification never splits a
+ * transaction across buckets.
+ */
+export function exportBusinessPnlCsv(statement: PnlStatement): string {
+  const rows = statement.periods.map((period) => pnlCsvRow(period.label, period));
+  const totals = pnlCsvRow('All periods', statement.totals);
+  return [PNL_CSV_HEADER, ...rows, totals].join('\n');
 }

--- a/apps/web/src/pages/BusinessPnlPage.css
+++ b/apps/web/src/pages/BusinessPnlPage.css
@@ -31,6 +31,28 @@
   max-width: 72ch;
 }
 
+.business-pnl__export-btn {
+  align-self: flex-start;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-elevated);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.business-pnl__export-btn:hover:not(:disabled) {
+  background: var(--semantic-background-secondary);
+}
+
+.business-pnl__export-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .business-pnl__description code {
   background: var(--semantic-background-secondary);
   border-radius: var(--radius-sm, 4px);

--- a/apps/web/src/pages/BusinessPnlPage.test.tsx
+++ b/apps/web/src/pages/BusinessPnlPage.test.tsx
@@ -151,4 +151,44 @@ describe('BusinessPnlPage', () => {
     render(<BusinessPnlPage />);
     expect(screen.getByText(/No revenue or expense transactions/i)).toBeInTheDocument();
   });
+
+  const EXPORT_BUTTON = /download profit and loss statement as csv/i;
+
+  it('enables the Download CSV button when the statement has periods', () => {
+    mockUseTransactions.mockReturnValue(mockResult());
+    render(<BusinessPnlPage />);
+    expect(screen.getByRole('button', { name: EXPORT_BUTTON })).toBeEnabled();
+  });
+
+  it('disables the Download CSV button when there are no transactions', () => {
+    mockUseTransactions.mockReturnValue(mockResult({ transactions: [] }));
+    render(<BusinessPnlPage />);
+    expect(screen.getByRole('button', { name: EXPORT_BUTTON })).toBeDisabled();
+  });
+
+  it('generates a CSV blob download when the button is clicked', async () => {
+    const user = userEvent.setup();
+    const createObjectURL = vi.fn((_blob: Blob | MediaSource) => 'blob:business-pnl');
+    const revokeObjectURL = vi.fn();
+    // jsdom does not implement the object-URL helpers; provide test doubles.
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL });
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+
+    mockUseTransactions.mockReturnValue(mockResult());
+    render(<BusinessPnlPage />);
+
+    await user.click(screen.getByRole('button', { name: EXPORT_BUTTON }));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(createObjectURL.mock.calls[0]?.[0]).toBeInstanceOf(Blob);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+
+    clickSpy.mockRestore();
+    delete (URL as unknown as Record<string, unknown>).createObjectURL;
+    delete (URL as unknown as Record<string, unknown>).revokeObjectURL;
+  });
 });

--- a/apps/web/src/pages/BusinessPnlPage.tsx
+++ b/apps/web/src/pages/BusinessPnlPage.tsx
@@ -11,13 +11,15 @@
  * happen in the pure {@link buildProfitAndLoss} engine. References: issue #2184.
  */
 
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { DateInput, ErrorBanner, LoadingSpinner } from '../components/common';
 import { useTransactions } from '../hooks/useTransactions';
 import { formatCurrency } from '../lib/currency';
+import { buildDatedExportFileName } from '../lib/export/simple-export';
 import {
   buildProfitAndLoss,
+  exportBusinessPnlCsv,
   formatMarginPercent,
   type PnlGranularity,
   type PnlTotals,
@@ -75,6 +77,19 @@ export function BusinessPnlPage() {
     [endDate, granularity, startDate, transactions],
   );
 
+  const handleExportCsv = useCallback(() => {
+    const csv = exportBusinessPnlCsv(statement);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = buildDatedExportFileName('business-pnl', 'csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [statement]);
+
   if (loading) {
     return <LoadingSpinner label="Loading profit and loss statement" />;
   }
@@ -100,6 +115,15 @@ export function BusinessPnlPage() {
           sold, labor and other operating expenses; untagged income counts as revenue and untagged
           expenses as overhead.
         </p>
+        <button
+          type="button"
+          className="business-pnl__export-btn"
+          onClick={handleExportCsv}
+          disabled={statement.periods.length === 0}
+          aria-label="Download profit and loss statement as CSV"
+        >
+          Download CSV
+        </button>
       </header>
 
       <section className="business-pnl__card" aria-labelledby="business-pnl-controls-title">


### PR DESCRIPTION
## Summary

Adds a **Download CSV** export to the Business P&L page (`/reports` → Profit & Loss) so freelancers can pull the full statement into a spreadsheet or hand it to an accountant at tax time. This mirrors the CSV exports already shipped for Cash Flow, Client Profitability, and the invoice pipeline.

## Changes

- `lib/business/profit-and-loss.ts`: new `exportBusinessPnlCsv(statement)` that emits a header row, one row per period, and an **All periods** totals row. Columns: Period, Revenue, COGS, Gross profit, Gross margin %, Labor, Overhead, Operating expenses, Net profit, Net margin %, Transactions. Amounts are dollars (`.toFixed(2)`); margins are `bps/100` to one decimal, blank when revenue is zero (margin is `null`). Reuses `escapeCsvField` from `lib/export/simple-export`.
- `pages/BusinessPnlPage.tsx`: a **Download CSV** button in the header, wired to a `useCallback` blob download via `buildDatedExportFileName('business-pnl', 'csv')`. Disabled (with `aria-label`) when the statement has no periods.
- `pages/BusinessPnlPage.css`: scoped `.business-pnl__export-btn` styling using design tokens only.
- Tests: `exportBusinessPnlCsv` unit tests (multi-period totals, null-margin period, empty statement) + page tests (button enabled/disabled + blob-download wiring).

The totals transaction count is exact here — unlike client profitability, P&L classification never splits a transaction across buckets.

## Issues

Closes #3230

## Testing

- [x] `npx tsc -b` — clean
- [x] `npx vitest run` profit-and-loss + BusinessPnlPage — 42/42 pass
- [x] `npx prettier --check` + `npx eslint --max-warnings 0` — clean

Found by persona: Diego Ramirez (freelance-designer irregular-income)