### PR TITLE
test(web): stabilize lazy-loaded a11y assertions under parallel load (#3523)

### DIFF
--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -184,6 +184,19 @@ describe('calculateSafeToSpend', () => {
 });
 
 describe('DashboardPage', () => {
+  // The mood-journal section is code-split via React.lazy (DashboardPage.tsx).
+  // Warm its dynamic import once, up front, so the module graph is transformed
+  // and evaluated OUTSIDE the findBy* timeout window. Under full-suite parallel
+  // CPU contention a cold import() can otherwise resolve slower than the
+  // landmark query's timeout, flaking the assertion (#3523). Pre-resolving it
+  // lets React.lazy render from the module cache so the real region landmark
+  // settles immediately — assertion intact. The hook gets a generous explicit
+  // timeout so this one-time cold transform is never killed by Vitest's default
+  // 10s hook timeout under pathological parallel load.
+  beforeAll(async () => {
+    await import('../components/dashboard/DashboardMoodJournalSection');
+  }, 60_000);
+
   beforeEach(() => {
     window.localStorage.clear();
     mockedUseRetirementPlanner.mockReturnValue({
@@ -963,10 +976,11 @@ describe('DashboardPage', () => {
       </MemoryRouter>,
     );
     expect(screen.getByRole('region', { name: /financial summary/i })).toBeInTheDocument();
-    // The mood journal is a lazily-loaded landmark; `findByRole` re-scans the
-    // dashboard accessibility tree on every poll. Allow extra time so the
-    // dynamic import can resolve and the role query settle, even when the full
-    // test suite runs in parallel and CPU is contended.
+    // The mood journal is a lazily-loaded landmark. Its chunk is pre-warmed in
+    // `beforeAll`, so React.lazy resolves from the module cache and `findByRole`
+    // only has to retry until the post-Suspense re-render commits. The generous
+    // timeout is a safety net for that settle (not the module load), keeping the
+    // assertion deterministic even under full-suite parallel CPU contention.
     expect(
       await screen.findByRole('region', { name: /mood and spending journal/i }, { timeout: 3000 }),
     ).toBeInTheDocument();

--- a/apps/web/src/pages/HouseholdPage.test.tsx
+++ b/apps/web/src/pages/HouseholdPage.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuth } from '../auth/auth-context';
 import { useToast } from '../components/common/Toast';
@@ -481,6 +481,19 @@ describe('household kids helpers', () => {
 });
 
 describe('HouseholdPage', () => {
+  // The couples "Money check-in" dialog body is code-split via lazy() in
+  // HouseholdPage.tsx. Warm its dynamic import once, up front, so the module is
+  // transformed and evaluated OUTSIDE the findByRole timeout window. Under
+  // full-suite parallel CPU contention a cold import() can otherwise resolve
+  // slower than the dialog query's timeout, flaking the assertion (#3523).
+  // Pre-resolving it lets React.lazy render from the module cache so the real
+  // dialog settles immediately — assertion intact. The hook gets a generous
+  // explicit timeout so this one-time cold transform is never killed by
+  // Vitest's default 10s hook timeout under pathological parallel load.
+  beforeAll(async () => {
+    await import('../components/household/MoneyCheckInDialog');
+  }, 60_000);
+
   beforeEach(() => {
     vi.clearAllMocks();
     // Default: no signed-in user.  Tests that exercise the OAuth-fallback
@@ -604,8 +617,11 @@ describe('HouseholdPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Start a money check-in/i }));
 
-    // Dialog body is lazy-loaded into its own chunk; wait for it to resolve.
-    const dialog = await screen.findByRole('dialog');
+    // Dialog body is lazy-loaded into its own chunk. The chunk is pre-warmed in
+    // `beforeAll` so React.lazy resolves from the module cache; `findByRole`
+    // retries until the post-Suspense re-render commits. The explicit timeout is
+    // a safety net for that settle under full-suite parallel load (#3523).
+    const dialog = await screen.findByRole('dialog', undefined, { timeout: 3000 });
     expect(within(dialog).getByRole('heading', { name: /Opt in together/i })).toBeInTheDocument();
     expect(within(dialog).getAllByRole('checkbox', { name: /opts in/i }).length).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary

Two `React.lazy()`-gated accessibility assertions in the web app timed out **only** under full-suite parallel CPU contention (both pass in isolation, 48/48):

1. `DashboardPage > has accessible landmarks` — the mood-journal `region` landmark, rendered inside the lazy `DashboardMoodJournalSection`.
2. `HouseholdPage > surfaces a supportive money check-in card` — the lazy `MoneyCheckInDialog`.

This is a **test-infra flake, not a product defect**. The assertions are intact and still run against the real components.

## Root cause

The first test to render each `React.lazy(() => import(...))` section pays the **cold dynamic-import cost** (Vite transform + eval of the module graph). Under full-suite parallel CPU starvation that one-time cost exceeds the `findBy*` poll window, so the role query times out.

## Fix

Warm each lazy chunk exactly once in a `beforeAll` that awaits the **same import specifier** `React.lazy` uses, so the transform/eval is pre-paid **outside** any assertion timeout. When the test renders, `React.lazy` resolves from the module cache within a microtask and the (retrying) `findByRole` settles immediately.

- The `beforeAll` hooks are given an explicit **60s hook timeout** so the one-time cold transform is never killed by Vitest's default 10s `hookTimeout` under pathological load (which would otherwise skip the whole block).
- Assertions are **unchanged**; a defensive 3000ms settle timeout is retained on both queries.
- **Test-only change** — no production code touched.

## Changes

- `apps/web/src/pages/DashboardPage.test.tsx` — import `beforeAll`; warm `DashboardMoodJournalSection` in a `beforeAll` (60s timeout); clarifying comments.
- `apps/web/src/pages/HouseholdPage.test.tsx` — import `beforeAll`; warm `MoneyCheckInDialog` in a `beforeAll` (60s timeout); dialog query uses `await screen.findByRole('dialog', undefined, { timeout: 3000 })`.

## Testing

Reproduced under an artificial CPU-contention load loop with `vitest run --maxWorkers=10` (full suite = 864 files / 9514 tests):

- **Baseline (fix stashed):** 1 failed / 9509 passed — the *only* failure was `DashboardPage > has accessible landmarks` (5757ms timeout). Deterministic reproduction.
- **With fix, run A:** 9514 / 9514 passed under identical load.
- **With fix, run B:** 9514 / 9514 passed under identical load.
- Isolation: both files 48/48 (2x).
- `npm run format:check` ✅ and `npx eslint . --max-warnings 0` ✅ both clean.

## Issues

Closes #3523