### PR TITLE
feat(web): accessible show/hide password + Caps Lock warning on first-run auth (#3770)

### DIFF
--- a/apps/web/src/components/auth/PasswordInput.test.tsx
+++ b/apps/web/src/components/auth/PasswordInput.test.tsx
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PasswordInput } from './PasswordInput';
+
+/** Render a PasswordInput with an associated label for querying. */
+function renderPasswordInput(props: Partial<React.ComponentProps<typeof PasswordInput>> = {}) {
+  return render(
+    <>
+      <label htmlFor="pw">Password</label>
+      <PasswordInput id="pw" value="" onChange={() => {}} {...props} />
+    </>,
+  );
+}
+
+/**
+ * Dispatch a keyboard event whose `getModifierState` reports the requested
+ * Caps Lock state. jsdom's KeyboardEvent init has no Caps Lock flag, so we
+ * override the getter on a real event and fire it through React's delegation.
+ */
+function fireCapsLock(input: HTMLElement, type: 'keydown' | 'keyup', capsLockOn: boolean): void {
+  const event = new KeyboardEvent(type, { key: 'a', bubbles: true });
+  Object.defineProperty(event, 'getModifierState', {
+    configurable: true,
+    value: (key: string) => (key === 'CapsLock' ? capsLockOn : false),
+  });
+  fireEvent(input, event);
+}
+
+describe('PasswordInput', () => {
+  it('renders a masked password field by default', () => {
+    renderPasswordInput();
+    const input = screen.getByLabelText('Password');
+    expect(input).toHaveAttribute('type', 'password');
+  });
+
+  it('reveals and re-hides the value via the toggle button', async () => {
+    const user = userEvent.setup();
+    renderPasswordInput();
+    const input = screen.getByLabelText('Password');
+    const toggle = screen.getByRole('button', { name: 'Show password' });
+
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    await user.click(toggle);
+    expect(input).toHaveAttribute('type', 'text');
+    expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Hide password' }));
+    expect(input).toHaveAttribute('type', 'password');
+  });
+
+  it('does not submit the surrounding form when the toggle is clicked', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <label htmlFor="pw">Password</label>
+        <PasswordInput id="pw" value="secret" onChange={() => {}} />
+      </form>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Show password' }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('honours custom toggle labels', () => {
+    renderPasswordInput({ showPasswordLabel: 'Reveal', hidePasswordLabel: 'Conceal' });
+    expect(screen.getByRole('button', { name: 'Reveal' })).toBeInTheDocument();
+  });
+
+  it('shows a Caps Lock warning while Caps Lock is active and links it to the field', () => {
+    renderPasswordInput();
+    const input = screen.getByLabelText('Password');
+
+    expect(screen.queryByText('Caps Lock is on')).not.toBeInTheDocument();
+
+    fireCapsLock(input, 'keydown', true);
+
+    const warning = screen.getByText('Caps Lock is on');
+    expect(warning).toBeInTheDocument();
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(describedBy).toContain(warning.closest('p')!.id);
+  });
+
+  it('clears the Caps Lock warning when Caps Lock turns off', () => {
+    renderPasswordInput();
+    const input = screen.getByLabelText('Password');
+
+    fireCapsLock(input, 'keydown', true);
+    expect(screen.getByText('Caps Lock is on')).toBeInTheDocument();
+
+    fireCapsLock(input, 'keyup', false);
+    expect(screen.queryByText('Caps Lock is on')).not.toBeInTheDocument();
+  });
+
+  it('clears the Caps Lock warning on blur', () => {
+    renderPasswordInput();
+    const input = screen.getByLabelText('Password');
+
+    fireCapsLock(input, 'keydown', true);
+    expect(screen.getByText('Caps Lock is on')).toBeInTheDocument();
+
+    fireEvent.blur(input);
+    expect(screen.queryByText('Caps Lock is on')).not.toBeInTheDocument();
+  });
+
+  it('preserves a caller-provided aria-describedby', () => {
+    render(
+      <>
+        <label htmlFor="pw">Password</label>
+        <p id="hint">At least 12 characters</p>
+        <PasswordInput id="pw" value="" onChange={() => {}} aria-describedby="hint" />
+      </>,
+    );
+    expect(screen.getByLabelText('Password')).toHaveAttribute('aria-describedby', 'hint');
+  });
+
+  it('disables the toggle when the field is disabled', () => {
+    renderPasswordInput({ disabled: true });
+    expect(screen.getByRole('button', { name: 'Show password' })).toBeDisabled();
+  });
+
+  it('forwards a ref to the underlying input', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(
+      <>
+        <label htmlFor="pw">Password</label>
+        <PasswordInput id="pw" ref={ref} value="" onChange={() => {}} />
+      </>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it('forwards change events from the input', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <>
+        <label htmlFor="pw">Password</label>
+        <PasswordInput id="pw" onChange={onChange} />
+      </>,
+    );
+    await user.type(screen.getByLabelText('Password'), 'a');
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/auth/PasswordInput.tsx
+++ b/apps/web/src/components/auth/PasswordInput.tsx
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * PasswordInput — accessible password field with a show/hide toggle and a
+ * Caps Lock warning. See critique #3770 (items 1 & 2).
+ *
+ * The component only owns the input + toggle wrapper and an optional Caps Lock
+ * notice; the surrounding label, hint and error markup stay with the caller so
+ * it drops into both the `auth-field` (signup/reset) and `form-group` (login)
+ * layouts. Pass the input's `className` as usual — the toggle is positioned
+ * over the field and the field is padded via the shared `.password-input`
+ * styles.
+ *
+ * Accessibility:
+ *  - Toggle is a real `<button type="button">` with `aria-pressed` and an
+ *    `aria-label` that flips between "Show password" / "Hide password".
+ *  - Caps Lock state is announced through a polite live region and linked to
+ *    the input via `aria-describedby` while active.
+ */
+
+import React, { forwardRef, useCallback, useId, useState } from 'react';
+
+export interface PasswordInputProps extends Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'type'
+> {
+  /** Extra class names for the positioned wrapper around the input + toggle. */
+  wrapperClassName?: string;
+  /** Accessible label for the toggle when the password is hidden. */
+  showPasswordLabel?: string;
+  /** Accessible label for the toggle when the password is visible. */
+  hidePasswordLabel?: string;
+  /** Message shown when Caps Lock is detected. */
+  capsLockWarning?: string;
+}
+
+function detectCapsLock(event: React.KeyboardEvent<HTMLInputElement>): boolean | null {
+  if (typeof event.getModifierState !== 'function') {
+    return null;
+  }
+  return event.getModifierState('CapsLock');
+}
+
+/**
+ * Password field with an accessible reveal toggle and Caps Lock detection.
+ */
+export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
+  (
+    {
+      wrapperClassName,
+      showPasswordLabel = 'Show password',
+      hidePasswordLabel = 'Hide password',
+      capsLockWarning = 'Caps Lock is on',
+      className,
+      onKeyUp,
+      onKeyDown,
+      onBlur,
+      'aria-describedby': ariaDescribedBy,
+      ...inputProps
+    },
+    ref,
+  ) => {
+    const [visible, setVisible] = useState(false);
+    const [capsLockOn, setCapsLockOn] = useState(false);
+
+    const generatedId = useId();
+    const capsWarningId = `${inputProps.id ?? generatedId}-caps-warning`;
+
+    const syncCapsLock = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+      const state = detectCapsLock(event);
+      if (state !== null) {
+        setCapsLockOn(state);
+      }
+    }, []);
+
+    const handleKeyUp = useCallback(
+      (event: React.KeyboardEvent<HTMLInputElement>) => {
+        syncCapsLock(event);
+        onKeyUp?.(event);
+      },
+      [onKeyUp, syncCapsLock],
+    );
+
+    const handleKeyDown = useCallback(
+      (event: React.KeyboardEvent<HTMLInputElement>) => {
+        syncCapsLock(event);
+        onKeyDown?.(event);
+      },
+      [onKeyDown, syncCapsLock],
+    );
+
+    const handleBlur = useCallback(
+      (event: React.FocusEvent<HTMLInputElement>) => {
+        // Clear the warning when focus leaves so it doesn't linger on an
+        // unfocused field.
+        setCapsLockOn(false);
+        onBlur?.(event);
+      },
+      [onBlur],
+    );
+
+    const describedBy =
+      [ariaDescribedBy, capsLockOn ? capsWarningId : null].filter(Boolean).join(' ') || undefined;
+
+    return (
+      <>
+        <div className={['password-input', wrapperClassName].filter(Boolean).join(' ')}>
+          <input
+            {...inputProps}
+            ref={ref}
+            type={visible ? 'text' : 'password'}
+            className={className}
+            onKeyUp={handleKeyUp}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            aria-describedby={describedBy}
+          />
+          <button
+            type="button"
+            className="password-input__toggle"
+            onClick={() => setVisible((current) => !current)}
+            aria-pressed={visible}
+            aria-label={visible ? hidePasswordLabel : showPasswordLabel}
+            disabled={inputProps.disabled}
+            tabIndex={0}
+          >
+            <PasswordVisibilityIcon visible={visible} />
+          </button>
+        </div>
+        {capsLockOn && (
+          <p
+            id={capsWarningId}
+            className="password-input__caps-warning"
+            role="status"
+            aria-live="polite"
+          >
+            <svg
+              className="password-input__caps-icon"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path d="M12 3 4 11h4v4h8v-4h4L12 3Zm-4 16h8v2H8v-2Z" fill="currentColor" />
+            </svg>
+            <span>{capsLockWarning}</span>
+          </p>
+        )}
+      </>
+    );
+  },
+);
+
+PasswordInput.displayName = 'PasswordInput';
+
+interface PasswordVisibilityIconProps {
+  visible: boolean;
+}
+
+/** Eye / eye-off glyph reflecting the current visibility state. */
+const PasswordVisibilityIcon: React.FC<PasswordVisibilityIconProps> = ({ visible }) => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
+    {visible ? (
+      <>
+        <path
+          d="M3 3l18 18"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M10.58 10.58a2 2 0 0 0 2.83 2.83M9.36 5.18A9.46 9.46 0 0 1 12 5c5 0 9 4.5 9 7 0 .93-.55 2.12-1.5 3.24M6.11 6.11C3.77 7.57 2 10.03 2 12c0 2.5 4 7 10 7 1.4 0 2.7-.25 3.86-.68"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </>
+    ) : (
+      <>
+        <path
+          d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="2" />
+      </>
+    )}
+  </svg>
+);
+
+export default PasswordInput;

