### PR TITLE
test(web): fix stale sidebar landmark locator blocking Pages deploy (#3498)

### DIFF
--- a/apps/web/e2e/dashboard.spec.ts
+++ b/apps/web/e2e/dashboard.spec.ts
@@ -19,7 +19,7 @@ async function navigateViaPrimaryNav(
   expectedUrl: RegExp,
 ): Promise<void> {
   const exactLabel = new RegExp(`^${label}$`, 'i');
-  const sidebar = page.locator('aside[aria-label="Main navigation"]');
+  const sidebar = page.locator('aside[aria-label="Sidebar"]');
 
   if (await sidebar.isVisible().catch(() => false)) {
     await sidebar.getByRole('button', { name: exactLabel }).click();

--- a/apps/web/e2e/fixtures.ts
+++ b/apps/web/e2e/fixtures.ts
@@ -200,9 +200,7 @@ async function waitForAuthenticatedApp(page: Page): Promise<void> {
   await page.waitForURL('**/dashboard', { timeout: 30_000 });
   await Promise.any([
     page.getByRole('main', { name: /dashboard/i }).waitFor({ state: 'visible', timeout: 30_000 }),
-    page
-      .locator('aside[aria-label="Main navigation"]')
-      .waitFor({ state: 'visible', timeout: 30_000 }),
+    page.locator('aside[aria-label="Sidebar"]').waitFor({ state: 'visible', timeout: 30_000 }),
     page.locator('nav.bottom-nav').waitFor({ state: 'visible', timeout: 30_000 }),
   ]);
 }

--- a/apps/web/e2e/nav-reachability.spec.ts
+++ b/apps/web/e2e/nav-reachability.spec.ts
@@ -161,7 +161,7 @@ test.describe('Desktop navigation reachability (#1930)', () => {
       await page.goto('/dashboard');
       await waitForAppShell(page);
 
-      const sidebar = page.locator('aside[aria-label="Main navigation"]');
+      const sidebar = page.locator('aside[aria-label="Sidebar"]');
       await expect(sidebar).toBeVisible();
 
       // Expand all collapsible group sections so every destination is queryable.

--- a/apps/web/e2e/responsive.spec.ts
+++ b/apps/web/e2e/responsive.spec.ts
@@ -83,7 +83,7 @@ test.describe('Mobile viewport (375px)', () => {
     await page.goto('/dashboard');
     await waitForPageLoad(page);
 
-    const sidebar = page.locator('aside[aria-label="Main navigation"]');
+    const sidebar = page.locator('aside[aria-label="Sidebar"]');
     await expect(sidebar).toBeHidden();
   });
 
@@ -192,7 +192,7 @@ test.describe('Tablet viewport (768px)', () => {
     await page.goto('/dashboard');
     await waitForPageLoad(page);
 
-    const sidebar = page.locator('aside[aria-label="Main navigation"]');
+    const sidebar = page.locator('aside[aria-label="Sidebar"]');
     await expect(sidebar).toBeVisible();
   });
 
@@ -250,7 +250,7 @@ test.describe('Tablet viewport (768px)', () => {
     await page.goto('/dashboard');
     await waitForPageLoad(page);
 
-    const sidebar = page.locator('aside[aria-label="Main navigation"]');
+    const sidebar = page.locator('aside[aria-label="Sidebar"]');
 
     for (const label of ['Dashboard', 'Accounts', 'Transactions', 'Budgets', 'Goals']) {
       // exact: true — accessible-name matching is a case-insensitive substring
@@ -275,7 +275,7 @@ test.describe('Desktop viewport (1280px)', () => {
     await page.goto('/dashboard');
     await waitForPageLoad(page);
 
-    const sidebar = page.locator('aside[aria-label="Main navigation"]');
+    const sidebar = page.locator('aside[aria-label="Sidebar"]');
     await expect(sidebar).toBeVisible();
 
     // The sidebar should show the "Finance" logo text.
@@ -293,7 +293,7 @@ test.describe('Desktop viewport (1280px)', () => {
     await page.goto('/dashboard');
     await waitForPageLoad(page);
 
-    const sidebar = page.locator('aside[aria-label="Main navigation"]');
+    const sidebar = page.locator('aside[aria-label="Sidebar"]');
     const sidebarWidth = await sidebar.evaluate((el) => {
       return el.getBoundingClientRect().width;
     });
@@ -382,7 +382,7 @@ test.describe('Large desktop viewport (1440px)', () => {
     await page.goto('/dashboard');
     await waitForPageLoad(page);
 
-    const sidebar = page.locator('aside[aria-label="Main navigation"]');
+    const sidebar = page.locator('aside[aria-label="Sidebar"]');
     await expect(sidebar).toBeVisible();
 
     const sidebarWidth = await sidebar.evaluate((el) => {
@@ -399,7 +399,7 @@ test.describe('Large desktop viewport (1440px)', () => {
     await page.goto('/dashboard');
     await waitForPageLoad(page);
 
-    const sidebar = page.locator('aside[aria-label="Main navigation"]');
+    const sidebar = page.locator('aside[aria-label="Sidebar"]');
     const footer = sidebar.locator('.app-sidebar__footer');
 
     await expect(footer.getByText('Settings')).toBeVisible();
@@ -440,7 +440,7 @@ test.describe('Cross-viewport navigation', () => {
     await page.goto('/dashboard');
     await waitForPageLoad(page);
 
-    const sidebar = page.locator('aside[aria-label="Main navigation"]');
+    const sidebar = page.locator('aside[aria-label="Sidebar"]');
 
     // Navigate to Accounts via sidebar.
     await sidebar.getByRole('button', { name: 'Accounts', exact: true }).click();
@@ -497,7 +497,7 @@ test.describe('Cross-viewport navigation', () => {
     await page.goto('/dashboard');
     await waitForPageLoad(page);
 
-    const sidebar = page.locator('aside[aria-label="Main navigation"]');
+    const sidebar = page.locator('aside[aria-label="Sidebar"]');
     const dashboardButton = sidebar.getByRole('button', { name: 'Dashboard' });
 
     await expect(dashboardButton).toHaveAttribute('aria-current', 'page');
@@ -513,7 +513,7 @@ test.describe('Cross-viewport navigation', () => {
 
     // Verify mobile layout.
     await expect(page.locator('nav.bottom-nav')).toBeVisible();
-    await expect(page.locator('aside[aria-label="Main navigation"]')).toBeHidden();
+    await expect(page.locator('aside[aria-label="Sidebar"]')).toBeHidden();
 
     // Resize to desktop.
     await page.setViewportSize(DESKTOP);
@@ -522,7 +522,7 @@ test.describe('Cross-viewport navigation', () => {
     await page.waitForTimeout(100);
 
     // Verify desktop layout.
-    await expect(page.locator('aside[aria-label="Main navigation"]')).toBeVisible();
+    await expect(page.locator('aside[aria-label="Sidebar"]')).toBeVisible();
     await expect(page.locator('nav.bottom-nav')).toBeHidden();
 
     // Resize back to mobile.
@@ -531,6 +531,6 @@ test.describe('Cross-viewport navigation', () => {
 
     // Verify mobile layout is restored.
     await expect(page.locator('nav.bottom-nav')).toBeVisible();
-    await expect(page.locator('aside[aria-label="Main navigation"]')).toBeHidden();
+    await expect(page.locator('aside[aria-label="Sidebar"]')).toBeHidden();
   });
 });


### PR DESCRIPTION
## Summary

Fixes the **P0 deploy blocker**: main's Web CI E2E Desktop Matrix has been failing (all browsers) at the shared authenticated fixture, which blocks the "Deploy — Web (Pages)" trigger. Build and Unit Tests are green; only the E2E locator is stale.

## Root cause

PR #3444 (#3339, commit `2f739bd4`) renamed the desktop sidebar landmark `aria-label="Main navigation"` → `"Sidebar"` — a legitimate a11y fix that removes a duplicate landmark (the mobile bottom-nav keeps `aria-label="Main navigation"`, and the desktop sidebar's inner `<nav>` is `aria-label="Primary"`). The e2e specs still targeted the old label via `aside[aria-label="Main navigation"]`, so the sidebar could not be found. Because E2E is not a required merge check, #3444 merged green while breaking main's E2E/deploy gate.

## Changes

- Swap the 15 stale `aside[aria-label="Main navigation"]` locators → `aside[aria-label="Sidebar"]` across:
  - `apps/web/e2e/fixtures.ts` (shared auth fixture — root cause of the full-suite failure)
  - `apps/web/e2e/dashboard.spec.ts`
  - `apps/web/e2e/nav-reachability.spec.ts`
  - `apps/web/e2e/responsive.spec.ts` (12)
- No production code change. Mobile-nav unit tests (`Navigation.test.tsx`, `AppLayout.test.tsx`) target the bottom-nav's unchanged `Main navigation` name and are unaffected.

## Issues

Closes #3498

## Testing

- [x] Prettier applied to changed files
- [x] Locator now matches current production landmark (`aside[aria-label="Sidebar"]`)
- [ ] Web CI E2E Desktop Matrix green (verified on this PR's run)
