### PR TITLE
feat(web): shared feedback-UX primitives — useAsyncAction, ErrorState, entity skeletons

### DIFF
--- a/apps/web/src/components/common/EmptyState.test.tsx
+++ b/apps/web/src/components/common/EmptyState.test.tsx
@@ -25,4 +25,14 @@ describe('EmptyState', () => {
     expect(screen.getByTestId('empty-state-icon')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create account' })).toBeInTheDocument();
   });
+
+  it('renders the title as an h2 by default', () => {
+    render(<EmptyState title="No accounts" />);
+    expect(screen.getByRole('heading', { name: 'No accounts' }).tagName).toBe('H2');
+  });
+
+  it('honours a custom heading level', () => {
+    render(<EmptyState title="No accounts" headingLevel={3} />);
+    expect(screen.getByRole('heading', { name: 'No accounts' }).tagName).toBe('H3');
+  });
 });

--- a/apps/web/src/components/common/EmptyState.tsx
+++ b/apps/web/src/components/common/EmptyState.tsx
@@ -9,6 +9,11 @@ export interface EmptyStateProps {
   description?: string;
   action?: React.ReactNode;
   className?: string;
+  /**
+   * Heading level for the title, so the empty state slots correctly into the
+   * surrounding document outline (WCAG 1.3.1 / heading-order). @default 2
+   */
+  headingLevel?: 2 | 3 | 4 | 5 | 6;
 }
 
 export const EmptyState: React.FC<EmptyStateProps> = ({
@@ -17,7 +22,9 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   description,
   action,
   className = '',
+  headingLevel = 2,
 }) => {
+  const Heading = `h${headingLevel}` as const;
   return (
     <section className={`empty-state ${className}`.trim()} role="status" aria-label={title}>
       {icon && (
@@ -25,7 +32,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
           {icon}
         </div>
       )}
-      <h2 className="empty-state__title">{title}</h2>
+      <Heading className="empty-state__title">{title}</Heading>
       {description && <p className="empty-state__description">{description}</p>}
       {action && <div className="empty-state__action">{action}</div>}
     </section>

--- a/apps/web/src/components/common/EntitySkeletons.test.tsx
+++ b/apps/web/src/components/common/EntitySkeletons.test.tsx
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { BudgetsSkeleton, GoalsSkeleton, ListSkeleton } from './EntitySkeletons';
+
+describe('EntitySkeletons', () => {
+  it('BudgetsSkeleton marks the region as busy', () => {
+    const { container } = render(<BudgetsSkeleton />);
+    const root = container.querySelector('.skeleton-page--budgets');
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('GoalsSkeleton renders a card grid', () => {
+    const { container } = render(<GoalsSkeleton />);
+    expect(container.querySelector('.skeleton-page--goals')).toBeInTheDocument();
+    expect(container.querySelectorAll('.skeleton-page__card').length).toBeGreaterThan(0);
+  });
+
+  it('ListSkeleton renders the requested number of rows and an accessible label', () => {
+    render(<ListSkeleton rows={3} aria-label="Loading budgets" />);
+    const region = screen.getByLabelText('Loading budgets');
+    expect(region).toHaveAttribute('aria-busy', 'true');
+    expect(region.querySelectorAll('.skeleton-page__row').length).toBe(3);
+  });
+});

--- a/apps/web/src/components/common/EntitySkeletons.tsx
+++ b/apps/web/src/components/common/EntitySkeletons.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type React from 'react';
+
+import { Skeleton, type PageSkeletonProps } from './Skeleton';
+
+import './entity-skeletons.css';
+
+/* --------------------------------------------------------------------------
+ * Additional page-specific composite skeletons
+ *
+ * Extends the Accounts / Transactions / Dashboard composites in `Skeleton.tsx`
+ * to cover the remaining primary entity pages, keeping loading UX consistent
+ * app-wide. Each composite reuses the `Skeleton` primitive (which already
+ * respects `prefers-reduced-motion`) and sets `aria-busy`.
+ * -------------------------------------------------------------------------- */
+
+/** Props for the {@link ListSkeleton} generic composite. */
+export interface ListSkeletonProps extends PageSkeletonProps {
+  /** Number of placeholder rows to render. @default 5 */
+  rows?: number;
+  /** Accessible label describing what is loading. @default 'Loading list' */
+  'aria-label'?: string;
+}
+
+/**
+ * Generic list skeleton for any entity page that renders a title and a list of
+ * rows. Use when a bespoke composite is unnecessary.
+ */
+export const ListSkeleton: React.FC<ListSkeletonProps> = ({
+  className = '',
+  rows = 5,
+  'aria-label': ariaLabel = 'Loading list',
+}) => (
+  <div
+    className={`skeleton-page skeleton-page--list ${className}`.trim()}
+    aria-busy="true"
+    aria-label={ariaLabel}
+  >
+    <Skeleton variant="line" width="40%" height="24px" aria-label="Loading page title" />
+    <div className="skeleton-page__list">
+      {Array.from({ length: rows }, (_, i) => (
+        <div className="skeleton-page__row" key={i}>
+          <Skeleton variant="circle" width="36px" height="36px" aria-label="Loading icon" />
+          <div className="skeleton-page__row-text">
+            <Skeleton variant="line" width="55%" height="16px" aria-label="Loading title" />
+            <Skeleton variant="line" width="25%" height="14px" aria-label="Loading detail" />
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+/**
+ * Skeleton layout mimicking the Budgets page.
+ * Shows a header line, summary cards, and a list of budget rows each with a
+ * progress-bar placeholder.
+ */
+export const BudgetsSkeleton: React.FC<PageSkeletonProps> = ({ className = '' }) => (
+  <div className={`skeleton-page skeleton-page--budgets ${className}`.trim()} aria-busy="true">
+    <Skeleton variant="line" width="35%" height="24px" aria-label="Loading page title" />
+    <div className="skeleton-page__summary">
+      <Skeleton
+        variant="rectangle"
+        width="100%"
+        height="80px"
+        aria-label="Loading budget summary"
+      />
+      <Skeleton
+        variant="rectangle"
+        width="100%"
+        height="80px"
+        aria-label="Loading budget summary"
+      />
+    </div>
+    <div className="skeleton-page__list">
+      {Array.from({ length: 4 }, (_, i) => (
+        <div className="skeleton-page__row" key={i}>
+          <Skeleton
+            variant="circle"
+            width="36px"
+            height="36px"
+            aria-label="Loading category icon"
+          />
+          <div className="skeleton-page__row-text">
+            <Skeleton variant="line" width="45%" height="16px" aria-label="Loading budget name" />
+            <Skeleton
+              variant="rectangle"
+              width="100%"
+              height="8px"
+              borderRadius="9999px"
+              aria-label="Loading budget progress"
+            />
+          </div>
+          <Skeleton variant="line" width="15%" height="14px" aria-label="Loading budget amount" />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+/**
+ * Skeleton layout mimicking the Goals page.
+ * Shows a header line and a grid of goal cards, each with a progress ring
+ * placeholder and supporting text lines.
+ */
+export const GoalsSkeleton: React.FC<PageSkeletonProps> = ({ className = '' }) => (
+  <div className={`skeleton-page skeleton-page--goals ${className}`.trim()} aria-busy="true">
+    <Skeleton variant="line" width="30%" height="24px" aria-label="Loading page title" />
+    <div className="skeleton-page__grid">
+      {Array.from({ length: 4 }, (_, i) => (
+        <div className="skeleton-page__card" key={i}>
+          <Skeleton
+            variant="circle"
+            width="56px"
+            height="56px"
+            aria-label="Loading goal progress"
+          />
+          <Skeleton variant="line" width="70%" height="16px" aria-label="Loading goal name" />
+          <Skeleton variant="line" width="45%" height="14px" aria-label="Loading goal target" />
+          <Skeleton
+            variant="rectangle"
+            width="100%"
+            height="8px"
+            borderRadius="9999px"
+            aria-label="Loading goal progress bar"
+          />
+        </div>
+      ))}
+    </div>
+  </div>
+);

--- a/apps/web/src/components/common/ErrorState.test.tsx
+++ b/apps/web/src/components/common/ErrorState.test.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ErrorState } from './ErrorState';
+
+describe('ErrorState', () => {
+  it('renders title, description, and a default alert role', () => {
+    render(<ErrorState title="Couldn't load budgets" description="Try again shortly." />);
+
+    const region = screen.getByRole('alert');
+    expect(region).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: "Couldn't load budgets" })).toBeInTheDocument();
+    expect(screen.getByText('Try again shortly.')).toBeInTheDocument();
+  });
+
+  it('renders a retry button that calls onRetry', () => {
+    const onRetry = vi.fn();
+    render(<ErrorState title="Failed" onRetry={onRetry} />);
+
+    const button = screen.getByRole('button', { name: 'Try again' });
+    fireEvent.click(button);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects a busy state while retrying', () => {
+    render(<ErrorState title="Failed" onRetry={() => {}} retrying />);
+
+    const button = screen.getByRole('button', { name: 'Retrying…' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('respects a custom heading level', () => {
+    render(<ErrorState title="Nope" headingLevel={3} />);
+
+    const heading = screen.getByRole('heading', { name: 'Nope' });
+    expect(heading.tagName).toBe('H3');
+  });
+
+  it('does not render an actions row when no retry or action is provided', () => {
+    const { container } = render(<ErrorState title="Just a message" />);
+    expect(container.querySelector('.error-state__actions')).toBeNull();
+  });
+});

--- a/apps/web/src/components/common/ErrorState.tsx
+++ b/apps/web/src/components/common/ErrorState.tsx
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React from 'react';
+
+import './error-state.css';
+
+/** Heading levels permitted for the {@link ErrorState} title. */
+export type ErrorStateHeadingLevel = 2 | 3 | 4 | 5 | 6;
+
+/** Props for the {@link ErrorState} component. */
+export interface ErrorStateProps {
+  /** Optional decorative icon rendered above the title. */
+  icon?: React.ReactNode;
+  /** Short, human-readable summary of what failed. */
+  title: string;
+  /** Optional supporting detail or recovery guidance. */
+  description?: string;
+  /** Called when the user activates the retry affordance. */
+  onRetry?: () => void;
+  /** Label for the retry button. @default 'Try again' */
+  retryLabel?: string;
+  /** Label shown while a retry is in flight. @default 'Retrying…' */
+  retryingLabel?: string;
+  /** When `true`, the retry button is disabled and marked `aria-busy`. */
+  retrying?: boolean;
+  /** Optional secondary action rendered next to (or instead of) retry. */
+  action?: React.ReactNode;
+  /** Heading level for the title, for correct document outline. @default 2 */
+  headingLevel?: ErrorStateHeadingLevel;
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+/** Default error icon: a circled exclamation mark. */
+const DEFAULT_ICON: React.ReactNode = (
+  <svg width="48" height="48" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
+    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+    <line
+      x1="12"
+      y1="7"
+      x2="12"
+      y2="13"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <circle cx="12" cy="17" r="1" fill="currentColor" />
+  </svg>
+);
+
+/**
+ * Section-level error state with an optional retry affordance.
+ *
+ * Bridges the gap between the inline {@link ErrorBanner} and the full-page
+ * {@link ErrorBoundary} crash screen: use it when a page or section fails to
+ * load and should present a centered message plus recovery action. Mirrors the
+ * `EmptyState` API so screens have a consistent failure-with-recovery pattern.
+ *
+ * Announces via `role="alert"`. When `retrying` is `true`, the retry button is
+ * disabled, its label swaps to `retryingLabel`, and `aria-busy` is set so
+ * assistive technology announces the in-progress retry.
+ *
+ * @example
+ * ```tsx
+ * const load = useAsyncAction(fetchBudgets);
+ * <ErrorState
+ *   title="Couldn't load budgets"
+ *   description="Check your connection and try again."
+ *   onRetry={() => load.run()}
+ *   retrying={load.isPending}
+ * />
+ * ```
+ */
+export const ErrorState: React.FC<ErrorStateProps> = ({
+  icon,
+  title,
+  description,
+  onRetry,
+  retryLabel = 'Try again',
+  retryingLabel = 'Retrying…',
+  retrying = false,
+  action,
+  headingLevel = 2,
+  className = '',
+}) => {
+  const Heading = `h${headingLevel}` as const;
+  const resolvedIcon = icon ?? DEFAULT_ICON;
+
+  return (
+    <section className={`error-state ${className}`.trim()} role="alert">
+      {resolvedIcon && (
+        <div className="error-state__icon" aria-hidden="true">
+          {resolvedIcon}
+        </div>
+      )}
+      <Heading className="error-state__title">{title}</Heading>
+      {description && <p className="error-state__description">{description}</p>}
+      {(onRetry || action) && (
+        <div className="error-state__actions">
+          {onRetry && (
+            <button
+              type="button"
+              className="error-state__retry"
+              onClick={onRetry}
+              disabled={retrying}
+              aria-busy={retrying}
+            >
+              {retrying ? retryingLabel : retryLabel}
+            </button>
+          )}
+          {action}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default ErrorState;

--- a/apps/web/src/components/common/entity-skeletons.css
+++ b/apps/web/src/components/common/entity-skeletons.css
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* -------------------------------------------------------------------
+ * Entity skeleton composite styles
+ *
+ * Layout-only additions for the Budgets, Goals, and generic List
+ * skeleton composites. Reuses `.skeleton-page*` primitives from
+ * skeleton.css and adds a responsive card grid for Goals. Uses design
+ * tokens throughout.
+ * ------------------------------------------------------------------- */
+
+.skeleton-page__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-4, 16px);
+}
+
+.skeleton-page__card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-3, 12px);
+  padding: var(--spacing-4, 16px);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md, 8px);
+  background: var(--semantic-background-elevated);
+}
+
+@media (max-width: 480px) {
+  .skeleton-page__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/src/components/common/error-state.css
+++ b/apps/web/src/components/common/error-state.css
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* -------------------------------------------------------------------
+ * ErrorState component styles
+ *
+ * Section-level failure-with-recovery layout. Mirrors EmptyState's
+ * centered composition and uses design-token CSS custom properties
+ * throughout so it adapts to light, dark, OLED, and high-contrast modes.
+ * ------------------------------------------------------------------- */
+
+.error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--spacing-10) var(--spacing-4);
+  gap: var(--spacing-4);
+}
+
+.error-state__icon {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--semantic-status-negative);
+}
+
+.error-state__title {
+  margin: 0;
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+}
+
+.error-state__description {
+  margin: 0;
+  font-size: var(--type-scale-body-font-size);
+  line-height: var(--type-scale-body-line-height);
+  color: var(--semantic-text-secondary);
+  max-width: 360px;
+}
+
+.error-state__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-2);
+}
+
+.error-state__retry {
+  padding: var(--spacing-2) var(--spacing-4);
+  border: 1px solid var(--semantic-status-negative);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-status-negative);
+  color: var(--semantic-text-inverse);
+  cursor: pointer;
+  font-size: var(--type-scale-label-font-size);
+  font-weight: var(--type-scale-label-font-weight);
+}
+
+.error-state__retry:hover:not(:disabled) {
+  background: none;
+  color: var(--semantic-status-negative);
+}
+
+.error-state__retry:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.error-state__retry:disabled {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+/* High contrast — thicker border for visibility. */
+@media (prefers-contrast: more), (forced-colors: active) {
+  .error-state__retry {
+    border-width: 2px;
+  }
+}

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -118,3 +118,9 @@ export type {
 
 export { ConvertedTotalIndicator } from './ConvertedTotalIndicator';
 export type { ConvertedTotalIndicatorProps } from './ConvertedTotalIndicator';
+
+// Feedback UX: section-level error state & additional entity skeletons
+export { ErrorState } from './ErrorState';
+export type { ErrorStateProps, ErrorStateHeadingLevel } from './ErrorState';
+export { BudgetsSkeleton, GoalsSkeleton, ListSkeleton } from './EntitySkeletons';
+export type { ListSkeletonProps } from './EntitySkeletons';

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -253,3 +253,11 @@ export type {
   UseDisplayCurrencyRollupResult,
   UseDisplayCurrencyRollupOptions,
 } from './useDisplayCurrencyRollup';
+
+export { useAsyncAction } from './useAsyncAction';
+export type {
+  AsyncActionStatus,
+  AsyncActionNotify,
+  UseAsyncActionOptions,
+  UseAsyncActionResult,
+} from './useAsyncAction';

--- a/apps/web/src/hooks/useAsyncAction.test.ts
+++ b/apps/web/src/hooks/useAsyncAction.test.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useAsyncAction } from './useAsyncAction';
+
+describe('useAsyncAction', () => {
+  it('starts idle and transitions to success', async () => {
+    const action = vi.fn(async (n: number) => n * 2);
+    const { result } = renderHook(() => useAsyncAction(action));
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.isIdle).toBe(true);
+
+    let returned: number | null = null;
+    await act(async () => {
+      returned = await result.current.run(21);
+    });
+
+    expect(returned).toBe(42);
+    expect(action).toHaveBeenCalledWith(21);
+    expect(result.current.status).toBe('success');
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('captures errors without throwing and resolves to null', async () => {
+    const boom = new Error('nope');
+    const action = vi.fn(async () => {
+      throw boom;
+    });
+    const onError = vi.fn();
+    const { result } = renderHook(() => useAsyncAction(action, { onError }));
+
+    let returned: unknown = 'unset';
+    await act(async () => {
+      returned = await result.current.run();
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.status).toBe('error');
+    expect(result.current.isError).toBe(true);
+    expect(result.current.error).toBe(boom);
+    expect(onError).toHaveBeenCalledWith(boom);
+  });
+
+  it('emits success and error toasts through notify', async () => {
+    const notify = vi.fn();
+    const okAction = vi.fn(async () => 'saved');
+    const { result: okResult } = renderHook(() =>
+      useAsyncAction(okAction, { notify, successMessage: (r) => `done: ${r}` }),
+    );
+    await act(async () => {
+      await okResult.current.run();
+    });
+    expect(notify).toHaveBeenCalledWith({ type: 'success', message: 'done: saved' });
+
+    const failAction = vi.fn(async () => {
+      throw new Error('bad');
+    });
+    const { result: failResult } = renderHook(() =>
+      useAsyncAction(failAction, { notify, errorMessage: 'Could not save' }),
+    );
+    await act(async () => {
+      await failResult.current.run();
+    });
+    expect(notify).toHaveBeenCalledWith({ type: 'error', message: 'Could not save' });
+  });
+
+  it('ignores overlapping runs while pending', async () => {
+    let resolveFn: ((value: string) => void) | undefined;
+    const action = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useAsyncAction(action));
+
+    let firstRun: Promise<string | null> | undefined;
+    act(() => {
+      firstRun = result.current.run();
+    });
+    expect(result.current.isPending).toBe(true);
+
+    // Second run while pending should be ignored and resolve to null.
+    let second: string | null = 'unset';
+    await act(async () => {
+      second = await result.current.run();
+    });
+    expect(second).toBeNull();
+    expect(action).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFn?.('ok');
+      await firstRun;
+    });
+    expect(result.current.status).toBe('success');
+  });
+
+  it('reset returns to idle and clears the error', async () => {
+    const action = vi.fn(async () => {
+      throw new Error('x');
+    });
+    const { result } = renderHook(() => useAsyncAction(action));
+
+    await act(async () => {
+      await result.current.run();
+    });
+    expect(result.current.isError).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.status).toBe('idle');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not update state after unmount', async () => {
+    let resolveFn: ((value: number) => void) | undefined;
+    const action = vi.fn(
+      () =>
+        new Promise<number>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+    const { result, unmount } = renderHook(() => useAsyncAction(action));
+
+    let pending: Promise<number | null> | undefined;
+    act(() => {
+      pending = result.current.run();
+    });
+
+    unmount();
+    await act(async () => {
+      resolveFn?.(1);
+      await pending;
+    });
+
+    // No throw / act warning means the post-unmount setState was skipped.
+    await waitFor(() => expect(action).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/web/src/hooks/useAsyncAction.ts
+++ b/apps/web/src/hooks/useAsyncAction.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Lifecycle status of an async action tracked by {@link useAsyncAction}.
+ *
+ * - `idle` — no run has started (or the hook was reset).
+ * - `pending` — a run is currently in flight.
+ * - `success` — the most recent run resolved successfully.
+ * - `error` — the most recent run rejected.
+ */
+export type AsyncActionStatus = 'idle' | 'pending' | 'success' | 'error';
+
+/** A minimal toast emitter, structurally compatible with `useToast().showToast`. */
+export type AsyncActionNotify = (toast: { type: 'success' | 'error'; message: string }) => void;
+
+/** Configuration for {@link useAsyncAction}. */
+export interface UseAsyncActionOptions<TArgs extends unknown[], TResult> {
+  /** Called after a successful run, with the result and the original arguments. */
+  onSuccess?: (result: TResult, ...args: TArgs) => void;
+  /** Called after a failed run, with the captured error and the original arguments. */
+  onError?: (error: Error, ...args: TArgs) => void;
+  /**
+   * Optional toast emitter. Pass `useToast().showToast` to surface success/error
+   * toasts automatically. When omitted, no toasts are emitted.
+   */
+  notify?: AsyncActionNotify;
+  /** Success toast message (or a factory receiving the result). Requires `notify`. */
+  successMessage?: string | ((result: TResult) => string);
+  /** Error toast message (or a factory receiving the error). Requires `notify`. */
+  errorMessage?: string | ((error: Error) => string);
+}
+
+/** Return shape of {@link useAsyncAction}. */
+export interface UseAsyncActionResult<TArgs extends unknown[], TResult> {
+  /**
+   * Execute the wrapped action. Never throws — failures are captured in `error`
+   * and reflected in `status`. Resolves with the result on success, or `null`
+   * on failure or when a run is already in flight.
+   */
+  run: (...args: TArgs) => Promise<TResult | null>;
+  /** Current lifecycle status. */
+  status: AsyncActionStatus;
+  /** The captured error from the most recent failed run, or `null`. */
+  error: Error | null;
+  /** `true` when `status === 'idle'`. */
+  isIdle: boolean;
+  /** `true` when a run is in flight. */
+  isPending: boolean;
+  /** `true` when the most recent run succeeded. */
+  isSuccess: boolean;
+  /** `true` when the most recent run failed. */
+  isError: boolean;
+  /** Reset back to the `idle` state and clear any captured error. */
+  reset: () => void;
+}
+
+/** Resolve a string-or-factory message option against a value. */
+function resolveMessage<T>(
+  message: string | ((value: T) => string) | undefined,
+  value: T,
+): string | undefined {
+  if (message === undefined) return undefined;
+  return typeof message === 'function' ? message(value) : message;
+}
+
+/**
+ * Standardises the "run an async action → reflect pending → surface
+ * success/error feedback" pattern used across mutation call sites.
+ *
+ * The hook never throws: errors are captured in state so components can render
+ * loading, error, and success feedback declaratively. It guards against
+ * overlapping runs (a second `run` while one is pending resolves to `null`) and
+ * against state updates after unmount.
+ *
+ * @example
+ * ```tsx
+ * const { showToast } = useToast();
+ * const save = useAsyncAction(
+ *   (input: CreateAccountInput) => createAccount(input),
+ *   { notify: showToast, successMessage: 'Account created', errorMessage: 'Could not create account' },
+ * );
+ *
+ * <button onClick={() => save.run(input)} disabled={save.isPending} aria-busy={save.isPending}>
+ *   {save.isPending ? 'Saving…' : 'Save'}
+ * </button>
+ * ```
+ *
+ * @param action The async function to wrap.
+ * @param options Optional success/error callbacks and toast configuration.
+ */
+export function useAsyncAction<TArgs extends unknown[], TResult>(
+  action: (...args: TArgs) => Promise<TResult>,
+  options: UseAsyncActionOptions<TArgs, TResult> = {},
+): UseAsyncActionResult<TArgs, TResult> {
+  const [status, setStatus] = useState<AsyncActionStatus>('idle');
+  const [error, setError] = useState<Error | null>(null);
+
+  // Keep the latest action/options without forcing `run` to change identity.
+  const actionRef = useRef(action);
+  const optionsRef = useRef(options);
+  const mountedRef = useRef(true);
+  const pendingRef = useRef(false);
+
+  useEffect(() => {
+    actionRef.current = action;
+    optionsRef.current = options;
+  });
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const reset = useCallback(() => {
+    if (!mountedRef.current) return;
+    setStatus('idle');
+    setError(null);
+  }, []);
+
+  const run = useCallback(async (...args: TArgs): Promise<TResult | null> => {
+    // Ignore overlapping runs so double-clicks don't fire the action twice.
+    if (pendingRef.current) return null;
+
+    pendingRef.current = true;
+    if (mountedRef.current) {
+      setStatus('pending');
+      setError(null);
+    }
+
+    const opts = optionsRef.current;
+
+    try {
+      const result = await actionRef.current(...args);
+      pendingRef.current = false;
+
+      if (mountedRef.current) {
+        setStatus('success');
+      }
+      opts.onSuccess?.(result, ...args);
+
+      const successMessage = resolveMessage(opts.successMessage, result);
+      if (opts.notify && successMessage) {
+        opts.notify({ type: 'success', message: successMessage });
+      }
+
+      return result;
+    } catch (caught) {
+      pendingRef.current = false;
+      const normalized = caught instanceof Error ? caught : new Error(String(caught));
+
+      if (mountedRef.current) {
+        setStatus('error');
+        setError(normalized);
+      }
+      opts.onError?.(normalized, ...args);
+
+      const errorMessage = resolveMessage(opts.errorMessage, normalized);
+      if (opts.notify && errorMessage) {
+        opts.notify({ type: 'error', message: errorMessage });
+      }
+
+      return null;
+    }
+  }, []);
+
+  return {
+    run,
+    status,
+    error,
+    isIdle: status === 'idle',
+    isPending: status === 'pending',
+    isSuccess: status === 'success',
+    isError: status === 'error',
+    reset,
+  };
+}
+
+export default useAsyncAction;


### PR DESCRIPTION
﻿## Summary
Adds a coherent set of **net-new shared feedback-UX primitives** for the web PWA
(`apps/web`), plus one small backward-compatible enhancement to `EmptyState`. These give
feature screens a consistent loading → error/retry → empty → success story without each
screen re-implementing the pattern.

This is Phase 2 of a feedback-UX critique pass. See the companion issues (below) for the
full backlog; this PR implements the coherent, low-collision subset.

## What's included
- **`useAsyncAction` hook** (`hooks/useAsyncAction.ts`) — standardises the
  "run an async action → reflect pending → surface success/error feedback" pattern.
  Returns `{ run, status, error, isIdle, isPending, isSuccess, isError, reset }`, never
  throws (errors captured in state), guards against overlapping runs and post-unmount
  state updates, and can emit success/error toasts through an optional `notify`
  (structurally compatible with `useToast().showToast`). Closes #3636.
- **`ErrorState` component** (`components/common/ErrorState.tsx` + `error-state.css`) —
  section-level failure-with-recovery UI that bridges the inline `ErrorBanner` and the
  full-page `ErrorBoundary`. Mirrors the `EmptyState` API, announces via `role="alert"`,
  and exposes a **busy-aware retry affordance** (`retrying` disables the button, swaps the
  label, and sets `aria-busy`). Closes #3645 and #3633.
- **Entity skeleton composites** (`components/common/EntitySkeletons.tsx` +
  `entity-skeletons.css`) — `BudgetsSkeleton`, `GoalsSkeleton`, and a generic
  `ListSkeleton`, reusing the existing `Skeleton` primitive (reduced-motion safe) so the
  Budgets/Goals loading UX matches the rest of the app. Closes #3641.
- **`EmptyState` heading level** — new optional `headingLevel` prop (default `2`, no visual
  change) so empty states slot into the surrounding document outline without heading-order
  violations. Closes #3642.

## Design & a11y
- All styles use design tokens; reduced-motion and high-contrast handling included.
- New surfaces carry correct ARIA roles (`alert`/`status`), busy states, and labels.
- Additions are net-new files plus a single contiguous export block in each barrel to
  minimise merge collisions with parallel sessions.

## Testing
- `useAsyncAction` — idle/success/error transitions, toast emission, overlapping-run guard,
  reset, and post-unmount safety.
- `ErrorState` — alert role, retry callback, busy state, heading level, actions row.
- `EntitySkeletons` — busy regions, grid rendering, configurable rows.
- `EmptyState` — default `h2` and custom heading level.
- Verified locally: Prettier (formatted), ESLint (`--max-warnings 0`, clean), and the new
  Vitest suites (18 tests passing). Per repo guidance, remote CI is the source of truth for
  type-check.

## Related issues (backlog from the same critique, not implemented here)
#3611, #3615, #3618, #3627, #3629, #3651, #3661
