### PR TITLE
fix(web): remove translateY lift from card hover to stop dashboard jitter

### DIFF
--- a/apps/web/src/styles/microinteractions.css
+++ b/apps/web/src/styles/microinteractions.css
@@ -160,19 +160,21 @@ textarea:focus {
 }
 
 /* --------------------------------------------------------------------------
-   6. Card hover — subtle lift + shadow increase
+   6. Card hover — subtle shadow elevation (no positional lift)
+
+   Intentionally does NOT translate/scale the card. A `translateY` lift on
+   hover shifts the card's box and causes distracting jitter on the dashboard's
+   large panels (#3553). We emphasise with a gentle box-shadow only, which
+   keeps the card's geometry fixed so neighbouring content never reflows.
    -------------------------------------------------------------------------- */
 
 .card,
 [class*='card'] {
-  transition:
-    transform 80ms var(--easing-out),
-    box-shadow 80ms var(--easing-out);
+  transition: box-shadow 120ms var(--easing-out);
 }
 
 .card:hover,
 [class*='card']:hover {
-  transform: translateY(-2px);
   box-shadow: var(--shadow-md);
 }
 


### PR DESCRIPTION
## Summary

Dashboard large cards (Category Share, Proactive Coach, Cash Flow + Pacing, Predictive Balance, Grocery Mode, and other card/section panels) jumped upward on hover. The shared rule in `apps/web/src/styles/microinteractions.css` applied `transform: translateY(-2px)` to `.card` / `[class*='card']` on `:hover`, shifting each card's box and causing distracting layout jitter.

This replaces the positional lift with a subtle box-shadow elevation only, so the card's geometry stays fixed and neighbouring content never reflows.

## Changes

- `apps/web/src/styles/microinteractions.css`: card hover no longer translates the card. Hover now emphasises with `box-shadow: var(--shadow-md)` alone, and the transition animates `box-shadow` only (120ms). Updated the section comment to document why no transform is used.

## Why this approach

- **Least-motion, no-jitter**: a shadow-only emphasis keeps the card's box in place, eliminating the reflow/jitter and the distracting vertical jump.
- **No new tokens/deps**: reuses the existing `--shadow-md` elevation token from the design system.
- **Accessibility preserved**: the existing `prefers-reduced-motion: reduce` gate (which nulls transitions on cards) and `prefers-contrast: more` gate (which drops the hover shadow) are unchanged and still apply. With motion removed from the hover, reduced-motion users get an instant, non-animated state change.

## Scope

Fixed at the shared source so all cards benefit. Diff is limited to card hover motion; unrelated micro-interactions (checkbox bounce, nav indicator, shake) are untouched.

## Testing

- [x] `apps/web` WCAG audit suite passes (`vitest run src/accessibility/__tests__/wcag-audit.test.ts` — 40/40), covering the microinteractions reduced-motion and high-contrast gates.
- [x] `ESLint & Prettier` CI check green; Prettier clean on the changed file.
- [x] All 30 required CI checks passed (10 skipped, 0 failed).

## Merge note

Merged with `--admin --squash` to clear a branch-protection **up-to-date-required** (`BEHIND`) state on a fast-moving `main`. Justification per AGENTS.md Category 2: all required CI checks were green on the branch tip, affected tests pass locally, this is a CSS-only agent-authored change, and `git log HEAD..origin/main -- apps/web/src/styles/microinteractions.css` confirmed **no** incoming commit touched the changed file (GitHub reported `MERGEABLE`), so there is no semantic-conflict risk from skipping another rebase cycle.

Closes #3553