### PR TITLE
feat(web): improve search, filtering & categorization UX (#3790)

### DIFF
--- a/apps/web/src/components/transactions/TransactionFilters.test.tsx
+++ b/apps/web/src/components/transactions/TransactionFilters.test.tsx
@@ -9,7 +9,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
-import { TransactionFilters, EMPTY_FILTERS, countActiveFilters } from './TransactionFilters';
+import {
+  TransactionFilters,
+  EMPTY_FILTERS,
+  countActiveFilters,
+  getActiveFilterChips,
+  isAmountRangeInverted,
+} from './TransactionFilters';
 import type { AdvancedFilters } from './TransactionFilters';
 import type { Account, Category } from '../../kmp/bridge';
 
@@ -184,7 +190,7 @@ describe('TransactionFilters', () => {
       />,
     );
 
-    expect(screen.getByText(/from: 2024-01-01/i)).toBeInTheDocument();
+    expect(screen.getByText(/from: jan 1, 2024/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText(/remove filter/i));
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ startDate: '' }));
@@ -222,5 +228,69 @@ describe('countActiveFilters', () => {
       amountMin: '10',
     };
     expect(countActiveFilters(filters)).toBe(3);
+  });
+});
+
+describe('isAmountRangeInverted', () => {
+  it('is false when either bound is missing', () => {
+    expect(isAmountRangeInverted({ ...EMPTY_FILTERS, amountMin: '50' })).toBe(false);
+    expect(isAmountRangeInverted({ ...EMPTY_FILTERS, amountMax: '50' })).toBe(false);
+  });
+
+  it('is true when min is greater than max', () => {
+    expect(isAmountRangeInverted({ ...EMPTY_FILTERS, amountMin: '500', amountMax: '10' })).toBe(
+      true,
+    );
+  });
+
+  it('is false for a valid range', () => {
+    expect(isAmountRangeInverted({ ...EMPTY_FILTERS, amountMin: '10', amountMax: '500' })).toBe(
+      false,
+    );
+  });
+});
+
+describe('getActiveFilterChips', () => {
+  it('formats amount chips as localized currency', () => {
+    const chips = getActiveFilterChips(
+      { ...EMPTY_FILTERS, amountMin: '1000', amountMax: '2500.5' },
+      mockCategories,
+      mockAccounts,
+    );
+    const min = chips.find((c) => c.key === 'amountMin');
+    const max = chips.find((c) => c.key === 'amountMax');
+    expect(min?.label).toContain('$1,000');
+    expect(max?.label).toContain('$2,500.5');
+  });
+
+  it('collapses many selected categories into a count', () => {
+    const chips = getActiveFilterChips(
+      { ...EMPTY_FILTERS, categoryIds: ['cat-1', 'cat-2', 'cat-3'] },
+      mockCategories,
+      mockAccounts,
+    );
+    const categoryChip = chips.find((c) => c.key === 'categories');
+    expect(categoryChip?.label).toBe('Categories: 3 categories selected');
+  });
+
+  it('lists names inline when few categories are selected', () => {
+    const chips = getActiveFilterChips(
+      { ...EMPTY_FILTERS, categoryIds: ['cat-1', 'cat-2'] },
+      mockCategories,
+      mockAccounts,
+    );
+    const categoryChip = chips.find((c) => c.key === 'categories');
+    expect(categoryChip?.label).toBe('Categories: Food, Transport');
+  });
+
+  it('renders start-date chips using a formatted date rather than the raw ISO string', () => {
+    const chips = getActiveFilterChips(
+      { ...EMPTY_FILTERS, startDate: '2024-01-05' },
+      mockCategories,
+      mockAccounts,
+    );
+    const dateChip = chips.find((c) => c.key === 'startDate');
+    expect(dateChip?.label).toContain('From:');
+    expect(dateChip?.label).not.toBe('From: 2024-01-05');
   });
 });

--- a/apps/web/src/components/transactions/TransactionFilters.tsx
+++ b/apps/web/src/components/transactions/TransactionFilters.tsx
@@ -15,6 +15,8 @@ import React, { useCallback, useId } from 'react';
 
 import { DatePicker } from '../common/DatePicker';
 import type { Account, Category, TransactionStatus, TransactionType } from '../../kmp/bridge';
+import { formatDate } from '../../utils/formatDate';
+import { formatCurrencyValue } from '../../lib/currency';
 import './transaction-filters.css';
 
 // ---------------------------------------------------------------------------
