### PR TITLE
fix(auth): provider-named OAuth-unavailable UX + document enablement (#3187)

### DIFF
--- a/apps/web/src/auth/auth-context.test.tsx
+++ b/apps/web/src/auth/auth-context.test.tsx
@@ -11,6 +11,7 @@ import {
   isNetworkError,
   isOAuthStartHealthy,
   isServiceUnavailableStatus,
+  oauthProviderUnavailableMessage,
   parseBetaAllowedEmails,
   useAuth,
   type AuthProviderConfig,
@@ -523,6 +524,33 @@ describe('isOAuthStartHealthy', () => {
   });
 });
 
+describe('oauthProviderUnavailableMessage (#3187)', () => {
+  it('names each supported provider in the friendly message', () => {
+    expect(oauthProviderUnavailableMessage('google')).toContain('Google sign-in');
+    expect(oauthProviderUnavailableMessage('github')).toContain('GitHub sign-in');
+    expect(oauthProviderUnavailableMessage('apple')).toContain('Apple sign-in');
+  });
+
+  it('always points the user at the email & password fallback', () => {
+    for (const provider of ['google', 'github', 'apple'] as const) {
+      expect(oauthProviderUnavailableMessage(provider)).toContain('email & password');
+    }
+  });
+
+  it('never leaks the raw GoTrue "provider is not enabled" string', () => {
+    for (const provider of ['google', 'github', 'apple'] as const) {
+      expect(oauthProviderUnavailableMessage(provider)).not.toContain('provider is not enabled');
+      expect(oauthProviderUnavailableMessage(provider)).not.toContain('validation_failed');
+    }
+  });
+
+  it('is more specific than the generic fallback constant', () => {
+    // The generic constant remains exported for callers that cannot resolve a
+    // provider; the per-provider message is distinct and names the provider.
+    expect(oauthProviderUnavailableMessage('google')).not.toBe(OAUTH_PROVIDER_UNAVAILABLE_MESSAGE);
+  });
+});
+
 describe('loginWithOAuth keeps users in-app on a failed start (#3109)', () => {
   const config: AuthProviderConfig = {
     supabaseUrl: 'https://finance-test.supabase.co',
@@ -630,7 +658,7 @@ describe('loginWithOAuth keeps users in-app on a failed start (#3109)', () => {
     expect(assignMock).not.toHaveBeenCalled();
   });
 
-  it('shows the provider-unavailable message when start is 4xx (not configured)', async () => {
+  it('shows the provider-named unavailable message when start is 4xx (not configured)', async () => {
     stubStart(() => Promise.resolve(jsonResponse({ error: 'Unsupported provider' }, 400)));
     await renderReady();
 
@@ -638,7 +666,7 @@ describe('loginWithOAuth keeps users in-app on a failed start (#3109)', () => {
 
     await waitFor(() =>
       expect(screen.getByTestId('auth-error')).toHaveTextContent(
-        OAUTH_PROVIDER_UNAVAILABLE_MESSAGE,
+        oauthProviderUnavailableMessage('google'),
       ),
     );
     expect(assignMock).not.toHaveBeenCalled();
@@ -648,8 +676,9 @@ describe('loginWithOAuth keeps users in-app on a failed start (#3109)', () => {
     // A statically-supported provider that GoTrue has NOT enabled now answers
     // the pre-flight probe with a 400 (auth-oauth-start gates on the provider
     // actually being enabled). The probe is non-healthy, so we keep the user
-    // in-app with the graceful "option unavailable" message and never hand off
-    // to a raw GoTrue "provider is not enabled" page.
+    // in-app with the graceful, provider-named "option unavailable" message
+    // (#3187) and never hand off to a raw GoTrue "provider is not enabled"
+    // page.
     stubStart(() => Promise.resolve(jsonResponse({ error: 'Provider not enabled' }, 400)));
     await renderReady();
 
@@ -657,7 +686,7 @@ describe('loginWithOAuth keeps users in-app on a failed start (#3109)', () => {
 
     await waitFor(() =>
       expect(screen.getByTestId('auth-error')).toHaveTextContent(
-        OAUTH_PROVIDER_UNAVAILABLE_MESSAGE,
+        oauthProviderUnavailableMessage('google'),
       ),
     );
     expect(assignMock).not.toHaveBeenCalled();

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -200,14 +200,37 @@ export const SERVICE_UNAVAILABLE_MESSAGE =
   'The server is temporarily unavailable. Please try again in a few minutes.';
 
 /**
- * User-facing message shown when an OAuth provider's sign-in cannot be
- * started because the provider is not configured/enabled on the backend
- * (e.g. the Edge Function answers 4xx for that provider). Distinct from
+ * Generic fallback shown when an OAuth provider's sign-in cannot be started
+ * because the provider is not configured/enabled on the backend (e.g. the
+ * Edge Function answers 4xx for that provider). Distinct from
  * {@link SERVICE_UNAVAILABLE_MESSAGE} so a not-yet-provisioned provider
- * doesn't masquerade as a transient outage (#3109).
+ * doesn't masquerade as a transient outage (#3109). Prefer the
+ * provider-named {@link oauthProviderUnavailableMessage} when the provider
+ * is known — it tells the user exactly which button failed (#3187).
  */
 export const OAUTH_PROVIDER_UNAVAILABLE_MESSAGE =
   'That sign-in option is unavailable right now. Try another option or use email & password.';
+
+/** Human-readable display labels for each supported OAuth provider. */
+const OAUTH_PROVIDER_LABELS: Record<OAuthProvider, string> = {
+  google: 'Google',
+  github: 'GitHub',
+  apple: 'Apple',
+};
+
+/**
+ * Build the user-facing message shown when a specific OAuth provider is not
+ * enabled/configured on the backend. Naming the provider (e.g. "Google
+ * sign-in isn't available right now") is clearer and more accessible than a
+ * generic "that option" string when three social buttons are offered — the
+ * user knows exactly which path failed and what to do instead (#3187). The
+ * message deliberately points at the always-available email & password path
+ * rather than promising passkey, which may be unsupported on the device.
+ */
+export function oauthProviderUnavailableMessage(provider: OAuthProvider): string {
+  const label = OAUTH_PROVIDER_LABELS[provider];
+  return `${label} sign-in isn't available right now. Try another option or use email & password.`;
+}
 
 // ---------------------------------------------------------------------------
 // Provider
@@ -957,7 +980,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         setError(
           isServiceUnavailableStatus(probe.status)
             ? SERVICE_UNAVAILABLE_MESSAGE
-            : OAUTH_PROVIDER_UNAVAILABLE_MESSAGE,
+            : oauthProviderUnavailableMessage(provider),
         );
         setIsLoading(false);
       } catch (err) {

--- a/docs/auth/oauth-provider-enablement.md
+++ b/docs/auth/oauth-provider-enablement.md
@@ -1,0 +1,145 @@
+# OAuth Provider Enablement (Deployment Config)
+
+> **Issue:** #3187 — social sign-in fails with `provider is not enabled`
+> **Audience:** Human operators with access to the Supabase deployment
+> **Related:** [`oauth-setup.md`](./oauth-setup.md) (per-provider credential setup)
+
+This document explains **why** the social sign-in buttons (Continue with
+Google / GitHub / Apple) can fail on a deployed environment and the **exact
+configuration a human must apply** to enable them. Enabling providers requires
+real OAuth credentials, which are secret-gated — **an AI agent cannot perform
+this step.** This doc gives the operator a copy-paste checklist.
+
+## Symptom
+
+On the deployed site, clicking **Continue with Google / GitHub / Apple** on
+`/login` fails. Before the app-side hardening (#3188/#3187) the browser landed
+on a raw JSON page:
+
+```
+400 validation_failed — "Unsupported provider: provider is not enabled"
+```
+
+That string is emitted by **Supabase GoTrue's** `/auth/v1/authorize`
+endpoint — not by our code. It means the external provider is **not enabled /
+not configured** in the deployed Supabase Auth instance.
+
+## How the app handles this today (graceful degradation)
+
+The web app no longer dumps the raw GoTrue page. The flow is:
+
+```mermaid
+flowchart LR
+  A["/login button click"] --> B["loginWithOAuth() pre-flight probe\nGET /api/auth/oauth-start"]
+  B --> C{"auth-oauth-start\nchecks GoTrue /settings"}
+  C -->|provider enabled| D["302 → GoTrue /authorize → provider"]
+  C -->|provider disabled 400| E["Inline message:\n'Google sign-in isn't available right now…'"]
+  C -->|settings unreadable 503| F["Inline message:\n'The server is temporarily unavailable…'"]
+```
+
+- `services/api/supabase/functions/auth-oauth-start/index.ts` calls
+  `fetchProviderEnabled()` (reads GoTrue's public `/auth/v1/settings`) **before**
+  issuing the redirect. A disabled provider returns `400`; an unreadable
+  settings document returns `503`.
+- `apps/web/src/auth/auth-context.tsx` pre-flights that endpoint with
+  `redirect: 'manual'` and, on a non-healthy response, shows a friendly,
+  accessible, **provider-named** inline message
+  (`oauthProviderUnavailableMessage`) instead of navigating the browser onto a
+  raw page. Passkey and email/password paths are unaffected.
+
+Because the app degrades gracefully, the social buttons can safely stay
+visible — they simply show a helpful message until an operator enables the
+providers using the config below.
+
+## Fix: enable the providers (human, secret-gated)
+
+There are two deployment shapes. Use whichever matches your environment.
+
+### Option A — Supabase Cloud (Dashboard)
+
+1. Open the [Supabase Dashboard](https://supabase.com/dashboard) → your project.
+2. **Authentication → Providers →** _Google_ / _GitHub_ / _Apple_.
+3. Toggle **Enable**, then paste the provider's **Client ID** and **Client
+   Secret** (obtain these per [`oauth-setup.md`](./oauth-setup.md)).
+4. **Authentication → URL Configuration → Redirect URLs**: add the app callback
+   `https://YOUR_APP_DOMAIN/api/auth/oauth-callback`.
+
+### Option B — Self-hosted GoTrue (environment variables)
+
+Set these on the GoTrue container/service. **Use your real values in the
+deployment secret store — never commit them and never place them in a
+`.env` file tracked by git.** Placeholders shown below:
+
+```bash
+# ── Google ───────────────────────────────────────────────────────────────
+GOTRUE_EXTERNAL_GOOGLE_ENABLED=true
+GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID=YOUR_GOOGLE_CLIENT_ID
+GOTRUE_EXTERNAL_GOOGLE_SECRET=YOUR_GOOGLE_CLIENT_SECRET
+GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback
+
+# ── GitHub ───────────────────────────────────────────────────────────────
+GOTRUE_EXTERNAL_GITHUB_ENABLED=true
+GOTRUE_EXTERNAL_GITHUB_CLIENT_ID=YOUR_GITHUB_CLIENT_ID
+GOTRUE_EXTERNAL_GITHUB_SECRET=YOUR_GITHUB_CLIENT_SECRET
+GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI=https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback
+
+# ── Apple ────────────────────────────────────────────────────────────────
+GOTRUE_EXTERNAL_APPLE_ENABLED=true
+GOTRUE_EXTERNAL_APPLE_CLIENT_ID=YOUR_APPLE_SERVICES_ID
+GOTRUE_EXTERNAL_APPLE_SECRET=YOUR_APPLE_CLIENT_SECRET_JWT
+GOTRUE_EXTERNAL_APPLE_REDIRECT_URI=https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback
+
+# Allow GoTrue to redirect back to our app callback after the provider hop.
+# Comma-separated allow list — include the app's oauth-callback URL.
+GOTRUE_URI_ALLOW_LIST=https://YOUR_APP_DOMAIN/api/auth/oauth-callback
+```
+
+> Enable only the providers you intend to offer. A provider left disabled
+> continues to show the graceful in-app message rather than an error page.
+
+### Edge Function environment (already required, for reference)
+
+The auth Edge Functions that broker the flow require these (see
+`services/api/supabase/functions/_shared/env.ts`). They are **not secrets you
+generate here** — they are the standard deployment values:
+
+| Variable              | Used by                                   | Value                                               |
+| --------------------- | ----------------------------------------- | --------------------------------------------------- |
+| `SUPABASE_URL`        | all functions                             | `https://YOUR_SUPABASE_REF.supabase.co`             |
+| `SUPABASE_ANON_KEY`   | `auth-oauth-start`, `auth-oauth-callback` | project anon key                                    |
+| `OAUTH_REDIRECT_BASE` | `auth-oauth-start`, `auth-oauth-callback` | `https://YOUR_APP_DOMAIN` (the app's public origin) |
+
+`auth-oauth-start` builds the return URL as
+`${OAUTH_REDIRECT_BASE}/api/auth/oauth-callback`, so `OAUTH_REDIRECT_BASE` must
+match the app's public origin and be present in `GOTRUE_URI_ALLOW_LIST`.
+
+## Redirect URL summary
+
+| Where                                                      | Value                                                    |
+| ---------------------------------------------------------- | -------------------------------------------------------- |
+| Provider console (Google/GitHub/Apple) authorized redirect | `https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback` |
+| GoTrue `..._REDIRECT_URI`                                  | `https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback` |
+| GoTrue `GOTRUE_URI_ALLOW_LIST` / Dashboard Redirect URLs   | `https://YOUR_APP_DOMAIN/api/auth/oauth-callback`        |
+
+## Verification checklist
+
+After applying the config, verify each enabled provider:
+
+- [ ] `GET https://YOUR_SUPABASE_REF.supabase.co/auth/v1/settings` shows the
+      provider `true` under `external` (this is what `auth-oauth-start` reads).
+- [ ] Clicking the provider button on `/login` redirects to the provider
+      (no raw JSON page).
+- [ ] After consent, the browser returns to the app and lands authenticated.
+- [ ] A provider you deliberately left disabled still shows the friendly
+      inline message — not a raw error page.
+- [ ] Passkey and email/password sign-in continue to work.
+- [ ] No client secrets are committed to the repo or exposed to the browser.
+
+## Alternative: hide the buttons
+
+Issue #3187 notes a second option — hide the social buttons until providers are
+configured — so users aren't offered options that can't work. Because the app
+already degrades gracefully with a clear, provider-named message, keeping the
+buttons visible is acceptable for beta. If you prefer to hide them, gate the
+`.auth-oauth-buttons` group in `apps/web/src/pages/LoginPage.tsx` on a
+per-provider enablement probe (tracked separately as a frontend enhancement).

--- a/docs/auth/oauth-setup.md
+++ b/docs/auth/oauth-setup.md
@@ -7,6 +7,12 @@ This document describes how to configure Google Sign-In and Apple Sign-In
 for the Finance app across all platforms, using **Supabase Auth** as the
 identity broker.
 
+> **Deploying?** For the exact environment configuration required to
+> **enable** providers in a live Supabase deployment (including the
+> `GOTRUE_EXTERNAL_*` variables and GitHub), and how the app degrades
+> gracefully when a provider is not yet enabled, see
+> [`oauth-provider-enablement.md`](./oauth-provider-enablement.md) (#3187).
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary

Improves the OAuth failure UX on `/login` and documents the deployment
configuration required to enable social sign-in. Addresses #3187.

On the live site, **Continue with Google / GitHub / Apple** fails because the
external providers are **not enabled/configured** in the deployed Supabase
Auth (GoTrue) instance. GoTrue emits `400 validation_failed — "provider is not
enabled"`. Passkey and email/password work.

The edge-function gate and generic in-app message already landed in #3188.
This PR makes the failure message **provider-named** (clearer + more
accessible when three social buttons are offered) and adds the missing
**deployment enablement doc** the issue calls for. Provider enablement itself
is human/secret-gated — see **Needs Human Action** below.

## Changes

- **Provider-named error** (`apps/web/src/auth/auth-context.tsx`): new
  `oauthProviderUnavailableMessage(provider)` helper. When the `oauth-start`
  pre-flight reports a disabled/unconfigured provider (4xx), `/login` now
  shows e.g. _"Google sign-in isn't available right now. Try another option or
  use email & password."_ instead of a generic string — and still never hands
  the browser off to the raw GoTrue JSON page. The generic
  `OAUTH_PROVIDER_UNAVAILABLE_MESSAGE` is retained as a fallback.
- **Tests** (`apps/web/src/auth/auth-context.test.tsx`): updated the two
  disabled-provider integration tests to assert the provider-named message and
  added a focused unit-test block covering all three providers, the
  email/password fallback, and that the raw GoTrue string never leaks.
- **Docs**: new `docs/auth/oauth-provider-enablement.md` documents the exact
  `GOTRUE_EXTERNAL_*` env config (placeholders only), the edge-function flow,
  `OAUTH_REDIRECT_BASE`, redirect URLs, and graceful degradation; cross-linked
  from `docs/auth/oauth-setup.md`.

Passkey and email/password paths are untouched. No dependencies added. No
secrets added or logged.

## Needs Human Action

Enabling the providers requires **real OAuth credentials** and is secret-gated
(Category 3/7) — an agent cannot do it. To make social sign-in actually work in
the deployment, a human must, for each provider they want to offer, set the
following on the Supabase/GoTrue deployment (**placeholders — use real values
in the secret store, never commit them**):

```bash
GOTRUE_EXTERNAL_GOOGLE_ENABLED=true
GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID=YOUR_GOOGLE_CLIENT_ID
GOTRUE_EXTERNAL_GOOGLE_SECRET=YOUR_GOOGLE_CLIENT_SECRET
GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback
# ...repeat for GITHUB / APPLE...
GOTRUE_URI_ALLOW_LIST=https://YOUR_APP_DOMAIN/api/auth/oauth-callback
```

Or, on Supabase Cloud: **Authentication → Providers →** enable + paste Client
ID/Secret, and add the app callback under **URL Configuration → Redirect URLs**.
Full checklist in `docs/auth/oauth-provider-enablement.md`.

Until then, the social buttons stay visible but show the friendly
provider-named message — no raw error page. #3187 stays open (this PR uses
`Refs`, not `Closes`) until a human completes enablement.

## Issues

Refs #3187

## Testing

- [x] `apps/web` auth-context, LoginPage, auth-flows tests pass (80 tests)
- [x] `npm run format:check` clean
- [x] `npx eslint . --max-warnings 0` clean
