### PR TITLE
feat(design-tokens): accessible financial status color system + reduced-motion tokens

### DIFF
--- a/packages/design-tokens/tokens/primitive/colors.json
+++ b/packages/design-tokens/tokens/primitive/colors.json
@@ -26,22 +26,39 @@
     },
     "green": {
       "50": { "$value": "#F0FDF4", "$type": "color" },
+      "100": { "$value": "#DCFCE7", "$type": "color" },
+      "200": { "$value": "#BBF7D0", "$type": "color" },
+      "300": { "$value": "#86EFAC", "$type": "color" },
+      "400": { "$value": "#4ADE80", "$type": "color" },
       "500": { "$value": "#22C55E", "$type": "color" },
       "600": { "$value": "#16A34A", "$type": "color" },
-      "700": { "$value": "#15803D", "$type": "color" }
+      "700": { "$value": "#15803D", "$type": "color" },
+      "800": { "$value": "#166534", "$type": "color" },
+      "900": { "$value": "#14532D", "$type": "color" }
     },
     "amber": {
       "50": { "$value": "#FFFBEB", "$type": "color" },
+      "100": { "$value": "#FEF3C7", "$type": "color" },
+      "200": { "$value": "#FDE68A", "$type": "color" },
+      "300": { "$value": "#FCD34D", "$type": "color" },
+      "400": { "$value": "#FBBF24", "$type": "color" },
       "500": { "$value": "#F59E0B", "$type": "color" },
       "600": { "$value": "#D97706", "$type": "color" },
-      "700": { "$value": "#B45309", "$type": "color" }
+      "700": { "$value": "#B45309", "$type": "color" },
+      "800": { "$value": "#92400E", "$type": "color" },
+      "900": { "$value": "#78350F", "$type": "color" }
     },
     "red": {
       "50": { "$value": "#FEF2F2", "$type": "color" },
+      "100": { "$value": "#FEE2E2", "$type": "color" },
+      "200": { "$value": "#FECACA", "$type": "color" },
+      "300": { "$value": "#FCA5A5", "$type": "color" },
       "400": { "$value": "#F87171", "$type": "color" },
       "500": { "$value": "#EF4444", "$type": "color" },
       "600": { "$value": "#DC2626", "$type": "color" },
-      "700": { "$value": "#B91C1C", "$type": "color" }
+      "700": { "$value": "#B91C1C", "$type": "color" },
+      "800": { "$value": "#991B1B", "$type": "color" },
+      "900": { "$value": "#7F1D1D", "$type": "color" }
     },
     "neutral": {
       "0": { "$value": "#FFFFFF", "$type": "color" },

--- a/packages/design-tokens/tokens/primitive/motion.json
+++ b/packages/design-tokens/tokens/primitive/motion.json
@@ -8,6 +8,11 @@
       "$value": "800ms",
       "$type": "duration",
       "$description": "Extended animations: celebrations, complex transitions"
+    },
+    "reduced": {
+      "$value": "1ms",
+      "$type": "duration",
+      "$description": "Reduced-motion duration — near-instant. Use for every animation when prefers-reduced-motion / Reduce Motion is enabled. 1ms (not 0ms) keeps transitionend/animationend events firing so state logic still completes."
     }
   },
   "easing": {
@@ -15,6 +20,11 @@
     "in": { "$value": "cubic-bezier(0.4, 0, 1, 1)", "$type": "cubicBezier" },
     "out": { "$value": "cubic-bezier(0, 0, 0.2, 1)", "$type": "cubicBezier" },
     "inOut": { "$value": "cubic-bezier(0.4, 0, 0.2, 1)", "$type": "cubicBezier" },
+    "linear": {
+      "$value": "cubic-bezier(0, 0, 1, 1)",
+      "$type": "cubicBezier",
+      "$description": "Linear (no acceleration, no overshoot) — used by reduced-motion equivalents to neutralize spring/bounce."
+    },
     "standard": {
       "$value": "cubic-bezier(0.2, 0, 0, 1)",
       "$type": "cubicBezier",

--- a/packages/design-tokens/tokens/semantic/animation.json
+++ b/packages/design-tokens/tokens/semantic/animation.json
@@ -41,5 +41,48 @@
       "duration": { "$value": "{duration.slower}", "$type": "duration" },
       "easing": { "$value": "{easing.inOut}", "$type": "cubicBezier" }
     }
+  },
+  "animationReduced": {
+    "$description": "Reduced-motion equivalents of the animation.* semantic tokens. Consumers MUST switch to these when prefers-reduced-motion / OS Reduce Motion is enabled. Every purpose collapses to a near-instant, linear (no spring/overshoot) transition so animation-driven state changes still complete without vestibular-triggering motion. Mirrors every key in `animation`.",
+    "pageTransition": {
+      "$description": "Reduced-motion page transition — near-instant crossfade",
+      "duration": { "$value": "{duration.reduced}", "$type": "duration" },
+      "easing": { "$value": "{easing.linear}", "$type": "cubicBezier" }
+    },
+    "listItem": {
+      "$description": "Reduced-motion list/grid item — no stagger, near-instant",
+      "duration": { "$value": "{duration.reduced}", "$type": "duration" },
+      "easing": { "$value": "{easing.linear}", "$type": "cubicBezier" }
+    },
+    "progress": {
+      "$description": "Reduced-motion progress — snap to value without animated sweep",
+      "duration": { "$value": "{duration.reduced}", "$type": "duration" },
+      "easing": { "$value": "{easing.linear}", "$type": "cubicBezier" }
+    },
+    "celebrate": {
+      "$description": "Reduced-motion celebration — spring/overshoot removed; show end state near-instantly",
+      "duration": { "$value": "{duration.reduced}", "$type": "duration" },
+      "easing": { "$value": "{easing.linear}", "$type": "cubicBezier" }
+    },
+    "fadeIn": {
+      "$description": "Reduced-motion fade-in — near-instant reveal",
+      "duration": { "$value": "{duration.reduced}", "$type": "duration" },
+      "easing": { "$value": "{easing.linear}", "$type": "cubicBezier" }
+    },
+    "fadeOut": {
+      "$description": "Reduced-motion fade-out — near-instant dismiss",
+      "duration": { "$value": "{duration.reduced}", "$type": "duration" },
+      "easing": { "$value": "{easing.linear}", "$type": "cubicBezier" }
+    },
+    "microInteraction": {
+      "$description": "Reduced-motion micro-interaction — instant feedback, no easing curve",
+      "duration": { "$value": "{duration.reduced}", "$type": "duration" },
+      "easing": { "$value": "{easing.linear}", "$type": "cubicBezier" }
+    },
+    "loading": {
+      "$description": "Reduced-motion loading — prefer a static/opacity-pulse indicator over sweeping shimmer",
+      "duration": { "$value": "{duration.reduced}", "$type": "duration" },
+      "easing": { "$value": "{easing.linear}", "$type": "cubicBezier" }
+    }
   }
 }

