### PR TITLE
fix(web): extend read-aloud to financial surfaces (#3278)

### DIFF
--- a/apps/web/src/components/common/ReadAloudButton.test.tsx
+++ b/apps/web/src/components/common/ReadAloudButton.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AccessibilityProvider } from '../../contexts/AccessibilityContext';
+import { ReadAloudButton } from './ReadAloudButton';
+
+const speakMock = vi.fn();
+const cancelMock = vi.fn();
+
+function installMatchMedia() {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+}
+
+function renderWithSpeech(ui: ReactNode, speakAmounts = true) {
+  return render(
+    <AccessibilityProvider initialSettings={{ speakAmounts }}>{ui}</AccessibilityProvider>,
+  );
+}
+
+describe('ReadAloudButton', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    speakMock.mockReset();
+    cancelMock.mockReset();
+    installMatchMedia();
+    vi.stubGlobal(
+      'SpeechSynthesisUtterance',
+      vi.fn().mockImplementation(function MockSpeechSynthesisUtterance(
+        this: { text: string },
+        text: string,
+      ) {
+        this.text = text;
+      }),
+    );
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: { cancel: cancelMock, speak: speakMock },
+    });
+  });
+
+  it('renders nothing when "Read amounts aloud" is disabled', () => {
+    renderWithSpeech(<ReadAloudButton amount={12345} context="net worth" />, false);
+
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('renders a keyboard-operable button when the preference is enabled', () => {
+    renderWithSpeech(<ReadAloudButton amount={12345} context="net worth" />);
+
+    const button = screen.getByRole('button', { name: 'Read aloud: net worth' });
+    // Native <button> is inherently focusable/operable by keyboard (no tabindex needed).
+    expect(button.tagName).toBe('BUTTON');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('uses the visible label as the start of the accessible name (WCAG 2.5.3)', () => {
+    renderWithSpeech(
+      <ReadAloudButton amount={500} context="remaining in Groceries budget" label="Read amount" />,
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Read amount: remaining in Groceries budget',
+    });
+    expect(button).toHaveTextContent('Read amount');
+  });
+
+  it('falls back to the plain label when no context is provided', () => {
+    renderWithSpeech(<ReadAloudButton amount={500} />);
+
+    expect(screen.getByRole('button', { name: 'Read aloud' })).toBeInTheDocument();
+  });
+
+  it('speaks the amount when activated', () => {
+    renderWithSpeech(<ReadAloudButton amount={12345} currency="USD" context="net worth" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Read aloud: net worth' }));
+
+    expect(speakMock).toHaveBeenCalledTimes(1);
+    const utterance = speakMock.mock.calls[0][0] as { text: string };
+    expect(typeof utterance.text).toBe('string');
+    expect(utterance.text.length).toBeGreaterThan(0);
+    expect(utterance.text).toContain('net worth');
+  });
+
+  it('hides the decorative speaker icon from assistive technology', () => {
+    const { container } = renderWithSpeech(<ReadAloudButton amount={100} context="balance" />);
+
+    const icon = container.querySelector('.read-aloud-button__icon');
+    expect(icon).not.toBeNull();
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/apps/web/src/components/common/ReadAloudButton.tsx
+++ b/apps/web/src/components/common/ReadAloudButton.tsx
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { FC } from 'react';
+
+import { useAccessibilityContext } from '../../contexts/AccessibilityContext';
+
+export interface ReadAloudButtonProps {
+  /** Amount in integer cents to speak (e.g., `12345` = $123.45). */
+  readonly amount: number;
+  /** ISO 4217 currency code (default: `"USD"`). */
+  readonly currency?: string;
+  /**
+   * Short description of what the amount represents
+   * (e.g., `"net worth"`, `"remaining in Groceries budget"`).
+   *
+   * Spoken after the amount and appended to the button's accessible name so
+   * each read-aloud control has a unique, meaningful label when several
+   * appear on one screen.
+   */
+  readonly context?: string;
+  /** Visible button text (default: `"Read aloud"`). */
+  readonly label?: string;
+  /** Additional CSS class names for placement/styling. */
+  readonly className?: string;
+}
+
+/**
+ * Opt-in "read aloud" control for a primary financial amount.
+ *
+ * Renders nothing unless the user has enabled **Read amounts aloud**
+ * (Settings → Preferences → Accessibility). When enabled it shows a
+ * keyboard-operable, screen-reader-labelled button that speaks the amount via
+ * the shared `speakAmount` helper from {@link useAccessibilityContext} — the
+ * same utility the Transactions list uses, so the app keeps a single
+ * read-aloud implementation rather than a per-page fork (#3278).
+ *
+ * Accessibility:
+ * - Native `<button>` so it is reachable and operable by keyboard.
+ * - The accessible name always begins with the visible label and appends
+ *   `context`, satisfying WCAG 2.2 §2.5.3 (Label in Name) while giving each
+ *   control a unique name (§4.1.2 Name, Role, Value).
+ * - The speaker glyph is decorative (`aria-hidden`); meaning is carried by the
+ *   text label and border, never colour alone (§1.4.1 Use of Color).
+ */
+export const ReadAloudButton: FC<ReadAloudButtonProps> = ({
+  amount,
+  currency = 'USD',
+  context,
+  label = 'Read aloud',
+  className,
+}) => {
+  const { speakAmounts, speakAmount } = useAccessibilityContext();
+
+  if (!speakAmounts) {
+    return null;
+  }
+
+  const accessibleName = context ? `${label}: ${context}` : label;
+  const buttonClassName = ['read-aloud-button', className].filter(Boolean).join(' ');
+
+  return (
+    <button
+      type="button"
+      className={buttonClassName}
+      onClick={() => speakAmount(amount, currency, context)}
+      aria-label={accessibleName}
+    >
+      <svg
+        className="read-aloud-button__icon"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+        <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+        <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+      </svg>
+      <span className="read-aloud-button__label">{label}</span>
+    </button>
+  );
+};
+
+export default ReadAloudButton;

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -8,6 +8,8 @@ export { ConflictResolutionDialog } from './ConflictResolutionDialog';
 export type { ConflictResolutionDialogProps } from './ConflictResolutionDialog';
 export { CurrencyDisplay } from './CurrencyDisplay';
 export type { CurrencyDisplayProps } from './CurrencyDisplay';
+export { ReadAloudButton } from './ReadAloudButton';
+export type { ReadAloudButtonProps } from './ReadAloudButton';
 export { CommandPalette } from './CommandPalette';
 export type { CommandPaletteAction, CommandPaletteProps } from './CommandPalette';
 export { DateInput } from './DateInput';

--- a/apps/web/src/pages/AccountsPage.test.tsx
+++ b/apps/web/src/pages/AccountsPage.test.tsx
@@ -7,6 +7,7 @@ import { PrivacyModeProvider } from '../contexts/PrivacyModeContext';
 import { useAccounts } from '../hooks';
 import { evaluatePrivacyScreenCoverage } from '../lib/security/privacy-screen';
 import { auditPrivacySurfaceCoverage, privacySurface } from '../lib/security/privacy-coverage';
+import { AccessibilityProvider } from '../contexts/AccessibilityContext';
 import type { Account } from '../kmp/bridge';
 import { AccountsPage } from './AccountsPage';
 
@@ -141,6 +142,18 @@ describe('AccountsPage', () => {
       updateAccount: vi.fn(),
       deleteAccount: vi.fn(),
     });
+  });
+
+  it('exposes a labelled read-aloud control for total net worth when "Read amounts aloud" is enabled (#3278)', () => {
+    render(
+      <AccessibilityProvider initialSettings={{ speakAmounts: true }}>
+        <MemoryRouter>
+          <AccountsPage />
+        </MemoryRouter>
+      </AccessibilityProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Read aloud: total net worth' })).toBeInTheDocument();
   });
 
   it('renders without crashing', () => {

--- a/apps/web/src/pages/AccountsPage.tsx
+++ b/apps/web/src/pages/AccountsPage.tsx
@@ -3,7 +3,13 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AccountPurposeBadge } from '../components/accounts';
-import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import {
+  CurrencyDisplay,
+  EmptyState,
+  ErrorBanner,
+  LoadingSpinner,
+  ReadAloudButton,
+} from '../components/common';
 import { AccountForm } from '../components/forms';
 import { OfflineBanner } from '../components/OfflineBanner';
 import { useEffectiveMaskingMode } from '../contexts/PrivacyModeContext';
@@ -62,7 +68,8 @@ const MultiCurrencyTotal: React.FC<{
     currency: { code: string };
   }>;
   colorize?: boolean;
-}> = ({ accounts, colorize = false }) => {
+  readAloud?: boolean;
+}> = ({ accounts, colorize = false, readAloud = false }) => {
   const maskingMode = useEffectiveMaskingMode();
   const currencyItems = accounts.map((acc) => ({
     currency: acc.currency.code,
@@ -74,7 +81,16 @@ const MultiCurrencyTotal: React.FC<{
     const singleCurrency = getSingleCurrency(currencyItems);
     const total = accounts.reduce((sum, acc) => sum + netWorthContribution(acc), 0);
     return (
-      <CurrencyDisplay amount={total} currency={singleCurrency ?? 'USD'} colorize={colorize} />
+      <>
+        <CurrencyDisplay amount={total} currency={singleCurrency ?? 'USD'} colorize={colorize} />
+        {readAloud ? (
+          <ReadAloudButton
+            amount={total}
+            currency={singleCurrency ?? 'USD'}
+            context="total net worth"
+          />
+        ) : null}
+      </>
     );
   }
 
@@ -236,7 +252,7 @@ export const AccountsPage: React.FC = () => {
       {offlineBanner}
       {pageHeader}
       <p className="page-summary" aria-live="polite">
-        Net worth: <MultiCurrencyTotal accounts={accounts} colorize />
+        Net worth: <MultiCurrencyTotal accounts={accounts} colorize readAloud />
         {isMultiCurrency && convertedTotal !== null && (
           <span
             className="page-summary__converted"

--- a/apps/web/src/pages/BudgetsPage.test.tsx
+++ b/apps/web/src/pages/BudgetsPage.test.tsx
@@ -8,6 +8,7 @@ import { useCategories } from '../hooks/useCategories';
 import { useSyncStatus } from '../hooks/useSyncStatus';
 import { useTransactions } from '../hooks/useTransactions';
 import { useDisplayCurrency } from '../hooks/useDisplayCurrency';
+import { AccessibilityProvider } from '../contexts/AccessibilityContext';
 import { useExchangeRates } from '../hooks/useExchangeRates';
 
 vi.mock('../components/forms', () => ({
@@ -325,6 +326,20 @@ describe('BudgetsPage', () => {
         missingSubcategoryDefinitions: [],
       }),
     });
+  });
+
+  it('exposes a labelled read-aloud control for total remaining when "Read amounts aloud" is enabled (#3278)', () => {
+    render(
+      <AccessibilityProvider initialSettings={{ speakAmounts: true }}>
+        <MemoryRouter>
+          <BudgetsPage />
+        </MemoryRouter>
+      </AccessibilityProvider>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Read aloud: total remaining across budgets' }),
+    ).toBeInTheDocument();
   });
 
   it('renders without crashing', () => {

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { BudgetAnalytics } from '../components/budgets';
 import { ConfirmDialog } from '../components/common/ConfirmDialog';
 import { CurrencyDisplay } from '../components/common/CurrencyDisplay';
+import { ReadAloudButton } from '../components/common/ReadAloudButton';
 import { EmptyState } from '../components/common/EmptyState';
 import { ErrorBanner } from '../components/common/ErrorBanner';
 import { ExplainThis } from '../components/common/ExplainThis';
@@ -805,6 +806,10 @@ export const BudgetsPage: React.FC = () => {
                   <p className="card__title">Remaining</p>
                   <p className="card__value">
                     <CurrencyDisplay amount={totalRemaining} colorize />
+                    <ReadAloudButton
+                      amount={totalRemaining}
+                      context="total remaining across budgets"
+                    />
                   </p>
                 </div>
               </div>

--- a/apps/web/src/pages/CashRunwayPage.test.tsx
+++ b/apps/web/src/pages/CashRunwayPage.test.tsx
@@ -21,6 +21,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CashRunwayPage } from './CashRunwayPage';
 import { useAccounts } from '../hooks/useAccounts';
 import { useExchangeRates, type UseExchangeRatesResult } from '../hooks/useExchangeRates';
+import { AccessibilityProvider } from '../contexts/AccessibilityContext';
 import type { Account } from '../kmp/bridge';
 
 vi.mock('../hooks/useAccounts', () => ({ useAccounts: vi.fn() }));
@@ -120,6 +121,20 @@ describe('CashRunwayPage multi-currency starting cash (#3240)', () => {
       ...baseRatesResult,
       rates: { INR: usdToInr },
     });
+  });
+
+  it('exposes a labelled read-aloud control for the minimum projected balance when "Read amounts aloud" is enabled (#3278)', () => {
+    mockAccounts([cashAccount('usd', 'USD', 2, 200000)]);
+
+    render(
+      <AccessibilityProvider initialSettings={{ speakAmounts: true }}>
+        <CashRunwayPage />
+      </AccessibilityProvider>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Read aloud: minimum projected balance' }),
+    ).toBeInTheDocument();
   });
 
   it('converts each cash balance into the display currency before summing', () => {

--- a/apps/web/src/pages/CashRunwayPage.tsx
+++ b/apps/web/src/pages/CashRunwayPage.tsx
@@ -20,7 +20,7 @@
 
 import { useMemo, useState } from 'react';
 
-import { EmptyState, Icon } from '../components/common';
+import { EmptyState, Icon, ReadAloudButton } from '../components/common';
 import { IconToken } from '../icons/tokens';
 import { useAccounts } from '../hooks/useAccounts';
 import { useBills } from '../hooks/useBills';
@@ -295,6 +295,11 @@ export function CashRunwayPage() {
                   <span className="cash-runway__metric-sub">
                     on {formatDate(forecast.minBalanceDate, { locale })}
                   </span>
+                  <ReadAloudButton
+                    amount={forecast.minBalanceCents}
+                    currency={displayCurrency}
+                    context="minimum projected balance"
+                  />
                 </dd>
               </div>
               <div className="cash-runway__metric">

--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -24,6 +24,7 @@ import { calculateSafeToSpend } from '../lib/dashboard/safe-to-spend';
 import { evaluatePrivacyScreenCoverage } from '../lib/security/privacy-screen';
 import { auditPrivacySurfaceCoverage, privacySurface } from '../lib/security/privacy-coverage';
 import { DashboardPage } from './DashboardPage';
+import { AccessibilityProvider } from '../contexts/AccessibilityContext';
 
 const dashboardCss = readFileSync(resolve(process.cwd(), 'src/pages/DashboardPage.css'), 'utf8');
 
@@ -641,6 +642,20 @@ describe('DashboardPage', () => {
       updateTransaction: vi.fn(),
       deleteTransaction: vi.fn(),
     }));
+  });
+
+  it('exposes a labelled read-aloud control for net worth when "Read amounts aloud" is enabled (#3278)', async () => {
+    render(
+      <AccessibilityProvider initialSettings={{ speakAmounts: true }}>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </AccessibilityProvider>,
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Read aloud: net worth' }),
+    ).toBeInTheDocument();
   });
 
   it('renders without crashing', async () => {

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -5,7 +5,13 @@ import { Link } from 'react-router-dom';
 import type { TimePeriod, ViewType } from '../components/charts';
 import { AccountPurposeFilterControl } from '../components/accounts';
 import { RecentTransactionsCard } from '../components/transactions';
-import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import {
+  CurrencyDisplay,
+  EmptyState,
+  ErrorBanner,
+  LoadingSpinner,
+  ReadAloudButton,
+} from '../components/common';
 import { ExplainThis } from '../components/common/ExplainThis';
 import { OfflineBanner } from '../components/OfflineBanner';
 import {
@@ -889,6 +895,11 @@ export const DashboardPage: React.FC = () => {
                           amount={displayNetWorth}
                           currency={netWorthRollup.displayCurrency}
                           colorize
+                          context="net worth"
+                        />
+                        <ReadAloudButton
+                          amount={displayNetWorth}
+                          currency={netWorthRollup.displayCurrency}
                           context="net worth"
                         />
                       </div>

--- a/apps/web/src/pages/GoalsPage.test.tsx
+++ b/apps/web/src/pages/GoalsPage.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { useAccounts, useCategories, useGoals, useTransactions } from '../hooks';
 import { GoalsPage } from './GoalsPage';
+import { AccessibilityProvider } from '../contexts/AccessibilityContext';
 
 vi.mock('../hooks', () => ({
   useAccounts: vi.fn(),
@@ -353,6 +354,20 @@ describe('GoalsPage', () => {
       updateTransaction: vi.fn(),
       deleteTransaction: vi.fn(),
     });
+  });
+
+  it('exposes a labelled read-aloud control for total saved when "Read amounts aloud" is enabled (#3278)', () => {
+    render(
+      <AccessibilityProvider initialSettings={{ speakAmounts: true }}>
+        <MemoryRouter>
+          <GoalsPage />
+        </MemoryRouter>
+      </AccessibilityProvider>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Read aloud: total saved across goals' }),
+    ).toBeInTheDocument();
   });
 
   it('renders without crashing', () => {

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -8,6 +8,7 @@ import {
   EmptyState,
   ErrorBanner,
   LoadingSpinner,
+  ReadAloudButton,
   SortableList,
   useToast,
 } from '../components/common';
@@ -674,6 +675,7 @@ export const GoalsPage: React.FC = () => {
                     <p className="card__title">Saved</p>
                     <p className="card__value">
                       <CurrencyDisplay amount={totalSaved} />
+                      <ReadAloudButton amount={totalSaved} context="total saved across goals" />
                     </p>
                   </div>
                   <div>

--- a/apps/web/src/pages/InvestmentsPage.test.tsx
+++ b/apps/web/src/pages/InvestmentsPage.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { useInvestments } from '../hooks';
 import { InvestmentsPage } from './InvestmentsPage';
+import { AccessibilityProvider } from '../contexts/AccessibilityContext';
 
 vi.mock('../hooks', () => ({
   useInvestments: vi.fn(),
@@ -113,6 +114,20 @@ describe('InvestmentsPage', () => {
   beforeEach(() => {
     window.localStorage.clear();
     mockedUseInvestments.mockReturnValue(baseMockReturn);
+  });
+
+  it('exposes a labelled read-aloud control for total portfolio value when "Read amounts aloud" is enabled (#3278)', () => {
+    render(
+      <AccessibilityProvider initialSettings={{ speakAmounts: true }}>
+        <MemoryRouter>
+          <InvestmentsPage />
+        </MemoryRouter>
+      </AccessibilityProvider>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Read aloud: total portfolio value' }),
+    ).toBeInTheDocument();
   });
 
   it('renders portfolio summary with total value', () => {

--- a/apps/web/src/pages/InvestmentsPage.tsx
+++ b/apps/web/src/pages/InvestmentsPage.tsx
@@ -16,6 +16,7 @@ import {
   ErrorBanner,
   ExplainThis,
   LoadingSpinner,
+  ReadAloudButton,
 } from '../components/common';
 import { DataExport } from '../components/DataExport';
 import {
@@ -248,6 +249,11 @@ export const InvestmentsPage: React.FC = () => {
                   <p className="card__title">Total Value</p>
                   <p className="card__value" aria-live="polite">
                     <CurrencyDisplay amount={summary.totalValue} currency={displayCurrency} />
+                    <ReadAloudButton
+                      amount={summary.totalValue}
+                      currency={displayCurrency}
+                      context="total portfolio value"
+                    />
                   </p>
                 </div>
                 <div>

--- a/apps/web/src/pages/NetWorthPage.test.tsx
+++ b/apps/web/src/pages/NetWorthPage.test.tsx
@@ -11,6 +11,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { NetWorthPage } from './NetWorthPage';
+import { AccessibilityProvider } from '../contexts/AccessibilityContext';
 
 // Mock the hook
 vi.mock('../hooks/useNetWorth', () => ({
@@ -60,6 +61,27 @@ function makeNetWorthResult(overrides: Partial<UseNetWorthResult> = {}): UseNetW
 describe('NetWorthPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('exposes a labelled read-aloud control for net worth when "Read amounts aloud" is enabled (#3278)', () => {
+    mockUseNetWorth.mockReturnValue(
+      makeNetWorthResult({
+        currentNetWorth: {
+          label: '2024-03-15',
+          assets: 2000000,
+          liabilities: 500000,
+          netWorth: 1500000,
+        },
+      }),
+    );
+
+    render(
+      <AccessibilityProvider initialSettings={{ speakAmounts: true }}>
+        <NetWorthPage />
+      </AccessibilityProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Read aloud: net worth' })).toBeInTheDocument();
   });
 
   it('shows loading spinner while loading', () => {

--- a/apps/web/src/pages/NetWorthPage.tsx
+++ b/apps/web/src/pages/NetWorthPage.tsx
@@ -20,6 +20,7 @@ import {
   ErrorBanner,
   ExplainThis,
   LoadingSpinner,
+  ReadAloudButton,
 } from '../components/common';
 import { AccountPurposeFilterControl } from '../components/accounts';
 import { AppIcon } from '../components/icons';
@@ -253,6 +254,11 @@ export const NetWorthPage: React.FC = () => {
               }`}
             >
               <CurrencyDisplay amount={currentNetWorth.netWorth} currency={displayCurrency} />
+              <ReadAloudButton
+                amount={currentNetWorth.netWorth}
+                currency={displayCurrency}
+                context="net worth"
+              />
             </p>
             {periodComparison && (
               <NetWorthChangeIndicator comparison={periodComparison} currency={displayCurrency} />

--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -90,6 +90,7 @@ vi.mock('../components/common', () => ({
       </div>
     ) : null,
   CurrencyDisplay: ({ amount }: { amount: number }) => <span>{amount}</span>,
+  ReadAloudButton: () => null,
   DragDropProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
   DraggableTransaction: ({
     children,

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -16,6 +16,7 @@ import {
   ErrorBanner,
   ExplainThis,
   LoadingSpinner,
+  ReadAloudButton,
   SyncIndicator,
   useToast,
 } from '../components/common';
@@ -288,7 +289,7 @@ function getCurrentYearStartIsoDate(): string {
 
 export const TransactionsPage: React.FC = () => {
   const navigate = useNavigate();
-  const { isSimplified, speakAmounts, speakAmount } = useAccessibility();
+  const { isSimplified } = useAccessibility();
   const [searchParams, setSearchParams] = useSearchParams();
   const [query, setQuery] = useState('');
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -1756,21 +1757,12 @@ export const TransactionsPage: React.FC = () => {
                                   context={`${transactionLabel} transaction amount`}
                                 />
                               </div>
-                              {speakAmounts ? (
-                                <button
-                                  type="button"
-                                  className="transaction-item__text-action transactions-page__speech-button"
-                                  onClick={() =>
-                                    speakAmount(
-                                      getTransactionDisplayAmount(transaction),
-                                      transaction.currency.code,
-                                      `${transactionLabel} transaction amount`,
-                                    )
-                                  }
-                                >
-                                  Read amount
-                                </button>
-                              ) : null}
+                              <ReadAloudButton
+                                amount={getTransactionDisplayAmount(transaction)}
+                                currency={transaction.currency.code}
+                                context={`${transactionLabel} transaction amount`}
+                                label="Read amount"
+                              />
                               <div
                                 className="transaction-item__actions"
                                 aria-label="Transaction actions"

--- a/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useState } from 'react';
 
 import { CurrencyDisplay } from '../../components/common/CurrencyDisplay';
+import { ReadAloudButton } from '../../components/common/ReadAloudButton';
 import { CategorizationSettings } from '../../components/categorization';
 import {
   HapticSettings,
@@ -111,7 +112,6 @@ export const SettingsPreferencesPage: React.FC = () => {
     setReduceMotion,
     setHighContrast,
     setSpeakAmounts,
-    speakAmount,
   } = useAccessibility();
   const displaySettings = useMoneyDisplay();
   // Display currency is the shared, app-wide preference (single source of
@@ -518,21 +518,12 @@ export const SettingsPreferencesPage: React.FC = () => {
                     className="accessibility-preview__amount"
                     context="Available for groceries, medications, and household bills"
                   />
-                  {speakAmounts ? (
-                    <button
-                      type="button"
-                      className="transaction-item__text-action accessibility-preview__speak-button"
-                      onClick={() =>
-                        speakAmount(
-                          248000,
-                          currency,
-                          'Available for groceries, medications, and household bills',
-                        )
-                      }
-                    >
-                      Read amount aloud
-                    </button>
-                  ) : null}
+                  <ReadAloudButton
+                    amount={248000}
+                    currency={currency}
+                    context="Available for groceries, medications, and household bills"
+                    label="Read amount aloud"
+                  />
                 </div>
                 <p className="accessibility-preview__note">
                   Essential pages stay visible, controls become larger, and buttons use clearer

--- a/apps/web/src/styles/accessibility.css
+++ b/apps/web/src/styles/accessibility.css
@@ -425,6 +425,7 @@ body.accessibility-simplified .more-sheet__item,
 body.accessibility-simplified .settings-item__select,
 body.accessibility-simplified .settings-item__input,
 body.accessibility-simplified .transaction-item__text-action,
+body.accessibility-simplified .read-aloud-button,
 body.accessibility-simplified .icon-button {
   font-size: 1rem;
   font-weight: var(--font-weight-semibold, 600);
@@ -582,6 +583,41 @@ body.accessibility-simplified .transactions-page--simplified .transaction-list-i
 .transactions-page__speech-button,
 .accessibility-preview__speak-button {
   background: var(--semantic-background-secondary, #f3f4f6);
+}
+
+/*
+ * Read-aloud control for primary amounts (#3278).
+ *
+ * Opt-in via the "Read amounts aloud" accessibility preference. Meaning is
+ * conveyed by the text label, border, and speaker icon — never colour alone
+ * (WCAG 2.2 §1.4.1). Uses semantic tokens so it flips correctly under the
+ * high-contrast palettes defined above, and inherits the base
+ * :focus-visible ring for keyboard operation.
+ */
+.read-aloud-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-1, 4px);
+  min-height: 40px;
+  margin-inline-start: var(--spacing-2, 8px);
+  padding: var(--spacing-2, 8px) var(--spacing-3, 12px);
+  border: 1px solid var(--semantic-border-default, #111111);
+  border-radius: var(--border-radius-md, 8px);
+  background: var(--semantic-background-secondary, #f3f4f6);
+  color: var(--semantic-text-primary, #111111);
+  font: inherit;
+  line-height: 1.2;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.read-aloud-button__icon {
+  flex: none;
+}
+
+.read-aloud-button__label {
+  white-space: nowrap;
 }
 
 body.accessibility-simplified .transaction-item__actions {


### PR DESCRIPTION
## Summary

Extends the opt-in **Read amounts aloud** accessibility feature (#3278) beyond the Transactions list and the Settings preview to every primary financial surface that shows a headline amount.

## Changes

- **New reusable `ReadAloudButton`** (`apps/web/src/components/common/`) that consumes the existing `speakAmount` helper from `AccessibilityContext` — a single implementation, **no per-page fork**. It renders nothing unless the user has enabled _Read amounts aloud_.
- **Wired into the hero amount** on Dashboard (net worth), Accounts (total net worth), Net Worth, Budgets (total remaining), Goals (total saved), Investments (total portfolio value), and Cash Runway (minimum projected balance).
- **Refactored** the two existing inline read-aloud buttons on `TransactionsPage` and `SettingsPreferencesPage` onto the shared component (removes the earlier fork).
- **Styles** in `accessibility.css` use semantic tokens (high-contrast safe), a 40px min touch target, a decorative `aria-hidden` speaker icon, and inherit the global `:focus-visible` ring.
- **Tests**: new `ReadAloudButton.test.tsx` (null when disabled; keyboard-operable + labelled when enabled; speaks on click; `aria-hidden` icon) plus per-page presence tests asserting the labelled control renders on each newly-covered page. Updated the `TransactionsPage` `components/common` mock to include the new export.

## Accessibility (WCAG 2.2 AA)

- **4.1.2 / keyboard operability**: native `<button type="button">` — reachable and operable by keyboard, no custom key handling required.
- **2.5.3 Label in Name**: the accessible name always begins with the visible label; the per-amount `context` (e.g. "net worth", "total remaining across budgets") makes each control's name unique.
- **1.4.1 Use of Color**: meaning is carried by text + border + icon, never colour alone; the control stays legible under the high-contrast palette via semantic tokens.

## Notes

- **#3294 (High Contrast in Onboarding) is already implemented on `main`.** `OnboardingPage` already offers a High Contrast toggle alongside Text Size and Reduce Motion (wired through `applyComfortPreferences` → `applyTheme('high-contrast')`), and an existing onboarding test covers it. This PR therefore **does not** include a `Closes #3294` line — it only closes #3278.
- **Estate** is intentionally excluded from read-aloud: it renders item counts, not monetary amounts.
- Per coordination with the concurrent session, this PR does **not** touch router route definitions or any document/tab-title files.

## Testing

- [x] `ReadAloudButton.test.tsx` — 6/6 pass
- [x] Per-page presence tests (Dashboard, Accounts, Net Worth, Budgets, Goals, Investments, Cash Runway) pass
- [x] Refactored `TransactionsPage` (29/29) and `SettingsPreferencesPage` suites pass
- [x] `prettier --check` and `eslint --max-warnings 0` clean on changed files
- ℹ️ A pre-existing, unrelated `DashboardPage > has accessible landmarks` test (lazy "mood and spending journal" dynamic import) times out locally on `main` as well; remote CI is the source of truth.

Closes #3278
