### PR TITLE
feat(i18n): enrich locale catalog, glossary, plurals & formatting contract

### DIFF
--- a/config/i18n/README.md
+++ b/config/i18n/README.md
@@ -6,10 +6,12 @@ platform agents integrate them into native localization systems.
 
 ## Files
 
-| File            | Purpose                                                                                |
-| --------------- | -------------------------------------------------------------------------------------- |
-| `glossary.json` | Financial-terminology glossary. Reviewed translations for money-critical terms.        |
-| `locales.json`  | Supported locales, fallback chain, and CLDR-aligned number/currency/date expectations. |
+| File                  | Purpose                                                                                |
+| --------------------- | -------------------------------------------------------------------------------------- |
+| `glossary.json`       | Financial-terminology glossary. Reviewed translations for money-critical terms.        |
+| `locales.json`        | Supported locales, fallback chain, and CLDR-aligned number/currency/date expectations. |
+| `plurals.json`        | CLDR plural-category contract per locale + count-bearing message concepts.             |
+| `length-budgets.json` | Text-expansion factors + max-length hints for space-constrained surfaces.              |
 
 ## How this feeds platform resources
 
@@ -50,3 +52,26 @@ non-enforced locales are reported as warnings only.
   not "Equilibrio").
 - Currency/number/date formatting follows CLDR via the account's ISO 4217 code —
   never hardcode symbols or separators.
+
+## Glossary invariants
+
+`glossary.json` is machine-checkable (a future `scripts/i18n/` hook can gate CI):
+
+1. Every `concept` supplies all locales listed in `locales`.
+2. No blank/whitespace-only values.
+3. A chosen term MUST NOT appear in that locale's `doNotUse`.
+4. `concept` values are unique.
+
+## Formatting & plural contract
+
+- `locales.json` per-locale `formatting` carries `conventionId`, currency `negative`
+  (incl. accounting style), number `groupingPattern` (`3` or South-Asian `3;2`),
+  `percent`, and full `date`/time patterns. Consumers resolve these from the active
+  locale — never hardcode. Currency is resolved from the ISO 4217 code, not the
+  language (`currencyResolution`).
+- `plurals.json` declares the CLDR plural categories each locale must supply and the
+  count-bearing message concepts. There is no runtime plural handling yet — do not
+  build counts by string concatenation.
+- `plannedLocales` in `locales.json` reconciles the `Locale.kt` constants that are not
+  yet backed by catalogs. See `docs/i18n/localization-guide.md` for the full contract
+  and the "Adding a new locale" checklist.