--- a/apps/web/src/components/auth/PasswordStrengthMeter.test.tsx
+++ b/apps/web/src/components/auth/PasswordStrengthMeter.test.tsx
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PasswordStrengthMeter } from './PasswordStrengthMeter';
+
+describe('PasswordStrengthMeter', () => {
+  it('renders a progressbar reflecting the password strength', () => {
+    render(<PasswordStrengthMeter password="correcthorsebatterystaple" />);
+    const meter = screen.getByRole('progressbar');
+    expect(meter).toHaveAttribute('aria-valuemin', '0');
+    expect(meter).toHaveAttribute('aria-valuemax', '4');
+    expect(meter).toHaveAttribute('aria-label', expect.stringContaining('Password strength:'));
+  });
+
+  it('scores a weak password lower than a strong one', () => {
+    const { rerender } = render(<PasswordStrengthMeter password="123456" />);
+    const weakScore = Number(screen.getByRole('progressbar').getAttribute('aria-valuenow'));
+
+    rerender(<PasswordStrengthMeter password="A9!kZ2@wQ7#mL4$p" />);
+    const strongScore = Number(screen.getByRole('progressbar').getAttribute('aria-valuenow'));
+
+    expect(strongScore).toBeGreaterThan(weakScore);
+  });
+});

--- a/apps/web/src/components/auth/PasswordStrengthMeter.tsx
+++ b/apps/web/src/components/auth/PasswordStrengthMeter.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * PasswordStrengthMeter — shared visual password-strength indicator.
+ *
+ * Extracted from SignupPage so the same accessible meter can be reused on
+ * every screen where a user chooses a password (signup, reset). See #3770.
+ */
+
+import React from 'react';
+
+import { calculatePasswordStrength } from '../../lib/password-strength';
+
+export interface PasswordStrengthMeterProps {
+  /** The current password value to score. */
+  password: string;
+}
+
+/** Visual password strength indicator with a colored bar and feedback. */
+export const PasswordStrengthMeter: React.FC<PasswordStrengthMeterProps> = ({ password }) => {
+  const strength = calculatePasswordStrength(password);
+  const widthPercent = ((strength.score + 1) / 5) * 100;
+
+  return (
+    <div className="auth-password-strength" aria-live="polite">
+      <div
+        className="auth-password-strength__bar"
+        role="progressbar"
+        aria-valuenow={strength.score}
+        aria-valuemin={0}
+        aria-valuemax={4}
+        aria-label={`Password strength: ${strength.label}`}
+      >
+        <div
+          className="auth-password-strength__fill"
+          style={{
+            width: `${widthPercent}%`,
+            backgroundColor: strength.color,
+          }}
+        />
+      </div>
+      <span className="auth-password-strength__label">{strength.label}</span>
+      {strength.feedback && (
+        <span className="auth-password-strength__feedback">{strength.feedback}</span>
+      )}
+    </div>
+  );
+};
+
+export default PasswordStrengthMeter;

