### PR TITLE
fix(web): unify divergent display-currency preferences (#3291)

### DIFF
--- a/apps/web/src/hooks/__tests__/useMultiCurrency.test.ts
+++ b/apps/web/src/hooks/__tests__/useMultiCurrency.test.ts
@@ -4,7 +4,12 @@ import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useMultiCurrency } from '../useMultiCurrency';
+import { useDisplayCurrency } from '../useDisplayCurrency';
 import { Currencies } from '../../kmp/bridge';
+import {
+  DISPLAY_CURRENCY_STORAGE_KEY,
+  LEGACY_MULTI_CURRENCY_STORAGE_KEY,
+} from '../../lib/display-currency';
 
 beforeEach(() => {
   localStorage.clear();
@@ -107,7 +112,7 @@ describe('useMultiCurrency', () => {
     expect(rate).toBeNull();
   });
 
-  it('sets default currency and persists it', () => {
+  it('persists the default currency to the shared display-currency key', () => {
     const { result, unmount } = renderHook(() => useMultiCurrency());
 
     act(() => {
@@ -115,11 +120,50 @@ describe('useMultiCurrency', () => {
     });
 
     expect(result.current.defaultCurrency.code).toBe('EUR');
+    // The choice is written to the single canonical key — never a private,
+    // divergent copy — so every surface stays in sync (#3291).
+    expect(localStorage.getItem(DISPLAY_CURRENCY_STORAGE_KEY)).toBe('EUR');
+    expect(localStorage.getItem(LEGACY_MULTI_CURRENCY_STORAGE_KEY)).toBeNull();
 
     unmount();
 
     const { result: result2 } = renderHook(() => useMultiCurrency());
     expect(result2.current.defaultCurrency.code).toBe('EUR');
+  });
+
+  it('hydrates the default currency from the shared display-currency preference (#3291)', () => {
+    localStorage.setItem(DISPLAY_CURRENCY_STORAGE_KEY, 'GBP');
+
+    const { result } = renderHook(() => useMultiCurrency());
+
+    expect(result.current.defaultCurrency.code).toBe('GBP');
+  });
+
+  it('propagates a single change to every reader of the shared preference (#3291)', () => {
+    const multi = renderHook(() => useMultiCurrency());
+    const display = renderHook(() => useDisplayCurrency());
+
+    expect(multi.result.current.defaultCurrency.code).toBe('USD');
+    expect(display.result.current.displayCurrency).toBe('USD');
+
+    // Changing the currency through the multi-currency dashboard hook...
+    act(() => {
+      multi.result.current.setDefaultCurrency(Currencies.EUR);
+    });
+
+    // ...is observed by the independent Settings/Budgets display-currency hook.
+    expect(display.result.current.displayCurrency).toBe('EUR');
+    expect(multi.result.current.defaultCurrency.code).toBe('EUR');
+
+    // ...and a change made the other way round flows back into the widgets,
+    // decimal places and all (JPY is zero-decimal).
+    act(() => {
+      display.result.current.setDisplayCurrency('JPY');
+    });
+
+    expect(multi.result.current.defaultCurrency.code).toBe('JPY');
+    expect(multi.result.current.defaultCurrency.decimalPlaces).toBe(0);
+    expect(display.result.current.displayCurrency).toBe('JPY');
   });
 
   it('calculates multi-currency totals', () => {
@@ -163,11 +207,8 @@ describe('useMultiCurrency', () => {
     expect(grandTotalCents).toBe(20000);
   });
 
-  it('falls back to USD when an unsupported default currency is stored', () => {
-    localStorage.setItem(
-      'finance-default-currency',
-      JSON.stringify({ code: 'ZZZ', decimalPlaces: 2 }),
-    );
+  it('falls back to USD when an invalid display currency is stored (#3291)', () => {
+    localStorage.setItem(DISPLAY_CURRENCY_STORAGE_KEY, 'not-a-currency');
 
     const { result } = renderHook(() => useMultiCurrency());
 

--- a/apps/web/src/hooks/useMultiCurrency.ts
+++ b/apps/web/src/hooks/useMultiCurrency.ts
@@ -11,16 +11,26 @@
  * const { convert, formatAmount, rates, defaultCurrency } = useMultiCurrency();
  * ```
  *
- * References: issue #1075
+ * The `defaultCurrency` is NOT a private preference: it is a view onto the single
+ * shared display-currency preference (`useDisplayCurrency` / the `finance-currency`
+ * key). Changing it here updates Settings, Budgets, and the dashboard rollups too,
+ * and changes made there flow back into this hook — so every surface agrees on the
+ * user's chosen currency (#3291).
+ *
+ * References: issue #1075, issue #3291
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { Currency } from '../kmp/bridge';
-import { Currencies } from '../kmp/bridge';
 import { formatCurrency } from '../lib/currency';
 import { STATIC_USD_RATES } from '../lib/currency/static-rates';
-import { SUPPORTED_CURRENCY_METADATA } from '../lib/currency-metadata';
+import { getCurrencyMetadata, SUPPORTED_CURRENCY_METADATA } from '../lib/currency-metadata';
+import {
+  DISPLAY_CURRENCY_CHANGE_EVENT,
+  getStoredDisplayCurrency,
+  setStoredDisplayCurrency,
+} from '../lib/display-currency';
 import { getCurrentLocale } from '../lib/i18n';
 
 // ---------------------------------------------------------------------------
@@ -81,7 +91,6 @@ export interface UseMultiCurrencyResult {
 // Constants
 // ---------------------------------------------------------------------------
 
-const STORAGE_KEY_DEFAULT_CURRENCY = 'finance-default-currency';
 const STORAGE_KEY_RATES = 'finance-exchange-rates';
 const STORAGE_KEY_RATES_UPDATED = 'finance-exchange-rates-updated';
 
@@ -92,29 +101,18 @@ const SUPPORTED_CURRENCIES: Currency[] = SUPPORTED_CURRENCY_METADATA.map(
   }),
 );
 
-const SUPPORTED_CURRENCY_CODES = new Set(SUPPORTED_CURRENCIES.map((currency) => currency.code));
-
 // ---------------------------------------------------------------------------
 // Storage helpers
 // ---------------------------------------------------------------------------
 
-function loadDefaultCurrency(): Currency {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY_DEFAULT_CURRENCY);
-    if (stored) {
-      const parsed = JSON.parse(stored) as Currency;
-      if (
-        parsed.code &&
-        typeof parsed.decimalPlaces === 'number' &&
-        SUPPORTED_CURRENCY_CODES.has(parsed.code)
-      ) {
-        return parsed;
-      }
-    }
-  } catch {
-    // Fall through to default
-  }
-  return Currencies.USD;
+/**
+ * Resolve a currency code to the {@link Currency} shape the multi-currency UI
+ * consumes, sourcing decimal places from the shared currency metadata. Unknown
+ * or invalid codes normalise to USD via {@link getCurrencyMetadata}.
+ */
+function resolveCurrency(code: string): Currency {
+  const { code: normalizedCode, decimalPlaces } = getCurrencyMetadata(code);
+  return { code: normalizedCode, decimalPlaces };
 }
 
 /**
@@ -154,12 +152,35 @@ function buildRates(): ExchangeRate[] {
 // ---------------------------------------------------------------------------
 
 export function useMultiCurrency(): UseMultiCurrencyResult {
-  const [defaultCurrency, setDefaultCurrencyState] = useState<Currency>(loadDefaultCurrency);
+  const [displayCurrencyCode, setDisplayCurrencyCode] = useState<string>(getStoredDisplayCurrency);
   const [rates, setRates] = useState<ExchangeRate[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState(0);
+
+  // Keep the default currency in lock-step with the single shared display-
+  // currency preference (the `finance-currency` key). This mirrors the pattern
+  // in `useDisplayCurrency`, so a change made in Settings, Budgets, or another
+  // multi-currency widget — in this tab (custom event) or another (storage
+  // event) — is reflected here without a reload (#3291).
+  useEffect(() => {
+    const refresh = (): void => {
+      setDisplayCurrencyCode(getStoredDisplayCurrency());
+    };
+    refresh();
+    globalThis.addEventListener?.(DISPLAY_CURRENCY_CHANGE_EVENT, refresh);
+    globalThis.addEventListener?.('storage', refresh);
+    return () => {
+      globalThis.removeEventListener?.(DISPLAY_CURRENCY_CHANGE_EVENT, refresh);
+      globalThis.removeEventListener?.('storage', refresh);
+    };
+  }, []);
+
+  const defaultCurrency = useMemo(
+    () => resolveCurrency(displayCurrencyCode),
+    [displayCurrencyCode],
+  );
 
   const refreshRates = useCallback(() => {
     setLoading(true);
@@ -185,8 +206,10 @@ export function useMultiCurrency(): UseMultiCurrencyResult {
   }, [refreshToken]);
 
   const setDefaultCurrency = useCallback((currency: Currency) => {
-    setDefaultCurrencyState(currency);
-    localStorage.setItem(STORAGE_KEY_DEFAULT_CURRENCY, JSON.stringify(currency));
+    // Persist through the canonical setter so Settings, Budgets, and the
+    // dashboard rollups all observe the change via the shared preference (#3291).
+    const normalized = setStoredDisplayCurrency(currency.code);
+    setDisplayCurrencyCode(normalized);
   }, []);
 
   const rateMap = useMemo(() => {

--- a/apps/web/src/lib/display-currency.test.ts
+++ b/apps/web/src/lib/display-currency.test.ts
@@ -12,8 +12,10 @@ import {
   DEFAULT_DISPLAY_CURRENCY,
   DISPLAY_CURRENCY_CHANGE_EVENT,
   DISPLAY_CURRENCY_STORAGE_KEY,
+  LEGACY_MULTI_CURRENCY_STORAGE_KEY,
   SUPPORTED_DISPLAY_CURRENCIES,
   getStoredDisplayCurrency,
+  migrateLegacyDisplayCurrencyPreference,
   setStoredDisplayCurrency,
 } from './display-currency';
 
@@ -62,5 +64,69 @@ describe('display-currency preference', () => {
   it('exposes a non-empty supported currency list including USD', () => {
     expect(SUPPORTED_DISPLAY_CURRENCIES.length).toBeGreaterThan(1);
     expect(SUPPORTED_DISPLAY_CURRENCIES.some((option) => option.value === 'USD')).toBe(true);
+  });
+});
+
+describe('migrateLegacyDisplayCurrencyPreference (#3291)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('seeds the canonical key from a legacy finance-default-currency object', () => {
+    localStorage.setItem(
+      LEGACY_MULTI_CURRENCY_STORAGE_KEY,
+      JSON.stringify({ code: 'EUR', decimalPlaces: 2 }),
+    );
+
+    migrateLegacyDisplayCurrencyPreference();
+
+    expect(localStorage.getItem(DISPLAY_CURRENCY_STORAGE_KEY)).toBe('EUR');
+    expect(getStoredDisplayCurrency()).toBe('EUR');
+    // The legacy key is removed so it can never diverge again.
+    expect(localStorage.getItem(LEGACY_MULTI_CURRENCY_STORAGE_KEY)).toBeNull();
+  });
+
+  it('tolerates a legacy bare code string', () => {
+    localStorage.setItem(LEGACY_MULTI_CURRENCY_STORAGE_KEY, '"gbp"');
+
+    migrateLegacyDisplayCurrencyPreference();
+
+    expect(getStoredDisplayCurrency()).toBe('GBP');
+    expect(localStorage.getItem(LEGACY_MULTI_CURRENCY_STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not overwrite an explicit canonical preference', () => {
+    localStorage.setItem(DISPLAY_CURRENCY_STORAGE_KEY, 'JPY');
+    localStorage.setItem(
+      LEGACY_MULTI_CURRENCY_STORAGE_KEY,
+      JSON.stringify({ code: 'EUR', decimalPlaces: 2 }),
+    );
+
+    migrateLegacyDisplayCurrencyPreference();
+
+    // The Settings choice (JPY) wins over the legacy widget copy (EUR)...
+    expect(getStoredDisplayCurrency()).toBe('JPY');
+    // ...and the redundant legacy key is still cleared.
+    expect(localStorage.getItem(LEGACY_MULTI_CURRENCY_STORAGE_KEY)).toBeNull();
+  });
+
+  it('is a no-op when no legacy value exists', () => {
+    migrateLegacyDisplayCurrencyPreference();
+
+    expect(localStorage.getItem(DISPLAY_CURRENCY_STORAGE_KEY)).toBeNull();
+    expect(getStoredDisplayCurrency()).toBe(DEFAULT_DISPLAY_CURRENCY);
+  });
+
+  it('is idempotent across repeated startups', () => {
+    localStorage.setItem(
+      LEGACY_MULTI_CURRENCY_STORAGE_KEY,
+      JSON.stringify({ code: 'CAD', decimalPlaces: 2 }),
+    );
+
+    migrateLegacyDisplayCurrencyPreference();
+    migrateLegacyDisplayCurrencyPreference();
+
+    expect(getStoredDisplayCurrency()).toBe('CAD');
+    expect(localStorage.getItem(LEGACY_MULTI_CURRENCY_STORAGE_KEY)).toBeNull();
   });
 });

--- a/apps/web/src/lib/display-currency.ts
+++ b/apps/web/src/lib/display-currency.ts
@@ -16,7 +16,7 @@
  * All monetary amounts elsewhere remain INTEGER minor units; this module only
  * tracks the currency *code* the totals should be presented in.
  *
- * References: issue #2203
+ * References: issue #2203, issue #3291
  */
 
 import { normalizeCurrencyCode, SUPPORTED_CURRENCY_METADATA } from './currency-metadata';
@@ -28,6 +28,17 @@ import { normalizeCurrencyCode, SUPPORTED_CURRENCY_METADATA } from './currency-m
  * secret-scanners never mistake it for a credential.
  */
 export const DISPLAY_CURRENCY_STORAGE_KEY = `finance${'-'}currency`;
+
+/**
+ * Legacy localStorage key that the old `useMultiCurrency` hook wrote its own,
+ * divergent display-currency copy to (as a JSON `{ code, decimalPlaces }`
+ * object). It is retained ONLY so the one-time migration below can seed the
+ * canonical key from it — no code should read or write it going forward (#3291).
+ *
+ * Built from a template literal (never an inline string literal constant) so
+ * secret-scanners never mistake it for a credential.
+ */
+export const LEGACY_MULTI_CURRENCY_STORAGE_KEY = `finance${'-'}default${'-'}currency`;
 
 /**
  * DOM event dispatched when the display currency changes within the same tab.
@@ -90,4 +101,67 @@ export function setStoredDisplayCurrency(currency: string): string {
     // Non-DOM environments (SSR / some test runners) have no event bus.
   }
   return normalized;
+}
+
+/**
+ * Extract a currency code from a legacy `finance-default-currency` value.
+ *
+ * The old `useMultiCurrency` hook serialised a `{ code, decimalPlaces }` object,
+ * but we also tolerate a bare `"EUR"` code string in case an even older build
+ * stored one. Returns `null` when no usable code can be recovered.
+ */
+function extractLegacyCurrencyCode(raw: string): string | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed === 'string') return parsed;
+    if (parsed !== null && typeof parsed === 'object' && 'code' in parsed) {
+      const { code } = parsed as { code?: unknown };
+      if (typeof code === 'string') return code;
+    }
+    return null;
+  } catch {
+    // Not JSON — treat the stored value itself as a bare code string.
+    return raw;
+  }
+}
+
+/**
+ * One-time migration that folds the legacy `finance-default-currency` value into
+ * the single canonical {@link DISPLAY_CURRENCY_STORAGE_KEY}.
+ *
+ * Before #3291 the multi-currency dashboard widgets persisted their own display
+ * currency under a separate key, so the currency chosen in Settings and the one
+ * the widgets showed could disagree. This seeds the canonical key from any legacy
+ * value — but only when the canonical key is not already set, so an explicit
+ * Settings choice always wins — and then removes the legacy key so the two can
+ * never diverge again.
+ *
+ * Idempotent and best-effort: safe to call on every startup, and a no-op once the
+ * legacy key has been removed or storage is unavailable (private browsing / SSR).
+ */
+export function migrateLegacyDisplayCurrencyPreference(): void {
+  try {
+    const store = globalThis.localStorage;
+    if (!store) return;
+
+    const legacyRaw = store.getItem(LEGACY_MULTI_CURRENCY_STORAGE_KEY);
+    if (legacyRaw === null) return;
+
+    // Only seed when the canonical key has no value yet — a preference already
+    // expressed through the shared key must never be clobbered by the old copy.
+    if (!store.getItem(DISPLAY_CURRENCY_STORAGE_KEY)) {
+      const code = extractLegacyCurrencyCode(legacyRaw);
+      if (code) {
+        // Reuse the canonical setter so the value is normalised and same-tab
+        // listeners are notified.
+        setStoredDisplayCurrency(code);
+      }
+    }
+
+    // Remove the legacy key regardless: keeping it would reintroduce a second
+    // source of truth that could drift from the canonical preference again.
+    store.removeItem(LEGACY_MULTI_CURRENCY_STORAGE_KEY);
+  } catch {
+    // Storage unavailable (private browsing / SSR) — nothing to migrate.
+  }
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -16,6 +16,7 @@ import { applyStoredReducedMotionPreference } from './hooks/useReducedMotion';
 import { applyStoredDisplayDensityPreference, applyStoredThemePreference } from './hooks/useTheme';
 import { MoneyDisplayProvider } from './lib/display-settings';
 import { applyStoredSimplifiedModePreference } from './lib/accessibility-preferences';
+import { migrateLegacyDisplayCurrencyPreference } from './lib/display-currency';
 import { initMonitoring } from './lib/monitoring';
 import {
   isViteDevServer,
@@ -45,6 +46,10 @@ applyStoredDisplayDensityPreference();
 applyStoredFontScalePreference();
 applyStoredReducedMotionPreference();
 applyStoredSimplifiedModePreference();
+
+// Fold any legacy per-widget display-currency copy into the single shared
+// preference before React mounts, so every surface reads one source of truth (#3291).
+migrateLegacyDisplayCurrencyPreference();
 
 function requiredProductionEnv(name: string): never {
   throw new Error(`${name} is required for production builds`);


### PR DESCRIPTION
## Summary

Two independent `which currency should totals use` preferences existed under different localStorage keys and never stayed in sync, so different surfaces disagreed about the display currency (found by persona Wei Zhang, an immigrant multi-currency remitter):

- `useDisplayCurrency` / `display-currency.ts` persisted to `finance-currency` (Settings, Budgets, dashboard rollups, net-worth conversion).
- `useMultiCurrency` persisted its `defaultCurrency` to a **separate** `finance-default-currency` key (the multi-currency dashboard widgets).

Changing the currency in Settings updated one; the multi-currency widgets read the other.

## Changes

- **`useMultiCurrency` now delegates to the single canonical preference.** `defaultCurrency` is derived from the shared `finance-currency` value (via `getStoredDisplayCurrency`) and the hook subscribes to the same same-tab custom event + cross-tab `storage` event as `useDisplayCurrency`. `setDefaultCurrency` writes through `setStoredDisplayCurrency`. The old `finance-default-currency` read/write path and its bespoke validation are removed.
- **One-time migration** (`migrateLegacyDisplayCurrencyPreference`) seeds the canonical key from any legacy `finance-default-currency` value **only when the canonical key is unset** (an explicit Settings choice always wins), then removes the legacy key so the two can never diverge again. Wired into `main.tsx` bootstrap alongside the other `applyStored*Preference()` calls. Tolerant of legacy JSON objects, bare code strings, and unavailable storage; idempotent.
- **Public API of `useMultiCurrency` is unchanged** (`defaultCurrency: Currency`, `setDefaultCurrency`), so the `CurrencyDisplay` widgets are untouched — avoiding conflicts with the in-flight i18n PR (#3306).

Net-worth (#3514), FX freshness / single static rate table (#3293/#3321), and dashboard/budget rollups (#2203) already consume `useDisplayCurrency`, so they now all read the same source after this change.

## Issues

Closes #3291

## Testing

- New: test proving a single change propagates to **every** reader — `setDefaultCurrency` on `useMultiCurrency` is observed by an independent `useDisplayCurrency` consumer, and vice-versa (decimals included for zero-decimal JPY).
- New: migration tests (seeds from legacy object, tolerates bare code string, does not overwrite an explicit choice, no-op when nothing stored, idempotent).
- Updated: `useMultiCurrency` persistence/hydration/fallback tests now target the canonical `finance-currency` key.
- `npx vitest run` — 44/44 in the 4 currency files; 88/88 across reader/regression files (net-worth, rollup, dashboard, budgets, settings).
- `npm run format:check` clean; `npx eslint apps/web --max-warnings 0` clean.