### PR TITLE
feat(web): persist household data in encrypted SQLite and wire real finances (#3378)

### DIFF
--- a/apps/web/src/db/repositories/householdData.test.ts
+++ b/apps/web/src/db/repositories/householdData.test.ts
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SqliteDb } from '../sqlite-wasm';
+
+// Shared in-memory table store for the mocked sqlite primitives. `vi.hoisted`
+// keeps it available to both the (hoisted) mock factory and the test body.
+const { tables } = vi.hoisted(() => ({
+  tables: {} as Record<string, Array<Record<string, unknown>>>,
+}));
+
+vi.mock('../sqlite-wasm', () => ({
+  execute: vi.fn((_db: unknown, sql: string, params?: unknown[]) => {
+    const deleteMatch = /^DELETE FROM\s+(\w+)/i.exec(sql);
+    if (deleteMatch) {
+      tables[deleteMatch[1]] = [];
+      return;
+    }
+    const insertMatch = /^INSERT INTO\s+(\w+)\s+\(([^)]+)\)\s+VALUES/i.exec(sql);
+    if (insertMatch) {
+      const columns = [...insertMatch[2].matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+      const row = Object.fromEntries(columns.map((column, index) => [column, params?.[index]]));
+      tables[insertMatch[1]] = [...(tables[insertMatch[1]] ?? []), row];
+    }
+    // SAVEPOINT / RELEASE / ROLLBACK statements are no-ops in this fake.
+  }),
+  query: vi.fn((_db: unknown, sql: string) => {
+    const table = /FROM\s+(\w+)/i.exec(sql)?.[1] ?? '';
+    return { columns: [], rows: tables[table] ?? [] };
+  }),
+  queryOne: vi.fn((_db: unknown, sql: string) => {
+    const table = /FROM\s+(\w+)/i.exec(sql)?.[1] ?? '';
+    return (tables[table] ?? [])[0] ?? null;
+  }),
+  releaseSavepoint: vi.fn(),
+  rollbackToSavepoint: vi.fn(),
+}));
+
+import { HOUSEHOLD_SINGLETON_KEY, readHouseholdValue, writeHouseholdValue } from './householdData';
+
+const db = {} as SqliteDb;
+
+const MEMBERS_KEY = 'finance-household-members';
+const CHILDREN_KEY = 'finance-household-children';
+const ACCOUNT_SHARINGS_KEY = 'finance-account-sharings';
+
+interface FakeMember {
+  id: string;
+  householdId: string;
+  displayName: string;
+  syncVersion: number;
+  isSynced: boolean;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+function makeMember(overrides: Partial<FakeMember> = {}): FakeMember {
+  return {
+    id: 'mem-1',
+    householdId: 'hh-1',
+    displayName: 'Jordan',
+    syncVersion: 0,
+    isSynced: false,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe('householdData repository', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(tables)) {
+      delete tables[key];
+    }
+    vi.clearAllMocks();
+  });
+
+  it('returns the fallback when nothing is persisted', () => {
+    expect(readHouseholdValue<FakeMember[]>(db, MEMBERS_KEY, [])).toEqual([]);
+    expect(readHouseholdValue<FakeMember | null>(db, HOUSEHOLD_SINGLETON_KEY, null)).toBeNull();
+  });
+
+  it('round-trips a collection faithfully, preserving order', () => {
+    const members = [
+      makeMember({ id: 'mem-1', displayName: 'Jordan' }),
+      makeMember({ id: 'mem-2', displayName: 'Riley' }),
+    ];
+
+    writeHouseholdValue(db, MEMBERS_KEY, members);
+
+    expect(readHouseholdValue<FakeMember[]>(db, MEMBERS_KEY, [])).toEqual(members);
+  });
+
+  it('round-trips deeply nested entities without loss', () => {
+    const children = [
+      {
+        id: 'child-1',
+        householdId: 'hh-1',
+        name: 'Maya',
+        balance: 1400,
+        chores: [
+          { id: 'chore-1', name: 'Dishes', value: 200, completedThisWeek: true },
+          { id: 'chore-2', name: 'Trash', value: 300, completedThisWeek: false },
+        ],
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+        deletedAt: null,
+        syncVersion: 2,
+        isSynced: true,
+      },
+    ];
+
+    writeHouseholdValue(db, CHILDREN_KEY, children);
+
+    expect(readHouseholdValue(db, CHILDREN_KEY, [])).toEqual(children);
+  });
+
+  it('persists and reads back the household singleton object', () => {
+    const household = {
+      id: 'hh-1',
+      name: 'Smith Family',
+      ownerId: 'user-1',
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+      deletedAt: null,
+      syncVersion: 1,
+      isSynced: true,
+    };
+
+    writeHouseholdValue(db, HOUSEHOLD_SINGLETON_KEY, household);
+
+    expect(readHouseholdValue(db, HOUSEHOLD_SINGLETON_KEY, null)).toEqual(household);
+  });
+
+  it('fully replaces prior contents on each write (delete-then-insert)', () => {
+    writeHouseholdValue(db, MEMBERS_KEY, [
+      makeMember({ id: 'mem-1' }),
+      makeMember({ id: 'mem-2' }),
+    ]);
+    writeHouseholdValue(db, MEMBERS_KEY, [makeMember({ id: 'mem-3', displayName: 'Sam' })]);
+
+    const stored = readHouseholdValue<FakeMember[]>(db, MEMBERS_KEY, []);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.id).toBe('mem-3');
+  });
+
+  it('preserves soft-deleted tombstones in the persisted array', () => {
+    const members = [
+      makeMember({ id: 'mem-1' }),
+      makeMember({ id: 'mem-2', deletedAt: '2025-02-01T00:00:00Z' }),
+    ];
+
+    writeHouseholdValue(db, MEMBERS_KEY, members);
+
+    const stored = readHouseholdValue<FakeMember[]>(db, MEMBERS_KEY, []);
+    expect(stored).toHaveLength(2);
+    expect(stored[1]?.deletedAt).toBe('2025-02-01T00:00:00Z');
+  });
+
+  it('promotes sync and query columns from each entity', () => {
+    writeHouseholdValue(db, ACCOUNT_SHARINGS_KEY, [
+      {
+        id: 'as-1',
+        householdId: 'hh-1',
+        accountId: 'acct-1',
+        ownerId: 'user-1',
+        sharingMode: 'SHARED',
+        syncVersion: 3,
+        isSynced: true,
+        createdAt: '2025-01-02T00:00:00Z',
+        updatedAt: '2025-01-03T00:00:00Z',
+        deletedAt: null,
+      },
+    ]);
+
+    const row = tables['hh_account_sharing']?.[0];
+    expect(row).toMatchObject({
+      id: 'as-1',
+      household_id: 'hh-1',
+      sync_version: 3,
+      is_synced: 1,
+      deleted_at: null,
+      created_at: '2025-01-02T00:00:00Z',
+      updated_at: '2025-01-03T00:00:00Z',
+    });
+    expect(JSON.parse(String(row?.data))).toMatchObject({ id: 'as-1', sharingMode: 'SHARED' });
+  });
+
+  it('throws for an unknown storage key', () => {
+    expect(() => readHouseholdValue(db, 'finance-not-a-household-key', [])).toThrow(
+      /Unknown household storage key/,
+    );
+    expect(() => writeHouseholdValue(db, 'finance-not-a-household-key', [])).toThrow(
+      /Unknown household storage key/,
+    );
+  });
+});

