### PR TITLE
feat(web): keyboard-accessible scrollable tables & safe-area insets

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Privacy-first personal finance tracker" />
     <meta property="og:title" content="Finance — Personal Financial Tracking" />
     <meta property="og:description" content="See your money clearly. Keep it private." />

--- a/apps/web/src/components/common/ScrollableRegion.test.tsx
+++ b/apps/web/src/components/common/ScrollableRegion.test.tsx
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ScrollableRegion } from './ScrollableRegion';
+
+/**
+ * jsdom reports `scrollWidth`/`clientWidth` as `0`, so overflow is not detected
+ * by default. These helpers let a test simulate a container whose content is
+ * wider than its box.
+ */
+function stubOverflow(scrollWidth: number, clientWidth: number): void {
+  Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+    configurable: true,
+    get() {
+      return scrollWidth;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return clientWidth;
+    },
+  });
+}
+
+function restoreOverflow(): void {
+  // Deleting the own-property override restores jsdom's native getter (0).
+  delete (HTMLElement.prototype as unknown as { scrollWidth?: number }).scrollWidth;
+  delete (HTMLElement.prototype as unknown as { clientWidth?: number }).clientWidth;
+}
+
+describe('ScrollableRegion', () => {
+  afterEach(() => {
+    restoreOverflow();
+    vi.restoreAllMocks();
+  });
+
+  it('exposes a labelled region for assistive tech', () => {
+    render(
+      <ScrollableRegion label="Investment holdings">
+        <table>
+          <tbody>
+            <tr>
+              <td>Row</td>
+            </tr>
+          </tbody>
+        </table>
+      </ScrollableRegion>,
+    );
+
+    expect(screen.getByRole('region', { name: 'Investment holdings' })).toBeInTheDocument();
+  });
+
+  it('applies the shared scroll + themed-scrollbar classes and any extra class', () => {
+    render(
+      <ScrollableRegion label="Report data" className="report-scroll">
+        <table />
+      </ScrollableRegion>,
+    );
+
+    const region = screen.getByRole('region', { name: 'Report data' });
+    expect(region).toHaveClass('data-table-scroll');
+    expect(region).toHaveClass('themed-scrollbar');
+    expect(region).toHaveClass('report-scroll');
+  });
+
+  it('is not a keyboard tab stop when the content fits (no overflow)', () => {
+    render(
+      <ScrollableRegion label="Fits fine">
+        <table />
+      </ScrollableRegion>,
+    );
+
+    expect(screen.getByRole('region', { name: 'Fits fine' })).not.toHaveAttribute('tabindex');
+  });
+
+  it('becomes keyboard focusable when the content overflows horizontally', () => {
+    stubOverflow(800, 320);
+
+    render(
+      <ScrollableRegion label="Wide table">
+        <table />
+      </ScrollableRegion>,
+    );
+
+    expect(screen.getByRole('region', { name: 'Wide table' })).toHaveAttribute('tabindex', '0');
+  });
+});

