### PR TITLE
fix(web): disclose estimated APR/minimum and honest payoff progress for imported debts (#3356, #3358)

### DIFF
--- a/apps/web/src/lib/debt-types.ts
+++ b/apps/web/src/lib/debt-types.ts
@@ -26,6 +26,10 @@ export interface Debt {
   readonly originalBalanceCents?: number;
   /** Historical interest already paid, when known or manually entered. */
   readonly interestPaidToDateCents?: number;
+  /** True when the annual rate is an assumed default rather than a confirmed value. */
+  readonly rateEstimated?: boolean;
+  /** True when the minimum payment is an assumed default rather than a confirmed value. */
+  readonly minimumEstimated?: boolean;
   /** Annual interest rate as basis points (e.g., 1999 = 19.99%). */
   readonly annualRateBps: number;
   /** Minimum monthly payment in cents. */

--- a/apps/web/src/lib/debt/debt-progress-rings.test.ts
+++ b/apps/web/src/lib/debt/debt-progress-rings.test.ts
@@ -52,6 +52,25 @@ describe('debt progress rings', () => {
     expect(card.detailItems).toContain('Next milestone: 50% paid off');
   });
 
+  it('shows a starting-balance prompt instead of 0% when progress is untracked (#3356)', () => {
+    const untracked: DebtMilestoneSummary = {
+      ...milestones,
+      totalOriginalDebtCents: 1_100_00,
+      paidOffCents: 0,
+      percentPaidOff: 0,
+    };
+    const card = buildDebtPayoffProgressRingCard({
+      milestones: untracked,
+      activeResult: strategyResult,
+      interestSavedCents: 0,
+      debtFreeLabel: 'Jan 2027',
+      hasTrackedProgress: false,
+    });
+
+    expect(card.primaryText).toBe('Set a starting balance to track progress');
+    expect(card.ariaLabel).toContain('not tracked yet');
+  });
+
   it('clamps student loan ring progress and keeps payoff/interest text equivalent', () => {
     const summary: StudentLoanDashboardSummary = {
       monthlyPaymentCents: 200_00,

--- a/apps/web/src/lib/debt/debt-progress-rings.ts
+++ b/apps/web/src/lib/debt/debt-progress-rings.ts
@@ -42,15 +42,23 @@ export function buildDebtPayoffProgressRingCard(input: {
   readonly activeResult: StrategyResult;
   readonly interestSavedCents: number;
   readonly debtFreeLabel: string;
+  readonly hasTrackedProgress?: boolean;
 }): DebtProgressRingCard {
   const percent = clampPercent(input.milestones.percentPaidOff);
   const nextMilestone = nextMilestoneText(input.milestones);
+  const tracked = input.hasTrackedProgress ?? true;
+  const primaryText = tracked
+    ? `${percent.toFixed(1)}% paid off`
+    : 'Set a starting balance to track progress';
+  const ariaLabel = tracked
+    ? `Debt payoff progress ${percent}% paid off. ${nextMilestone}.`
+    : 'Debt payoff progress not tracked yet. Set a starting balance on your debts to see progress.';
   return {
     id: 'debt-payoff',
     title: 'Debt payoff progress',
     percent,
-    ariaLabel: `Debt payoff progress ${percent}% paid off. ${nextMilestone}.`,
-    primaryText: `${percent.toFixed(1)}% paid off`,
+    ariaLabel,
+    primaryText,
     secondaryText: input.debtFreeLabel,
     detailItems: [
       `Interest saved versus minimum payments: ${input.interestSavedCents} cents`,

--- a/apps/web/src/pages/DebtPage.css
+++ b/apps/web/src/pages/DebtPage.css
@@ -813,7 +813,8 @@
 
 .debt-import-list__item h3,
 .debt-entry-form button,
-.debt-entry-form__error {
+.debt-entry-form__error,
+.debt-import-list__hint {
   grid-column: 1 / -1;
 }
 

--- a/apps/web/src/pages/DebtPage.test.tsx
+++ b/apps/web/src/pages/DebtPage.test.tsx
@@ -508,4 +508,42 @@ describe('DebtPage', () => {
     expect(screen.queryByTestId('empty-state')).toBeNull();
     expect(screen.queryByText(/Please fix the following/)).toBeNull();
   });
+
+  it('marks imported APR and minimum as estimated until confirmed (#3358)', () => {
+    mockUseAccountsState.accounts = [
+      buildAccount({
+        id: 'auto-est',
+        name: 'Car Loan',
+        type: 'LOAN',
+        currentBalance: { amount: -900_000 },
+      }),
+    ];
+    render(<DebtPage />);
+    const importRegion = screen.getByRole('region', { name: 'Imported debt accounts' });
+    const item = within(importRegion).getByText('Car Loan').closest('li') as HTMLElement;
+
+    expect(within(item).getByText(/Estimated APR/)).toBeDefined();
+    expect(within(item).getByText(/Estimated minimum payment/)).toBeDefined();
+
+    // Confirming the APR clears its "estimated" hint.
+    fireEvent.change(within(item).getByLabelText('APR (%)'), { target: { value: '6.5' } });
+    expect(within(item).queryByText(/Estimated APR/)).toBeNull();
+  });
+
+  it('prompts for a starting balance instead of showing 0% progress on imported debts (#3356)', () => {
+    mockUseAccountsState.accounts = [
+      buildAccount({
+        id: 'cc-fresh',
+        name: 'Store Card',
+        type: 'CREDIT_CARD',
+        currentBalance: { amount: -50_000 },
+      }),
+    ];
+    render(<DebtPage />);
+
+    // Imported debts default their original balance to the current balance, so
+    // no real payoff progress exists yet — guide rather than demoralize with 0%.
+    expect(screen.getByText(/setting each debt.*starting balance/i)).toBeDefined();
+    expect(screen.queryByText('0.0% paid off. Every payment is progress.')).toBeNull();
+  });
 });

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -407,8 +407,26 @@ function defaultDebtRateBps(type: Debt['type']): number {
   return 900;
 }
 
+function defaultInstallmentTermMonths(type: Debt['type']): number {
+  if (type === 'auto_loan') return 60;
+  if (type === 'mortgage') return 360;
+  if (type === 'student_loan') return 120;
+  if (type === 'personal_loan') return 60;
+  return 0;
+}
+
 function defaultMinimumPaymentCents(balanceCents: number, type: Debt['type']): number {
   if (balanceCents <= 0) return 0;
+  const termMonths = defaultInstallmentTermMonths(type);
+  if (termMonths > 0) {
+    // Installment loans carry a fixed amortizing payment, not a percent of balance.
+    const monthlyRate = defaultDebtRateBps(type) / 120_000;
+    const payment =
+      monthlyRate > 0
+        ? (balanceCents * monthlyRate) / (1 - Math.pow(1 + monthlyRate, -termMonths))
+        : balanceCents / termMonths;
+    return Math.max(2_500, Math.round(payment));
+  }
   const percent = type === 'credit_card' ? 0.03 : 0.015;
   return Math.max(2_500, Math.round(balanceCents * percent));
 }
@@ -425,6 +443,8 @@ function accountToDebt(account: Account): Debt | null {
     annualRateBps: defaultDebtRateBps(type),
     minimumPaymentCents: defaultMinimumPaymentCents(balanceCents, type),
     type,
+    rateEstimated: true,
+    minimumEstimated: true,
   };
 }
 
@@ -742,6 +762,7 @@ function PayoffPlannerPanel(): React.ReactElement {
             activeResult,
             interestSavedCents,
             debtFreeLabel: formatMonthYear(addMonthsToIsoDate(todayIso, activeResult.totalMonths)),
+            hasTrackedProgress: milestones.paidOffCents > 0,
           })
         : null,
     [activeResult, interestSavedCents, milestones, todayIso],
@@ -939,7 +960,14 @@ function PayoffPlannerPanel(): React.ReactElement {
           <section aria-label="Debt milestones" className="debt-milestones">
             <div className="debt-milestones__summary">
               <h2>Debt Milestones</h2>
-              <p>{milestones.percentPaidOff.toFixed(1)}% paid off. Every payment is progress.</p>
+              {milestones.paidOffCents > 0 ? (
+                <p>{milestones.percentPaidOff.toFixed(1)}% paid off. Every payment is progress.</p>
+              ) : (
+                <p>
+                  Track payoff progress by setting each debt&rsquo;s starting balance. Every payment
+                  is progress.
+                </p>
+              )}
               <label>
                 Historical interest paid ($)
                 <input
@@ -1154,6 +1182,12 @@ function PayoffPlannerPanel(): React.ReactElement {
                     }
                   />
                 </label>
+                {(debt.originalBalanceCents ?? debt.balanceCents) <= debt.balanceCents && (
+                  <p className="form-help debt-import-list__hint">
+                    Defaults to your current balance. Enter your original balance to track payoff
+                    progress.
+                  </p>
+                )}
                 <label>
                   APR (%)
                   <input
@@ -1164,10 +1198,16 @@ function PayoffPlannerPanel(): React.ReactElement {
                     onChange={(event) =>
                       handleAdjustment(debt.id, {
                         annualRateBps: parseRateInput(event.target.value),
+                        rateEstimated: false,
                       })
                     }
                   />
                 </label>
+                {debt.rateEstimated && (
+                  <p className="form-help debt-import-list__hint">
+                    Estimated APR — confirm your real rate for an accurate payoff date.
+                  </p>
+                )}
                 <label>
                   Minimum payment ($)
                   <input
@@ -1178,10 +1218,16 @@ function PayoffPlannerPanel(): React.ReactElement {
                     onChange={(event) =>
                       handleAdjustment(debt.id, {
                         minimumPaymentCents: parseCurrencyInput(event.target.value),
+                        minimumEstimated: false,
                       })
                     }
                   />
                 </label>
+                {debt.minimumEstimated && (
+                  <p className="form-help debt-import-list__hint">
+                    Estimated minimum payment — confirm it to plan accurately.
+                  </p>
+                )}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary

Imported debt accounts previously assumed an APR and minimum payment with no disclosure, and defaulted each debt's original balance to its current balance, so the payoff progress ring and milestone hero always read 0% paid off. For a debt-payoff user who has made real progress, that is both inaccurate and demoralizing.

## Changes

- Disclose estimates (#3358): Imported APR and minimum-payment fields now show an "Estimated, confirm your real value" hint. Editing the field clears the flag, so the disclosure disappears once the user confirms a real number.
- Amortizing minimum for installment loans (#3358): defaultMinimumPaymentCents now amortizes installment loans (auto/mortgage/student/personal) over a realistic term instead of applying a flat percent-of-balance, giving a trustworthy payoff date. Revolving accounts keep the percent-of-balance minimum.
- Honest payoff progress (#3356): When no debt has a starting balance greater than its current balance, the progress ring and milestone hero now prompt the user to set a starting balance to track progress instead of showing a misleading 0% paid off. A guidance hint appears under the original-balance field.

## Issues

Closes #3356
Closes #3358

Found by persona: Marcus Johnson (aggressive debt-payoff)

## Testing

- [x] vitest run DebtPage + debt-progress-rings + debt-payoff-engine (78 passed, incl. 4 new)
- [x] Prettier + ESLint clean on changed files
