### PR TITLE
feat(web): add a per-debt payoff milestone timeline (#3368)

### DIFF
--- a/apps/web/src/lib/debt/payoff-milestones.test.ts
+++ b/apps/web/src/lib/debt/payoff-milestones.test.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { buildPayoffMilestones } from './payoff-milestones';
+import type { AmortizationSchedule, StrategyResult } from '../debt-types';
+
+function schedule(debtId: string, debtName: string, monthsToPayoff: number): AmortizationSchedule {
+  return {
+    debtId,
+    debtName,
+    entries: [],
+    totalInterestCents: 0,
+    totalPaidCents: 0,
+    monthsToPayoff,
+  };
+}
+
+function result(
+  schedules: AmortizationSchedule[],
+  fullyPaidOff: boolean,
+): Pick<StrategyResult, 'schedules' | 'fullyPaidOff'> {
+  return { schedules, fullyPaidOff };
+}
+
+describe('buildPayoffMilestones', () => {
+  it('orders milestones by the month each debt clears and stamps dates', () => {
+    const milestones = buildPayoffMilestones(
+      result(
+        [schedule('b', 'Card B', 9), schedule('a', 'Card A', 4), schedule('c', 'Car Loan', 20)],
+        true,
+      ),
+      '2026-01-15',
+    );
+
+    expect(milestones.map((m) => m.debtId)).toEqual(['a', 'b', 'c']);
+    expect(milestones[0]).toMatchObject({
+      debtName: 'Card A',
+      monthsToPayoff: 4,
+      payoffDateIso: '2026-05-15',
+    });
+    expect(milestones[1].payoffDateIso).toBe('2026-10-15');
+    expect(milestones[2].payoffDateIso).toBe('2027-09-15');
+  });
+
+  it('returns an empty list when the plan never reaches debt-free', () => {
+    const milestones = buildPayoffMilestones(
+      result([schedule('a', 'Card A', 4), schedule('b', 'Card B', 1200)], false),
+      '2026-01-15',
+    );
+    expect(milestones).toEqual([]);
+  });
+
+  it('skips debts that never register a payoff month', () => {
+    const milestones = buildPayoffMilestones(
+      result([schedule('a', 'Card A', 0), schedule('b', 'Card B', 6)], true),
+      '2026-01-15',
+    );
+    expect(milestones.map((m) => m.debtId)).toEqual(['b']);
+  });
+
+  it('does not mutate the input schedules order', () => {
+    const schedules = [schedule('b', 'Card B', 9), schedule('a', 'Card A', 4)];
+    buildPayoffMilestones(result(schedules, true), '2026-01-15');
+    expect(schedules.map((s) => s.debtId)).toEqual(['b', 'a']);
+  });
+});

--- a/apps/web/src/lib/debt/payoff-milestones.ts
+++ b/apps/web/src/lib/debt/payoff-milestones.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Per-debt payoff milestone timeline.
+ *
+ * The payoff engine already records the month each debt reaches zero
+ * (`AmortizationSchedule.monthsToPayoff`). This helper turns that raw data into
+ * an ordered, date-stamped milestone list so the UI can show the user *when*
+ * each individual debt clears — the emotional core of the snowball method —
+ * instead of only the single aggregate debt-free date.
+ *
+ * Pure function — no side effects, fully testable.
+ */
+
+import { addMonthsToIsoDate } from '../date-utils';
+import type { StrategyResult } from '../debt-types';
+
+/** A single debt's projected payoff moment. */
+export interface PayoffMilestone {
+  /** Stable id of the debt that clears at this milestone. */
+  readonly debtId: string;
+  /** Human-readable debt name. */
+  readonly debtName: string;
+  /** Number of months from today until this debt is fully paid. */
+  readonly monthsToPayoff: number;
+  /** Projected ISO date (YYYY-MM-DD) the debt is fully paid. */
+  readonly payoffDateIso: string;
+}
+
+/**
+ * Build a chronological, date-stamped payoff milestone list for a strategy
+ * result.
+ *
+ * Only meaningful when the plan actually reaches debt-free: if any debt never
+ * amortizes (`fullyPaidOff === false`), the per-debt months are capped at the
+ * simulation horizon and would render as a fake countdown, so an empty list is
+ * returned instead. Debts are sorted by the month they clear (ascending) so the
+ * list reads as a true timeline regardless of internal strategy ordering.
+ *
+ * @param result - A completed strategy simulation.
+ * @param todayIso - Reference "today" as an ISO date (YYYY-MM-DD).
+ * @returns Ordered milestones, earliest payoff first; empty when not fully paid.
+ */
+export function buildPayoffMilestones(
+  result: Pick<StrategyResult, 'schedules' | 'fullyPaidOff'>,
+  todayIso: string,
+): PayoffMilestone[] {
+  if (!result.fullyPaidOff) return [];
+
+  return result.schedules
+    .filter((schedule) => schedule.monthsToPayoff > 0)
+    .slice()
+    .sort((a, b) => a.monthsToPayoff - b.monthsToPayoff)
+    .map((schedule) => ({
+      debtId: schedule.debtId,
+      debtName: schedule.debtName,
+      monthsToPayoff: schedule.monthsToPayoff,
+      payoffDateIso: addMonthsToIsoDate(todayIso, schedule.monthsToPayoff),
+    }));
+}

--- a/apps/web/src/pages/DebtPage.css
+++ b/apps/web/src/pages/DebtPage.css
@@ -1160,3 +1160,70 @@
   background: var(--semantic-background-primary, #1f2937);
   border-color: var(--semantic-border, #374151);
 }
+
+/* ---------------------------------------------------------------------------
+ * Payoff timeline (#3368) — per-debt payoff dates / snowball milestones
+ * ------------------------------------------------------------------------- */
+
+.payoff-timeline {
+  margin-top: var(--spacing-5, 1.5rem);
+}
+
+.payoff-timeline__intro {
+  color: var(--semantic-text-secondary, #666);
+  margin: 0 0 var(--spacing-3, 0.75rem);
+}
+
+.payoff-timeline__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2, 0.5rem);
+}
+
+.payoff-timeline__item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--spacing-1, 0.25rem) var(--spacing-3, 0.75rem);
+  padding: var(--spacing-3, 0.75rem);
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--semantic-background-primary, #fff);
+}
+
+.payoff-timeline__index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: var(--radius-full, 9999px);
+  background: var(--semantic-primary-bg, #dbeafe);
+  color: var(--semantic-primary, #2563eb);
+  font-weight: var(--font-weight-bold, 700);
+  font-size: var(--font-size-sm, 0.875rem);
+}
+
+.payoff-timeline__name {
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--semantic-text-primary, #111);
+}
+
+.payoff-timeline__date {
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-positive, #059669);
+}
+
+.payoff-timeline__months {
+  grid-column: 2 / -1;
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-secondary, #666);
+}
+
+[data-theme='dark'] .payoff-timeline__item {
+  background: var(--semantic-background-primary, #1f2937);
+  border-color: var(--semantic-border, #374151);
+}

--- a/apps/web/src/pages/DebtPage.test.tsx
+++ b/apps/web/src/pages/DebtPage.test.tsx
@@ -182,6 +182,32 @@ describe('DebtPage', () => {
     expect(screen.getAllByText('Personal Loan').length).toBeGreaterThan(0);
   });
 
+  it('shows a per-debt payoff timeline with projected dates (#3368)', () => {
+    mockUseAccountsState.accounts = [
+      buildAccount({
+        id: 'cc-1',
+        name: 'Rewards Credit Card',
+        type: 'CREDIT_CARD',
+        currentBalance: { amount: -400_000 },
+      }),
+      buildAccount({
+        id: 'loan-1',
+        name: 'Personal Loan',
+        type: 'LOAN',
+        currentBalance: { amount: 800_000 },
+      }),
+    ];
+
+    render(<DebtPage />);
+
+    const timeline = screen.getByRole('region', { name: 'Payoff timeline' });
+    expect(within(timeline).getByText('Payoff Timeline')).toBeDefined();
+    // Each debt shows as its own dated milestone, in payoff order.
+    expect(within(timeline).getByText('Rewards Credit Card')).toBeDefined();
+    expect(within(timeline).getByText('Personal Loan')).toBeDefined();
+    expect(within(timeline).getAllByRole('listitem')).toHaveLength(2);
+  });
+
   it('warns instead of showing a countdown when the payment never covers interest (#3355)', () => {
     mockUseAccountsState.accounts = [
       buildAccount({

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -40,6 +40,7 @@ import {
   compareStrategies,
 } from '../lib/debt-payoff-engine';
 import { addMonthsToIsoDate } from '../lib/date-utils';
+import { buildPayoffMilestones } from '../lib/debt/payoff-milestones';
 import { aggregateBnplDashboard, type BnplObligationDraft } from '../lib/debt/bnpl-aggregation';
 import {
   calculateStudentLoanDashboardSummary,
@@ -702,6 +703,10 @@ function PayoffPlannerPanel(): React.ReactElement {
       debts.length > 0 ? calculateStrategyResult(debts, activeStrategy, extraPaymentCents) : null,
     [activeStrategy, debts, extraPaymentCents],
   );
+  const payoffMilestones = useMemo(
+    () => (activeResult ? buildPayoffMilestones(activeResult, todayIso) : []),
+    [activeResult, todayIso],
+  );
   const minimumOnlyResult = useMemo(
     () => (debts.length > 0 ? calculateStrategyResult(debts, activeStrategy, 0) : null),
     [activeStrategy, debts],
@@ -968,6 +973,32 @@ function PayoffPlannerPanel(): React.ReactElement {
             ))}
 
           {debtProgressRing && <ProgressRingCard card={debtProgressRing} />}
+
+          {payoffMilestones.length > 1 && (
+            <section className="payoff-timeline" aria-label="Payoff timeline">
+              <h2>Payoff Timeline</h2>
+              <p className="payoff-timeline__intro">
+                Your {formatStrategyName(activeStrategy)} plan clears one debt at a time &mdash;
+                here&rsquo;s when each one is gone.
+              </p>
+              <ol className="payoff-timeline__list">
+                {payoffMilestones.map((milestone, index) => (
+                  <li key={milestone.debtId} className="payoff-timeline__item">
+                    <span className="payoff-timeline__index" aria-hidden="true">
+                      {index + 1}
+                    </span>
+                    <span className="payoff-timeline__name">{milestone.debtName}</span>
+                    <span className="payoff-timeline__date">
+                      {formatMonthYear(milestone.payoffDateIso)}
+                    </span>
+                    <span className="payoff-timeline__months">
+                      in {milestone.monthsToPayoff} {pluralize(milestone.monthsToPayoff, 'month')}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            </section>
+          )}
 
           <section aria-label="Debt milestones" className="debt-milestones">
             <div className="debt-milestones__summary">


### PR DESCRIPTION
## Summary

For a snowball-method user like Marcus, the motivation comes from clearing debts one at a time — but the planner only showed the single final debt-free date. The payoff engine already records the month each debt clears (`AmortizationSchedule.monthsToPayoff`); it was just never surfaced. This adds a dated, ordered **Payoff Timeline** under the debt-free countdown so the user can see and celebrate each debt disappearing.

## Changes

- `lib/debt/payoff-milestones.ts` (new): pure `buildPayoffMilestones(result, todayIso)` that converts a strategy result into a chronological, date-stamped milestone list. Returns an empty list when the plan never reaches debt-free (`fullyPaidOff === false`), so a capped simulation horizon is never rendered as a real countdown. Does not mutate its input.
- `pages/DebtPage.tsx`: `payoffMilestones` memo + a new "Payoff Timeline" section (only shown when 2+ debts clear) listing each debt in payoff order with its projected clear date and months-from-now.
- `pages/DebtPage.css`: `.payoff-timeline` styles using existing semantic tokens, including a dark-theme variant.

No engine change required — this is a pure surfacing of existing data.

## Accessibility

- Semantic `<ol>` conveys the payoff sequence; the numeric badge is `aria-hidden` (decorative) so screen readers read "Card A, May 2026, in 4 months".
- The projected date is emphasized with text + weight, never color alone.

## Issues

Closes #3368

Found by persona: Marcus Johnson (aggressive debt-payoff)

## Testing

- `payoff-milestones.test.ts` (new): 4 cases — chronological ordering + date stamping, empty when not fully paid off, skips debts with no payoff month, input not mutated.
- `DebtPage.test.tsx`: new integration test asserting the timeline region renders both debts as dated milestones in a 2-item ordered list.
- Affected suite green: `payoff-milestones.test.ts` + `DebtPage.test.tsx` (29 tests pass).
- `prettier --write` + `eslint --max-warnings 0` clean on all changed files.
