### PR TITLE
feat(ios): reachable Settings, theme override, and dashboard a11y/token polish

### DIFF
--- a/apps/ios/Finance/Components/CurrencyLabel.swift
+++ b/apps/ios/Finance/Components/CurrencyLabel.swift
@@ -49,7 +49,48 @@ struct CurrencyLabel: View {
 
     // MARK: - Private
 
-    private var decimalPlaces: Int {
+    private var formattedAmount: String {
+        let base = Self.formatted(
+            minorUnits: amountInMinorUnits,
+            currencyCode: currencyCode
+        )
+        // Reinforce sign with a non-color cue (WCAG 1.4.1): negatives already
+        // carry a leading "-" from the formatter, so add an explicit "+" for
+        // positive signed amounts. (#3594)
+        if showSign, amountInMinorUnits > 0 {
+            return "+\(base)"
+        }
+        return base
+    }
+
+    private var amountColor: Color {
+        guard showSign else { return .primary }
+        // Use WCAG-tuned semantic tokens rather than raw system colors so
+        // amounts keep sufficient contrast on light/dark surfaces. (#3579)
+        if amountInMinorUnits > 0 { return FinanceColors.amountPositive }
+        if amountInMinorUnits < 0 { return FinanceColors.amountNegative }
+        return .primary
+    }
+
+    private var accessibilityDescription: String {
+        let formatted = Self.formatted(
+            minorUnits: amountInMinorUnits,
+            currencyCode: currencyCode
+        )
+        if showSign && amountInMinorUnits > 0 {
+            return String(localized: "Income of \(formatted)")
+        } else if showSign && amountInMinorUnits < 0 {
+            return String(localized: "Expense of \(formatted)")
+        }
+        return formatted
+    }
+}
+
+// MARK: - Reusable Formatting
+
+extension CurrencyLabel {
+    /// Minor-unit decimal places for a given ISO currency code.
+    static func decimalPlaces(for currencyCode: String) -> Int {
         switch currencyCode {
         case "JPY", "KRW", "VND": 0
         case "BHD", "KWD", "OMR": 3
@@ -57,35 +98,18 @@ struct CurrencyLabel: View {
         }
     }
 
-    private var currencyFormatter: NumberFormatter {
-        Self.formatterCache.formatter(currencyCode: currencyCode, decimalPlaces: decimalPlaces)
-    }
-
-    private var formattedAmount: String {
-        let divisor = NSDecimalNumber(decimal: pow(10, decimalPlaces))
-        let amount = NSDecimalNumber(value: amountInMinorUnits)
+    /// Formats a minor-unit amount as a localized currency string.
+    ///
+    /// Exposed so other views (e.g. accessibility labels that combine an
+    /// amount with surrounding context) can reuse the exact same formatting
+    /// and cached formatters as `CurrencyLabel` itself.
+    static func formatted(minorUnits: Int64, currencyCode: String) -> String {
+        let places = decimalPlaces(for: currencyCode)
+        let formatter = formatterCache.formatter(currencyCode: currencyCode, decimalPlaces: places)
+        let divisor = NSDecimalNumber(decimal: pow(10, places))
+        let amount = NSDecimalNumber(value: minorUnits)
         let majorUnits = amount.dividing(by: divisor)
-        return currencyFormatter.string(from: majorUnits) ?? "\(currencyCode) \(amountInMinorUnits)"
-    }
-
-    private var amountColor: Color {
-        guard showSign else { return .primary }
-        if amountInMinorUnits > 0 { return .green }
-        if amountInMinorUnits < 0 { return .red }
-        return .primary
-    }
-
-    private var accessibilityDescription: String {
-        let divisor = NSDecimalNumber(decimal: pow(10, decimalPlaces))
-        let amount = NSDecimalNumber(value: amountInMinorUnits)
-        let majorUnits = amount.dividing(by: divisor)
-        let formatted = currencyFormatter.string(from: majorUnits) ?? "\(amountInMinorUnits) \(currencyCode)"
-        if showSign && amountInMinorUnits > 0 {
-            return String(localized: "Income of \(formatted)")
-        } else if showSign && amountInMinorUnits < 0 {
-            return String(localized: "Expense of \(formatted)")
-        }
-        return formatted
+        return formatter.string(from: majorUnits) ?? "\(currencyCode) \(minorUnits)"
     }
 }
 

--- a/apps/ios/Finance/FinanceApp.swift
+++ b/apps/ios/Finance/FinanceApp.swift
@@ -27,6 +27,7 @@ struct FinanceApp: App {
         forKey: OnboardingView.hasCompletedOnboardingKey
     )
     @State private var showConsent = !ConsentManager.shared.hasShownConsentDialog
+    @AppStorage(AppThemePreference.key) private var themePreferenceRaw = AppThemePreference.system.rawValue
     @Environment(\.scenePhase) private var scenePhase
 
     private static let logger = Logger(
@@ -77,6 +78,9 @@ struct FinanceApp: App {
                 )
                 deepLinkHandler.handle(url)
             }
+            .preferredColorScheme(
+                AppThemePreference.resolved(from: themePreferenceRaw).colorScheme
+            )
             .onChange(of: scenePhase) { _, newPhase in
                 handleScenePhaseChange(newPhase)
             }

--- a/apps/ios/Finance/Screens/AppearanceSettingsView.swift
+++ b/apps/ios/Finance/Screens/AppearanceSettingsView.swift
@@ -4,11 +4,26 @@ import SwiftUI
 
 struct AppearanceSettingsView: View {
     @AppStorage(IconPackPreference.key) private var selectedIconPackId = IconPackID.defaultIOS.rawValue
+    @AppStorage(AppThemePreference.key) private var themePreferenceRaw = AppThemePreference.system.rawValue
 
     private let previewTokens: [IconToken] = [.home, .transactions, .budget, .settings]
 
     var body: some View {
         Form {
+            Section(String(localized: "Theme")) {
+                Picker(String(localized: "Theme"), selection: $themePreferenceRaw) {
+                    ForEach(AppThemePreference.allCases) { theme in
+                        Text(theme.displayName).tag(theme.rawValue)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("theme_picker")
+                .accessibilityLabel(String(localized: "App theme"))
+                .accessibilityHint(String(localized: "Choose System, Light, or Dark appearance"))
+            } footer: {
+                Text(String(localized: "System follows your device's appearance. Light and Dark override it everywhere in Finance."))
+            }
+
             Section(String(localized: "Icon Style")) {
                 Picker(String(localized: "Icon Style"), selection: $selectedIconPackId) {
                     ForEach(IconPackID.allCases) { pack in

--- a/apps/ios/Finance/Screens/DashboardView.swift
+++ b/apps/ios/Finance/Screens/DashboardView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct DashboardView: View {
     @State private var viewModel: DashboardViewModel
     @State private var showingAskFinance = false
+    @State private var showingSettings = false
     @Environment(NetworkMonitor.self) private var networkMonitor: NetworkMonitor?
 
     init(viewModel: DashboardViewModel = DashboardViewModel(
@@ -27,12 +28,10 @@ struct DashboardView: View {
         NavigationStack {
             Group {
                 if viewModel.isLoading && viewModel.accounts.isEmpty {
-                    ProgressView()
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .accessibilityLabel(String(localized: "Loading"))
+                    DashboardSkeletonView()
                 } else {
                     ScrollView {
-                        VStack(spacing: 20) {
+                        VStack(spacing: FinanceSpacing.lg) {
                             if let monitor = networkMonitor, !monitor.isConnected {
                                 OfflineBanner()
                             }
@@ -44,7 +43,7 @@ struct DashboardView: View {
                             recentTransactionsSection
                         }
                         .padding(.horizontal)
-                        .padding(.bottom, 20)
+                        .padding(.bottom, FinanceSpacing.lg)
                     }
                 }
             }
@@ -58,9 +57,20 @@ struct DashboardView: View {
                     .accessibilityLabel(String(localized: "Ask Finance"))
                     .accessibilityHint(String(localized: "Ask a natural-language question about your money"))
                 }
+                ToolbarItem(placement: .topBarLeading) {
+                    Button { showingSettings = true } label: {
+                        Image(systemName: "gearshape")
+                    }
+                    .accessibilityIdentifier("settings_button")
+                    .accessibilityLabel(String(localized: "Settings"))
+                    .accessibilityHint(String(localized: "Opens app settings"))
+                }
             }
             .sheet(isPresented: $showingAskFinance) {
                 FinanceQueryView()
+            }
+            .sheet(isPresented: $showingSettings) {
+                SettingsView()
             }
             .refreshable { await viewModel.loadDashboard() }
             .task { await viewModel.loadDashboard() }
@@ -79,7 +89,7 @@ struct DashboardView: View {
     // MARK: - Net Worth Card
 
     private var netWorthCard: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: FinanceSpacing.xs) {
             Text(String(localized: "Net Worth"))
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
@@ -89,13 +99,37 @@ struct DashboardView: View {
                 showSign: false,
                 font: .largeTitle.bold()
             )
+            .foregroundStyle(netWorthColor)
+            .accessibilityLabel(netWorthAccessibilityLabel)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 24)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
-        .accessibilityElement(children: .combine)
+        .padding(.vertical, FinanceSpacing.xl)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl))
         .accessibilityIdentifier("net_worth_card")
-        .accessibilityLabel(String(localized: "Net Worth"))
+    }
+
+    /// Net worth < 0 is emphasized with the negative semantic token so it is
+    /// not visually identical to a positive balance. (#3593)
+    private var netWorthColor: Color {
+        viewModel.netWorth < 0 ? FinanceColors.amountNegative : .primary
+    }
+
+    /// Spoken label for the net-worth amount so VoiceOver conveys the figure
+    /// and, when negative, an explicit qualifier. The "Net Worth" caption
+    /// remains a discrete element for context. (#3578, #3593)
+    private var netWorthAccessibilityLabel: String {
+        if viewModel.netWorth < 0 {
+            let amount = CurrencyLabel.formatted(
+                minorUnits: abs(viewModel.netWorth),
+                currencyCode: viewModel.currencyCode
+            )
+            return String(localized: "Net worth, negative \(amount)")
+        }
+        let amount = CurrencyLabel.formatted(
+            minorUnits: viewModel.netWorth,
+            currencyCode: viewModel.currencyCode
+        )
+        return String(localized: "Net worth, \(amount)")
     }
 
     // MARK: - Savings Rate (#2162)
@@ -171,23 +205,32 @@ struct DashboardView: View {
     // MARK: - Spending Summary
 
     private var spendingSummaryCard: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
             Text(String(localized: "This Month"))
                 .font(.headline)
-            HStack(spacing: 16) {
+            HStack(spacing: FinanceSpacing.md) {
                 summaryColumn(title: String(localized: "Income"), amount: viewModel.monthlyIncome)
-                Divider().frame(height: 44)
+                Divider().frame(height: FinanceSpacing.minTapTarget)
                 summaryColumn(title: String(localized: "Expenses"), amount: viewModel.monthlyExpenses)
-                Divider().frame(height: 44)
+                Divider().frame(height: FinanceSpacing.minTapTarget)
                 summaryColumn(title: String(localized: "Net"), amount: viewModel.monthlyIncome - viewModel.monthlyExpenses)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
-        .accessibilityElement(children: .combine)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl))
+        .accessibilityElement(children: .ignore)
         .accessibilityIdentifier("spending_summary_card")
-        .accessibilityLabel(String(localized: "Monthly spending summary"))
+        .accessibilityLabel(spendingSummaryAccessibilityLabel)
+    }
+
+    /// Composes the three amounts into one spoken label so VoiceOver conveys
+    /// the actual figures rather than just "Monthly spending summary". (#3578)
+    private var spendingSummaryAccessibilityLabel: String {
+        let income = CurrencyLabel.formatted(minorUnits: viewModel.monthlyIncome, currencyCode: viewModel.currencyCode)
+        let expenses = CurrencyLabel.formatted(minorUnits: viewModel.monthlyExpenses, currencyCode: viewModel.currencyCode)
+        let net = CurrencyLabel.formatted(minorUnits: viewModel.monthlyIncome - viewModel.monthlyExpenses, currencyCode: viewModel.currencyCode)
+        return String(localized: "This month. Income \(income). Expenses \(expenses). Net \(net).")
     }
 
     private func summaryColumn(title: String, amount: Int64) -> some View {
@@ -201,12 +244,22 @@ struct DashboardView: View {
     // MARK: - Budget Health
 
     private var budgetHealthSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
             Text(String(localized: "Budget Health")).font(.headline)
             ScrollView(.horizontal, showsIndicators: false) {
-                LazyHStack(spacing: 16) {
+                LazyHStack(spacing: FinanceSpacing.md) {
                     ForEach(viewModel.budgets) { budget in
-                        budgetHealthCard(budget)
+                        NavigationLink {
+                            BudgetsView()
+                        } label: {
+                            budgetHealthCard(budget)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(budget.name)
+                        .accessibilityValue(String(localized: "\(Int(budget.progress * 100)) percent of budget used"))
+                        .accessibilityHint(String(localized: "Opens your budgets"))
+                        .accessibilityAddTraits(.isButton)
                     }
                 }
                 .padding(.horizontal, 1)
@@ -215,22 +268,20 @@ struct DashboardView: View {
     }
 
     private func budgetHealthCard(_ budget: BudgetItem) -> some View {
-        VStack(spacing: 8) {
+        VStack(spacing: FinanceSpacing.xs) {
             ProgressRing(progress: budget.progress, lineWidth: 6, progressColor: budget.progressColor, size: 60)
             Text(budget.name).font(.caption).foregroundStyle(.secondary).lineLimit(1)
         }
         .frame(width: 80)
-        .padding(.vertical, 12).padding(.horizontal, 8)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(budget.name)
-        .accessibilityValue(String(localized: "\(Int(budget.progress * 100)) percent of budget used"))
+        .padding(.vertical, FinanceSpacing.sm).padding(.horizontal, FinanceSpacing.xs)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.lg))
+        .accessibilityElement(children: .ignore)
     }
 
     // MARK: - Quick Access
 
     private var quickAccessSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
             Text(String(localized: "More"))
                 .font(.headline)
                 .accessibilityAddTraits(.isHeader)
@@ -239,7 +290,7 @@ struct DashboardView: View {
                 GridItem(.flexible()),
                 GridItem(.flexible()),
                 GridItem(.flexible()),
-            ], spacing: 12) {
+            ], spacing: FinanceSpacing.sm) {
                 NavigationLink {
                     InvestmentPortfolioView()
                 } label: {
@@ -280,25 +331,25 @@ struct DashboardView: View {
     }
 
     private func quickAccessCard(title: String, iconToken: IconToken, color: Color) -> some View {
-        VStack(spacing: 8) {
+        VStack(spacing: FinanceSpacing.xs) {
             IconView(iconToken, size: 22)
                 .foregroundStyle(color)
-                .frame(width: 44, height: 44)
-                .background(color.opacity(0.1), in: RoundedRectangle(cornerRadius: 12))
+                .frame(width: FinanceSpacing.minTapTarget, height: FinanceSpacing.minTapTarget)
+                .background(color.opacity(0.1), in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.lg))
             Text(title)
                 .font(.caption)
                 .foregroundStyle(.primary)
                 .lineLimit(1)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 12)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .padding(.vertical, FinanceSpacing.sm)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.lg))
     }
 
     // MARK: - Recent Transactions
 
     private var recentTransactionsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
             HStack {
                 Text(String(localized: "Recent Transactions")).font(.headline)
                 Spacer()
@@ -321,32 +372,74 @@ struct DashboardView: View {
                     ForEach(viewModel.recentTransactions) { transaction in
                         transactionRow(transaction)
                         if transaction.id != viewModel.recentTransactions.last?.id {
-                            Divider().padding(.leading, 44)
+                            Divider().padding(.leading, FinanceSpacing.minTapTarget)
                         }
                     }
                 }
                 .padding()
-                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl))
             }
         }
     }
 
     private func transactionRow(_ transaction: TransactionItem) -> some View {
-        HStack(spacing: 12) {
+        HStack(spacing: FinanceSpacing.sm) {
             IconView(transaction.isExpense ? .expense : .income, size: 16)
-                .foregroundStyle(transaction.isExpense ? .red : .green)
+                .foregroundStyle(transaction.isExpense ? FinanceColors.amountNegative : FinanceColors.amountPositive)
                 .frame(width: 32, height: 32)
-                .background((transaction.isExpense ? Color.red : Color.green).opacity(0.1), in: Circle())
-            VStack(alignment: .leading, spacing: 2) {
+                .background((transaction.isExpense ? FinanceColors.amountNegative : FinanceColors.amountPositive).opacity(0.1), in: Circle())
+            VStack(alignment: .leading, spacing: FinanceSpacing.xxs) {
                 Text(transaction.payee).font(.body).lineLimit(1)
                 Text(transaction.category).font(.caption).foregroundStyle(.secondary)
             }
             Spacer()
             CurrencyLabel(amountInMinorUnits: transaction.amountMinorUnits, currencyCode: transaction.currencyCode, font: .callout.bold())
         }
-        .padding(.vertical, 6)
+        .padding(.vertical, FinanceSpacing.xxs)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(transaction.accessibilityRowLabel(includeAccount: false))
+    }
+}
+
+// MARK: - Loading Skeleton
+
+/// A content-shaped placeholder shown during the dashboard's initial load.
+///
+/// Mirrors the real card stack and uses `.redacted(reason: .placeholder)` so
+/// the layout doesn't shift when data arrives, reducing perceived latency.
+/// The skeleton is hidden from VoiceOver and announces a single "Loading"
+/// status instead. (#3582)
+private struct DashboardSkeletonView: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: FinanceSpacing.lg) {
+                card(height: 96)
+                card(height: 120)
+                card(height: 110)
+                HStack(spacing: FinanceSpacing.md) {
+                    ForEach(0..<3, id: \.self) { _ in
+                        RoundedRectangle(cornerRadius: FinanceSpacing.Radius.lg)
+                            .fill(.regularMaterial)
+                            .frame(width: 80, height: 96)
+                    }
+                    Spacer(minLength: 0)
+                }
+                card(height: 160)
+            }
+            .padding(.horizontal)
+            .padding(.bottom, FinanceSpacing.lg)
+        }
+        .redacted(reason: .placeholder)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(localized: "Loading"))
+        .accessibilityAddTraits(.updatesFrequently)
+    }
+
+    private func card(height: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl)
+            .fill(.regularMaterial)
+            .frame(maxWidth: .infinity)
+            .frame(height: height)
     }
 }
 

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -157,11 +157,11 @@ struct SettingsView: View {
             } label: {
                 HStack {
                     IconView(.settings, size: 20)
-                    Text(String(localized: "Icon Style"))
+                    Text(String(localized: "Theme & Icons"))
                 }
             }
-            .accessibilityLabel(String(localized: "Icon Style"))
-            .accessibilityHint(String(localized: "Choose between Standard Lucide icons and SF Symbols"))
+            .accessibilityLabel(String(localized: "Theme and icons"))
+            .accessibilityHint(String(localized: "Choose appearance and icon style"))
         }
     }
 

--- a/apps/ios/Finance/Theme/AppThemePreference.swift
+++ b/apps/ios/Finance/Theme/AppThemePreference.swift
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// AppThemePreference.swift
+// Finance
+//
+// User-selectable appearance override (System / Light / Dark) applied at the
+// app root via `.preferredColorScheme`. Persisted in UserDefaults so the
+// choice survives launches. References: #3581
+
+import SwiftUI
+
+/// A user preference that overrides the system color scheme app-wide.
+///
+/// `system` defers to the OS setting; `light` and `dark` force the
+/// corresponding appearance regardless of the system schedule.
+enum AppThemePreference: String, CaseIterable, Identifiable, Sendable {
+    case system
+    case light
+    case dark
+
+    /// `@AppStorage` key backing this preference.
+    static let key = "appThemePreference"
+
+    var id: String { rawValue }
+
+    /// Localized label shown in the appearance picker.
+    var displayName: String {
+        switch self {
+        case .system: String(localized: "System")
+        case .light: String(localized: "Light")
+        case .dark: String(localized: "Dark")
+        }
+    }
+
+    /// The SwiftUI `ColorScheme` to force, or `nil` to follow the system.
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: nil
+        case .light: .light
+        case .dark: .dark
+        }
+    }
+
+    /// Resolves a stored raw value to a preference, defaulting to `.system`.
+    static func resolved(from rawValue: String) -> AppThemePreference {
+        AppThemePreference(rawValue: rawValue) ?? .system
+    }
+}

--- a/apps/ios/Tests/CurrencyFormattingTests.swift
+++ b/apps/ios/Tests/CurrencyFormattingTests.swift
@@ -119,4 +119,27 @@ final class CurrencyFormattingTests: XCTestCase {
         let result = format(1_000_000_000, currencyCode: "USD")
         XCTAssertNotNil(result, "Formatter should handle large amounts")
     }
+
+    // MARK: - Reusable Static Formatter (#3578, #3579)
+
+    func testStaticDecimalPlacesMatchesReference() {
+        XCTAssertEqual(CurrencyLabel.decimalPlaces(for: "USD"), 2)
+        XCTAssertEqual(CurrencyLabel.decimalPlaces(for: "JPY"), 0)
+        XCTAssertEqual(CurrencyLabel.decimalPlaces(for: "BHD"), 3)
+    }
+
+    func testStaticFormattedProducesCurrencyString() {
+        let result = CurrencyLabel.formatted(minorUnits: 125_050, currencyCode: "USD")
+        XCTAssertTrue(result.contains("1,250.50"),
+                      "USD 125050 minor units should format to 1,250.50, got \(result)")
+    }
+
+    func testStaticFormattedHandlesNegativeAndZeroDecimalCurrencies() {
+        let negative = CurrencyLabel.formatted(minorUnits: -42_99, currencyCode: "USD")
+        XCTAssertTrue(negative.contains("42.99"),
+                      "Negative amount should still contain the magnitude, got \(negative)")
+        let jpy = CurrencyLabel.formatted(minorUnits: 15_000, currencyCode: "JPY")
+        XCTAssertFalse(jpy.contains(".0"),
+                       "JPY should format without decimal places, got \(jpy)")
+    }
 }


### PR DESCRIPTION
﻿## Summary

Implements a coherent, iOS-only UX subset from the Phase 1 critique. **All changes are strictly within `apps/ios`** to avoid conflicts with other parallel sessions.

The standout fix: **the Settings screen was completely unreachable** — `SettingsView` was fully built and tested but only referenced from its own `#Preview`. There was no tab, toolbar, sheet, or deep link that opened it, so users could not reach biometric app-lock, notifications, appearance, data export/deletion, or sync.

## Changes

- **Settings reachable (#3577)** — adds a `gearshape` toolbar button on the Dashboard that presents `SettingsView` as a sheet (it already hosts its own `NavigationStack`). Fully labelled for VoiceOver, 44pt target.
- **VoiceOver announces amounts (#3578)** — the Net Worth and Monthly Spending cards previously combined children and then overrode the label, dropping the dollar figures from VoiceOver. Amounts are now spoken. The "Net Worth" caption stays a discrete element (keeps existing UI test valid).
- **Semantic amount colors (#3579, #3594)** — `CurrencyLabel` and dashboard rows now use WCAG-tuned `FinanceColors.amountPositive/amountNegative` instead of raw `.green`/`.red`, and signed positives get an explicit `+` so meaning isn't color-only.
- **Spacing tokens (#3580)** — Dashboard magic numbers replaced with `FinanceSpacing` / `FinanceSpacing.Radius` tokens.
- **Manual appearance override (#3581)** — new `AppThemePreference` (System/Light/Dark) with a segmented picker in `AppearanceSettingsView`, persisted via `@AppStorage` and applied app-wide with `preferredColorScheme` at the root.
- **Skeleton loading (#3582)** — Dashboard initial load now shows a content-shaped `.redacted(reason: .placeholder)` skeleton instead of a bare spinner; hidden from VoiceOver with a single "Loading" announcement.
- **Navigable budget rings (#3591)** — Budget Health cards are now `NavigationLink`s with button traits + hints.
- **Negative net worth (#3593)** — negative balances use the negative semantic color and a spoken "negative" qualifier.

## Testing

- Added unit tests for the new reusable `CurrencyLabel.formatted`/`decimalPlaces` static helpers.
- Swift is prettier-ignored and eslint-ignored; the diff touches no JS/TS/JSON/MD/YAML, so `format:check` / `eslint` are unaffected. iOS build/tests run via the iOS CI workflow.

## Issues

Closes #3577
Closes #3578
Closes #3579
Closes #3580
Closes #3581
Closes #3582
Closes #3591
Closes #3593
Closes #3594
