### PR TITLE
feat(auth): add Microsoft (Azure) OAuth sign-in

### DIFF
--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -29,6 +29,7 @@ test('keeps social sign-in outside the collapsible email form (#3178)', async ({
   const oauthSection = page.locator('.auth-oauth-section');
   await expect(oauthSection.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
   await expect(oauthSection.getByRole('button', { name: 'Sign in with GitHub' })).toBeVisible();
+  await expect(oauthSection.getByRole('button', { name: 'Sign in with Microsoft' })).toBeVisible();
   await expect(oauthSection.getByRole('button', { name: 'Sign in with Apple' })).toBeVisible();
 
   // None of the social buttons may be nested inside the collapsible email form.

--- a/apps/web/src/auth/auth-context.test.tsx
+++ b/apps/web/src/auth/auth-context.test.tsx
@@ -529,16 +529,17 @@ describe('oauthProviderUnavailableMessage (#3187)', () => {
     expect(oauthProviderUnavailableMessage('google')).toContain('Google sign-in');
     expect(oauthProviderUnavailableMessage('github')).toContain('GitHub sign-in');
     expect(oauthProviderUnavailableMessage('apple')).toContain('Apple sign-in');
+    expect(oauthProviderUnavailableMessage('azure')).toContain('Microsoft sign-in');
   });
 
   it('always points the user at the email & password fallback', () => {
-    for (const provider of ['google', 'github', 'apple'] as const) {
+    for (const provider of ['google', 'github', 'apple', 'azure'] as const) {
       expect(oauthProviderUnavailableMessage(provider)).toContain('email & password');
     }
   });
 
   it('never leaks the raw GoTrue "provider is not enabled" string', () => {
-    for (const provider of ['google', 'github', 'apple'] as const) {
+    for (const provider of ['google', 'github', 'apple', 'azure'] as const) {
       expect(oauthProviderUnavailableMessage(provider)).not.toContain('provider is not enabled');
       expect(oauthProviderUnavailableMessage(provider)).not.toContain('validation_failed');
     }

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -118,8 +118,13 @@ export interface AuthActions {
   signupWithEmail: (email: string, password: string) => Promise<SignupResult>;
 }
 
-/** Supported OAuth providers. */
-export type OAuthProvider = 'google' | 'github' | 'apple';
+/**
+ * Supported OAuth providers.
+ *
+ * `azure` is Supabase GoTrue's slug for Microsoft sign-in — the value we
+ * forward to the auth broker and show to users as "Microsoft".
+ */
+export type OAuthProvider = 'google' | 'github' | 'apple' | 'azure';
 
 /** The shape of the auth context value. */
 export interface AuthContextValue extends AuthActions {
@@ -216,6 +221,7 @@ const OAUTH_PROVIDER_LABELS: Record<OAuthProvider, string> = {
   google: 'Google',
   github: 'GitHub',
   apple: 'Apple',
+  azure: 'Microsoft',
 };
 
 /**

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -226,6 +226,7 @@ describe('LoginPage', () => {
       // live inside the hidden form (the bug this fixes).
       expect(screen.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
       expect(screen.getByRole('button', { name: 'Sign in with GitHub' })).toBeVisible();
+      expect(screen.getByRole('button', { name: 'Sign in with Microsoft' })).toBeVisible();
       expect(screen.getByRole('button', { name: 'Sign in with Apple' })).toBeVisible();
     });
 

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -479,6 +479,23 @@ export const LoginPage: React.FC = () => {
               type="button"
               className="form-button form-button--secondary auth-oauth-button"
               onClick={() => {
+                void loginWithOAuth('azure');
+              }}
+              disabled={isBusy}
+              aria-label="Sign in with Microsoft"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                <path fill="#F25022" d="M2 2h9.5v9.5H2z" />
+                <path fill="#7FBA00" d="M12.5 2H22v9.5h-9.5z" />
+                <path fill="#00A4EF" d="M2 12.5h9.5V22H2z" />
+                <path fill="#FFB900" d="M12.5 12.5H22V22h-9.5z" />
+              </svg>
+              Microsoft
+            </button>
+            <button
+              type="button"
+              className="form-button form-button--secondary auth-oauth-button"
+              onClick={() => {
                 void loginWithOAuth('apple');
               }}
               disabled={isBusy}

--- a/docs/auth/oauth-provider-enablement.md
+++ b/docs/auth/oauth-provider-enablement.md
@@ -5,16 +5,20 @@
 > **Related:** [`oauth-setup.md`](./oauth-setup.md) (per-provider credential setup)
 
 This document explains **why** the social sign-in buttons (Continue with
-Google / GitHub / Apple) can fail on a deployed environment and the **exact
-configuration a human must apply** to enable them. Enabling providers requires
-real OAuth credentials, which are secret-gated — **an AI agent cannot perform
-this step.** This doc gives the operator a copy-paste checklist.
+Google / GitHub / Microsoft / Apple) can fail on a deployed environment and the
+**exact configuration a human must apply** to enable them. Enabling providers
+requires real OAuth credentials, which are secret-gated — **an AI agent cannot
+perform this step.** This doc gives the operator a copy-paste checklist.
+
+> **Microsoft = `azure`.** Supabase GoTrue brokers Microsoft sign-in under the
+> `azure` provider slug. Everywhere below where a provider slug appears
+> (env var names, the `/settings.external` map), Microsoft is `azure`.
 
 ## Symptom
 
-On the deployed site, clicking **Continue with Google / GitHub / Apple** on
-`/login` fails. Before the app-side hardening (#3188/#3187) the browser landed
-on a raw JSON page:
+On the deployed site, clicking **Continue with Google / GitHub / Microsoft /
+Apple** on `/login` fails. Before the app-side hardening (#3188/#3187) the
+browser landed on a raw JSON page:
 
 ```
 400 validation_failed — "Unsupported provider: provider is not enabled"
@@ -58,7 +62,8 @@ There are two deployment shapes. Use whichever matches your environment.
 ### Option A — Supabase Cloud (Dashboard)
 
 1. Open the [Supabase Dashboard](https://supabase.com/dashboard) → your project.
-2. **Authentication → Providers →** _Google_ / _GitHub_ / _Apple_.
+2. **Authentication → Providers →** _Google_ / _GitHub_ / _Azure (Microsoft)_ /
+   _Apple_.
 3. Toggle **Enable**, then paste the provider's **Client ID** and **Client
    Secret** (obtain these per [`oauth-setup.md`](./oauth-setup.md)).
 4. **Authentication → URL Configuration → Redirect URLs**: add the app callback
@@ -89,6 +94,16 @@ GOTRUE_EXTERNAL_APPLE_CLIENT_ID=YOUR_APPLE_SERVICES_ID
 GOTRUE_EXTERNAL_APPLE_SECRET=YOUR_APPLE_CLIENT_SECRET_JWT
 GOTRUE_EXTERNAL_APPLE_REDIRECT_URI=https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback
 
+# ── Microsoft (azure) ────────────────────────────────────────────────────
+# GoTrue brokers Microsoft under the `azure` slug. The default tenant is
+# `common` (personal + work/school accounts); set AZURE_URL to a specific
+# tenant (e.g. https://login.microsoftonline.com/<tenant-id>) to restrict it.
+GOTRUE_EXTERNAL_AZURE_ENABLED=true
+GOTRUE_EXTERNAL_AZURE_CLIENT_ID=YOUR_AZURE_APPLICATION_CLIENT_ID
+GOTRUE_EXTERNAL_AZURE_SECRET=YOUR_AZURE_CLIENT_SECRET
+GOTRUE_EXTERNAL_AZURE_REDIRECT_URI=https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback
+GOTRUE_EXTERNAL_AZURE_URL=https://login.microsoftonline.com/common
+
 # Allow GoTrue to redirect back to our app callback after the provider hop.
 # Comma-separated allow list — include the app's oauth-callback URL.
 GOTRUE_URI_ALLOW_LIST=https://YOUR_APP_DOMAIN/api/auth/oauth-callback
@@ -115,11 +130,11 @@ match the app's public origin and be present in `GOTRUE_URI_ALLOW_LIST`.
 
 ## Redirect URL summary
 
-| Where                                                      | Value                                                    |
-| ---------------------------------------------------------- | -------------------------------------------------------- |
-| Provider console (Google/GitHub/Apple) authorized redirect | `https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback` |
-| GoTrue `..._REDIRECT_URI`                                  | `https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback` |
-| GoTrue `GOTRUE_URI_ALLOW_LIST` / Dashboard Redirect URLs   | `https://YOUR_APP_DOMAIN/api/auth/oauth-callback`        |
+| Where                                                                | Value                                                    |
+| -------------------------------------------------------------------- | -------------------------------------------------------- |
+| Provider console (Google/GitHub/Microsoft/Apple) authorized redirect | `https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback` |
+| GoTrue `..._REDIRECT_URI`                                            | `https://YOUR_SUPABASE_REF.supabase.co/auth/v1/callback` |
+| GoTrue `GOTRUE_URI_ALLOW_LIST` / Dashboard Redirect URLs             | `https://YOUR_APP_DOMAIN/api/auth/oauth-callback`        |
 
 ## Verification checklist
 

--- a/docs/auth/oauth-setup.md
+++ b/docs/auth/oauth-setup.md
@@ -3,9 +3,10 @@
 > **Issue:** #1241
 > **Branch:** `feat/oauth-scaffolding-1241`
 
-This document describes how to configure Google Sign-In and Apple Sign-In
-for the Finance app across all platforms, using **Supabase Auth** as the
-identity broker.
+This document describes how to configure Google, Microsoft (Azure), and Apple
+Sign-In for the Finance app across all platforms, using **Supabase Auth** as the
+identity broker. (GitHub is enabled the same way — see
+[`oauth-provider-enablement.md`](./oauth-provider-enablement.md).)
 
 > **Deploying?** For the exact environment configuration required to
 > **enable** providers in a live Supabase deployment (including the
@@ -43,6 +44,8 @@ never see or handle authorization codes directly — they call
 | -------------------------------- | ---------------------------------------- |
 | `SUPABASE_AUTH_GOOGLE_CLIENT_ID` | Same as `VITE_GOOGLE_CLIENT_ID`          |
 | `SUPABASE_AUTH_GOOGLE_SECRET`    | Google OAuth 2.0 Client Secret           |
+| `SUPABASE_AUTH_AZURE_CLIENT_ID`  | Microsoft Entra Application (client) ID  |
+| `SUPABASE_AUTH_AZURE_SECRET`     | Microsoft Entra client secret value      |
 | `SUPABASE_AUTH_APPLE_CLIENT_ID`  | Apple Services ID                        |
 | `SUPABASE_AUTH_APPLE_SECRET`     | Apple client secret (generated from key) |
 
@@ -87,6 +90,42 @@ never see or handle authorization codes directly — they call
    - `com.finance.android://auth/callback`
    - `com.finance.ios://auth/callback`
    - `finance://auth/callback`
+
+## Step-by-Step: Microsoft Sign-In (Azure)
+
+> Supabase brokers Microsoft under the **`azure`** provider. The web app
+> forwards `provider=azure` and labels the button **"Sign in with Microsoft"**.
+
+### 1. Register an App in Microsoft Entra ID
+
+1. Go to the [Microsoft Entra admin center](https://entra.microsoft.com/) →
+   **Identity → Applications → App registrations → New registration**.
+2. Name: `Finance App`.
+3. **Supported account types**: choose **Accounts in any organizational
+   directory and personal Microsoft accounts** (multi-tenant + personal) for the
+   widest reach, or a single tenant to restrict access.
+4. **Redirect URI**: platform **Web** →
+   `https://<your-supabase-ref>.supabase.co/auth/v1/callback`.
+5. Click **Register** and copy the **Application (client) ID**.
+
+### 2. Create a Client Secret
+
+1. In the app registration → **Certificates & secrets → New client secret**.
+2. Add a description and expiry, then **Add**.
+3. Copy the secret **Value** immediately (it is shown only once).
+
+### 3. Configure Supabase
+
+1. Go to **Authentication → Providers → Azure**.
+2. Toggle **Enable Azure provider**.
+3. Paste the **Application (client) ID** and the **client secret Value**.
+4. **Azure Tenant URL**: `https://login.microsoftonline.com/common` for
+   multi-tenant + personal accounts, or
+   `https://login.microsoftonline.com/<tenant-id>` to restrict to one tenant.
+5. Save.
+
+Redirect URLs are shared with the other providers — see
+[Configure Redirect URLs in Supabase](#3-configure-redirect-urls-in-supabase).
 
 ## Step-by-Step: Apple Sign-In
 
@@ -148,6 +187,7 @@ Apple's client secret is a JWT signed with a private key:
 After completing the setup, verify:
 
 - [ ] Google Sign-In works on web (dev + production)
+- [ ] Microsoft (Azure) Sign-In works on web (dev + production)
 - [ ] Apple Sign-In works on web (production only — Apple requires HTTPS)
 - [ ] Redirect URIs are registered in both provider consoles AND Supabase
 - [ ] User profile data (name, email, avatar) is populated after first sign-in

--- a/services/api/supabase/functions/_shared/supabase-auth.test.ts
+++ b/services/api/supabase/functions/_shared/supabase-auth.test.ts
@@ -28,20 +28,22 @@ import {
 // isSupportedProvider
 // ---------------------------------------------------------------------------
 
-Deno.test('isSupportedProvider — accepts google, github, apple', () => {
+Deno.test('isSupportedProvider — accepts google, github, apple, azure', () => {
   assertEquals(isSupportedProvider('google'), true);
   assertEquals(isSupportedProvider('github'), true);
   assertEquals(isSupportedProvider('apple'), true);
+  assertEquals(isSupportedProvider('azure'), true); // Microsoft is brokered via azure
 });
 
 Deno.test('isSupportedProvider — rejects unknown provider', () => {
   assertEquals(isSupportedProvider('facebook'), false);
+  assertEquals(isSupportedProvider('microsoft'), false); // GoTrue slug is `azure`, not `microsoft`
   assertEquals(isSupportedProvider(''), false);
   assertEquals(isSupportedProvider('GOOGLE'), false); // case-sensitive
 });
 
-Deno.test('SUPPORTED_PROVIDERS — exposes exactly google/github/apple', () => {
-  assertEquals([...SUPPORTED_PROVIDERS], ['google', 'github', 'apple']);
+Deno.test('SUPPORTED_PROVIDERS — exposes exactly google/github/apple/azure', () => {
+  assertEquals([...SUPPORTED_PROVIDERS], ['google', 'github', 'apple', 'azure']);
 });
 
 // ---------------------------------------------------------------------------

--- a/services/api/supabase/functions/_shared/supabase-auth.ts
+++ b/services/api/supabase/functions/_shared/supabase-auth.ts
@@ -52,8 +52,14 @@ export interface PkceMaterial {
   codeChallenge: string;
 }
 
-/** Identity providers supported by these endpoints. */
-export const SUPPORTED_PROVIDERS = ['google', 'github', 'apple'] as const;
+/**
+ * Identity providers supported by these endpoints.
+ *
+ * These map 1:1 to Supabase GoTrue provider slugs. Note that Microsoft
+ * sign-in is brokered through GoTrue's `azure` provider — the slug the
+ * `/authorize` endpoint and the `/settings.external` map both use.
+ */
+export const SUPPORTED_PROVIDERS = ['google', 'github', 'apple', 'azure'] as const;
 export type AuthProvider = (typeof SUPPORTED_PROVIDERS)[number];
 
 /** Type guard for {@link AuthProvider}. */
@@ -220,8 +226,8 @@ export async function revokeRefreshToken(accessToken: string): Promise<void> {
 /**
  * Build the Supabase OAuth authorize URL with PKCE.
  *
- * Supabase Cloud handles the provider hop (Google, GitHub, Apple) and
- * redirects back to {@link redirectTo} with a `?code=` query parameter
+ * Supabase Cloud handles the provider hop (Google, GitHub, Apple, Microsoft)
+ * and redirects back to {@link redirectTo} with a `?code=` query parameter
  * that the callback function consumes. We deliberately do NOT pass our
  * own `state` parameter: Supabase Cloud uses its own internal signed
  * state token and rejects arbitrary nonces with `bad_oauth_state`. PKCE
@@ -265,8 +271,8 @@ export type ProviderEnabledResult = 'enabled' | 'disabled' | 'unknown';
  * Query GoTrue's public settings document to determine whether `provider` is
  * actually enabled on the backend.
  *
- * A provider can be statically supported (google/github/apple) yet not enabled
- * in GoTrue. Without this check, `auth-oauth-start` would 302 the browser to
+ * A provider can be statically supported (google/github/apple/azure) yet not
+ * enabled in GoTrue. Without this check, `auth-oauth-start` would 302 the browser to
  * `/authorize` and the user would land on a raw
  * `validation_failed: provider is not enabled` JSON page (#3188). Reading
  * `/auth/v1/settings` auto-tracks whatever gets enabled later with no manual env

--- a/services/api/supabase/functions/auth-oauth-start/index.ts
+++ b/services/api/supabase/functions/auth-oauth-start/index.ts
@@ -9,7 +9,7 @@
  * short-lived HttpOnly cookies, then redirects the browser to Supabase
  * Cloud's `/auth/v1/authorize` with the matching `code_challenge` +
  * `state` query parameters. The user lands on the provider (Google,
- * GitHub, Apple) and is returned to {@link auth-oauth-callback}.
+ * GitHub, Apple, Microsoft) and is returned to {@link auth-oauth-callback}.
  *
  * The `redirect_to` query parameter is validated against a strict
  * allowlist to prevent open-redirect via the post-login navigation.


### PR DESCRIPTION
## Summary

Adds **Microsoft** social sign-in and verifies the **Google** and **GitHub** paths. All three go through the existing server-side PKCE OAuth broker (`auth-oauth-start` / `auth-oauth-callback`), which forwards the provider slug straight to Supabase GoTrue. Google and GitHub were already wired end-to-end; this change threads GoTrue's **`azure`** provider (its slug for Microsoft) through the stack. Apple is intentionally left untouched (out of scope for now).

## Changes

- **Broker:** add `azure` to `SUPPORTED_PROVIDERS` in `_shared/supabase-auth.ts` (+ doc comments).
- **Web auth:** extend the `OAuthProvider` union with `'azure'` and map `azure → "Microsoft"` in the provider label table.
- **Login UI:** add a "Sign in with Microsoft" button (branded 4-square logo) between GitHub and Apple.
- **Tests:** cover the Microsoft provider in `LoginPage.test.tsx`, `auth-context.test.tsx`, the shared `supabase-auth.test.ts`, and the `e2e/auth.spec.ts` visibility check.
- **Docs:** add Microsoft/Azure setup steps and enablement env vars to `docs/auth/oauth-setup.md` and `docs/auth/oauth-provider-enablement.md`.

Note: `apps/web/src/lib/auth/oauth-config.ts` and `auth-providers.ts` are unused scaffolding for a client-side `signInWithOAuth` approach (not the live broker path) and were left untouched.

## Follow-up (human, secret-gated)

Enabling each provider requires real OAuth credentials configured in Supabase / GoTrue — see `docs/auth/oauth-provider-enablement.md`. The UI degrades gracefully (friendly inline message) until a provider is enabled.

## Testing

- [x] `npx prettier --check` on changed files — clean
- [x] `npx eslint --max-warnings 0` on changed files — clean
- [x] Web unit tests (`LoginPage`, `auth-context`) — 52 passed
- [ ] Deno edge-function tests — not runnable locally (Deno not installed); covered by CI

Closes #3535