### PR TITLE
fix(web): persist manual debts and imported-debt edits across reloads (#3357)

### DIFF
--- a/apps/web/src/lib/debt/debt-tracker-persistence.test.ts
+++ b/apps/web/src/lib/debt/debt-tracker-persistence.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEBT_TRACKER_STORAGE_KEY,
+  readDebtTracker,
+  writeDebtTracker,
+} from './debt-tracker-persistence';
+import type { Debt } from '../debt-types';
+
+const debt: Debt = {
+  id: 'manual-1',
+  name: 'Marcus Visa',
+  balanceCents: 150_000,
+  originalBalanceCents: 200_000,
+  annualRateBps: 1999,
+  minimumPaymentCents: 4_500,
+  type: 'credit_card',
+  rateEstimated: false,
+  minimumEstimated: false,
+};
+
+function memoryStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    store,
+  };
+}
+
+describe('debt tracker persistence', () => {
+  it('round-trips manual debts and adjustments through storage (#3357)', () => {
+    const storage = memoryStorage();
+    writeDebtTracker(storage, {
+      manualDebts: [debt],
+      debtAdjustments: { 'acct-1': { annualRateBps: 650, rateEstimated: false } },
+    });
+
+    expect(storage.store.has(DEBT_TRACKER_STORAGE_KEY)).toBe(true);
+    const restored = readDebtTracker(storage);
+    expect(restored.manualDebts).toEqual([debt]);
+    expect(restored.debtAdjustments).toEqual({
+      'acct-1': { annualRateBps: 650, rateEstimated: false },
+    });
+  });
+
+  it('returns empty state for missing, corrupt, or wrong-version data', () => {
+    const storage = memoryStorage();
+    expect(readDebtTracker(storage)).toEqual({ manualDebts: [], debtAdjustments: {} });
+
+    storage.setItem(DEBT_TRACKER_STORAGE_KEY, '{not json');
+    expect(readDebtTracker(storage)).toEqual({ manualDebts: [], debtAdjustments: {} });
+
+    storage.setItem(DEBT_TRACKER_STORAGE_KEY, JSON.stringify({ version: 2, manualDebts: [debt] }));
+    expect(readDebtTracker(storage)).toEqual({ manualDebts: [], debtAdjustments: {} });
+  });
+
+  it('drops malformed debts and unknown adjustment values', () => {
+    const storage = memoryStorage();
+    storage.setItem(
+      DEBT_TRACKER_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        manualDebts: [debt, { id: 'bad', name: 'No amounts' }],
+        debtAdjustments: {
+          'acct-1': { annualRateBps: 650, bogusField: 'x', minimumEstimated: true },
+          'acct-2': 'not-an-object',
+        },
+      }),
+    );
+
+    const restored = readDebtTracker(storage);
+    expect(restored.manualDebts).toEqual([debt]);
+    expect(restored.debtAdjustments['acct-1']).toEqual({
+      annualRateBps: 650,
+      minimumEstimated: true,
+    });
+    expect(restored.debtAdjustments['acct-2']).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/debt/debt-tracker-persistence.ts
+++ b/apps/web/src/lib/debt/debt-tracker-persistence.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { Debt, DebtType } from '../debt-types';
+
+/**
+ * Persists the user's manually-entered debts and their per-debt overrides
+ * (APR, original balance, minimum payment) so debt-payoff progress survives a
+ * page reload. Without this the payoff planner silently forgets every edit the
+ * moment the tab is refreshed. See issue #3357.
+ */
+export const DEBT_TRACKER_STORAGE_KEY = 'finance.debt.tracker.v1';
+
+const DEBT_TYPES: ReadonlySet<string> = new Set<DebtType>([
+  'credit_card',
+  'student_loan',
+  'auto_loan',
+  'mortgage',
+  'personal_loan',
+  'bnpl',
+  'medical',
+  'other',
+]);
+
+export interface PersistedDebtTracker {
+  readonly version: 1;
+  readonly manualDebts: readonly Debt[];
+  readonly debtAdjustments: Readonly<Record<string, Partial<Debt>>>;
+}
+
+export interface RestoredDebtTracker {
+  readonly manualDebts: Debt[];
+  readonly debtAdjustments: Record<string, Partial<Debt>>;
+}
+
+export interface DebtTrackerStorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function isDebtType(value: unknown): value is DebtType {
+  return typeof value === 'string' && DEBT_TYPES.has(value);
+}
+
+function isDebt(value: unknown): value is Debt {
+  if (!value || typeof value !== 'object') return false;
+  const debt = value as Partial<Debt>;
+  return (
+    typeof debt.id === 'string' &&
+    typeof debt.name === 'string' &&
+    typeof debt.balanceCents === 'number' &&
+    typeof debt.annualRateBps === 'number' &&
+    typeof debt.minimumPaymentCents === 'number' &&
+    isDebtType(debt.type)
+  );
+}
+
+/**
+ * Copies only the recognised, correctly-typed override fields from a stored
+ * value so corrupted storage cannot inject unexpected keys into app state.
+ */
+function sanitizeAdjustment(value: unknown): Partial<Debt> | null {
+  if (!value || typeof value !== 'object') return null;
+  const source = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  const numericFields: Array<keyof Debt> = [
+    'balanceCents',
+    'originalBalanceCents',
+    'interestPaidToDateCents',
+    'annualRateBps',
+    'minimumPaymentCents',
+  ];
+  for (const field of numericFields) {
+    if (typeof source[field] === 'number') result[field] = source[field];
+  }
+  if (typeof source.name === 'string') result.name = source.name;
+  if (isDebtType(source.type)) result.type = source.type;
+  if (typeof source.rateEstimated === 'boolean') result.rateEstimated = source.rateEstimated;
+  if (typeof source.minimumEstimated === 'boolean') {
+    result.minimumEstimated = source.minimumEstimated;
+  }
+  return result as Partial<Debt>;
+}
+
+function sanitizeAdjustments(value: unknown): Record<string, Partial<Debt>> {
+  if (!value || typeof value !== 'object') return {};
+  const result: Record<string, Partial<Debt>> = {};
+  for (const [id, raw] of Object.entries(value as Record<string, unknown>)) {
+    const adjustment = sanitizeAdjustment(raw);
+    if (adjustment) result[id] = adjustment;
+  }
+  return result;
+}
+
+export function readDebtTracker(storage: DebtTrackerStorageLike): RestoredDebtTracker {
+  const raw = storage.getItem(DEBT_TRACKER_STORAGE_KEY);
+  if (!raw) return { manualDebts: [], debtAdjustments: {} };
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || (parsed as PersistedDebtTracker).version !== 1) {
+      return { manualDebts: [], debtAdjustments: {} };
+    }
+    const tracker = parsed as PersistedDebtTracker;
+    const manualDebts = Array.isArray(tracker.manualDebts)
+      ? tracker.manualDebts.filter(isDebt)
+      : [];
+    return {
+      manualDebts,
+      debtAdjustments: sanitizeAdjustments(tracker.debtAdjustments),
+    };
+  } catch {
+    return { manualDebts: [], debtAdjustments: {} };
+  }
+}
+
+export function writeDebtTracker(
+  storage: DebtTrackerStorageLike,
+  tracker: {
+    manualDebts: readonly Debt[];
+    debtAdjustments: Readonly<Record<string, Partial<Debt>>>;
+  },
+): void {
+  storage.setItem(
+    DEBT_TRACKER_STORAGE_KEY,
+    JSON.stringify({
+      version: 1,
+      manualDebts: tracker.manualDebts,
+      debtAdjustments: tracker.debtAdjustments,
+    }),
+  );
+}

