### PR TITLE
feat(web): surface sent invoices as expected income (#3229)

### DIFF
--- a/apps/web/src/pages/ExpectedIncomePage.css
+++ b/apps/web/src/pages/ExpectedIncomePage.css
@@ -308,3 +308,27 @@
     transition: none;
   }
 }
+
+.expected-income__invoices {
+  margin-top: var(--spacing-6);
+}
+
+.expected-income__invoices-note {
+  margin: 0 0 var(--spacing-4);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.expected-income__item--invoice {
+  background: var(--semantic-surface-secondary, var(--semantic-background-primary));
+}
+
+.expected-income__invoices-total {
+  margin: var(--spacing-4) 0 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.expected-income__invoices-total strong {
+  color: var(--semantic-text-primary);
+}

--- a/apps/web/src/pages/ExpectedIncomePage.test.tsx
+++ b/apps/web/src/pages/ExpectedIncomePage.test.tsx
@@ -119,4 +119,32 @@ describe('ExpectedIncomePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Add payment' }));
     expect(screen.getByRole('alert')).toHaveTextContent(/amount/i);
   });
+
+  it('surfaces sent and overdue invoices as expected income without re-entry (#3229)', () => {
+    window.localStorage.setItem(
+      'finance:invoices',
+      JSON.stringify([
+        {
+          id: 'inv-1',
+          clientName: 'Studio Delacroix',
+          amountCents: 120000,
+          issueDate: '2099-01-01',
+          paymentTerm: 'net-30',
+          status: 'Sent',
+          expectedPayDate: '2099-02-01',
+          createdAt: '2099-01-01T00:00:00.000Z',
+          updatedAt: '2099-01-01T00:00:00.000Z',
+        },
+      ]),
+    );
+
+    render(<ExpectedIncomePage />);
+
+    const section = screen.getByRole('region', { name: /from your invoices/i });
+    expect(
+      within(section).getByRole('heading', { level: 3, name: 'Studio Delacroix' }),
+    ).toBeInTheDocument();
+    const invoiceList = within(section).getByRole('list');
+    expect(within(invoiceList).getByText('$1,200.00')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/ExpectedIncomePage.tsx
+++ b/apps/web/src/pages/ExpectedIncomePage.tsx
@@ -20,6 +20,8 @@ import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react
 import { ConfirmDialog, EmptyState, Icon } from '../components/common';
 import { IconToken } from '../icons/tokens';
 import { formatCurrency } from '../lib/currency';
+import { useInvoices } from '../hooks/useInvoices';
+import { invoiceOutstandingCents } from '../lib/analytics/invoices';
 import {
   CONFIDENCE_LABELS,
   CONFIDENCE_LEVELS,
@@ -102,6 +104,35 @@ export function ExpectedIncomePage() {
   const sortedItems = useMemo(
     () => sortExpectedIncome(items, referenceDate),
     [items, referenceDate],
+  );
+
+  // Issue #3229: sent/overdue invoices are also money the user is waiting on.
+  // Surface them here (read-only, derived from the invoice pipeline) so a
+  // freelancer sees one list instead of re-entering payments. These are managed
+  // on the Invoices page and already feed Cash Runway, so we never write them to
+  // the expected-income store — that would double-count them.
+  const { invoices } = useInvoices();
+  const invoiceExpectedRows = useMemo(
+    () =>
+      invoices
+        .filter(
+          (invoice) =>
+            (invoice.status === 'Sent' || invoice.status === 'Overdue') &&
+            invoiceOutstandingCents(invoice) > 0,
+        )
+        .map((invoice) => ({
+          id: invoice.id,
+          clientName: invoice.clientName,
+          outstandingCents: invoiceOutstandingCents(invoice),
+          expectedPayDate: invoice.expectedPayDate,
+          status: invoice.status,
+        }))
+        .sort((a, b) => a.expectedPayDate.localeCompare(b.expectedPayDate)),
+    [invoices],
+  );
+  const invoiceExpectedTotalCents = useMemo(
+    () => invoiceExpectedRows.reduce((total, row) => total + row.outstandingCents, 0),
+    [invoiceExpectedRows],
   );
 
   const handleSubmit = useCallback(
@@ -435,6 +466,51 @@ export function ExpectedIncomePage() {
           </ul>
         )}
       </section>
+
+      {invoiceExpectedRows.length > 0 && (
+        <section
+          className="expected-income__list-section expected-income__invoices"
+          aria-labelledby="expected-income-invoices-title"
+        >
+          <h2 id="expected-income-invoices-title" className="expected-income__section-title">
+            From your invoices ({invoiceExpectedRows.length})
+          </h2>
+          <p className="expected-income__invoices-note">
+            Sent and overdue invoices are money you are waiting on too. They are managed on the
+            Invoices page and already flow into your Cash Runway, so you do not need to re-enter
+            them here.
+          </p>
+          <ul className="expected-income__list">
+            {invoiceExpectedRows.map((row) => (
+              <li key={row.id} className="expected-income__item expected-income__item--invoice">
+                <div className="expected-income__item-main">
+                  <h3 className="expected-income__item-title">{row.clientName}</h3>
+                  <p className="expected-income__item-meta">
+                    <span className="expected-income__item-amount">
+                      {formatCurrency(row.outstandingCents)}
+                    </span>
+                    {' · '}
+                    <time dateTime={row.expectedPayDate}>
+                      {formatExpectedDate(row.expectedPayDate)}
+                    </time>
+                    {' · '}
+                    <span className="expected-income__item-confidence">Invoice · {row.status}</span>
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <p className="expected-income__invoices-total">
+            Invoiced and awaiting payment:{' '}
+            <strong>{formatCurrency(invoiceExpectedTotalCents)}</strong>
+            {' · '}
+            Total you are waiting on (manual entries plus invoices):{' '}
+            <strong>
+              {formatCurrency(summary.expectedNotYetReceivedCents + invoiceExpectedTotalCents)}
+            </strong>
+          </p>
+        </section>
+      )}
 
       <ConfirmDialog
         isOpen={pendingDelete !== null}


### PR DESCRIPTION
## Summary

Invoices (`useInvoices`, localStorage `finance:invoices`) and the **Expected Income** page were two disconnected lists of "money I am waiting on", forcing Diego to enter the same client payment twice. This adds a read-only **"From your invoices"** section to the Expected Income page that derives sent/overdue invoices straight from the invoice pipeline — no re-entry.

## Changes

- New section on `ExpectedIncomePage` lists each **Sent/Overdue** invoice with its **outstanding** amount (respects partial payments via `invoiceOutstandingCents`) and expected pay date, sorted soonest-first.
- Shows an *"invoiced and awaiting payment"* subtotal plus a combined *"total you are waiting on (manual entries plus invoices)"* figure.
- **Read-only by design**: invoices are managed on the Invoices page and already feed Cash Runway, so they are **never written into the expected-income store**. This deliberately avoids double-counting them in any forecast.
- Section is hidden when there are no open invoices (no clutter for non-freelancers).

## Why not fully merge the two stores?

Full unification (a single persisted source) is intentionally deferred. The three surfaces read **different** notions of expected income today — Cash Runway reads invoices, Cash Flow uses an average-based estimate, and the Expected Income store is manual-only. Merging them is a **forecast design decision** (double-count risk), not a display change, so this PR delivers the user-facing "one list" value safely and leaves the store-level merge as a follow-up.

## Accessibility

- `section` labelled by its heading (region role); semantic `ul` / `h3` / `time`; no color-only signalling. Amounts and dates use the shared formatters.

## Testing

- [x] `npx tsc -b` clean
- [x] `ExpectedIncomePage.test.tsx` — 7 pass (new test seeds a sent invoice and asserts it appears in the section)
- [x] `prettier@3.9.4 --check` clean, `eslint --max-warnings 0` clean

## Issues

Closes #3229

Found by persona: Diego Ramirez (freelance-designer irregular-income)