### PR TITLE
feat(web): render orphaned dashboard widgets and add greeting header (#3778)

### DIFF
--- a/apps/web/src/components/dashboard/AccountSummaryCard.test.tsx
+++ b/apps/web/src/components/dashboard/AccountSummaryCard.test.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import { AccountSummaryCard } from './AccountSummaryCard';
+import type { Account } from '../../kmp/bridge';
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: 'account-1',
+    type: 'CHECKING',
+    currency: { code: 'USD', decimalPlaces: 2 },
+    currentBalance: { amount: 100000 },
+    isArchived: false,
+    ...overrides,
+  } as unknown as Account;
+}
+
+function renderCard(accounts: Account[]) {
+  return render(
+    <MemoryRouter>
+      <AccountSummaryCard accounts={accounts} currency="USD" />
+    </MemoryRouter>,
+  );
+}
+
+describe('AccountSummaryCard', () => {
+  it('groups accounts by type with per-type totals and counts', () => {
+    renderCard([
+      makeAccount({ id: 'a', type: 'CHECKING', currentBalance: { amount: 100000 } }),
+      makeAccount({ id: 'b', type: 'CHECKING', currentBalance: { amount: 50000 } }),
+      makeAccount({ id: 'c', type: 'SAVINGS', currentBalance: { amount: 300000 } }),
+    ]);
+
+    const card = screen.getByRole('article', { name: 'Account summary by type' });
+    // Savings sorts first (largest absolute total).
+    expect(within(card).getByText('Savings')).toBeInTheDocument();
+    expect(within(card).getByText('Checking')).toBeInTheDocument();
+    // Two checking accounts -> "(2 accounts)"
+    expect(within(card).getByText(/\(2 accounts\)/)).toBeInTheDocument();
+    expect(within(card).getByText(/\$1,500\.00/)).toBeInTheDocument();
+    expect(within(card).getByText(/\$3,000\.00/)).toBeInTheDocument();
+  });
+
+  it('ignores archived accounts', () => {
+    renderCard([
+      makeAccount({ id: 'a', type: 'CHECKING', currentBalance: { amount: 100000 } }),
+      makeAccount({
+        id: 'b',
+        type: 'INVESTMENT',
+        currentBalance: { amount: 999999 },
+        isArchived: true,
+      }),
+    ]);
+
+    const card = screen.getByRole('article', { name: 'Account summary by type' });
+    expect(within(card).queryByText('Investments')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state with a call to action when there are no accounts', () => {
+    renderCard([]);
+
+    const card = screen.getByRole('article', { name: 'Account summary by type' });
+    expect(within(card).getByText(/No accounts yet/i)).toBeInTheDocument();
+    expect(within(card).getByRole('link', { name: /Add an account/i })).toHaveAttribute(
+      'href',
+      '/accounts',
+    );
+  });
+});

--- a/apps/web/src/components/dashboard/AccountSummaryCard.tsx
+++ b/apps/web/src/components/dashboard/AccountSummaryCard.tsx
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+
+import { CurrencyDisplay } from '../common';
+import type { Account } from '../../kmp/bridge';
+
+export interface AccountSummaryCardProps {
+  /** Visible accounts (already purpose-filtered). */
+  readonly accounts: readonly Account[];
+  /** Fallback ISO 4217 currency code when an account has none. */
+  readonly currency?: string;
+}
+
+/** User-facing labels for each account type grouping. */
+const ACCOUNT_TYPE_LABELS: Record<string, string> = {
+  CHECKING: 'Checking',
+  SAVINGS: 'Savings',
+  INVESTMENT: 'Investments',
+  CASH: 'Cash',
+  CREDIT_CARD: 'Credit Cards',
+  LOAN: 'Loans',
+  OTHER: 'Other',
+};
+
+interface AccountTypeGroup {
+  readonly type: string;
+  readonly label: string;
+  readonly totalCents: number;
+  readonly count: number;
+  readonly currency: string;
+}
+
+function groupAccountsByType(
+  accounts: readonly Account[],
+  fallbackCurrency: string,
+): AccountTypeGroup[] {
+  const groups = new Map<string, { total: number; count: number; currency: string }>();
+
+  for (const account of accounts) {
+    if (account.isArchived) {
+      continue;
+    }
+    const existing = groups.get(account.type);
+    if (existing) {
+      existing.total += account.currentBalance.amount;
+      existing.count += 1;
+    } else {
+      groups.set(account.type, {
+        total: account.currentBalance.amount,
+        count: 1,
+        currency: account.currency.code ?? fallbackCurrency,
+      });
+    }
+  }
+
+  return Array.from(groups, ([type, value]) => ({
+    type,
+    label: ACCOUNT_TYPE_LABELS[type] ?? type,
+    totalCents: value.total,
+    count: value.count,
+    currency: value.currency,
+  })).sort((left, right) => Math.abs(right.totalCents) - Math.abs(left.totalCents));
+}
+
+/**
+ * Breaks the visible accounts down by type (Checking, Savings, Investments,
+ * Credit Cards, Loans…) with a per-type balance total and account count, so
+ * users can see where their money sits without leaving the home screen.
+ */
+export const AccountSummaryCard: React.FC<AccountSummaryCardProps> = ({
+  accounts,
+  currency = 'USD',
+}) => {
+  const groups = useMemo(() => groupAccountsByType(accounts, currency), [accounts, currency]);
+
+  return (
+    <article className="card account-summary-card" aria-label="Account summary by type">
+      <div className="card__header">
+        <h3 className="card__title">Account Summary</h3>
+      </div>
+      {groups.length === 0 ? (
+        <p className="list-item__secondary">
+          No accounts yet. <Link to="/accounts">Add an account</Link> to see balances by type.
+        </p>
+      ) : (
+        <ul className="account-summary-card__list">
+          {groups.map((group) => (
+            <li key={group.type} className="account-summary-card__item">
+              <span className="account-summary-card__label">
+                {group.label}
+                <span className="account-summary-card__count">
+                  {' '}
+                  ({group.count} {group.count === 1 ? 'account' : 'accounts'})
+                </span>
+              </span>
+              <span className="account-summary-card__amount">
+                <CurrencyDisplay
+                  amount={group.totalCents}
+                  currency={group.currency}
+                  context={`${group.label} balance`}
+                />
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Link to="/accounts" className="auth-footer__link">
+        Open Accounts
+      </Link>
+    </article>
+  );
+};
+
+export default AccountSummaryCard;

--- a/apps/web/src/components/dashboard/GoalsProgressCard.test.tsx
+++ b/apps/web/src/components/dashboard/GoalsProgressCard.test.tsx
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import { GoalsProgressCard } from './GoalsProgressCard';
+import type { Goal } from '../../kmp/bridge';
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: 'goal-1',
+    name: 'Emergency fund',
+    status: 'ACTIVE',
+    currency: { code: 'USD', decimalPlaces: 2 },
+    targetAmount: { amount: 100000 },
+    currentAmount: { amount: 25000 },
+    ...overrides,
+  } as unknown as Goal;
+}
+
+function renderCard(goals: Goal[], maxVisible?: number) {
+  return render(
+    <MemoryRouter>
+      <GoalsProgressCard goals={goals} currency="USD" maxVisible={maxVisible} />
+    </MemoryRouter>,
+  );
+}
+
+describe('GoalsProgressCard', () => {
+  it('renders a labelled progress bar and percent for each active goal', () => {
+    renderCard([
+      makeGoal({
+        id: 'g1',
+        name: 'Emergency fund',
+        currentAmount: { amount: 25000 },
+        targetAmount: { amount: 100000 },
+      }),
+    ]);
+
+    const card = screen.getByRole('article', { name: 'Savings goals progress' });
+    expect(within(card).getByText('Emergency fund')).toBeInTheDocument();
+    expect(within(card).getByText('25%')).toBeInTheDocument();
+    const bar = within(card).getByRole('progressbar', {
+      name: /Emergency fund: 25 percent funded/i,
+    });
+    expect(bar).toHaveAttribute('aria-valuenow', '25');
+  });
+
+  it('excludes non-active goals and caps a percentage at 100', () => {
+    renderCard([
+      makeGoal({ id: 'g1', name: 'Vacation', status: 'COMPLETED' as Goal['status'] }),
+      makeGoal({
+        id: 'g2',
+        name: 'New laptop',
+        currentAmount: { amount: 200000 },
+        targetAmount: { amount: 100000 },
+      }),
+    ]);
+
+    const card = screen.getByRole('article', { name: 'Savings goals progress' });
+    expect(within(card).queryByText('Vacation')).not.toBeInTheDocument();
+    expect(within(card).getByText(/100%/)).toBeInTheDocument();
+  });
+
+  it('links to all goals when more exist than are shown inline', () => {
+    renderCard(
+      [
+        makeGoal({ id: 'g1', name: 'A' }),
+        makeGoal({ id: 'g2', name: 'B' }),
+        makeGoal({ id: 'g3', name: 'C' }),
+        makeGoal({ id: 'g4', name: 'D' }),
+      ],
+      2,
+    );
+
+    const card = screen.getByRole('article', { name: 'Savings goals progress' });
+    expect(within(card).getByRole('link', { name: /View all 4 goals/i })).toHaveAttribute(
+      'href',
+      '/goals',
+    );
+  });
+
+  it('shows an empty state with a call to action when there are no active goals', () => {
+    renderCard([]);
+
+    const card = screen.getByRole('article', { name: 'Savings goals progress' });
+    expect(within(card).getByText(/No active goals yet/i)).toBeInTheDocument();
+    expect(within(card).getByRole('link', { name: /Create a goal/i })).toHaveAttribute(
+      'href',
+      '/goals',
+    );
+  });
+});

--- a/apps/web/src/components/dashboard/GoalsProgressCard.tsx
+++ b/apps/web/src/components/dashboard/GoalsProgressCard.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+
+import { CurrencyDisplay } from '../common';
+import type { Goal } from '../../kmp/bridge';
+
+export interface GoalsProgressCardProps {
+  /** Goals (already purpose-filtered). */
+  readonly goals: readonly Goal[];
+  /** Fallback ISO 4217 currency code when a goal has none. */
+  readonly currency?: string;
+  /** Maximum number of goals to show inline before linking out. */
+  readonly maxVisible?: number;
+}
+
+interface GoalProgress {
+  readonly id: string;
+  readonly name: string;
+  readonly currentCents: number;
+  readonly targetCents: number;
+  readonly percent: number;
+  readonly currency: string;
+  readonly isComplete: boolean;
+}
+
+function toGoalProgress(goal: Goal, fallbackCurrency: string): GoalProgress {
+  const targetCents = Math.max(0, goal.targetAmount.amount);
+  const currentCents = Math.max(0, goal.currentAmount.amount);
+  const percent =
+    targetCents > 0 ? Math.min(100, Math.round((currentCents / targetCents) * 100)) : 0;
+
+  return {
+    id: goal.id,
+    name: goal.name,
+    currentCents,
+    targetCents,
+    percent,
+    currency: goal.currency.code ?? fallbackCurrency,
+    isComplete: targetCents > 0 && currentCents >= targetCents,
+  };
+}
+
+/**
+ * Surfaces progress toward active savings goals directly on the home screen,
+ * with a labelled progress bar and percent-complete per goal.
+ *
+ * Progress is conveyed with text (the percent and the amounts) alongside the
+ * bar, and the bar exposes `role="progressbar"` with `aria-valuenow`, so the
+ * meaning never depends on the visual fill alone (WCAG 2.2 AA).
+ */
+export const GoalsProgressCard: React.FC<GoalsProgressCardProps> = ({
+  goals,
+  currency = 'USD',
+  maxVisible = 3,
+}) => {
+  const activeGoals = useMemo(
+    () =>
+      goals
+        .filter((goal) => goal.status === 'ACTIVE')
+        .map((goal) => toGoalProgress(goal, currency))
+        .sort((left, right) => right.percent - left.percent),
+    [goals, currency],
+  );
+
+  const visibleGoals = activeGoals.slice(0, maxVisible);
+  const remaining = activeGoals.length - visibleGoals.length;
+
+  return (
+    <article className="card goals-progress-card" aria-label="Savings goals progress">
+      <div className="card__header">
+        <h3 className="card__title">Goals Progress</h3>
+      </div>
+      {activeGoals.length === 0 ? (
+        <p className="list-item__secondary">
+          No active goals yet. <Link to="/goals">Create a goal</Link> to start tracking progress.
+        </p>
+      ) : (
+        <ul className="goals-progress-card__list">
+          {visibleGoals.map((goal) => (
+            <li key={goal.id} className="goals-progress-card__item">
+              <div className="goals-progress-card__row">
+                <span className="goals-progress-card__name">{goal.name}</span>
+                <span className="goals-progress-card__percent">
+                  {goal.percent}%{goal.isComplete ? ' ✓' : ''}
+                  {goal.isComplete ? <span className="sr-only"> complete</span> : null}
+                </span>
+              </div>
+              <div
+                className="progress-bar"
+                role="progressbar"
+                aria-valuenow={goal.percent}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${goal.name}: ${goal.percent} percent funded`}
+              >
+                <div
+                  className={`progress-bar__fill progress-bar__fill--${goal.isComplete ? 'positive' : 'neutral'}`}
+                  style={{ width: `${goal.percent}%` }}
+                />
+              </div>
+              <p className="goals-progress-card__amounts list-item__secondary">
+                <CurrencyDisplay
+                  amount={goal.currentCents}
+                  currency={goal.currency}
+                  context={`${goal.name} saved`}
+                />{' '}
+                of{' '}
+                <CurrencyDisplay
+                  amount={goal.targetCents}
+                  currency={goal.currency}
+                  context={`${goal.name} target`}
+                />
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+      {remaining > 0 ? (
+        <Link to="/goals" className="auth-footer__link">
+          View all {activeGoals.length} goals
+        </Link>
+      ) : activeGoals.length > 0 ? (
+        <Link to="/goals" className="auth-footer__link">
+          Open Goals
+        </Link>
+      ) : null}
+    </article>
+  );
+};
+
+export default GoalsProgressCard;

--- a/apps/web/src/components/dashboard/IncomeVsExpenseCard.test.tsx
+++ b/apps/web/src/components/dashboard/IncomeVsExpenseCard.test.tsx
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { IncomeVsExpenseCard } from './IncomeVsExpenseCard';
+
+describe('IncomeVsExpenseCard', () => {
+  it('shows money in, money out, and a surplus when income exceeds spend', () => {
+    render(<IncomeVsExpenseCard incomeCents={450000} expenseCents={240000} currency="USD" />);
+
+    const card = screen.getByRole('article', { name: 'Income versus expenses this month' });
+    expect(within(card).getByText('Money in')).toBeInTheDocument();
+    expect(within(card).getByText('Money out')).toBeInTheDocument();
+    // Net surplus = 450000 - 240000 = 210000 -> $2,100.00
+    expect(within(card).getByText(/\$2,100\.00/)).toBeInTheDocument();
+    // Meaning is conveyed with a word, not colour alone.
+    expect(within(card).getAllByText(/surplus this month/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('describes a shortfall when spending exceeds income', () => {
+    render(<IncomeVsExpenseCard incomeCents={100000} expenseCents={160000} currency="USD" />);
+
+    const card = screen.getByRole('article', { name: 'Income versus expenses this month' });
+    expect(within(card).getAllByText(/shortfall this month/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('treats an equal in/out month as balanced', () => {
+    render(<IncomeVsExpenseCard incomeCents={120000} expenseCents={120000} currency="USD" />);
+
+    const card = screen.getByRole('article', { name: 'Income versus expenses this month' });
+    expect(within(card).getAllByText(/balanced this month/i).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/src/components/dashboard/IncomeVsExpenseCard.tsx
+++ b/apps/web/src/components/dashboard/IncomeVsExpenseCard.tsx
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React from 'react';
+
+import { CurrencyDisplay } from '../common';
+
+export interface IncomeVsExpenseCardProps {
+  /** Total income this month, in integer cents (already purpose-filtered). */
+  readonly incomeCents: number;
+  /** Total spending this month, in integer cents (already purpose-filtered). */
+  readonly expenseCents: number;
+  /** ISO 4217 currency code for the displayed figures. */
+  readonly currency?: string;
+}
+
+/** Shape icon for the net result — paired with text, never colour alone. */
+const NET_ICON = { surplus: '▲', shortfall: '▼', even: '→' } as const;
+
+/**
+ * At-a-glance monthly cash-flow card: money in vs money out and the resulting
+ * surplus or shortfall.
+ *
+ * The net figure is conveyed with a sign, a shape icon, and an explicit
+ * "surplus"/"shortfall"/"balanced" word (plus an `sr-only` restatement), so the
+ * meaning never depends on colour alone (WCAG 2.2 AA, 1.4.1 Use of Colour).
+ */
+export const IncomeVsExpenseCard: React.FC<IncomeVsExpenseCardProps> = ({
+  incomeCents,
+  expenseCents,
+  currency = 'USD',
+}) => {
+  const income = Math.max(0, Math.round(incomeCents));
+  const expense = Math.max(0, Math.round(expenseCents));
+  const netCents = income - expense;
+  const tone = netCents > 0 ? 'surplus' : netCents < 0 ? 'shortfall' : 'even';
+  const netWord = tone === 'surplus' ? 'surplus' : tone === 'shortfall' ? 'shortfall' : 'balanced';
+
+  return (
+    <article
+      className={`card income-expense-card income-expense-card--${tone}`}
+      aria-label="Income versus expenses this month"
+    >
+      <div className="card__header">
+        <h3 className="card__title">Income vs Expense</h3>
+      </div>
+      <dl className="income-expense-card__rows">
+        <div className="income-expense-card__row">
+          <dt className="income-expense-card__label">Money in</dt>
+          <dd className="income-expense-card__amount">
+            <CurrencyDisplay amount={income} currency={currency} context="income this month" />
+          </dd>
+        </div>
+        <div className="income-expense-card__row">
+          <dt className="income-expense-card__label">Money out</dt>
+          <dd className="income-expense-card__amount">
+            <CurrencyDisplay amount={expense} currency={currency} context="spent this month" />
+          </dd>
+        </div>
+      </dl>
+      <p className="income-expense-card__net" aria-live="polite">
+        <span className="income-expense-card__net-icon" aria-hidden="true">
+          {NET_ICON[tone]}
+        </span>
+        <CurrencyDisplay
+          amount={netCents}
+          currency={currency}
+          colorize
+          showSign
+          context={`net ${netWord} this month`}
+        />{' '}
+        <span aria-hidden="true">{netWord} this month</span>
+        <span className="sr-only">{`${netWord} this month`}</span>
+      </p>
+    </article>
+  );
+};
+
+export default IncomeVsExpenseCard;

--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -869,3 +869,120 @@
   background-color: var(--semantic-background-secondary);
   background-color: color-mix(in srgb, var(--semantic-text-primary) 6%, transparent);
 }
+
+/* ---------------------------------------------------------------------------
+ * Financial-overview widgets: Income vs Expense, Account Summary, Goals
+ * Progress (#3778). These three widgets are configured in the customize panel
+ * and default layout; the styles below give them a scannable, tokenised layout
+ * that matches the rest of the dashboard grid.
+ * ------------------------------------------------------------------------- */
+
+.dashboard-overview-grid > .card {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+/* Income vs Expense --------------------------------------------------------- */
+
+.income-expense-card__rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  margin: 0;
+}
+
+.income-expense-card__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+}
+
+.income-expense-card__label {
+  color: var(--semantic-text-secondary);
+}
+
+.income-expense-card__amount {
+  font-weight: 600;
+}
+
+.income-expense-card__net {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  margin: var(--spacing-3) 0 0;
+  padding-top: var(--spacing-3);
+  border-top: 1px solid var(--semantic-border-default);
+  font-weight: 700;
+}
+
+.income-expense-card__net-icon {
+  font-size: 0.85em;
+}
+
+/* Account Summary ----------------------------------------------------------- */
+
+.account-summary-card__list {
+  list-style: none;
+  margin: 0 0 var(--spacing-3);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.account-summary-card__item {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+}
+
+.account-summary-card__count {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size, 0.85em);
+}
+
+.account-summary-card__amount {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* Goals Progress ------------------------------------------------------------ */
+
+.goals-progress-card__list {
+  list-style: none;
+  margin: 0 0 var(--spacing-3);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.goals-progress-card__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-2);
+}
+
+.goals-progress-card__name {
+  font-weight: 600;
+}
+
+.goals-progress-card__percent {
+  font-variant-numeric: tabular-nums;
+  color: var(--semantic-text-secondary);
+}
+
+.goals-progress-card__amounts {
+  margin: var(--spacing-2) 0 0;
+}
+
+@media (prefers-contrast: more) {
+  .income-expense-card__net {
+    border-top-width: 2px;
+  }
+}

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -12,6 +12,12 @@ export { CustomizePanel } from './CustomizePanel';
 export type { CustomizePanelProps } from './CustomizePanel';
 export { SafeToSpendCard } from './SafeToSpendCard';
 export type { SafeToSpendCardProps } from './SafeToSpendCard';
+export { IncomeVsExpenseCard } from './IncomeVsExpenseCard';
+export type { IncomeVsExpenseCardProps } from './IncomeVsExpenseCard';
+export { AccountSummaryCard } from './AccountSummaryCard';
+export type { AccountSummaryCardProps } from './AccountSummaryCard';
+export { GoalsProgressCard } from './GoalsProgressCard';
+export type { GoalsProgressCardProps } from './GoalsProgressCard';
 export {
   WIDGET_DEFINITIONS,
   WIDGET_DEFINITION_MAP,

--- a/apps/web/src/pages/DashboardPage.css
+++ b/apps/web/src/pages/DashboardPage.css
@@ -29,6 +29,72 @@
   overflow-wrap: anywhere;
 }
 
+/* ---------------------------------------------------------------------------
+ * Dashboard header (greeting + date + RMD badge). Moved off inline styles onto
+ * tokenised classes so the header themes correctly (dark mode / high contrast)
+ * and can be adjusted responsively. References: issue #3778.
+ * ------------------------------------------------------------------------- */
+.dashboard-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-6);
+}
+
+.dashboard-header__heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.dashboard-header__eyebrow {
+  margin: 0;
+  font-size: var(--type-scale-label-font-size);
+  font-weight: var(--type-scale-label-font-weight);
+  color: var(--semantic-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.dashboard-header__title {
+  margin: 0;
+  font-size: var(--type-scale-headline-font-size);
+  font-weight: var(--type-scale-headline-font-weight);
+}
+
+.dashboard-header__date {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+}
+
+.dashboard-rmd-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: 999px;
+  border: 1px solid var(--semantic-border-default);
+  text-decoration: none;
+  font-weight: 700;
+  color: var(--semantic-interactive-default);
+}
+
+.dashboard-rmd-badge--negative {
+  color: var(--semantic-status-negative);
+}
+
+.dashboard-rmd-badge--warning {
+  color: var(--semantic-status-warning);
+}
+
+@media (prefers-contrast: more) {
+  .dashboard-rmd-badge {
+    border-width: 2px;
+  }
+}
+
 /* Larger phones / portrait tablets: two readable columns instead of one. */
 @media (min-width: 376px) and (max-width: 767px) {
   .card-grid.dashboard-summary-grid {

--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -758,6 +758,39 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Client Retainer')).toBeInTheDocument();
   });
 
+  it('shows a time-aware greeting header while keeping the Dashboard label', () => {
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
+
+    // The route identity is preserved as an eyebrow above the greeting heading.
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /Good (morning|afternoon|evening)/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the income-vs-expense, account-summary, and goals-progress widgets (#3778)', async () => {
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
+
+    const incomeExpense = await screen.findByRole('article', {
+      name: 'Income versus expenses this month',
+    });
+    expect(within(incomeExpense).getByText('Money in')).toBeInTheDocument();
+
+    const accountSummary = await screen.findByRole('article', { name: 'Account summary by type' });
+    expect(within(accountSummary).getByText('Checking')).toBeInTheDocument();
+
+    const goalsProgress = await screen.findByRole('article', { name: 'Savings goals progress' });
+    expect(within(goalsProgress).getByText('Emergency fund')).toBeInTheDocument();
+  });
+
   it('aggregates the All workspace net worth as the sum of every workspace (#3160)', () => {
     // Personal $20,000 + Business $10,000 + shared "Both" $5,000.
     mockedUseAccounts.mockReturnValue({

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -99,6 +99,21 @@ const SavingsRateCard = React.lazy(() =>
   })),
 );
 const GroceryModeSection = React.lazy(() => import('../components/dashboard/GroceryModeSection'));
+const IncomeVsExpenseCard = React.lazy(() =>
+  import('../components/dashboard/IncomeVsExpenseCard').then((module) => ({
+    default: module.IncomeVsExpenseCard,
+  })),
+);
+const AccountSummaryCard = React.lazy(() =>
+  import('../components/dashboard/AccountSummaryCard').then((module) => ({
+    default: module.AccountSummaryCard,
+  })),
+);
+const GoalsProgressCard = React.lazy(() =>
+  import('../components/dashboard/GoalsProgressCard').then((module) => ({
+    default: module.GoalsProgressCard,
+  })),
+);
 
 const ChartFallback = () => <LoadingSpinner size={24} label="Loading chart" />;
 const SectionFallback = ({ label }: { readonly label: string }) => (
@@ -120,6 +135,27 @@ function formatLocalDate(date: Date): string {
   const day = String(date.getDate()).padStart(2, '0');
 
   return `${year}-${month}-${day}`;
+}
+
+/** Time-of-day greeting used in the dashboard header for a personal, oriented feel. */
+function getTimeOfDayGreeting(date: Date): string {
+  const hour = date.getHours();
+  if (hour < 12) {
+    return 'Good morning';
+  }
+  if (hour < 18) {
+    return 'Good afternoon';
+  }
+  return 'Good evening';
+}
+
+/** Localized long-form date (e.g. "Wednesday, July 9") for the dashboard header. */
+function formatHeaderDate(date: Date): string {
+  return date.toLocaleDateString(getCurrentLocale(), {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
 }
 
 function getLastNDaysBounds(days: number): { startDate: string; endDate: string } {
@@ -755,51 +791,23 @@ export const DashboardPage: React.FC = () => {
   return (
     <>
       <OfflineBanner />
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: 'var(--spacing-4)',
-          flexWrap: 'wrap',
-          marginBottom: 'var(--spacing-6)',
-        }}
-      >
-        <h2
-          style={{
-            fontSize: 'var(--type-scale-headline-font-size)',
-            fontWeight: 'var(--type-scale-headline-font-weight)',
-            margin: 0,
-          }}
-        >
-          Dashboard
-        </h2>
+      <header className="dashboard-header">
+        <div className="dashboard-header__heading">
+          <p className="dashboard-header__eyebrow">Dashboard</p>
+          <h2 className="dashboard-header__title">{getTimeOfDayGreeting(dashboardAsOf)}</h2>
+          <p className="dashboard-header__date">{formatHeaderDate(dashboardAsOf)}</p>
+        </div>
         {!rmdLoading && rmdDueCount > 0 && (
           <Link
             to="/planning"
+            className={`dashboard-rmd-badge dashboard-rmd-badge--${rmdBadgeTone}`}
             aria-label={`${rmdDueCount} required minimum distribution ${rmdDueCount === 1 ? 'reminder' : 'reminders'} due`}
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 'var(--spacing-2)',
-              padding: 'var(--spacing-2) var(--spacing-3)',
-              borderRadius: '999px',
-              border: '1px solid var(--semantic-border-default)',
-              color:
-                rmdBadgeTone === 'negative'
-                  ? 'var(--semantic-status-negative)'
-                  : rmdBadgeTone === 'warning'
-                    ? 'var(--semantic-status-warning)'
-                    : 'var(--semantic-interactive-default)',
-              textDecoration: 'none',
-              fontWeight: 700,
-            }}
           >
             RMD due
             <span aria-hidden="true">{rmdDueCount}</span>
           </Link>
         )}
-      </div>
+      </header>
       <button
         type="button"
         className="dashboard-customize-btn"
@@ -991,6 +999,38 @@ export const DashboardPage: React.FC = () => {
                   ) : null}
                 </div>
               </section>
+              {visibleWidgetIds.has('income-vs-expense') ||
+              visibleWidgetIds.has('account-summary') ||
+              visibleWidgetIds.has('goals-progress') ? (
+                <section className="page-section" aria-label="Financial overview">
+                  <div className="card-grid card-grid--3 dashboard-overview-grid">
+                    {visibleWidgetIds.has('income-vs-expense') ? (
+                      <Suspense
+                        fallback={<SectionFallback label="Loading income versus expense" />}
+                      >
+                        <IncomeVsExpenseCard
+                          incomeCents={incomeThisMonth}
+                          expenseCents={spentThisMonth}
+                          currency={safeToSpendCurrency}
+                        />
+                      </Suspense>
+                    ) : null}
+                    {visibleWidgetIds.has('account-summary') ? (
+                      <Suspense fallback={<SectionFallback label="Loading account summary" />}>
+                        <AccountSummaryCard
+                          accounts={filteredAccounts}
+                          currency={safeToSpendCurrency}
+                        />
+                      </Suspense>
+                    ) : null}
+                    {visibleWidgetIds.has('goals-progress') && !hiddenModules.has('goals') ? (
+                      <Suspense fallback={<SectionFallback label="Loading goals progress" />}>
+                        <GoalsProgressCard goals={filteredGoals} currency={safeToSpendCurrency} />
+                      </Suspense>
+                    ) : null}
+                  </div>
+                </section>
+              ) : null}
               <Suspense fallback={<SectionFallback label="Loading things to check" />}>
                 <DashboardThingsToCheckSection
                   accounts={accounts}


### PR DESCRIPTION
## Summary

This PR fixes a real dashboard bug and delivers a coherent, tested set of home-screen improvements from the UX critique in #3778.

**The core bug:** `income-vs-expense`, `account-summary`, and `goals-progress` are all listed in `WIDGET_DEFINITIONS`, shipped "on" in `DEFAULT_WIDGET_ORDER`/`buildDefaultLayout()`, and are toggleable + reorderable in the Customize panel — but **no JSX in `DashboardPage.tsx` ever rendered them**. Toggling them did nothing, silently breaking the personalization promise. This PR implements all three as real cards.

### What changed

- **`IncomeVsExpenseCard`** — at-a-glance monthly cash flow: money in, money out, and the resulting surplus/shortfall. Positive/negative is conveyed with a sign, a shape icon, and an explicit word + `sr-only` restatement (never colour alone).
- **`AccountSummaryCard`** — balances grouped by account type (Checking, Savings, Investments, Credit Cards, Loans…) with per-type totals and account counts, plus an empty state. Ignores archived accounts.
- **`GoalsProgressCard`** — progress toward active savings goals with a labelled `role="progressbar"`, percent complete, amounts, and an empty state. Honors the `goals` minimalist-mode toggle.
- **Time-aware greeting header** — "Good morning/afternoon/evening" + localized date, with the route identity kept as an eyebrow so the "Dashboard" label and heading semantics are preserved.
- **Header CSS cleanup** — the header container and RMD badge moved off large inline `style={{…}}` objects onto tokenised classes in `DashboardPage.css`, so they theme correctly (dark mode / high contrast) and stay maintainable.
- All new widgets are wired into `DashboardPage.tsx`, lazy-loaded, workspace-purpose-scoped, and gated by `visibleWidgetIds` (matching the existing widget pattern).

### Accessibility (WCAG 2.2 AA)

- Money direction is never colour-only (1.4.1): sign + icon + word + `sr-only`.
- Progress bars expose `role="progressbar"` with `aria-valuenow/min/max` and descriptive labels.
- `prefers-contrast: more` support for the new borders; semantic tokens throughout.

### Testing (local only)

- `npm run format:check` ✅ and `npx eslint . --max-warnings 0` ✅ (repo-wide)
- `apps/web` unit tests: **883 files / 9,679 tests passing** ✅
- Added 10 new component tests + 2 new `DashboardPage` tests (greeting header + all three widgets rendering).

---

## Full UX critique (10+ items) — from #3778

1. **BUG: Three configured widgets never render (`income-vs-expense`, `account-summary`, `goals-progress`).** They're in the customize panel + default layout but no JSX rendered them, so toggling did nothing. **Fixed here.**
2. **No personalized / time-aware greeting** — bare static `<h2>Dashboard</h2>`. **Implemented** time-of-day greeting + date.
3. **Header + RMD badge used large inline style objects** instead of tokenised CSS (theming/maintenance cost). **Moved to `DashboardPage.css`.**
4. **Header actions ungrouped / low hierarchy** — grouped the greeting + badge into a coherent header region.
5. **No at-a-glance income-vs-expense (cash flow) comparison** — the key "how am I doing this month?" signal was missing. **Implemented.**
6. **No account-summary breakdown by type** — only a single net-worth figure; users had to leave the home screen. **Implemented.**
7. **Savings goals not surfaced on the home screen** despite a defined widget. **Implemented.**
8. **Inconsistent navigation affordances** — Debt card links out but others don't; new widgets add contextual detail links (Accounts, Goals).
9. **New/empty widgets need graceful per-widget empty states.** **Added** for account summary and goals.
10. **Positive/negative money must not be colour-only (WCAG 1.4.1).** **Enforced** via sign + icon + word + `sr-only`.
11. **Net Worth card lacks trend/direction context** (future): add a period-over-period delta.
12. **Information density / scannability** — new widgets kept tight and scannable; prose reserved for progressive-disclosure explainers.

Closes #3778
