### PR TITLE
fix(ci): install devDependencies for production web VM rebuild (#3531)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -414,13 +414,15 @@ jobs:
             export VITE_ENVIRONMENT=production
             export VITE_APP_VERSION="$SHA_SHORT"
             export NODE_ENV=production
+            export HUSKY=0  # husky is a devDep; skip its git-hook install on the production VM
             cd "$DEPLOY_PATH"
             echo "→ git fetch --force --prune origin main"
             git fetch --force --prune origin main
             echo "→ git reset --hard $TARGET_SHA"
             git reset --hard "$TARGET_SHA"
             echo "→ npm ci (this can take a few minutes on first run)"
-            npm ci --no-audit --no-fund --silent
+            # Build from source needs devDependencies (vite, style-dictionary); NODE_ENV=production alone would omit them
+            npm ci --include=dev --no-audit --no-fund --silent
             echo "→ build design tokens"
             npm run build -w packages/design-tokens --silent
             echo "→ build apps/web"
@@ -730,8 +732,10 @@ jobs:
               export VITE_ENVIRONMENT=production
               export VITE_APP_VERSION="$ROLLBACK_TAG"
               export NODE_ENV=production
+              export HUSKY=0  # husky is a devDep; skip its git-hook install on the production VM
               echo "→ npm ci"
-              npm ci --no-audit --no-fund --silent
+              # Build from source needs devDependencies (vite, style-dictionary); NODE_ENV=production alone would omit them
+              npm ci --include=dev --no-audit --no-fund --silent
               echo "→ build design tokens"
               npm run build -w packages/design-tokens --silent
               echo "→ build apps/web"


### PR DESCRIPTION
## Summary

The production `deploy-web` job (and the `rollback` job) rebuild `apps/web/dist` on the Azure VM. They exported `NODE_ENV=production` **before** `npm ci`, which makes npm omit `devDependencies`. The root `package.json` has `"prepare": "husky"` and `husky` is a devDependency, so the `prepare` lifecycle script failed with `husky: not found` (exit 127). Omitting devDeps also meant the build tools (`vite`, `style-dictionary`) were absent, so the build would have failed regardless — this VM web-rebuild path has never succeeded, which is why every prior production deploy run failed here.

`deploy-backend` was unaffected because it rebuilds Docker images and runs no host `npm ci`.

## Changes

- `deploy-web` and `rollback` jobs: `npm ci` → `npm ci --include=dev` so build-time devDependencies (husky, vite, style-dictionary) install even under `NODE_ENV=production`.
- Added `export HUSKY=0` so husky's git-hook install is skipped on the production VM (devDep present, but no hooks needed there).
- Inline comments explaining both.

## Root cause

`NODE_ENV=production` + `npm ci` omits devDependencies → `prepare: husky` can't find the `husky` binary → exit 127. Observed in run `28962946423`.

## Issues

Closes #3531

## Testing

- [x] Prettier passes (`npx prettier --check .github/workflows/deploy-production.yml`)
- [x] Change is confined to the two VM `npm ci` invocations; deploy-backend path untouched
- [ ] End-to-end verified by re-running `Deploy — Production` after merge