### PR TITLE
feat(web): accurate, accessible budget status and planner income (#3774)

### DIFF
--- a/apps/web/src/lib/a11y.test.ts
+++ b/apps/web/src/lib/a11y.test.ts
@@ -93,8 +93,16 @@ describe('getGoalStatusIndicator', () => {
 });
 
 describe('getBudgetStatusIndicator', () => {
-  it('returns over limit for >90%', () => {
-    expect(getBudgetStatusIndicator(95).tone).toBe('negative');
+  it('returns over budget only once spending reaches the limit (>=100%)', () => {
+    const status = getBudgetStatusIndicator(130);
+    expect(status.tone).toBe('negative');
+    expect(status.label).toBe('Over budget');
+  });
+
+  it('labels the 90-99% band "Almost at limit" rather than over budget (#3774)', () => {
+    const status = getBudgetStatusIndicator(95);
+    expect(status.tone).toBe('negative');
+    expect(status.label).toBe('Almost at limit');
   });
 
   it('returns near limit for 76-90%', () => {

--- a/apps/web/src/lib/a11y.ts
+++ b/apps/web/src/lib/a11y.ts
@@ -159,11 +159,18 @@ export function getGoalStatusIndicator(percentComplete: number): {
 /**
  * Return a text indicator for budget usage percentage.
  *
+ * The bands are deliberately ordered most-severe first so the label always
+ * matches reality: a budget is only described as "Over budget" once spending
+ * has actually reached or exceeded the limit (>= 100%). The 90–99% band is the
+ * high-pressure "Almost at limit" warning — previously this was mislabelled as
+ * "Over limit" even though money still remained (#3774).
+ *
  * @param percentUsed - Budget usage percentage (0–100+).
  *
  * @example
  * ```ts
- * getBudgetStatusIndicator(95);  // { icon: 'alert-triangle', label: 'Over limit', tone: 'negative' }
+ * getBudgetStatusIndicator(130); // { icon: 'alert-triangle', label: 'Over budget', tone: 'negative' }
+ * getBudgetStatusIndicator(95);  // { icon: 'alert-triangle', label: 'Almost at limit', tone: 'negative' }
  * getBudgetStatusIndicator(80);  // { icon: 'target', label: 'Near limit', tone: 'warning' }
  * getBudgetStatusIndicator(50);  // { icon: 'check', label: 'On track', tone: 'positive' }
  * ```
@@ -173,8 +180,11 @@ export function getBudgetStatusIndicator(percentUsed: number): {
   label: string;
   tone: 'positive' | 'warning' | 'negative';
 } {
+  if (percentUsed >= 100) {
+    return { icon: 'alert-triangle', label: 'Over budget', tone: 'negative' };
+  }
   if (percentUsed > 90) {
-    return { icon: 'alert-triangle', label: 'Over limit', tone: 'negative' };
+    return { icon: 'alert-triangle', label: 'Almost at limit', tone: 'negative' };
   }
   if (percentUsed > 75) {
     return { icon: 'target', label: 'Near limit', tone: 'warning' };

--- a/apps/web/src/lib/budget-current-income.test.ts
+++ b/apps/web/src/lib/budget-current-income.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { computeCurrentPeriodIncome, type CurrentIncomeTransaction } from './budget-current-income';
+
+const reference = new Date(2025, 2, 15); // March 2025
+
+function tx(overrides: Partial<CurrentIncomeTransaction>): CurrentIncomeTransaction {
+  return {
+    type: 'INCOME',
+    amountCents: 100000,
+    date: '2025-03-05',
+    deleted: false,
+    ...overrides,
+  };
+}
+
+describe('computeCurrentPeriodIncome', () => {
+  it('sums INCOME transactions within the current month', () => {
+    const total = computeCurrentPeriodIncome(
+      [
+        tx({ amountCents: 200000, date: '2025-03-01' }),
+        tx({ amountCents: 150000, date: '2025-03-31' }),
+      ],
+      reference,
+    );
+    expect(total).toBe(350000);
+  });
+
+  it('ignores non-income, deleted, and out-of-month transactions', () => {
+    const total = computeCurrentPeriodIncome(
+      [
+        tx({ type: 'EXPENSE', amountCents: 500000 }),
+        tx({ deleted: true, amountCents: 500000 }),
+        tx({ date: '2025-02-28', amountCents: 500000 }),
+        tx({ date: '2025-04-01', amountCents: 500000 }),
+        tx({ amountCents: 120000, date: '2025-03-10' }),
+      ],
+      reference,
+    );
+    expect(total).toBe(120000);
+  });
+
+  it('uses the absolute value of amounts', () => {
+    expect(computeCurrentPeriodIncome([tx({ amountCents: -90000 })], reference)).toBe(90000);
+  });
+
+  it('returns 0 when there is no matching income', () => {
+    expect(computeCurrentPeriodIncome([], reference)).toBe(0);
+  });
+});

--- a/apps/web/src/lib/budget-current-income.ts
+++ b/apps/web/src/lib/budget-current-income.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Computes the current calendar month's actual income from transaction history
+ * so the budget analytics "Savings Rate" widget reflects real income vs.
+ * spending instead of substituting the total budgeted amount for income.
+ *
+ * The income convention mirrors the spend convention used elsewhere: only
+ * `INCOME` transactions count, soft-deleted rows are ignored, and each amount is
+ * taken as its absolute value in cents. See issue #3774.
+ */
+
+export interface CurrentIncomeTransaction {
+  /** Transaction type; only `INCOME` contributes. */
+  readonly type: string;
+  /** Signed amount in cents (absolute value is used). */
+  readonly amountCents: number;
+  /** Calendar date as an ISO `YYYY-MM-DD` string. */
+  readonly date: string;
+  /** True when the transaction has been soft-deleted. */
+  readonly deleted: boolean;
+}
+
+function toIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Aggregate the current calendar month's income relative to `referenceDate`.
+ *
+ * @param transactions - Full transaction history (already currency-normalized).
+ * @param referenceDate - Any date within the current period; only its year and
+ *   month are used to locate the current calendar month.
+ * @returns Total income in cents for the current month (0 when none matched).
+ */
+export function computeCurrentPeriodIncome(
+  transactions: readonly CurrentIncomeTransaction[],
+  referenceDate: Date,
+): number {
+  const year = referenceDate.getFullYear();
+  const month = referenceDate.getMonth();
+  const startIso = toIsoDate(new Date(year, month, 1));
+  const endIso = toIsoDate(new Date(year, month + 1, 0));
+
+  let total = 0;
+  for (const transaction of transactions) {
+    if (transaction.deleted || transaction.type !== 'INCOME') continue;
+    if (transaction.date < startIso || transaction.date > endIso) continue;
+    total += Math.abs(transaction.amountCents);
+  }
+
+  return total;
+}

--- a/apps/web/src/pages/BudgetDetailPage.tsx
+++ b/apps/web/src/pages/BudgetDetailPage.tsx
@@ -168,8 +168,9 @@ export const BudgetDetailPage: React.FC = () => {
     budget.amount.amount > 0
       ? Math.round((budget.spentAmount.amount / budget.amount.amount) * 100)
       : 0;
-  const statusTone = percentUsed > 90 ? 'negative' : percentUsed > 75 ? 'warning' : 'positive';
   const budgetStatus = getBudgetStatusIndicator(percentUsed);
+  const statusTone = budgetStatus.tone;
+  const percentValueText = `${percentUsed}% used — ${budgetStatus.label}`;
   const radius = 36;
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (Math.min(percentUsed, 100) / 100) * circumference;
@@ -308,7 +309,8 @@ export const BudgetDetailPage: React.FC = () => {
             aria-valuenow={Math.min(percentUsed, 100)}
             aria-valuemin={0}
             aria-valuemax={100}
-            aria-label={`${budget.name} budget: ${percentUsed} percent used, ${budgetStatus.label}`}
+            aria-valuetext={percentValueText}
+            aria-label={`${budget.name} budget: ${percentValueText}`}
           >
             <svg
               className="progress-ring__svg"

--- a/apps/web/src/pages/BudgetsPage.css
+++ b/apps/web/src/pages/BudgetsPage.css
@@ -80,3 +80,17 @@
   font-size: var(--type-scale-caption-font-size);
   line-height: 1.6;
 }
+
+.budget-planner__income-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.budget-planner__error {
+  margin: var(--spacing-2) 0 0;
+  font-size: var(--type-scale-caption-font-size);
+  line-height: 1.4;
+  color: var(--semantic-status-negative);
+}

--- a/apps/web/src/pages/BudgetsPage.test.tsx
+++ b/apps/web/src/pages/BudgetsPage.test.tsx
@@ -423,6 +423,43 @@ describe('BudgetsPage', () => {
     expect(progressBars.length).toBe(9);
   });
 
+  it('exposes the true usage percentage and status via aria-valuetext (#3774)', () => {
+    render(
+      <MemoryRouter>
+        <BudgetsPage />
+      </MemoryRouter>,
+    );
+    // Housing is spent 120000 of 120000 = 100% → genuinely over budget.
+    const ring = screen.getByRole('progressbar', { name: /Housing budget/i });
+    expect(ring.getAttribute('aria-valuetext')).toContain('100% used');
+    expect(ring.getAttribute('aria-valuetext')).toContain('Over budget');
+  });
+
+  it('validates, adds, and removes planner income events (#3774)', () => {
+    render(
+      <MemoryRouter>
+        <BudgetsPage />
+      </MemoryRouter>,
+    );
+
+    const addButton = screen.getByRole('button', { name: /add income event/i });
+
+    // Submitting without an amount surfaces an accessible error instead of failing silently.
+    fireEvent.click(addButton);
+    expect(screen.getByText(/greater than zero/i)).toBeInTheDocument();
+
+    // A valid amount adds a removable income row and clears the error.
+    fireEvent.change(screen.getByLabelText('Income amount'), { target: { value: '2000' } });
+    fireEvent.click(addButton);
+    expect(screen.queryByText(/greater than zero/i)).not.toBeInTheDocument();
+
+    const removeButton = screen.getByRole('button', { name: /remove income event/i });
+    expect(removeButton).toBeInTheDocument();
+
+    fireEvent.click(removeButton);
+    expect(screen.queryByRole('button', { name: /remove income event/i })).not.toBeInTheDocument();
+  });
+
   it('shows the Food & Meals quick-start template card', () => {
     render(
       <MemoryRouter>

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -26,6 +26,7 @@ import type { Budget } from '../kmp/bridge';
 import { getBudgetStatusIndicator } from '../lib/a11y';
 import { getBudgetStarterTemplates } from '../lib/budgeting/starter-budget-templates';
 import { computePreviousPeriodSpending } from '../lib/budget-previous-period';
+import { computeCurrentPeriodIncome } from '../lib/budget-current-income';
 import type { DisplayExchangeRate } from '../lib/budgeting/display-currency-rollups';
 import type { TripBudgetTransaction } from '../lib/budgeting/trip-country-budget-scope';
 import {
@@ -167,6 +168,7 @@ export const BudgetsPage: React.FC = () => {
   const [incomeAmountInput, setIncomeAmountInput] = useState('');
   const [incomeDateInput, setIncomeDateInput] = useState(todayIso);
   const [incomeEvents, setIncomeEvents] = useState<IncomeEventInput[]>([]);
+  const [incomeError, setIncomeError] = useState<string | null>(null);
   const [tripBudgets, setTripBudgets] = useState<readonly TripCountryBudget[]>(() =>
     loadTripCountryBudgets(resolveTripBudgetStorage()),
   );
@@ -286,20 +288,27 @@ export const BudgetsPage: React.FC = () => {
   const handleAddIncomeEvent = useCallback(() => {
     const amountCents = centsFromInput(incomeAmountInput);
     if (amountCents <= 0) {
+      setIncomeError('Enter an income amount greater than zero.');
       return;
     }
 
+    const source = incomeSourceInput.trim() || 'Income';
     setIncomeEvents((events) => [
       ...events,
       {
         id: `income-${Date.now()}-${events.length}`,
-        source: incomeSourceInput.trim() || 'Income',
+        source,
         amountCents,
         date: incomeDateInput || todayIso(),
       },
     ]);
+    setIncomeError(null);
     setIncomeAmountInput('');
   }, [incomeAmountInput, incomeDateInput, incomeSourceInput]);
+
+  const handleRemoveIncomeEvent = useCallback((id: string) => {
+    setIncomeEvents((events) => events.filter((event) => event.id !== id));
+  }, []);
 
   /** Close the budget form dialog without saving. */
   const handleFormCancel = useCallback(() => {
@@ -466,6 +475,24 @@ export const BudgetsPage: React.FC = () => {
     [transactions, categoryNameById, currentYear, currentMonth],
   );
 
+  // Real income for the current period drives the savings-rate analytics.
+  // Fall back to the budgeted total only when no income has been recorded yet,
+  // so the widget never regresses to a misleading "-100%" on a fresh ledger.
+  const currentPeriodIncome = useMemo(
+    () =>
+      computeCurrentPeriodIncome(
+        transactions.map((transaction) => ({
+          type: transaction.type,
+          amountCents: transaction.amount.amount,
+          date: transaction.date,
+          deleted: transaction.deletedAt != null,
+        })),
+        new Date(currentYear, currentMonth, 1),
+      ),
+    [transactions, currentYear, currentMonth],
+  );
+  const analyticsIncome = currentPeriodIncome > 0 ? currentPeriodIncome : totalBudgeted;
+
   return (
     <>
       <OfflineBanner />
@@ -625,11 +652,30 @@ export const BudgetsPage: React.FC = () => {
                 Add income event
               </button>
             </div>
+            <p
+              className="budget-planner__error"
+              role="alert"
+              aria-live="assertive"
+              hidden={incomeError === null}
+            >
+              {incomeError}
+            </p>
             {incomeEvents.length > 0 && (
               <ul className="budget-planner__income-list">
                 {incomeEvents.map((event) => (
-                  <li key={event.id}>
-                    {event.source} on {event.date}: <CurrencyDisplay amount={event.amountCents} />
+                  <li key={event.id} className="budget-planner__income-item">
+                    <span>
+                      {event.source} on {event.date}: <CurrencyDisplay amount={event.amountCents} />
+                    </span>
+                    <button
+                      type="button"
+                      className="icon-button icon-button--delete"
+                      onClick={() => handleRemoveIncomeEvent(event.id)}
+                      aria-label={`Remove income event: ${event.source} on ${event.date}`}
+                      title="Remove income event"
+                    >
+                      <AppIcon name="trash" />
+                    </button>
                   </li>
                 ))}
               </ul>
@@ -799,7 +845,7 @@ export const BudgetsPage: React.FC = () => {
             </div>
           </section>
           <BudgetAnalytics
-            totalIncome={totalBudgeted}
+            totalIncome={analyticsIncome}
             totalSpent={totalSpent}
             totalBudget={totalBudgeted}
             daysElapsed={daysElapsed}
@@ -860,9 +906,9 @@ export const BudgetsPage: React.FC = () => {
                     ? Math.round((budget.spentAmount.amount / budget.amount.amount) * 100)
                     : 0;
                 const remainingAmount = budget.remainingAmount.amount;
-                const statusTone =
-                  percentUsed > 90 ? 'negative' : percentUsed > 75 ? 'warning' : 'positive';
                 const budgetStatus = getBudgetStatusIndicator(percentUsed);
+                const statusTone = budgetStatus.tone;
+                const valueText = `${percentUsed}% used — ${budgetStatus.label}`;
                 const radius = 36;
                 const circumference = 2 * Math.PI * radius;
                 const offset = circumference - (Math.min(percentUsed, 100) / 100) * circumference;
@@ -886,7 +932,8 @@ export const BudgetsPage: React.FC = () => {
                       aria-valuenow={Math.min(percentUsed, 100)}
                       aria-valuemin={0}
                       aria-valuemax={100}
-                      aria-label={`${budget.name} budget: ${percentUsed} percent used, ${budgetStatus.label}`}
+                      aria-valuetext={valueText}
+                      aria-label={`${budget.name} budget: ${valueText}`}
                     >
                       <svg
                         className="progress-ring__svg"


### PR DESCRIPTION
## Summary

Implements items **1–5** of the budgeting UX critique in **#3774** (fleet focus: Budgeting features & flows). All changes are in the locally-testable Web PWA (`apps/web`) and ship with tests.

Closes #3774

### What changed

1. **Fix misleading "Over limit" status** — `getBudgetStatusIndicator` now has a true `>= 100%` **"Over budget"** tier and relabels the 90–99% band **"Almost at limit"**. Previously a budget at 91–99% (still with money left) was announced as "Over limit". Tone thresholds are unchanged, so ring colors are unaffected.
2. **Accessible progress rings** — Added `aria-valuetext` to the rings on `BudgetsPage` and `BudgetDetailPage` so assistive tech hears the true, uncapped percentage plus status (e.g. "150% used — Over budget") instead of the capped `aria-valuenow` of 100 that contradicted the visible label (WCAG 2.2 AA 4.1.2).
3. **Centralized status tone** — Ring color now derives from the central helper's `tone`, removing the duplicated `>90 / >75` threshold logic that was hand-inlined on the budgets surfaces (drift risk).
4. **Planner income events** — Invalid/empty amounts now surface an inline `aria-live` error instead of failing silently (WCAG 3.3.1), and each added income event has a **Remove** button so mistakes are recoverable.
5. **Real income for Savings Rate** — New pure helper `computeCurrentPeriodIncome` feeds actual current-month `INCOME` into `BudgetAnalytics` instead of substituting the budgeted total. Falls back to the budgeted total only when no income exists, so a fresh ledger never regresses to a misleading "-100%".

### Testing (local only)

- `npm run format:check` → clean
- `npx eslint . --max-warnings 0` → clean
- `cd apps/web && npm test` → **878 files / 9651 tests passing**
- New/updated unit tests: `budget-current-income.test.ts`, `a11y.test.ts` (new over-budget vs. almost-at-limit tiers), `BudgetsPage.test.tsx` (aria-valuetext + income event validate/add/remove).

---

### Full critique list (from #3774)

1. "Over limit" status is announced before a budget is actually over — **(implemented)**
2. Progress rings announce a capped value that contradicts the visible label — **(implemented)**
3. "Savings Rate" analytics uses the budgeted amount as income — **(implemented)**
4. Planner income events can't be removed and give no validation feedback — **(implemented)**
5. Budget status thresholds are duplicated in four places — **(implemented)**
6. Over-budget state relies on color alone in the ring — _follow-up_
7. "Beginning carryover" on the detail page is always $0 — _follow-up_
8. Summary totals sum across currencies naively — _follow-up_
9. Percentage rounding can misrepresent edge states — _follow-up_
10. Redundant nested `aria-label`s cause double announcements — _follow-up_
11. Invalid income amount keeps focus ambiguous — _follow-up_
12. No guidance distinguishing "no envelopes" from "nothing assigned" — _follow-up_
