### PR TITLE
fix(web): make Keyboard Shortcuts modal a normal centered dialog (#3555)

### DIFF
--- a/apps/web/src/components/common/KeyboardShortcutsModal.test.tsx
+++ b/apps/web/src/components/common/KeyboardShortcutsModal.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../accessibility/aria', () => ({
@@ -42,14 +42,17 @@ describe('KeyboardShortcutsModal', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders a shortcuts table with header columns', () => {
+  it('renders a shortcuts table for each category with a caption', () => {
     render(<KeyboardShortcutsModal isOpen={true} onClose={vi.fn()} />);
 
-    const table = screen.getByRole('table');
-    expect(table).toBeInTheDocument();
+    // One table per category (previously a single combined table).
+    const tables = screen.getAllByRole('table');
+    expect(tables.length).toBeGreaterThanOrEqual(4);
 
-    expect(within(table).getByRole('columnheader', { name: 'Shortcut' })).toBeInTheDocument();
-    expect(within(table).getByRole('columnheader', { name: 'Action' })).toBeInTheDocument();
+    // Category titles are rendered as table captions.
+    expect(screen.getByText('Navigation')).toBeInTheDocument();
+    expect(screen.getByText('Transaction List')).toBeInTheDocument();
+    expect(tables.every((table) => table.querySelector('caption') !== null)).toBe(true);
   });
 
   it('renders kbd elements for keyboard shortcut keys', () => {

--- a/apps/web/src/components/common/KeyboardShortcutsModal.tsx
+++ b/apps/web/src/components/common/KeyboardShortcutsModal.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useCallback, useEffect, useId, useRef, type KeyboardEvent } from 'react';
+import { useCallback, useEffect, useId, useRef, type KeyboardEvent } from 'react';
 
 import { useFocusTrap } from '../../accessibility/aria';
 import { SHORTCUT_CATEGORIES, type ShortcutCategory } from '../../hooks/useKeyboardShortcuts';
@@ -94,39 +94,33 @@ export function KeyboardShortcutsModal({
             : ' Character-key shortcuts are currently disabled; use visible controls or Ctrl/Cmd+K.'}
         </p>
 
-        <table className="keyboard-shortcuts__table">
-          <thead>
-            <tr>
-              <th scope="col">Shortcut</th>
-              <th scope="col">Action</th>
-            </tr>
-          </thead>
-          <tbody>
+        <div className="keyboard-shortcuts__body themed-scrollbar">
+          <div className="keyboard-shortcuts__grid">
             {categories.map((category) => (
-              <React.Fragment key={category.title}>
-                <tr className="keyboard-shortcuts__category-row">
-                  <th scope="rowgroup" colSpan={2}>
-                    {category.title}
-                  </th>
-                </tr>
-                {category.shortcuts.map((shortcut) => (
-                  <tr key={`${category.title}-${shortcut.keys}`}>
-                    <th scope="row">
-                      <kbd className="keyboard-shortcuts__key">{shortcut.keys}</kbd>
-                    </th>
-                    <td>{shortcut.description}</td>
-                  </tr>
-                ))}
-              </React.Fragment>
+              <section className="keyboard-shortcuts__group" key={category.title}>
+                <table className="keyboard-shortcuts__table">
+                  <caption>{category.title}</caption>
+                  <tbody>
+                    {category.shortcuts.map((shortcut) => (
+                      <tr key={`${category.title}-${shortcut.keys}`}>
+                        <th scope="row">
+                          <kbd className="keyboard-shortcuts__key">{shortcut.keys}</kbd>
+                        </th>
+                        <td className="keyboard-shortcuts__action">{shortcut.description}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </section>
             ))}
-          </tbody>
-        </table>
+          </div>
+        </div>
 
         <div className="form-actions keyboard-shortcuts__actions">
           <button
             ref={closeButtonRef}
             type="button"
-            className="form-button form-button--secondary"
+            className="form-button form-button--primary keyboard-shortcuts__close"
             onClick={handleClose}
           >
             Close

--- a/apps/web/src/components/forms/forms.css
+++ b/apps/web/src/components/forms/forms.css
@@ -501,12 +501,22 @@
  * Keyboard shortcuts dialog
  * ------------------------------------------------------------------------- */
 
+/*
+ * Normal, comfortably-proportioned centered modal (#3555). A fixed header
+ * (title + description) and footer (Close) anchor a scrollable body; the many
+ * shortcut categories flow into balanced columns so the dialog reads as a
+ * wide rectangle instead of a tall, skinny strip.
+ */
 .keyboard-shortcuts__panel {
-  max-width: 560px;
+  max-width: min(880px, 92vw);
+  max-height: min(720px, calc(100dvh - var(--spacing-8)));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .keyboard-shortcuts__title {
-  margin-bottom: var(--spacing-3);
+  margin-bottom: var(--spacing-2);
 }
 
 .keyboard-shortcuts__description {
@@ -515,32 +525,62 @@
   line-height: var(--line-height-relaxed, 1.5);
 }
 
+.keyboard-shortcuts__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.keyboard-shortcuts__grid {
+  columns: 300px;
+  column-gap: var(--spacing-6);
+}
+
+.keyboard-shortcuts__group {
+  break-inside: avoid;
+  margin: 0 0 var(--spacing-5);
+}
+
 .keyboard-shortcuts__table {
   width: 100%;
   border-collapse: collapse;
 }
 
-.keyboard-shortcuts__table th,
-.keyboard-shortcuts__table td {
-  padding: var(--spacing-3);
-  border-top: 1px solid var(--semantic-border-default);
+.keyboard-shortcuts__table caption {
+  caption-side: top;
   text-align: left;
-  vertical-align: top;
-}
-
-.keyboard-shortcuts__table thead th {
-  color: var(--semantic-text-secondary);
-  font-size: var(--type-scale-caption-font-size);
-  font-weight: var(--font-weight-semibold);
-}
-
-.keyboard-shortcuts__category-row th {
-  background: var(--semantic-background-secondary);
+  margin-bottom: var(--spacing-1);
+  padding-bottom: var(--spacing-1);
   color: var(--semantic-text-secondary);
   font-size: var(--type-scale-caption-font-size);
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+
+.keyboard-shortcuts__table th,
+.keyboard-shortcuts__table td {
+  padding: var(--spacing-2) 0;
+  border-top: 1px solid var(--semantic-border-default);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.keyboard-shortcuts__table tbody tr:first-child th,
+.keyboard-shortcuts__table tbody tr:first-child td {
+  border-top: none;
+}
+
+.keyboard-shortcuts__table th[scope='row'] {
+  width: 1%;
+  white-space: nowrap;
+  padding-right: var(--spacing-4);
+}
+
+.keyboard-shortcuts__action {
+  color: var(--semantic-text-primary);
+  font-weight: var(--font-weight-normal);
 }
 
 .keyboard-shortcuts__key {
@@ -559,7 +599,15 @@
 }
 
 .keyboard-shortcuts__actions {
+  flex: 0 0 auto;
   justify-content: flex-end;
+  margin-top: var(--spacing-4);
+  padding-top: var(--spacing-4);
+  border-top: 1px solid var(--semantic-border-default);
+}
+
+.keyboard-shortcuts__close {
+  min-width: 7rem;
 }
 
 /* ---------------------------------------------------------------------------

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -35,6 +35,43 @@
   min-width: 0;
   min-height: 100dvh;
 }
+
+/* ---------------------------------------------------------------------------
+ * Themed scrollbar — shared utility (#3555)
+ *
+ * Central, token-driven scrollbar styling reused across scroll containers
+ * (sidebar nav, dashboard customize panel, keyboard-shortcuts modal, ...).
+ * Track blends into the surface; the thumb uses theme-aware tokens so it
+ * follows light/dark automatically. Apply by adding the `themed-scrollbar`
+ * class to any element that scrolls. Existing one-off scrollbar rules
+ * (`.app-sidebar__nav`, `.customize-panel__list`) can migrate to this class.
+ * ------------------------------------------------------------------------- */
+.themed-scrollbar {
+  /* Firefox / standards */
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--semantic-border-default) 70%, transparent) transparent;
+}
+
+/* Chromium / WebKit */
+.themed-scrollbar::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.themed-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.themed-scrollbar::-webkit-scrollbar-thumb {
+  background-color: color-mix(in srgb, var(--semantic-border-default) 70%, transparent);
+  border: 2px solid transparent;
+  border-radius: var(--border-radius-md);
+  background-clip: padding-box;
+}
+
+.themed-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: var(--semantic-interactive-default);
+}
 .update-banner {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

The Keyboard Shortcuts help dialog (opened with `?`) rendered as a tall, narrow vertical strip using the default browser scrollbar and an under-styled `Close` button. This reworks it into a normal, comfortably-proportioned centered modal that matches the app's design system.

## Changes

- **Normal centered modal (no more skinny strip):** `KeyboardShortcutsModal` now has a fixed header (title + description) and footer (Close) with a scrollable body in between. The ~27 shortcut rows flow into **balanced columns** (`columns: 300px`) inside a wider panel (`max-width: min(880px, 92vw)`, `max-height: min(720px, calc(100dvh - spacing-8))`), so the dialog reads as a wide rectangle instead of a full-height vertical strip. Each category is its own `<table>` with a `<caption>` heading.
- **Shared themed scrollbar:** Promoted a central, token-driven `.themed-scrollbar` utility into the globally-imported `responsive.css` (Firefox `scrollbar-width`/`scrollbar-color` + WebKit `::-webkit-scrollbar*`, driven by `--semantic-border-default` / `--semantic-interactive-default`). Applied it to the modal's scroll region, replacing the stock scrollbar. The existing one-off sidebar/dashboard scrollbar rules can migrate to this class later.
- **Close button:** Restyled to the design-system primary button (`form-button--primary`) with a comfortable min-width.

## Accessibility (WCAG 2.2 AA)

- Dialog semantics preserved: `role="dialog"`, `aria-modal`, `aria-labelledby`/`aria-describedby`, focus trap, Esc to close, focus return, visible focus.
- Each category table is labelled by its `<caption>`; shortcut keys are row headers (`<th scope="row">`).

## Coordination

- No shared `Button` component had merged to `main` at implementation time, so the Close button uses the existing `.form-button` design-system classes (can migrate to the shared Button later).
- Rebased on `origin/main` before push; diff is scoped to the shortcuts modal + the promoted scrollbar utility.

## Issues

Closes #3555

## Testing

- [x] `npx prettier --check` on all changed files — clean
- [ ] `vitest` affected suites (updated `KeyboardShortcutsModal.test.tsx` for the new multi-table/caption structure) — verified via CI
- [ ] `eslint` / type-check — verified via CI (local full install skipped: machine low on disk; remote CI is the source of truth per repo docs)