### PR TITLE
fix(sync): restore valid PowerSync sync rules to end production 502 (#3528)

### DIFF
--- a/services/api/powersync/sync-rules.yaml
+++ b/services/api/powersync/sync-rules.yaml
@@ -53,27 +53,36 @@ bucket_definitions:
       # CHANGED (#1326): Added `tags` (needed by clients for tag display/filtering).
       # CHANGED (#1326): Removed legacy `recurring_rule` column — `recurring_rule_id`
       #   (the proper FK) is already present and is what clients use.
+      # CHANGED (#3528): Reverted the biometric-protection filter. A PowerSync data
+      #   query may not JOIN another table or reference token_parameters, so the
+      #   `LEFT JOIN categories` + `token_parameters.user_id` clause was a fatal
+      #   sync-rules error that crash-looped the replicator (production 502).
+      #   Hiding protected-category transactions from non-owners requires a
+      #   denormalized `is_biometric_protected` column on `transactions` — tracked
+      #   as a follow-up; see #3528.
       - >
-        SELECT t.id, t.household_id, t.account_id, t.category_id, t.amount_cents,
-               t.currency_code, t.type, t.payee, t.note, t.date, t.is_recurring,
-               t.transfer_account_id, t.status,
-               t.transfer_transaction_id, t.recurring_rule_id, t.tags, t.owner_id,
-               t.created_at, t.updated_at, t.deleted_at
-        FROM transactions t
-        LEFT JOIN categories c ON c.id = t.category_id AND c.deleted_at IS NULL
-        WHERE t.household_id = bucket.household_id AND t.deleted_at IS NULL
-          AND (COALESCE(c.is_biometric_protected, false) = false OR t.owner_id = token_parameters.user_id)
+        SELECT id, household_id, account_id, category_id, amount_cents,
+               currency_code, type, payee, note, date, is_recurring,
+               transfer_account_id, status,
+               transfer_transaction_id, recurring_rule_id, tags, owner_id,
+               created_at, updated_at, deleted_at
+        FROM transactions
+        WHERE household_id = bucket.household_id AND deleted_at IS NULL
 
       # Spending / income categories
       # CHANGED (#1326): Added `is_system` (clients need to distinguish
       #   system-provided categories from user-created ones).
+      # CHANGED (#3528): Reverted the biometric-protection filter — a PowerSync data
+      #   query may not reference token_parameters (fatal sync-rules error). The
+      #   `is_biometric_protected` flag is still synced so clients can gate display
+      #   locally; server-side owner-only filtering (owner_id = bucket.user_id via a
+      #   user-scoped bucket) is a follow-up. See #3528.
       - >
         SELECT id, household_id, name, icon, color, parent_id, is_income,
                is_system, sort_order, is_biometric_protected, owner_id,
                created_at, updated_at, deleted_at
         FROM categories
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
-          AND (is_biometric_protected = false OR owner_id = token_parameters.user_id)
 
       # Budget allocations per category/period
       # CHANGED (#1326): Added `name` (Budget model has a name field that


### PR DESCRIPTION
## Summary

Production PowerSync has been down (Caddy `502` on `/sync/`) because the replicator crash-loops on **invalid sync rules**. Two data queries in `services/api/powersync/sync-rules.yaml` (the `by_household` bucket) use constructs PowerSync sync-rule **data queries forbid**, introduced by the biometric-protected-categories work in `72f472af` (#1883):

- **transactions** — `FROM transactions t LEFT JOIN categories c …` → `Must SELECT from a single table`, **and** `token_parameters.user_id` in the `WHERE` → `Undefined reference: token_parameters.user_id`.
- **categories** — `token_parameters.user_id` in the `WHERE` → same `Undefined reference` error.

Token parameters are only valid inside a bucket's `parameters:` query, never a `data:` query, and data queries can't JOIN. The service threw a `fatal` sync-rules error on startup and never came up. Diagnosed live on the production VM via Azure Run-command.

## Changes

- Revert the **transactions** data query to a single-table select (drop the `LEFT JOIN categories` and the biometric `WHERE` clause); keep all schema-aligned columns (`transfer_transaction_id`, `recurring_rule_id`, `tags`, `owner_id`).
- Revert the **categories** data query to drop the `token_parameters.user_id` clause; keep the `is_biometric_protected` column in the output so clients can still gate display locally.
- Add `CHANGED (#3528)` comments explaining why the biometric filter was removed and what the correct fix requires.

Net: `+19 / −10`, one file. Every remaining query already follows these valid patterns.

## Why revert rather than fix the feature here

The biometric filter **never functioned in production** — it crash-looped the replicator from the moment #1883 merged, so there is no working behavior to lose. Implementing it *correctly* is a deliberate, separate change (PowerSync forbids JOINs / `token_parameters` in data queries):

- **categories** → filter with a bucket parameter (`owner_id = bucket.user_id`) via a user-scoped bucket.
- **transactions** → protection status lives on the joined `categories` row, so it needs `is_biometric_protected` **denormalized onto `transactions`** (migration + backfill + trigger).

Tracked in #3528 as a follow-up so it can go through proper schema + security review instead of being guessed at during an outage.

## Issues

Closes #3528

## Testing

- [x] `npx prettier --check services/api/powersync/sync-rules.yaml` — passes (validates YAML parse + format)
- [x] Grep confirms no `token_parameters` and no `JOIN` remain in any data query (only in the two legal `parameters:` queries + explanatory comments)
- [x] Bucket structure intact (`by_household`, `user_profile`, `exchange_rates`)
- [ ] Post-merge: pull onto the production VM and `docker compose restart powersync`; confirm `/sync/` returns healthy and the `postgresql-postgres` replicator starts

## Deploy note

The sync-rules file is bind-mounted into the `powersync` container (`services/api/powersync/sync-rules.yaml` → `/config/sync-config.yaml`, read-only), so applying the fix on the VM is: update the checkout to this commit, then restart `powersync`.