### PR TITLE
fix(web): themed scrollbar for sidebar navigation (#3536)

### DIFF
--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -977,6 +977,27 @@
   .app-sidebar__nav {
     flex: 1;
     overflow-y: auto;
+    /* Themed scrollbar — Firefox / standards. Track blends into the navy
+       sidebar; thumb uses the theme-aware border token so it follows
+       light/dark automatically (#3536). */
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--semantic-border-default) 70%, transparent) transparent;
+  }
+  /* Themed scrollbar — Chromium / WebKit, scoped to the sidebar nav. */
+  .app-sidebar__nav::-webkit-scrollbar {
+    width: 8px;
+  }
+  .app-sidebar__nav::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .app-sidebar__nav::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--semantic-border-default) 70%, transparent);
+    border: 2px solid transparent;
+    border-radius: var(--border-radius-md);
+    background-clip: padding-box;
+  }
+  .app-sidebar__nav::-webkit-scrollbar-thumb:hover {
+    background-color: var(--semantic-interactive-default);
   }
   .app-sidebar__footer {
     display: grid;


### PR DESCRIPTION
## Summary

The web app's left sidebar navigation (`.app-sidebar__nav`) rendered the default stock OS/browser scrollbar — a light-gray bar that clashed with the app's dark navy navigation. This applies a custom, themed scrollbar cohesive with the design system, matching the pattern already used by the dashboard "customize" panel list.

## Changes

- Add a thin, theme-aware scrollbar to `.app-sidebar__nav` in `apps/web/src/styles/responsive.css`:
  - **Firefox / standards**: `scrollbar-width: thin` + `scrollbar-color` using a translucent `--semantic-border-default` thumb over a transparent track.
  - **Chromium / WebKit**: `::-webkit-scrollbar` (8px), transparent track, translucent border-token thumb with `background-clip: padding-box`, and a `--semantic-interactive-default` hover state.
- Driven entirely by existing theme-aware CSS tokens (`--semantic-border-default`, `--semantic-interactive-default`, `--border-radius-md`), so it follows light/dark themes automatically — no new tokens introduced.
- Scoped to the sidebar nav scroll container only; the scroll affordance stays visible and usable (accessibility preserved).

## Issues

Closes #3536

## Testing

- [x] Prettier passes on the changed file (`npx prettier --check apps/web/src/styles/responsive.css`)
- [x] CSS-only change; reuses the proven themed-scrollbar approach from `dashboard.css`
- [x] Thumb/track tokens are theme-aware (light/dark + high-contrast variants defined in `theme/tokens.css`)