### PR TITLE
feat(web): add lump-sum and target-date payoff what-ifs (#3369, #3370)

### DIFF
--- a/apps/web/src/lib/date-utils.test.ts
+++ b/apps/web/src/lib/date-utils.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { addMonthsToIsoDate } from './date-utils';
+import { addMonthsToIsoDate, monthsUntilIsoDate } from './date-utils';
 
 describe('addMonthsToIsoDate', () => {
   it('adds whole months for a mid-month start date', () => {
@@ -35,5 +35,34 @@ describe('addMonthsToIsoDate', () => {
 
   it('handles large month counts (100-year non-amortizing horizon)', () => {
     expect(addMonthsToIsoDate('2025-01-31', 1200)).toBe('2125-01-31');
+  });
+});
+
+describe('monthsUntilIsoDate', () => {
+  it('counts whole months within a year', () => {
+    expect(monthsUntilIsoDate('2025-01-15', '2025-05-15')).toBe(4);
+  });
+
+  it('counts across a year boundary', () => {
+    expect(monthsUntilIsoDate('2025-11-01', '2026-03-01')).toBe(4);
+  });
+
+  it('ignores the day component', () => {
+    expect(monthsUntilIsoDate('2025-01-31', '2025-02-01')).toBe(1);
+  });
+
+  it('returns zero within the same month', () => {
+    expect(monthsUntilIsoDate('2025-06-01', '2025-06-30')).toBe(0);
+  });
+
+  it('returns a negative count for past dates', () => {
+    expect(monthsUntilIsoDate('2025-06-01', '2025-03-01')).toBe(-3);
+  });
+
+  it('is the month-granularity inverse of addMonthsToIsoDate', () => {
+    const today = '2025-04-10';
+    for (const n of [0, 1, 6, 18, 60]) {
+      expect(monthsUntilIsoDate(today, addMonthsToIsoDate(today, n))).toBe(n);
+    }
   });
 });

--- a/apps/web/src/lib/date-utils.ts
+++ b/apps/web/src/lib/date-utils.ts
@@ -32,3 +32,22 @@ export function addMonthsToIsoDate(todayIso: string, months: number): string {
   target.setUTCDate(Math.min(day, lastDayOfTargetMonth));
   return target.toISOString().slice(0, 10);
 }
+
+/**
+ * Counts whole calendar months from one ISO `YYYY-MM-DD` date to another, based
+ * on year and month only (the day component is ignored).
+ *
+ * This is the month-granularity inverse of {@link addMonthsToIsoDate}:
+ * `monthsUntilIsoDate(today, addMonthsToIsoDate(today, n))` returns `n` for any
+ * non-negative `n`. A `toIso` earlier than `fromIso` yields a negative count,
+ * which callers can treat as an unreachable (past) target date.
+ *
+ * @param fromIso - Start date as `YYYY-MM-DD`.
+ * @param toIso - End date as `YYYY-MM-DD`.
+ * @returns Whole months between the two dates (may be negative).
+ */
+export function monthsUntilIsoDate(fromIso: string, toIso: string): number {
+  const [fromYear, fromMonth] = fromIso.split('-').map((value) => Number.parseInt(value, 10));
+  const [toYear, toMonth] = toIso.split('-').map((value) => Number.parseInt(value, 10));
+  return (toYear - fromYear) * 12 + (toMonth - fromMonth);
+}

--- a/apps/web/src/lib/debt-payoff-engine.test.ts
+++ b/apps/web/src/lib/debt-payoff-engine.test.ts
@@ -23,11 +23,13 @@ import {
   calculateDebtToIncomeTrend,
   calculateExtraPaymentImpactScenarios,
   calculateInterestSavedCents,
+  calculateLumpSumImpact,
   calculateMonthlyInterestCents,
   calculatePayoffStrategyRecommendation,
   calculateSnowballOrder,
   calculateStrategyResult,
   compareStrategies,
+  solveExtraPaymentForTargetDate,
 } from './debt-payoff-engine';
 import type { Debt } from './debt-types';
 
@@ -777,5 +779,117 @@ describe('debt beta milestone and DTI additions', () => {
     );
 
     expect(changedIncomeTrend.trend[1].monthlyIncomeCents).toBe(200_000);
+  });
+});
+
+describe('calculateLumpSumImpact', () => {
+  const debts: Debt[] = [
+    {
+      id: 'cc',
+      name: 'Credit Card',
+      balanceCents: 500_000,
+      annualRateBps: 1999,
+      minimumPaymentCents: 15_000,
+      type: 'credit_card',
+    },
+    {
+      id: 'car',
+      name: 'Car Loan',
+      balanceCents: 900_000,
+      annualRateBps: 599,
+      minimumPaymentCents: 20_000,
+      type: 'auto_loan',
+    },
+  ];
+
+  it('reduces months and interest versus the same plan without the lump sum', () => {
+    const impact = calculateLumpSumImpact(debts, 'snowball', 10_000, 300_000, 1);
+
+    expect(impact.lumpSumCents).toBe(300_000);
+    expect(impact.appliedMonth).toBe(1);
+    expect(impact.withLumpSumMonths).toBeLessThan(impact.baselineMonths);
+    expect(impact.monthsSaved).toBeGreaterThan(0);
+    expect(impact.interestSavedCents).toBeGreaterThan(0);
+  });
+
+  it('reports no impact for a zero lump sum', () => {
+    const impact = calculateLumpSumImpact(debts, 'snowball', 10_000, 0);
+
+    expect(impact.monthsSaved).toBe(0);
+    expect(impact.interestSavedCents).toBe(0);
+    expect(impact.withLumpSumMonths).toBe(impact.baselineMonths);
+  });
+
+  it('clamps negative lump sums and fractional months to safe values', () => {
+    const impact = calculateLumpSumImpact(debts, 'avalanche', 5_000, -100_000, 2.9);
+
+    expect(impact.lumpSumCents).toBe(0);
+    expect(impact.appliedMonth).toBe(2);
+    expect(impact.monthsSaved).toBe(0);
+  });
+
+  it('saves more when the lump sum lands sooner', () => {
+    const early = calculateLumpSumImpact(debts, 'avalanche', 10_000, 300_000, 1);
+    const late = calculateLumpSumImpact(debts, 'avalanche', 10_000, 300_000, 12);
+
+    expect(early.interestSavedCents).toBeGreaterThanOrEqual(late.interestSavedCents);
+  });
+});
+
+describe('solveExtraPaymentForTargetDate', () => {
+  const debts: Debt[] = [
+    {
+      id: 'cc',
+      name: 'Credit Card',
+      balanceCents: 500_000,
+      annualRateBps: 1999,
+      minimumPaymentCents: 15_000,
+      type: 'credit_card',
+    },
+  ];
+
+  it('returns zero extra when the minimum-only plan already meets the target', () => {
+    const baseline = calculateStrategyResult(debts, 'avalanche', 0);
+    const solution = solveExtraPaymentForTargetDate(debts, 'avalanche', baseline.totalMonths + 12);
+
+    expect(solution.feasible).toBe(true);
+    expect(solution.requiredExtraPaymentCents).toBe(0);
+    expect(solution.resultingMonths).toBeLessThanOrEqual(baseline.totalMonths);
+  });
+
+  it('finds the minimum extra payment needed to hit an aggressive target', () => {
+    const target = 12;
+    const solution = solveExtraPaymentForTargetDate(debts, 'avalanche', target);
+
+    expect(solution.feasible).toBe(true);
+    expect(solution.requiredExtraPaymentCents).toBeGreaterThan(0);
+    expect(solution.resultingMonths).toBeLessThanOrEqual(target);
+
+    // The solution is minimal: one cent less misses the target.
+    const oneCentLess = calculateStrategyResult(
+      debts,
+      'avalanche',
+      solution.requiredExtraPaymentCents - 1,
+    );
+    const monthsOneCentLess = oneCentLess.fullyPaidOff
+      ? oneCentLess.totalMonths
+      : Number.POSITIVE_INFINITY;
+    expect(monthsOneCentLess).toBeGreaterThan(target);
+  });
+
+  it('marks impossible targets as infeasible', () => {
+    const solution = solveExtraPaymentForTargetDate(debts, 'avalanche', 0);
+
+    expect(solution.feasible).toBe(false);
+    expect(solution.requiredExtraPaymentCents).toBe(0);
+    expect(solution.resultingMonths).toBeGreaterThan(0);
+  });
+
+  it('returns a trivially feasible solution for an empty debt list', () => {
+    const solution = solveExtraPaymentForTargetDate([], 'avalanche', 12);
+
+    expect(solution.feasible).toBe(true);
+    expect(solution.requiredExtraPaymentCents).toBe(0);
+    expect(solution.resultingMonths).toBe(0);
   });
 });

--- a/apps/web/src/lib/debt-payoff-engine.ts
+++ b/apps/web/src/lib/debt-payoff-engine.ts
@@ -25,10 +25,13 @@ import type {
   DebtToIncomeTrendOptions,
   DebtToIncomeTrendPoint,
   ExtraPaymentImpactScenario,
+  LumpSumImpact,
+  OneTimePayment,
   PayoffStrategy,
   PayoffStrategyRecommendation,
   StrategyComparison,
   StrategyResult,
+  TargetDateSolution,
 } from './debt-types';
 
 // ---------------------------------------------------------------------------
@@ -214,12 +217,16 @@ export function calculateSnowballOrder(debts: readonly Debt[]): string[] {
  * @param debts - All debts to include.
  * @param strategy - 'avalanche' or 'snowball'.
  * @param extraPaymentCents - Additional monthly payment beyond all minimums (in cents).
+ * @param oneTimePayments - Optional one-time lump sums applied in specific months
+ *   (e.g. a tax refund). Each joins that month's shared pool and cascades in
+ *   strategy order like any other extra.
  * @returns Full strategy result with per-debt schedules and timeline.
  */
 export function calculateStrategyResult(
   debts: readonly Debt[],
   strategy: PayoffStrategy,
   extraPaymentCents: number,
+  oneTimePayments: readonly OneTimePayment[] = [],
 ): StrategyResult {
   if (debts.length === 0) {
     return {
@@ -236,6 +243,15 @@ export function calculateStrategyResult(
   }
 
   const safeExtra = Math.max(0, extraPaymentCents);
+
+  // Sum any one-time lump sums by the month they land in. Only positive amounts
+  // in real (>= 1) months count.
+  const oneTimeByMonth = new Map<number, number>();
+  for (const payment of oneTimePayments) {
+    if (payment.month >= 1 && payment.cents > 0) {
+      oneTimeByMonth.set(payment.month, (oneTimeByMonth.get(payment.month) ?? 0) + payment.cents);
+    }
+  }
 
   // Order debts by strategy
   const orderedIds =
@@ -272,7 +288,7 @@ export function calculateStrategyResult(
     // that cascades to debts in strategy order within THIS month.
     const monthInterest = new Map<string, number>();
     const monthPayment = new Map<string, number>();
-    let pool = safeExtra + freedUpPayment;
+    let pool = safeExtra + freedUpPayment + (oneTimeByMonth.get(month) ?? 0);
 
     for (const id of orderedIds) {
       const balance = balances.get(id) ?? 0;
@@ -406,6 +422,132 @@ export function compareStrategies(
     snowball,
     interestSavingsCents: snowball.totalInterestCents - avalanche.totalInterestCents,
     timeSavingsMonths: snowball.totalMonths - avalanche.totalMonths,
+  };
+}
+
+/**
+ * Model the effect of a one-time lump-sum payment on the active plan.
+ *
+ * Runs the same strategy twice — once with the recurring extra only, once with
+ * the lump sum added in the chosen month — and reports how much sooner the user
+ * reaches debt-free and how much interest they avoid. Savings are clamped at
+ * zero so a lump sum never appears to cost time or money.
+ *
+ * @param debts - All debts to include.
+ * @param strategy - Active payoff strategy.
+ * @param extraPaymentCents - Recurring monthly extra payment (cents).
+ * @param lumpSumCents - One-time amount to apply (cents); <= 0 yields no effect.
+ * @param appliedMonth - 1-indexed month to apply the lump sum (default: 1).
+ * @returns The lump sum's impact on months-to-debt-free and total interest.
+ */
+export function calculateLumpSumImpact(
+  debts: readonly Debt[],
+  strategy: PayoffStrategy,
+  extraPaymentCents: number,
+  lumpSumCents: number,
+  appliedMonth = 1,
+): LumpSumImpact {
+  const safeMonth = Math.max(1, Math.floor(appliedMonth));
+  const safeLumpSum = Math.max(0, lumpSumCents);
+
+  const baseline = calculateStrategyResult(debts, strategy, extraPaymentCents);
+  const withLumpSum =
+    safeLumpSum > 0
+      ? calculateStrategyResult(debts, strategy, extraPaymentCents, [
+          { month: safeMonth, cents: safeLumpSum },
+        ])
+      : baseline;
+
+  return {
+    lumpSumCents: safeLumpSum,
+    appliedMonth: safeMonth,
+    baselineMonths: baseline.totalMonths,
+    withLumpSumMonths: withLumpSum.totalMonths,
+    monthsSaved: Math.max(0, baseline.totalMonths - withLumpSum.totalMonths),
+    interestSavedCents: Math.max(0, baseline.totalInterestCents - withLumpSum.totalInterestCents),
+  };
+}
+
+/**
+ * Solve for the minimum recurring extra payment needed to be debt-free by a
+ * target month.
+ *
+ * More extra payment never increases the number of months to debt-free, so the
+ * relationship is monotonic and a binary search over the extra amount finds the
+ * smallest payment that reaches the target. The search upper bound pays every
+ * balance (plus its first month of interest) at once, clearing all debt in the
+ * first month; if even that cannot meet the target, the target is infeasible.
+ *
+ * @param debts - All debts to include.
+ * @param strategy - Active payoff strategy.
+ * @param targetMonths - Desired months-to-debt-free (>= 1).
+ * @returns The required extra payment and whether the target is achievable.
+ */
+export function solveExtraPaymentForTargetDate(
+  debts: readonly Debt[],
+  strategy: PayoffStrategy,
+  targetMonths: number,
+): TargetDateSolution {
+  if (debts.length === 0) {
+    return { feasible: true, requiredExtraPaymentCents: 0, resultingMonths: 0 };
+  }
+
+  const target = Math.floor(targetMonths);
+
+  // Months to debt-free at a given extra; Infinity when the plan never clears.
+  const monthsAt = (extraCents: number): number => {
+    const result = calculateStrategyResult(debts, strategy, extraCents);
+    return result.fullyPaidOff ? result.totalMonths : Number.POSITIVE_INFINITY;
+  };
+
+  const baseline = calculateStrategyResult(debts, strategy, 0);
+
+  if (target < 1) {
+    return { feasible: false, requiredExtraPaymentCents: 0, resultingMonths: baseline.totalMonths };
+  }
+
+  // Already on track with no extra payment.
+  if (baseline.fullyPaidOff && baseline.totalMonths <= target) {
+    return { feasible: true, requiredExtraPaymentCents: 0, resultingMonths: baseline.totalMonths };
+  }
+
+  // Upper bound: enough extra to clear every balance (and its first-month
+  // interest) in month one.
+  const totalBalanceCents = debts.reduce((sum, d) => sum + Math.max(0, d.balanceCents), 0);
+  const firstMonthInterestCents = debts.reduce(
+    (sum, d) => sum + calculateMonthlyInterestCents(Math.max(0, d.balanceCents), d.annualRateBps),
+    0,
+  );
+  const maxExtraCents = totalBalanceCents + firstMonthInterestCents;
+
+  const fastestMonths = monthsAt(maxExtraCents);
+  if (fastestMonths > target) {
+    // Even the largest payment cannot beat the target; report the soonest the
+    // user could realistically be debt-free instead of the minimum-only plan.
+    return {
+      feasible: false,
+      requiredExtraPaymentCents: 0,
+      resultingMonths: Number.isFinite(fastestMonths) ? fastestMonths : baseline.totalMonths,
+    };
+  }
+
+  // Binary search the smallest extra in [0, maxExtraCents] meeting the target.
+  let lo = 0;
+  let hi = maxExtraCents;
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    if (monthsAt(mid) <= target) {
+      hi = mid;
+    } else {
+      lo = mid + 1;
+    }
+  }
+
+  const resultingMonths = monthsAt(lo);
+  return {
+    feasible: true,
+    requiredExtraPaymentCents: lo,
+    resultingMonths: Number.isFinite(resultingMonths) ? resultingMonths : baseline.totalMonths,
   };
 }
 

--- a/apps/web/src/lib/debt-types.ts
+++ b/apps/web/src/lib/debt-types.ts
@@ -153,6 +153,51 @@ export interface ExtraPaymentImpactScenario {
   readonly payoffOrder: string[];
 }
 
+/**
+ * A one-time extra payment applied in a specific month (e.g. a tax refund or
+ * bonus thrown at the current target debt), on top of any recurring extra.
+ */
+export interface OneTimePayment {
+  /** 1-indexed month the lump sum is applied (month 1 = the coming month). */
+  readonly month: number;
+  /** Lump-sum amount in cents. */
+  readonly cents: number;
+}
+
+/**
+ * Effect of a one-time lump-sum payment on the active plan: how much sooner the
+ * user reaches debt-free and how much interest they avoid versus the same plan
+ * without the lump sum.
+ */
+export interface LumpSumImpact {
+  /** The lump sum modeled, in cents. */
+  readonly lumpSumCents: number;
+  /** Month the lump sum is applied (1-indexed). */
+  readonly appliedMonth: number;
+  /** Plan result without the lump sum. */
+  readonly baselineMonths: number;
+  /** Plan result with the lump sum applied. */
+  readonly withLumpSumMonths: number;
+  /** Months shaved off the debt-free date (>= 0). */
+  readonly monthsSaved: number;
+  /** Interest avoided by applying the lump sum, in cents (>= 0). */
+  readonly interestSavedCents: number;
+}
+
+/**
+ * Result of solving for the recurring extra payment needed to be debt-free by a
+ * target month. Infeasible when no achievable payment reaches the target (e.g.
+ * the target is in the past or sooner than paying every balance in full allows).
+ */
+export interface TargetDateSolution {
+  /** Whether a payment exists that meets the target. */
+  readonly feasible: boolean;
+  /** Minimum recurring extra payment (cents) that meets the target; 0 when infeasible. */
+  readonly requiredExtraPaymentCents: number;
+  /** Months to debt-free at the required payment; the capped horizon when infeasible. */
+  readonly resultingMonths: number;
+}
+
 /** Payoff milestone reached as principal is paid down. */
 export interface DebtMilestone {
   /** Milestone threshold percentage. */

--- a/apps/web/src/pages/DebtPage.css
+++ b/apps/web/src/pages/DebtPage.css
@@ -569,9 +569,14 @@
 [data-theme='dark'] .student-loan-stat-card,
 [data-theme='dark'] .student-loan-card,
 [data-theme='dark'] .student-loan-form,
-[data-theme='dark'] .student-loan-what-if {
+[data-theme='dark'] .student-loan-what-if,
+[data-theme='dark'] .debt-whatif {
   background: var(--semantic-background-primary, #1f2937);
   border-color: var(--semantic-border, #374151);
+}
+
+[data-theme='dark'] .debt-whatif__result {
+  background: var(--semantic-background-secondary, #111827);
 }
 
 /* ---------------------------------------------------------------------------
@@ -600,7 +605,8 @@
   .student-loan-stat-card,
   .student-loan-card,
   .student-loan-form,
-  .student-loan-what-if {
+  .student-loan-what-if,
+  .debt-whatif {
     border-width: 2px;
   }
 
@@ -936,6 +942,59 @@
   padding: var(--spacing-2, 0.5rem);
   text-align: left;
   vertical-align: top;
+}
+
+.debt-whatif {
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-radius: var(--radius-lg, 0.75rem);
+  background: var(--semantic-background-primary, #fff);
+  padding: var(--spacing-4, 1rem);
+  margin-bottom: var(--spacing-4, 1rem);
+}
+
+.debt-whatif__header h2 {
+  margin: 0 0 var(--spacing-1, 0.25rem);
+  font-size: var(--font-size-lg, 1.125rem);
+}
+
+.debt-whatif__header p {
+  margin: 0 0 var(--spacing-3, 0.75rem);
+  color: var(--semantic-text-secondary, #6b7280);
+  font-size: var(--font-size-sm, 0.875rem);
+}
+
+.debt-whatif__controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--spacing-3, 0.75rem);
+  align-items: end;
+}
+
+.debt-whatif label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2, 0.5rem);
+  font-size: var(--font-size-sm, 0.875rem);
+  font-weight: var(--font-weight-medium, 500);
+}
+
+.debt-whatif input {
+  width: 100%;
+  padding: var(--spacing-3, 0.75rem);
+  border: 1px solid var(--semantic-border, #e5e7eb);
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--semantic-background-primary, #fff);
+  color: inherit;
+  box-sizing: border-box;
+}
+
+.debt-whatif__result {
+  margin: var(--spacing-3, 0.75rem) 0 0;
+  padding: var(--spacing-3, 0.75rem);
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--semantic-background-secondary, #f9fafb);
+  font-size: var(--font-size-sm, 0.875rem);
+  line-height: var(--line-height-relaxed, 1.6);
 }
 
 .credit-card-form {

--- a/apps/web/src/pages/DebtPage.test.tsx
+++ b/apps/web/src/pages/DebtPage.test.tsx
@@ -208,6 +208,75 @@ describe('DebtPage', () => {
     expect(within(timeline).getAllByRole('listitem')).toHaveLength(2);
   });
 
+  it('models a one-time lump-sum payment what-if (#3370)', () => {
+    mockUseAccountsState.accounts = [
+      buildAccount({
+        id: 'cc-1',
+        name: 'Rewards Credit Card',
+        type: 'CREDIT_CARD',
+        currentBalance: { amount: -400_000 },
+      }),
+      buildAccount({
+        id: 'loan-1',
+        name: 'Personal Loan',
+        type: 'LOAN',
+        currentBalance: { amount: 800_000 },
+      }),
+    ];
+
+    render(<DebtPage />);
+
+    const region = screen.getByRole('region', { name: 'One-time payment what-if' });
+    // Prompts for input before an amount is entered.
+    expect(within(region).getByText(/Enter a lump-sum amount/i)).toBeDefined();
+
+    fireEvent.change(within(region).getByLabelText('Lump sum ($)'), {
+      target: { value: '2000' },
+    });
+
+    // The prompt is replaced by an impact summary that renders the lump sum.
+    expect(within(region).queryByText(/Enter a lump-sum amount/i)).toBeNull();
+    expect(
+      within(region)
+        .getAllByTestId('currency')
+        .some((element) => element.textContent === '200000'),
+    ).toBe(true);
+  });
+
+  it('solves for the extra payment needed to hit a target date (#3369)', () => {
+    mockUseAccountsState.accounts = [
+      buildAccount({
+        id: 'cc-1',
+        name: 'Rewards Credit Card',
+        type: 'CREDIT_CARD',
+        currentBalance: { amount: -400_000 },
+      }),
+      buildAccount({
+        id: 'loan-1',
+        name: 'Personal Loan',
+        type: 'LOAN',
+        currentBalance: { amount: 800_000 },
+      }),
+    ];
+
+    render(<DebtPage />);
+
+    const region = screen.getByRole('region', { name: 'Target debt-free date calculator' });
+    expect(within(region).getByText(/Pick a target month/i)).toBeDefined();
+
+    // An aggressive six-month target on ~$12k of debt requires a real extra payment.
+    const now = new Date();
+    const targetMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 6, 1))
+      .toISOString()
+      .slice(0, 7);
+    fireEvent.change(within(region).getByLabelText('Target debt-free month'), {
+      target: { value: targetMonth },
+    });
+
+    expect(within(region).getByText(/pay about/i)).toBeDefined();
+    expect(within(region).getAllByTestId('currency').length).toBeGreaterThan(0);
+  });
+
   it('warns instead of showing a countdown when the payment never covers interest (#3355)', () => {
     mockUseAccountsState.accounts = [
       buildAccount({

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -34,12 +34,14 @@ import {
   calculateDebtToIncomeTrend,
   calculateExtraPaymentImpactScenarios,
   calculateInterestSavedCents,
+  calculateLumpSumImpact,
   calculateMonthlyInterestCents,
   calculatePayoffStrategyRecommendation,
   calculateStrategyResult,
   compareStrategies,
+  solveExtraPaymentForTargetDate,
 } from '../lib/debt-payoff-engine';
-import { addMonthsToIsoDate } from '../lib/date-utils';
+import { addMonthsToIsoDate, monthsUntilIsoDate } from '../lib/date-utils';
 import { buildPayoffMilestones } from '../lib/debt/payoff-milestones';
 import { aggregateBnplDashboard, type BnplObligationDraft } from '../lib/debt/bnpl-aggregation';
 import {
@@ -616,6 +618,9 @@ function PayoffPlannerPanel(): React.ReactElement {
   const [dtiAnnualRaise, setDtiAnnualRaise] = useState('0');
   const [dtiTarget, setDtiTarget] = useState('36');
   const [impactScenarioInput, setImpactScenarioInput] = useState('25, 50, 100, 200');
+  const [lumpSumInput, setLumpSumInput] = useState('');
+  const [lumpSumMonthsInput, setLumpSumMonthsInput] = useState('1');
+  const [targetMonthInput, setTargetMonthInput] = useState('');
   const [consolidationForm, setConsolidationForm] = useState<ConsolidationFormState>(
     DEFAULT_CONSOLIDATION_FORM,
   );
@@ -748,6 +753,31 @@ function PayoffPlannerPanel(): React.ReactElement {
   );
   const diminishingReturnScenario = extraPaymentScenarios.find(
     (scenario) => scenario.isDiminishingReturn,
+  );
+  const lumpSumCents = parseCurrencyInput(lumpSumInput);
+  const lumpSumMonths = Math.max(1, Number.parseInt(lumpSumMonthsInput, 10) || 1);
+  const lumpSumImpact = useMemo(
+    () =>
+      debts.length > 0 && lumpSumCents > 0
+        ? calculateLumpSumImpact(
+            debts,
+            activeStrategy,
+            extraPaymentCents,
+            lumpSumCents,
+            lumpSumMonths,
+          )
+        : null,
+    [debts, activeStrategy, extraPaymentCents, lumpSumCents, lumpSumMonths],
+  );
+  const targetMonths = targetMonthInput
+    ? monthsUntilIsoDate(todayIso, `${targetMonthInput}-01`)
+    : null;
+  const targetDateSolution = useMemo(
+    () =>
+      debts.length > 0 && targetMonths !== null && targetMonths >= 1
+        ? solveExtraPaymentForTargetDate(debts, activeStrategy, targetMonths)
+        : null,
+    [debts, activeStrategy, targetMonths],
   );
   const consolidationComparison = useMemo(() => {
     if (debts.length === 0) return null;
@@ -1700,6 +1730,131 @@ function PayoffPlannerPanel(): React.ReactElement {
                 </tbody>
               </table>
             </div>
+          </section>
+          <section aria-label="One-time payment what-if" className="debt-whatif">
+            <div className="debt-whatif__header">
+              <h2>One-Time Payment What-If</h2>
+              <p>
+                Model a windfall — a tax refund, bonus, or gift — thrown at your{' '}
+                {formatStrategyName(activeStrategy)} plan to see how much sooner you reach
+                debt-free.
+              </p>
+            </div>
+            <div className="debt-whatif__controls">
+              <label>
+                Lump sum ($)
+                <input
+                  type="text"
+                  inputMode="decimal"
+                  value={lumpSumInput}
+                  onChange={(event) => setLumpSumInput(event.target.value)}
+                  placeholder="1,500"
+                />
+              </label>
+              <label>
+                Apply in (months from now)
+                <input
+                  type="number"
+                  min={1}
+                  value={lumpSumMonthsInput}
+                  onChange={(event) => setLumpSumMonthsInput(event.target.value)}
+                />
+              </label>
+            </div>
+            <p className="debt-whatif__result" role="status" aria-live="polite">
+              {debts.length === 0 ? (
+                'Add a debt to model a one-time payment.'
+              ) : lumpSumImpact && lumpSumImpact.lumpSumCents > 0 ? (
+                <>
+                  A{' '}
+                  <CurrencyDisplay amount={lumpSumImpact.lumpSumCents} context="one-time payment" />{' '}
+                  payment applied{' '}
+                  {formatMonthYear(addMonthsToIsoDate(todayIso, lumpSumImpact.appliedMonth))}{' '}
+                  {lumpSumImpact.monthsSaved > 0 ? (
+                    <>
+                      makes you debt-free by{' '}
+                      {formatMonthYear(
+                        addMonthsToIsoDate(todayIso, lumpSumImpact.withLumpSumMonths),
+                      )}{' '}
+                      — {lumpSumImpact.monthsSaved} {pluralize(lumpSumImpact.monthsSaved, 'month')}{' '}
+                      sooner and{' '}
+                      <CurrencyDisplay
+                        amount={lumpSumImpact.interestSavedCents}
+                        context="interest saved"
+                      />{' '}
+                      less interest.
+                    </>
+                  ) : lumpSumImpact.interestSavedCents > 0 ? (
+                    <>
+                      saves{' '}
+                      <CurrencyDisplay
+                        amount={lumpSumImpact.interestSavedCents}
+                        context="interest saved"
+                      />{' '}
+                      in interest, though your debt-free month stays the same.
+                    </>
+                  ) : (
+                    'is too small to change your payoff timeline at this size.'
+                  )}
+                </>
+              ) : (
+                'Enter a lump-sum amount to see the impact.'
+              )}
+            </p>
+          </section>
+          <section aria-label="Target debt-free date calculator" className="debt-whatif">
+            <div className="debt-whatif__header">
+              <h2>Hit a Target Date</h2>
+              <p>
+                Pick the month you want to be debt-free and we&apos;ll find the extra monthly
+                payment it takes on your {formatStrategyName(activeStrategy)} plan.
+              </p>
+            </div>
+            <label>
+              Target debt-free month
+              <input
+                type="month"
+                value={targetMonthInput}
+                onChange={(event) => setTargetMonthInput(event.target.value)}
+              />
+            </label>
+            <p className="debt-whatif__result" role="status" aria-live="polite">
+              {debts.length === 0 ? (
+                'Add a debt to calculate a target payoff.'
+              ) : !targetMonthInput ? (
+                'Pick a target month to see the required payment.'
+              ) : targetMonths !== null && targetMonths < 1 ? (
+                'Pick a month in the future.'
+              ) : targetDateSolution && targetDateSolution.feasible ? (
+                targetDateSolution.requiredExtraPaymentCents === 0 ? (
+                  <>
+                    You are already on track to be debt-free by{' '}
+                    {formatMonthYear(`${targetMonthInput}-01`)} with your current plan — no extra
+                    payment needed.
+                  </>
+                ) : (
+                  <>
+                    To be debt-free by {formatMonthYear(`${targetMonthInput}-01`)}, pay about{' '}
+                    <CurrencyDisplay
+                      amount={targetDateSolution.requiredExtraPaymentCents}
+                      context="required extra payment"
+                    />{' '}
+                    extra per month on top of your minimums.
+                  </>
+                )
+              ) : targetDateSolution ? (
+                <>
+                  That target is sooner than your plan allows. The soonest you can realistically be
+                  debt-free is{' '}
+                  {formatMonthYear(
+                    addMonthsToIsoDate(todayIso, Math.max(1, targetDateSolution.resultingMonths)),
+                  )}
+                  .
+                </>
+              ) : (
+                'Pick a target month to see the required payment.'
+              )}
+            </p>
           </section>
         </>
       )}


### PR DESCRIPTION
## Summary

Adds two debt-payoff planning tools to the **Payoff Planner** tab so a
tight-budget, debt-focused user (persona: Marcus) can plan around windfalls and
payoff deadlines:

- **One-time lump-sum what-if (#3370):** model a windfall — a tax refund, bonus,
  or gift — thrown at the active plan. Reports how many months it shaves off and
  how much interest it avoids, plus the resulting debt-free date. Supports
  choosing which month the lump sum lands in.
- **Target-date calculator (#3369):** pick the month you want to be debt-free
  and the tool binary-searches the recurring extra payment required on your
  active strategy. Shows a clear message when you're already on track (no extra
  needed) and an honest "sooner than your plan allows" message when a target is
  infeasible.

## Changes

**Engine (`apps/web/src/lib/debt-payoff-engine.ts`, pure + fully tested):**

- `calculateStrategyResult` now accepts an optional `oneTimePayments` argument.
  Lump sums are summed by month and injected into the shared monthly payment
  pool, so they cascade across debts in strategy order exactly like recurring
  extra. Existing three-argument callers are unaffected (default `[]`).
- New `calculateLumpSumImpact(debts, strategy, extraCents, lumpSumCents, month)`
  — runs the plan with and without the lump sum and returns months/interest
  saved (both clamped at zero).
- New `solveExtraPaymentForTargetDate(debts, strategy, targetMonths)` — monotonic
  binary search over the extra payment; upper bound clears every balance (plus
  first-month interest) in month one. Returns `{ feasible, requiredExtraPaymentCents, resultingMonths }`.

**Types (`debt-types.ts`):** `OneTimePayment`, `LumpSumImpact`, `TargetDateSolution`.

**Date helper (`date-utils.ts`):** `monthsUntilIsoDate` — the month-granularity
inverse of `addMonthsToIsoDate`, used to turn a target month into a month count.

**UI (`DebtPage.tsx` + `DebtPage.css`):** two accessible `<section>` cards with
labelled inputs, `aria-live="polite"` result text, no color-alone signals, and
dark-theme + high-contrast variants matching the existing debt cards.

## Issues

Closes #3369
Closes #3370

## Testing

- [x] Engine unit tests: lump-sum reduces months/interest, zero/negative lump
      sums are no-ops, earlier lump sums save at least as much, solver finds the
      minimal extra (one cent less misses the target), infeasible/empty cases.
- [x] `monthsUntilIsoDate` unit tests incl. inverse-of-`addMonthsToIsoDate`.
- [x] DebtPage integration tests for both controls (lump-sum impact renders;
      target-date solver returns a required payment).
- [x] `npx vitest run` — 101 affected tests pass.
- [x] `npx prettier --check` + `npx eslint --max-warnings 0` clean.

Found by persona: Marcus Johnson (aggressive debt-payoff)
