### PR TITLE
fix(web): single-source nav titles and consistent active-state (#3780)

### DIFF
--- a/apps/web/src/App.title.test.ts
+++ b/apps/web/src/App.title.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Regression tests for page-title derivation (#3780).
+ *
+ * Nine primary destinations used to fall back to the generic "Finance" title
+ * because `PAGE_TITLES` in App.tsx drifted from `NAV_CONFIG`. Titles are now
+ * seeded from the nav config, so every sidebar route resolves to its real name
+ * for both the header `<h1>` and the browser tab title.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { derivePageTitle } from './App';
+import { NAV_CONFIG } from './components/layout/navConfig';
+
+describe('derivePageTitle', () => {
+  it('resolves every primary nav destination to a non-generic title', () => {
+    for (const item of NAV_CONFIG) {
+      const title = derivePageTitle(item.href);
+      expect(title).not.toBe('Finance');
+      expect(title.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('titles the routes that previously fell back to "Finance"', () => {
+    const previouslyBroken: Record<string, string> = {
+      '/remittances': 'Remittances',
+      '/expected-income': 'Expected Income',
+      '/live-pnl': 'Live P&L',
+      '/estimated-tax': 'Estimated Taxes',
+      '/trip-budgets': 'Trip Budgets',
+      '/building-credit': 'Building Credit',
+      '/fire': 'FIRE Planner',
+      '/cash-runway': 'Cash Runway',
+      '/business-pnl': 'Profit & Loss',
+    };
+
+    for (const [path, title] of Object.entries(previouslyBroken)) {
+      expect(derivePageTitle(path)).toBe(title);
+    }
+  });
+
+  it('keeps bespoke non-nav titles that override the nav defaults', () => {
+    expect(derivePageTitle('/report-builder')).toBe('Report Builder');
+    expect(derivePageTitle('/settings/security')).toBe('Settings · Security & Encryption');
+    expect(derivePageTitle('/legal/privacy')).toBe('Privacy Policy');
+  });
+
+  it('falls back to the first path segment for detail routes', () => {
+    expect(derivePageTitle('/accounts/abc123')).toBe('Accounts');
+    expect(derivePageTitle('/transactions/42/edit')).toBe('Transactions');
+  });
+
+  it('uses the generic app name only for genuinely unknown routes', () => {
+    expect(derivePageTitle('/totally-unknown-route')).toBe('Finance');
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { MilestoneToast } from './components/celebrations';
 import { ConsentDialog } from './components/gdpr';
 import { AppLayout } from './components/layout';
+import { NAV_ROUTE_TITLES } from './components/layout/navConfig';
 import { FocusManager } from './components/layout/FocusManager';
 import { PrivacyModeProvider } from './contexts/PrivacyModeContext';
 import { NotificationsProvider, useNotificationCenter } from './contexts/NotificationsContext';
@@ -24,10 +25,16 @@ import { AppRoutes } from './routes';
 /**
  * Map path segments to human-readable page titles.
  *
+ * Nav destinations are seeded from `NAV_ROUTE_TITLES` (derived from the single
+ * `NAV_CONFIG` source of truth) so every sidebar route has a real title and the
+ * two can never drift (#3780). Bespoke, non-nav titles below — Settings
+ * sub-pages, legal docs, import sub-flows — are layered on top and win.
+ *
  * Used by the AppLayout header. Dynamic / detail routes fall back to a
  * sensible default derived from the path's first segment.
  */
 const PAGE_TITLES: Record<string, string> = {
+  ...NAV_ROUTE_TITLES,
   '/': 'Dashboard',
   '/dashboard': 'Dashboard',
   '/notifications': 'Notifications',
@@ -140,7 +147,7 @@ export function shouldAutoLaunchOnboarding(pathname: string, onboardingComplete:
   return !onboardingComplete && !isFirstRunAllowedPath(pathname);
 }
 
-function derivePageTitle(pathname: string): string {
+export function derivePageTitle(pathname: string): string {
   if (PAGE_TITLES[pathname]) {
     return PAGE_TITLES[pathname];
   }

--- a/apps/web/src/components/layout/MoreNavSheet.tsx
+++ b/apps/web/src/components/layout/MoreNavSheet.tsx
@@ -25,6 +25,7 @@ import {
   NAV_GROUP_LABELS,
   NAV_GROUP_ORDER,
   getMoreSheetItems,
+  isNavItemActive,
   type NavConfigItem,
   type NavGroup,
 } from './navConfig';
@@ -227,7 +228,7 @@ export const MoreNavSheet: React.FC<MoreNavSheetProps> = ({
                 </h3>
                 <ul className="more-sheet__list" role="list">
                   {items.map((item) => {
-                    const isActive = activePath === item.href;
+                    const isActive = isNavItemActive(activePath, item.href);
                     return (
                       <li key={item.id}>
                         <button

--- a/apps/web/src/components/layout/Navigation.test.tsx
+++ b/apps/web/src/components/layout/Navigation.test.tsx
@@ -122,6 +122,21 @@ describe('BottomNavigation', () => {
     );
   });
 
+  it('highlights the parent destination in the More sheet on a nested route (#3780)', () => {
+    // Net Worth lives in the More sheet. On a sub-route the sheet should still
+    // mark it active — previously it used strict equality and highlighted
+    // nothing.
+    render(<BottomNavigation {...defaultProps} activePath="/net-worth/2024-06" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'More destinations' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByRole('button', { name: 'Net Worth' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
   it('does not set aria-current on inactive items', () => {
     render(<BottomNavigation {...defaultProps} activePath="/accounts" />);
 
@@ -465,6 +480,61 @@ describe('SidebarNavigation', () => {
 
     // Money still contains the active route; no rising edge → stays collapsed.
     expect(moneyToggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('persists a group collapse across remounts (#3780)', () => {
+    const { unmount } = render(<SidebarNavigation {...defaultProps} activePath="/dashboard" />);
+
+    const moneyToggle = screen.getByRole('button', { name: 'Money section' });
+    // Money is expanded by default; collapse it.
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(moneyToggle);
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'false');
+
+    unmount();
+    render(<SidebarNavigation {...defaultProps} activePath="/dashboard" />);
+
+    // The persisted collapse survives the remount instead of resetting to the
+    // static default.
+    expect(screen.getByRole('button', { name: 'Money section' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('persists a group expansion across remounts (#3780)', () => {
+    const { unmount } = render(<SidebarNavigation {...defaultProps} activePath="/dashboard" />);
+
+    // Insights starts collapsed by default; expand it.
+    const insightsToggle = screen.getByRole('button', { name: 'Insights section' });
+    expect(insightsToggle).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(insightsToggle);
+    expect(insightsToggle).toHaveAttribute('aria-expanded', 'true');
+
+    unmount();
+    render(<SidebarNavigation {...defaultProps} activePath="/dashboard" />);
+
+    expect(screen.getByRole('button', { name: 'Insights section' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('marks a collapsed group that contains the active route (#3780)', () => {
+    // Insights starts collapsed and contains /net-worth. The toggle should
+    // advertise that the current page lives inside it.
+    render(<SidebarNavigation {...defaultProps} activePath="/net-worth" />);
+
+    // On mount the group force-opens so the active item is visible, so the
+    // cue is not shown yet.
+    const expandedToggle = screen.getByRole('button', { name: 'Insights section' });
+    expect(expandedToggle).toHaveAttribute('aria-expanded', 'true');
+
+    // Collapsing it while it still owns the active route surfaces the cue.
+    fireEvent.click(expandedToggle);
+    expect(
+      screen.getByRole('button', { name: 'Insights section, contains current page' }),
+    ).toHaveAttribute('aria-expanded', 'false');
   });
 
   // ─── Relocated header quick actions (#3197) ────────────────────────────────

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -34,6 +34,7 @@ import {
   getItemsByGroup,
   getPinnedNavItems,
   getVisibleNavItems,
+  isNavItemActive,
   type NavConfigItem,
   type NavGroup,
 } from './navConfig';
@@ -113,9 +114,7 @@ export interface SidebarNavigationProps extends NavigationProps {
 }
 
 function isActive(activePath: string, href: string): boolean {
-  if (activePath === href) return true;
-  if (!activePath.startsWith(href + '/')) return false;
-  return !NAV_CONFIG.some((item) => item.href === activePath);
+  return isNavItemActive(activePath, href);
 }
 
 // ---------------------------------------------------------------------------
@@ -184,7 +183,6 @@ export const BottomNavigation: React.FC<NavigationProps> = ({
               type="button"
               className={`nav-item${active ? ' nav-item--active' : ''}`}
               aria-current={active ? 'page' : undefined}
-              aria-label={item.label}
               onClick={() => onNavigate(item.href)}
             >
               <span className="nav-item__icon">{item.icon}</span>
@@ -232,6 +230,41 @@ interface SidebarGroupProps {
   defaultExpanded: boolean;
 }
 
+/** localStorage key for a group's persisted expand/collapse state (#3780). */
+function groupExpandedStorageKey(group: NavGroup): string {
+  return `finance:sidebar-group-expanded:${group}`;
+}
+
+/**
+ * Read a group's persisted expand/collapse preference. Returns `null` when the
+ * user has never toggled it (so callers fall back to the static default).
+ */
+function readStoredGroupExpanded(group: NavGroup): boolean | null {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(groupExpandedStorageKey(group));
+    if (raw === 'true') return true;
+    if (raw === 'false') return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredGroupExpanded(group: NavGroup, expanded: boolean): void {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(groupExpandedStorageKey(group), String(expanded));
+  } catch {
+    // Storage may be unavailable (private mode / quota); expand state is
+    // non-critical, so silently ignore.
+  }
+}
+
 const SidebarGroup: React.FC<SidebarGroupProps> = ({
   group,
   items,
@@ -240,10 +273,15 @@ const SidebarGroup: React.FC<SidebarGroupProps> = ({
   defaultExpanded,
 }) => {
   const containsActive = items.some((item) => isActive(activePath, item.href));
-  // Initialise from the static default, OR force-open if the active route is
-  // already inside this group at mount (so the user always lands on a visible
-  // active item even when the group would otherwise start collapsed, #2005).
-  const [userExpanded, setUserExpanded] = useState(defaultExpanded || containsActive);
+  // Initialise from the user's persisted choice when present, otherwise the
+  // static default, OR force-open if the active route is already inside this
+  // group at mount (so the user always lands on a visible active item even when
+  // the group would otherwise start collapsed, #2005). Persisting the toggle
+  // means a user's collapse/expand choice survives reloads and remounts (#3780).
+  const [userExpanded, setUserExpanded] = useState(() => {
+    const stored = readStoredGroupExpanded(group);
+    return (stored ?? defaultExpanded) || containsActive;
+  });
 
   // Auto-expand only on the *rising edge* of containsActive — i.e. when the
   // user navigates INTO this group from another. This keeps the helpful
@@ -257,24 +295,47 @@ const SidebarGroup: React.FC<SidebarGroupProps> = ({
     prevContainsActive.current = containsActive;
   }, [containsActive]);
 
+  const toggleExpanded = useCallback(() => {
+    setUserExpanded((prev) => {
+      const next = !prev;
+      writeStoredGroupExpanded(group, next);
+      return next;
+    });
+  }, [group]);
+
   const expanded = userExpanded;
 
   const sectionId = `sidebar-group-${group}`;
   const headingId = `sidebar-group-${group}-heading`;
   const label = NAV_GROUP_LABELS[group];
+  // Surface a cue when a collapsed group still contains the active route, so a
+  // returning user who collapsed it can tell their current page is inside
+  // (#3780). The visible dot is decorative; the accessible name carries the
+  // meaning for AT users.
+  const showsCollapsedActiveCue = containsActive && !expanded;
 
   return (
-    <section className="app-sidebar__group" aria-labelledby={headingId} data-expanded={expanded}>
+    <section
+      className="app-sidebar__group"
+      aria-labelledby={headingId}
+      data-expanded={expanded}
+      data-contains-active={containsActive || undefined}
+    >
       <h2 id={headingId} className="app-sidebar__group-heading">
         <button
           type="button"
           className="app-sidebar__group-toggle"
           aria-expanded={expanded}
           aria-controls={sectionId}
-          aria-label={`${label} section`}
-          onClick={() => setUserExpanded((prev) => !prev)}
+          aria-label={
+            showsCollapsedActiveCue ? `${label} section, contains current page` : `${label} section`
+          }
+          onClick={toggleExpanded}
         >
           <span className="app-sidebar__group-label">{label}</span>
+          {showsCollapsedActiveCue ? (
+            <span className="app-sidebar__group-active-dot" aria-hidden="true" />
+          ) : null}
           <span
             className={`app-sidebar__group-chevron${expanded ? ' app-sidebar__group-chevron--expanded' : ''}`}
             aria-hidden="true"

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -8,10 +8,12 @@ export {
   NAV_CONFIG,
   NAV_GROUP_LABELS,
   NAV_GROUP_ORDER,
+  NAV_ROUTE_TITLES,
   BOTTOM_NAV_PRIORITY_ITEMS,
   PINNED_NAV_ITEMS,
   MORE_SHEET_ITEMS,
   getItemsByGroup,
+  isNavItemActive,
 } from './navConfig';
 export type { NavConfigItem, NavGroup } from './navConfig';
 export { MoreNavSheet } from './MoreNavSheet';

--- a/apps/web/src/components/layout/navConfig.test.ts
+++ b/apps/web/src/components/layout/navConfig.test.ts
@@ -2,7 +2,12 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { BOTTOM_NAV_PRIORITY_ITEMS, NAV_CONFIG } from './navConfig';
+import {
+  BOTTOM_NAV_PRIORITY_ITEMS,
+  NAV_CONFIG,
+  NAV_ROUTE_TITLES,
+  isNavItemActive,
+} from './navConfig';
 
 describe('navConfig mobilePriority', () => {
   it('assigns a unique mobilePriority to every destination', () => {
@@ -30,5 +35,45 @@ describe('navConfig mobilePriority', () => {
 
     expect(BOTTOM_NAV_PRIORITY_ITEMS.map((item) => item.id)).toEqual(expected);
     expect(expected).toEqual(['dashboard', 'accounts', 'transactions', 'debt']);
+  });
+});
+
+describe('NAV_ROUTE_TITLES', () => {
+  it('provides a title for every primary destination', () => {
+    // Guards the drift that left 9 routes (e.g. /remittances, /fire, /live-pnl)
+    // falling back to the generic "Finance" page/tab title (#3780).
+    for (const item of NAV_CONFIG) {
+      expect(NAV_ROUTE_TITLES[item.href]).toBe(item.label);
+    }
+  });
+
+  it('never yields the generic "Finance" fallback for a nav route', () => {
+    for (const item of NAV_CONFIG) {
+      expect(NAV_ROUTE_TITLES[item.href]).not.toBe('Finance');
+    }
+  });
+});
+
+describe('isNavItemActive', () => {
+  it('matches an exact path', () => {
+    expect(isNavItemActive('/transactions', '/transactions')).toBe(true);
+  });
+
+  it('matches a sub-route to its parent destination', () => {
+    expect(isNavItemActive('/transactions/abc123', '/transactions')).toBe(true);
+    expect(isNavItemActive('/accounts/42/edit', '/accounts')).toBe(true);
+  });
+
+  it('does not match unrelated paths', () => {
+    expect(isNavItemActive('/budgets', '/transactions')).toBe(false);
+    // A path-prefix that is not a segment boundary must not match.
+    expect(isNavItemActive('/transactions-archive', '/transactions')).toBe(false);
+  });
+
+  it('lets a more specific destination own a nested path', () => {
+    // /investments/tax is its own destination (Tax Center), so it must NOT
+    // also light up Investments.
+    expect(isNavItemActive('/investments/tax', '/investments')).toBe(false);
+    expect(isNavItemActive('/investments/tax', '/investments/tax')).toBe(true);
   });
 });

--- a/apps/web/src/components/layout/navConfig.tsx
+++ b/apps/web/src/components/layout/navConfig.tsx
@@ -482,6 +482,35 @@ export function getMoreSheetItems(
 }
 
 /**
+ * Page/browser titles for every primary destination, derived from
+ * `NAV_CONFIG` so the header `<h1>`, the document title and the sidebar can
+ * never disagree about a route's name (#3780, item 1).
+ *
+ * Keyed by `href`. Consumers (e.g. `App.tsx`) spread this first and then layer
+ * bespoke, non-nav titles (Settings sub-pages, legal docs, detail routes) on
+ * top so those overrides win.
+ */
+export const NAV_ROUTE_TITLES: Readonly<Record<string, string>> = Object.freeze(
+  Object.fromEntries(NAV_CONFIG.map((item) => [item.href, item.label])),
+);
+
+/**
+ * Prefix-aware "is this destination active" test, shared by the sidebar,
+ * bottom-nav and the mobile "More" sheet so every surface highlights the same
+ * item for a given route (#3780, item 3).
+ *
+ * A destination is active when the path matches exactly, or when the path is a
+ * sub-route of it (`/transactions/123` → Transactions) *unless* a more specific
+ * destination in `NAV_CONFIG` owns that exact path (so `/investments/tax` marks
+ * Tax Center, not Investments).
+ */
+export function isNavItemActive(activePath: string, href: string): boolean {
+  if (activePath === href) return true;
+  if (!activePath.startsWith(href + '/')) return false;
+  return !NAV_CONFIG.some((item) => item.href === activePath);
+}
+
+/**
  * Items shown inside the mobile "More" sheet — everything that is not a
  * bottom-nav priority item, grouped for scanning.
  */

--- a/apps/web/src/styles/navigation-chrome.css
+++ b/apps/web/src/styles/navigation-chrome.css
@@ -97,6 +97,21 @@
   }
 }
 
+/* Cue shown when a collapsed group still contains the active route (#3780).
+   Decorative dot; the button's accessible name carries the meaning for AT. */
+.app-sidebar__group-active-dot {
+  display: inline-flex;
+  width: 6px;
+  height: 6px;
+  margin-inline-end: var(--spacing-1, 4px);
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(
+    --navigation-indicator,
+    var(--semantic-interactive-default, var(--color-blue-700, currentColor))
+  );
+}
+
 .sidebar-nav__list--nested {
   padding-top: 0;
   padding-bottom: var(--spacing-1);


### PR DESCRIPTION
## Summary

Navigation & information-architecture pass on the Web PWA (`apps/web`). Makes `NAV_CONFIG` the single source of truth for route metadata and unifies the "you are here" cues across every navigation surface.

Closes #3780

## Changes

- **Single-source page/document titles.** `App.tsx`'s `PAGE_TITLES` now seeds from `NAV_ROUTE_TITLES` (derived from `NAV_CONFIG`). Nine primary destinations previously fell back to the generic **"Finance"** header + browser-tab title: `/remittances`, `/expected-income`, `/live-pnl`, `/estimated-tax`, `/trip-budgets`, `/building-credit`, `/fire`, `/cash-runway`, `/business-pnl`. They now show their real names. Bespoke non-nav titles (Settings sub-pages, legal docs, Report Builder, Tax Center) still override the defaults.
- **Consistent active-state.** Extracted one prefix-aware `isNavItemActive` helper in `navConfig` and used it in the sidebar, bottom-nav **and** the mobile "More" sheet. The sheet previously used strict equality, so nested routes (e.g. `/net-worth/2024-06`) highlighted nothing.
- **Persisted sidebar groups.** Each group's expand/collapse choice is stored in `localStorage`, so it survives reloads/remounts instead of resetting to the static default. Auto-expand-on-enter behaviour is preserved and does not overwrite the stored preference.
- **Collapsed-active cue.** A collapsed sidebar group that still contains the active route shows a decorative dot and an accessible hint (`"Money section, contains current page"`), respecting `prefers-reduced-motion`.
- **A11y cleanup.** Dropped the redundant `aria-label` on bottom-nav items whose visible label already names the control.

## Tests

- `navConfig.test.ts` — title coverage for every nav href; `isNavItemActive` exact/sub-route/specificity cases.
- `App.title.test.ts` — the nine previously-broken routes resolve correctly; bespoke overrides and detail-route fallbacks preserved.
- `Navigation.test.tsx` — group persistence across remounts, collapsed-active cue, and More-sheet nested-route highlight.

Local verification: `npm run format:check && npx eslint . --max-warnings 0` clean; `apps/web` suite **9694 passed**.

## Full critique list (issue #3780)

1. **Nine destinations render the generic "Finance" title** — `PAGE_TITLES` drifted from `NAV_CONFIG`. *(fixed)*
2. **Two competing sources of truth** for route metadata (labels vs titles vs shortcuts). *(addressed for titles)*
3. **`MoreNavSheet` used strict-equality active detection** while sidebar/bottom-nav are prefix-aware. *(fixed)*
4. **"Breadcrumbs" are actually a recent-navigation history trail**, not hierarchical breadcrumbs. *(follow-up)*
5. **Sidebar group expand/collapse state not persisted.** *(fixed)*
6. **Collapsed group gives no "contains active route" cue.** *(fixed)*
7. **38 primary destinations is a very large, flat IA** with sparse, non-contiguous `mobilePriority` values. *(follow-up)*
8. **Hardcoded id lists** (`SIMPLE_MODE_BOTTOM_NAV_IDS`, `SIMPLIFIED_NAV_ITEM_IDS`, `NAV_SHORTCUT_BY_ID`) can drift from the config. *(follow-up)*
9. **Redundant `aria-label` duplicating visible text** on nav buttons. *(fixed for bottom-nav)*
10. **`aria-current="page"` on the mobile "More" button**, which opens a dialog rather than being a page. *(follow-up)*
11. **Settings sub-pages unreachable** from primary nav / command palette (six exist). *(follow-up)*
12. **Grouping vs URL hierarchy mismatch** for Tax Center (in "Money" but routed under `/investments/tax`). *(follow-up)*