### PR TITLE
feat(web): add invoice pipeline CSV export (#3228)

### DIFF
--- a/apps/web/src/lib/analytics/invoices.test.ts
+++ b/apps/web/src/lib/analytics/invoices.test.ts
@@ -10,8 +10,10 @@ import { describe, expect, it } from 'vitest';
 import {
   computeExpectedPayDate,
   computeInvoiceForecast,
+  exportInvoicesCsv,
   getEffectiveInvoiceStatus,
   groupInvoicesByStatus,
+  INVOICE_CSV_HEADER,
   type Invoice,
 } from './invoices';
 
@@ -121,5 +123,60 @@ describe('computeInvoiceForecast', () => {
     expect(forecast.find((bucket) => bucket.id === 'days-31-60')?.totalCents).toBe(30000);
     expect(forecast.find((bucket) => bucket.id === 'days-61-90')?.totalCents).toBe(40000);
     expect(forecast.find((bucket) => bucket.id === 'days-90-plus')?.totalCents).toBe(50000);
+  });
+});
+
+describe('exportInvoicesCsv', () => {
+  it('emits a header, one sorted row per invoice with status/bucket, and a totals row', () => {
+    const csv = exportInvoicesCsv(
+      [
+        makeInvoice({
+          id: 'a',
+          clientName: 'Acme Studio',
+          amountCents: 100000,
+          status: 'Sent',
+          expectedPayDate: '2024-01-31',
+        }),
+        makeInvoice({
+          id: 'b',
+          clientName: 'Beta Co',
+          amountCents: 50000,
+          status: 'Sent',
+          expectedPayDate: '2024-01-10',
+        }),
+        makeInvoice({
+          id: 'c',
+          clientName: 'Ceta LLC',
+          amountCents: 30000,
+          status: 'Paid',
+          expectedPayDate: '2024-01-05',
+        }),
+      ],
+      '2024-01-15',
+    );
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe(INVOICE_CSV_HEADER);
+    // Sorted by expected pay date: Ceta (paid, no bucket), Beta (overdue), Acme.
+    expect(lines[1]).toBe('Ceta LLC,300.00,2024-01-01,Net-30,Paid,2024-01-05,');
+    expect(lines[2]).toBe('Beta Co,500.00,2024-01-01,Net-30,Overdue,2024-01-10,Past due');
+    expect(lines[3]).toBe('Acme Studio,1000.00,2024-01-01,Net-30,Sent,2024-01-31,Next 30 days');
+    expect(lines[lines.length - 1]).toBe('Total,1800.00,,,,,');
+  });
+
+  it('quotes client names that contain commas', () => {
+    const csv = exportInvoicesCsv(
+      [makeInvoice({ id: 'a', clientName: 'Ramirez, Diego', amountCents: 20000 })],
+      '2024-01-01',
+    );
+
+    expect(csv).toContain('"Ramirez, Diego",200.00,');
+  });
+
+  it('returns the header and a zero totals row for an empty pipeline', () => {
+    expect(exportInvoicesCsv([], '2024-01-15').split('\n')).toEqual([
+      INVOICE_CSV_HEADER,
+      'Total,0.00,,,,,',
+    ]);
   });
 });

--- a/apps/web/src/lib/analytics/invoices.ts
+++ b/apps/web/src/lib/analytics/invoices.ts
@@ -10,6 +10,8 @@
  * References: issue #2169
  */
 
+import { escapeCsvField } from '../export/simple-export';
+
 export type InvoicePaymentTerm = 'due-on-receipt' | 'net-15' | 'net-30' | 'net-45' | 'net-60';
 
 export type InvoiceStatus = 'Draft' | 'Sent' | 'Paid' | 'Overdue';
@@ -195,4 +197,52 @@ export function computeInvoiceForecast(invoices: Invoice[], todayIso: string): F
       a.expectedPayDate.localeCompare(b.expectedPayDate),
     ),
   }));
