### PR TITLE
feat(web): add a tax-deductible / business flag to the transaction form (#3226)

### DIFF
--- a/apps/web/src/components/forms/TransactionForm.test.tsx
+++ b/apps/web/src/components/forms/TransactionForm.test.tsx
@@ -255,6 +255,39 @@ describe('TransactionForm', () => {
     );
   });
 
+  it('persists tax-treatment custom fields when a business category is selected', async () => {
+    const { onSubmit } = renderTransactionForm();
+
+    const amountInput = screen.getByLabelText('Amount');
+    fireEvent.keyDown(amountInput, { key: '9' });
+    fireEvent.keyDown(amountInput, { key: '9' });
+    fireEvent.keyDown(amountInput, { key: '0' });
+    fireEvent.keyDown(amountInput, { key: '0' });
+
+    fireEvent.change(screen.getByLabelText('Payee'), { target: { value: 'Design software' } });
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-1' } });
+    fireEvent.change(screen.getByLabelText('Tax category'), {
+      target: { value: 'SCHEDULE_C_EXPENSE' },
+    });
+    fireEvent.change(screen.getByLabelText('Business purpose (optional)'), {
+      target: { value: 'Client logo design' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add Transaction' }));
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customFields: expect.objectContaining({
+          'tax.category': 'SCHEDULE_C_EXPENSE',
+          'tax.deductibleStatus': 'DEDUCTIBLE',
+          'tax.businessPurposeNote': 'Client logo design',
+        }),
+      }),
+    );
+  });
+
   it('submits balanced split lines with per-line categories and notes', async () => {
     const { onSubmit } = renderTransactionForm();
 

--- a/apps/web/src/components/forms/TransactionForm.tsx
+++ b/apps/web/src/components/forms/TransactionForm.tsx
@@ -64,6 +64,11 @@ import {
   getRetirementAccountTypeLabel,
   supportsEmployerRetirementContributions,
 } from '../../lib/tax/retirement-contribution-metadata';
+import {
+  TAX_CATEGORY_PLANNING_COPY,
+  buildTaxCategoryCustomFieldPatch,
+} from '../../lib/tax/tax-category-ui-model';
+import type { DeductibleStatus, TaxCategory } from '../../lib/tax/tax-category-tagging';
 import type { CategorySuggestion } from '../../lib/categorization';
 import type { MerchantMatchResult } from '../../lib/merchants';
 import {
@@ -205,6 +210,63 @@ function normalizeTransactionAmount(amountCents: number, type: TransactionType):
   return amountCents;
 }
 
+// Tax treatment options (issue #3226). Selecting a category writes the `tax.*`
+// custom fields the tax-reserve engine and Schedule C report already consume.
+// Labels stay in the presentation layer; the enum lives in tax-category-tagging.
+const TAX_CATEGORY_OPTIONS: readonly { value: TaxCategory; label: string }[] = [
+  { value: 'SCHEDULE_C_INCOME', label: 'Business income (Schedule C)' },
+  { value: 'SCHEDULE_C_EXPENSE', label: 'Business expense (Schedule C)' },
+  { value: 'BUSINESS_MEALS', label: 'Business meals' },
+  { value: 'HOME_OFFICE', label: 'Home office' },
+  { value: 'BUSINESS_MILEAGE', label: 'Car / mileage' },
+  { value: 'CAPITALIZED_ASSET', label: 'Equipment / capitalized asset' },
+  { value: 'CHARITABLE_CASH', label: 'Charitable donation (cash)' },
+  { value: 'CHARITABLE_NON_CASH', label: 'Charitable donation (non-cash)' },
+  { value: 'MEDICAL', label: 'Medical' },
+  { value: 'EDUCATION', label: 'Education' },
+  { value: 'STATE_LOCAL_TAX', label: 'State / local tax' },
+  { value: 'RETIREMENT_CONTRIBUTION', label: 'Retirement contribution' },
+  { value: 'INVESTMENT_TAX', label: 'Investment / capital gains' },
+  { value: 'REVIEW_NEEDED', label: 'Needs review' },
+];
+
+const DEDUCTIBLE_STATUS_OPTIONS: readonly { value: DeductibleStatus; label: string }[] = [
+  { value: 'DEDUCTIBLE', label: 'Fully deductible' },
+  { value: 'PARTIALLY_DEDUCTIBLE', label: 'Partially deductible' },
+  { value: 'NON_DEDUCTIBLE', label: 'Not deductible' },
+  { value: 'REIMBURSABLE', label: 'Reimbursable' },
+  { value: 'CAPITALIZED', label: 'Capitalized' },
+  { value: 'REVIEW_NEEDED', label: 'Needs review' },
+];
+
+const MANAGED_TAX_FIELD_KEYS = new Set([
+  'tax.category',
+  'tax.deductibleStatus',
+  'tax.businessPurposeNote',
+]);
+
+/** Whether a custom-field key is owned by the Tax treatment section (issue #3226). */
+function isManagedTaxFieldKey(key: string): boolean {
+  return MANAGED_TAX_FIELD_KEYS.has(key);
+}
+
+/** Sensible default deductible status when a tax category is first selected. */
+function defaultDeductibleStatusFor(category: string): DeductibleStatus {
+  switch (category) {
+    case 'SCHEDULE_C_INCOME':
+    case 'STATE_LOCAL_TAX':
+      return 'NON_DEDUCTIBLE';
+    case 'BUSINESS_MEALS':
+      return 'PARTIALLY_DEDUCTIBLE';
+    case 'CAPITALIZED_ASSET':
+      return 'CAPITALIZED';
+    case 'REVIEW_NEEDED':
+      return 'REVIEW_NEEDED';
+    default:
+      return 'DEDUCTIBLE';
+  }
+}
+
 function buildTransactionSnapshot(initialData?: Transaction) {
   const existingLocalTimestamp = localTimestampFromCustomFields(initialData?.customFields ?? null);
   const fxMetadata = readFxMetadata(initialData?.customFields ?? null);
@@ -243,6 +305,9 @@ function buildTransactionSnapshot(initialData?: Transaction) {
     isBnplLiability: initialData?.customFields?.[BNPL_CUSTOM_FIELD_KEYS.liabilityType] === 'BNPL',
     bnplInstallmentCount:
       initialData?.customFields?.[BNPL_CUSTOM_FIELD_KEYS.installmentCount] ?? '4',
+    taxCategory: initialData?.customFields?.['tax.category'] ?? '',
+    taxDeductibleStatus: initialData?.customFields?.['tax.deductibleStatus'] ?? '',
+    taxBusinessPurposeNote: initialData?.customFields?.['tax.businessPurposeNote'] ?? '',
     merchantCity: initialData?.merchantCity ?? '',
     merchantState: initialData?.merchantState ?? '',
     merchantZip: initialData?.merchantZip ?? '',
@@ -252,7 +317,10 @@ function buildTransactionSnapshot(initialData?: Transaction) {
     extraNotes: initialData?.extraNotes ?? '',
     customFieldEntries: initialData?.customFields
       ? Object.entries(initialData.customFields)
-          .filter(([key]) => !isLocalTimestampFieldKey(key) && !isFxFieldKey(key))
+          .filter(
+            ([key]) =>
+              !isLocalTimestampFieldKey(key) && !isFxFieldKey(key) && !isManagedTaxFieldKey(key),
+          )
           .map(([key, value]) => ({ key, value }))
       : [],
     localTime:
@@ -404,6 +472,9 @@ export function TransactionForm({
   const [merchantMatch, setMerchantMatch] = useState<MerchantMatchResult | null>(null);
   const [isBnplLiability, setIsBnplLiability] = useState(false);
   const [bnplInstallmentCount, setBnplInstallmentCount] = useState('4');
+  const [taxCategory, setTaxCategory] = useState('');
+  const [taxDeductibleStatus, setTaxDeductibleStatus] = useState('');
+  const [taxBusinessPurposeNote, setTaxBusinessPurposeNote] = useState('');
 
   // -- additional details state ---------------------------------------------
   const [additionalOpen, setAdditionalOpen] = useState(false);
@@ -442,6 +513,9 @@ export function TransactionForm({
       counterpartyName,
       isBnplLiability,
       bnplInstallmentCount,
+      taxCategory,
+      taxDeductibleStatus,
+      taxBusinessPurposeNote,
       merchantCity,
       merchantState,
       merchantZip,
@@ -484,6 +558,9 @@ export function TransactionForm({
       statementDescription,
       status,
       tagsInput,
+      taxBusinessPurposeNote,
+      taxCategory,
+      taxDeductibleStatus,
       transactionType,
     ],
   );
@@ -567,6 +644,9 @@ export function TransactionForm({
     setMerchantMatch(null);
     setIsBnplLiability(initialSnapshot.isBnplLiability);
     setBnplInstallmentCount(initialSnapshot.bnplInstallmentCount);
+    setTaxCategory(initialSnapshot.taxCategory);
+    setTaxDeductibleStatus(initialSnapshot.taxDeductibleStatus);
+    setTaxBusinessPurposeNote(initialSnapshot.taxBusinessPurposeNote);
     setErrors({});
     setSubmitting(false);
     setSubmitError(null);
@@ -778,6 +858,27 @@ export function TransactionForm({
       } else {
         delete customFields[BNPL_CUSTOM_FIELD_KEYS.liabilityType];
         delete customFields[BNPL_CUSTOM_FIELD_KEYS.installmentCount];
+      }
+
+      // Tax treatment (issue #3226): persist the tax.* custom fields the
+      // tax-reserve engine and Schedule C report read. Cleared when no category
+      // is selected so the deductible pipeline never sees stale data.
+      if (taxCategory) {
+        Object.assign(
+          customFields,
+          buildTaxCategoryCustomFieldPatch({
+            category: taxCategory as TaxCategory,
+            deductibleStatus: (taxDeductibleStatus ||
+              defaultDeductibleStatusFor(taxCategory)) as DeductibleStatus,
+            ...(taxBusinessPurposeNote.trim()
+              ? { businessPurposeNote: taxBusinessPurposeNote.trim() }
+              : {}),
+          }),
+        );
+      } else {
+        delete customFields['tax.category'];
+        delete customFields['tax.deductibleStatus'];
+        delete customFields['tax.businessPurposeNote'];
       }
 
       // Foreign-currency entry: the user typed the ORIGINAL local amount; store
@@ -1216,6 +1317,67 @@ export function TransactionForm({
                   onChange={(event) => setBnplInstallmentCount(event.target.value)}
                   aria-label="Number of BNPL installments"
                 />
+              )}
+            </fieldset>
+
+            <fieldset className="form-group form-fieldset">
+              <legend className="form-group__label">Tax treatment</legend>
+              <p className="form-group__help">
+                Flag business income and tax-deductible expenses so your Schedule C view and
+                quarterly tax reserve run on real data instead of guesses.{' '}
+                {TAX_CATEGORY_PLANNING_COPY}
+              </p>
+              <label htmlFor="txn-tax-category" className="form-group__label">
+                Tax category
+              </label>
+              <select
+                id="txn-tax-category"
+                className="form-select"
+                value={taxCategory}
+                onChange={(event) => {
+                  const next = event.target.value;
+                  setTaxCategory(next);
+                  if (next && !taxDeductibleStatus) {
+                    setTaxDeductibleStatus(defaultDeductibleStatusFor(next));
+                  }
+                }}
+              >
+                <option value="">Not a business / tax item</option>
+                {TAX_CATEGORY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              {taxCategory && (
+                <>
+                  <label htmlFor="txn-tax-deductible-status" className="form-group__label">
+                    Deductible status
+                  </label>
+                  <select
+                    id="txn-tax-deductible-status"
+                    className="form-select"
+                    value={taxDeductibleStatus || defaultDeductibleStatusFor(taxCategory)}
+                    onChange={(event) => setTaxDeductibleStatus(event.target.value)}
+                  >
+                    {DEDUCTIBLE_STATUS_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <label htmlFor="txn-tax-note" className="form-group__label">
+                    Business purpose (optional)
+                  </label>
+                  <input
+                    id="txn-tax-note"
+                    className="form-input"
+                    type="text"
+                    value={taxBusinessPurposeNote}
+                    onChange={(event) => setTaxBusinessPurposeNote(event.target.value)}
+                    placeholder="e.g. Client logo design software"
+                  />
+                </>
               )}
             </fieldset>
 


### PR DESCRIPTION
## Summary

Diego tracks deductible business expenses (software, hardware, home office, travel) and reserves quarterly estimated taxes, but the transaction form had **no first-class way to mark a transaction as business income or a deductible expense**. The tax-reserve engine (`lib/tax-reserve.ts:207-212`) and the new Schedule C report both read `tax.category` / `tax.deductibleStatus` custom fields, yet **nothing in the UI ever set them** — so the deductible pipeline had no data source.

## Changes

- **New "Tax treatment" fieldset** on `TransactionForm`: a tax-category select (business income/expense, meals, home office, mileage, capitalized asset, charitable, medical, education, SALT, retirement, investment, needs-review), a deductible-status select, and an optional business-purpose note.
- **Sensible status defaults** when a category is first chosen (meals → partially deductible, equipment → capitalized, income/SALT → non-deductible, else fully deductible).
- **Persists via the `tax.*` custom fields** using the existing `buildTaxCategoryCustomFieldPatch` helper; clears them when no category is selected so the pipeline never sees stale data.
- The managed `tax.*` keys are filtered out of the raw custom-field editor to avoid double-editing; other `tax.*` keys are preserved untouched.
- Standard planning-estimate disclaimer shown (`TAX_CATEGORY_PLANNING_COPY` — not tax advice).

This closes the loop with #3232: transactions flagged here now flow into the Schedule C view and the quarterly tax reserve.

## Accessibility

- `fieldset` / `legend` grouping; explicit `label htmlFor` on every control; help text describes intent. No color-only signalling.

## Testing

- [x] `npx tsc -b` clean
- [x] `TransactionForm.test.tsx` — 20 pass (new test asserts `tax.category` / `tax.deductibleStatus` / `tax.businessPurposeNote` are written on submit)
- [x] `prettier@3.9.4 --check` clean, `eslint --max-warnings 0` clean

## Issues

Closes #3226

Found by persona: Diego Ramirez (freelance-designer irregular-income)