--- a/config/i18n/glossary.json
+++ b/config/i18n/glossary.json
@@ -1,5 +1,5 @@
 {
-  "description": "Canonical financial-terminology glossary. Source of truth for translated financial terms across every localized surface (Android, iOS, web, shared KMP Strings). A mistranslated financial term is a correctness bug, not polish — keep these consistent across all locales.",
+  "description": "Canonical financial-terminology glossary. Source of truth for translated financial terms across every localized surface (Android, iOS, web, shared KMP Strings). A mistranslated financial term is a correctness bug, not polish — keep these consistent across all locales. Invariants (see docs/i18n/localization-guide.md): every concept supplies all locales listed in 'locales'; no blank values; a term MUST NOT appear in its own locale's doNotUse; concepts are unique.",
   "sourceLocale": "en-US",
   "locales": ["en-US", "es-ES", "fr-FR"],
   "terms": [
@@ -9,7 +9,9 @@
       "es-ES": "Saldo",
       "fr-FR": "Solde",
       "notes": "Account balance (money available), not 'equilibrio'.",
-      "doNotUse": { "es-ES": ["Equilibrio", "Balance"] }
+      "doNotUse": {
+        "es-ES": ["Equilibrio", "Balance"]
+      }
     },
     {
       "concept": "Credit",
@@ -17,7 +19,9 @@
       "es-ES": "Abono",
       "fr-FR": "Crédit",
       "notes": "Inflow to an account. Disambiguate from lending (línea de crédito).",
-      "doNotUse": { "es-ES": ["Crédito (cuando significa entrada de dinero)"] }
+      "doNotUse": {
+        "es-ES": ["Crédito (cuando significa entrada de dinero)"]
+      }
     },
     {
       "concept": "Debit",
@@ -100,6 +104,157 @@
       "en-US": "Currency conversion",
       "es-ES": "Conversión de divisa",
       "fr-FR": "Conversion de devise"
+    },
+    {
+      "concept": "Transfer",
+      "en-US": "Transfer",
+      "es-ES": "Transferencia",
+      "fr-FR": "Virement",
+      "notes": "Movement of money between the user’s own accounts (distinct from an expense/income).",
+      "doNotUse": {
+        "es-ES": ["Traspaso (ambiguo)"]
+      }
+    },
+    {
+      "concept": "Deposit",
+      "en-US": "Deposit",
+      "es-ES": "Depósito",
+      "fr-FR": "Dépôt"
+    },
+    {
+      "concept": "Withdrawal",
+      "en-US": "Withdrawal",
+      "es-ES": "Retiro",
+      "fr-FR": "Retrait",
+      "notes": "Funds taken out of an account. \"Retirada\" is acceptable in Spain; prefer \"Retiro\" for a neutral catalog."
+    },
+    {
+      "concept": "Payee",
+      "en-US": "Payee",
+      "es-ES": "Beneficiario",
+      "fr-FR": "Bénéficiaire",
+      "notes": "Recipient of a payment."
+    },
+    {
+      "concept": "Merchant",
+      "en-US": "Merchant",
+      "es-ES": "Comercio",
+      "fr-FR": "Commerçant",
+      "notes": "Store/vendor where a transaction occurred.",
+      "doNotUse": {
+        "es-ES": ["Mercader"]
+      }
+    },
+    {
+      "concept": "Fee",
+      "en-US": "Fee",
+      "es-ES": "Comisión",
+      "fr-FR": "Frais",
+      "notes": "Bank/service charge. Not a price/rate.",
+      "doNotUse": {
+        "es-ES": ["Tarifa", "Cuota"]
+      }
+    },
+    {
+      "concept": "Interest",
+      "en-US": "Interest",
+      "es-ES": "Interés",
+      "fr-FR": "Intérêts"
+    },
+    {
+      "concept": "Interest rate",
+      "en-US": "Interest rate",
+      "es-ES": "Tasa de interés",
+      "fr-FR": "Taux d'intérêt",
+      "notes": "APR/APY expressed as a rate."
+    },
+    {
+      "concept": "Statement",
+      "en-US": "Statement",
+      "es-ES": "Estado de cuenta",
+      "fr-FR": "Relevé",
+      "notes": "Periodic account statement. \"Extracto\" is common in Spain; prefer \"Estado de cuenta\" for a neutral catalog.",
+      "doNotUse": {
+        "es-ES": ["Declaración"]
+      }
+    },
+    {
+      "concept": "Recurring",
+      "en-US": "Recurring",
+      "es-ES": "Recurrente",
+      "fr-FR": "Récurrent",
+      "notes": "Repeating transaction/rule."
+    },
+    {
+      "concept": "Subscription",
+      "en-US": "Subscription",
+      "es-ES": "Suscripción",
+      "fr-FR": "Abonnement"
+    },
+    {
+      "concept": "Reconcile",
+      "en-US": "Reconcile",
+      "es-ES": "Conciliar",
+      "fr-FR": "Rapprocher",
+      "notes": "Match app records against the bank statement.",
+      "doNotUse": {
+        "es-ES": ["Reconciliar"]
+      }
+    },
+    {
+      "concept": "Cleared",
+      "en-US": "Cleared",
+      "es-ES": "Compensado",
+      "fr-FR": "Compensé",
+      "notes": "Bank-cleared transaction. Distinct from \"reconciled\" (Conciliado)."
+    },
+    {
+      "concept": "Pending",
+      "en-US": "Pending",
+      "es-ES": "Pendiente",
+      "fr-FR": "En attente"
+    },
+    {
+      "concept": "Overdraft",
+      "en-US": "Overdraft",
+      "es-ES": "Sobregiro",
+      "fr-FR": "Découvert",
+      "notes": "Negative balance. \"Descubierto\" is used in Spain; prefer \"Sobregiro\" for LatAm-neutral."
+    },
+    {
+      "concept": "Tag",
+      "en-US": "Tag",
+      "es-ES": "Etiqueta",
+      "fr-FR": "Étiquette",
+      "notes": "User label on a transaction (distinct from Category)."
+    },
+    {
+      "concept": "Available balance",
+      "en-US": "Available balance",
+      "es-ES": "Saldo disponible",
+      "fr-FR": "Solde disponible"
+    },
+    {
+      "concept": "Due date",
+      "en-US": "Due date",
+      "es-ES": "Fecha de vencimiento",
+      "fr-FR": "Date d'échéance"
+    },
+    {
+      "concept": "Minimum payment",
+      "en-US": "Minimum payment",
+      "es-ES": "Pago mínimo",
+      "fr-FR": "Paiement minimum"
+    },
+    {
+      "concept": "Exchange rate",
+      "en-US": "Exchange rate",
+      "es-ES": "Tipo de cambio",
+      "fr-FR": "Taux de change",
+      "notes": "FX rate. Distinct from \"Currency conversion\".",
+      "doNotUse": {
+        "es-ES": ["Tasa de cambio (aceptable en LatAm; preferir Tipo de cambio)"]
+      }
     }
   ]
 }

