### PR TITLE
fix(ci): unstrand production deploy pipeline — concurrency + smoke health (#3186)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -84,8 +84,19 @@ on:
       - '!v[0-9]+.[0-9]+.[0-9]+-windows'
 
 concurrency:
+  # Serialize every production deploy onto ONE lane so two deploys never race on
+  # the same host. Production jobs sit behind the manual `production` environment
+  # gate (wait timer + required reviewer); a run that is never approved/rejected
+  # stays `waiting` indefinitely. With `cancel-in-progress: false` that wedged
+  # run blocked the whole lane, so automated promotions queued behind it hung
+  # `pending` for hours with zero jobs started (#3086, #3186).
+  #
+  # Fix: let a newer automated promotion (workflow_run -> workflow_call) or a
+  # manual `workflow_dispatch` cancel the older, superseded run (newest-wins) so
+  # the lane is freed instead of stranded. Tag pushes are distinct, immutable
+  # releases, so they keep the non-cancelling behaviour.
   group: deploy-production
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 permissions:
   contents: write
@@ -552,7 +563,10 @@ jobs:
             local attempt http_code
             for attempt in 1 2 3 4 5 6; do
               http_code=$(curl -sSL -o "$HEALTH_RESPONSE" -w '%{http_code}' "$BASE_URL/health" || echo '000')
-              if [ "$http_code" = '200' ] && grep -Eqi '"status"[[:space:]]*:[[:space:]]*"healthy"|healthy' "$HEALTH_RESPONSE"; then
+              # The edge-runtime liveness endpoint (Caddy rewrites /health ->
+              # /health-check) answers {"status":"ok"}, so accept "ok" or
+              # "healthy" — a healthy deploy must not fail the smoke gate (#3084).
+              if [ "$http_code" = '200' ] && grep -Eqi '"status"[[:space:]]*:[[:space:]]*"(ok|healthy)"' "$HEALTH_RESPONSE"; then
                 return 0
               fi
               echo "Health check attempt ${attempt}/6 returned HTTP ${http_code}; retrying in 10s"
@@ -582,7 +596,7 @@ jobs:
           echo '### ✅ Post-deploy Smoke Tests Passed' >> "$GITHUB_STEP_SUMMARY"
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo '- Homepage returned HTTP 200' >> "$GITHUB_STEP_SUMMARY"
-          echo '- /health returned healthy' >> "$GITHUB_STEP_SUMMARY"
+          echo '- /health returned a passing liveness status (ok/healthy)' >> "$GITHUB_STEP_SUMMARY"
           echo '- Basic page load marker detected' >> "$GITHUB_STEP_SUMMARY"
           echo "- URL: $BASE_URL" >> "$GITHUB_STEP_SUMMARY"
 
@@ -734,7 +748,8 @@ jobs:
           set -euo pipefail
           for attempt in 1 2 3 4 5 6; do
             HTTP_CODE=$(curl -sSL -o rollback-health.json -w '%{http_code}' "${BASE_URL%/}/health" || echo '000')
-            if [ "$HTTP_CODE" = '200' ] && grep -Eqi '"status"[[:space:]]*:[[:space:]]*"healthy"|healthy' rollback-health.json; then
+            # Liveness returns {"status":"ok"}; accept "ok" or "healthy" (#3084).
+            if [ "$HTTP_CODE" = '200' ] && grep -Eqi '"status"[[:space:]]*:[[:space:]]*"(ok|healthy)"' rollback-health.json; then
               echo 'Rollback health check succeeded.'
               exit 0
             fi


### PR DESCRIPTION
## Summary

Fixes the two **workflow-YAML** root causes that have kept the **production**
deploy pipeline from completing a clean run since 2026-06-27 (#3186). Staging
(`finance.jrmoulckers.com`, Azure VM/Caddy) is healthy and unaffected — this PR
only touches the production pipeline definition.

Scope is limited to `.github/workflows/deploy-production.yml`. No app or package
code is changed. The env-protection repo settings and clearing the currently
stuck runs are **human-gated** (see **Needs Human Action** below), so #3186 is
referenced (`Refs`) rather than closed.

## Changes

`.github/workflows/deploy-production.yml`:

- **Concurrency no longer strands the lane (#3086, #3186).** `cancel-in-progress`
  is now `${{ github.event_name != 'push' }}` instead of a hard `false`. A newer
  automated promotion (`workflow_run` → `workflow_call`) or a manual
  `workflow_dispatch` now cancels the older, superseded run (newest-wins), so a
  run wedged at the manual `production` environment gate can no longer block the
  single `deploy-production` lane and hang later promotions `pending` for hours
  with zero jobs. Tag pushes stay non-cancelling (distinct, immutable releases).
  The group name is unchanged, so all production deploys remain serialized onto
  one lane (two deploys never race on the same host).
- **Smoke health check accepts the real liveness body (#3084).** The post-deploy
  and rollback health assertions now accept `{"status":"ok"}` via
  `'"status"[[:space:]]*:[[:space:]]*"(ok|healthy)"'` instead of only `"healthy"`.
  The edge-runtime `main` service answers `/health-check` (which Caddy rewrites
  `/health` to) with `{ "status": "ok" }`, so the old grep failed every attempt
  even on a healthy deploy. This matches the pattern the **staging** smoke check
  already uses (`deploy-staging.yml`), which is why staging is green.
- Added explanatory comments beside both fixes and updated the step-summary line
  to say `/health returned a passing liveness status (ok/healthy)`.

## Why this is the right fix

- The staging pipeline already uses the exact `(ok|healthy)` grep and is healthy;
  this brings production to parity (fixing forward without touching app code).
- A job-level `timeout-minutes` would **not** help: the timeout clock does not run
  while a job is `waiting` on an environment protection gate, so only a concurrency
  change can free a lane wedged at the gate. This is issue #3186's own recommended
  option 6 ("`cancel-in-progress: true` for superseded promotions").

## Needs Human Action

The following are GitHub **repo settings / remote platform** operations that an
agent cannot perform (AGENTS.md Category 3). A human with repo-admin access must:

1. **Clear the stuck production runs to release the `deploy-production` lane.**
   Cancel any `pending`/`waiting` `Deploy — Production` and `Promote to Production`
   runs (the issue captured `promote-production` runs **28431668279** and
   **28431161908** stuck since 2026-06-30; verify current IDs with
   `gh run list --workflow "Deploy — Production"` and
   `gh run list --workflow "Promote to Production"`). Cancelling/re-triggering
   production deploys is human-gated.
2. **Reject any stuck `pending_deployments`** for the `production` environment
   (`gh api repos/jrmoulckers/finance/actions/runs/<run_id>/pending_deployments`
   → POST `state: "rejected"`) so the group is freed.
3. **Audit Settings → Environments → `production` protection rules.** The 06-27
   failures logged *"The deployment was rejected or didn't satisfy other
   protection rules."* Confirm the **deployment branch/tag restriction allows the
   `main` HEAD commit SHA** (promotions deploy the SHA, not a tag — a tag-only
   restriction rejects `deploy-web`). Also review the required reviewer and the
   5-minute wait timer.
4. **Verify the production web deploy target + secrets** exist and are distinct
   from staging (prod host/credentials, Pages-vs-VM target).
5. **Check org/runner availability/quota** — "pending with no jobs" can also
   indicate runner starvation.
6. After clearing, **re-run `deploy-production`** via `workflow_dispatch`
   (version = current `main` HEAD SHA, component `all`) and watch `deploy-web`
   and `post-deploy-smoke`.

Steps 1–3 unblock the lane immediately; this PR ensures it cannot re-wedge the
same way. Once the `production` environment protection is confirmed to allow
SHA-based promotions (step 3), #3186 can be closed.

## Issues

Closes #3084
Closes #3086
Refs #3186

## Testing

- [x] `deploy-production.yml` parses cleanly (Prettier 3.9.1 `--check` passes;
      Prettier's YAML parser validates well-formedness).
- [x] Concurrency expression `${{ github.event_name != 'push' }}` is a valid
      boolean expression for `cancel-in-progress`.
- [x] No JS/TS changed — ESLint scope unaffected; YAML formatting verified.
- [ ] End-to-end production run — **blocked on the human env-protection step
      above**; cannot be exercised from a PR.
