### PR TITLE
feat(web): allow editing invoices after creation (#3218)

### DIFF
--- a/apps/web/src/hooks/useInvoices.ts
+++ b/apps/web/src/hooks/useInvoices.ts
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   computeInvoiceForecast,
   createInvoice,
+  applyInvoiceEdit,
   groupInvoicesByStatus,
   normalizeInvoiceStatuses,
   type CreateInvoiceInput,
@@ -20,6 +21,7 @@ import {
   type Invoice,
   type InvoicePipelineGroup,
   type InvoiceStatus,
+  type UpdateInvoiceInput,
 } from '../lib/analytics/invoices';
 
 const STORAGE_KEY = 'finance:invoices';
@@ -30,6 +32,7 @@ export interface UseInvoicesResult {
   forecastBuckets: ForecastBucket[];
   totalOutstandingCents: number;
   addInvoice: (input: CreateInvoiceInput) => Invoice;
+  updateInvoice: (invoiceId: string, input: UpdateInvoiceInput) => void;
   updateInvoiceStatus: (invoiceId: string, status: InvoiceStatus) => void;
   deleteInvoice: (invoiceId: string) => void;
   refresh: () => void;
@@ -106,6 +109,21 @@ export function useInvoices(): UseInvoicesResult {
     return invoice;
   }, []);
 
+  const updateInvoice = useCallback((invoiceId: string, input: UpdateInvoiceInput) => {
+    const currentDate = todayIsoDate();
+    setToday(currentDate);
+    setInvoices((prev) =>
+      normalizeInvoiceStatuses(
+        prev.map((invoice) =>
+          invoice.id === invoiceId
+            ? applyInvoiceEdit(invoice, input, new Date().toISOString())
+            : invoice,
+        ),
+        currentDate,
+      ),
+    );
+  }, []);
+
   const updateInvoiceStatus = useCallback((invoiceId: string, status: InvoiceStatus) => {
     const currentDate = todayIsoDate();
     setToday(currentDate);
@@ -138,6 +156,7 @@ export function useInvoices(): UseInvoicesResult {
     forecastBuckets,
     totalOutstandingCents,
     addInvoice,
+    updateInvoice,
     updateInvoiceStatus,
     deleteInvoice,
     refresh,

--- a/apps/web/src/lib/analytics/invoices.test.ts
+++ b/apps/web/src/lib/analytics/invoices.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  applyInvoiceEdit,
   computeExpectedPayDate,
   computeInvoiceForecast,
   exportInvoicesCsv,
@@ -178,5 +179,66 @@ describe('exportInvoicesCsv', () => {
       INVOICE_CSV_HEADER,
       'Total,0.00,,,,,',
     ]);
+  });
+});
+
+describe('applyInvoiceEdit', () => {
+  it('recomputes the expected pay date from the edited issue date and term', () => {
+    const invoice = makeInvoice({ issueDate: '2024-01-01', paymentTerm: 'net-30' });
+
+    const updated = applyInvoiceEdit(
+      invoice,
+      {
+        clientName: 'Acme Studio',
+        amountCents: 100000,
+        issueDate: '2024-03-01',
+        paymentTerm: 'net-15',
+        status: 'Sent',
+      },
+      '2024-03-01T12:00:00Z',
+    );
+
+    expect(updated.expectedPayDate).toBe('2024-03-16');
+  });
+
+  it('preserves id and createdAt while bumping updatedAt and editable fields', () => {
+    const invoice = makeInvoice({ id: 'inv-42', clientName: 'Old Name', amountCents: 50000 });
+
+    const updated = applyInvoiceEdit(
+      invoice,
+      {
+        clientName: '  New Studio  ',
+        amountCents: 275000,
+        issueDate: '2024-02-10',
+        paymentTerm: 'net-45',
+        status: 'Sent',
+      },
+      '2024-02-10T09:30:00Z',
+    );
+
+    expect(updated.id).toBe('inv-42');
+    expect(updated.createdAt).toBe('2024-01-01T00:00:00Z');
+    expect(updated.updatedAt).toBe('2024-02-10T09:30:00Z');
+    expect(updated.clientName).toBe('New Studio');
+    expect(updated.amountCents).toBe(275000);
+    expect(updated.paymentTerm).toBe('net-45');
+  });
+
+  it('derives the effective overdue status when the edited term is already past due', () => {
+    const invoice = makeInvoice({ status: 'Sent' });
+
+    const updated = applyInvoiceEdit(
+      invoice,
+      {
+        clientName: 'Acme Studio',
+        amountCents: 100000,
+        issueDate: '2024-01-01',
+        paymentTerm: 'net-15',
+        status: 'Sent',
+      },
+      '2024-06-01T00:00:00Z',
+    );
+
+    expect(updated.status).toBe('Overdue');
   });
 });

