### PR TITLE
fix(core): budget status accuracy (category/currency) + forecast + exact money math

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetCalculator.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetCalculator.kt
@@ -26,7 +26,9 @@ object BudgetCalculator {
     ): BudgetStatus {
         val period = getCurrentPeriod(budget.period, budget.startDate, referenceDate)
         val periodTransactions = transactions.filter { txn ->
-            txn.date >= period.start && txn.date <= period.end &&
+            txn.categoryId == budget.categoryId &&
+                txn.currency == budget.currency &&
+                txn.date >= period.start && txn.date <= period.end &&
                 txn.deletedAt == null &&
                 txn.type == TransactionType.EXPENSE
         }
@@ -62,9 +64,11 @@ object BudgetCalculator {
             }
             BudgetPeriod.BIWEEKLY -> {
                 val daysSinceStart = startDate.daysUntil(referenceDate)
-                val periodIndex = daysSinceStart / 14
-                val periodStart = startDate.plus(periodIndex * 14, DateTimeUnit.DAY)
-                DatePeriod(periodStart, periodStart.plus(13, DateTimeUnit.DAY))
+                // Floor division so dates before startDate bucket into the
+                // correct (earlier) period rather than truncating toward zero.
+                val periodIndex = floorDiv(daysSinceStart, BIWEEKLY_DAYS)
+                val periodStart = startDate.plus(periodIndex * BIWEEKLY_DAYS, DateTimeUnit.DAY)
+                DatePeriod(periodStart, periodStart.plus(BIWEEKLY_DAYS - 1, DateTimeUnit.DAY))
             }
             BudgetPeriod.MONTHLY -> {
                 val start = referenceDate.startOfMonth()
@@ -96,6 +100,73 @@ object BudgetCalculator {
         val remaining = budget.amount - spent
         if (remaining.isNegative()) return Cents.ZERO
         return MoneyOperations.divide(remaining, daysRemaining)
+    }
+
+    /**
+     * Project end-of-period spending from the current daily run rate and report
+     * whether the budget is on track to be exceeded.
+     *
+     * The projection assumes spending continues at the average daily pace so far
+     * (`spent / daysElapsed`) for the whole period. All money math stays in
+     * [Cents]; the projection is `spent * daysTotal / daysElapsed` with
+     * round-half-to-even.
+     *
+     * Edge handling:
+     *  - Before the period starts, `daysElapsed` is clamped to 1.
+     *  - On/after the period end, `daysElapsed == daysTotal`, so the projection
+     *    equals actual spend to date.
+     *  - With zero spend the projection is zero.
+     *
+     * @param budget The budget definition.
+     * @param transactions Transactions to evaluate (filtered by the same rules as [calculateStatus]).
+     * @param referenceDate The "as of" date for the projection.
+     * @return A [BudgetForecast] with projected spend and remaining.
+     */
+    fun forecast(
+        budget: Budget,
+        transactions: List<Transaction>,
+        referenceDate: LocalDate,
+    ): BudgetForecast {
+        val status = calculateStatus(budget, transactions, referenceDate)
+        val period = status.period
+        val daysTotal = period.daysTotal
+
+        val clampedRef = when {
+            referenceDate < period.start -> period.start
+            referenceDate > period.end -> period.end
+            else -> referenceDate
+        }
+        val daysElapsed = (period.start.daysUntil(clampedRef) + 1).coerceIn(1, daysTotal)
+        val daysRemaining = (daysTotal - daysElapsed).coerceAtLeast(0)
+
+        val projectedSpend = MoneyOperations.divide(status.spent * daysTotal, daysElapsed)
+        val projectedRemaining = budget.amount - projectedSpend
+
+        return BudgetForecast(
+            period = period,
+            spent = status.spent,
+            daysElapsed = daysElapsed,
+            daysRemaining = daysRemaining,
+            projectedSpend = projectedSpend,
+            projectedRemaining = projectedRemaining,
+            isProjectedOverBudget = projectedSpend.amount > budget.amount.amount,
+        )
+    }
+
+    /** Number of days in a biweekly budget period. */
+    private const val BIWEEKLY_DAYS = 14
+
+    /**
+     * Integer floor division (rounds toward negative infinity), unlike Kotlin's
+     * `/` which truncates toward zero. Ensures negative day offsets bucket into
+     * the correct earlier period.
+     */
+    private fun floorDiv(dividend: Int, divisor: Int): Int {
+        var quotient = dividend / divisor
+        if ((dividend xor divisor) < 0 && quotient * divisor != dividend) {
+            quotient -= 1
+        }
+        return quotient
     }
 }
 
@@ -133,3 +204,24 @@ data class BudgetStatus(
 }
 
 enum class BudgetHealth { HEALTHY, WARNING, OVER }
+
+/**
+ * Forward-looking projection of budget spend for the current period.
+ *
+ * @property period The active budget period.
+ * @property spent Actual spend to date within the period (in cents).
+ * @property daysElapsed Days elapsed in the period so far (>= 1).
+ * @property daysRemaining Days remaining in the period (>= 0).
+ * @property projectedSpend Expected total spend by period end at the current run rate.
+ * @property projectedRemaining Budget amount minus [projectedSpend] (negative = projected overspend).
+ * @property isProjectedOverBudget `true` when [projectedSpend] exceeds the budget amount.
+ */
+data class BudgetForecast(
+    val period: DatePeriod,
+    val spent: Cents,
+    val daysElapsed: Int,
+    val daysRemaining: Int,
+    val projectedSpend: Cents,
+    val projectedRemaining: Cents,
+    val isProjectedOverBudget: Boolean,
+)

--- a/packages/core/src/commonMain/kotlin/com/finance/core/money/MoneyOperations.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/money/MoneyOperations.kt
@@ -14,6 +14,10 @@ object MoneyOperations {
     /**
      * Multiply cents by a decimal factor with banker's rounding.
      * Used for tax calculations, percentage-based budgets, etc.
+     *
+     * NOTE: this convenience overload routes through [Double] and therefore
+     * loses precision for magnitudes above 2^53 minor units. For exact money
+     * math prefer an integer basis — see [percentageExact] and [divide].
      */
     fun multiply(amount: Cents, factor: Double): Cents {
         val result = amount.amount.toDouble() * factor
@@ -21,22 +25,45 @@ object MoneyOperations {
     }
 
     /**
-     * Divide cents with banker's rounding.
-     * Used for splitting bills, averaging, etc.
+     * Divide cents by an integer divisor with round-half-to-even.
+     *
+     * Uses exact `Long` arithmetic — never floating point — so there is no
+     * precision loss regardless of magnitude. Used for splitting bills,
+     * averaging, and run-rate projections.
      */
     fun divide(amount: Cents, divisor: Int): Cents {
         require(divisor != 0) { "Cannot divide by zero" }
-        val result = amount.amount.toDouble() / divisor
-        return Cents(bankersRound(result))
+        return Cents(roundedDiv(amount.amount, divisor.toLong()))
     }
 
     /**
      * Calculate percentage of an amount.
      * @param amount The base amount
      * @param percentage The percentage (e.g., 15.5 for 15.5%)
+     *
+     * NOTE: convenience overload — routes through [Double]. For exact results
+     * (e.g. tax or budget splits at extreme magnitudes) use [percentageExact].
      */
     fun percentage(amount: Cents, percentage: Double): Cents {
         return multiply(amount, percentage / 100.0)
+    }
+
+    /**
+     * Calculate a percentage of [amount] using an exact integer basis, with
+     * round-half-to-even. No floating point is involved, so the result is exact
+     * for every representable magnitude.
+     *
+     * Express the percentage as [numerator] / [denominator], e.g. 8.25% is
+     * `percentageExact(amount, 825, 10000)` and 50% is
+     * `percentageExact(amount, 50, 100)`.
+     *
+     * @throws IllegalArgumentException if [denominator] is zero.
+     * @throws ArithmeticException if the intermediate product overflows `Long`.
+     */
+    fun percentageExact(amount: Cents, numerator: Long, denominator: Long): Cents {
+        require(denominator != 0L) { "Percentage denominator cannot be zero" }
+        val product = checkedMultiply(amount.amount, numerator)
+        return Cents(roundedDiv(product, denominator))
     }
 
     /**
@@ -44,6 +71,46 @@ object MoneyOperations {
      */
     fun sum(amounts: List<Cents>): Cents {
         return Cents(amounts.sumOf { it.amount })
+    }
+
+    /**
+     * Divide two [Long] values with round-half-to-even ("banker's rounding"),
+     * using only integer arithmetic. Symmetric about zero: `roundedDiv(-n, d)`
+     * equals `-roundedDiv(n, d)`.
+     *
+     * @throws IllegalArgumentException if [denominator] is zero.
+     */
+    internal fun roundedDiv(numerator: Long, denominator: Long): Long {
+        require(denominator != 0L) { "Cannot divide by zero" }
+        require(numerator != Long.MIN_VALUE && denominator != Long.MIN_VALUE) {
+            "Value out of representable range for exact division"
+        }
+        val negative = (numerator < 0) != (denominator < 0)
+        val n = abs(numerator)
+        val d = abs(denominator)
+        val quotient = n / d
+        val remainder = n % d
+        // Compare remainder against half of the divisor without overflow.
+        val magnitude = when {
+            remainder < d - remainder -> quotient
+            remainder > d - remainder -> quotient + 1
+            quotient % 2 == 0L -> quotient // exact half: round to even
+            else -> quotient + 1
+        }
+        return if (negative) -magnitude else magnitude
+    }
+
+    /**
+     * Multiply two [Long] values, throwing on overflow rather than silently
+     * wrapping. Keeps exact-money helpers honest about their limits.
+     */
+    private fun checkedMultiply(a: Long, b: Long): Long {
+        if (b == 0L) return 0L
+        val result = a * b
+        if (result / b != a) {
+            throw ArithmeticException("Long overflow in multiplication")
+        }
+        return result
     }
 
     /**

--- a/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetCalculatorAccuracyTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetCalculatorAccuracyTest.kt
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.core.TestFixtures
+import com.finance.models.BudgetPeriod
+import com.finance.models.TransactionType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Correctness tests for budget status filtering (category + currency),
+ * biweekly period bucketing before the anchor date, and spend forecasting.
+ */
+class BudgetCalculatorAccuracyTest {
+
+    // ── calculateStatus filters by budget category ───────────────────
+
+    @Test
+    fun calculateStatus_countsOnlyMatchingCategory() {
+        val budget = TestFixtures.createBudget(
+            categoryId = SyncId("groceries"),
+            amount = Cents(50000),
+            period = BudgetPeriod.MONTHLY,
+            startDate = LocalDate(2024, 6, 1),
+        )
+        val transactions = listOf(
+            TestFixtures.createTransaction(
+                type = TransactionType.EXPENSE,
+                amount = Cents(10000),
+                date = LocalDate(2024, 6, 10),
+                categoryId = SyncId("groceries"),
+            ),
+            // Different category — must be excluded.
+            TestFixtures.createTransaction(
+                type = TransactionType.EXPENSE,
+                amount = Cents(30000),
+                date = LocalDate(2024, 6, 12),
+                categoryId = SyncId("dining"),
+            ),
+        )
+
+        val status = BudgetCalculator.calculateStatus(budget, transactions, LocalDate(2024, 6, 15))
+
+        assertEquals(Cents(10000), status.spent)
+    }
+
+    @Test
+    fun calculateStatus_mixedListMatchesPreFilteredList() {
+        val budget = TestFixtures.createBudget(
+            categoryId = SyncId("groceries"),
+            startDate = LocalDate(2024, 6, 1),
+        )
+        val groceries = TestFixtures.createTransaction(
+            type = TransactionType.EXPENSE,
+            amount = Cents(12000),
+            date = LocalDate(2024, 6, 10),
+            categoryId = SyncId("groceries"),
+        )
+        val other = TestFixtures.createTransaction(
+            type = TransactionType.EXPENSE,
+            amount = Cents(8000),
+            date = LocalDate(2024, 6, 11),
+            categoryId = SyncId("dining"),
+        )
+
+        val mixed = BudgetCalculator.calculateStatus(budget, listOf(groceries, other), LocalDate(2024, 6, 15))
+        val preFiltered = BudgetCalculator.calculateStatus(budget, listOf(groceries), LocalDate(2024, 6, 15))
+
+        assertEquals(preFiltered.spent, mixed.spent)
+    }
+
+    // ── calculateStatus filters by budget currency ───────────────────
+
+    @Test
+    fun calculateStatus_countsOnlyMatchingCurrency() {
+        val budget = TestFixtures.createBudget(
+            categoryId = SyncId("travel"),
+            currency = Currency.USD,
+            amount = Cents(50000),
+            startDate = LocalDate(2024, 6, 1),
+        )
+        val transactions = listOf(
+            TestFixtures.createTransaction(
+                type = TransactionType.EXPENSE,
+                amount = Cents(10000),
+                date = LocalDate(2024, 6, 10),
+                categoryId = SyncId("travel"),
+                currency = Currency.USD,
+            ),
+            // Same category, different currency — must be excluded, not summed as raw cents.
+            TestFixtures.createTransaction(
+                type = TransactionType.EXPENSE,
+                amount = Cents(40000),
+                date = LocalDate(2024, 6, 12),
+                categoryId = SyncId("travel"),
+                currency = Currency.EUR,
+            ),
+        )
+
+        val status = BudgetCalculator.calculateStatus(budget, transactions, LocalDate(2024, 6, 15))
+
+        assertEquals(Cents(10000), status.spent)
+        assertFalse(status.isOverBudget)
+    }
+
+    // ── BIWEEKLY buckets dates before the anchor correctly ───────────
+
+    @Test
+    fun getCurrentPeriod_biweekly_oneDayBeforeStart() {
+        val start = LocalDate(2024, 1, 1)
+        val ref = LocalDate(2023, 12, 31)
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.BIWEEKLY, start, ref)
+
+        assertTrue(period.contains(ref))
+        assertEquals(LocalDate(2023, 12, 18), period.start)
+        assertEquals(LocalDate(2023, 12, 31), period.end)
+    }
+
+    @Test
+    fun getCurrentPeriod_biweekly_exactlyOnePeriodBeforeStart() {
+        val start = LocalDate(2024, 1, 1)
+        val ref = LocalDate(2023, 12, 18)
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.BIWEEKLY, start, ref)
+
+        assertTrue(period.contains(ref))
+        assertEquals(LocalDate(2023, 12, 18), period.start)
+        assertEquals(LocalDate(2023, 12, 31), period.end)
+    }
+
+    @Test
+    fun getCurrentPeriod_biweekly_severalPeriodsBeforeStart() {
+        val start = LocalDate(2024, 1, 1)
+        val ref = LocalDate(2023, 12, 17) // 15 days before -> two periods back
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.BIWEEKLY, start, ref)
+
+        assertTrue(period.contains(ref))
+        assertEquals(LocalDate(2023, 12, 4), period.start)
+        assertEquals(LocalDate(2023, 12, 17), period.end)
+    }
+
+    @Test
+    fun getCurrentPeriod_biweekly_onOrAfterStart_unchanged() {
+        val start = LocalDate(2024, 1, 1)
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.BIWEEKLY, start, LocalDate(2024, 1, 20))
+        assertEquals(LocalDate(2024, 1, 15), period.start)
+        assertEquals(LocalDate(2024, 1, 28), period.end)
+    }
+
+    // ── forecast() ───────────────────────────────────────────────────
+
+    private fun grocerBudget() = TestFixtures.createBudget(
+        categoryId = SyncId("groceries"),
+        amount = Cents(50000), // $500 monthly
+        period = BudgetPeriod.MONTHLY,
+        startDate = LocalDate(2024, 6, 1),
+    )
+
+    private fun grocerExpense(amount: Cents, date: LocalDate) = TestFixtures.createTransaction(
+        type = TransactionType.EXPENSE,
+        amount = amount,
+        date = date,
+        categoryId = SyncId("groceries"),
+    )
+
+    @Test
+    fun forecast_onTrack() {
+        // $250 spent by day 15 of a 30-day month -> projected $500 == budget.
+        val txns = listOf(
+            grocerExpense(Cents(10000), LocalDate(2024, 6, 5)),
+            grocerExpense(Cents(15000), LocalDate(2024, 6, 15)),
+        )
+        val f = BudgetCalculator.forecast(grocerBudget(), txns, LocalDate(2024, 6, 15))
+
+        assertEquals(15, f.daysElapsed)
+        assertEquals(15, f.daysRemaining)
+        assertEquals(Cents(25000), f.spent)
+        assertEquals(Cents(50000), f.projectedSpend)
+        assertEquals(Cents(0), f.projectedRemaining)
+        assertFalse(f.isProjectedOverBudget)
+    }
+
+    @Test
+    fun forecast_projectedOver() {
+        // $150 by day 5 -> run rate 3000/day -> projected 90000 >> 50000.
+        val txns = listOf(grocerExpense(Cents(15000), LocalDate(2024, 6, 3)))
+        val f = BudgetCalculator.forecast(grocerBudget(), txns, LocalDate(2024, 6, 5))
+
+        assertEquals(5, f.daysElapsed)
+        assertEquals(Cents(90000), f.projectedSpend)
+        assertTrue(f.projectedRemaining.isNegative())
+        assertTrue(f.isProjectedOverBudget)
+    }
+
+    @Test
+    fun forecast_atPeriodEnd_projectionEqualsActual() {
+        val txns = listOf(grocerExpense(Cents(40000), LocalDate(2024, 6, 20)))
+        val f = BudgetCalculator.forecast(grocerBudget(), txns, LocalDate(2024, 6, 30))
+
+        assertEquals(30, f.daysElapsed)
+        assertEquals(0, f.daysRemaining)
+        assertEquals(f.spent, f.projectedSpend) // no extrapolation on the last day
+        assertFalse(f.isProjectedOverBudget)
+    }
+
+    @Test
+    fun forecast_zeroSpend() {
+        val f = BudgetCalculator.forecast(grocerBudget(), emptyList(), LocalDate(2024, 6, 15))
+
+        assertEquals(Cents(0), f.spent)
+        assertEquals(Cents(0), f.projectedSpend)
+        assertEquals(Cents(50000), f.projectedRemaining)
+        assertFalse(f.isProjectedOverBudget)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/money/MoneyExactMathTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/money/MoneyExactMathTest.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.money
+
+import com.finance.models.types.Cents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+
+/**
+ * Tests for the exact, integer-only money helpers added to eliminate the
+ * floating-point precision loss in [MoneyOperations.divide] / [percentage].
+ */
+class MoneyExactMathTest {
+
+    // ── divide() is now exact integer round-half-to-even ─────────────
+
+    @Test
+    fun divide_roundsHalfToEven_oddQuotient() {
+        // 3 / 2 = 1.5 -> quotient 1 (odd) -> 2
+        assertEquals(Cents(2), MoneyOperations.divide(Cents(3), 2))
+    }
+
+    @Test
+    fun divide_roundsHalfToEven_evenQuotient() {
+        // 1 / 2 = 0.5 -> quotient 0 (even) -> 0
+        assertEquals(Cents(0), MoneyOperations.divide(Cents(1), 2))
+        // 5 / 2 = 2.5 -> quotient 2 (even) -> 2
+        assertEquals(Cents(2), MoneyOperations.divide(Cents(5), 2))
+    }
+
+    @Test
+    fun divide_negativeIsSymmetric() {
+        assertEquals(Cents(-2), MoneyOperations.divide(Cents(-3), 2))
+        assertEquals(Cents(-2), MoneyOperations.divide(Cents(-5), 2))
+        assertEquals(Cents(0), MoneyOperations.divide(Cents(-1), 2))
+    }
+
+    @Test
+    fun divide_negativeDivisor() {
+        assertEquals(Cents(-500), MoneyOperations.divide(Cents(1000), -2))
+        assertEquals(Cents(500), MoneyOperations.divide(Cents(-1000), -2))
+    }
+
+    @Test
+    fun divide_byZero_throws() {
+        assertFailsWith<IllegalArgumentException> { MoneyOperations.divide(Cents(1), 0) }
+    }
+
+    // ── roundedDiv() direct ──────────────────────────────────────────
+
+    @Test
+    fun roundedDiv_belowAndAboveHalf() {
+        assertEquals(3L, MoneyOperations.roundedDiv(10L, 3L)) // 3.33 -> 3
+        assertEquals(4L, MoneyOperations.roundedDiv(11L, 3L)) // 3.67 -> 4
+    }
+
+    @Test
+    fun roundedDiv_exactHalfToEven() {
+        assertEquals(2L, MoneyOperations.roundedDiv(5L, 2L))  // 2.5 -> 2 (even)
+        assertEquals(2L, MoneyOperations.roundedDiv(3L, 2L))  // 1.5 -> 2 (even)
+        assertEquals(4L, MoneyOperations.roundedDiv(7L, 2L))  // 3.5 -> 4 (even)
+    }
+
+    // ── percentageExact() ────────────────────────────────────────────
+
+    @Test
+    fun percentageExact_basicPercentages() {
+        assertEquals(Cents(500), MoneyOperations.percentageExact(Cents(1000), 50, 100))
+        assertEquals(Cents(1000), MoneyOperations.percentageExact(Cents(1000), 100, 100))
+        assertEquals(Cents(0), MoneyOperations.percentageExact(Cents(1000), 0, 100))
+    }
+
+    @Test
+    fun percentageExact_salesTaxBasisPoints() {
+        // $49.99 * 8.875% (887.5 bps) = 443.66125 -> 444 (round half to even not triggered)
+        assertEquals(Cents(444), MoneyOperations.percentageExact(Cents(4999), 8875, 100_000))
+    }
+
+    @Test
+    fun percentageExact_zeroDenominator_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            MoneyOperations.percentageExact(Cents(1000), 50, 0)
+        }
+    }
+
+    /**
+     * Regression guard: for magnitudes above 2^53 minor units the `Double` path
+     * silently loses precision, but the exact path is correct. 2^53 + 1 is the
+     * smallest integer a `Double` cannot represent.
+     */
+    @Test
+    fun percentageExact_isExactAboveDoublePrecision() {
+        val huge = Cents(9_007_199_254_740_993L) // 2^53 + 1
+
+        // 100% of the value must equal the value exactly.
+        assertEquals(huge, MoneyOperations.percentageExact(huge, 100, 100))
+
+        // The legacy Double-based path cannot represent this and drifts by 1 cent,
+        // which is exactly why the exact path exists.
+        assertNotEquals(huge, MoneyOperations.percentage(huge, 100.0))
+    }
+}


