### PR TITLE
feat(windows): keyboard, window-shell & navigation UX hardening

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
@@ -34,6 +34,7 @@ import com.finance.desktop.navigation.SidebarNavigation
 import com.finance.desktop.screens.AccountsScreen
 import com.finance.desktop.screens.BudgetNegotiationScreen
 import com.finance.desktop.screens.BudgetsScreen
+import com.finance.desktop.screens.ComingSoonScreen
 import com.finance.desktop.screens.CurrencyConversionScreen
 import com.finance.desktop.screens.DashboardScreen
 import com.finance.desktop.screens.DiagnosticsScreen
@@ -107,6 +108,7 @@ fun FinanceApp(
     shortcutHandler: ShortcutHandler,
     quickAddManager: QuickAddTransactionManager,
     systemTray: FinanceSystemTray,
+    onWindowTitleChange: (String) -> Unit = {},
 ) {
     val authViewModel = koinGet<AuthViewModel>()
     val authState by authViewModel.uiState.collectAsState()
@@ -173,12 +175,14 @@ fun FinanceApp(
                 val isFullyAuthenticated = authState.isAuthenticated || sessionAuthenticated
 
                 if (!isFullyAuthenticated && authState.requiresAuth) {
+                    LaunchedEffect(Unit) { onWindowTitleChange("Finance") }
                     AuthGateContent(authState = authState, authViewModel = authViewModel)
                 } else {
                     MainAppContent(
                         shortcutHandler = shortcutHandler,
                         quickAddManager = quickAddManager,
                         systemTray = systemTray,
+                        onWindowTitleChange = onWindowTitleChange,
                     )
                 }
 
@@ -261,10 +265,12 @@ private fun AuthGateContent(
  * Main app content — shown when user IS authenticated.
  */
 @Composable
+@Suppress("CyclomaticComplexMethod") // Navigation routing when() over all screens
 private fun MainAppContent(
     shortcutHandler: ShortcutHandler,
     quickAddManager: QuickAddTransactionManager,
     systemTray: FinanceSystemTray,
+    onWindowTitleChange: (String) -> Unit = {},
 ) {
     val loginViewModel = koinGet<LoginViewModel>()
     var showSignInScreen by remember { mutableStateOf(false) }
@@ -277,6 +283,7 @@ private fun MainAppContent(
         SidebarNavigation(
             shortcutHandler = shortcutHandler,
             onAccountSelected = { /* Settings shows the Account section. */ },
+            onScreenChanged = { screen -> onWindowTitleChange("${screen.label} - Finance") },
         ) { screen ->
             when (screen) {
                 Screen.Dashboard -> DashboardScreen()
@@ -287,15 +294,15 @@ private fun MainAppContent(
                 Screen.Widgets -> WidgetBoardScreen()
                 Screen.Upgrade -> UpgradeScreen()
                 Screen.Tips -> TipsScreen()
-                Screen.Investments -> {} // placeholder
-                Screen.Household -> {} // placeholder
+                Screen.Investments -> ComingSoonScreen(Screen.Investments)
+                Screen.Household -> ComingSoonScreen(Screen.Household)
                 Screen.Achievements -> GamificationScreen()
                 Screen.Diagnostics -> DiagnosticsScreen()
                 Screen.HealthScore -> HealthScoreScreen()
                 Screen.Reports -> ReportBuilderScreen()
                 Screen.QuickAdd -> {} // handled by dialog
                 Screen.Import -> ReceiptOcrScreen()
-                Screen.Referral -> {} // placeholder
+                Screen.Referral -> ComingSoonScreen(Screen.Referral)
                 Screen.Negotiate -> BudgetNegotiationScreen()
                 Screen.Currency -> CurrencyConversionScreen()
                 Screen.Settings -> SettingsScreen(onSignInRequested = openSignIn)

--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -2,11 +2,13 @@
 
 package com.finance.desktop
 
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import com.finance.desktop.components.rememberShortcutHandler
@@ -24,6 +26,7 @@ import com.finance.desktop.widgets.WidgetRegistrationManager
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
+import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 import javax.swing.JOptionPane
 import kotlin.system.exitProcess
@@ -67,9 +70,17 @@ fun main() {
 
     application {
         val windowState = rememberWindowState(
-            size = DpSize(width = 1280.dp, height = 800.dp),
-            position = WindowPosition(Alignment.Center),
+            size = WindowStatePersistence.loadSize(),
+            position = WindowStatePersistence.loadPosition(),
         )
+
+        // Persist window size/position so the next launch restores them (#3589).
+        LaunchedEffect(windowState) {
+            snapshotFlow { windowState.size to windowState.position }
+                .collect { WindowStatePersistence.save(windowState) }
+        }
+
+        var windowTitle by remember { mutableStateOf("Finance") }
 
         val shortcutHandler = rememberShortcutHandler()
 
@@ -103,6 +114,7 @@ fun main() {
 
         Window(
             onCloseRequest = {
+                WindowStatePersistence.save(windowState)
                 PerformanceMonitor.stop()
                 systemTray.dispose()
                 widgetManager.dispose()
@@ -110,11 +122,23 @@ fun main() {
                 stopKoin()
                 exitApplication()
             },
-            title = "Finance",
+            title = windowTitle,
             state = windowState,
-            onPreviewKeyEvent = { shortcutHandler.onKeyEvent(it) },
+            onKeyEvent = { shortcutHandler.onKeyEvent(it) },
         ) {
-            FinanceApp(shortcutHandler, quickAddManager, systemTray)
+            // Enforce a minimum window size so the sidebar + content stay usable (#3589).
+            LaunchedEffect(window) {
+                window.minimumSize = Dimension(
+                    WindowStatePersistence.MIN_WIDTH_DP,
+                    WindowStatePersistence.MIN_HEIGHT_DP,
+                )
+            }
+            FinanceApp(
+                shortcutHandler = shortcutHandler,
+                quickAddManager = quickAddManager,
+                systemTray = systemTray,
+                onWindowTitleChange = { windowTitle = it },
+            )
         }
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/WindowStatePersistence.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/WindowStatePersistence.kt
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop
+
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
+import java.util.prefs.Preferences
+
+/**
+ * Persists and restores the main window's size and position across launches,
+ * and exposes the minimum window size the shell should enforce.
+ *
+ * Backed by [Preferences] (`java.util.prefs`) so no additional dependency or
+ * on-disk file format is required. All reads are defensive: a missing or
+ * invalid value falls back to a sensible default (centered, 1280x800).
+ *
+ * See issues #3589 (persist window bounds + minimum size).
+ */
+object WindowStatePersistence {
+    private const val KEY_WIDTH = "window.width"
+    private const val KEY_HEIGHT = "window.height"
+    private const val KEY_X = "window.x"
+    private const val KEY_Y = "window.y"
+
+    /** Minimum window width in density-independent pixels. */
+    const val MIN_WIDTH_DP: Int = 960
+
+    /** Minimum window height in density-independent pixels. */
+    const val MIN_HEIGHT_DP: Int = 640
+
+    private val DEFAULT_SIZE = DpSize(1280.dp, 800.dp)
+
+    private val prefs: Preferences =
+        Preferences.userRoot().node("com/finance/desktop/window")
+
+    /**
+     * Restores the last persisted window size, clamped to the minimum size.
+     * Falls back to [DEFAULT_SIZE] when no valid value has been stored.
+     */
+    fun loadSize(): DpSize {
+        val width = prefs.getFloat(KEY_WIDTH, -1f)
+        val height = prefs.getFloat(KEY_HEIGHT, -1f)
+        if (width <= 0f || height <= 0f) return DEFAULT_SIZE
+        return DpSize(
+            width.coerceAtLeast(MIN_WIDTH_DP.toFloat()).dp,
+            height.coerceAtLeast(MIN_HEIGHT_DP.toFloat()).dp,
+        )
+    }
+
+    /**
+     * Restores the last persisted window position, or centers the window when
+     * no absolute position has been stored.
+     */
+    fun loadPosition(): WindowPosition {
+        val x = prefs.getFloat(KEY_X, Float.NaN)
+        val y = prefs.getFloat(KEY_Y, Float.NaN)
+        if (x.isNaN() || y.isNaN()) return WindowPosition(Alignment.Center)
+        return WindowPosition(x.dp, y.dp)
+    }
+
+    /**
+     * Persists the current window [state]. Only absolute positions are stored;
+     * aligned/default positions are ignored so the next launch can re-center.
+     */
+    fun save(state: WindowState) {
+        val size = state.size
+        if (size.width.value > 0f && size.height.value > 0f) {
+            prefs.putFloat(KEY_WIDTH, size.width.value)
+            prefs.putFloat(KEY_HEIGHT, size.height.value)
+        }
+        val position = state.position
+        if (position is WindowPosition.Absolute) {
+            prefs.putFloat(KEY_X, position.x.value)
+            prefs.putFloat(KEY_Y, position.y.value)
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
@@ -23,7 +23,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ShowChart
@@ -55,6 +57,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -136,6 +139,7 @@ private val SIDEBAR_COLLAPSED_WIDTH = 64.dp
 fun SidebarNavigation(
     shortcutHandler: ShortcutHandler,
     onAccountSelected: () -> Unit = {},
+    onScreenChanged: (Screen) -> Unit = {},
     content: @Composable (Screen) -> Unit,
 ) {
     var currentScreen by rememberSaveable { mutableStateOf(Screen.Dashboard) }
@@ -143,6 +147,11 @@ fun SidebarNavigation(
     val authRepository = koinGet<AuthRepository>()
     val account by authRepository.currentAccount.collectAsState()
     val isSignedIn by authRepository.isAuthenticated.collectAsState()
+
+    // Report the active screen so the window title can reflect it (#3693).
+    LaunchedEffect(currentScreen) {
+        onScreenChanged(currentScreen)
+    }
 
     // Register keyboard shortcuts (Ctrl+1 … Ctrl+6)
     KeyboardShortcutEffect(shortcutHandler) {
@@ -239,19 +248,24 @@ private fun SidebarPanel(
             )
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
 
-            // Navigation items — all except Settings
-            Screen.entries
-                .filter { it != Screen.Settings }
-                .forEach { screen ->
-                    SidebarItem(
-                        screen = screen,
-                        isSelected = currentScreen == screen,
-                        isExpanded = isExpanded,
-                        onClick = { onScreenSelected(screen) },
-                    )
-                }
-
-            Spacer(Modifier.weight(1f))
+            // Navigation items — all except Settings.
+            // Scrollable + weighted so lower items never clip on short windows (#3592).
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                Screen.entries
+                    .filter { it != Screen.Settings }
+                    .forEach { screen ->
+                        SidebarItem(
+                            screen = screen,
+                            isSelected = currentScreen == screen,
+                            isExpanded = isExpanded,
+                            onClick = { onScreenSelected(screen) },
+                        )
+                    }
+            }
 
             // Account status and settings at bottom
             AccountStatusItem(

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/ComingSoonScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/ComingSoonScreen.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.navigation.Screen
+import com.finance.desktop.theme.FinanceDesktopTheme
+
+/**
+ * Placeholder shown for navigation destinations that are not yet implemented,
+ * so selecting them never renders a blank content pane (#3587).
+ *
+ * Uses the destination's own icon and label and exposes a proper heading for
+ * Narrator, communicating clearly that the feature is planned rather than broken.
+ *
+ * @param screen The destination this placeholder is standing in for.
+ */
+@Composable
+fun ComingSoonScreen(
+    screen: Screen,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .semantics { contentDescription = "${screen.label} screen, coming soon" },
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                imageVector = screen.icon,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+            Text(
+                text = screen.label,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+            Text(
+                text = "This feature is coming soon.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.widthIn(max = 360.dp),
+            )
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/KeyboardShortcutsHelpDialog.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/KeyboardShortcutsHelpDialog.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.finance.desktop.navigation.Screen
 import com.finance.desktop.theme.FinanceDesktopTheme
 
 /**
@@ -46,8 +47,11 @@ data class ShortcutHelpEntry(
 /**
  * Keyboard shortcuts reference dialog.
  *
- * Shows all available keyboard shortcuts grouped by category.
- * Accessible via F1 or Ctrl+? (Ctrl+Shift+/).
+ * Shows all available keyboard shortcuts grouped by category. The Navigation
+ * section is derived directly from [Screen.entries] so it can never drift out
+ * of sync with the actually-registered navigation shortcuts (#3660).
+ *
+ * Accessible via F1.
  *
  * Narrator: each shortcut entry reads as "keys: description".
  * Section headings are marked as headings. The dialog itself
@@ -59,25 +63,16 @@ data class ShortcutHelpEntry(
 fun KeyboardShortcutsHelpDialog(onDismiss: () -> Unit) {
     val sections = remember {
         listOf(
-            "Navigation" to listOf(
-                ShortcutHelpEntry("Ctrl+1", "Go to Dashboard"),
-                ShortcutHelpEntry("Ctrl+2", "Go to Accounts"),
-                ShortcutHelpEntry("Ctrl+3", "Go to Transactions"),
-                ShortcutHelpEntry("Ctrl+4", "Go to Budgets"),
-                ShortcutHelpEntry("Ctrl+5", "Go to Goals"),
-            ),
+            "Navigation" to Screen.entries.map { screen ->
+                ShortcutHelpEntry(screen.shortcutLabel, "Go to ${screen.label}")
+            },
             "Actions" to listOf(
                 ShortcutHelpEntry("Ctrl+Shift+N", "New transaction"),
-                ShortcutHelpEntry("Ctrl+F", "Focus search"),
-                ShortcutHelpEntry("/", "Focus search (alternative)"),
-                ShortcutHelpEntry("Delete", "Delete selected item"),
-                ShortcutHelpEntry("Enter", "Open selected item"),
-                ShortcutHelpEntry("Escape", "Close dialog / go back"),
             ),
             "App" to listOf(
                 ShortcutHelpEntry("F1", "Show keyboard shortcuts"),
                 ShortcutHelpEntry("Ctrl+Shift+F", "Report bug / send feedback"),
-                ShortcutHelpEntry("Ctrl+Shift+V", "Voice transaction entry"),
+                ShortcutHelpEntry("Escape", "Close dialog"),
             ),
         )
     }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/LockScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/LockScreen.kt
@@ -27,8 +27,12 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.liveRegion
@@ -76,6 +80,14 @@ fun LockScreen(
         modifier = modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background,
     ) {
+        // Focus the primary action so keyboard/Narrator users can authenticate
+        // immediately and Enter/Space triggers it, without tabbing first (#3709).
+        val primaryActionFocus = remember { FocusRequester() }
+        LaunchedEffect(isAuthenticating, isWindowsHelloAvailable) {
+            if (!isAuthenticating) {
+                runCatching { primaryActionFocus.requestFocus() }
+            }
+        }
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -168,6 +180,7 @@ fun LockScreen(
                         modifier = Modifier
                             .width(280.dp)
                             .height(48.dp)
+                            .focusRequester(primaryActionFocus)
                             .semantics {
                                 contentDescription =
                                     "Unlock with Windows Hello. Uses fingerprint, face recognition, or PIN."
@@ -204,6 +217,7 @@ fun LockScreen(
                                 modifier = Modifier
                                     .width(280.dp)
                                     .height(48.dp)
+                                    .focusRequester(primaryActionFocus)
                                     .semantics {
                                         contentDescription =
                                             "Continue without authentication. Windows Hello is not configured."


### PR DESCRIPTION
﻿## Summary

A focused pass of desktop UX hardening for the Windows (Compose Desktop) app. All changes are strictly within pps/windows. Each item was filed as an issue first (Phase 1 critique) and this PR implements a coherent, low-conflict subset.

## Changes

- **Global shortcuts no longer hijack text-field editing combos** - the app window now dispatches keyboard shortcuts via `Window.onKeyEvent` (bubble phase) instead of `onPreviewKeyEvent`. Previously the sidebar's `Ctrl+A` (Achievements) binding swallowed *Select All* and other editing combos inside focused text fields. Closes #3585
- **No more blank panes** - the placeholder destinations (Investments, Household, Referral) rendered empty content. They now render a shared `ComingSoonScreen` (icon + label + "coming soon", with heading semantics for Narrator). Closes #3587
- **Window size/position persistence + minimum size** - new `WindowStatePersistence` helper (backed by `java.util.prefs.Preferences`) restores the last window size and position on launch, saves on change/close, and enforces a sensible minimum window size (960x640). Closes #3589
- **Scrollable sidebar** - the navigation list is now wrapped in a weighted, vertically scrollable column so destinations never clip on short windows. Closes #3592
- **Accurate shortcuts help dialog** - the Navigation section is now derived from `Screen.entries` (single source of truth) and phantom/unregistered entries were removed so the dialog always matches the real bindings. Closes #3660
- **Window title reflects the active screen** - the title now updates to `"<Screen> - Finance"` as you navigate, and resets to `"Finance"` at the auth gate. Closes #3693
- **Lock screen default focus + Enter-to-authenticate** - the primary unlock action (and its fallback) now receive focus on show, so keyboard and Narrator users land on it and can activate with Enter/Space. Closes #3709

## Verification

- `:apps:windows:compileKotlin` - BUILD SUCCESSFUL
- Root `detekt` - clean for all touched files
- Changes are Kotlin-only; Prettier/ESLint ignore `*.kt`

## Scope

Strictly `apps/windows` - 5 modified files + 2 new files (`WindowStatePersistence.kt`, `ComingSoonScreen.kt`). Remaining filed-but-not-implemented critiques (#3655, #3665, #3677, #3685, #3715, #3722) are left for follow-up PRs.
