### PR TITLE
feat(web): add discoverable estimated-tax view (#3225)

### DIFF
--- a/apps/web/src/components/layout/navConfig.tsx
+++ b/apps/web/src/components/layout/navConfig.tsx
@@ -169,7 +169,16 @@ export const NAV_CONFIG: readonly NavConfigItem[] = ensureStableNavOrder([
     icon: <ReportsIcon />,
     group: 'money',
     mobilePriority: 8,
-    description: 'Lot-level gains, estimated taxes and wash-sale guardrails.',
+    description: 'Lot-level investment gains and wash-sale guardrails.',
+  },
+  {
+    id: 'estimated-tax',
+    label: 'Estimated Taxes',
+    href: '/estimated-tax',
+    icon: <ReportsIcon />,
+    group: 'money',
+    mobilePriority: 35,
+    description: 'Quarterly self-employment tax set-aside and next due date.',
   },
   {
     id: 'subscriptions',

--- a/apps/web/src/lib/ux/module-visibility.ts
+++ b/apps/web/src/lib/ux/module-visibility.ts
@@ -101,6 +101,7 @@ export const HIDEABLE_MODULE_IDS: readonly string[] = Object.freeze([
   'expected-income',
   'investments',
   'tax-center',
+  'estimated-tax',
   'safety',
   // Plan
   'budgets',
@@ -182,7 +183,13 @@ export const HIDEABLE_MODULES: readonly HideableModule[] = [
   {
     id: 'tax-center',
     label: 'Tax Center',
-    description: 'Lot-level gains, estimated taxes and wash-sale guardrails.',
+    description: 'Lot-level investment gains and wash-sale guardrails.',
+    category: 'money',
+  },
+  {
+    id: 'estimated-tax',
+    label: 'Estimated Taxes',
+    description: 'Quarterly self-employment tax set-aside and next due date.',
     category: 'money',
   },
   {

--- a/apps/web/src/pages/EstimatedTaxPage.css
+++ b/apps/web/src/pages/EstimatedTaxPage.css
@@ -1,0 +1,32 @@
+.estimated-tax {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.estimated-tax__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.estimated-tax__eyebrow {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.estimated-tax__title {
+  font-size: var(--type-scale-display-font-size);
+  font-weight: var(--type-scale-display-font-weight);
+  margin: 0;
+}
+
+.estimated-tax__description {
+  color: var(--semantic-text-secondary);
+  margin: 0;
+  max-width: 72ch;
+}

--- a/apps/web/src/pages/EstimatedTaxPage.test.tsx
+++ b/apps/web/src/pages/EstimatedTaxPage.test.tsx
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EstimatedTaxPage } from './EstimatedTaxPage';
+import { useAccounts, useTransactions } from '../hooks';
+
+vi.mock('../hooks', () => ({
+  useAccounts: vi.fn(),
+  useTransactions: vi.fn(),
+}));
+
+vi.mock('../components/dashboard/DashboardTaxReserveSection', () => ({
+  default: () => <div data-testid="tax-reserve-section" />,
+}));
+
+const mockUseAccounts = vi.mocked(useAccounts);
+const mockUseTransactions = vi.mocked(useTransactions);
+
+function accountsResult(overrides: Record<string, unknown> = {}): ReturnType<typeof useAccounts> {
+  return {
+    accounts: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useAccounts>;
+}
+
+function transactionsResult(
+  overrides: Record<string, unknown> = {},
+): ReturnType<typeof useTransactions> {
+  return {
+    transactions: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useTransactions>;
+}
+
+function renderPage(): void {
+  render(
+    <MemoryRouter>
+      <EstimatedTaxPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('EstimatedTaxPage', () => {
+  beforeEach(() => {
+    mockUseAccounts.mockReturnValue(accountsResult());
+    mockUseTransactions.mockReturnValue(transactionsResult());
+  });
+
+  it('renders the estimated-tax heading and the reserve guidance section', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { level: 1, name: /estimated taxes/i })).toBeInTheDocument();
+    expect(screen.getByTestId('tax-reserve-section')).toBeInTheDocument();
+  });
+
+  it('links to the Goals tax reserve bucket for managing the rate and payments', () => {
+    renderPage();
+
+    const link = screen.getByRole('link', { name: /tax reserve bucket in goals/i });
+    expect(link).toHaveAttribute('href', '/goals');
+  });
+
+  it('shows a loading state while accounts or transactions load', () => {
+    mockUseTransactions.mockReturnValue(transactionsResult({ loading: true }));
+    renderPage();
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.queryByTestId('tax-reserve-section')).not.toBeInTheDocument();
+  });
+
+  it('shows an error banner with a retry when loading fails', () => {
+    mockUseAccounts.mockReturnValue(accountsResult({ error: 'Could not load accounts' }));
+    renderPage();
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not load accounts');
+    expect(screen.queryByTestId('tax-reserve-section')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/EstimatedTaxPage.tsx
+++ b/apps/web/src/pages/EstimatedTaxPage.tsx
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Estimated Taxes page: a discoverable home for self-employment quarterly
+ * estimated-tax planning. Surfaces the recommended set-aside per IRS quarter,
+ * the next due date, and current reserve progress without routing the user
+ * through the Goals screen or the investment-only Tax Center.
+ */
+
+import { useMemo, type FC } from 'react';
+import { Link } from 'react-router-dom';
+
+import { ErrorBanner, LoadingSpinner } from '../components/common';
+import DashboardTaxReserveSection from '../components/dashboard/DashboardTaxReserveSection';
+import { useAccounts, useTransactions } from '../hooks';
+import { getCurrentMonthBounds } from '../lib/tax-reserve';
+import './EstimatedTaxPage.css';
+
+export const EstimatedTaxPage: FC = () => {
+  const asOf = useMemo(() => new Date(), []);
+  const currentMonthRange = useMemo(() => getCurrentMonthBounds(asOf), [asOf]);
+  const currentMonthFilters = useMemo(
+    () => ({ startDate: currentMonthRange.startDate, endDate: currentMonthRange.endDate }),
+    [currentMonthRange],
+  );
+
+  const {
+    accounts,
+    loading: accountsLoading,
+    error: accountsError,
+    refresh: refreshAccounts,
+  } = useAccounts();
+  const {
+    transactions: currentMonthTransactions,
+    loading: transactionsLoading,
+    error: transactionsError,
+    refresh: refreshTransactions,
+  } = useTransactions(currentMonthFilters);
+
+  const loading = accountsLoading || transactionsLoading;
+  const error = accountsError ?? transactionsError;
+  const fallbackCurrency = currentMonthTransactions[0]?.currency.code ?? 'USD';
+
+  const handleRetry = () => {
+    refreshAccounts();
+    refreshTransactions();
+  };
+
+  return (
+    <main className="estimated-tax" aria-labelledby="estimated-tax-title">
+      <header className="estimated-tax__header">
+        <p className="estimated-tax__eyebrow">Self-employment taxes</p>
+        <h1 id="estimated-tax-title" className="estimated-tax__title">
+          Estimated Taxes
+        </h1>
+        <p className="estimated-tax__description">
+          See how much to set aside for each IRS quarter based on your self-employment income, and
+          when the next estimated payment is due. Adjust your reserve rate or record a payment from
+          the <Link to="/goals">tax reserve bucket in Goals</Link>.
+        </p>
+      </header>
+
+      {loading ? (
+        <LoadingSpinner label="Loading estimated tax guidance" />
+      ) : error ? (
+        <ErrorBanner message={error} onRetry={handleRetry} />
+      ) : (
+        <DashboardTaxReserveSection
+          accounts={accounts}
+          currentMonthTransactions={currentMonthTransactions}
+          fallbackCurrency={fallbackCurrency}
+        />
+      )}
+    </main>
+  );
+};
+
+export default EstimatedTaxPage;

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -56,6 +56,7 @@ const Household = lazy(() => import('./pages/HouseholdPage'));
 const ReportBuilder = lazy(() => import('./pages/ReportBuilderPage'));
 const ClientProfitability = lazy(() => import('./pages/ClientProfitabilityPage'));
 const BusinessPnl = lazy(() => import('./pages/BusinessPnlPage'));
+const EstimatedTax = lazy(() => import('./pages/EstimatedTaxPage'));
 const GigDriver = lazy(() => import('./pages/GigDriverPage'));
 const Investments = lazy(() => import('./pages/InvestmentsPage'));
 const LivePnl = lazy(() => import('./pages/LivePnlPage'));
@@ -458,6 +459,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Profit & Loss">
             <BusinessPnl />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/estimated-tax"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Estimated Taxes">
+            <EstimatedTax />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Summary

Adds a discoverable **Estimated Taxes** view at `/estimated-tax` so self-employed users (freelancers, contractors) can see how much to set aside for each IRS quarter and when the next estimated payment is due — without hunting through the Goals screen or landing on the investment-only Tax Center.

Previously the estimated self-employment tax-reserve UI was only reachable inside the **Goals** page, and the "Tax Center" nav item (labelled as covering "estimated taxes") routed to `/investments/tax` — lot-level gains, FIFO/LIFO and wash-sale guardrails, which are irrelevant to a freelancer's quarterly estimates.

## Changes

- **New `/estimated-tax` route + page** (`EstimatedTaxPage`): a thin, accessible wrapper that reuses the existing, tested tax-reserve engine (`buildTaxReserveSummary` / `useTaxReserve`) through the shared `DashboardTaxReserveSection` component. Shows recommended quarterly set-aside, next due date/countdown, bucket balance and progress. Links to Goals for adjusting the reserve rate or recording a payment.
- **Nav**: new "Estimated Taxes" destination in the *money* group (unique `mobilePriority` 35); updated the **Tax Center** description so it no longer implies estimated-tax planning ("Lot-level investment gains and wash-sale guardrails").
- **Module visibility**: registered `estimated-tax` in the hideable-module catalogue (kept in sync with `HIDEABLE_MODULE_IDS` order).
- Page unit tests (heading, reserve section, Goals link, loading + error states).

No business logic is added — this is a discoverability/IA fix that surfaces an engine that already existed.

## Issues

Closes #3225

## Testing

- [x] `npx tsc -b` — clean
- [x] `npx vitest run` EstimatedTaxPage + navConfig + module-visibility + Navigation + NavShortcuts — 87/87 pass (uniqueness + catalogue-parity guards included)
- [x] `npx prettier --check` + `npx eslint --max-warnings 0` — clean

## Accessibility

- Route renders a single `<h1>` and semantic `<main aria-labelledby>`; loading uses `role="status"`, errors use `role="alert"` with retry (reuses shared common components).

Found by persona: Diego Ramirez (freelance-designer irregular-income)