### PR TITLE
feat(web): add household invite-acceptance flow (#3377)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -96,6 +96,7 @@ const STANDALONE_ROUTES: readonly string[] = [
   '/legal',
   '/beta',
   '/onboarding',
+  '/invite',
 ];
 
 /*
@@ -126,6 +127,7 @@ const FIRST_RUN_ALLOWED_ROUTES: readonly string[] = [
   '/terms',
   '/ccpa',
   '/onboarding',
+  '/invite',
 ];
 
 function isStandalonePath(pathname: string): boolean {

--- a/apps/web/src/hooks/__tests__/useHousehold.invite.test.ts
+++ b/apps/web/src/hooks/__tests__/useHousehold.invite.test.ts
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Cross-device household invite-acceptance tests (#3377).
+ *
+ * The critical property these tests protect: an invitation created on one
+ * device (the inviter's) can be accepted on a *different* device (the invitee's)
+ * whose local store only ever received the invitation row via sync — with the
+ * new membership bound to the invitee's own authenticated identity, not a random
+ * id. They also lock in the accessible error states the accept screen renders
+ * (not-found / expired / revoked / already-accepted) and idempotency.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DatabaseContext, type DatabaseContextValue } from '../../db/DatabaseProvider';
+import type { SqliteDb } from '../../db/sqlite-wasm';
+import type { HouseholdInvitation } from '../../kmp/bridge';
+import { useHousehold } from '../useHousehold';
+
+// Two (or more) independent in-memory stores stand in for the encrypted SQLite
+// repository on separate devices. `active` points at whichever device is
+// "current"; swapping it simulates opening the app on the other device. Only the
+// rows we deliberately copy across simulate what sync would have delivered.
+const { stores } = vi.hoisted(() => ({
+  stores: { active: new Map<string, string>() },
+}));
+
+vi.mock('../../db/repositories/householdData', () => ({
+  HOUSEHOLD_SINGLETON_KEY: 'finance-household',
+  readHouseholdValue: (_db: unknown, key: string, fallback: unknown): unknown =>
+    stores.active.has(key) ? JSON.parse(stores.active.get(key) as string) : fallback,
+  writeHouseholdValue: (_db: unknown, key: string, value: unknown): void => {
+    stores.active.set(key, JSON.stringify(value));
+  },
+}));
+
+// Controllable authenticated user; each "device" signs in as a different person.
+const { auth } = vi.hoisted(() => ({
+  auth: { user: null as { id: string; email: string; name?: string } | null },
+}));
+
+vi.mock('../../auth/auth-context', () => ({
+  useAuth: () => ({ user: auth.user }),
+}));
+
+const INVITATIONS_KEY = 'finance-household-invitations';
+const MEMBERS_KEY = 'finance-household-members';
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(
+    DatabaseContext.Provider,
+    { value: { db: {} as SqliteDb, diagnostics: {} as DatabaseContextValue['diagnostics'] } },
+    children,
+  );
+
+let uuidCounter = 0;
+vi.stubGlobal('crypto', {
+  randomUUID: () => `uuid-${++uuidCounter}`,
+  getRandomValues: (arr: Uint8Array) => {
+    for (let i = 0; i < arr.length; i++) arr[i] = i + 1;
+    return arr;
+  },
+});
+
+beforeEach(() => {
+  uuidCounter = 0;
+  stores.active = new Map();
+  auth.user = null;
+  vi.clearAllMocks();
+});
+
+/** Parse the invitation rows persisted in a given device store. */
+function readInvitations(store: Map<string, string>): HouseholdInvitation[] {
+  const raw = store.get(INVITATIONS_KEY);
+  return raw ? (JSON.parse(raw) as HouseholdInvitation[]) : [];
+}
+
+/** Patch the (single) stored invitation in a device store. */
+function patchStoredInvitation(store: Map<string, string>, patch: Partial<HouseholdInvitation>) {
+  const invites = readInvitations(store);
+  invites[0] = { ...invites[0], ...patch } as HouseholdInvitation;
+  store.set(INVITATIONS_KEY, JSON.stringify(invites));
+}
+
+/**
+ * Seed device A with a household + a pending invitation, returning the created
+ * invitation and the raw device-A store. The inviter is signed in as the owner.
+ */
+function seedInviteOnDeviceA(): { invitation: HouseholdInvitation; deviceA: Map<string, string> } {
+  const deviceA = new Map<string, string>();
+  stores.active = deviceA;
+  auth.user = { id: 'owner-1', email: 'owner@example.com', name: 'Olive Owner' };
+
+  const hook = renderHook(() => useHousehold(), { wrapper });
+  act(() => {
+    hook.result.current.createHousehold({ name: 'Rivera Household' });
+  });
+  let invitation: HouseholdInvitation | null = null;
+  act(() => {
+    invitation = hook.result.current.inviteMember({
+      email: 'partner@example.com',
+      role: 'MEMBER',
+    });
+  });
+  hook.unmount();
+
+  if (!invitation) {
+    throw new Error('Failed to seed invitation on device A');
+  }
+  return { invitation, deviceA };
+}
+
+describe('useHousehold — invite acceptance (#3377)', () => {
+  it('accepts an invitation created on device A from a fresh device B store', () => {
+    const { invitation, deviceA } = seedInviteOnDeviceA();
+
+    // Sync: only the invitation row reaches the invitee's fresh device — the
+    // inviter's household + member rows never arrive.
+    const deviceB = new Map<string, string>();
+    deviceB.set(INVITATIONS_KEY, deviceA.get(INVITATIONS_KEY) as string);
+
+    // Device B: the invitee signs in and opens the invite link.
+    stores.active = deviceB;
+    auth.user = { id: 'invitee-2', email: 'partner@example.com', name: 'Pat Partner' };
+
+    const deviceBHook = renderHook(() => useHousehold(), { wrapper });
+
+    // The invitation resolves on device B even though its household never synced.
+    expect(deviceBHook.result.current.getInvitationByCode(invitation.inviteCode)?.email).toBe(
+      'partner@example.com',
+    );
+
+    let outcome!: ReturnType<typeof deviceBHook.result.current.acceptInvitation>;
+    act(() => {
+      outcome = deviceBHook.result.current.acceptInvitation(invitation.inviteCode);
+    });
+
+    expect(outcome.status).toBe('ACCEPTED');
+    if (outcome.status === 'ACCEPTED') {
+      // Membership binds to the *invitee's* auth id, not a random one.
+      expect(outcome.member.userId).toBe('invitee-2');
+      expect(outcome.member.householdId).toBe(invitation.householdId);
+      expect(outcome.member.role).toBe('MEMBER');
+      expect(outcome.member.displayName).toBe('Pat Partner');
+    }
+
+    // Device B persisted the membership and flipped the invitation to ACCEPTED,
+    // leaving it unsynced so the change propagates back.
+    const persistedMembers = JSON.parse(deviceB.get(MEMBERS_KEY) as string);
+    expect(persistedMembers).toHaveLength(1);
+    expect(persistedMembers[0].userId).toBe('invitee-2');
+
+    const persistedInvites = readInvitations(deviceB);
+    expect(persistedInvites[0]?.status).toBe('ACCEPTED');
+    expect(persistedInvites[0]?.isSynced).toBe(false);
+  });
+
+  it('falls back to the invitee email for the member display name when no name is set', () => {
+    const { invitation, deviceA } = seedInviteOnDeviceA();
+
+    const deviceB = new Map<string, string>();
+    deviceB.set(INVITATIONS_KEY, deviceA.get(INVITATIONS_KEY) as string);
+    stores.active = deviceB;
+    auth.user = { id: 'invitee-2', email: 'partner@example.com' };
+
+    const hook = renderHook(() => useHousehold(), { wrapper });
+    let outcome!: ReturnType<typeof hook.result.current.acceptInvitation>;
+    act(() => {
+      outcome = hook.result.current.acceptInvitation(invitation.inviteCode);
+    });
+
+    expect(outcome.status).toBe('ACCEPTED');
+    if (outcome.status === 'ACCEPTED') {
+      expect(outcome.member.displayName).toBe('partner@example.com');
+    }
+  });
+
+  it('returns NOT_FOUND when no invitation matches the code', () => {
+    stores.active = new Map();
+    auth.user = { id: 'invitee-2', email: 'partner@example.com' };
+
+    const { result } = renderHook(() => useHousehold(), { wrapper });
+    expect(result.current.getInvitationByCode('does-not-exist')).toBeNull();
+
+    let outcome!: ReturnType<typeof result.current.acceptInvitation>;
+    act(() => {
+      outcome = result.current.acceptInvitation('does-not-exist');
+    });
+    expect(outcome.status).toBe('NOT_FOUND');
+  });
+
+  it('returns EXPIRED for an invitation past its expiry and marks it expired in the store', () => {
+    const { invitation, deviceA } = seedInviteOnDeviceA();
+
+    const deviceB = new Map<string, string>();
+    deviceB.set(INVITATIONS_KEY, deviceA.get(INVITATIONS_KEY) as string);
+    // Age the invitation out on the invitee's device.
+    patchStoredInvitation(deviceB, { expiresAt: new Date(Date.now() - 1_000).toISOString() });
+
+    stores.active = deviceB;
+    auth.user = { id: 'invitee-2', email: 'partner@example.com' };
+
+    const hook = renderHook(() => useHousehold(), { wrapper });
+    let outcome!: ReturnType<typeof hook.result.current.acceptInvitation>;
+    act(() => {
+      outcome = hook.result.current.acceptInvitation(invitation.inviteCode);
+    });
+
+    expect(outcome.status).toBe('EXPIRED');
+    // No membership was created and the row is persisted as EXPIRED.
+    expect(deviceB.has(MEMBERS_KEY)).toBe(false);
+    expect(readInvitations(deviceB)[0]?.status).toBe('EXPIRED');
+  });
+
+  it('returns REVOKED for a revoked invitation', () => {
+    const deviceA = new Map<string, string>();
+    stores.active = deviceA;
+    auth.user = { id: 'owner-1', email: 'owner@example.com', name: 'Olive Owner' };
+
+    const hook = renderHook(() => useHousehold(), { wrapper });
+    act(() => {
+      hook.result.current.createHousehold({ name: 'Rivera Household' });
+    });
+    let invitation!: HouseholdInvitation;
+    act(() => {
+      invitation = hook.result.current.inviteMember({
+        email: 'partner@example.com',
+        role: 'MEMBER',
+      }) as HouseholdInvitation;
+    });
+    act(() => {
+      hook.result.current.revokeInvitation(invitation.id);
+    });
+
+    let outcome!: ReturnType<typeof hook.result.current.acceptInvitation>;
+    act(() => {
+      outcome = hook.result.current.acceptInvitation(invitation.inviteCode);
+    });
+    expect(outcome.status).toBe('REVOKED');
+  });
+
+  it('is idempotent — a second accept on the same device returns ALREADY_MEMBER', () => {
+    const { invitation, deviceA } = seedInviteOnDeviceA();
+
+    const deviceB = new Map<string, string>();
+    deviceB.set(INVITATIONS_KEY, deviceA.get(INVITATIONS_KEY) as string);
+    stores.active = deviceB;
+    auth.user = { id: 'invitee-2', email: 'partner@example.com', name: 'Pat Partner' };
+
+    const hook = renderHook(() => useHousehold(), { wrapper });
+    let first!: ReturnType<typeof hook.result.current.acceptInvitation>;
+    act(() => {
+      first = hook.result.current.acceptInvitation(invitation.inviteCode);
+    });
+    expect(first.status).toBe('ACCEPTED');
+
+    let second!: ReturnType<typeof hook.result.current.acceptInvitation>;
+    act(() => {
+      second = hook.result.current.acceptInvitation(invitation.inviteCode);
+    });
+    expect(second.status).toBe('ALREADY_MEMBER');
+    if (second.status === 'ALREADY_MEMBER') {
+      expect(second.member.userId).toBe('invitee-2');
+    }
+
+    // No duplicate membership row was created.
+    expect(JSON.parse(deviceB.get(MEMBERS_KEY) as string)).toHaveLength(1);
+  });
+
+  it('returns ALREADY_ACCEPTED when a different user opens an already-accepted invite', () => {
+    const { invitation, deviceA } = seedInviteOnDeviceA();
+
+    // Invitee accepts on device B.
+    const deviceB = new Map<string, string>();
+    deviceB.set(INVITATIONS_KEY, deviceA.get(INVITATIONS_KEY) as string);
+    stores.active = deviceB;
+    auth.user = { id: 'invitee-2', email: 'partner@example.com', name: 'Pat Partner' };
+    const bHook = renderHook(() => useHousehold(), { wrapper });
+    act(() => {
+      bHook.result.current.acceptInvitation(invitation.inviteCode);
+    });
+    bHook.unmount();
+
+    // A different person syncs only the (now ACCEPTED) invitation and tries it.
+    const deviceC = new Map<string, string>();
+    deviceC.set(INVITATIONS_KEY, deviceB.get(INVITATIONS_KEY) as string);
+    stores.active = deviceC;
+    auth.user = { id: 'other-3', email: 'other@example.com' };
+    const cHook = renderHook(() => useHousehold(), { wrapper });
+
+    let outcome!: ReturnType<typeof cHook.result.current.acceptInvitation>;
+    act(() => {
+      outcome = cHook.result.current.acceptInvitation(invitation.inviteCode);
+    });
+    expect(outcome.status).toBe('ALREADY_ACCEPTED');
+  });
+});

