### PR TITLE
fix(web): rebuild feedback modal with design system and fix nav icon

### DIFF
--- a/apps/web/src/components/FeedbackDialog.tsx
+++ b/apps/web/src/components/FeedbackDialog.tsx
@@ -7,7 +7,7 @@
  * GitHub issue for beta triage using a server-side token.
  *
  * @module components/FeedbackDialog
- * References: issues #1476, #2031
+ * References: issues #1476, #2031, #3552
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -15,6 +15,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import packageJson from '../../package.json';
 import { buildFeedbackDiagnostics, submitFeedback } from '../lib/feedback';
 import { useFocusTrap } from '../accessibility/aria';
+import './forms/forms.css';
 
 const BUILD_SHA =
   import.meta.env.VITE_BUILD_SHA ??
@@ -105,30 +106,34 @@ export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose 
 
   if (!isOpen) return null;
 
+  const subjectInvalid = Boolean(error) && !subject.trim();
+  const bodyInvalid = Boolean(error) && !body.trim();
+
   return (
-    <div className="form-backdrop" onClick={onClose}>
+    <div className="form-dialog" role="presentation" onKeyDown={handlePanelKeyDown}>
+      <div className="form-dialog__backdrop" aria-hidden="true" onClick={onClose} />
       <div
         ref={panelRef}
-        className="form-dialog"
+        className="form-dialog__panel"
         role="dialog"
         aria-modal="true"
         aria-labelledby="feedback-dialog-title"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={handlePanelKeyDown}
       >
         <h2 id="feedback-dialog-title" className="form-dialog__title">
           Send feedback
         </h2>
 
         {submitted ? (
-          <div className="feedback-dialog__success" role="status" aria-live="polite">
-            <p className="feedback-dialog__success-text">
+          <>
+            <p className="form-group__help" role="status" aria-live="polite">
               Thank you! Your feedback has been sent to GitHub triage.
             </p>
-            <button type="button" className="form-button form-button--primary" onClick={onClose}>
-              Close
-            </button>
-          </div>
+            <div className="form-actions">
+              <button type="button" className="form-button form-button--primary" onClick={onClose}>
+                Close
+              </button>
+            </div>
+          </>
         ) : (
           <form onSubmit={handleSubmit} noValidate>
             {error && (
@@ -137,59 +142,59 @@ export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose 
               </div>
             )}
 
-            <div className="form-group">
-              <label
-                htmlFor="feedback-subject"
-                className="form-group__label form-group__label--required"
-              >
-                Subject
-              </label>
-              <input
-                id="feedback-subject"
-                ref={firstInputRef}
-                className="form-group__input"
-                value={subject}
-                onChange={(e) => setSubject(e.target.value)}
-                maxLength={160}
-                placeholder="Briefly summarize your feedback"
-                aria-required="true"
-                aria-invalid={error && !subject.trim() ? 'true' : undefined}
-              />
-            </div>
+            <div className="form-fields">
+              <div className="form-group">
+                <label
+                  htmlFor="feedback-subject"
+                  className="form-group__label form-group__label--required"
+                >
+                  Subject
+                </label>
+                <input
+                  id="feedback-subject"
+                  ref={firstInputRef}
+                  className={`form-input${subjectInvalid ? ' form-input--error' : ''}`}
+                  value={subject}
+                  onChange={(e) => setSubject(e.target.value)}
+                  maxLength={160}
+                  placeholder="Briefly summarize your feedback"
+                  aria-required="true"
+                  aria-invalid={subjectInvalid ? 'true' : undefined}
+                />
+              </div>
 
-            <div className="form-group">
-              <label
-                htmlFor="feedback-body"
-                className="form-group__label form-group__label--required"
-              >
-                Details
-              </label>
-              <textarea
-                id="feedback-body"
-                className="form-group__input form-group__textarea"
-                value={body}
-                onChange={(e) => setBody(e.target.value)}
-                rows={5}
-                maxLength={12000}
-                placeholder="Tell us what happened, what you expected, or what would help..."
-                aria-required="true"
-                aria-invalid={error && !body.trim() ? 'true' : undefined}
-              />
-            </div>
+              <div className="form-group">
+                <label
+                  htmlFor="feedback-body"
+                  className="form-group__label form-group__label--required"
+                >
+                  Details
+                </label>
+                <textarea
+                  id="feedback-body"
+                  className={`form-textarea${bodyInvalid ? ' form-textarea--error' : ''}`}
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  rows={5}
+                  maxLength={12000}
+                  placeholder="Tell us what happened, what you expected, or what would help..."
+                  aria-required="true"
+                  aria-invalid={bodyInvalid ? 'true' : undefined}
+                />
+              </div>
 
-            <div className="form-group">
-              <label htmlFor="feedback-diagnostics" className="form-group__label">
+              <label htmlFor="feedback-diagnostics" className="form-checkbox-row">
                 <input
                   id="feedback-diagnostics"
                   type="checkbox"
                   checked={includeDiagnostics}
                   onChange={(e) => setIncludeDiagnostics(e.target.checked)}
-                />{' '}
-                Include diagnostic info
+                />
+                <span>Include diagnostic info</span>
               </label>
             </div>
 
-            <div className="form-dialog__actions">
+            <div className="form-actions">
               <button
                 type="button"
                 className="form-button form-button--secondary"
@@ -202,6 +207,7 @@ export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose 
                 type="submit"
                 className="form-button form-button--primary"
                 disabled={isSubmitting}
+                aria-busy={isSubmitting}
               >
                 {isSubmitting ? 'Sending…' : 'Submit'}
               </button>

--- a/apps/web/src/components/layout/MoreNavSheet.tsx
+++ b/apps/web/src/components/layout/MoreNavSheet.tsx
@@ -28,7 +28,7 @@ import {
   type NavConfigItem,
   type NavGroup,
 } from './navConfig';
-import { CloseIcon, KeyboardIcon, SignOutIcon } from './navIcons';
+import { CloseIcon, FeedbackIcon, KeyboardIcon, SignOutIcon } from './navIcons';
 
 const FOCUSABLE_SELECTOR = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
@@ -315,7 +315,7 @@ export const MoreNavSheet: React.FC<MoreNavSheetProps> = ({
                     }}
                   >
                     <span className="more-sheet__item-icon" aria-hidden="true">
-                      <KeyboardIcon />
+                      <FeedbackIcon />
                     </span>
                     <span className="more-sheet__item-text">
                       <span className="more-sheet__item-label">Send feedback</span>

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -41,6 +41,7 @@ import {
   ChevronDownIcon,
   EyeIcon,
   EyeOffIcon,
+  FeedbackIcon,
   KeyboardIcon,
   MoreIcon,
   SignOutIcon,
@@ -449,7 +450,7 @@ export const SidebarNavigation: React.FC<SidebarNavigationProps> = ({
             onClick={onOpenFeedback}
           >
             <span className="sidebar-nav__item-icon" aria-hidden="true">
-              <KeyboardIcon />
+              <FeedbackIcon />
             </span>
             <span>Feedback</span>
           </button>

--- a/apps/web/src/components/layout/navIcons.tsx
+++ b/apps/web/src/components/layout/navIcons.tsx
@@ -277,6 +277,15 @@ export const KeyboardIcon: FC<IconProps> = ({ className }) => (
   </Svg>
 );
 
+export const FeedbackIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+    <path d="M8 10h.01" />
+    <path d="M12 10h.01" />
+    <path d="M16 10h.01" />
+  </Svg>
+);
+
 export const SignOutIcon: FC<IconProps> = ({ className }) => (
   <Svg className={className}>
     <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />


### PR DESCRIPTION
## Summary

Fixes two related web feedback-experience bugs (screenshots in #3552):

1. **FeedbackDialog was broken/unstyled.** It never imported `forms.css` and used non-existent class names (`form-backdrop`, `form-dialog` as the panel, `form-group__input`, `form-dialog__actions`), so it rendered with **no backdrop** (page content bled through), **stark white browser-default inputs**, a **raw monospace `<textarea>`** with a default resize handle, cramped layout, and ad-hoc buttons.
2. **Feedback nav icon was a keyboard.** The sidebar and mobile "More" sheet reused `KeyboardIcon`, which doesn't represent feedback.

## Changes

- **Rebuilt `FeedbackDialog`** on the shared `forms.css` design-system dialog structure:
  - Real overlay + `form-dialog__backdrop` (click-to-close), centered `form-dialog__panel`
  - Tokenized dark `form-input` / `form-textarea` (with `--error` states), `form-checkbox-row` for the styled diagnostics checkbox
  - Proper `form-fields` spacing/hierarchy, secondary **Cancel** + primary **Submit** buttons, `form-banner-error` alerts
  - Preserved the existing focus trap, Esc-to-close, focus return, `aria-required`/`aria-invalid`, and success state
- **Added `FeedbackIcon`** (chat/speech bubble, matching the 24×24 stroke nav-icon style) to `navIcons.tsx` and used it for the Feedback item in `Navigation.tsx` (sidebar) and `MoreNavSheet.tsx` (mobile). `KeyboardIcon` is retained for the Keyboard Shortcuts item.

No new one-off components were introduced; the modal now uses only existing shared design-system classes so it can migrate cleanly to a centralized `Button`/`Checkbox`/input set when those land.

## Accessibility (WCAG 2.2 AA)

- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` title
- Focus trapped in panel, first field auto-focused, focus returned to trigger on close
- Esc closes, labeled required fields with `aria-invalid`, visible focus rings via `.form-button:focus-visible` / input focus styles

## Issues

Closes #3552

## Testing

- [x] Prettier clean on all changed files
- [ ] Remote CI (lint / type-check / affected web suites) — deferred to CI; local `node_modules` not installed due to low disk on the dev machine
- [x] Manual review: every referenced CSS class verified present in `apps/web/src/components/forms/forms.css`