### PR TITLE
fix(web): keep notice banners inside content column so dashboard fills width (#3537)

### DIFF
--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -290,6 +290,20 @@ describe('AppLayout', () => {
     expect(screen.getByTestId('install-banner')).toBeInTheDocument();
   });
 
+  it('nests notice banners inside the content column (.app-shell) so they do not break the desktop layout row (#3537)', () => {
+    const { container } = renderLayout();
+
+    const shell = container.querySelector('.app-shell');
+    const installBanner = screen.getByTestId('install-banner');
+
+    expect(shell).not.toBeNull();
+    // The banners must live inside `.app-shell`, not as siblings of it. When
+    // they were direct children of `.app-layout` (a flex row at >=768px), they
+    // were pulled into the row and squished the main content into the left half
+    // of the viewport. Keeping them inside the column guarantees full width.
+    expect(shell?.contains(installBanner)).toBe(true);
+  });
+
   it('applies the simple-mode route plan to core route content', () => {
     localStorage.setItem('finance-simplified-mode', 'true');
 

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -388,9 +388,14 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
           onOpenFeedback={openFeedbackDialog}
           simpleMode={simpleModeEnabled}
         />
+        {/* Notice banners live inside the content column (`.app-shell`) so they
+            render full-width at the bottom of the content on every breakpoint.
+            Rendering them as siblings of `.app-shell` pulled them into the
+            `.app-layout` flex row at >=768px, squishing the main content into
+            the left half of the viewport (#3537). */}
+        <InstallBanner />
+        <SampleDataBanner />
       </div>
-      <InstallBanner />
-      <SampleDataBanner />
       <CommandPalette
         isOpen={showCommandPalette}
         actions={commandPaletteActions}


### PR DESCRIPTION
## Summary

On wide / full-screen viewports (>=768px) the web Dashboard rendered all its content crammed into roughly the left half of the window, with the right half an empty dead-space region separated by a stray vertical amber divider. The "Clear sample data & start fresh" banner floated in that empty area.

## Root cause

`InstallBanner` and `SampleDataBanner` were rendered in `AppLayout.tsx` as **direct children of `.app-layout`**, siblings of `.app-shell`. At `min-width: 768px`, `.app-layout` switches to `display: flex; flex-direction: row` (sidebar + shell side-by-side). Because the banners are in-flow flex items with no positioning, they got pulled into that horizontal row as extra columns:

- `.sample-data-banner` (internal `flex: 1 1 20rem`) claimed a large slice of horizontal space on the right, so `.app-shell` (`flex: 1`) shrank to only the leftover width — the left half.
- `.app-layout` uses the default `align-items: stretch`, so the banner stretched to full viewport height and its amber `border` (`1px solid --semantic-status-warning`) rendered as the full-height vertical divider.

`InstallBanner` had the same latent bug (only visible when a PWA install prompt is available).

## Changes

- Move `<InstallBanner />` and `<SampleDataBanner />` inside `.app-shell` (the content column) so they no longer participate in the desktop `.app-layout` flex row. They now render full-width at the bottom of the content on every breakpoint, and the main area fills all available width to the right of the sidebar.
- Add a regression test asserting the notice banners nest inside `.app-shell` (fails against the old sibling structure).

## Testing

- [x] `AppLayout` unit tests pass (19/19, incl. new regression test)
- [x] Prettier clean (`prettier --check`)
- [x] ESLint clean (`--max-warnings 0`)
- Note: full in-browser render couldn't boot in the bare local dev server due to an unrelated SQLite-WASM MIME issue (the `.wasm` asset was served as `index.html`); the fix is CSS-layout/DOM-structure only and is covered by the regression test.

Closes #3537
