### PR TITLE
feat(deploy): wire Microsoft (azure) OAuth into self-hosted GoTrue

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -115,6 +115,23 @@ GITHUB_CLIENT_ID=
 GITHUB_SECRET=
 
 # ---------------------------------------------------------------------------
+# OAuth — Microsoft / Azure (optional, leave empty to disable)
+#
+# GoTrue brokers Microsoft sign-in under the "azure" provider. Register an app
+# in the Microsoft Entra admin center (https://entra.microsoft.com/) →
+# App registrations → New registration, add the Web redirect URI
+# https://YOUR_DOMAIN_HERE/auth/v1/callback, create a client secret, then set
+# AZURE_AUTH_ENABLED=true and paste the Application (client) ID and secret Value
+# below. AZURE_URL is the tenant authority: keep the /common default for
+# multi-tenant + personal accounts, or use
+# https://login.microsoftonline.com/<tenant-id> to restrict to one tenant.
+# ---------------------------------------------------------------------------
+AZURE_AUTH_ENABLED=false
+AZURE_CLIENT_ID=
+AZURE_SECRET=
+AZURE_URL=https://login.microsoftonline.com/common
+
+# ---------------------------------------------------------------------------
 # WebAuthn / Passkeys
 # ---------------------------------------------------------------------------
 WEBAUTHN_RP_NAME=Finance App

--- a/deploy/.env.staging.example
+++ b/deploy/.env.staging.example
@@ -102,6 +102,14 @@ GITHUB_CLIENT_ID=
 GITHUB_SECRET=
 
 # ---------------------------------------------------------------------------
+# OAuth — Microsoft / Azure (optional for staging; GoTrue provider = "azure")
+# ---------------------------------------------------------------------------
+AZURE_AUTH_ENABLED=false
+AZURE_CLIENT_ID=
+AZURE_SECRET=
+AZURE_URL=https://login.microsoftonline.com/common
+
+# ---------------------------------------------------------------------------
 # WebAuthn / Passkeys
 # ---------------------------------------------------------------------------
 WEBAUTHN_RP_NAME=Finance App (Staging)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -181,6 +181,15 @@ services:
       GOTRUE_EXTERNAL_GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
       GOTRUE_EXTERNAL_GITHUB_SECRET: ${GITHUB_SECRET:-}
 
+      # OAuth — Microsoft (optional; GoTrue brokers Microsoft as "azure")
+      GOTRUE_EXTERNAL_AZURE_ENABLED: ${AZURE_AUTH_ENABLED:-false}
+      GOTRUE_EXTERNAL_AZURE_CLIENT_ID: ${AZURE_CLIENT_ID:-}
+      GOTRUE_EXTERNAL_AZURE_SECRET: ${AZURE_SECRET:-}
+      # Tenant authority URL. Default allows multi-tenant + personal Microsoft
+      # accounts; set to https://login.microsoftonline.com/<tenant-id> to
+      # restrict sign-in to a single Entra tenant.
+      GOTRUE_EXTERNAL_AZURE_URL: ${AZURE_URL:-https://login.microsoftonline.com/common}
+
       # Custom access token hook (injects household_ids into JWT)
       # The public.custom_access_token_hook function is created via migrations.
       # Disabled by default; set ENABLED to 'true' and uncomment the URI to activate.


### PR DESCRIPTION
## Summary

Follow-up to the Microsoft sign-in work (PR #3540). That PR wired Microsoft (`azure`) sign-in through the app, the OAuth broker allowlist, the login UI, tests, and setup docs — but the **self-hosted deployment plumbing** was missed, so a self-hosted operator had no env knob to actually turn Microsoft on.

## Changes

- `deploy/docker-compose.yml` — map `AZURE_AUTH_ENABLED` / `AZURE_CLIENT_ID` / `AZURE_SECRET` / `AZURE_URL` into `GOTRUE_EXTERNAL_AZURE_*`, mirroring the existing Google/GitHub/Apple blocks. `AZURE_URL` defaults to the multi-tenant/personal `.../common` authority.
- `deploy/.env.example` — add a documented Microsoft/Azure OAuth block.
- `deploy/.env.staging.example` — add the matching staging block.

With this merged, the only remaining steps to enable Microsoft sign-in are the human/secret-gated ones: register an app in Microsoft Entra ID, create a client secret, and set `AZURE_AUTH_ENABLED=true` + the credentials in the deployment's `.env` (or the provider in Supabase Cloud). Full walkthrough in `docs/auth/oauth-setup.md`.

## Issues

Closes #3547

## Testing

- [x] `npx prettier --check` clean on the edited compose files
- [x] `.env.example` files are prettier-ignored (`*.env*`); no JS/TS touched, so ESLint unaffected
- [x] Azure block mirrors the verified Google/GitHub/Apple mapping already in use