### PR TITLE
perf(web): skeleton loading states & debounced transaction search (#3798)

### DIFF
--- a/apps/web/src/__tests__/dashboard-visualizations.test.tsx
+++ b/apps/web/src/__tests__/dashboard-visualizations.test.tsx
@@ -661,7 +661,7 @@ describe('Dashboard accessible landmarks (#1334)', () => {
 // ---------------------------------------------------------------------------
 
 describe('DashboardPage loading state (#1334)', () => {
-  it('shows loading spinner when data is loading', () => {
+  it('shows a content-shaped loading skeleton when data is loading', () => {
     mockedUseDashboardData.mockReturnValue({
       data: null,
       loading: true,
@@ -669,13 +669,15 @@ describe('DashboardPage loading state (#1334)', () => {
       refresh: vi.fn(),
     });
 
-    render(
+    const { container } = render(
       <MemoryRouter>
         <DashboardPage />
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+    const skeleton = container.querySelector('.skeleton-page--dashboard');
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toHaveAttribute('aria-busy', 'true');
   });
 
   it('does not show summary cards while loading', () => {

--- a/apps/web/src/components/common/EntitySkeletons.tsx
+++ b/apps/web/src/components/common/EntitySkeletons.tsx
@@ -34,6 +34,7 @@ export const ListSkeleton: React.FC<ListSkeletonProps> = ({
 }) => (
   <div
     className={`skeleton-page skeleton-page--list ${className}`.trim()}
+    role="status"
     aria-busy="true"
     aria-label={ariaLabel}
   >

--- a/apps/web/src/pages/AccountsPage.test.tsx
+++ b/apps/web/src/pages/AccountsPage.test.tsx
@@ -165,6 +165,28 @@ describe('AccountsPage', () => {
     expect(screen.getByText('Accounts')).toBeInTheDocument();
   });
 
+  it('shows a content-shaped skeleton while accounts load (#3798)', () => {
+    mockedUseAccounts.mockReturnValue({
+      accounts: [],
+      loading: true,
+      error: null,
+      refresh: vi.fn(),
+      createAccount: vi.fn(),
+      updateAccount: vi.fn(),
+      deleteAccount: vi.fn(),
+    });
+
+    const { container } = render(
+      <MemoryRouter>
+        <AccountsPage />
+      </MemoryRouter>,
+    );
+
+    const skeleton = container.querySelector('.skeleton-page--accounts');
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toHaveAttribute('aria-busy', 'true');
+  });
+
   it('groups accounts by purpose', () => {
     render(
       <MemoryRouter>

--- a/apps/web/src/pages/AccountsPage.tsx
+++ b/apps/web/src/pages/AccountsPage.tsx
@@ -4,10 +4,10 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AccountPurposeBadge } from '../components/accounts';
 import {
+  AccountsSkeleton,
   CurrencyDisplay,
   EmptyState,
   ErrorBanner,
-  LoadingSpinner,
   ReadAloudButton,
 } from '../components/common';
 import { AccountForm } from '../components/forms';
@@ -216,9 +216,7 @@ export const AccountsPage: React.FC = () => {
       <>
         {offlineBanner}
         <h2 className="page-heading">Accounts</h2>
-        <div className="page-loading">
-          <LoadingSpinner label="Loading accounts" />
-        </div>
+        <AccountsSkeleton />
       </>
     );
   }

--- a/apps/web/src/pages/BillsPage.tsx
+++ b/apps/web/src/pages/BillsPage.tsx
@@ -16,7 +16,7 @@ import {
   CurrencyDisplay,
   EmptyState,
   ErrorBanner,
-  LoadingSpinner,
+  ListSkeleton,
 } from '../components/common';
 import { useBills } from '../hooks';
 import type { Bill, BillFrequency, BillStatus } from '../kmp/bridge';
@@ -180,9 +180,7 @@ export const BillsPage: React.FC = () => {
       </div>
 
       {loading ? (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--spacing-8) 0' }}>
-          <LoadingSpinner label="Loading bills" />
-        </div>
+        <ListSkeleton rows={6} aria-label="Loading bills" />
       ) : error ? (
         <ErrorBanner message={error} onRetry={refresh} />
       ) : bills.length === 0 ? (

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -9,7 +9,7 @@ import { ReadAloudButton } from '../components/common/ReadAloudButton';
 import { EmptyState } from '../components/common/EmptyState';
 import { ErrorBanner } from '../components/common/ErrorBanner';
 import { ExplainThis } from '../components/common/ExplainThis';
-import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import { BudgetsSkeleton } from '../components/common/EntitySkeletons';
 import { SortableList } from '../components/common/SortableList';
 import { SyncIndicator } from '../components/common/SyncIndicator';
 import { BudgetForm } from '../components/forms';
@@ -788,9 +788,7 @@ export const BudgetsPage: React.FC = () => {
         onCancel={handleDeleteCancel}
       />
       {isLoading ? (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--spacing-8) 0' }}>
-          <LoadingSpinner label="Loading budgets" />
-        </div>
+        <BudgetsSkeleton />
       ) : resolvedError ? (
         <ErrorBanner message={resolvedError} onRetry={handleRetry} />
       ) : budgets.length === 0 ? (

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -7,6 +7,7 @@ import { AccountPurposeFilterControl } from '../components/accounts';
 import { RecentTransactionsCard } from '../components/transactions';
 import {
   CurrencyDisplay,
+  DashboardSkeleton,
   EmptyState,
   ErrorBanner,
   LoadingSpinner,
@@ -822,9 +823,7 @@ export const DashboardPage: React.FC = () => {
         label="Filter dashboard by account purpose"
       />
       {isLoading ? (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--spacing-8) 0' }}>
-          <LoadingSpinner label="Loading dashboard" />
-        </div>
+        <DashboardSkeleton />
       ) : resolvedError ? (
         <ErrorBanner message={resolvedError} onRetry={handleRetry} />
       ) : (

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -7,6 +7,7 @@ import {
   CurrencyDisplay,
   EmptyState,
   ErrorBanner,
+  GoalsSkeleton,
   LoadingSpinner,
   ReadAloudButton,
   SortableList,
@@ -713,9 +714,7 @@ export const GoalsPage: React.FC = () => {
         </article>
       </section>
       {loading ? (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--spacing-8) 0' }}>
-          <LoadingSpinner label="Loading goals" />
-        </div>
+        <GoalsSkeleton />
       ) : error ? (
         <ErrorBanner message={error} onRetry={refresh} />
       ) : (

--- a/apps/web/src/pages/SubscriptionsPage.test.tsx
+++ b/apps/web/src/pages/SubscriptionsPage.test.tsx
@@ -31,7 +31,7 @@ describe('SubscriptionsPage', () => {
     vi.clearAllMocks();
   });
 
-  it('shows loading spinner while loading', () => {
+  it('shows a loading skeleton while loading', () => {
     mockUseSubscriptions.mockReturnValue({
       subscriptions: [],
       summary: {
@@ -52,7 +52,7 @@ describe('SubscriptionsPage', () => {
     });
 
     render(<SubscriptionsPage />);
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Analyzing subscriptions' })).toBeInTheDocument();
   });
 
   it('shows an error state with retry on error', () => {

--- a/apps/web/src/pages/SubscriptionsPage.tsx
+++ b/apps/web/src/pages/SubscriptionsPage.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from 'react';
-import { CurrencyDisplay, EmptyState, ErrorState, LoadingSpinner } from '../components/common';
+import { CurrencyDisplay, EmptyState, ErrorState, ListSkeleton } from '../components/common';
 import { useSubscriptions } from '../hooks/useSubscriptions';
 import type {
   DetectedSubscription,
@@ -133,7 +133,7 @@ export const SubscriptionsPage: React.FC = () => {
   if (loading) {
     return (
       <div className="analytics-page__loading">
-        <LoadingSpinner label="Analyzing subscriptions" />
+        <ListSkeleton rows={6} aria-label="Analyzing subscriptions" />
       </div>
     );
   }

--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { ReactNode } from 'react';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -507,7 +507,7 @@ describe('TransactionsPage', () => {
     expect(within(summary).getByText('USD 430858')).toBeInTheDocument();
   });
 
-  it('offers a Clear filters action when a search yields no results', () => {
+  it('offers a Clear filters action when a search yields no results', async () => {
     render(
       <MemoryRouter>
         <TransactionsPage />
@@ -517,7 +517,9 @@ describe('TransactionsPage', () => {
     fireEvent.change(screen.getByLabelText('Search transactions'), {
       target: { value: 'zzz-no-such-transaction' },
     });
-    expect(screen.getByText('No transactions found')).toBeInTheDocument();
+    // The free-text filter is debounced (#3798), so wait for the register to
+    // reflect the search before asserting the empty state.
+    await waitFor(() => expect(screen.getByText('No transactions found')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
 
@@ -651,7 +653,7 @@ describe('TransactionsPage', () => {
     expect(screen.getByText('Monthly Salary')).toBeInTheDocument();
   });
 
-  it('filters the register live by free-text search and restores on clear (#3200)', () => {
+  it('filters the register by debounced free-text search and restores on clear (#3200, #3798)', async () => {
     render(
       <MemoryRouter>
         <TransactionsPage />
@@ -665,23 +667,24 @@ describe('TransactionsPage', () => {
 
     const searchBox = screen.getByRole('searchbox', { name: /search transactions/i });
 
-    // Typing a payee substring narrows the rendered register immediately, even
-    // though the mocked data hook returns every row regardless of its filters.
+    // Typing a payee substring narrows the rendered register after the search
+    // debounce settles (#3798), even though the mocked data hook returns every
+    // row regardless of its filters.
     fireEvent.change(searchBox, { target: { value: 'Grocery' } });
 
+    await waitFor(() => expect(screen.queryByText('Monthly Salary')).not.toBeInTheDocument());
     expect(screen.getByText('Grocery Store')).toBeInTheDocument();
-    expect(screen.queryByText('Monthly Salary')).not.toBeInTheDocument();
     expect(screen.queryByText('Electric Bill')).not.toBeInTheDocument();
 
     // Clearing the search restores the full list.
     fireEvent.change(searchBox, { target: { value: '' } });
 
+    await waitFor(() => expect(screen.getByText('Monthly Salary')).toBeInTheDocument());
     expect(screen.getByText('Grocery Store')).toBeInTheDocument();
-    expect(screen.getByText('Monthly Salary')).toBeInTheDocument();
     expect(screen.getByText('Electric Bill')).toBeInTheDocument();
   });
 
-  it('matches free-text search against transaction tags (#3200)', () => {
+  it('matches free-text search against transaction tags (#3200)', async () => {
     render(
       <MemoryRouter>
         <TransactionsPage />
@@ -693,12 +696,12 @@ describe('TransactionsPage', () => {
       target: { value: 'groceries' },
     });
 
+    await waitFor(() => expect(screen.queryByText('Monthly Salary')).not.toBeInTheDocument());
     expect(screen.getByText('Grocery Store')).toBeInTheDocument();
-    expect(screen.queryByText('Monthly Salary')).not.toBeInTheDocument();
     expect(screen.queryByText('Electric Bill')).not.toBeInTheDocument();
   });
 
-  it('composes free-text search with the account-purpose filter (#3200)', () => {
+  it('composes free-text search with the account-purpose filter (#3200)', async () => {
     render(
       <MemoryRouter>
         <TransactionsPage />
@@ -715,12 +718,12 @@ describe('TransactionsPage', () => {
     // A search matching only a personal-account transaction yields no rows,
     // proving purpose + search compose with AND semantics.
     fireEvent.change(searchBox, { target: { value: 'Grocery' } });
-    expect(screen.queryByText('Monthly Salary')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('Monthly Salary')).not.toBeInTheDocument());
     expect(screen.queryByText('Grocery Store')).not.toBeInTheDocument();
 
     // A search matching the in-scope transaction keeps it visible.
     fireEvent.change(searchBox, { target: { value: 'Salary' } });
-    expect(screen.getByText('Monthly Salary')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Monthly Salary')).toBeInTheDocument());
   });
 
   it('displays edit and delete actions for each transaction', () => {

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -57,6 +57,7 @@ import { useAccessibility } from '../hooks/useAccessibility';
 import { useAutoCategorize } from '../hooks/useAutoCategorize';
 import { useBulkTransactions } from '../hooks/useBulkTransactions';
 import { useCategories } from '../hooks/useCategories';
+import { useDebouncedSearch } from '../hooks/useDebouncedSearch';
 import { prefersCoarsePointer } from '../hooks/useCoarsePointer';
 import { useFontScale } from '../hooks/useFontScale';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
@@ -334,7 +335,16 @@ export const TransactionsPage: React.FC = () => {
   const navigate = useNavigate();
   const { isSimplified } = useAccessibility();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [query, setQuery] = useState('');
+  // Free-text search: the raw `query` drives the input (updates immediately),
+  // while `debouncedQuery` (300ms) drives the client-side filter/sort in the
+  // `transactions` memo below so large registers are not re-filtered and
+  // re-sorted on every keystroke (#3798).
+  const {
+    searchTerm: query,
+    debouncedTerm: debouncedQuery,
+    setSearchTerm: setQuery,
+    clearSearch,
+  } = useDebouncedSearch();
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [editPanelTransaction, setEditPanelTransaction] = useState<Transaction | null>(null);
@@ -483,7 +493,7 @@ export const TransactionsPage: React.FC = () => {
       selectedPurposeFilter,
     );
     const searched = purposeFiltered.filter((transaction) =>
-      matchesTransactionQuery(transaction, query, searchContext),
+      matchesTransactionQuery(transaction, debouncedQuery, searchContext),
     );
     const filtered = applyAdvancedFilters(searched, advancedFilters);
     return sortTransactions(filtered, sortConfig, categoryNames);
@@ -491,7 +501,7 @@ export const TransactionsPage: React.FC = () => {
     rawTransactions,
     accounts,
     selectedPurposeFilter,
-    query,
+    debouncedQuery,
     searchContext,
     advancedFilters,
     sortConfig,
@@ -691,13 +701,13 @@ export const TransactionsPage: React.FC = () => {
   // preserving the current sort. Used by the empty-state "Clear filters" CTA
   // (#3772).
   const handleClearAllFilters = useCallback(() => {
-    setQuery('');
+    clearSearch();
     setSelectedPurposeFilter('all');
     const params: Record<string, string> = {};
     if (sortConfig.field !== DEFAULT_SORT.field) params.sortField = sortConfig.field;
     if (sortConfig.direction !== DEFAULT_SORT.direction) params.sortDir = sortConfig.direction;
     setSearchParams(params, { replace: true });
-  }, [sortConfig, setSearchParams]);
+  }, [clearSearch, sortConfig, setSearchParams]);
 
   // Form handlers
   const handleOpenCreateForm = useCallback(() => {
@@ -1427,7 +1437,7 @@ export const TransactionsPage: React.FC = () => {
               <button
                 type="button"
                 className="search-bar__clear"
-                onClick={() => setQuery('')}
+                onClick={() => clearSearch()}
                 aria-label="Clear search"
               >
                 <span aria-hidden="true">✕</span>


### PR DESCRIPTION
﻿Closes #3798

## Summary
The web app already ships a full, tested perceived-speed toolkit (skeleton composites, `PageLoader`, `useDebouncedSearch`) that **no page actually used** — every page rendered a centered `<LoadingSpinner>`. This PR wires that infrastructure into the primary entity pages and debounces the transactions search.

### Changes
- **Skeletons instead of spinners** on the main loading branch of:
  - `AccountsPage` → `AccountsSkeleton`
  - `DashboardPage` → `DashboardSkeleton`
  - `BudgetsPage` → `BudgetsSkeleton`
  - `GoalsPage` → `GoalsSkeleton`
  - `SubscriptionsPage` → `ListSkeleton`
  - `BillsPage` → `ListSkeleton`
  Content-shaped placeholders read as faster than a spinner and keep the box model stable, reducing **CLS** (tracked by the Lighthouse budget). Section/chart-level `Suspense` spinners are intentionally left as-is.
- **A11y:** `ListSkeleton` now renders a named `role="status"` region so its `aria-busy`/`aria-live` loading semantics are consistent (WCAG 2.2 AA).
- **Debounced transactions search:** `TransactionsPage` now uses `useDebouncedSearch`. The `<input>` value stays immediate, but the client-side filter + sort keys off the 300 ms debounced term, so a large register is no longer re-filtered and re-sorted on every keystroke.
- **Tests:** adjusted the affected search tests to await the debounced result, updated the Subscriptions/Bills/Dashboard loading-state assertions to the skeleton, and added an Accounts loading-skeleton test.

### Verification (local only)
- `npm run format:check` ✅
- `npx eslint . --max-warnings 0` ✅
- `apps/web` unit tests: **9787 passed** ✅

---

## Full critique — Performance & perceived speed (12 items)
> Headline: the app has a full, tested perceived-speed toolkit (`Skeleton` + composites, `PageLoader`, `useDebouncedSearch`) with **0** page usages; `React.memo` and `content-visibility` are also unused.

1. **Skeleton screens exist but are never rendered** — pages use centered spinners; the tested composites are imported by zero pages. *Fix: render the matching skeleton in each loading branch.* ✅ implemented
2. **`PageLoader` state machine is dead code** — unifies loading/error/empty/loaded with `aria-live` but no page imports it. *Fix: adopt it (or at least the skeletons).*
3. **Layout shift (CLS) on load** — centered spinner box collapses then expands to full content. *Fix: layout-matched skeletons.* ✅ implemented
4. **`useDebouncedSearch` unused; transaction search re-filters + re-sorts every keystroke** — `TransactionsPage` filters/sorts in a `useMemo` keyed on the immediate `query`. *Fix: debounce the value used for filtering.* ✅ implemented
5. **No `React.memo` anywhere** — long lists re-render every row on unrelated parent state changes. *Fix: memoize row/item components + stabilize callbacks.*
6. **No `content-visibility`** — long offscreen sections still paint. *Fix: `content-visibility:auto` + `contain-intrinsic-size`.*
7. **Receipt thumbnails don't reserve space (CLS)** — `LazyReceiptImage`'s `<img>` has no width/height/aspect-ratio. *Fix: fixed intrinsic dimensions.*
8. **No route-chunk prefetch on intent** — lazy routes always wait on click. *Fix: prefetch dynamic import on hover/focus, respecting Save-Data.*
9. **Spinner-only loading gives no progress cue on analytics pages** — e.g. Subscriptions. *Fix: `ListSkeleton` with representative rows.* ✅ implemented
10. **Inconsistent loading semantics for assistive tech** — ad-hoc inline loader divs, some without `role="status"`/`aria-busy`. *Fix: standardize on skeletons/PageLoader.* ✅ partially (ListSkeleton status region)
11. **Duplicated inline centering styles for loaders** — `{display:'flex',justifyContent:'center',padding}` copy-pasted across pages. *Fix: skeletons remove the inline styles.* ✅ implemented
12. **Heavy filter/sort recomputation not deferred** — combined with immediate `query`, typing feels laggy on big datasets. *Fix: debounce (item 4) and/or `useDeferredValue`.* ✅ implemented (debounce)

Items 2, 5, 6, 7, 8 are left as clearly-scoped follow-ups tracked by #3798.
