### PR TITLE
feat(web): snooze, date grouping & a11y for notifications & reminders

### DIFF
--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../../hooks', () => ({
     markAsRead: vi.fn(),
     markAllAsRead: vi.fn(),
     dismiss: vi.fn(),
+    snooze: vi.fn(),
     clearDismissed: vi.fn(),
     addNotification: vi.fn(),
     addNotifications: vi.fn(),

--- a/apps/web/src/components/notifications/NotificationCenter.tsx
+++ b/apps/web/src/components/notifications/NotificationCenter.tsx
@@ -168,7 +168,9 @@ export const NotificationCenter: FC<NotificationCenterProps> = ({
     onViewAll?.();
   }, [closePanel, onViewAll]);
 
-  const visibleNotifications = notifications.filter((n) => n.status !== 'dismissed');
+  const visibleNotifications = notifications.filter(
+    (n) => n.status !== 'dismissed' && n.status !== 'snoozed',
+  );
 
   const bellLabel = unreadCount > 0 ? `Notifications, ${unreadCount} unread` : 'Notifications';
 

--- a/apps/web/src/components/notifications/NotificationHistory.test.tsx
+++ b/apps/web/src/components/notifications/NotificationHistory.test.tsx
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the NotificationHistory component — grouping, filtering,
+ * result count, snooze, and accessible item semantics.
+ *
+ * @module components/notifications/NotificationHistory.test
+ * References: #1659, #3792
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AppNotification } from '../../lib/notifications';
+import { NotificationHistory } from './NotificationHistory';
+
+function daysAgo(days: number, hour = 9): string {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  d.setHours(hour, 0, 0, 0);
+  return d.toISOString();
+}
+
+const notifications: AppNotification[] = [
+  {
+    id: 'today-1',
+    type: 'bill_due',
+    severity: 'warning',
+    title: 'Rent due soon',
+    message: 'Rent is due in 3 days.',
+    createdAt: daysAgo(0),
+    status: 'unread',
+  },
+  {
+    id: 'yesterday-1',
+    type: 'budget_threshold',
+    severity: 'info',
+    title: 'Groceries at 75%',
+    message: 'You have used 75% of the groceries budget.',
+    createdAt: daysAgo(1),
+    status: 'read',
+  },
+  {
+    id: 'older-1',
+    type: 'goal_milestone',
+    severity: 'success',
+    title: 'Halfway to vacation',
+    message: 'Your vacation goal is 50% funded.',
+    createdAt: daysAgo(20),
+    status: 'read',
+  },
+];
+
+function renderHistory(overrides: Partial<Parameters<typeof NotificationHistory>[0]> = {}) {
+  const props = {
+    notifications,
+    onMarkAsRead: vi.fn(),
+    onDismiss: vi.fn(),
+    onClearDismissed: vi.fn(),
+    onAction: vi.fn(),
+    onSnooze: vi.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<NotificationHistory {...props} />) };
+}
+
+describe('NotificationHistory', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('groups notifications under date headings', () => {
+    renderHistory();
+    expect(screen.getByRole('heading', { name: 'Today' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Yesterday' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Older' })).toBeInTheDocument();
+  });
+
+  it('announces the filtered result count via a status region', () => {
+    renderHistory();
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('3 notifications');
+  });
+
+  it('renders each item primary action as a real button with severity in its name', () => {
+    renderHistory();
+    expect(
+      screen.getByRole('button', { name: 'Warning: Rent due soon. Rent is due in 3 days.' }),
+    ).toBeInTheDocument();
+  });
+
+  it('marks unread items as read when activated', () => {
+    const { props } = renderHistory();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Warning: Rent due soon. Rent is due in 3 days.' }),
+    );
+    expect(props.onMarkAsRead).toHaveBeenCalledWith('today-1');
+  });
+
+  it('filters to a single status and updates the count', () => {
+    renderHistory();
+    fireEvent.click(screen.getByRole('button', { name: /^Unread/ }));
+    expect(screen.getByRole('status')).toHaveTextContent('1 notification match your filters');
+    expect(screen.queryByText('Groceries at 75%')).toBeNull();
+  });
+
+  it('shows a clear-filters affordance when a filter yields no results', () => {
+    renderHistory({ notifications: [notifications[1]] }); // read-only item
+    fireEvent.click(screen.getByRole('button', { name: /^Unread/ }));
+    expect(screen.getByText('No notifications match your filters.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    expect(screen.getByText('Groceries at 75%')).toBeInTheDocument();
+  });
+
+  it('snoozes a notification through the snooze menu', async () => {
+    const { props } = renderHistory();
+    fireEvent.click(screen.getAllByRole('button', { name: 'Snooze' })[0]);
+    const menu = screen.getByRole('menu');
+    fireEvent.click(within(menu).getByRole('menuitem', { name: '1 hour' }));
+    expect(props.onSnooze).toHaveBeenCalledTimes(1);
+    expect(props.onSnooze).toHaveBeenCalledWith('today-1', expect.any(String));
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+  });
+
+  it('shows the snooze label and hides the snooze control for snoozed items', () => {
+    renderHistory({
+      notifications: [
+        {
+          ...notifications[0],
+          status: 'snoozed',
+          snoozedUntil: daysAgo(-1),
+        },
+      ],
+    });
+    expect(screen.getByText(/^Snoozed until /)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Snooze' })).toBeNull();
+  });
+
+  it('renders a machine-readable time element', () => {
+    const { container } = renderHistory();
+    const timeEl = container.querySelector('time');
+    expect(timeEl).not.toBeNull();
+    expect(timeEl?.getAttribute('datetime')).toBe(notifications[0].createdAt);
+  });
+});

--- a/apps/web/src/components/notifications/NotificationHistory.tsx
+++ b/apps/web/src/components/notifications/NotificationHistory.tsx
@@ -3,17 +3,20 @@
 /**
  * Notification history/log viewer component.
  *
- * Displays a full-page list of all notifications with filtering
- * by type and status. Provides a persistent activity history
- * per acceptance criteria (#1659).
+ * Displays a full-page list of all notifications with filtering by type and
+ * status, date grouping (Today / Yesterday / Earlier this week / Older), a
+ * live-announced result count, and per-notification snooze. Provides a
+ * persistent activity history per acceptance criteria (#1659) and the
+ * reminders UX critique (#3792).
  *
  * @module components/notifications/NotificationHistory
- * References: #1655, #1659
+ * References: #1655, #1659, #3792
  */
 
 import type { FC } from 'react';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import type { AlertType, AppNotification, NotificationStatus } from '../../lib/notifications';
+import { SNOOZE_OPTIONS, formatSnoozeUntil, snoozeUntil } from '../../lib/notifications';
 import './notifications.css';
 
 // ---------------------------------------------------------------------------
@@ -32,6 +35,8 @@ export interface NotificationHistoryProps {
   onClearDismissed: () => void;
   /** Callback when a notification action is clicked. */
   onAction?: (notification: AppNotification) => void;
+  /** Callback to snooze a notification until the given ISO-8601 timestamp. */
+  onSnooze?: (id: string, until: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -45,6 +50,7 @@ const STATUS_FILTERS: Array<{ value: StatusFilter; label: string }> = [
   { value: 'all', label: 'All' },
   { value: 'unread', label: 'Unread' },
   { value: 'read', label: 'Read' },
+  { value: 'snoozed', label: 'Snoozed' },
   { value: 'dismissed', label: 'Dismissed' },
 ];
 
@@ -60,10 +66,58 @@ const TYPE_FILTERS: Array<{ value: TypeFilter; label: string }> = [
 ];
 
 // ---------------------------------------------------------------------------
+// Date grouping
+// ---------------------------------------------------------------------------
+
+/** A named bucket of notifications sharing a recency band. */
+interface DateGroup {
+  readonly key: 'today' | 'yesterday' | 'this-week' | 'older';
+  readonly label: string;
+  readonly items: AppNotification[];
+}
+
+/** Number of whole calendar days between two dates (a - b), ignoring time. */
+function calendarDaysBetween(a: Date, b: Date): number {
+  const startA = new Date(a.getFullYear(), a.getMonth(), a.getDate()).getTime();
+  const startB = new Date(b.getFullYear(), b.getMonth(), b.getDate()).getTime();
+  return Math.round((startA - startB) / 86_400_000);
+}
+
+/** Assign a notification to a recency bucket relative to `now`. */
+function bucketFor(isoTimestamp: string, now: Date): DateGroup['key'] {
+  const created = new Date(isoTimestamp);
+  if (Number.isNaN(created.getTime())) return 'older';
+  const diff = calendarDaysBetween(now, created);
+  if (diff <= 0) return 'today';
+  if (diff === 1) return 'yesterday';
+  if (diff < 7) return 'this-week';
+  return 'older';
+}
+
+const GROUP_LABELS: Record<DateGroup['key'], string> = {
+  today: 'Today',
+  yesterday: 'Yesterday',
+  'this-week': 'Earlier this week',
+  older: 'Older',
+};
+
+/** Group notifications (already newest-first) into recency buckets. */
+function groupByDate(notifications: readonly AppNotification[], now: Date): DateGroup[] {
+  const groups: DateGroup[] = (['today', 'yesterday', 'this-week', 'older'] as const).map(
+    (key) => ({ key, label: GROUP_LABELS[key], items: [] as AppNotification[] }),
+  );
+  const byKey = new Map(groups.map((g) => [g.key, g]));
+  for (const n of notifications) {
+    byKey.get(bucketFor(n.createdAt, now))?.items.push(n);
+  }
+  return groups.filter((g) => g.items.length > 0);
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Format a date for display in the history log. */
+/** Format a compact date/time for display in the history log. */
 function formatTimestamp(isoTimestamp: string): string {
   const date = new Date(isoTimestamp);
   return date.toLocaleString(undefined, {
@@ -74,6 +128,25 @@ function formatTimestamp(isoTimestamp: string): string {
   });
 }
 
+/** Format the full, unambiguous date/time used as a tooltip and screen-reader hint. */
+function formatFullTimestamp(isoTimestamp: string): string {
+  const date = new Date(isoTimestamp);
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+const SEVERITY_LABELS: Record<AppNotification['severity'], string> = {
+  info: 'Info',
+  success: 'Success',
+  warning: 'Warning',
+  critical: 'Critical',
+};
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -81,8 +154,9 @@ function formatTimestamp(isoTimestamp: string): string {
 /**
  * Full notification history viewer.
  *
- * Accessible with ARIA labels on filter buttons, list role on
- * the notification list, and keyboard-navigable items.
+ * Accessible with ARIA labels on filter buttons, a `role="list"` structure,
+ * a live-announced result count, and a real `<button>` for each item's primary
+ * action so keyboard and screen-reader users get native semantics.
  */
 export const NotificationHistory: FC<NotificationHistoryProps> = ({
   notifications,
@@ -90,9 +164,26 @@ export const NotificationHistory: FC<NotificationHistoryProps> = ({
   onDismiss,
   onClearDismissed,
   onAction,
+  onSnooze,
 }) => {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [openSnoozeId, setOpenSnoozeId] = useState<string | null>(null);
+  const itemButtonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  const statusCounts = useMemo(() => {
+    const counts: Record<StatusFilter, number> = {
+      all: notifications.length,
+      unread: 0,
+      read: 0,
+      snoozed: 0,
+      dismissed: 0,
+    };
+    for (const n of notifications) {
+      counts[n.status] += 1;
+    }
+    return counts;
+  }, [notifications]);
 
   const filtered = useMemo(() => {
     return notifications.filter((n) => {
@@ -102,7 +193,50 @@ export const NotificationHistory: FC<NotificationHistoryProps> = ({
     });
   }, [notifications, statusFilter, typeFilter]);
 
-  const dismissedCount = notifications.filter((n) => n.status === 'dismissed').length;
+  const groups = useMemo(() => groupByDate(filtered, new Date()), [filtered]);
+
+  const dismissedCount = statusCounts.dismissed;
+  const hasActiveFilter = statusFilter !== 'all' || typeFilter !== 'all';
+
+  const focusItem = useCallback((id: string) => {
+    requestAnimationFrame(() => {
+      itemButtonRefs.current.get(id)?.focus();
+    });
+  }, []);
+
+  const handleActivate = useCallback(
+    (notification: AppNotification) => {
+      if (notification.status === 'unread') {
+        onMarkAsRead(notification.id);
+      }
+      onAction?.(notification);
+    },
+    [onMarkAsRead, onAction],
+  );
+
+  const handleDismiss = useCallback(
+    (id: string) => {
+      onDismiss(id);
+      setOpenSnoozeId((current) => (current === id ? null : current));
+      // Keep the user's place: focus stays on the item's primary button, which
+      // remains in the list (dismissed entries are still shown under "All").
+      focusItem(id);
+    },
+    [onDismiss, focusItem],
+  );
+
+  const handleSnooze = useCallback(
+    (id: string, optionId: (typeof SNOOZE_OPTIONS)[number]['id']) => {
+      onSnooze?.(id, snoozeUntil(optionId));
+      setOpenSnoozeId(null);
+      focusItem(id);
+    },
+    [onSnooze, focusItem],
+  );
+
+  const resultSummary = `${filtered.length} ${
+    filtered.length === 1 ? 'notification' : 'notifications'
+  }${hasActiveFilter ? ' match your filters' : ''}`;
 
   return (
     <section className="notification-history" aria-label="Notification history">
@@ -121,19 +255,28 @@ export const NotificationHistory: FC<NotificationHistoryProps> = ({
 
       {/* Status filter */}
       <div className="notification-history__filter" role="group" aria-label="Filter by status">
-        {STATUS_FILTERS.map(({ value, label }) => (
-          <button
-            key={value}
-            className={`notification-history__filter-btn ${
-              statusFilter === value ? 'notification-history__filter-btn--active' : ''
-            }`}
-            onClick={() => setStatusFilter(value)}
-            aria-pressed={statusFilter === value}
-            type="button"
-          >
-            {label}
-          </button>
-        ))}
+        {STATUS_FILTERS.map(({ value, label }) => {
+          const count = statusCounts[value];
+          return (
+            <button
+              key={value}
+              className={`notification-history__filter-btn ${
+                statusFilter === value ? 'notification-history__filter-btn--active' : ''
+              }`}
+              onClick={() => setStatusFilter(value)}
+              aria-pressed={statusFilter === value}
+              type="button"
+            >
+              {label}
+              <span className="notification-history__filter-count" aria-hidden="true">
+                {count}
+              </span>
+              <span className="sr-only">{`, ${count} ${
+                count === 1 ? 'notification' : 'notifications'
+              }`}</span>
+            </button>
+          );
+        })}
       </div>
 
       {/* Type filter */}
@@ -153,94 +296,150 @@ export const NotificationHistory: FC<NotificationHistoryProps> = ({
         ))}
       </div>
 
+      {/* Live-announced result count (WCAG 4.1.3) */}
+      <p className="notification-history__result-count" role="status" aria-live="polite">
+        {resultSummary}
+      </p>
+
       {/* Notification list */}
       {filtered.length === 0 ? (
         <div className="notification-panel__empty">
-          <p>No notifications match your filters</p>
-        </div>
-      ) : (
-        <ul
-          className="notification-history__list"
-          role="list"
-          aria-label="Notification history entries"
-        >
-          {filtered.map((notification) => (
-            <li
-              key={notification.id}
-              role="listitem"
-              className={`notification-item ${
-                notification.status === 'unread' ? 'notification-item--unread' : ''
-              }`}
-              tabIndex={0}
-              aria-label={`${notification.title}: ${notification.message}`}
+          <p>
+            {hasActiveFilter
+              ? 'No notifications match your filters.'
+              : 'No notifications yet — alerts and reminders will appear here.'}
+          </p>
+          {hasActiveFilter && (
+            <button
+              className="notification-panel__action-btn"
+              type="button"
               onClick={() => {
-                if (notification.status === 'unread') {
-                  onMarkAsRead(notification.id);
-                }
-                if (onAction) {
-                  onAction(notification);
-                }
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  if (notification.status === 'unread') {
-                    onMarkAsRead(notification.id);
-                  }
-                  if (onAction) {
-                    onAction(notification);
-                  }
-                }
+                setStatusFilter('all');
+                setTypeFilter('all');
               }}
             >
-              <span
-                className={`notification-item__indicator notification-item__indicator--${
-                  notification.status === 'read' ? 'read' : notification.severity
-                }`}
-                aria-hidden="true"
-              />
-              <div className="notification-item__content">
-                <p className="notification-item__title">{notification.title}</p>
-                <p className="notification-item__message">{notification.message}</p>
-                {notification.actionHint ? (
-                  <p className="notification-item__hint">{notification.actionHint}</p>
-                ) : null}
-                <span className="notification-item__time">
-                  {formatTimestamp(notification.createdAt)}
-                </span>
-              </div>
-              <div className="notification-item__action">
-                {notification.actionLabel && (
-                  <button
-                    className="notification-item__action-link"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (onAction) {
-                        onAction(notification);
-                      }
-                    }}
-                    type="button"
+              Clear filters
+            </button>
+          )}
+        </div>
+      ) : (
+        groups.map((group) => (
+          <section key={group.key} className="notification-history__group" aria-label={group.label}>
+            <h3 className="notification-history__group-title">{group.label}</h3>
+            <ul className="notification-history__list" role="list">
+              {group.items.map((notification) => {
+                const isSnoozed = notification.status === 'snoozed';
+                const canSnooze = onSnooze && !isSnoozed && notification.status !== 'dismissed';
+                const severityLabel = SEVERITY_LABELS[notification.severity];
+                return (
+                  <li
+                    key={notification.id}
+                    className={`notification-item ${
+                      notification.status === 'unread' ? 'notification-item--unread' : ''
+                    }`}
                   >
-                    {notification.actionLabel}
-                  </button>
-                )}
-                {notification.status !== 'dismissed' && (
-                  <button
-                    className="notification-item__dismiss"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onDismiss(notification.id);
-                    }}
-                    aria-label={`Dismiss: ${notification.title}`}
-                    type="button"
-                  >
-                    ✕
-                  </button>
-                )}
-              </div>
-            </li>
-          ))}
-        </ul>
+                    <button
+                      ref={(el) => {
+                        if (el) itemButtonRefs.current.set(notification.id, el);
+                        else itemButtonRefs.current.delete(notification.id);
+                      }}
+                      type="button"
+                      className="notification-item__main"
+                      onClick={() => handleActivate(notification)}
+                      aria-label={`${severityLabel}: ${notification.title}. ${notification.message}`}
+                    >
+                      <span
+                        className={`notification-item__indicator notification-item__indicator--${
+                          notification.status === 'read' ? 'read' : notification.severity
+                        }`}
+                        aria-hidden="true"
+                      />
+                      <span className="notification-item__content">
+                        <span className="notification-item__title">{notification.title}</span>
+                        <span className="notification-item__message">{notification.message}</span>
+                        {notification.actionHint ? (
+                          <span className="notification-item__hint">{notification.actionHint}</span>
+                        ) : null}
+                        {isSnoozed && notification.snoozedUntil ? (
+                          <span className="notification-item__snooze-label">
+                            {formatSnoozeUntil(notification.snoozedUntil)}
+                          </span>
+                        ) : null}
+                        <time
+                          className="notification-item__time"
+                          dateTime={notification.createdAt}
+                          title={formatFullTimestamp(notification.createdAt)}
+                        >
+                          {formatTimestamp(notification.createdAt)}
+                        </time>
+                      </span>
+                    </button>
+                    <div className="notification-item__action">
+                      {notification.actionLabel && (
+                        <button
+                          className="notification-item__action-link"
+                          onClick={() => onAction?.(notification)}
+                          type="button"
+                        >
+                          {notification.actionLabel}
+                        </button>
+                      )}
+                      {canSnooze && (
+                        <div className="notification-item__snooze">
+                          <button
+                            className="notification-item__snooze-toggle"
+                            type="button"
+                            aria-haspopup="menu"
+                            aria-expanded={openSnoozeId === notification.id}
+                            onClick={() =>
+                              setOpenSnoozeId((current) =>
+                                current === notification.id ? null : notification.id,
+                              )
+                            }
+                          >
+                            Snooze
+                          </button>
+                          {openSnoozeId === notification.id && (
+                            <ul
+                              className="notification-item__snooze-menu"
+                              role="menu"
+                              aria-label={`Snooze: ${notification.title}`}
+                            >
+                              {SNOOZE_OPTIONS.map((option) => (
+                                <li key={option.id} role="none">
+                                  <button
+                                    role="menuitem"
+                                    type="button"
+                                    className="notification-item__snooze-option"
+                                    onClick={() => handleSnooze(notification.id, option.id)}
+                                  >
+                                    {option.label}
+                                  </button>
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </div>
+                      )}
+                      {notification.status !== 'dismissed' && (
+                        <button
+                          className="notification-item__dismiss"
+                          onClick={() => handleDismiss(notification.id)}
+                          aria-label={`Dismiss: ${notification.title}`}
+                          type="button"
+                        >
+                          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                            <path d="M6 6l12 12M18 6L6 18" />
+                          </svg>
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        ))
       )}
     </section>
   );

--- a/apps/web/src/components/notifications/NotificationToast.test.tsx
+++ b/apps/web/src/components/notifications/NotificationToast.test.tsx
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for NotificationToast auto-dismiss timing behavior.
+ *
+ * Covers WCAG 2.2.1 Timing Adjustable: toasts pause on hover/focus and
+ * critical toasts never auto-dismiss.
+ *
+ * @module components/notifications/NotificationToast.test
+ * References: #3792
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppNotification } from '../../lib/notifications';
+import { NotificationToast } from './NotificationToast';
+
+function makeToast(overrides: Partial<AppNotification> = {}): AppNotification {
+  return {
+    id: 't1',
+    type: 'balance_low',
+    severity: 'info',
+    title: 'Heads up',
+    message: 'Checking balance is low.',
+    createdAt: new Date().toISOString(),
+    status: 'unread',
+    ...overrides,
+  };
+}
+
+describe('NotificationToast timing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it('auto-dismisses a non-critical toast after the configured delay', () => {
+    const onDismiss = vi.fn();
+    render(
+      <NotificationToast notification={makeToast()} onDismiss={onDismiss} autoDismissMs={5000} />,
+    );
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(5000);
+    expect(onDismiss).toHaveBeenCalledWith('t1');
+  });
+
+  it('never auto-dismisses a critical toast', () => {
+    const onDismiss = vi.fn();
+    render(
+      <NotificationToast
+        notification={makeToast({ severity: 'critical' })}
+        onDismiss={onDismiss}
+        autoDismissMs={5000}
+      />,
+    );
+
+    vi.advanceTimersByTime(60_000);
+    expect(onDismiss).not.toHaveBeenCalled();
+    // A critical toast is announced assertively for screen readers.
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('pauses the countdown while hovered', () => {
+    const onDismiss = vi.fn();
+    render(
+      <NotificationToast notification={makeToast()} onDismiss={onDismiss} autoDismissMs={5000} />,
+    );
+
+    const toast = screen.getByRole('status');
+    vi.advanceTimersByTime(3000);
+    fireEvent.mouseEnter(toast);
+    // Time passes while hovered — no dismissal.
+    vi.advanceTimersByTime(10_000);
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    // On leave the remaining ~2s resumes.
+    fireEvent.mouseLeave(toast);
+    vi.advanceTimersByTime(2000);
+    expect(onDismiss).toHaveBeenCalledWith('t1');
+  });
+});

--- a/apps/web/src/components/notifications/NotificationToast.tsx
+++ b/apps/web/src/components/notifications/NotificationToast.tsx
@@ -47,33 +47,59 @@ export const NotificationToast: FC<NotificationToastProps> = ({
   autoDismissMs = 5000,
 }) => {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const remainingRef = useRef<number>(autoDismissMs);
+  const startedAtRef = useRef<number>(0);
 
-  useEffect(() => {
-    timerRef.current = setTimeout(() => {
-      onDismiss(notification.id);
-    }, autoDismissMs);
+  const isCritical = notification.severity === 'critical';
 
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-    };
-  }, [notification.id, onDismiss, autoDismissMs]);
-
-  const handleDismiss = useCallback(() => {
+  const clearTimer = useCallback(() => {
     if (timerRef.current) {
       clearTimeout(timerRef.current);
+      timerRef.current = null;
     }
-    onDismiss(notification.id);
-  }, [notification.id, onDismiss]);
+  }, []);
 
-  const role = notification.severity === 'critical' ? 'alert' : 'status';
+  const startTimer = useCallback(() => {
+    // Critical alerts (fraud, overdraft) must be dismissed manually so they are
+    // never lost to a timeout (WCAG 2.2.1 Timing Adjustable).
+    if (isCritical) return;
+    clearTimer();
+    startedAtRef.current = Date.now();
+    timerRef.current = setTimeout(() => {
+      onDismiss(notification.id);
+    }, remainingRef.current);
+  }, [clearTimer, isCritical, notification.id, onDismiss]);
+
+  // Pause the countdown, preserving the time remaining so hover/focus can be
+  // released without losing already-elapsed time.
+  const pauseTimer = useCallback(() => {
+    if (isCritical || timerRef.current === null) return;
+    clearTimer();
+    remainingRef.current = Math.max(0, remainingRef.current - (Date.now() - startedAtRef.current));
+  }, [clearTimer, isCritical]);
+
+  useEffect(() => {
+    remainingRef.current = autoDismissMs;
+    startTimer();
+    return clearTimer;
+  }, [autoDismissMs, clearTimer, startTimer]);
+
+  const handleDismiss = useCallback(() => {
+    clearTimer();
+    onDismiss(notification.id);
+  }, [clearTimer, notification.id, onDismiss]);
+
+  const role = isCritical ? 'alert' : 'status';
 
   return (
     <div
       className={`notification-toast notification-toast--${notification.severity}`}
       role={role}
-      aria-live={notification.severity === 'critical' ? 'assertive' : 'polite'}
+      aria-live={isCritical ? 'assertive' : 'polite'}
+      onMouseEnter={pauseTimer}
+      onMouseLeave={startTimer}
+      onFocus={pauseTimer}
+      onBlur={startTimer}
     >
       <div className="notification-toast__content">
         <p className="notification-toast__title">{notification.title}</p>

--- a/apps/web/src/components/notifications/notifications.css
+++ b/apps/web/src/components/notifications/notifications.css
@@ -302,6 +302,11 @@
 }
 
 .notification-item__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
   padding: var(--spacing-1, 4px);
   border: none;
   border-radius: var(--radius-sm, 4px);
@@ -309,6 +314,15 @@
   color: var(--semantic-text-disabled);
   cursor: pointer;
   font-size: var(--font-size-sm, 0.875rem);
+}
+
+.notification-item__dismiss svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
 }
 
 .notification-item__dismiss:hover {
@@ -472,6 +486,103 @@
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.notification-history__filter-count {
+  margin-inline-start: var(--spacing-2, 8px);
+  padding: 0 var(--spacing-2, 8px);
+  border-radius: var(--radius-full, 50px);
+  background: var(--semantic-background-secondary);
+  color: inherit;
+  font-size: var(--font-size-xs, 0.75rem);
+  font-variant-numeric: tabular-nums;
+}
+
+.notification-history__filter-btn--active .notification-history__filter-count {
+  background: rgb(255 255 255 / 25%);
+}
+
+.notification-history__result-count {
+  margin: 0 0 var(--spacing-3, 12px);
+  color: var(--semantic-text-secondary);
+  font-size: var(--font-size-sm, 0.875rem);
+}
+
+.notification-history__group {
+  margin-bottom: var(--spacing-4, 16px);
+}
+
+.notification-history__group-title {
+  margin: 0 0 var(--spacing-2, 8px);
+  color: var(--semantic-text-secondary);
+  font-size: var(--font-size-xs, 0.75rem);
+  font-weight: var(--font-weight-semibold, 600);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.notification-item__snooze-label {
+  font-size: var(--font-size-xs, 0.75rem);
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--semantic-status-info, var(--semantic-text-secondary));
+}
+
+.notification-item__snooze {
+  position: relative;
+  display: inline-block;
+}
+
+.notification-item__snooze-toggle {
+  min-height: 44px;
+  padding: var(--spacing-1, 4px) var(--spacing-2, 8px);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-sm, 4px);
+  background: transparent;
+  color: var(--semantic-interactive-default);
+  font-size: var(--font-size-xs, 0.75rem);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.notification-item__snooze-toggle:hover {
+  background: var(--semantic-background-secondary);
+}
+
+.notification-item__snooze-toggle:focus-visible,
+.notification-item__snooze-option:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.notification-item__snooze-menu {
+  position: absolute;
+  inset-inline-end: 0;
+  z-index: 10;
+  min-width: 10rem;
+  margin: var(--spacing-1, 4px) 0 0;
+  padding: var(--spacing-1, 4px);
+  list-style: none;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-md, 8px);
+  background: var(--semantic-background-elevated);
+  box-shadow: var(--shadow-lg, 0 10px 15px -3px rgb(0 0 0 / 10%));
+}
+
+.notification-item__snooze-option {
+  display: block;
+  width: 100%;
+  padding: var(--spacing-2, 8px);
+  border: none;
+  border-radius: var(--radius-sm, 4px);
+  background: transparent;
+  color: var(--semantic-text-primary);
+  font-size: var(--font-size-sm, 0.875rem);
+  text-align: start;
+  cursor: pointer;
+}
+
+.notification-item__snooze-option:hover {
+  background: var(--semantic-background-secondary);
 }
 
 /* ---------------------------------------------------------------------------

--- a/apps/web/src/hooks/useNotifications.test.ts
+++ b/apps/web/src/hooks/useNotifications.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the snooze behavior of the useNotifications hook.
+ *
+ * @module hooks/useNotifications.test
+ * References: #3792
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppNotification } from '../lib/notifications';
+import { useNotifications } from './useNotifications';
+
+const STORAGE_KEY = 'finance-notifications';
+
+function seed(notifications: AppNotification[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(notifications));
+}
+
+const baseNotification: AppNotification = {
+  id: 'n1',
+  type: 'bill_due',
+  severity: 'warning',
+  title: 'Rent due',
+  message: 'Rent is due in 3 days.',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  status: 'unread',
+};
+
+describe('useNotifications snooze', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it('marks a notification snoozed with a wake time and drops it from the unread count', () => {
+    seed([baseNotification]);
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.snooze('n1', '2999-01-01T00:00:00.000Z');
+    });
+
+    const snoozed = result.current.notifications.find((n) => n.id === 'n1');
+    expect(snoozed?.status).toBe('snoozed');
+    expect(snoozed?.snoozedUntil).toBe('2999-01-01T00:00:00.000Z');
+    expect(result.current.unreadCount).toBe(0);
+  });
+
+  it('restores an already-expired snooze to unread on mount', () => {
+    seed([{ ...baseNotification, status: 'snoozed', snoozedUntil: '2000-01-01T00:00:00.000Z' }]);
+    const { result } = renderHook(() => useNotifications());
+
+    const woken = result.current.notifications.find((n) => n.id === 'n1');
+    expect(woken?.status).toBe('unread');
+    expect(woken?.snoozedUntil).toBeUndefined();
+    expect(result.current.unreadCount).toBe(1);
+  });
+});

--- a/apps/web/src/hooks/useNotifications.ts
+++ b/apps/web/src/hooks/useNotifications.ts
@@ -22,6 +22,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AppNotification, NotificationId, NotificationStatus } from '../lib/notifications';
 import { rateLimitNotifications, shouldDeliverNotification } from '../lib/notifications';
 import { loadNotificationPreferences } from '../lib/notifications/preferences';
+import { wakeExpiredSnoozes } from '../lib/notifications/snooze';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -29,6 +30,8 @@ import { loadNotificationPreferences } from '../lib/notifications/preferences';
 
 const STORAGE_KEY = 'finance-notifications';
 const MAX_STORED_NOTIFICATIONS = 200;
+/** How often to re-check for snoozed notifications whose wake time has passed. */
+const SNOOZE_WAKE_INTERVAL_MS = 60_000;
 
 // ---------------------------------------------------------------------------
 // Public interface
@@ -48,6 +51,11 @@ export interface UseNotificationsResult {
   markAllAsRead: () => void;
   /** Dismiss (hide) a notification. */
   dismiss: (id: NotificationId) => void;
+  /**
+   * Snooze a notification until the given ISO-8601 timestamp. The notification
+   * is hidden from active views until then, when it is restored to `unread`.
+   */
+  snooze: (id: NotificationId, until: string) => void;
   /** Clear all dismissed notifications from history. */
   clearDismissed: () => void;
   /** Add a new notification (used by alert evaluators and transaction confirmations). */
@@ -96,11 +104,24 @@ export function useNotifications(): UseNotificationsResult {
   const [loading, setLoading] = useState(true);
   const firedTimestampsRef = useRef<Map<string, number>>(new Map());
 
-  // Load persisted notifications on mount
+  // Load persisted notifications on mount, waking any snoozes that have already
+  // elapsed while the app was closed.
   useEffect(() => {
     const stored = loadNotifications();
-    setNotifications(stored);
+    setNotifications([...wakeExpiredSnoozes(stored)]);
     setLoading(false);
+  }, []);
+
+  // Periodically restore snoozed notifications whose wake time has passed.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setNotifications((prev) => {
+        const woken = wakeExpiredSnoozes(prev);
+        return woken === prev ? prev : [...woken];
+      });
+    }, SNOOZE_WAKE_INTERVAL_MS);
+
+    return () => clearInterval(interval);
   }, []);
 
   // Persist whenever notifications change (skip initial load)
@@ -178,6 +199,12 @@ export function useNotifications(): UseNotificationsResult {
     [updateStatus],
   );
 
+  const snooze = useCallback((id: NotificationId, until: string) => {
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, status: 'snoozed', snoozedUntil: until } : n)),
+    );
+  }, []);
+
   const clearDismissed = useCallback(() => {
     setNotifications((prev) => prev.filter((n) => n.status !== 'dismissed'));
   }, []);
@@ -191,6 +218,7 @@ export function useNotifications(): UseNotificationsResult {
     markAsRead,
     markAllAsRead,
     dismiss,
+    snooze,
     clearDismissed,
     addNotification,
     addNotifications,

--- a/apps/web/src/lib/notifications/index.ts
+++ b/apps/web/src/lib/notifications/index.ts
@@ -233,3 +233,12 @@ export type {
 } from './notification-delivery-plan';
 
 export { loadNotificationPreferences, saveNotificationPreferences } from './preferences';
+
+export {
+  SNOOZE_OPTIONS,
+  formatSnoozeUntil,
+  isSnoozeExpired,
+  snoozeUntil,
+  wakeExpiredSnoozes,
+} from './snooze';
+export type { SnoozeOption } from './snooze';

--- a/apps/web/src/lib/notifications/snooze.test.ts
+++ b/apps/web/src/lib/notifications/snooze.test.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the snooze helpers.
+ *
+ * @module lib/notifications/snooze.test
+ * References: #3792
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AppNotification } from './types';
+import {
+  SNOOZE_OPTIONS,
+  formatSnoozeUntil,
+  isSnoozeExpired,
+  snoozeUntil,
+  wakeExpiredSnoozes,
+} from './snooze';
+
+function makeNotification(overrides: Partial<AppNotification> = {}): AppNotification {
+  return {
+    id: 'n1',
+    type: 'bill_due',
+    severity: 'info',
+    title: 'Rent due',
+    message: 'Rent is due in 3 days.',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    status: 'unread',
+    ...overrides,
+  };
+}
+
+describe('snoozeUntil', () => {
+  const from = new Date('2025-01-01T12:00:00.000Z');
+
+  it('adds one hour for the one-hour option', () => {
+    expect(snoozeUntil('one-hour', from)).toBe('2025-01-01T13:00:00.000Z');
+  });
+
+  it('adds three hours for the three-hours option', () => {
+    expect(snoozeUntil('three-hours', from)).toBe('2025-01-01T15:00:00.000Z');
+  });
+
+  it('resolves tomorrow to 08:00 local the next day', () => {
+    const result = new Date(snoozeUntil('tomorrow', from));
+    expect(result.getHours()).toBe(8);
+    expect(result.getDate()).toBe(2);
+  });
+
+  it('resolves next week to 08:00 local seven days ahead', () => {
+    const result = new Date(snoozeUntil('next-week', from));
+    expect(result.getHours()).toBe(8);
+    // 1 Jan + 7 days = 8 Jan.
+    expect(result.getDate()).toBe(8);
+  });
+
+  it('offers exactly the four documented options', () => {
+    expect(SNOOZE_OPTIONS.map((o) => o.id)).toEqual([
+      'one-hour',
+      'three-hours',
+      'tomorrow',
+      'next-week',
+    ]);
+  });
+});
+
+describe('isSnoozeExpired', () => {
+  it('is false for non-snoozed notifications', () => {
+    expect(isSnoozeExpired(makeNotification({ status: 'unread' }), Date.now())).toBe(false);
+  });
+
+  it('is false while the wake time is still in the future', () => {
+    const n = makeNotification({ status: 'snoozed', snoozedUntil: '2025-01-01T13:00:00.000Z' });
+    expect(isSnoozeExpired(n, new Date('2025-01-01T12:30:00.000Z').getTime())).toBe(false);
+  });
+
+  it('is true once the wake time has passed', () => {
+    const n = makeNotification({ status: 'snoozed', snoozedUntil: '2025-01-01T13:00:00.000Z' });
+    expect(isSnoozeExpired(n, new Date('2025-01-01T13:00:01.000Z').getTime())).toBe(true);
+  });
+});
+
+describe('wakeExpiredSnoozes', () => {
+  const now = new Date('2025-01-01T13:30:00.000Z').getTime();
+
+  it('restores expired snoozes to unread and clears the wake time', () => {
+    const input = [
+      makeNotification({ id: 'a', status: 'snoozed', snoozedUntil: '2025-01-01T13:00:00.000Z' }),
+    ];
+    const [woken] = wakeExpiredSnoozes(input, now);
+    expect(woken.status).toBe('unread');
+    expect(woken.snoozedUntil).toBeUndefined();
+  });
+
+  it('leaves future snoozes untouched and returns the same reference', () => {
+    const input = [
+      makeNotification({ id: 'b', status: 'snoozed', snoozedUntil: '2025-01-02T08:00:00.000Z' }),
+    ];
+    expect(wakeExpiredSnoozes(input, now)).toBe(input);
+  });
+});
+
+describe('formatSnoozeUntil', () => {
+  it('produces a "Snoozed until …" label', () => {
+    expect(formatSnoozeUntil('2025-01-02T08:00:00.000Z')).toMatch(/^Snoozed until /);
+  });
+
+  it('degrades gracefully for an invalid timestamp', () => {
+    expect(formatSnoozeUntil('not-a-date')).toBe('Snoozed');
+  });
+});

--- a/apps/web/src/lib/notifications/snooze.ts
+++ b/apps/web/src/lib/notifications/snooze.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Snooze helpers for the notification center.
+ *
+ * A snoozed notification is hidden from the bell popover and the active views
+ * until its {@link AppNotification.snoozedUntil} time passes, at which point it
+ * is automatically restored to `unread`. These helpers are pure so the timing
+ * logic can be unit-tested without React or timers.
+ *
+ * @module lib/notifications/snooze
+ * References: #3792
+ */
+
+import type { AppNotification } from './types';
+
+/** A selectable snooze duration offered in the UI. */
+export interface SnoozeOption {
+  /** Stable identifier used as a React key and in tests. */
+  readonly id: 'one-hour' | 'three-hours' | 'tomorrow' | 'next-week';
+  /** Short human-readable label (e.g. "1 hour"). */
+  readonly label: string;
+}
+
+/** Snooze durations offered to the user, in display order. */
+export const SNOOZE_OPTIONS: readonly SnoozeOption[] = [
+  { id: 'one-hour', label: '1 hour' },
+  { id: 'three-hours', label: '3 hours' },
+  { id: 'tomorrow', label: 'Tomorrow morning' },
+  { id: 'next-week', label: 'Next week' },
+];
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * Compute the wake-up timestamp for a snooze option relative to `from`.
+ *
+ * "Tomorrow morning" resolves to 08:00 local time on the next day; "Next week"
+ * resolves to 08:00 local time seven days ahead. Fixed durations add the exact
+ * offset so short snoozes remain predictable.
+ *
+ * @param optionId - The chosen {@link SnoozeOption} id.
+ * @param from - Reference time (defaults to now); injectable for testing.
+ * @returns ISO-8601 timestamp at which the notification should wake.
+ */
+export function snoozeUntil(optionId: SnoozeOption['id'], from: Date = new Date()): string {
+  switch (optionId) {
+    case 'one-hour':
+      return new Date(from.getTime() + HOUR_MS).toISOString();
+    case 'three-hours':
+      return new Date(from.getTime() + 3 * HOUR_MS).toISOString();
+    case 'tomorrow': {
+      const next = new Date(from.getTime() + DAY_MS);
+      next.setHours(8, 0, 0, 0);
+      return next.toISOString();
+    }
+    case 'next-week': {
+      const next = new Date(from.getTime() + 7 * DAY_MS);
+      next.setHours(8, 0, 0, 0);
+      return next.toISOString();
+    }
+    default: {
+      // Exhaustiveness guard — unreachable for valid SnoozeOption ids.
+      const exhaustive: never = optionId;
+      return exhaustive;
+    }
+  }
+}
+
+/**
+ * Whether a snoozed notification's wake time has passed.
+ *
+ * Non-snoozed notifications and snoozes without a wake time are never due.
+ *
+ * @param notification - The notification to test.
+ * @param now - Reference time in ms (defaults to `Date.now()`).
+ */
+export function isSnoozeExpired(notification: AppNotification, now: number = Date.now()): boolean {
+  if (notification.status !== 'snoozed' || !notification.snoozedUntil) {
+    return false;
+  }
+  const wake = new Date(notification.snoozedUntil).getTime();
+  return Number.isFinite(wake) && wake <= now;
+}
+
+/**
+ * Restore any snoozed notifications whose wake time has passed back to `unread`.
+ *
+ * Returns the same array reference when nothing changed so callers can bail out
+ * of state updates cheaply.
+ *
+ * @param notifications - Current notifications.
+ * @param now - Reference time in ms (defaults to `Date.now()`).
+ */
+export function wakeExpiredSnoozes(
+  notifications: readonly AppNotification[],
+  now: number = Date.now(),
+): readonly AppNotification[] {
+  let changed = false;
+  const next = notifications.map((n) => {
+    if (isSnoozeExpired(n, now)) {
+      changed = true;
+      const { snoozedUntil: _snoozedUntil, ...rest } = n;
+      return { ...rest, status: 'unread' as const };
+    }
+    return n;
+  });
+  return changed ? next : notifications;
+}
+
+/**
+ * Format a snoozed notification's wake time as a short, human-readable label
+ * (e.g. "Snoozed until Mon 8:00 AM").
+ *
+ * @param isoTimestamp - The `snoozedUntil` value.
+ */
+export function formatSnoozeUntil(isoTimestamp: string): string {
+  const date = new Date(isoTimestamp);
+  if (Number.isNaN(date.getTime())) return 'Snoozed';
+  const label = date.toLocaleString(undefined, {
+    weekday: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  return `Snoozed until ${label}`;
+}

--- a/apps/web/src/lib/notifications/types.ts
+++ b/apps/web/src/lib/notifications/types.ts
@@ -47,7 +47,7 @@ export type AlertType =
 export type NotificationChannel = 'in_app' | 'browser_push' | 'email';
 
 /** Possible states for a notification. */
-export type NotificationStatus = 'unread' | 'read' | 'dismissed';
+export type NotificationStatus = 'unread' | 'read' | 'dismissed' | 'snoozed';
 
 // ---------------------------------------------------------------------------
 // Notification model
@@ -69,8 +69,14 @@ export interface AppNotification {
   readonly actionHint?: string;
   /** ISO-8601 timestamp when the notification was created. */
   readonly createdAt: string;
-  /** Current status (read/unread/dismissed). */
+  /** Current status (read/unread/dismissed/snoozed). */
   readonly status: NotificationStatus;
+  /**
+   * ISO-8601 timestamp until which the notification is snoozed. Only set when
+   * {@link status} is `'snoozed'`; once this time passes the notification is
+   * automatically restored to `'unread'`.
+   */
+  readonly snoozedUntil?: string;
   /** Optional entity ID for quick navigation (budget, goal, account). */
   readonly entityId?: SyncId;
   /** Optional entity type for building navigation links. */

--- a/apps/web/src/pages/NotificationsPage.test.tsx
+++ b/apps/web/src/pages/NotificationsPage.test.tsx
@@ -47,6 +47,7 @@ function buildStore(overrides: Partial<UseNotificationsResult> = {}): UseNotific
     markAsRead: vi.fn(),
     markAllAsRead: vi.fn(),
     dismiss: vi.fn(),
+    snooze: vi.fn(),
     clearDismissed: vi.fn(),
     addNotification: vi.fn(),
     addNotifications: vi.fn(),

--- a/apps/web/src/pages/NotificationsPage.tsx
+++ b/apps/web/src/pages/NotificationsPage.tsx
@@ -24,7 +24,7 @@ import './NotificationsPage.css';
 /** Dedicated notifications screen for browsing the full notification history. */
 export const NotificationsPage: FC = () => {
   const navigate = useNavigate();
-  const { notifications, unreadCount, markAsRead, markAllAsRead, dismiss, clearDismissed } =
+  const { notifications, unreadCount, markAsRead, markAllAsRead, dismiss, snooze, clearDismissed } =
     useNotificationCenter();
 
   const handleAction = (notification: AppNotification): void => {
@@ -58,6 +58,7 @@ export const NotificationsPage: FC = () => {
         notifications={notifications}
         onMarkAsRead={markAsRead}
         onDismiss={dismiss}
+        onSnooze={snooze}
         onClearDismissed={clearDismissed}
         onAction={handleAction}
       />


### PR DESCRIPTION
## Summary

Improves the **Notifications & reminders** surface in `apps/web`, implementing a coherent, tested subset (items **1–5**, plus supporting a11y from 6 & 11) of the critique in #3792.

Closes #3792

### What changed
- **Snooze / remind-me-later** (headline reminder feature) — new `snoozed` status + `snoozedUntil` on the notification model, a `snooze()` action in `useNotifications`, quick options (1 hour / 3 hours / tomorrow / next week), and an auto-wake effect (on mount + a 60s interval) that restores expired snoozes to `unread`. Snoozed items are hidden from the bell popover.
- **Date grouping** in `NotificationHistory` — Today / Yesterday / Earlier this week / Older, with semantic sub-headings.
- **Accessibility** — replaced the clickable `<li>` anti-pattern with a real `<button>` primary action (native keyboard semantics), included severity in each item's accessible name (WCAG 1.4.1), used a machine-readable `<time>` element with a full-date tooltip, sized the dismiss control to a 44px target (WCAG 2.5.8), and kept focus on the item after dismiss/snooze (no focus loss).
- **Filter feedback** — a live-announced filtered result count (`role="status"`, WCAG 4.1.3), per-status counts on the filter chips, and a **Clear filters** affordance in the empty state.
- **Toast timing (WCAG 2.2.1)** — toasts pause auto-dismiss on hover/focus and resume on leave/blur; **critical** toasts never auto-dismiss and must be closed manually.

### Tests
Added unit tests for the snooze library (`snooze.test.ts`), the history component (`NotificationHistory.test.tsx`), toast timing (`NotificationToast.test.tsx`), and the hook (`useNotifications.test.ts`). Full `apps/web` suite: **9775 tests passing**. `npm run format:check` and `npx eslint . --max-warnings 0` both clean.

---

## Full critique — Notifications & reminders (#3792)

1. **No snooze / "remind me later" for reminders** — dismiss is destructive and there's no way to resurface a reminder. *Fix: snooze status + timestamp, quick options, auto-wake.* ✅ implemented
2. **History is one flat, undated list** — hard to scan up to 200 items. *Fix: recency date groups.* ✅ implemented
3. **Clickable `<li>` is an a11y anti-pattern** — generic clickable element wrapping nested buttons (WCAG 4.1.2). *Fix: real `<button>` primary action.* ✅ implemented
4. **Filtering gives no feedback / no result count** (WCAG 4.1.3). *Fix: `aria-live` count + chip counts.* ✅ implemented
5. **Toasts auto-dismiss with no pause; critical toasts vanish** (WCAG 2.2.1). *Fix: pause on hover/focus, critical stays.* ✅ implemented
6. **Severity conveyed by color only** (WCAG 1.4.1). *Fix: severity word in accessible name.* ✅ implemented (supporting)
7. **Timestamps absolute, non-semantic, year-less.** *Fix: `<time dateTime>` + full-date tooltip.* ✅ implemented (supporting)
8. **"Mark all read" is irreversible with no confirmation.** *Fix: report count + Undo.* — follow-up
9. **Empty states are generic and unhelpful.** *Fix: context-aware copy + reset.* ✅ partially (Clear filters)
10. **Dismiss uses a bare `✕` glyph with a small target** (WCAG 2.5.8). *Fix: SVG icon in a 44px target.* ✅ implemented (supporting)
11. **Focus lost after dismissing an item.** *Fix: keep focus on the item.* ✅ implemented (supporting)
12. **No "actionable vs. informational" filter for reminders.** *Fix: derived "Action needed" filter.* — follow-up

Items 8 and 12 (and deeper 9) remain as tracked follow-ups.