--- a/apps/web/src/components/common/ScrollableRegion.tsx
+++ b/apps/web/src/components/common/ScrollableRegion.tsx
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+export interface ScrollableRegionProps {
+  /**
+   * Accessible name announced when a keyboard user focuses the scroll region.
+   * Describe the content, e.g. "Investment holdings" — not "scroll area".
+   */
+  label: string;
+  /** Content to make horizontally scrollable (typically a wide `<table>`). */
+  children: React.ReactNode;
+  /** Extra class names appended after the shared scroll classes. */
+  className?: string;
+}
+
+// useLayoutEffect logs a warning during SSR; the web app renders on the client,
+// but fall back to useEffect when `window` is unavailable so unit tests and any
+// server render stay quiet.
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+/**
+ * Horizontally scrollable, keyboard-accessible wrapper for wide content
+ * (primarily data tables) on narrow viewports.
+ *
+ * Renders the shared `.data-table-scroll themed-scrollbar` container (defined in
+ * `styles/tables.css`) and, following the established "responsive table region"
+ * pattern, exposes it as a labelled `role="region"`. A `tabIndex` of `0` is
+ * applied only while the content actually overflows, so keyboard-only users can
+ * scroll to clipped columns (WCAG 2.1.1) without the region becoming a needless
+ * tab stop when everything already fits.
+ */
+export const ScrollableRegion: React.FC<ScrollableRegionProps> = ({
+  label,
+  children,
+  className,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [overflowing, setOverflowing] = useState(false);
+
+  const measure = useCallback(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    // +1 tolerates sub-pixel rounding so we don't flag a 1px phantom overflow.
+    setOverflowing(el.scrollWidth > el.clientWidth + 1);
+  }, []);
+
+  // Re-measure after every commit so newly rendered rows/columns are accounted
+  // for; React bails out of the state update when the value is unchanged.
+  useIsomorphicLayoutEffect(measure);
+
+  useEffect(() => {
+    if (typeof ResizeObserver === 'undefined') {
+      if (typeof window === 'undefined') {
+        return undefined;
+      }
+      window.addEventListener('resize', measure);
+      return () => window.removeEventListener('resize', measure);
+    }
+    const observer = new ResizeObserver(measure);
+    const el = ref.current;
+    if (el) {
+      observer.observe(el);
+    }
+    return () => observer.disconnect();
+  }, [measure]);
+
+  const classes = ['data-table-scroll', 'themed-scrollbar', className].filter(Boolean).join(' ');
+
+  return (
+    <div
+      ref={ref}
+      className={classes}
+      role="region"
+      aria-label={label}
+      tabIndex={overflowing ? 0 : undefined}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default ScrollableRegion;

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -31,6 +31,8 @@ export type { ErrorBannerProps } from './ErrorBanner';
 export { ErrorBoundary } from './ErrorBoundary';
 export { RouteErrorBoundary } from './RouteErrorBoundary';
 export type { RouteErrorBoundaryProps } from './RouteErrorBoundary';
+export { ScrollableRegion } from './ScrollableRegion';
+export type { ScrollableRegionProps } from './ScrollableRegion';
 export { WidgetErrorBoundary } from './WidgetErrorBoundary';
 export type { WidgetErrorBoundaryProps } from './WidgetErrorBoundary';
 export { InstallBanner } from './InstallBanner';

--- a/apps/web/src/pages/InvestmentsPage.tsx
+++ b/apps/web/src/pages/InvestmentsPage.tsx
@@ -17,6 +17,7 @@ import {
   ExplainThis,
   LoadingSpinner,
   ReadAloudButton,
+  ScrollableRegion,
 } from '../components/common';
 import { DataExport } from '../components/DataExport';
 import {
@@ -420,7 +421,7 @@ export const InvestmentsPage: React.FC = () => {
 
           <section aria-label="Investment holdings">
             <div className="card">
-              <div style={{ overflowX: 'auto' }}>
+              <ScrollableRegion label="Investment holdings">
                 <table
                   style={{ width: '100%', borderCollapse: 'collapse' }}
                   aria-label="Investment holdings table"
@@ -603,7 +604,7 @@ export const InvestmentsPage: React.FC = () => {
                     })}
                   </tbody>
                 </table>
-              </div>
+              </ScrollableRegion>
             </div>
           </section>
         </>

--- a/apps/web/src/pages/TaxCenterPage.tsx
+++ b/apps/web/src/pages/TaxCenterPage.tsx
@@ -4,7 +4,13 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import {
+  CurrencyDisplay,
+  EmptyState,
+  ErrorBanner,
+  LoadingSpinner,
+  ScrollableRegion,
+} from '../components/common';
 import { Checkbox } from '../components/common/Checkbox';
 import { useAccounts, useInvestments, useTransactions } from '../hooks';
 import type { Investment, InvestmentLot } from '../kmp/bridge';
@@ -319,7 +325,7 @@ export const TaxCenterPage: React.FC = () => {
             </div>
           )}
 
-          <div style={{ overflowX: 'auto' }}>
+          <ScrollableRegion label="Retirement contribution limits">
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead>
                 <tr>
@@ -365,7 +371,7 @@ export const TaxCenterPage: React.FC = () => {
                 ))}
               </tbody>
             </table>
-          </div>
+          </ScrollableRegion>
         </div>
       </section>
 
@@ -631,7 +637,7 @@ export const TaxCenterPage: React.FC = () => {
                   Enter a sale above to preview realized gains and holding-period classification.
                 </p>
               ) : (
-                <div style={{ overflowX: 'auto' }}>
+                <ScrollableRegion label="Realized gains by lot">
                   <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                     <thead>
                       <tr>
@@ -688,7 +694,7 @@ export const TaxCenterPage: React.FC = () => {
                       ))}
                     </tbody>
                   </table>
-                </div>
+                </ScrollableRegion>
               )}
             </div>
           </section>
@@ -703,7 +709,7 @@ export const TaxCenterPage: React.FC = () => {
               >
                 Open lots · unrealized gains
               </h2>
-              <div style={{ overflowX: 'auto' }}>
+              <ScrollableRegion label="Open lots and unrealized gains">
                 <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                   <thead>
                     <tr>
@@ -778,7 +784,7 @@ export const TaxCenterPage: React.FC = () => {
                     })}
                   </tbody>
                 </table>
