### PR TITLE
feat(web): shared a11y primitives - VisuallyHidden, focus tokens, reliable toast announcements

### DIFF
--- a/apps/web/src/components/common/Toast.test.tsx
+++ b/apps/web/src/components/common/Toast.test.tsx
@@ -52,7 +52,7 @@ describe('ToastProvider + useToast', () => {
     expect(screen.getByText('Account created!')).toBeInTheDocument();
   });
 
-  it('uses role="alert" for error toasts', async () => {
+  it('announces error toasts via the assertive live region', async () => {
     const user = userEvent.setup();
     render(
       <ToastProvider>
@@ -61,10 +61,12 @@ describe('ToastProvider + useToast', () => {
     );
 
     await user.click(screen.getByRole('button', { name: 'Show Toast' }));
-    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('Error: Failed to save');
+    // The visible toast itself is presentational (no competing live region).
+    expect(screen.getByText('Failed to save')).toBeInTheDocument();
   });
 
-  it('uses role="status" for success toasts', async () => {
+  it('announces success toasts via the polite live region', async () => {
     const user = userEvent.setup();
     render(
       <ToastProvider>
@@ -73,11 +75,13 @@ describe('ToastProvider + useToast', () => {
     );
 
     await user.click(screen.getByRole('button', { name: 'Show Toast' }));
-    expect(screen.getByRole('status', { name: 'Success: Saved' })).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Success: Saved');
+    // Visible message and severity label are still rendered.
+    expect(screen.getByText('Saved')).toBeInTheDocument();
     expect(screen.getByText('Success')).toBeInTheDocument();
   });
 
-  it('uses role="status" for info toasts', async () => {
+  it('announces info toasts via the polite live region', async () => {
     const user = userEvent.setup();
     render(
       <ToastProvider>
@@ -86,7 +90,19 @@ describe('ToastProvider + useToast', () => {
     );
 
     await user.click(screen.getByRole('button', { name: 'Show Toast' }));
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Info: FYI');
+  });
+
+  it('mounts the live regions empty before any toast is shown', () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+
+    // Regions must pre-exist (and be empty) so later text changes are announced.
+    expect(screen.getByRole('status')).toBeEmptyDOMElement();
+    expect(screen.getByRole('alert')).toBeEmptyDOMElement();
   });
 
   it('auto-dismisses after the specified duration', () => {

--- a/apps/web/src/components/common/Toast.tsx
+++ b/apps/web/src/components/common/Toast.tsx
@@ -7,6 +7,7 @@ import {
   getToastDismissLabel,
   getToastTypeLabel,
 } from '../../lib/i18n/forms-catalog';
+import { VisuallyHidden } from './VisuallyHidden';
 
 /* --------------------------------------------------------------------------
  * Types
@@ -84,13 +85,18 @@ let toastIdCounter = 0;
 /**
  * Provides a toast notification system to the component tree.
  *
- * Renders a fixed toast container with `aria-live` announcements.
+ * Renders a fixed toast container plus two persistent, visually-hidden live
+ * regions (one polite, one assertive). Announcements are written into those
+ * pre-existing regions so screen readers reliably narrate them — a live region
+ * must exist in the DOM *before* its text changes (WCAG 4.1.3 Status Messages).
+ * The visible toasts themselves are not live regions, so the message is
+ * announced exactly once, from its localized announcement text.
  * Toasts auto-dismiss after the configured duration (default 5 s).
- * Error toasts use `role="alert"` for immediate screen-reader announcement;
- * other types use `role="status"`.
  */
 export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
   const [toasts, setToasts] = useState<Toast[]>([]);
+  const [politeAnnouncement, setPoliteAnnouncement] = useState('');
+  const [assertiveAnnouncement, setAssertiveAnnouncement] = useState('');
   const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   /** Clean up all auto-dismiss timers on unmount. */
@@ -115,14 +121,24 @@ export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
     (options: ToastOptions) => {
       const id = `toast-${++toastIdCounter}`;
       const duration = options.duration ?? 5000;
+      const type = options.type ?? 'info';
       const toast: Toast = {
         id,
-        type: options.type ?? 'info',
+        type,
         message: options.message,
         duration,
       };
 
       setToasts((prev) => [...prev, toast]);
+
+      // Route the announcement through the appropriate persistent live region.
+      // Errors are assertive (interrupt); everything else is polite.
+      const announcement = getToastAriaLabel(type, options.message);
+      if (type === 'error') {
+        setAssertiveAnnouncement(announcement);
+      } else {
+        setPoliteAnnouncement(announcement);
+      }
 
       if (duration > 0) {
         const timer = setTimeout(() => {
@@ -137,6 +153,14 @@ export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
   return (
     <ToastContext.Provider value={{ showToast, dismissToast }}>
       {children}
+      {/* Persistent live regions — mounted empty so later text changes are
+          announced by assistive technology (WCAG 4.1.3). */}
+      <VisuallyHidden as="div" role="status" aria-live="polite" aria-atomic="true">
+        {politeAnnouncement}
+      </VisuallyHidden>
+      <VisuallyHidden as="div" role="alert" aria-live="assertive" aria-atomic="true">
+        {assertiveAnnouncement}
+      </VisuallyHidden>
       <div className="toast-container" aria-label="Notifications" role="region" tabIndex={-1}>
         {toasts.map((toast) => (
           <ToastItem key={toast.id} toast={toast} onDismiss={dismissToast} />
@@ -252,13 +276,14 @@ const TOAST_ICONS: Record<ToastType, React.ReactNode> = {
 /**
  * Individual toast notification element.
  *
- * Uses `role="alert"` for errors (immediate announcement) and
- * `role="status"` for other types (polite announcement).
+ * This element is presentational only — announcements are handled by the
+ * dedicated live regions in {@link ToastProvider}, so the toast itself carries
+ * neither a live-region role nor an `aria-label` (which would suppress or
+ * duplicate the announced message). The visible type label keeps the severity
+ * readable for everyone.
  */
 const ToastItem: React.FC<ToastItemProps> = ({ toast, onDismiss }) => {
-  const role = toast.type === 'error' ? 'alert' : 'status';
   const typeLabel = getToastTypeLabel(toast.type);
-  const ariaLabel = getToastAriaLabel(toast.type, toast.message);
   const rootRef = useRef<HTMLDivElement>(null);
 
   const handleDismiss = useCallback(() => {
@@ -284,7 +309,7 @@ const ToastItem: React.FC<ToastItemProps> = ({ toast, onDismiss }) => {
   }, [onDismiss, toast.id]);
 
   return (
-    <div ref={rootRef} className={`toast toast--${toast.type}`} role={role} aria-label={ariaLabel}>
+    <div ref={rootRef} className={`toast toast--${toast.type}`}>
       <span className="toast__icon">{TOAST_ICONS[toast.type]}</span>
       <span className="toast__type-label">{typeLabel}</span>
       <p className="toast__message">{toast.message}</p>

--- a/apps/web/src/components/common/VisuallyHidden.test.tsx
+++ b/apps/web/src/components/common/VisuallyHidden.test.tsx
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { VisuallyHidden } from './VisuallyHidden';
+
+describe('VisuallyHidden', () => {
+  it('renders children inside a span by default with the sr-only class', () => {
+    render(<VisuallyHidden>Delete transaction</VisuallyHidden>);
+
+    const el = screen.getByText('Delete transaction');
+    expect(el.tagName).toBe('SPAN');
+    expect(el).toHaveClass('sr-only');
+    expect(el).not.toHaveClass('sr-only-focusable');
+  });
+
+  it('renders as the element supplied via the `as` prop', () => {
+    render(
+      <VisuallyHidden as="div" data-testid="region" aria-live="polite">
+        Saved
+      </VisuallyHidden>,
+    );
+
+    const el = screen.getByTestId('region');
+    expect(el.tagName).toBe('DIV');
+    expect(el).toHaveAttribute('aria-live', 'polite');
+    expect(el).toHaveTextContent('Saved');
+  });
+
+  it('adds the focusable modifier when `focusable` is set', () => {
+    render(
+      <VisuallyHidden as="a" href="#main" focusable>
+        Skip to content
+      </VisuallyHidden>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Skip to content' });
+    expect(link).toHaveClass('sr-only');
+    expect(link).toHaveClass('sr-only-focusable');
+    expect(link).toHaveAttribute('href', '#main');
+  });
+
+  it('merges a caller-supplied className', () => {
+    render(<VisuallyHidden className="extra">Hidden</VisuallyHidden>);
+
+    const el = screen.getByText('Hidden');
+    expect(el).toHaveClass('sr-only');
+    expect(el).toHaveClass('extra');
+  });
+});

--- a/apps/web/src/components/common/VisuallyHidden.tsx
+++ b/apps/web/src/components/common/VisuallyHidden.tsx
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * VisuallyHidden — reusable primitive for screen-reader-only content.
+ *
+ * Renders content that is removed from the visual layout but remains in the
+ * accessibility tree, so assistive technology can read it. Use it for
+ * off-screen labels, live-region text, and supplementary context that would be
+ * redundant or cluttering if shown visually.
+ *
+ * Prefer this typed component over sprinkling `className="sr-only"` strings so
+ * the hiding technique stays consistent across the app (WCAG 1.3.1 Info and
+ * Relationships, 4.1.2 Name, Role, Value).
+ *
+ * The visual hiding is provided by the global `.sr-only` utility defined in
+ * `styles/accessibility.css`.
+ *
+ * @example
+ * ```tsx
+ * <button>
+ *   <TrashIcon aria-hidden="true" />
+ *   <VisuallyHidden>Delete transaction</VisuallyHidden>
+ * </button>
+ *
+ * // Announce dynamic status to screen readers:
+ * <VisuallyHidden as="div" aria-live="polite">{statusMessage}</VisuallyHidden>
+ *
+ * // "Skip link" style content that appears when focused:
+ * <VisuallyHidden as="a" href="#main" focusable>Skip to content</VisuallyHidden>
+ * ```
+ *
+ * @module components/common/VisuallyHidden
+ * References: issue #3601
+ */
+
+import React from 'react';
+
+/** Props shared by every VisuallyHidden rendering, independent of element type. */
+interface VisuallyHiddenOwnProps {
+  /**
+   * When true, the content becomes visible while it (or a descendant) has
+   * focus. Use for interactive off-screen content such as skip links.
+   * @default false
+   */
+  focusable?: boolean;
+  /** Content to hide visually but expose to assistive technology. */
+  children?: React.ReactNode;
+}
+
+/**
+ * Polymorphic element type. Defaults to `'span'` but can render any element
+ * (e.g. `'div'` for a live region, `'a'` for a focusable skip link) via `as`.
+ */
+type VisuallyHiddenProps<E extends React.ElementType> = VisuallyHiddenOwnProps & {
+  /** Element or component to render as. Defaults to `'span'`. */
+  as?: E;
+} & Omit<React.ComponentPropsWithoutRef<E>, keyof VisuallyHiddenOwnProps | 'as'>;
+
+/** Compose the class name for visually-hidden content. */
+function visuallyHiddenClassName(focusable: boolean, className?: string): string {
+  return ['sr-only', focusable ? 'sr-only-focusable' : '', className ?? '']
+    .filter(Boolean)
+    .join(' ');
+}
+
+/**
+ * Reusable screen-reader-only wrapper. Renders a `<span>` by default, or any
+ * element supplied via the `as` prop.
+ */
+export function VisuallyHidden<E extends React.ElementType = 'span'>({
+  as,
+  focusable = false,
+  className,
+  children,
+  ...rest
+}: VisuallyHiddenProps<E>): React.ReactElement {
+  const Component = (as ?? 'span') as React.ElementType;
+  return (
+    <Component className={visuallyHiddenClassName(focusable, className)} {...rest}>
+      {children}
+    </Component>
+  );
+}
+
+export type { VisuallyHiddenProps };
+export default VisuallyHidden;

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -44,6 +44,8 @@ export { SyncStatusPanel } from './SyncStatusPanel';
 export { UpdateBanner } from './UpdateBanner';
 export { SkipLink } from './SkipLink';
 export type { SkipLinkProps } from './SkipLink';
+export { VisuallyHidden } from './VisuallyHidden';
+export type { VisuallyHiddenProps } from './VisuallyHidden';
 export { SortableList } from './SortableList';
 export type {
   SortableListProps,

--- a/apps/web/src/styles/accessibility.css
+++ b/apps/web/src/styles/accessibility.css
@@ -32,10 +32,10 @@
  * Uses :focus-visible to avoid showing focus on mouse clicks.
  * ------------------------------------------------------------------- */
 
-/* Base focus-visible ring */
+/* Base focus-visible ring — driven by focus-ring tokens (theme/tokens.css) */
 :focus-visible {
-  outline: 2px solid var(--semantic-border-focus, #3b82f6);
-  outline-offset: 2px;
+  outline: var(--focus-ring, 2px solid var(--semantic-border-focus, #3b82f6));
+  outline-offset: var(--focus-ring-offset, 2px);
 }
 
 /* Enhanced focus for buttons and links */
@@ -48,8 +48,8 @@ a:focus-visible,
 select:focus-visible,
 input:focus-visible,
 textarea:focus-visible {
-  outline: 2px solid var(--semantic-border-focus, #3b82f6);
-  outline-offset: 2px;
+  outline: var(--focus-ring, 2px solid var(--semantic-border-focus, #3b82f6));
+  outline-offset: var(--focus-ring-offset, 2px);
   border-radius: inherit;
 }
 
@@ -57,8 +57,8 @@ textarea:focus-visible {
 [role='listbox']:focus-within,
 [role='menu']:focus-within,
 [role='tablist']:focus-within {
-  outline: 2px solid var(--semantic-border-focus, #3b82f6);
-  outline-offset: 2px;
+  outline: var(--focus-ring, 2px solid var(--semantic-border-focus, #3b82f6));
+  outline-offset: var(--focus-ring-offset, 2px);
 }
 
 /* High contrast mode: stronger focus indicators */
@@ -321,6 +321,23 @@ html[data-reduced-motion='true'] *::after {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border-width: 0;
+}
+
+/*
+ * Focusable variant: visually hidden until the element (or a descendant)
+ * receives focus, then rendered on-screen. Used by the VisuallyHidden
+ * primitive for skip-link-style "hidden unless focused" content.
+ */
+.sr-only-focusable:focus,
+.sr-only-focusable:focus-within {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: revert;
+  margin: revert;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
 }
 
 /* -------------------------------------------------------------------

--- a/apps/web/src/theme/tokens.css
+++ b/apps/web/src/theme/tokens.css
@@ -133,9 +133,28 @@ body {
 }
 
 /*
+ * Focus ring tokens — single source of truth for the keyboard focus
+ * indicator (WCAG 2.4.7 Focus Visible, 2.4.11 Focus Not Obscured,
+ * 2.4.13 Focus Appearance). Consumed by styles/accessibility.css and
+ * component stylesheets so width, offset, and color stay consistent and
+ * can be tuned per theme in one place.
+ *
+ * A 2px solid outline satisfies the 2.4.13 minimum-area requirement (an
+ * indicator at least as thick as a 2 CSS-px perimeter). --focus-ring-color
+ * resolves to --semantic-border-focus, which is themed to keep >=3:1
+ * contrast against adjacent surfaces.
+ */
+:root {
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 2px;
+  --focus-ring-color: var(--semantic-border-focus);
+  --focus-ring: var(--focus-ring-width) solid var(--focus-ring-color);
+}
+
+/*
  * Focus styles - visible outline for keyboard navigation (WCAG 2.4.7).
  */
 :focus-visible {
-  outline: 2px solid var(--semantic-border-focus);
-  outline-offset: 2px;
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
 }


### PR DESCRIPTION
﻿## Summary

Adds cross-cutting **WCAG 2.2 AA** accessibility primitives to `apps/web` (React 19 + TypeScript). Scope is deliberately limited to shared/reusable components and tokens to minimize conflicts with feature-specific work.

### Changes

**1. VisuallyHidden component (#3601)**
- New typed, polymorphic screen-reader-only primitive at `components/common/VisuallyHidden.tsx`.
- Defaults to `<span>`; `as` prop renders any element (e.g. `div` live region, `a` skip link).
- Optional `focusable` prop (adds `.sr-only-focusable`) for skip-link-style content that appears on focus.
- Replaces ad-hoc `className="sr-only"` sprinkling with a consistent, discoverable API. Exported from `common/index.ts`.
- WCAG 1.3.1 Info and Relationships, 4.1.2 Name, Role, Value.

**2. Focus-ring design tokens (#3609, #3610)**
- Added `--focus-ring-width`, `--focus-ring-offset`, `--focus-ring-color`, and `--focus-ring` tokens to `theme/tokens.css`.
- Refactored base `:focus-visible` rules in `tokens.css` and `styles/accessibility.css` to consume them (with literal fallbacks), giving a single, themeable source of truth for focus appearance.
- Added a `.sr-only-focusable` CSS variant.
- WCAG 2.4.7 Focus Visible, 2.4.13 Focus Appearance.

**3. Reliable toast announcements (#3603, #3606)**
- `ToastProvider` now renders **persistent, empty** live regions — polite (`role=status`) and assertive (`role=alert`) — populated on `showToast`. Live regions must exist empty in the DOM *before* text is injected to announce reliably; the previous implementation inserted pre-filled role nodes, which assistive tech often fails to announce.
- Errors route to the assertive region; everything else to polite.
- `ToastItem` is now presentational only: no live-region role and no `aria-label` (an accessible name on a live region can suppress or duplicate the announced message). The visible severity label is retained.
- Public API (`useToast` / `showToast` / `dismissToast`) is unchanged.
- WCAG 4.1.3 Status Messages.

## Issues closed
Closes #3601
Closes #3603
Closes #3606
Closes #3609
Closes #3610

## Testing
- Added `VisuallyHidden.test.tsx` (4 tests) and rewrote the toast live-region tests in `Toast.test.tsx` to target the dedicated regions and assert they mount empty.
- All changed files verified Prettier-clean via standalone `prettier`.
- Local ESLint / Vitest / type-check could not run in this cloud environment (monorepo install did not complete). Per AGENTS.md, remote CI is the source of truth for lint and type-check; CI will be monitored and self-healed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
