### PR TITLE
fix(ci): extend verify-ci-green check discovery to 10 min (#3533)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -280,6 +280,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
           allowed-conclusions: success,skipped
+          # Wait up to 10 min for the gatekeeper check-run to be discovered. When a
+          # deploy is triggered right after a squash-merge, the push-triggered
+          # `ci-security.yml` gatekeeper may not register its check-run within the
+          # action's 60s default, which fails the gate on a commit whose CI actually
+          # passes moments later (#3533). 600s stays well inside this job's 30-min timeout.
+          checks-discovery-timeout: '600'
 
   smoke-tests:
     name: Pre-deploy Smoke Tests


### PR DESCRIPTION
## Summary

The production `verify-ci-green` gate waits for the `Required Checks Gatekeeper` check on the target SHA using `lewagon/wait-on-check-action`, but did not set `checks-discovery-timeout` — so it used the action's **60s** default to *discover* the check. Triggering a deploy shortly after a squash-merge fails during discovery because the push-triggered `ci-security.yml` gatekeeper hasn't registered its check-run yet, even though it passes moments later.

Confirmed in run `28964869728` (SHA `a190fa4e`): the deploy's discovery window was `18:06:55–18:07:58`, but the `Required Checks Gatekeeper` check-run didn't start until `18:08:15` (green at `18:10:15`) → `The requested check was never run against this ref`.

## Changes

- `verify-ci-green` job: add `checks-discovery-timeout: '600'` (10 min) with an explanatory comment. This stays well inside the job's existing `timeout-minutes: 30`, and `fail-on-no-checks` remains `true` so a SHA that genuinely never ran CI still fails the gate.

## Root cause

`wait-on-check-action` default `checks-discovery-timeout` is 60s; the push-triggered gatekeeper check-run can take longer than that to appear on a fresh merge commit → false-negative gate failure.

## Issues

Closes #3533

## Testing

- [x] Prettier passes (`npx prettier --check .github/workflows/deploy-production.yml`)
- [x] Change is a single input addition to the existing gate step; `fail-on-no-checks` behavior unchanged
- [ ] Confirmed durable by a future post-merge deploy triggered immediately after merge