--- a/config/i18n/length-budgets.json
+++ b/config/i18n/length-budgets.json
@@ -1,0 +1,27 @@
+{
+  "description": "Text-expansion budgeting for localized UI. Translated strings routinely grow vs. English (German/French especially); constrained surfaces (widgets, tiles, notifications, chart legends) truncate without a length contract. 'expansionFactors' give the multiplier to design headroom for by source length; 'constrainedKeyPrefixes' marks Android string-key prefixes whose surfaces are space-limited; 'maxLengthHints' sets soft caps (in en-US characters) for specific keys. Consumers/translators SHOULD keep translations within source_length * factor and honor maxLengthHints on constrained keys.",
+  "sourceLocale": "en-US",
+  "expansionFactors": [
+    { "upToSourceChars": 10, "factor": 2.0, "note": "Very short labels expand the most." },
+    { "upToSourceChars": 20, "factor": 1.8 },
+    { "upToSourceChars": 30, "factor": 1.6 },
+    { "upToSourceChars": 50, "factor": 1.4 },
+    { "upToSourceChars": 70, "factor": 1.3 },
+    { "upToSourceChars": 1000, "factor": 1.3 }
+  ],
+  "highExpansionLocales": ["de-DE", "fr-FR", "es-ES", "pt-BR"],
+  "constrainedKeyPrefixes": ["widget_", "tile_", "notification_", "parity_", "a11y_"],
+  "maxLengthHints": {
+    "widget_balance_summary_label": 24,
+    "widget_quick_transaction_label": 24,
+    "widget_budget_summary_label": 24,
+    "widget_goal_progress_label": 24,
+    "tile_quick_transaction_label": 20,
+    "widget_quick_entry_label": 20
+  },
+  "rules": [
+    "Never rely on hard truncation for constrained surfaces; prefer flexible/wrapping layouts and min/max width constraints.",
+    "Design widget/tile/notification surfaces against the localized worst case (source_length * factor), not the English length.",
+    "When a translation cannot fit, request a shorter source string rather than truncating the translation."
+  ]
+}

--- a/config/i18n/locales.json
+++ b/config/i18n/locales.json
@@ -1,5 +1,5 @@
 {
-  "description": "Locale catalog metadata: supported locales, fallback chain, and CLDR-aligned formatting expectations. The Android string resources under apps/android/src/main/res/values[-<locale>]/strings.xml are the platform projection of these locales; the 'enforced' locales below must reach 100% key coverage against the default catalog (checked by scripts/i18n/validate-locale-catalogs.js).",
+  "description": "Locale catalog metadata: supported locales, fallback chain, and CLDR-aligned formatting expectations (currency, negative/accounting, number grouping, percent, date/time). The Android string resources under apps/android/src/main/res/values[-<locale>]/strings.xml are the platform projection of these locales; the 'enforced' locales below must reach 100% key coverage against the default catalog (checked by scripts/i18n/validate-locale-catalogs.js). Currency is resolved from the account's ISO 4217 code (see currencyResolution) — never hardcode a symbol per language.",
   "sourceLocale": "en-US",
   "defaultPlatformResource": "apps/android/src/main/res/values/strings.xml",
   "locales": [
@@ -16,10 +16,34 @@
           "pattern": "$1,234.56",
           "decimalSeparator": ".",
           "groupSeparator": ",",
-          "symbolPosition": "before"
+          "symbolPosition": "before",
+          "negative": {
+            "defaultStyle": "minusPrefix",
+            "accountingStyle": "parentheses",
+            "example": "-$1,234.56",
+            "accountingExample": "($1,234.56)"
+          }
         },
-        "number": { "decimalSeparator": ".", "groupSeparator": "," },
-        "date": { "shortPattern": "M/d/yy", "firstDayOfWeek": "sunday" }
+        "number": {
+          "decimalSeparator": ".",
+          "groupSeparator": ",",
+          "groupingPattern": "3"
+        },
+        "date": {
+          "shortPattern": "M/d/yy",
+          "firstDayOfWeek": "sunday",
+          "mediumPattern": "MMM d, yyyy",
+          "longPattern": "MMMM d, yyyy",
+          "timePattern": "h:mm a",
+          "hour12": true
+        },
+        "conventionId": "us_uk",
+        "percent": {
+          "decimalSeparator": ".",
+          "spaceBeforeSymbol": false,
+          "symbolPosition": "after",
+          "example": "75.5%"
+        }
       }
     },
     {
@@ -35,11 +59,34 @@
           "pattern": "1.234,56 €",
           "decimalSeparator": ",",
           "groupSeparator": ".",
-          "symbolPosition": "after"
+          "symbolPosition": "after",
+          "negative": {
+            "defaultStyle": "minusPrefix",
+            "accountingStyle": "minusPrefix",
+            "example": "-1.234,56 €"
+          }
         },
