### PR TITLE
feat(web): theme-color meta sync, semantic scrim & token cleanup (#3796)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,7 +8,11 @@
     <meta property="og:description" content="See your money clearly. Keep it private." />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary" />
-    <meta name="theme-color" content="#2563eb" />
+    <!-- Pre-JS defaults track the OS scheme so the browser/PWA chrome matches
+         the app background before useTheme runs. JS (applyThemeColorMeta)
+         overrides these for explicit light/dark/OLED/high-contrast themes. -->
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0f1020" media="(prefers-color-scheme: dark)" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/apps/web/src/components/settings/encryption-unlock.css
+++ b/apps/web/src/components/settings/encryption-unlock.css
@@ -101,7 +101,7 @@
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-1, 0.25rem) var(--spacing-2);
-  border-radius: var(--radius-full, 999px);
+  border-radius: var(--border-radius-full, 999px);
   border: 1px solid var(--semantic-border-default, var(--card-border));
   font-size: var(--type-scale-caption-font-size, 0.8125rem);
   font-weight: var(--font-weight-medium, 600);
@@ -111,7 +111,7 @@
 .encryption-chip__dot {
   width: 0.5rem;
   height: 0.5rem;
-  border-radius: var(--radius-full, 999px);
+  border-radius: var(--border-radius-full, 999px);
   background: var(--semantic-text-secondary);
 }
 
@@ -135,8 +135,8 @@
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--semantic-border-default, var(--card-border));
-  border-radius: var(--radius-md, 0.5rem);
-  background: var(--theme-surface, var(--card-background));
+  border-radius: var(--border-radius-md, 0.5rem);
+  background: var(--semantic-background-primary, var(--card-background));
   color: var(--semantic-text-primary);
   cursor: pointer;
   font-size: var(--type-scale-caption-font-size, 0.875rem);
@@ -150,7 +150,7 @@
   position: relative;
   width: 2.25rem;
   height: 1.25rem;
-  border-radius: var(--radius-full, 999px);
+  border-radius: var(--border-radius-full, 999px);
   background: var(--semantic-interactive-disabled, #9ca3af);
   transition: background-color 150ms ease;
 }
@@ -165,7 +165,7 @@
   left: 0.125rem;
   width: 1rem;
   height: 1rem;
-  border-radius: var(--radius-full, 999px);
+  border-radius: var(--border-radius-full, 999px);
   background: var(--semantic-text-inverse, #ffffff);
   transition: transform 150ms ease;
 }
