### PR TITLE
feat(web): centralize buttons onto a shared, accessible Button component

### DIFF
--- a/apps/web/src/components/common/Button.css
+++ b/apps/web/src/components/common/Button.css
@@ -1,0 +1,165 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Centralized Button component styling.
+ *
+ * Extends the shared `.form-button` design language (base, `--primary`, and
+ * `--secondary` live in `forms.css`) with the additional variants, sizes,
+ * states, and internal layout used by the `Button` React component so that
+ * every button across the app can be resourced from one place.
+ *
+ * References: issue #3550
+ */
+
+/* Internal layout: icon + label alignment and loading spinner. */
+.form-button__label {
+  display: inline-flex;
+  align-items: center;
+}
+
+.form-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.form-button__spinner {
+  width: 0.875rem;
+  height: 0.875rem;
+  border: 2px solid color-mix(in srgb, currentColor 35%, transparent);
+  border-top-color: currentColor;
+  border-radius: 999px;
+  animation: form-button-spinner-rotate 1s linear infinite;
+  flex: none;
+}
+
+@keyframes form-button-spinner-rotate {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Variants (extend the base + primary/secondary defined in forms.css)
+ * ------------------------------------------------------------------------- */
+
+/* Tertiary: quiet, bordered, low-emphasis action. */
+.form-button.form-button--tertiary {
+  background: transparent;
+  color: var(--semantic-interactive-default);
+  border-color: transparent;
+}
+
+.form-button.form-button--tertiary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--semantic-interactive-default) 12%, transparent);
+}
+
+.form-button.form-button--tertiary:active:not(:disabled) {
+  background: color-mix(in srgb, var(--semantic-interactive-default) 20%, transparent);
+}
+
+/* Ghost: no chrome until interacted with; neutral text. */
+.form-button.form-button--ghost {
+  background: transparent;
+  color: var(--semantic-text-primary);
+  border-color: transparent;
+}
+
+.form-button.form-button--ghost:hover:not(:disabled) {
+  background: var(--semantic-background-secondary);
+}
+
+.form-button.form-button--ghost:active:not(:disabled) {
+  background: color-mix(in srgb, var(--semantic-text-primary) 12%, transparent);
+}
+
+/* Destructive: irreversible / dangerous actions. */
+.form-button.form-button--destructive {
+  background: var(--semantic-status-negative);
+  color: var(--color-neutral-50, #ffffff);
+  border-color: var(--semantic-status-negative);
+}
+
+.form-button.form-button--destructive:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--semantic-status-negative) 85%, #000000);
+  border-color: color-mix(in srgb, var(--semantic-status-negative) 85%, #000000);
+}
+
+.form-button.form-button--destructive:active:not(:disabled) {
+  background: color-mix(in srgb, var(--semantic-status-negative) 75%, #000000);
+  border-color: color-mix(in srgb, var(--semantic-status-negative) 75%, #000000);
+}
+
+/* ---------------------------------------------------------------------------
+ * Sizes (md is the default defined in forms.css)
+ * ------------------------------------------------------------------------- */
+
+.form-button.form-button--sm {
+  min-height: 32px;
+  padding: var(--spacing-1) var(--spacing-3);
+  font-size: var(--type-scale-caption-font-size, 0.8125rem);
+}
+
+.form-button.form-button--lg {
+  min-height: 48px;
+  padding: var(--spacing-3) var(--spacing-6);
+  font-size: var(--type-scale-title-font-size, 1.0625rem);
+}
+
+/* ---------------------------------------------------------------------------
+ * Modifiers
+ * ------------------------------------------------------------------------- */
+
+.form-button.form-button--full {
+  width: 100%;
+}
+
+/* Loading buttons keep the cursor busy and prevent double activation. */
+.form-button.form-button--loading {
+  cursor: progress;
+}
+
+/* ---------------------------------------------------------------------------
+ * Link-rendered buttons (as={Link}) — normalize anchor defaults so a button
+ * rendered as an <a> never leaks the browser's default link color/underline.
+ * This is the root cause of the "purple Cancel" bug.
+ * ------------------------------------------------------------------------- */
+
+a.form-button,
+a.form-button:hover,
+a.form-button:visited,
+a.form-button:active {
+  text-decoration: none;
+}
+
+a.form-button--secondary,
+a.form-button--secondary:visited {
+  color: var(--semantic-text-primary);
+}
+
+a.form-button--tertiary,
+a.form-button--tertiary:visited {
+  color: var(--semantic-interactive-default);
+}
+
+a.form-button--ghost,
+a.form-button--ghost:visited {
+  color: var(--semantic-text-primary);
+}
+
+/* Anchors have no :disabled — support aria-disabled for link-styled buttons. */
+.form-button[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .form-button__spinner {
+    animation-duration: 2s;
+  }
+}

--- a/apps/web/src/components/common/Button.stories.tsx
+++ b/apps/web/src/components/common/Button.stories.tsx
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Common/Button',
+  component: Button,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    children: 'Button',
+    onClick: fn(),
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'ghost', 'destructive'],
+    },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    loading: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    fullWidth: { control: 'boolean' },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = { args: { variant: 'primary', children: 'Create Bill' } };
+export const Secondary: Story = { args: { variant: 'secondary', children: 'Cancel' } };
+export const Tertiary: Story = { args: { variant: 'tertiary', children: 'Learn more' } };
+export const Ghost: Story = { args: { variant: 'ghost', children: 'Dismiss' } };
+export const Destructive: Story = { args: { variant: 'destructive', children: 'Delete' } };
+export const Loading: Story = { args: { variant: 'primary', loading: true, children: 'Saving…' } };
+export const Disabled: Story = { args: { variant: 'primary', disabled: true, children: 'Save' } };
+
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 'var(--spacing-3)', flexWrap: 'wrap' }}>
+      <Button variant="primary">Primary</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="tertiary">Tertiary</Button>
+      <Button variant="ghost">Ghost</Button>
+      <Button variant="destructive">Destructive</Button>
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-3)' }}>
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+  ),
+};