-        "number": { "decimalSeparator": ",", "groupSeparator": "." },
-        "date": { "shortPattern": "d/M/yy", "firstDayOfWeek": "monday" },
-        "notes": "es-US / es-MX users see USD with es number conventions ($1,234.56 grouping varies by region). Format via CLDR with the account's ISO 4217 currency — never hardcode the symbol or separators."
+        "number": {
+          "decimalSeparator": ",",
+          "groupSeparator": ".",
+          "groupingPattern": "3"
+        },
+        "date": {
+          "shortPattern": "d/M/yy",
+          "firstDayOfWeek": "monday",
+          "mediumPattern": "d MMM yyyy",
+          "longPattern": "d 'de' MMMM 'de' yyyy",
+          "timePattern": "H:mm",
+          "hour12": false
+        },
+        "notes": "es-US / es-MX users see USD with es number conventions ($1,234.56 grouping varies by region). Format via CLDR with the account's ISO 4217 currency — never hardcode the symbol or separators.",
+        "conventionId": "european",
+        "percent": {
+          "decimalSeparator": ",",
+          "spaceBeforeSymbol": true,
+          "symbolPosition": "after",
+          "example": "75,5 %"
+        }
       }
     },
     {
@@ -55,11 +102,165 @@
           "pattern": "1 234,56 €",
           "decimalSeparator": ",",
           "groupSeparator": " ",
-          "symbolPosition": "after"
+          "symbolPosition": "after",
+          "negative": {
+            "defaultStyle": "minusPrefix",
+            "accountingStyle": "minusPrefix",
+            "example": "-1 234,56 €"
+          }
         },
-        "number": { "decimalSeparator": ",", "groupSeparator": " " },
-        "date": { "shortPattern": "dd/MM/yyyy", "firstDayOfWeek": "monday" }
+        "number": {
+          "decimalSeparator": ",",
+          "groupSeparator": " ",
+          "groupingPattern": "3"
+        },
+        "date": {
+          "shortPattern": "dd/MM/yyyy",
+          "firstDayOfWeek": "monday",
+          "mediumPattern": "d MMM yyyy",
+          "longPattern": "d MMMM yyyy",
+          "timePattern": "HH:mm",
+          "hour12": false
+        },
+        "conventionId": "french",
+        "percent": {
+          "decimalSeparator": ",",
+          "spaceBeforeSymbol": true,
+          "symbolPosition": "after",
+          "example": "75,5 %"
+        }
       }