@@ -185,7 +185,7 @@
 .encryption-button {
   min-height: 2.25rem;
   padding: var(--spacing-2) var(--spacing-4);
-  border-radius: var(--radius-md, 0.5rem);
+  border-radius: var(--border-radius-md, 0.5rem);
   border: 1px solid transparent;
   font-size: var(--type-scale-caption-font-size, 0.875rem);
   font-weight: var(--font-weight-medium, 600);
@@ -213,7 +213,7 @@
 }
 
 .encryption-button--secondary:hover:not(:disabled) {
-  background: var(--theme-surface-elevated, var(--card-background));
+  background: var(--semantic-background-elevated, var(--card-background));
 }
 
 .encryption-button--danger {
@@ -263,7 +263,7 @@
   display: grid;
   place-items: center;
   padding: var(--spacing-4);
-  background: rgba(15, 23, 42, 0.72);
+  background: var(--semantic-overlay-scrim, rgba(15, 23, 42, 0.72));
 }
 
 .encryption-dialog {
@@ -272,7 +272,7 @@
   overflow-y: auto;
   padding: var(--spacing-6, 1.5rem);
   border-radius: var(--card-border-radius, 0.75rem);
-  background: var(--theme-surface, var(--card-background, #ffffff));
+  background: var(--semantic-background-elevated, var(--card-background, #ffffff));
   color: var(--semantic-text-primary);
   box-shadow: var(--shadow-xl, 0 24px 64px rgba(0, 0, 0, 0.28));
 }
@@ -310,8 +310,8 @@
   min-height: 2.5rem;
   padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--semantic-border-default, var(--card-border));
-  border-radius: var(--radius-md, 0.5rem);
-  background: var(--theme-surface, var(--card-background));
+  border-radius: var(--border-radius-md, 0.5rem);
+  background: var(--semantic-background-primary, var(--card-background));
   color: var(--semantic-text-primary);
   font-size: var(--type-scale-body-font-size, 1rem);
 }
@@ -354,8 +354,8 @@
   margin: 0;
   padding: var(--spacing-4);
   border: 1px dashed var(--semantic-border-default, var(--card-border));
-  border-radius: var(--radius-md, 0.5rem);
-  background: var(--theme-surface-elevated, var(--card-background));
+  border-radius: var(--border-radius-md, 0.5rem);
+  background: var(--semantic-background-elevated, var(--card-background));
   color: var(--semantic-text-primary);
   font-family: var(--font-family-mono, ui-monospace, monospace);
   font-size: var(--type-scale-title-font-size, 1.125rem);

--- a/apps/web/src/hooks/useTheme.test.ts
+++ b/apps/web/src/hooks/useTheme.test.ts
@@ -3,7 +3,12 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useTheme } from './useTheme';
+import { useTheme, applyThemeColorMeta, applyStoredThemePreference } from './useTheme';
+
+/** Read the JS-managed theme-color meta content, if present. */
+function getThemeColor(): string | null {
+  return document.getElementById('theme-color-dynamic')?.getAttribute('content') ?? null;
+}
 
 // ---------------------------------------------------------------------------
 // Mock localStorage and matchMedia
@@ -50,6 +55,7 @@ afterEach(() => {
   // Clean up root attributes
   document.documentElement.removeAttribute('data-theme');
   document.documentElement.removeAttribute('data-density');
+  document.getElementById('theme-color-dynamic')?.remove();
   vi.restoreAllMocks();
 });
 
@@ -206,5 +212,80 @@ describe('useTheme', () => {
     });
 
     expect(result.current.resolvedTheme).toBe('dark');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// theme-color meta synchronization
+// ---------------------------------------------------------------------------
+
+describe('theme-color meta', () => {
+  it('creates a single dynamic meta as the first head child', () => {
+    applyThemeColorMeta('light');
+
+    const meta = document.getElementById('theme-color-dynamic');
+    expect(meta).not.toBeNull();
+    expect(meta?.getAttribute('name')).toBe('theme-color');
+    expect(document.head.firstChild).toBe(meta);
+  });
+
+  it('reuses the same meta on repeated calls (no duplicates)', () => {
+    applyThemeColorMeta('light');
+    applyThemeColorMeta('dark');
+
+    expect(document.querySelectorAll('#theme-color-dynamic')).toHaveLength(1);
+    expect(getThemeColor()).toBe('#0f1020');
+  });
+
+  it('maps each resolved theme to its background-primary color', () => {
+    applyThemeColorMeta('light');
+    expect(getThemeColor()).toBe('#ffffff');
+    applyThemeColorMeta('dark');
+    expect(getThemeColor()).toBe('#0f1020');
+    applyThemeColorMeta('dark-oled');
+    expect(getThemeColor()).toBe('#000000');
+    applyThemeColorMeta('high-contrast');
+    expect(getThemeColor()).toBe('#ffffff');
+  });
+
+  it('sets the meta from the hook on mount using the resolved theme', () => {
+    mockStorage['finance-theme-preference'] = 'dark-oled';
+
+    renderHook(() => useTheme());
+
+    expect(getThemeColor()).toBe('#000000');
+  });
+
+  it('updates the meta when the theme changes via setTheme', () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setTheme('dark');
+    });
+
+    expect(getThemeColor()).toBe('#0f1020');
+  });
+
+  it('follows the OS scheme for system mode and reacts to changes', () => {
+    isDarkMode = false;
+
+    renderHook(() => useTheme());
+    expect(getThemeColor()).toBe('#ffffff');
+
+    act(() => {
+      for (const listener of darkModeListeners) {
+        listener({ matches: true });
+      }
+    });
+
+    expect(getThemeColor()).toBe('#0f1020');
+  });
+
+  it('applyStoredThemePreference seeds the meta at boot', () => {
+    mockStorage['finance-theme-preference'] = 'dark';
+
+    applyStoredThemePreference();
+
+    expect(getThemeColor()).toBe('#0f1020');
   });
 });

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -80,6 +80,20 @@ const AVAILABLE_THEMES: readonly ThemeValue[] = [
 const AVAILABLE_DENSITIES: readonly DisplayDensity[] = ['comfortable', 'compact'] as const;
 
 /**
+ * Browser/PWA chrome color per resolved theme.
+ *
+ * Mirrors `--semantic-background-primary` for each theme so the mobile browser
+ * address bar and PWA status bar (`<meta name="theme-color">`) stay in sync
+ * with the rendered app background instead of a single static value.
+ */
+const THEME_COLOR_BY_RESOLVED: Record<ResolvedTheme, string> = {
+  light: '#ffffff',
+  dark: '#0f1020',
+  'dark-oled': '#000000',
+  'high-contrast': '#ffffff',
+};
+
+/**
  * Read the persisted theme preference from localStorage.
  * Falls back to 'system' if nothing stored or value is invalid.
  */
@@ -127,6 +141,33 @@ function getSystemPreference(): 'light' | 'dark' {
   return 'light';
 }
 
+/** Resolve a theme preference (which may be 'system') to an effective theme. */
+function resolveTheme(value: ThemeValue): ResolvedTheme {
+  return value === 'system' ? getSystemPreference() : value;
+}
+
+/**
+ * Keep the browser/PWA chrome color in sync with the resolved theme.
+ *
+ * `index.html` ships two `prefers-color-scheme` fallbacks for the pre-JS boot.
+ * Once JS runs we own a dedicated, media-less tag inserted as the FIRST
+ * `theme-color` meta so it always wins (per the HTML spec the first matching
+ * tag is used) and stays correct across explicit themes and OS changes.
+ */
+export function applyThemeColorMeta(resolved: ResolvedTheme): void {
+  if (typeof document === 'undefined' || !document.head) return;
+
+  const DYNAMIC_ID = 'theme-color-dynamic';
+  let meta = document.getElementById(DYNAMIC_ID) as HTMLMetaElement | null;
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.id = DYNAMIC_ID;
+    meta.setAttribute('name', 'theme-color');
+    document.head.insertBefore(meta, document.head.firstChild);
+  }
+  meta.setAttribute('content', THEME_COLOR_BY_RESOLVED[resolved]);
+}
+
 /**
  * Apply the resolved theme to the document element.
  * - For explicit themes: sets `data-theme="<value>"` on `<html>`.
@@ -156,7 +197,9 @@ export function applyDisplayDensity(value: DisplayDensity): void {
 }
 
 export function applyStoredThemePreference(): void {
-  applyTheme(getStoredTheme());
+  const stored = getStoredTheme();
+  applyTheme(stored);
+  applyThemeColorMeta(resolveTheme(stored));
 }
 
 export function applyStoredDisplayDensityPreference(): void {
@@ -215,6 +258,11 @@ export function useTheme(): UseThemeResult {
     }
     return theme;
   }, [theme, systemPref]);
+
+  // Keep the browser/PWA chrome color in sync with the effective theme.
+  useEffect(() => {
+    applyThemeColorMeta(resolvedTheme);
+  }, [resolvedTheme]);
 
   return {
     theme,

--- a/apps/web/src/styles/navigation-chrome.css
+++ b/apps/web/src/styles/navigation-chrome.css
@@ -187,7 +187,7 @@
   border: none;
   padding: 0;
   margin: 0;
-  background: rgba(15, 23, 42, 0.55);
+  background: var(--semantic-overlay-scrim, rgba(15, 23, 42, 0.55));
   cursor: pointer;
   /* Don't show a focus ring on the scrim — the close button is the
    * focusable affordance. */

