### PR TITLE
fix(web): wire real previous-period data into budget analytics comparison (#3363)

### DIFF
--- a/apps/web/src/lib/budget-previous-period.test.ts
+++ b/apps/web/src/lib/budget-previous-period.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import {
+  computePreviousPeriodSpending,
+  type PreviousPeriodTransaction,
+} from './budget-previous-period';
+
+const categoryNameById = new Map<string, string>([
+  ['cat-a', 'Groceries'],
+  ['cat-b', 'Gas'],
+]);
+
+function tx(overrides: Partial<PreviousPeriodTransaction>): PreviousPeriodTransaction {
+  return {
+    type: 'EXPENSE',
+    amountCents: 0,
+    date: '2026-02-15',
+    categoryId: 'cat-a',
+    deleted: false,
+    ...overrides,
+  };
+}
+
+describe('computePreviousPeriodSpending', () => {
+  it('sums previous-month expenses by category using absolute amounts (#3363)', () => {
+    const reference = new Date(2026, 2, 15); // March 2026 → previous month February
+    const result = computePreviousPeriodSpending(
+      [
+        tx({ amountCents: 10_000, categoryId: 'cat-a' }),
+        tx({ amountCents: -5_000, categoryId: 'cat-b' }), // negative outflow → abs
+        tx({ amountCents: 1_000, categoryId: null }), // uncategorized
+        tx({ type: 'INCOME', amountCents: 20_000 }), // ignored: not an expense
+        tx({ amountCents: 3_000, deleted: true }), // ignored: soft-deleted
+        tx({ amountCents: 99_900, date: '2026-03-02' }), // ignored: current month
+        tx({ amountCents: 4_000, date: '2026-01-20' }), // ignored: older period
+      ],
+      categoryNameById,
+      reference,
+    );
+
+    expect(result.previousPeriodSpent).toBe(16_000);
+    expect(result.previousCategorySpending.get('Groceries')).toBe(10_000);
+    expect(result.previousCategorySpending.get('Gas')).toBe(5_000);
+    expect(result.previousCategorySpending.get('Uncategorized')).toBe(1_000);
+  });
+
+  it('returns null and an empty map when there is no prior-period data', () => {
+    const reference = new Date(2026, 2, 15);
+    const result = computePreviousPeriodSpending(
+      [tx({ amountCents: 5_000, date: '2026-03-10' })],
+      categoryNameById,
+      reference,
+    );
+
+    expect(result.previousPeriodSpent).toBeNull();
+    expect(result.previousCategorySpending.size).toBe(0);
+  });
+
+  it('handles the January year boundary (previous month is December of prior year)', () => {
+    const reference = new Date(2026, 0, 10); // January 2026 → previous month December 2025
+    const result = computePreviousPeriodSpending(
+      [
+        tx({ amountCents: 7_000, date: '2025-12-31', categoryId: 'cat-a' }),
+        tx({ amountCents: 8_000, date: '2025-11-30', categoryId: 'cat-a' }), // ignored: too old
+        tx({ amountCents: 9_000, date: '2026-01-01', categoryId: 'cat-a' }), // ignored: current
+      ],
+      categoryNameById,
+      reference,
+    );
+
+    expect(result.previousPeriodSpent).toBe(7_000);
+    expect(result.previousCategorySpending.get('Groceries')).toBe(7_000);
+  });
+});

--- a/apps/web/src/lib/budget-previous-period.ts
+++ b/apps/web/src/lib/budget-previous-period.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Computes the previous calendar month's spending totals from transaction
+ * history so the budget analytics "vs. Last Period" comparison and per-category
+ * trend arrows reflect real data instead of a hardcoded empty baseline.
+ *
+ * The spend convention mirrors the budgets repository exactly: only `EXPENSE`
+ * transactions count, and each amount is taken as its absolute value (see
+ * `apps/web/src/db/repositories/budgets.ts` `SUM(CASE WHEN t.type = 'EXPENSE'
+ * THEN ABS(t.amount) ...)`). See issue #3363.
+ */
+
+export interface PreviousPeriodTransaction {
+  /** Transaction type; only `EXPENSE` contributes to spending. */
+  readonly type: string;
+  /** Signed amount in cents (absolute value is used for spend). */
+  readonly amountCents: number;
+  /** Calendar date as an ISO `YYYY-MM-DD` string. */
+  readonly date: string;
+  /** Owning category id, or null when uncategorized. */
+  readonly categoryId: string | null;
+  /** True when the transaction has been soft-deleted. */
+  readonly deleted: boolean;
+}
+
+export interface PreviousPeriodSpending {
+  /** Total previous-period spend in cents, or null when there is no prior data. */
+  readonly previousPeriodSpent: number | null;
+  /** Previous-period spend per category name (cents). */
+  readonly previousCategorySpending: Map<string, number>;
+}
+
+function toIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Aggregate the previous calendar month's expenses relative to `referenceDate`.
+ *
+ * @param transactions - Full transaction history (already currency-normalized).
+ * @param categoryNameById - Map of category id → display name.
+ * @param referenceDate - Any date within the current period; only its year and
+ *   month are used to locate the immediately preceding calendar month.
+ */
+export function computePreviousPeriodSpending(
+  transactions: readonly PreviousPeriodTransaction[],
+  categoryNameById: ReadonlyMap<string, string>,
+  referenceDate: Date,
+): PreviousPeriodSpending {
+  const year = referenceDate.getFullYear();
+  const month = referenceDate.getMonth();
+  const startIso = toIsoDate(new Date(year, month - 1, 1));
+  const endIso = toIsoDate(new Date(year, month, 0));
+
+  const previousCategorySpending = new Map<string, number>();
+  let total = 0;
+  let matched = 0;
+
+  for (const transaction of transactions) {
+    if (transaction.deleted || transaction.type !== 'EXPENSE') continue;
+    if (transaction.date < startIso || transaction.date > endIso) continue;
+
+    const spend = Math.abs(transaction.amountCents);
+    total += spend;
+    matched += 1;
+
+    const name =
+      (transaction.categoryId && categoryNameById.get(transaction.categoryId)) || 'Uncategorized';
+    previousCategorySpending.set(name, (previousCategorySpending.get(name) ?? 0) + spend);
+  }
+
+  return {
+    previousPeriodSpent: matched > 0 ? total : null,
+    previousCategorySpending,
+  };
+}

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -24,6 +24,7 @@ import { useExchangeRates } from '../hooks/useExchangeRates';
 import type { Budget } from '../kmp/bridge';
 import { getBudgetStatusIndicator } from '../lib/a11y';
 import { getBudgetStarterTemplates } from '../lib/budgeting/starter-budget-templates';
+import { computePreviousPeriodSpending } from '../lib/budget-previous-period';
 import type { DisplayExchangeRate } from '../lib/budgeting/display-currency-rollups';
 import type { TripBudgetTransaction } from '../lib/budgeting/trip-country-budget-scope';
 import {
@@ -430,6 +431,27 @@ export const BudgetsPage: React.FC = () => {
     return map;
   }, [budgets, categoriesById]);
 
+  const categoryNameById = useMemo(
+    () => new Map(categories.map((category) => [category.id, category.name])),
+    [categories],
+  );
+
+  const previousPeriod = useMemo(
+    () =>
+      computePreviousPeriodSpending(
+        transactions.map((transaction) => ({
+          type: transaction.type,
+          amountCents: transaction.amount.amount,
+          date: transaction.date,
+          categoryId: transaction.categoryId,
+          deleted: transaction.deletedAt != null,
+        })),
+        categoryNameById,
+        new Date(currentYear, currentMonth, 1),
+      ),
+    [transactions, categoryNameById, currentYear, currentMonth],
+  );
+
   return (
     <>
       <OfflineBanner />
@@ -784,9 +806,9 @@ export const BudgetsPage: React.FC = () => {
             totalBudget={totalBudgeted}
             daysElapsed={daysElapsed}
             totalDays={daysInMonth}
-            previousPeriodSpent={null}
+            previousPeriodSpent={previousPeriod.previousPeriodSpent}
             currentCategorySpending={currentCategorySpending}
-            previousCategorySpending={new Map()}
+            previousCategorySpending={previousPeriod.previousCategorySpending}
           />
           <section aria-label="Variance coaching" style={{ marginBottom: 'var(--spacing-6)' }}>
             <div className="card">


### PR DESCRIPTION
## Summary

The budget analytics **"vs. Last Period"** card always said _"Not enough data for comparison,"_ and the category-trend arrows were meaningless, because `BudgetsPage` passed `previousPeriodSpent={null}` and `previousCategorySpending={new Map()}` straight into `BudgetAnalytics`. For an overspend-conscious user, a period-comparison widget that never actually compares is dead weight.

## Changes

- New tested helper `computePreviousPeriodSpending` derives the previous calendar month's spend from full transaction history. It mirrors the budgets repository's `spent_amount` convention exactly: **EXPENSE only, absolute amounts, keyed by category name**.
- `BudgetsPage` now computes previous-period totals + per-category spend and passes real values into `BudgetAnalytics`.
- The honest `null` fallback is preserved: when there is genuinely no prior-period data, the card still shows "Not enough data" rather than a fake comparison.

## Issues

Closes #3363

Found by persona: Marcus Johnson (aggressive debt-payoff)

## Testing

- [x] New `budget-previous-period.test.ts` — sign handling, EXPENSE/deleted/cross-month filtering, null fallback, January year-boundary, uncategorized bucket
- [x] Existing `BudgetsPage.test.tsx` (9) and `BudgetAnalytics.test.tsx` comparison coverage still pass
- [x] Prettier + ESLint clean on changed files

## Cross-Platform

Web only. iOS/Android/Windows have separate budget UIs; `packages/core` `BudgetCalculator.kt` uses a different utilization model with no `comparePeriods`.