-              </div>
+              </ScrollableRegion>
             </div>
           </section>
         </>

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -160,7 +160,15 @@
 .app-main {
   flex: 1;
   padding: var(--layout-content-padding);
-  padding-bottom: calc(var(--layout-bottom-nav-height) + var(--spacing-4));
+  /* Clear the fixed bottom nav *and* the device home-indicator safe area so the
+     last row / primary CTA is never hidden on notched phones (needs
+     viewport-fit=cover on the viewport meta to resolve to a non-zero value). */
+  padding-bottom: calc(
+    var(--layout-bottom-nav-height) + var(--spacing-4) + env(safe-area-inset-bottom, 0px)
+  );
+  /* Respect the notch in landscape so content isn't clipped behind it. */
+  padding-left: max(var(--layout-content-padding), env(safe-area-inset-left, 0px));
+  padding-right: max(var(--layout-content-padding), env(safe-area-inset-right, 0px));
   max-width: var(--layout-content-max-width);
   width: 100%;
   margin: 0 auto;


### PR DESCRIPTION
## Summary

Part of the fleet UX critique for **Responsive layout & touch targets** (see #3794). This PR implements a coherent subset focused on **safe-area handling** and **keyboard-accessible, horizontally-scrollable tables** on small screens.

Closes #3794

## Changes

### Safe-area insets (were silently disabled)
- **`viewport-fit=cover`** added to the viewport meta in `index.html`. Without it iOS reports every `env(safe-area-inset-*)` as `0`, so the existing safe-area padding on `.bottom-nav` and `.more-sheet` was a **no-op** — the tab bar / More sheet could sit under the home indicator on notched iPhones.
- **`.app-main`** now reserves `env(safe-area-inset-bottom)` in its bottom padding (so the last row / primary CTA clears the tab bar + home indicator) and honours `env(safe-area-inset-left/right)` so content isn't clipped behind the notch in landscape.

### New `ScrollableRegion` component (WCAG 2.1.1 keyboard access)
- Added `apps/web/src/components/common/ScrollableRegion.tsx` (+ exported from the `common` barrel).
- Renders the shared `.data-table-scroll themed-scrollbar` container (from `styles/tables.css`) as a labelled `role="region"`.
- Applies `tabIndex={0}` **only while the content actually overflows** (measured via `ResizeObserver` + a post-commit layout measure), so keyboard-only users can scroll to clipped columns without the region becoming a needless tab stop when everything fits.
- Fully unit-tested (`ScrollableRegion.test.tsx`, 4 cases: labelled region, shared classes, no tab stop when it fits, focusable when overflowing).

### Adopted the component to fix inaccessible table scrollers
Several wide financial tables were wrapped in bare `<div style={{ overflowX: 'auto' }}>` — scrollable by mouse/touch but **not keyboard operable** (no `tabindex`/`role`/`aria-label`), and using the raw OS scrollbar. Converted to `ScrollableRegion`:
- **`TaxCenterPage`** — Retirement contribution limits, Realized gains by lot, and Open lots / unrealized gains tables.
- **`InvestmentsPage`** — Investment holdings table.

## Testing (local only)
- `npm run format:check` — clean
- `npx eslint . --max-warnings 0` — clean
- `npx tsc --noEmit` (apps/web) — clean
- `apps/web` unit tests — new `ScrollableRegion` suite (4) + `TaxCenterPage`/`InvestmentsPage` suites (14) pass; full suite run locally.

## Full critique list (12 items — tracked in #3794)
1. `viewport-fit=cover` missing → all `env(safe-area-inset-*)` rules are a no-op. **(fixed)**
2. `.app-main` doesn't reserve the bottom safe-area inset → content hidden behind tab bar/home indicator. **(fixed)**
3. Shared `.data-table-scroll` wrapper exists but was used **zero** times. **(addressed via `ScrollableRegion`)**
4. Several visible tables had no horizontal-scroll wrapper → whole-page overflow (WCAG 1.4.10). *(partially — component provided; more adoption tracked)*
5. Inline `overflowX:auto` scrollers not keyboard operable (WCAG 2.1.1). **(fixed for TaxCenter + Investments)**
6. Inconsistent scroll styling (no themed scrollbar). **(fixed for adopted tables)**
7. Global `min-width:44px` on all `<a>` risks inflating inline text links. *(tracked)*
8. 58 `opacity:0` hover-reveal rules can be invisible/unusable on touch. *(tracked)*
9. Data tables lack sticky headers on small screens. *(tracked)*
10. No table→card/stacked fallback on very narrow screens. *(tracked)*
11. Inline `style={{…}}` table layout bypasses `.data-table` design-system classes. *(tracked)*
12. Bottom-nav tab targets — verified already covered by the global `button { min-height: 44px }` rule. *(no change needed)*

🤖 Generated with GitHub Copilot
