### PR TITLE
fix(web): stop navbar tab switch leaving stale page content (#3551)

### DIFF
--- a/apps/web/src/AppBrowserRouter.test.tsx
+++ b/apps/web/src/AppBrowserRouter.test.tsx
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Regression tests for navbar tab switching (#3551).
+ *
+ * Guards against react-router v7's default `startTransition`-wrapped navigation
+ * leaving stale page content on screen. Every app route is a `lazy()` page
+ * behind a shared `<Suspense>` boundary; with transitions enabled React keeps
+ * the previously committed page **visible** while the incoming lazy chunk
+ * suspends, so the URL/active-nav move but the content does not. `AppBrowserRouter`
+ * pins `useTransitions={false}` so navigation is urgent: React hides the old
+ * page, the shared Suspense boundary reveals its loader, and the new page commits
+ * once its chunk resolves.
+ *
+ * The user-observable regression signal is **visibility**, not DOM presence:
+ * React 19 keeps the outgoing page mounted-but-hidden (`display: none`) while a
+ * sibling route suspends. Under the bug the old page stays *visible* with no
+ * loader; with the fix it is *hidden* behind the loader. These tests exercise
+ * the real `AppBrowserRouter` wrapper, so removing `useTransitions={false}`
+ * makes the first test fail.
+ */
+
+import { lazy, Suspense, type ComponentType, type ReactNode } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+
+import { AppBrowserRouter } from './AppBrowserRouter';
+
+/** Mirrors the shared, reused Suspense wrapper every route uses in `routes.tsx`. */
+function RouteBoundary({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<div role="status">Loading page</div>}>{children}</Suspense>;
+}
+
+function Sidebar() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  return (
+    <nav>
+      <span data-testid="active-path">{location.pathname}</span>
+      <button type="button" onClick={() => navigate('/accounts')}>
+        Accounts nav
+      </button>
+      <button type="button" onClick={() => navigate('/transactions')}>
+        Transactions nav
+      </button>
+    </nav>
+  );
+}
+
+/**
+ * Builds a fresh harness per test. `React.lazy` memoizes its factory for the
+ * life of the component identity, so each test needs its own lazy components to
+ * control suspension independently (a module-level lazy would leak resolved
+ * state across tests).
+ */
+function setup() {
+  const LazyAccounts = lazy(() => Promise.resolve({ default: () => <h1>Accounts Screen</h1> }));
+
+  let resolveTransactions!: () => void;
+  const LazyTransactions = lazy(
+    () =>
+      new Promise<{ default: ComponentType }>((resolve) => {
+        resolveTransactions = () => resolve({ default: () => <h1>Transactions Screen</h1> });
+      }),
+  );
+
+  window.history.replaceState(null, '', '/accounts');
+  render(
+    <AppBrowserRouter>
+      <Sidebar />
+      <Routes>
+        <Route
+          path="/accounts"
+          element={
+            <RouteBoundary>
+              <LazyAccounts />
+            </RouteBoundary>
+          }
+        />
+        <Route
+          path="/transactions"
+          element={
+            <RouteBoundary>
+              <LazyTransactions />
+            </RouteBoundary>
+          }
+        />
+      </Routes>
+    </AppBrowserRouter>,
+  );
+
+  return {
+    resolveTransactions: () => resolveTransactions(),
+  };
+}
+
+/** Resolve a pending lazy chunk and flush React's retry. */
+async function resolveAndFlush(resolve: () => void) {
+  await act(async () => {
+    resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('navbar tab switching (#3551)', () => {
+  afterEach(() => {
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('hides the previous page and shows the loader immediately when switching to a still-loading tab', async () => {
+    setup();
+    expect(await screen.findByText('Accounts Screen')).toBeVisible();
+
+    fireEvent.click(screen.getByText('Transactions nav'));
+
+    // The URL and the router location both advance to the new tab...
+    expect(window.location.pathname).toBe('/transactions');
+    await waitFor(() =>
+      expect(screen.getByTestId('active-path')).toHaveTextContent('/transactions'),
+    );
+
+    // ...the shared Suspense boundary reveals its loader while the chunk streams...
+    await waitFor(() => expect(screen.getByRole('status')).toBeVisible());
+
+    // ...and the stale Accounts content must NOT stay on screen. Under
+    // react-router's default transition wrapping the suspending Transactions
+    // chunk keeps the old Accounts page *visible* here — the core regression.
+    expect(screen.getByText('Accounts Screen')).not.toBeVisible();
+  });
+
+  it('renders the destination page once its lazy chunk resolves', async () => {
+    const { resolveTransactions } = setup();
+    await screen.findByText('Accounts Screen');
+
+    fireEvent.click(screen.getByText('Transactions nav'));
+    await waitFor(() => expect(screen.getByRole('status')).toBeVisible());
+
+    await resolveAndFlush(resolveTransactions);
+
+    expect(await screen.findByText('Transactions Screen')).toBeVisible();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(window.location.pathname).toBe('/transactions');
+  });
+
+  it('supports switching back and forth between tabs', async () => {
+    const { resolveTransactions } = setup();
+    await screen.findByText('Accounts Screen');
+
+    // Accounts -> Transactions (resolve the chunk so it commits).
+    fireEvent.click(screen.getByText('Transactions nav'));
+    await waitFor(() => expect(screen.getByRole('status')).toBeVisible());
+    await resolveAndFlush(resolveTransactions);
+    expect(await screen.findByText('Transactions Screen')).toBeVisible();
+
+    // Transactions -> Accounts: content must follow the URL back. Accounts is
+    // already resolved, so it commits synchronously and Transactions unmounts
+    // outright (no hidden-but-present retention this time).
+    fireEvent.click(screen.getByText('Accounts nav'));
+    expect(await screen.findByText('Accounts Screen')).toBeVisible();
+    expect(screen.queryByText('Transactions Screen')).not.toBeInTheDocument();
+    expect(window.location.pathname).toBe('/accounts');
+  });
+});

--- a/apps/web/src/AppBrowserRouter.tsx
+++ b/apps/web/src/AppBrowserRouter.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { FC, ReactNode } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+
+export interface AppBrowserRouterProps {
+  /** Application routes / tree to render inside the router. */
+  children: ReactNode;
+  /** Router basename (defaults to the Vite `BASE_URL`). */
+  basename?: string;
+}
+
+/**
+ * Application router wrapper.
+ *
+ * Wraps {@link BrowserRouter} with `useTransitions={false}` so that navigations
+ * are committed as **urgent** updates rather than being wrapped in
+ * `React.startTransition`.
+ *
+ * ## Why `useTransitions={false}` (#3551)
+ *
+ * `react-router-dom` v7's `<BrowserRouter>` wraps every location/router-state
+ * update in `React.startTransition` by default (the library's own docs note the
+ * default "can lead to buggy behaviors"). Every route in `routes.tsx` is a
+ * `lazy()` page wrapped in a shared `RouteBoundary` → `<Suspense>` with the
+ * `PageLoader` fallback.
+ *
+ * When a tab is clicked, the URL updates synchronously via `history.pushState`,
+ * but the router state change runs inside a transition. React reconciles the
+ * reused `<Suspense>` boundary, the incoming lazy page suspends, and — because
+ * it is a transition — React keeps the **previously committed page content on
+ * screen (stale)** instead of revealing the fallback. The result was the
+ * reported bug: the URL and active-nav indicator move to the new tab while the
+ * main content stays on the old page ("switching tabs almost always fails").
+ *
+ * Disabling transitions makes each navigation an urgent update: the reused
+ * `<Suspense>` immediately shows its `PageLoader` and then commits the new page,
+ * which matches this app's per-route loader design. The app surfaces loading
+ * through those Suspense fallbacks, not through transition/`isPending` UI, so it
+ * gains nothing from the default transition wrapping and only suffered its
+ * stale-content failure mode.
+ */
+export const AppBrowserRouter: FC<AppBrowserRouterProps> = ({ children, basename }) => (
+  <BrowserRouter basename={basename} useTransitions={false}>
+    {children}
+  </BrowserRouter>
+);
+
+export default AppBrowserRouter;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,8 +3,9 @@
 import { StrictMode } from 'react';
 import type { FC, ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { App } from './App';
+import { AppBrowserRouter } from './AppBrowserRouter';
 import { AuthProvider } from './auth/auth-context';
 import { PRE_AUTH_ROUTE_SET, isUnauthenticatedSafeRoute } from './lib/auth/pre-auth-routes';
 import { ErrorBoundary, ToastProvider, UpdateBanner } from './components/common';
@@ -204,7 +205,7 @@ createRoot(rootElement).render(
         <AuthProvider config={authConfig}>
           <MoneyDisplayProvider>
             <AccessibilityProvider>
-              <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '') || '/'}>
+              <AppBrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '') || '/'}>
                 <NavigationGuard>
                   <ScrollToTop />
                   <UpdateBanner />
@@ -212,7 +213,7 @@ createRoot(rootElement).render(
                     <App />
                   </DatabaseGate>
                 </NavigationGuard>
-              </BrowserRouter>
+              </AppBrowserRouter>
             </AccessibilityProvider>
           </MoneyDisplayProvider>
         </AuthProvider>


### PR DESCRIPTION
## Summary

Fixes the critical bug where **switching navbar tabs almost always failed to switch the page** — the URL and the active-nav indicator moved to the new tab, but the rendered content stayed on the previous screen (e.g. clicking **Transactions** while on **Accounts** left the Accounts page showing under a `/transactions` URL).

## Root cause

`react-router-dom` v7's `<BrowserRouter>` wraps **every** location / router-state update in `React.startTransition` by default (the `useTransitions` prop defaults to `undefined`; the library's own docs warn this default "can lead to buggy behaviors").

Every route in `routes.tsx` is a `lazy()` page rendered inside a **shared** `RouteBoundary` → `<Suspense fallback={<PageLoader/>}>`. On a tab click:

1. `history.pushState` updates the URL **synchronously**, and the active-nav indicator (driven by `useLocation()`) moves.
2. The router state change runs **inside a transition**. React reconciles the reused `<Suspense>` boundary; the incoming lazy chunk suspends.
3. Because it's a transition, React keeps the **previously committed page visible** instead of revealing the fallback.

Net effect: URL + nav move, content stays stale. It reproduced near-deterministically because the shared Suspense boundary is reused across every route.

## Fix

Introduce `AppBrowserRouter` — a small, testable wrapper that pins `useTransitions={false}` — and route `main.tsx` through it. Navigations are now **urgent**: the shared `<Suspense>` reveals its `PageLoader` immediately and the destination page commits once its chunk resolves. This matches the app's design, which surfaces loading through per-route Suspense fallbacks (not transition/`isPending` UI), so nothing is lost by disabling the default transition wrapping.

## Changes

- Add `apps/web/src/AppBrowserRouter.tsx` — `BrowserRouter` wrapper with `useTransitions={false}` and a doc comment explaining the react-router v7 rationale.
- Wire `apps/web/src/main.tsx` to use `AppBrowserRouter`.
- Add `apps/web/src/AppBrowserRouter.test.tsx` — regression tests that reproduce the shared-Suspense lazy-route setup, navigate Accounts→Transactions, and assert the old page is hidden behind the loader and the destination commits. **Verified they fail if `useTransitions={false}` is removed.**

## Testing

- New regression suite passes (3/3), and fails without the fix (proven by temporarily removing the prop).
- Existing navigation component tests pass (24/24).
- `prettier --check` and `eslint --max-warnings 0` clean on changed files.

> Note: two unrelated route-adjacent suites can't load locally due to a missing `lucide-react` in this constrained environment (junctioned `node_modules`); remote CI installs it. No changed file imports `lucide-react`.

Closes #3551
