### PR TITLE
fix(deploy): set OAuth provider redirect URIs for self-hosted GoTrue

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -166,25 +166,39 @@ services:
       GOTRUE_MAILER_URLPATHS_RECOVERY: /auth/v1/verify
       GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: /auth/v1/verify
 
+      # OAuth — provider callback URL.
+      #
+      # Self-hosted GoTrue's ValidateOAuth() rejects any enabled provider with an
+      # empty redirect URI ("missing redirect URI"), so each provider below sets
+      # its REDIRECT_URI explicitly. All providers share the single GoTrue
+      # callback: Caddy's `handle_path /auth/v1/*` strips the prefix and proxies
+      # to auth:9999, so https://<domain>/auth/v1/callback reaches GoTrue's
+      # /callback handler. This exact URL must also be registered in each
+      # provider's console (Entra redirect URI, Google authorized redirect, etc).
+
       # OAuth — Apple (optional)
       GOTRUE_EXTERNAL_APPLE_ENABLED: ${APPLE_AUTH_ENABLED:-false}
       GOTRUE_EXTERNAL_APPLE_CLIENT_ID: ${APPLE_CLIENT_ID:-}
       GOTRUE_EXTERNAL_APPLE_SECRET: ${APPLE_SECRET:-}
+      GOTRUE_EXTERNAL_APPLE_REDIRECT_URI: https://${DOMAIN}/auth/v1/callback
 
       # OAuth — Google (optional)
       GOTRUE_EXTERNAL_GOOGLE_ENABLED: ${GOOGLE_AUTH_ENABLED:-false}
       GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOTRUE_EXTERNAL_GOOGLE_SECRET: ${GOOGLE_SECRET:-}
+      GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: https://${DOMAIN}/auth/v1/callback
 
       # OAuth — GitHub (optional)
       GOTRUE_EXTERNAL_GITHUB_ENABLED: ${GITHUB_AUTH_ENABLED:-false}
       GOTRUE_EXTERNAL_GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
       GOTRUE_EXTERNAL_GITHUB_SECRET: ${GITHUB_SECRET:-}
+      GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI: https://${DOMAIN}/auth/v1/callback
 
       # OAuth — Microsoft (optional; GoTrue brokers Microsoft as "azure")
       GOTRUE_EXTERNAL_AZURE_ENABLED: ${AZURE_AUTH_ENABLED:-false}
       GOTRUE_EXTERNAL_AZURE_CLIENT_ID: ${AZURE_CLIENT_ID:-}
       GOTRUE_EXTERNAL_AZURE_SECRET: ${AZURE_SECRET:-}
+      GOTRUE_EXTERNAL_AZURE_REDIRECT_URI: https://${DOMAIN}/auth/v1/callback
       # Tenant authority URL. Default allows multi-tenant + personal Microsoft
       # accounts; set to https://login.microsoftonline.com/<tenant-id> to
       # restrict sign-in to a single Entra tenant.


### PR DESCRIPTION
## Summary

Enabling Microsoft (`azure`) surfaced a GoTrue config bug: `GET /auth/v1/authorize?provider=azure` returned `400 "Unsupported provider: missing redirect URI"` even though `/auth/v1/settings` showed `"azure":true`.

Self-hosted GoTrue's `ValidateOAuth()` rejects any enabled external provider whose redirect URI is empty. The `deploy/docker-compose.yml` OAuth blocks set `*_ENABLED` / `*_CLIENT_ID` / `*_SECRET` (and `AZURE_URL`) but never mapped `GOTRUE_EXTERNAL_<PROVIDER>_REDIRECT_URI`. The same gap affects Google, GitHub, and Apple — unnoticed only because they're disabled on the server.

## Changes

- `deploy/docker-compose.yml` — set `GOTRUE_EXTERNAL_<PROVIDER>_REDIRECT_URI: https://${DOMAIN}/auth/v1/callback` for Apple, Google, GitHub, and Azure, with a comment explaining the GoTrue validation requirement and the Caddy `/auth/v1/*` → `auth:9999` prefix strip.

No `.env` change required — the value derives from the existing `DOMAIN` variable. Operators re-pull and run `docker compose up -d auth`.

## Issues

Closes #3575

## Testing

- [x] `npx prettier --check deploy/docker-compose.yml` clean
- [x] Verified live symptom: `authorize?provider=azure` → `400 missing redirect URI` before the fix
- [x] Caddyfile confirmed: `handle_path /auth/v1/*` strips prefix → GoTrue `/callback`, so the callback URL is correct