### PR TITLE
fix(web): migrate Dashboard Things-to-check Review buttons onto shared Button (fix illegible contrast)

### DIFF
--- a/apps/web/src/components/dashboard/DashboardThingsToCheckSection.test.tsx
+++ b/apps/web/src/components/dashboard/DashboardThingsToCheckSection.test.tsx
@@ -112,4 +112,16 @@ describe('DashboardThingsToCheckSection', () => {
 
     expect(screen.getAllByRole('link', { name: /^Review/ })).toHaveLength(2);
   });
+
+  it('renders the review action as the shared secondary Button for legible, consistent styling', () => {
+    mockedDetectScamAlerts.mockReturnValue([singleTransactionAlert]);
+
+    renderSection();
+
+    const reviewLink = screen.getByRole('link', {
+      name: 'Review the flagged charge from Unknown Merchant',
+    });
+    expect(reviewLink).toHaveClass('form-button');
+    expect(reviewLink).toHaveClass('form-button--secondary');
+  });
 });

--- a/apps/web/src/components/dashboard/DashboardThingsToCheckSection.tsx
+++ b/apps/web/src/components/dashboard/DashboardThingsToCheckSection.tsx
@@ -14,7 +14,7 @@ import {
   type ScamSpendingAlert,
   type UnusualSpendRouteTarget,
 } from '../../lib/notifications';
-import { ErrorBanner, LoadingSpinner } from '../common';
+import { ErrorBanner, LoadingSpinner, Button } from '../common';
 
 export interface DashboardThingsToCheckSectionProps {
   readonly accounts: readonly Pick<Account, 'id' | 'purpose'>[];
@@ -87,9 +87,16 @@ const DashboardThingsToCheckSection: FC<DashboardThingsToCheckSectionProps> = ({
                     <strong>NEXT STEP:</strong> {alert.nextStep}
                   </p>
                 </div>
-                <Link to={to} className="list-item__action" aria-label={actionLabel}>
+                <Button
+                  as={Link}
+                  to={to}
+                  variant="secondary"
+                  size="sm"
+                  className="list-item__action"
+                  aria-label={actionLabel}
+                >
                   Review
-                </Link>
+                </Button>
               </li>
             ))}
           </ul>

--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -823,53 +823,19 @@
 }
 
 /* ---------------------------------------------------------------------------
- * Things to check - per-item "Review" action link (issue #3153)
+ * Things to check - per-item "Review" action (issues #3153, #3569)
  *
- * Renders as a compact, right-aligned button-like link inside .list-item.
- * Navigation target is computed per alert via routeUnusualSpendAlert.
+ * Layout-only hook: the visual styling (fill, border, color, padding, hover,
+ * and focus ring) is provided by the shared, accessible `Button` component
+ * (variant="secondary" size="sm"). Keeping only layout properties here avoids
+ * the light-on-light contrast bug the old bespoke styling caused and keeps the
+ * action consistent with buttons across the app.
  * ------------------------------------------------------------------------- */
 
 .list-item__action {
   flex-shrink: 0;
   align-self: center;
-  display: inline-flex;
-  align-items: center;
-  padding: var(--spacing-2, 8px) var(--spacing-3, 12px);
-  border: 1px solid var(--semantic-border-default, #e5e7eb);
-  border-radius: var(--radius-sm, 4px);
-  background-color: var(--semantic-surface-secondary, #f3f4f6);
-  color: var(--semantic-text-primary, #111827);
-  font-size: var(--type-scale-caption-font-size, 0.75rem);
-  font-weight: var(--font-weight-medium, 500);
   white-space: nowrap;
-  text-decoration: none;
-  cursor: pointer;
-  transition: background-color 120ms ease;
-}
-
-.list-item__action:hover {
-  background-color: var(--semantic-surface-tertiary, #e5e7eb);
-}
-
-.list-item__action:focus-visible {
-  outline: 2px solid var(--semantic-focus-ring, #3b82f6);
-  outline-offset: 2px;
-}
-
-[data-theme='dark'] .list-item__action:hover {
-  background-color: var(--semantic-surface-tertiary, #374151);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .list-item__action {
-    transition: none;
-  }
-}
-
-@media (prefers-contrast: more) {
-  .list-item__action {
-    border-width: 2px;
-  }
 }
 
 /*


### PR DESCRIPTION
﻿## Summary

Fixes the illegible **Review** buttons in the Dashboard "Things to check" section (`DashboardThingsToCheckSection`). They rendered as near-invisible light-gray text on a light/near-white fill (failing WCAG 2.2 AA 1.4.3 contrast) because of the one-off `.list-item__action` style, which filled the button with `--semantic-surface-secondary` (a light surface) while the text resolved light in the dark dashboard.

Follow-up to the Button centralization in #3566 (#3550).

## Changes

- Migrated the Review action onto the centralized shared `Button` component: `<Button as={Link} variant="secondary" size="sm">`, preserving navigation, link semantics, and the descriptive `aria-label`.
- Reduced `.list-item__action` (in `dashboard.css`) to a **layout-only** hook — all fill/border/color/padding/hover/focus now come from the shared component, eliminating the light-on-light contrast bug and keeping the action consistent with buttons app-wide.
- Added a test asserting the Review action renders as the shared secondary Button.

## Accessibility (WCAG 2.2 AA)

- Legible token-based contrast in both light and dark themes via the secondary Button variant.
- Visible focus ring from the shared component; descriptive `aria-label` and link semantics/navigation preserved.

## Testing

- `DashboardThingsToCheckSection` suite — 5/5 pass (incl. new shared-Button assertion)
- `eslint --max-warnings 0` on changed files — clean
- `tsc --noEmit` (apps/web) — clean

Closes #3569
