### PR TITLE
fix(web): P&L sign + invoice cash inflow (#3223, #3266)

### DIFF
--- a/apps/web/src/components/invoices/InvoicePaymentDialog.test.tsx
+++ b/apps/web/src/components/invoices/InvoicePaymentDialog.test.tsx
@@ -12,7 +12,23 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { MoneyDisplayProvider } from '../../lib/display-settings';
 import type { Invoice } from '../../lib/analytics/invoices';
+import type { Account } from '../../kmp/bridge';
 import { InvoicePaymentDialog } from './InvoicePaymentDialog';
+
+const ACCOUNTS = [
+  {
+    id: 'acc-1',
+    householdId: 'hh-1',
+    name: 'Checking',
+    currency: { code: 'USD', decimalPlaces: 2 },
+  },
+  {
+    id: 'acc-2',
+    householdId: 'hh-1',
+    name: 'Savings',
+    currency: { code: 'USD', decimalPlaces: 2 },
+  },
+] as unknown as Account[];
 
 function makeInvoice(overrides: Partial<Invoice> = {}): Invoice {
   return {
@@ -39,6 +55,7 @@ function renderDialog(props: Partial<ComponentProps<typeof InvoicePaymentDialog>
       <InvoicePaymentDialog
         isOpen
         invoice={makeInvoice()}
+        accounts={ACCOUNTS}
         onSubmit={onSubmit}
         onCancel={onCancel}
         {...props}
@@ -50,7 +67,7 @@ function renderDialog(props: Partial<ComponentProps<typeof InvoicePaymentDialog>
 }
 
 describe('InvoicePaymentDialog', () => {
-  it('records a valid partial payment with the entered date', () => {
+  it('records a valid partial payment with the entered date and deposit account', () => {
     const { onSubmit, onCancel } = renderDialog();
 
     expect(
@@ -61,8 +78,28 @@ describe('InvoicePaymentDialog', () => {
     fireEvent.change(screen.getByLabelText('Payment date'), { target: { value: '2024-02-15' } });
     fireEvent.click(screen.getByRole('button', { name: 'Record payment' }));
 
-    expect(onSubmit).toHaveBeenCalledWith(150000, '2024-02-15');
+    expect(onSubmit).toHaveBeenCalledWith(150000, '2024-02-15', 'acc-1');
     expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('submits the chosen deposit account when the user picks a different one', () => {
+    const { onSubmit } = renderDialog();
+
+    fireEvent.change(screen.getByLabelText('Payment amount'), { target: { value: '1500.00' } });
+    fireEvent.change(screen.getByLabelText('Deposit account'), { target: { value: 'acc-2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Record payment' }));
+
+    expect(onSubmit).toHaveBeenCalledWith(150000, expect.any(String), 'acc-2');
+  });
+
+  it('disables recording a payment when there are no accounts to deposit into', () => {
+    const { onSubmit } = renderDialog({ accounts: [] });
+
+    expect(screen.getByRole('button', { name: 'Record payment' })).toBeDisabled();
+    expect(
+      screen.getByText('Add an account first to record this payment as a cash inflow.'),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it('rejects a non-positive amount', () => {

--- a/apps/web/src/components/invoices/InvoicePaymentDialog.tsx
+++ b/apps/web/src/components/invoices/InvoicePaymentDialog.tsx
@@ -19,6 +19,7 @@ import {
 import { useFocusTrap } from '../../accessibility/aria';
 import { useAmountInput } from '../../hooks/useAmountInput';
 import { invoiceOutstandingCents, type Invoice } from '../../lib/analytics/invoices';
+import type { Account } from '../../kmp/bridge';
 import { CurrencyDisplay } from '../common';
 import { AmountInput } from '../forms/AmountInput';
 import '../forms/forms.css';
@@ -26,7 +27,9 @@ import '../forms/forms.css';
 export interface InvoicePaymentDialogProps {
   isOpen: boolean;
   invoice: Invoice | null;
-  onSubmit: (paymentCents: number, paidDate: string) => void;
+  /** Accounts the cash inflow can be deposited into (#3266). */
+  accounts: Account[];
+  onSubmit: (paymentCents: number, paidDate: string, accountId: string) => void;
   onCancel: () => void;
 }
 
@@ -37,12 +40,14 @@ function todayIsoDate(): string {
 export function InvoicePaymentDialog({
   isOpen,
   invoice,
+  accounts,
   onSubmit,
   onCancel,
 }: InvoicePaymentDialogProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const amountInputRef = useRef<HTMLInputElement>(null);
   const amountErrorId = useId();
+  const accountErrorId = useId();
   const titleId = useId();
 
   const amountInput = useAmountInput({
@@ -52,6 +57,8 @@ export function InvoicePaymentDialog({
   });
   const [paidDate, setPaidDate] = useState(todayIsoDate);
   const [amountError, setAmountError] = useState<string | null>(null);
+  const [accountId, setAccountId] = useState('');
+  const [accountError, setAccountError] = useState<string | null>(null);
 
   useFocusTrap(panelRef, { active: isOpen, restoreFocus: true });
 
@@ -61,6 +68,8 @@ export function InvoicePaymentDialog({
     amountInput.reset(0);
     setPaidDate(todayIsoDate());
     setAmountError(null);
+    setAccountError(null);
+    setAccountId(invoice?.paymentAccountId ?? accounts[0]?.id ?? '');
 
     const id = requestAnimationFrame(() => {
       amountInputRef.current?.focus();
@@ -99,11 +108,17 @@ export function InvoicePaymentDialog({
         setAmountError('Payment cannot exceed the outstanding balance.');
         return;
       }
+      if (!accountId) {
+        setAmountError(null);
+        setAccountError('Select an account to deposit the payment into.');
+        return;
+      }
 
       setAmountError(null);
-      onSubmit(paymentCents, paidDate);
+      setAccountError(null);
+      onSubmit(paymentCents, paidDate, accountId);
     },
-    [amountInput.cents, invoice, onSubmit, paidDate],
+    [accountId, amountInput.cents, invoice, onSubmit, paidDate],
   );
 
   if (!isOpen || invoice === null) {
@@ -113,8 +128,11 @@ export function InvoicePaymentDialog({
   const outstanding = invoiceOutstandingCents(invoice);
   const projectedOutstanding = Math.max(0, outstanding - amountInput.cents);
   const hasAmountError = amountError !== null;
+  const hasAccountError = accountError !== null;
+  const noAccounts = accounts.length === 0;
   const amountId = `${titleId}-amount`;
   const dateInputId = `${titleId}-date`;
+  const accountInputId = `${titleId}-account`;
 
   return (
     <div className="form-dialog" role="presentation" onKeyDown={handleKeyDown}>
@@ -190,6 +208,51 @@ export function InvoicePaymentDialog({
                 onChange={(event) => setPaidDate(event.target.value)}
               />
             </div>
+
+            <div className="form-group">
+              <label
+                htmlFor={accountInputId}
+                className="form-group__label form-group__label--required"
+              >
+                Deposit account
+              </label>
+              <select
+                id={accountInputId}
+                className={`form-input${hasAccountError ? ' form-input--error' : ''}`}
+                value={accountId}
+                disabled={noAccounts}
+                aria-invalid={hasAccountError}
+                aria-describedby={hasAccountError ? accountErrorId : undefined}
+                aria-required="true"
+                onChange={(event) => {
+                  setAccountId(event.target.value);
+                  setAccountError(null);
+                }}
+              >
+                {noAccounts ? (
+                  <option value="">No accounts available</option>
+                ) : (
+                  accounts.map((account) => (
+                    <option key={account.id} value={account.id}>
+                      {account.name} · {account.currency.code}
+                    </option>
+                  ))
+                )}
+              </select>
+              <p className="form-hint">
+                Records the payment as a cash inflow so it hits your balance and net worth.
+              </p>
+              {hasAccountError && (
+                <span id={accountErrorId} className="form-error" role="alert">
+                  {accountError}
+                </span>
+              )}
+              {noAccounts && (
+                <span className="form-error" role="alert">
+                  Add an account first to record this payment as a cash inflow.
+                </span>
+              )}
+            </div>
           </div>
 
           <div className="form-actions">
@@ -200,7 +263,11 @@ export function InvoicePaymentDialog({
             >
               Cancel
             </button>
-            <button type="submit" className="form-button form-button--primary">
+            <button
+              type="submit"
+              className="form-button form-button--primary"
+              disabled={noAccounts}
+            >
               Record payment
             </button>
           </div>

--- a/apps/web/src/hooks/useInvoices.ts
+++ b/apps/web/src/hooks/useInvoices.ts
@@ -21,6 +21,7 @@ import {
   type CreateInvoiceInput,
   type ForecastBucket,
   type Invoice,
+  type InvoicePaymentLink,
   type InvoicePipelineGroup,
   type InvoiceStatus,
   type UpdateInvoiceInput,
@@ -37,7 +38,12 @@ export interface UseInvoicesResult {
   updateInvoice: (invoiceId: string, input: UpdateInvoiceInput) => void;
   updateInvoiceStatus: (invoiceId: string, status: InvoiceStatus) => void;
   logInvoiceContact: (invoiceId: string) => void;
-  recordPayment: (invoiceId: string, paymentCents: number, paidDate?: string) => void;
+  recordPayment: (
+    invoiceId: string,
+    paymentCents: number,
+    paidDate?: string,
+    link?: InvoicePaymentLink,
+  ) => void;
   deleteInvoice: (invoiceId: string) => void;
   refresh: () => void;
 }
@@ -163,7 +169,7 @@ export function useInvoices(): UseInvoicesResult {
   }, []);
 
   const recordPayment = useCallback(
-    (invoiceId: string, paymentCents: number, paidDate?: string) => {
+    (invoiceId: string, paymentCents: number, paidDate?: string, link?: InvoicePaymentLink) => {
       const currentDate = todayIsoDate();
       setToday(currentDate);
       setInvoices((prev) =>
@@ -175,6 +181,7 @@ export function useInvoices(): UseInvoicesResult {
                   paymentCents,
                   paidDate ?? currentDate,
                   new Date().toISOString(),
+                  link,
                 )
               : invoice,
           ),

--- a/apps/web/src/lib/analytics/invoices.test.ts
+++ b/apps/web/src/lib/analytics/invoices.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyInvoiceEdit,
+  buildInvoiceCashInflow,
   computeExpectedPayDate,
   computeInvoiceForecast,
   exportInvoicesCsv,
@@ -24,6 +25,7 @@ import {
   recordInvoicePayment,
   type Invoice,
 } from './invoices';
+import { Currencies } from '../../kmp/bridge';
 
 function makeInvoice(overrides: Partial<Invoice>): Invoice {
   return {
@@ -379,6 +381,60 @@ describe('recordInvoicePayment', () => {
     const negative = recordInvoicePayment(invoice, -5000, '2024-02-10', '2024-02-10T10:00:00Z');
     expect(negative.amountPaidCents).toBe(0);
     expect(negative.status).toBe('Sent');
+  });
+
+  it('links the cash-inflow account and transaction when a link is supplied (#3266)', () => {
+    const invoice = makeInvoice({ amountCents: 400000, status: 'Sent' });
+    const paid = recordInvoicePayment(invoice, 400000, '2024-02-10', '2024-02-10T10:00:00Z', {
+      accountId: 'acc-1',
+      transactionId: 'txn-9',
+    });
+
+    expect(paid.status).toBe('Paid');
+    expect(paid.paymentAccountId).toBe('acc-1');
+    expect(paid.paymentTransactionId).toBe('txn-9');
+  });
+
+  it('leaves the payment link fields unset when no link is supplied', () => {
+    const invoice = makeInvoice({ amountCents: 400000, status: 'Sent' });
+    const paid = recordInvoicePayment(invoice, 150000, '2024-02-10', '2024-02-10T10:00:00Z');
+
+    expect(paid.paymentAccountId).toBeUndefined();
+    expect(paid.paymentTransactionId).toBeUndefined();
+  });
+});
+
+describe('buildInvoiceCashInflow', () => {
+  it('builds a positive INCOME transaction in the receiving account currency (#3266)', () => {
+    const invoice = makeInvoice({ clientName: 'Acme Studio', amountCents: 400000 });
+    const input = buildInvoiceCashInflow(invoice, {
+      accountId: 'acc-1',
+      householdId: 'hh-1',
+      currency: Currencies.EUR,
+      paymentCents: 250000,
+      paidDateIso: '2024-02-10',
+    });
+
+    expect(input.type).toBe('INCOME');
+    expect(input.amount).toEqual({ amount: 250000 });
+    expect(input.accountId).toBe('acc-1');
+    expect(input.householdId).toBe('hh-1');
+    expect(input.currency).toEqual(Currencies.EUR);
+    expect(input.payee).toBe('Acme Studio');
+    expect(input.date).toBe('2024-02-10');
+  });
+
+  it('always records a positive inflow even if given a negative amount', () => {
+    const invoice = makeInvoice({ amountCents: 400000 });
+    const input = buildInvoiceCashInflow(invoice, {
+      accountId: 'acc-1',
+      householdId: 'hh-1',
+      currency: Currencies.USD,
+      paymentCents: -5000,
+      paidDateIso: '2024-02-10',
+    });
+
+    expect(input.amount).toEqual({ amount: 5000 });
   });
 });
 

--- a/apps/web/src/lib/analytics/invoices.ts
+++ b/apps/web/src/lib/analytics/invoices.ts
@@ -11,6 +11,8 @@
  */
 
 import { escapeCsvField } from '../export/simple-export';
+import type { Currency } from '../../kmp/bridge';
+import type { CreateTransactionInput } from '../../db/repositories/transactions';
 
 export type InvoicePaymentTerm = 'due-on-receipt' | 'net-15' | 'net-30' | 'net-45' | 'net-60';
 
@@ -32,6 +34,10 @@ export interface Invoice {
   readonly amountPaidCents?: number;
   /** ISO date the most recent payment was received. */
   readonly paidDate?: string;
+  /** Account id the most recent cash inflow for this invoice landed in (#3266). */
+  readonly paymentAccountId?: string;
+  /** Transaction id of the most recent cash inflow recorded for this invoice (#3266). */
+  readonly paymentTransactionId?: string;
 }
 
 export interface CreateInvoiceInput {
@@ -187,18 +193,29 @@ export function invoiceIsFullyPaid(invoice: Invoice): boolean {
   return (invoice.amountPaidCents ?? 0) >= invoice.amountCents;
 }
 
+/** Links an invoice payment to the cash-inflow transaction it produced (#3266). */
+export interface InvoicePaymentLink {
+  /** Account the cash inflow landed in. */
+  readonly accountId: string;
+  /** Id of the created cash-inflow transaction. */
+  readonly transactionId: string;
+}
+
 /**
  * Record a (full or partial) payment against an invoice.
  *
  * Payments accumulate; the total is clamped to the invoice amount so the
  * outstanding balance never goes negative. Negative payment amounts are
  * ignored. When the cumulative payment covers the full amount the status is
- * advanced to `Paid`.
+ * advanced to `Paid`. When a `link` is supplied the invoice records the
+ * account and transaction the cash inflow landed in so paid revenue is tied to
+ * a real balance (issue #3266).
  *
  * @param invoice - The invoice receiving payment.
  * @param paymentCents - Amount received in this payment, in cents.
  * @param paidDateIso - ISO date the payment was received.
  * @param nowIso - Current timestamp (ISO 8601) for updatedAt.
+ * @param link - Optional link to the cash-inflow transaction and its account.
  * @returns A new invoice with the payment recorded.
  */
 export function recordInvoicePayment(
@@ -206,6 +223,7 @@ export function recordInvoicePayment(
   paymentCents: number,
   paidDateIso: string,
   nowIso: string,
+  link?: InvoicePaymentLink,
 ): Invoice {
   const priorPaid = invoice.amountPaidCents ?? 0;
   const nextPaid = Math.min(priorPaid + Math.max(0, paymentCents), invoice.amountCents);
@@ -216,6 +234,48 @@ export function recordInvoicePayment(
     paidDate: paidDateIso,
     status: fullyPaid ? 'Paid' : invoice.status,
     updatedAt: nowIso,
+    ...(link ? { paymentAccountId: link.accountId, paymentTransactionId: link.transactionId } : {}),
+  };
+}
+
+/** Context needed to turn an invoice payment into a cash-inflow transaction. */
+export interface InvoiceCashInflowContext {
+  /** Account the money landed in. */
+  readonly accountId: string;
+  /** Household that owns the receiving account. */
+  readonly householdId: string;
+  /** Currency of the receiving account. */
+  readonly currency: Currency;
+  /** Amount received in this payment, in cents. */
+  readonly paymentCents: number;
+  /** ISO date the payment was received. */
+  readonly paidDateIso: string;
+}
+
+/**
+ * Build the cash-inflow transaction for an invoice payment.
+ *
+ * Marking an invoice paid should move real money: this produces an `INCOME`
+ * transaction against the chosen account so paid revenue shows up in balances,
+ * net worth and reconciliation instead of living only in the invoice pipeline
+ * (issue #3266). Amounts are positive cents (the app's income convention) and
+ * the transaction adopts the receiving account's currency — invoices do not yet
+ * carry their own currency (see #14), so the account the payment lands in is the
+ * source of truth for currency.
+ */
+export function buildInvoiceCashInflow(
+  invoice: Invoice,
+  context: InvoiceCashInflowContext,
+): CreateTransactionInput {
+  return {
+    householdId: context.householdId,
+    accountId: context.accountId,
+    type: 'INCOME',
+    amount: { amount: Math.abs(Math.round(context.paymentCents)) },
+    currency: context.currency,
+    payee: invoice.clientName,
+    note: `Invoice payment from ${invoice.clientName}`,
+    date: context.paidDateIso,
   };
 }
 

--- a/apps/web/src/lib/business/profit-and-loss.test.ts
+++ b/apps/web/src/lib/business/profit-and-loss.test.ts
@@ -331,6 +331,74 @@ describe('buildProfitAndLoss', () => {
     expect(statement.totals.grossProfitCents).toBe(60_000);
   });
 
+  it('reduces revenue when a refund/chargeback (expense classified as revenue) is recorded', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 100_000 }), // sale $1,000
+        // A refund to a client: money leaves the business (EXPENSE) but reverses
+        // revenue, so it is tagged into the revenue bucket.
+        makeTransaction({
+          date: '2024-01-20',
+          type: 'EXPENSE',
+          amountCents: 15_000,
+          tags: ['revenue'],
+        }),
+      ],
+      { granularity: 'monthly' },
+    );
+
+    // The refund reduces revenue instead of inflating it (issue #3223).
+    expect(statement.totals.revenueCents).toBe(85_000);
+    expect(statement.totals.grossProfitCents).toBe(85_000);
+    expect(statement.totals.netProfitCents).toBe(85_000);
+    expect(statement.totals.transactionCount).toBe(2);
+  });
+
+  it('reduces a cost bucket when a vendor refund (income classified as a cost) is recorded', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 100_000 }),
+        makeTransaction({
+          date: '2024-01-06',
+          type: 'EXPENSE',
+          amountCents: 40_000,
+          tags: ['cogs'],
+        }),
+        // A supplier refunds part of a COGS purchase: money comes back in
+        // (INCOME) but reverses a cost, so it is tagged into the cogs bucket.
+        makeTransaction({
+          date: '2024-01-15',
+          type: 'INCOME',
+          amountCents: 10_000,
+          tags: ['cogs'],
+        }),
+      ],
+      { granularity: 'monthly' },
+    );
+
+    expect(statement.totals.cogsCents).toBe(30_000);
+    expect(statement.totals.grossProfitCents).toBe(70_000);
+  });
+
+  it('returns null margins when refunds push revenue to zero or below', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 50_000 }),
+        makeTransaction({
+          date: '2024-01-25',
+          type: 'EXPENSE',
+          amountCents: 60_000,
+          tags: ['sales'],
+        }),
+      ],
+      { granularity: 'monthly' },
+    );
+
+    expect(statement.totals.revenueCents).toBe(-10_000);
+    expect(statement.totals.grossMarginBps).toBeNull();
+    expect(statement.totals.netMarginBps).toBeNull();
+  });
+
   it('groups transactions into monthly periods sorted chronologically', () => {
     const statement = buildProfitAndLoss(
       [

--- a/apps/web/src/lib/business/profit-and-loss.ts
+++ b/apps/web/src/lib/business/profit-and-loss.ts
@@ -32,6 +32,13 @@
  * When revenue is zero the margin is `null` (N/A) rather than a divide-by-zero.
  * ──────────────────────────────────────────────────────────────────────────
  *
+ * SIGN & REFUNDS — a transaction's *type* carries its direction (income is an
+ * inflow, expense an outflow) and amounts are stored as unsigned magnitudes,
+ * matching the rest of the app (see `reconciliation.ts`). A refund/chargeback
+ * is therefore an expense classified as revenue and *reduces* the revenue
+ * bucket; symmetrically a vendor refund is income classified as a cost and
+ * *reduces* that cost bucket. Buckets are thus net figures (issue #3223).
+ *
  * This module is pure and deterministic: same input → same output, no clock,
  * no I/O. Splits are not expanded — a transaction's whole amount is allocated
  * to its single classified bucket.
@@ -75,13 +82,13 @@ export interface PnlOptions extends PnlTagConfig {
 
 /** The aggregated money + margin figures for a slice of activity. */
 export interface PnlTotals {
-  /** Total sales (cents, ≥ 0). */
+  /** Total sales, net of refunds/chargebacks (cents; normally ≥ 0). */
   readonly revenueCents: number;
-  /** Cost of goods sold (cents, ≥ 0). */
+  /** Cost of goods sold, net of vendor refunds (cents; normally ≥ 0). */
   readonly cogsCents: number;
-  /** Labor / payroll cost (cents, ≥ 0). */
+  /** Labor / payroll cost, net of reversals (cents; normally ≥ 0). */
   readonly laborCents: number;
-  /** Other operating expenses (cents, ≥ 0). */
+  /** Other operating expenses, net of reversals (cents; normally ≥ 0). */
   readonly overheadCents: number;
   /** Gross profit: revenue − COGS (cents, may be negative). */
   readonly grossProfitCents: number;
@@ -140,6 +147,32 @@ function magnitudeCents(value: number): number {
     return 0;
   }
   return Math.abs(Math.round(value));
+}
+
+/**
+ * Signed cash-flow magnitude for a transaction: income is a positive inflow and
+ * expense a negative outflow. Mirrors the app-wide convention (see
+ * `reconciliation.ts`) where amounts are stored as unsigned magnitudes and the
+ * transaction *type* carries the direction. Transfers and voids never reach
+ * this helper — {@link classifyTransaction} drops them first.
+ */
+function signedFlowCents(transaction: Transaction): number {
+  const magnitude = magnitudeCents(transaction.amount.amount);
+  return transaction.type === 'EXPENSE' ? -magnitude : magnitude;
+}
+
+/**
+ * The signed amount a transaction contributes to its P&L bucket.
+ *
+ * Revenue is fed by inflows, so an income sale *adds* to revenue while a refund
+ * or chargeback (an expense classified as revenue) *reduces* it. Cost buckets
+ * are fed by outflows, so an expense *adds* cost while a vendor refund (income
+ * classified as a cost) *reduces* it. Honouring the sign this way stops refunds
+ * from inflating revenue or costs (issue #3223).
+ */
+function bucketContributionCents(transaction: Transaction, category: PnlCategory): number {
+  const flow = signedFlowCents(transaction);
+  return category === 'revenue' ? flow : -flow;
 }
 
 function normalizeTag(tag: string): string {
@@ -387,7 +420,7 @@ export function buildProfitAndLoss(
       continue;
     }
 
-    const cents = magnitudeCents(transaction.amount.amount);
+    const cents = bucketContributionCents(transaction, category);
     const key = periodKey(transaction.date, granularity);
     const bucket = buckets.get(key) ?? emptyBucket();
     addToBucket(bucket, category, cents);

--- a/apps/web/src/pages/InvoicesPage.test.tsx
+++ b/apps/web/src/pages/InvoicesPage.test.tsx
@@ -15,15 +15,29 @@ import { render, screen, fireEvent } from '@testing-library/react';
 
 import { InvoicesPage } from './InvoicesPage';
 import type { Invoice } from '../lib/analytics/invoices';
+import type { Account, Transaction } from '../kmp/bridge';
 
 vi.mock('../hooks/useInvoices', () => ({ useInvoices: vi.fn() }));
 vi.mock('../hooks/useLocalePreferences', () => ({ useLocalePreferences: vi.fn() }));
+vi.mock('../hooks/useAccounts', () => ({ useAccounts: vi.fn() }));
+vi.mock('../hooks/useTransactions', () => ({ useTransactions: vi.fn() }));
 
 import { useInvoices } from '../hooks/useInvoices';
 import { useLocalePreferences } from '../hooks/useLocalePreferences';
+import { useAccounts } from '../hooks/useAccounts';
+import { useTransactions } from '../hooks/useTransactions';
 
 const mockedUseInvoices = vi.mocked(useInvoices);
 const mockedUseLocalePreferences = vi.mocked(useLocalePreferences);
+const mockedUseAccounts = vi.mocked(useAccounts);
+const mockedUseTransactions = vi.mocked(useTransactions);
+
+const SAMPLE_ACCOUNT = {
+  id: 'acc-1',
+  householdId: 'hh-1',
+  name: 'Checking',
+  currency: { code: 'USD', decimalPlaces: 2 },
+} as unknown as Account;
 
 function mockLocale(locale: string): void {
   mockedUseLocalePreferences.mockReturnValue({
@@ -34,6 +48,33 @@ function mockLocale(locale: string): void {
     setLocale: vi.fn(),
     setTimeZone: vi.fn(),
   });
+}
+
+const SAMPLE_TRANSACTION = { id: 'txn-1' } as unknown as Transaction;
+
+function mockAccounts(accounts: Account[]): void {
+  mockedUseAccounts.mockReturnValue({
+    accounts,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    createAccount: vi.fn(),
+    updateAccount: vi.fn(),
+    deleteAccount: vi.fn(),
+  });
+}
+
+function mockTransactions(createTransaction = vi.fn(() => SAMPLE_TRANSACTION)) {
+  mockedUseTransactions.mockReturnValue({
+    transactions: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    createTransaction,
+    updateTransaction: vi.fn(),
+    deleteTransaction: vi.fn(),
+  });
+  return createTransaction;
 }
 
 const SAMPLE_INVOICE: Invoice = {
@@ -51,6 +92,8 @@ const SAMPLE_INVOICE: Invoice = {
 beforeEach(() => {
   vi.clearAllMocks();
   mockLocale('en-US');
+  mockAccounts([SAMPLE_ACCOUNT]);
+  mockTransactions();
   mockedUseInvoices.mockReturnValue({
     invoices: [],
     pipelineGroups: [],
@@ -106,8 +149,9 @@ describe('InvoicesPage', () => {
     expect(deleteInvoice).toHaveBeenCalledWith('inv-1');
   });
 
-  it('records a payment through the payment dialog', () => {
+  it('records a payment through the payment dialog and books a linked cash inflow', () => {
     const recordPayment = vi.fn();
+    const createTransaction = mockTransactions();
     mockedUseInvoices.mockReturnValue({
       invoices: [SAMPLE_INVOICE],
       pipelineGroups: [
@@ -133,10 +177,67 @@ describe('InvoicesPage', () => {
     fireEvent.change(screen.getByLabelText('Payment amount'), { target: { value: '500.00' } });
     fireEvent.click(screen.getByRole('button', { name: 'Record payment' }));
 
+    // A cash-inflow (INCOME) transaction is booked against the chosen account.
+    expect(createTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: 'acc-1',
+        householdId: 'hh-1',
+        type: 'INCOME',
+        amount: { amount: 50_000 },
+        currency: { code: 'USD', decimalPlaces: 2 },
+      }),
+    );
+    // The invoice payment is linked to the account and the created transaction.
     expect(recordPayment).toHaveBeenCalledWith(
       'inv-1',
       50_000,
       expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      { accountId: 'acc-1', transactionId: 'txn-1' },
+    );
+  });
+
+  it('routes a "Paid" status selection through the payment dialog to book the inflow', () => {
+    const recordPayment = vi.fn();
+    const updateInvoiceStatus = vi.fn();
+    const createTransaction = mockTransactions();
+    mockedUseInvoices.mockReturnValue({
+      invoices: [SAMPLE_INVOICE],
+      pipelineGroups: [
+        { status: 'Sent', label: 'Sent', invoices: [SAMPLE_INVOICE], totalCents: 120_000 },
+      ],
+      forecastBuckets: [],
+      totalOutstandingCents: 120_000,
+      addInvoice: vi.fn(),
+      updateInvoice: vi.fn(),
+      updateInvoiceStatus,
+      logInvoiceContact: vi.fn(),
+      recordPayment,
+      deleteInvoice: vi.fn(),
+      refresh: vi.fn(),
+    });
+    render(<InvoicesPage />);
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Status for Etsy Wholesale' }), {
+      target: { value: 'Paid' },
+    });
+
+    // Marking Paid opens the payment dialog rather than silently flipping status.
+    expect(
+      screen.getByRole('dialog', { name: 'Record payment for Etsy Wholesale' }),
+    ).toBeInTheDocument();
+    expect(updateInvoiceStatus).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText('Payment amount'), { target: { value: '1200.00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Record payment' }));
+
+    expect(createTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'INCOME', amount: { amount: 120_000 } }),
+    );
+    expect(recordPayment).toHaveBeenCalledWith(
+      'inv-1',
+      120_000,
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      { accountId: 'acc-1', transactionId: 'txn-1' },
     );
   });
 

--- a/apps/web/src/pages/InvoicesPage.tsx
+++ b/apps/web/src/pages/InvoicesPage.tsx
@@ -12,9 +12,12 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { ConfirmDialog, CurrencyDisplay, EmptyState } from '../components/common';
 import { InvoicePaymentDialog } from '../components/invoices/InvoicePaymentDialog';
+import { useAccounts } from '../hooks/useAccounts';
 import { useInvoices } from '../hooks/useInvoices';
 import { useLocalePreferences } from '../hooks/useLocalePreferences';
+import { useTransactions } from '../hooks/useTransactions';
 import {
+  buildInvoiceCashInflow,
   computeExpectedPayDate,
   exportInvoicesCsv,
   FOLLOW_UP_STALE_DAYS,
@@ -160,6 +163,8 @@ export const InvoicesPage: React.FC = () => {
     recordPayment,
     deleteInvoice,
   } = useInvoices();
+  const { accounts } = useAccounts();
+  const { createTransaction } = useTransactions();
   const { locale } = useLocalePreferences();
   const [clientName, setClientName] = useState('');
   const [amount, setAmount] = useState('');
@@ -199,13 +204,49 @@ export const InvoicesPage: React.FC = () => {
   };
 
   const handleRecordPayment = useCallback(
-    (paymentCents: number, paidDate: string) => {
-      if (payingInvoice) {
-        recordPayment(payingInvoice.id, paymentCents, paidDate);
-        setPayingInvoice(null);
-      }
+    (paymentCents: number, paidDate: string, accountId: string) => {
+      if (!payingInvoice) return;
+
+      const account = accounts.find((candidate) => candidate.id === accountId);
+      if (!account) return;
+
+      // Marking an invoice paid must move real money: record the cash inflow
+      // first, and only tie the payment to the invoice once it succeeds so a
+      // "paid" invoice always has a linked transaction backing it (#3266).
+      const transaction = createTransaction(
+        buildInvoiceCashInflow(payingInvoice, {
+          accountId: account.id,
+          householdId: account.householdId,
+          currency: account.currency,
+          paymentCents,
+          paidDateIso: paidDate,
+        }),
+      );
+      if (!transaction) return;
+
+      recordPayment(payingInvoice.id, paymentCents, paidDate, {
+        accountId: account.id,
+        transactionId: transaction.id,
+      });
+      setPayingInvoice(null);
     },
-    [payingInvoice, recordPayment],
+    [accounts, createTransaction, payingInvoice, recordPayment],
+  );
+
+  const handleStatusChange = useCallback(
+    (invoiceId: string, nextStatus: InvoiceStatus) => {
+      // Routing a "Paid" selection through the payment dialog records the cash
+      // inflow instead of silently flipping status with no money movement.
+      if (nextStatus === 'Paid') {
+        const invoice = invoices.find((candidate) => candidate.id === invoiceId);
+        if (invoice && !invoiceIsFullyPaid(invoice)) {
+          setPayingInvoice(invoice);
+          return;
+        }
+      }
+      updateInvoiceStatus(invoiceId, nextStatus);
+    },
+    [invoices, updateInvoiceStatus],
   );
 
   const expectedPayDate = useMemo(
@@ -503,7 +544,7 @@ export const InvoicesPage: React.FC = () => {
                         locale={locale}
                         isEditing={invoice.id === editingInvoiceId}
                         onEdit={handleEdit}
-                        onStatusChange={updateInvoiceStatus}
+                        onStatusChange={handleStatusChange}
                         onRecordPayment={setPayingInvoice}
                         onDelete={setDeletingInvoice}
                       />
@@ -532,6 +573,7 @@ export const InvoicesPage: React.FC = () => {
       <InvoicePaymentDialog
         isOpen={payingInvoice !== null}
         invoice={payingInvoice}
+        accounts={accounts}
         onSubmit={handleRecordPayment}
         onCancel={() => setPayingInvoice(null)}
       />


### PR DESCRIPTION
## Summary

Fixes two business-finance correctness bugs in the web app.

### #3223 — Business P&L discarded the transaction sign

The P&L aggregation summed each transaction's **magnitude** (`magnitudeCents`),
so a refund/chargeback classified as `revenue` **inflated** revenue instead of
reducing it (and a vendor refund inflated costs). The module now aggregates a
**signed bucket contribution**:

- `signedFlowCents` — income is a positive inflow, expense a negative outflow
  (mirrors the app-wide convention in `reconciliation.ts`, where amounts are
  stored as unsigned magnitudes and the transaction _type_ carries direction).
- Revenue bucket = `+flow` → an income sale adds, an expense refund subtracts.
- Cost buckets = `−flow` → an expense adds cost, an income vendor-refund subtracts.

`PnlTotals` bucket figures are now **net** and may go negative when refunds
exceed sales; existing margin logic already treats non-positive revenue as
`null` margins.

### #3266 — Marking an invoice Paid booked no cash inflow

Recording a payment — or selecting the **Paid** status from the pipeline
dropdown — now routes through the payment dialog, which:

- adds a **required deposit-account picker** (accessible label, disabled with
  guidance when no accounts exist),
- books a positive `INCOME` transaction against the chosen account in **that
  account's currency** (invoices carry no currency of their own yet — see #14 —
  so the receiving account is the source of truth), and
- links the invoice to the created transaction (`paymentTransactionId`) and
  account (`paymentAccountId`).

The payment is only committed once the cash-inflow transaction succeeds, so a
paid invoice always has a backing transaction. Paid revenue now shows up in
balances, net worth, and reconciliation instead of living only in the invoice
pipeline.

## Changes

- `lib/business/profit-and-loss.ts` — `signedFlowCents` + `bucketContributionCents` helpers; signed aggregation; updated field docs.
- `lib/analytics/invoices.ts` — `buildInvoiceCashInflow`, `InvoicePaymentLink`, `recordInvoicePayment` link persistence, optional `paymentAccountId`/`paymentTransactionId` on `Invoice`.
- `hooks/useInvoices.ts` — `recordPayment` forwards an optional payment link.
- `components/invoices/InvoicePaymentDialog.tsx` — required deposit-account picker; `onSubmit` now passes `accountId`.
- `pages/InvoicesPage.tsx` — wires `useAccounts` + `useTransactions`; creates the linked inflow; routes a "Paid" selection through the dialog.
- Tests extended across all five modules.

## Issues

Closes #3223
Closes #3266

## Testing

- [x] Affected Vitest suites pass (`invoices`, `profit-and-loss`, `InvoicePaymentDialog`, `InvoicesPage`) — 90 tests.
- [x] `npm run format:check` (only the gitignored `.impeccable` cache is flagged).
- [x] `npx eslint . --max-warnings 0` — clean.
- New tests: a refund reduces P&L revenue; a vendor refund reduces COGS; net-negative revenue yields null margins; a Paid invoice books a linked `INCOME` cash inflow; the "Paid" status selection routes through the dialog.