--- a/apps/web/src/hooks/useHousehold.ts
+++ b/apps/web/src/hooks/useHousehold.ts
@@ -78,6 +78,29 @@ export interface InviteMemberInput {
   role: HouseholdRole;
 }
 
+/**
+ * Discriminated outcome of an attempt to accept a household invitation (#3377).
+ *
+ * The accept screen needs to distinguish *why* an acceptance did or didn't
+ * succeed so it can render precise, accessible messaging (not-found vs expired
+ * vs revoked vs already-joined) instead of a single opaque error.
+ */
+export type AcceptInvitationResult =
+  /** Joined successfully — `member` is the newly created membership. */
+  | { status: 'ACCEPTED'; member: HouseholdMember }
+  /** The current user was already a member of this household — idempotent no-op. */
+  | { status: 'ALREADY_MEMBER'; member: HouseholdMember }
+  /** No invitation matched the supplied code (wrong/expired link, not yet synced). */
+  | { status: 'NOT_FOUND' }
+  /** The invitation was already accepted (by this or another device). */
+  | { status: 'ALREADY_ACCEPTED' }
+  /** The invitation's expiry has passed. */
+  | { status: 'EXPIRED' }
+  /** The inviter revoked the invitation before it was accepted. */
+  | { status: 'REVOKED' }
+  /** An unexpected error occurred while accepting. */
+  | { status: 'ERROR'; message: string };
+
 /** Friendly local-first ways a read-only trusted helper can access shared finances. */
 export type TrustedHelperAccessMethod = 'SHARED_DEVICE' | 'READ_ONLY_SUMMARY' | 'INVITE_LATER';
 
