### PR TITLE
feat(android): semantic finance color tokens + UX polish

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/ui/components/AmountInput.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/components/AmountInput.kt
@@ -109,8 +109,7 @@ fun AmountInput(
                 color = MaterialTheme.colorScheme.error,
                 style = MaterialTheme.typography.bodySmall,
                 modifier = Modifier
-                    .padding(start = 16.dp, top = 4.dp)
-                    .semantics { contentDescription = "Error: $errorMessage" },
+                    .padding(start = 16.dp, top = 4.dp),
             )
         }
     }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceBottomBar.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceBottomBar.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -72,7 +73,7 @@ fun FinanceBottomBar(
 
     NavigationBar(modifier = modifier) {
         TopLevelDestination.entries.forEach { destination ->
-            val selected = currentDestination?.route == destination.route
+            val selected = currentDestination?.hierarchy?.any { it.route == destination.route } == true
 
             NavigationBarItem(
                 selected = selected,

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.finance.android.ui.components.IconView
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
@@ -259,7 +258,7 @@ private fun DetailItem(label: String, value: String) {
 private fun AccountTxnItem(txn: Transaction, currency: Currency) {
     val isExp = txn.type == TransactionType.EXPENSE
     val amt = CurrencyFormatter.format(txn.amount, currency, showSign = true)
-    val color = if (isExp) MaterialTheme.colorScheme.error else Color(0xFF2E7D32)
+    val color = if (isExp) MaterialTheme.colorScheme.error else FinanceTheme.financeColors.income
     val payee = txn.payee ?: "Unknown"
     val cat = SampleData.categoryMap[txn.categoryId]?.name ?: "Uncategorized"
     Card(Modifier.fillMaxWidth().semantics { contentDescription = "Transaction: $amt at $payee, ${txn.date}" }) {

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/BudgetsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/BudgetsScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
@@ -188,8 +187,8 @@ private fun BudgetSummaryCard(
         BudgetHealth.OVER -> "Over budget"
     }
     val healthColor = when (overallHealth) {
-        BudgetHealth.HEALTHY -> Color(0xFF2E7D32)
-        BudgetHealth.WARNING -> Color(0xFFFF9800)
+        BudgetHealth.HEALTHY -> FinanceTheme.financeColors.income
+        BudgetHealth.WARNING -> FinanceTheme.financeColors.warning
         BudgetHealth.OVER -> MaterialTheme.colorScheme.error
     }
 
@@ -266,7 +265,7 @@ private fun BudgetSummaryCard(
 private fun BudgetItemCard(budget: BudgetItemUi, onClick: () -> Unit = {}) {
     val healthColor = when (budget.health) {
         BudgetHealth.HEALTHY -> MaterialTheme.colorScheme.primary
-        BudgetHealth.WARNING -> Color(0xFFFF9800)
+        BudgetHealth.WARNING -> FinanceTheme.financeColors.warning
         BudgetHealth.OVER -> MaterialTheme.colorScheme.error
     }
     val healthLabel = when (budget.health) {

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/DashboardScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/DashboardScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -198,7 +197,7 @@ private fun BudgetHealthRow(budgets: List<BudgetStatusUi>) {
 private fun BudgetHealthCard(budget: BudgetStatusUi) {
     val healthColor = when (budget.health) {
         BudgetHealth.HEALTHY -> MaterialTheme.colorScheme.primary
-        BudgetHealth.WARNING -> Color(0xFFFF9800)
+        BudgetHealth.WARNING -> FinanceTheme.financeColors.warning
         BudgetHealth.OVER -> MaterialTheme.colorScheme.error
     }
     val healthLabel = when (budget.health) {
@@ -234,7 +233,7 @@ private fun BudgetHealthCard(budget: BudgetStatusUi) {
 private fun RecentTransactionItem(transaction: Transaction, currency: Currency) {
     val isExpense = transaction.type == TransactionType.EXPENSE
     val amtFmt = CurrencyFormatter.format(transaction.amount, currency, showSign = true)
-    val color = if (isExpense) MaterialTheme.colorScheme.error else Color(0xFF2E7D32)
+    val color = if (isExpense) MaterialTheme.colorScheme.error else FinanceTheme.financeColors.income
     val cat = SampleData.categoryMap[transaction.categoryId]?.name ?: "Uncategorized"
     val payee = transaction.payee ?: "Unknown"
     Card(Modifier.fillMaxWidth().semantics { contentDescription = "Transaction: $amtFmt at $payee, $cat" }) {

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt
@@ -151,7 +151,12 @@ fun TransactionCreateScreen(
             StepIndicator(state.currentStep, Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
             if (state.errors.isNotEmpty()) ErrorMessages(state.errors, Modifier.padding(horizontal = 16.dp))
             AnimatedContent(state.currentStep, transitionSpec = {
-                slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+                val forward = targetState.index > initialState.index
+                if (forward) {
+                    slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+                } else {
+                    slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
+                }
             }, label = "step", modifier = Modifier.weight(1f).fillMaxWidth()) { step ->
                 when (step) {
                     CreateStep.AMOUNT -> AmountStep(state, viewModel::updateAmount, viewModel::updatePayee,

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionDetailScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionDetailScreen.kt
@@ -64,7 +64,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
@@ -204,7 +203,7 @@ private fun TransactionDetailContent(
 ) {
     val amountColor = when (state.type) {
         TransactionType.EXPENSE -> MaterialTheme.colorScheme.error
-        TransactionType.INCOME -> Color(0xFF2E7D32)
+        TransactionType.INCOME -> FinanceTheme.financeColors.income
         TransactionType.TRANSFER -> MaterialTheme.colorScheme.tertiary
     }
     val typeIcon: ImageVector = when (state.type) {

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionsScreen.kt
@@ -207,7 +207,7 @@ private fun SwipeableTxnItem(txn: Transaction, onDelete: () -> Unit, onEdit: () 
 private fun TxnListItem(txn: Transaction, onClick: () -> Unit) {
     val amt = CurrencyFormatter.format(txn.amount, txn.currency, showSign = true)
     val color = when (txn.type) { TransactionType.EXPENSE -> MaterialTheme.colorScheme.error
-        TransactionType.INCOME -> Color(0xFF2E7D32); TransactionType.TRANSFER -> MaterialTheme.colorScheme.tertiary }
+        TransactionType.INCOME -> FinanceTheme.financeColors.income; TransactionType.TRANSFER -> MaterialTheme.colorScheme.tertiary }
     val payee = txn.payee ?: "Unknown"
     val cat = SampleData.categoryMap[txn.categoryId]?.name ?: "Uncategorized"
     val acct = SampleData.accountMap[txn.accountId]?.name ?: "Unknown"

--- a/apps/android/src/main/kotlin/com/finance/android/ui/theme/FinanceColors.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/theme/FinanceColors.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Semantic finance colors that live outside the Material 3
+ * [androidx.compose.material3.ColorScheme].
+ *
+ * These express domain semantics — positive money movement (income) and
+ * cautionary thresholds (warning) — in a single place instead of hardcoding hex
+ * literals across individual screens.
+ *
+ * Exposed through the [LocalFinanceColors] [androidx.compose.runtime.CompositionLocal]
+ * and accessible within a themed tree via `FinanceTheme.financeColors`.
+ */
+@Immutable
+data class FinanceSemanticColors(
+    /** Positive money movement: income, gains, on-track budgets. */
+    val income: Color,
+    /** Cautionary thresholds: near-limit budgets, due-soon bills. */
+    val warning: Color,
+)
+
+// Design-token references. Light and dark currently resolve to the same values so
+// existing golden snapshots stay pixel-identical; dedicated dark-mode contrast
+// tuning is tracked as a separate issue.
+private val IncomeGreen = Color(0xFF2E7D32)
+private val WarningOrange = Color(0xFFFF9800)
+
+internal val LightFinanceColors = FinanceSemanticColors(
+    income = IncomeGreen,
+    warning = WarningOrange,
+)
+
+internal val DarkFinanceColors = FinanceSemanticColors(
+    income = IncomeGreen,
+    warning = WarningOrange,
+)
+
+/**
+ * Resolves the [FinanceSemanticColors] for the current theme mode.
+ */
+internal fun financeSemanticColors(darkTheme: Boolean): FinanceSemanticColors =
+    if (darkTheme) DarkFinanceColors else LightFinanceColors
+
+/**
+ * [androidx.compose.runtime.CompositionLocal] carrying the active
+ * [FinanceSemanticColors].
+ *
+ * Defaults to the light palette so composables rendered outside [FinanceTheme]
+ * still resolve sensible values.
+ */
+val LocalFinanceColors = staticCompositionLocalOf { LightFinanceColors }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/theme/FinanceTheme.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/theme/FinanceTheme.kt
@@ -169,7 +169,10 @@ fun FinanceTheme(
         else -> LightColorScheme
     }
 
-    CompositionLocalProvider(LocalSpacing provides Spacing()) {
+    CompositionLocalProvider(
+        LocalSpacing provides Spacing(),
+        LocalFinanceColors provides financeSemanticColors(darkTheme),
+    ) {
         MaterialTheme(
             colorScheme = colorScheme,
             typography = FinanceTypography,
@@ -189,4 +192,12 @@ object FinanceTheme {
         @Composable
         @ReadOnlyComposable
         get() = LocalSpacing.current
+
+    /**
+     * The current [FinanceSemanticColors] provided by [FinanceTheme].
+     */
+    val financeColors: FinanceSemanticColors
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalFinanceColors.current
 }


### PR DESCRIPTION
## Summary

Android UX polish focused on a small, snapshot-safe subset of the critique issues. All changes are strictly within `apps/android`.

### Changes

**Semantic finance color tokens (#3698)**
- New `FinanceColors.kt` defining `FinanceSemanticColors(income, warning)` design tokens, wired into `FinanceTheme` via `LocalFinanceColors` and exposed as `FinanceTheme.financeColors`.
- Replaced hardcoded `Color(0xFF2E7D32)` (income) and `Color(0xFFFF9800)` (warning) hex literals across Dashboard, Transactions, TransactionDetail, Accounts, and Budgets screens with the new tokens; removed now-unused `Color` imports.
- Light and dark currently resolve to identical values so existing Paparazzi goldens stay pixel-identical; dedicated dark-mode contrast tuning remains tracked separately.

**Directional transaction-wizard animation (#3691)**
- `TransactionCreateScreen` step transitions now slide directionally: forward steps enter from the right, back steps from the left (compares `targetState.index` vs `initialState.index`).

**Remove duplicate TalkBack error announcement (#3701)**
- `AmountInput` announced validation errors twice (field `error()` semantics + a redundant `contentDescription` on the error text). Removed the redundant text `contentDescription`.

**Hierarchy-based bottom-nav selection (#3705)**
- `FinanceBottomBar` now marks a tab selected when the destination is anywhere in the current back-stack hierarchy, not only on exact route equality, so nested destinations keep the correct tab highlighted.

## Testing
- Kotlin-only changes; all edited files are `*.kt` (Prettier-ignored, not eslint-linted). Working tree stays clean under `npm run format`.
- Color token values are pixel-identical to prior literals, keeping `verifyPaparazziDebug` goldens valid.
- Detekt validated in CI.

Closes #3698
Closes #3691
Closes #3701
Closes #3705