--- a/packages/design-tokens/tokens/semantic/colors.dark-oled.json
+++ b/packages/design-tokens/tokens/semantic/colors.dark-oled.json
@@ -99,6 +99,46 @@
         "$value": "{color.blue.400}",
         "$type": "color",
         "$description": "Info status — 8.3:1 vs #000000"
+      },
+      "pending": {
+        "$value": "{color.teal.400}",
+        "$type": "color",
+        "$description": "Pending/in-progress status — 11.3:1 vs #000000. Distinct from info; pair with icon/label."
+      },
+      "neutral": {
+        "$value": "{color.neutral.400}",
+        "$type": "color",
+        "$description": "Neutral/uncategorized status — 8.3:1 vs #000000. Pair with icon/label."
+      },
+      "positiveSubtle": {
+        "$value": "{color.green.900}",
+        "$type": "color",
+        "$description": "Low-emphasis positive background for OLED theme. text.primary reads 8.7:1 on this fill."
+      },
+      "negativeSubtle": {
+        "$value": "{color.red.900}",
+        "$type": "color",
+        "$description": "Low-emphasis negative background for OLED theme. text.primary reads 9.6:1 on this fill."
+      },
+      "warningSubtle": {
+        "$value": "{color.amber.900}",
+        "$type": "color",
+        "$description": "Low-emphasis warning background for OLED theme. text.primary reads 8.7:1 on this fill."
+      },
+      "infoSubtle": {
+        "$value": "{color.blue.900}",
+        "$type": "color",
+        "$description": "Low-emphasis info background for OLED theme. text.primary reads 9.9:1 on this fill."
+      },
+      "pendingSubtle": {
+        "$value": "{color.teal.900}",
+        "$type": "color",
+        "$description": "Low-emphasis pending background for OLED theme. text.primary reads 9.1:1 on this fill."
+      },
+      "neutralSubtle": {
+        "$value": "{color.neutral.900}",
+        "$type": "color",
+        "$description": "Low-emphasis neutral background for OLED theme (near true-black elevated tint)."
       }
     },
     "amount": {

--- a/packages/design-tokens/tokens/semantic/colors.dark.json
+++ b/packages/design-tokens/tokens/semantic/colors.dark.json
@@ -26,7 +26,47 @@
       "positive": { "$value": "{color.green.500}", "$type": "color" },
       "negative": { "$value": "{color.red.500}", "$type": "color" },
       "warning": { "$value": "{color.amber.500}", "$type": "color" },
-      "info": { "$value": "{color.blue.400}", "$type": "color" }
+      "info": { "$value": "{color.blue.400}", "$type": "color" },
+      "pending": {
+        "$value": "{color.teal.400}",
+        "$type": "color",
+        "$description": "Pending/in-progress status — 10.8:1 vs background.primary. Distinct from info; pair with icon/label."
+      },
+      "neutral": {
+        "$value": "{color.neutral.400}",
+        "$type": "color",
+        "$description": "Neutral/uncategorized status — 7.9:1 vs background.primary. Pair with icon/label."
+      },
+      "positiveSubtle": {
+        "$value": "{color.green.900}",
+        "$type": "color",
+        "$description": "Low-emphasis positive background for dark theme. text.primary reads 8.7:1 on this fill."
+      },
+      "negativeSubtle": {
+        "$value": "{color.red.900}",
+        "$type": "color",
+        "$description": "Low-emphasis negative background for dark theme. text.primary reads 9.6:1 on this fill."
+      },
+      "warningSubtle": {
+        "$value": "{color.amber.900}",
+        "$type": "color",
+        "$description": "Low-emphasis warning background for dark theme. text.primary reads 8.7:1 on this fill."
+      },
+      "infoSubtle": {
+        "$value": "{color.blue.900}",
+        "$type": "color",
+        "$description": "Low-emphasis info background for dark theme. text.primary reads 9.9:1 on this fill."
+      },
+      "pendingSubtle": {
+        "$value": "{color.teal.900}",
+        "$type": "color",
+        "$description": "Low-emphasis pending background for dark theme. text.primary reads 9.1:1 on this fill."
+      },
+      "neutralSubtle": {
+        "$value": "{color.neutral.800}",
+        "$type": "color",
+        "$description": "Low-emphasis neutral background for dark theme. text.primary reads 14.1:1 on this fill."
+      }
     },
     "amount": {
       "positive": { "$value": "{color.green.500}", "$type": "color" },

--- a/packages/design-tokens/tokens/semantic/colors.high-contrast.json
+++ b/packages/design-tokens/tokens/semantic/colors.high-contrast.json
@@ -99,6 +99,46 @@
         "$value": "{color.blue.800}",
         "$type": "color",
         "$description": "Dark blue info — 8.6:1 vs white (AAA)"
+      },
+      "pending": {
+        "$value": "{color.teal.800}",
+        "$type": "color",
+        "$description": "Dark teal pending — 7.58:1 vs white (AAA). Distinct from info; pair with icon/label."
+      },
+      "neutral": {
+        "$value": "{color.neutral.700}",
+        "$type": "color",
+        "$description": "Dark gray neutral — 10.31:1 vs white (AAA). Pair with icon/label."
+      },
+      "positiveSubtle": {
+        "$value": "{color.green.100}",
+        "$type": "color",
+        "$description": "High-contrast positive background. text.primary reads 18.3:1 on this fill."
+      },
+      "negativeSubtle": {
+        "$value": "{color.red.100}",
+        "$type": "color",
+        "$description": "High-contrast negative background. text.primary reads 16.5:1 on this fill."
+      },
+      "warningSubtle": {
+        "$value": "{color.amber.100}",
+        "$type": "color",
+        "$description": "High-contrast warning background. text.primary reads 18.1:1 on this fill."
+      },
+      "infoSubtle": {
+        "$value": "{color.blue.100}",
+        "$type": "color",
+        "$description": "High-contrast info background. text.primary reads 16.5:1 on this fill."
+      },
+      "pendingSubtle": {
+        "$value": "{color.teal.100}",
+        "$type": "color",
+        "$description": "High-contrast pending background. text.primary reads 17.9:1 on this fill."
+      },
+      "neutralSubtle": {
+        "$value": "{color.neutral.100}",
+        "$type": "color",
+        "$description": "High-contrast neutral background. text.primary reads 18.3:1 on this fill."
       }
     },
     "amount": {

--- a/packages/design-tokens/tokens/semantic/colors.light.json
+++ b/packages/design-tokens/tokens/semantic/colors.light.json
@@ -23,10 +23,66 @@
       "disabled": { "$value": "{color.neutral.300}", "$type": "color" }
     },
     "status": {
-      "positive": { "$value": "{color.green.600}", "$type": "color" },
-      "negative": { "$value": "{color.red.600}", "$type": "color" },
-      "warning": { "$value": "{color.amber.600}", "$type": "color" },
-      "info": { "$value": "{color.blue.600}", "$type": "color" }
+      "positive": {
+        "$value": "{color.green.700}",
+        "$type": "color",
+        "$description": "Positive/on-track status — 5.02:1 vs background.primary (WCAG AA); retargeted from green.600 (3.30:1, failed AA). Pair with icon/label, never color alone."
+      },
+      "negative": {
+        "$value": "{color.red.600}",
+        "$type": "color",
+        "$description": "Negative/error status — 4.83:1 vs background.primary (WCAG AA). Pair with icon/label."
+      },
+      "warning": {
+        "$value": "{color.amber.700}",
+        "$type": "color",
+        "$description": "Warning status — 5.02:1 vs background.primary (WCAG AA); retargeted from amber.600 (3.19:1, failed AA). Pair with icon/label."
+      },
+      "info": {
+        "$value": "{color.blue.600}",
+        "$type": "color",
+        "$description": "Informational status — 5.17:1 vs background.primary (WCAG AA)."
+      },
+      "pending": {
+        "$value": "{color.teal.700}",
+        "$type": "color",
+        "$description": "Pending/in-progress status (processing, syncing, unsettled) — 5.47:1 vs background.primary (WCAG AA). Distinct from info; pair with icon/label."
+      },
+      "neutral": {
+        "$value": "{color.neutral.600}",
+        "$type": "color",
+        "$description": "Neutral/uncategorized status — 7.56:1 vs background.primary (WCAG AAA). Pair with icon/label."
+      },
+      "positiveSubtle": {
+        "$value": "{color.green.50}",
+        "$type": "color",
+        "$description": "Low-emphasis positive background (badges/banners). text.primary reads 16.9:1 on this fill."
+      },
+      "negativeSubtle": {
+        "$value": "{color.red.50}",
+        "$type": "color",
+        "$description": "Low-emphasis negative background. text.primary reads 16.2:1 on this fill."
+      },
+      "warningSubtle": {
+        "$value": "{color.amber.50}",
+        "$type": "color",
+        "$description": "Low-emphasis warning background. text.primary reads 17.1:1 on this fill."
+      },
+      "infoSubtle": {
+        "$value": "{color.blue.50}",
+        "$type": "color",
+        "$description": "Low-emphasis info background. text.primary reads 16.3:1 on this fill."
+      },
+      "pendingSubtle": {
+        "$value": "{color.teal.50}",
+        "$type": "color",
+        "$description": "Low-emphasis pending background. text.primary reads 17.0:1 on this fill."
+      },
+      "neutralSubtle": {
+        "$value": "{color.neutral.100}",
+        "$type": "color",
+        "$description": "Low-emphasis neutral background. text.primary reads 16.1:1 on this fill."
+      }
     },
     "amount": {
       "positive": { "$value": "{color.green.700}", "$type": "color" },


### PR DESCRIPTION
## Summary
Hardens and completes the **financial status color system** in `packages/design-tokens` and adds the missing **reduced-motion** token layer mandated by `tokens.instructions.md`. All changes are token-source edits (generated `build/` is gitignored); outputs were regenerated with `npm run build:tokens` and the full reference graph validates (0 unresolved).

Every change is **additive or a value-only retarget** — no token names removed or renamed, so there is no breaking change for platform consumers.

## What changed
### Complete primitive color ramps — Closes #3663
`green`, `amber`, and `red` were sparse (e.g. green only had 50/500/600/700) while `blue`/`neutral`/`teal` were full. Filled all three to the standard `50–900` ramp (Tailwind-family values); existing steps unchanged.

### Fix WCAG AA contrast failures (light theme) — Closes #3646
Verified with the WCAG relative-luminance formula:
| Token | Before | Ratio | After | Ratio |
|-------|--------|-------|-------|-------|
| `status.positive` | `green.600` | **3.30:1 ❌** | `green.700` | **5.02:1 ✅** |
| `status.warning` | `amber.600` | **3.19:1 ❌** | `amber.700` | **5.02:1 ✅** |

Token names are unchanged (value/reference only). Ratios recorded in each `$description`.

### Subtle status background tints — Closes #3657
Added `status.{positive,negative,warning,info,pending,neutral}Subtle` low-emphasis background fills for badges/banners/toasts across **light / dark / OLED / high-contrast**, each with documented on-fill contrast for `text.primary` (16–18:1 light, 8.7–14:1 dark).

### Financial `pending` + `neutral` status — Closes #3704
Added `status.pending` (processing/syncing/unsettled) and `status.neutral` (uncategorized) to all four color themes. Each meets AA+ on its theme background (light: teal.700 5.47:1, neutral.600 7.56:1; dark/OLED 7.9–11.3:1; HC AAA). Descriptions remind consumers to pair with icon/label — never color alone.

### Reduced-motion tokens — Closes #3652
`tokens.instructions.md` requires reduced-motion equivalents; none existed. Added:
- Primitives: `duration.reduced` (`1ms` — keeps `transitionend`/`animationend` firing) and `easing.linear` (neutralizes spring/overshoot).
- A full semantic `animationReduced.*` group mirroring every `animation.*` purpose, collapsing to near-instant linear transitions. Consumers switch to this set under `prefers-reduced-motion` / OS Reduce Motion.

## Validation
- `npm run build:tokens` ✅ (light + dark + dark-oled + high-contrast, all platforms).
- Token reference graph: 412 tokens, 343 references, **0 unresolved**.
- Prettier: all changed files pass `--check` (printWidth 100, LF).
- Contrast ratios computed and embedded in token `$description`s.

## Notes for reviewers
- Files touched are split by tier/domain (primitive vs semantic) to minimize fleet conflicts.
- `build/` outputs are intentionally not committed (gitignored); CI regenerates them.

Closes #3646
Closes #3652
Closes #3657
Closes #3663
Closes #3704
