### PR TITLE
fix(i18n): locale-correct dates, translated dashboard, honest fallback locales (#3300 #3306 #3312)

### DIFF
--- a/apps/web/src/components/bills/BillCalendarView.tsx
+++ b/apps/web/src/components/bills/BillCalendarView.tsx
@@ -36,6 +36,7 @@ import {
   type PaydayCadence,
 } from '../../lib/bills/bill-calendar';
 import type { Bill } from '../../kmp/bridge';
+import { getCurrentLocale } from '../../lib/i18n';
 
 /** Props for {@link BillCalendarView}. */
 export interface BillCalendarViewProps {
@@ -65,7 +66,11 @@ function todayIso(): string {
 /** Format an ISO local date as a short, human-readable label. */
 function formatDate(iso: string): string {
   const date = new Date(`${iso}T00:00:00`);
-  return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+  return date.toLocaleDateString(getCurrentLocale(), {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
 }
 
 /** Convert a dollars string into integer cents. */

--- a/apps/web/src/components/dashboard/CurrencyDisplay.test.tsx
+++ b/apps/web/src/components/dashboard/CurrencyDisplay.test.tsx
@@ -1,17 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useMultiCurrency } from '../../hooks/useMultiCurrency';
 import type { UseMultiCurrencyResult } from '../../hooks/useMultiCurrency';
 import { Currencies } from '../../kmp/bridge';
 import type { Currency } from '../../kmp/bridge';
+import { getCurrentLocale } from '../../lib/i18n';
 import { CurrencySelector, ExchangeRateIndicator, MultiCurrencyTotals } from './CurrencyDisplay';
 
 vi.mock('../../hooks/useMultiCurrency', () => ({
   useMultiCurrency: vi.fn(),
 }));
+
+// Keep the real catalog + translate(); only steer which locale is active so we
+// can assert the dashboard chrome resolves from the i18n catalog per locale.
+vi.mock('../../lib/i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/i18n')>();
+  return { ...actual, getCurrentLocale: vi.fn(() => 'en-US') };
+});
 
 const mockedHook = vi.mocked(useMultiCurrency);
 
@@ -155,5 +163,55 @@ describe('MultiCurrencyTotals', () => {
     expect(screen.getByText('USD')).toBeInTheDocument();
     expect(screen.getByText('EUR')).toBeInTheDocument();
     expect(screen.getByText('Total')).toBeInTheDocument();
+  });
+});
+
+describe('CurrencyDisplay resolves dashboard chrome from the i18n catalog (issue #3306)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Active locale drives which catalog translate() resolves.
+    vi.mocked(getCurrentLocale).mockReturnValue('es-ES');
+  });
+
+  afterEach(() => {
+    vi.mocked(getCurrentLocale).mockReturnValue('en-US');
+  });
+
+  it('translates the currency selector label and select aria-label', () => {
+    mockedHook.mockReturnValue(mockResult());
+
+    render(<CurrencySelector value="USD" onChange={vi.fn()} />);
+
+    expect(screen.getByText('Moneda')).toBeInTheDocument();
+    expect(screen.getByLabelText(/seleccionar moneda/i)).toBeInTheDocument();
+    // The previously-hardcoded English aria-label must no longer appear.
+    expect(screen.queryByLabelText(/select currency/i)).not.toBeInTheDocument();
+  });
+
+  it('translates the exchange-rate loading string', () => {
+    mockedHook.mockReturnValue(mockResult({ loading: true }));
+
+    render(<ExchangeRateIndicator from="USD" to="EUR" />);
+
+    expect(screen.getByText('Cargando tipos…')).toBeInTheDocument();
+    expect(screen.queryByText('Loading rates…')).not.toBeInTheDocument();
+  });
+
+  it('translates the exchange-rate offline-reference disclaimer', () => {
+    mockedHook.mockReturnValue(mockResult());
+
+    render(<ExchangeRateIndicator from="USD" to="EUR" />);
+
+    expect(screen.getByText(/tipo aproximado/i)).toBeInTheDocument();
+  });
+
+  it('translates the multi-currency totals title and empty state', () => {
+    mockedHook.mockReturnValue(mockResult());
+
+    render(<MultiCurrencyTotals items={[]} />);
+
+    expect(screen.getByText('Totales multidivisa')).toBeInTheDocument();
+    expect(screen.getByText('No hay elementos para mostrar.')).toBeInTheDocument();
+    expect(screen.queryByText('No items to display.')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/dashboard/CurrencyDisplay.tsx
+++ b/apps/web/src/components/dashboard/CurrencyDisplay.tsx
@@ -11,11 +11,25 @@
 
 import { useCallback } from 'react';
 
+import { useLocalePreferences } from '../../hooks/useLocalePreferences';
 import { useMultiCurrency } from '../../hooks/useMultiCurrency';
 import type { Currency } from '../../kmp/bridge';
-import { getCurrentLocale } from '../../lib/i18n';
+import { translate } from '../../lib/i18n';
 
 import './CurrencyDisplay.css';
+
+/**
+ * Resolve catalog strings against the active locale so the multi-currency
+ * dashboard chrome stays translated and reacts to locale preference changes.
+ */
+function useCurrencyStrings() {
+  const { locale } = useLocalePreferences();
+  const t = useCallback(
+    (id: string, values?: Record<string, string | number>) => translate(id, values, locale).text,
+    [locale],
+  );
+  return { t, locale };
+}
 
 // ---------------------------------------------------------------------------
 // CurrencySelector
@@ -35,10 +49,12 @@ export interface CurrencySelectorProps {
 export function CurrencySelector({
   value,
   onChange,
-  label = 'Currency',
+  label,
   id = 'currency-selector',
 }: CurrencySelectorProps) {
   const { supportedCurrencies } = useMultiCurrency();
+  const { t } = useCurrencyStrings();
+  const resolvedLabel = label ?? t('dashboard.currency.selector.label');
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -53,19 +69,24 @@ export function CurrencySelector({
   return (
     <div className="currency-selector">
       <label htmlFor={id} className="currency-selector__label">
-        {label}
+        {resolvedLabel}
       </label>
       <select
         id={id}
         className="currency-selector__select"
         value={value}
         onChange={handleChange}
-        aria-label={`Select ${label.toLowerCase()}`}
+        aria-label={t('dashboard.currency.selector.selectAria', {
+          label: resolvedLabel.toLowerCase(),
+        })}
       >
         {supportedCurrencies.map((currency) => (
           <option key={currency.code} value={currency.code}>
             {currency.code} (
-            {currency.decimalPlaces === 0 ? 'no decimals' : `${currency.decimalPlaces} decimals`})
+            {currency.decimalPlaces === 0
+              ? t('dashboard.currency.selector.noDecimals')
+              : t('dashboard.currency.selector.decimals', { count: currency.decimalPlaces })}
+            )
           </option>
         ))}
       </select>
@@ -86,6 +107,7 @@ export interface ExchangeRateIndicatorProps {
 
 export function ExchangeRateIndicator({ from, to }: ExchangeRateIndicatorProps) {
   const { getRate, lastUpdated, loading } = useMultiCurrency();
+  const { t, locale } = useCurrencyStrings();
 
   if (from === to) return null;
 
@@ -95,27 +117,31 @@ export function ExchangeRateIndicator({ from, to }: ExchangeRateIndicatorProps) 
     <div
       className="exchange-rate-indicator"
       role="status"
-      aria-label={`Exchange rate from ${from} to ${to}`}
+      aria-label={t('dashboard.currency.rate.regionAria', { from, to })}
     >
       {loading ? (
-        <span className="exchange-rate-indicator__loading">Loading rates…</span>
+        <span className="exchange-rate-indicator__loading">
+          {t('dashboard.currency.rate.loading')}
+        </span>
       ) : rate !== null ? (
         <>
           <span className="exchange-rate-indicator__rate">
             1 {from} = {rate.toFixed(4)} {to}
           </span>
           <span className="exchange-rate-indicator__source">
-            Approximate rate — offline reference, not a live quote
+            {t('dashboard.currency.rate.source')}
           </span>
           {lastUpdated && (
             <span className="exchange-rate-indicator__updated">
-              Snapshot as of {new Date(lastUpdated).toLocaleDateString(getCurrentLocale())}
+              {t('dashboard.currency.rate.snapshot', {
+                date: new Date(lastUpdated).toLocaleDateString(locale),
+              })}
             </span>
           )}
         </>
       ) : (
         <span className="exchange-rate-indicator__unavailable">
-          Rate unavailable for {from}/{to}
+          {t('dashboard.currency.rate.unavailable', { from, to })}
         </span>
       )}
     </div>
@@ -133,27 +159,30 @@ export interface MultiCurrencyTotalsProps {
   title?: string;
 }
 
-export function MultiCurrencyTotals({
-  items,
-  title = 'Multi-Currency Totals',
-}: MultiCurrencyTotalsProps) {
+export function MultiCurrencyTotals({ items, title }: MultiCurrencyTotalsProps) {
   const { calculateMultiCurrencyTotal, formatWithSymbol, defaultCurrency } = useMultiCurrency();
+  const { t } = useCurrencyStrings();
 
   const totals = calculateMultiCurrencyTotal(items);
+  const resolvedTitle = title ?? t('dashboard.currency.totals.title');
 
-  const grandTotalCents = totals.reduce((sum, t) => sum + t.convertedCents, 0);
+  const grandTotalCents = totals.reduce((sum, entry) => sum + entry.convertedCents, 0);
 
   return (
     <section className="multi-currency-totals" aria-labelledby="multi-currency-title">
       <h3 id="multi-currency-title" className="multi-currency-totals__title">
-        {title}
+        {resolvedTitle}
       </h3>
 
       {totals.length === 0 ? (
-        <p className="multi-currency-totals__empty">No items to display.</p>
+        <p className="multi-currency-totals__empty">{t('dashboard.currency.totals.empty')}</p>
       ) : (
         <>
-          <ul className="multi-currency-totals__list" role="list" aria-label="Currency breakdown">
+          <ul
+            className="multi-currency-totals__list"
+            role="list"
+            aria-label={t('dashboard.currency.totals.breakdownAria')}
+          >
             {totals.map((total) => (
               <li key={total.currency.code} className="multi-currency-totals__item">
                 <span className="multi-currency-totals__currency">{total.currency.code}</span>
@@ -163,7 +192,9 @@ export function MultiCurrencyTotals({
                 {total.currency.code !== defaultCurrency.code && (
                   <span
                     className="multi-currency-totals__converted"
-                    aria-label={`Converted to ${defaultCurrency.code}`}
+                    aria-label={t('dashboard.currency.totals.convertedAria', {
+                      code: defaultCurrency.code,
+                    })}
                   >
                     ≈ {formatWithSymbol(total.convertedCents, defaultCurrency)}
                   </span>
@@ -174,9 +205,11 @@ export function MultiCurrencyTotals({
 
           <div
             className="multi-currency-totals__grand"
-            aria-label={`Grand total in ${defaultCurrency.code}`}
+            aria-label={t('dashboard.currency.totals.grandAria', { code: defaultCurrency.code })}
           >
-            <span className="multi-currency-totals__grand-label">Total</span>
+            <span className="multi-currency-totals__grand-label">
+              {t('dashboard.currency.totals.grandLabel')}
+            </span>
             <span className="multi-currency-totals__grand-value">
               {formatWithSymbol(grandTotalCents, defaultCurrency)}
             </span>

--- a/apps/web/src/components/dashboard/DashboardTaxReserveSection.tsx
+++ b/apps/web/src/components/dashboard/DashboardTaxReserveSection.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { useTransactions } from '../../hooks';
 import { useTaxReserve } from '../../hooks/useTaxReserve';
 import type { Account, Transaction } from '../../kmp/bridge';
+import { getCurrentLocale } from '../../lib/i18n';
 import { getNextQuarterlyTaxDueDate } from '../../lib/tax-reserve';
 import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../common';
 
@@ -15,7 +16,7 @@ export interface DashboardTaxReserveSectionProps {
 }
 
 function formatDueDate(date: Date): string {
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return date.toLocaleDateString(getCurrentLocale(), { month: 'short', day: 'numeric' });
 }
 
 function formatDueCountdown(days: number): string {

--- a/apps/web/src/components/insights/WeeklyDigest.tsx
+++ b/apps/web/src/components/insights/WeeklyDigest.tsx
@@ -10,6 +10,7 @@ import {
   normalizeValuePreferences,
   type UserValuePreference,
 } from '../../lib/alignment';
+import { getCurrentLocale } from '../../lib/i18n';
 import type { DigestPeriod, GoalProgressUpdate, WealthDigest } from '../../lib/insights';
 import { AlignmentRadar, AlignmentScore, MisalignmentAlerts, ValuesSetup } from '../alignment';
 import { CurrencyDisplay } from '../common/CurrencyDisplay';
@@ -44,7 +45,7 @@ function formatPercent(value: number): string {
 }
 
 function formatDigestDate(timestamp: string): string {
-  return new Date(timestamp).toLocaleDateString('en-US', {
+  return new Date(timestamp).toLocaleDateString(getCurrentLocale(), {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/apps/web/src/components/mood/SpendingMoodChart.tsx
+++ b/apps/web/src/components/mood/SpendingMoodChart.tsx
@@ -14,6 +14,7 @@ import {
 } from 'recharts';
 
 import { formatCurrencyValue } from '../../lib/currency';
+import { getCurrentLocale } from '../../lib/i18n';
 import { calculateMoodCorrelations, type MoodJournalEntry } from '../../lib/mood';
 
 function formatCorrelationLabel(value: number): string {
@@ -53,7 +54,7 @@ export const SpendingMoodChart: React.FC<SpendingMoodChartProps> = ({
 
     return Array.from(grouped, ([date, value]) => ({
       date,
-      label: new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
+      label: new Date(`${date}T00:00:00`).toLocaleDateString(getCurrentLocale(), {
         month: 'short',
         day: 'numeric',
       }),

--- a/apps/web/src/components/savings/GoalProjection.tsx
+++ b/apps/web/src/components/savings/GoalProjection.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 
 import { CurrencyDisplay } from '../common';
+import { getCurrentLocale } from '../../lib/i18n';
 import type { SuggestedGoalProjection } from '../../lib/savings';
 
 export interface GoalProjectionProps {
@@ -15,7 +16,7 @@ function formatProjectionDate(date: string | null): string {
     return 'Keep contributing to unlock a projection';
   }
 
-  return new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
+  return new Date(`${date}T00:00:00`).toLocaleDateString(getCurrentLocale(), {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/apps/web/src/lib/debt/payoff.ts
+++ b/apps/web/src/lib/debt/payoff.ts
@@ -20,6 +20,8 @@
  * References: issue #2175
  */
 
+import { getCurrentLocale } from '../i18n';
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -209,7 +211,7 @@ export function formatPercent(value: number): string {
 
 /** Formats an ISO date (YYYY-MM-DD) as "Mon YYYY" in UTC. */
 export function formatMonthYear(dateIso: string): string {
-  return new Intl.DateTimeFormat('en-US', {
+  return new Intl.DateTimeFormat(getCurrentLocale(), {
     month: 'short',
     year: 'numeric',
     timeZone: 'UTC',

--- a/apps/web/src/lib/i18n/locales/en-US.ts
+++ b/apps/web/src/lib/i18n/locales/en-US.ts
@@ -227,4 +227,24 @@ export const EN_US_CATALOG: MessageCatalog = {
     'Delete the remittance to {recipient} on {date}? This permanently removes it from your payment history and FX/fee totals.',
   'remittance.history.confirmDelete.confirm': 'Delete remittance',
   'remittance.history.confirmDelete.cancel': 'Cancel',
+
+  // ── Multi-currency dashboard (issue #3306) ───────────────────────────────
+  'dashboard.currency.selector.label': 'Currency',
+  'dashboard.currency.selector.selectAria': 'Select {label}',
+  'dashboard.currency.selector.noDecimals': 'no decimals',
+  'dashboard.currency.selector.decimals': {
+    one: '{count} decimal',
+    other: '{count} decimals',
+  },
+  'dashboard.currency.rate.regionAria': 'Exchange rate from {from} to {to}',
+  'dashboard.currency.rate.loading': 'Loading rates…',
+  'dashboard.currency.rate.source': 'Approximate rate — offline reference, not a live quote',
+  'dashboard.currency.rate.snapshot': 'Snapshot as of {date}',
+  'dashboard.currency.rate.unavailable': 'Rate unavailable for {from}/{to}',
+  'dashboard.currency.totals.title': 'Multi-Currency Totals',
+  'dashboard.currency.totals.empty': 'No items to display.',
+  'dashboard.currency.totals.breakdownAria': 'Currency breakdown',
+  'dashboard.currency.totals.convertedAria': 'Converted to {code}',
+  'dashboard.currency.totals.grandAria': 'Grand total in {code}',
+  'dashboard.currency.totals.grandLabel': 'Total',
 };

--- a/apps/web/src/lib/i18n/locales/en-US.ts
+++ b/apps/web/src/lib/i18n/locales/en-US.ts
@@ -16,6 +16,9 @@ export const EN_US_CATALOG: MessageCatalog = {
   'settings.language': 'Language',
   'settings.timeZone': 'Home time zone',
   'settings.languageDescription': 'Detected from your browser; change it anytime.',
+  'settings.language.betaBadge': 'beta · mostly English',
+  'settings.language.betaNotice':
+    'This language is in beta — most screens still appear in English until translation is complete.',
   'settings.currencyRates.title': 'Currency Rates',
   'settings.currencyRates.loading': 'Loading rates…',
   'settings.currencyRates.error': 'Error loading rates: {error}',

--- a/apps/web/src/lib/i18n/locales/es-ES.ts
+++ b/apps/web/src/lib/i18n/locales/es-ES.ts
@@ -16,6 +16,9 @@ export const ES_ES_CATALOG: MessageCatalog = {
   'settings.language': 'Idioma',
   'settings.timeZone': 'Zona horaria de casa',
   'settings.languageDescription': 'Detectado desde tu navegador; puedes cambiarlo cuando quieras.',
+  'settings.language.betaBadge': 'beta · mayormente en inglés',
+  'settings.language.betaNotice':
+    'Este idioma está en fase beta: la mayoría de las pantallas seguirán en inglés hasta que se complete la traducción.',
   'settings.currencyRates.title': 'Tipos de cambio',
   'settings.currencyRates.loading': 'Cargando tipos…',
   'settings.currencyRates.error': 'Error al cargar los tipos: {error}',

--- a/apps/web/src/lib/i18n/locales/es-ES.ts
+++ b/apps/web/src/lib/i18n/locales/es-ES.ts
@@ -228,4 +228,25 @@ export const ES_ES_CATALOG: MessageCatalog = {
     '¿Eliminar la remesa a {recipient} del {date}? Esto la quita permanentemente de tu historial de pagos y de los totales de FX y comisiones.',
   'remittance.history.confirmDelete.confirm': 'Eliminar remesa',
   'remittance.history.confirmDelete.cancel': 'Cancelar',
+
+  // ── Panel multidivisa (incidencia #3306) ─────────────────────────────────
+  'dashboard.currency.selector.label': 'Moneda',
+  'dashboard.currency.selector.selectAria': 'Seleccionar {label}',
+  'dashboard.currency.selector.noDecimals': 'sin decimales',
+  'dashboard.currency.selector.decimals': {
+    one: '{count} decimal',
+    other: '{count} decimales',
+  },
+  'dashboard.currency.rate.regionAria': 'Tipo de cambio de {from} a {to}',
+  'dashboard.currency.rate.loading': 'Cargando tipos…',
+  'dashboard.currency.rate.source':
+    'Tipo aproximado: referencia sin conexión, no una cotización en vivo',
+  'dashboard.currency.rate.snapshot': 'Instantánea del {date}',
+  'dashboard.currency.rate.unavailable': 'Tipo no disponible para {from}/{to}',
+  'dashboard.currency.totals.title': 'Totales multidivisa',
+  'dashboard.currency.totals.empty': 'No hay elementos para mostrar.',
+  'dashboard.currency.totals.breakdownAria': 'Desglose por moneda',
+  'dashboard.currency.totals.convertedAria': 'Convertido a {code}',
+  'dashboard.currency.totals.grandAria': 'Total general en {code}',
+  'dashboard.currency.totals.grandLabel': 'Total',
 };

--- a/apps/web/src/lib/i18n/locales/zh-Hans.ts
+++ b/apps/web/src/lib/i18n/locales/zh-Hans.ts
@@ -29,6 +29,8 @@ export const ZH_HANS_CATALOG: MessageCatalog = {
   'settings.language': '语言',
   'settings.timeZone': '家乡时区',
   'settings.languageDescription': '根据你的浏览器检测；可随时更改。',
+  'settings.language.betaBadge': '测试版 · 多为英文',
+  'settings.language.betaNotice': '此语言尚处于测试阶段——在翻译完成前，大多数界面仍以英文显示。',
   'settings.currencyRates.title': '汇率',
   'settings.currencyRates.loading': '正在加载汇率…',
   'settings.currencyRates.error': '加载汇率失败：{error}',

--- a/apps/web/src/lib/i18n/locales/zh-Hans.ts
+++ b/apps/web/src/lib/i18n/locales/zh-Hans.ts
@@ -177,4 +177,24 @@ export const ZH_HANS_CATALOG: MessageCatalog = {
   'remittance.history.deleteAria': '删除 {date} 汇给 {recipient} 的记录',
   'remittance.history.itemAria': '{date} 汇给 {country} 的 {recipient} {amount}',
   'remittance.history.loading': '正在加载汇款记录',
+
+  // ── 多币种仪表板（问题 #3306）────────────────────────────────────────────
+  'dashboard.currency.selector.label': '货币',
+  'dashboard.currency.selector.selectAria': '选择{label}',
+  'dashboard.currency.selector.noDecimals': '无小数位',
+  'dashboard.currency.selector.decimals': {
+    one: '{count} 位小数',
+    other: '{count} 位小数',
+  },
+  'dashboard.currency.rate.regionAria': '从 {from} 到 {to} 的汇率',
+  'dashboard.currency.rate.loading': '正在加载汇率…',
+  'dashboard.currency.rate.source': '近似汇率——离线参考，非实时报价',
+  'dashboard.currency.rate.snapshot': '截至 {date} 的快照',
+  'dashboard.currency.rate.unavailable': '{from}/{to} 汇率不可用',
+  'dashboard.currency.totals.title': '多币种合计',
+  'dashboard.currency.totals.empty': '暂无可显示的项目。',
+  'dashboard.currency.totals.breakdownAria': '按货币细分',
+  'dashboard.currency.totals.convertedAria': '换算为 {code}',
+  'dashboard.currency.totals.grandAria': '{code} 总计',
+  'dashboard.currency.totals.grandLabel': '合计',
 };

--- a/apps/web/src/lib/insights/helpers.ts
+++ b/apps/web/src/lib/insights/helpers.ts
@@ -2,6 +2,7 @@
 
 import type { DigestPeriod, MetricChange, TrendDirection } from './types';
 import { computeSavingsRatePercent } from '../savings/savings-rate-format';
+import { getCurrentLocale } from '../i18n';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -89,7 +90,7 @@ function makeMonthWindow(baseDate: Date, endDay?: number): PeriodWindow {
   const endDate = new Date(baseDate.getFullYear(), baseDate.getMonth(), endDayOfMonth);
 
   return {
-    label: startDate.toLocaleDateString('en-US', { month: 'short' }),
+    label: startDate.toLocaleDateString(getCurrentLocale(), { month: 'short' }),
     startDate: toLocalDate(startDate),
     endDate: toLocalDate(endDate),
   };
@@ -107,7 +108,7 @@ export function buildPeriodWindows(
       const startDate = addDays(endDate, -6);
 
       return {
-        label: endDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+        label: endDate.toLocaleDateString(getCurrentLocale(), { month: 'short', day: 'numeric' }),
         startDate: toLocalDate(startDate),
         endDate: toLocalDate(endDate),
       };

--- a/apps/web/src/lib/reports/reporting-beta.ts
+++ b/apps/web/src/lib/reports/reporting-beta.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { Account, Category, LocalDate, SyncId, Transaction } from '../../kmp/bridge';
+import { getCurrentLocale } from '../i18n';
 
 export interface ReportDataFilters {
   readonly startDate?: LocalDate | null;
@@ -117,7 +118,7 @@ function addMonths(month: string, delta: number): string {
 }
 
 function monthName(monthIndex: number): string {
-  return new Date(2024, monthIndex - 1, 1).toLocaleString('en-US', { month: 'long' });
+  return new Date(2024, monthIndex - 1, 1).toLocaleString(getCurrentLocale(), { month: 'long' });
 }
 
 function endOfMonth(month: string): LocalDate {

--- a/apps/web/src/lib/savings/goalSuggester.ts
+++ b/apps/web/src/lib/savings/goalSuggester.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { Account, Category, Goal, Transaction } from '../../kmp/bridge';
+import { getCurrentLocale } from '../i18n';
 import { analyzeSpendingByCategory, isLiquidAccountType } from '../insights';
 import { calculateContributionPlan } from './contributionSchedule';
 import type {
@@ -474,7 +475,7 @@ export function suggestSavingsGoals(
           wishlistItem.targetDate
             ? `At your selected pace, aim to finish before ${new Date(
                 `${wishlistItem.targetDate}T00:00:00`,
-              ).toLocaleDateString('en-US', {
+              ).toLocaleDateString(getCurrentLocale(), {
                 month: 'short',
                 year: 'numeric',
               })}.`

--- a/apps/web/src/lib/transactions/local-timestamp.ts
+++ b/apps/web/src/lib/transactions/local-timestamp.ts
@@ -31,6 +31,8 @@
  * References: issue #2206
  */
 
+import { getCurrentLocale } from '../i18n';
+
 // ---------------------------------------------------------------------------
 // Types & constants
 // ---------------------------------------------------------------------------
@@ -325,7 +327,7 @@ export function formatLocalTimestamp(
   const utcMillis = wallClockToUtcMillis(timestamp.localDateTime);
   if (utcMillis === null) return timestamp.localDateTime;
 
-  const formatted = new Intl.DateTimeFormat('en-US', {
+  const formatted = new Intl.DateTimeFormat(getCurrentLocale(), {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/apps/web/src/lib/visualization/net-worth-projection.ts
+++ b/apps/web/src/lib/visualization/net-worth-projection.ts
@@ -18,6 +18,8 @@
  * References: issue #2116
  */
 
+import { getCurrentLocale } from '../i18n';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -139,7 +141,7 @@ function addMonthsIso(iso: string, months: number): string {
 
 function monthShortLabel(iso: string): string {
   const date = new Date(`${iso.slice(0, 10)}T00:00:00.000Z`);
-  return date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' });
+  return date.toLocaleDateString(getCurrentLocale(), { month: 'short', timeZone: 'UTC' });
 }
 
 function projectedLabel(lastPoint: NetWorthSeriesPoint, monthOffset: number): string {

--- a/apps/web/src/lib/wellness/moodCorrelation.ts
+++ b/apps/web/src/lib/wellness/moodCorrelation.ts
@@ -3,6 +3,7 @@
 import type { Transaction } from '../../kmp/bridge';
 import { normalizeMoodTag, type MoodTag as EmojiMoodTag } from '../mood-tags';
 import { clamp, roundToOne } from '../insights/helpers';
+import { getCurrentLocale } from '../i18n';
 import type {
   EmotionalSpendingPattern,
   MoodCorrelationSummary,
@@ -75,7 +76,7 @@ function getStressLevel(intensity: number): StressLevel {
 }
 
 function formatShortDate(date: string): string {
-  return new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
+  return new Date(`${date}T00:00:00`).toLocaleDateString(getCurrentLocale(), {
     month: 'short',
     day: 'numeric',
   });

--- a/apps/web/src/pages/BillDetailPage.tsx
+++ b/apps/web/src/pages/BillDetailPage.tsx
@@ -10,6 +10,7 @@
 import React, { useCallback } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
+import { getCurrentLocale } from '../lib/i18n';
 import { useBills } from '../hooks';
 import type { BillFrequency, BillStatus } from '../kmp/bridge';
 
@@ -155,7 +156,7 @@ export const BillDetailPage: React.FC = () => {
             <div>
               <p className="card__title">Due Date</p>
               <p className="card__value">
-                {dueDate.toLocaleDateString('en-US', {
+                {dueDate.toLocaleDateString(getCurrentLocale(), {
                   month: 'long',
                   day: 'numeric',
                   year: 'numeric',
@@ -213,18 +214,21 @@ export const BillDetailPage: React.FC = () => {
               <>
                 <dt style={{ color: 'var(--semantic-text-secondary)' }}>Last Paid</dt>
                 <dd style={{ margin: 0 }}>
-                  {new Date(`${bill.lastPaidDate}T00:00:00`).toLocaleDateString('en-US', {
-                    month: 'long',
-                    day: 'numeric',
-                    year: 'numeric',
-                  })}
+                  {new Date(`${bill.lastPaidDate}T00:00:00`).toLocaleDateString(
+                    getCurrentLocale(),
+                    {
+                      month: 'long',
+                      day: 'numeric',
+                      year: 'numeric',
+                    },
+                  )}
                 </dd>
               </>
             )}
 
             <dt style={{ color: 'var(--semantic-text-secondary)' }}>Added</dt>
             <dd style={{ margin: 0 }}>
-              {new Date(bill.createdAt).toLocaleDateString('en-US', {
+              {new Date(bill.createdAt).toLocaleDateString(getCurrentLocale(), {
                 year: 'numeric',
                 month: 'short',
                 day: 'numeric',

--- a/apps/web/src/pages/BillsPage.tsx
+++ b/apps/web/src/pages/BillsPage.tsx
@@ -9,6 +9,7 @@
 
 import React, { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { getCurrentLocale } from '../lib/i18n';
 import { pluralize } from '../lib/ui/pluralize';
 import {
   ConfirmDialog,
@@ -96,7 +97,11 @@ function formatDueDate(dueDate: string): string {
   if (diffDays === -1) return '1 day overdue';
   if (diffDays < 0) return `${Math.abs(diffDays)} days overdue`;
   if (diffDays <= 7) return `Due in ${diffDays} days`;
-  return due.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  return due.toLocaleDateString(getCurrentLocale(), {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
 }
 
 /** Bills list page component. */

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -26,6 +26,7 @@ import { useWidgetLayout } from '../hooks/useWidgetLayout';
 import type { BudgetWithSpending } from '../db/repositories/budgets';
 import type { Bill, Goal, Transaction } from '../kmp/bridge';
 import { getBudgetStatusIndicator } from '../lib/a11y';
+import { getCurrentLocale } from '../lib/i18n';
 import {
   selectWorkspaceAccounts,
   selectWorkspaceTransactions,
@@ -167,7 +168,7 @@ function buildTrendData(transactions: Transaction[], days: number) {
     const dateKey = formatLocalDate(pointDate);
 
     return {
-      label: pointDate.toLocaleDateString('en-US', {
+      label: pointDate.toLocaleDateString(getCurrentLocale(), {
         month: 'short',
         day: 'numeric',
       }),

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -14,6 +14,7 @@
 
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { CurrencyDisplay, EmptyState } from '../components/common';
+import { getCurrentLocale } from '../lib/i18n';
 import { pluralize } from '../lib/ui/pluralize';
 import { ExplainThis } from '../components/common/ExplainThis';
 import { useAccounts } from '../hooks/useAccounts';
@@ -314,7 +315,7 @@ function formatRateBps(bps: number): string {
 }
 
 function formatMonthYear(dateIso: string): string {
-  return new Intl.DateTimeFormat('en-US', {
+  return new Intl.DateTimeFormat(getCurrentLocale(), {
     month: 'short',
     year: 'numeric',
     timeZone: 'UTC',

--- a/apps/web/src/pages/GoalDetailPage.tsx
+++ b/apps/web/src/pages/GoalDetailPage.tsx
@@ -17,6 +17,7 @@ import type { CreateGoalInput, GoalContributionInput } from '../db/repositories/
 import { useGoals } from '../hooks';
 import type { Goal } from '../kmp/bridge';
 import { getGoalStatusIndicator } from '../lib/a11y';
+import { getCurrentLocale } from '../lib/i18n';
 import { ShareCelebrationButton } from '../components/social/ShareCelebrationButton';
 import { SharedGoalContributions } from '../components/goals/SharedGoalContributions';
 import { GoalContributionDialog } from '../components/goals/GoalContributionDialog';
@@ -149,7 +150,7 @@ export const GoalDetailPage: React.FC = () => {
 
   const formattedTargetDate =
     targetDate !== null
-      ? targetDate.toLocaleDateString('en-US', {
+      ? targetDate.toLocaleDateString(getCurrentLocale(), {
           year: 'numeric',
           month: 'long',
           day: 'numeric',

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -30,6 +30,7 @@ import { useAccounts, useCategories, useGoals, useTransactions } from '../hooks'
 import { useTaxReserve } from '../hooks/useTaxReserve';
 import type { Goal } from '../kmp/bridge';
 import { getGoalStatusIndicator } from '../lib/a11y';
+import { getCurrentLocale } from '../lib/i18n';
 import {
   buildSavingsAnalysisSnapshot,
   generateSavingsNudges,
@@ -154,7 +155,7 @@ function formatCurrencyAmount(amount: number, currency = 'USD'): string {
 }
 
 function formatDueDate(date: Date): string {
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return date.toLocaleDateString(getCurrentLocale(), { month: 'short', day: 'numeric' });
 }
 
 function formatDueCountdown(days: number): string {
@@ -859,7 +860,7 @@ export const GoalsPage: React.FC = () => {
                             }}
                           >
                             {targetDate !== null
-                              ? targetDate.toLocaleDateString('en-US', {
+                              ? targetDate.toLocaleDateString(getCurrentLocale(), {
                                   month: 'short',
                                   year: 'numeric',
                                 })

--- a/apps/web/src/pages/InvestmentDetailPage.tsx
+++ b/apps/web/src/pages/InvestmentDetailPage.tsx
@@ -12,6 +12,7 @@ import { Link, useParams } from 'react-router-dom';
 import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { useInvestments } from '../hooks';
 import { formatGainLoss } from '../lib/currency';
+import { getCurrentLocale } from '../lib/i18n';
 import type { InvestmentType } from '../kmp/bridge';
 
 /** Human-readable labels for investment types. */
@@ -231,7 +232,7 @@ export const InvestmentDetailPage: React.FC = () => {
               <>
                 <dt style={{ color: 'var(--semantic-text-secondary)' }}>Last Price Update</dt>
                 <dd style={{ margin: 0 }}>
-                  {new Date(investment.lastPriceUpdate).toLocaleDateString('en-US', {
+                  {new Date(investment.lastPriceUpdate).toLocaleDateString(getCurrentLocale(), {
                     year: 'numeric',
                     month: 'short',
                     day: 'numeric',
@@ -244,7 +245,7 @@ export const InvestmentDetailPage: React.FC = () => {
 
             <dt style={{ color: 'var(--semantic-text-secondary)' }}>Added</dt>
             <dd style={{ margin: 0 }}>
-              {new Date(investment.createdAt).toLocaleDateString('en-US', {
+              {new Date(investment.createdAt).toLocaleDateString(getCurrentLocale(), {
                 year: 'numeric',
                 month: 'short',
                 day: 'numeric',

--- a/apps/web/src/pages/TransactionDetailPage.tsx
+++ b/apps/web/src/pages/TransactionDetailPage.tsx
@@ -19,6 +19,7 @@ import {
   isBnplLiabilityTransaction,
 } from '../lib/bnpl-liability';
 import { isTransactionLockedByReconciliation } from '../lib/reconciliation';
+import { getCurrentLocale } from '../lib/i18n';
 import {
   formatLocalTimestamp,
   isLocalTimestampFieldKey,
@@ -227,12 +228,15 @@ export const TransactionDetailPage: React.FC = () => {
       ? -Math.abs(transaction.amount.amount)
       : transaction.amount.amount;
 
-  const formattedDate = new Date(`${transaction.date}T00:00:00`).toLocaleDateString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+  const formattedDate = new Date(`${transaction.date}T00:00:00`).toLocaleDateString(
+    getCurrentLocale(),
+    {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    },
+  );
 
   const localTimestamp = localTimestampFromCustomFields(transaction.customFields);
   const formattedLocalTimestamp = formatLocalTimestamp(localTimestamp);

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { getCurrentLocale } from '../lib/i18n';
 import { AppIcon } from '../components/icons';
 
 import { AccountPurposeFilterControl } from '../components/accounts';
@@ -567,7 +568,7 @@ export const TransactionsPage: React.FC = () => {
 
     return Array.from(groups, ([date, datedTransactions]) => ({
       date,
-      label: new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
+      label: new Date(`${date}T00:00:00`).toLocaleDateString(getCurrentLocale(), {
         weekday: 'long',
         month: 'short',
         day: 'numeric',

--- a/apps/web/src/pages/settings/SettingsPreferencesPage.test.tsx
+++ b/apps/web/src/pages/settings/SettingsPreferencesPage.test.tsx
@@ -121,6 +121,43 @@ describe('SettingsPreferencesPage currency display polish', () => {
     expect(localStorage.getItem('finance-time-zone-preference')).toBe('Asia/Tokyo');
   });
 
+  it('honestly marks fallback-only locales as beta and leaves translated locales unmarked', () => {
+    renderPreferences();
+
+    const languageSelect = screen.getByLabelText('Language');
+    const options = within(languageSelect).getAllByRole('option');
+
+    const badged = options.filter((option) =>
+      /beta · mostly English/i.test(option.textContent ?? ''),
+    );
+    const badgedValues = badged.map((option) => option.getAttribute('value')).sort();
+
+    // de-DE, ja-JP, and ar are fallback-only (English placeholder catalogs).
+    expect(badgedValues).toEqual(['ar', 'de-DE', 'ja-JP']);
+
+    // Source (en-US) and starter (es-ES, zh-Hans) locales must NOT be badged.
+    const spanishOption = within(languageSelect).getByRole('option', { name: /Español/ });
+    expect(spanishOption.textContent).not.toMatch(/beta/i);
+    const chineseOption = within(languageSelect).getByRole('option', { name: /简体中文/ });
+    expect(chineseOption.textContent).not.toMatch(/beta/i);
+  });
+
+  it('surfaces a beta notice only while a fallback-only locale is active', () => {
+    renderPreferences();
+
+    // Default active locale (en-US) is fully translated — no notice.
+    expect(screen.queryByText(/this language is in beta/i)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Language'), { target: { value: 'de-DE' } });
+
+    expect(localStorage.getItem('finance-locale-preference')).toBe('de-DE');
+    expect(screen.getByText(/this language is in beta/i)).toBeInTheDocument();
+
+    // Switching back to a translated locale removes the notice.
+    fireEvent.change(screen.getByLabelText('Language'), { target: { value: 'es-ES' } });
+    expect(screen.queryByText(/this language is in beta/i)).not.toBeInTheDocument();
+  });
+
   it('offers and persists compact display density', () => {
     renderPreferences();
 

--- a/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../lib/accessibility-preferences';
 import { SUPPORTED_CURRENCY_METADATA } from '../../lib/currency-metadata';
 import { translate } from '../../lib/i18n';
+import { getLocalePack } from '../../lib/i18n/locale-packs';
 import { createSettingsCopy } from '../../lib/i18n/settings-catalog';
 import { setOnboardingComplete } from '../../lib/local-only-mode';
 
@@ -265,20 +266,36 @@ export const SettingsPreferencesPage: React.FC = () => {
                 <select
                   id="settings-language"
                   aria-label="Language"
+                  aria-describedby={
+                    getLocalePack(localePreferences.locale)?.status === 'fallback-only'
+                      ? 'settings-language-beta'
+                      : undefined
+                  }
                   className="settings-item__select"
                   value={localePreferences.locale}
                   onChange={handleLocaleChange}
                 >
-                  {localePreferences.supportedLocales.map((option) => (
-                    <option key={option.code} value={option.code}>
-                      {option.nativeLabel} ({option.label})
-                    </option>
-                  ))}
+                  {localePreferences.supportedLocales.map((option) => {
+                    const isFallbackOnly = getLocalePack(option.code)?.status === 'fallback-only';
+                    const betaBadge = isFallbackOnly
+                      ? ` — ${translate('settings.language.betaBadge', {}, localePreferences.locale).text}`
+                      : '';
+                    return (
+                      <option key={option.code} value={option.code}>
+                        {option.nativeLabel} ({option.label}){betaBadge}
+                      </option>
+                    );
+                  })}
                 </select>
               </div>
               <p className="settings-item__description">
                 {translate('settings.languageDescription', {}, localePreferences.locale).text}
               </p>
+              {getLocalePack(localePreferences.locale)?.status === 'fallback-only' && (
+                <p id="settings-language-beta" className="settings-item__description" role="status">
+                  {translate('settings.language.betaNotice', {}, localePreferences.locale).text}
+                </p>
+              )}
             </div>
           </SettingInfoWidget>
           <SettingInfoWidget settingKey="time-zone">

--- a/apps/web/src/utils/formatDate.test.ts
+++ b/apps/web/src/utils/formatDate.test.ts
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { getCurrentLocale } from '../lib/i18n';
 import { formatDate, formatTransactionTimestamp, parseTransactionTimestamp } from './formatDate';
+
+vi.mock('../lib/i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/i18n')>();
+  return { ...actual, getCurrentLocale: vi.fn(() => 'en-US') };
+});
 
 describe('formatDate', () => {
   it('formats an ISO date string', () => {
@@ -74,5 +80,65 @@ describe('formatDate', () => {
 
     expect(formatted).toContain('Jan 31, 2024');
     expect(formatted).toContain('PST');
+  });
+});
+
+describe('formatDate honors the active locale preference', () => {
+  const numericOptions = { day: '2-digit', month: '2-digit', year: 'numeric' } as const;
+  // dateFromDateOnly('2024-03-01') anchors the date at UTC noon (see formatDate.ts).
+  const dateOnlyAnchor = new Date(Date.UTC(2024, 2, 1, 12, 0, 0));
+
+  afterEach(() => {
+    vi.mocked(getCurrentLocale).mockReturnValue('en-US');
+  });
+
+  it('formats a date-only value using the active locale, not a hardcoded en-US format', () => {
+    vi.mocked(getCurrentLocale).mockReturnValue('de-DE');
+
+    const result = formatDate('2024-03-01', numericOptions);
+    const reference = new Intl.DateTimeFormat('de-DE', {
+      ...numericOptions,
+      timeZone: 'UTC',
+    }).format(dateOnlyAnchor);
+
+    expect(result).toBe(reference);
+    // German convention is DD.MM.YYYY — distinct from the US MM/DD/YYYY default.
+    expect(result).toBe('01.03.2024');
+  });
+
+  it('produces locale-distinct output when the active locale changes', () => {
+    vi.mocked(getCurrentLocale).mockReturnValue('en-US');
+    const usFormatted = formatDate('2024-03-01', numericOptions);
+
+    vi.mocked(getCurrentLocale).mockReturnValue('es-ES');
+    const esFormatted = formatDate('2024-03-01', numericOptions);
+
+    expect(usFormatted).toBe('03/01/2024');
+    // Spain uses DD/MM/YYYY, so the same instant renders differently.
+    expect(esFormatted).toBe('01/03/2024');
+    expect(esFormatted).not.toBe(usFormatted);
+  });
+
+  it('falls back to the default locale when the active locale is en-US', () => {
+    vi.mocked(getCurrentLocale).mockReturnValue('en-US');
+
+    const result = formatDate('2024-03-01', numericOptions);
+    const reference = new Intl.DateTimeFormat('en-US', {
+      ...numericOptions,
+      timeZone: 'UTC',
+    }).format(dateOnlyAnchor);
+
+    expect(result).toBe(reference);
+  });
+
+  it('formats transaction timestamps with the active locale by default', () => {
+    vi.mocked(getCurrentLocale).mockReturnValue('en-US');
+    const usFormatted = formatTransactionTimestamp('2024-03-01T12:00:00Z', { timeZone: 'UTC' });
+
+    vi.mocked(getCurrentLocale).mockReturnValue('de-DE');
+    const deFormatted = formatTransactionTimestamp('2024-03-01T12:00:00Z', { timeZone: 'UTC' });
+
+    // Same instant + timezone, different active locale → different rendering.
+    expect(deFormatted).not.toBe(usFormatted);
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,62 @@ const moneyTemplateRule = {
   },
 };
 
+const dateLocaleRule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "Disallow hardcoded 'en-US' locales in date formatting; dates must follow the user's active locale via getCurrentLocale() or the formatDate helper.",
+    },
+    schema: [],
+    messages: {
+      hardcodedDateLocale:
+        "Hardcoded 'en-US' date formatting ignores the user's locale. Pass getCurrentLocale() (from lib/i18n) or use the formatDate helper from utils/formatDate.",
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename?.() ?? '';
+    const normalized = filename.replace(/\\/g, '/');
+    const isTestFile =
+      /\.test\.[cm]?[jt]sx?$/.test(normalized) || normalized.includes('/__tests__/');
+
+    function firstArgIsEnUs(node) {
+      const first = node.arguments?.[0];
+      return first != null && first.type === 'Literal' && first.value === 'en-US';
+    }
+
+    return {
+      CallExpression(node) {
+        if (isTestFile) return;
+        const callee = node.callee;
+        if (
+          callee?.type === 'MemberExpression' &&
+          callee.property?.type === 'Identifier' &&
+          (callee.property.name === 'toLocaleDateString' ||
+            callee.property.name === 'toLocaleTimeString') &&
+          firstArgIsEnUs(node)
+        ) {
+          context.report({ node: node.arguments[0], messageId: 'hardcodedDateLocale' });
+        }
+      },
+      NewExpression(node) {
+        if (isTestFile) return;
+        const callee = node.callee;
+        if (
+          callee?.type === 'MemberExpression' &&
+          callee.object?.type === 'Identifier' &&
+          callee.object.name === 'Intl' &&
+          callee.property?.type === 'Identifier' &&
+          callee.property.name === 'DateTimeFormat' &&
+          firstArgIsEnUs(node)
+        ) {
+          context.report({ node: node.arguments[0], messageId: 'hardcodedDateLocale' });
+        }
+      },
+    };
+  },
+};
+
 export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
@@ -54,6 +110,7 @@ export default [
       finance: {
         rules: {
           'no-money-template-interpolation': moneyTemplateRule,
+          'no-hardcoded-date-locale': dateLocaleRule,
         },
       },
     },
@@ -74,6 +131,12 @@ export default [
     ],
     rules: {
       'finance/no-money-template-interpolation': 'error',
+    },
+  },
+  {
+    files: ['apps/web/**/*.{ts,tsx}'],
+    rules: {
+      'finance/no-hardcoded-date-locale': 'error',
     },
   },
   {


### PR DESCRIPTION
## Summary

Fixes three i18n date/locale correctness bugs in the web app so dates, the multi-currency dashboard, and the language switcher all respect the active locale and are honest about translation coverage.

## Changes

### #3300 — dates rendered in US format
- Swapped hardcoded `'en-US'` for `getCurrentLocale()` in `toLocaleDateString` / `toLocaleTimeString` / `Intl.DateTimeFormat` / month `toLocaleString` calls across non-household pages and `lib` helpers (timeZone / UTC handling preserved).
- Added ESLint rule `finance/no-hardcoded-date-locale` (errors on the `'en-US'` literal in date formatting; ignores the canonical `'en-CA'` `formatToParts` extractors and money `toLocaleString`; exempts test files).
- Added a `formatDate` regression test asserting output follows the active locale preference.

### #3306 — multi-currency dashboard hardcoded English
- Routed every user-facing string and aria-label in `CurrencyDisplay.tsx` (CurrencySelector, ExchangeRateIndicator, MultiCurrencyTotals) through the i18n catalog via a reactive `useCurrencyStrings()` hook.
- Added `dashboard.currency.*` keys to en-US, es-ES and zh-Hans.
- Added a catalog-resolution test asserting Spanish renders and the English strings are absent.

### #3312 — fallback-only locales looked fully translated
- The language switcher now badges fallback-only locales (de-DE, ja-JP, ar) as `beta - mostly English` and shows a beta notice (with `aria-describedby` on the select + `role="status"`) while such a locale is active.
- Source (en-US) and starter (es-ES, zh-Hans) locales are left unmarked.
- Added `settings.language.beta*` catalog keys and switcher-honesty tests.

## Issues

Closes #3300
Closes #3306
Closes #3312

## Out of scope / follow-ups
- **Household files untouched per coordination.** `apps/web/src/pages/HouseholdPage.tsx` and `apps/web/src/hooks/useHousehold.ts` were left unedited (concurrent household rebuild, since merged as #3518). `HouseholdPage.tsx:720` uses `toLocaleString` for a date and should be routed through the locale-aware helper in a follow-up. Refs #3300.
- `CashRunwayPage.tsx:64` referenced in #3300 is a locale-aware string-compare helper, not a date-format bug — no change needed (stale line ref).
- I could not message the dispatching session back (cross-session messaging tool unavailable); noting here instead.

## Testing
- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean (new date-locale rule active)
- [x] `npx vitest run` (from apps/web) — affected + all i18n suites green (82 tests)
- [x] Rebased on `origin/main` (33f9f62c)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>