### PR TITLE
feat(web): warn when a budget category is on pace to overspend (#3365)

### DIFF
--- a/apps/web/src/components/budgets/BudgetAnalytics.test.tsx
+++ b/apps/web/src/components/budgets/BudgetAnalytics.test.tsx
@@ -141,4 +141,30 @@ describe('BudgetAnalytics', () => {
     render(<BudgetAnalytics {...defaultProps} totalIncome={0} />);
     expect(screen.getByText('0%')).toBeInTheDocument();
   });
+
+  it('warns when a category is on pace to overspend its budget', () => {
+    render(
+      <BudgetAnalytics
+        {...defaultProps}
+        categoryBudgets={
+          new Map([
+            ['Food', 150_000], // spent $1,000 in 15/30 days -> projects $2,000 vs $1,500 budget
+            ['Housing', 400_000],
+            ['Transport', 200_000],
+            ['Entertainment', 200_000],
+            ['Health', 200_000],
+          ])
+        }
+      />,
+    );
+    const warnings = screen.getAllByText(/On pace to overspend by/);
+    expect(warnings).toHaveLength(1);
+    // Projected $2,000 - $1,500 budget = $500 (50,000 cents) overspend.
+    expect(screen.getByLabelText(/Food:.*on pace to overspend by/i)).toBeInTheDocument();
+  });
+
+  it('omits overspend warnings when no category budgets are provided', () => {
+    render(<BudgetAnalytics {...defaultProps} />);
+    expect(screen.queryByText(/On pace to overspend by/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/budgets/BudgetAnalytics.tsx
+++ b/apps/web/src/components/budgets/BudgetAnalytics.tsx
@@ -21,12 +21,15 @@ import {
   calculateSpendingTrajectory,
   comparePeriods,
   getBudgetHealth,
+  projectCategoryOverspend,
   type BudgetHealthStatus,
+  type CategoryProjection,
   type CategoryTrend,
   type ChangeDirection,
 } from '../../lib/budget-analytics';
 import './budget-analytics.css';
 import { AppIcon, type IconName } from '../icons';
+import { formatCurrencyForScreenReader } from '../../lib/a11y';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -50,6 +53,11 @@ export interface BudgetAnalyticsProps {
   currentCategorySpending: ReadonlyMap<string, number>;
   /** Map of category name → spending in previous period (cents). */
   previousCategorySpending: ReadonlyMap<string, number>;
+  /**
+   * Map of category name → budgeted amount for the current period (cents).
+   * Used to project per-category overspend. Omitted maps disable the warning.
+   */
+  categoryBudgets?: ReadonlyMap<string, number>;
   /** ISO 4217 currency code (default: "USD"). */
   currency?: string;
 }
@@ -124,6 +132,7 @@ export const BudgetAnalytics: React.FC<BudgetAnalyticsProps> = ({
   previousPeriodSpent,
   currentCategorySpending,
   previousCategorySpending,
+  categoryBudgets,
   currency = 'USD',
 }) => {
   // Compute analytics
@@ -136,6 +145,19 @@ export const BudgetAnalytics: React.FC<BudgetAnalyticsProps> = ({
     previousPeriodSpent !== null ? comparePeriods(totalSpent, previousPeriodSpent) : null;
 
   const categoryTrends = buildCategoryTrends(currentCategorySpending, previousCategorySpending, 5);
+
+  // Per-category early overspend projection (only when budgets are provided).
+  const categoryOverspend = categoryBudgets
+    ? projectCategoryOverspend(
+        [...currentCategorySpending].map(([name, spentCents]) => ({
+          name,
+          spentCents,
+          budgetCents: categoryBudgets.get(name) ?? 0,
+        })),
+        daysElapsed,
+        totalDays,
+      )
+    : new Map<string, CategoryProjection>();
 
   // Progress bar percentage (capped at 100% visually)
   const progressPercent = totalBudget > 0 ? Math.min((totalSpent / totalBudget) * 100, 100) : 0;
@@ -251,6 +273,7 @@ export const BudgetAnalytics: React.FC<BudgetAnalyticsProps> = ({
           <CategoryTrendsList
             trends={categoryTrends}
             maxSpending={maxCategorySpending}
+            overspendByName={categoryOverspend}
             currency={currency}
           />
         ) : (
@@ -268,23 +291,32 @@ export const BudgetAnalytics: React.FC<BudgetAnalyticsProps> = ({
 function CategoryTrendsList({
   trends,
   maxSpending,
+  overspendByName,
   currency,
 }: {
   trends: CategoryTrend[];
   maxSpending: number;
+  overspendByName: ReadonlyMap<string, CategoryProjection>;
   currency: string;
 }) {
   return (
     <ul className="category-trends__list" role="list" aria-label="Top spending categories">
       {trends.map((trend) => {
         const barPercent = maxSpending > 0 ? (trend.current / maxSpending) * 100 : 0;
+        const overspend = overspendByName.get(trend.name);
+        const trendSummary = trend.isNew
+          ? 'new spending this period'
+          : `${trend.change}% ${trend.direction}`;
+        const overspendSummary = overspend
+          ? `, on pace to overspend by ${formatCurrencyForScreenReader(overspend.overspendCents, currency)}`
+          : '';
 
         return (
           <li
             key={trend.name}
             className="category-trends__item"
             role="listitem"
-            aria-label={`${trend.name}: ${trend.isNew ? 'new spending this period' : `${trend.change}% ${trend.direction}`}`}
+            aria-label={`${trend.name}: ${trendSummary}${overspendSummary}`}
           >
             <span className="category-trends__name">{trend.name}</span>
             <div
@@ -305,6 +337,12 @@ function CategoryTrendsList({
               />{' '}
               <CurrencyDisplay amount={trend.current} currency={currency} />
             </span>
+            {overspend && (
+              <span className="category-trends__overspend" aria-hidden="true">
+                <AppIcon name="alert-triangle" /> On pace to overspend by{' '}
+                <CurrencyDisplay amount={overspend.overspendCents} currency={currency} />
+              </span>
+            )}
           </li>
         );
       })}

--- a/apps/web/src/components/budgets/budget-analytics.css
+++ b/apps/web/src/components/budgets/budget-analytics.css
@@ -183,8 +183,10 @@
 
 .category-trends__item {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--spacing-3);
+  row-gap: var(--spacing-1);
 }
 
 .category-trends__name {
@@ -216,6 +218,15 @@
   flex: 0 0 60px;
   font-size: var(--type-scale-caption-font-size);
   text-align: right;
+}
+
+.category-trends__overspend {
+  flex: 0 0 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-status-warning);
 }
 
 /* ---------------------------------------------------------------------------

--- a/apps/web/src/lib/budget-analytics.test.ts
+++ b/apps/web/src/lib/budget-analytics.test.ts
@@ -7,6 +7,7 @@ import {
   calculateSpendingTrajectory,
   comparePeriods,
   getBudgetHealth,
+  projectCategoryOverspend,
 } from './budget-analytics';
 
 describe('calculateSavingsRate', () => {
@@ -184,5 +185,43 @@ describe('buildCategoryTrends', () => {
   it('returns empty array when no categories', () => {
     const trends = buildCategoryTrends(new Map(), new Map());
     expect(trends).toHaveLength(0);
+  });
+});
+
+describe('projectCategoryOverspend', () => {
+  it('flags a category on pace to exceed its budget', () => {
+    // Spent $600 in 10 of 30 days -> projects to $1,800 against a $1,000 budget.
+    const projections = projectCategoryOverspend(
+      [{ name: 'Dining', spentCents: 60_000, budgetCents: 100_000 }],
+      10,
+      30,
+    );
+    const dining = projections.get('Dining');
+    expect(dining).toBeDefined();
+    expect(dining?.projectedCents).toBe(180_000);
+    expect(dining?.overspendCents).toBe(80_000);
+  });
+
+  it('omits categories projected to stay within budget', () => {
+    // Spent $200 in 10 of 30 days -> projects to $600 against a $1,000 budget.
+    const projections = projectCategoryOverspend(
+      [{ name: 'Groceries', spentCents: 20_000, budgetCents: 100_000 }],
+      10,
+      30,
+    );
+    expect(projections.has('Groceries')).toBe(false);
+  });
+
+  it('ignores categories without a positive budget', () => {
+    const projections = projectCategoryOverspend(
+      [{ name: 'Uncategorized', spentCents: 50_000, budgetCents: 0 }],
+      10,
+      30,
+    );
+    expect(projections.size).toBe(0);
+  });
+
+  it('returns an empty map when there are no categories', () => {
+    expect(projectCategoryOverspend([], 10, 30).size).toBe(0);
   });
 });

--- a/apps/web/src/lib/budget-analytics.ts
+++ b/apps/web/src/lib/budget-analytics.ts
@@ -55,6 +55,28 @@ export interface CategoryTrend {
   readonly isNew?: boolean;
 }
 
+/** Per-category end-of-period spend projection used for early overspend warnings. */
+export interface CategoryProjection {
+  /** Display name of the category. */
+  readonly name: string;
+  /** Projected end-of-period spend in cents at the current daily pace. */
+  readonly projectedCents: number;
+  /** The category's budget for the period (cents). */
+  readonly budgetCents: number;
+  /** Amount the projection exceeds the budget by (cents); 0 when within budget. */
+  readonly overspendCents: number;
+}
+
+/** Per-category spent-so-far and budget amounts used to project overspend. */
+export interface CategoryProjectionInput {
+  /** Display name of the category. */
+  readonly name: string;
+  /** Amount already spent this period (cents). */
+  readonly spentCents: number;
+  /** Budgeted amount for this category this period (cents). */
+  readonly budgetCents: number;
+}
+
 // ---------------------------------------------------------------------------
 // Core calculations
 // ---------------------------------------------------------------------------
@@ -209,4 +231,36 @@ export function buildCategoryTrends(
   // Sort by current spending descending, take top N
   trends.sort((a, b) => b.current - a.current);
   return trends.slice(0, topN);
+}
+
+/**
+ * Project each category's end-of-period spend from its current pace and flag the
+ * ones on track to exceed their budget. Only categories with a positive budget
+ * that are projected to overspend are returned, keyed by category name, so the
+ * UI can surface an early "on pace to overspend by $X" warning before the
+ * category is actually blown.
+ *
+ * @param categories - Per-category spent-so-far and budget amounts (cents).
+ * @param daysElapsed - Days elapsed in the current period.
+ * @param totalDays - Total days in the current period.
+ * @returns Map of category name → projection, for projected-over categories only.
+ */
+export function projectCategoryOverspend(
+  categories: readonly CategoryProjectionInput[],
+  daysElapsed: number,
+  totalDays: number,
+): Map<string, CategoryProjection> {
+  const projections = new Map<string, CategoryProjection>();
+  for (const category of categories) {
+    if (category.budgetCents <= 0) continue;
+    const projectedCents = calculateSpendingTrajectory(category.spentCents, daysElapsed, totalDays);
+    if (projectedCents <= category.budgetCents) continue;
+    projections.set(category.name, {
+      name: category.name,
+      projectedCents,
+      budgetCents: category.budgetCents,
+      overspendCents: projectedCents - category.budgetCents,
+    });
+  }
+  return projections;
 }

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -431,6 +431,16 @@ export const BudgetsPage: React.FC = () => {
     return map;
   }, [budgets, categoriesById]);
 
+  const categoryBudgets = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const budget of budgets) {
+      const category = categoriesById.get(budget.categoryId);
+      const name = category?.name ?? budget.name;
+      map.set(name, (map.get(name) ?? 0) + budget.amount.amount);
+    }
+    return map;
+  }, [budgets, categoriesById]);
+
   const categoryNameById = useMemo(
     () => new Map(categories.map((category) => [category.id, category.name])),
     [categories],
@@ -809,6 +819,7 @@ export const BudgetsPage: React.FC = () => {
             previousPeriodSpent={previousPeriod.previousPeriodSpent}
             currentCategorySpending={currentCategorySpending}
             previousCategorySpending={previousPeriod.previousCategorySpending}
+            categoryBudgets={categoryBudgets}
           />
           <section aria-label="Variance coaching" style={{ marginBottom: 'var(--spacing-6)' }}>
             <div className="card">


### PR DESCRIPTION
## Summary

Marcus tracks every dollar on a tight budget, but the Budgets page only tells him a category is blown *after* it happens. This adds an early, per-category overspend projection so he gets an amber "on pace to overspend" warning mid-period, while he can still course-correct.

## Changes

- `lib/budget-analytics.ts`: new `projectCategoryOverspend(categories, daysElapsed, totalDays)` that projects each category's end-of-period spend from its current daily pace (reusing `calculateSpendingTrajectory`) and returns only the categories projected to exceed their budget, keyed by name. Adds `CategoryProjection` / `CategoryProjectionInput` types.
- `components/budgets/BudgetAnalytics.tsx`: new optional `categoryBudgets` prop; computes the projection map and renders an accessible amber warning chip (alert-triangle icon + text) per over-pace category in the Category Trends card. The warning is folded into each row's `aria-label` (via `formatCurrencyForScreenReader`) so it is announced to screen readers and never conveyed by color alone.
- `components/budgets/budget-analytics.css`: `.category-trends__overspend` chip styling using `--semantic-status-warning`; row now wraps so the chip sits below the bar.
- `pages/BudgetsPage.tsx`: builds a `categoryBudgets` map (category name to budgeted cents, mirroring `currentCategorySpending`) and passes it through.

Spend convention matches the budgets repo exactly (EXPENSE only, absolute cents, keyed by category name).

## Issues

Closes #3365

Found by persona: Marcus Johnson (aggressive debt-payoff)

## Testing

- `budget-analytics.test.ts`: 4 new cases for `projectCategoryOverspend` (flags over-pace, omits within-budget, ignores non-positive budgets, empty input).
- `BudgetAnalytics.test.tsx`: 2 new cases (warning chip renders once for the over-pace category; no chip when `categoryBudgets` omitted).
- Full affected suite green: `budget-analytics.test.ts`, `BudgetAnalytics.test.tsx`, `BudgetsPage.test.tsx` (57 tests pass).
- `npm run format:check` and `eslint --max-warnings 0` clean on all changed files.
