### PR TITLE
feat(web): add invoice late-payment follow-up tracking (#3227)

### DIFF
--- a/apps/web/src/hooks/useInvoices.ts
+++ b/apps/web/src/hooks/useInvoices.ts
@@ -16,6 +16,7 @@ import {
   applyInvoiceEdit,
   groupInvoicesByStatus,
   normalizeInvoiceStatuses,
+  recordInvoiceContact,
   type CreateInvoiceInput,
   type ForecastBucket,
   type Invoice,
@@ -34,6 +35,7 @@ export interface UseInvoicesResult {
   addInvoice: (input: CreateInvoiceInput) => Invoice;
   updateInvoice: (invoiceId: string, input: UpdateInvoiceInput) => void;
   updateInvoiceStatus: (invoiceId: string, status: InvoiceStatus) => void;
+  logInvoiceContact: (invoiceId: string) => void;
   deleteInvoice: (invoiceId: string) => void;
   refresh: () => void;
 }
@@ -143,6 +145,21 @@ export function useInvoices(): UseInvoicesResult {
     setInvoices((prev) => prev.filter((invoice) => invoice.id !== invoiceId));
   }, []);
 
+  const logInvoiceContact = useCallback((invoiceId: string) => {
+    const currentDate = todayIsoDate();
+    setToday(currentDate);
+    setInvoices((prev) =>
+      normalizeInvoiceStatuses(
+        prev.map((invoice) =>
+          invoice.id === invoiceId
+            ? recordInvoiceContact(invoice, currentDate, new Date().toISOString())
+            : invoice,
+        ),
+        currentDate,
+      ),
+    );
+  }, []);
+
   const pipelineGroups = useMemo(() => groupInvoicesByStatus(invoices, today), [invoices, today]);
   const forecastBuckets = useMemo(() => computeInvoiceForecast(invoices, today), [invoices, today]);
   const totalOutstandingCents = useMemo(
@@ -158,6 +175,7 @@ export function useInvoices(): UseInvoicesResult {
     addInvoice,
     updateInvoice,
     updateInvoiceStatus,
+    logInvoiceContact,
     deleteInvoice,
     refresh,
   };

--- a/apps/web/src/lib/analytics/invoices.test.ts
+++ b/apps/web/src/lib/analytics/invoices.test.ts
@@ -12,9 +12,13 @@ import {
   computeExpectedPayDate,
   computeInvoiceForecast,
   exportInvoicesCsv,
+  FOLLOW_UP_STALE_DAYS,
   getEffectiveInvoiceStatus,
+  getInvoicesNeedingFollowUp,
   groupInvoicesByStatus,
   INVOICE_CSV_HEADER,
+  invoiceNeedsFollowUp,
+  recordInvoiceContact,
   type Invoice,
 } from './invoices';
 
@@ -29,6 +33,7 @@ function makeInvoice(overrides: Partial<Invoice>): Invoice {
     expectedPayDate: overrides.expectedPayDate ?? '2024-01-31',
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
+    lastContactedDate: overrides.lastContactedDate,
   };
 }
 
@@ -240,5 +245,75 @@ describe('applyInvoiceEdit', () => {
     );
 
     expect(updated.status).toBe('Overdue');
+  });
+});
+
+describe('invoiceNeedsFollowUp', () => {
+  it('flags an overdue invoice that has never been contacted', () => {
+    const invoice = makeInvoice({ status: 'Sent', expectedPayDate: '2024-01-31' });
+    expect(invoiceNeedsFollowUp(invoice, '2024-02-15')).toBe(true);
+  });
+
+  it('does not flag an invoice that is not yet overdue', () => {
+    const invoice = makeInvoice({ status: 'Sent', expectedPayDate: '2024-02-28' });
+    expect(invoiceNeedsFollowUp(invoice, '2024-02-15')).toBe(false);
+  });
+
+  it('does not flag a paid invoice', () => {
+    const invoice = makeInvoice({ status: 'Paid', expectedPayDate: '2024-01-31' });
+    expect(invoiceNeedsFollowUp(invoice, '2024-02-15')).toBe(false);
+  });
+
+  it('does not flag an overdue invoice contacted within the stale window', () => {
+    const invoice = makeInvoice({
+      status: 'Sent',
+      expectedPayDate: '2024-01-31',
+      lastContactedDate: '2024-02-14',
+    });
+    expect(invoiceNeedsFollowUp(invoice, '2024-02-15')).toBe(false);
+  });
+
+  it('flags an overdue invoice last contacted at least the stale window ago', () => {
+    const contacted = makeInvoice({
+      status: 'Sent',
+      expectedPayDate: '2024-01-31',
+      lastContactedDate: '2024-02-01',
+    });
+    expect(getEffectiveInvoiceStatus(contacted, '2024-02-15')).toBe('Overdue');
+    expect(FOLLOW_UP_STALE_DAYS).toBe(7);
+    expect(invoiceNeedsFollowUp(contacted, '2024-02-15')).toBe(true);
+  });
+});
+
+describe('getInvoicesNeedingFollowUp', () => {
+  it('returns only overdue invoices needing follow-up, oldest expected pay date first', () => {
+    const oldest = makeInvoice({ id: 'a', expectedPayDate: '2024-01-15', status: 'Sent' });
+    const newer = makeInvoice({ id: 'b', expectedPayDate: '2024-01-31', status: 'Sent' });
+    const paid = makeInvoice({ id: 'c', expectedPayDate: '2024-01-10', status: 'Paid' });
+    const recentlyContacted = makeInvoice({
+      id: 'd',
+      expectedPayDate: '2024-01-20',
+      status: 'Sent',
+      lastContactedDate: '2024-02-15',
+    });
+
+    const result = getInvoicesNeedingFollowUp(
+      [newer, paid, recentlyContacted, oldest],
+      '2024-02-16',
+    );
+
+    expect(result.map((invoice) => invoice.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('recordInvoiceContact', () => {
+  it('records the contact date and bumps updatedAt without mutating the original', () => {
+    const invoice = makeInvoice({ id: 'inv-9' });
+    const updated = recordInvoiceContact(invoice, '2024-02-15', '2024-02-15T09:30:00Z');
+
+    expect(updated.lastContactedDate).toBe('2024-02-15');
+    expect(updated.updatedAt).toBe('2024-02-15T09:30:00Z');
+    expect(updated.id).toBe('inv-9');
+    expect(invoice.lastContactedDate).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/analytics/invoices.ts
+++ b/apps/web/src/lib/analytics/invoices.ts
@@ -26,6 +26,8 @@ export interface Invoice {
   readonly expectedPayDate: string;
   readonly createdAt: string;
   readonly updatedAt: string;
+  /** ISO date of the most recent follow-up sent for an overdue invoice. */
+  readonly lastContactedDate?: string;
 }
 
 export interface CreateInvoiceInput {
@@ -130,6 +132,45 @@ export function normalizeInvoiceStatuses(invoices: Invoice[], todayIso: string):
     const effectiveStatus = getEffectiveInvoiceStatus(invoice, todayIso);
     return effectiveStatus === invoice.status ? invoice : { ...invoice, status: effectiveStatus };
   });
+}
+
+/** Days without a follow-up before an overdue invoice is flagged for chasing. */
+export const FOLLOW_UP_STALE_DAYS = 7;
+
+/**
+ * Record that a follow-up was sent for an invoice on the given date.
+ *
+ * @param invoice - The invoice being chased.
+ * @param contactDateIso - ISO date the follow-up was sent.
+ * @param nowIso - Current timestamp (ISO 8601) for updatedAt.
+ * @returns A new invoice with the last-contacted date recorded.
+ */
+export function recordInvoiceContact(
+  invoice: Invoice,
+  contactDateIso: string,
+  nowIso: string,
+): Invoice {
+  return { ...invoice, lastContactedDate: contactDateIso, updatedAt: nowIso };
+}
+
+/**
+ * Whether an overdue invoice needs a follow-up: it is effectively overdue and
+ * has either never been contacted or was last contacted at least
+ * {@link FOLLOW_UP_STALE_DAYS} days ago.
+ */
+export function invoiceNeedsFollowUp(invoice: Invoice, todayIso: string): boolean {
+  if (getEffectiveInvoiceStatus(invoice, todayIso) !== 'Overdue') return false;
+  if (!invoice.lastContactedDate) return true;
+  return diffDays(invoice.lastContactedDate, todayIso) >= FOLLOW_UP_STALE_DAYS;
+}
+
+/**
+ * Overdue invoices that need a follow-up, oldest expected pay date first.
+ */
+export function getInvoicesNeedingFollowUp(invoices: Invoice[], todayIso: string): Invoice[] {
+  return invoices
+    .filter((invoice) => invoiceNeedsFollowUp(invoice, todayIso))
+    .sort((a, b) => a.expectedPayDate.localeCompare(b.expectedPayDate));
 }
 
 export function createInvoice(input: CreateInvoiceInput, nowIso: string, id: string): Invoice {

--- a/apps/web/src/pages/InvoicesPage.test.tsx
+++ b/apps/web/src/pages/InvoicesPage.test.tsx
@@ -59,6 +59,7 @@ beforeEach(() => {
     addInvoice: vi.fn(),
     updateInvoice: vi.fn(),
     updateInvoiceStatus: vi.fn(),
+    logInvoiceContact: vi.fn(),
     deleteInvoice: vi.fn(),
     refresh: vi.fn(),
   });
@@ -89,6 +90,7 @@ describe('InvoicesPage', () => {
       addInvoice: vi.fn(),
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
       deleteInvoice,
       refresh: vi.fn(),
     });
@@ -115,6 +117,7 @@ describe('InvoicesPage', () => {
       addInvoice: vi.fn(),
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -136,6 +139,7 @@ describe('InvoicesPage', () => {
       addInvoice: vi.fn(),
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -157,6 +161,7 @@ describe('InvoicesPage', () => {
       addInvoice: vi.fn(),
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -185,6 +190,7 @@ describe('InvoicesPage', () => {
       addInvoice: vi.fn(),
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -207,6 +213,7 @@ describe('InvoicesPage', () => {
       addInvoice: vi.fn(),
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -230,6 +237,7 @@ describe('InvoicesPage', () => {
       addInvoice: vi.fn(),
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -266,6 +274,7 @@ describe('InvoicesPage', () => {
       addInvoice: vi.fn(),
       updateInvoice,
       updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -299,6 +308,7 @@ describe('InvoicesPage', () => {
       addInvoice: vi.fn(),
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -311,5 +321,68 @@ describe('InvoicesPage', () => {
 
     expect(screen.queryByRole('button', { name: 'Save changes' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Add invoice' })).toBeInTheDocument();
+  });
+
+  it('surfaces overdue invoices needing follow-up and logs a reminder (#3227)', () => {
+    const logInvoiceContact = vi.fn();
+    const overdue: Invoice = {
+      ...SAMPLE_INVOICE,
+      id: 'inv-od',
+      clientName: 'Late Corp',
+      status: 'Sent',
+      issueDate: '2019-12-01',
+      expectedPayDate: '2020-01-01',
+    };
+    mockedUseInvoices.mockReturnValue({
+      invoices: [overdue],
+      pipelineGroups: [
+        { status: 'Overdue', label: 'Overdue', invoices: [overdue], totalCents: 120_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      logInvoiceContact,
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    expect(screen.getByRole('heading', { name: 'Needs follow-up' })).toBeInTheDocument();
+    expect(screen.getByText(/last contacted never/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Log follow-up for Late Corp' }));
+    expect(logInvoiceContact).toHaveBeenCalledWith('inv-od');
+  });
+
+  it('hides the follow-up section when the overdue invoice was recently contacted (#3227)', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const contacted: Invoice = {
+      ...SAMPLE_INVOICE,
+      id: 'inv-od2',
+      clientName: 'Late Corp',
+      status: 'Sent',
+      issueDate: '2019-12-01',
+      expectedPayDate: '2020-01-01',
+      lastContactedDate: today,
+    };
+    mockedUseInvoices.mockReturnValue({
+      invoices: [contacted],
+      pipelineGroups: [
+        { status: 'Overdue', label: 'Overdue', invoices: [contacted], totalCents: 120_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    expect(screen.queryByRole('heading', { name: 'Needs follow-up' })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/InvoicesPage.tsx
+++ b/apps/web/src/pages/InvoicesPage.tsx
@@ -16,6 +16,8 @@ import { useLocalePreferences } from '../hooks/useLocalePreferences';
 import {
   computeExpectedPayDate,
   exportInvoicesCsv,
+  FOLLOW_UP_STALE_DAYS,
+  getInvoicesNeedingFollowUp,
   PAYMENT_TERM_LABELS,
   PAYMENT_TERMS,
   INVOICE_STATUSES,
@@ -119,6 +121,7 @@ export const InvoicesPage: React.FC = () => {
     addInvoice,
     updateInvoice,
     updateInvoiceStatus,
+    logInvoiceContact,
     deleteInvoice,
   } = useInvoices();
   const { locale } = useLocalePreferences();
@@ -169,6 +172,11 @@ export const InvoicesPage: React.FC = () => {
       Array.from(
         new Set(invoices.map((invoice) => invoice.clientName.trim()).filter(Boolean)),
       ).sort((a, b) => a.localeCompare(b)),
+    [invoices],
+  );
+
+  const followUpInvoices = useMemo(
+    () => getInvoicesNeedingFollowUp(invoices, todayIsoDate()),
     [invoices],
   );
 
@@ -381,6 +389,39 @@ export const InvoicesPage: React.FC = () => {
           ))}
         </div>
       </section>
+
+      {followUpInvoices.length > 0 && (
+        <section className="analytics-section" aria-label="Invoices needing follow-up">
+          <h2 className="analytics-section__title">Needs follow-up</h2>
+          <p className="invoice-followup__subtitle">
+            Overdue invoices you haven&rsquo;t chased in the last {FOLLOW_UP_STALE_DAYS} days.
+          </p>
+          <ul className="invoice-followup-list">
+            {followUpInvoices.map((invoice) => (
+              <li key={invoice.id} className="invoice-followup-row">
+                <div className="invoice-followup-row__info">
+                  <span className="invoice-followup-row__client">{invoice.clientName}</span>
+                  <span className="invoice-followup-row__meta">
+                    <CurrencyDisplay amount={invoice.amountCents} /> &middot; expected{' '}
+                    {formatDate(invoice.expectedPayDate, { locale })} &middot; last contacted{' '}
+                    {invoice.lastContactedDate
+                      ? formatDate(invoice.lastContactedDate, { locale })
+                      : 'never'}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  className="invoice-followup-row__action"
+                  aria-label={`Log follow-up for ${invoice.clientName}`}
+                  onClick={() => logInvoiceContact(invoice.id)}
+                >
+                  Log follow-up
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       <section className="analytics-section" aria-label="Invoice pipeline">
         <h2 className="analytics-section__title">Pipeline by status</h2>

--- a/apps/web/src/pages/analytics.css
+++ b/apps/web/src/pages/analytics.css
@@ -516,6 +516,66 @@
   outline-offset: 2px;
 }
 
+.invoice-followup__subtitle {
+  margin: 0 0 var(--spacing-3);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-sm-font-size);
+}
+
+.invoice-followup-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.invoice-followup-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  background: var(--semantic-background-elevated);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+}
+
+.invoice-followup-row__info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  min-width: 0;
+}
+
+.invoice-followup-row__client {
+  color: var(--semantic-text-primary);
+  font-weight: var(--font-weight-medium);
+}
+
+.invoice-followup-row__meta {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.invoice-followup-row__action {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-elevated);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.invoice-followup-row__action:hover {
+  background: var(--semantic-background-secondary);
+}
+
 .invoice-forecast-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Diego juggles 5-8 clients with lumpy pay, so chasing late payers is core to his cash flow. The invoices page tracked overdue status but gave no way to see **which** overdue invoices still need a nudge or to record that he already reached out. This adds lightweight late-payment follow-up tracking.

## Changes

- `lib/analytics/invoices.ts`: add optional `lastContactedDate` to `Invoice` plus pure helpers `invoiceNeedsFollowUp` (overdue AND never/stale-contacted), `getInvoicesNeedingFollowUp` (sorted oldest-first), `recordInvoiceContact`, and `FOLLOW_UP_STALE_DAYS` (7). No change to forecast math.
- `hooks/useInvoices.ts`: add `logInvoiceContact(invoiceId)` mutation that stamps today's date and re-normalizes statuses.
- `pages/InvoicesPage.tsx`: new **Needs follow-up** section listing stale overdue invoices with amount, expected date, last-contacted status ("never" or date), and a per-invoice **Log follow-up** action.
- `pages/analytics.css`: styles for the new section (semantic tokens only).
- Unit tests for the helpers, hook wiring, and the page flow (surface + log, and hidden-when-recently-contacted).

## Accessibility

- The section is a labelled `<section aria-label="Invoices needing follow-up">` with an `<h2>` heading (fits the existing heading hierarchy).
- Each action button has a distinct accessible name (`Log follow-up for {client}`).
- Uses semantic list markup and design-token colors (no color-only signalling).

## Platform scope

Web-only. The invoice pipeline lives in `apps/web` (localStorage-backed `useInvoices`); there is no shared KMP invoice model, so iOS/Android/Windows are unaffected.

## Issues

Closes #3227

## Testing

- [x] `tsc -b` clean
- [x] `vitest run` invoices lib + InvoicesPage suites (33 passed)
- [x] `prettier@3.9.4 --check` + `eslint --max-warnings 0` clean

Found by persona: Diego Ramirez (freelance-designer irregular-income)