+    },
+    {
+      "id": "ar",
+      "name": "Arabic",
+      "androidQualifier": "values-ar",
+      "fallback": "en-US",
+      "enforced": false,
+      "rtl": true,
+      "formatting": {
+        "conventionId": "us_uk",
+        "currency": {
+          "iso4217Example": "AED",
+          "pattern": "1,234.56 د.إ",
+          "decimalSeparator": ".",
+          "groupSeparator": ",",
+          "symbolPosition": "after",
+          "negative": {
+            "defaultStyle": "minusPrefix",
+            "accountingStyle": "minusPrefix",
+            "example": "-1,234.56 د.إ"
+          }
+        },
+        "number": {
+          "decimalSeparator": ".",
+          "groupSeparator": ",",
+          "groupingPattern": "3"
+        },
+        "percent": {
+          "decimalSeparator": ".",
+          "spaceBeforeSymbol": false,
+          "symbolPosition": "after",
+          "example": "75.5%"
+        },
+        "date": {
+          "shortPattern": "d/M/yy",
+          "mediumPattern": "d MMM yyyy",
+          "longPattern": "d MMMM yyyy",
+          "timePattern": "h:mm a",
+          "hour12": true,
+          "firstDayOfWeek": "saturday"
+        },
+        "notes": "RTL locale. Amounts, account numbers and any LTR run MUST be wrapped in Unicode bidi isolates (FSI U+2068 ... PDI U+2069) so signs/parentheses render on the correct side. Western digits assumed; Arabic-Indic digits are an optional per-region display choice. Currency still resolved from ISO 4217 (see currencyResolution)."
+      }
+    }
+  ],
+  "currencyResolution": "The displayed currency is ALWAYS driven by the account/transaction ISO 4217 code, NOT by the locale. The locale only selects separators, symbol position, grouping, and negative style. A Spanish speaker in the US (es + USD) sees '$1,234.56' with es text; a Spanish speaker in Spain (es + EUR) sees '1.234,56 €'. The iso4217Example fields below are illustrative defaults only.",
+  "conventions": {
+    "us_uk": "Symbol before, '.' decimal, ',' grouping (groups of 3). e.g. $1,234.56",
+    "european": "Symbol after, ',' decimal, '.' grouping (groups of 3). e.g. 1.234,56 €",
+    "french": "Symbol after, ',' decimal, narrow no-break space grouping. e.g. 1 234,56 €",
+    "swiss": "Symbol/code before, '.' decimal, apostrophe grouping. e.g. CHF 1'234.56",
+    "south_asian": "Symbol before, '.' decimal, '3;2' lakh/crore grouping. e.g. ₹1,23,456.78"
+  },
+  "plannedLocales": [
+    {
+      "id": "en-GB",
+      "name": "English (United Kingdom)",
+      "conventionId": "us_uk",
+      "iso4217Example": "GBP",
+      "rtl": false,
+      "status": "planned"
+    },
+    {
+      "id": "es-MX",
+      "name": "Spanish (Mexico)",
+      "conventionId": "us_uk",
+      "iso4217Example": "MXN",
+      "rtl": false,
+      "status": "planned",
+      "notes": "LatAm/US Spanish: dot decimal, comma grouping; currency per ISO 4217."
+    },
+    {
+      "id": "es-419",
+      "name": "Spanish (Latin America)",
+      "conventionId": "us_uk",
+      "iso4217Example": "USD",
+      "rtl": false,
+      "status": "planned",
+      "notes": "Neutral LatAm Spanish; resolves the es-ES(EUR) vs es-US(USD) split."
+    },
+    {
+      "id": "fr-CA",
+      "name": "French (Canada)",
+      "conventionId": "us_uk",
+      "iso4217Example": "CAD",
+      "rtl": false,
+      "status": "planned"
+    },
+    {
+      "id": "de-DE",
+      "name": "German (Germany)",
+      "conventionId": "european",
+      "iso4217Example": "EUR",
+      "rtl": false,
+      "status": "planned",
+      "notes": "High text-expansion locale (~35%)."
+    },
+    {
+      "id": "pt-BR",
+      "name": "Portuguese (Brazil)",
+      "conventionId": "european",
+      "iso4217Example": "BRL",
+      "rtl": false,
+      "status": "planned"
+    },
+    {
+      "id": "hi-IN",
+      "name": "Hindi (India)",
+      "conventionId": "south_asian",
+      "iso4217Example": "INR",
+      "rtl": false,
+      "status": "planned",
+      "notes": "South-Asian lakh grouping (groupingPattern 3;2), e.g. INR 1,23,456.78."
+    },
+    {
+      "id": "ja-JP",
+      "name": "Japanese (Japan)",
+      "conventionId": "us_uk",
+      "iso4217Example": "JPY",
+      "rtl": false,
+      "status": "planned",
+      "notes": "Zero-decimal currency; plural category: other only."
+    },
+    {
+      "id": "zh-CN",
+      "name": "Chinese (Simplified)",
+      "conventionId": "us_uk",
+      "iso4217Example": "CNY",
+      "rtl": false,
+      "status": "planned",
+      "notes": "Plural category: other only."
     }
   ]
 }

--- a/config/i18n/plurals.json
+++ b/config/i18n/plurals.json
@@ -1,0 +1,65 @@
+{
+  "description": "Canonical pluralization contract. The i18n stack has no runtime plural handling yet (StringProvider does naive {0} substitution and Android has zero <plurals>). This file declares, per locale, the CLDR plural categories a translation MUST supply, plus the set of count-bearing message concepts. Platform projection: Android <plurals>, iOS .stringsdict, ICU MessageFormat {count, plural, ...} for web/KMP. Counts must NEVER be built by string concatenation.",
+  "sourceLocale": "en-US",
+  "cldrReference": "https://cldr.unicode.org/index/cldr-spec/plural-rules",
+  "localeCategories": {
+    "en-US": ["one", "other"],
+    "es-ES": ["one", "many", "other"],
+    "fr-FR": ["one", "many", "other"],
+    "ar": ["zero", "one", "two", "few", "many", "other"],
+    "ja-JP": ["other"],
+    "zh-CN": ["other"],
+    "de-DE": ["one", "other"],
+    "pt-BR": ["one", "many", "other"]
+  },
+  "concepts": [
+    {
+      "key": "transactions_count",
+      "description": "N transactions (lists, summaries, widgets).",
+      "sourceCategories": {
+        "one": "%d transaction",
+        "other": "%d transactions"
+      }
+    },
+    {
+      "key": "accounts_count",
+      "description": "N accounts.",
+      "sourceCategories": {
+        "one": "%d account",
+        "other": "%d accounts"
+      }
+    },
+    {
+      "key": "days_ago",
+      "description": "Relative recency for a transaction/sync timestamp.",
+      "sourceCategories": {
+        "one": "%d day ago",
+        "other": "%d days ago"
+      }
+    },
+    {
+      "key": "budgets_over_count",
+      "description": "N budgets over limit (dashboard alert).",
+      "sourceCategories": {
+        "one": "%d budget over limit",
+        "other": "%d budgets over limit"
+      }
+    },
+    {
+      "key": "goals_count",
+      "description": "N savings goals.",
+      "sourceCategories": {
+        "one": "%d goal",
+        "other": "%d goals"
+      }
+    },
+    {
+      "key": "months_remaining",
+      "description": "Months left to reach a savings goal.",
+      "sourceCategories": {
+        "one": "%d month left",
+        "other": "%d months left"
+      }
+    }
+  ]
+}

