### PR TITLE
feat(web): persist invoices & remittances in encrypted SQLite + sync (#3273)

### DIFF
--- a/apps/web/src/db/repositories/index.ts
+++ b/apps/web/src/db/repositories/index.ts
@@ -10,3 +10,5 @@ export * from './investments';
 export * from './investment-lots';
 export * from './bills';
 export * from './household';
+export * from './invoices';
+export * from './remittances';

--- a/apps/web/src/db/repositories/invoices.test.ts
+++ b/apps/web/src/db/repositories/invoices.test.ts
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the invoice persistence repository (issue #3273).
+ *
+ * The repository is a thin layer over the SQLite-WASM primitives, so these
+ * tests mock `../sqlite-wasm` (and the household helper) and assert the SQL /
+ * parameters, the row → {@link Invoice} mapping (including the #3266 payment
+ * link), soft-delete, and the one-time localStorage → database migration.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Row, SqliteDb } from '../sqlite-wasm';
+
+vi.mock('../sqlite-wasm', () => ({
+  execute: vi.fn(),
+  query: vi.fn(),
+  queryOne: vi.fn(),
+}));
+
+vi.mock('./household', () => ({
+  getPrimaryHouseholdId: vi.fn(),
+}));
+
+import { execute, query, queryOne } from '../sqlite-wasm';
+import { getPrimaryHouseholdId } from './household';
+import {
+  deleteInvoiceRecord,
+  getAllInvoices,
+  importLegacyInvoices,
+  insertInvoice,
+  updateInvoiceRecord,
+} from './invoices';
+import type { Invoice } from '../../lib/analytics/invoices';
+
+const mockExecute = vi.mocked(execute);
+const mockQuery = vi.mocked(query);
+const mockQueryOne = vi.mocked(queryOne);
+const mockGetPrimaryHouseholdId = vi.mocked(getPrimaryHouseholdId);
+
+const mockDb = {} as SqliteDb;
+
+function invoiceRow(overrides: Partial<Row> = {}): Row {
+  return {
+    id: 'inv-1',
+    household_id: 'hh-1',
+    client_name: 'Studio Delacroix',
+    amount_cents: 120000,
+    issue_date: '2026-01-01',
+    payment_term: 'net-30',
+    status: 'Sent',
+    expected_pay_date: '2026-01-31',
+    last_contacted_date: null,
+    amount_paid_cents: 0,
+    paid_date: null,
+    payment_account_id: null,
+    payment_transaction_id: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    deleted_at: null,
+    sync_version: 1,
+    is_synced: 0,
+    ...overrides,
+  };
+}
+
+function baseInvoice(overrides: Partial<Invoice> = {}): Invoice {
+  return {
+    id: 'inv-1',
+    clientName: 'Studio Delacroix',
+    amountCents: 120000,
+    issueDate: '2026-01-01',
+    paymentTerm: 'net-30',
+    status: 'Sent',
+    expectedPayDate: '2026-01-31',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Wire the mocked primitives to an in-memory table keyed by id so inserts are
+ * observable by the follow-up read (`getInvoiceById`) the repository performs.
+ */
+function useInMemoryInvoiceTable(seed: Row[] = []): Map<string, Row> {
+  const table = new Map<string, Row>(seed.map((row) => [String(row.id), row]));
+
+  mockExecute.mockImplementation((_db, sql, params) => {
+    const text = String(sql);
+    if (text.includes('INSERT INTO invoice')) {
+      const id = String((params as unknown[])?.[0]);
+      table.set(id, invoiceRow({ id, household_id: (params as unknown[])?.[1] as Row[string] }));
+    }
+    return { rowsAffected: 1 };
+  });
+
+  mockQueryOne.mockImplementation((_db, _sql, params) => {
+    const id = String((params as unknown[])?.[0]);
+    return table.get(id) ?? null;
+  });
+
+  mockQuery.mockImplementation(() => ({ columns: [], rows: [...table.values()] }));
+
+  return table;
+}
+
+describe('invoices repository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPrimaryHouseholdId.mockReturnValue('hh-1');
+    globalThis.localStorage?.clear();
+  });
+
+  it('maps a full row to the Invoice domain shape, including the #3266 payment link', () => {
+    mockQuery.mockReturnValue({
+      columns: [],
+      rows: [
+        invoiceRow({
+          last_contacted_date: '2026-02-05',
+          amount_paid_cents: 120000,
+          paid_date: '2026-02-10',
+          status: 'Paid',
+          payment_account_id: 'acc-9',
+          payment_transaction_id: 'txn-9',
+        }),
+      ],
+    });
+
+    const [invoice] = getAllInvoices(mockDb);
+
+    expect(invoice).toEqual({
+      id: 'inv-1',
+      clientName: 'Studio Delacroix',
+      amountCents: 120000,
+      issueDate: '2026-01-01',
+      paymentTerm: 'net-30',
+      status: 'Paid',
+      expectedPayDate: '2026-01-31',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      lastContactedDate: '2026-02-05',
+      amountPaidCents: 120000,
+      paidDate: '2026-02-10',
+      paymentAccountId: 'acc-9',
+      paymentTransactionId: 'txn-9',
+    });
+  });
+
+  it('omits optional fields when unset so the mapped shape matches the domain factory', () => {
+    mockQuery.mockReturnValue({ columns: [], rows: [invoiceRow()] });
+
+    const [invoice] = getAllInvoices(mockDb);
+
+    expect(invoice).not.toHaveProperty('lastContactedDate');
+    expect(invoice).not.toHaveProperty('amountPaidCents');
+    expect(invoice).not.toHaveProperty('paidDate');
+    expect(invoice).not.toHaveProperty('paymentAccountId');
+    expect(invoice).not.toHaveProperty('paymentTransactionId');
+  });
+
+  it('inserts an invoice with the resolved household and the domain timestamps', () => {
+    useInMemoryInvoiceTable();
+
+    const created = insertInvoice(mockDb, baseInvoice());
+
+    expect(mockGetPrimaryHouseholdId).toHaveBeenCalledWith(mockDb);
+    const [, sql, params] = mockExecute.mock.calls[0];
+    expect(String(sql)).toContain('INSERT INTO invoice');
+    expect(params).toEqual([
+      'inv-1',
+      'hh-1',
+      'Studio Delacroix',
+      120000,
+      '2026-01-01',
+      'net-30',
+      'Sent',
+      '2026-01-31',
+      null,
+      0,
+      null,
+      null,
+      null,
+      '2026-01-01T00:00:00.000Z',
+      '2026-01-01T00:00:00.000Z',
+    ]);
+    expect(created.id).toBe('inv-1');
+  });
+
+  it('stores a null household when no household exists yet (clean-slate workspace)', () => {
+    mockGetPrimaryHouseholdId.mockReturnValue(null);
+    useInMemoryInvoiceTable();
+
+    insertInvoice(mockDb, baseInvoice());
+
+    expect(mockExecute.mock.calls[0][2]?.[1]).toBeNull();
+  });
+
+  it('persists the #3266 payment link columns when present', () => {
+    useInMemoryInvoiceTable();
+
+    insertInvoice(
+      mockDb,
+      baseInvoice({
+        status: 'Paid',
+        amountPaidCents: 120000,
+        paidDate: '2026-02-10',
+        paymentAccountId: 'acc-9',
+        paymentTransactionId: 'txn-9',
+      }),
+    );
+
+    const params = mockExecute.mock.calls[0][2] as unknown[];
+    expect(params[9]).toBe(120000); // amount_paid_cents
+    expect(params[10]).toBe('2026-02-10'); // paid_date
+    expect(params[11]).toBe('acc-9'); // payment_account_id
+    expect(params[12]).toBe('txn-9'); // payment_transaction_id
+  });
+
+  it('returns null when updating an invoice that does not exist', () => {
+    mockQueryOne.mockReturnValue(null);
+
+    expect(updateInvoiceRecord(mockDb, baseInvoice())).toBeNull();
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('soft-deletes an invoice by marking deleted_at', () => {
+    useInMemoryInvoiceTable([invoiceRow()]);
+
+    expect(deleteInvoiceRecord(mockDb, 'inv-1')).toBe(true);
+    const updateCall = mockExecute.mock.calls.find(([, sql]) =>
+      String(sql).includes('UPDATE invoice'),
+    );
+    expect(updateCall?.[1]).toContain('deleted_at =');
+  });
+
+  it('returns false when deleting an invoice that does not exist', () => {
+    mockQueryOne.mockReturnValue(null);
+
+    expect(deleteInvoiceRecord(mockDb, 'missing')).toBe(false);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('imports legacy localStorage invoices into the database and clears the key', () => {
+    globalThis.localStorage.setItem(
+      'finance:invoices',
+      JSON.stringify([
+        baseInvoice({ id: 'legacy-1' }),
+        baseInvoice({ id: 'legacy-2', clientName: 'Atelier Rousseau' }),
+      ]),
+    );
+    useInMemoryInvoiceTable();
+
+    const imported = importLegacyInvoices(mockDb);
+
+    expect(imported).toBe(2);
+    expect(globalThis.localStorage.getItem('finance:invoices')).toBeNull();
+    const insertCalls = mockExecute.mock.calls.filter(([, sql]) =>
+      String(sql).includes('INSERT INTO invoice'),
+    );
+    expect(insertCalls).toHaveLength(2);
+  });
+
+  it('skips legacy records whose id already exists (idempotent re-import)', () => {
+    globalThis.localStorage.setItem(
+      'finance:invoices',
+      JSON.stringify([baseInvoice({ id: 'existing' })]),
+    );
+    useInMemoryInvoiceTable([invoiceRow({ id: 'existing' })]);
+
+    expect(importLegacyInvoices(mockDb)).toBe(0);
+    const insertCalls = mockExecute.mock.calls.filter(([, sql]) =>
+      String(sql).includes('INSERT INTO invoice'),
+    );
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('returns 0 and writes nothing when there is no legacy data', () => {
+    useInMemoryInvoiceTable();
+
+    expect(importLegacyInvoices(mockDb)).toBe(0);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/db/repositories/invoices.ts
+++ b/apps/web/src/db/repositories/invoices.ts
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Invoice persistence repository (issue #3273).
+ *
+ * Durable, encrypted storage for the freelancer invoice pipeline. Replaces the
+ * previous `localStorage` store so invoice records survive a browser-cache clear
+ * and ride the SQLite-WASM (OPFS) + sync path used by accounts/transactions —
+ * no plaintext financial data on disk.
+ *
+ * This layer is deliberately thin: the invoice domain logic (expected pay dates,
+ * overdue normalization, partial payments, the #3266 cash-inflow link) lives in
+ * the pure, well-tested `lib/analytics/invoices` module. The repository only
+ * reads and writes fully-formed {@link Invoice} records.
+ */
+
+import {
+  computeExpectedPayDate,
+  type Invoice,
+  type InvoicePaymentTerm,
+  type InvoiceStatus,
+} from '../../lib/analytics/invoices';
+import { execute, query, queryOne, type Row, type SqliteDb } from '../sqlite-wasm';
+import { getPrimaryHouseholdId } from './household';
+import { SQLITE_NOW_EXPRESSION, optionalString, requireNumber, requireString } from './helpers';
+
+/** localStorage key the pre-#3273 invoice store wrote to. */
+const LEGACY_INVOICES_STORAGE_KEY = 'finance:invoices';
+
+const INVOICE_COLUMNS = [
+  'id',
+  'household_id',
+  'client_name',
+  'amount_cents',
+  'issue_date',
+  'payment_term',
+  'status',
+  'expected_pay_date',
+  'last_contacted_date',
+  'amount_paid_cents',
+  'paid_date',
+  'payment_account_id',
+  'payment_transaction_id',
+  'created_at',
+  'updated_at',
+  'deleted_at',
+  'sync_version',
+  'is_synced',
+].join(', ');
+
+const INVOICE_BASE_QUERY = `SELECT ${INVOICE_COLUMNS} FROM invoice WHERE deleted_at IS NULL`;
+
+/**
+ * Map a database row to the {@link Invoice} domain shape.
+ *
+ * Optional fields (payment link, last-contacted date, partial-payment total) are
+ * only included when present so the mapped object matches the shape produced by
+ * the pure `lib/analytics/invoices` factory functions.
+ */
+function mapInvoice(row: Row): Invoice {
+  const base: Invoice = {
+    id: requireString(row.id, 'invoice.id'),
+    clientName: requireString(row.client_name, 'invoice.client_name'),
+    amountCents: requireNumber(row.amount_cents, 'invoice.amount_cents'),
+    issueDate: requireString(row.issue_date, 'invoice.issue_date'),
+    paymentTerm: requireString(row.payment_term, 'invoice.payment_term') as InvoicePaymentTerm,
+    status: requireString(row.status, 'invoice.status') as InvoiceStatus,
+    expectedPayDate: requireString(row.expected_pay_date, 'invoice.expected_pay_date'),
+    createdAt: requireString(row.created_at, 'invoice.created_at'),
+    updatedAt: requireString(row.updated_at, 'invoice.updated_at'),
+  };
+
+  const lastContactedDate = optionalString(row.last_contacted_date);
+  const paidDate = optionalString(row.paid_date);
+  const paymentAccountId = optionalString(row.payment_account_id);
+  const paymentTransactionId = optionalString(row.payment_transaction_id);
+  const amountPaidCents =
+    row.amount_paid_cents == null
+      ? 0
+      : requireNumber(row.amount_paid_cents, 'invoice.amount_paid_cents');
+
+  return {
+    ...base,
+    ...(lastContactedDate ? { lastContactedDate } : {}),
+    ...(amountPaidCents > 0 ? { amountPaidCents } : {}),
+    ...(paidDate ? { paidDate } : {}),
+    ...(paymentAccountId ? { paymentAccountId } : {}),
+    ...(paymentTransactionId ? { paymentTransactionId } : {}),
+  };
+}
+
+/** Return all non-deleted invoices, newest first. */
+export function getAllInvoices(db: SqliteDb): Invoice[] {
+  return query<Row>(db, `${INVOICE_BASE_QUERY} ORDER BY created_at DESC, id DESC`).rows.map(
+    mapInvoice,
+  );
+}
+
+/** Find a single non-deleted invoice by its identifier. */
+export function getInvoiceById(db: SqliteDb, invoiceId: string): Invoice | null {
+  const row = queryOne<Row>(db, `${INVOICE_BASE_QUERY} AND id = ?`, [invoiceId]);
+  return row ? mapInvoice(row) : null;
+}
+
+/**
+ * Insert a fully-formed invoice and return the persisted record.
+ *
+ * The invoice's own timestamps are preserved (the domain layer is the source of
+ * truth for `createdAt`/`updatedAt`). `household_id` is resolved to the primary
+ * household when one exists so the record is scoped for sync/RLS; it stays null
+ * in a clean-slate workspace with no household yet.
+ */
+export function insertInvoice(db: SqliteDb, invoice: Invoice): Invoice {
+  const householdId = getPrimaryHouseholdId(db);
+
+  execute(
+    db,
+    `INSERT INTO invoice (
+      id,
+      household_id,
+      client_name,
+      amount_cents,
+      issue_date,
+      payment_term,
+      status,
+      expected_pay_date,
+      last_contacted_date,
+      amount_paid_cents,
+      paid_date,
+      payment_account_id,
+      payment_transaction_id,
+      created_at,
+      updated_at,
+      deleted_at,
+      sync_version,
+      is_synced
+    ) VALUES (
+      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+      NULL,
+      1,
+      0
+    )`,
+    [
+      invoice.id,
+      householdId,
+      invoice.clientName,
+      invoice.amountCents,
+      invoice.issueDate,
+      invoice.paymentTerm,
+      invoice.status,
+      invoice.expectedPayDate,
+      invoice.lastContactedDate ?? null,
+      invoice.amountPaidCents ?? 0,
+      invoice.paidDate ?? null,
+      invoice.paymentAccountId ?? null,
+      invoice.paymentTransactionId ?? null,
+      invoice.createdAt,
+      invoice.updatedAt,
+    ],
+  );
+
+  const created = getInvoiceById(db, invoice.id);
+  if (!created) {
+    throw new Error('Failed to persist invoice.');
+  }
+  return created;
+}
+
+/**
+ * Persist an edit to an existing invoice from a fully-formed record.
+ *
+ * Used for edits, status changes, follow-up logging and payments — the caller
+ * computes the next {@link Invoice} via the pure domain helpers and this writes
+ * every mutable column. Returns `null` when the invoice does not exist.
+ */
+export function updateInvoiceRecord(db: SqliteDb, invoice: Invoice): Invoice | null {
+  const existing = getInvoiceById(db, invoice.id);
+  if (!existing) {
+    return null;
+  }
+
+  execute(
+    db,
+    `UPDATE invoice
+        SET client_name = ?,
+            amount_cents = ?,
+            issue_date = ?,
+            payment_term = ?,
+            status = ?,
+            expected_pay_date = ?,
+            last_contacted_date = ?,
+            amount_paid_cents = ?,
+            paid_date = ?,
+            payment_account_id = ?,
+            payment_transaction_id = ?,
+            updated_at = ?,
+            sync_version = 1,
+            is_synced = 0
+      WHERE id = ?
+        AND deleted_at IS NULL`,
+    [
+      invoice.clientName,
+      invoice.amountCents,
+      invoice.issueDate,
+      invoice.paymentTerm,
+      invoice.status,
+      invoice.expectedPayDate,
+      invoice.lastContactedDate ?? null,
+      invoice.amountPaidCents ?? 0,
+      invoice.paidDate ?? null,
+      invoice.paymentAccountId ?? null,
+      invoice.paymentTransactionId ?? null,
+      invoice.updatedAt,
+      invoice.id,
+    ],
+  );
+
+  return getInvoiceById(db, invoice.id);
+}
+
+/** Soft-delete an invoice by marking its deleted timestamp. */
+export function deleteInvoiceRecord(db: SqliteDb, invoiceId: string): boolean {
+  const existing = getInvoiceById(db, invoiceId);
+  if (!existing) {
+    return false;
+  }
+
+  execute(
+    db,
+    `UPDATE invoice
+        SET deleted_at = ${SQLITE_NOW_EXPRESSION},
+            updated_at = ${SQLITE_NOW_EXPRESSION},
+            sync_version = 1,
+            is_synced = 0
+      WHERE id = ?
+        AND deleted_at IS NULL`,
+    [invoiceId],
+  );
+
+  return true;
+}
+
+/** Narrow an unknown legacy localStorage entry to an invoice-like record. */
+function isLegacyInvoice(value: unknown): value is Invoice {
+  if (!value || typeof value !== 'object') return false;
+  const invoice = value as Partial<Invoice>;
+  return (
+    typeof invoice.id === 'string' &&
+    typeof invoice.clientName === 'string' &&
+    typeof invoice.amountCents === 'number' &&
+    typeof invoice.issueDate === 'string' &&
+    typeof invoice.paymentTerm === 'string' &&
+    typeof invoice.status === 'string'
+  );
+}
+
+/** Coerce a legacy record into a complete {@link Invoice}, filling derived gaps. */
+function normalizeLegacyInvoice(entry: Invoice): Invoice {
+  const nowIso = new Date().toISOString();
+  return {
+    ...entry,
+    expectedPayDate:
+      entry.expectedPayDate || computeExpectedPayDate(entry.issueDate, entry.paymentTerm),
+    createdAt: entry.createdAt || nowIso,
+    updatedAt: entry.updatedAt || nowIso,
+  };
+}
+
+/**
+ * One-time migration of any invoices left in the pre-#3273 `localStorage` store
+ * into the database, then clear the legacy key so it is never read again.
+ *
+ * Best-effort and idempotent: the key is removed before importing so concurrent
+ * hook instances cannot double-import, and records whose id already exists are
+ * skipped. Returns the number of records imported.
+ */
+export function importLegacyInvoices(db: SqliteDb): number {
+  let raw: string | null;
+  try {
+    raw = globalThis.localStorage?.getItem(LEGACY_INVOICES_STORAGE_KEY) ?? null;
+  } catch {
+    return 0;
+  }
+  if (!raw) return 0;
+
+  // Remove first so a second concurrent caller sees nothing to import.
+  try {
+    globalThis.localStorage?.removeItem(LEGACY_INVOICES_STORAGE_KEY);
+  } catch {
+    // Ignore: storage may be unavailable (private mode, quota).
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return 0;
+  }
+  if (!Array.isArray(parsed)) return 0;
+
+  let imported = 0;
+  for (const entry of parsed) {
+    if (!isLegacyInvoice(entry)) continue;
+    try {
+      if (getInvoiceById(db, entry.id)) continue;
+      insertInvoice(db, normalizeLegacyInvoice(entry));
+      imported += 1;
+    } catch {
+      // Best-effort per record — a single bad row must not abort the migration.
+    }
+  }
+  return imported;
+}

--- a/apps/web/src/db/repositories/remittances.test.ts
+++ b/apps/web/src/db/repositories/remittances.test.ts
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the remittance persistence repository (issue #3273).
+ *
+ * Mocks `../sqlite-wasm` (and the household helper) and asserts the SQL /
+ * parameters, the row → {@link RemittanceRecord} mapping (nested recipient,
+ * nullable reference rate), soft-delete, and the one-time localStorage →
+ * database migration.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Row, SqliteDb } from '../sqlite-wasm';
+
+vi.mock('../sqlite-wasm', () => ({
+  execute: vi.fn(),
+  query: vi.fn(),
+  queryOne: vi.fn(),
+}));
+
+vi.mock('./household', () => ({
+  getPrimaryHouseholdId: vi.fn(),
+}));
+
+import { execute, query, queryOne } from '../sqlite-wasm';
+import { getPrimaryHouseholdId } from './household';
+import {
+  deleteRemittanceRecord,
+  getAllRemittances,
+  importLegacyRemittances,
+  insertRemittance,
+} from './remittances';
+import type { RemittanceRecord } from '../../lib/remittance';
+
+const mockExecute = vi.mocked(execute);
+const mockQuery = vi.mocked(query);
+const mockQueryOne = vi.mocked(queryOne);
+const mockGetPrimaryHouseholdId = vi.mocked(getPrimaryHouseholdId);
+
+const mockDb = {} as SqliteDb;
+
+function remittanceRow(overrides: Partial<Row> = {}): Row {
+  return {
+    id: 'rem-1',
+    household_id: 'hh-1',
+    date: '2026-06-01',
+    source_currency: 'USD',
+    dest_currency: 'INR',
+    send_amount_minor: 50000,
+    fee_minor: 500,
+    fx_rate: 83.25,
+    fee_model: 'ADDITIVE',
+    reference_rate: 83.5,
+    recipient_name: 'Priya Supplier',
+    recipient_country: 'IN',
+    note: 'June fabric order',
+    created_at: '2026-06-01T09:00:00.000Z',
+    updated_at: '2026-06-01T09:00:00.000Z',
+    deleted_at: null,
+    sync_version: 1,
+    is_synced: 0,
+    ...overrides,
+  };
+}
+
+function baseRemittance(overrides: Partial<RemittanceRecord> = {}): RemittanceRecord {
+  return {
+    id: 'rem-1',
+    date: '2026-06-01',
+    sourceCurrency: 'USD',
+    destCurrency: 'INR',
+    sendAmountMinor: 50000,
+    feeMinor: 500,
+    fxRate: 83.25,
+    feeModel: 'ADDITIVE',
+    referenceRate: 83.5,
+    recipient: { name: 'Priya Supplier', country: 'IN' },
+    note: 'June fabric order',
+    createdAt: '2026-06-01T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** Wire the mocked primitives to an in-memory table keyed by id. */
+function useInMemoryRemittanceTable(seed: Row[] = []): Map<string, Row> {
+  const table = new Map<string, Row>(seed.map((row) => [String(row.id), row]));
+
+  mockExecute.mockImplementation((_db, sql, params) => {
+    const text = String(sql);
+    if (text.includes('INSERT INTO remittance')) {
+      const id = String((params as unknown[])?.[0]);
+      table.set(id, remittanceRow({ id }));
+    }
+    return { rowsAffected: 1 };
+  });
+
+  mockQueryOne.mockImplementation((_db, _sql, params) => {
+    const id = String((params as unknown[])?.[0]);
+    return table.get(id) ?? null;
+  });
+
+  mockQuery.mockImplementation(() => ({ columns: [], rows: [...table.values()] }));
+
+  return table;
+}
+
+describe('remittances repository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPrimaryHouseholdId.mockReturnValue('hh-1');
+    globalThis.localStorage?.clear();
+  });
+
+  it('maps a row to the RemittanceRecord domain shape with a nested recipient', () => {
+    mockQuery.mockReturnValue({ columns: [], rows: [remittanceRow()] });
+
+    const [record] = getAllRemittances(mockDb);
+
+    expect(record).toEqual({
+      id: 'rem-1',
+      date: '2026-06-01',
+      sourceCurrency: 'USD',
+      destCurrency: 'INR',
+      sendAmountMinor: 50000,
+      feeMinor: 500,
+      fxRate: 83.25,
+      feeModel: 'ADDITIVE',
+      referenceRate: 83.5,
+      recipient: { name: 'Priya Supplier', country: 'IN' },
+      note: 'June fabric order',
+      createdAt: '2026-06-01T09:00:00.000Z',
+    });
+  });
+
+  it('maps a null reference rate and note back to null', () => {
+    mockQuery.mockReturnValue({
+      columns: [],
+      rows: [remittanceRow({ reference_rate: null, note: null })],
+    });
+
+    const [record] = getAllRemittances(mockDb);
+
+    expect(record.referenceRate).toBeNull();
+    expect(record.note).toBeNull();
+  });
+
+  it('inserts a remittance with the resolved household and split recipient columns', () => {
+    useInMemoryRemittanceTable();
+
+    const created = insertRemittance(mockDb, baseRemittance());
+
+    expect(mockGetPrimaryHouseholdId).toHaveBeenCalledWith(mockDb);
+    const [, sql, params] = mockExecute.mock.calls[0];
+    expect(String(sql)).toContain('INSERT INTO remittance');
+    expect(params).toEqual([
+      'rem-1',
+      'hh-1',
+      '2026-06-01',
+      'USD',
+      'INR',
+      50000,
+      500,
+      83.25,
+      'ADDITIVE',
+      83.5,
+      'Priya Supplier',
+      'IN',
+      'June fabric order',
+      '2026-06-01T09:00:00.000Z',
+      '2026-06-01T09:00:00.000Z',
+    ]);
+    expect(created.id).toBe('rem-1');
+  });
+
+  it('stores a null household when no household exists yet', () => {
+    mockGetPrimaryHouseholdId.mockReturnValue(null);
+    useInMemoryRemittanceTable();
+
+    insertRemittance(mockDb, baseRemittance());
+
+    expect(mockExecute.mock.calls[0][2]?.[1]).toBeNull();
+  });
+
+  it('soft-deletes a remittance by marking deleted_at', () => {
+    useInMemoryRemittanceTable([remittanceRow()]);
+
+    expect(deleteRemittanceRecord(mockDb, 'rem-1')).toBe(true);
+    const updateCall = mockExecute.mock.calls.find(([, sql]) =>
+      String(sql).includes('UPDATE remittance'),
+    );
+    expect(updateCall?.[1]).toContain('deleted_at =');
+  });
+
+  it('returns false when deleting a remittance that does not exist', () => {
+    mockQueryOne.mockReturnValue(null);
+
+    expect(deleteRemittanceRecord(mockDb, 'missing')).toBe(false);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('imports legacy localStorage remittances into the database and clears the key', () => {
+    globalThis.localStorage.setItem(
+      'finance-remittances',
+      JSON.stringify([
+        baseRemittance({ id: 'legacy-1' }),
+        baseRemittance({ id: 'legacy-2', recipient: { name: 'Vendor Two', country: 'IN' } }),
+      ]),
+    );
+    useInMemoryRemittanceTable();
+
+    const imported = importLegacyRemittances(mockDb);
+
+    expect(imported).toBe(2);
+    expect(globalThis.localStorage.getItem('finance-remittances')).toBeNull();
+    const insertCalls = mockExecute.mock.calls.filter(([, sql]) =>
+      String(sql).includes('INSERT INTO remittance'),
+    );
+    expect(insertCalls).toHaveLength(2);
+  });
+
+  it('skips legacy records whose id already exists (idempotent re-import)', () => {
+    globalThis.localStorage.setItem(
+      'finance-remittances',
+      JSON.stringify([baseRemittance({ id: 'existing' })]),
+    );
+    useInMemoryRemittanceTable([remittanceRow({ id: 'existing' })]);
+
+    expect(importLegacyRemittances(mockDb)).toBe(0);
+    const insertCalls = mockExecute.mock.calls.filter(([, sql]) =>
+      String(sql).includes('INSERT INTO remittance'),
+    );
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('returns 0 and writes nothing when there is no legacy data', () => {
+    useInMemoryRemittanceTable();
+
+    expect(importLegacyRemittances(mockDb)).toBe(0);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/db/repositories/remittances.ts
+++ b/apps/web/src/db/repositories/remittances.ts
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Remittance persistence repository (issue #3273).
+ *
+ * Durable, encrypted storage for the cross-border remittance history. Replaces
+ * the previous `localStorage` store so records survive a browser-cache clear and
+ * ride the SQLite-WASM (OPFS) + sync path used by accounts/transactions — no
+ * plaintext financial data on disk.
+ *
+ * All FX/fee math and aggregation stays in the pure `lib/remittance` module; the
+ * repository only reads and writes fully-formed {@link RemittanceRecord}s. Money
+ * is stored in integer minor units and FX rates as reals.
+ */
+
+import type { RemittanceFeeModel, RemittanceRecord } from '../../lib/remittance';
+import { execute, query, queryOne, type Row, type SqliteDb } from '../sqlite-wasm';
+import { getPrimaryHouseholdId } from './household';
+import { SQLITE_NOW_EXPRESSION, optionalString, requireNumber, requireString } from './helpers';
+
+/** localStorage key the pre-#3273 remittance store wrote to. */
+const LEGACY_REMITTANCES_STORAGE_KEY = 'finance-remittances';
+
+const REMITTANCE_COLUMNS = [
+  'id',
+  'household_id',
+  'date',
+  'source_currency',
+  'dest_currency',
+  'send_amount_minor',
+  'fee_minor',
+  'fx_rate',
+  'fee_model',
+  'reference_rate',
+  'recipient_name',
+  'recipient_country',
+  'note',
+  'created_at',
+  'updated_at',
+  'deleted_at',
+  'sync_version',
+  'is_synced',
+].join(', ');
+
+const REMITTANCE_BASE_QUERY = `SELECT ${REMITTANCE_COLUMNS} FROM remittance WHERE deleted_at IS NULL`;
+
+/** Map a database row to the {@link RemittanceRecord} domain shape. */
+function mapRemittance(row: Row): RemittanceRecord {
+  return {
+    id: requireString(row.id, 'remittance.id'),
+    date: requireString(row.date, 'remittance.date'),
+    sourceCurrency: requireString(row.source_currency, 'remittance.source_currency'),
+    destCurrency: requireString(row.dest_currency, 'remittance.dest_currency'),
+    sendAmountMinor: requireNumber(row.send_amount_minor, 'remittance.send_amount_minor'),
+    feeMinor: requireNumber(row.fee_minor, 'remittance.fee_minor'),
+    fxRate: requireNumber(row.fx_rate, 'remittance.fx_rate'),
+    feeModel: requireString(row.fee_model, 'remittance.fee_model') as RemittanceFeeModel,
+    referenceRate:
+      row.reference_rate == null
+        ? null
+        : requireNumber(row.reference_rate, 'remittance.reference_rate'),
+    recipient: {
+      name: requireString(row.recipient_name, 'remittance.recipient_name'),
+      country: requireString(row.recipient_country, 'remittance.recipient_country'),
+    },
+    note: optionalString(row.note),
+    createdAt: requireString(row.created_at, 'remittance.created_at'),
+  };
+}
+
+/** Return all non-deleted remittances, most recent send date first. */
+export function getAllRemittances(db: SqliteDb): RemittanceRecord[] {
+  return query<Row>(
+    db,
+    `${REMITTANCE_BASE_QUERY} ORDER BY date DESC, created_at DESC, id DESC`,
+  ).rows.map(mapRemittance);
+}
+
+/** Find a single non-deleted remittance by its identifier. */
+export function getRemittanceById(db: SqliteDb, remittanceId: string): RemittanceRecord | null {
+  const row = queryOne<Row>(db, `${REMITTANCE_BASE_QUERY} AND id = ?`, [remittanceId]);
+  return row ? mapRemittance(row) : null;
+}
+
+/**
+ * Insert a fully-formed remittance and return the persisted record.
+ *
+ * The record's own `createdAt` is preserved (the hook is the source of truth for
+ * it). `household_id` is resolved to the primary household when one exists so the
+ * record is scoped for sync/RLS; it stays null in a clean-slate workspace.
+ */
+export function insertRemittance(db: SqliteDb, record: RemittanceRecord): RemittanceRecord {
+  const householdId = getPrimaryHouseholdId(db);
+
+  execute(
+    db,
+    `INSERT INTO remittance (
+      id,
+      household_id,
+      date,
+      source_currency,
+      dest_currency,
+      send_amount_minor,
+      fee_minor,
+      fx_rate,
+      fee_model,
+      reference_rate,
+      recipient_name,
+      recipient_country,
+      note,
+      created_at,
+      updated_at,
+      deleted_at,
+      sync_version,
+      is_synced
+    ) VALUES (
+      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+      NULL,
+      1,
+      0
+    )`,
+    [
+      record.id,
+      householdId,
+      record.date,
+      record.sourceCurrency,
+      record.destCurrency,
+      record.sendAmountMinor,
+      record.feeMinor,
+      record.fxRate,
+      record.feeModel,
+      record.referenceRate,
+      record.recipient.name,
+      record.recipient.country,
+      record.note,
+      record.createdAt,
+      record.createdAt,
+    ],
+  );
+
+  const created = getRemittanceById(db, record.id);
+  if (!created) {
+    throw new Error('Failed to persist remittance.');
+  }
+  return created;
+}
+
+/** Soft-delete a remittance by marking its deleted timestamp. */
+export function deleteRemittanceRecord(db: SqliteDb, remittanceId: string): boolean {
+  const existing = getRemittanceById(db, remittanceId);
+  if (!existing) {
+    return false;
+  }
+
+  execute(
+    db,
+    `UPDATE remittance
+        SET deleted_at = ${SQLITE_NOW_EXPRESSION},
+            updated_at = ${SQLITE_NOW_EXPRESSION},
+            sync_version = 1,
+            is_synced = 0
+      WHERE id = ?
+        AND deleted_at IS NULL`,
+    [remittanceId],
+  );
+
+  return true;
+}
+
+/** Narrow an unknown legacy localStorage entry to a remittance-like record. */
+function isLegacyRemittance(value: unknown): value is RemittanceRecord {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Partial<RemittanceRecord>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.date === 'string' &&
+    typeof record.sourceCurrency === 'string' &&
+    typeof record.destCurrency === 'string' &&
+    typeof record.sendAmountMinor === 'number' &&
+    typeof record.feeMinor === 'number' &&
+    typeof record.fxRate === 'number' &&
+    typeof record.feeModel === 'string' &&
+    typeof record.recipient === 'object' &&
+    record.recipient !== null &&
+    typeof record.recipient.name === 'string' &&
+    typeof record.recipient.country === 'string'
+  );
+}
+
+/** Coerce a legacy record into a complete {@link RemittanceRecord}. */
+function normalizeLegacyRemittance(entry: RemittanceRecord): RemittanceRecord {
+  return {
+    ...entry,
+    referenceRate: entry.referenceRate ?? null,
+    note: entry.note ?? null,
+    createdAt: entry.createdAt || new Date().toISOString(),
+  };
+}
+
+/**
+ * One-time migration of any remittances left in the pre-#3273 `localStorage`
+ * store into the database, then clear the legacy key so it is never read again.
+ *
+ * Best-effort and idempotent: the key is removed before importing so concurrent
+ * hook instances cannot double-import, and records whose id already exists are
+ * skipped. Returns the number of records imported.
+ */
+export function importLegacyRemittances(db: SqliteDb): number {
+  let raw: string | null;
+  try {
+    raw = globalThis.localStorage?.getItem(LEGACY_REMITTANCES_STORAGE_KEY) ?? null;
+  } catch {
+    return 0;
+  }
+  if (!raw) return 0;
+
+  // Remove first so a second concurrent caller sees nothing to import.
+  try {
+    globalThis.localStorage?.removeItem(LEGACY_REMITTANCES_STORAGE_KEY);
+  } catch {
+    // Ignore: storage may be unavailable (private mode, quota).
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return 0;
+  }
+  if (!Array.isArray(parsed)) return 0;
+
+  let imported = 0;
+  for (const entry of parsed) {
+    if (!isLegacyRemittance(entry)) continue;
+    try {
+      if (getRemittanceById(db, entry.id)) continue;
+      insertRemittance(db, normalizeLegacyRemittance(entry));
+      imported += 1;
+    } catch {
+      // Best-effort per record — a single bad row must not abort the migration.
+    }
+  }
+  return imported;
+}

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -598,6 +598,72 @@ export const MIGRATIONS: Migration[] = [
       `CREATE INDEX IF NOT EXISTS idx_category_sort ON category (sort_order);`,
     ],
   },
+  {
+    version: 14,
+    label: 'add-invoices-and-remittances',
+    up: [
+      // Move the freelancer invoice pipeline and cross-border remittance history
+      // off browser localStorage onto the encrypted SQLite/OPFS store so business
+      // records are durable and ride the sync path like accounts/transactions
+      // (#3273). These are web-first tables today; the durable model is expected
+      // to land in the shared KMP/PowerSync schema next (note for @kmp-engineer /
+      // @backend-engineer). `household_id` is nullable so a record created before
+      // any household exists (e.g. a clean-slate workspace) still persists; it is
+      // resolved to the primary household when one is present, mirroring the goal
+      // onboarding pattern (getPrimaryHouseholdId, #3405).
+      `CREATE TABLE IF NOT EXISTS invoice (
+        id                     TEXT    NOT NULL PRIMARY KEY,
+        household_id           TEXT,
+        client_name            TEXT    NOT NULL,
+        amount_cents           INTEGER NOT NULL,
+        issue_date             TEXT    NOT NULL,
+        payment_term           TEXT    NOT NULL,
+        status                 TEXT    NOT NULL DEFAULT 'Sent',
+        expected_pay_date      TEXT    NOT NULL,
+        last_contacted_date    TEXT,
+        amount_paid_cents      INTEGER NOT NULL DEFAULT 0,
+        paid_date              TEXT,
+        payment_account_id     TEXT,
+        payment_transaction_id TEXT,
+        created_at             TEXT    NOT NULL,
+        updated_at             TEXT    NOT NULL,
+        deleted_at             TEXT,
+        sync_version           INTEGER NOT NULL DEFAULT 0,
+        is_synced              INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (household_id)           REFERENCES household(id),
+        FOREIGN KEY (payment_account_id)     REFERENCES account(id),
+        FOREIGN KEY (payment_transaction_id) REFERENCES "transaction"(id)
+      );`,
+      `CREATE INDEX IF NOT EXISTS idx_invoice_household ON invoice (household_id);`,
+      `CREATE INDEX IF NOT EXISTS idx_invoice_status    ON invoice (status);`,
+      `CREATE INDEX IF NOT EXISTS idx_invoice_sync      ON invoice (is_synced);`,
+
+      `CREATE TABLE IF NOT EXISTS remittance (
+        id                TEXT    NOT NULL PRIMARY KEY,
+        household_id      TEXT,
+        date              TEXT    NOT NULL,
+        source_currency   TEXT    NOT NULL,
+        dest_currency     TEXT    NOT NULL,
+        send_amount_minor INTEGER NOT NULL,
+        fee_minor         INTEGER NOT NULL,
+        fx_rate           REAL    NOT NULL,
+        fee_model         TEXT    NOT NULL,
+        reference_rate    REAL,
+        recipient_name    TEXT    NOT NULL,
+        recipient_country TEXT    NOT NULL,
+        note              TEXT,
+        created_at        TEXT    NOT NULL,
+        updated_at        TEXT    NOT NULL,
+        deleted_at        TEXT,
+        sync_version      INTEGER NOT NULL DEFAULT 0,
+        is_synced         INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (household_id) REFERENCES household(id)
+      );`,
+      `CREATE INDEX IF NOT EXISTS idx_remittance_household ON remittance (household_id);`,
+      `CREATE INDEX IF NOT EXISTS idx_remittance_date      ON remittance (date);`,
+      `CREATE INDEX IF NOT EXISTS idx_remittance_sync      ON remittance (is_synced);`,
+    ],
+  },
 ];
 // ---------------------------------------------------------------------------
 // OPFS / IndexedDB feature detection

--- a/apps/web/src/hooks/__tests__/useInvoices.test.ts
+++ b/apps/web/src/hooks/__tests__/useInvoices.test.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the useInvoices hook (issues #2169, #3273).
+ *
+ * The hook now reads and writes through the database-backed invoices repository
+ * instead of localStorage. These tests mock the DatabaseProvider and the
+ * repository (a stateful in-memory store) so they can prove the durable
+ * behaviour that #3273 requires: records survive a simulated cache clear, the
+ * one-time legacy migration runs on mount, the #3266 payment link round-trips,
+ * and nothing is ever written to `localStorage`.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useInvoices } from '../useInvoices';
+import type { CreateInvoiceInput, Invoice } from '../../lib/analytics/invoices';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDb = {} as ReturnType<typeof import('../../db/DatabaseProvider').useDatabase>;
+
+vi.mock('../../db/DatabaseProvider', () => ({
+  useDatabase: () => mockDb,
+}));
+
+/** Durable in-memory store standing in for the SQLite-backed repository. */
+const store = new Map<string, Invoice>();
+const importLegacyInvoices = vi.fn<() => number>(() => 0);
+
+vi.mock('../../db/repositories/invoices', () => ({
+  getAllInvoices: () =>
+    [...store.values()].sort(
+      (a, b) => b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id),
+    ),
+  getInvoiceById: (_db: unknown, id: string) => store.get(id) ?? null,
+  insertInvoice: (_db: unknown, invoice: Invoice) => {
+    store.set(invoice.id, invoice);
+    return invoice;
+  },
+  updateInvoiceRecord: (_db: unknown, invoice: Invoice) => {
+    if (!store.has(invoice.id)) return null;
+    store.set(invoice.id, invoice);
+    return invoice;
+  },
+  deleteInvoiceRecord: (_db: unknown, id: string) => store.delete(id),
+  importLegacyInvoices: () => importLegacyInvoices(),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function input(overrides: Partial<CreateInvoiceInput> = {}): CreateInvoiceInput {
+  return {
+    clientName: 'Studio Delacroix',
+    amountCents: 120000,
+    issueDate: '2026-01-01',
+    paymentTerm: 'net-30',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useInvoices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store.clear();
+    importLegacyInvoices.mockReturnValue(0);
+    localStorage.clear();
+  });
+
+  it('starts empty and runs the one-time legacy migration on mount', () => {
+    const { result } = renderHook(() => useInvoices());
+
+    expect(result.current.invoices).toEqual([]);
+    expect(importLegacyInvoices).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds an invoice through the repository and returns it', () => {
+    const { result } = renderHook(() => useInvoices());
+
+    let created: Invoice | undefined;
+    act(() => {
+      created = result.current.addInvoice(input());
+    });
+
+    expect(created?.clientName).toBe('Studio Delacroix');
+    expect(result.current.invoices).toHaveLength(1);
+    expect(result.current.invoices[0]?.id).toBe(created?.id);
+  });
+
+  it('never writes invoices to localStorage', () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+    const { result } = renderHook(() => useInvoices());
+
+    act(() => {
+      result.current.addInvoice(input());
+    });
+
+    expect(localStorage.getItem('finance:invoices')).toBeNull();
+    expect(setItem).not.toHaveBeenCalledWith('finance:invoices', expect.anything());
+    setItem.mockRestore();
+  });
+
+  it('persists across a simulated cache clear (data lives in the database)', () => {
+    const first = renderHook(() => useInvoices());
+    let created: Invoice | undefined;
+    act(() => {
+      created = first.result.current.addInvoice(input());
+    });
+    first.unmount();
+
+    // Simulate the user clearing browser storage — the durable copy is in the
+    // repository/database, not localStorage, so it must still be readable.
+    localStorage.clear();
+
+    const second = renderHook(() => useInvoices());
+    expect(second.result.current.invoices).toHaveLength(1);
+    expect(second.result.current.invoices[0]?.id).toBe(created?.id);
+  });
+
+  it('records a payment and preserves the #3266 cash-inflow link', () => {
+    const { result } = renderHook(() => useInvoices());
+    let created: Invoice | undefined;
+    act(() => {
+      created = result.current.addInvoice(input({ amountCents: 10000 }));
+    });
+
+    act(() => {
+      result.current.recordPayment(created!.id, 10000, '2026-02-01', {
+        accountId: 'acc-1',
+        transactionId: 'txn-1',
+      });
+    });
+
+    const paid = result.current.invoices.find((invoice) => invoice.id === created?.id);
+    expect(paid?.status).toBe('Paid');
+    expect(paid?.paymentAccountId).toBe('acc-1');
+    expect(paid?.paymentTransactionId).toBe('txn-1');
+    expect(paid?.amountPaidCents).toBe(10000);
+  });
+
+  it('updates an invoice status through the repository', () => {
+    const { result } = renderHook(() => useInvoices());
+    let created: Invoice | undefined;
+    act(() => {
+      created = result.current.addInvoice(input());
+    });
+
+    act(() => {
+      result.current.updateInvoiceStatus(created!.id, 'Draft');
+    });
+
+    expect(result.current.invoices[0]?.status).toBe('Draft');
+  });
+
+  it('deletes an invoice through the repository', () => {
+    const { result } = renderHook(() => useInvoices());
+    let created: Invoice | undefined;
+    act(() => {
+      created = result.current.addInvoice(input());
+    });
+    expect(result.current.invoices).toHaveLength(1);
+
+    act(() => {
+      result.current.deleteInvoice(created!.id);
+    });
+
+    expect(result.current.invoices).toHaveLength(0);
+  });
+});

--- a/apps/web/src/hooks/useInvoices.ts
+++ b/apps/web/src/hooks/useInvoices.ts
@@ -1,15 +1,28 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Local-first invoice pipeline state for freelancers.
+ * Invoice pipeline state for freelancers, backed by the local database.
  *
- * Persists invoice records in localStorage and derives pipeline totals,
- * net-terms expected pay dates, overdue status, and forecast buckets.
+ * Persists invoice records in the encrypted SQLite-WASM (OPFS) store via the
+ * invoices repository — the same durable, sync-enabled path used by accounts,
+ * transactions and goals — instead of browser `localStorage`, so records survive
+ * a cache clear and no plaintext financial data is written to disk (issue #3273).
+ * Derives pipeline totals, net-terms expected pay dates, overdue status, and
+ * forecast buckets from the pure `lib/analytics/invoices` domain module.
  *
- * References: issue #2169
+ * References: issue #2169 (feature), issue #3273 (durable persistence)
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDatabase } from '../db/DatabaseProvider';
+import {
+  deleteInvoiceRecord,
+  getAllInvoices,
+  getInvoiceById,
+  importLegacyInvoices,
+  insertInvoice,
+  updateInvoiceRecord,
+} from '../db/repositories/invoices';
 import {
   computeInvoiceForecast,
   createInvoice,
@@ -26,8 +39,6 @@ import {
   type InvoiceStatus,
   type UpdateInvoiceInput,
 } from '../lib/analytics/invoices';
-
-const STORAGE_KEY = 'finance:invoices';
 
 export interface UseInvoicesResult {
   invoices: Invoice[];
@@ -63,133 +74,124 @@ function makeId(): string {
   );
 }
 
-function isInvoice(value: unknown): value is Invoice {
-  if (!value || typeof value !== 'object') return false;
-  const invoice = value as Partial<Invoice>;
-  return (
-    typeof invoice.id === 'string' &&
-    typeof invoice.clientName === 'string' &&
-    typeof invoice.amountCents === 'number' &&
-    typeof invoice.issueDate === 'string' &&
-    typeof invoice.paymentTerm === 'string' &&
-    typeof invoice.status === 'string' &&
-    typeof invoice.expectedPayDate === 'string'
-  );
-}
-
-function loadInvoices(): Invoice[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    return Array.isArray(parsed) ? parsed.filter(isInvoice) : [];
-  } catch {
-    return [];
-  }
-}
-
-function persistInvoices(invoices: Invoice[]): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(invoices));
-  } catch {
-    // Local storage may be unavailable or full.
-  }
-}
-
 export function useInvoices(): UseInvoicesResult {
-  const [invoices, setInvoices] = useState<Invoice[]>(() =>
-    normalizeInvoiceStatuses(loadInvoices(), todayIsoDate()),
-  );
+  const db = useDatabase();
+
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [today, setToday] = useState(todayIsoDate);
+  const [refreshToken, setRefreshToken] = useState(0);
 
   useEffect(() => {
-    persistInvoices(invoices);
-  }, [invoices]);
+    const currentDate = todayIsoDate();
+    setToday(currentDate);
+    try {
+      // One-time migration of any records left in the pre-#3273 localStorage
+      // store, then read the durable list back from the database.
+      importLegacyInvoices(db);
+      setInvoices(normalizeInvoiceStatuses(getAllInvoices(db), currentDate));
+    } catch {
+      setInvoices([]);
+    }
+  }, [db, refreshToken]);
 
   const refresh = useCallback(() => {
-    const currentDate = todayIsoDate();
-    setToday(currentDate);
-    setInvoices((prev) => normalizeInvoiceStatuses(prev, currentDate));
+    setRefreshToken((token) => token + 1);
   }, []);
 
-  const addInvoice = useCallback((input: CreateInvoiceInput) => {
-    const now = new Date().toISOString();
-    const invoice = createInvoice(input, now, makeId());
-    setInvoices((prev) => normalizeInvoiceStatuses([invoice, ...prev], todayIsoDate()));
-    return invoice;
-  }, []);
+  const addInvoice = useCallback(
+    (input: CreateInvoiceInput): Invoice => {
+      const invoice = createInvoice(input, new Date().toISOString(), makeId());
+      try {
+        insertInvoice(db, invoice);
+        refresh();
+      } catch {
+        // Non-throwing convention: return the computed invoice even if the
+        // write failed so callers keep a stable synchronous signature.
+      }
+      return invoice;
+    },
+    [db, refresh],
+  );
 
-  const updateInvoice = useCallback((invoiceId: string, input: UpdateInvoiceInput) => {
-    const currentDate = todayIsoDate();
-    setToday(currentDate);
-    setInvoices((prev) =>
-      normalizeInvoiceStatuses(
-        prev.map((invoice) =>
-          invoice.id === invoiceId
-            ? applyInvoiceEdit(invoice, input, new Date().toISOString())
-            : invoice,
-        ),
-        currentDate,
-      ),
-    );
-  }, []);
+  const updateInvoice = useCallback(
+    (invoiceId: string, input: UpdateInvoiceInput) => {
+      try {
+        const existing = getInvoiceById(db, invoiceId);
+        if (!existing) return;
+        updateInvoiceRecord(db, applyInvoiceEdit(existing, input, new Date().toISOString()));
+        refresh();
+      } catch {
+        // Swallow — the invoices surface has no error channel.
+      }
+    },
+    [db, refresh],
+  );
 
-  const updateInvoiceStatus = useCallback((invoiceId: string, status: InvoiceStatus) => {
-    const currentDate = todayIsoDate();
-    setToday(currentDate);
-    setInvoices((prev) =>
-      normalizeInvoiceStatuses(
-        prev.map((invoice) =>
-          invoice.id === invoiceId
-            ? { ...invoice, status, updatedAt: new Date().toISOString() }
-            : invoice,
-        ),
-        currentDate,
-      ),
-    );
-  }, []);
+  const updateInvoiceStatus = useCallback(
+    (invoiceId: string, status: InvoiceStatus) => {
+      try {
+        const existing = getInvoiceById(db, invoiceId);
+        if (!existing) return;
+        updateInvoiceRecord(db, { ...existing, status, updatedAt: new Date().toISOString() });
+        refresh();
+      } catch {
+        // Swallow — the invoices surface has no error channel.
+      }
+    },
+    [db, refresh],
+  );
 
-  const deleteInvoice = useCallback((invoiceId: string) => {
-    setInvoices((prev) => prev.filter((invoice) => invoice.id !== invoiceId));
-  }, []);
+  const deleteInvoice = useCallback(
+    (invoiceId: string) => {
+      try {
+        deleteInvoiceRecord(db, invoiceId);
+        refresh();
+      } catch {
+        // Swallow — the invoices surface has no error channel.
+      }
+    },
+    [db, refresh],
+  );
 
-  const logInvoiceContact = useCallback((invoiceId: string) => {
-    const currentDate = todayIsoDate();
-    setToday(currentDate);
-    setInvoices((prev) =>
-      normalizeInvoiceStatuses(
-        prev.map((invoice) =>
-          invoice.id === invoiceId
-            ? recordInvoiceContact(invoice, currentDate, new Date().toISOString())
-            : invoice,
-        ),
-        currentDate,
-      ),
-    );
-  }, []);
+  const logInvoiceContact = useCallback(
+    (invoiceId: string) => {
+      try {
+        const existing = getInvoiceById(db, invoiceId);
+        if (!existing) return;
+        updateInvoiceRecord(
+          db,
+          recordInvoiceContact(existing, todayIsoDate(), new Date().toISOString()),
+        );
+        refresh();
+      } catch {
+        // Swallow — the invoices surface has no error channel.
+      }
+    },
+    [db, refresh],
+  );
 
   const recordPayment = useCallback(
     (invoiceId: string, paymentCents: number, paidDate?: string, link?: InvoicePaymentLink) => {
-      const currentDate = todayIsoDate();
-      setToday(currentDate);
-      setInvoices((prev) =>
-        normalizeInvoiceStatuses(
-          prev.map((invoice) =>
-            invoice.id === invoiceId
-              ? recordInvoicePayment(
-                  invoice,
-                  paymentCents,
-                  paidDate ?? currentDate,
-                  new Date().toISOString(),
-                  link,
-                )
-              : invoice,
+      try {
+        const existing = getInvoiceById(db, invoiceId);
+        if (!existing) return;
+        const currentDate = todayIsoDate();
+        updateInvoiceRecord(
+          db,
+          recordInvoicePayment(
+            existing,
+            paymentCents,
+            paidDate ?? currentDate,
+            new Date().toISOString(),
+            link,
           ),
-          currentDate,
-        ),
-      );
+        );
+        refresh();
+      } catch {
+        // Swallow — the invoices surface has no error channel.
+      }
     },
-    [],
+    [db, refresh],
   );
 
   const pipelineGroups = useMemo(() => groupInvoicesByStatus(invoices, today), [invoices, today]);

--- a/apps/web/src/hooks/useRemittances.test.ts
+++ b/apps/web/src/hooks/useRemittances.test.ts
@@ -1,17 +1,52 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Tests for the useRemittances hook (issue #2170).
+ * Tests for the useRemittances hook (issues #2170, #3273).
  *
- * The hook is edge/client-side only — it persists to localStorage, so these
- * tests exercise the real (jsdom) localStorage rather than mocking a repository.
+ * The hook now reads and writes through the database-backed remittances
+ * repository instead of localStorage. These tests mock the DatabaseProvider and
+ * the repository (a stateful in-memory store) so they can prove the durable
+ * behaviour that #3273 requires: records survive a simulated cache clear, the
+ * one-time legacy migration runs on mount, and nothing is written to
+ * `localStorage`.
  */
 
 import { act, renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useRemittances } from './useRemittances';
-import type { CreateRemittanceInput } from '../lib/remittance';
+import type { CreateRemittanceInput, RemittanceRecord } from '../lib/remittance';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDb = {} as ReturnType<typeof import('../db/DatabaseProvider').useDatabase>;
+
+vi.mock('../db/DatabaseProvider', () => ({
+  useDatabase: () => mockDb,
+}));
+
+/** Durable in-memory store standing in for the SQLite-backed repository. */
+const store = new Map<string, RemittanceRecord>();
+const importLegacyRemittances = vi.fn<() => number>(() => 0);
+
+vi.mock('../db/repositories/remittances', () => ({
+  getAllRemittances: () =>
+    [...store.values()].sort(
+      (a, b) => b.date.localeCompare(a.date) || b.createdAt.localeCompare(a.createdAt),
+    ),
+  insertRemittance: (_db: unknown, record: RemittanceRecord) => {
+    store.set(record.id, record);
+    return record;
+  },
+  deleteRemittanceRecord: (_db: unknown, id: string) => store.delete(id),
+  importLegacyRemittances: () => importLegacyRemittances(),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
 
 function input(overrides: Partial<CreateRemittanceInput> = {}): CreateRemittanceInput {
   return {
@@ -31,14 +66,18 @@ function input(overrides: Partial<CreateRemittanceInput> = {}): CreateRemittance
 
 describe('useRemittances', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    store.clear();
+    importLegacyRemittances.mockReturnValue(0);
     localStorage.clear();
   });
 
-  it('starts empty', () => {
+  it('starts empty and runs the one-time legacy migration on mount', () => {
     const { result } = renderHook(() => useRemittances());
     expect(result.current.remittances).toEqual([]);
     expect(result.current.loading).toBe(false);
     expect(result.current.summary.count).toBe(0);
+    expect(importLegacyRemittances).toHaveBeenCalledTimes(1);
   });
 
   it('creates a remittance and updates the summary', () => {
@@ -55,12 +94,29 @@ describe('useRemittances', () => {
     expect(result.current.remittances[0]?.id).toBeTruthy();
   });
 
-  it('persists across hook remounts (localStorage)', () => {
+  it('never writes remittances to localStorage', () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+    const { result } = renderHook(() => useRemittances());
+
+    act(() => {
+      result.current.createRemittance(input());
+    });
+
+    expect(localStorage.getItem('finance-remittances')).toBeNull();
+    expect(setItem).not.toHaveBeenCalledWith('finance-remittances', expect.anything());
+    setItem.mockRestore();
+  });
+
+  it('persists across a simulated cache clear (data lives in the database)', () => {
     const first = renderHook(() => useRemittances());
     act(() => {
       first.result.current.createRemittance(input());
     });
     first.unmount();
+
+    // Simulate the user clearing browser storage — the durable copy is in the
+    // repository/database, not localStorage, so it must still be readable.
+    localStorage.clear();
 
     const second = renderHook(() => useRemittances());
     expect(second.result.current.remittances).toHaveLength(1);

--- a/apps/web/src/hooks/useRemittances.ts
+++ b/apps/web/src/hooks/useRemittances.ts
@@ -1,17 +1,28 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * React hook for remittance tracking (issue #2170).
+ * React hook for remittance tracking (issue #2170), backed by the local database.
  *
- * Edge / client-side only: remittance entries are persisted to `localStorage`
- * (no SQLite repository, no network) so the workflow is fully offline. Follows
- * the project's hook conventions — captures errors in state (never throws),
- * exposes a `refresh()` and a `refreshToken`-driven effect, and returns a
- * consistent CRUD-style shape.
+ * Persists remittance history in the encrypted SQLite-WASM (OPFS) store via the
+ * remittances repository — the same durable, sync-enabled path used by accounts
+ * and transactions — instead of browser `localStorage`, so records survive a
+ * cache clear and no plaintext financial data is written to disk (issue #3273).
+ * Follows the project's hook conventions — captures errors in state (never
+ * throws), exposes a `refresh()` and a `refreshToken`-driven effect, and returns
+ * a consistent CRUD-style shape.
+ *
+ * References: issue #2170 (feature), issue #3273 (durable persistence)
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useDatabase } from '../db/DatabaseProvider';
+import {
+  deleteRemittanceRecord,
+  getAllRemittances,
+  importLegacyRemittances,
+  insertRemittance,
+} from '../db/repositories/remittances';
 import { summarizeRemittances, summarizeByRecipient } from '../lib/remittance';
 import type {
   CreateRemittanceInput,
@@ -19,8 +30,6 @@ import type {
   RemittanceSummary,
   RemittanceRecipientBreakdown,
 } from '../lib/remittance';
-
-const STORAGE_KEY = 'finance-remittances';
 
 export interface UseRemittancesResult {
   readonly remittances: readonly RemittanceRecord[];
@@ -33,25 +42,6 @@ export interface UseRemittancesResult {
   readonly deleteRemittance: (id: string) => boolean;
 }
 
-function readStorage(): RemittanceRecord[] {
-  try {
-    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as RemittanceRecord[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-function writeStorage(records: readonly RemittanceRecord[]): void {
-  try {
-    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(records));
-  } catch {
-    // Best-effort persistence; storage may be unavailable (private mode, quota).
-  }
-}
-
 function generateId(): string {
   try {
     return (
@@ -62,15 +52,9 @@ function generateId(): string {
   }
 }
 
-/** Most recent first (by send date, then creation instant). */
-function sortRecords(records: readonly RemittanceRecord[]): RemittanceRecord[] {
-  return [...records].sort((a, b) => {
-    if (a.date !== b.date) return a.date < b.date ? 1 : -1;
-    return a.createdAt < b.createdAt ? 1 : -1;
-  });
-}
-
 export function useRemittances(): UseRemittancesResult {
+  const db = useDatabase();
+
   const [remittances, setRemittances] = useState<readonly RemittanceRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -85,48 +69,52 @@ export function useRemittances(): UseRemittancesResult {
     setLoading(true);
     setError(null);
     try {
-      setRemittances(sortRecords(readStorage()));
+      // One-time migration of any records left in the pre-#3273 localStorage
+      // store, then read the durable list back from the database (sorted).
+      importLegacyRemittances(db);
+      setRemittances(getAllRemittances(db));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load remittances.');
+      setRemittances([]);
     } finally {
       setLoading(false);
     }
-  }, [refreshToken]);
+  }, [db, refreshToken]);
 
-  const createRemittance = useCallback((input: CreateRemittanceInput): RemittanceRecord | null => {
-    try {
-      const record: RemittanceRecord = {
-        ...input,
-        id: generateId(),
-        createdAt: new Date().toISOString(),
-      };
-      setRemittances((current) => {
-        const next = sortRecords([record, ...current]);
-        writeStorage(next);
-        return next;
-      });
-      return record;
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save the remittance.');
-      return null;
-    }
-  }, []);
+  const createRemittance = useCallback(
+    (input: CreateRemittanceInput): RemittanceRecord | null => {
+      try {
+        const record: RemittanceRecord = {
+          ...input,
+          id: generateId(),
+          createdAt: new Date().toISOString(),
+        };
+        const persisted = insertRemittance(db, record);
+        refresh();
+        return persisted;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to save the remittance.');
+        return null;
+      }
+    },
+    [db, refresh],
+  );
 
-  const deleteRemittance = useCallback((id: string): boolean => {
-    try {
-      let removed = false;
-      setRemittances((current) => {
-        const next = current.filter((record) => record.id !== id);
-        removed = next.length !== current.length;
-        writeStorage(next);
-        return next;
-      });
-      return removed;
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete the remittance.');
-      return false;
-    }
-  }, []);
+  const deleteRemittance = useCallback(
+    (id: string): boolean => {
+      try {
+        const removed = deleteRemittanceRecord(db, id);
+        if (removed) {
+          refresh();
+        }
+        return removed;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to delete the remittance.');
+        return false;
+      }
+    },
+    [db, refresh],
+  );
 
   const summary = useMemo(() => summarizeRemittances(remittances), [remittances]);
   const recipientBreakdown = useMemo(() => summarizeByRecipient(remittances), [remittances]);

--- a/apps/web/src/pages/ExpectedIncomePage.test.tsx
+++ b/apps/web/src/pages/ExpectedIncomePage.test.tsx
@@ -3,15 +3,40 @@
 /**
  * Tests for ExpectedIncomePage (#2193).
  *
- * Uses the real localStorage-backed store (cleared between tests) to verify the
- * add/list flow and that the page keeps spendable-now money separate from
- * expected money.
+ * The #2193 expected-income store is still localStorage-backed (cleared between
+ * tests) so the add/list flow is exercised directly. The invoice pipeline it
+ * surfaces (#3229) now lives in the database, so `useInvoices` is mocked per
+ * project conventions rather than seeding its old localStorage key.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 
 import { ExpectedIncomePage } from './ExpectedIncomePage';
+import type { Invoice } from '../lib/analytics/invoices';
+
+vi.mock('../hooks/useInvoices', () => ({ useInvoices: vi.fn() }));
+
+import { useInvoices } from '../hooks/useInvoices';
+
+const mockedUseInvoices = vi.mocked(useInvoices);
+
+/** Point the mocked `useInvoices` at a fixed invoice list (page reads `.invoices`). */
+function mockInvoices(invoices: Invoice[]): void {
+  mockedUseInvoices.mockReturnValue({
+    invoices,
+    pipelineGroups: [],
+    forecastBuckets: [],
+    totalOutstandingCents: 0,
+    addInvoice: vi.fn(),
+    updateInvoice: vi.fn(),
+    updateInvoiceStatus: vi.fn(),
+    logInvoiceContact: vi.fn(),
+    recordPayment: vi.fn(),
+    deleteInvoice: vi.fn(),
+    refresh: vi.fn(),
+  });
+}
 
 function addPayment(options: {
   name: string;
@@ -37,6 +62,8 @@ function addPayment(options: {
 describe('ExpectedIncomePage', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    vi.clearAllMocks();
+    mockInvoices([]);
   });
 
   it('renders the heading and an empty state initially', () => {
@@ -121,22 +148,19 @@ describe('ExpectedIncomePage', () => {
   });
 
   it('surfaces sent and overdue invoices as expected income without re-entry (#3229)', () => {
-    window.localStorage.setItem(
-      'finance:invoices',
-      JSON.stringify([
-        {
-          id: 'inv-1',
-          clientName: 'Studio Delacroix',
-          amountCents: 120000,
-          issueDate: '2099-01-01',
-          paymentTerm: 'net-30',
-          status: 'Sent',
-          expectedPayDate: '2099-02-01',
-          createdAt: '2099-01-01T00:00:00.000Z',
-          updatedAt: '2099-01-01T00:00:00.000Z',
-        },
-      ]),
-    );
+    mockInvoices([
+      {
+        id: 'inv-1',
+        clientName: 'Studio Delacroix',
+        amountCents: 120000,
+        issueDate: '2099-01-01',
+        paymentTerm: 'net-30',
+        status: 'Sent',
+        expectedPayDate: '2099-02-01',
+        createdAt: '2099-01-01T00:00:00.000Z',
+        updatedAt: '2099-01-01T00:00:00.000Z',
+      },
+    ]);
 
     render(<ExpectedIncomePage />);
 


### PR DESCRIPTION
## Summary

Moves the web **Invoices** and **Remittances** features off browser `localStorage` onto the encrypted SQLite-WASM (OPFS) repository + sync path used by accounts, goals and budgets. Business records now survive a browser-cache clear, are ready to ride the sync engine cross-device, and no plaintext financial data is written to disk — fixing the same class of offline-durability bug as the household #3378 work.

Mirrors the established `useGoals`/`useBudgets` pattern (repository + `useDatabase()`), keeps the well-tested pure domain libs (`lib/analytics/invoices`, `lib/remittance`) as the source of truth for computation, and preserves every recent behaviour on these surfaces.

## Changes

- **Migration v14** (`db/sqlite-wasm.ts`): new `invoice` and `remittance` tables with the standard sync columns (`created_at/updated_at/deleted_at/sync_version/is_synced`) and a nullable `household_id` (resolved at write time via `getPrimaryHouseholdId`, the same pattern goals use for pre-household records). Invoice rows carry the #3266 payment-link columns (`payment_account_id`, `payment_transaction_id`); remittance rows store the recipient as two columns and money in integer minor units with `REAL` FX rates.
- **New repositories** `db/repositories/invoices.ts` and `db/repositories/remittances.ts`: thin persistence over the pure domain libs — `getAll*`, `insert*`, `update*Record`, soft-delete `delete*Record`, and a one-time `importLegacy*` that reads the old `localStorage` key, **removes it first** (so concurrent hook instances can't double-import), then inserts, skipping ids that already exist.
- **Rewrote** `hooks/useInvoices.ts` and `hooks/useRemittances.ts` to use `useDatabase()` + the repos. **Public APIs are unchanged** (`UseInvoicesResult` / `UseRemittancesResult`), so `InvoicesPage`, `RemittancesPage`, `ExpectedIncomePage` and `CashRunwayPage` need no changes. Status normalization (Sent→Overdue) stays in-memory on read; raw status is stored.
- **Barrel**: export the two repos from `db/repositories/index.ts`.

## Non-regressions protected

- **#3266** — marking an invoice Paid still records the linked cash inflow (`paymentAccountId`/`paymentTransactionId` round-trip; covered by a hook test).
- **#3229** — sent/overdue invoices still surface as expected income on `ExpectedIncomePage`.
- **#3269** — per-supplier remittance breakdown (`summarizeByRecipient`) is untouched (pure lib).

## Testing

- `npx vitest run` on the affected specs — **7 files, 68 tests pass**; full `src/db` + `src/hooks` — **76 files, 953 tests pass**.
- New repo unit tests (mock `../sqlite-wasm` + `./household`): SQL/params, row→domain mapping incl. the #3266 link and nested recipient, soft-delete, and legacy import clearing the key.
- New/updated hook tests: **records survive a simulated cache clear** (create → unmount → `localStorage.clear()` → remount → still read back from the repo) and the hooks **write nothing to `localStorage`**; the one-time legacy migration runs on mount.
- Updated `ExpectedIncomePage.test.tsx` to mock `useInvoices` (the page now reads invoices from the DB) instead of seeding the old key.
- `npx prettier --check` and `npx eslint --max-warnings 0` clean on all changed files; `tsc --noEmit` clean for the web app.

## Notes for follow-up (out of scope)

These are **web-first tables** today. The durable model should land in the shared KMP/PowerSync schema next so invoices/remittances sync cross-platform (a coordinated `@backend-engineer` migration + `@kmp-engineer` SQLDelight task). The web `household_id` is nullable to keep create-in-empty-workspace working, matching the existing web mirror.

Closes #3273