@@ -78,6 +80,38 @@ export function countActiveFilters(filters: AdvancedFilters): number {
   return count;
 }
 
+/**
+ * Whether the amount range is inverted (min greater than max).
+ *
+ * Both bounds must be present and numeric; an inverted range would silently
+ * filter out every transaction, so the UI surfaces it as a validation error
+ * instead (#3790).
+ */
+export function isAmountRangeInverted(filters: AdvancedFilters): boolean {
+  if (!filters.amountMin || !filters.amountMax) return false;
+  const min = parseFloat(filters.amountMin);
+  const max = parseFloat(filters.amountMax);
+  if (Number.isNaN(min) || Number.isNaN(max)) return false;
+  return min > max;
+}
+
+/** Collapse a list of names into a chip-friendly summary. */
+function summarizeNames(names: string[], noun: string): string {
+  if (names.length <= 2) {
+    return names.join(', ');
+  }
+  return `${names.length} ${noun} selected`;
+}
+
+/** Format a raw amount filter string (major units) as localized currency. */
+function formatAmountChip(rawAmount: string): string {
+  const parsed = parseFloat(rawAmount);
+  if (Number.isNaN(parsed)) {
+    return rawAmount;
+  }
+  return formatCurrencyValue(parsed);
+}
+
 /** Get human-readable chip descriptions for active filters. */
 export function getActiveFilterChips(
   filters: AdvancedFilters,
@@ -87,28 +121,24 @@ export function getActiveFilterChips(
   const chips: { key: string; label: string }[] = [];
 
   if (filters.startDate) {
-    chips.push({ key: 'startDate', label: `From: ${filters.startDate}` });
+    chips.push({ key: 'startDate', label: `From: ${formatDate(filters.startDate)}` });
   }
   if (filters.endDate) {
-    chips.push({ key: 'endDate', label: `To: ${filters.endDate}` });
+    chips.push({ key: 'endDate', label: `To: ${formatDate(filters.endDate)}` });
   }
   if (filters.categoryIds.length > 0) {
-    const names = filters.categoryIds
-      .map((id) => categories.find((c) => c.id === id)?.name ?? id)
-      .join(', ');
-    chips.push({ key: 'categories', label: `Categories: ${names}` });
+    const names = filters.categoryIds.map((id) => categories.find((c) => c.id === id)?.name ?? id);
+    chips.push({ key: 'categories', label: `Categories: ${summarizeNames(names, 'categories')}` });
   }
   if (filters.accountIds.length > 0) {
-    const names = filters.accountIds
-      .map((id) => accounts.find((a) => a.id === id)?.name ?? id)
-      .join(', ');
-    chips.push({ key: 'accounts', label: `Accounts: ${names}` });
+    const names = filters.accountIds.map((id) => accounts.find((a) => a.id === id)?.name ?? id);
+    chips.push({ key: 'accounts', label: `Accounts: ${summarizeNames(names, 'accounts')}` });
   }
   if (filters.amountMin) {
-    chips.push({ key: 'amountMin', label: `Min: $${filters.amountMin}` });
+    chips.push({ key: 'amountMin', label: `Min: ${formatAmountChip(filters.amountMin)}` });
   }
   if (filters.amountMax) {
-    chips.push({ key: 'amountMax', label: `Max: $${filters.amountMax}` });
+    chips.push({ key: 'amountMax', label: `Max: ${formatAmountChip(filters.amountMax)}` });
   }
   if (filters.types.length > 0) {
     chips.push({ key: 'types', label: `Type: ${filters.types.join(', ')}` });
@@ -137,6 +167,8 @@ export const TransactionFilters: React.FC<TransactionFiltersProps> = ({
 }) => {
   const idPrefix = useId();
   const activeCount = countActiveFilters(filters);
+  const amountRangeInverted = isAmountRangeInverted(filters);
+  const amountErrorId = `${idPrefix}-amount-error`;
 
   const handleFieldChange = useCallback(
     (field: keyof AdvancedFilters, value: AdvancedFilters[keyof AdvancedFilters]) => {
@@ -330,6 +362,8 @@ export const TransactionFilters: React.FC<TransactionFiltersProps> = ({
               placeholder="0.00"
               min="0"
               step="0.01"
+              aria-invalid={amountRangeInverted}
+              aria-describedby={amountRangeInverted ? amountErrorId : undefined}
             />
           </div>
 
@@ -346,8 +380,17 @@ export const TransactionFilters: React.FC<TransactionFiltersProps> = ({
               placeholder="0.00"
               min="0"
               step="0.01"
+              aria-invalid={amountRangeInverted}
+              aria-describedby={amountRangeInverted ? amountErrorId : undefined}
             />
           </div>
+
+          {amountRangeInverted && (
+            <p id={amountErrorId} className="transaction-filters-panel__error" role="alert">
+              Minimum amount is greater than the maximum, so no transactions can match. Adjust the
+              range.
+            </p>
+          )}
 
           {/* Type toggles */}
           <div className="transaction-filters-panel__group">

--- a/apps/web/src/components/transactions/transaction-filters.css
+++ b/apps/web/src/components/transactions/transaction-filters.css
@@ -88,6 +88,13 @@
   letter-spacing: 0.05em;
 }
 
+.transaction-filters-panel__error {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-status-negative, #b91c1c);
+}
+
 .transaction-filters-panel__row {
   display: flex;
   gap: var(--spacing-2);

--- a/apps/web/src/lib/categories/filter-sort.test.ts
+++ b/apps/web/src/lib/categories/filter-sort.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import type { Category } from '../../kmp/bridge';
+import { filterAndSortCategories } from './filter-sort';
+
+function makeCategory(overrides: Partial<Category> = {}): Category {
+  return {
+    id: 'cat-1',
+    householdId: 'household-1',
+    name: 'Groceries',
+    parentId: null,
+    icon: 'groceries',
+    color: '#22c55e',
+    isIncome: false,
+    isSystem: false,
+    sortOrder: 0,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+    ...overrides,
+  } as Category;
+}
+
+const categories: Category[] = [
+  makeCategory({ id: 'food', name: 'Food', sortOrder: 2, isIncome: false }),
+  makeCategory({ id: 'salary', name: 'Salary', sortOrder: 0, isIncome: true }),
+  makeCategory({ id: 'rent', name: 'Rent', sortOrder: 1, isIncome: false }),
+  makeCategory({ id: 'cafe', name: 'Café', sortOrder: 3, isIncome: false }),
+];
+
+const usageCounts = new Map<string, number>([
+  ['food', 10],
+  ['salary', 1],
+  ['rent', 5],
+  ['cafe', 0],
+]);
+
+describe('filterAndSortCategories', () => {
+  it('returns all categories sorted by name when unfiltered', () => {
+    const result = filterAndSortCategories(
+      categories,
+      { query: '', typeFilter: 'all', sortField: 'name' },
+      usageCounts,
+    );
+    expect(result.map((c) => c.id)).toEqual(['cafe', 'food', 'rent', 'salary']);
+  });
+
+  it('filters by income type', () => {
+    const result = filterAndSortCategories(
+      categories,
+      { query: '', typeFilter: 'income', sortField: 'name' },
+      usageCounts,
+    );
+    expect(result.map((c) => c.id)).toEqual(['salary']);
+  });
+
+  it('filters by expense type', () => {
+    const result = filterAndSortCategories(
+      categories,
+      { query: '', typeFilter: 'expense', sortField: 'name' },
+      usageCounts,
+    );
+    expect(result.map((c) => c.id)).toEqual(['cafe', 'food', 'rent']);
+  });
+
+  it('matches the name query ignoring case and diacritics', () => {
+    const result = filterAndSortCategories(
+      categories,
+      { query: 'cafe', typeFilter: 'all', sortField: 'name' },
+      usageCounts,
+    );
+    expect(result.map((c) => c.id)).toEqual(['cafe']);
+  });
+
+  it('sorts by usage descending, then name', () => {
+    const result = filterAndSortCategories(
+      categories,
+      { query: '', typeFilter: 'all', sortField: 'usage' },
+      usageCounts,
+    );
+    expect(result.map((c) => c.id)).toEqual(['food', 'rent', 'salary', 'cafe']);
+  });
+
+  it('sorts by manual sort order', () => {
+    const result = filterAndSortCategories(
+      categories,
+      { query: '', typeFilter: 'all', sortField: 'sortOrder' },
+      usageCounts,
+    );
+    expect(result.map((c) => c.id)).toEqual(['salary', 'rent', 'food', 'cafe']);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    const result = filterAndSortCategories(
+      categories,
+      { query: 'nonexistent', typeFilter: 'all', sortField: 'name' },
+      usageCounts,
+    );
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/categories/filter-sort.ts
+++ b/apps/web/src/lib/categories/filter-sort.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Pure search / filter / sort helpers for the Categories page.
+ *
+ * Extracted from `CategoriesPage` so the narrowing logic is unit-testable
+ * without rendering React. All functions are pure and side-effect free.
+ *
+ * References: issue #3790
+ */
+
+import type { Category } from '../../kmp/bridge';
+
+/** Which category kinds to include. */
+export type CategoryTypeFilter = 'all' | 'income' | 'expense';
+
+/** How to order the resulting category list. */
+export type CategorySortField = 'name' | 'usage' | 'sortOrder';
+
+export interface CategoryFilterOptions {
+  /** Free-text query matched (case/diacritic-insensitive) against the name. */
+  query: string;
+  /** Restrict to income, expense, or all categories. */
+  typeFilter: CategoryTypeFilter;
+  /** Primary sort field. */
+  sortField: CategorySortField;
+}
+
+/** Lower-case and strip diacritics so `cafe` matches `Café`. */
+function normalize(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+/**
+ * Filter categories by name query and income/expense type, then sort.
+ *
+ * `name` sorts alphabetically (locale-aware), `usage` sorts by transaction
+ * count descending (most-used first), and `sortOrder` respects the stored
+ * manual ordering. Ties fall back to alphabetical name order so the output is
+ * deterministic.
+ */
+export function filterAndSortCategories(
+  categories: readonly Category[],
+  options: CategoryFilterOptions,
+  usageCounts: ReadonlyMap<string, number>,
+): Category[] {
+  const term = normalize(options.query.trim());
+
+  const filtered = categories.filter((category) => {
+    if (options.typeFilter === 'income' && !category.isIncome) return false;
+    if (options.typeFilter === 'expense' && category.isIncome) return false;
+    if (term !== '' && !normalize(category.name).includes(term)) return false;
+    return true;
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    switch (options.sortField) {
+      case 'usage': {
+        const usageA = usageCounts.get(a.id) ?? 0;
+        const usageB = usageCounts.get(b.id) ?? 0;
+        if (usageA !== usageB) return usageB - usageA;
+        return a.name.localeCompare(b.name);
+      }
+      case 'sortOrder': {
+        if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
+        return a.name.localeCompare(b.name);
+      }
+      case 'name':
+      default:
+        return a.name.localeCompare(b.name);
+    }
+  });
+
+  return sorted;
+}

--- a/apps/web/src/lib/transactions/filter-sort.test.ts
+++ b/apps/web/src/lib/transactions/filter-sort.test.ts
@@ -223,4 +223,21 @@ describe('matchesTransactionQuery', () => {
       false,
     );
   });
+
+  it('matches ignoring diacritics in either direction', () => {
+    const accented = makeTransaction({ payee: 'Café Rico' });
+    expect(matchesTransactionQuery(accented, 'cafe')).toBe(true);
+    expect(matchesTransactionQuery(accented, 'café')).toBe(true);
+
+    const plain = makeTransaction({ payee: 'Cafe Rico' });
+    expect(matchesTransactionQuery(plain, 'café')).toBe(true);
+
+    const resolvedCategory = makeTransaction({ categoryId: 'category-accented' });
+    const accentedCategoryNames = new Map<string, string>([['category-accented', 'Épicerie']]);
+    expect(
+      matchesTransactionQuery(resolvedCategory, 'epicerie', {
+        categoryNames: accentedCategoryNames,
+      }),
+    ).toBe(true);
+  });
 });

--- a/apps/web/src/lib/transactions/filter-sort.ts
+++ b/apps/web/src/lib/transactions/filter-sort.ts
@@ -118,6 +118,20 @@ export interface TransactionSearchContext {
 }
 
 /**
+ * Lower-case and strip diacritics so `cafe` matches `Café` (and vice versa).
+ *
+ * Uses Unicode NFD decomposition to split accented characters into a base
+ * letter plus a combining mark, then removes the combining marks. Keeps search
+ * relevance consistent for international merchant and payee names (#3790).
+ */
+export function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+/**
  * Test whether a transaction matches a free-text query.
  *
  * Mirrors the repository's SQL search fields (payee, note, tags, status,
@@ -130,7 +144,7 @@ export function matchesTransactionQuery(
   query: string,
   context: TransactionSearchContext = {},
 ): boolean {
-  const term = query.trim().toLowerCase();
+  const term = normalizeSearchText(query.trim());
   if (term === '') return true;
 
   const haystacks: string[] = [
@@ -146,7 +160,7 @@ export function matchesTransactionQuery(
   }
   haystacks.push(context.accountNames?.get(transaction.accountId) ?? '');
 
-  if (haystacks.some((value) => value.toLowerCase().includes(term))) {
+  if (haystacks.some((value) => normalizeSearchText(value).includes(term))) {
     return true;
   }
 

--- a/apps/web/src/pages/CategoriesPage.test.tsx
+++ b/apps/web/src/pages/CategoriesPage.test.tsx
@@ -227,9 +227,9 @@ describe('CategoriesPage', () => {
     render(<CategoriesPage />);
 
     expect(screen.getByRole('heading', { name: 'Categories', level: 1 })).toBeInTheDocument();
-    expect(screen.getByText('Food')).toBeInTheDocument();
-    expect(screen.getByText('Income')).toBeInTheDocument();
-    expect(screen.getByText('Utilities')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Food', level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Income', level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Utilities', level: 3 })).toBeInTheDocument();
     expect(screen.getByText('#16A34A')).toBeInTheDocument();
     expect(screen.getByText('utensils')).toBeInTheDocument();
   });
@@ -340,5 +340,41 @@ describe('CategoriesPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete Category' }));
 
     expect(deleteCategoryMock).toHaveBeenCalledWith('category-food');
+  });
+
+  it('filters categories by search query', () => {
+    render(<CategoriesPage />);
+
+    fireEvent.change(screen.getByLabelText('Search categories by name'), {
+      target: { value: 'util' },
+    });
+
+    expect(screen.getByRole('heading', { name: 'Utilities', level: 3 })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Food', level: 3 })).not.toBeInTheDocument();
+    expect(screen.getByText(/Showing 1 of 3 categories/i)).toBeInTheDocument();
+  });
+
+  it('filters categories by income type', () => {
+    render(<CategoriesPage />);
+
+    fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'income' } });
+
+    expect(screen.getByRole('heading', { name: 'Income', level: 3 })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Food', level: 3 })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Utilities', level: 3 })).not.toBeInTheDocument();
+  });
+
+  it('shows a no-results state and clears filters', () => {
+    render(<CategoriesPage />);
+
+    fireEvent.change(screen.getByLabelText('Search categories by name'), {
+      target: { value: 'zzz-nope' },
+    });
+
+    expect(screen.getByRole('heading', { name: /no categories match/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /clear filters/i }));
+
+    expect(screen.getByRole('heading', { name: 'Food', level: 3 })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/CategoriesPage.tsx
+++ b/apps/web/src/pages/CategoriesPage.tsx
@@ -3,11 +3,22 @@
 import React, { lazy, Suspense, useCallback, useMemo, useState } from 'react';
 import { AppIcon, type IconName } from '../components/icons';
 
-import { ConfirmDialog, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import {
+  ConfirmDialog,
+  EmptyState,
+  ErrorBanner,
+  LoadingSpinner,
+  NoResultsEmptyState,
+} from '../components/common';
 import { CategoryForm } from '../components/forms';
 import type { CreateCategoryInput } from '../db/repositories/categories';
 import { useCategories, useTransactions } from '../hooks';
 import type { Category } from '../kmp/bridge';
+import {
+  filterAndSortCategories,
+  type CategorySortField,
+  type CategoryTypeFilter,
+} from '../lib/categories/filter-sort';
 import '../styles/pages.css';
 
 const FamilyKidsCategoryCard = lazy(
@@ -77,6 +88,9 @@ export const CategoriesPage: React.FC = () => {
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
   const [deletingCategory, setDeletingCategory] = useState<Category | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [typeFilter, setTypeFilter] = useState<CategoryTypeFilter>('all');
+  const [sortField, setSortField] = useState<CategorySortField>('name');
 
   const categoriesById = useMemo(
     () => new Map(categories.map((category) => [category.id, category])),
@@ -105,6 +119,23 @@ export const CategoriesPage: React.FC = () => {
 
   const isLoading = loading || transactionsLoading;
   const resolvedError = error ?? transactionsError;
+
+  const visibleCategories = useMemo(
+    () =>
+      filterAndSortCategories(
+        categories,
+        { query: searchQuery, typeFilter, sortField },
+        transactionCountsByCategory,
+      ),
+    [categories, searchQuery, typeFilter, sortField, transactionCountsByCategory],
+  );
+
+  const isFiltering = searchQuery.trim() !== '' || typeFilter !== 'all';
+
+  const handleClearCategoryFilters = useCallback(() => {
+    setSearchQuery('');
+    setTypeFilter('all');
+  }, []);
 
   const handleRetry = useCallback(() => {
     refresh();
@@ -313,84 +344,151 @@ export const CategoriesPage: React.FC = () => {
               onError={setDeleteError}
             />
           </Suspense>
+          <section className="category-toolbar" aria-label="Search and filter categories">
+            <div className="search-bar" role="search">
+              <input
+                type="search"
+                className="search-bar__input"
+                placeholder="Search categories..."
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                aria-label="Search categories by name"
+              />
+              {searchQuery.trim() !== '' && (
+                <button
+                  type="button"
+                  className="search-bar__clear"
+                  onClick={() => setSearchQuery('')}
+                  aria-label="Clear category search"
+                >
+                  <span aria-hidden="true">✕</span>
+                </button>
+              )}
+            </div>
+            <div className="category-toolbar__controls">
+              <div className="category-toolbar__field">
+                <label className="category-toolbar__label" htmlFor="category-type-filter">
+                  Type
+                </label>
+                <select
+                  id="category-type-filter"
+                  className="category-toolbar__select"
+                  value={typeFilter}
+                  onChange={(event) => setTypeFilter(event.target.value as CategoryTypeFilter)}
+                >
+                  <option value="all">All</option>
+                  <option value="income">Income</option>
+                  <option value="expense">Expense</option>
+                </select>
+              </div>
+              <div className="category-toolbar__field">
+                <label className="category-toolbar__label" htmlFor="category-sort">
+                  Sort by
+                </label>
+                <select
+                  id="category-sort"
+                  className="category-toolbar__select"
+                  value={sortField}
+                  onChange={(event) => setSortField(event.target.value as CategorySortField)}
+                >
+                  <option value="name">Name</option>
+                  <option value="usage">Most used</option>
+                  <option value="sortOrder">Sort order</option>
+                </select>
+              </div>
+            </div>
+          </section>
           <p className="page-summary" aria-live="polite">
-            {categories.length} categor{categories.length === 1 ? 'y' : 'ies'} available for
-            transaction organization.
+            {isFiltering
+              ? `Showing ${visibleCategories.length} of ${categories.length} categor${
+                  categories.length === 1 ? 'y' : 'ies'
+                }.`
+              : `${categories.length} categor${
+                  categories.length === 1 ? 'y' : 'ies'
+                } available for transaction organization.`}
           </p>
           <section aria-label="Categories list">
-            <div className="card-grid card-grid--2">
-              {categories.map((category) => {
-                const transactionCount = transactionCountsByCategory.get(category.id) ?? 0;
-                const parentCategory = category.parentId
-                  ? categoriesById.get(category.parentId)
-                  : undefined;
+            {visibleCategories.length === 0 ? (
+              <NoResultsEmptyState
+                title="No categories match"
+                description="Try a different search term or type filter."
+                onClearFilters={handleClearCategoryFilters}
+              />
+            ) : (
+              <div className="card-grid card-grid--2">
+                {visibleCategories.map((category) => {
+                  const transactionCount = transactionCountsByCategory.get(category.id) ?? 0;
+                  const parentCategory = category.parentId
+                    ? categoriesById.get(category.parentId)
+                    : undefined;
 
-                return (
-                  <article
-                    key={category.id}
-                    className="card category-card"
-                    aria-label={`${category.name} category`}
-                  >
-                    <header className="category-card__header">
-                      <div className="category-card__title-row">
-                        <span
-                          aria-hidden="true"
-                          className="category-card__icon"
-                          style={{
-                            background: category.color ?? 'var(--semantic-background-secondary)',
-                          }}
-                        >
-                          {isCustomCategoryIcon(category.icon) ? (
-                            category.icon
-                          ) : (
-                            <AppIcon name={getCategoryIcon(category.icon)} />
-                          )}
-                        </span>
-                        <h3 className="category-card__name">{category.name}</h3>
-                      </div>
-                      <p className="category-card__meta">
-                        {category.isIncome ? 'Income' : 'Expense'} ·{' '}
-                        {getUsageLabel(transactionCount)}
-                        {parentCategory ? ` · Child of ${parentCategory.name}` : ''}
-                        {category.isSystem ? ' · System' : ''}
-                      </p>
-                      <div className="category-card__actions">
-                        <button
-                          type="button"
-                          className="form-button form-button--secondary"
-                          onClick={() => handleEditCategory(category)}
-                          aria-label={`Edit ${category.name} category`}
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          className="form-button form-button--secondary"
-                          onClick={() => handleRequestDelete(category)}
-                          aria-label={`Delete ${category.name} category`}
-                        >
-                          Delete
-                        </button>
-                      </div>
-                    </header>
-                    <dl className="category-card__details">
-                      <div>
-                        <dt className="card__title">Icon</dt>
-                        <dd className="card__value">{category.icon ?? 'Default'}</dd>
-                      </div>
-                      <div>
-                        <dt className="card__title">Color</dt>
-                        <dd className="card__value">{category.color ?? 'Default'}</dd>
-                      </div>
-                      <div>
-                        <dt className="card__title">Sort order</dt>
-                        <dd className="card__value">{category.sortOrder}</dd>
-                      </div>
-                    </dl>
-                  </article>
-                );
-              })}
-            </div>
+                  return (
+                    <article
+                      key={category.id}
+                      className="card category-card"
+                      aria-label={`${category.name} category`}
+                    >
+                      <header className="category-card__header">
+                        <div className="category-card__title-row">
+                          <span
+                            aria-hidden="true"
+                            className="category-card__icon"
+                            style={{
+                              background: category.color ?? 'var(--semantic-background-secondary)',
+                            }}
+                          >
+                            {isCustomCategoryIcon(category.icon) ? (
+                              category.icon
+                            ) : (
+                              <AppIcon name={getCategoryIcon(category.icon)} />
+                            )}
+                          </span>
+                          <h3 className="category-card__name">{category.name}</h3>
+                        </div>
+                        <p className="category-card__meta">
+                          {category.isIncome ? 'Income' : 'Expense'} ·{' '}
+                          {getUsageLabel(transactionCount)}
+                          {parentCategory ? ` · Child of ${parentCategory.name}` : ''}
+                          {category.isSystem ? ' · System' : ''}
+                        </p>
+                        <div className="category-card__actions">
+                          <button
+                            type="button"
+                            className="form-button form-button--secondary"
+                            onClick={() => handleEditCategory(category)}
+                            aria-label={`Edit ${category.name} category`}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            className="form-button form-button--secondary"
+                            onClick={() => handleRequestDelete(category)}
+                            aria-label={`Delete ${category.name} category`}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </header>
+                      <dl className="category-card__details">
+                        <div>
+                          <dt className="card__title">Icon</dt>
+                          <dd className="card__value">{category.icon ?? 'Default'}</dd>
+                        </div>
+                        <div>
+                          <dt className="card__title">Color</dt>
+                          <dd className="card__value">{category.color ?? 'Default'}</dd>
+                        </div>
+                        <div>
+                          <dt className="card__title">Sort order</dt>
+                          <dd className="card__value">{category.sortOrder}</dd>
+                        </div>
+                      </dl>
+                    </article>
+                  );
+                })}
+              </div>
+            )}
           </section>
         </>
       )}

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -1423,7 +1423,26 @@ export const TransactionsPage: React.FC = () => {
               onChange={(event) => setQuery(event.target.value)}
               aria-label="Search transactions"
             />
+            {query.trim() !== '' && (
+              <button
+                type="button"
+                className="search-bar__clear"
+                onClick={() => setQuery('')}
+                aria-label="Clear search"
+              >
+                <span aria-hidden="true">✕</span>
+              </button>
+            )}
           </div>
+          {hasActiveFilters && !isLoading && !resolvedError && (
+            <p className="sr-only" role="status" aria-live="polite">
+              {transactions.length === 0
+                ? 'No transactions match the current search and filters'
+                : `${transactions.length} transaction${
+                    transactions.length === 1 ? '' : 's'
+                  } match the current search and filters`}
+            </p>
+          )}
 
           {/* Filter/Sort controls */}
           {!isSimplified ? (

--- a/apps/web/src/styles/pages.css
+++ b/apps/web/src/styles/pages.css
@@ -304,6 +304,55 @@
  * overlapping or crowding the title. Actions are right-aligned and
  * wrap on small viewports.
  * ------------------------------------------------------------------- */
+.category-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+}
+
+.category-toolbar .search-bar {
+  flex: 1 1 16rem;
+  margin-bottom: 0;
+}
+
+.category-toolbar__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+}
+
+.category-toolbar__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.category-toolbar__label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.category-toolbar__select {
+  min-height: 2.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--input-border);
+  border-radius: var(--input-border-radius);
+  background: var(--input-background);
+  color: var(--input-text);
+  font-size: inherit;
+}
+
+.category-toolbar__select:focus-visible {
+  outline: none;
+  border-color: var(--input-border-focus);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
 .category-card__header {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -538,6 +538,28 @@
   border-color: var(--input-border-focus);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
 }
+.search-bar__clear {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  padding: var(--spacing-2);
+  border: 1px solid var(--input-border);
+  border-radius: var(--input-border-radius);
+  background: var(--input-background);
+  color: var(--semantic-text-secondary);
+  cursor: pointer;
+}
+.search-bar__clear:hover {
+  color: var(--semantic-text-primary);
+}
+.search-bar__clear:focus-visible {
+  outline: none;
+  border-color: var(--input-border-focus);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
 .filter-chips {
   display: flex;
   gap: var(--spacing-2);


### PR DESCRIPTION
## Summary

Improves the **Search, filtering & categorization** surface of the web app (`apps/web`). Issue-first: implements a coherent subset of the critique in #3790.

Closes #3790

## What changed

- **CategoriesPage — search / filter / sort (critique #1).** The page previously rendered every category in a flat grid with no way to narrow it. Added a name search box (with clear button), an income/expense/all type filter, and a sort control (Name / Most used / Sort order). Shows a live `aria-live` "Showing N of M" count and a dedicated no-results state with a one-click "Clear filters" action. Narrowing logic lives in a pure, unit-tested helper (`lib/categories/filter-sort.ts`).
- **Transactions search — clear button + result count (critique #2, #3).** Added an explicit "Clear search" button (native `type=search` clear is inconsistent across browsers) and an `aria-live="polite"` status announcing how many transactions match the current search/filters for screen-reader users.
- **Amount range validation (critique #5).** An inverted range (min > max) previously produced a silent empty list. It now surfaces an accessible `role="alert"` message and marks the inputs `aria-invalid`.
- **Formatted filter chips (critique #6, #7).** Chips now render locale-formatted dates (`Jan 1, 2024` instead of `2024-01-01`) and localized currency amounts, and collapse many-category selections to `Categories: N selected` instead of an unbounded inline list.
- **Diacritic-insensitive search (critique #8).** `matchesTransactionQuery` now normalizes accents, so `cafe` matches `Café` (and vice versa) across payee, note, tags, and resolved category/account names.

## Accessibility (WCAG 2.2 AA)

- New controls have visible `<label>`s and/or `aria-label`s; clear buttons meet the 44×44 target size.
- Result counts and the amount-range error use live regions / `role="alert"`.
- No-results state reuses the shared `NoResultsEmptyState` (`role="status"`, correct heading order).

## Testing (local only)

- `npm run format:check` — clean
- `npx eslint . --max-warnings 0` — clean
- `cd apps/web && npm test` — **890 files, 9749 tests passing**
- Added/updated unit tests: `lib/categories/filter-sort.test.ts` (new), transaction search diacritics, chip formatting + amount-range validation, CategoriesPage search/filter/no-results.

## Full critique list (from #3790)

1. **CategoriesPage has no search, filter, or sort.** ✅ implemented
2. **Transaction search has no explicit clear button.** ✅ implemented
3. **No live result-count announcement for search/filter results.** ✅ implemented
4. **Category/account filters use a tiny native `<select multiple size={3}>`.** — searchable combobox / checkbox list (follow-up)
5. **Amount range allows min > max with no validation → silent zero results.** ✅ implemented
6. **Filter chips show raw ISO dates and unformatted amounts.** ✅ implemented
7. **Multi-category chip concatenates every selected name.** ✅ implemented
8. **Search is diacritics-sensitive.** ✅ implemented
9. **No saved filters / filter presets.** — follow-up
10. **`NoResultsEmptyState` can't distinguish "no search match" from "filters too narrow".** — follow-up
11. **Deleting a parent category orphans subcategories and dangling transaction references.** — follow-up
12. **Amount filter sign/units are unexplained.** — follow-up
13. **Search input has no visible label or search icon.** — partially addressed (CategoriesPage search labeled); follow-up for global styling

Items 4, 9–13 are intentionally left as tracked follow-ups to keep this PR focused and reviewable.
