### PR TITLE
feat(web): centralize checkboxes into shared accessible component + fix focus ring (#3545)

### DIFF
--- a/apps/web/src/components/DataExport.tsx
+++ b/apps/web/src/components/DataExport.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDatabase } from '../db/DatabaseProvider';
 import { useFocusTrap } from '../accessibility/aria';
+import { Checkbox } from './common/Checkbox';
 import type { SqliteDb } from '../db/sqlite-wasm';
 import { getAllAccounts } from '../db/repositories/accounts';
 import { getAllTransactions } from '../db/repositories/transactions';
@@ -865,87 +866,48 @@ export const DataExport: React.FC<DataExportProps> = ({
           <fieldset className="data-export__fieldset">
             <legend className="data-export__legend">Data categories</legend>
             {domainSummaries.map((summary) => (
-              <label className="data-export__option" key={summary.domain}>
-                <input
-                  type="checkbox"
-                  className="data-export__checkbox"
-                  checked={selectedDomains.includes(summary.domain)}
-                  onChange={(event) => toggleDomain(summary.domain, event.target.checked)}
-                />
-                <span className="data-export__option-text">
-                  <span className="data-export__option-label">
-                    {summary.label} ({summary.recordCount} record
-                    {summary.recordCount === 1 ? '' : 's'})
-                  </span>
-                  <span className="data-export__option-help">{summary.warning}</span>
-                </span>
-              </label>
+              <Checkbox
+                key={summary.domain}
+                label={`${summary.label} (${summary.recordCount} record${
+                  summary.recordCount === 1 ? '' : 's'
+                })`}
+                hint={summary.warning}
+                checked={selectedDomains.includes(summary.domain)}
+                onChange={(event) => toggleDomain(summary.domain, event.target.checked)}
+              />
             ))}
           </fieldset>
 
           <fieldset className="data-export__fieldset">
             <legend className="data-export__legend">Privacy options</legend>
 
-            <label className="data-export__option">
-              <input
-                type="checkbox"
-                className="data-export__checkbox"
-                checked={includeProtectedCategories}
-                onChange={(event) => setIncludeProtectedCategories(event.target.checked)}
-              />
-              <span className="data-export__option-text">
-                <span className="data-export__option-label">Include protected categories</span>
-                <span className="data-export__option-help">
-                  Sensitive categories like medical or debt. Redacted by default.
-                </span>
-              </span>
-            </label>
+            <Checkbox
+              label="Include protected categories"
+              hint="Sensitive categories like medical or debt. Redacted by default."
+              checked={includeProtectedCategories}
+              onChange={(event) => setIncludeProtectedCategories(event.target.checked)}
+            />
 
-            <label className="data-export__option">
-              <input
-                type="checkbox"
-                className="data-export__checkbox"
-                checked={includeMoodTags}
-                onChange={(event) => setIncludeMoodTags(event.target.checked)}
-              />
-              <span className="data-export__option-text">
-                <span className="data-export__option-label">Include mood tags</span>
-                <span className="data-export__option-help">
-                  Mood tag data can reveal sensitive wellbeing patterns. Off by default.
-                </span>
-              </span>
-            </label>
+            <Checkbox
+              label="Include mood tags"
+              hint="Mood tag data can reveal sensitive wellbeing patterns. Off by default."
+              checked={includeMoodTags}
+              onChange={(event) => setIncludeMoodTags(event.target.checked)}
+            />
 
-            <label className="data-export__option">
-              <input
-                type="checkbox"
-                className="data-export__checkbox"
-                checked={includeNotes}
-                onChange={(event) => setIncludeNotes(event.target.checked)}
-              />
-              <span className="data-export__option-text">
-                <span className="data-export__option-label">Include transaction notes</span>
-                <span className="data-export__option-help">
-                  Notes may contain names, health details, or private context. Off by default.
-                </span>
-              </span>
-            </label>
+            <Checkbox
+              label="Include transaction notes"
+              hint="Notes may contain names, health details, or private context. Off by default."
+              checked={includeNotes}
+              onChange={(event) => setIncludeNotes(event.target.checked)}
+            />
 
-            <label className="data-export__option">
-              <input
-                type="checkbox"
-                className="data-export__checkbox"
-                checked={includeAttachmentBinaries}
-                onChange={(event) => setIncludeAttachmentBinaries(event.target.checked)}
-              />
-              <span className="data-export__option-text">
-                <span className="data-export__option-label">Include attachment binaries</span>
-                <span className="data-export__option-help">
-                  Receipts and files can reveal addresses, card digits, or account numbers. Metadata
-                  only by default.
-                </span>
-              </span>
-            </label>
+            <Checkbox
+              label="Include attachment binaries"
+              hint="Receipts and files can reveal addresses, card digits, or account numbers. Metadata only by default."
+              checked={includeAttachmentBinaries}
+              onChange={(event) => setIncludeAttachmentBinaries(event.target.checked)}
+            />
 
             <label className="data-export__option">
               <span className="data-export__option-text">

--- a/apps/web/src/components/FeedbackDialog.tsx
+++ b/apps/web/src/components/FeedbackDialog.tsx
@@ -15,6 +15,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import packageJson from '../../package.json';
 import { buildFeedbackDiagnostics, submitFeedback } from '../lib/feedback';
 import { useFocusTrap } from '../accessibility/aria';
+import { Checkbox } from './common/Checkbox';
 import './forms/forms.css';
 
 const BUILD_SHA =
@@ -183,15 +184,12 @@ export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose 
                 />
               </div>
 
-              <label htmlFor="feedback-diagnostics" className="form-checkbox-row">
-                <input
-                  id="feedback-diagnostics"
-                  type="checkbox"
-                  checked={includeDiagnostics}
-                  onChange={(e) => setIncludeDiagnostics(e.target.checked)}
-                />
-                <span>Include diagnostic info</span>
-              </label>
+              <Checkbox
+                id="feedback-diagnostics"
+                label="Include diagnostic info"
+                checked={includeDiagnostics}
+                onChange={(e) => setIncludeDiagnostics(e.target.checked)}
+              />
             </div>
 
             <div className="form-actions">

--- a/apps/web/src/components/accounts/AccountDeleteDialog.tsx
+++ b/apps/web/src/components/accounts/AccountDeleteDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 
 import { useFocusTrap } from '../../accessibility/aria';
+import { Checkbox } from '../common/Checkbox';
 
 import '../forms/forms.css';
 import './account-delete-dialog.css';
@@ -151,18 +152,15 @@ export function AccountDeleteDialog({
         {/* Section 3: Optional cascade delete */}
         {transactionCount > 0 && (
           <div className="account-delete-dialog__section">
-            <label className="account-delete-dialog__checkbox-label">
-              <input
-                type="checkbox"
-                checked={deleteTransactions}
-                onChange={handleCheckboxChange}
-                aria-describedby={cascadeWarningId}
-              />
-              <span>
-                Also delete all {transactionCount} transaction
-                {transactionCount === 1 ? '' : 's'}
-              </span>
-            </label>
+            <Checkbox
+              className="account-delete-dialog__checkbox-label"
+              label={`Also delete all ${transactionCount} transaction${
+                transactionCount === 1 ? '' : 's'
+              }`}
+              checked={deleteTransactions}
+              onChange={handleCheckboxChange}
+              aria-describedby={cascadeWarningId}
+            />
             <p
               id={cascadeWarningId}
               className="account-delete-dialog__cascade-warning"

--- a/apps/web/src/components/accounts/account-delete-dialog.css
+++ b/apps/web/src/components/accounts/account-delete-dialog.css
@@ -37,6 +37,13 @@
   accent-color: var(--semantic-error);
 }
 
+/* Keep the destructive (red) intent when using the shared Checkbox component. */
+.account-delete-dialog__checkbox-label .checkbox__input:checked,
+.account-delete-dialog__checkbox-label .checkbox__input:indeterminate {
+  background-color: var(--semantic-error);
+  border-color: var(--semantic-error);
+}
+
 .account-delete-dialog__cascade-warning {
   margin: var(--spacing-2) 0 0;
   min-height: 1.5em;

--- a/apps/web/src/components/budgets/TripCountryBudgetsSection.tsx
+++ b/apps/web/src/components/budgets/TripCountryBudgetsSection.tsx
@@ -27,6 +27,7 @@ import React, { useId, useState } from 'react';
 
 import { AppIcon, type IconName } from '../icons';
 import { CurrencyDisplay } from '../common/CurrencyDisplay';
+import { Checkbox } from '../common/Checkbox';
 import {
   getTripBudgetStatus,
   parseTripBudgetAmount,
@@ -514,15 +515,13 @@ export const TripCountryBudgetsSection: React.FC<TripCountryBudgetsSectionProps>
             ))}
           </select>
         </div>
-        <label className="tcb-checkbox" htmlFor={id('show-archived')}>
-          <input
-            id={id('show-archived')}
-            type="checkbox"
-            checked={showArchived}
-            onChange={(event) => onShowArchivedChange(event.target.checked)}
-          />
-          Show archived trips
-        </label>
+        <Checkbox
+          id={id('show-archived')}
+          className="tcb-checkbox"
+          label="Show archived trips"
+          checked={showArchived}
+          onChange={(event) => onShowArchivedChange(event.target.checked)}
+        />
       </div>
 
       <p className="tcb__count" role="status" aria-live="polite">

--- a/apps/web/src/components/categorization/CategorizationSettings.tsx
+++ b/apps/web/src/components/categorization/CategorizationSettings.tsx
@@ -3,7 +3,7 @@
 import type { Category } from '../../kmp/bridge';
 import { useAutoCategorize } from '../../hooks/useAutoCategorize';
 import { RuleManager } from './RuleManager';
-
+import { Checkbox } from '../common/Checkbox';
 import './categorization.css';
 
 export interface CategorizationSettingsProps {
@@ -21,10 +21,10 @@ export function CategorizationSettings({ categories }: CategorizationSettingsPro
         <label className="settings-item__label" htmlFor="settings-auto-categorization-enabled">
           Enable smart categorization
         </label>
-        <input
+        <Checkbox
           id="settings-auto-categorization-enabled"
-          type="checkbox"
-          className="settings-item__checkbox"
+          className="settings-item__checkbox-wrapper"
+          aria-label="Enable smart categorization"
           checked={settings.enabled}
           onChange={(event) => setEnabled(event.target.checked)}
         />

--- a/apps/web/src/components/common/Checkbox.test.tsx
+++ b/apps/web/src/components/common/Checkbox.test.tsx
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Checkbox } from './Checkbox';
+
+describe('Checkbox', () => {
+  it('renders a checkbox with an associated label', () => {
+    render(<Checkbox label="Auto-pay enabled" />);
+    const input = screen.getByRole('checkbox', { name: 'Auto-pay enabled' });
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveClass('checkbox__input');
+  });
+
+  it('reflects the checked prop', () => {
+    render(<Checkbox label="Enabled" checked readOnly />);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('calls onChange when toggled via keyboard', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Checkbox label="Toggle me" onChange={onChange} />);
+    const input = screen.getByRole('checkbox');
+    input.focus();
+    await user.keyboard(' ');
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('is operable with a mouse click on the label', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Checkbox label="Click label" onChange={onChange} />);
+    await user.click(screen.getByText('Click label'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the native indeterminate DOM property', () => {
+    render(<Checkbox label="Mixed" indeterminate />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(input.indeterminate).toBe(true);
+  });
+
+  it('supports the disabled state', () => {
+    render(<Checkbox label="Disabled" disabled />);
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+  });
+
+  it('associates hint text via aria-describedby', () => {
+    render(<Checkbox label="With hint" hint="Extra context" />);
+    const input = screen.getByRole('checkbox');
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)).toHaveTextContent('Extra context');
+  });
+
+  it('marks the control invalid and exposes the error message', () => {
+    render(<Checkbox label="With error" error="Required" />);
+    const input = screen.getByRole('checkbox');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('alert')).toHaveTextContent('Required');
+  });
+
+  it('forwards a ref to the underlying input', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<Checkbox label="Ref" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it('honours an explicit id', () => {
+    render(<Checkbox label="Explicit" id="my-checkbox" />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute('id', 'my-checkbox');
+  });
+});

--- a/apps/web/src/components/common/Checkbox.tsx
+++ b/apps/web/src/components/common/Checkbox.tsx
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Checkbox — Shared, accessible checkbox control for the web app.
+ *
+ * Renders a native `<input type="checkbox">` wrapped in a `<label>` so the
+ * label text and control are associated without needing a matching `htmlFor`.
+ * The native input is styled with `appearance: none` and a CSS-drawn checkmark
+ * so size, colors, and the focus ring are identical everywhere it is used.
+ *
+ * Features:
+ * - checked / unchecked / indeterminate / disabled states
+ * - clean, correctly-sized `:focus-visible` ring (WCAG 2.2 AA, 2.4.11/2.4.7)
+ * - optional hint and error text associated via `aria-describedby`
+ * - keyboard operable via native semantics
+ *
+ * @module components/common/Checkbox
+ * References: issue #3545
+ */
+
+import React, { useEffect, useId, useRef } from 'react';
+
+import './checkbox.css';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CheckboxProps extends Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'type' | 'ref'
+> {
+  /** Visible label content rendered next to the control. */
+  label?: React.ReactNode;
+
+  /**
+   * Indeterminate ("mixed") visual state. Maps to the native
+   * `input.indeterminate` DOM property and `aria-checked="mixed"`.
+   */
+  indeterminate?: boolean;
+
+  /** Optional hint text rendered below the label. */
+  hint?: React.ReactNode;
+
+  /** Validation error message. When set, marks the control invalid. */
+  error?: string | null;
+
+  /** Additional CSS class for the wrapping label. */
+  className?: string;
+
+  /** Position of the label relative to the control. Defaults to `end`. */
+  labelPosition?: 'start' | 'end';
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Accessible, design-system checkbox.
+ *
+ * @example
+ * ```tsx
+ * <Checkbox
+ *   label="Auto-pay enabled"
+ *   checked={isAutoPay}
+ *   onChange={(e) => setIsAutoPay(e.target.checked)}
+ * />
+ * ```
+ */
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  {
+    label,
+    indeterminate = false,
+    hint,
+    error,
+    className = '',
+    labelPosition = 'end',
+    id,
+    disabled,
+    'aria-describedby': ariaDescribedByProp,
+    ...inputProps
+  },
+  forwardedRef,
+) {
+  const localRef = useRef<HTMLInputElement>(null);
+  const reactId = useId();
+  const inputId = id ?? `checkbox-${reactId}`;
+  const hintId = hint ? `${inputId}-hint` : undefined;
+  const errorId = error ? `${inputId}-error` : undefined;
+  const hasError = Boolean(error);
+
+  // Merge the forwarded ref with the local ref used for the indeterminate DOM prop.
+  const setRef = React.useCallback(
+    (node: HTMLInputElement | null) => {
+      localRef.current = node;
+      if (typeof forwardedRef === 'function') {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        forwardedRef.current = node;
+      }
+    },
+    [forwardedRef],
+  );
+
+  // `indeterminate` is a DOM property, not an attribute — sync it manually.
+  useEffect(() => {
+    if (localRef.current) {
+      localRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  const describedBy = [ariaDescribedByProp, hintId, errorId].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <label
+      className={`checkbox ${labelPosition === 'start' ? 'checkbox--label-start' : ''} ${
+        disabled ? 'checkbox--disabled' : ''
+      } ${hasError ? 'checkbox--error' : ''} ${className}`
+        .replace(/\s+/g, ' ')
+        .trim()}
+    >
+      <input
+        {...inputProps}
+        ref={setRef}
+        id={inputId}
+        type="checkbox"
+        className="checkbox__input"
+        disabled={disabled}
+        aria-invalid={hasError || undefined}
+        aria-describedby={describedBy}
+      />
+      {(label || hint || error) && (
+        <span className="checkbox__content">
+          {label != null && <span className="checkbox__label">{label}</span>}
+          {hint && (
+            <span id={hintId} className="checkbox__hint">
+              {hint}
+            </span>
+          )}
+          {hasError && (
+            <span id={errorId} className="checkbox__error" role="alert">
+              {error}
+            </span>
+          )}
+        </span>
+      )}
+    </label>
+  );
+});
+
+export default Checkbox;

--- a/apps/web/src/components/common/checkbox.css
+++ b/apps/web/src/components/common/checkbox.css
@@ -1,0 +1,182 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for the shared Checkbox component.
+ *
+ * The native checkbox is rendered with `appearance: none` and a CSS-drawn
+ * checkmark so that size, colors, checked/indeterminate/disabled states, and
+ * the focus ring are identical across the whole app. All colors come from the
+ * design-token custom properties so themes and high-contrast mode adapt
+ * automatically.
+ *
+ * References: issue #3545
+ */
+
+.checkbox {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: var(--spacing-2, 8px);
+  /* Touch target lives on the label wrapper, not on the tiny control, so the
+     focus ring can wrap the control cleanly (fixes the misaligned outline). */
+  min-height: 44px;
+  padding-block: var(--spacing-1, 4px);
+  color: var(--semantic-text-primary, #111827);
+  font-size: var(--type-scale-body-font-size, 1rem);
+  line-height: var(--line-height-normal, 1.5);
+  cursor: pointer;
+}
+
+.checkbox--label-start {
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
+.checkbox--disabled {
+  cursor: not-allowed;
+  color: var(--semantic-text-disabled, #9ca3af);
+}
+
+/* ---------------------------------------------------------------------------
+ * The control
+ * ------------------------------------------------------------------------- */
+
+.checkbox__input {
+  appearance: none;
+  -webkit-appearance: none;
+  flex: 0 0 auto;
+  /* Nudge down so a single line of label text aligns with the box centre. */
+  margin: 0.1875rem 0 0;
+  inline-size: 1.125rem;
+  block-size: 1.125rem;
+  /* Override the global `input { min-height: 44px }` touch-target rule so the
+     control is its true size and the focus ring wraps it cleanly. */
+  min-inline-size: 0;
+  min-block-size: 0;
+  display: inline-grid;
+  place-content: center;
+  border: 2px solid var(--semantic-border-default, #6b7280);
+  border-radius: var(--border-radius-sm, 4px);
+  background-color: var(--semantic-background-primary, #ffffff);
+  cursor: inherit;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+/* CSS-drawn checkmark, hidden until checked/indeterminate. */
+.checkbox__input::before {
+  content: '';
+  inline-size: 0.7rem;
+  block-size: 0.7rem;
+  transform: scale(0);
+  transform-origin: center;
+  transition: transform 120ms ease-in-out;
+  clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+  background-color: var(--semantic-text-inverse, #ffffff);
+}
+
+.checkbox__input:checked,
+.checkbox__input:indeterminate {
+  background-color: var(--semantic-interactive-default, #3b82f6);
+  border-color: var(--semantic-interactive-default, #3b82f6);
+}
+
+.checkbox__input:checked::before {
+  transform: scale(1);
+}
+
+/* Indeterminate renders a horizontal dash instead of the checkmark. */
+.checkbox__input:indeterminate::before {
+  transform: scale(1);
+  clip-path: none;
+  inline-size: 0.7rem;
+  block-size: 2px;
+  border-radius: 1px;
+}
+
+.checkbox__input:hover:not(:disabled):not(:checked):not(:indeterminate) {
+  border-color: var(--semantic-interactive-default, #3b82f6);
+}
+
+/* Clean, correctly-sized focus ring (WCAG 2.2 AA — 2.4.7 / 2.4.11). */
+.checkbox__input:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+.checkbox__input:disabled {
+  border-color: var(--semantic-interactive-disabled, #d1d5db);
+  background-color: var(--semantic-background-secondary, #f3f4f6);
+  cursor: not-allowed;
+}
+
+.checkbox__input:disabled:checked,
+.checkbox__input:disabled:indeterminate {
+  background-color: var(--semantic-interactive-disabled, #d1d5db);
+  border-color: var(--semantic-interactive-disabled, #d1d5db);
+}
+
+.checkbox--error .checkbox__input {
+  border-color: var(--semantic-border-error, #ef4444);
+}
+
+/* ---------------------------------------------------------------------------
+ * Label / hint / error
+ * ------------------------------------------------------------------------- */
+
+.checkbox__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1, 4px);
+  min-inline-size: 0;
+}
+
+.checkbox__label {
+  align-self: center;
+}
+
+.checkbox--label-start .checkbox__label {
+  align-self: center;
+}
+
+.checkbox__hint {
+  font-size: var(--type-scale-caption-font-size, 0.8125rem);
+  color: var(--semantic-text-secondary, #6b7280);
+}
+
+.checkbox__error {
+  font-size: var(--type-scale-caption-font-size, 0.8125rem);
+  color: var(--semantic-border-error, #ef4444);
+}
+
+/* ---------------------------------------------------------------------------
+ * Reduced motion
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .checkbox__input,
+  .checkbox__input::before {
+    transition: none;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * High contrast
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-contrast: more) {
+  .checkbox__input {
+    border-width: 2px;
+    border-color: CanvasText;
+  }
+
+  .checkbox__input:checked,
+  .checkbox__input:indeterminate {
+    background-color: Highlight;
+    border-color: Highlight;
+  }
+
+  .checkbox__input::before {
+    background-color: HighlightText;
+  }
+}

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -2,6 +2,8 @@
 
 export { Button, buttonClassName } from './Button';
 export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
+export { Checkbox } from './Checkbox';
+export type { CheckboxProps } from './Checkbox';
 export { ConfirmDialog } from './ConfirmDialog';
 export type { ConfirmDialogProps } from './ConfirmDialog';
 export { ExplainThis } from './ExplainThis';

--- a/apps/web/src/components/dashboard/CustomizePanel.tsx
+++ b/apps/web/src/components/dashboard/CustomizePanel.tsx
@@ -13,6 +13,7 @@
 import { useCallback, useRef, useState, type DragEvent, type FC, type KeyboardEvent } from 'react';
 
 import { useFocusTrap } from '../../accessibility/aria';
+import { Checkbox } from '../common/Checkbox';
 import { WIDGET_DEFINITION_MAP, type WidgetConfig, type WidgetId } from './widget-types';
 
 // ---------------------------------------------------------------------------
@@ -173,18 +174,18 @@ export const CustomizePanel: FC<CustomizePanelProps> = ({
                 >
                   ⠿
                 </span>
-                <label className="customize-panel__toggle">
-                  <input
-                    type="checkbox"
-                    checked={widget.visible}
-                    onChange={() => onToggle(widget.id)}
-                    aria-label={`Show ${def.label} widget`}
-                  />
-                  <span className="customize-panel__label">
-                    <span className="customize-panel__name">{def.label}</span>
-                    <span className="customize-panel__desc">{def.description}</span>
-                  </span>
-                </label>
+                <Checkbox
+                  className="customize-panel__toggle"
+                  checked={widget.visible}
+                  onChange={() => onToggle(widget.id)}
+                  aria-label={`Show ${def.label} widget`}
+                  label={
+                    <span className="customize-panel__label">
+                      <span className="customize-panel__name">{def.label}</span>
+                      <span className="customize-panel__desc">{def.description}</span>
+                    </span>
+                  }
+                />
                 <div
                   className="customize-panel__reorder"
                   role="group"

--- a/apps/web/src/components/debt/JointDebtPlanner.tsx
+++ b/apps/web/src/components/debt/JointDebtPlanner.tsx
@@ -26,6 +26,7 @@
 
 import React, { useCallback, useId, useMemo, useState } from 'react';
 import { EmptyState } from '../common';
+import { Checkbox } from '../common/Checkbox';
 import type { Debt } from '../../lib/debt-types';
 import { formatUsdCents } from '../../lib/debt/payoff';
 import {
@@ -255,15 +256,12 @@ export function JointDebtPlanner({ debts, todayIso }: JointDebtPlannerProps): Re
           />
         </div>
         <div className="joint-debt__field joint-debt__mode">
-          <label htmlFor={`${baseId}-mode`}>
-            <input
-              id={`${baseId}-mode`}
-              type="checkbox"
-              checked={simpleMode}
-              onChange={(event) => setSimpleMode(event.target.checked)}
-            />
-            Recommendation mode (just tell us what to do)
-          </label>
+          <Checkbox
+            id={`${baseId}-mode`}
+            label="Recommendation mode (just tell us what to do)"
+            checked={simpleMode}
+            onChange={(event) => setSimpleMode(event.target.checked)}
+          />
         </div>
       </div>
 

--- a/apps/web/src/components/estate/TrustedContacts.tsx
+++ b/apps/web/src/components/estate/TrustedContacts.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback } from 'react';
 
 import { createEmptyAccessContact } from '../../lib/estate/accessInfo';
+import { Checkbox } from '../common/Checkbox';
 import type { AccessContact, EstateAccessInfo } from '../../lib/estate/types';
 
 export interface TrustedContactsProps {
@@ -209,16 +210,14 @@ export const TrustedContacts: React.FC<TrustedContactsProps> = ({ accessInfo, on
               </label>
             </div>
 
-            <label className="estate-checkbox">
-              <input
-                type="checkbox"
-                checked={contact.isPrimary}
-                onChange={(event) =>
-                  handleContactChange(contact.id, 'isPrimary', event.target.checked)
-                }
-              />
-              <span>Primary emergency contact</span>
-            </label>
+            <Checkbox
+              className="estate-checkbox"
+              label="Primary emergency contact"
+              checked={contact.isPrimary}
+              onChange={(event) =>
+                handleContactChange(contact.id, 'isPrimary', event.target.checked)
+              }
+            />
           </article>
         ))}
       </div>

--- a/apps/web/src/components/forms/AccountForm.tsx
+++ b/apps/web/src/components/forms/AccountForm.tsx
@@ -55,6 +55,7 @@ import {
   getDefaultRetirementTaxTreatment,
 } from '../../lib/tax/retirement-contribution-metadata';
 import { AmountInput } from './AmountInput';
+import { Checkbox } from '../common/Checkbox';
 import { FormErrorSummary, type FormErrorSummaryItem } from './FormErrorSummary';
 
 import './forms.css';
@@ -489,24 +490,21 @@ export function AccountForm({ onSubmit, onCancel, isOpen, initialData }: Account
 
             <fieldset className="form-group form-fieldset">
               <legend className="form-group__label">Retirement classification</legend>
-              <label className="form-checkbox-row">
-                <input
-                  type="checkbox"
-                  checked={isRetirementAccount}
-                  onChange={(event) => {
-                    if (event.target.checked) {
-                      const defaultType = 'TRADITIONAL_IRA' as RetirementAccountType;
-                      setRetirementAccountType(defaultType);
-                      setRetirementTaxTreatment(getDefaultRetirementTaxTreatment(defaultType));
-                    } else {
-                      setRetirementAccountType('');
-                      setRetirementTaxTreatment('PRE_TAX');
-                      setHsaCoverageLevel('SELF_ONLY');
-                    }
-                  }}
-                />
-                Mark this as a retirement or tax-advantaged account
-              </label>
+              <Checkbox
+                label="Mark this as a retirement or tax-advantaged account"
+                checked={isRetirementAccount}
+                onChange={(event) => {
+                  if (event.target.checked) {
+                    const defaultType = 'TRADITIONAL_IRA' as RetirementAccountType;
+                    setRetirementAccountType(defaultType);
+                    setRetirementTaxTreatment(getDefaultRetirementTaxTreatment(defaultType));
+                  } else {
+                    setRetirementAccountType('');
+                    setRetirementTaxTreatment('PRE_TAX');
+                    setHsaCoverageLevel('SELF_ONLY');
+                  }
+                }}
+              />
               {isRetirementAccount && (
                 <>
                   <div className="form-group">

--- a/apps/web/src/components/forms/BudgetForm.tsx
+++ b/apps/web/src/components/forms/BudgetForm.tsx
@@ -41,6 +41,7 @@ import type { BudgetStarterTemplate } from '../../lib/budgeting/starter-budget-t
 import { budgetSchema } from '../../lib/validation';
 import { DatePicker } from '../common/DatePicker';
 import { Button } from '../common/Button';
+import { Checkbox } from '../common/Checkbox';
 import { AmountInput } from './AmountInput';
 
 import './forms.css';
@@ -665,25 +666,12 @@ export function BudgetForm({
                 </div>
 
                 <div className="form-group">
-                  <label
-                    style={{
-                      display: 'flex',
-                      gap: 'var(--spacing-2)',
-                      alignItems: 'flex-start',
-                    }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={isRollover}
-                      onChange={(e) => setIsRollover(e.target.checked)}
-                    />
-                    <span>
-                      <span className="form-group__label">Envelope / rollover category</span>
-                      <span className="form-group__help" style={{ display: 'block' }}>
-                        Preserve unused money and carry overspending into the next budget period.
-                      </span>
-                    </span>
-                  </label>
+                  <Checkbox
+                    checked={isRollover}
+                    onChange={(e) => setIsRollover(e.target.checked)}
+                    label="Envelope / rollover category"
+                    hint="Preserve unused money and carry overspending into the next budget period."
+                  />
                 </div>
 
                 <div className="form-group">

--- a/apps/web/src/components/forms/TransactionForm.tsx
+++ b/apps/web/src/components/forms/TransactionForm.tsx
@@ -85,6 +85,7 @@ import { DateInput } from '../common';
 import { Button } from '../common/Button';
 import { CategoryConfirmation } from '../categorization';
 import { AmountInput } from './AmountInput';
+import { Checkbox } from '../common/Checkbox';
 import { CounterpartyInput } from '../transactions/CounterpartyInput';
 import { FormErrorSummary, type FormErrorSummaryItem } from './FormErrorSummary';
 
@@ -1300,14 +1301,11 @@ export function TransactionForm({
 
             <fieldset className="form-group form-fieldset">
               <legend className="form-group__label">Buy-now-pay-later liability</legend>
-              <label className="form-checkbox-row">
-                <input
-                  type="checkbox"
-                  checked={isBnplLiability}
-                  onChange={(event) => setIsBnplLiability(event.target.checked)}
-                />
-                Track this purchase as a BNPL liability with installments
-              </label>
+              <Checkbox
+                label="Track this purchase as a BNPL liability with installments"
+                checked={isBnplLiability}
+                onChange={(event) => setIsBnplLiability(event.target.checked)}
+              />
               {isBnplLiability && (
                 <input
                   id="txn-bnpl-installments"
@@ -1554,19 +1552,16 @@ export function TransactionForm({
 
             <fieldset className="form-group form-fieldset">
               <legend className="form-group__label">Retirement contribution</legend>
-              <label className="form-checkbox-row">
-                <input
-                  type="checkbox"
-                  checked={isRetirementContribution}
-                  onChange={(event) => {
-                    setIsRetirementContribution(event.target.checked);
-                    if (event.target.checked && retirementContributionYear.trim() === '') {
-                      setRetirementContributionYear(date.slice(0, 4));
-                    }
-                  }}
-                />
-                Count this transaction or transfer toward an annual contribution limit
-              </label>
+              <Checkbox
+                label="Count this transaction or transfer toward an annual contribution limit"
+                checked={isRetirementContribution}
+                onChange={(event) => {
+                  setIsRetirementContribution(event.target.checked);
+                  if (event.target.checked && retirementContributionYear.trim() === '') {
+                    setRetirementContributionYear(date.slice(0, 4));
+                  }
+                }}
+              />
               {isRetirementContribution && (
                 <>
                   <div className="form-group">

--- a/apps/web/src/components/gdpr/ConsentDialog.tsx
+++ b/apps/web/src/components/gdpr/ConsentDialog.tsx
@@ -23,6 +23,7 @@ import {
   type ConsentCategory,
 } from '../../lib/consent-storage';
 import { useConsent } from '../../hooks/useConsent';
+import { Checkbox } from '../common/Checkbox';
 import './consent-dialog.css';
 
 // ---------------------------------------------------------------------------
@@ -198,13 +199,7 @@ export const ConsentDialog: React.FC<ConsentDialogProps> = ({ onComplete }) => {
 
               {/* Essential — always on */}
               <div className="consent-dialog__category consent-dialog__category--disabled">
-                <input
-                  type="checkbox"
-                  checked
-                  disabled
-                  aria-label={`${CONSENT_LABELS.essential} (required)`}
-                  className="consent-dialog__category-checkbox"
-                />
+                <Checkbox checked disabled aria-label={`${CONSENT_LABELS.essential} (required)`} />
                 <div>
                   <span className="consent-dialog__category-label">
                     {CONSENT_LABELS.essential}{' '}
@@ -219,12 +214,10 @@ export const ConsentDialog: React.FC<ConsentDialogProps> = ({ onComplete }) => {
               {/* Toggleable categories */}
               {TOGGLEABLE_CATEGORIES.map((category) => (
                 <div key={category} className="consent-dialog__category">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={localPreferences[category]}
                     onChange={() => handleToggle(category)}
                     aria-label={CONSENT_LABELS[category]}
-                    className="consent-dialog__category-checkbox"
                   />
                   <div>
                     <span className="consent-dialog__category-label">

--- a/apps/web/src/components/gdpr/CrashReportingSettings.tsx
+++ b/apps/web/src/components/gdpr/CrashReportingSettings.tsx
@@ -20,6 +20,7 @@ import {
   generateExamplePayload,
 } from '../../lib/crash-report-scrubber';
 import { initMonitoring } from '../../lib/monitoring';
+import { Checkbox } from '../common/Checkbox';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -85,13 +86,12 @@ export const CrashReportingSettings: React.FC<CrashReportingSettingsProps> = ({
             Helps us identify and fix bugs. You can turn this off at any time.
           </p>
         </div>
-        <input
+        <Checkbox
           id="crash-reporting-toggle"
-          type="checkbox"
+          className="settings-item__checkbox-wrapper"
           checked={enabled}
           onChange={handleToggle}
           aria-label="Send anonymous crash reports to help improve the app"
-          className="settings-item__checkbox"
         />
       </div>
 

--- a/apps/web/src/components/gdpr/PrivacySettings.tsx
+++ b/apps/web/src/components/gdpr/PrivacySettings.tsx
@@ -16,6 +16,7 @@
 
 import React, { useCallback, useState } from 'react';
 import { useConsent } from '../../hooks/useConsent';
+import { Checkbox } from '../common/Checkbox';
 import {
   CONSENT_DESCRIPTIONS,
   CONSENT_LABELS,
@@ -122,12 +123,11 @@ export const PrivacySettings: React.FC<PrivacySettingsProps> = ({
               {CONSENT_DESCRIPTIONS.essential}
             </p>
           </div>
-          <input
-            type="checkbox"
+          <Checkbox
+            className="settings-item__checkbox-wrapper"
             checked
             disabled
             aria-label={`${CONSENT_LABELS.essential} (always required)`}
-            className="settings-item__checkbox"
           />
         </div>
 
@@ -142,13 +142,12 @@ export const PrivacySettings: React.FC<PrivacySettingsProps> = ({
                 {CONSENT_DESCRIPTIONS[category]}
               </p>
             </div>
-            <input
+            <Checkbox
               id={`privacy-${category}`}
-              type="checkbox"
+              className="settings-item__checkbox-wrapper"
               checked={consent.categories[category]}
               onChange={() => handleToggle(category)}
               aria-label={CONSENT_LABELS[category]}
-              className="settings-item__checkbox"
             />
           </div>
         ))}

--- a/apps/web/src/components/gig/GigPlatformEarningsSection.tsx
+++ b/apps/web/src/components/gig/GigPlatformEarningsSection.tsx
@@ -26,6 +26,7 @@ import React, { useId, useMemo, useState } from 'react';
 
 import { CHART_COLORS } from '../charts/chart-palette';
 import { CurrencyDisplay } from '../common/CurrencyDisplay';
+import { Checkbox } from '../common/Checkbox';
 import { useGigPlatformEarnings } from '../../hooks/useGigPlatformEarnings';
 import { formatCentsDisplay, parseAmountInput } from '../../hooks/useAmountInput';
 import { platformPercent, reconcilePlatformPayouts } from '../../lib/gig/platform-earnings';
@@ -327,15 +328,13 @@ const RuleManager: React.FC<RuleManagerProps> = ({ rules, onAdd, onToggle, onRem
                 {rule.matchField} contains {rule.keywords.join(', ')}
                 {rule.isBuiltIn ? ' (built-in)' : ''}
               </span>
-              <span className="gig-toggle">
-                <input
-                  id={toggleId}
-                  type="checkbox"
-                  checked={rule.enabled}
-                  onChange={() => onToggle(rule.id)}
-                />
-                <label htmlFor={toggleId}>Enabled</label>
-              </span>
+              <Checkbox
+                id={toggleId}
+                className="gig-toggle"
+                label="Enabled"
+                checked={rule.enabled}
+                onChange={() => onToggle(rule.id)}
+              />
               <button
                 type="button"
                 className="gig-btn"

--- a/apps/web/src/components/goals/SharedGoalContributions.tsx
+++ b/apps/web/src/components/goals/SharedGoalContributions.tsx
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { FormEvent, ReactElement } from 'react';
 
 import { CurrencyDisplay } from '../common';
+import { Checkbox } from '../common/Checkbox';
 import { AppIcon } from '../icons';
 import {
   monthsUntil,
@@ -400,14 +401,12 @@ export function SharedGoalContributions({
             <CurrencyDisplay amount={plan.householdMonthlyCents} currency={currency} /> / month for{' '}
             {plan.months} month{plan.months === 1 ? '' : 's'}
           </span>
-          <label className="shared-goal__toggle">
-            <input
-              type="checkbox"
-              checked={config.incomeWeighted}
-              onChange={toggleIncomeWeighted}
-            />
-            <span>Split suggestions by income</span>
-          </label>
+          <Checkbox
+            className="shared-goal__toggle"
+            label="Split suggestions by income"
+            checked={config.incomeWeighted}
+            onChange={toggleIncomeWeighted}
+          />
         </p>
       )}
 

--- a/apps/web/src/components/household/MoneyCheckInDialog.tsx
+++ b/apps/web/src/components/household/MoneyCheckInDialog.tsx
@@ -27,6 +27,7 @@ import {
 
 import { useFocusTrap, announce } from '../../accessibility/aria';
 import { CurrencyDisplay } from '../common/CurrencyDisplay';
+import { Checkbox } from '../common/Checkbox';
 import {
   ALL_CHECK_IN_SUMMARY_TYPES,
   buildNeutralSummary,
@@ -342,16 +343,15 @@ export function MoneyCheckInDialog({
               <fieldset className="money-check-in__fieldset">
                 <legend className="money-check-in__legend">Who is opting in?</legend>
                 {partners.map((partner) => (
-                  <label key={partner.id} className="money-check-in__checkbox">
-                    <input
-                      type="checkbox"
-                      checked={consent[partner.id] ?? false}
-                      onChange={(event) =>
-                        setConsent((prev) => ({ ...prev, [partner.id]: event.target.checked }))
-                      }
-                    />
-                    <span>{partner.name} opts in</span>
-                  </label>
+                  <Checkbox
+                    key={partner.id}
+                    className="money-check-in__checkbox"
+                    label={`${partner.name} opts in`}
+                    checked={consent[partner.id] ?? false}
+                    onChange={(event) =>
+                      setConsent((prev) => ({ ...prev, [partner.id]: event.target.checked }))
+                    }
+                  />
                 ))}
               </fieldset>
 
@@ -489,14 +489,12 @@ export function MoneyCheckInDialog({
                       placeholder="Something supportive to remember from this prompt"
                       aria-label="Note for this prompt"
                     />
-                    <label className="money-check-in__checkbox">
-                      <input
-                        type="checkbox"
-                        checked={notePrivate}
-                        onChange={(event) => setNotePrivate(event.target.checked)}
-                      />
-                      <span>Keep this note private (redacted in the shared recap)</span>
-                    </label>
+                    <Checkbox
+                      className="money-check-in__checkbox"
+                      label="Keep this note private (redacted in the shared recap)"
+                      checked={notePrivate}
+                      onChange={(event) => setNotePrivate(event.target.checked)}
+                    />
                     <button
                       type="button"
                       className="money-check-in__link-button"
@@ -538,14 +536,13 @@ export function MoneyCheckInDialog({
                 <fieldset key={partner.id} className="money-check-in__fieldset">
                   <legend className="money-check-in__legend">{partner.name} shares</legend>
                   {ALL_CHECK_IN_SUMMARY_TYPES.map((type) => (
-                    <label key={type} className="money-check-in__checkbox">
-                      <input
-                        type="checkbox"
-                        checked={(sharingPrefs[partner.id] ?? []).includes(type)}
-                        onChange={() => toggleSharing(partner.id, type)}
-                      />
-                      <span>{SUMMARY_TYPE_LABELS[type]}</span>
-                    </label>
+                    <Checkbox
+                      key={type}
+                      className="money-check-in__checkbox"
+                      label={SUMMARY_TYPE_LABELS[type]}
+                      checked={(sharingPrefs[partner.id] ?? []).includes(type)}
+                      onChange={() => toggleSharing(partner.id, type)}
+                    />
                   ))}
                 </fieldset>
               ))}

--- a/apps/web/src/components/import/ImportPreview.tsx
+++ b/apps/web/src/components/import/ImportPreview.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React from 'react';
-
+import { Checkbox } from '../common/Checkbox';
 import type { UseImportResult } from '../../hooks/useImport';
 
 export interface ImportPreviewProps {
@@ -110,9 +110,8 @@ export const ImportPreview: React.FC<ImportPreviewProps> = ({
                   return (
                     <tr key={dup.importRow.rowIndex}>
                       <td>
-                        <input
+                        <Checkbox
                           id={checkboxId}
-                          type="checkbox"
                           checked={skippedDuplicates.has(dup.importRow.rowIndex)}
                           onChange={() => onToggleSkipDuplicate(dup.importRow.rowIndex)}
                           aria-label={`Skip row ${dup.importRow.rowIndex + 1}`}

--- a/apps/web/src/components/investments/InvestingBetaFeatures.tsx
+++ b/apps/web/src/components/investments/InvestingBetaFeatures.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useMemo, useState } from 'react';
+import { Checkbox } from '../common/Checkbox';
 import type { Investment, InvestmentLot, SyncId } from '../../kmp/bridge';
 import {
   analyzeCostBasis,
@@ -404,14 +405,11 @@ const RebalancingSection: React.FC<{
           style={{ marginLeft: 'var(--spacing-2)', width: 120 }}
         />
       </label>
-      <label>
-        <input
-          type="checkbox"
-          checked={features.allowSellRebalancing}
-          onChange={(event) => features.setAllowSellRebalancing(event.target.checked)}
-        />{' '}
-        Enable sell-based rebalancing
-      </label>
+      <Checkbox
+        label="Enable sell-based rebalancing"
+        checked={features.allowSellRebalancing}
+        onChange={(event) => features.setAllowSellRebalancing(event.target.checked)}
+      />
     </div>
     <p style={{ color: 'var(--semantic-text-secondary)' }}>
       Buy-only mode allocates new cash toward underweight classes. Sell suggestions are hidden
@@ -768,9 +766,8 @@ const FeeSection: React.FC<{
                 <tr key={investment.id}>
                   <TableCell>{investment.symbol}</TableCell>
                   <TableCell>
-                    <input
+                    <Checkbox
                       aria-label={`Fees apply to ${investment.symbol}`}
-                      type="checkbox"
                       checked={setting.applies}
                       onChange={(event) =>
                         features.updateExpenseRatioSetting(investment.id, {

--- a/apps/web/src/components/mileage/BusinessExpenseTag.tsx
+++ b/apps/web/src/components/mileage/BusinessExpenseTag.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { formatCurrency } from '../../lib/currency';
+import { Checkbox } from '../common/Checkbox';
 import {
   buildBusinessExpenseUpdate,
   getBusinessExpenseDefaults,
@@ -114,15 +115,12 @@ export function BusinessExpenseTag({
         {isTagged ? <span className="business-expense-tag__pill">Tagged</span> : null}
       </div>
 
-      <label className="form-checkbox-row">
-        <input
-          type="checkbox"
-          checked={enabled}
-          onChange={(event) => setEnabled(event.target.checked)}
-          disabled={disabled}
-        />
-        Count this as a business expense
-      </label>
+      <Checkbox
+        label="Count this as a business expense"
+        checked={enabled}
+        onChange={(event) => setEnabled(event.target.checked)}
+        disabled={disabled}
+      />
 
       {enabled ? (
         <>

--- a/apps/web/src/components/settings/MinimalistModeSettings.tsx
+++ b/apps/web/src/components/settings/MinimalistModeSettings.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback } from 'react';
 
 import { useModuleVisibility } from '../../hooks/useModuleVisibility';
+import { Checkbox } from '../common/Checkbox';
 import {
   HIDEABLE_MODULE_CATEGORY_LABELS,
   HIDEABLE_MODULE_CATEGORY_ORDER,
@@ -81,11 +82,9 @@ export const MinimalistModeSettings: React.FC = () => {
                       <span className="minimalist-mode__state" aria-hidden="true">
                         {visible ? 'Shown' : 'Hidden'}
                       </span>
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         role="switch"
                         id={switchId}
-                        className="settings-item__checkbox"
                         checked={visible}
                         onChange={handleToggle(module.id)}
                         aria-describedby={descriptionId}

--- a/apps/web/src/components/settings/PassphraseDialog.tsx
+++ b/apps/web/src/components/settings/PassphraseDialog.tsx
@@ -17,6 +17,7 @@
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 
 import { MIN_PASSPHRASE_LENGTH } from '../../db/data-key-wrapping';
+import { Checkbox } from '../common/Checkbox';
 
 import './encryption-unlock.css';
 
@@ -257,15 +258,13 @@ export const PassphraseDialog: React.FC<PassphraseDialogProps> = ({
             </>
           )}
 
-          <label className="encryption-field__reveal">
-            <input
-              type="checkbox"
-              checked={reveal}
-              onChange={(event) => setReveal(event.target.checked)}
-              disabled={submitting}
-            />
-            Show passphrase
-          </label>
+          <Checkbox
+            className="encryption-field__reveal"
+            label="Show passphrase"
+            checked={reveal}
+            onChange={(event) => setReveal(event.target.checked)}
+            disabled={submitting}
+          />
 
           {error && (
             <p id={errorId} className="encryption-dialog__error" role="alert" aria-live="assertive">

--- a/apps/web/src/components/settings/RecoveryCodeDialog.tsx
+++ b/apps/web/src/components/settings/RecoveryCodeDialog.tsx
@@ -11,7 +11,7 @@
  */
 
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
-
+import { Checkbox } from '../common/Checkbox';
 import './encryption-unlock.css';
 
 export interface RecoveryCodeDialogProps {
@@ -118,14 +118,12 @@ export const RecoveryCodeDialog: React.FC<RecoveryCodeDialogProps> = ({ code, on
               : ''}
         </p>
 
-        <label className="encryption-field__reveal">
-          <input
-            type="checkbox"
-            checked={confirmed}
-            onChange={(event) => setConfirmed(event.target.checked)}
-          />
-          I have saved my recovery code somewhere safe.
-        </label>
+        <Checkbox
+          className="encryption-field__reveal"
+          label="I have saved my recovery code somewhere safe."
+          checked={confirmed}
+          onChange={(event) => setConfirmed(event.target.checked)}
+        />
 
         <div className="encryption-dialog__actions">
           <button

--- a/apps/web/src/components/social/ShareCelebrationButton.tsx
+++ b/apps/web/src/components/social/ShareCelebrationButton.tsx
@@ -25,6 +25,7 @@ import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 
 
 import { announce, useFocusTrap } from '../../accessibility/aria';
 import { AppIcon } from '../icons';
+import { Checkbox } from '../common/Checkbox';
 import {
   buildShareCelebration,
   toShareData,
@@ -265,16 +266,14 @@ export const ShareCelebrationButton: React.FC<ShareCelebrationButtonProps> = ({
             </div>
 
             {hasAmount && (
-              <label className="share-celebration__option">
-                <input
-                  type="checkbox"
-                  checked={revealAmount}
-                  onChange={(e) => setRevealAmount(e.target.checked)}
-                />
-                <span>
-                  Include the amount I&rsquo;ve saved (off by default to keep balances private)
-                </span>
-              </label>
+              <Checkbox
+                className="share-celebration__option"
+                label={
+                  <>Include the amount I&rsquo;ve saved (off by default to keep balances private)</>
+                }
+                checked={revealAmount}
+                onChange={(e) => setRevealAmount(e.target.checked)}
+              />
             )}
 
             <p

--- a/apps/web/src/components/tagging/RuleManager.tsx
+++ b/apps/web/src/components/tagging/RuleManager.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
 
 import { useFocusTrap } from '../../accessibility/aria';
 import { useTaggingRules } from '../../hooks/useTaggingRules';
+import { Checkbox } from '../common/Checkbox';
 import type { Transaction } from '../../kmp/bridge';
 import { matchCondition } from '../../lib/tagging/rule-engine';
 import type {
@@ -276,15 +277,13 @@ export function RuleManager({ recentTransactions = [] }: RuleManagerProps) {
           {rules.map((rule) => (
             <li key={rule.id} className="tagging-rule-item" role="listitem">
               <div className="tagging-rule-item__header">
-                <label className="tagging-rule-item__toggle">
-                  <input
-                    type="checkbox"
-                    checked={rule.enabled}
-                    onChange={() => toggleRule(rule.id)}
-                    aria-label={`${rule.enabled ? 'Disable' : 'Enable'} rule: ${rule.name}`}
-                  />
-                  <span className="tagging-rule-item__name">{rule.name}</span>
-                </label>
+                <Checkbox
+                  className="tagging-rule-item__toggle"
+                  checked={rule.enabled}
+                  onChange={() => toggleRule(rule.id)}
+                  aria-label={`${rule.enabled ? 'Disable' : 'Enable'} rule: ${rule.name}`}
+                  label={<span className="tagging-rule-item__name">{rule.name}</span>}
+                />
                 <span className="tagging-rule-item__meta">
                   Priority: {rule.priority} · Matched: {rule.matchCount}
                 </span>

--- a/apps/web/src/pages/AccountDetailPage.tsx
+++ b/apps/web/src/pages/AccountDetailPage.tsx
@@ -6,6 +6,7 @@ import { AppIcon } from '../components/icons';
 import { pluralize } from '../lib/ui/pluralize';
 
 import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
+import { Checkbox } from '../components/common/Checkbox';
 import { AccountDeleteDialog, AccountPurposeBadge } from '../components/accounts';
 import { AccountForm } from '../components/forms';
 import { Breadcrumb } from '../components/navigation';
@@ -415,20 +416,20 @@ export const AccountDetailPage: React.FC = () => {
 
                     return (
                       <li key={transaction.id} role="listitem" className="list-item">
-                        <label className="list-item__content">
-                          <input
-                            type="checkbox"
-                            checked={clearedTransactionIds.has(transaction.id)}
-                            onChange={() => handleToggleCleared(transaction.id)}
-                            aria-label={`Cleared ${label}`}
-                          />
-                          <span>
-                            <span className="list-item__primary">{label}</span>
-                            <span className="list-item__secondary">
-                              {formatDate(transaction.date)} · {transaction.status.toLowerCase()}
+                        <Checkbox
+                          className="list-item__content"
+                          checked={clearedTransactionIds.has(transaction.id)}
+                          onChange={() => handleToggleCleared(transaction.id)}
+                          aria-label={`Cleared ${label}`}
+                          label={
+                            <span>
+                              <span className="list-item__primary">{label}</span>
+                              <span className="list-item__secondary">
+                                {formatDate(transaction.date)} · {transaction.status.toLowerCase()}
+                              </span>
                             </span>
-                          </span>
-                        </label>
+                          }
+                        />
                         <div className="list-item__trailing">
                           <CurrencyDisplay
                             amount={signedAmount}

--- a/apps/web/src/pages/CreateBillPage.tsx
+++ b/apps/web/src/pages/CreateBillPage.tsx
@@ -15,6 +15,7 @@ import type { BillFrequency } from '../kmp/bridge';
 import type { CreateBillInput } from '../db/repositories/bills';
 import { DatePicker } from '../components/common/DatePicker';
 import { Button } from '../components/common/Button';
+import { Checkbox } from '../components/common/Checkbox';
 import { dollarsToCents, minorUnitStep, normalizeAmountInputValue } from '../lib/currency';
 
 /** Resolve the first available household ID from the local database. */
@@ -316,22 +317,12 @@ export const CreateBillPage: React.FC = () => {
 
           {/* Auto-Pay */}
           <div className="form-group" style={{ marginBottom: 'var(--spacing-4)' }}>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 'var(--spacing-2)',
-                cursor: 'pointer',
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={isAutoPay}
-                onChange={(e) => setIsAutoPay(e.target.checked)}
-                disabled={submitting}
-              />
-              Auto-pay enabled
-            </label>
+            <Checkbox
+              label="Auto-pay enabled"
+              checked={isAutoPay}
+              onChange={(e) => setIsAutoPay(e.target.checked)}
+              disabled={submitting}
+            />
           </div>
 
           {/* Reminder Days */}

--- a/apps/web/src/pages/DataImportWizardPage.tsx
+++ b/apps/web/src/pages/DataImportWizardPage.tsx
@@ -14,6 +14,7 @@
 import { useCallback, useId, useRef, useState } from 'react';
 import type { DragEvent, ChangeEvent } from 'react';
 import { AppIcon } from '../components/icons';
+import { Checkbox } from '../components/common/Checkbox';
 import { useDatabase } from '../db/DatabaseProvider';
 
 import { useAccounts } from '../hooks/useAccounts';
@@ -641,14 +642,12 @@ export function DataImportWizardPage() {
                 Review what will be imported. Existing records with the same id are skipped unless
                 you choose a clean restore.
               </p>
-              <label className="import-checkbox-row">
-                <input
-                  type="checkbox"
-                  checked={backupWipeFirst}
-                  onChange={(event) => handleBackupWipeChange(event.target.checked)}
-                />
-                <span>Wipe local data first</span>
-              </label>
+              <Checkbox
+                className="import-checkbox-row"
+                label="Wipe local data first"
+                checked={backupWipeFirst}
+                onChange={(event) => handleBackupWipeChange(event.target.checked)}
+              />
               <div
                 className="import-mapping-table-wrapper"
                 role="region"

--- a/apps/web/src/pages/DebtPage.tsx
+++ b/apps/web/src/pages/DebtPage.tsx
@@ -14,6 +14,7 @@
 
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { CurrencyDisplay, EmptyState } from '../components/common';
+import { Checkbox } from '../components/common/Checkbox';
 import { getCurrentLocale } from '../lib/i18n';
 import { pluralize } from '../lib/ui/pluralize';
 import { ExplainThis } from '../components/common/ExplainThis';
@@ -1517,16 +1518,12 @@ function PayoffPlannerPanel(): React.ReactElement {
                 Select all debts
               </button>
               {debts.map((debt) => (
-                <label key={debt.id}>
-                  <input
-                    type="checkbox"
-                    checked={effectiveConsolidationDebtIds.includes(debt.id)}
-                    onChange={(event) =>
-                      handleConsolidationDebtToggle(debt.id, event.target.checked)
-                    }
-                  />
-                  {debt.name}
-                </label>
+                <Checkbox
+                  key={debt.id}
+                  label={debt.name}
+                  checked={effectiveConsolidationDebtIds.includes(debt.id)}
+                  onChange={(event) => handleConsolidationDebtToggle(debt.id, event.target.checked)}
+                />
               ))}
             </fieldset>
             {consolidationPanelModel && (
@@ -2633,16 +2630,14 @@ function StudentLoanPanel(): React.ReactElement {
                   }
                 />
               </label>
-              <label className="student-loan-checkbox">
-                <input
-                  type="checkbox"
-                  checked={refinanceForm.feesFinanced}
-                  onChange={(event) =>
-                    handleRefinanceFieldChange('feesFinanced', event.target.checked)
-                  }
-                />
-                Finance fees into principal
-              </label>
+              <Checkbox
+                className="student-loan-checkbox"
+                label="Finance fees into principal"
+                checked={refinanceForm.feesFinanced}
+                onChange={(event) =>
+                  handleRefinanceFieldChange('feesFinanced', event.target.checked)
+                }
+              />
             </div>
             {refinancePanelModel && (
               <>
@@ -2977,22 +2972,18 @@ function StudentLoanPanel(): React.ReactElement {
               ))}
             </select>
           </label>
-          <label className="student-loan-checkbox">
-            <input
-              type="checkbox"
-              checked={formState.isFederal}
-              onChange={(event) => handleFieldChange('isFederal', event.target.checked)}
-            />
-            Federal loan
-          </label>
-          <label className="student-loan-checkbox">
-            <input
-              type="checkbox"
-              checked={formState.isPslfEligible}
-              onChange={(event) => handleFieldChange('isPslfEligible', event.target.checked)}
-            />
-            PSLF eligible
-          </label>
+          <Checkbox
+            className="student-loan-checkbox"
+            label="Federal loan"
+            checked={formState.isFederal}
+            onChange={(event) => handleFieldChange('isFederal', event.target.checked)}
+          />
+          <Checkbox
+            className="student-loan-checkbox"
+            label="PSLF eligible"
+            checked={formState.isPslfEligible}
+            onChange={(event) => handleFieldChange('isPslfEligible', event.target.checked)}
+          />
           <label>
             Qualifying PSLF payments made
             <input

--- a/apps/web/src/pages/ExpectedIncomePage.tsx
+++ b/apps/web/src/pages/ExpectedIncomePage.tsx
@@ -18,6 +18,7 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 
 import { ConfirmDialog, EmptyState, Icon } from '../components/common';
+import { Checkbox } from '../components/common/Checkbox';
 import { IconToken } from '../icons/tokens';
 import { formatCurrency } from '../lib/currency';
 import { useInvoices } from '../hooks/useInvoices';
@@ -303,16 +304,12 @@ export function ExpectedIncomePage() {
           </div>
 
           <div className="expected-income__field expected-income__field--checkbox">
-            <input
+            <Checkbox
               id="expected-income-cleared"
-              className="expected-income__checkbox"
-              type="checkbox"
+              label="Already received (counts as spendable now)"
               checked={cleared}
               onChange={(event) => setCleared(event.target.checked)}
             />
-            <label className="expected-income__checkbox-label" htmlFor="expected-income-cleared">
-              Already received (counts as spendable now)
-            </label>
           </div>
 
           {formError ? (

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -17,6 +17,7 @@ import { AppIcon } from '../components/icons';
 import { useAuth } from '../auth/auth-context';
 import { ConfirmDialog } from '../components/common/ConfirmDialog';
 import { CurrencyDisplay } from '../components/common/CurrencyDisplay';
+import { Checkbox } from '../components/common/Checkbox';
 import { useToast } from '../components/common/Toast';
 import {
   ALLOWANCE_DAY_OPTIONS,
@@ -2059,15 +2060,13 @@ export function HouseholdPage() {
               const isSelected = sharedExpenseSelectedMembers[member.id] ?? true;
               return (
                 <div key={member.id} className="household-settle-up-member-row">
-                  <label className="household-settle-up-member-row__check">
-                    <input
-                      type="checkbox"
-                      checked={isSelected}
-                      onChange={(e) => handleToggleSharedExpenseMember(member.id, e.target.checked)}
-                      aria-label={'Include ' + name + ' in split'}
-                    />
-                    <span>{name}</span>
-                  </label>
+                  <Checkbox
+                    className="household-settle-up-member-row__check"
+                    label={name}
+                    checked={isSelected}
+                    onChange={(e) => handleToggleSharedExpenseMember(member.id, e.target.checked)}
+                    aria-label={'Include ' + name + ' in split'}
+                  />
                   {sharedExpenseSplitMode === 'CUSTOM' && isSelected && (
                     <input
                       className="household-form-input household-settle-up-member-row__amount"
@@ -2563,19 +2562,22 @@ export function HouseholdPage() {
                       <ul className="household-kid-card__chore-list" role="list">
                         {child.chores.map((chore) => (
                           <li key={chore.id} className="household-kid-card__chore-item">
-                            <label className="household-kid-card__chore-toggle">
-                              <input
-                                type="checkbox"
-                                checked={chore.completedThisWeek}
-                                onChange={() => toggleChildChoreCompletion(child.id, chore.id)}
-                              />
-                              <span>
-                                <span className="household-kid-card__chore-name">{chore.name}</span>
-                                <span className="household-kid-card__chore-meta">
-                                  {currencyFormatter.format(chore.value)} bonus • {chore.frequency}
+                            <Checkbox
+                              className="household-kid-card__chore-toggle"
+                              checked={chore.completedThisWeek}
+                              onChange={() => toggleChildChoreCompletion(child.id, chore.id)}
+                              label={
+                                <span>
+                                  <span className="household-kid-card__chore-name">
+                                    {chore.name}
+                                  </span>
+                                  <span className="household-kid-card__chore-meta">
+                                    {currencyFormatter.format(chore.value)} bonus •{' '}
+                                    {chore.frequency}
+                                  </span>
                                 </span>
-                              </span>
-                            </label>
+                              }
+                            />
                           </li>
                         ))}
                       </ul>

--- a/apps/web/src/pages/InsightsPage.tsx
+++ b/apps/web/src/pages/InsightsPage.tsx
@@ -17,6 +17,7 @@ import { WeeklyDigest } from '../components/insights';
 import { RecommendationsFeed } from '../components/recommendations';
 import { WellnessOverview } from '../components/wellness';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import { Checkbox } from '../components/common/Checkbox';
 import { AppIcon, type IconName } from '../components/icons';
 import { useInsights } from '../hooks/useInsights';
 import { useRecommendations } from '../hooks/useRecommendations';
@@ -650,14 +651,11 @@ export const InsightsPage: React.FC = () => {
                       ))}
                     </select>
                   </label>
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={privateMode}
-                      onChange={(event) => setPrivateMode(event.target.checked)}
-                    />{' '}
-                    Privacy mode
-                  </label>
+                  <Checkbox
+                    label="Privacy mode"
+                    checked={privateMode}
+                    onChange={(event) => setPrivateMode(event.target.checked)}
+                  />
                 </div>
               </div>
               <YearInReviewCard summary={activeAnnualSummary} privateMode={privateMode} />

--- a/apps/web/src/pages/LearningPage.tsx
+++ b/apps/web/src/pages/LearningPage.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { LearningDashboard } from '../components/learning';
 import { ErrorBanner } from '../components/common/ErrorBanner';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import { Checkbox } from '../components/common/Checkbox';
 import { useAccounts, useDashboardData, useGoals, useTransactions } from '../hooks';
 import { useLocalePreferences } from '../hooks/useLocalePreferences';
 import {
@@ -191,25 +192,24 @@ export function CreditBuildingSection(): React.ReactElement {
                     : 'credit-building__checklist-item'
                 }
               >
-                <label className="credit-building__checkbox-label">
-                  <input
-                    type="checkbox"
-                    className="credit-building__checkbox"
-                    checked={checked}
-                    onChange={() => toggleItem(item.id)}
-                  />
-                  <span className="credit-building__checkbox-text">
-                    <span className="credit-building__checkbox-title">
-                      {item.label}
-                      {checked && (
-                        <span className="credit-building__checkbox-badge">
-                          {content.checklistDoneBadge}
-                        </span>
-                      )}
+                <Checkbox
+                  className="credit-building__checkbox-label"
+                  checked={checked}
+                  onChange={() => toggleItem(item.id)}
+                  label={
+                    <span className="credit-building__checkbox-text">
+                      <span className="credit-building__checkbox-title">
+                        {item.label}
+                        {checked && (
+                          <span className="credit-building__checkbox-badge">
+                            {content.checklistDoneBadge}
+                          </span>
+                        )}
+                      </span>
+                      <span className="credit-building__checkbox-detail">{item.detail}</span>
                     </span>
-                    <span className="credit-building__checkbox-detail">{item.detail}</span>
-                  </span>
-                </label>
+                  }
+                />
               </li>
             );
           })}

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -21,6 +21,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../auth/auth-context';
 import { AppIcon } from '../components/icons';
+import { Checkbox } from '../components/common/Checkbox';
 import { useDatabase } from '../db/DatabaseProvider';
 import { getPrimaryHouseholdId } from '../db/repositories/household';
 import { useBudgets } from '../hooks/useBudgets';
@@ -1547,17 +1548,18 @@ const OnboardingPage: React.FC = () => {
 
             <div className="onboarding__choice-grid" role="group" aria-label="Life stages">
               {LIFE_STAGE_OPTIONS.map((option) => (
-                <label key={option.id} className="onboarding__choice-card">
-                  <input
-                    type="checkbox"
-                    checked={selectedLifeStages.includes(option.id)}
-                    onChange={() => handleLifeStageToggle(option.id)}
-                  />
-                  <span>
-                    <strong>{option.label}</strong>
-                    <small>{option.setupCopy}</small>
-                  </span>
-                </label>
+                <Checkbox
+                  key={option.id}
+                  className="onboarding__choice-card"
+                  checked={selectedLifeStages.includes(option.id)}
+                  onChange={() => handleLifeStageToggle(option.id)}
+                  label={
+                    <span>
+                      <strong>{option.label}</strong>
+                      <small>{option.setupCopy}</small>
+                    </span>
+                  }
+                />
               ))}
             </div>
 

--- a/apps/web/src/pages/PlanningPage.tsx
+++ b/apps/web/src/pages/PlanningPage.tsx
@@ -19,6 +19,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ErrorBanner, LoadingSpinner } from '../components/common';
+import { Checkbox } from '../components/common/Checkbox';
 import { useScenarioModeler } from '../hooks/useScenarioModeler';
 import { useRetirementPlanner } from '../hooks/useRetirementPlanner';
 import { useRmdTracking } from '../hooks/useRmdTracking';
@@ -1709,9 +1710,8 @@ const SweepPanel: React.FC = () => {
                 key={rule.id}
                 className={`sweep-rule ${!rule.enabled ? 'sweep-rule--disabled' : ''}`}
               >
-                <input
+                <Checkbox
                   className="sweep-rule__toggle"
-                  type="checkbox"
                   checked={rule.enabled}
                   onChange={() => toggleRule(rule.id)}
                   aria-label={`${rule.enabled ? 'Disable' : 'Enable'} ${rule.name}`}

--- a/apps/web/src/pages/PrivacyDashboardPage.tsx
+++ b/apps/web/src/pages/PrivacyDashboardPage.tsx
@@ -22,6 +22,7 @@ import { useConsentHistory } from '../hooks/useConsentHistory';
 import { usePrivacyDashboard } from '../hooks/usePrivacyDashboard';
 import { ConsentHistoryViewer } from '../components/gdpr/ConsentHistoryViewer';
 import { SecurityAuditLogViewer, ThirdPartyPermissionReview } from '../components/gdpr';
+import { Checkbox } from '../components/common/Checkbox';
 import {
   CONSENT_LABELS,
   CONSENT_DESCRIPTIONS,
@@ -208,13 +209,7 @@ const PrivacyDashboardPage: React.FC = () => {
               {CONSENT_DESCRIPTIONS.essential}
             </p>
           </div>
-          <input
-            type="checkbox"
-            checked
-            disabled
-            aria-label={`${CONSENT_LABELS.essential}, always required`}
-            className="privacy-dashboard__consent-toggle"
-          />
+          <Checkbox checked disabled aria-label={`${CONSENT_LABELS.essential}, always required`} />
         </div>
 
         {/* Toggleable categories */}
@@ -228,13 +223,11 @@ const PrivacyDashboardPage: React.FC = () => {
                 {CONSENT_DESCRIPTIONS[category]}
               </p>
             </div>
-            <input
+            <Checkbox
               id={`consent-${category}`}
-              type="checkbox"
               checked={consent.categories[category]}
               onChange={() => handleToggleConsent(category)}
               aria-label={`${consent.categories[category] ? 'Withdraw' : 'Grant'} consent for ${CONSENT_LABELS[category]}`}
-              className="privacy-dashboard__consent-toggle"
             />
           </div>
         ))}

--- a/apps/web/src/pages/ReceiptOcrPage.tsx
+++ b/apps/web/src/pages/ReceiptOcrPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
-import { DateInput } from '../components/common';
+import { Checkbox, DateInput } from '../components/common';
 import { AmountInput } from '../components/forms/AmountInput';
 import { AppIcon } from '../components/icons';
 import '../components/forms/forms.css';
@@ -346,8 +346,7 @@ export const ReceiptOcrPage: React.FC = () => {
                     return (
                       <tr key={`${item.description}-${index}`}>
                         <td>
-                          <input
-                            type="checkbox"
+                          <Checkbox
                             checked={item.included}
                             aria-label={`Include ${item.description}`}
                             onChange={() => handleToggleIncluded(index)}

--- a/apps/web/src/pages/ReportBuilderPage.tsx
+++ b/apps/web/src/pages/ReportBuilderPage.tsx
@@ -37,7 +37,7 @@ import type {
   DatePreset,
 } from '../hooks/useReportBuilder';
 import type { AnomalyModule, CategoryDrillDown } from '../lib/reports/reporting-beta';
-import { DateInput } from '../components/common';
+import { Checkbox, DateInput } from '../components/common';
 import { CHART_COLORS, formatChartCurrency } from '../components/charts/chart-palette';
 import { DatePicker } from '../components/common/DatePicker';
 
@@ -560,19 +560,18 @@ export function ReportBuilderPage() {
           Schedule
         </h2>
         <div className="report-schedule-row">
-          <label className="report-toggle-label" htmlFor="report-schedule-toggle">
-            <input
-              id="report-schedule-toggle"
-              type="checkbox"
-              checked={config.isScheduled}
-              onChange={(e) => setScheduled(e.target.checked)}
-              className="report-toggle-input"
-              aria-label="Enable scheduled report"
-            />
-            <span className="report-toggle-text">
-              {config.isScheduled ? 'Scheduled' : 'Not Scheduled'}
-            </span>
-          </label>
+          <Checkbox
+            id="report-schedule-toggle"
+            className="report-toggle-label"
+            checked={config.isScheduled}
+            onChange={(e) => setScheduled(e.target.checked)}
+            aria-label="Enable scheduled report"
+            label={
+              <span className="report-toggle-text">
+                {config.isScheduled ? 'Scheduled' : 'Not Scheduled'}
+              </span>
+            }
+          />
           {config.isScheduled && (
             <select
               className="report-select report-schedule-freq"
@@ -600,14 +599,13 @@ export function ReportBuilderPage() {
         </p>
         <div className="report-checkbox-grid">
           {ANOMALY_OPTIONS.map((option) => (
-            <label key={option.value} className="report-checkbox-row">
-              <input
-                type="checkbox"
-                checked={config.anomalyModules.includes(option.value)}
-                onChange={() => toggleAnomalyModule(option.value)}
-              />
-              {option.label}
-            </label>
+            <Checkbox
+              key={option.value}
+              className="report-checkbox-row"
+              label={option.label}
+              checked={config.anomalyModules.includes(option.value)}
+              onChange={() => toggleAnomalyModule(option.value)}
+            />
           ))}
         </div>
       </section>

--- a/apps/web/src/pages/TaxCenterPage.tsx
+++ b/apps/web/src/pages/TaxCenterPage.tsx
@@ -5,6 +5,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import { Checkbox } from '../components/common/Checkbox';
 import { useAccounts, useInvestments, useTransactions } from '../hooks';
 import type { Investment, InvestmentLot } from '../kmp/bridge';
 import { dollarsToCents as toCents, formatCurrency, formatGainLoss } from '../lib/currency';
@@ -459,15 +460,17 @@ export const TaxCenterPage: React.FC = () => {
                   <p className="card__title">Select lots to sell, in selection order</p>
                   <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--spacing-3)' }}>
                     {activeLots.map((lot) => (
-                      <label key={lot.id} style={{ display: 'flex', gap: 'var(--spacing-2)' }}>
-                        <input
-                          type="checkbox"
-                          checked={selectedLotIds.includes(lot.id)}
-                          onChange={() => toggleSpecificLot(lot.id)}
-                        />
-                        {lot.acquiredDate} · {lot.shares.toLocaleString()} shares @{' '}
-                        {formatCurrency(lot.costPerShare, { currency: lot.currency })}
-                      </label>
+                      <Checkbox
+                        key={lot.id}
+                        checked={selectedLotIds.includes(lot.id)}
+                        onChange={() => toggleSpecificLot(lot.id)}
+                        label={
+                          <>
+                            {lot.acquiredDate} · {lot.shares.toLocaleString()} shares @{' '}
+                            {formatCurrency(lot.costPerShare, { currency: lot.currency })}
+                          </>
+                        }
+                      />
                     ))}
                   </div>
                 </div>

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -22,6 +22,7 @@ import {
 } from '../components/common';
 import { SkipLink } from '../components/common/SkipLink';
 import { SwipeableRow } from '../components/common/SwipeableRow';
+import { Checkbox } from '../components/common/Checkbox';
 import { CategoryConfirmation } from '../components/categorization';
 import { TransactionForm } from '../components/forms';
 import { OfflineBanner } from '../components/OfflineBanner';
@@ -312,7 +313,6 @@ export const TransactionsPage: React.FC = () => {
     typeof window === 'undefined' ? 1024 : window.innerWidth,
   );
   const addMenuRef = useRef<HTMLDivElement>(null);
-  const selectAllCheckboxRef = useRef<HTMLInputElement>(null);
   const transactionRowRefs = useRef(new Map<string, HTMLElement>());
 
   // Get filters/sort from URL params
@@ -472,12 +472,6 @@ export const TransactionsPage: React.FC = () => {
   const allVisibleSelected =
     transactions.length > 0 && bulkTransactions.selectionCount === transactions.length;
   const someVisibleSelected = bulkTransactions.selectionCount > 0 && !allVisibleSelected;
-
-  useEffect(() => {
-    if (selectAllCheckboxRef.current) {
-      selectAllCheckboxRef.current.indeterminate = someVisibleSelected;
-    }
-  }, [someVisibleSelected]);
 
   const transactionLookup = useMemo(
     () => new Map(transactions.map((transaction) => [transaction.id, transaction])),
@@ -1176,9 +1170,7 @@ export const TransactionsPage: React.FC = () => {
           }}
         >
           <div className="transaction-register__checkbox-cell">
-            <input
-              type="checkbox"
-              className="bulk-select-checkbox"
+            <Checkbox
               checked={isSelected}
               readOnly
               aria-label={`Select ${transactionLabel}`}
@@ -1569,23 +1561,20 @@ export const TransactionsPage: React.FC = () => {
                       bulkTransactions.selectionCount === 1 ? '' : 's'
                     } selected`}
               </p>
-              <label className="transaction-register__select-all">
-                <input
-                  ref={selectAllCheckboxRef}
-                  type="checkbox"
-                  className="bulk-select-checkbox"
-                  checked={allVisibleSelected}
-                  onChange={(event) => {
-                    if (event.currentTarget.checked) {
-                      bulkTransactions.selectAll();
-                    } else {
-                      bulkTransactions.clearSelection();
-                    }
-                  }}
-                  aria-label="Select all visible transactions"
-                />
-                Select all visible transactions
-              </label>
+              <Checkbox
+                className="transaction-register__select-all"
+                checked={allVisibleSelected}
+                indeterminate={someVisibleSelected}
+                onChange={(event) => {
+                  if (event.currentTarget.checked) {
+                    bulkTransactions.selectAll();
+                  } else {
+                    bulkTransactions.clearSelection();
+                  }
+                }}
+                aria-label="Select all visible transactions"
+                label="Select all visible transactions"
+              />
               {groupedTransactions.map((group) => (
                 <section key={group.date} className="page-section" aria-label={group.label}>
                   <h3 className="list-group__header">{group.label}</h3>
@@ -1674,9 +1663,7 @@ export const TransactionsPage: React.FC = () => {
                           >
                             {!isSimplified ? (
                               <div className="transaction-list-item__selection">
-                                <input
-                                  type="checkbox"
-                                  className="bulk-select-checkbox"
+                                <Checkbox
                                   checked={isSelected(transaction.id)}
                                   onChange={(event) =>
                                     handleTransactionSelection(

--- a/apps/web/src/pages/settings/SettingsAdvancedPage.tsx
+++ b/apps/web/src/pages/settings/SettingsAdvancedPage.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useState } from 'react';
 
 import { SettingInfoWidget } from '../../components/settings';
+import { Checkbox } from '../../components/common/Checkbox';
 import { useDatabase } from '../../db/DatabaseProvider';
 import { eraseAllMoodTags } from '../../db/repositories/transactions';
 import { clearMoodJournalEntries } from '../../lib/mood';
@@ -72,13 +73,12 @@ export const SettingsAdvancedPage: React.FC = () => {
               <label className="settings-item__label" htmlFor="settings-mood-tags">
                 Allow mood tags on transactions
               </label>
-              <input
-                type="checkbox"
+              <Checkbox
                 id="settings-mood-tags"
+                className="settings-item__checkbox-wrapper"
                 checked={moodTagsEnabled}
                 onChange={handleMoodTagsEnabledChange}
                 aria-label="Allow mood tags on transactions"
-                className="settings-item__checkbox"
               />
             </div>
           </SettingInfoWidget>
@@ -88,13 +88,12 @@ export const SettingsAdvancedPage: React.FC = () => {
                 <label className="settings-item__label" htmlFor="settings-mood-tags-sync">
                   Sync mood tags across my devices
                 </label>
-                <input
-                  type="checkbox"
+                <Checkbox
                   id="settings-mood-tags-sync"
+                  className="settings-item__checkbox-wrapper"
                   checked={moodTagsSyncEnabled}
                   onChange={handleMoodTagsSyncChange}
                   aria-label="Sync mood tags across my devices"
-                  className="settings-item__checkbox"
                 />
               </div>
             </SettingInfoWidget>

--- a/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useState } from 'react';
 
 import { CurrencyDisplay } from '../../components/common/CurrencyDisplay';
 import { ReadAloudButton } from '../../components/common/ReadAloudButton';
+import { Checkbox } from '../../components/common/Checkbox';
 import { CategorizationSettings } from '../../components/categorization';
 import {
   HapticSettings,
@@ -369,13 +370,12 @@ export const SettingsPreferencesPage: React.FC = () => {
               <label className="settings-item__label" htmlFor="s-notif">
                 {settingsCopy.text('notificationsLabel')}
               </label>
-              <input
-                type="checkbox"
+              <Checkbox
                 id="s-notif"
+                className="settings-item__checkbox-wrapper"
                 checked={notificationsEnabled}
                 onChange={handleNotificationsChange}
                 aria-label={settingsCopy.text('notificationsAria')}
-                className="settings-item__checkbox"
               />
             </div>
           </SettingInfoWidget>
@@ -383,13 +383,12 @@ export const SettingsPreferencesPage: React.FC = () => {
             <label className="settings-item__label" htmlFor="settings-single-key-shortcuts">
               Single-key shortcuts
             </label>
-            <input
-              type="checkbox"
+            <Checkbox
               id="settings-single-key-shortcuts"
+              className="settings-item__checkbox-wrapper"
               checked={singleKeyShortcutsEnabled}
               onChange={handleSingleKeyShortcutsChange}
               aria-describedby="settings-single-key-shortcuts-help"
-              className="settings-item__checkbox"
             />
             <p id="settings-single-key-shortcuts-help" className="settings-item__description">
               Turn off character-key shortcuts like N, /, ?, and G then D if they conflict with
@@ -416,13 +415,12 @@ export const SettingsPreferencesPage: React.FC = () => {
             <label className="settings-item__label" htmlFor="settings-accessibility-simplified">
               Simplified mode
             </label>
-            <input
-              type="checkbox"
+            <Checkbox
               id="settings-accessibility-simplified"
+              className="settings-item__checkbox-wrapper"
               checked={accessibilityMode === 'simplified'}
               onChange={handleAccessibilityModeChange}
               aria-label="Simplified mode"
-              className="settings-item__checkbox"
             />
             <p className="settings-item__description">
               Uses larger text, 56px touch targets, calmer motion, and simplified navigation.
@@ -454,13 +452,12 @@ export const SettingsPreferencesPage: React.FC = () => {
             <label className="settings-item__label" htmlFor="settings-accessibility-contrast">
               High contrast
             </label>
-            <input
-              type="checkbox"
+            <Checkbox
               id="settings-accessibility-contrast"
+              className="settings-item__checkbox-wrapper"
               checked={highContrast}
               onChange={(event) => setHighContrast(event.target.checked)}
               aria-label="High contrast"
-              className="settings-item__checkbox"
             />
           </div>
 
@@ -468,13 +465,12 @@ export const SettingsPreferencesPage: React.FC = () => {
             <label className="settings-item__label" htmlFor="settings-accessibility-motion">
               Reduce motion
             </label>
-            <input
-              type="checkbox"
+            <Checkbox
               id="settings-accessibility-motion"
+              className="settings-item__checkbox-wrapper"
               checked={reduceMotion}
               onChange={(event) => setReduceMotion(event.target.checked)}
               aria-label="Reduce motion"
-              className="settings-item__checkbox"
             />
             <p className="settings-item__description">
               {effectiveReduceMotion && !reduceMotion
@@ -487,13 +483,12 @@ export const SettingsPreferencesPage: React.FC = () => {
             <label className="settings-item__label" htmlFor="settings-accessibility-speech">
               Read amounts aloud
             </label>
-            <input
-              type="checkbox"
+            <Checkbox
               id="settings-accessibility-speech"
+              className="settings-item__checkbox-wrapper"
               checked={speakAmounts}
               onChange={(event) => setSpeakAmounts(event.target.checked)}
               aria-label="Read amounts aloud"
-              className="settings-item__checkbox"
             />
             <p className="settings-item__description">
               Adds a read-aloud control for key amounts using the Web Speech API in supported
@@ -647,13 +642,12 @@ export const SettingsPreferencesPage: React.FC = () => {
             <label className="settings-item__label" htmlFor="s-show-decimals">
               Show cents
             </label>
-            <input
-              type="checkbox"
+            <Checkbox
               id="s-show-decimals"
+              className="settings-item__checkbox-wrapper"
               checked={displaySettings.showDecimals}
               onChange={(e) => displaySettings.updateSettings({ showDecimals: e.target.checked })}
               aria-label="Show cents (decimal places)"
-              className="settings-item__checkbox"
             />
           </div>
 

--- a/apps/web/src/pages/settings/SettingsPrivacyPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPrivacyPage.tsx
@@ -9,6 +9,7 @@ import {
   ThirdPartyPermissionReview,
 } from '../../components/gdpr';
 import { useAccountDeletion } from '../../components/settings/AccountDeletionModal';
+import { Checkbox } from '../../components/common/Checkbox';
 import { PrivacyPersistenceOption, usePrivacyMode } from '../../contexts/PrivacyModeContext';
 import { useAuth } from '../../auth/auth-context';
 import { initMonitoring } from '../../lib/monitoring';
@@ -91,13 +92,11 @@ export const SettingsPrivacyPage: React.FC = () => {
               Privacy Mode
             </label>
             <div className="settings-item__control">
-              <input
-                type="checkbox"
+              <Checkbox
                 id="s-privacy-mode"
                 checked={isPrivacyMode}
                 onChange={() => togglePrivacyMode()}
                 aria-label="Hide all financial amounts and balances"
-                className="settings-item__checkbox"
               />
             </div>
           </div>
@@ -134,13 +133,12 @@ export const SettingsPrivacyPage: React.FC = () => {
             <label className="settings-item__label" htmlFor="s-app-lock">
               App lock
             </label>
-            <input
-              type="checkbox"
+            <Checkbox
               id="s-app-lock"
+              className="settings-item__checkbox-wrapper"
               checked={appLockEnabled}
               onChange={handleAppLockChange}
               aria-label="Require passkey app lock before showing finance data"
-              className="settings-item__checkbox"
             />
           </div>
           <p className="settings-item__description">
@@ -179,13 +177,12 @@ export const SettingsPrivacyPage: React.FC = () => {
             <label className="settings-item__label" htmlFor="s-monitoring">
               Error Reporting
             </label>
-            <input
-              type="checkbox"
+            <Checkbox
               id="s-monitoring"
+              className="settings-item__checkbox-wrapper"
               checked={monitoringEnabled}
               onChange={handleMonitoringChange}
               aria-label="Send anonymous error reports to help improve the app"
-              className="settings-item__checkbox"
             />
           </div>
         </div>

--- a/apps/web/src/styles/accessibility.css
+++ b/apps/web/src/styles/accessibility.css
@@ -204,6 +204,15 @@ input[type='week']::-webkit-calendar-picker-indicator:hover {
   }
 }
 
+/* Checkboxes and radios are small by design; the 44px touch target is provided
+   by their surrounding label/wrapper. Inflating the control itself pushes the
+   :focus-visible ring away from the visible glyph, producing an oversized,
+   offset outline (issue #3545). Exclude them here. */
+input[type='checkbox'],
+input[type='radio'] {
+  min-height: 0;
+}
+
 /* Icon buttons — ensure padding creates adequate touch target */
 .icon-button {
   display: inline-flex;

--- a/apps/web/src/styles/font-scaling.css
+++ b/apps/web/src/styles/font-scaling.css
@@ -184,7 +184,9 @@ html {
 [data-font-scale='huge'] .settings-item__status,
 [data-font-scale='huge'] .settings-item__select,
 [data-font-scale='huge'] .settings-item__input,
-[data-font-scale='huge'] .settings-item__checkbox {
+[data-font-scale='huge'] .settings-item__checkbox,
+[data-font-scale='extra-large'] .settings-item__checkbox-wrapper,
+[data-font-scale='huge'] .settings-item__checkbox-wrapper {
   grid-column: 1;
   justify-self: stretch;
   max-width: 100%;

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -771,6 +771,11 @@
   justify-self: end;
   accent-color: var(--semantic-interactive-default);
 }
+/* Wrapper label for the shared Checkbox component takes the grid slot the bare
+   input used to occupy so the settings row layout is unchanged. */
+.settings-item__checkbox-wrapper {
+  justify-self: end;
+}
 .settings-item__description,
 .settings-item__help {
   grid-column: 2;
@@ -910,13 +915,15 @@
   .settings-item__status,
   .settings-item__select,
   .settings-item__input,
-  .settings-item__checkbox {
+  .settings-item__checkbox,
+  .settings-item__checkbox-wrapper {
     grid-column: 1;
     justify-self: stretch;
     text-align: left;
   }
 
   .settings-item__checkbox,
+  .settings-item__checkbox-wrapper,
   .settings-item__color-input {
     justify-self: start;
   }


### PR DESCRIPTION
## Summary

Fixes the misaligned/oversized checkbox focus ring (screenshot: the "Auto-pay enabled" checkbox on the Create Bill form) and centralizes every ad-hoc `<input type="checkbox">` in `apps/web` onto a single shared, accessible `Checkbox` component.

## Root cause (focus bug)

`apps/web/src/styles/accessibility.css` had a global `input { min-height: 44px }` touch-target rule that also matched checkboxes/radios. The native ~16px glyph stayed small while the input box inflated to 44px, so the global `input:focus-visible` outline wrapped the oversized 44px box ? the misaligned/offset focus ring.

**Fix:** exclude `input[type="checkbox"]`/`input[type="radio"]` from that rule. The 44px touch target is now provided by the wrapping `<label>`, and the focus ring wraps the true control.

## Shared component

New `apps/web/src/components/common/Checkbox.tsx` (+ `checkbox.css`, `Checkbox.test.tsx`):

- Native `<input type="checkbox">` with `appearance: none` and a CSS-drawn checkmark ? keeps full native semantics/keyboard operability.
- Clean, correctly-sized `:focus-visible` ring using the design-system `--semantic-border-focus` token (WCAG 2.2 AA focus appearance).
- States: checked / unchecked / **indeterminate** (synced via the DOM `indeterminate` prop) / **disabled** / error.
- Accessibility: wrapping `<label>` for label association, `aria-describedby` wiring for hint/error text, honors `prefers-reduced-motion` and forced-colors/high-contrast.
- Built on semantic design tokens (no hardcoded colors).

## Refactor

Converted 43 `.tsx` files (66 checkboxes) across forms, components, and pages onto `<Checkbox>`, preserving intent:

- Destructive/red checkbox (AccountDeleteDialog) keeps its danger styling via a scoped `.checkbox__input` override.
- Table bulk-select (TransactionsPage, ImportPreview) uses the `indeterminate` prop for partial selection.
- Settings grid layouts (Preferences/Privacy/Advanced, MinimalistMode) keep their grid via a wrapper class.
- 3 OnboardingPage toggle *switches* intentionally left native ? they are custom pill switches, not checkboxes.

## Testing

- [x] `tsc --noEmit` (apps/web) ? clean
- [x] `eslint apps/web/src --max-warnings 0` ? clean
- [x] `prettier --check` on changed files ? clean
- [x] `vitest run --changed origin/main` ? 1270/1271 pass; the single failure (DashboardPage "savings rate" card) is a pre-existing async-timeout flake under parallel load and passes 19/19 in isolation. DashboardPage is not in this changeset.
- [x] New `Checkbox.test.tsx` ? 10 tests pass

Closes #3545
