### PR TITLE
fix(web): count manual debts in learning recommendations (#3372)

### DIFF
--- a/apps/web/src/lib/learning/adaptive.test.ts
+++ b/apps/web/src/lib/learning/adaptive.test.ts
@@ -170,4 +170,50 @@ describe('learning adaptive recommendations', () => {
     expect(recommendations.map((item) => item.moduleId)).toContain('debt-management');
     expect(recommendations.map((item) => item.moduleId)).toContain('investing-fundamentals');
   });
+
+  it('raises the debt topic when only manually-entered debts exist (#3372)', () => {
+    const profile = buildLearningActivityProfile({
+      dashboardData: {
+        ...emptyDashboard,
+        monthlyBudget: 300000,
+        budgetSpent: 180000,
+        incomeThisMonth: 500000,
+        spentThisMonth: 240000,
+      },
+      // No CREDIT_CARD/LOAN accounts — the user tracks debts by hand.
+      accounts: [createAccount({ id: 'check-1', type: 'CHECKING' })],
+      goals: [createGoal({ name: 'Vacation' })],
+      transactions: [createTransaction({}), createTransaction({ id: 'transaction-2' })],
+      manualDebtCount: 3,
+    });
+
+    expect(profile.hasDebtAccounts).toBe(true);
+
+    const recommendations = suggestNextLessons({
+      modules: LEARNING_MODULES,
+      progress: createEmptyLearningProgress(),
+      activityProfile: profile,
+      limit: 3,
+    });
+
+    expect(recommendations.map((item) => item.moduleId)).toContain('debt-management');
+  });
+
+  it('leaves the debt topic quiet without debt accounts or manual debts', () => {
+    const profile = buildLearningActivityProfile({
+      dashboardData: {
+        ...emptyDashboard,
+        monthlyBudget: 300000,
+        budgetSpent: 180000,
+        incomeThisMonth: 500000,
+        spentThisMonth: 240000,
+      },
+      accounts: [createAccount({ id: 'check-1', type: 'CHECKING' })],
+      goals: [createGoal({ name: 'Vacation' })],
+      transactions: [createTransaction({})],
+      manualDebtCount: 0,
+    });
+
+    expect(profile.hasDebtAccounts).toBe(false);
+  });
 });

--- a/apps/web/src/lib/learning/adaptive.ts
+++ b/apps/web/src/lib/learning/adaptive.ts
@@ -36,17 +36,20 @@ export function buildLearningActivityProfile(input: {
   accounts: readonly Account[];
   goals: readonly Goal[];
   transactions: readonly Transaction[];
+  manualDebtCount?: number;
 }): LearningActivityProfile {
-  const { dashboardData, accounts, goals, transactions } = input;
+  const { dashboardData, accounts, goals, transactions, manualDebtCount = 0 } = input;
   const hasBudget = (dashboardData?.monthlyBudget ?? 0) > 0;
   const budgetUtilization =
     dashboardData !== null && dashboardData.monthlyBudget > 0
       ? dashboardData.budgetSpent / dashboardData.monthlyBudget
       : null;
   const savingsAccounts = accounts.filter((account) => account.type === 'SAVINGS');
-  const hasDebtAccounts = accounts.some(
-    (account) => account.type === 'CREDIT_CARD' || account.type === 'LOAN',
-  );
+  // Count manually-tracked debts too: a debt-payoff user who enters cards and
+  // loans by hand (rather than linking accounts) still needs debt lessons.
+  const hasDebtAccounts =
+    accounts.some((account) => account.type === 'CREDIT_CARD' || account.type === 'LOAN') ||
+    manualDebtCount > 0;
   const hasInvestmentAccounts = accounts.some((account) => account.type === 'INVESTMENT');
   const monthlySurplusCents =
     (dashboardData?.incomeThisMonth ?? 0) - (dashboardData?.spentThisMonth ?? 0);

--- a/apps/web/src/pages/LearningPage.tsx
+++ b/apps/web/src/pages/LearningPage.tsx
@@ -27,6 +27,7 @@ import {
   getCreditEducation,
   resolveCreditEducationLocale,
 } from '../lib/education/credit-building';
+import { readDebtTracker } from '../lib/debt/debt-tracker-persistence';
 import './LearningPage.css';
 
 // Built from a template literal so storage keys never look like hard-coded
@@ -265,16 +266,17 @@ export function LearningPage(): React.ReactElement {
     saveLearningProgress(progress);
   }, [progress]);
 
-  const activityProfile = useMemo(
-    () =>
-      buildLearningActivityProfile({
-        dashboardData: data,
-        accounts,
-        goals,
-        transactions,
-      }),
-    [accounts, data, goals, transactions],
-  );
+  const activityProfile = useMemo(() => {
+    const storage = typeof window === 'undefined' ? null : window.localStorage;
+    const manualDebtCount = storage ? readDebtTracker(storage).manualDebts.length : 0;
+    return buildLearningActivityProfile({
+      dashboardData: data,
+      accounts,
+      goals,
+      transactions,
+      manualDebtCount,
+    });
+  }, [accounts, data, goals, transactions]);
 
   const recommendations = useMemo(
     () =>


### PR DESCRIPTION
## Summary

The Learning page's adaptive recommendations decide whether to surface the
**Debt Management** module based on whether the user has debt. That check only
looked at linked `CREDIT_CARD` / `LOAN` **accounts** — so a debt-payoff user
(persona: Marcus) who enters their credit cards and car loan **by hand** on the
Debt page saw the debt module under-weighted or missing, even though debt is
their whole focus.

## Changes

- `buildLearningActivityProfile` (`apps/web/src/lib/learning/adaptive.ts`) now
  accepts an optional `manualDebtCount`. `hasDebtAccounts` is true when the user
  has either a linked debt account **or** at least one manually-entered debt.
- `LearningPage.tsx` reads the persisted manual-debt tracker (the same
  `readDebtTracker` store the Debt page uses) and passes the count into the
  profile builder.
- Existing callers are unaffected — `manualDebtCount` defaults to `0`.

## Issues

Closes #3372

## Testing

- [x] New unit tests: manual debts alone surface `debt-management`; no debt
      accounts and no manual debts keeps `hasDebtAccounts` false.
- [x] `npx vitest run` — adaptive + LearningPage suites pass.
- [x] `npx prettier --check` + `npx eslint --max-warnings 0` clean.

Found by persona: Marcus Johnson (aggressive debt-payoff)