--- a/docs/i18n/localization-guide.md
+++ b/docs/i18n/localization-guide.md
@@ -39,6 +39,163 @@ ISO 4217 currency code (never a hardcoded symbol). See `config/i18n/locales.json
 Note `es-US`/`es-MX` users typically transact in USD with regional separators —
 always format with locale **+** currency code, not a fixed pattern.
 
+## Formatting contract (`config/i18n/locales.json`)
+
+Each locale carries a full, CLDR-aligned formatting contract. **Consumers must read
+these from the active locale — never hardcode a symbol, separator, sign, or pattern
+at the call site.**
+
+### Currency resolution (locale ≠ currency)
+
+The displayed currency is **always** driven by the account/transaction ISO 4217 code,
+never by the language. The locale only chooses separators, symbol position, grouping,
+and negative style. So:
+
+- `es` + `USD` → `$1,234.56` (Spanish text, USD)
+- `es-ES` + `EUR` → `1.234,56 €`
+
+The `iso4217Example` fields are illustrative defaults only. This resolves the old
+`es-ES` (EUR) vs `es-US`/`es-MX` (USD) ambiguity: pick separators from the region,
+currency from the account. Regional Spanish is captured under `plannedLocales`
+(`es-419`, `es-MX`).
+
+### `conventionId` → formatting convention
+
+Every locale has a stable `formatting.conventionId` that consumers switch on instead
+of passing a convention manually (which previously let `es-ES` be formatted as
+`$1,234.56`). Enumerated in the top-level `conventions` map:
+
+| conventionId  | Example        | Notes                                         |
+| ------------- | -------------- | --------------------------------------------- |
+| `us_uk`       | `$1,234.56`    | symbol before, `.` decimal, `,` grouping      |
+| `european`    | `1.234,56 €`   | symbol after, `,` decimal, `.` grouping       |
+| `french`      | `1 234,56 €`   | symbol after, `,` decimal, **space** grouping |
+| `swiss`       | `CHF 1'234.56` | code before, `.` decimal, `'` grouping        |
+| `south_asian` | `₹1,23,456.78` | `.` decimal, `3;2` lakh/crore grouping        |
+
+> `french` is deliberately distinct from `european` because French groups with a
+> narrow no-break space, not `.`. The `LocaleCurrencyFormatter.EUROPEAN` enum in
+> `packages/core` does **not** capture this — platform agents should resolve the
+> convention from `conventionId`, not the four-value Kotlin enum.
+
+### Negative & accounting amounts
+
+`formatting.currency.negative` describes how negatives render per locale:
+`defaultStyle` + `accountingStyle` ∈ `minusPrefix | parentheses | minusAfterSymbol |
+trailingMinus`, with an `example` / `accountingExample`. US accounting uses
+parentheses: `($1,234.56)`.
+
+> **Accessibility:** negativity must never be signalled by colour alone (WCAG). The
+> sign/parentheses are the primary signal; red/green is secondary.
+
+### Number grouping (incl. South-Asian lakh)
+
+`formatting.number.groupingPattern` uses CLDR primary/secondary notation: `"3"` for
+Western (groups of three) and `"3;2"` for the South-Asian lakh/crore system
+(`₹1,23,456.78`). A fixed mod-3 grouping mis-renders every large INR amount — see the
+`LocaleCurrencyFormatter.INDIAN` gap (comment: "lakh grouping not implemented").
+
+### Percent
+
+`formatting.percent` = `decimalSeparator` + `spaceBeforeSymbol` + `symbolPosition` +
+`example`. English is `75.5%`; French is `75,5 %` (comma decimal, narrow space before
+`%`). `NumberFormatting.formatPercent` in `packages/core` currently hardcodes `.` and
+no space — fix the consumer to read this block.
+
+### Date & time
+
+`formatting.date` now carries `shortPattern`, `mediumPattern`, `longPattern`,
+`timePattern`, `hour12`, and `firstDayOfWeek`. Use these for statement ranges,
+timestamps, due dates, and recurring-rule descriptions. e.g. a statement range:
+
+- en-US: `Jul 1 – 31, 2026`, times `3:45 PM` (12h)
+- fr-FR: `1 – 31 juil. 2026`, times `15:45` (24h)
+
+## Pluralization (`config/i18n/plurals.json`)
+
+The stack has **no runtime plural handling** today: `StringProvider.get(key, args)`
+does naive `{0}` substitution and there are **zero `<plurals>`** in the Android
+catalogs. `plurals.json` is the contract:
+
+- `localeCategories` — the CLDR plural categories each locale MUST supply
+  (`en`: one/other; `fr`/`es`: one/many/other; `ar`: zero/one/two/few/many/other;
+  `ja`/`zh`: other).
+- `concepts` — the count-bearing messages (`transactions_count`, `days_ago`, …) with
+  their source (`en-US`) category strings.
+
+Platform projection: Android `<plurals>`, iOS `.stringsdict`, ICU MessageFormat
+`{count, plural, one {…} other {…}}` for web/KMP. **Never** build a count by
+concatenating a number with a string.
+
+## RTL & bidirectional text
+
+The catalog now includes an RTL scaffold (`ar`, `"rtl": true`). RTL is a correctness
+concern for money UI, not cosmetics:
+
+- **Bidi isolation is mandatory.** Wrap every amount, account number, and LTR run in
+  Unicode isolates `FSI` (U+2068) … `PDI` (U+2069) so the sign/parentheses/currency
+  symbol render on the correct side inside RTL text. Without this, `-$1,234.56` in an
+  Arabic sentence mis-places the minus.
+- **Layout uses `start`/`end`, never `left`/`right`.** Mirror directional icons
+  (back/forward, progress, trends). Charts and number axes need explicit direction.
+- Western vs Arabic-Indic digits is a per-region display choice; currency is still
+  resolved from ISO 4217.
+
+`ar` ships as non-enforced (no `values-ar/strings.xml` yet) so the validator warns
+rather than fails; add the catalog + native review before flipping `enforced: true`.
+
+## Text expansion & length budgeting (`config/i18n/length-budgets.json`)
+
+Translations expand vs. English (German/French up to ~35%). `length-budgets.json`
+defines:
+
+- `expansionFactors` — design-headroom multipliers by source length (short labels
+  expand most — up to 2×).
+- `constrainedKeyPrefixes` — Android key prefixes on space-limited surfaces
+  (`widget_`, `tile_`, `notification_`, `parity_`, `a11y_`).
+- `maxLengthHints` — soft caps (in en-US chars) for specific constrained keys.
+
+Design widget/tile/notification surfaces against the localized worst case
+(`source_length × factor`), prefer flexible/wrapping layouts, and request a shorter
+**source** string rather than truncating a translation.
+
+## Glossary invariants (`config/i18n/glossary.json`)
+
+A mistranslated financial term is a correctness bug, so the glossary has enforceable
+invariants (a future `scripts/i18n/` hook can gate these in CI):
+
+1. Every `concept` supplies **all** locales listed in `locales`.
+2. No blank/whitespace-only values.
+3. A chosen term MUST NOT appear in that locale's `doNotUse` (false-friend guard).
+4. `concept` values are unique.
+
+Add money-critical terms here before they ship on any surface (Transfer, Fee,
+Statement, Overdraft, Exchange rate, …). `ar` translations are a staged follow-up
+pending native review.
+
+## Adding a new locale (scaffolding checklist)
+
+The `Locale.kt` constants (`de`, `pt-BR`, `ja`, `zh-CN`, `en-GB`, `es-MX`, `fr-CA`)
+are **not** all backed by catalogs. `plannedLocales` in `locales.json` reconciles this
+explicitly (what's real vs planned). To promote a planned locale to real:
+
+1. **`config/i18n/locales.json`** — add a full entry to `locales[]`: `id`,
+   `androidQualifier`, `fallback`, `enforced` (start `false`), `rtl`, and the complete
+   `formatting` block (`conventionId`, currency + `negative`, number +
+   `groupingPattern`, `percent`, `date`).
+2. **`config/i18n/plurals.json`** — add the locale's CLDR categories to
+   `localeCategories`.
+3. **`config/i18n/glossary.json`** — add the locale to `locales` and translate every
+   `concept` (respect `doNotUse`).
+4. **Android** — create `apps/android/src/main/res/values-<qualifier>/strings.xml`
+   with 100% key coverage of the default catalog.
+5. **Validate** — `node scripts/i18n/validate-locale-catalogs.js`. Flip
+   `enforced: true` only once coverage is 100% and a native review is done.
+
+> Ownership: the canonical catalog lives here (`@localization-engineer`). The KMP
+> `Strings` expect/actual mechanism in `packages/core/.../i18n/` is
+> `@kmp-engineer` — coordinate there; don't edit it from `config/i18n`.
+
 ## Scope boundary
 
 This PR is **i18n-only**: locale catalogs, glossary, docs, and the validator. The


### PR DESCRIPTION
## Summary

Enriches the canonical **i18n source catalog** (`config/i18n/`) and its docs
(`docs/i18n/`) into a complete, CLDR-aligned localization + formatting contract for
the Finance app. i18n-only: no app/platform code is touched (owned by other sessions).

This is the implementation half of a localization critique that filed 12 issues; this
PR ships a coherent config/docs subset that closes all of them.

## What changed

**`config/i18n/locales.json`**
- `formatting.conventionId` per locale + top-level `conventions` map (`us_uk`,
  `european`, `french`, `swiss`, `south_asian`) so consumers resolve convention from
  the active locale instead of passing a decoupled enum. (#3620)
- `currency.negative` per locale: `defaultStyle`/`accountingStyle`
  (`minusPrefix`/`parentheses`/…) + examples, incl. US accounting `($1,234.56)`. (#3598)
- `number.groupingPattern` incl. South-Asian lakh `"3;2"`. (#3602)
- `formatting.percent` per locale (e.g. `75.5%` vs `75,5 %`). (#3622)
- Full `date` block: `mediumPattern`, `longPattern`, `timePattern`, `hour12`. (#3630)
- RTL scaffold locale `ar` (`rtl: true`, non-enforced). (#3597)
- `plannedLocales[]` reconciling the `Locale.kt` constants not yet backed by catalogs
  (`en-GB`, `es-MX`, `es-419`, `fr-CA`, `de-DE`, `pt-BR`, `hi-IN`, `ja-JP`, `zh-CN`). (#3607)
- `currencyResolution` note: currency comes from the account ISO 4217 code, not the
  language — resolves the `es-ES`(EUR) vs `es-US`(USD) ambiguity. (#3635)

**`config/i18n/glossary.json`** — +20 money-critical terms (Transfer, Deposit,
Withdrawal, Payee, Merchant, Fee, Interest, Statement, Recurring, Subscription,
Reconcile, Cleared, Pending, Overdraft, Tag, Available balance, Due date, Minimum
payment, Exchange rate, Interest rate) with `notes`/`doNotUse` false-friend traps;
documented invariants. (#3599, #3614)

**`config/i18n/plurals.json`** (new) — CLDR plural-category contract per locale +
count-bearing message concepts (`transactions_count`, `days_ago`, …). Closes the gap
that there is zero plural handling today. (#3596)

**`config/i18n/length-budgets.json`** (new) — text-expansion factors, constrained
key prefixes, and per-key max-length hints. (#3604)

**Docs** — `docs/i18n/localization-guide.md` and `config/i18n/README.md` gain sections
on the formatting contract, pluralization, RTL & bidi isolation, text-expansion
budgeting, glossary invariants, and an "Adding a new locale" checklist.

## Validation

- `node scripts/i18n/validate-locale-catalogs.js` → **exit 0** (enforced `es` still
  100%; `fr`/`ar` are non-enforced warnings, unchanged behavior).
- `prettier --check` (v3.9.4, repo config) → clean on all changed files.
- All JSON validated + glossary invariants asserted (full locale coverage, non-empty,
  chosen term ∉ doNotUse, unique concepts).
- ESLint targets only `**/*.{ts,tsx,mjs,js}` — these JSON/MD changes are out of scope.

## Follow-ups (owned elsewhere)

Consumers in `packages/core` (`LocaleCurrencyFormatter`, `NumberFormatting`,
`StringProvider`) must be wired to read this contract (lakh grouping, percent, negative
styles, plurals) — flagged inline in the docs for platform/KMP agents. `ar` needs a
native-reviewed `values-ar/strings.xml` before `enforced: true`.

Closes #3596
Closes #3597
Closes #3598
Closes #3599
Closes #3602
Closes #3604
Closes #3607
Closes #3614
Closes #3620
Closes #3622
Closes #3630
Closes #3635