--- a/apps/web/src/db/repositories/householdData.ts
+++ b/apps/web/src/db/repositories/householdData.ts
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Household data repository — encrypted SQLite persistence for every household
+ * collection (issue #3378).
+ *
+ * The household feature previously persisted household, members, invitations,
+ * account sharing, shared budgets/goals, expenses, settlements, children,
+ * activity, recurring bills, goal pledges, shopping budgets and reconciliation
+ * data to plaintext `localStorage`. That data never synced to a partner's
+ * device, never survived a cache clear, and was not encrypted — a serious
+ * privacy issue for financial data.
+ *
+ * This module moves all of it into the encrypted SQLite/OPFS database (the same
+ * at-rest-encrypted, sync-metadata-carrying store used by goals and budgets).
+ * Each collection is stored in a `hh_`-prefixed "document" table: the queryable
+ * and sync columns (`id`, `household_id`, timestamps, `sync_version`,
+ * `is_synced`) are promoted while the full entity — including nested aggregates
+ * such as a child's chores or a reconciliation plan's obligations — is stored as
+ * JSON in `data`. This mirrors the existing JSON-column pattern (transaction
+ * splits) and keeps the persisted shape a faithful, loss-free round-trip of the
+ * hook's in-memory model.
+ *
+ * The public API intentionally matches the previous `localStorage` helpers
+ * (`readHouseholdValue` / `writeHouseholdValue`, keyed by the same string keys)
+ * so the consuming hook only swaps its storage backend, not its logic.
+ *
+ * References: issues #3378, #1780, #1781, #1784, #1786
+ */
+
+import {
+  execute,
+  query,
+  queryOne,
+  releaseSavepoint,
+  rollbackToSavepoint,
+  type Row,
+  type SqliteDb,
+} from '../sqlite-wasm';
+
+// ---------------------------------------------------------------------------
+// Storage-key → table mapping
+// ---------------------------------------------------------------------------
+
+/** Storage key for the single household record (stored as one row). */
+export const HOUSEHOLD_SINGLETON_KEY = 'finance-household';
+
+/**
+ * Maps each household storage key to its backing `hh_` table. Keys mirror the
+ * legacy `localStorage` keys exactly so the hook can swap backends transparently.
+ */
+const TABLE_BY_KEY: Readonly<Record<string, string>> = {
+  'finance-household': 'hh_household',
+  'finance-household-members': 'hh_member',
+  'finance-household-invitations': 'hh_invitation',
+  'finance-account-sharings': 'hh_account_sharing',
+  'finance-shared-budgets': 'hh_shared_budget',
+  'finance-shared-goals': 'hh_shared_goal',
+  'finance-household-shared-expenses': 'hh_shared_expense',
+  'finance-household-shared-settlements': 'hh_shared_settlement',
+  'finance-household-children': 'hh_child',
+  'finance-household-activity-events': 'hh_activity_event',
+  'finance-household-recurring-bills': 'hh_recurring_bill',
+  'finance-household-goal-pledges': 'hh_goal_pledge',
+  'finance-household-shopping-budgets': 'hh_shopping_budget',
+  'finance-household-reconciliation-plans': 'hh_reconciliation_plan',
+  'finance-household-reconciliation-snapshots': 'hh_reconciliation_snapshot',
+};
+
+function tableForKey(key: string): string {
+  const table = TABLE_BY_KEY[key];
+  if (!table) {
+    throw new Error(`Unknown household storage key: ${key}`);
+  }
+  return table;
+}
+
+// ---------------------------------------------------------------------------
+// Row (de)serialization
+// ---------------------------------------------------------------------------
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+function optionalIsoString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+interface DocumentColumns {
+  id: string;
+  householdId: string;
+  data: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  deletedAt: string | null;
+  syncVersion: number;
+  isSynced: number;
+}
+
+/** Derive the promoted sync/query columns from an entity, with safe fallbacks. */
+function toDocumentColumns(
+  entity: unknown,
+  index: number,
+  fallbackHouseholdId: string,
+  nowIso: string,
+): DocumentColumns {
+  const record = asRecord(entity);
+  const id = typeof record.id === 'string' && record.id.length > 0 ? record.id : `row-${index}`;
+  const householdId =
+    typeof record.householdId === 'string' && record.householdId.length > 0
+      ? record.householdId
+      : fallbackHouseholdId;
+  const syncVersion = typeof record.syncVersion === 'number' ? record.syncVersion : 0;
+  const isSynced = record.isSynced === true || record.isSynced === 1;
+
+  return {
+    id,
+    householdId,
+    data: JSON.stringify(entity),
+    createdAt: optionalIsoString(record.createdAt) ?? nowIso,
+    updatedAt: optionalIsoString(record.updatedAt) ?? nowIso,
+    deletedAt: optionalIsoString(record.deletedAt),
+    syncVersion,
+    isSynced: isSynced ? 1 : 0,
+  };
+}
+
+function parseRows<T>(rows: Row[]): T[] {
+  const parsed: T[] = [];
+  for (const row of rows) {
+    const raw = row.data;
+    if (typeof raw !== 'string') {
+      continue;
+    }
+    try {
+      parsed.push(JSON.parse(raw) as T);
+    } catch {
+      // Skip corrupt rows rather than failing the entire load.
+    }
+  }
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+function readCollection<T>(db: SqliteDb, table: string): T[] {
+  const result = query<Row>(db, `SELECT data FROM ${table} ORDER BY rowid ASC`);
+  return parseRows<T>(result.rows);
+}
+
+function readSingleton<T>(db: SqliteDb, table: string): T | null {
+  const row = queryOne<Row>(db, `SELECT data FROM ${table} ORDER BY rowid ASC LIMIT 1`);
+  if (!row || typeof row.data !== 'string') {
+    return null;
+  }
+  try {
+    return JSON.parse(row.data) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Look up the id of the persisted household, used as a fallback owner scope. */
+function currentHouseholdId(db: SqliteDb): string {
+  const household = readSingleton<{ id?: unknown }>(db, 'hh_household');
+  return household && typeof household.id === 'string' ? household.id : 'local';
+}
+
+/**
+ * Read a household value by its storage key. Returns `fallback` when nothing is
+ * persisted yet (an empty array for collections, `null` for the singleton).
+ */
+export function readHouseholdValue<T>(db: SqliteDb, key: string, fallback: T): T {
+  const table = tableForKey(key);
+  if (key === HOUSEHOLD_SINGLETON_KEY) {
+    const value = readSingleton<T>(db, table);
+    return value ?? fallback;
+  }
+  const rows = readCollection<unknown>(db, table);
+  return rows as unknown as T;
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+const INSERT_COLUMNS =
+  '("id","household_id","data","created_at","updated_at","deleted_at","sync_version","is_synced")';
+
+function insertDocument(db: SqliteDb, table: string, columns: DocumentColumns): void {
+  execute(db, `INSERT INTO ${table} ${INSERT_COLUMNS} VALUES (?, ?, ?, ?, ?, ?, ?, ?);`, [
+    columns.id,
+    columns.householdId,
+    columns.data,
+    columns.createdAt,
+    columns.updatedAt,
+    columns.deletedAt,
+    columns.syncVersion,
+    columns.isSynced,
+  ]);
+}
+
+/**
+ * Persist a household value by its storage key.
+ *
+ * The device holds exactly one household, so each write fully replaces the
+ * table contents (delete-then-insert) inside a savepoint. This preserves array
+ * order and faithfully round-trips soft-deleted tombstones, exactly matching the
+ * previous "serialize the whole array" `localStorage` semantics — now durable,
+ * encrypted, and sync-ready.
+ */
+export function writeHouseholdValue<T>(db: SqliteDb, key: string, value: T): void {
+  const table = tableForKey(key);
+  const nowIso = new Date().toISOString();
+  const savepointName = 'hh_write_collection';
+
+  execute(db, `SAVEPOINT ${savepointName};`);
+  try {
+    execute(db, `DELETE FROM ${table};`);
+
+    if (key === HOUSEHOLD_SINGLETON_KEY) {
+      if (value !== null && value !== undefined) {
+        const record = asRecord(value);
+        const householdId = typeof record.id === 'string' ? record.id : 'local';
+        insertDocument(db, table, toDocumentColumns(value, 0, householdId, nowIso));
+      }
+    } else if (Array.isArray(value)) {
+      const fallbackHouseholdId = currentHouseholdId(db);
+      value.forEach((entity, index) => {
+        insertDocument(db, table, toDocumentColumns(entity, index, fallbackHouseholdId, nowIso));
+      });
+    }
+
+    releaseSavepoint(db, savepointName);
+  } catch (writeError) {
+    try {
+      rollbackToSavepoint(db, savepointName);
+      releaseSavepoint(db, savepointName);
+    } catch {
+      // Preserve the original write error if SQLite already ended the savepoint.
+    }
+    throw writeError;
+  }
+}

--- a/apps/web/src/db/repositories/index.ts
+++ b/apps/web/src/db/repositories/index.ts
@@ -12,3 +12,4 @@ export * from './bills';
 export * from './household';
 export * from './invoices';
 export * from './remittances';
+export * from './householdData';

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -664,6 +664,58 @@ export const MIGRATIONS: Migration[] = [
       `CREATE INDEX IF NOT EXISTS idx_remittance_sync      ON remittance (is_synced);`,
     ],
   },
+  {
+    version: 15,
+    label: 'add-household-collection-tables',
+    up: [
+      // Household / shared-finance data previously lived in plaintext
+      // `localStorage` (issue #3378), which never synced to a partner's device,
+      // never survived a cache clear, and was not encrypted. These tables move
+      // every household collection into the encrypted SQLite/OPFS database so it
+      // rides the same at-rest encryption and (future) PowerSync path as goals
+      // and budgets.
+      //
+      // Each collection uses a uniform "document" row: the queryable / sync
+      // columns (id, household_id, timestamps, sync metadata) are promoted, and
+      // the full entity — including nested aggregates such as a child's chores,
+      // a recurring bill's cycles, or a reconciliation plan's obligations — is
+      // stored as JSON in `data`. This mirrors the existing JSON-column pattern
+      // (transaction splits, reconciliation history) and keeps the shape a
+      // faithful, loss-free round-trip of the hook's in-memory model.
+      //
+      // Names are `hh_`-prefixed so they never collide with the normalized
+      // `household` / `household_member` tables from migration v1.
+      ...[
+        'hh_household',
+        'hh_member',
+        'hh_invitation',
+        'hh_account_sharing',
+        'hh_shared_budget',
+        'hh_shared_goal',
+        'hh_shared_expense',
+        'hh_shared_settlement',
+        'hh_child',
+        'hh_activity_event',
+        'hh_recurring_bill',
+        'hh_goal_pledge',
+        'hh_shopping_budget',
+        'hh_reconciliation_plan',
+        'hh_reconciliation_snapshot',
+      ].flatMap((table) => [
+        `CREATE TABLE IF NOT EXISTS ${table} (
+          id TEXT PRIMARY KEY,
+          household_id TEXT NOT NULL,
+          data TEXT NOT NULL,
+          created_at TEXT,
+          updated_at TEXT,
+          deleted_at TEXT,
+          sync_version INTEGER NOT NULL DEFAULT 0,
+          is_synced INTEGER NOT NULL DEFAULT 0
+        );`,
+        `CREATE INDEX IF NOT EXISTS idx_${table}_household ON ${table} (household_id);`,
+      ]),
+    ],
+  },
 ];
 // ---------------------------------------------------------------------------
 // OPFS / IndexedDB feature detection

--- a/apps/web/src/hooks/__tests__/useHousehold.test.ts
+++ b/apps/web/src/hooks/__tests__/useHousehold.test.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { act, renderHook } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DatabaseContext, type DatabaseContextValue } from '../../db/DatabaseProvider';
+import type { SqliteDb } from '../../db/sqlite-wasm';
 
 import {
   buildRecurringBillReminders,
@@ -13,6 +17,32 @@ import {
   simplifySettleUpBalances,
   useHousehold,
 } from '../useHousehold';
+
+// Household persistence is exercised against an in-memory stand-in for the
+// encrypted SQLite repository so the hook's storage round-trips can be asserted
+// without booting SQLite-WASM. The store survives unmount/remount within a test
+// and is cleared between tests (issue #3378).
+const { householdStore } = vi.hoisted(() => ({
+  householdStore: new Map<string, string>(),
+}));
+
+vi.mock('../../db/repositories/householdData', () => ({
+  HOUSEHOLD_SINGLETON_KEY: 'finance-household',
+  readHouseholdValue: (_db: unknown, key: string, fallback: unknown): unknown =>
+    householdStore.has(key) ? JSON.parse(householdStore.get(key) as string) : fallback,
+  writeHouseholdValue: (_db: unknown, key: string, value: unknown): void => {
+    householdStore.set(key, JSON.stringify(value));
+  },
+}));
+
+// Provide a database context so `useHousehold` follows its SQLite persistence
+// path. The handle itself is opaque — the mocked repository above ignores it.
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(
+    DatabaseContext.Provider,
+    { value: { db: {} as SqliteDb, diagnostics: {} as DatabaseContextValue['diagnostics'] } },
+    children,
+  );
 
 // ---------------------------------------------------------------------------
 // Setup
@@ -31,6 +61,7 @@ vi.stubGlobal('crypto', {
 beforeEach(() => {
   uuidCounter = 0;
   localStorage.clear();
+  householdStore.clear();
   vi.clearAllMocks();
 });
 
@@ -40,7 +71,7 @@ beforeEach(() => {
 
 describe('useHousehold', () => {
   it('returns null household when none exists', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     expect(result.current.loading).toBe(false);
     expect(result.current.household).toBeNull();
@@ -49,7 +80,7 @@ describe('useHousehold', () => {
   });
 
   it('creates a household with the owner as first member', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     let household!: ReturnType<typeof result.current.createHousehold>;
     act(() => {
@@ -63,7 +94,7 @@ describe('useHousehold', () => {
   });
 
   it('invites a member with specified role', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'Test Household' });
@@ -85,7 +116,7 @@ describe('useHousehold', () => {
   });
 
   it('returns null when inviting without a household', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     let invitation!: ReturnType<typeof result.current.inviteMember>;
     act(() => {
@@ -100,7 +131,7 @@ describe('useHousehold', () => {
   });
 
   it('revokes a pending invitation', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'Test' });
@@ -122,7 +153,7 @@ describe('useHousehold', () => {
   });
 
   it('adds and revokes a trusted helper as a read-only VIEWER member', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'Test Household' });
@@ -156,7 +187,7 @@ describe('useHousehold', () => {
   });
 
   it('updates a member role', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'Test' });
@@ -176,7 +207,7 @@ describe('useHousehold', () => {
   });
 
   it('removes a member', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'Test' });
@@ -194,7 +225,7 @@ describe('useHousehold', () => {
   });
 
   it('sets account sharing mode', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'Test' });
@@ -214,8 +245,8 @@ describe('useHousehold', () => {
     expect(result.current.accountSharings[0]?.sharingMode).toBe('PRIVATE');
   });
 
-  it('persists household data to localStorage', () => {
-    const { result, unmount } = renderHook(() => useHousehold());
+  it('persists household data across remounts via the encrypted database', () => {
+    const { result, unmount } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'Persistent Family' });
@@ -224,14 +255,14 @@ describe('useHousehold', () => {
     unmount();
 
     // Re-mount and check data is restored
-    const { result: result2 } = renderHook(() => useHousehold());
+    const { result: result2 } = renderHook(() => useHousehold(), { wrapper });
 
     expect(result2.current.household?.name).toBe('Persistent Family');
     expect(result2.current.members).toHaveLength(1);
   });
 
   it('links and persists a college fund goal for an existing child profile', () => {
-    const { result, unmount } = renderHook(() => useHousehold());
+    const { result, unmount } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'College Family' });
@@ -256,12 +287,12 @@ describe('useHousehold', () => {
 
     unmount();
 
-    const { result: result2 } = renderHook(() => useHousehold());
+    const { result: result2 } = renderHook(() => useHousehold(), { wrapper });
     expect(result2.current.children[0]?.collegeFundGoalId).toBe('goal-college-1');
   });
 
   it('checks permissions correctly', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     expect(result.current.checkPermission('OWNER', 'MANAGE_MEMBERS')).toBe(true);
     expect(result.current.checkPermission('VIEWER', 'MANAGE_MEMBERS')).toBe(false);
@@ -341,7 +372,7 @@ describe('shared expense settlement helpers', () => {
 
 describe('household beta helpers and persistence', () => {
   it('creates recurring bill reminders and marks a cycle paid into shared expenses', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'Beta Household' });
@@ -386,7 +417,7 @@ describe('household beta helpers and persistence', () => {
   });
 
   it('tracks goal pledges, contributions, and catch-up recommendations', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'Goal Household' });
@@ -413,7 +444,7 @@ describe('household beta helpers and persistence', () => {
   });
 
   it('summarizes shopping trips and can generate a shared expense', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'Shopping Household' });
@@ -454,7 +485,7 @@ describe('household beta helpers and persistence', () => {
   });
 
   it('calculates privacy-aware reconciliation true-up suggestions and snapshots a period', () => {
-    const { result } = renderHook(() => useHousehold());
+    const { result } = renderHook(() => useHousehold(), { wrapper });
 
     act(() => {
       result.current.createHousehold({ name: 'Reconcile Household' });

--- a/apps/web/src/hooks/useHousehold.ts
+++ b/apps/web/src/hooks/useHousehold.ts
@@ -25,9 +25,12 @@
  * References: issues #1780, #1779, #1781, #1716, #1784, #1786, #2144, #2156
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAuth } from '../auth/auth-context';
+import { useDatabase } from '../db/DatabaseProvider';
+import { readHouseholdValue, writeHouseholdValue } from '../db/repositories/householdData';
+import type { SqliteDb } from '../db/sqlite-wasm';
 import type {
   AddChildChoreInput,
   ChildProfile,
@@ -624,46 +627,8 @@ export interface UseHouseholdResult {
   refresh: () => void;
 }
 
-/** Stable demo seed used to distribute shared-budget pace across members. */
-export interface HouseholdScorecardSeed {
-  readonly memberWeight: number;
-  readonly paceOffset: number;
-}
-
-const SCORECARD_PACE_OFFSETS = [-0.1, 0.18, 0.08, -0.02] as const;
-
-/**
- * Return deterministic local-first scorecard seeds for household members.
- *
- * The scorecard is currently demo-backed, so we use small role-aware weight
- * and pace offsets to create believable per-member pacing until real member-
- * level budget attribution lands.
- */
-export function getHouseholdScorecardSeeds(
-  members: readonly Pick<HouseholdMember, 'role'>[],
-): HouseholdScorecardSeed[] {
-  if (members.length === 0) {
-    return [];
-  }
-
-  if (members.length === 1) {
-    return [{ memberWeight: 1, paceOffset: 0 }];
-  }
-
-  const rawWeights = members.map((member, index) => {
-    const roleBias = member.role === 'OWNER' ? 0.15 : member.role === 'ADMIN' ? 0.08 : 0;
-    return Math.max(0.7, 1 + roleBias - index * 0.04);
-  });
-  const totalWeight = rawWeights.reduce((sum, value) => sum + value, 0) || members.length;
-
-  return members.map((_, index) => ({
-    memberWeight: rawWeights[index] / totalWeight,
-    paceOffset: SCORECARD_PACE_OFFSETS[index % SCORECARD_PACE_OFFSETS.length] ?? 0,
-  }));
-}
-
 // ---------------------------------------------------------------------------
-// Simulated storage (local state — bridged to SQLite repositories in production)
+// Persistence (encrypted SQLite/OPFS via the household data repository, #3378)
 // ---------------------------------------------------------------------------
 
 const STORAGE_KEY_HOUSEHOLD = 'finance-household';
@@ -682,17 +647,22 @@ const STORAGE_KEY_SHOPPING_BUDGETS = 'finance-household-shopping-budgets';
 const STORAGE_KEY_RECONCILIATION_PLANS = 'finance-household-reconciliation-plans';
 const STORAGE_KEY_RECONCILIATION_SNAPSHOTS = 'finance-household-reconciliation-snapshots';
 
-function loadFromStorage<T>(key: string, fallback: T): T {
+function loadFromStorage<T>(db: SqliteDb | null, key: string, fallback: T): T {
+  if (!db) {
+    return fallback;
+  }
   try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
+    return readHouseholdValue<T>(db, key, fallback);
   } catch {
     return fallback;
   }
 }
 
-function saveToStorage<T>(key: string, value: T): void {
-  localStorage.setItem(key, JSON.stringify(value));
+function saveToStorage<T>(db: SqliteDb | null, key: string, value: T): void {
+  if (!db) {
+    return;
+  }
+  writeHouseholdValue(db, key, value);
 }
 
 function toCents(amount: number): number {
@@ -1128,6 +1098,17 @@ export function useHousehold(): UseHouseholdResult {
   // guard with a try/catch and degrade gracefully to anonymous behaviour.
   const authUser = useOptionalAuthUser();
 
+  // Household data is persisted in the encrypted SQLite/OPFS database (issue
+  // #3378). Access the database defensively: if the household screen is ever
+  // mounted without a `DatabaseProvider` (e.g. isolated unit tests, or the
+  // guarded reads elsewhere on this page), the hook still renders with
+  // in-memory-only state instead of throwing. `dbRef` lets the memoized
+  // mutation callbacks reach the current database handle without adding it to
+  // every dependency array.
+  const db = useOptionalDatabase();
+  const dbRef = useRef<SqliteDb | null>(db);
+  dbRef.current = db;
+
   const [household, setHousehold] = useState<Household | null>(null);
   const [members, setMembers] = useState<HouseholdMember[]>([]);
   const [invitations, setInvitations] = useState<HouseholdInvitation[]>([]);
@@ -1160,40 +1141,68 @@ export function useHousehold(): UseHouseholdResult {
     setError(null);
 
     try {
-      setHousehold(loadFromStorage<Household | null>(STORAGE_KEY_HOUSEHOLD, null));
-      setMembers(loadFromStorage<HouseholdMember[]>(STORAGE_KEY_MEMBERS, []));
-      setInvitations(loadFromStorage<HouseholdInvitation[]>(STORAGE_KEY_INVITATIONS, []));
-      setAccountSharings(loadFromStorage<AccountSharing[]>(STORAGE_KEY_ACCOUNT_SHARINGS, []));
-      setSharedBudgets(loadFromStorage<SharedBudget[]>(STORAGE_KEY_SHARED_BUDGETS, []));
-      setSharedGoals(loadFromStorage<SharedGoal[]>(STORAGE_KEY_SHARED_GOALS, []));
-      setSharedExpenses(loadFromStorage<SharedExpense[]>(STORAGE_KEY_SHARED_EXPENSES, []));
-      setSharedSettlements(loadFromStorage<SharedSettlement[]>(STORAGE_KEY_SHARED_SETTLEMENTS, []));
-      setActivityEvents(loadFromStorage<HouseholdActivityEvent[]>(STORAGE_KEY_ACTIVITY_EVENTS, []));
-      setRecurringBills(loadFromStorage<RecurringSharedBill[]>(STORAGE_KEY_RECURRING_BILLS, []));
-      setGoalPledges(loadFromStorage<GoalContributionPledge[]>(STORAGE_KEY_GOAL_PLEDGES, []));
-      setShoppingBudgets(loadFromStorage<SharedShoppingBudget[]>(STORAGE_KEY_SHOPPING_BUDGETS, []));
+      setHousehold(loadFromStorage<Household | null>(dbRef.current, STORAGE_KEY_HOUSEHOLD, null));
+      setMembers(loadFromStorage<HouseholdMember[]>(dbRef.current, STORAGE_KEY_MEMBERS, []));
+      setInvitations(
+        loadFromStorage<HouseholdInvitation[]>(dbRef.current, STORAGE_KEY_INVITATIONS, []),
+      );
+      setAccountSharings(
+        loadFromStorage<AccountSharing[]>(dbRef.current, STORAGE_KEY_ACCOUNT_SHARINGS, []),
+      );
+      setSharedBudgets(
+        loadFromStorage<SharedBudget[]>(dbRef.current, STORAGE_KEY_SHARED_BUDGETS, []),
+      );
+      setSharedGoals(loadFromStorage<SharedGoal[]>(dbRef.current, STORAGE_KEY_SHARED_GOALS, []));
+      setSharedExpenses(
+        loadFromStorage<SharedExpense[]>(dbRef.current, STORAGE_KEY_SHARED_EXPENSES, []),
+      );
+      setSharedSettlements(
+        loadFromStorage<SharedSettlement[]>(dbRef.current, STORAGE_KEY_SHARED_SETTLEMENTS, []),
+      );
+      setActivityEvents(
+        loadFromStorage<HouseholdActivityEvent[]>(dbRef.current, STORAGE_KEY_ACTIVITY_EVENTS, []),
+      );
+      setRecurringBills(
+        loadFromStorage<RecurringSharedBill[]>(dbRef.current, STORAGE_KEY_RECURRING_BILLS, []),
+      );
+      setGoalPledges(
+        loadFromStorage<GoalContributionPledge[]>(dbRef.current, STORAGE_KEY_GOAL_PLEDGES, []),
+      );
+      setShoppingBudgets(
+        loadFromStorage<SharedShoppingBudget[]>(dbRef.current, STORAGE_KEY_SHOPPING_BUDGETS, []),
+      );
       setReconciliationPlans(
-        loadFromStorage<HouseholdReconciliationPlan[]>(STORAGE_KEY_RECONCILIATION_PLANS, []),
+        loadFromStorage<HouseholdReconciliationPlan[]>(
+          dbRef.current,
+          STORAGE_KEY_RECONCILIATION_PLANS,
+          [],
+        ),
       );
       setReconciliationSnapshots(
-        loadFromStorage<ReconciliationSnapshot[]>(STORAGE_KEY_RECONCILIATION_SNAPSHOTS, []),
+        loadFromStorage<ReconciliationSnapshot[]>(
+          dbRef.current,
+          STORAGE_KEY_RECONCILIATION_SNAPSHOTS,
+          [],
+        ),
       );
 
-      const storedChildren = loadFromStorage<ChildProfile[]>(STORAGE_KEY_CHILDREN, []).map(
-        normalizeChildProfile,
-      );
+      const storedChildren = loadFromStorage<ChildProfile[]>(
+        dbRef.current,
+        STORAGE_KEY_CHILDREN,
+        [],
+      ).map(normalizeChildProfile);
       const processedChildren = applyHouseholdKidsWeeklyProcessing(storedChildren);
       setChildren(processedChildren);
 
       if (JSON.stringify(storedChildren) !== JSON.stringify(processedChildren)) {
-        saveToStorage(STORAGE_KEY_CHILDREN, processedChildren);
+        saveToStorage(dbRef.current, STORAGE_KEY_CHILDREN, processedChildren);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load household data.');
     } finally {
       setLoading(false);
     }
-  }, [refreshToken]);
+  }, [db, refreshToken]);
 
   const getActorMemberId = useCallback((): SyncId | null => {
     return (
@@ -1233,7 +1242,7 @@ export function useHousehold(): UseHouseholdResult {
 
       setActivityEvents((current) => {
         const updated = [event, ...current].slice(0, 100);
-        saveToStorage(STORAGE_KEY_ACTIVITY_EVENTS, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_ACTIVITY_EVENTS, updated);
         return updated;
       });
       return event;
@@ -1280,16 +1289,16 @@ export function useHousehold(): UseHouseholdResult {
           isSynced: false,
         };
 
-        saveToStorage(STORAGE_KEY_HOUSEHOLD, newHousehold);
-        saveToStorage(STORAGE_KEY_MEMBERS, [ownerMember]);
-        saveToStorage(STORAGE_KEY_SHARED_EXPENSES, []);
-        saveToStorage(STORAGE_KEY_SHARED_SETTLEMENTS, []);
-        saveToStorage(STORAGE_KEY_ACTIVITY_EVENTS, []);
-        saveToStorage(STORAGE_KEY_RECURRING_BILLS, []);
-        saveToStorage(STORAGE_KEY_GOAL_PLEDGES, []);
-        saveToStorage(STORAGE_KEY_SHOPPING_BUDGETS, []);
-        saveToStorage(STORAGE_KEY_RECONCILIATION_PLANS, []);
-        saveToStorage(STORAGE_KEY_RECONCILIATION_SNAPSHOTS, []);
+        saveToStorage(dbRef.current, STORAGE_KEY_HOUSEHOLD, newHousehold);
+        saveToStorage(dbRef.current, STORAGE_KEY_MEMBERS, [ownerMember]);
+        saveToStorage(dbRef.current, STORAGE_KEY_SHARED_EXPENSES, []);
+        saveToStorage(dbRef.current, STORAGE_KEY_SHARED_SETTLEMENTS, []);
+        saveToStorage(dbRef.current, STORAGE_KEY_ACTIVITY_EVENTS, []);
+        saveToStorage(dbRef.current, STORAGE_KEY_RECURRING_BILLS, []);
+        saveToStorage(dbRef.current, STORAGE_KEY_GOAL_PLEDGES, []);
+        saveToStorage(dbRef.current, STORAGE_KEY_SHOPPING_BUDGETS, []);
+        saveToStorage(dbRef.current, STORAGE_KEY_RECONCILIATION_PLANS, []);
+        saveToStorage(dbRef.current, STORAGE_KEY_RECONCILIATION_SNAPSHOTS, []);
 
         const createdEvent: HouseholdActivityEvent = {
           id: crypto.randomUUID(),
@@ -1306,7 +1315,7 @@ export function useHousehold(): UseHouseholdResult {
           syncVersion: 1,
           isSynced: false,
         };
-        saveToStorage(STORAGE_KEY_ACTIVITY_EVENTS, [createdEvent]);
+        saveToStorage(dbRef.current, STORAGE_KEY_ACTIVITY_EVENTS, [createdEvent]);
 
         setHousehold(newHousehold);
         setMembers([ownerMember]);
@@ -1356,7 +1365,7 @@ export function useHousehold(): UseHouseholdResult {
         };
 
         const updated = [...invitations, invitation];
-        saveToStorage(STORAGE_KEY_INVITATIONS, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_INVITATIONS, updated);
         setInvitations(updated);
         appendActivity({
           type: 'MEMBERS',
@@ -1395,7 +1404,7 @@ export function useHousehold(): UseHouseholdResult {
               ? { ...inv, status: 'EXPIRED' as const, updatedAt: new Date().toISOString() }
               : inv,
           );
-          saveToStorage(STORAGE_KEY_INVITATIONS, updatedInvs);
+          saveToStorage(dbRef.current, STORAGE_KEY_INVITATIONS, updatedInvs);
           setInvitations(updatedInvs);
           setError('This invitation has expired.');
           return null;
@@ -1425,8 +1434,8 @@ export function useHousehold(): UseHouseholdResult {
 
         const updatedMembers = [...members, newMember];
 
-        saveToStorage(STORAGE_KEY_INVITATIONS, updatedInvs);
-        saveToStorage(STORAGE_KEY_MEMBERS, updatedMembers);
+        saveToStorage(dbRef.current, STORAGE_KEY_INVITATIONS, updatedInvs);
+        saveToStorage(dbRef.current, STORAGE_KEY_MEMBERS, updatedMembers);
         setInvitations(updatedInvs);
         setMembers(updatedMembers);
         appendActivity({
@@ -1463,7 +1472,7 @@ export function useHousehold(): UseHouseholdResult {
         );
         const changed = updated.some((inv, i) => inv !== invitations[i]);
         if (!changed) return false;
-        saveToStorage(STORAGE_KEY_INVITATIONS, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_INVITATIONS, updated);
         setInvitations(updated);
         appendActivity({
           type: 'MEMBERS',
@@ -1514,7 +1523,7 @@ export function useHousehold(): UseHouseholdResult {
         };
 
         const updated = [...members, helper];
-        saveToStorage(STORAGE_KEY_MEMBERS, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_MEMBERS, updated);
         setMembers(updated);
         appendActivity({
           type: 'MEMBERS',
@@ -1544,7 +1553,7 @@ export function useHousehold(): UseHouseholdResult {
         );
         const changed = updated.some((m, i) => m !== members[i]);
         if (!changed) return false;
-        saveToStorage(STORAGE_KEY_MEMBERS, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_MEMBERS, updated);
         setMembers(updated);
         appendActivity({
           type: 'MEMBERS',
@@ -1569,7 +1578,7 @@ export function useHousehold(): UseHouseholdResult {
       try {
         const updated = members.filter((m) => m.id !== memberId);
         if (updated.length === members.length) return false;
-        saveToStorage(STORAGE_KEY_MEMBERS, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_MEMBERS, updated);
         setMembers(updated);
         appendActivity({
           type: 'MEMBERS',
@@ -1614,7 +1623,7 @@ export function useHousehold(): UseHouseholdResult {
               ? { ...as, sharingMode: input.sharingMode, updatedAt: now }
               : as,
           );
-          saveToStorage(STORAGE_KEY_ACCOUNT_SHARINGS, updated);
+          saveToStorage(dbRef.current, STORAGE_KEY_ACCOUNT_SHARINGS, updated);
           setAccountSharings(updated);
           appendActivity({
             type: 'ACCOUNTS',
@@ -1645,7 +1654,7 @@ export function useHousehold(): UseHouseholdResult {
         };
 
         const updated = [...accountSharings, newSharing];
-        saveToStorage(STORAGE_KEY_ACCOUNT_SHARINGS, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_ACCOUNT_SHARINGS, updated);
         setAccountSharings(updated);
         appendActivity({
           type: 'ACCOUNTS',
@@ -1698,7 +1707,7 @@ export function useHousehold(): UseHouseholdResult {
               ? { ...sb, mode: input.mode, isActive: true, updatedAt: now }
               : sb,
           );
-          saveToStorage(STORAGE_KEY_SHARED_BUDGETS, updated);
+          saveToStorage(dbRef.current, STORAGE_KEY_SHARED_BUDGETS, updated);
           setSharedBudgets(updated);
           appendActivity({
             type: 'BUDGETS',
@@ -1726,7 +1735,7 @@ export function useHousehold(): UseHouseholdResult {
         };
 
         const updated = [...sharedBudgets, newSharedBudget];
-        saveToStorage(STORAGE_KEY_SHARED_BUDGETS, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_SHARED_BUDGETS, updated);
         setSharedBudgets(updated);
         appendActivity({
           type: 'BUDGETS',
@@ -1751,7 +1760,7 @@ export function useHousehold(): UseHouseholdResult {
       try {
         const updated = sharedBudgets.filter((sb) => sb.id !== sharedBudgetId);
         if (updated.length === sharedBudgets.length) return false;
-        saveToStorage(STORAGE_KEY_SHARED_BUDGETS, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_SHARED_BUDGETS, updated);
         setSharedBudgets(updated);
         appendActivity({
           type: 'BUDGETS',
@@ -1787,7 +1796,7 @@ export function useHousehold(): UseHouseholdResult {
           const updated = sharedGoals.map((sg) =>
             sg.goalId === input.goalId ? { ...sg, isShared: input.isShared, updatedAt: now } : sg,
           );
-          saveToStorage(STORAGE_KEY_SHARED_GOALS, updated);
+          saveToStorage(dbRef.current, STORAGE_KEY_SHARED_GOALS, updated);
           setSharedGoals(updated);
           appendActivity({
             type: 'GOALS',
@@ -1814,7 +1823,7 @@ export function useHousehold(): UseHouseholdResult {
         };
 
         const updated = [...sharedGoals, newSharedGoal];
-        saveToStorage(STORAGE_KEY_SHARED_GOALS, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_SHARED_GOALS, updated);
         setSharedGoals(updated);
         appendActivity({
           type: 'GOALS',
@@ -1883,7 +1892,7 @@ export function useHousehold(): UseHouseholdResult {
         };
 
         const updated = [...sharedExpenses, expense];
-        saveToStorage(STORAGE_KEY_SHARED_EXPENSES, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_SHARED_EXPENSES, updated);
         setSharedExpenses(updated);
         appendActivity({
           type: 'EXPENSES',
@@ -1938,7 +1947,7 @@ export function useHousehold(): UseHouseholdResult {
         };
 
         const updated = [...sharedSettlements, settlement];
-        saveToStorage(STORAGE_KEY_SHARED_SETTLEMENTS, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_SHARED_SETTLEMENTS, updated);
         setSharedSettlements(updated);
         appendActivity({
           type: 'SETTLEMENTS',
@@ -2009,7 +2018,7 @@ export function useHousehold(): UseHouseholdResult {
       bill.cycles = [buildRecurringBillCycle(bill, 0, new Date(), crypto.randomUUID())];
 
       const updated = [...recurringBills, bill];
-      saveToStorage(STORAGE_KEY_RECURRING_BILLS, updated);
+      saveToStorage(dbRef.current, STORAGE_KEY_RECURRING_BILLS, updated);
       setRecurringBills(updated);
       appendActivity({
         type: 'BILLS',
@@ -2034,7 +2043,7 @@ export function useHousehold(): UseHouseholdResult {
       );
       const changed = updated.some((bill, index) => bill !== recurringBills[index]);
       if (!changed) return false;
-      saveToStorage(STORAGE_KEY_RECURRING_BILLS, updated);
+      saveToStorage(dbRef.current, STORAGE_KEY_RECURRING_BILLS, updated);
       setRecurringBills(updated);
       appendActivity({
         type: 'BILLS',
@@ -2082,7 +2091,7 @@ export function useHousehold(): UseHouseholdResult {
       }
 
       const activityCycle = updatedCycle as RecurringSharedBillCycle;
-      saveToStorage(STORAGE_KEY_RECURRING_BILLS, updatedBills);
+      saveToStorage(dbRef.current, STORAGE_KEY_RECURRING_BILLS, updatedBills);
       setRecurringBills(updatedBills);
       appendActivity({
         type: 'BILLS',
@@ -2159,8 +2168,8 @@ export function useHousehold(): UseHouseholdResult {
           : entry,
       );
 
-      saveToStorage(STORAGE_KEY_SHARED_EXPENSES, updatedExpenses);
-      saveToStorage(STORAGE_KEY_RECURRING_BILLS, updatedBills);
+      saveToStorage(dbRef.current, STORAGE_KEY_SHARED_EXPENSES, updatedExpenses);
+      saveToStorage(dbRef.current, STORAGE_KEY_RECURRING_BILLS, updatedBills);
       setSharedExpenses(updatedExpenses);
       setRecurringBills(updatedBills);
       appendActivity({
@@ -2240,7 +2249,7 @@ export function useHousehold(): UseHouseholdResult {
       const updated = existing
         ? goalPledges.map((pledge) => (pledge.id === existing.id ? saved : pledge))
         : [...goalPledges, saved];
-      saveToStorage(STORAGE_KEY_GOAL_PLEDGES, updated);
+      saveToStorage(dbRef.current, STORAGE_KEY_GOAL_PLEDGES, updated);
       setGoalPledges(updated);
       appendActivity({
         type: 'GOALS',
@@ -2291,7 +2300,7 @@ export function useHousehold(): UseHouseholdResult {
       }
 
       const savedPledge = saved as GoalContributionPledge;
-      saveToStorage(STORAGE_KEY_GOAL_PLEDGES, updated);
+      saveToStorage(dbRef.current, STORAGE_KEY_GOAL_PLEDGES, updated);
       setGoalPledges(updated);
       appendActivity({
         type: 'GOALS',
@@ -2347,7 +2356,7 @@ export function useHousehold(): UseHouseholdResult {
       const updated = existing
         ? shoppingBudgets.map((budget) => (budget.id === existing.id ? saved : budget))
         : [...shoppingBudgets, saved];
-      saveToStorage(STORAGE_KEY_SHOPPING_BUDGETS, updated);
+      saveToStorage(dbRef.current, STORAGE_KEY_SHOPPING_BUDGETS, updated);
       setShoppingBudgets(updated);
       appendActivity({
         type: 'SHOPPING',
@@ -2401,7 +2410,7 @@ export function useHousehold(): UseHouseholdResult {
         };
         sharedExpenseId = expense.id;
         const updatedExpenses = [...sharedExpenses, expense];
-        saveToStorage(STORAGE_KEY_SHARED_EXPENSES, updatedExpenses);
+        saveToStorage(dbRef.current, STORAGE_KEY_SHARED_EXPENSES, updatedExpenses);
         setSharedExpenses(updatedExpenses);
       }
 
@@ -2423,7 +2432,7 @@ export function useHousehold(): UseHouseholdResult {
           ? { ...entry, trips: [...entry.trips, trip], updatedAt: now }
           : entry,
       );
-      saveToStorage(STORAGE_KEY_SHOPPING_BUDGETS, updatedBudgets);
+      saveToStorage(dbRef.current, STORAGE_KEY_SHOPPING_BUDGETS, updatedBudgets);
       setShoppingBudgets(updatedBudgets);
       appendActivity({
         type: 'SHOPPING',
@@ -2486,7 +2495,7 @@ export function useHousehold(): UseHouseholdResult {
         isSynced: false,
       };
       const updated = [plan, ...reconciliationPlans.filter((entry) => entry.name !== name)];
-      saveToStorage(STORAGE_KEY_RECONCILIATION_PLANS, updated);
+      saveToStorage(dbRef.current, STORAGE_KEY_RECONCILIATION_PLANS, updated);
       setReconciliationPlans(updated);
       appendActivity({
         type: 'RECONCILIATION',
@@ -2529,7 +2538,7 @@ export function useHousehold(): UseHouseholdResult {
         isSynced: false,
       };
       const updated = [snapshot, ...reconciliationSnapshots];
-      saveToStorage(STORAGE_KEY_RECONCILIATION_SNAPSHOTS, updated);
+      saveToStorage(dbRef.current, STORAGE_KEY_RECONCILIATION_SNAPSHOTS, updated);
       setReconciliationSnapshots(updated);
       appendActivity({
         type: 'RECONCILIATION',
@@ -2556,7 +2565,7 @@ export function useHousehold(): UseHouseholdResult {
       try {
         const newChild = buildChildProfile(input, crypto.randomUUID());
         const updated = [...applyHouseholdKidsWeeklyProcessing(children), newChild];
-        saveToStorage(STORAGE_KEY_CHILDREN, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_CHILDREN, updated);
         setChildren(updated);
         return newChild;
       } catch (err) {
@@ -2580,7 +2589,7 @@ export function useHousehold(): UseHouseholdResult {
           return null;
         }
 
-        saveToStorage(STORAGE_KEY_CHILDREN, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_CHILDREN, updated);
         setChildren(updated);
         return chore;
       } catch (err) {
@@ -2599,7 +2608,7 @@ export function useHousehold(): UseHouseholdResult {
           return false;
         }
 
-        saveToStorage(STORAGE_KEY_CHILDREN, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_CHILDREN, updated);
         setChildren(updated);
         return true;
       } catch (err) {
@@ -2620,7 +2629,7 @@ export function useHousehold(): UseHouseholdResult {
           return null;
         }
 
-        saveToStorage(STORAGE_KEY_CHILDREN, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_CHILDREN, updated);
         setChildren(updated);
         return child;
       } catch (err) {
@@ -2641,7 +2650,7 @@ export function useHousehold(): UseHouseholdResult {
           return null;
         }
 
-        saveToStorage(STORAGE_KEY_CHILDREN, updated);
+        saveToStorage(dbRef.current, STORAGE_KEY_CHILDREN, updated);
         setChildren(updated);
         return child;
       } catch (err) {
@@ -2719,6 +2728,25 @@ export function useHousehold(): UseHouseholdResult {
 function useOptionalAuthUser(): { id: string; email: string; name?: string } | null {
   try {
     return useAuth().user;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Access the encrypted SQLite database without crashing if the household screen
+ * is mounted outside a `DatabaseProvider`.
+ *
+ * `useDatabase` throws when no provider is mounted. The household feature keeps
+ * all persistence behind this guard (mirroring the optional account/budget
+ * reads on {@link ../pages/HouseholdPage}) so the hook degrades to in-memory
+ * state — never throwing — in isolated tests or provider-less render paths.
+ *
+ * Issue #3378.
+ */
+function useOptionalDatabase(): SqliteDb | null {
+  try {
+    return useDatabase();
   } catch {
     return null;
   }

--- a/apps/web/src/pages/HouseholdPage.test.tsx
+++ b/apps/web/src/pages/HouseholdPage.test.tsx
@@ -14,6 +14,8 @@ import {
 } from '../hooks/householdKids';
 import { useBudgets } from '../hooks/useBudgets';
 import type { UseBudgetsResult } from '../hooks/useBudgets';
+import { useAccounts } from '../hooks/useAccounts';
+import type { UseAccountsResult } from '../hooks/useAccounts';
 import { useCategories } from '../hooks/useCategories';
 import type { UseCategoriesResult } from '../hooks/useCategories';
 import { useGoals } from '../hooks/useGoals';
@@ -35,20 +37,6 @@ vi.mock('../hooks/useHousehold', async () => {
   return {
     ...actual,
     useHousehold: vi.fn(),
-    getHouseholdScorecardSeeds: (members: Array<{ role: string }>) => {
-      if (members.length === 0) {
-        return [];
-      }
-
-      if (members.length === 1) {
-        return [{ memberWeight: 1, paceOffset: 0 }];
-      }
-
-      return members.map(() => ({
-        memberWeight: 1 / members.length,
-        paceOffset: 0,
-      }));
-    },
   };
 });
 
@@ -59,6 +47,10 @@ vi.mock('../hooks/useBudgets', async () => {
     useBudgets: vi.fn(),
   };
 });
+
+vi.mock('../hooks/useAccounts', () => ({
+  useAccounts: vi.fn(),
+}));
 
 vi.mock('../hooks/useGoals', () => ({
   useGoals: vi.fn(),
@@ -82,6 +74,7 @@ vi.mock('../components/common/Toast', () => ({
 
 const mockedUseHousehold = vi.mocked(useHousehold);
 const mockedUseBudgets = vi.mocked(useBudgets);
+const mockedUseAccounts = vi.mocked(useAccounts);
 const mockedUseGoals = vi.mocked(useGoals);
 const mockedUseTransactions = vi.mocked(useTransactions);
 const mockedUseCategories = vi.mocked(useCategories);
@@ -102,6 +95,93 @@ function mockBudgetsResult(overrides: Partial<UseBudgetsResult> = {}): UseBudget
     getBudgetSpendingBreakdown: vi.fn().mockReturnValue([]),
     ...overrides,
   };
+}
+
+function mockAccountsResult(overrides: Partial<UseAccountsResult> = {}): UseAccountsResult {
+  return {
+    accounts: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    createAccount: vi.fn(),
+    updateAccount: vi.fn(),
+    deleteAccount: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** Minimal account fixture for the account-sharing surface (#3375). */
+function makeAccount(
+  overrides: Record<string, unknown> = {},
+): UseAccountsResult['accounts'][number] {
+  return {
+    id: 'acct-1',
+    householdId: 'hh-1',
+    name: 'Account',
+    type: 'CHECKING',
+    currency: 'USD',
+    currentBalance: { amount: 0 },
+    isArchived: false,
+    sortOrder: 0,
+    icon: null,
+    color: null,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+    ...overrides,
+  } as unknown as UseAccountsResult['accounts'][number];
+}
+
+/** Minimal budget fixture for the shared-budget surface (#3375). */
+function makeBudget(overrides: Record<string, unknown> = {}): UseBudgetsResult['budgets'][number] {
+  return {
+    id: 'budget-1',
+    householdId: 'hh-1',
+    categoryId: 'cat-1',
+    name: 'Budget',
+    amount: { amount: 50000 },
+    spentAmount: { amount: 0 },
+    remainingAmount: { amount: 50000 },
+    currency: 'USD',
+    period: 'MONTHLY',
+    startDate: '2025-01-01',
+    endDate: null,
+    isRollover: false,
+    sortOrder: 0,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+    ...overrides,
+  } as unknown as UseBudgetsResult['budgets'][number];
+}
+
+/** Minimal goal fixture for the shared-goal surface (#3376). */
+function makeGoal(overrides: Record<string, unknown> = {}): UseGoalsResult['goals'][number] {
+  return {
+    id: 'goal-1',
+    householdId: 'hh-1',
+    name: 'Goal',
+    description: null,
+    targetAmount: { amount: 100000 },
+    currentAmount: { amount: 0 },
+    currency: 'USD',
+    targetDate: null,
+    status: 'ACTIVE',
+    icon: null,
+    color: null,
+    accountId: null,
+    sortOrder: 0,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+    ...overrides,
+  } as unknown as UseGoalsResult['goals'][number];
 }
 
 function mockGoalsResult(overrides: Partial<UseGoalsResult> = {}): UseGoalsResult {
@@ -430,6 +510,7 @@ describe('HouseholdPage', () => {
       dismissToast: vi.fn(),
     });
     mockedUseBudgets.mockReturnValue(mockBudgetsResult());
+    mockedUseAccounts.mockReturnValue(mockAccountsResult());
     mockedUseGoals.mockReturnValue(mockGoalsResult());
     mockedUseTransactions.mockReturnValue(mockTransactionsResult());
     mockedUseCategories.mockReturnValue(mockCategoriesResult());
@@ -1084,6 +1165,11 @@ describe('HouseholdPage', () => {
         ],
       }),
     );
+    mockedUseAccounts.mockReturnValue(
+      mockAccountsResult({
+        accounts: [makeAccount({ id: 'acct-checking', name: 'Checking Account' })],
+      }),
+    );
 
     render(<HouseholdPage />);
 
@@ -1119,6 +1205,13 @@ describe('HouseholdPage', () => {
         ],
       }),
     );
+    mockedUseBudgets.mockReturnValue(
+      mockBudgetsResult({
+        budgets: [
+          makeBudget({ id: 'budget-groceries', name: 'Groceries', categoryId: 'cat-groceries' }),
+        ],
+      }),
+    );
 
     render(<HouseholdPage />);
 
@@ -1143,6 +1236,11 @@ describe('HouseholdPage', () => {
             isSynced: true,
           },
         ],
+      }),
+    );
+    mockedUseGoals.mockReturnValue(
+      mockGoalsResult({
+        goals: [makeGoal({ id: 'goal-vacation', name: 'Family Vacation' })],
       }),
     );
 

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -34,7 +34,6 @@ import {
   calculateReconciliationSummary,
   calculateShoppingBudgetSummary,
   createEqualSharedExpenseSplits,
-  getHouseholdScorecardSeeds,
   type HouseholdActivityType,
   type PayerRotationMode,
   type RecurringBillCadence,
@@ -46,6 +45,8 @@ import {
 } from '../hooks/useHousehold';
 import { getScorecardBudgetSnapshots, useBudgets } from '../hooks/useBudgets';
 import type { ScorecardBudgetSnapshot, UseBudgetsResult } from '../hooks/useBudgets';
+import { useAccounts } from '../hooks/useAccounts';
+import type { UseAccountsResult } from '../hooks/useAccounts';
 import { useCategories } from '../hooks/useCategories';
 import type { UseCategoriesResult } from '../hooks/useCategories';
 import { useGoals } from '../hooks/useGoals';
@@ -53,10 +54,12 @@ import type { UseGoalsResult } from '../hooks/useGoals';
 import { useTransactions } from '../hooks/useTransactions';
 import type { UseTransactionsResult } from '../hooks/useTransactions';
 import type {
+  AccountSharing,
   HouseholdMember,
   HouseholdRole,
   AccountSharingMode,
   SharedBudgetMode,
+  Transaction,
 } from '../kmp/bridge';
 import { ROLE_PERMISSIONS } from '../kmp/bridge';
 import { buildInviteUrl, getMemberDisplayName } from '../lib/household/display-name';
@@ -120,30 +123,6 @@ const SHARING_MODE_LABELS: Record<AccountSharingMode, string> = {
 const BUDGET_MODE_LABELS: Record<SharedBudgetMode, string> = {
   FLEX: 'Flex (overall limit)',
   CATEGORY: 'Category (per-category limits)',
-};
-
-/** Demo account IDs for account sharing toggles. */
-const DEMO_ACCOUNT_IDS = ['acct-checking', 'acct-savings', 'acct-credit'];
-const DEMO_ACCOUNT_NAMES: Record<string, string> = {
-  'acct-checking': 'Checking Account',
-  'acct-savings': 'Savings Account',
-  'acct-credit': 'Credit Card',
-};
-
-/** Demo budget IDs for shared budget configuration. */
-const DEMO_BUDGET_IDS = ['budget-groceries', 'budget-dining', 'budget-entertainment'];
-const DEMO_BUDGET_NAMES: Record<string, string> = {
-  'budget-groceries': 'Groceries',
-  'budget-dining': 'Dining Out',
-  'budget-entertainment': 'Entertainment',
-};
-
-/** Demo goal IDs for shared goals. */
-const DEMO_GOAL_IDS = ['goal-vacation', 'goal-emergency', 'goal-car'];
-const DEMO_GOAL_NAMES: Record<string, string> = {
-  'goal-vacation': 'Family Vacation',
-  'goal-emergency': 'Emergency Fund',
-  'goal-car': 'New Car',
 };
 
 const DEFAULT_CHORE_FREQUENCY: ChoreFrequency = 'weekly';
@@ -222,12 +201,24 @@ export function HouseholdPage() {
   // Issue #2188: scorecard pace uses live budgets when available and falls
   // back to deterministic demo snapshots for local-first households.
   const budgetData = useOptionalBudgets();
+  const accountData = useOptionalAccounts();
 
   // Issue #2191: child finance rollups combine existing child profiles with
   // local transactions and savings goals.
   const goalData = useOptionalGoals();
   const transactionData = useOptionalTransactions();
   const categoryData = useOptionalCategories();
+
+  // Issues #3375/#3376: resolve real account/budget/goal names for household
+  // sharing surfaces and reconciliation labels instead of hardcoded demo maps.
+  const budgetNameById = useMemo(
+    () => new Map(budgetData.budgets.map((budget) => [budget.id, budget.name])),
+    [budgetData.budgets],
+  );
+  const goalNameById = useMemo(
+    () => new Map(goalData.goals.map((goal) => [goal.id, goal.name])),
+    [goalData.goals],
+  );
   const childFinance = useMemo(
     () =>
       buildChildFinanceRollup({
@@ -281,7 +272,7 @@ export function HouseholdPage() {
   const [recurringBillPayer, setRecurringBillPayer] = useState('');
   const [recurringBillRotation, setRecurringBillRotation] =
     useState<PayerRotationMode>('ROUND_ROBIN');
-  const [goalPledgeGoalId, setGoalPledgeGoalId] = useState(DEMO_GOAL_IDS[0]);
+  const [goalPledgeGoalId, setGoalPledgeGoalId] = useState('');
   const [goalPledgeMemberId, setGoalPledgeMemberId] = useState('');
   const [goalPledgeAmount, setGoalPledgeAmount] = useState('');
   const [shoppingBudgetName, setShoppingBudgetName] = useState('Groceries and supplies');
@@ -664,7 +655,7 @@ export function HouseholdPage() {
     }
     const obligationSeeds = [
       ...sharedBudgets.map((budget) => ({
-        label: DEMO_BUDGET_NAMES[budget.budgetId] ?? 'Shared budget',
+        label: budgetNameById.get(budget.budgetId) ?? 'Shared budget',
         amount: 300,
         sourceId: budget.budgetId,
         sourceType: 'BUDGET' as const,
@@ -708,7 +699,14 @@ export function HouseholdPage() {
     if (!plan) {
       setHouseholdBetaError('Failed to create reconciliation plan.');
     }
-  }, [members, recurringBills, setReconciliationPlan, sharedBudgets, sharedExpenseBalances]);
+  }, [
+    budgetNameById,
+    members,
+    recurringBills,
+    setReconciliationPlan,
+    sharedBudgets,
+    sharedExpenseBalances,
+  ]);
 
   const handleMarkReconciled = useCallback(
     (planId: string) => {
@@ -1091,20 +1089,29 @@ export function HouseholdPage() {
       buildHouseholdScorecard({
         members,
         budgetSnapshots: getScorecardBudgetSnapshots(budgetData.budgets, household.id),
+        transactions: transactionData.transactions,
+        accountSharings,
         resolveMemberName,
         referenceDate: new Date(),
       }),
-    [budgetData.budgets, household.id, members, resolveMemberName],
+    [
+      accountSharings,
+      budgetData.budgets,
+      household.id,
+      members,
+      resolveMemberName,
+      transactionData.transactions,
+    ],
   );
 
   const recurringBillReminders = useMemo(
     () => buildRecurringBillReminders(recurringBills),
     [recurringBills],
   );
-  const goalPledgeProgress = useMemo(
-    () => DEMO_GOAL_IDS.map((goalId) => calculateGoalPledgeProgress(goalPledges, goalId)),
-    [goalPledges],
-  );
+  const goalPledgeProgress = useMemo(() => {
+    const pledgedGoalIds = Array.from(new Set(goalPledges.map((pledge) => pledge.goalId)));
+    return pledgedGoalIds.map((goalId) => calculateGoalPledgeProgress(goalPledges, goalId));
+  }, [goalPledges]);
   const shoppingBudgetSummaries = useMemo(
     () =>
       shoppingBudgets.map((budget) => ({
@@ -1530,15 +1537,20 @@ export function HouseholdPage() {
           <form onSubmit={handleSaveGoalPledge} className="household-beta-form" noValidate>
             <select
               className="household-form-select"
-              value={goalPledgeGoalId}
+              value={goalPledgeGoalId || goalData.goals[0]?.id || ''}
               onChange={(e) => setGoalPledgeGoalId(e.target.value)}
               aria-label="Pledge goal"
+              disabled={goalData.goals.length === 0}
             >
-              {DEMO_GOAL_IDS.map((goalId) => (
-                <option key={goalId} value={goalId}>
-                  Pledge: {DEMO_GOAL_NAMES[goalId]}
-                </option>
-              ))}
+              {goalData.goals.length === 0 ? (
+                <option value="">No goals yet — create one first</option>
+              ) : (
+                goalData.goals.map((goal) => (
+                  <option key={goal.id} value={goal.id}>
+                    Pledge: {goal.name}
+                  </option>
+                ))
+              )}
             </select>
             <select
               className="household-form-select"
@@ -1570,9 +1582,9 @@ export function HouseholdPage() {
             {goalPledgeProgress.map((progress) => (
               <li key={progress.goalId} className="household-beta-list__item">
                 <span>
-                  <strong>Goal: {DEMO_GOAL_NAMES[progress.goalId]}</strong> pledged{' '}
-                  <CurrencyDisplay amount={dollarsToCents(progress.totalPledged)} /> · contributed{' '}
-                  <CurrencyDisplay amount={dollarsToCents(progress.totalContributed)} />
+                  <strong>Goal: {goalNameById.get(progress.goalId) ?? 'Shared goal'}</strong>{' '}
+                  pledged <CurrencyDisplay amount={dollarsToCents(progress.totalPledged)} /> ·
+                  contributed <CurrencyDisplay amount={dollarsToCents(progress.totalContributed)} />
                 </span>
                 {progress.members.map((memberProgress) => (
                   <button
@@ -2888,50 +2900,56 @@ export function HouseholdPage() {
           are visible to all members (ours).
         </p>
         <ul className="household-sharing-list" role="list" aria-label="Account sharing settings">
-          {DEMO_ACCOUNT_IDS.map((accountId) => {
-            const sharing = accountSharings.find((as) => as.accountId === accountId);
-            const mode: AccountSharingMode = sharing?.sharingMode ?? 'PRIVATE';
-            const isShared = mode === 'SHARED';
-            return (
-              <li key={accountId} className="household-sharing-item">
-                <div className="household-sharing-item__info">
-                  <span className="household-sharing-item__name">
-                    {DEMO_ACCOUNT_NAMES[accountId]}
-                  </span>
-                  <span
-                    className={`household-sharing-item__badge ${isShared ? 'household-sharing-item__badge--shared' : 'household-sharing-item__badge--private'}`}
+          {accountData.accounts.length === 0 ? (
+            <li className="household-sharing-item household-sharing-item--empty">
+              <span className="household-sharing-item__name">
+                No accounts yet. Add an account to choose what to share with your household.
+              </span>
+            </li>
+          ) : (
+            accountData.accounts.map((account) => {
+              const sharing = accountSharings.find((as) => as.accountId === account.id);
+              const mode: AccountSharingMode = sharing?.sharingMode ?? 'PRIVATE';
+              const isShared = mode === 'SHARED';
+              return (
+                <li key={account.id} className="household-sharing-item">
+                  <div className="household-sharing-item__info">
+                    <span className="household-sharing-item__name">{account.name}</span>
+                    <span
+                      className={`household-sharing-item__badge ${isShared ? 'household-sharing-item__badge--shared' : 'household-sharing-item__badge--private'}`}
+                    >
+                      {isShared ? (
+                        <>
+                          <AppIcon name="unlock" /> Shared
+                        </>
+                      ) : (
+                        <>
+                          <AppIcon name="lock" /> Private
+                        </>
+                      )}
+                    </span>
+                  </div>
+                  <button
+                    className={`household-toggle ${isShared ? 'household-toggle--active' : ''}`}
+                    role="switch"
+                    aria-checked={isShared}
+                    aria-label={`Toggle sharing for ${account.name}`}
+                    onClick={() =>
+                      setAccountSharing({
+                        accountId: account.id,
+                        sharingMode: isShared ? 'PRIVATE' : 'SHARED',
+                      })
+                    }
                   >
-                    {isShared ? (
-                      <>
-                        <AppIcon name="unlock" /> Shared
-                      </>
-                    ) : (
-                      <>
-                        <AppIcon name="lock" /> Private
-                      </>
-                    )}
-                  </span>
-                </div>
-                <button
-                  className={`household-toggle ${isShared ? 'household-toggle--active' : ''}`}
-                  role="switch"
-                  aria-checked={isShared}
-                  aria-label={`Toggle sharing for ${DEMO_ACCOUNT_NAMES[accountId]}`}
-                  onClick={() =>
-                    setAccountSharing({
-                      accountId,
-                      sharingMode: isShared ? 'PRIVATE' : 'SHARED',
-                    })
-                  }
-                >
-                  <span className="household-toggle__track">
-                    <span className="household-toggle__thumb" />
-                  </span>
-                  <span className="household-toggle__label">{SHARING_MODE_LABELS[mode]}</span>
-                </button>
-              </li>
-            );
-          })}
+                    <span className="household-toggle__track">
+                      <span className="household-toggle__thumb" />
+                    </span>
+                    <span className="household-toggle__label">{SHARING_MODE_LABELS[mode]}</span>
+                  </button>
+                </li>
+              );
+            })
+          )}
         </ul>
         <div className="household-card__note" role="note">
           <strong>Privacy boundary:</strong> Private ("mine only") accounts, transactions, and
@@ -2952,59 +2970,69 @@ export function HouseholdPage() {
           overall spending limit) or category mode (per-category limits).
         </p>
         <ul className="household-budget-list" role="list" aria-label="Shared budget settings">
-          {DEMO_BUDGET_IDS.map((budgetId) => {
-            const shared = sharedBudgets.find((sb) => sb.budgetId === budgetId);
-            const isActive = shared?.isActive ?? false;
-            const mode: SharedBudgetMode = shared?.mode ?? 'CATEGORY';
-            return (
-              <li key={budgetId} className="household-budget-item">
-                <div className="household-budget-item__info">
-                  <span className="household-budget-item__name">{DEMO_BUDGET_NAMES[budgetId]}</span>
-                  {isActive && (
-                    <span className="household-budget-item__mode">{BUDGET_MODE_LABELS[mode]}</span>
-                  )}
-                </div>
-                <div className="household-budget-item__controls">
-                  {isActive && (
-                    <select
-                      className="household-form-select household-form-select--small"
-                      value={mode}
-                      onChange={(e) =>
-                        setSharedBudget({
-                          budgetId,
-                          mode: e.target.value as SharedBudgetMode,
-                        })
-                      }
-                      aria-label={`Budget mode for ${DEMO_BUDGET_NAMES[budgetId]}`}
+          {budgetData.budgets.length === 0 ? (
+            <li className="household-budget-item household-budget-item--empty">
+              <span className="household-budget-item__name">
+                No budgets yet. Create a budget to share it with your household.
+              </span>
+            </li>
+          ) : (
+            budgetData.budgets.map((budget) => {
+              const shared = sharedBudgets.find((sb) => sb.budgetId === budget.id);
+              const isActive = shared?.isActive ?? false;
+              const mode: SharedBudgetMode = shared?.mode ?? 'CATEGORY';
+              return (
+                <li key={budget.id} className="household-budget-item">
+                  <div className="household-budget-item__info">
+                    <span className="household-budget-item__name">{budget.name}</span>
+                    {isActive && (
+                      <span className="household-budget-item__mode">
+                        {BUDGET_MODE_LABELS[mode]}
+                      </span>
+                    )}
+                  </div>
+                  <div className="household-budget-item__controls">
+                    {isActive && (
+                      <select
+                        className="household-form-select household-form-select--small"
+                        value={mode}
+                        onChange={(e) =>
+                          setSharedBudget({
+                            budgetId: budget.id,
+                            mode: e.target.value as SharedBudgetMode,
+                          })
+                        }
+                        aria-label={`Budget mode for ${budget.name}`}
+                      >
+                        <option value="FLEX">Flex</option>
+                        <option value="CATEGORY">Category</option>
+                      </select>
+                    )}
+                    <button
+                      className={`household-toggle ${isActive ? 'household-toggle--active' : ''}`}
+                      role="switch"
+                      aria-checked={isActive}
+                      aria-label={`Toggle sharing for ${budget.name}`}
+                      onClick={() => {
+                        if (isActive && shared) {
+                          removeSharedBudget(shared.id);
+                        } else {
+                          setSharedBudget({ budgetId: budget.id, mode });
+                        }
+                      }}
                     >
-                      <option value="FLEX">Flex</option>
-                      <option value="CATEGORY">Category</option>
-                    </select>
-                  )}
-                  <button
-                    className={`household-toggle ${isActive ? 'household-toggle--active' : ''}`}
-                    role="switch"
-                    aria-checked={isActive}
-                    aria-label={`Toggle sharing for ${DEMO_BUDGET_NAMES[budgetId]}`}
-                    onClick={() => {
-                      if (isActive && shared) {
-                        removeSharedBudget(shared.id);
-                      } else {
-                        setSharedBudget({ budgetId, mode });
-                      }
-                    }}
-                  >
-                    <span className="household-toggle__track">
-                      <span className="household-toggle__thumb" />
-                    </span>
-                    <span className="household-toggle__label">
-                      {isActive ? 'Shared' : 'Personal'}
-                    </span>
-                  </button>
-                </div>
-              </li>
-            );
-          })}
+                      <span className="household-toggle__track">
+                        <span className="household-toggle__thumb" />
+                      </span>
+                      <span className="household-toggle__label">
+                        {isActive ? 'Shared' : 'Personal'}
+                      </span>
+                    </button>
+                  </div>
+                </li>
+              );
+            })
+          )}
         </ul>
       </section>
 
@@ -3020,34 +3048,42 @@ export function HouseholdPage() {
           contribution tracking shows who contributed what.
         </p>
         <ul className="household-goal-list" role="list" aria-label="Shared goal settings">
-          {DEMO_GOAL_IDS.map((goalId) => {
-            const shared = sharedGoals.find((sg) => sg.goalId === goalId);
-            const isShared = shared?.isShared ?? false;
-            return (
-              <li key={goalId} className="household-goal-item">
-                <div className="household-goal-item__info">
-                  <span className="household-goal-item__name">{DEMO_GOAL_NAMES[goalId]}</span>
-                  {isShared && (
-                    <span className="household-goal-item__badge">Shared with household</span>
-                  )}
-                </div>
-                <button
-                  className={`household-toggle ${isShared ? 'household-toggle--active' : ''}`}
-                  role="switch"
-                  aria-checked={isShared}
-                  aria-label={`Toggle sharing for ${DEMO_GOAL_NAMES[goalId]}`}
-                  onClick={() => setSharedGoal({ goalId, isShared: !isShared })}
-                >
-                  <span className="household-toggle__track">
-                    <span className="household-toggle__thumb" />
-                  </span>
-                  <span className="household-toggle__label">
-                    {isShared ? 'Shared' : 'Personal'}
-                  </span>
-                </button>
-              </li>
-            );
-          })}
+          {goalData.goals.length === 0 ? (
+            <li className="household-goal-item household-goal-item--empty">
+              <span className="household-goal-item__name">
+                No goals yet. Create a savings goal to share it with your household.
+              </span>
+            </li>
+          ) : (
+            goalData.goals.map((goal) => {
+              const shared = sharedGoals.find((sg) => sg.goalId === goal.id);
+              const isShared = shared?.isShared ?? false;
+              return (
+                <li key={goal.id} className="household-goal-item">
+                  <div className="household-goal-item__info">
+                    <span className="household-goal-item__name">{goal.name}</span>
+                    {isShared && (
+                      <span className="household-goal-item__badge">Shared with household</span>
+                    )}
+                  </div>
+                  <button
+                    className={`household-toggle ${isShared ? 'household-toggle--active' : ''}`}
+                    role="switch"
+                    aria-checked={isShared}
+                    aria-label={`Toggle sharing for ${goal.name}`}
+                    onClick={() => setSharedGoal({ goalId: goal.id, isShared: !isShared })}
+                  >
+                    <span className="household-toggle__track">
+                      <span className="household-toggle__thumb" />
+                    </span>
+                    <span className="household-toggle__label">
+                      {isShared ? 'Shared' : 'Personal'}
+                    </span>
+                  </button>
+                </li>
+              );
+            })
+          )}
         </ul>
       </section>
 
@@ -3197,6 +3233,15 @@ function useOptionalBudgets(): Pick<UseBudgetsResult, 'budgets'> {
   }
 }
 
+/** Read account data without crashing if no DatabaseProvider is mounted. */
+function useOptionalAccounts(): Pick<UseAccountsResult, 'accounts'> {
+  try {
+    return { accounts: useAccounts().accounts };
+  } catch {
+    return { accounts: [] };
+  }
+}
+
 function useOptionalGoals(): Pick<UseGoalsResult, 'goals' | 'createGoal'> {
   try {
     const { goals, createGoal } = useGoals();
@@ -3304,11 +3349,15 @@ interface HouseholdScorecardViewModel {
 function buildHouseholdScorecard({
   members,
   budgetSnapshots,
+  transactions,
+  accountSharings,
   resolveMemberName,
   referenceDate,
 }: {
   members: HouseholdMember[];
   budgetSnapshots: ScorecardBudgetSnapshot[];
+  transactions: Transaction[];
+  accountSharings: AccountSharing[];
   resolveMemberName: (member: HouseholdMember) => string;
   referenceDate: Date;
 }): HouseholdScorecardViewModel {
@@ -3339,7 +3388,40 @@ function buildHouseholdScorecard({
     };
   }
 
-  const seeds = getHouseholdScorecardSeeds(members);
+  // Real per-member attribution (#3379). Spend is distributed using each
+  // member's ACTUAL transactions in the category, attributed via the owning
+  // account (account_sharing.owner_id -> member.userId). Budgets have no
+  // per-member assignment in the data model, so a household category budget is
+  // split equally across members — a transparent, non-fabricated basis. No
+  // synthetic role/index/pace weighting remains.
+  const memberIndexByUserId = new Map<string, number>();
+  members.forEach((member, index) => {
+    memberIndexByUserId.set(member.userId, index);
+  });
+  const memberIndexByAccountId = new Map<string, number>();
+  accountSharings.forEach((sharing) => {
+    const memberIndex = memberIndexByUserId.get(sharing.ownerId);
+    if (memberIndex !== undefined) {
+      memberIndexByAccountId.set(sharing.accountId, memberIndex);
+    }
+  });
+
+  const realSpendByCategory = new Map<string, number[]>();
+  transactions.forEach((transaction) => {
+    if (transaction.type !== 'EXPENSE' || !transaction.categoryId) {
+      return;
+    }
+    const memberIndex = memberIndexByAccountId.get(transaction.accountId);
+    if (memberIndex === undefined) {
+      return;
+    }
+    const perMember =
+      realSpendByCategory.get(transaction.categoryId) ?? new Array<number>(members.length).fill(0);
+    perMember[memberIndex] += Math.abs(transaction.amount.amount);
+    realSpendByCategory.set(transaction.categoryId, perMember);
+  });
+
+  const equalWeights = members.map(() => 1);
   const categoriesByMember = members.map(() =>
     budgetSnapshots.map((budget) => ({
       name: budget.name,
@@ -3349,37 +3431,13 @@ function buildHouseholdScorecard({
   );
 
   budgetSnapshots.forEach((budget, budgetIndex) => {
-    const budgetWeights =
-      members.length === 1
-        ? [1]
-        : normalizeWeights(
-            seeds.map((seed, memberIndex) => {
-              const focusIndex =
-                budgetSnapshots.length > 1 ? (memberIndex + 1) % budgetSnapshots.length : 0;
-              const focusFactor =
-                budgetSnapshots.length > 1 && budgetIndex === focusIndex ? 1.08 : 1;
-              return seed.memberWeight * focusFactor;
-            }),
-          );
-
+    const realSpendWeights = realSpendByCategory.get(budget.categoryId);
     const spentWeights =
-      members.length === 1
-        ? [1]
-        : normalizeWeights(
-            budgetWeights.map((weight, memberIndex) => {
-              const seed = seeds[memberIndex];
-              const focusIndex =
-                budgetSnapshots.length > 1 ? (memberIndex + 1) % budgetSnapshots.length : 0;
-              const paceFactor = 1 + seed.paceOffset * 1.6;
-              const focusFactor =
-                budgetSnapshots.length > 1 && budgetIndex === focusIndex
-                  ? 1 + Math.max(seed.paceOffset, 0) * 2.5
-                  : 1;
-              return Math.max(0.35, weight * paceFactor * focusFactor);
-            }),
-          );
+      realSpendWeights && realSpendWeights.some((weight) => weight > 0)
+        ? realSpendWeights
+        : equalWeights;
 
-    const allocatedBudget = allocateAmount(budget.budgetAmount, budgetWeights);
+    const allocatedBudget = allocateAmount(budget.budgetAmount, equalWeights);
     const allocatedSpent = allocateAmount(budget.spentAmount, spentWeights);
 
     members.forEach((_, memberIndex) => {


### PR DESCRIPTION
## Summary

Makes the web Household / shared-finance feature **real**: it now persists to the
encrypted SQLite/OPFS data path (so it syncs, survives a cache clear, and is
encrypted at rest) and every surface binds to real account / budget / goal /
transaction data instead of demo IDs or synthetic numbers.

All four issues touch the same two files (`useHousehold.ts` +
`HouseholdPage.tsx`), so they are resolved together in one PR.

## Changes

### Data layer — #3378 (foundational)

- **Migration v15 `add-household-collection-tables`** in `sqlite-wasm.ts` creates
  15 `hh_*` document tables (uniform id / household_id / timestamps / sync
  columns + a JSON `data` payload), mirroring the goals/budgets pattern.
- **New `householdData` repository** (`readHouseholdValue` / `writeHouseholdValue`)
  — delete-then-insert under a savepoint, JSON payload column, sync/tombstone
  columns preserved. Exported from the repositories barrel.
- **`useHousehold` persistence rewritten** from `localStorage` to the repository,
  so household, members, invitations, account-sharing, shared budgets/goals,
  expenses, settlements, children, activity, recurring bills, and goal pledges
  all live in the encrypted DB. **No plaintext financial data in `localStorage`.**
- `useHousehold` is **provider-optional** via a local `useOptionalDatabase`
  helper, matching `HouseholdPage`'s existing "render without a DatabaseProvider"
  design intent (the page already wraps budgets/accounts/goals the same way).

### Account sharing & shared budgets — #3375

- Replaced hardcoded `DEMO_ACCOUNT_IDS` / `DEMO_BUDGET_IDS` with real
  `useAccounts()` / `useBudgets()` data, including accessible empty states.

### Shared goals & goal pledges — #3376

- Bound shared goals and the pledge picker/progress to real `useGoals()` data
  instead of `DEMO_GOAL_IDS` (the per-child 529 creator already made real goals).

### Household scorecard — #3379

- Removed `getHouseholdScorecardSeeds` and the `SCORECARD_PACE_OFFSETS` synthetic
  weighting. Per-member **spend** is now attributed from each member's
  owned-account transactions (via `accountSharing.ownerId`), distributed across
  each budget snapshot's real `spentAmount`.

> **Modeling decision (needs a nod):** the data model has **no per-member budget
> assignment**, so per-member **budget** is an **equal split** of the household
> category budget. Per-member **spend** is fully real. If you'd prefer a
> different allocation (e.g. proportional-to-income, or contribution-weighted),
> say so and I'll adjust — I didn't want to invent a weighting.

## Rebase note

Rebased onto `main` after #3273 (invoices/remittances) landed its own migration
at **v14**; renumbered the household migration to **v15** and merged the barrel
exports. The migration runner applies by ascending `version`, so v15 runs after
v14 — validated by `sqlite-wasm-savepoint.test.ts`.

## Out of scope (deliberate)

- **#3377 (`/invite` acceptance flow)** is a separate follow-up that builds on
  this data layer. `acceptInvitation` is left in a buildable state; not
  implemented here.

## Testing

- [x] `householdData` round-trip repository tests (new)
- [x] `useHousehold` hook tests updated to mock the repo and exercise the
      encrypted persistence path across remounts (19/19)
- [x] `HouseholdPage` tests updated to provide real accounts/budgets/goals (29/29)
- [x] DB/migration suites green post-rebase (`sqlite-wasm`,
      `sqlite-wasm-savepoint`, `spending-visibility-migration`) — 88 tests across
      the 6 affected files
- [x] `npm run format:check` + `npx eslint --max-warnings 0` clean on all changed files

> Note: `DashboardPage > has accessible landmarks` can fail **locally** under
> heavy multi-process contention (its `mood and spending journal` region is a
> lazy `import()` asserted with a fixed 3000 ms `findByRole` budget). It is
> unrelated to this change — it passes 3/3 when the machine is uncontended and
> on clean `main`; CI runs uncontended and sharded. No files I own touch
> `DashboardPage`.

## Issues

Closes #3378
Closes #3375
Closes #3376
Closes #3379
Refs #3377

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