--- a/apps/web/src/pages/DebtPage.test.tsx
+++ b/apps/web/src/pages/DebtPage.test.tsx
@@ -125,6 +125,7 @@ function buildAccount(overrides: Partial<Account>): Account {
 describe('DebtPage', () => {
   beforeEach(() => {
     mockUseAccountsState.accounts = [];
+    localStorage.clear();
   });
   it('renders the page title', () => {
     render(<DebtPage />);
@@ -545,5 +546,22 @@ describe('DebtPage', () => {
     // no real payoff progress exists yet — guide rather than demoralize with 0%.
     expect(screen.getByText(/setting each debt.*starting balance/i)).toBeDefined();
     expect(screen.queryByText('0.0% paid off. Every payment is progress.')).toBeNull();
+  });
+
+  it('persists manually-entered debts across a reload (#3357)', () => {
+    const { unmount } = render(<DebtPage />);
+    fireEvent.change(screen.getByLabelText('Debt name'), { target: { value: 'Marcus Visa' } });
+    fireEvent.change(screen.getByLabelText('Debt balance ($)'), { target: { value: '1500' } });
+    fireEvent.change(screen.getByLabelText('Minimum payment ($)'), { target: { value: '45' } });
+    fireEvent.submit(document.querySelector('form.debt-entry-form') as HTMLFormElement);
+
+    // The debt is registered (empty state replaced) and written to storage.
+    expect(screen.queryByTestId('empty-state')).toBeNull();
+    expect(localStorage.getItem('finance.debt.tracker.v1')).toContain('Marcus Visa');
+
+    // Simulate a page reload: a fresh mount must rehydrate from localStorage.
+    unmount();
+    render(<DebtPage />);
+    expect(screen.queryByTestId('empty-state')).toBeNull();
   });
 });

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -66,6 +66,7 @@ import {
   buildStudentLoanProgressRingCard,
   type DebtProgressRingCard,
 } from '../lib/debt/debt-progress-rings';
+import { readDebtTracker, writeDebtTracker } from '../lib/debt/debt-tracker-persistence';
 import { buildCreditScoreSimulatorPanelModel } from '../lib/debt/credit-score-simulator-panel';
 import { buildCreditScoreAssumptionSummary } from '../lib/debt/credit-score-simulator-assumptions';
 import {
@@ -592,8 +593,14 @@ function JointDebtPanel(): React.ReactElement {
 
 function PayoffPlannerPanel(): React.ReactElement {
   const { accounts, loading, error } = useAccounts();
-  const [manualDebts, setManualDebts] = useState<Debt[]>([]);
-  const [debtAdjustments, setDebtAdjustments] = useState<Record<string, Partial<Debt>>>({});
+  const [manualDebts, setManualDebts] = useState<Debt[]>(() => {
+    const storage = getLocalStorage();
+    return storage ? readDebtTracker(storage).manualDebts : [];
+  });
+  const [debtAdjustments, setDebtAdjustments] = useState<Record<string, Partial<Debt>>>(() => {
+    const storage = getLocalStorage();
+    return storage ? readDebtTracker(storage).debtAdjustments : {};
+  });
   const [manualForm, setManualForm] = useState<DebtFormState>(DEFAULT_DEBT_FORM);
   const [manualErrors, setManualErrors] = useState<
     Partial<Record<'name' | 'balance' | 'minimumPayment', string>>
@@ -671,6 +678,11 @@ function PayoffPlannerPanel(): React.ReactElement {
     }
     setHasRestoredConsolidation(true);
   }, [debts, hasRestoredConsolidation]);
+
+  useEffect(() => {
+    const storage = getLocalStorage();
+    if (storage) writeDebtTracker(storage, { manualDebts, debtAdjustments });
+  }, [manualDebts, debtAdjustments]);
   const extraPaymentCents = parseCurrencyInput(extraPayment);
   const monthlyIncomeCents = parseCurrencyInput(monthlyIncome);
   const manualInterestPaidCents = parseCurrencyInput(manualInterestPaid);


### PR DESCRIPTION
## Summary

Manual debts and per-debt overrides (APR, original balance, minimum payment) lived only in React component state, so **every browser refresh silently wiped the user's entire payoff plan**. For a debt-payoff user who tracks every dollar and re-tunes their numbers, losing all that work on reload is a trust-breaking bug.

## Changes

- New versioned persistence module `debt-tracker-persistence.ts` (mirrors the existing BNPL/consolidation localStorage pattern) that round-trips `manualDebts` and `debtAdjustments`.
- `PayoffPlannerPanel` now hydrates both from localStorage on mount and writes them back whenever they change.
- Stored values are validated and sanitized on read: malformed debts are dropped, unknown adjustment keys are stripped, and a version/JSON mismatch falls back to empty state — corrupted storage can never inject bad app state.

## Issues

Closes #3357

Found by persona: Marcus Johnson (aggressive debt-payoff)

## Testing

- [x] New `debt-tracker-persistence.test.ts` — round-trip, corrupt/missing/wrong-version fallback, malformed-input sanitization
- [x] New DebtPage integration test — a manually added debt survives an unmount/remount (reload)
- [x] Added `localStorage.clear()` to the DebtPage test `beforeEach` for isolation
- [x] `vitest run` DebtPage + debt-tracker-persistence (27 passed)
- [x] Prettier + ESLint clean on changed files
