### PR TITLE
feat(web): add Schedule C category mapping and report (#3232)

### DIFF
--- a/apps/web/src/lib/tax/index.ts
+++ b/apps/web/src/lib/tax/index.ts
@@ -21,6 +21,7 @@ export * from './home-office-deductions';
 export * from './charitable-donations';
 export * from './tax-document-export';
 export * from './tax-category-tagging';
+export * from './schedule-c';
 export * from './capital-gains-reporting';
 export * from './retirement-contribution-limits';
 export * from './regional-conventions';

--- a/apps/web/src/lib/tax/schedule-c.test.ts
+++ b/apps/web/src/lib/tax/schedule-c.test.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the Schedule C mapping and report builder.
+ *
+ * References: issue #3232
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type {
+  TaxCategory,
+  TaxCategorySummary,
+  TaxCategorySummaryRow,
+} from './tax-category-tagging';
+import {
+  buildScheduleCReport,
+  mapTaxCategoryToScheduleCLine,
+  SCHEDULE_C_DISCLAIMER,
+  SCHEDULE_C_LINES,
+  unmappedCategoryReason,
+} from './schedule-c';
+
+function row(
+  category: TaxCategory,
+  overrides: Partial<TaxCategorySummaryRow> = {},
+): TaxCategorySummaryRow {
+  return {
+    category,
+    transactionCount: 1,
+    grossAmountCents: 0,
+    deductibleAmountCents: 0,
+    missingReceiptCount: 0,
+    reviewNeededCount: 0,
+    ...overrides,
+  };
+}
+
+function summary(
+  rows: TaxCategorySummaryRow[],
+  overrides: Partial<TaxCategorySummary> = {},
+): TaxCategorySummary {
+  return {
+    taxYear: 2024,
+    rows,
+    totalDeductibleAmountCents: rows.reduce((sum, r) => sum + r.deductibleAmountCents, 0),
+    missingReceiptTransactionIds: [],
+    reviewTransactionIds: [],
+    uncategorizedTransactionIds: [],
+    ...overrides,
+  };
+}
+
+describe('mapTaxCategoryToScheduleCLine', () => {
+  it('maps business categories to the expected Schedule C lines', () => {
+    expect(mapTaxCategoryToScheduleCLine('SCHEDULE_C_INCOME')?.lineNumber).toBe('1');
+    expect(mapTaxCategoryToScheduleCLine('SCHEDULE_C_EXPENSE')?.lineNumber).toBe('27a');
+    expect(mapTaxCategoryToScheduleCLine('BUSINESS_MEALS')?.lineNumber).toBe('24b');
+    expect(mapTaxCategoryToScheduleCLine('HOME_OFFICE')?.lineNumber).toBe('30');
+    expect(mapTaxCategoryToScheduleCLine('BUSINESS_MILEAGE')?.lineNumber).toBe('9');
+    expect(mapTaxCategoryToScheduleCLine('CAPITALIZED_ASSET')?.lineNumber).toBe('13');
+  });
+
+  it('returns null for personal / non-Schedule-C categories', () => {
+    expect(mapTaxCategoryToScheduleCLine('CHARITABLE_CASH')).toBeNull();
+    expect(mapTaxCategoryToScheduleCLine('MEDICAL')).toBeNull();
+    expect(mapTaxCategoryToScheduleCLine('STATE_LOCAL_TAX')).toBeNull();
+    expect(mapTaxCategoryToScheduleCLine('REIMBURSABLE')).toBeNull();
+    expect(mapTaxCategoryToScheduleCLine('REVIEW_NEEDED')).toBeNull();
+  });
+
+  it('every mapped line is part of the published catalog', () => {
+    for (const line of SCHEDULE_C_LINES) {
+      expect(line.id).toMatch(/^line-/);
+    }
+  });
+});
+
+describe('unmappedCategoryReason', () => {
+  it('explains why charitable gifts are excluded', () => {
+    expect(unmappedCategoryReason('CHARITABLE_CASH')).toContain('Schedule A');
+  });
+
+  it('flags review-needed items', () => {
+    expect(unmappedCategoryReason('REVIEW_NEEDED')).toContain('review');
+  });
+});
+
+describe('buildScheduleCReport', () => {
+  it('splits income and expense lines and computes net profit', () => {
+    const report = buildScheduleCReport(
+      summary([
+        row('SCHEDULE_C_INCOME', { grossAmountCents: 900000, transactionCount: 3 }),
+        row('SCHEDULE_C_EXPENSE', {
+          grossAmountCents: 120000,
+          deductibleAmountCents: 120000,
+          transactionCount: 2,
+        }),
+        row('HOME_OFFICE', { grossAmountCents: 60000, deductibleAmountCents: 60000 }),
+      ]),
+    );
+
+    expect(report.taxYear).toBe(2024);
+    expect(report.incomeRows).toHaveLength(1);
+    expect(report.incomeRows[0].line.lineNumber).toBe('1');
+    expect(report.totalIncomeCents).toBe(900000);
+    expect(report.totalExpenseCents).toBe(180000);
+    expect(report.netProfitCents).toBe(720000);
+    expect(report.expenseRows.map((r) => r.line.lineNumber)).toEqual(['27a', '30']);
+  });
+
+  it('uses the deductible amount for partially deductible expense lines', () => {
+    const report = buildScheduleCReport(
+      summary([
+        // A $200 meal is only 50% deductible.
+        row('BUSINESS_MEALS', { grossAmountCents: 20000, deductibleAmountCents: 10000 }),
+      ]),
+    );
+
+    const meals = report.expenseRows.find((r) => r.line.lineNumber === '24b');
+    expect(meals?.amountCents).toBe(10000);
+    expect(report.totalExpenseCents).toBe(10000);
+  });
+
+  it('rolls multiple categories that share a line into one row', () => {
+    const report = buildScheduleCReport(
+      summary([
+        row('SCHEDULE_C_EXPENSE', { deductibleAmountCents: 5000, transactionCount: 1 }),
+        row('SCHEDULE_C_EXPENSE', { deductibleAmountCents: 3000, transactionCount: 1 }),
+      ]),
+    );
+
+    // summarizeTaxCategories dedupes categories, but the builder must still be
+    // additive if a category appears more than once.
+    const other = report.expenseRows.filter((r) => r.line.lineNumber === '27a');
+    expect(other).toHaveLength(1);
+    expect(other[0].amountCents).toBe(8000);
+    expect(other[0].transactionCount).toBe(2);
+  });
+
+  it('surfaces non-Schedule-C categories with a reason instead of dropping them', () => {
+    const report = buildScheduleCReport(
+      summary([
+        row('CHARITABLE_CASH', { grossAmountCents: 25000 }),
+        row('MEDICAL', { grossAmountCents: 40000 }),
+      ]),
+    );
+
+    expect(report.expenseRows).toHaveLength(0);
+    expect(report.unmappedRows).toHaveLength(2);
+    expect(report.unmappedRows.map((r) => r.category)).toContain('CHARITABLE_CASH');
+    expect(report.unmappedRows[0].reason).toBeTruthy();
+  });
+
+  it('carries review and missing-receipt counts through', () => {
+    const report = buildScheduleCReport(
+      summary([row('SCHEDULE_C_EXPENSE', { deductibleAmountCents: 1000 })], {
+        reviewTransactionIds: ['t1', 't2'],
+        missingReceiptTransactionIds: ['t3'],
+      }),
+    );
+
+    expect(report.reviewNeededCount).toBe(2);
+    expect(report.missingReceiptCount).toBe(1);
+  });
+
+  it('produces an empty report for an empty summary', () => {
+    const report = buildScheduleCReport(summary([]));
+
+    expect(report.incomeRows).toHaveLength(0);
+    expect(report.expenseRows).toHaveLength(0);
+    expect(report.netProfitCents).toBe(0);
+    expect(report.unmappedRows).toHaveLength(0);
+  });
+
+  it('publishes a non-empty tax-advice disclaimer', () => {
+    expect(SCHEDULE_C_DISCLAIMER).toContain('not tax advice');
+  });
+});

--- a/apps/web/src/lib/tax/schedule-c.ts
+++ b/apps/web/src/lib/tax/schedule-c.ts
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Schedule C (Form 1040) line mapping and report builder for sole proprietors.
+ *
+ * Maps the app's {@link TaxCategory} taxonomy onto US IRS Schedule C lines so a
+ * freelancer can read a Schedule-C-style summary instead of hand-translating
+ * generic P&L buckets at tax time. This module is intentionally pure and
+ * consumes the output of {@link summarizeTaxCategories}, so UI, export, and
+ * future platforms can share one mapping.
+ *
+ * These mappings are automated estimates, NOT tax advice. Only business
+ * categories map to Schedule C; personal deductions (charitable, medical,
+ * state/local tax) belong on other schedules and are surfaced separately so
+ * nothing is silently dropped.
+ *
+ * References: IRS Form 1040 Schedule C (2023); issue #3232.
+ */
+
+import type { TaxCategory, TaxCategorySummary } from './tax-category-tagging';
+
+export const SCHEDULE_C_DISCLAIMER =
+  'Schedule C mappings are automated estimates, not tax advice. Only business ' +
+  'expenses map to Schedule C — review every line (and any unmapped or ' +
+  'review-needed items) with a tax professional before filing.';
+
+/** Which Schedule C part a line belongs to. */
+export type ScheduleCPart = 'income' | 'expenses' | 'home';
+
+/** A single Schedule C line the app can map transactions onto. */
+export interface ScheduleCLine {
+  /** Stable identifier for React keys and lookups. */
+  readonly id: string;
+  /** IRS line number as printed on the form (e.g. '1', '24b', '27a', '30'). */
+  readonly lineNumber: string;
+  /** Human-readable line label. */
+  readonly label: string;
+  /** Part of the form this line belongs to. */
+  readonly part: ScheduleCPart;
+}
+
+const LINE_GROSS_RECEIPTS: ScheduleCLine = {
+  id: 'line-1-gross-receipts',
+  lineNumber: '1',
+  label: 'Gross receipts or sales',
+  part: 'income',
+};
+
+const LINE_CAR_AND_TRUCK: ScheduleCLine = {
+  id: 'line-9-car-and-truck',
+  lineNumber: '9',
+  label: 'Car and truck expenses',
+  part: 'expenses',
+};
+
+const LINE_DEPRECIATION: ScheduleCLine = {
+  id: 'line-13-depreciation',
+  lineNumber: '13',
+  label: 'Depreciation and section 179',
+  part: 'expenses',
+};
+
+const LINE_MEALS: ScheduleCLine = {
+  id: 'line-24b-meals',
+  lineNumber: '24b',
+  label: 'Deductible meals',
+  part: 'expenses',
+};
+
+const LINE_OTHER_EXPENSES: ScheduleCLine = {
+  id: 'line-27a-other-expenses',
+  lineNumber: '27a',
+  label: 'Other business expenses',
+  part: 'expenses',
+};
+
+const LINE_HOME_OFFICE: ScheduleCLine = {
+  id: 'line-30-home-office',
+  lineNumber: '30',
+  label: 'Expenses for business use of home',
+  part: 'home',
+};
+
+/**
+ * Ordered catalog of the Schedule C lines this module can populate today.
+ *
+ * Finer expense lines (advertising, supplies, contract labor, etc.) require the
+ * deductible-category detail tracked in issue #3226; until a transaction can
+ * carry that detail, general business expenses roll up into line 27a.
+ */
+export const SCHEDULE_C_LINES: readonly ScheduleCLine[] = [
+  LINE_GROSS_RECEIPTS,
+  LINE_CAR_AND_TRUCK,
+  LINE_DEPRECIATION,
+  LINE_MEALS,
+  LINE_OTHER_EXPENSES,
+  LINE_HOME_OFFICE,
+];
+
+const CATEGORY_TO_LINE: Readonly<Partial<Record<TaxCategory, ScheduleCLine>>> = {
+  SCHEDULE_C_INCOME: LINE_GROSS_RECEIPTS,
+  SCHEDULE_C_EXPENSE: LINE_OTHER_EXPENSES,
+  BUSINESS_MEALS: LINE_MEALS,
+  HOME_OFFICE: LINE_HOME_OFFICE,
+  BUSINESS_MILEAGE: LINE_CAR_AND_TRUCK,
+  CAPITALIZED_ASSET: LINE_DEPRECIATION,
+};
+
+const UNMAPPED_REASONS: Readonly<Partial<Record<TaxCategory, string>>> = {
+  CHARITABLE_CASH: 'Personal charitable gift — Schedule A, not Schedule C.',
+  CHARITABLE_NON_CASH: 'Personal charitable gift — Schedule A, not Schedule C.',
+  MEDICAL: 'Personal medical expense — Schedule A, not Schedule C.',
+  EDUCATION: 'Personal education — reported on another schedule, not Schedule C.',
+  STATE_LOCAL_TAX: 'Personal state/local tax — Schedule A, not Schedule C.',
+  RETIREMENT_CONTRIBUTION: 'Self-employed retirement contribution — Schedule 1, not Schedule C.',
+  INVESTMENT_TAX: 'Investment-related — Schedule D or other, not Schedule C.',
+  PERSONAL_NON_DEDUCTIBLE: 'Personal, non-deductible expense.',
+  REIMBURSABLE: 'Reimbursable — excluded (not your deduction to take).',
+  REVIEW_NEEDED: 'Needs review before it can be mapped to a Schedule C line.',
+};
+
+/**
+ * Map an app tax category to its Schedule C line, or `null` when the category
+ * does not belong on Schedule C (personal deduction, reimbursable, or review).
+ */
+export function mapTaxCategoryToScheduleCLine(category: TaxCategory): ScheduleCLine | null {
+  return CATEGORY_TO_LINE[category] ?? null;
+}
+
+/** Explain why a category is not mapped to a Schedule C line. */
+export function unmappedCategoryReason(category: TaxCategory): string {
+  return UNMAPPED_REASONS[category] ?? 'Not mapped to a Schedule C line.';
+}
+
+/** A populated Schedule C line with its rolled-up amount. */
+export interface ScheduleCReportRow {
+  readonly line: ScheduleCLine;
+  readonly transactionCount: number;
+  readonly amountCents: number;
+}
+
+/** A category that carries value but does not map onto Schedule C. */
+export interface ScheduleCUnmappedRow {
+  readonly category: TaxCategory;
+  readonly transactionCount: number;
+  readonly amountCents: number;
+  readonly reason: string;
+}
+
+/** A Schedule-C-style report for a single tax year. */
+export interface ScheduleCReport {
+  readonly taxYear: number;
+  readonly incomeRows: readonly ScheduleCReportRow[];
+  readonly expenseRows: readonly ScheduleCReportRow[];
+  readonly totalIncomeCents: number;
+  readonly totalExpenseCents: number;
+  readonly netProfitCents: number;
+  readonly unmappedRows: readonly ScheduleCUnmappedRow[];
+  readonly reviewNeededCount: number;
+  readonly missingReceiptCount: number;
+}
+
+interface MutableLineBucket {
+  readonly line: ScheduleCLine;
+  transactionCount: number;
+  amountCents: number;
+}
+
+function lineOrder(row: ScheduleCReportRow): number {
+  const index = SCHEDULE_C_LINES.findIndex((line) => line.id === row.line.id);
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+}
+
+/**
+ * Group a {@link TaxCategorySummary} into a Schedule-C-style report.
+ *
+ * Income lines use gross amounts (gross receipts are reported gross); expense
+ * lines use the deductible amount so partially deductible categories (e.g.
+ * meals) contribute only their deductible share. Categories that do not map to
+ * Schedule C are returned in `unmappedRows` with a reason.
+ */
+export function buildScheduleCReport(summary: TaxCategorySummary): ScheduleCReport {
+  const buckets = new Map<string, MutableLineBucket>();
+  const unmappedRows: ScheduleCUnmappedRow[] = [];
+
+  for (const row of summary.rows) {
+    const line = mapTaxCategoryToScheduleCLine(row.category);
+    if (line === null) {
+      if (row.grossAmountCents > 0 || row.transactionCount > 0) {
+        unmappedRows.push({
+          category: row.category,
+          transactionCount: row.transactionCount,
+          amountCents: row.grossAmountCents,
+          reason: unmappedCategoryReason(row.category),
+        });
+      }
+      continue;
+    }
+
+    const amountCents = line.part === 'income' ? row.grossAmountCents : row.deductibleAmountCents;
+    const existing = buckets.get(line.id);
+    if (existing) {
+      existing.transactionCount += row.transactionCount;
+      existing.amountCents += amountCents;
+    } else {
+      buckets.set(line.id, {
+        line,
+        transactionCount: row.transactionCount,
+        amountCents,
+      });
+    }
+  }
+
+  const allRows: ScheduleCReportRow[] = [...buckets.values()].map((bucket) => ({
+    line: bucket.line,
+    transactionCount: bucket.transactionCount,
+    amountCents: bucket.amountCents,
+  }));
+
+  const incomeRows = allRows.filter((row) => row.line.part === 'income').sort(byLine);
+  const expenseRows = allRows.filter((row) => row.line.part !== 'income').sort(byLine);
+
+  const totalIncomeCents = incomeRows.reduce((sum, row) => sum + row.amountCents, 0);
+  const totalExpenseCents = expenseRows.reduce((sum, row) => sum + row.amountCents, 0);
+
+  return {
+    taxYear: summary.taxYear,
+    incomeRows,
+    expenseRows,
+    totalIncomeCents,
+    totalExpenseCents,
+    netProfitCents: totalIncomeCents - totalExpenseCents,
+    unmappedRows,
+    reviewNeededCount: summary.reviewTransactionIds.length,
+    missingReceiptCount: summary.missingReceiptTransactionIds.length,
+  };
+}
+
+function byLine(a: ScheduleCReportRow, b: ScheduleCReportRow): number {
+  return lineOrder(a) - lineOrder(b);
+}

--- a/apps/web/src/pages/BusinessPnlPage.css
+++ b/apps/web/src/pages/BusinessPnlPage.css
@@ -301,3 +301,43 @@
     transition: none;
   }
 }