@@ -544,8 +567,19 @@ export interface UseHouseholdResult {
   // -- Invitation flow (#1779) ---
   /** Invite a member to the household. */
   inviteMember: (input: InviteMemberInput) => HouseholdInvitation | null;
-  /** Accept an invitation by invite code. */
-  acceptInvitation: (inviteCode: string) => HouseholdMember | null;
+  /**
+   * Look up a single invitation by its invite code, reading directly from the
+   * synced store so it resolves on the invitee's own device (#3377). Returns
+   * the invitation regardless of status so the accept screen can distinguish
+   * pending / accepted / expired / revoked. `null` when no invitation matches.
+   */
+  getInvitationByCode: (inviteCode: string) => HouseholdInvitation | null;
+  /**
+   * Accept an invitation by invite code, joining the current authenticated user
+   * to the invitation's household. Reads the invitation from the synced store
+   * (not just in-memory state) so acceptance works cross-device (#3377).
+   */
+  acceptInvitation: (inviteCode: string) => AcceptInvitationResult;
   /** Revoke a pending invitation. */
   revokeInvitation: (invitationId: SyncId) => boolean;
 
@@ -1385,76 +1419,170 @@ export function useHousehold(): UseHouseholdResult {
     [appendActivity, household, invitations],
   );
 
+  // Read the freshest invitation snapshot from the synced store. Acceptance
+  // happens on the *invitee's* device, whose in-memory `invitations` state is
+  // empty until sync delivers the row — so we must read the store directly
+  // rather than trust the render-time snapshot (#3377). Falls back to in-memory
+  // state when no database is mounted (isolated tests / provider-less renders).
+  const readStoredInvitations = useCallback(
+    (): HouseholdInvitation[] =>
+      loadFromStorage<HouseholdInvitation[]>(dbRef.current, STORAGE_KEY_INVITATIONS, invitations),
+    [invitations],
+  );
+
+  const getInvitationByCode = useCallback(
+    (inviteCode: string): HouseholdInvitation | null => {
+      const code = inviteCode.trim();
+      if (!code) {
+        return null;
+      }
+      const stored = readStoredInvitations();
+      return (
+        stored.find((inv) => inv.inviteCode === code) ??
+        invitations.find((inv) => inv.inviteCode === code) ??
+        null
+      );
+    },
+    [invitations, readStoredInvitations],
+  );
+
   const acceptInvitation = useCallback(
-    (inviteCode: string): HouseholdMember | null => {
+    (inviteCode: string): AcceptInvitationResult => {
+      const code = inviteCode.trim();
+      if (!code) {
+        setError('Invalid or expired invitation code.');
+        return { status: 'NOT_FOUND' };
+      }
+
       try {
-        const invitation = invitations.find(
-          (inv) => inv.inviteCode === inviteCode && inv.status === 'PENDING',
+        // Authoritative, freshest view of the synced store (see note above).
+        const invitationList = readStoredInvitations();
+        const memberList = loadFromStorage<HouseholdMember[]>(
+          dbRef.current,
+          STORAGE_KEY_MEMBERS,
+          members,
         );
 
+        const invitation = invitationList.find((inv) => inv.inviteCode === code);
         if (!invitation) {
           setError('Invalid or expired invitation code.');
-          return null;
+          return { status: 'NOT_FOUND' };
         }
 
-        // Check expiry
-        if (new Date(invitation.expiresAt) < new Date()) {
-          const updatedInvs = invitations.map((inv) =>
-            inv.id === invitation.id
-              ? { ...inv, status: 'EXPIRED' as const, updatedAt: new Date().toISOString() }
-              : inv,
-          );
-          saveToStorage(dbRef.current, STORAGE_KEY_INVITATIONS, updatedInvs);
-          setInvitations(updatedInvs);
+        if (invitation.status === 'REVOKED' || invitation.deletedAt) {
+          setError('This invitation has been revoked.');
+          return { status: 'REVOKED' };
+        }
+
+        const now = new Date();
+        const nowIso = now.toISOString();
+        const isExpired =
+          invitation.status === 'EXPIRED' ||
+          new Date(invitation.expiresAt).getTime() < now.getTime();
+        if (isExpired) {
+          if (invitation.status !== 'EXPIRED') {
+            const updatedInvs = invitationList.map((inv) =>
+              inv.id === invitation.id
+                ? {
+                    ...inv,
+                    status: 'EXPIRED' as const,
+                    updatedAt: nowIso,
+                    syncVersion: inv.syncVersion + 1,
+                    isSynced: false,
+                  }
+                : inv,
+            );
+            saveToStorage(dbRef.current, STORAGE_KEY_INVITATIONS, updatedInvs);
+            setInvitations(updatedInvs);
+          }
           setError('This invitation has expired.');
-          return null;
+          return { status: 'EXPIRED' };
         }
 
-        const now = new Date().toISOString();
+        const currentUserId = authUser?.id?.trim() ? authUser.id : null;
 
-        // Privacy-by-default: new member joins with no shared accounts
+        // Idempotency: if this user already belongs to the invitation's
+        // household, don't mint a duplicate membership — just return it.
+        const existingMember = currentUserId
+          ? memberList.find(
+              (member) =>
+                member.householdId === invitation.householdId &&
+                member.userId === currentUserId &&
+                !member.deletedAt,
+            )
+          : undefined;
+
+        if (invitation.status === 'ACCEPTED') {
+          if (existingMember) {
+            return { status: 'ALREADY_MEMBER', member: existingMember };
+          }
+          setError('This invitation has already been accepted.');
+          return { status: 'ALREADY_ACCEPTED' };
+        }
+
+        const acceptedInvitations = invitationList.map((inv) =>
+          inv.id === invitation.id
+            ? {
+                ...inv,
+                status: 'ACCEPTED' as const,
+                updatedAt: nowIso,
+                syncVersion: inv.syncVersion + 1,
+                isSynced: false,
+              }
+            : inv,
+        );
+
+        if (existingMember) {
+          saveToStorage(dbRef.current, STORAGE_KEY_INVITATIONS, acceptedInvitations);
+          setInvitations(acceptedInvitations);
+          return { status: 'ALREADY_MEMBER', member: existingMember };
+        }
+
+        // Privacy-by-default: new member joins with no shared accounts. Bind the
+        // membership to the *authenticated* invitee so it maps back to their
+        // account (falling back to a random id only for anonymous/demo flows).
         const newMember: HouseholdMember = {
           id: crypto.randomUUID(),
           householdId: invitation.householdId,
-          userId: crypto.randomUUID(),
-          displayName: null,
+          userId: currentUserId ?? crypto.randomUUID(),
+          displayName:
+            (authUser?.name && authUser.name.trim().length > 0 ? authUser.name.trim() : null) ??
+            (authUser?.email && authUser.email.trim().length > 0 ? authUser.email.trim() : null),
           role: invitation.role,
-          joinedAt: now,
-          createdAt: now,
-          updatedAt: now,
+          joinedAt: nowIso,
+          createdAt: nowIso,
+          updatedAt: nowIso,
           deletedAt: null,
           syncVersion: 1,
           isSynced: false,
         };
 
-        // Mark invitation as accepted
-        const updatedInvs = invitations.map((inv) =>
-          inv.id === invitation.id ? { ...inv, status: 'ACCEPTED' as const, updatedAt: now } : inv,
-        );
+        const updatedMembers = [...memberList, newMember];
 
-        const updatedMembers = [...members, newMember];
-
-        saveToStorage(dbRef.current, STORAGE_KEY_INVITATIONS, updatedInvs);
+        saveToStorage(dbRef.current, STORAGE_KEY_INVITATIONS, acceptedInvitations);
         saveToStorage(dbRef.current, STORAGE_KEY_MEMBERS, updatedMembers);
-        setInvitations(updatedInvs);
+        setInvitations(acceptedInvitations);
         setMembers(updatedMembers);
         appendActivity({
           type: 'MEMBERS',
           action: 'INVITATION_ACCEPTED',
           affectedObjectType: 'member',
           affectedObjectId: newMember.id,
+          householdId: invitation.householdId,
+          actorMemberId: newMember.id,
           summary: 'Invitation accepted',
           detail: 'New member joined without sharing private accounts by default.',
           privacy: 'PUBLIC',
         });
 
-        return newMember;
+        return { status: 'ACCEPTED', member: newMember };
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to accept invitation.');
-        return null;
+        const message = err instanceof Error ? err.message : 'Failed to accept invitation.';
+        setError(message);
+        return { status: 'ERROR', message };
       }
     },
-    [appendActivity, invitations, members],
+    [appendActivity, authUser?.email, authUser?.id, authUser?.name, members, readStoredInvitations],
   );
 
   const revokeInvitation = useCallback(
@@ -2683,6 +2811,7 @@ export function useHousehold(): UseHouseholdResult {
     error,
     createHousehold,
     inviteMember,
+    getInvitationByCode,
     acceptInvitation,
     revokeInvitation,
     addTrustedHelper,

--- a/apps/web/src/pages/AcceptInvitePage.test.tsx
+++ b/apps/web/src/pages/AcceptInvitePage.test.tsx
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the household invite-acceptance screen (#3377).
+ *
+ * Covers the full state matrix the invitee can land in: a valid pending invite
+ * (with a working Accept CTA), the four accessible terminal states
+ * (not-found / expired / revoked / already-accepted), an inline accept error,
+ * the loading guard, and the paste-a-code entry form — plus focus management.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import type { Household, HouseholdInvitation, HouseholdMember } from '../kmp/bridge';
+import { useHousehold } from '../hooks/useHousehold';
+import type { AcceptInvitationResult, UseHouseholdResult } from '../hooks/useHousehold';
+import { AcceptInvitePage } from './AcceptInvitePage';
+
+vi.mock('../hooks/useHousehold', async () => {
+  const actual =
+    await vi.importActual<typeof import('../hooks/useHousehold')>('../hooks/useHousehold');
+  return { ...actual, useHousehold: vi.fn() };
+});
+
+const mockedUseHousehold = vi.mocked(useHousehold);
+
+const syncMetadata = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+};
+
+const baseInvitation: HouseholdInvitation = {
+  id: 'inv-1',
+  householdId: 'hh-1',
+  invitedBy: 'owner-1',
+  email: 'partner@example.com',
+  role: 'MEMBER',
+  status: 'PENDING',
+  inviteCode: 'ABC123',
+  expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+  ...syncMetadata,
+};
+
+const baseMember: HouseholdMember = {
+  id: 'member-1',
+  householdId: 'hh-1',
+  userId: 'invitee-2',
+  displayName: 'Pat Partner',
+  role: 'MEMBER',
+  joinedAt: '2025-01-01T00:00:00Z',
+  ...syncMetadata,
+};
+
+const baseHousehold: Household = {
+  id: 'hh-1',
+  name: 'Rivera Household',
+  ownerId: 'owner-1',
+  ...syncMetadata,
+};
+
+interface MockOptions {
+  household?: Household | null;
+  loading?: boolean;
+  invitation?: HouseholdInvitation | null;
+  acceptResult?: AcceptInvitationResult;
+}
+
+function mockHousehold(options: MockOptions = {}) {
+  const acceptInvitation = vi
+    .fn()
+    .mockReturnValue(
+      options.acceptResult ??
+        ({ status: 'ACCEPTED', member: baseMember } as AcceptInvitationResult),
+    );
+  const getInvitationByCode = vi.fn().mockReturnValue(options.invitation ?? null);
+
+  mockedUseHousehold.mockReturnValue({
+    household: options.household ?? null,
+    loading: options.loading ?? false,
+    getInvitationByCode,
+    acceptInvitation,
+  } as unknown as UseHouseholdResult);
+
+  return { acceptInvitation, getInvitationByCode };
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/invite" element={<AcceptInvitePage />} />
+        <Route path="/invite/:code" element={<AcceptInvitePage />} />
+        <Route path="/household" element={<div>Household screen</div>} />
+        <Route path="/dashboard" element={<div>Dashboard screen</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AcceptInvitePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the pending invitation with role and a working Accept CTA', () => {
+    const { acceptInvitation } = mockHousehold({
+      household: baseHousehold,
+      invitation: baseInvitation,
+    });
+
+    renderAt('/invite/ABC123');
+
+    // Household name resolves because the local household matches the invite.
+    expect(screen.getByRole('heading', { name: 'Join a household' })).toBeInTheDocument();
+    expect(screen.getByText('Rivera Household')).toBeInTheDocument();
+    expect(screen.getByText('Member')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Accept invitation' }));
+
+    expect(acceptInvitation).toHaveBeenCalledWith('ABC123');
+    // Success state replaces the form.
+    expect(screen.getByRole('heading', { name: "You're in!" })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go to household' })).toBeInTheDocument();
+  });
+
+  it('moves focus to the heading for screen-reader users', () => {
+    mockHousehold({ household: baseHousehold, invitation: baseInvitation });
+    renderAt('/invite/ABC123');
+    expect(screen.getByRole('heading', { name: 'Join a household' })).toHaveFocus();
+  });
+
+  it('renders a generic household label when the invite is for another household', () => {
+    mockHousehold({
+      household: null,
+      invitation: baseInvitation,
+    });
+
+    renderAt('/invite/ABC123');
+
+    expect(screen.getByText(/invited to join a shared household/i)).toBeInTheDocument();
+  });
+
+  it('shows an accessible not-found state when the invitation is missing', () => {
+    mockHousehold({ invitation: null });
+
+    renderAt('/invite/UNKNOWN');
+
+    expect(screen.getByRole('heading', { name: 'Invitation not found' })).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(/couldn't find that invitation/i);
+  });
+
+  it('shows an expired state for an invitation past its expiry', () => {
+    mockHousehold({
+      invitation: {
+        ...baseInvitation,
+        expiresAt: new Date(Date.now() - 1_000).toISOString(),
+      },
+    });
+
+    renderAt('/invite/ABC123');
+
+    expect(screen.getByRole('heading', { name: 'Invitation expired' })).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(/has expired/i);
+  });
+
+  it('shows a revoked state for a revoked invitation', () => {
+    mockHousehold({
+      invitation: { ...baseInvitation, status: 'REVOKED' },
+    });
+
+    renderAt('/invite/ABC123');
+
+    expect(screen.getByRole('heading', { name: 'Invitation revoked' })).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(/was revoked/i);
+  });
+
+  it('shows an already-accepted state for an accepted invitation', () => {
+    mockHousehold({
+      invitation: { ...baseInvitation, status: 'ACCEPTED' },
+    });
+
+    renderAt('/invite/ABC123');
+
+    expect(screen.getByRole('heading', { name: 'Already accepted' })).toBeInTheDocument();
+  });
+
+  it('surfaces an inline error when accepting fails', () => {
+    const { acceptInvitation } = mockHousehold({
+      household: baseHousehold,
+      invitation: baseInvitation,
+      acceptResult: { status: 'ERROR', message: 'Something went wrong.' },
+    });
+
+    renderAt('/invite/ABC123');
+    fireEvent.click(screen.getByRole('button', { name: 'Accept invitation' }));
+
+    expect(acceptInvitation).toHaveBeenCalledWith('ABC123');
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong.');
+    // Still on the pending screen so the invitee can retry.
+    expect(screen.getByRole('button', { name: 'Accept invitation' })).toBeInTheDocument();
+  });
+
+  it('shows a loading state before the store settles', () => {
+    mockHousehold({ loading: true, invitation: null });
+
+    renderAt('/invite/ABC123');
+
+    expect(screen.getByRole('heading', { name: /checking your invitation/i })).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('lets an invitee paste a code and navigates to the invite route', () => {
+    mockHousehold({ invitation: null });
+
+    renderAt('/invite');
+
+    const input = screen.getByLabelText('Invite code');
+    const submit = screen.getByRole('button', { name: 'Continue' });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'XYZ789' } });
+    expect(submit).toBeEnabled();
+
+    fireEvent.click(submit);
+
+    // Navigated to /invite/XYZ789, which resolves to the not-found state
+    // because the default mock has no matching invitation.
+    expect(screen.getByRole('heading', { name: 'Invitation not found' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/AcceptInvitePage.tsx
+++ b/apps/web/src/pages/AcceptInvitePage.tsx
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * AcceptInvitePage — household invitation acceptance screen (#3377).
+ *
+ * Opened via the shareable invite link (`/invite/<code>`) the inviter copies
+ * from the Household page, or via `/invite` where an invitee can paste a code by
+ * hand. It looks the invitation up in the encrypted, synced household store (so
+ * it resolves on the invitee's *own* device) and lets them join from there —
+ * closing the loop that previously dead-ended because no route opened the link
+ * and nothing ever called `acceptInvitation`.
+ *
+ * The screen is deliberately standalone (no app nav shell) so it reads cleanly
+ * when reached straight from an email link, and every branch renders accessible,
+ * status-specific messaging (not-found vs expired vs revoked vs already-joined)
+ * with focus moved to the heading on each state change.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { FC, FormEvent, ReactNode } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { useHousehold } from '../hooks/useHousehold';
+import type { AcceptInvitationResult } from '../hooks/useHousehold';
+import type { HouseholdRole } from '../kmp/bridge';
+import '../styles/auth.css';
+import '../styles/invite.css';
+
+/** Human-readable labels for each household role shown on the accept screen. */
+const ROLE_LABELS: Record<HouseholdRole, string> = {
+  OWNER: 'Owner',
+  ADMIN: 'Admin',
+  MEMBER: 'Member',
+  VIEWER: 'Viewer (read-only)',
+};
+
+/** Terminal states that render a single status message with return links. */
+type TerminalView = 'not_found' | 'revoked' | 'expired' | 'already_accepted';
+
+const TERMINAL_MESSAGES: Record<TerminalView, { title: string; body: string }> = {
+  not_found: {
+    title: 'Invitation not found',
+    body: "We couldn't find that invitation. The link may be mistyped, already used, or not synced to this device yet. Ask whoever invited you to resend it.",
+  },
+  revoked: {
+    title: 'Invitation revoked',
+    body: 'This invitation was revoked by the household owner. Ask them to send you a new one.',
+  },
+  expired: {
+    title: 'Invitation expired',
+    body: 'This invitation has expired. Ask the household owner to send you a fresh invite.',
+  },
+  already_accepted: {
+    title: 'Already accepted',
+    body: 'This invitation has already been accepted. If that was you, head to your household to get started.',
+  },
+};
+
+/**
+ * Household invitation acceptance page.
+ *
+ * Reads the `:code` route param, resolves the invitation from the synced
+ * household store, and renders the appropriate state. Requires an authenticated
+ * session (mounted under an authenticated route) because the invitation only
+ * exists in the invitee's encrypted local store once they have signed in and
+ * synced.
+ */
+export const AcceptInvitePage: FC = () => {
+  const { code: codeParam } = useParams<{ code?: string }>();
+  const code = codeParam?.trim() ?? '';
+  const navigate = useNavigate();
+  const { household, loading, getInvitationByCode, acceptInvitation } = useHousehold();
+
+  const [result, setResult] = useState<AcceptInvitationResult | null>(null);
+  const [pastedCode, setPastedCode] = useState('');
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  const invitation = useMemo(
+    () => (code ? getInvitationByCode(code) : null),
+    [code, getInvitationByCode],
+  );
+
+  // Move focus to the heading whenever the rendered state changes so keyboard
+  // and screen-reader users always land on the new message.
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, [code, result, loading]);
+
+  const handleAccept = useCallback(() => {
+    setResult(acceptInvitation(code));
+  }, [acceptInvitation, code]);
+
+  const handlePasteSubmit = useCallback(
+    (event: FormEvent) => {
+      event.preventDefault();
+      const next = pastedCode.trim();
+      if (next) {
+        navigate(`/invite/${encodeURIComponent(next)}`);
+      }
+    },
+    [navigate, pastedCode],
+  );
+
+  const householdName =
+    invitation && household?.id === invitation.householdId ? household.name : null;
+
+  const renderCard = (title: string, body: ReactNode) => (
+    <main className="auth-page">
+      <section className="auth-card" aria-labelledby="invite-title">
+        <header className="auth-brand">
+          <h1 id="invite-title" className="auth-brand__name" tabIndex={-1} ref={headingRef}>
+            {title}
+          </h1>
+        </header>
+        {body}
+      </section>
+    </main>
+  );
+
+  // --- No code in the URL: let the invitee paste one (helper text points here) -
+  if (!code) {
+    return renderCard(
+      'Join a household',
+      <>
+        <p className="auth-brand__tagline">
+          Paste the invite code the household owner shared with you.
+        </p>
+        <form className="auth-form" onSubmit={handlePasteSubmit} noValidate>
+          <div className="auth-field">
+            <label htmlFor="invite-code" className="auth-field__label">
+              Invite code
+            </label>
+            <input
+              id="invite-code"
+              className="auth-field__input"
+              value={pastedCode}
+              onChange={(event) => setPastedCode(event.target.value)}
+              autoComplete="off"
+              autoCapitalize="characters"
+              spellCheck={false}
+              aria-required="true"
+            />
+          </div>
+          <div className="auth-actions">
+            <button type="submit" className="auth-submit" disabled={pastedCode.trim().length === 0}>
+              Continue
+            </button>
+          </div>
+        </form>
+        <p className="auth-footer">
+          <Link to="/dashboard" className="auth-footer__link">
+            Back to dashboard
+          </Link>
+        </p>
+      </>,
+    );
+  }
+
+  // --- Still loading the store: avoid flashing "not found" before it settles ---
+  if (loading && !result) {
+    return renderCard(
+      'Checking your invitation…',
+      <p className="auth-brand__tagline" role="status">
+        One moment while we look up this invite.
+      </p>,
+    );
+  }
+
+  // --- Success: joined now, or already a member ------------------------------
+  if (result && (result.status === 'ACCEPTED' || result.status === 'ALREADY_MEMBER')) {
+    const joinedName = householdName ?? 'your shared household';
+    return renderCard(
+      result.status === 'ACCEPTED' ? "You're in!" : 'Already joined',
+      <>
+        <p className="auth-brand__tagline" role="status">
+          {result.status === 'ACCEPTED'
+            ? `You've joined ${joinedName}. Nothing is shared automatically — your accounts stay private until you choose to share them.`
+            : `You're already a member of ${joinedName}.`}
+        </p>
+        <div className="invite-actions">
+          <Link to="/household" className="auth-submit">
+            Go to household
+          </Link>
+          <p className="invite-secondary-action">
+            <Link to="/dashboard" className="auth-footer__link">
+              Back to dashboard
+            </Link>
+          </p>
+        </div>
+      </>,
+    );
+  }
+
+  // --- Terminal error states (from an accept attempt or derived from the row) -
+  const terminalView: TerminalView | null =
+    result && result.status === 'NOT_FOUND'
+      ? 'not_found'
+      : result && result.status === 'REVOKED'
+        ? 'revoked'
+        : result && result.status === 'EXPIRED'
+          ? 'expired'
+          : result && result.status === 'ALREADY_ACCEPTED'
+            ? 'already_accepted'
+            : !invitation
+              ? 'not_found'
+              : invitation.status === 'REVOKED' || invitation.deletedAt
+                ? 'revoked'
+                : invitation.status === 'EXPIRED' ||
+                    new Date(invitation.expiresAt).getTime() < Date.now()
+                  ? 'expired'
+                  : invitation.status === 'ACCEPTED'
+                    ? 'already_accepted'
+                    : null;
+
+  if (terminalView) {
+    const { title, body } = TERMINAL_MESSAGES[terminalView];
+    return renderCard(
+      title,
+      <>
+        <p className="auth-brand__tagline" role="alert">
+          {body}
+        </p>
+        <div className="invite-actions">
+          <Link to="/household" className="auth-submit">
+            Go to household
+          </Link>
+          <p className="invite-secondary-action">
+            <Link to="/dashboard" className="auth-footer__link">
+              Back to dashboard
+            </Link>
+          </p>
+        </div>
+      </>,
+    );
+  }
+
+  // --- Pending & valid: show the invitation and let the invitee accept -------
+  return renderCard(
+    'Join a household',
+    <>
+      <p className="auth-brand__tagline">
+        You&apos;ve been invited to join {householdName ?? 'a shared household'}. Joining shares
+        nothing automatically — your accounts stay private until you choose to share them.
+      </p>
+      <dl className="invite-details">
+        {householdName && (
+          <div className="invite-details__row">
+            <dt className="invite-details__label">Household</dt>
+            <dd className="invite-details__value">{householdName}</dd>
+          </div>
+        )}
+        <div className="invite-details__row">
+          <dt className="invite-details__label">Your role</dt>
+          <dd className="invite-details__value">
+            {invitation ? ROLE_LABELS[invitation.role] : '—'}
+          </dd>
+        </div>
+        {invitation?.email && (
+          <div className="invite-details__row">
+            <dt className="invite-details__label">Invited email</dt>
+            <dd className="invite-details__value">{invitation.email}</dd>
+          </div>
+        )}
+      </dl>
+      {result?.status === 'ERROR' && (
+        <p className="auth-error" role="alert">
+          {result.message}
+        </p>
+      )}
+      <div className="invite-actions">
+        <button type="button" className="auth-submit" onClick={handleAccept}>
+          Accept invitation
+        </button>
+        <p className="invite-secondary-action">
+          <Link to="/dashboard" className="auth-footer__link">
+            Not now
+          </Link>
+        </p>
+      </div>
+    </>,
+  );
+};
+
+export default AcceptInvitePage;

--- a/apps/web/src/pages/HouseholdPage.css
+++ b/apps/web/src/pages/HouseholdPage.css
@@ -677,6 +677,20 @@
   margin-bottom: var(--spacing-3);
 }
 
+/* Shareable invite link surfaced after an invitation is persisted (#3377). */
+.household-invite-success__message {
+  margin: 0 0 var(--spacing-2);
+}
+
+.household-invite-success__link {
+  display: inline-flex;
+  max-width: 100%;
+}
+
+.household-invite-success__link .household-invitation-item__code-text {
+  overflow-wrap: anywhere;
+}
+
 /* ---------------------------------------------------------------------------
  * Household scorecard (#2188)
  * ------------------------------------------------------------------------- */

--- a/apps/web/src/pages/HouseholdPage.test.tsx
+++ b/apps/web/src/pages/HouseholdPage.test.tsx
@@ -257,6 +257,7 @@ function mockHouseholdResult(overrides: Partial<UseHouseholdResult> = {}): UseHo
     createHousehold: vi.fn(),
     inviteMember: vi.fn(),
     acceptInvitation: vi.fn(),
+    getInvitationByCode: vi.fn(),
     revokeInvitation: vi.fn(),
     addTrustedHelper: vi.fn(),
     updateMemberRole: vi.fn(),

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -244,6 +244,9 @@ export function HouseholdPage() {
   } | null>(null);
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [inviteSuccess, setInviteSuccess] = useState(false);
+  // The just-created invite's code, surfaced as a shareable link once the
+  // invitation has actually been persisted to the synced store (#3377).
+  const [lastInviteCode, setLastInviteCode] = useState<string | null>(null);
 
   // -- Trusted helper form state -------------------------------------------
   const [trustedHelperName, setTrustedHelperName] = useState('');
@@ -332,7 +335,7 @@ export function HouseholdPage() {
       e.preventDefault();
       setInviteError(null);
       setInviteSuccess(false);
-
+      setLastInviteCode(null);
       const trimmedEmail = inviteEmail.trim();
       if (!trimmedEmail) {
         setInviteError('Email address is required.');
@@ -348,6 +351,7 @@ export function HouseholdPage() {
       if (result) {
         setInviteEmail('');
         setInviteSuccess(true);
+        setLastInviteCode(result.inviteCode);
       } else {
         setInviteError('Failed to send invitation.');
       }
@@ -2769,9 +2773,26 @@ export function HouseholdPage() {
           Nothing is shared until they explicitly choose to share accounts.
         </p>
 
-        {inviteSuccess && (
+        {inviteSuccess && lastInviteCode && (
           <div className="household-banner--success" role="status">
-            Invitation sent successfully! The invite code has been generated.
+            <p className="household-invite-success__message">
+              Invitation saved. Share this link with the person you invited — they open it, sign in,
+              and join from their own device:
+            </p>
+            <button
+              type="button"
+              className="household-invitation-item__code household-invite-success__link"
+              onClick={() => void handleCopyInvite(lastInviteCode)}
+              aria-label="Copy the invitation link to share"
+              title="Click to copy the full invite link"
+            >
+              <code className="household-invitation-item__code-text">
+                {buildInviteUrl(lastInviteCode)}
+              </code>
+              <span aria-hidden="true" className="household-invitation-item__code-hint">
+                Copy link
+              </span>
+            </button>
           </div>
         )}
 
@@ -2794,6 +2815,7 @@ export function HouseholdPage() {
               onChange={(e) => {
                 setInviteEmail(e.target.value);
                 setInviteSuccess(false);
+                setLastInviteCode(null);
               }}
               placeholder="partner@example.com"
               aria-required="true"

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -53,6 +53,7 @@ const BetaLanding = lazy(() => import('./pages/BetaLanding'));
 const NotFound = lazy(() => import('./pages/NotFoundPage'));
 const Watchlists = lazy(() => import('./pages/WatchlistsPage'));
 const Household = lazy(() => import('./pages/HouseholdPage'));
+const AcceptInvite = lazy(() => import('./pages/AcceptInvitePage'));
 const ReportBuilder = lazy(() => import('./pages/ReportBuilderPage'));
 const ClientProfitability = lazy(() => import('./pages/ClientProfitabilityPage'));
 const BusinessPnl = lazy(() => import('./pages/BusinessPnlPage'));
@@ -429,6 +430,32 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Household">
             <Household />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    {/*
+     * Household invite acceptance (#3377). `/invite/:code` opens the shareable
+     * link; `/invite` lets an invitee paste a code by hand. Authenticated because
+     * the invitation only exists in the invitee's encrypted local store once they
+     * have signed in and synced.
+     */}
+    <Route
+      path="/invite"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Accept Invitation">
+            <AcceptInvite />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/invite/:code"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Accept Invitation">
+            <AcceptInvite />
           </RouteBoundary>
         </AuthenticatedRoute>
       }

--- a/apps/web/src/styles/invite.css
+++ b/apps/web/src/styles/invite.css
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/*
+ * Household invite-acceptance screen (#3377).
+ *
+ * Layered on top of auth.css, which provides the centred `.auth-page` /
+ * `.auth-card` shell reused here so the accept screen matches the Login,
+ * Signup, and 404 pages. Only the invitation-specific details block and the
+ * stacked action layout are defined here. All values use design tokens.
+ */
+
+.invite-details {
+  margin: var(--spacing-4) 0;
+  padding: var(--spacing-4);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+  list-style: none;
+}
+
+.invite-details__row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  padding: var(--spacing-1) 0;
+}
+
+.invite-details__label {
+  color: var(--semantic-text-secondary);
+}
+
+.invite-details__value {
+  font-weight: var(--font-weight-semibold);
+  text-align: right;
+  color: var(--semantic-text-primary);
+}
+
+.invite-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-5);
+}
+
+.invite-secondary-action {
+  margin: 0;
+  text-align: center;
+}
+
+/* The success / terminal cards use a Link styled as the primary button. */
+a.auth-submit {
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary

Builds the household **invite-acceptance flow** so an invited partner can actually join a household from their own device. Previously inviting a partner was a dead end: the app minted a copyable `/invite/<code>` link and claimed an invitation was "sent", but there was **no `/invite` route** to open the link, **nothing ever called** the hook's `acceptInvitation`, and the old `acceptInvitation` searched the _inviter's_ in-memory state while minting a **random** `userId` — so the invitee could never join.

Builds directly on PR #3518, which migrated household data (incl. invitations) off `localStorage` into the encrypted, sync-ready SQLite `hh_*` repositories. This PR adds the missing accept route + wires acceptance to read from that synced store.

## Changes

- **New `/invite/:code` route + `AcceptInvitePage`** (plus an `/invite` paste-code form): looks the invitation up in the synced household store — so it resolves on the _invitee's_ device — and joins them via `acceptInvitation`, binding the new membership to their **authenticated identity** (falling back to a random id only for anonymous/demo flows). Privacy-by-default: joining shares no accounts.
- **`useHousehold` rework**: `acceptInvitation` now reads a fresh snapshot from the synced repository (not just render-time state), is **idempotent**, and returns a discriminated `AcceptInvitationResult` (`ACCEPTED` / `ALREADY_MEMBER` / `NOT_FOUND` / `ALREADY_ACCEPTED` / `EXPIRED` / `REVOKED` / `ERROR`). New `getInvitationByCode` reads fresh for the accept screen. Persists with bumped `syncVersion` / `isSynced: false` so the change syncs back.
- **Accessible state matrix**: not-found / expired / revoked / already-accepted / already-member / inline accept error, each with `role="alert"` / `role="status"` messaging and focus moved to the heading on every state change. The route renders standalone (no nav shell) and is exempt from the first-run onboarding bounce (`STANDALONE_ROUTES` + `FIRST_RUN_ALLOWED_ROUTES`). It stays **authenticated** because the invitation only exists locally once the invitee signs in and syncs.
- **HouseholdPage invite section** surfaces the shareable link (with copy button) **only after** the invitation is actually persisted, and the copy is honest ("Invitation saved… share this link") rather than claiming an email was sent.

## Testing

- `apps/web/src/hooks/__tests__/useHousehold.invite.test.ts` — an invite created on **device A** is accepted on a **fresh device B store** (sync delivers only the invitation row); membership binds to the invitee's auth id; plus NOT_FOUND / EXPIRED / REVOKED / ALREADY_ACCEPTED and idempotency (ALREADY_MEMBER, no duplicate membership).
- `apps/web/src/pages/AcceptInvitePage.test.tsx` — full state matrix, Accept CTA wiring, inline error, loading guard, paste-form navigation, and heading focus.
- `HouseholdPage.test.tsx` mock updated with `getInvitationByCode`.
- ✅ 46 tests pass · ✅ `prettier --check` · ✅ `eslint . --max-warnings 0` · ✅ `tsc --noEmit` (web).

## Scope

Web-only, within the assigned file scope (the `/invite` route + component, `HouseholdPage` invite section, `useHousehold` accept + persistence, router config, tests). No schema or KMP type changes — `HouseholdInvitation` remains KMP-owned.

Closes #3377
