### PR TITLE
feat(web): scannable transactions ledger with totals and better empty states (#3772)

### DIFF
--- a/apps/web/src/components/transactions/TransactionSort.test.tsx
+++ b/apps/web/src/components/transactions/TransactionSort.test.tsx
@@ -16,7 +16,7 @@ describe('TransactionSort', () => {
     render(<TransactionSort sort={DEFAULT_SORT} onChange={vi.fn()} />);
 
     expect(screen.getByLabelText(/sort field/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/sort direction/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/sort order/i)).toBeInTheDocument();
   });
 
   it('displays the current sort field', () => {
@@ -38,7 +38,7 @@ describe('TransactionSort', () => {
     const onChange = vi.fn();
     render(<TransactionSort sort={{ field: 'date', direction: 'desc' }} onChange={onChange} />);
 
-    fireEvent.click(screen.getByLabelText(/sort direction/i));
+    fireEvent.click(screen.getByLabelText(/sort order/i));
     expect(onChange).toHaveBeenCalledWith({ field: 'date', direction: 'asc' });
   });
 
@@ -52,5 +52,30 @@ describe('TransactionSort', () => {
     render(<TransactionSort sort={{ field: 'date', direction: 'desc' }} onChange={vi.fn()} />);
 
     expect(screen.getByText('↓')).toBeInTheDocument();
+  });
+
+  it('describes date direction in human terms', () => {
+    const { rerender } = render(
+      <TransactionSort sort={{ field: 'date', direction: 'desc' }} onChange={vi.fn()} />,
+    );
+    expect(screen.getByLabelText(/newest first/i)).toBeInTheDocument();
+
+    rerender(<TransactionSort sort={{ field: 'date', direction: 'asc' }} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/oldest first/i)).toBeInTheDocument();
+  });
+
+  it('describes amount direction as largest/smallest first', () => {
+    const { rerender } = render(
+      <TransactionSort sort={{ field: 'amount', direction: 'desc' }} onChange={vi.fn()} />,
+    );
+    expect(screen.getByLabelText(/largest first/i)).toBeInTheDocument();
+
+    rerender(<TransactionSort sort={{ field: 'amount', direction: 'asc' }} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/smallest first/i)).toBeInTheDocument();
+  });
+
+  it('describes payee direction alphabetically', () => {
+    render(<TransactionSort sort={{ field: 'payee', direction: 'asc' }} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/a to z/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/transactions/TransactionSort.tsx
+++ b/apps/web/src/components/transactions/TransactionSort.tsx
@@ -54,6 +54,23 @@ const SORT_FIELD_LABELS: Record<SortField, string> = {
   category: 'Category',
 };
 
+/**
+ * Human-meaningful description of what the current direction means for the
+ * selected field (e.g. "Newest first" rather than a bare "ascending"), so the
+ * control is understandable to screen-reader and sighted users alike (#3772).
+ */
+function describeSortDirection(field: SortField, direction: SortDirection): string {
+  switch (field) {
+    case 'date':
+      return direction === 'desc' ? 'Newest first' : 'Oldest first';
+    case 'amount':
+      return direction === 'desc' ? 'Largest first' : 'Smallest first';
+    case 'payee':
+    case 'category':
+      return direction === 'asc' ? 'A to Z' : 'Z to A';
+  }
+}
+
 export const TransactionSort: React.FC<TransactionSortProps> = ({ sort, onChange }) => {
   const idPrefix = useId();
 
@@ -67,6 +84,8 @@ export const TransactionSort: React.FC<TransactionSortProps> = ({ sort, onChange
   const handleDirectionToggle = useCallback(() => {
     onChange({ ...sort, direction: sort.direction === 'asc' ? 'desc' : 'asc' });
   }, [sort, onChange]);
+
+  const directionLabel = describeSortDirection(sort.field, sort.direction);
 
   return (
     <div className="transaction-sort" role="group" aria-label="Sort transactions">
@@ -90,8 +109,8 @@ export const TransactionSort: React.FC<TransactionSortProps> = ({ sort, onChange
         type="button"
         className="transaction-sort__direction"
         onClick={handleDirectionToggle}
-        aria-label={`Sort direction: ${sort.direction === 'asc' ? 'ascending' : 'descending'}. Click to toggle.`}
-        title={sort.direction === 'asc' ? 'Ascending' : 'Descending'}
+        aria-label={`Sort order: ${directionLabel}. Activate to reverse.`}
+        title={directionLabel}
       >
         <span aria-hidden="true">{sort.direction === 'asc' ? '↑' : '↓'}</span>
       </button>

--- a/apps/web/src/components/transactions/TransactionsSummaryBar.test.tsx
+++ b/apps/web/src/components/transactions/TransactionsSummaryBar.test.tsx
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for TransactionsSummaryBar.
+ * References: issue #3772
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import type { TransactionSummary } from '../../lib/transactions/summary';
+import { TransactionsSummaryBar } from './TransactionsSummaryBar';
+
+vi.mock('../common', () => ({
+  CurrencyDisplay: ({ amount, currency }: { amount: number; currency: string }) => (
+    <span data-testid="currency">
+      {currency} {amount}
+    </span>
+  ),
+}));
+
+function summary(overrides: Partial<TransactionSummary>): TransactionSummary {
+  return {
+    count: 0,
+    totalsByCurrency: [],
+    isMixedCurrency: false,
+    singleCurrencyNet: null,
+    ...overrides,
+  };
+}
+
+describe('TransactionsSummaryBar', () => {
+  it('pluralizes the transaction count', () => {
+    const { rerender } = render(<TransactionsSummaryBar summary={summary({ count: 1 })} />);
+    expect(screen.getAllByText(/1 transaction\b/).length).toBeGreaterThan(0);
+
+    rerender(<TransactionsSummaryBar summary={summary({ count: 4 })} />);
+    expect(screen.getAllByText(/4 transactions/).length).toBeGreaterThan(0);
+  });
+
+  it('renders a single net total', () => {
+    render(
+      <TransactionsSummaryBar
+        summary={summary({
+          count: 3,
+          totalsByCurrency: [{ currency: 'USD', net: 2500 }],
+          singleCurrencyNet: { currency: 'USD', net: 2500 },
+        })}
+      />,
+    );
+    expect(screen.getByText('USD 2500')).toBeInTheDocument();
+  });
+
+  it('lists each currency separately when mixed', () => {
+    render(
+      <TransactionsSummaryBar
+        summary={summary({
+          count: 2,
+          isMixedCurrency: true,
+          totalsByCurrency: [
+            { currency: 'EUR', net: -700 },
+            { currency: 'USD', net: 600 },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText('EUR -700')).toBeInTheDocument();
+    expect(screen.getByText('USD 600')).toBeInTheDocument();
+  });
+
+  it('announces the net total in a live region for screen readers', () => {
+    render(
+      <TransactionsSummaryBar
+        summary={summary({
+          count: 3,
+          totalsByCurrency: [{ currency: 'USD', net: -1500 }],
+          singleCurrencyNet: { currency: 'USD', net: -1500 },
+        })}
+      />,
+    );
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('3 transactions');
+    expect(status).toHaveTextContent(/net total negative 15\.00 USD/i);
+  });
+
+  it('omits the net when there are no net-contributing transactions', () => {
+    render(<TransactionsSummaryBar summary={summary({ count: 2 })} />);
+    expect(screen.queryByTestId('currency')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/transactions/TransactionsSummaryBar.tsx
+++ b/apps/web/src/components/transactions/TransactionsSummaryBar.tsx
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * TransactionsSummaryBar — at-a-glance count and net total for the visible
+ * ledger. Renders a visible summary and mirrors it in a polite live region so
+ * screen-reader users hear the totals update as filters and search change.
+ *
+ * Net total = income − expenses; transfers are excluded. When the visible set
+ * spans multiple currencies each currency's net is listed separately so unlike
+ * currencies are never summed into a misleading single figure.
+ *
+ * References: issue #3772
+ * @module components/transactions/TransactionsSummaryBar
+ */
+
+import React from 'react';
+
+import type { TransactionSummary } from '../../lib/transactions/summary';
+import { CurrencyDisplay } from '../common';
+
+import './transactions-summary-bar.css';
+
+export interface TransactionsSummaryBarProps {
+  /** Summary of the currently visible transactions. */
+  summary: TransactionSummary;
+}
+
+function countLabel(count: number): string {
+  return `${count} ${count === 1 ? 'transaction' : 'transactions'}`;
+}
+
+function netScreenReaderText(summary: TransactionSummary): string {
+  if (summary.totalsByCurrency.length === 0) {
+    return '';
+  }
+  const parts = summary.totalsByCurrency.map((total) => {
+    const magnitude = (Math.abs(total.net) / 100).toFixed(2);
+    const sign = total.net < 0 ? 'negative ' : '';
+    return `${sign}${magnitude} ${total.currency}`;
+  });
+  return `. Net total ${parts.join(', ')}`;
+}
+
+export const TransactionsSummaryBar: React.FC<TransactionsSummaryBarProps> = ({ summary }) => {
+  const hasNet = summary.totalsByCurrency.length > 0;
+
+  return (
+    <div className="transactions-summary-bar">
+      <span className="transactions-summary-bar__count">{countLabel(summary.count)}</span>
+      {hasNet && (
+        <span className="transactions-summary-bar__net" aria-hidden="true">
+          <span className="transactions-summary-bar__net-label">Net</span>
+          {summary.totalsByCurrency.map((total) => (
+            <CurrencyDisplay
+              key={total.currency}
+              className="transactions-summary-bar__amount"
+              amount={total.net}
+              currency={total.currency}
+              colorize
+              showSign
+            />
+          ))}
+        </span>
+      )}
+      <span className="sr-only" role="status" aria-live="polite">
+        {countLabel(summary.count)}
+        {netScreenReaderText(summary)}
+      </span>
+    </div>
+  );
+};
+
+export default TransactionsSummaryBar;

--- a/apps/web/src/components/transactions/index.ts
+++ b/apps/web/src/components/transactions/index.ts
@@ -16,3 +16,5 @@ export { LazyReceiptImage } from './LazyReceiptImage';
 export type { LazyReceiptImageProps } from './LazyReceiptImage';
 export { CounterpartyInput } from './CounterpartyInput';
 export type { CounterpartyInputProps } from './CounterpartyInput';
+export { TransactionsSummaryBar } from './TransactionsSummaryBar';
+export type { TransactionsSummaryBarProps } from './TransactionsSummaryBar';

--- a/apps/web/src/components/transactions/transactions-summary-bar.css
+++ b/apps/web/src/components/transactions/transactions-summary-bar.css
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for TransactionsSummaryBar — the at-a-glance count + net total shown
+ * above the transactions ledger. Uses design tokens for consistent theming.
+ * References: issue #3772
+ */
+
+.transactions-summary-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-2) var(--spacing-4);
+  padding: var(--spacing-2) var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-secondary);
+}
+
+.transactions-summary-bar__count {
+  font-size: var(--type-scale-body-font-size);
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-secondary);
+}
+
+.transactions-summary-bar__net {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--spacing-2);
+}
+
+.transactions-summary-bar__net-label {
+  font-size: var(--type-scale-caption-font-size, 0.8125rem);
+  font-weight: var(--font-weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--semantic-text-tertiary, var(--semantic-text-secondary));
+}
+
+.transactions-summary-bar__amount {
+  font-size: var(--type-scale-body-large-font-size, 1.0625rem);
+  font-weight: var(--font-weight-semibold, 600);
+  font-variant-numeric: tabular-nums;
+}

--- a/apps/web/src/lib/transactions/index.ts
+++ b/apps/web/src/lib/transactions/index.ts
@@ -13,3 +13,4 @@ export * from './rules-engine';
 export * from './merchant-insights';
 export * from './daily-spending';
 export * from './inflation-comparison';
+export * from './summary';

--- a/apps/web/src/lib/transactions/summary.test.ts
+++ b/apps/web/src/lib/transactions/summary.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import type { Transaction, TransactionType } from '../../kmp/bridge';
+import { summarizeTransactions } from './summary';
+
+let idCounter = 0;
+
+function makeTransaction(opts: {
+  type: TransactionType;
+  amount: number;
+  currency?: string;
+  id?: string;
+}): Transaction {
+  const { type, amount, currency = 'USD', id } = opts;
+  return {
+    id: id ?? `txn-${(idCounter += 1)}`,
+    householdId: 'household-1',
+    accountId: 'account-1',
+    categoryId: null,
+    type,
+    status: 'CLEARED',
+    amount: { amount },
+    currency: { code: currency, decimalPlaces: 2 },
+    payee: 'Payee',
+    note: null,
+    date: '2025-03-06',
+    transferAccountId: null,
+    transferTransactionId: null,
+    isRecurring: false,
+    recurringRuleId: null,
+    tags: [],
+    merchantAddress: null,
+    merchantCity: null,
+    merchantState: null,
+    merchantZip: null,
+    merchantCountry: null,
+    externalReferenceId: null,
+    statementDescription: null,
+    customFields: null,
+    extraNotes: null,
+    counterpartyName: null,
+    counterpartyAccountId: null,
+    createdAt: '2025-03-06T00:00:00.000Z',
+    updatedAt: '2025-03-06T00:00:00.000Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  };
+}
+
+describe('summarizeTransactions', () => {
+  it('counts every transaction including transfers', () => {
+    const summary = summarizeTransactions([
+      makeTransaction({ type: 'INCOME', amount: 5000 }),
+      makeTransaction({ type: 'EXPENSE', amount: 2000 }),
+      makeTransaction({ type: 'TRANSFER', amount: 9999 }),
+    ]);
+    expect(summary.count).toBe(3);
+  });
+
+  it('nets income minus expenses in integer cents', () => {
+    const summary = summarizeTransactions([
+      makeTransaction({ type: 'INCOME', amount: 5000 }),
+      makeTransaction({ type: 'EXPENSE', amount: 2000 }),
+      makeTransaction({ type: 'EXPENSE', amount: 500 }),
+    ]);
+    expect(summary.singleCurrencyNet).toEqual({ currency: 'USD', net: 2500 });
+    expect(summary.isMixedCurrency).toBe(false);
+  });
+
+  it('treats expense amounts as negative regardless of stored sign', () => {
+    const summary = summarizeTransactions([
+      makeTransaction({ type: 'EXPENSE', amount: -3000 }),
+      makeTransaction({ type: 'INCOME', amount: 1000 }),
+    ]);
+    expect(summary.singleCurrencyNet).toEqual({ currency: 'USD', net: -2000 });
+  });
+
+  it('excludes transfers from the net total', () => {
+    const summary = summarizeTransactions([
+      makeTransaction({ type: 'INCOME', amount: 1000 }),
+      makeTransaction({ type: 'TRANSFER', amount: 50000 }),
+    ]);
+    expect(summary.singleCurrencyNet).toEqual({ currency: 'USD', net: 1000 });
+  });
+
+  it('reports per-currency totals and flags mixed currencies', () => {
+    const summary = summarizeTransactions([
+      makeTransaction({ type: 'INCOME', amount: 1000, currency: 'USD' }),
+      makeTransaction({ type: 'EXPENSE', amount: 400, currency: 'USD' }),
+      makeTransaction({ type: 'EXPENSE', amount: 700, currency: 'EUR' }),
+    ]);
+    expect(summary.isMixedCurrency).toBe(true);
+    expect(summary.singleCurrencyNet).toBeNull();
+    expect(summary.totalsByCurrency).toEqual([
+      { currency: 'EUR', net: -700 },
+      { currency: 'USD', net: 600 },
+    ]);
+  });
+
+  it('returns an empty net when only transfers are present', () => {
+    const summary = summarizeTransactions([
+      makeTransaction({ type: 'TRANSFER', amount: 1000 }),
+      makeTransaction({ type: 'TRANSFER', amount: 2000 }),
+    ]);
+    expect(summary.count).toBe(2);
+    expect(summary.totalsByCurrency).toEqual([]);
+    expect(summary.singleCurrencyNet).toBeNull();
+    expect(summary.isMixedCurrency).toBe(false);
+  });
+
+  it('handles an empty list', () => {
+    const summary = summarizeTransactions([]);
+    expect(summary).toEqual({
+      count: 0,
+      totalsByCurrency: [],
+      isMixedCurrency: false,
+      singleCurrencyNet: null,
+    });
+  });
+});

--- a/apps/web/src/lib/transactions/summary.ts
+++ b/apps/web/src/lib/transactions/summary.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Transaction summary helpers.
+ *
+ * Produces at-a-glance totals for a set of transactions so the ledger can
+ * surface a results summary (count + net total) and per-day subtotals.
+ *
+ * Net total = income − expenses. Transfers are excluded from the net because
+ * they move money between the user's own accounts and are not spend or income.
+ * Totals are computed per ISO 4217 currency so mixed-currency lists never sum
+ * unlike currencies into a misleading single figure.
+ *
+ * References: issue #3772
+ * @module lib/transactions/summary
+ */
+
+import type { Transaction } from '../../kmp/bridge';
+
+/** Net total (in integer cents) for a single currency. */
+export interface CurrencyTotal {
+  /** ISO 4217 currency code. */
+  readonly currency: string;
+  /** Net amount in integer cents (income positive, expenses negative). */
+  readonly net: number;
+}
+
+/** Aggregate summary of a set of transactions. */
+export interface TransactionSummary {
+  /** Number of transactions in the set (all types, including transfers). */
+  readonly count: number;
+  /** Net totals per currency, sorted by currency code. Transfers excluded. */
+  readonly totalsByCurrency: readonly CurrencyTotal[];
+  /** True when more than one currency contributes to the net total. */
+  readonly isMixedCurrency: boolean;
+  /**
+   * The net total when every net-contributing transaction shares a single
+   * currency; `null` when the set spans multiple currencies or contains no
+   * net-contributing transactions (e.g. transfers only).
+   */
+  readonly singleCurrencyNet: CurrencyTotal | null;
+}
+
+/**
+ * Signed contribution of a transaction to a net total, in integer cents.
+ * Expenses are negative, income positive, transfers contribute nothing.
+ */
+function netContribution(transaction: Transaction): number {
+  switch (transaction.type) {
+    case 'EXPENSE':
+      return -Math.abs(transaction.amount.amount);
+    case 'INCOME':
+      return Math.abs(transaction.amount.amount);
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Summarize a set of transactions into a count and per-currency net totals.
+ *
+ * @param transactions Transactions to summarize (order-independent).
+ * @returns A {@link TransactionSummary}.
+ */
+export function summarizeTransactions(transactions: readonly Transaction[]): TransactionSummary {
+  const netByCurrency = new Map<string, number>();
+
+  for (const transaction of transactions) {
+    if (transaction.type === 'TRANSFER') {
+      continue;
+    }
+    const code = transaction.currency.code;
+    netByCurrency.set(code, (netByCurrency.get(code) ?? 0) + netContribution(transaction));
+  }
+
+  const totalsByCurrency: CurrencyTotal[] = Array.from(netByCurrency, ([currency, net]) => ({
+    currency,
+    net,
+  })).sort((a, b) => a.currency.localeCompare(b.currency));
+
+  const isMixedCurrency = totalsByCurrency.length > 1;
+  const singleCurrencyNet = totalsByCurrency.length === 1 ? totalsByCurrency[0] : null;
+
+  return {
+    count: transactions.length,
+    totalsByCurrency,
+    isMixedCurrency,
+    singleCurrencyNet,
+  };
+}

--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -90,6 +90,11 @@ vi.mock('../components/common', () => ({
       </div>
     ) : null,
   CurrencyDisplay: ({ amount }: { amount: number }) => <span>{amount}</span>,
+  Button: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
   ReadAloudButton: () => null,
   DragDropProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
   DraggableTransaction: ({
@@ -115,7 +120,12 @@ vi.mock('../components/common', () => ({
       {children}
     </div>
   ),
-  EmptyState: ({ title }: { title: string }) => <div>{title}</div>,
+  EmptyState: ({ title, action }: { title: string; action?: ReactNode }) => (
+    <div>
+      {title}
+      {action}
+    </div>
+  ),
   ErrorBanner: ({ message }: { message: string }) => <div>{message}</div>,
   ExplainThis: () => null,
   LoadingSpinner: ({ label }: { label: string }) => <div>{label}</div>,
@@ -165,6 +175,20 @@ vi.mock('../components/transactions', () => ({
       </div>
     ) : null,
   LazyReceiptImage: () => null,
+  TransactionsSummaryBar: ({
+    summary,
+  }: {
+    summary: { count: number; totalsByCurrency: { currency: string; net: number }[] };
+  }) => (
+    <div data-testid="transactions-summary">
+      <span>{summary.count} transactions</span>
+      {summary.totalsByCurrency.map((total) => (
+        <span key={total.currency} data-testid="summary-net">
+          {total.currency} {total.net}
+        </span>
+      ))}
+    </div>
+  ),
   EMPTY_FILTERS: {
     startDate: '',
     endDate: '',
@@ -452,6 +476,61 @@ describe('TransactionsPage', () => {
       </MemoryRouter>,
     );
     expect(screen.getByText('Transactions')).toBeInTheDocument();
+  });
+
+  it('shows a results summary with count and net total for the visible ledger', () => {
+    render(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    );
+
+    const summary = screen.getByTestId('transactions-summary');
+    // 3 transactions: +450000 income, -6742 and -12400 expenses = net 430858.
+    expect(within(summary).getByText('3 transactions')).toBeInTheDocument();
+    expect(within(summary).getByText('USD 430858')).toBeInTheDocument();
+  });
+
+  it('offers a Clear filters action when a search yields no results', () => {
+    render(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Search transactions'), {
+      target: { value: 'zzz-no-such-transaction' },
+    });
+    expect(screen.getByText('No transactions found')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    // Results return and the summary reflects the full set again.
+    expect(
+      within(screen.getByTestId('transactions-summary')).getByText('3 transactions'),
+    ).toBeInTheDocument();
+  });
+
+  it('offers an Add transaction action from the empty state when there are no transactions', () => {
+    mockedUseTransactions.mockReturnValue({
+      transactions: [],
+      loading: false,
+      error: null,
+      refresh: refreshTransactionsMock,
+      createTransaction: createTransactionMock,
+      updateTransaction: updateTransactionMock,
+      deleteTransaction: deleteTransactionMock,
+    });
+
+    render(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('No transactions yet')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Add transaction' }));
+    expect(screen.getByRole('dialog', { name: 'Transaction form' })).toBeInTheDocument();
   });
 
   it('opens the default add transaction action from the split button primary action', () => {

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -19,6 +19,7 @@ import {
   ReadAloudButton,
   SyncIndicator,
   useToast,
+  Button,
 } from '../components/common';
 import { SkipLink } from '../components/common/SkipLink';
 import { SwipeableRow } from '../components/common/SwipeableRow';
@@ -41,6 +42,7 @@ import {
   TransactionFilters,
   TransactionSort,
   TransactionEditPanel,
+  TransactionsSummaryBar,
   LazyReceiptImage,
   DEFAULT_SORT,
 } from '../components/transactions';
@@ -86,6 +88,7 @@ import {
   matchesTransactionQuery,
   sortTransactions,
 } from '../lib/transactions/filter-sort';
+import { summarizeTransactions, type TransactionSummary } from '../lib/transactions/summary';
 
 // Lazy-loaded so the quick-add affordance (dialog, presets, persistence helper)
 // lands in its own async chunk and stays out of the saturated ledger route chunk.
@@ -199,6 +202,33 @@ function getTransactionLabel(transaction: Transaction): string {
   );
 }
 
+/**
+ * Renders the net subtotal for a group of transactions (e.g. a single day),
+ * shown to the right of the date header. Currency-aware: each currency is
+ * listed separately so unlike currencies are never summed. Renders nothing
+ * when the group has no net-contributing transactions (transfers only).
+ */
+function DaySubtotal({ summary }: { summary: TransactionSummary }): React.ReactElement | null {
+  if (summary.totalsByCurrency.length === 0) {
+    return null;
+  }
+  return (
+    <span className="list-group__header-subtotal">
+      {summary.totalsByCurrency.map((total) => (
+        <CurrencyDisplay
+          key={total.currency}
+          className="list-group__header-amount"
+          amount={total.net}
+          currency={total.currency}
+          colorize
+          showSign
+          context="daily net total"
+        />
+      ))}
+    </span>
+  );
+}
+
 const VIRTUAL_REGISTER_THRESHOLD = 200;
 const VIRTUAL_REGISTER_ROW_HEIGHT = 76;
 const VIRTUAL_REGISTER_OVERSCAN = 16;
@@ -207,6 +237,7 @@ interface TransactionRegisterHeaderRow {
   readonly kind: 'header';
   readonly id: string;
   readonly label: string;
+  readonly summary: TransactionSummary;
 }
 
 interface TransactionRegisterTransactionRow {
@@ -224,11 +255,21 @@ function getRegisterViewportHeight(): number {
 }
 
 function flattenTransactionGroups(
-  groups: Array<{ date: string; label: string; transactions: Transaction[] }>,
+  groups: Array<{
+    date: string;
+    label: string;
+    transactions: Transaction[];
+    summary: TransactionSummary;
+  }>,
 ): TransactionRegisterRow[] {
   let transactionPosition = 0;
   return groups.flatMap((group) => [
-    { kind: 'header' as const, id: `header-${group.date}`, label: group.label },
+    {
+      kind: 'header' as const,
+      id: `header-${group.date}`,
+      label: group.label,
+      summary: group.summary,
+    },
     ...group.transactions.map((transaction) => ({
       kind: 'transaction' as const,
       id: transaction.id,
@@ -569,8 +610,13 @@ export const TransactionsPage: React.FC = () => {
         day: 'numeric',
       }),
       transactions: datedTransactions,
+      summary: summarizeTransactions(datedTransactions),
     }));
   }, [transactions]);
+
+  // Overall summary (count + net total) for the visible/filtered set, shown in
+  // the summary bar above the ledger (#3772).
+  const transactionsSummary = useMemo(() => summarizeTransactions(transactions), [transactions]);
 
   const transactionRegisterRows = useMemo(
     () => flattenTransactionGroups(groupedTransactions),
@@ -639,6 +685,18 @@ export const TransactionsPage: React.FC = () => {
     },
     [advancedFilters, setSearchParams],
   );
+
+  // Reset all narrowing controls (search, purpose, advanced filters) while
+  // preserving the current sort. Used by the empty-state "Clear filters" CTA
+  // (#3772).
+  const handleClearAllFilters = useCallback(() => {
+    setQuery('');
+    setSelectedPurposeFilter('all');
+    const params: Record<string, string> = {};
+    if (sortConfig.field !== DEFAULT_SORT.field) params.sortField = sortConfig.field;
+    if (sortConfig.direction !== DEFAULT_SORT.direction) params.sortDir = sortConfig.direction;
+    setSearchParams(params, { replace: true });
+  }, [sortConfig, setSearchParams]);
 
   // Form handlers
   const handleOpenCreateForm = useCallback(() => {
@@ -1451,6 +1509,10 @@ export const TransactionsPage: React.FC = () => {
             Transaction results
           </h2>
 
+          {!isLoading && !resolvedError && transactions.length > 0 && (
+            <TransactionsSummaryBar summary={transactionsSummary} />
+          )}
+
           {isLoading ? (
             <div
               style={{ display: 'flex', justifyContent: 'center', padding: 'var(--spacing-8) 0' }}
@@ -1467,6 +1529,17 @@ export const TransactionsPage: React.FC = () => {
                   ? 'Try adjusting your search or filters.'
                   : 'Transactions you add will appear here.'
               }
+              action={
+                hasActiveFilters ? (
+                  <Button variant="secondary" onClick={handleClearAllFilters}>
+                    Clear filters
+                  </Button>
+                ) : (
+                  <Button variant="primary" onClick={handleOpenCreateForm}>
+                    Add transaction
+                  </Button>
+                )
+              }
             />
           ) : useCardRegister ? (
             <div className="card transaction-card-list-fallback">
@@ -1480,7 +1553,10 @@ export const TransactionsPage: React.FC = () => {
                   className="page-section"
                   aria-label={`${group.label} transaction cards`}
                 >
-                  <h3 className="list-group__header">{group.label}</h3>
+                  <h3 className="list-group__header">
+                    <span>{group.label}</span>
+                    <DaySubtotal summary={group.summary} />
+                  </h3>
                   <ul
                     className="list-group transaction-card-list"
                     role="list"
@@ -1538,7 +1614,8 @@ export const TransactionsPage: React.FC = () => {
                           role="presentation"
                           style={rowStyle}
                         >
-                          {item.label}
+                          <span>{item.label}</span>
+                          <DaySubtotal summary={item.summary} />
                         </li>
                       );
                     }
@@ -1577,7 +1654,10 @@ export const TransactionsPage: React.FC = () => {
               />
               {groupedTransactions.map((group) => (
                 <section key={group.date} className="page-section" aria-label={group.label}>
-                  <h3 className="list-group__header">{group.label}</h3>
+                  <h3 className="list-group__header">
+                    <span>{group.label}</span>
+                    <DaySubtotal summary={group.summary} />
+                  </h3>
                   <div className="card">
                     <ul className="list-group" role="list">
                       {group.transactions.map((transaction) => {

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -443,11 +443,24 @@
   list-style: none;
 }
 .list-group__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-2);
   font-size: var(--type-scale-label-font-size);
   color: var(--semantic-text-secondary);
   padding: var(--spacing-2) 0;
   text-transform: uppercase;
   border-bottom: 1px solid var(--semantic-border-default);
+}
+.list-group__header-subtotal {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--spacing-2);
+  text-transform: none;
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--font-weight-semibold, 600);
 }
 .list-item {
   display: flex;


### PR DESCRIPTION
## Summary

Part of the fleet UX-critique program for the **Transactions list & entry** surface. This PR implements a coherent "scannable ledger" subset of the critique filed in #3772: give users at-a-glance totals and actionable empty states so the ledger answers "how much moved?" without manual mental math.

Closes #3772

## What changed

- **Results summary bar** above the ledger — visible count + currency-aware **net total** (income − expenses), mirrored in a polite `aria-live` region for screen readers.
- **Per-day net subtotals** in each date-group header (standard, virtualized, and large-text card registers).
- **Actionable empty states** — "Clear filters" when a search/filter yields nothing, "Add transaction" when the ledger is genuinely empty (both via the shared `Button`).
- **Human-meaningful sort labels** — the direction toggle now announces "Newest/Oldest first", "Largest/Smallest first", and "A to Z / Z to A" instead of a bare "ascending/descending".
- New pure, unit-tested `summarizeTransactions` helper: nets income minus expenses, **excludes transfers**, and aggregates **per currency** so mixed-currency lists are never summed into a misleading figure.

## Correctness & accessibility notes

- Net totals are computed per ISO 4217 currency; when a set spans multiple currencies each is listed separately rather than added.
- All amounts flow through the existing privacy-aware `CurrencyDisplay`, so masking and negative-format settings are respected.
- Summary and subtotals are announced to assistive tech; sort-direction labels are contextual (WCAG 2.2 AA, no color-only meaning).

## Testing (local only)

- `npm run format:check` — clean
- `npx eslint . --max-warnings 0` — clean
- `apps/web` `tsc --noEmit` — clean
- `cd apps/web && npm test` — **877 files, 9644 tests passing** (incl. new `summary`, `TransactionsSummaryBar`, `TransactionSort`, and `TransactionsPage` cases)

---

## Full critique list (from #3772)

1. **No results summary / running total above the ledger** — a finance ledger's most useful number (count + net total) was absent. *Fixed here.*
2. **Date-group headers have no daily subtotal** — daily spend is a core budgeting signal. *Fixed here.*
3. **Empty state offers no call to action** — `EmptyState` supports `action` but the page passed none. *Fixed here.*
4. **Sort direction toggle announces raw "ascending/descending"** — ambiguous per field. *Fixed here.*
5. **CSV export ignores currency** — a multi-currency export is ambiguous without a currency column. *(Follow-up.)*
6. **Bulk actions dropdowns don't close on outside click or Escape** — unpredictable dismissal. *(Follow-up.)*
7. **Search input has no clear ("×") button** — no fast keyboard reset or match count. *(Partially addressed via summary count; clear button is a follow-up.)*
8. **Delete has no undo** — destructive row action loses the record with no recovery. *(Follow-up.)*
9. **Amount color is the only income/expense cue in the row** — add a non-color type indicator. *(Follow-up.)*
10. **"Select all" scope is unclear when filters are active** — risk of bulk-deleting a misunderstood scope. *(Follow-up.)*
11. **`aria-selected` on `role="listitem"`** — invalid ARIA pairing. *(Follow-up.)*
12. **No discoverability for the roving-focus keyboard navigation** — arrow-key nav is invisible. *(Follow-up.)*

Items 1–4 are implemented in this PR; the remainder are tracked in #3772 for follow-up PRs.
