### PR TITLE
fix(web): DebtPage empty-state CTA, form validation, and tab keyboard nav (#3360, #3361, #3362)

### DIFF
--- a/apps/web/src/pages/DebtPage.css
+++ b/apps/web/src/pages/DebtPage.css
@@ -812,7 +812,8 @@
 }
 
 .debt-import-list__item h3,
-.debt-entry-form button {
+.debt-entry-form button,
+.debt-entry-form__error {
   grid-column: 1 / -1;
 }
 
@@ -965,6 +966,31 @@
 
 .credit-utilization--warning {
   background: var(--semantic-warning-bg, #fef3c7);
+}
+
+/* ---------------------------------------------------------------------------
+ * Manual debt entry — validation feedback (#3361)
+ * ------------------------------------------------------------------------ */
+
+.debt-entry-form input[aria-invalid='true'] {
+  border-color: var(--semantic-negative, #dc2626);
+  outline-color: var(--semantic-negative, #dc2626);
+}
+
+.debt-entry-form__error {
+  color: var(--semantic-negative, #dc2626);
+  font-size: var(--font-size-xs, 0.75rem);
+  font-weight: var(--font-weight-regular, 400);
+}
+
+.debt-entry-form__error-summary {
+  padding: var(--spacing-3, 0.75rem);
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--semantic-negative-bg, #fee2e2);
+  border-left: 3px solid var(--semantic-negative, #dc2626);
+  color: var(--semantic-negative, #b91c1c);
+  font-size: var(--font-size-sm, 0.875rem);
+  font-weight: var(--font-weight-medium, 500);
 }
 
 .credit-utilization--high,

--- a/apps/web/src/pages/DebtPage.test.tsx
+++ b/apps/web/src/pages/DebtPage.test.tsx
@@ -439,4 +439,73 @@ describe('DebtPage', () => {
     const labelledBy = tabpanel.getAttribute('aria-labelledby');
     expect(labelledBy).toBe('debt-tab-payoff');
   });
+
+  it('moves between tabs with arrow keys using roving tabindex (#3362)', () => {
+    render(<DebtPage />);
+    const payoffTab = screen.getByRole('tab', { name: 'Payoff Planner' });
+    const ringsTab = screen.getByRole('tab', { name: 'Payoff Rings' });
+    const creditTab = screen.getByRole('tab', { name: 'Credit Cards' });
+
+    // Roving tabindex: only the active tab is in the tab order.
+    expect(payoffTab.getAttribute('tabindex')).toBe('0');
+    expect(ringsTab.getAttribute('tabindex')).toBe('-1');
+
+    // ArrowRight moves focus + selection to the next tab (automatic activation).
+    fireEvent.keyDown(payoffTab, { key: 'ArrowRight' });
+    expect(ringsTab.getAttribute('aria-selected')).toBe('true');
+    expect(ringsTab.getAttribute('tabindex')).toBe('0');
+    expect(payoffTab.getAttribute('tabindex')).toBe('-1');
+    expect(document.activeElement).toBe(ringsTab);
+
+    // Home jumps to the first tab.
+    fireEvent.keyDown(ringsTab, { key: 'Home' });
+    expect(payoffTab.getAttribute('aria-selected')).toBe('true');
+
+    // ArrowLeft from the first tab wraps to the last.
+    fireEvent.keyDown(payoffTab, { key: 'ArrowLeft' });
+    expect(creditTab.getAttribute('aria-selected')).toBe('true');
+
+    // End jumps to the last tab.
+    fireEvent.keyDown(payoffTab, { key: 'End' });
+    expect(creditTab.getAttribute('aria-selected')).toBe('true');
+    expect(creditTab.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('focuses the manual debt name field when the empty-state CTA is activated (#3360)', () => {
+    render(<DebtPage />);
+    const emptyState = screen.getByTestId('empty-state');
+    const addButton = within(emptyState).getByRole('button', { name: 'Add Debt' });
+    fireEvent.click(addButton);
+    expect(document.activeElement).toBe(screen.getByLabelText('Debt name'));
+  });
+
+  it('surfaces manual-entry validation errors instead of failing silently (#3361)', () => {
+    const { container } = render(<DebtPage />);
+    const form = container.querySelector('form.debt-entry-form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('Enter a name for this debt.');
+
+    const nameInput = screen.getByLabelText('Debt name');
+    expect(nameInput.getAttribute('aria-invalid')).toBe('true');
+    expect(document.activeElement).toBe(nameInput);
+
+    // Empty state is still shown because no valid debt was added.
+    expect(screen.getByTestId('empty-state')).toBeDefined();
+  });
+
+  it('adds a manual debt and clears the error summary when the form is valid (#3361)', () => {
+    const { container } = render(<DebtPage />);
+    fireEvent.change(screen.getByLabelText('Debt name'), { target: { value: 'Visa' } });
+    fireEvent.change(screen.getByLabelText('Debt balance ($)'), { target: { value: '1200' } });
+    fireEvent.change(screen.getByLabelText('Minimum payment ($)'), { target: { value: '50' } });
+
+    const form = container.querySelector('form.debt-entry-form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    // Adding a valid debt replaces the empty state with payoff results.
+    expect(screen.queryByTestId('empty-state')).toBeNull();
+    expect(screen.queryByText(/Please fix the following/)).toBeNull();
+  });
 });

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -12,7 +12,7 @@
  * References: issues #1662, #1685, #1690, #1681, #1761, #1569
  */
 
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { CurrencyDisplay, EmptyState } from '../components/common';
 import { pluralize } from '../lib/ui/pluralize';
 import { ExplainThis } from '../components/common/ExplainThis';
@@ -441,6 +441,40 @@ function getLocalStorage(): Storage | null {
  */
 export function DebtPage(): React.ReactElement {
   const [activeTab, setActiveTab] = useState<DebtTab>('payoff');
+  const debtTabKeys = useMemo(() => Object.keys(TAB_LABELS) as DebtTab[], []);
+
+  const handleTabKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, tab: DebtTab) => {
+      const currentIndex = debtTabKeys.indexOf(tab);
+      let nextIndex: number;
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          nextIndex = (currentIndex + 1) % debtTabKeys.length;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          nextIndex = (currentIndex - 1 + debtTabKeys.length) % debtTabKeys.length;
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = debtTabKeys.length - 1;
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+      const nextTab = debtTabKeys[nextIndex];
+      if (!nextTab) {
+        return;
+      }
+      setActiveTab(nextTab);
+      document.getElementById(`debt-tab-${nextTab}`)?.focus();
+    },
+    [debtTabKeys],
+  );
 
   return (
     <section className="debt-page" aria-label="Debt Management">
@@ -451,15 +485,17 @@ export function DebtPage(): React.ReactElement {
 
       <nav className="debt-page__tabs" aria-label="Debt management sections">
         <ul role="tablist" className="debt-page__tab-list">
-          {(Object.keys(TAB_LABELS) as DebtTab[]).map((tab) => (
+          {debtTabKeys.map((tab) => (
             <li key={tab} role="presentation">
               <button
                 role="tab"
                 aria-selected={activeTab === tab}
                 aria-controls={`debt-panel-${tab}`}
                 id={`debt-tab-${tab}`}
+                tabIndex={activeTab === tab ? 0 : -1}
                 className={`debt-page__tab ${activeTab === tab ? 'debt-page__tab--active' : ''}`}
                 onClick={() => setActiveTab(tab)}
+                onKeyDown={(event) => handleTabKeyDown(event, tab)}
               >
                 {TAB_LABELS[tab]}
               </button>
@@ -539,6 +575,12 @@ function PayoffPlannerPanel(): React.ReactElement {
   const [manualDebts, setManualDebts] = useState<Debt[]>([]);
   const [debtAdjustments, setDebtAdjustments] = useState<Record<string, Partial<Debt>>>({});
   const [manualForm, setManualForm] = useState<DebtFormState>(DEFAULT_DEBT_FORM);
+  const [manualErrors, setManualErrors] = useState<
+    Partial<Record<'name' | 'balance' | 'minimumPayment', string>>
+  >({});
+  const manualNameRef = useRef<HTMLInputElement>(null);
+  const manualBalanceRef = useRef<HTMLInputElement>(null);
+  const manualMinimumRef = useRef<HTMLInputElement>(null);
   const [extraPayment, setExtraPayment] = useState('100');
   const [activeStrategy, setActiveStrategy] = useState<PayoffStrategy>('avalanche');
   const [monthlyIncome, setMonthlyIncome] = useState('5000');
@@ -770,6 +812,30 @@ function PayoffPlannerPanel(): React.ReactElement {
       const balanceCents = parseCurrencyInput(manualForm.balance);
       const originalInput = parseCurrencyInput(manualForm.originalBalance);
       const minimumPaymentCents = parseCurrencyInput(manualForm.minimumPayment);
+
+      const errors: Partial<Record<'name' | 'balance' | 'minimumPayment', string>> = {};
+      if (!manualForm.name.trim()) {
+        errors.name = 'Enter a name for this debt.';
+      }
+      if (!(balanceCents > 0)) {
+        errors.balance = 'Enter a balance greater than $0.';
+      }
+      if (!(minimumPaymentCents > 0)) {
+        errors.minimumPayment = 'Enter a minimum payment greater than $0.';
+      }
+
+      if (Object.keys(errors).length > 0) {
+        setManualErrors(errors);
+        if (errors.name) {
+          manualNameRef.current?.focus();
+        } else if (errors.balance) {
+          manualBalanceRef.current?.focus();
+        } else {
+          manualMinimumRef.current?.focus();
+        }
+        return;
+      }
+
       const debt: Debt = {
         id: createDebtId(),
         name: manualForm.name.trim(),
@@ -780,11 +846,15 @@ function PayoffPlannerPanel(): React.ReactElement {
         type: manualForm.type,
       };
 
-      if (!debt.name || debt.balanceCents <= 0 || debt.minimumPaymentCents <= 0) return;
+      setManualErrors({});
       setManualDebts((current) => [...current, debt]);
       setManualForm(DEFAULT_DEBT_FORM);
     },
     [manualForm],
+  );
+
+  const manualErrorMessages = Object.values(manualErrors).filter((message): message is string =>
+    Boolean(message),
   );
 
   return (
@@ -793,7 +863,17 @@ function PayoffPlannerPanel(): React.ReactElement {
         <EmptyState
           title="No debts added"
           description="Add your debts or connect debt accounts to compare payoff strategies and see how extra payments can save you money."
-          action={<button type="button">Add Debt</button>}
+          action={
+            <button
+              type="button"
+              onClick={() => {
+                manualNameRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+                manualNameRef.current?.focus();
+              }}
+            >
+              Add Debt
+            </button>
+          }
         />
       ) : (
         <>
@@ -1110,27 +1190,48 @@ function PayoffPlannerPanel(): React.ReactElement {
 
       <section aria-label="Manual debt entry">
         <h2>Add Debt Manually</h2>
+        {manualErrorMessages.length > 0 ? (
+          <div role="alert" className="debt-entry-form__error-summary">
+            Please fix the following before adding this debt: {manualErrorMessages.join(' ')}
+          </div>
+        ) : null}
         <form className="debt-entry-form" onSubmit={handleManualSubmit} noValidate>
           <label>
             Debt name
             <input
+              ref={manualNameRef}
               type="text"
               value={manualForm.name}
               onChange={(event) => handleManualFieldChange('name', event.target.value)}
               required
+              aria-invalid={manualErrors.name ? true : undefined}
+              aria-describedby={manualErrors.name ? 'manual-debt-name-error' : undefined}
             />
           </label>
+          {manualErrors.name ? (
+            <span id="manual-debt-name-error" className="debt-entry-form__error">
+              {manualErrors.name}
+            </span>
+          ) : null}
           <label>
             Debt balance ($)
             <input
+              ref={manualBalanceRef}
               type="number"
               min="0"
               step="0.01"
               value={manualForm.balance}
               onChange={(event) => handleManualFieldChange('balance', event.target.value)}
               required
+              aria-invalid={manualErrors.balance ? true : undefined}
+              aria-describedby={manualErrors.balance ? 'manual-debt-balance-error' : undefined}
             />
           </label>
+          {manualErrors.balance ? (
+            <span id="manual-debt-balance-error" className="debt-entry-form__error">
+              {manualErrors.balance}
+            </span>
+          ) : null}
           <label>
             Original balance ($)
             <input
@@ -1155,14 +1256,24 @@ function PayoffPlannerPanel(): React.ReactElement {
           <label>
             Minimum payment ($)
             <input
+              ref={manualMinimumRef}
               type="number"
               min="0"
               step="0.01"
               value={manualForm.minimumPayment}
               onChange={(event) => handleManualFieldChange('minimumPayment', event.target.value)}
               required
+              aria-invalid={manualErrors.minimumPayment ? true : undefined}
+              aria-describedby={
+                manualErrors.minimumPayment ? 'manual-debt-minimum-error' : undefined
+              }
             />
           </label>
+          {manualErrors.minimumPayment ? (
+            <span id="manual-debt-minimum-error" className="debt-entry-form__error">
+              {manualErrors.minimumPayment}
+            </span>
+          ) : null}
           <label>
             Debt type
             <select


### PR DESCRIPTION
﻿## Summary

Fixes three DebtPage UX + accessibility issues found by the Marcus Johnson (aggressive debt-payoff) persona while working the `/debt` payoff planner on a tight budget.

## Changes

- **#3360** — The empty-state `Add Debt` CTA was a dead button (no `onClick`). It now scrolls to and focuses the manual debt-entry name field, so a first-time user with zero debts has a working path to add one.
- **#3361** — The manual add form failed silently: `handleManualSubmit` early-returned on invalid input with no feedback. It now sets per-field errors, marks fields `aria-invalid` with `aria-describedby` messages, renders a `role="alert"` summary, and moves focus to the first invalid field.
- **#3362** — The debt tablist had no keyboard support. Added roving `tabindex` and Arrow/Home/End navigation with automatic activation (selection follows focus) per WAI-ARIA Tabs pattern.

## Accessibility

- Error messages are the accessible **description** (`aria-describedby`), kept out of the label so the accessible **name** stays clean.
- Tablist follows the WAI-ARIA APG roving-tabindex pattern; only the active tab is in the tab order.
- Error styling uses existing `--semantic-negative` design tokens.

## Testing

- `npx vitest run src/pages/DebtPage.test.tsx` — 21 passed (4 new: arrow-key nav, empty-state focus, invalid-submit feedback, valid-submit clears errors).
- `npm run format:check` + `eslint --max-warnings 0` — clean on changed files.

## Issues

Closes #3360
Closes #3361
Closes #3362

Found by persona: Marcus Johnson (aggressive debt-payoff)
