### PR TITLE
feat(web): consistent chart privacy masking, NaN guards & empty states (#3784)

### DIFF
--- a/apps/web/src/__tests__/dashboard-visualizations.test.tsx
+++ b/apps/web/src/__tests__/dashboard-visualizations.test.tsx
@@ -839,7 +839,11 @@ describe('SpendingBarChart (#1334)', () => {
   it('handles empty data with descriptive aria-label', () => {
     render(<SpendingBarChart data={[]} />);
     const container = screen.getByRole('figure');
-    expect(container).toHaveAttribute('aria-label', 'Bar chart with no data.');
+    expect(container).toHaveAttribute(
+      'aria-label',
+      'Spending by category: No data to display yet.',
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('No data to display yet.');
   });
 
   it('includes sr-only description for screen readers', () => {
@@ -942,7 +946,11 @@ describe('CategoryPieChart (#1334)', () => {
   it('handles empty data', () => {
     render(<CategoryPieChart data={[]} />);
     const container = screen.getByRole('figure');
-    expect(container).toHaveAttribute('aria-label', 'Pie chart with no data.');
+    expect(container).toHaveAttribute(
+      'aria-label',
+      'Spending by category: No data to display yet.',
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('No data to display yet.');
   });
 
   it('renders no path elements when data is empty', () => {

--- a/apps/web/src/components/charts/BudgetDonutChart.test.tsx
+++ b/apps/web/src/components/charts/BudgetDonutChart.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { BudgetDonutChart, type BudgetSlice } from './BudgetDonutChart';
+import { PrivacyModeProvider } from '../../contexts/PrivacyModeContext';
 
 // ---------------------------------------------------------------------------
 // Stubs
@@ -76,7 +77,8 @@ describe('BudgetDonutChart', () => {
   it('handles empty data', () => {
     render(<BudgetDonutChart data={[]} />);
     const container = screen.getByRole('figure');
-    expect(container).toHaveAttribute('aria-label', 'Donut chart with no data.');
+    expect(container).toHaveAttribute('aria-label', 'Budget breakdown: No data to display yet.');
+    expect(screen.getByRole('status')).toHaveTextContent('No data to display yet.');
   });
 
   // -- Accessibility ----------------------------------------------------------
@@ -127,5 +129,36 @@ describe('BudgetDonutChart', () => {
   it('omits the data table when there is no data', () => {
     render(<BudgetDonutChart data={[]} />);
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  // -- Zero-total robustness --------------------------------------------------
+
+  it('renders 0.0% shares instead of NaN when every slice is zero', () => {
+    const { container } = render(
+      <BudgetDonutChart
+        data={[
+          { name: 'Housing', value: 0 },
+          { name: 'Groceries', value: 0 },
+        ]}
+      />,
+    );
+    expect(container).not.toHaveTextContent('NaN');
+    const table = screen.getByRole('table', { name: /budget breakdown data table/i });
+    expect(within(table).getAllByText('0.0%').length).toBeGreaterThan(0);
+  });
+
+  // -- Privacy masking --------------------------------------------------------
+
+  it('masks amounts in the description and data table when privacy mode is active', () => {
+    render(
+      <PrivacyModeProvider initialValue>
+        <BudgetDonutChart data={sampleData} />
+      </PrivacyModeProvider>,
+    );
+    const figure = screen.getByRole('figure');
+    expect(figure.getAttribute('aria-label')).toContain('•••');
+    expect(figure.getAttribute('aria-label')).not.toContain('$2,200');
+    const table = screen.getByRole('table', { name: /budget breakdown data table/i });
+    expect(within(table).queryByText('$1,200')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/charts/BudgetDonutChart.tsx
+++ b/apps/web/src/components/charts/BudgetDonutChart.tsx
@@ -8,7 +8,9 @@ import { type FC, useCallback, useId, useMemo, useRef, useState } from 'react';
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Label } from 'recharts';
 import { CHART_COLORS, buildChartDescription, formatChartCurrency } from './chart-palette';
 import { AccessibleChartDataTable } from './chart-accessibility';
+import { ChartEmptyState } from './ChartEmptyState';
 import { useArrowKeyNavigation } from '../../accessibility/aria';
+import { useEffectiveMaskingMode } from '../../contexts/PrivacyModeContext';
 
 export interface BudgetSlice {
   name: string;
@@ -38,23 +40,29 @@ export const BudgetDonutChart: FC<BudgetDonutChartProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const [announcement, setAnnouncement] = useState('');
   const disableAnimation = prefersReducedMotion();
+  const maskingMode = useEffectiveMaskingMode();
   const total = useMemo(() => data.reduce((sum, d) => sum + d.value, 0), [data]);
+  const percentFor = useCallback(
+    (value: number) => (total > 0 ? ((value / total) * 100).toFixed(1) : '0.0'),
+    [total],
+  );
   const description = useMemo(
     () =>
       buildChartDescription(
         'Donut chart',
         data.map((d) => ({ label: d.name, value: d.value })),
         currency,
+        maskingMode,
       ),
-    [data, currency],
+    [data, currency, maskingMode],
   );
   const pointAnnouncements = useMemo(
     () =>
       data.map(
         (entry, index) =>
-          `${title}. Focused slice ${index + 1} of ${data.length}. ${entry.name}: ${formatChartCurrency(entry.value, currency)} (${total > 0 ? ((entry.value / total) * 100).toFixed(1) : '0.0'}%).`,
+          `${title}. Focused slice ${index + 1} of ${data.length}. ${entry.name}: ${formatChartCurrency(entry.value, currency, 'en-US', maskingMode)} (${percentFor(entry.value)}%).`,
       ),
-    [currency, data, title, total],
+    [currency, data, maskingMode, percentFor, title],
   );
   const { handleKeyDown } = useArrowKeyNavigation(containerRef, {
     orientation: 'both',
@@ -67,8 +75,8 @@ export const BudgetDonutChart: FC<BudgetDonutChartProps> = ({
   const tableRows = useMemo(
     () =>
       data.map((entry, index) => {
-        const percent = total > 0 ? ((entry.value / total) * 100).toFixed(1) : '0.0';
-        const formattedValue = formatChartCurrency(entry.value, currency);
+        const percent = percentFor(entry.value);
+        const formattedValue = formatChartCurrency(entry.value, currency, 'en-US', maskingMode);
         return {
           id: `${chartId}-row-${index}`,
           rowHeader: entry.name,
@@ -76,8 +84,12 @@ export const BudgetDonutChart: FC<BudgetDonutChartProps> = ({
           ariaLabel: `${entry.name}: ${formattedValue} (${percent}%)`,
         };
       }),
-    [chartId, currency, data, total],
+    [chartId, currency, data, maskingMode, percentFor],
   );
+
+  if (data.length === 0) {
+    return <ChartEmptyState title={title} titleId={`${chartId}-title`} />;
+  }
 
   return (
     <div
@@ -127,11 +139,11 @@ export const BudgetDonutChart: FC<BudgetDonutChartProps> = ({
                 data-chart-point=""
                 tabIndex={-1}
                 role="listitem"
-                aria-label={`${entry.name}: ${formatChartCurrency(entry.value, currency)} (${((entry.value / total) * 100).toFixed(1)}%)`}
+                aria-label={`${entry.name}: ${formatChartCurrency(entry.value, currency, 'en-US', maskingMode)} (${percentFor(entry.value)}%)`}
               />
             ))}
             <Label
-              value={centerLabel ?? formatChartCurrency(total, currency)}
+              value={centerLabel ?? formatChartCurrency(total, currency, 'en-US', maskingMode)}
               position="center"
               style={{
                 fontSize: '1.25rem',
@@ -142,7 +154,7 @@ export const BudgetDonutChart: FC<BudgetDonutChartProps> = ({
           </Pie>
           <Tooltip
             formatter={(value, name) => [
-              formatChartCurrency(Number(value ?? 0), currency),
+              formatChartCurrency(Number(value ?? 0), currency, 'en-US', maskingMode),
               String(name),
             ]}
             contentStyle={{

--- a/apps/web/src/components/charts/CategoryPieChart.test.tsx
+++ b/apps/web/src/components/charts/CategoryPieChart.test.tsx
@@ -83,7 +83,11 @@ describe('CategoryPieChart', () => {
   it('handles empty data', () => {
     render(<CategoryPieChart data={[]} />);
     const container = screen.getByRole('figure');
-    expect(container).toHaveAttribute('aria-label', 'Pie chart with no data.');
+    expect(container).toHaveAttribute(
+      'aria-label',
+      'Spending by category: No data to display yet.',
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('No data to display yet.');
   });
 
   it('renders no path elements when data is empty', () => {

--- a/apps/web/src/components/charts/CategoryPieChart.tsx
+++ b/apps/web/src/components/charts/CategoryPieChart.tsx
@@ -12,6 +12,7 @@ import { type FC, useCallback, useEffect, useId, useRef, useState } from 'react'
 import * as d3 from 'd3';
 import { CHART_COLORS, buildChartDescription, formatChartCurrency } from './chart-palette';
 import { AccessibleChartDataTable } from './chart-accessibility';
+import { ChartEmptyState } from './ChartEmptyState';
 import { useEffectiveMaskingMode } from '../../contexts/PrivacyModeContext';
 
 export interface CategorySlice {
@@ -75,7 +76,7 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
       .attr(
         'aria-label',
         (d) =>
-          `${d.data.name}: ${formatChartCurrency(d.data.value, currency, 'en-US', maskingMode)} (${((d.data.value / total) * 100).toFixed(1)}%)`,
+          `${d.data.name}: ${formatChartCurrency(d.data.value, currency, 'en-US', maskingMode)} (${total > 0 ? ((d.data.value / total) * 100).toFixed(1) : '0.0'}%)`,
       )
       .attr('fill', (_d, i) => CHART_COLORS[i % CHART_COLORS.length])
       .attr('stroke', 'var(--semantic-background-primary, #FFFFFF)')
@@ -142,6 +143,10 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
       ariaLabel: `${slice.name}: ${formattedValue} (${percent}%)`,
     };
   });
+
+  if (data.length === 0) {
+    return <ChartEmptyState title={title} titleId={`${chartId}-title`} />;
+  }
 
   return (
     <div ref={containerRef} role="figure" aria-label={description} aria-roledescription="pie chart">

--- a/apps/web/src/components/charts/ChartEmptyState.test.tsx
+++ b/apps/web/src/components/charts/ChartEmptyState.test.tsx
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ChartEmptyState, DEFAULT_CHART_EMPTY_MESSAGE } from './ChartEmptyState';
+
+describe('ChartEmptyState', () => {
+  it('renders the title heading and default message', () => {
+    render(<ChartEmptyState title="Spending by category" />);
+    expect(screen.getByRole('heading', { name: 'Spending by category' })).toBeInTheDocument();
+    expect(screen.getByText(DEFAULT_CHART_EMPTY_MESSAGE)).toBeInTheDocument();
+  });
+
+  it('exposes the empty message through role="status" for assistive tech', () => {
+    render(<ChartEmptyState title="Budget" message="Nothing here." />);
+    expect(screen.getByRole('status')).toHaveTextContent('Nothing here.');
+  });
+
+  it('labels the figure with the title and message', () => {
+    render(<ChartEmptyState title="Net worth" message="No history yet." />);
+    expect(screen.getByRole('figure')).toHaveAttribute('aria-label', 'Net worth: No history yet.');
+  });
+
+  it('applies the provided title id so charts can reference it', () => {
+    render(<ChartEmptyState title="Trend" titleId="trend-title" />);
+    expect(screen.getByRole('heading', { name: 'Trend' })).toHaveAttribute('id', 'trend-title');
+  });
+});

--- a/apps/web/src/components/charts/ChartEmptyState.tsx
+++ b/apps/web/src/components/charts/ChartEmptyState.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * ChartEmptyState — shared, accessible empty state for chart components.
+ *
+ * Charts that render no data used to either display a blank canvas (pie/donut)
+ * or an empty gridded axis frame (bar), which reads as broken and offers no
+ * guidance. This primitive standardises the "no data" affordance so every
+ * chart surfaces the same `role="status"` message and visual treatment.
+ *
+ * Accessibility (WCAG 2.2 AA):
+ * - Exposes `role="status"` so assistive tech announces the empty condition.
+ * - Renders the chart title as a visible heading for context.
+ * - Uses semantic text/border tokens with hardcoded fallbacks for contrast.
+ *
+ * References: issue #3784
+ *
+ * @module components/charts/ChartEmptyState
+ */
+
+import { type FC } from 'react';
+import './chart-empty-state.css';
+
+export interface ChartEmptyStateProps {
+  /** Chart title, rendered as a visible heading above the message. */
+  title: string;
+  /** Optional element id applied to the heading (for `aria-labelledby`). */
+  titleId?: string;
+  /** Empty-state message. Defaults to a generic prompt. */
+  message?: string;
+}
+
+export const DEFAULT_CHART_EMPTY_MESSAGE = 'No data to display yet.';
+
+export const ChartEmptyState: FC<ChartEmptyStateProps> = ({
+  title,
+  titleId,
+  message = DEFAULT_CHART_EMPTY_MESSAGE,
+}) => (
+  <div className="chart-empty-state" role="figure" aria-label={`${title}: ${message}`}>
+    <h3 id={titleId} className="chart-title">
+      {title}
+    </h3>
+    <p className="chart-empty-state__message" role="status">
+      {message}
+    </p>
+  </div>
+);
+
+export default ChartEmptyState;

--- a/apps/web/src/components/charts/NetWorthProjectionChart.test.tsx
+++ b/apps/web/src/components/charts/NetWorthProjectionChart.test.tsx
@@ -14,6 +14,7 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { NetWorthProjectionChart } from './NetWorthProjectionChart';
 import type { NetWorthSeriesPoint } from '../../lib/visualization/net-worth-projection';
+import { PrivacyModeProvider } from '../../contexts/PrivacyModeContext';
 
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
@@ -141,5 +142,18 @@ describe('NetWorthProjectionChart', () => {
     // A purely-positive series keeps full vertical resolution — no zero line.
     rerender(<NetWorthProjectionChart history={GROWING} />);
     expect(container.querySelector('[data-label="Break-even ($0)"]')).toBeNull();
+  });
+
+  it('masks net worth values everywhere when privacy mode is active', () => {
+    render(
+      <PrivacyModeProvider initialValue>
+        <NetWorthProjectionChart history={GROWING} />
+      </PrivacyModeProvider>,
+    );
+    const figure = screen.getByRole('figure');
+    expect(figure.getAttribute('aria-label')).toContain('•••');
+    expect(figure.getAttribute('aria-label')).not.toMatch(/\$\d/);
+    const table = screen.getByRole('table', { name: /data table/ });
+    expect(within(table).queryByText(/\$\d/)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/charts/NetWorthProjectionChart.tsx
+++ b/apps/web/src/components/charts/NetWorthProjectionChart.tsx
@@ -36,6 +36,7 @@ import {
   CHART_KEYBOARD_INSTRUCTIONS,
   useChartKeyboardNavigation,
 } from './chart-accessibility';
+import { useEffectiveMaskingMode } from '../../contexts/PrivacyModeContext';
 import {
   PROJECTION_RANGES,
   projectNetWorth,
@@ -170,6 +171,7 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
 }) => {
   const chartId = useId();
   const disableAnimation = prefersReducedMotion();
+  const maskingMode = useEffectiveMaskingMode();
   const [range, setRange] = useState<ProjectionRange>(defaultRange);
 
   const visible = useMemo(() => sliceSeriesToRange(history, range), [history, range]);
@@ -215,21 +217,35 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
   const description = useMemo(() => {
     if (visible.length === 0) return `${title}: no net worth history yet.`;
     const values = visible.map((point) => point.netWorthCents);
-    const min = formatChartCurrency(centsToMajor(Math.min(...values)), currency);
-    const max = formatChartCurrency(centsToMajor(Math.max(...values)), currency);
+    const min = formatChartCurrency(
+      centsToMajor(Math.min(...values)),
+      currency,
+      'en-US',
+      maskingMode,
+    );
+    const max = formatChartCurrency(
+      centsToMajor(Math.max(...values)),
+      currency,
+      'en-US',
+      maskingMode,
+    );
     const projectedNote = projection.hasProjection
       ? ` Projected ${projection.horizonMonths} months forward to ${formatChartCurrency(
           centsToMajor(projection.endNetWorthCents),
           currency,
+          'en-US',
+          maskingMode,
         )}.`
       : ' No projection is shown for this range yet.';
     return `${title}: ${visible.length} actual points ranging ${min} to ${max}.${projectedNote}`;
-  }, [visible, projection, currency, title]);
+  }, [visible, projection, currency, title, maskingMode]);
 
   const paceText = useMemo(() => {
     const magnitude = formatChartCurrency(
       centsToMajor(Math.abs(projection.monthlyPaceCents)),
       currency,
+      'en-US',
+      maskingMode,
     );
     const direction =
       projection.paceDirection === 'up'
@@ -238,7 +254,7 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
           ? 'decline'
           : 'change';
     return `${magnitude}/month ${direction}`;
-  }, [projection, currency]);
+  }, [projection, currency, maskingMode]);
 
   const assumptionsText = projection.hasProjection
     ? `Forecast assumes a steady ${paceText} (${projection.methodSummary}), projected ${projection.horizonMonths} months ahead. Estimate only. Not financial advice.`
@@ -246,7 +262,12 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
 
   const dataPointRows = useMemo(() => {
     const actualRows = visible.map((point, index) => {
-      const formattedValue = formatChartCurrency(centsToMajor(point.netWorthCents), currency);
+      const formattedValue = formatChartCurrency(
+        centsToMajor(point.netWorthCents),
+        currency,
+        'en-US',
+        maskingMode,
+      );
       return {
         id: `${chartId}-actual-${index}`,
         rowHeader: point.label,
@@ -255,7 +276,12 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
       };
     });
     const projectedRows = projection.points.map((point, index) => {
-      const formattedValue = formatChartCurrency(centsToMajor(point.netWorthCents), currency);
+      const formattedValue = formatChartCurrency(
+        centsToMajor(point.netWorthCents),
+        currency,
+        'en-US',
+        maskingMode,
+      );
       return {
         id: `${chartId}-projected-${index}`,
         rowHeader: point.label,
@@ -264,7 +290,7 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
       };
     });
     return [...actualRows, ...projectedRows];
-  }, [visible, projection, currency, chartId]);
+  }, [visible, projection, currency, chartId, maskingMode]);
 
   const { announcement, handleFocus, handleKeyDown } = useChartKeyboardNavigation(dataPointRows);
 
@@ -323,7 +349,9 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
                   tick={{ fill: 'var(--semantic-text-secondary, #6B7280)', fontSize: 12 }}
                 />
                 <YAxis
-                  tickFormatter={(value: number) => formatChartCurrency(value, currency)}
+                  tickFormatter={(value: number) =>
+                    formatChartCurrency(value, currency, 'en-US', maskingMode)
+                  }
                   tick={{ fill: 'var(--semantic-text-secondary, #6B7280)', fontSize: 12 }}
                   width={80}
                   domain={
@@ -333,7 +361,9 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
                   }
                 />
                 <Tooltip
-                  formatter={(value) => formatChartCurrency(Number(value ?? 0), currency)}
+                  formatter={(value) =>
+                    formatChartCurrency(Number(value ?? 0), currency, 'en-US', maskingMode)
+                  }
                   contentStyle={{
                     background: 'var(--semantic-background-elevated, #FFFFFF)',
                     border: '1px solid var(--semantic-border-default, #E5E7EB)',

--- a/apps/web/src/components/charts/SpendingBarChart.test.tsx
+++ b/apps/web/src/components/charts/SpendingBarChart.test.tsx
@@ -78,7 +78,11 @@ describe('SpendingBarChart', () => {
   it('handles empty data', () => {
     render(<SpendingBarChart data={[]} />);
     const container = screen.getByRole('figure');
-    expect(container).toHaveAttribute('aria-label', 'Bar chart with no data.');
+    expect(container).toHaveAttribute(
+      'aria-label',
+      'Spending by category: No data to display yet.',
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('No data to display yet.');
   });
 
   // -- Accessibility ----------------------------------------------------------

--- a/apps/web/src/components/charts/SpendingBarChart.tsx
+++ b/apps/web/src/components/charts/SpendingBarChart.tsx
@@ -19,6 +19,7 @@ import {
 } from 'recharts';
 import { CHART_COLORS, buildChartDescription, formatChartCurrency } from './chart-palette';
 import { AccessibleChartDataTable } from './chart-accessibility';
+import { ChartEmptyState } from './ChartEmptyState';
 import { useArrowKeyNavigation } from '../../accessibility/aria';
 import { useEffectiveMaskingMode } from '../../contexts/PrivacyModeContext';
 
@@ -94,6 +95,10 @@ export const SpendingBarChart: FC<SpendingBarChartProps> = ({
       }),
     [chartId, currency, data, maskingMode, total],
   );
+
+  if (data.length === 0) {
+    return <ChartEmptyState title={title} titleId={`${chartId}-title`} />;
+  }
 
   return (
     <div

--- a/apps/web/src/components/charts/TrendLineChart.test.tsx
+++ b/apps/web/src/components/charts/TrendLineChart.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { TrendLineChart, type TrendDataPoint, type TrendSeries } from './TrendLineChart';
+import { PrivacyModeProvider } from '../../contexts/PrivacyModeContext';
 
 // ---------------------------------------------------------------------------
 // Stubs
@@ -163,5 +164,19 @@ describe('TrendLineChart', () => {
     fireEvent.keyDown(navigator, { key: 'ArrowRight' });
     expect(screen.getByRole('status')).toHaveTextContent('Focused point 2 of 3.');
     expect(screen.getByRole('status')).toHaveTextContent('Expenses Feb: $1,398');
+  });
+
+  // -- Privacy masking --------------------------------------------------------
+
+  it('masks currency values in the data table when privacy mode is active', () => {
+    render(
+      <PrivacyModeProvider initialValue>
+        <TrendLineChart data={sampleData} series={sampleSeries} />
+      </PrivacyModeProvider>,
+    );
+
+    const janRow = screen.getByText('Jan').closest('tr')!;
+    expect(janRow).toHaveTextContent('•••');
+    expect(janRow.getAttribute('aria-label')).not.toContain('$4,000');
   });
 });

--- a/apps/web/src/components/charts/TrendLineChart.tsx
+++ b/apps/web/src/components/charts/TrendLineChart.tsx
@@ -23,6 +23,7 @@ import {
   useChartKeyboardNavigation,
 } from './chart-accessibility';
 import { buildChartTextSummary } from '../../lib/a11y/chart-table-audit';
+import { useEffectiveMaskingMode } from '../../contexts/PrivacyModeContext';
 import './trend-line-chart.css';
 
 /**
@@ -84,6 +85,7 @@ export const TrendLineChart: FC<TrendLineChartProps> = ({
 }) => {
   const chartId = useId();
   const disableAnimation = prefersReducedMotion();
+  const maskingMode = useEffectiveMaskingMode();
 
   const description = useMemo(() => {
     if (data.length === 0) return 'Line chart with no data.';
@@ -94,11 +96,11 @@ export const TrendLineChart: FC<TrendLineChartProps> = ({
         );
         const min = Math.min(...values);
         const max = Math.max(...values);
-        return `${s.name} (${seriesPattern(index).name} line): range ${formatChartCurrency(min, currency)} to ${formatChartCurrency(max, currency)}`;
+        return `${s.name} (${seriesPattern(index).name} line): range ${formatChartCurrency(min, currency, 'en-US', maskingMode)} to ${formatChartCurrency(max, currency, 'en-US', maskingMode)}`;
       })
       .join('. ');
     return `Line chart "${title}" with ${data.length} data points and ${series.length} series. ${seriesDesc}.`;
-  }, [data, series, currency, title]);
+  }, [data, series, currency, title, maskingMode]);
 
   const dataPointRows = useMemo(
     () =>
@@ -108,7 +110,7 @@ export const TrendLineChart: FC<TrendLineChartProps> = ({
             typeof point[trendSeries.dataKey] === 'number' ? Number(point[trendSeries.dataKey]) : 0;
           return {
             name: trendSeries.name,
-            formattedValue: formatChartCurrency(rawValue, currency),
+            formattedValue: formatChartCurrency(rawValue, currency, 'en-US', maskingMode),
           };
         });
 
@@ -130,7 +132,7 @@ export const TrendLineChart: FC<TrendLineChartProps> = ({
           }),
         };
       }),
-    [chartId, currency, data, series, title],
+    [chartId, currency, data, series, title, maskingMode],
   );
 
   const { announcement, handleFocus, handleKeyDown } = useChartKeyboardNavigation(dataPointRows);
@@ -173,12 +175,16 @@ export const TrendLineChart: FC<TrendLineChartProps> = ({
                 tick={{ fill: 'var(--semantic-text-secondary, #6B7280)', fontSize: 12 }}
               />
               <YAxis
-                tickFormatter={(v: number) => formatChartCurrency(v, currency)}
+                tickFormatter={(v: number) =>
+                  formatChartCurrency(v, currency, 'en-US', maskingMode)
+                }
                 tick={{ fill: 'var(--semantic-text-secondary, #6B7280)', fontSize: 12 }}
                 width={80}
               />
               <Tooltip
-                formatter={(value) => formatChartCurrency(Number(value ?? 0), currency)}
+                formatter={(value) =>
+                  formatChartCurrency(Number(value ?? 0), currency, 'en-US', maskingMode)
+                }
                 contentStyle={{
                   background: 'var(--semantic-background-elevated, #FFFFFF)',
                   border: '1px solid var(--semantic-border-default, #E5E7EB)',

--- a/apps/web/src/components/charts/chart-empty-state.css
+++ b/apps/web/src/components/charts/chart-empty-state.css
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Shared chart empty state. Mirrors the dashed, centered treatment used by
+ * SpendingTrendChart / NetWorthProjectionChart so every chart's "no data"
+ * affordance is visually and semantically consistent (issue #3784).
+ */
+
+.chart-empty-state__message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 8rem;
+  margin: var(--spacing-2, 0.5rem) 0 0;
+  padding: var(--spacing-4, 1rem);
+  border: 1px dashed var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-md, 0.375rem);
+  color: var(--semantic-text-secondary, #6b7280);
+  font-size: var(--type-scale-body-font-size, 0.875rem);
+  text-align: center;
+}
+
+@media (prefers-contrast: more) {
+  .chart-empty-state__message {
+    border-width: 2px;
+  }
+}

--- a/apps/web/src/components/charts/index.ts
+++ b/apps/web/src/components/charts/index.ts
@@ -16,6 +16,8 @@ export { BudgetDonutChart } from './BudgetDonutChart';
 export type { BudgetDonutChartProps, BudgetSlice } from './BudgetDonutChart';
 export { CategoryPieChart } from './CategoryPieChart';
 export type { CategoryPieChartProps, CategorySlice } from './CategoryPieChart';
+export { ChartEmptyState, DEFAULT_CHART_EMPTY_MESSAGE } from './ChartEmptyState';
+export type { ChartEmptyStateProps } from './ChartEmptyState';
 export {
   CHART_COLORS,
   CHART_COLORS_HEX,


### PR DESCRIPTION
## Summary

Fixes three coherent, high-impact gaps in the web data-visualization layer (charts / reporting), all found by reading `apps/web/src/components/charts/*`. Implements a meaningful subset of the critique in #3784.

Closes #3784

### What changed
1. **Privacy masking now applied consistently across all charts.** `BudgetDonutChart`, `TrendLineChart`, and `NetWorthProjectionChart` never consumed `useEffectiveMaskingMode()`, so turning on privacy mode still exposed real currency values in their tooltips, axes, center labels, slice `aria-label`s, screen-reader descriptions, and hidden data tables — while `CategoryPieChart`/`SpendingBarChart`/`SpendingTrendChart` correctly masked. All three now thread the effective masking mode through every `formatChartCurrency` / `buildChartDescription` call. **This is a financial-data privacy leak fix.**
2. **Divide-by-zero "NaN%" guards.** `BudgetDonutChart`'s per-slice `aria-label` computed `(value / total) * 100` with no guard, announcing `NaN%` to screen readers for an all-zero budget. `CategoryPieChart` had the same issue in its slice labels. Both now fall back to `0.0%`.
3. **Shared, accessible empty state.** `CategoryPieChart`, `SpendingBarChart`, and `BudgetDonutChart` previously rendered a blank canvas / empty gridded axis / `$NaN` ring with no message when given no data. Added a reusable `ChartEmptyState` (`role="status"` message + visible heading + labelled `role="figure"`) and wired it into all three.

### Tests
- Added `ChartEmptyState.test.tsx`.
- Added masking tests (privacy-on) for `BudgetDonutChart`, `TrendLineChart`, `NetWorthProjectionChart`.
- Added a zero-total "renders 0.0% not NaN" test for `BudgetDonutChart`.
- Updated existing empty-state assertions in the chart specs and `dashboard-visualizations.test.tsx` to reflect the improved empty state.
- Full local suite: `npm run format:check` ✅, `npx eslint . --max-warnings 0` ✅, `apps/web` unit tests **9708 passing** ✅.

---

## Full critique list (issue #3784)

1. **`BudgetDonutChart` ignores privacy masking mode (data leak).** Real amounts shown in masked mode. → *Fixed here.*
2. **`TrendLineChart` ignores privacy masking mode (data leak).** → *Fixed here.*
3. **`NetWorthProjectionChart` ignores privacy masking mode (data leak).** Net worth is highly sensitive. → *Fixed here.*
4. **`BudgetDonutChart` announces "NaN%" when the budget total is 0.** Slice `aria-label` divided by zero. → *Fixed here.*
5. **`CategoryPieChart` has no empty state** (blank SVG + empty legend + NaN%). → *Fixed here.*
6. **`SpendingBarChart` has no empty state** (empty gridded axis frame). → *Fixed here.*
7. **`BudgetDonutChart` has no empty state** (renders a `$NaN` ring). → *Fixed here.*
8. **Charts hardcode `en-US`, defeating app-wide i18n.** de-DE/fr-FR users see US-formatted numbers on charts only. → *Documented for follow-up (avoids churning many existing chart snapshots).*
9. **Pie/donut charts have no "Other" grouping for long-tail categories.** 15+ categories become unreadable slivers. → *Follow-up.*
10. **Tooltip hex fallbacks may fail WCAG contrast in dark mode.** Inline `#FFFFFF`/`#E5E7EB` fallbacks. → *Follow-up.*
11. **No shared chart empty-state / masking primitive → drift.** Root cause of #1–#7. → *Addressed via new `ChartEmptyState` + standardizing on `useEffectiveMaskingMode()`.*
12. **`BudgetDonutChart` center label shows the raw total even when masked/empty.** → *Fixed here (masked + suppressed in empty state).*

## Accessibility
- Empty state exposes `role="status"` and a visible message (WCAG 2.2 AA — status changes announced, not conveyed only visually).
- Masking fixes ensure screen-reader descriptions and data tables never leak values the visual chart hides.
- No color-only information introduced.
