### PR TITLE
fix(web): distinguish malformed vs invalid calendar dates & centralize date validation

### DIFF
--- a/apps/web/src/components/common/DatePicker.test.tsx
+++ b/apps/web/src/components/common/DatePicker.test.tsx
@@ -65,13 +65,23 @@ describe('DatePicker', () => {
     expect(input).toHaveValue('01/20/2025');
   });
 
-  it('validates manual MM/DD/YYYY entry and commits valid dates', () => {
+  it('reports invalid calendar dates distinctly from malformed input', () => {
     const { input, onValueChange } = renderDatePicker();
 
-    fireEvent.change(input, { target: { value: '13/40/2025' } });
+    // Well-formed MM/DD/YYYY shape, but not a real calendar date.
+    fireEvent.change(input, { target: { value: '12/33/2000' } });
     fireEvent.blur(input);
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Enter a date in MM/DD/YYYY.');
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Not a valid calendar date — check the month and day.',
+    );
+    expect(onValueChange).not.toHaveBeenCalled();
+
+    // Genuinely malformed shape gets the format message instead.
+    fireEvent.change(input, { target: { value: '6/18/25' } });
+    fireEvent.blur(input);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a date in MM/DD/YYYY format.');
     expect(onValueChange).not.toHaveBeenCalled();
 
     fireEvent.change(input, { target: { value: '06/18/2025' } });

--- a/apps/web/src/components/common/DatePicker.tsx
+++ b/apps/web/src/components/common/DatePicker.tsx
@@ -12,11 +12,18 @@ import {
 import { CalendarDays, ChevronLeft, ChevronRight, X } from 'lucide-react';
 
 import { formatDate } from '../../utils/formatDate';
+import {
+  formatDisplayDate as formatInputDate,
+  formatIsoDate,
+  getRangeValidationMessage,
+  ISO_DATE_PATTERN,
+  parseDateInput,
+  parseDisplayDate,
+  parseIsoDate,
+} from '../../utils/dateValidation';
 
 import './date-picker.css';
 
-const DISPLAY_DATE_PATTERN = /^(\d{2})\/(\d{2})\/(\d{4})$/;
-const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 const WEEKDAY_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'] as const;
 const MONTH_LABELS = [
   'January',
@@ -32,7 +39,6 @@ const MONTH_LABELS = [
   'November',
   'December',
 ] as const;
-const INVALID_DATE_MESSAGE = 'Enter a date in MM/DD/YYYY.';
 
 export interface DatePickerProps extends Omit<
   InputHTMLAttributes<HTMLInputElement>,
@@ -40,52 +46,6 @@ export interface DatePickerProps extends Omit<
 > {
   value?: string | null;
   onChange: (value: string) => void;
-}
-
-function createDate(year: number, monthIndex: number, day: number): Date | null {
-  const nextDate = new Date(year, monthIndex, day);
-
-  if (
-    nextDate.getFullYear() !== year ||
-    nextDate.getMonth() !== monthIndex ||
-    nextDate.getDate() !== day
-  ) {
-    return null;
-  }
-
-  nextDate.setHours(0, 0, 0, 0);
-  return nextDate;
-}
-
-function parseIsoDate(value: string | null | undefined): Date | null {
-  if (!value) return null;
-
-  const match = ISO_DATE_PATTERN.exec(value);
-  if (!match) return null;
-
-  const [, yearText, monthText, dayText] = match;
-  return createDate(Number(yearText), Number(monthText) - 1, Number(dayText));
-}
-
-function parseDisplayDate(value: string): Date | null {
-  const match = DISPLAY_DATE_PATTERN.exec(value.trim());
-  if (!match) return null;
-
-  const [, monthText, dayText, yearText] = match;
-  return createDate(Number(yearText), Number(monthText) - 1, Number(dayText));
-}
-
-function formatIsoDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-function formatInputDate(date: Date): string {
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${month}/${day}/${date.getFullYear()}`;
 }
 
 function getToday(): Date {
@@ -143,20 +103,6 @@ function isDateSelectable(isoDate: string, min?: string, max?: string): boolean 
   if (min && isoDate < min) return false;
   if (max && isoDate > max) return false;
   return true;
-}
-
-function getRangeValidationMessage(isoDate: string, min?: string, max?: string): string | null {
-  if (min && isoDate < min) {
-    const minDate = parseIsoDate(min);
-    return minDate ? `Date must be on or after ${formatInputDate(minDate)}.` : 'Date is too early.';
-  }
-
-  if (max && isoDate > max) {
-    const maxDate = parseIsoDate(max);
-    return maxDate ? `Date must be on or before ${formatInputDate(maxDate)}.` : 'Date is too late.';
-  }
-
-  return null;
 }
 
 function clampDateToRange(date: Date, minDate: Date | null, maxDate: Date | null): Date {
@@ -323,16 +269,14 @@ export function DatePicker({
       return true;
     }
 
-    const parsedDate = ISO_DATE_PATTERN.test(trimmedValue)
-      ? parseIsoDate(trimmedValue)
-      : parseDisplayDate(trimmedValue);
+    const parseResult = parseDateInput(trimmedValue);
 
-    if (parsedDate === null) {
-      setValidationMessage(INVALID_DATE_MESSAGE);
+    if (!parseResult.ok) {
+      setValidationMessage(parseResult.message);
       return false;
     }
 
-    const isoDate = formatIsoDate(parsedDate);
+    const { date: parsedDate, iso: isoDate } = parseResult;
     const rangeMessage = getRangeValidationMessage(isoDate, minValue, maxValue);
     if (rangeMessage) {
       setValidationMessage(rangeMessage);

--- a/apps/web/src/utils/dateValidation.test.ts
+++ b/apps/web/src/utils/dateValidation.test.ts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DATE_VALIDATION_MESSAGES,
+  createCalendarDate,
+  formatDisplayDate,
+  formatIsoDate,
+  getRangeValidationMessage,
+  parseDateInput,
+  parseDisplayDate,
+  parseIsoDate,
+  validateDateInput,
+} from './dateValidation';
+
+describe('createCalendarDate', () => {
+  it('accepts a real calendar date', () => {
+    const date = createCalendarDate(2024, 1, 29); // 29 Feb 2024 (leap year)
+    expect(date).not.toBeNull();
+    expect(formatIsoDate(date as Date)).toBe('2024-02-29');
+  });
+
+  it('rejects a day that rolls over into the next month', () => {
+    expect(createCalendarDate(2000, 11, 33)).toBeNull(); // 33 Dec 2000
+    expect(createCalendarDate(2024, 1, 30)).toBeNull(); // 30 Feb 2024
+    expect(createCalendarDate(2023, 1, 29)).toBeNull(); // 29 Feb 2023 (non-leap)
+  });
+
+  it('rejects an out-of-range month', () => {
+    expect(createCalendarDate(2000, 12, 1)).toBeNull(); // month index 12 === month 13
+  });
+});
+
+describe('parseDisplayDate', () => {
+  it('parses a valid MM/DD/YYYY value', () => {
+    expect(formatIsoDate(parseDisplayDate('06/18/2025') as Date)).toBe('2025-06-18');
+  });
+
+  it('returns null for well-formed but invalid calendar dates', () => {
+    expect(parseDisplayDate('12/33/2000')).toBeNull();
+    expect(parseDisplayDate('02/30/2024')).toBeNull();
+    expect(parseDisplayDate('13/01/2000')).toBeNull();
+    expect(parseDisplayDate('00/00/0000')).toBeNull();
+  });
+
+  it('returns null for malformed shapes', () => {
+    expect(parseDisplayDate('6/18/25')).toBeNull();
+    expect(parseDisplayDate('2025-06-18')).toBeNull();
+    expect(parseDisplayDate('hello')).toBeNull();
+  });
+});
+
+describe('parseIsoDate', () => {
+  it('parses a valid ISO date', () => {
+    expect(formatDisplayDate(parseIsoDate('2024-02-29') as Date)).toBe('02/29/2024');
+  });
+
+  it('returns null for invalid ISO calendar dates', () => {
+    expect(parseIsoDate('2023-02-29')).toBeNull();
+    expect(parseIsoDate('2000-13-01')).toBeNull();
+  });
+
+  it('returns null for empty or malformed values', () => {
+    expect(parseIsoDate('')).toBeNull();
+    expect(parseIsoDate(null)).toBeNull();
+    expect(parseIsoDate('06/18/2025')).toBeNull();
+  });
+});
+
+describe('parseDateInput', () => {
+  it('flags empty input distinctly', () => {
+    const result = parseDateInput('   ');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errorKind).toBe('empty');
+      expect(result.message).toBe(DATE_VALIDATION_MESSAGES.empty);
+    }
+  });
+
+  it('flags malformed shapes with the format message', () => {
+    for (const value of ['6/18/25', '2025.01.01', 'hello', '2025/06/18']) {
+      const result = parseDateInput(value);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errorKind).toBe('malformed');
+        expect(result.message).toBe(DATE_VALIDATION_MESSAGES.malformed);
+      }
+    }
+  });
+
+  it('flags well-formed but invalid calendar dates distinctly from malformed input', () => {
+    for (const value of ['12/33/2000', '02/30/2024', '13/01/2000', '00/00/0000', '2023-02-29']) {
+      const result = parseDateInput(value);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errorKind).toBe('invalid-calendar-date');
+        expect(result.message).toBe(DATE_VALIDATION_MESSAGES.invalidCalendarDate);
+      }
+    }
+  });
+
+  it('accepts a valid leap-year date', () => {
+    const result = parseDateInput('02/29/2024');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.iso).toBe('2024-02-29');
+    }
+  });
+
+  it('accepts and normalizes both display and ISO input', () => {
+    const display = parseDateInput('06/18/2025');
+    const iso = parseDateInput('2025-06-18');
+    expect(display.ok && display.iso).toBe('2025-06-18');
+    expect(iso.ok && iso.iso).toBe('2025-06-18');
+  });
+});
+
+describe('getRangeValidationMessage', () => {
+  it('returns null within range', () => {
+    expect(getRangeValidationMessage('2025-06-18', '2025-06-01', '2025-06-30')).toBeNull();
+  });
+
+  it('reports before-min with the boundary date', () => {
+    expect(getRangeValidationMessage('2025-06-15', '2025-06-16')).toBe(
+      'Date must be on or after 06/16/2025.',
+    );
+  });
+
+  it('reports after-max with the boundary date', () => {
+    expect(getRangeValidationMessage('2025-07-01', undefined, '2025-06-30')).toBe(
+      'Date must be on or before 06/30/2025.',
+    );
+  });
+});
+
+describe('validateDateInput', () => {
+  it('treats empty as valid by default and invalid when required', () => {
+    expect(validateDateInput('')).toEqual({ valid: true, iso: '' });
+
+    const required = validateDateInput('', { required: true });
+    expect(required).toEqual({
+      valid: false,
+      errorKind: 'empty',
+      message: DATE_VALIDATION_MESSAGES.empty,
+    });
+  });
+
+  it('distinguishes malformed from invalid calendar dates', () => {
+    expect(validateDateInput('6/18/25')).toEqual({
+      valid: false,
+      errorKind: 'malformed',
+      message: DATE_VALIDATION_MESSAGES.malformed,
+    });
+
+    expect(validateDateInput('12/33/2000')).toEqual({
+      valid: false,
+      errorKind: 'invalid-calendar-date',
+      message: DATE_VALIDATION_MESSAGES.invalidCalendarDate,
+    });
+  });
+
+  it('applies min/max range checks', () => {
+    expect(validateDateInput('06/15/2025', { min: '2025-06-16' })).toEqual({
+      valid: false,
+      errorKind: 'before-min',
+      message: 'Date must be on or after 06/16/2025.',
+    });
+
+    expect(validateDateInput('07/01/2025', { max: '2025-06-30' })).toEqual({
+      valid: false,
+      errorKind: 'after-max',
+      message: 'Date must be on or before 06/30/2025.',
+    });
+  });
+
+  it('returns the normalized ISO value for a valid date', () => {
+    expect(validateDateInput('06/18/2025', { min: '2025-01-01', max: '2025-12-31' })).toEqual({
+      valid: true,
+      iso: '2025-06-18',
+    });
+  });
+});

--- a/apps/web/src/utils/dateValidation.ts
+++ b/apps/web/src/utils/dateValidation.ts
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Centralized date parsing and validation shared across every web date input.
+ *
+ * This module is the single source of truth for how the web app parses and
+ * validates user-entered dates. It deliberately distinguishes the two failure
+ * modes that were previously collapsed into one misleading message:
+ *
+ * - **Malformed** — the text is not shaped like a date at all (e.g. `6/18/25`,
+ *   `2025.01.01`, `hello`). The user needs to fix the *format*.
+ * - **Invalid calendar date** — the text is well-formed (`MM/DD/YYYY` or ISO
+ *   `YYYY-MM-DD`) but does not correspond to a real day on the calendar
+ *   (e.g. `12/33/2000`, `02/30/2024`, `13/01/2000`). The format is fine; the
+ *   *value* is wrong.
+ *
+ * Range checks (`min`/`max`) are also handled here so that every field applies
+ * the same boundary semantics and messaging.
+ */
+
+/** Matches a display date shaped `MM/DD/YYYY` (two/two/four digits). */
+export const DISPLAY_DATE_PATTERN = /^(\d{2})\/(\d{2})\/(\d{4})$/;
+
+/** Matches an ISO date shaped `YYYY-MM-DD`. */
+export const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/** The distinct reasons a date input can fail validation. */
+export type DateValidationErrorKind =
+  'empty' | 'malformed' | 'invalid-calendar-date' | 'before-min' | 'after-max';
+
+/**
+ * User-facing messages for each failure mode. `before-min`/`after-max` are
+ * produced dynamically (they embed the boundary date) via
+ * {@link getRangeValidationMessage}.
+ */
+export const DATE_VALIDATION_MESSAGES = {
+  empty: 'Enter a date.',
+  malformed: 'Enter a date in MM/DD/YYYY format.',
+  invalidCalendarDate: 'Not a valid calendar date — check the month and day.',
+} as const;
+
+/**
+ * Construct a local `Date` at midnight, rejecting values that roll over into a
+ * different month/day (e.g. day 33, month 13, Feb 30). Returns `null` when the
+ * requested year/month/day is not a real calendar date.
+ */
+export function createCalendarDate(year: number, monthIndex: number, day: number): Date | null {
+  const nextDate = new Date(year, monthIndex, day);
+
+  if (
+    nextDate.getFullYear() !== year ||
+    nextDate.getMonth() !== monthIndex ||
+    nextDate.getDate() !== day
+  ) {
+    return null;
+  }
+
+  nextDate.setHours(0, 0, 0, 0);
+  return nextDate;
+}
+
+/**
+ * Parse an ISO `YYYY-MM-DD` string into a local `Date`, or `null` if the string
+ * is not a well-formed, real calendar date.
+ */
+export function parseIsoDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+
+  const match = ISO_DATE_PATTERN.exec(value);
+  if (!match) return null;
+
+  const [, yearText, monthText, dayText] = match;
+  return createCalendarDate(Number(yearText), Number(monthText) - 1, Number(dayText));
+}
+
+/**
+ * Parse a display `MM/DD/YYYY` string into a local `Date`, or `null` if the
+ * string is not a well-formed, real calendar date.
+ */
+export function parseDisplayDate(value: string): Date | null {
+  const match = DISPLAY_DATE_PATTERN.exec(value.trim());
+  if (!match) return null;
+
+  const [, monthText, dayText, yearText] = match;
+  return createCalendarDate(Number(yearText), Number(monthText) - 1, Number(dayText));
+}
+
+/** Format a `Date` as an ISO `YYYY-MM-DD` string. */
+export function formatIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** Format a `Date` as a display `MM/DD/YYYY` string. */
+export function formatDisplayDate(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${month}/${day}/${date.getFullYear()}`;
+}
+
+/** Successful parse of a date string. */
+export interface DateParseSuccess {
+  readonly ok: true;
+  /** Parsed local date at midnight. */
+  readonly date: Date;
+  /** Canonical ISO `YYYY-MM-DD` representation. */
+  readonly iso: string;
+}
+
+/** Failed parse of a date string, with a distinct reason and message. */
+export interface DateParseFailure {
+  readonly ok: false;
+  readonly errorKind: Extract<
+    DateValidationErrorKind,
+    'empty' | 'malformed' | 'invalid-calendar-date'
+  >;
+  readonly message: string;
+}
+
+/** Result of {@link parseDateInput}. */
+export type DateParseResult = DateParseSuccess | DateParseFailure;
+
+/**
+ * Parse a user-entered date string, accepting either `MM/DD/YYYY` or ISO
+ * `YYYY-MM-DD`. Distinguishes malformed input from well-formed-but-invalid
+ * calendar dates so callers can surface an accurate message.
+ */
+export function parseDateInput(rawValue: string): DateParseResult {
+  const trimmed = rawValue.trim();
+
+  if (!trimmed) {
+    return { ok: false, errorKind: 'empty', message: DATE_VALIDATION_MESSAGES.empty };
+  }
+
+  const isIso = ISO_DATE_PATTERN.test(trimmed);
+  const isDisplay = DISPLAY_DATE_PATTERN.test(trimmed);
+
+  // Not shaped like a supported date format at all.
+  if (!isIso && !isDisplay) {
+    return { ok: false, errorKind: 'malformed', message: DATE_VALIDATION_MESSAGES.malformed };
+  }
+
+  // Well-formed shape — now check it is a real calendar date.
+  const date = isIso ? parseIsoDate(trimmed) : parseDisplayDate(trimmed);
+  if (date === null) {
+    return {
+      ok: false,
+      errorKind: 'invalid-calendar-date',
+      message: DATE_VALIDATION_MESSAGES.invalidCalendarDate,
+    };
+  }
+
+  return { ok: true, date, iso: formatIsoDate(date) };
+}
+
+/**
+ * Produce a range-violation message for an ISO date against optional ISO
+ * `min`/`max` bounds, or `null` when the date is within range. ISO strings sort
+ * lexicographically, so plain string comparison is a valid date comparison.
+ */
+export function getRangeValidationMessage(
+  isoDate: string,
+  min?: string,
+  max?: string,
+): string | null {
+  if (min && isoDate < min) {
+    const minDate = parseIsoDate(min);
+    return minDate
+      ? `Date must be on or after ${formatDisplayDate(minDate)}.`
+      : 'Date is too early.';
+  }
+
+  if (max && isoDate > max) {
+    const maxDate = parseIsoDate(max);
+    return maxDate
+      ? `Date must be on or before ${formatDisplayDate(maxDate)}.`
+      : 'Date is too late.';
+  }
+
+  return null;
+}
+
+/** Options controlling {@link validateDateInput}. */
+export interface DateValidationOptions {
+  /** Inclusive lower bound as an ISO `YYYY-MM-DD` string. */
+  readonly min?: string;
+  /** Inclusive upper bound as an ISO `YYYY-MM-DD` string. */
+  readonly max?: string;
+  /** When `true`, an empty value is treated as invalid. Defaults to `false`. */
+  readonly required?: boolean;
+}
+
+/** A valid date input result. */
+export interface DateValidationSuccess {
+  readonly valid: true;
+  /** Canonical ISO `YYYY-MM-DD` value, or `''` for an accepted empty value. */
+  readonly iso: string;
+}
+
+/** An invalid date input result, with the specific failure reason and message. */
+export interface DateValidationFailure {
+  readonly valid: false;
+  readonly errorKind: DateValidationErrorKind;
+  readonly message: string;
+}
+
+/** Result of {@link validateDateInput}. */
+export type DateValidationResult = DateValidationSuccess | DateValidationFailure;
+
+/**
+ * Fully validate a user-entered date string: shape, calendar validity, and
+ * range. This is the entry point web date inputs should use so behavior and
+ * messaging stay consistent across the app.
+ *
+ * An empty value is valid unless `required` is set. Both `MM/DD/YYYY` and ISO
+ * `YYYY-MM-DD` inputs are accepted and normalized to ISO.
+ */
+export function validateDateInput(
+  rawValue: string,
+  options: DateValidationOptions = {},
+): DateValidationResult {
+  const { min, max, required = false } = options;
+  const trimmed = rawValue.trim();
+
+  if (!trimmed) {
+    if (required) {
+      return { valid: false, errorKind: 'empty', message: DATE_VALIDATION_MESSAGES.empty };
+    }
+    return { valid: true, iso: '' };
+  }
+
+  const parsed = parseDateInput(trimmed);
+  if (!parsed.ok) {
+    return { valid: false, errorKind: parsed.errorKind, message: parsed.message };
+  }
+
+  const rangeMessage = getRangeValidationMessage(parsed.iso, min, max);
+  if (rangeMessage) {
+    return {
+      valid: false,
+      errorKind: min && parsed.iso < min ? 'before-min' : 'after-max',
+      message: rangeMessage,
+    };
+  }
+
+  return { valid: true, iso: parsed.iso };
+}


### PR DESCRIPTION
## Summary

Fixes a misleading date-validation error and centralizes web date parsing/validation into a single shared utility.

The `DatePicker` previously showed **"Enter a date in MM/DD/YYYY."** for a value like `12/33/2000`. That value *is* in `MM/DD/YYYY` shape — the real problem is that it is not a valid calendar date. The old code collapsed both failure modes into one message because `parseDisplayDate` returned `null` for malformed input *and* well-formed-but-invalid dates alike.

## Changes

- **New shared utility** `apps/web/src/utils/dateValidation.ts` — the single source of truth for web date handling:
  - `parseDateInput` distinguishes `malformed` (wrong shape) from `invalid-calendar-date` (well-formed but not a real day), plus `empty`.
  - `validateDateInput` adds inclusive `min`/`max` range checks (`before-min` / `after-max`) with consistent messaging.
  - Exposes shared parse/format helpers (`parseDisplayDate`, `parseIsoDate`, `formatIsoDate`, `formatDisplayDate`, `getRangeValidationMessage`) so callers stop re-implementing them.
  - Distinct messages: malformed → "Enter a date in MM/DD/YYYY format."; invalid calendar date → "Not a valid calendar date — check the month and day."
- **Refactored `DatePicker`** to consume the shared util, removing its duplicated parsing/validation/formatting helpers and fixing the misleading message.
- **Tests**:
  - `dateValidation.test.ts` covers boundary cases: `12/33/2000`, `02/30/2024`, `13/01/2000`, `00/00/0000`, leap-year `02/29/2024` (valid) / `02/29/2023` (invalid), empty, partial, ISO invalids, and min/max ranges.
  - Updated `DatePicker.test.tsx` to assert the malformed-vs-invalid distinction.

## Architecture note

The web app is TypeScript-only today; the KMP→JS bridge (`apps/web/src/kmp/`) is still type-only (dual-path). So the centralized *web* surface is this TS module. Porting the same parse/validate rules into `packages/core` (KMP) for native platforms (Android/iOS/Windows) once the JS bridge is wired is tracked as a follow-up.

## Issues

Closes #3544

## Testing

- [x] `npx vitest run` for `dateValidation` + `DatePicker` — 26 passed
- [x] `npx tsc --noEmit` (apps/web) clean
- [x] `npx eslint` on changed files, `--max-warnings 0` clean
- [x] `npx prettier --write` on changed files

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>