### PR TITLE
fix(web): centralize input & picker styling — strip native browser chrome

### DIFF
--- a/apps/web/src/components/forms/forms.css
+++ b/apps/web/src/components/forms/forms.css
@@ -168,6 +168,21 @@
   padding-right: 2.25rem;
 }
 
+/* Strip native number-input spinner arrows so the shared input keeps
+ * the design-system chrome regardless of global stylesheet load order.
+ * Mirrors the app-wide reset in styles/accessibility.css. */
+.form-input[type='number'] {
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+
+.form-input[type='number']::-webkit-outer-spin-button,
+.form-input[type='number']::-webkit-inner-spin-button {
+  appearance: none;
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 /* ---------------------------------------------------------------------------
  * Error state
  * ------------------------------------------------------------------------- */

--- a/apps/web/src/styles/accessibility.css
+++ b/apps/web/src/styles/accessibility.css
@@ -131,6 +131,79 @@ textarea {
   min-height: 44px;
 }
 
+/* -------------------------------------------------------------------
+ * Native form-control chrome normalization (centralized)
+ *
+ * The browser's stock number spinner arrows and native date/time
+ * picker indicators clash with the app's design system (especially in
+ * dark themes). These global rules strip the stock chrome so every
+ * input in the web app is driven by the shared, centrally styled
+ * components/rules — no native styling leaks through. Number inputs
+ * that want a stepper use a custom, design-system-styled control; date
+ * selection uses the shared <DatePicker> component.
+ * ------------------------------------------------------------------- */
+
+/* Remove native number-input spinner buttons app-wide (WebKit/Blink). */
+input[type='number']::-webkit-outer-spin-button,
+input[type='number']::-webkit-inner-spin-button {
+  appearance: none;
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Remove native number-input spinners (Firefox). */
+input[type='number'] {
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+
+/* Style the native date/time picker indicator to match the design
+ * system. Give it a consistent hit area and pointer affordance. */
+input[type='date']::-webkit-calendar-picker-indicator,
+input[type='time']::-webkit-calendar-picker-indicator,
+input[type='datetime-local']::-webkit-calendar-picker-indicator,
+input[type='month']::-webkit-calendar-picker-indicator,
+input[type='week']::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+  border-radius: var(--border-radius-sm, 4px);
+  opacity: 0.7;
+  transition: opacity var(--duration-fast, 120ms) ease;
+}
+
+input[type='date']::-webkit-calendar-picker-indicator:hover,
+input[type='time']::-webkit-calendar-picker-indicator:hover,
+input[type='datetime-local']::-webkit-calendar-picker-indicator:hover,
+input[type='month']::-webkit-calendar-picker-indicator:hover,
+input[type='week']::-webkit-calendar-picker-indicator:hover {
+  opacity: 1;
+}
+
+/* Invert the stock (dark-on-light) calendar glyph so it reads against
+ * dark surfaces. Applies to the dark and OLED themes, and to users
+ * whose OS prefers dark without an explicit light override. */
+[data-theme='dark'] input[type='date']::-webkit-calendar-picker-indicator,
+[data-theme='dark'] input[type='time']::-webkit-calendar-picker-indicator,
+[data-theme='dark'] input[type='datetime-local']::-webkit-calendar-picker-indicator,
+[data-theme='dark'] input[type='month']::-webkit-calendar-picker-indicator,
+[data-theme='dark'] input[type='week']::-webkit-calendar-picker-indicator,
+[data-theme='dark-oled'] input[type='date']::-webkit-calendar-picker-indicator,
+[data-theme='dark-oled'] input[type='time']::-webkit-calendar-picker-indicator,
+[data-theme='dark-oled'] input[type='datetime-local']::-webkit-calendar-picker-indicator,
+[data-theme='dark-oled'] input[type='month']::-webkit-calendar-picker-indicator,
+[data-theme='dark-oled'] input[type='week']::-webkit-calendar-picker-indicator {
+  filter: invert(1) brightness(1.4);
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme='light']) input[type='date']::-webkit-calendar-picker-indicator,
+  html:not([data-theme='light']) input[type='time']::-webkit-calendar-picker-indicator,
+  html:not([data-theme='light']) input[type='datetime-local']::-webkit-calendar-picker-indicator,
+  html:not([data-theme='light']) input[type='month']::-webkit-calendar-picker-indicator,
+  html:not([data-theme='light']) input[type='week']::-webkit-calendar-picker-indicator {
+    filter: invert(1) brightness(1.4);
+  }
+}
+
 /* Icon buttons — ensure padding creates adequate touch target */
 .icon-button {
   display: inline-flex;


### PR DESCRIPTION
## Summary

Native browser chrome was leaking through the app's dark design system on web forms — most visibly the stock up/down **spinner arrows** on `Amount ($)` (`<input type="number">`) and the browser's default calendar-picker indicator on native date inputs. This routes all inputs/pickers through **centralized styling** so no stock chrome shows.

## Changes

- **`apps/web/src/styles/accessibility.css`** (globally loaded): added a centralized native-chrome reset —
  - Hide number-input spinner buttons app-wide (`::-webkit-inner-spin-button` / `::-webkit-outer-spin-button` + Firefox `appearance: textfield`).
  - Style native date/time/`datetime-local`/`month`/`week` picker indicators (hit area, pointer, hover) and **invert** the stock glyph in dark / OLED / OS-dark themes so it reads on dark surfaces.
- **`apps/web/src/components/forms/forms.css`**: reinforced the shared `.form-input` class to strip number spinners regardless of stylesheet load order (mirrors the global reset).

The already-custom shared `DatePicker` component (custom calendar + clear button) continues to own date selection; `.form-select` already resets native select chrome. This change makes the number-input and native date/time chrome consistent with those.

## Scope / coordination

- **Visual styling only.** No date-validation or money-rounding logic touched, to avoid clobbering parallel work on those areas. Left the pre-existing per-component spinner hack in `quick-entry.css` untouched (not a new duplicate).
- Rebased onto latest `origin/main` before push.

## Accessibility

- Preserves visible focus, labels, and the global 44×44 touch targets (WCAG 2.2 AA). Hover/opacity affordance on the date indicator; no information conveyed by color alone.

## Testing

- `npx prettier --check` on both files — clean.
- `npx vitest run` — DatePicker + form field suites pass (12 tests).

## Issues

Closes #3546