--- a/apps/web/src/components/common/Button.test.tsx
+++ b/apps/web/src/components/common/Button.test.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Link } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Button, buttonClassName } from './Button';
+
+describe('Button', () => {
+  it('renders a native button by default with type="button"', () => {
+    render(<Button>Save</Button>);
+    const btn = screen.getByRole('button', { name: 'Save' });
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn).toHaveAttribute('type', 'button');
+  });
+
+  it('applies the primary variant class by default', () => {
+    render(<Button>Save</Button>);
+    const btn = screen.getByRole('button', { name: 'Save' });
+    expect(btn).toHaveClass('form-button');
+    expect(btn).toHaveClass('form-button--primary');
+  });
+
+  it.each([
+    ['secondary', 'form-button--secondary'],
+    ['tertiary', 'form-button--tertiary'],
+    ['ghost', 'form-button--ghost'],
+    ['destructive', 'form-button--destructive'],
+  ] as const)('applies the %s variant class', (variant, className) => {
+    render(<Button variant={variant}>Action</Button>);
+    expect(screen.getByRole('button', { name: 'Action' })).toHaveClass(className);
+  });
+
+  it('applies size and full-width modifiers', () => {
+    render(
+      <Button size="lg" fullWidth>
+        Big
+      </Button>,
+    );
+    const btn = screen.getByRole('button', { name: 'Big' });
+    expect(btn).toHaveClass('form-button--lg');
+    expect(btn).toHaveClass('form-button--full');
+  });
+
+  it('fires onClick when enabled', () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Go</Button>);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables and marks aria-busy while loading', () => {
+    const onClick = vi.fn();
+    render(
+      <Button loading onClick={onClick}>
+        Saving
+      </Button>,
+    );
+    const btn = screen.getByRole('button', { name: 'Saving' });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('respects an explicit disabled prop', () => {
+    render(<Button disabled>Nope</Button>);
+    expect(screen.getByRole('button', { name: 'Nope' })).toBeDisabled();
+  });
+
+  it('honors an explicit type="submit"', () => {
+    render(<Button type="submit">Submit</Button>);
+    expect(screen.getByRole('button', { name: 'Submit' })).toHaveAttribute('type', 'submit');
+  });
+
+  it('renders as a router Link when as={Link}, without leaking anchor defaults', () => {
+    render(
+      <MemoryRouter>
+        <Button as={Link} to="/bills" variant="secondary">
+          Cancel
+        </Button>
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole('link', { name: 'Cancel' });
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/bills');
+    expect(link).toHaveClass('form-button');
+    expect(link).toHaveClass('form-button--secondary');
+    // No native button attributes on a link rendering.
+    expect(link).not.toHaveAttribute('type');
+  });
+
+  it('buttonClassName composes the expected class list', () => {
+    expect(buttonClassName({ variant: 'destructive', size: 'sm', fullWidth: true })).toBe(
+      'form-button form-button--destructive form-button--sm form-button--full',
+    );
+    expect(buttonClassName({ className: 'extra' })).toBe('form-button form-button--primary extra');
+  });
+});