+}
+
+/** CSV header for {@link exportInvoicesCsv}. */
+export const INVOICE_CSV_HEADER =
+  'Client,Amount,Issue date,Payment term,Status,Expected pay date,Aging bucket';
+
+function invoiceAmountDollars(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+/**
+ * Serialize the invoice pipeline to CSV for bookkeeping/reconciliation outside
+ * the app. One row per invoice (with its effective status and aging bucket)
+ * plus a trailing totals row. Draft and paid invoices have a blank aging
+ * bucket because they are not part of the receivables forecast.
+ */
+export function exportInvoicesCsv(invoices: Invoice[], todayIso: string): string {
+  const normalized = normalizeInvoiceStatuses(invoices, todayIso);
+
+  const bucketByInvoiceId = new Map<string, string>();
+  for (const bucket of computeInvoiceForecast(invoices, todayIso)) {
+    for (const invoice of bucket.invoices) {
+      bucketByInvoiceId.set(invoice.id, bucket.label);
+    }
+  }
+
+  const rows = [...normalized]
+    .sort(
+      (a, b) =>
+        a.expectedPayDate.localeCompare(b.expectedPayDate) ||
+        a.clientName.localeCompare(b.clientName),
+    )
+    .map((invoice) =>
+      [
+        escapeCsvField(invoice.clientName),
+        invoiceAmountDollars(invoice.amountCents),
+        invoice.issueDate,
+        PAYMENT_TERM_LABELS[invoice.paymentTerm],
+        invoice.status,
+        invoice.expectedPayDate,
+        bucketByInvoiceId.get(invoice.id) ?? '',
+      ].join(','),
+    );
+
+  const totalCents = normalized.reduce((sum, invoice) => sum + invoice.amountCents, 0);
+  const totalRow = ['Total', invoiceAmountDollars(totalCents), '', '', '', '', ''].join(',');
+
+  return [INVOICE_CSV_HEADER, ...rows, totalRow].join('\n');
 }

--- a/apps/web/src/pages/InvoicesPage.test.tsx
+++ b/apps/web/src/pages/InvoicesPage.test.tsx
@@ -207,4 +207,42 @@ describe('InvoicesPage', () => {
 
     expect(screen.getByRole('article', { name: 'Past due forecast' })).toBeInTheDocument();
   });
+
+  it('disables the Export CSV button when there are no invoices (#3228)', () => {
+    render(<InvoicesPage />);
+
+    expect(screen.getByRole('button', { name: /export invoices as csv/i })).toBeDisabled();
+  });
+
+  it('exports a CSV blob download when invoices exist (#3228)', () => {
+    mockedUseInvoices.mockReturnValue({
+      invoices: [SAMPLE_INVOICE],
+      pipelineGroups: [],
+      forecastBuckets: [],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    const createObjectURL = vi.fn((_blob: Blob | MediaSource) => 'blob:invoices');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL });
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+
+    render(<InvoicesPage />);
+    fireEvent.click(screen.getByRole('button', { name: /export invoices as csv/i }));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(createObjectURL.mock.calls[0]?.[0]).toBeInstanceOf(Blob);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+
+    clickSpy.mockRestore();
+    delete (URL as unknown as Record<string, unknown>).createObjectURL;
+    delete (URL as unknown as Record<string, unknown>).revokeObjectURL;
+  });
 });

--- a/apps/web/src/pages/InvoicesPage.tsx
+++ b/apps/web/src/pages/InvoicesPage.tsx
@@ -9,12 +9,13 @@
  * References: issue #2169
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { ConfirmDialog, CurrencyDisplay, EmptyState } from '../components/common';
 import { useInvoices } from '../hooks/useInvoices';
 import { useLocalePreferences } from '../hooks/useLocalePreferences';
 import {
   computeExpectedPayDate,
+  exportInvoicesCsv,
   PAYMENT_TERM_LABELS,
   PAYMENT_TERMS,
   INVOICE_STATUSES,
@@ -22,6 +23,7 @@ import {
   type InvoicePaymentTerm,
   type InvoiceStatus,
 } from '../lib/analytics/invoices';
+import { buildDatedExportFileName } from '../lib/export/simple-export';
 import { formatDate } from '../utils/formatDate';
 import './analytics.css';
 
@@ -133,6 +135,19 @@ export const InvoicesPage: React.FC = () => {
     [invoices],
   );
 
+  const handleExportCsv = useCallback(() => {
+    const csv = exportInvoicesCsv(invoices, todayIsoDate());
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = buildDatedExportFileName('invoices', 'csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [invoices]);
+
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const amountCents = parseAmountToCents(amount);
@@ -167,6 +182,15 @@ export const InvoicesPage: React.FC = () => {
             Track net-terms work and forecast when freelance income should land.
           </p>
         </div>
+        <button
+          type="button"
+          className="analytics-export-btn"
+          onClick={handleExportCsv}
+          disabled={invoices.length === 0}
+          aria-label="Export invoices as CSV"
+        >
+          Export CSV
+        </button>
       </div>
 
       <section className="analytics-section" aria-label="Add invoice">


### PR DESCRIPTION
## Summary

Adds a **CSV export** to the Invoices pipeline (`/invoices`) so freelancers with irregular income can hand their accountant (or their own tax spreadsheet) a clean list of every outstanding invoice and what it is expected to pay, without retyping it by hand.

This closes the last of the CSV-export gaps flagged in the Diego bug bash — cash flow, business P&L, and client profitability already export; the invoice pipeline did not.

## Changes

- `lib/analytics/invoices.ts`: new `exportInvoicesCsv(invoices, todayIso)` + `INVOICE_CSV_HEADER` + `invoiceAmountDollars` helper. Columns: Client, Amount, Issue date, Payment term, Status (effective — Sent past its expected pay date shows as Overdue), Expected pay date, Aging bucket. Rows are sorted by expected pay date then client, free-text client names are CSV-escaped, and a trailing `Total` row sums the amounts.
- `pages/InvoicesPage.tsx`: **Export CSV** button in the page header (disabled when there are no invoices), wired through a `useCallback` that builds a dated filename and triggers a Blob download — same pattern as the existing cash-flow / P&L / client-profitability exports.
- Tests: `invoices.test.ts` covers multi-row sorting + totals, comma escaping, and the empty case; `InvoicesPage.test.tsx` covers the disabled-empty state and the blob-download happy path.

## Issues

Closes #3228

## Testing

- [x] `npx tsc -b` clean
- [x] `vitest run` — 19/19 pass across the two touched test files
- [x] `prettier --check` + `eslint --max-warnings 0` clean

Found by persona: Diego Ramirez (freelance-designer irregular-income)