### PR DESCRIPTION
## Budget status accuracy + forecast (packages/core)

This PR hardens the core budgeting logic so budget status reflects the *right*
transactions, money math stays exact at integer `Cents` precision, and adds a
run-rate spend **forecast**. All changes are confined to `packages/core`
budgeting files plus unit tests — no schema or SQLDelight changes.

### What changed

**`BudgetCalculator.kt`**
- **Category-aware status (Closes #3584):** `calculateStatus` now only sums
  transactions whose `categoryId` matches `budget.categoryId`. Previously every
  expense in the list was counted against every budget, so category budgets were
  meaningless.
- **Currency-safe status (Closes #3590):** spend summation now filters to
  `txn.currency == budget.currency` so amounts in different currencies are never
  added together as raw cents.
- **BIWEEKLY pre-start bucketing (Closes #3624):** period bucketing now uses
  `floorDiv` so dates *before* `startDate` land in the correct 14-day window
  instead of being mis-bucketed by truncating integer division.
- **Projected/forecast spend (Closes #3671):** new `forecast(budget,
  transactions, referenceDate): BudgetForecast` projects end-of-period spend
  from the current run-rate (`spent * daysTotal / daysElapsed`) and flags
  `isProjectedOverBudget`. New `BudgetForecast` data class carries the period,
  spent, days elapsed/remaining, projected spend/remaining, and the over-budget
  flag.

**`MoneyOperations.kt`**
- **Exact integer money math (Closes #3637):** `divide(Cents, Int)` now uses an
  exact integer `roundedDiv` (round-half-to-even, symmetric about zero,
  guards `Long.MIN_VALUE`) instead of routing through `Double`. Added
  `percentageExact(amount, numerator, denominator)` for lossless scaling and an
  overflow-checked `checkedMultiply`. The lossy `Double` overloads are kept but
  documented as precision-losing above 2^53.

### Tests
- `MoneyExactMathTest.kt` — exact divide, round-half-to-even behavior,
  `roundedDiv`, `percentageExact`, and a regression proving exactness above
  2^53 (`2^53 + 1`), where the `Double` path drifts by 1.
- `BudgetCalculatorAccuracyTest.kt` — category filtering, currency filtering,
  mixed-vs-prefiltered equality, BIWEEKLY pre-start bucketing, and forecast
  (on-track, projected-over, at-period-end, zero-spend).

All money stays integer `Cents`; no floats are used in financial paths.

### Validation
- `npm run test:kmp` (`:packages:core:jvmTest`) — BUILD SUCCESSFUL, all tests pass.
- `detekt` — no findings in changed files.

Closes #3584
Closes #3590
Closes #3624
Closes #3671
Closes #3637