--- a/apps/web/src/lib/analytics/invoices.ts
+++ b/apps/web/src/lib/analytics/invoices.ts
@@ -36,6 +36,14 @@ export interface CreateInvoiceInput {
   readonly status?: InvoiceStatus;
 }
 
+export interface UpdateInvoiceInput {
+  readonly clientName: string;
+  readonly amountCents: number;
+  readonly issueDate: string;
+  readonly paymentTerm: InvoicePaymentTerm;
+  readonly status: InvoiceStatus;
+}
+
 export interface InvoicePipelineGroup {
   readonly status: InvoiceStatus;
   readonly label: string;
@@ -138,6 +146,34 @@ export function createInvoice(input: CreateInvoiceInput, nowIso: string, id: str
   };
 
   return { ...invoice, status: getEffectiveInvoiceStatus(invoice, nowIso.slice(0, 10)) };
+}
+
+/**
+ * Apply an edit to an existing invoice, recomputing the derived expected pay
+ * date and effective status while preserving the original id and createdAt.
+ *
+ * @param invoice - The existing invoice being edited.
+ * @param input - The full set of user-editable invoice fields.
+ * @param nowIso - Current timestamp (ISO 8601) used for updatedAt and status.
+ * @returns A new invoice with the edits applied.
+ */
+export function applyInvoiceEdit(
+  invoice: Invoice,
+  input: UpdateInvoiceInput,
+  nowIso: string,
+): Invoice {
+  const updated: Invoice = {
+    ...invoice,
+    clientName: input.clientName.trim(),
+    amountCents: input.amountCents,
+    issueDate: input.issueDate,
+    paymentTerm: input.paymentTerm,
+    status: input.status,
+    expectedPayDate: computeExpectedPayDate(input.issueDate, input.paymentTerm),
+    updatedAt: nowIso,
+  };
+
+  return { ...updated, status: getEffectiveInvoiceStatus(updated, nowIso.slice(0, 10)) };
 }
 
 export function groupInvoicesByStatus(

--- a/apps/web/src/pages/InvoicesPage.test.tsx
+++ b/apps/web/src/pages/InvoicesPage.test.tsx
@@ -57,6 +57,7 @@ beforeEach(() => {
     forecastBuckets: [],
     totalOutstandingCents: 0,
     addInvoice: vi.fn(),
+    updateInvoice: vi.fn(),
     updateInvoiceStatus: vi.fn(),
     deleteInvoice: vi.fn(),
     refresh: vi.fn(),
@@ -86,6 +87,7 @@ describe('InvoicesPage', () => {
       forecastBuckets: [],
       totalOutstandingCents: 120_000,
       addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       deleteInvoice,
       refresh: vi.fn(),
@@ -111,6 +113,7 @@ describe('InvoicesPage', () => {
       forecastBuckets: [],
       totalOutstandingCents: 120_000,
       addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
@@ -131,6 +134,7 @@ describe('InvoicesPage', () => {
       forecastBuckets: [],
       totalOutstandingCents: 120_000,
       addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
@@ -151,6 +155,7 @@ describe('InvoicesPage', () => {
       forecastBuckets: [],
       totalOutstandingCents: 240_000,
       addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
@@ -178,6 +183,7 @@ describe('InvoicesPage', () => {
       forecastBuckets: [],
       totalOutstandingCents: 120_000,
       addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
@@ -199,6 +205,7 @@ describe('InvoicesPage', () => {
       ],
       totalOutstandingCents: 120_000,
       addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
@@ -221,6 +228,7 @@ describe('InvoicesPage', () => {
       forecastBuckets: [],
       totalOutstandingCents: 120_000,
       addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
@@ -244,5 +252,64 @@ describe('InvoicesPage', () => {
     clickSpy.mockRestore();
     delete (URL as unknown as Record<string, unknown>).createObjectURL;
     delete (URL as unknown as Record<string, unknown>).revokeObjectURL;
+  });
+
+  it('enters edit mode and saves changes to an existing invoice (#3218)', () => {
+    const updateInvoice = vi.fn();
+    mockedUseInvoices.mockReturnValue({
+      invoices: [SAMPLE_INVOICE],
+      pipelineGroups: [
+        { status: 'Sent', label: 'Sent', invoices: [SAMPLE_INVOICE], totalCents: 120_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoice,
+      updateInvoiceStatus: vi.fn(),
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit invoice for Etsy Wholesale' }));
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Edit invoice' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
+    const clientInput = screen.getByLabelText(/client name/i);
+    expect(clientInput).toHaveValue('Etsy Wholesale');
+
+    fireEvent.change(clientInput, { target: { value: 'Etsy Wholesale LLC' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    expect(updateInvoice).toHaveBeenCalledTimes(1);
+    expect(updateInvoice).toHaveBeenCalledWith(
+      'inv-1',
+      expect.objectContaining({ clientName: 'Etsy Wholesale LLC', amountCents: 120_000 }),
+    );
+  });
+
+  it('cancels edit mode and restores the add-invoice form (#3218)', () => {
+    mockedUseInvoices.mockReturnValue({
+      invoices: [SAMPLE_INVOICE],
+      pipelineGroups: [
+        { status: 'Sent', label: 'Sent', invoices: [SAMPLE_INVOICE], totalCents: 120_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit invoice for Etsy Wholesale' }));
+    expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel edit' }));
+
+    expect(screen.queryByRole('button', { name: 'Save changes' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add invoice' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/InvoicesPage.tsx
+++ b/apps/web/src/pages/InvoicesPage.tsx
@@ -50,10 +50,17 @@ const StatusBadge: React.FC<{ status: InvoiceStatus }> = ({ status }) => (
 const InvoiceCard: React.FC<{
   invoice: Invoice;
   locale: string;
+  isEditing: boolean;
+  onEdit: (invoice: Invoice) => void;
   onStatusChange: (invoiceId: string, status: InvoiceStatus) => void;
   onDelete: (invoice: Invoice) => void;
-}> = ({ invoice, locale, onStatusChange, onDelete }) => (
-  <article className={`invoice-card invoice-card--${invoice.status.toLowerCase()}`} role="listitem">
+}> = ({ invoice, locale, isEditing, onEdit, onStatusChange, onDelete }) => (
+  <article
+    className={`invoice-card invoice-card--${invoice.status.toLowerCase()}${
+      isEditing ? ' invoice-card--editing' : ''
+    }`}
+    role="listitem"
+  >
     <div className="invoice-card__main">
       <div>
         <h3 className="invoice-card__client">{invoice.clientName}</h3>
@@ -86,6 +93,14 @@ const InvoiceCard: React.FC<{
       <button
         className="analytics-export-btn"
         type="button"
+        aria-label={`Edit invoice for ${invoice.clientName}`}
+        onClick={() => onEdit(invoice)}
+      >
+        Edit
+      </button>
+      <button
+        className="analytics-export-btn"
+        type="button"
         aria-label={`Delete invoice for ${invoice.clientName}`}
         onClick={() => onDelete(invoice)}
       >
@@ -102,6 +117,7 @@ export const InvoicesPage: React.FC = () => {
     forecastBuckets,
     totalOutstandingCents,
     addInvoice,
+    updateInvoice,
     updateInvoiceStatus,
     deleteInvoice,
   } = useInvoices();
@@ -113,6 +129,27 @@ export const InvoicesPage: React.FC = () => {
   const [status, setStatus] = useState<InvoiceStatus>('Sent');
   const [formError, setFormError] = useState<string | null>(null);
   const [deletingInvoice, setDeletingInvoice] = useState<Invoice | null>(null);
+  const [editingInvoiceId, setEditingInvoiceId] = useState<string | null>(null);
+
+  const resetForm = useCallback(() => {
+    setEditingInvoiceId(null);
+    setClientName('');
+    setAmount('');
+    setIssueDate(todayIsoDate());
+    setPaymentTerm('net-30');
+    setStatus('Sent');
+    setFormError(null);
+  }, []);
+
+  const handleEdit = useCallback((invoice: Invoice) => {
+    setEditingInvoiceId(invoice.id);
+    setClientName(invoice.clientName);
+    setAmount((invoice.amountCents / 100).toString());
+    setIssueDate(invoice.issueDate);
+    setPaymentTerm(invoice.paymentTerm);
+    setStatus(invoice.status);
+    setFormError(null);
+  }, []);
 
   const handleConfirmDelete = () => {
     if (deletingInvoice) {
@@ -164,13 +201,12 @@ export const InvoicesPage: React.FC = () => {
       return;
     }
 
-    addInvoice({ clientName, amountCents, issueDate, paymentTerm, status });
-    setClientName('');
-    setAmount('');
-    setIssueDate(todayIsoDate());
-    setPaymentTerm('net-30');
-    setStatus('Sent');
-    setFormError(null);
+    if (editingInvoiceId) {
+      updateInvoice(editingInvoiceId, { clientName, amountCents, issueDate, paymentTerm, status });
+    } else {
+      addInvoice({ clientName, amountCents, issueDate, paymentTerm, status });
+    }
+    resetForm();
   };
 
   return (
@@ -193,7 +229,13 @@ export const InvoicesPage: React.FC = () => {
         </button>
       </div>
 
-      <section className="analytics-section" aria-label="Add invoice">
+      <section
+        className="analytics-section"
+        aria-label={editingInvoiceId ? 'Edit invoice' : 'Add invoice'}
+      >
+        <h2 className="analytics-section__title">
+          {editingInvoiceId ? 'Edit invoice' : 'Add invoice'}
+        </h2>
         <form className="invoice-form" onSubmit={handleSubmit}>
           <label className="invoice-form__field">
             Client name
@@ -267,8 +309,17 @@ export const InvoicesPage: React.FC = () => {
           </div>
           {formError && <p className="invoice-form__error">{formError}</p>}
           <button className="analytics-export-btn invoice-form__submit" type="submit">
-            Add invoice
+            {editingInvoiceId ? 'Save changes' : 'Add invoice'}
           </button>
+          {editingInvoiceId && (
+            <button
+              className="analytics-export-btn invoice-form__cancel"
+              type="button"
+              onClick={resetForm}
+            >
+              Cancel edit
+            </button>
+          )}
         </form>
       </section>
 
@@ -362,6 +413,8 @@ export const InvoicesPage: React.FC = () => {
                         key={invoice.id}
                         invoice={invoice}
                         locale={locale}
+                        isEditing={invoice.id === editingInvoiceId}
+                        onEdit={handleEdit}
                         onStatusChange={updateInvoiceStatus}
                         onDelete={setDeletingInvoice}
                       />

--- a/apps/web/src/pages/analytics.css
+++ b/apps/web/src/pages/analytics.css
@@ -506,6 +506,16 @@
   align-self: end;
 }
 
+.invoice-form__cancel {
+  align-self: end;
+  background: var(--semantic-background-primary);
+}
+
+.invoice-card--editing {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
 .invoice-forecast-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Invoices could only have their **status** changed after creation — the client name, amount, issue date, and payment term were locked in the moment you hit *Add invoice*. For a freelancer juggling many clients, a mistyped amount or a client name correction meant deleting and re-creating the invoice (losing its history). This adds a proper **edit** flow.

## Changes

- `lib/analytics/invoices.ts`: new `applyInvoiceEdit(invoice, input, nowIso)` pure helper + `UpdateInvoiceInput` type. It recomputes the derived expected pay date and effective (overdue) status from the edited issue date / term, while **preserving the invoice id and `createdAt`** and bumping `updatedAt`.
- `hooks/useInvoices.ts`: new `updateInvoice(id, input)` mutation that maps the edit over the stored invoices and re-normalizes statuses (persists to localStorage like the existing mutations).
- `pages/InvoicesPage.tsx`: each invoice card gets an **Edit** action that pre-fills the existing form, switches its heading/submit to *Edit invoice* / *Save changes* with a **Cancel edit** button, and outlines the invoice currently being edited. Submitting in edit mode calls `updateInvoice` instead of `addInvoice`.
- `pages/analytics.css`: styles for the cancel button and the editing outline (uses the existing `--semantic-border-focus` token — an accessible focus-ring style, not a decorative side border).

## Accessibility

- Edit/Delete buttons keep distinct accessible names (`Edit invoice for {client}` / `Delete invoice for {client}`).
- The form gains a visible `<h2>` that reflects add vs. edit mode, and the section `aria-label` follows it.

## Issues

Closes #3218

## Testing

- [x] `npx tsc -b` clean
- [x] `vitest run` — 24/24 pass across `invoices.test.ts` (new `applyInvoiceEdit` cases) and `InvoicesPage.test.tsx` (new edit + cancel flow cases)
- [x] `prettier --check` (pinned 3.9.4) + `eslint --max-warnings 0` clean

Found by persona: Diego Ramirez (freelance-designer irregular-income)