--- a/apps/web/src/styles/offline-banner.css
+++ b/apps/web/src/styles/offline-banner.css
@@ -5,9 +5,15 @@
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-3) var(--spacing-4);
-  background-color: var(--color-amber-50, #fffbeb);
-  color: var(--color-amber-900, #78350f);
-  border-bottom: 1px solid var(--color-amber-400, #fbbf24);
+  /* Semantic warning tint over the current surface — one rule that adapts to
+     light, dark, dark-oled, and high-contrast without per-theme overrides. */
+  background-color: color-mix(
+    in srgb,
+    var(--semantic-status-warning) 14%,
+    var(--semantic-background-primary)
+  );
+  color: var(--semantic-text-primary);
+  border-bottom: 1px solid color-mix(in srgb, var(--semantic-status-warning) 55%, transparent);
   transition:
     transform var(--duration-normal, 200ms) ease,
     opacity var(--duration-normal, 200ms) ease;
@@ -23,26 +29,13 @@
 
 .offline-banner__icon {
   flex-shrink: 0;
+  color: var(--semantic-status-warning);
 }
 
 .offline-banner__text {
   flex: 1;
   font-size: var(--type-scale-caption-font-size);
   line-height: var(--line-height-normal);
-}
-
-@media (prefers-color-scheme: dark) {
-  html:not([data-theme='light']) .offline-banner {
-    background-color: rgba(245, 158, 11, 0.16);
-    color: var(--color-amber-200, #fde68a);
-    border-bottom-color: rgba(252, 211, 77, 0.6);
-  }
-}
-
-[data-theme='dark'] .offline-banner {
-  background-color: rgba(245, 158, 11, 0.16);
-  color: var(--color-amber-200, #fde68a);
-  border-bottom-color: rgba(252, 211, 77, 0.6);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/theme/finance-overlay.css
+++ b/apps/web/src/theme/finance-overlay.css
@@ -37,4 +37,24 @@
    */
   --semantic-amount-positive: var(--semantic-status-positive);
   --semantic-amount-negative: var(--semantic-status-negative);
+
+  /*
+   * Modal / drawer scrim. Previously hardcoded as slate rgba() literals in
+   * every overlay (more-sheet, dialogs), identical across themes and too weak
+   * over a true-black OLED background. Tokenized here so every overlay shares
+   * one value and dark / OLED can strengthen it (see overrides below).
+   */
+  --semantic-overlay-scrim: color-mix(in srgb, #0f172a 55%, transparent);
+}
+
+/* Stronger scrim on dark surfaces so modals read clearly over near-black. */
+[data-theme='dark'],
+[data-theme='dark-oled'] {
+  --semantic-overlay-scrim: color-mix(in srgb, #000000 72%, transparent);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --semantic-overlay-scrim: color-mix(in srgb, #000000 72%, transparent);
+  }
 }


### PR DESCRIPTION
## Summary

Fleet critique + implementation for **Visual design system / theming / dark mode** in the web PWA. Closes #3796.

This PR lands a coherent, locally-tested subset of the 12-item critique below, focused on real theming correctness (not cosmetics):

- **Dynamic `theme-color` chrome (#2):** `useTheme` now drives `<meta name="theme-color">` from the resolved theme, so the mobile browser address bar / PWA status bar match the app background across light / dark / dark-oled / high-contrast (and follow OS changes in `system` mode). `index.html` ships `prefers-color-scheme` fallbacks so the pre-JS boot is already correct. The previous static `#2563eb` (legacy blue) never changed.
- **Tokenized overlay scrim (#7):** new `--semantic-overlay-scrim` token (in `finance-overlay.css`, strengthened on dark/OLED) replaces repeated `rgba(15,23,42,…)` slate literals in the more-sheet drawer and encryption dialog overlays.
- **Dead theme layer + radius scale cleanup (#1 / #3 / #9):** `encryption-unlock.css` used `--theme-surface*` from `styles/themes.css`, which is **never imported** — so those values silently fell back. Migrated to `--semantic-background-*`. Also standardized on the `--border-radius-*` scale (the vendored `--radius-md:14px` / undefined `--radius-full` were a second, conflicting radius system).
- **Theme-adaptive offline banner (#4 / #10):** `offline-banner.css` was amber primitives with a hardcoded `[data-theme='dark']` block and no dark-oled/high-contrast coverage. Recolored from `--semantic-status-warning` via `color-mix()` — one rule that adapts to every theme; duplicated dark blocks removed.

### Testing (local only)
- `npm run format:check` ✓
- `npx eslint . --max-warnings 0` ✓
- `cd apps/web && npx vitest run` — **895 files / 9786 tests pass**, incl. 7 new theme-color meta tests in `useTheme.test.ts`.

---

## Full critique (12 items) — from #3796

1. **Orphaned `themes.css` / dead `--theme-*` layer** — file never imported; `encryption-unlock.css` consumed it via fallbacks only. *(fixed here)*
2. **Static `<meta name="theme-color">`** — hardcoded legacy blue, never follows the theme. *(fixed here)*
3. **Two conflicting radius scales** — `--radius-*` (9/14px) vs `--border-radius-*` (4/8/12/16px) used interchangeably; `--radius-full` undefined. *(partially fixed here)*
4. **Per-component dark overrides skip dark-oled / high-contrast** — 14 style files hand-write `[data-theme='dark']` blocks only. *(offline-banner fixed here)*
5. **Hardcoded elevation / box-shadows** instead of `--elevation-*` tokens. *(follow-up)*
6. **Inconsistent focus-ring styling** — varying `outline-offset`, no shared focus token. *(follow-up)*
7. **Hardcoded, theme-blind scrim/overlay colors.** *(fixed here)*
8. **Duplicated / triple-defined auto-switch & reduced-motion blocks.** *(follow-up)*
9. **Misleading, inconsistent token fallback values.** *(radius fallbacks fixed here)*
10. **Amber offline banner bypasses the semantic layer.** *(fixed here)*
11. **Theme `<select>` has no preview; two overlapping "contrast" mechanisms.** *(follow-up)*
12. **`color-scheme` not guaranteed for OLED/HC native controls.** *(follow-up)*

Follow-up items (#5, #6, #8, #11, #12) remain tracked in #3796.