+
+.business-pnl__schedule-c-note {
+  margin: 0 0 var(--spacing-3);
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--semantic-background-secondary);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-md);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.business-pnl__schedule-c-unmapped {
+  margin-top: var(--spacing-3);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.business-pnl__schedule-c-unmapped > summary {
+  cursor: pointer;
+  color: var(--semantic-text-primary);
+  font-weight: var(--font-weight-medium);
+}
+
+.business-pnl__schedule-c-unmapped-list {
+  margin: var(--spacing-2) 0 0;
+  padding-left: var(--spacing-4);
+  display: grid;
+  gap: var(--spacing-1);
+}
+
+.business-pnl__schedule-c-unmapped-amount {
+  color: var(--semantic-text-primary);
+  font-weight: var(--font-weight-medium);
+}
+
+.business-pnl__schedule-c-flags {
+  margin: var(--spacing-3) 0 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}

--- a/apps/web/src/pages/BusinessPnlPage.test.tsx
+++ b/apps/web/src/pages/BusinessPnlPage.test.tsx
@@ -29,6 +29,7 @@ function makeTransaction(options: {
   type: TransactionType;
   amountCents: number;
   tags?: readonly string[];
+  customFields?: Record<string, string> | null;
 }): Transaction {
   nextId += 1;
   return {
@@ -55,7 +56,7 @@ function makeTransaction(options: {
     merchantCountry: null,
     externalReferenceId: null,
     statementDescription: null,
-    customFields: null,
+    customFields: options.customFields ?? null,
     extraNotes: null,
     counterpartyName: null,
     counterpartyAccountId: null,
@@ -190,5 +191,53 @@ describe('BusinessPnlPage', () => {
     clickSpy.mockRestore();
     delete (URL as unknown as Record<string, unknown>).createObjectURL;
     delete (URL as unknown as Record<string, unknown>).revokeObjectURL;
+  });
+
+  it('maps tagged transactions to Schedule C lines with a disclaimer', () => {
+    mockUseTransactions.mockReturnValue(
+      mockResult({
+        transactions: [
+          makeTransaction({
+            date: '2024-02-01',
+            type: 'INCOME',
+            amountCents: 900_000,
+            customFields: {
+              'tax.category': 'SCHEDULE_C_INCOME',
+              'tax.deductibleStatus': 'DEDUCTIBLE',
+            },
+          }),
+          makeTransaction({
+            date: '2024-02-02',
+            type: 'EXPENSE',
+            amountCents: 120_000,
+            customFields: {
+              'tax.category': 'HOME_OFFICE',
+              'tax.deductibleStatus': 'DEDUCTIBLE',
+            },
+          }),
+          makeTransaction({
+            date: '2024-02-03',
+            type: 'EXPENSE',
+            amountCents: 40_000,
+            customFields: {
+              'tax.category': 'CHARITABLE_CASH',
+              'tax.deductibleStatus': 'DEDUCTIBLE',
+            },
+          }),
+        ],
+      }),
+    );
+    render(<BusinessPnlPage />);
+
+    const section = screen.getByRole('region', { name: /Schedule C view/i });
+    // Income line 1 and expense line 30 are mapped from the tagged transactions.
+    expect(within(section).getByText('Gross receipts or sales')).toBeInTheDocument();
+    expect(within(section).getByText('Expenses for business use of home')).toBeInTheDocument();
+    // Net profit = $9,000 income − $1,200 home office = $7,800.
+    expect(within(section).getByText('$7,800.00')).toBeInTheDocument();
+    // Personal charitable gift is surfaced as not-on-Schedule-C, never silently dropped.
+    expect(within(section).getByText(/Not on Schedule C/i)).toBeInTheDocument();
+    // The advisory disclaimer is always present.
+    expect(within(section).getByText(/not tax advice/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/BusinessPnlPage.tsx
+++ b/apps/web/src/pages/BusinessPnlPage.tsx
@@ -15,6 +15,7 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { DateInput, ErrorBanner, LoadingSpinner } from '../components/common';
 import { useTransactions } from '../hooks/useTransactions';
+import type { Transaction } from '../kmp/bridge';
 import { formatCurrency } from '../lib/currency';
 import { buildDatedExportFileName } from '../lib/export/simple-export';
 import {
@@ -24,6 +25,13 @@ import {
   type PnlGranularity,
   type PnlTotals,
 } from '../lib/business/profit-and-loss';
+import {
+  buildScheduleCReport,
+  SCHEDULE_C_DISCLAIMER,
+  summarizeTaxCategories,
+  type ScheduleCReportRow,
+  type TaxTaggableTransaction,
+} from '../lib/tax';
 
 import './BusinessPnlPage.css';
 
@@ -50,6 +58,32 @@ function amountClass(cents: number): string {
   if (cents > 0) return ' business-pnl__amount--positive';
   if (cents < 0) return ' business-pnl__amount--negative';
   return '';
+}
+
+/** Adapt an app transaction to the tax-tagging engine's input shape. */
+function toTaxTaggable(transaction: Transaction): TaxTaggableTransaction {
+  return {
+    id: transaction.id,
+    date: transaction.date,
+    type: transaction.type,
+    amountCents: transaction.amount.amount,
+    payee: transaction.payee ?? undefined,
+    memo: transaction.note ?? undefined,
+    customFields: transaction.customFields ?? undefined,
+  };
+}
+
+/** Pick the tax year to report: the end-date year, else the latest data year, else now. */
+function deriveTaxYear(transactions: readonly Transaction[], endDate: string): number {
+  const fromEnd = Number.parseInt(endDate.slice(0, 4), 10);
+  if (Number.isInteger(fromEnd)) return fromEnd;
+
+  let latest = 0;
+  for (const transaction of transactions) {
+    const year = Number.parseInt(transaction.date.slice(0, 4), 10);
+    if (Number.isInteger(year) && year > latest) latest = year;
+  }
+  return latest > 0 ? latest : new Date().getFullYear();
 }
 
 export function BusinessPnlPage() {
@@ -89,6 +123,18 @@ export function BusinessPnlPage() {
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
   }, [statement]);
+
+  const taxYear = useMemo(() => deriveTaxYear(transactions, endDate), [endDate, transactions]);
+
+  const scheduleC = useMemo(
+    () => buildScheduleCReport(summarizeTaxCategories(transactions.map(toTaxTaggable), taxYear)),
+    [taxYear, transactions],
+  );
+
+  const hasScheduleCData =
+    scheduleC.incomeRows.length > 0 ||
+    scheduleC.expenseRows.length > 0 ||
+    scheduleC.unmappedRows.length > 0;
 
   if (loading) {
     return <LoadingSpinner label="Loading profit and loss statement" />;
@@ -325,7 +371,117 @@ export function BusinessPnlPage() {
           </p>
         )}
       </section>
+
+      <section className="business-pnl__card" aria-labelledby="business-pnl-schedule-c-title">
+        <h2 id="business-pnl-schedule-c-title" className="business-pnl__card-title">
+          Schedule C view · tax year {taxYear}
+        </h2>
+        <p className="business-pnl__schedule-c-note" role="note">
+          {SCHEDULE_C_DISCLAIMER}
+        </p>
+        {hasScheduleCData ? (
+          <>
+            <div className="business-pnl__table-wrapper" tabIndex={0}>
+              <table className="business-pnl__table business-pnl__table--statement">
+                <caption className="business-pnl__caption business-pnl__sr-only">
+                  Estimated Schedule C income and expense lines for tax year {taxYear}.
+                </caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Line</th>
+                    <th scope="col">Category</th>
+                    <th scope="col">Amount</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="business-pnl__row business-pnl__row--emphasis">
+                    <th scope="row" colSpan={2}>
+                      Part I · Income
+                    </th>
+                    <td className={amountClass(scheduleC.totalIncomeCents).trim()}>
+                      {formatCurrency(scheduleC.totalIncomeCents)}
+                    </td>
+                  </tr>
+                  {scheduleC.incomeRows.map((row) => (
+                    <ScheduleCRow key={row.line.id} row={row} />
+                  ))}
+                  <tr className="business-pnl__row business-pnl__row--emphasis">
+                    <th scope="row" colSpan={2}>
+                      Part II · Expenses
+                    </th>
+                    <td>{formatCurrency(scheduleC.totalExpenseCents)}</td>
+                  </tr>
+                  {scheduleC.expenseRows.length > 0 ? (
+                    scheduleC.expenseRows.map((row) => <ScheduleCRow key={row.line.id} row={row} />)
+                  ) : (
+                    <tr className="business-pnl__row">
+                      <td colSpan={3}>No deductible business expenses mapped yet.</td>
+                    </tr>
+                  )}
+                  <tr className="business-pnl__row business-pnl__row--emphasis">
+                    <th scope="row" colSpan={2}>
+                      Net profit (Line 31)
+                    </th>
+                    <td className={amountClass(scheduleC.netProfitCents).trim()}>
+                      {formatCurrency(scheduleC.netProfitCents)}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            {scheduleC.unmappedRows.length > 0 && (
+              <details className="business-pnl__schedule-c-unmapped">
+                <summary>
+                  Not on Schedule C ({scheduleC.unmappedRows.length}
+                  {scheduleC.unmappedRows.length === 1 ? ' category' : ' categories'})
+                </summary>
+                <ul className="business-pnl__schedule-c-unmapped-list">
+                  {scheduleC.unmappedRows.map((row) => (
+                    <li key={row.category}>
+                      <span className="business-pnl__schedule-c-unmapped-amount">
+                        {formatCurrency(row.amountCents)}
+                      </span>{' '}
+                      {row.reason}
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            )}
+
+            {(scheduleC.reviewNeededCount > 0 || scheduleC.missingReceiptCount > 0) && (
+              <p className="business-pnl__schedule-c-flags">
+                {scheduleC.reviewNeededCount > 0 &&
+                  `${scheduleC.reviewNeededCount} transaction${
+                    scheduleC.reviewNeededCount === 1 ? '' : 's'
+                  } need review. `}
+                {scheduleC.missingReceiptCount > 0 &&
+                  `${scheduleC.missingReceiptCount} missing a receipt.`}
+              </p>
+            )}
+          </>
+        ) : (
+          <p className="business-pnl__empty">
+            No categorized business income or expenses for {taxYear} yet. Tag transactions as
+            business/deductible so they map onto Schedule C lines.
+          </p>
+        )}
+      </section>
     </main>
+  );
+}
+
+interface ScheduleCRowProps {
+  row: ScheduleCReportRow;
+}
+
+function ScheduleCRow({ row }: ScheduleCRowProps) {
+  return (
+    <tr className="business-pnl__row">
+      <th scope="row">{row.line.lineNumber}</th>
+      <td>{row.line.label}</td>
+      <td>{formatCurrency(row.amountCents)}</td>
+    </tr>
   );
 }
 


### PR DESCRIPTION
## Summary

Diego reserves quarterly estimated taxes and obsessively categorizes business vs. personal expenses, but the Business P&L never mapped those tax categories onto the **IRS Schedule C** lines he actually files. This adds a pure mapping engine and a Schedule C view to the Business P&L page.

## Changes

- **New `lib/tax/schedule-c.ts`** — pure engine that maps each `TaxCategory` to its Schedule C line (Line 1 gross receipts, Line 9 car/truck, Line 13 depreciation, Line 24b meals, Line 27a other expenses, Line 30 home office), builds an income/expense report, and computes **net profit (Line 31)**.
  - Income lines use **gross** amounts; expense lines use the **deductible** amount so partial deductions (e.g. 50% meals) report correctly.
  - Personal categories (charitable, medical, SALT, retirement, investment) are surfaced as **unmapped rows with a reason** (Schedule A / Schedule 1) rather than silently dropped.
  - Carries review-needed / missing-receipt counts through to the UI.
- **`BusinessPnlPage`** renders a **"Schedule C view"** section: Part I / Part II tables, a net-profit emphasis row, an expandable unmapped list, and review/receipt flags. Clean empty state when no tagged data exists.
- Non-advice disclaimer shown in both the report UI and as an engine constant.

The app's `TaxCategory` enum is coarse, so only six lines are mapped today; finer lines (advertising, supplies, etc.) depend on the deductible-category detail tracked in #3226. This is documented truthfully in code comments.

## Testing

- [x] `npx tsc -b` clean
- [x] 12 new engine unit tests (`schedule-c.test.ts`) + BusinessPnlPage Schedule C test — 22 pass
- [x] `prettier@3.9.4 --check` clean, `eslint --max-warnings 0` clean

## Issues

Closes #3232

Found by persona: Diego Ramirez (freelance-designer irregular-income)