### PR TITLE
feat(web): add invoice paid-date and partial-payment tracking (#3224)

### DIFF
--- a/apps/web/src/components/invoices/InvoicePaymentDialog.test.tsx
+++ b/apps/web/src/components/invoices/InvoicePaymentDialog.test.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for InvoicePaymentDialog.
+ *
+ * References: issue #3224
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MoneyDisplayProvider } from '../../lib/display-settings';
+import type { Invoice } from '../../lib/analytics/invoices';
+import { InvoicePaymentDialog } from './InvoicePaymentDialog';
+
+function makeInvoice(overrides: Partial<Invoice> = {}): Invoice {
+  return {
+    id: 'inv-1',
+    clientName: 'Acme Studio',
+    amountCents: 400000,
+    issueDate: '2024-01-01',
+    paymentTerm: 'net-30',
+    status: 'Sent',
+    expectedPayDate: '2024-01-31',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    amountPaidCents: 100000,
+    ...overrides,
+  };
+}
+
+function renderDialog(props: Partial<ComponentProps<typeof InvoicePaymentDialog>> = {}) {
+  const onSubmit = vi.fn<NonNullable<ComponentProps<typeof InvoicePaymentDialog>['onSubmit']>>();
+  const onCancel = vi.fn();
+
+  render(
+    <MoneyDisplayProvider>
+      <InvoicePaymentDialog
+        isOpen
+        invoice={makeInvoice()}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+        {...props}
+      />
+    </MoneyDisplayProvider>,
+  );
+
+  return { onSubmit, onCancel };
+}
+
+describe('InvoicePaymentDialog', () => {
+  it('records a valid partial payment with the entered date', () => {
+    const { onSubmit, onCancel } = renderDialog();
+
+    expect(
+      screen.getByRole('dialog', { name: 'Record payment for Acme Studio' }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Payment amount'), { target: { value: '1500.00' } });
+    fireEvent.change(screen.getByLabelText('Payment date'), { target: { value: '2024-02-15' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Record payment' }));
+
+    expect(onSubmit).toHaveBeenCalledWith(150000, '2024-02-15');
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-positive amount', () => {
+    const { onSubmit } = renderDialog();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record payment' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Enter a payment amount greater than zero.',
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('rejects a payment larger than the outstanding balance', () => {
+    const { onSubmit } = renderDialog();
+
+    fireEvent.change(screen.getByLabelText('Payment amount'), { target: { value: '4000.00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Record payment' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Payment cannot exceed the outstanding balance.',
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('closes on Cancel', () => {
+    const { onCancel } = renderDialog();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/invoices/InvoicePaymentDialog.tsx
+++ b/apps/web/src/components/invoices/InvoicePaymentDialog.tsx
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Accessible dialog for recording a full or partial payment against an invoice.
+ *
+ * References: issue #3224
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react';
+
+import { useFocusTrap } from '../../accessibility/aria';
+import { useAmountInput } from '../../hooks/useAmountInput';
+import { invoiceOutstandingCents, type Invoice } from '../../lib/analytics/invoices';
+import { CurrencyDisplay } from '../common';
+import { AmountInput } from '../forms/AmountInput';
+import '../forms/forms.css';
+
+export interface InvoicePaymentDialogProps {
+  isOpen: boolean;
+  invoice: Invoice | null;
+  onSubmit: (paymentCents: number, paidDate: string) => void;
+  onCancel: () => void;
+}
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function InvoicePaymentDialog({
+  isOpen,
+  invoice,
+  onSubmit,
+  onCancel,
+}: InvoicePaymentDialogProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const amountInputRef = useRef<HTMLInputElement>(null);
+  const amountErrorId = useId();
+  const titleId = useId();
+
+  const amountInput = useAmountInput({
+    currencySymbol: '$',
+    decimalPlaces: 2,
+    allowNegative: false,
+  });
+  const [paidDate, setPaidDate] = useState(todayIsoDate);
+  const [amountError, setAmountError] = useState<string | null>(null);
+
+  useFocusTrap(panelRef, { active: isOpen, restoreFocus: true });
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    amountInput.reset(0);
+    setPaidDate(todayIsoDate());
+    setAmountError(null);
+
+    const id = requestAnimationFrame(() => {
+      amountInputRef.current?.focus();
+    });
+
+    return () => cancelAnimationFrame(id);
+  }, [invoice?.id, isOpen]);
+
+  const handleCancel = useCallback(() => {
+    onCancel();
+  }, [onCancel]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCancel();
+      }
+    },
+    [handleCancel],
+  );
+
+  const handleSubmit = useCallback(
+    (event: FormEvent) => {
+      event.preventDefault();
+      if (!invoice) return;
+
+      const paymentCents = amountInput.cents;
+      const outstanding = invoiceOutstandingCents(invoice);
+
+      if (paymentCents <= 0) {
+        setAmountError('Enter a payment amount greater than zero.');
+        return;
+      }
+      if (paymentCents > outstanding) {
+        setAmountError('Payment cannot exceed the outstanding balance.');
+        return;
+      }
+
+      setAmountError(null);
+      onSubmit(paymentCents, paidDate);
+    },
+    [amountInput.cents, invoice, onSubmit, paidDate],
+  );
+
+  if (!isOpen || invoice === null) {
+    return null;
+  }
+
+  const outstanding = invoiceOutstandingCents(invoice);
+  const projectedOutstanding = Math.max(0, outstanding - amountInput.cents);
+  const hasAmountError = amountError !== null;
+  const amountId = `${titleId}-amount`;
+  const dateInputId = `${titleId}-date`;
+
+  return (
+    <div className="form-dialog" role="presentation" onKeyDown={handleKeyDown}>
+      <div className="form-dialog__backdrop" aria-hidden="true" onClick={handleCancel} />
+      <div
+        ref={panelRef}
+        className="form-dialog__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+      >
+        <h2 id={titleId} className="form-dialog__title">
+          Record payment for {invoice.clientName}
+        </h2>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: 'var(--spacing-3)',
+            marginBottom: 'var(--spacing-4)',
+          }}
+        >
+          <div>
+            <p className="card__title">Outstanding now</p>
+            <p className="card__value">
+              <CurrencyDisplay amount={outstanding} />
+            </p>
+          </div>
+          <div>
+            <p className="card__title">After payment</p>
+            <p className="card__value">
+              <CurrencyDisplay amount={projectedOutstanding} />
+            </p>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="form-fields">
+            <div className="form-group">
+              <label htmlFor={amountId} className="form-group__label form-group__label--required">
+                Payment amount
+              </label>
+              <AmountInput
+                ref={amountInputRef}
+                id={amountId}
+                amountInput={amountInput}
+                className={`form-input${hasAmountError ? ' form-input--error' : ''}`}
+                placeholder={amountInput.placeholderValue}
+                displayLabel="Entered payment amount"
+                aria-invalid={hasAmountError}
+                aria-describedby={hasAmountError ? amountErrorId : undefined}
+                aria-required="true"
+                autoComplete="off"
+              />
+              {hasAmountError && (
+                <span id={amountErrorId} className="form-error" role="alert">
+                  {amountError}
+                </span>
+              )}
+            </div>
+
+            <div className="form-group">
+              <label htmlFor={dateInputId} className="form-group__label">
+                Payment date
+              </label>
+              <input
+                id={dateInputId}
+                type="date"
+                className="form-input"
+                value={paidDate}
+                max={todayIsoDate()}
+                onChange={(event) => setPaidDate(event.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="form-actions">
+            <button
+              type="button"
+              className="form-button form-button--secondary"
+              onClick={handleCancel}
+            >
+              Cancel
+            </button>
+            <button type="submit" className="form-button form-button--primary">
+              Record payment
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default InvoicePaymentDialog;

--- a/apps/web/src/hooks/useInvoices.ts
+++ b/apps/web/src/hooks/useInvoices.ts
@@ -17,6 +17,7 @@ import {
   groupInvoicesByStatus,
   normalizeInvoiceStatuses,
   recordInvoiceContact,
+  recordInvoicePayment,
   type CreateInvoiceInput,
   type ForecastBucket,
   type Invoice,
@@ -36,6 +37,7 @@ export interface UseInvoicesResult {
   updateInvoice: (invoiceId: string, input: UpdateInvoiceInput) => void;
   updateInvoiceStatus: (invoiceId: string, status: InvoiceStatus) => void;
   logInvoiceContact: (invoiceId: string) => void;
+  recordPayment: (invoiceId: string, paymentCents: number, paidDate?: string) => void;
   deleteInvoice: (invoiceId: string) => void;
   refresh: () => void;
 }
@@ -160,6 +162,29 @@ export function useInvoices(): UseInvoicesResult {
     );
   }, []);
 
+  const recordPayment = useCallback(
+    (invoiceId: string, paymentCents: number, paidDate?: string) => {
+      const currentDate = todayIsoDate();
+      setToday(currentDate);
+      setInvoices((prev) =>
+        normalizeInvoiceStatuses(
+          prev.map((invoice) =>
+            invoice.id === invoiceId
+              ? recordInvoicePayment(
+                  invoice,
+                  paymentCents,
+                  paidDate ?? currentDate,
+                  new Date().toISOString(),
+                )
+              : invoice,
+          ),
+          currentDate,
+        ),
+      );
+    },
+    [],
+  );
+
   const pipelineGroups = useMemo(() => groupInvoicesByStatus(invoices, today), [invoices, today]);
   const forecastBuckets = useMemo(() => computeInvoiceForecast(invoices, today), [invoices, today]);
   const totalOutstandingCents = useMemo(
@@ -176,6 +201,7 @@ export function useInvoices(): UseInvoicesResult {
     updateInvoice,
     updateInvoiceStatus,
     logInvoiceContact,
+    recordPayment,
     deleteInvoice,
     refresh,
   };

--- a/apps/web/src/lib/analytics/invoices.test.ts
+++ b/apps/web/src/lib/analytics/invoices.test.ts
@@ -17,8 +17,11 @@ import {
   getInvoicesNeedingFollowUp,
   groupInvoicesByStatus,
   INVOICE_CSV_HEADER,
+  invoiceIsFullyPaid,
   invoiceNeedsFollowUp,
+  invoiceOutstandingCents,
   recordInvoiceContact,
+  recordInvoicePayment,
   type Invoice,
 } from './invoices';
 
@@ -34,6 +37,8 @@ function makeInvoice(overrides: Partial<Invoice>): Invoice {
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
     lastContactedDate: overrides.lastContactedDate,
+    amountPaidCents: overrides.amountPaidCents,
+    paidDate: overrides.paidDate,
   };
 }
 
@@ -315,5 +320,91 @@ describe('recordInvoiceContact', () => {
     expect(updated.updatedAt).toBe('2024-02-15T09:30:00Z');
     expect(updated.id).toBe('inv-9');
     expect(invoice.lastContactedDate).toBeUndefined();
+  });
+});
+
+describe('invoiceOutstandingCents', () => {
+  it('returns the full amount when nothing is paid', () => {
+    expect(invoiceOutstandingCents(makeInvoice({ amountCents: 400000 }))).toBe(400000);
+  });
+
+  it('subtracts partial payments', () => {
+    expect(
+      invoiceOutstandingCents(makeInvoice({ amountCents: 400000, amountPaidCents: 150000 })),
+    ).toBe(250000);
+  });
+
+  it('never returns a negative outstanding balance', () => {
+    expect(
+      invoiceOutstandingCents(makeInvoice({ amountCents: 400000, amountPaidCents: 500000 })),
+    ).toBe(0);
+  });
+});
+
+describe('invoiceIsFullyPaid', () => {
+  it('is false when a balance remains', () => {
+    expect(invoiceIsFullyPaid(makeInvoice({ amountCents: 400000, amountPaidCents: 150000 }))).toBe(
+      false,
+    );
+  });
+
+  it('is true when payments cover the full amount', () => {
+    expect(invoiceIsFullyPaid(makeInvoice({ amountCents: 400000, amountPaidCents: 400000 }))).toBe(
+      true,
+    );
+  });
+});
+
+describe('recordInvoicePayment', () => {
+  it('accumulates partial payments without mutating the original', () => {
+    const invoice = makeInvoice({ amountCents: 400000, status: 'Sent' });
+    const first = recordInvoicePayment(invoice, 150000, '2024-02-10', '2024-02-10T10:00:00Z');
+    expect(first.amountPaidCents).toBe(150000);
+    expect(first.paidDate).toBe('2024-02-10');
+    expect(first.status).toBe('Sent');
+    expect(invoice.amountPaidCents).toBeUndefined();
+
+    const second = recordInvoicePayment(first, 250000, '2024-02-20', '2024-02-20T10:00:00Z');
+    expect(second.amountPaidCents).toBe(400000);
+    expect(second.paidDate).toBe('2024-02-20');
+    expect(second.status).toBe('Paid');
+  });
+
+  it('clamps overpayment to the invoice amount and ignores negative payments', () => {
+    const invoice = makeInvoice({ amountCents: 400000, status: 'Sent' });
+    const over = recordInvoicePayment(invoice, 999999, '2024-02-10', '2024-02-10T10:00:00Z');
+    expect(over.amountPaidCents).toBe(400000);
+    expect(over.status).toBe('Paid');
+
+    const negative = recordInvoicePayment(invoice, -5000, '2024-02-10', '2024-02-10T10:00:00Z');
+    expect(negative.amountPaidCents).toBe(0);
+    expect(negative.status).toBe('Sent');
+  });
+});
+
+describe('computeInvoiceForecast with partial payments', () => {
+  it('buckets only the outstanding balance and drops fully-paid invoices', () => {
+    const partiallyPaid = makeInvoice({
+      id: 'p',
+      amountCents: 400000,
+      amountPaidCents: 150000,
+      status: 'Sent',
+      expectedPayDate: '2024-02-10',
+    });
+    const fullyPaidSent = makeInvoice({
+      id: 'f',
+      amountCents: 200000,
+      amountPaidCents: 200000,
+      status: 'Sent',
+      expectedPayDate: '2024-02-10',
+    });
+
+    const forecast = computeInvoiceForecast([partiallyPaid, fullyPaidSent], '2024-02-01');
+    const total = forecast.reduce((sum, bucket) => sum + bucket.totalCents, 0);
+
+    expect(total).toBe(250000);
+    const bucket = forecast.find((b) => b.invoices.some((invoice) => invoice.id === 'p'));
+    expect(bucket?.totalCents).toBe(250000);
+    expect(forecast.every((b) => b.invoices.every((invoice) => invoice.id !== 'f'))).toBe(true);
   });
 });

--- a/apps/web/src/lib/analytics/invoices.ts
+++ b/apps/web/src/lib/analytics/invoices.ts
@@ -28,6 +28,10 @@ export interface Invoice {
   readonly updatedAt: string;
   /** ISO date of the most recent follow-up sent for an overdue invoice. */
   readonly lastContactedDate?: string;
+  /** Total amount received so far, in cents (supports partial payments). */
+  readonly amountPaidCents?: number;
+  /** ISO date the most recent payment was received. */
+  readonly paidDate?: string;
 }
 
 export interface CreateInvoiceInput {
@@ -173,6 +177,48 @@ export function getInvoicesNeedingFollowUp(invoices: Invoice[], todayIso: string
     .sort((a, b) => a.expectedPayDate.localeCompare(b.expectedPayDate));
 }
 
+/** Amount still owed on an invoice after any partial payments, in cents (never negative). */
+export function invoiceOutstandingCents(invoice: Invoice): number {
+  return Math.max(0, invoice.amountCents - (invoice.amountPaidCents ?? 0));
+}
+
+/** Whether an invoice has been paid in full (recorded payments cover the total). */
+export function invoiceIsFullyPaid(invoice: Invoice): boolean {
+  return (invoice.amountPaidCents ?? 0) >= invoice.amountCents;
+}
+
+/**
+ * Record a (full or partial) payment against an invoice.
+ *
+ * Payments accumulate; the total is clamped to the invoice amount so the
+ * outstanding balance never goes negative. Negative payment amounts are
+ * ignored. When the cumulative payment covers the full amount the status is
+ * advanced to `Paid`.
+ *
+ * @param invoice - The invoice receiving payment.
+ * @param paymentCents - Amount received in this payment, in cents.
+ * @param paidDateIso - ISO date the payment was received.
+ * @param nowIso - Current timestamp (ISO 8601) for updatedAt.
+ * @returns A new invoice with the payment recorded.
+ */
+export function recordInvoicePayment(
+  invoice: Invoice,
+  paymentCents: number,
+  paidDateIso: string,
+  nowIso: string,
+): Invoice {
+  const priorPaid = invoice.amountPaidCents ?? 0;
+  const nextPaid = Math.min(priorPaid + Math.max(0, paymentCents), invoice.amountCents);
+  const fullyPaid = nextPaid >= invoice.amountCents;
+  return {
+    ...invoice,
+    amountPaidCents: nextPaid,
+    paidDate: paidDateIso,
+    status: fullyPaid ? 'Paid' : invoice.status,
+    updatedAt: nowIso,
+  };
+}
+
 export function createInvoice(input: CreateInvoiceInput, nowIso: string, id: string): Invoice {
   const invoice: Invoice = {
     id,
@@ -253,6 +299,9 @@ export function computeInvoiceForecast(invoices: Invoice[], todayIso: string): F
   for (const invoice of normalizeInvoiceStatuses(invoices, todayIso)) {
     if (invoice.status === 'Draft' || invoice.status === 'Paid') continue;
 
+    const outstandingCents = invoiceOutstandingCents(invoice);
+    if (outstandingCents <= 0) continue;
+
     const daysUntilPay = diffDays(todayIso, invoice.expectedPayDate);
     let bucketId: ForecastBucketId;
     if (daysUntilPay < 0) bucketId = 'past-due';
@@ -264,7 +313,7 @@ export function computeInvoiceForecast(invoices: Invoice[], todayIso: string): F
     const bucket = bucketById.get(bucketId);
     if (bucket) {
       bucket.invoices.push(invoice);
-      (bucket as { totalCents: number }).totalCents += invoice.amountCents;
+      (bucket as { totalCents: number }).totalCents += outstandingCents;
     }
   }
 

--- a/apps/web/src/pages/InvoicesPage.test.tsx
+++ b/apps/web/src/pages/InvoicesPage.test.tsx
@@ -60,6 +60,7 @@ beforeEach(() => {
     updateInvoice: vi.fn(),
     updateInvoiceStatus: vi.fn(),
     logInvoiceContact: vi.fn(),
+    recordPayment: vi.fn(),
     deleteInvoice: vi.fn(),
     refresh: vi.fn(),
   });
@@ -91,6 +92,7 @@ describe('InvoicesPage', () => {
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       logInvoiceContact: vi.fn(),
+      recordPayment: vi.fn(),
       deleteInvoice,
       refresh: vi.fn(),
     });
@@ -102,6 +104,79 @@ describe('InvoicesPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete invoice' }));
     expect(deleteInvoice).toHaveBeenCalledWith('inv-1');
+  });
+
+  it('records a payment through the payment dialog', () => {
+    const recordPayment = vi.fn();
+    mockedUseInvoices.mockReturnValue({
+      invoices: [SAMPLE_INVOICE],
+      pipelineGroups: [
+        { status: 'Sent', label: 'Sent', invoices: [SAMPLE_INVOICE], totalCents: 120_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
+      recordPayment,
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record payment for Etsy Wholesale' }));
+    expect(
+      screen.getByRole('dialog', { name: 'Record payment for Etsy Wholesale' }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Payment amount'), { target: { value: '500.00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Record payment' }));
+
+    expect(recordPayment).toHaveBeenCalledWith(
+      'inv-1',
+      50_000,
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+    );
+  });
+
+  it('summarizes progress on a partially paid invoice and hides payment on drafts', () => {
+    const partiallyPaid: Invoice = {
+      ...SAMPLE_INVOICE,
+      id: 'inv-paid',
+      amountPaidCents: 40_000,
+      paidDate: '2026-06-15',
+    };
+    const draft: Invoice = { ...SAMPLE_INVOICE, id: 'inv-draft', status: 'Draft' };
+    mockedUseInvoices.mockReturnValue({
+      invoices: [partiallyPaid, draft],
+      pipelineGroups: [
+        {
+          status: 'Sent',
+          label: 'Sent',
+          invoices: [partiallyPaid],
+          totalCents: 120_000,
+        },
+        { status: 'Draft', label: 'Draft', invoices: [draft], totalCents: 120_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 80_000,
+      addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
+      updateInvoiceStatus: vi.fn(),
+      logInvoiceContact: vi.fn(),
+      recordPayment: vi.fn(),
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    const paymentLine = screen.getByText(
+      (_, element) => element?.classList.contains('invoice-card__payment') ?? false,
+    );
+    expect(paymentLine).toHaveTextContent('outstanding');
+    // Draft invoices cannot receive payments, so only the Sent invoice offers the control.
+    expect(screen.getAllByRole('button', { name: /^Record payment for/ })).toHaveLength(1);
   });
 
   it('pluralizes the invoice count per pipeline group', () => {
@@ -118,6 +193,7 @@ describe('InvoicesPage', () => {
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       logInvoiceContact: vi.fn(),
+      recordPayment: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -140,6 +216,7 @@ describe('InvoicesPage', () => {
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       logInvoiceContact: vi.fn(),
+      recordPayment: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -162,6 +239,7 @@ describe('InvoicesPage', () => {
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       logInvoiceContact: vi.fn(),
+      recordPayment: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -191,6 +269,7 @@ describe('InvoicesPage', () => {
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       logInvoiceContact: vi.fn(),
+      recordPayment: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -214,6 +293,7 @@ describe('InvoicesPage', () => {
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       logInvoiceContact: vi.fn(),
+      recordPayment: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -238,6 +318,7 @@ describe('InvoicesPage', () => {
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       logInvoiceContact: vi.fn(),
+      recordPayment: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -275,6 +356,7 @@ describe('InvoicesPage', () => {
       updateInvoice,
       updateInvoiceStatus: vi.fn(),
       logInvoiceContact: vi.fn(),
+      recordPayment: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -309,6 +391,7 @@ describe('InvoicesPage', () => {
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       logInvoiceContact: vi.fn(),
+      recordPayment: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -344,6 +427,7 @@ describe('InvoicesPage', () => {
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       logInvoiceContact,
+      recordPayment: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });
@@ -378,6 +462,7 @@ describe('InvoicesPage', () => {
       updateInvoice: vi.fn(),
       updateInvoiceStatus: vi.fn(),
       logInvoiceContact: vi.fn(),
+      recordPayment: vi.fn(),
       deleteInvoice: vi.fn(),
       refresh: vi.fn(),
     });

--- a/apps/web/src/pages/InvoicesPage.tsx
+++ b/apps/web/src/pages/InvoicesPage.tsx
@@ -11,6 +11,7 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import { ConfirmDialog, CurrencyDisplay, EmptyState } from '../components/common';
+import { InvoicePaymentDialog } from '../components/invoices/InvoicePaymentDialog';
 import { useInvoices } from '../hooks/useInvoices';
 import { useLocalePreferences } from '../hooks/useLocalePreferences';
 import {
@@ -18,6 +19,8 @@ import {
   exportInvoicesCsv,
   FOLLOW_UP_STALE_DAYS,
   getInvoicesNeedingFollowUp,
+  invoiceIsFullyPaid,
+  invoiceOutstandingCents,
   PAYMENT_TERM_LABELS,
   PAYMENT_TERMS,
   INVOICE_STATUSES,
@@ -55,62 +58,94 @@ const InvoiceCard: React.FC<{
   isEditing: boolean;
   onEdit: (invoice: Invoice) => void;
   onStatusChange: (invoiceId: string, status: InvoiceStatus) => void;
+  onRecordPayment: (invoice: Invoice) => void;
   onDelete: (invoice: Invoice) => void;
-}> = ({ invoice, locale, isEditing, onEdit, onStatusChange, onDelete }) => (
-  <article
-    className={`invoice-card invoice-card--${invoice.status.toLowerCase()}${
-      isEditing ? ' invoice-card--editing' : ''
-    }`}
-    role="listitem"
-  >
-    <div className="invoice-card__main">
-      <div>
-        <h3 className="invoice-card__client">{invoice.clientName}</h3>
-        <p className="invoice-card__meta">
-          Issued {formatDate(invoice.issueDate, { locale })} ·{' '}
-          {PAYMENT_TERM_LABELS[invoice.paymentTerm]} · expected{' '}
-          {formatDate(invoice.expectedPayDate, { locale })}
+}> = ({ invoice, locale, isEditing, onEdit, onStatusChange, onRecordPayment, onDelete }) => {
+  const paidCents = invoice.amountPaidCents ?? 0;
+  const outstandingCents = invoiceOutstandingCents(invoice);
+  const fullyPaid = invoiceIsFullyPaid(invoice);
+  const canRecordPayment = invoice.status !== 'Draft' && !fullyPaid;
+
+  return (
+    <article
+      className={`invoice-card invoice-card--${invoice.status.toLowerCase()}${
+        isEditing ? ' invoice-card--editing' : ''
+      }`}
+      role="listitem"
+    >
+      <div className="invoice-card__main">
+        <div>
+          <h3 className="invoice-card__client">{invoice.clientName}</h3>
+          <p className="invoice-card__meta">
+            Issued {formatDate(invoice.issueDate, { locale })} ·{' '}
+            {PAYMENT_TERM_LABELS[invoice.paymentTerm]} · expected{' '}
+            {formatDate(invoice.expectedPayDate, { locale })}
+          </p>
+        </div>
+        <div className="invoice-card__amount">
+          <CurrencyDisplay amount={invoice.amountCents} />
+          <StatusBadge status={invoice.status} />
+        </div>
+      </div>
+      {paidCents > 0 && (
+        <p className="invoice-card__payment">
+          Paid <CurrencyDisplay amount={paidCents} /> of{' '}
+          <CurrencyDisplay amount={invoice.amountCents} /> ·{' '}
+          {fullyPaid ? (
+            'paid in full'
+          ) : (
+            <>
+              <CurrencyDisplay amount={outstandingCents} /> outstanding
+            </>
+          )}
+          {invoice.paidDate ? ` · last payment ${formatDate(invoice.paidDate, { locale })}` : ''}
         </p>
-      </div>
-      <div className="invoice-card__amount">
-        <CurrencyDisplay amount={invoice.amountCents} />
-        <StatusBadge status={invoice.status} />
-      </div>
-    </div>
-    <div className="invoice-card__actions">
-      <label className="invoice-card__status-label">
-        Status
-        <select
-          aria-label={`Status for ${invoice.clientName}`}
-          value={invoice.status}
-          onChange={(event) => onStatusChange(invoice.id, event.target.value as InvoiceStatus)}
+      )}
+      <div className="invoice-card__actions">
+        <label className="invoice-card__status-label">
+          Status
+          <select
+            aria-label={`Status for ${invoice.clientName}`}
+            value={invoice.status}
+            onChange={(event) => onStatusChange(invoice.id, event.target.value as InvoiceStatus)}
+          >
+            {INVOICE_STATUSES.map((status) => (
+              <option key={status} value={status}>
+                {status}
+              </option>
+            ))}
+          </select>
+        </label>
+        {canRecordPayment && (
+          <button
+            className="analytics-export-btn"
+            type="button"
+            aria-label={`Record payment for ${invoice.clientName}`}
+            onClick={() => onRecordPayment(invoice)}
+          >
+            Record payment
+          </button>
+        )}
+        <button
+          className="analytics-export-btn"
+          type="button"
+          aria-label={`Edit invoice for ${invoice.clientName}`}
+          onClick={() => onEdit(invoice)}
         >
-          {INVOICE_STATUSES.map((status) => (
-            <option key={status} value={status}>
-              {status}
-            </option>
-          ))}
-        </select>
-      </label>
-      <button
-        className="analytics-export-btn"
-        type="button"
-        aria-label={`Edit invoice for ${invoice.clientName}`}
-        onClick={() => onEdit(invoice)}
-      >
-        Edit
-      </button>
-      <button
-        className="analytics-export-btn"
-        type="button"
-        aria-label={`Delete invoice for ${invoice.clientName}`}
-        onClick={() => onDelete(invoice)}
-      >
-        Delete
-      </button>
-    </div>
-  </article>
-);
+          Edit
+        </button>
+        <button
+          className="analytics-export-btn"
+          type="button"
+          aria-label={`Delete invoice for ${invoice.clientName}`}
+          onClick={() => onDelete(invoice)}
+        >
+          Delete
+        </button>
+      </div>
+    </article>
+  );
+};
 
 export const InvoicesPage: React.FC = () => {
   const {
@@ -122,6 +157,7 @@ export const InvoicesPage: React.FC = () => {
     updateInvoice,
     updateInvoiceStatus,
     logInvoiceContact,
+    recordPayment,
     deleteInvoice,
   } = useInvoices();
   const { locale } = useLocalePreferences();
@@ -133,6 +169,7 @@ export const InvoicesPage: React.FC = () => {
   const [formError, setFormError] = useState<string | null>(null);
   const [deletingInvoice, setDeletingInvoice] = useState<Invoice | null>(null);
   const [editingInvoiceId, setEditingInvoiceId] = useState<string | null>(null);
+  const [payingInvoice, setPayingInvoice] = useState<Invoice | null>(null);
 
   const resetForm = useCallback(() => {
     setEditingInvoiceId(null);
@@ -160,6 +197,16 @@ export const InvoicesPage: React.FC = () => {
       setDeletingInvoice(null);
     }
   };
+
+  const handleRecordPayment = useCallback(
+    (paymentCents: number, paidDate: string) => {
+      if (payingInvoice) {
+        recordPayment(payingInvoice.id, paymentCents, paidDate);
+        setPayingInvoice(null);
+      }
+    },
+    [payingInvoice, recordPayment],
+  );
 
   const expectedPayDate = useMemo(
     () => (issueDate ? computeExpectedPayDate(issueDate, paymentTerm) : todayIsoDate()),
@@ -457,6 +504,7 @@ export const InvoicesPage: React.FC = () => {
                         isEditing={invoice.id === editingInvoiceId}
                         onEdit={handleEdit}
                         onStatusChange={updateInvoiceStatus}
+                        onRecordPayment={setPayingInvoice}
                         onDelete={setDeletingInvoice}
                       />
                     ))}
@@ -479,6 +527,13 @@ export const InvoicesPage: React.FC = () => {
         confirmLabel="Delete invoice"
         onConfirm={handleConfirmDelete}
         onCancel={() => setDeletingInvoice(null)}
+      />
+
+      <InvoicePaymentDialog
+        isOpen={payingInvoice !== null}
+        invoice={payingInvoice}
+        onSubmit={handleRecordPayment}
+        onCancel={() => setPayingInvoice(null)}
       />
     </div>
   );

--- a/apps/web/src/pages/analytics.css
+++ b/apps/web/src/pages/analytics.css
@@ -688,6 +688,12 @@
   font-size: var(--type-scale-caption-font-size);
 }
 
+.invoice-card__payment {
+  margin: var(--spacing-2) 0 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
 .invoice-card__amount {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Invoices could only be flipped `Sent` -> `Paid` with no record of **how much** was received or **when**. As a freelancer who takes deposits and staged payments (Diego), I could not see a per-invoice outstanding balance, and the cash-flow forecast counted the *full* invoice amount even after a client had partially paid — overstating expected income.

This adds paid-date and partial-payment tracking to the invoice pipeline.

## Changes

- **Model + domain** (`lib/analytics/invoices.ts`): optional `amountPaidCents` and `paidDate` on `Invoice`; `invoiceOutstandingCents` (never negative), `invoiceIsFullyPaid`, and `recordInvoicePayment` (accumulates payments, clamps the total to the invoice amount, ignores negatives, sets `paidDate`/`updatedAt`, and flips `status` to `Paid` once fully settled).
- **Forecast**: `computeInvoiceForecast` now buckets the **outstanding** balance and drops fully-paid invoices, so projected income reflects real receivables.
- **Hook** (`hooks/useInvoices.ts`): new `recordPayment(invoiceId, paymentCents, paidDate?)` mutation.
- **UI** (`pages/InvoicesPage.tsx` + new `components/invoices/InvoicePaymentDialog.tsx`): an accessible, focus-trapped payment dialog (mirrors `GoalContributionDialog`) with amount + date inputs, live outstanding/after-payment preview, and validation; a "Record payment" action and a payment-progress summary line on each invoice card (hidden for Drafts and fully-paid invoices).

## Accessibility

- Dialog uses `role="dialog"` + `aria-modal` + labelled title, `useFocusTrap` with focus restore, Escape-to-close, `role="alert"` validation errors, and distinct control names (`Record payment for {client}`).

## Issues

Closes #3224

Found by persona: Diego Ramirez (freelance-designer irregular-income)

## Testing

- [x] `tsc -b` clean
- [x] `prettier@3.9.4 --check` + `eslint --max-warnings 0` clean
- [x] `vitest run` — 47 tests pass across the 3 touched suites (lib helpers incl. cumulative/clamp/negative/forecast, dialog validation + submit, page record-payment flow + partial-paid summary + Draft hides control)