--- a/apps/web/src/components/auth/password-input.css
+++ b/apps/web/src/components/auth/password-input.css
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * PasswordInput — reveal toggle + Caps Lock warning styles.
+ *
+ * The wrapper positions the toggle button over the right edge of the field and
+ * reserves space via padding so entered text never runs under the button. It is
+ * layout-agnostic: it targets its own child input regardless of whether the
+ * caller uses the `auth-field__input` or `form-input` class.
+ */
+
+.password-input {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+}
+
+.password-input > input {
+  flex: 1 1 auto;
+  width: 100%;
+  /* Reserve room for the toggle button so masked text is never occluded. */
+  padding-right: 2.75rem;
+}
+
+.password-input__toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* WCAG 2.2 AA target size (2.5.8): >= 24x24; we use a comfortable 44px. */
+  width: 44px;
+  min-height: 44px;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--semantic-text-secondary);
+  cursor: pointer;
+  border-radius: var(--input-border-radius, 6px);
+}
+
+.password-input__toggle:hover {
+  color: var(--semantic-text-primary);
+}
+
+.password-input__toggle:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, var(--input-border-focus));
+  outline-offset: -2px;
+}
+
+.password-input__toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.password-input__caps-warning {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1, 0.25rem);
+  margin-top: var(--spacing-1, 0.25rem);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-status-warning, var(--semantic-text-secondary));
+}
+
+.password-input__caps-icon {
+  flex: 0 0 auto;
+}

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -81,6 +81,10 @@ export const ForgotPasswordPage: React.FC = () => {
               className="auth-field__input"
               type="email"
               autoComplete="email"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              inputMode="email"
               required
               value={email}
               onChange={(event) => {

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LoginPage } from './LoginPage';
@@ -118,6 +119,26 @@ describe('LoginPage', () => {
     renderLoginPage();
 
     expect(screen.getByRole('link', { name: 'Sign up' })).toHaveAttribute('href', '/signup');
+  });
+
+  it('reveals the password via the show-password toggle', async () => {
+    const user = userEvent.setup();
+    renderLoginPage();
+
+    const password = screen.getByLabelText('Password');
+    expect(password).toHaveAttribute('type', 'password');
+
+    await user.click(screen.getByRole('button', { name: 'Show password' }));
+    expect(password).toHaveAttribute('type', 'text');
+  });
+
+  it('marks the email field as mobile-friendly (no auto-capitalize/correct)', () => {
+    renderLoginPage();
+
+    const email = screen.getByLabelText('Email');
+    expect(email).toHaveAttribute('autocapitalize', 'none');
+    expect(email).toHaveAttribute('autocorrect', 'off');
+    expect(email).toHaveAttribute('inputmode', 'email');
   });
 
   it('shows hosted legal links in the login footer', () => {

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -6,11 +6,13 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../auth/auth-context';
 import { getPreferredAuthMethod, setPreferredAuthMethod } from '../auth/preferred-auth-method';
 import { PasskeySetupPrompt } from '../components/auth/PasskeySetupPrompt';
+import { PasswordInput } from '../components/auth/PasswordInput';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
 import { LegalLinks } from '../components/legal/LegalLinks';
 import { hasRegisteredPasskey } from '../lib/passkey-preferences';
 import { loginSchema } from '../lib/validation';
 
+import '../components/auth/password-input.css';
 import '../components/forms/forms.css';
 import '../styles/auth.css';
 
@@ -316,6 +318,10 @@ export const LoginPage: React.FC = () => {
                 type="email"
                 required
                 autoComplete="email"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+                inputMode="email"
                 className={`form-input${fieldErrors.email ? ' form-input--error' : ''}`}
                 value={email}
                 onChange={(event) => {
@@ -340,11 +346,10 @@ export const LoginPage: React.FC = () => {
               <label htmlFor={passwordId} className="form-group__label form-group__label--required">
                 Password
               </label>
-              <input
+              <PasswordInput
                 ref={passwordInputRef}
                 id={passwordId}
                 name="password"
-                type="password"
                 required
                 autoComplete="current-password"
                 className={`form-input${fieldErrors.password ? ' form-input--error' : ''}`}

--- a/apps/web/src/pages/ResetPasswordPage.test.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.test.tsx
@@ -116,4 +116,27 @@ describe('ResetPasswordPage', () => {
       expect(screen.getByRole('alert')).toHaveTextContent('Reset link is invalid or expired.');
     });
   });
+
+  it('shows a password strength meter once the user types a new password', () => {
+    renderResetPasswordPage();
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('New password'), {
+      target: { value: 'newStrongPass123' },
+    });
+
+    const meter = screen.getByRole('progressbar');
+    expect(meter).toHaveAttribute('aria-label', expect.stringContaining('Password strength:'));
+  });
+
+  it('reveals the new password via the show-password toggle', () => {
+    renderResetPasswordPage();
+
+    const password = screen.getByLabelText('New password');
+    expect(password).toHaveAttribute('type', 'password');
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Show password' })[0]);
+    expect(password).toHaveAttribute('type', 'text');
+  });
 });

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -3,10 +3,13 @@
 import React, { useId, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
+import { PasswordInput } from '../components/auth/PasswordInput';
+import { PasswordStrengthMeter } from '../components/auth/PasswordStrengthMeter';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
 import { resetPassword } from '../lib/auth/password-reset';
 import { passwordSchema } from '../lib/validation';
 
+import '../components/auth/password-input.css';
 import '../styles/auth.css';
 
 interface ResetFieldErrors {
@@ -115,10 +118,9 @@ export const ResetPasswordPage: React.FC = () => {
             <label className="auth-field__label" htmlFor={passwordId}>
               New password
             </label>
-            <input
+            <PasswordInput
               id={passwordId}
               className="auth-field__input"
-              type="password"
               autoComplete="new-password"
               required
               minLength={12}
@@ -132,6 +134,7 @@ export const ResetPasswordPage: React.FC = () => {
               aria-describedby={fieldErrors.password ? passwordErrorId : undefined}
             />
             <p className="auth-field__hint">Must be at least 12 characters</p>
+            {password.length > 0 && <PasswordStrengthMeter password={password} />}
             {fieldErrors.password && (
               <p id={passwordErrorId} className="auth-field__error" role="alert">
                 {fieldErrors.password}
@@ -143,10 +146,9 @@ export const ResetPasswordPage: React.FC = () => {
             <label className="auth-field__label" htmlFor={confirmPasswordId}>
               Confirm new password
             </label>
-            <input
+            <PasswordInput
               id={confirmPasswordId}
               className="auth-field__input"
-              type="password"
               autoComplete="new-password"
               required
               value={confirmPassword}

--- a/apps/web/src/pages/SignupPage.test.tsx
+++ b/apps/web/src/pages/SignupPage.test.tsx
@@ -80,6 +80,27 @@ describe('SignupPage', () => {
     expect(screen.getByRole('button', { name: 'Sign up' })).toBeInTheDocument();
   });
 
+  it('reveals the password via the show-password toggle', () => {
+    renderSignupPage();
+
+    const password = screen.getByLabelText('Password');
+    expect(password).toHaveAttribute('type', 'password');
+
+    // Password + confirm each render their own toggle; the first controls the
+    // password field.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Show password' })[0]);
+    expect(password).toHaveAttribute('type', 'text');
+  });
+
+  it('marks the email field as mobile-friendly (no auto-capitalize/correct)', () => {
+    renderSignupPage();
+
+    const email = screen.getByLabelText('Email');
+    expect(email).toHaveAttribute('autocapitalize', 'none');
+    expect(email).toHaveAttribute('autocorrect', 'off');
+    expect(email).toHaveAttribute('inputmode', 'email');
+  });
+
   it('shows link to login page', () => {
     renderSignupPage();
 

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -14,10 +14,12 @@ import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../auth/auth-context';
+import { PasswordInput } from '../components/auth/PasswordInput';
+import { PasswordStrengthMeter } from '../components/auth/PasswordStrengthMeter';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
-import { calculatePasswordStrength } from '../lib/password-strength';
 import { signupSchema } from '../lib/validation';
 
+import '../components/auth/password-input.css';
 import '../styles/auth.css';
 
 /** Minimum password length enforced by client-side validation. */
@@ -251,6 +253,10 @@ export const SignupPage: React.FC = () => {
                 className="auth-field__input"
                 type="email"
                 autoComplete="email"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+                inputMode="email"
                 required
                 value={email}
                 onChange={(event) => {
@@ -272,10 +278,9 @@ export const SignupPage: React.FC = () => {
               <label className="auth-field__label" htmlFor={passwordId}>
                 Password
               </label>
-              <input
+              <PasswordInput
                 id={passwordId}
                 className="auth-field__input"
-                type="password"
                 autoComplete="new-password"
                 required
                 minLength={MIN_PASSWORD_LENGTH}
@@ -312,10 +317,9 @@ export const SignupPage: React.FC = () => {
               <label className="auth-field__label" htmlFor={confirmPasswordId}>
                 Confirm Password
               </label>
-              <input
+              <PasswordInput
                 id={confirmPasswordId}
                 className="auth-field__input"
-                type="password"
                 autoComplete="new-password"
                 required
                 value={confirmPassword}
@@ -361,45 +365,6 @@ export const SignupPage: React.FC = () => {
         </p>
       </div>
     </main>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// Password Strength Meter Sub-Component
-// ---------------------------------------------------------------------------
-
-interface PasswordStrengthMeterProps {
-  password: string;
-}
-
-/** Visual password strength indicator with colored bar and feedback. */
-const PasswordStrengthMeter: React.FC<PasswordStrengthMeterProps> = ({ password }) => {
-  const strength = calculatePasswordStrength(password);
-  const widthPercent = ((strength.score + 1) / 5) * 100;
-
-  return (
-    <div className="auth-password-strength" aria-live="polite">
-      <div
-        className="auth-password-strength__bar"
-        role="progressbar"
-        aria-valuenow={strength.score}
-        aria-valuemin={0}
-        aria-valuemax={4}
-        aria-label={`Password strength: ${strength.label}`}
-      >
-        <div
-          className="auth-password-strength__fill"
-          style={{
-            width: `${widthPercent}%`,
-            backgroundColor: strength.color,
-          }}
-        />
-      </div>
-      <span className="auth-password-strength__label">{strength.label}</span>
-      {strength.feedback && (
-        <span className="auth-password-strength__feedback">{strength.feedback}</span>
-      )}
-    </div>
   );
 };
 


### PR DESCRIPTION
﻿## Summary

Hardens the **onboarding / first-run auth surface** (`apps/web`) for usability and WCAG 2.2 AA accessibility. Implements items **1–5** of the critique in #3770.

### Changes
- **New reusable `PasswordInput`** (`components/auth/PasswordInput.tsx`)
  - Accessible **show/hide reveal toggle**: real `<button type="button">` with `aria-pressed` and a label that flips between "Show password" / "Hide password"; 44px target (WCAG 2.5.8); does not submit the form.
  - **Caps Lock warning**: detected via keyboard events, announced through a polite live region and linked to the field via `aria-describedby`; cleared on blur.
  - Layout-agnostic — drops into both the `auth-field` (signup/reset) and `form-group` (login) markup; forwards refs and passes through input props.
- **Extracted shared `PasswordStrengthMeter`** out of `SignupPage` into `components/auth/` and **reused it on `ResetPasswordPage`** for parity (item 4/5).
- **Wired `PasswordInput`** into `SignupPage` (password + confirm), `LoginPage` (password), `ResetPasswordPage` (password + confirm).
- **Mobile-friendly email inputs** (`autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}`, `inputMode="email"`) on `SignupPage`, `LoginPage`, `ForgotPasswordPage` (item 3).

### Tests
- New: `PasswordInput.test.tsx` (toggle, Caps Lock, describedby, ref, disabled) and `PasswordStrengthMeter.test.tsx`.
- Updated page tests for the toggle + email attributes on Signup/Login/Reset.
- Local gates green: `tsc --noEmit`, `npm run format:check`, `npx eslint . --max-warnings 0`, and the full `apps/web` suite (9626 tests).

Closes #3770

---

## Full critique (from #3770 — Onboarding & first-run)

1. **No show/hide password toggle** — users cannot verify what they typed; a leading cause of failed first logins/signups. *(implemented)*
2. **No Caps Lock warning on password fields** — silent cause of "wrong password" errors. *(implemented)*
3. **Email inputs not mobile-optimized** — missing `autoCapitalize`/`autoCorrect`/`spellCheck`/`inputMode`, producing invalid emails on phones. *(implemented)*
4. **Reset-password screen lacks strength guidance** present on signup. *(implemented)*
5. **Password strength meter not reusable** (privately defined in SignupPage). *(implemented — extracted & shared)*
6. **Reset/link errors are not focus-managed** — keyboard/SR users may miss them. *(follow-up)*
7. **`BetaLanding` health check has no request timeout** — status can hang indefinitely. *(follow-up)*
8. **Onboarding localStorage writes fail silently** — users lose choices with no feedback. *(follow-up)*
9. **Signup "Resend confirmation email" can be double-submitted** — no throttle/feedback. *(follow-up)*
10. **Auth cards lack an accessible form-level heading** (`<h2>`). *(follow-up)*
11. **No back navigation on the earliest onboarding steps.** *(follow-up)*
12. **Login gives no feedback after repeated failures** (no Caps Lock hint, no recovery nudge). *(partially addressed via #2; rest follow-up)*