--- a/apps/web/src/components/common/Button.tsx
+++ b/apps/web/src/components/common/Button.tsx
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Centralized, design-system-consistent button component for the web app.
+ *
+ * All buttons across `apps/web` should render through this component (or its
+ * polymorphic `as` form) so that variants, sizes, states, and accessibility
+ * behaviour stay consistent. It emits the shared `.form-button` class family
+ * defined in `forms.css`, which is the canonical button design language.
+ *
+ * References: issue #3550
+ */
+
+import React from 'react';
+
+import './Button.css';
+import '../forms/forms.css';
+
+/** Visual style of a button. */
+export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'ghost' | 'destructive';
+
+/** Size of a button. */
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+/** Props shared by every button rendering, independent of the element type. */
+interface ButtonOwnProps {
+  /** Visual style. Defaults to `primary`. */
+  variant?: ButtonVariant;
+  /** Size. Defaults to `md`. */
+  size?: ButtonSize;
+  /** Stretch to fill the width of the container. */
+  fullWidth?: boolean;
+  /**
+   * When true, shows a spinner, sets `aria-busy`, and disables interaction.
+   * Only meaningful for `<button>` renderings.
+   */
+  loading?: boolean;
+  /** Optional leading icon element (hidden from assistive tech). */
+  leadingIcon?: React.ReactNode;
+  /** Optional trailing icon element (hidden from assistive tech). */
+  trailingIcon?: React.ReactNode;
+  /** Button label / contents. */
+  children?: React.ReactNode;
+}
+
+/**
+ * Polymorphic element type. Defaults to `'button'` but can render any element
+ * or component (e.g. a react-router `Link`) via the `as` prop.
+ */
+type PolymorphicProps<E extends React.ElementType> = ButtonOwnProps & {
+  /** Element or component to render as. Defaults to `'button'`. */
+  as?: E;
+} & Omit<React.ComponentPropsWithoutRef<E>, keyof ButtonOwnProps | 'as'>;
+
+/** Props for {@link Button} when rendered as a native `<button>`. */
+export type ButtonProps = PolymorphicProps<React.ElementType>;
+
+const VARIANT_CLASS: Record<ButtonVariant, string> = {
+  primary: 'form-button--primary',
+  secondary: 'form-button--secondary',
+  tertiary: 'form-button--tertiary',
+  ghost: 'form-button--ghost',
+  destructive: 'form-button--destructive',
+};
+
+const SIZE_CLASS: Record<ButtonSize, string> = {
+  sm: 'form-button--sm',
+  md: '',
+  lg: 'form-button--lg',
+};
+
+/**
+ * Compose the class name for a button from its props.
+ */
+export function buttonClassName({
+  variant = 'primary',
+  size = 'md',
+  fullWidth = false,
+  loading = false,
+  className,
+}: {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  fullWidth?: boolean;
+  loading?: boolean;
+  className?: string;
+}): string {
+  return [
+    'form-button',
+    VARIANT_CLASS[variant],
+    SIZE_CLASS[size],
+    fullWidth ? 'form-button--full' : '',
+    loading ? 'form-button--loading' : '',
+    className ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+/**
+ * The centralized button. Renders a native `<button>` by default, or any other
+ * element/component supplied via the `as` prop (for link-styled buttons, pass
+ * `as={Link}` from react-router and a `to` prop).
+ */
+export const Button = React.forwardRef(function Button<E extends React.ElementType = 'button'>(
+  {
+    as,
+    variant = 'primary',
+    size = 'md',
+    fullWidth = false,
+    loading = false,
+    leadingIcon,
+    trailingIcon,
+    children,
+    className,
+    ...rest
+  }: PolymorphicProps<E>,
+  ref: React.Ref<Element>,
+) {
+  const Component = (as ?? 'button') as React.ElementType;
+  const isNativeButton = Component === 'button';
+
+  const composedClassName = buttonClassName({ variant, size, fullWidth, loading, className });
+
+  // Native buttons need an explicit type and support disabled/aria-busy.
+  const nativeButtonProps = isNativeButton
+    ? {
+        type: (rest as { type?: 'button' | 'submit' | 'reset' }).type ?? 'button',
+        disabled: (rest as { disabled?: boolean }).disabled === true || loading || undefined,
+        'aria-busy': loading || undefined,
+      }
+    : {};
+
+  return (
+    <Component ref={ref} className={composedClassName} {...rest} {...nativeButtonProps}>
+      {loading && <span className="form-button__spinner" aria-hidden="true" />}
+      {!loading && leadingIcon && (
+        <span className="form-button__icon" aria-hidden="true">
+          {leadingIcon}
+        </span>
+      )}
+      {children != null && <span className="form-button__label">{children}</span>}
+      {trailingIcon && (
+        <span className="form-button__icon" aria-hidden="true">
+          {trailingIcon}
+        </span>
+      )}
+    </Component>
+  );
+}) as <E extends React.ElementType = 'button'>(
+  props: PolymorphicProps<E> & { ref?: React.Ref<Element> },
+) => React.ReactElement | null;
+
+export default Button;

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+export { Button, buttonClassName } from './Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
 export { ConfirmDialog } from './ConfirmDialog';
 export type { ConfirmDialogProps } from './ConfirmDialog';
 export { ExplainThis } from './ExplainThis';

--- a/apps/web/src/components/forms/AccountForm.tsx
+++ b/apps/web/src/components/forms/AccountForm.tsx
@@ -34,6 +34,7 @@ import { useDatabase } from '../../db/DatabaseProvider';
 import type { CreateAccountInput } from '../../db/repositories/accounts';
 import { useAmountInput } from '../../hooks/useAmountInput';
 import { useNavigationGuard } from '../../hooks/useNavigationGuard';
+import { Button } from '../common/Button';
 import type {
   Account,
   AccountPurpose,
@@ -619,20 +620,10 @@ export function AccountForm({ onSubmit, onCancel, isOpen, initialData }: Account
 
           {/* Actions */}
           <div className="form-actions">
-            <button
-              type="button"
-              className="form-button form-button--secondary"
-              onClick={handleCancel}
-              disabled={submitting}
-            >
+            <Button type="button" variant="secondary" onClick={handleCancel} disabled={submitting}>
               {getFormCopy('accountCancel')}
-            </button>
-            <button
-              type="submit"
-              className="form-button form-button--primary"
-              disabled={submitting}
-              aria-busy={submitting}
-            >
+            </Button>
+            <Button type="submit" variant="primary" loading={submitting}>
               {submitting
                 ? initialData
                   ? getFormCopy('accountUpdating')
@@ -640,7 +631,7 @@ export function AccountForm({ onSubmit, onCancel, isOpen, initialData }: Account
                 : initialData
                   ? getFormCopy('accountUpdate')
                   : getFormCopy('accountCreate')}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/apps/web/src/components/forms/BudgetForm.tsx
+++ b/apps/web/src/components/forms/BudgetForm.tsx
@@ -40,6 +40,7 @@ import type { Budget, BudgetPeriod, Category } from '../../kmp/bridge';
 import type { BudgetStarterTemplate } from '../../lib/budgeting/starter-budget-templates';
 import { budgetSchema } from '../../lib/validation';
 import { DatePicker } from '../common/DatePicker';
+import { Button } from '../common/Button';
 import { AmountInput } from './AmountInput';
 
 import './forms.css';
@@ -701,20 +702,10 @@ export function BudgetForm({
           </div>
 
           <div className="form-actions">
-            <button
-              type="button"
-              className="form-button form-button--secondary"
-              onClick={handleCancel}
-              disabled={submitting}
-            >
+            <Button type="button" variant="secondary" onClick={handleCancel} disabled={submitting}>
               Cancel
-            </button>
-            <button
-              type="submit"
-              className="form-button form-button--primary"
-              disabled={submitting}
-              aria-busy={submitting}
-            >
+            </Button>
+            <Button type="submit" variant="primary" loading={submitting}>
               {submitting
                 ? creationMode === 'template' && !isEditMode
                   ? 'Creating starter budget…'
@@ -726,7 +717,7 @@ export function BudgetForm({
                   : isEditMode
                     ? 'Update Budget'
                     : 'Create Budget'}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/apps/web/src/components/forms/CategoryForm.tsx
+++ b/apps/web/src/components/forms/CategoryForm.tsx
@@ -16,6 +16,7 @@ import type { CreateCategoryInput } from '../../db/repositories/categories';
 import { queryOne, type Row } from '../../db/sqlite-wasm';
 import { useNavigationGuard } from '../../hooks/useNavigationGuard';
 import type { Category, SyncId } from '../../kmp/bridge';
+import { Button } from '../common/Button';
 
 import './forms.css';
 
@@ -373,22 +374,12 @@ export function CategoryForm({
           </div>
 
           <div className="form-actions">
-            <button
-              type="button"
-              className="form-button form-button--secondary"
-              onClick={handleCancel}
-              disabled={submitting}
-            >
+            <Button type="button" variant="secondary" onClick={handleCancel} disabled={submitting}>
               Cancel
-            </button>
-            <button
-              type="submit"
-              className="form-button form-button--primary"
-              disabled={submitting}
-              aria-busy={submitting}
-            >
+            </Button>
+            <Button type="submit" variant="primary" loading={submitting}>
               {submitting ? submittingLabel : submitLabel}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/apps/web/src/components/forms/GoalForm.tsx
+++ b/apps/web/src/components/forms/GoalForm.tsx
@@ -39,6 +39,7 @@ import { useNavigationGuard } from '../../hooks/useNavigationGuard';
 import type { Goal, GoalStatus, SyncId } from '../../kmp/bridge';
 import { goalSchema } from '../../lib/validation';
 import { DatePicker } from '../common/DatePicker';
+import { Button } from '../common/Button';
 import { AmountInput } from './AmountInput';
 
 import './forms.css';
@@ -465,22 +466,12 @@ export function GoalForm({ isOpen, onCancel, onSubmit, initialData }: GoalFormPr
           </div>
 
           <div className="form-actions">
-            <button
-              type="button"
-              className="form-button form-button--secondary"
-              onClick={handleCancel}
-              disabled={submitting}
-            >
+            <Button type="button" variant="secondary" onClick={handleCancel} disabled={submitting}>
               Cancel
-            </button>
-            <button
-              type="submit"
-              className="form-button form-button--primary"
-              disabled={submitting}
-              aria-busy={submitting}
-            >
+            </Button>
+            <Button type="submit" variant="primary" loading={submitting}>
               {submitting ? submittingLabel : submitLabel}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/apps/web/src/components/forms/QuickEntry.tsx
+++ b/apps/web/src/components/forms/QuickEntry.tsx
@@ -35,6 +35,7 @@ import { useAmountInput } from '../../hooks/useAmountInput';
 import type { Account, Category, TransactionType } from '../../kmp/bridge';
 import type { CategorySuggestion } from '../../lib/categorization';
 import { AutoCategoryBadge } from '../categorization';
+import { Button } from '../common/Button';
 import { AmountInput } from './AmountInput';
 
 import './forms.css';
@@ -434,9 +435,9 @@ export const QuickEntry: FC<QuickEntryProps> = ({
             </select>
           )}
 
-          <button type="submit" className="form-button form-button--primary quick-entry__submit">
+          <Button type="submit" variant="primary" className="quick-entry__submit">
             Add {transactionType === 'INCOME' ? 'Income' : 'Expense'}
-          </button>
+          </Button>
         </form>
       </div>
     </div>

--- a/apps/web/src/components/forms/TransactionForm.tsx
+++ b/apps/web/src/components/forms/TransactionForm.tsx
@@ -82,6 +82,7 @@ import { validateTransactionSplits } from '../../lib/transactions/splits';
 import { getCurrencyDecimals, isFxFieldKey, readFxMetadata } from '../../lib/currency/minor-units';
 import { transactionSchema } from '../../lib/validation';
 import { DateInput } from '../common';
+import { Button } from '../common/Button';
 import { CategoryConfirmation } from '../categorization';
 import { AmountInput } from './AmountInput';
 import { CounterpartyInput } from '../transactions/CounterpartyInput';
@@ -1995,22 +1996,12 @@ export function TransactionForm({
 
           {/* Actions */}
           <div className="form-actions">
-            <button
-              type="button"
-              className="form-button form-button--secondary"
-              onClick={handleCancel}
-              disabled={submitting}
-            >
+            <Button type="button" variant="secondary" onClick={handleCancel} disabled={submitting}>
               Cancel
-            </button>
-            <button
-              type="submit"
-              className="form-button form-button--primary"
-              disabled={submitting}
-              aria-busy={submitting}
-            >
+            </Button>
+            <Button type="submit" variant="primary" loading={submitting}>
               {submitting ? submittingLabel : submitButtonLabel}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/apps/web/src/pages/CreateBillPage.tsx
+++ b/apps/web/src/pages/CreateBillPage.tsx
@@ -14,6 +14,7 @@ import { useBills } from '../hooks';
 import type { BillFrequency } from '../kmp/bridge';
 import type { CreateBillInput } from '../db/repositories/bills';
 import { DatePicker } from '../components/common/DatePicker';
+import { Button } from '../components/common/Button';
 
 /** Resolve the first available household ID from the local database. */
 function getFirstHouseholdId(db: ReturnType<typeof useDatabase>): string | null {
@@ -360,22 +361,17 @@ export const CreateBillPage: React.FC = () => {
 
           {/* Actions */}
           <div style={{ display: 'flex', gap: 'var(--spacing-3)' }}>
-            <button
-              type="submit"
-              className="form-button form-button--primary"
-              disabled={submitting}
-              aria-busy={submitting}
-            >
+            <Button type="submit" variant="primary" loading={submitting}>
               {submitting ? 'Creating…' : 'Create Bill'}
-            </button>
-            <Link
+            </Button>
+            <Button
+              as={Link}
               to="/bills"
-              className="form-button"
-              style={{ textDecoration: 'none' }}
-              aria-disabled={submitting}
+              variant="secondary"
+              aria-disabled={submitting || undefined}
             >
               Cancel
-            </Link>
+            </Button>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary

Fixes the reported bug where the **Create Bill** form's `Cancel` action rendered as bare purple/violet link text (the browser's default anchor color leaking through `.form-button`, which sets no color of its own) and establishes a single centralized, accessible `Button` component that all buttons should be resourced from.

## Root cause

`.form-button` (base) intentionally carries no background/color — variants supply those. The `Cancel` action was a `<Link className="form-button">` with **no variant modifier**, so an `<a>`'s default link color showed through. There was no shared `Button` component, so buttons were ad-hoc `<button>`/`<Link>` elements with hand-applied classes that drift easily.

## Changes

- **New `Button` component** (`apps/web/src/components/common/Button.tsx` + `Button.css`):
  - Variants: `primary` / `secondary` / `tertiary` / `ghost` / `destructive`
  - Sizes: `sm` / `md` / `lg`; `fullWidth` modifier
  - States: hover / active / focus-visible / disabled / `loading` (spinner + `aria-busy`, blocks activation)
  - Polymorphic `as` prop — renders a native `<button>` by default or any element/component (e.g. `as={Link}` for link-styled buttons). Anchor rendering normalizes link color/underline so the purple-leak bug can't recur, and supports `aria-disabled` for disabled links.
  - Backed entirely by design-system tokens; extends the existing `.form-button` design language so migrated call sites are visually identical.
- **Bug fix** — `CreateBillPage` now uses `<Button variant="primary" loading>` for submit and `<Button as={Link} variant="secondary">` for Cancel.
- **Migrations onto the shared component** — Account / Budget / Category / Goal / Transaction form actions and the QuickEntry submit.
- **Tests + stories** — `Button.test.tsx` (13 cases: variants, sizes, loading/disabled semantics, `as={Link}` rendering, class composition) and `Button.stories.tsx`.
- Exported `Button` from `components/common/index.ts`.

## Accessibility (WCAG 2.2 AA)

- Native `<button>` semantics by default; `type` defaults to `button` to avoid accidental form submits.
- Visible focus ring via existing `.form-button:focus-visible` token.
- `loading` sets `aria-busy` and disables interaction; disabled links use `aria-disabled` + `pointer-events: none`.
- Every variant uses semantic status/interactive tokens for sufficient contrast; spinner respects `prefers-reduced-motion`.

## Scope / coordination

Diff is intentionally scoped to buttons to avoid clobbering the parallel checkbox and input/picker centralization work. Remaining ad-hoc buttons across `apps/web` can migrate incrementally onto this component in follow-ups. Rebased onto `origin/main` before push.

## Testing

- `vitest run` Button suite — 13/13 pass
- Affected form suites (Account/Budget/Transaction/ConfirmDialog) — 43/43 pass
- `eslint --max-warnings 0` on all changed files — clean
- `tsc --noEmit` (apps/web) — clean
- `prettier --write` applied

Closes #3550