### PR TITLE
feat(web): dashboard & charts batch (#3748-#3757)

### DIFF
--- a/apps/web/src/components/charts/CategoryPieChart.test.tsx
+++ b/apps/web/src/components/charts/CategoryPieChart.test.tsx
@@ -146,4 +146,57 @@ describe('CategoryPieChart', () => {
     render(<CategoryPieChart data={[]} />);
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
+
+  // -- Donut center total (#3754) --------------------------------------------
+
+  it('renders the formatted total in the donut center', () => {
+    const { container } = render(<CategoryPieChart data={sampleData} />);
+    const center = container.querySelector('.pie-chart-center__value');
+    expect(center).not.toBeNull();
+    expect(center).toHaveTextContent('$800');
+    expect(container.querySelector('.pie-chart-center__label')).toHaveTextContent('Total');
+  });
+
+  it('uses a non-zero inner radius (donut, not full pie)', () => {
+    const { container } = render(<CategoryPieChart data={sampleData} />);
+    const path = container.querySelector<SVGPathElement>('path[data-chart-point]');
+    // A donut arc path contains two arc commands (outer + inner); a full pie
+    // collapses to the centre so its path has a single arc. Assert the inner
+    // arc is present.
+    const d = path?.getAttribute('d') ?? '';
+    const arcCount = (d.match(/A/g) ?? []).length;
+    expect(arcCount).toBeGreaterThanOrEqual(2);
+  });
+
+  // -- Texture patterns (#3749) ----------------------------------------------
+
+  it('defines an SVG texture pattern per slice and fills slices with them', () => {
+    const { container } = render(<CategoryPieChart data={sampleData} />);
+    const patterns = container.querySelectorAll('pattern');
+    expect(patterns).toHaveLength(sampleData.length);
+    const paths = container.querySelectorAll<SVGPathElement>('path[data-chart-point]');
+    for (const path of Array.from(paths)) {
+      expect(path.getAttribute('fill')).toMatch(/^url\(#.*chart-pattern-\d+\)$/);
+    }
+  });
+
+  it('gives legend swatches the same pattern fill as the slices', () => {
+    const { container } = render(<CategoryPieChart data={sampleData} />);
+    const swatchRects = container.querySelectorAll<SVGRectElement>(
+      '.pie-chart-legend__swatch rect',
+    );
+    expect(swatchRects).toHaveLength(sampleData.length);
+    expect(swatchRects[0].getAttribute('fill')).toMatch(/^url\(#.*chart-pattern-0\)$/);
+  });
+
+  // -- Visible caption (#3755) -----------------------------------------------
+
+  it('renders a compact visible caption beneath the title', () => {
+    const { container } = render(<CategoryPieChart data={sampleData} />);
+    const caption = container.querySelector('.chart-caption');
+    expect(caption).not.toBeNull();
+    expect(caption).toHaveTextContent('Food is largest at 56%');
+    // Marked aria-hidden so screen readers do not double-announce it.
+    expect(caption).toHaveAttribute('aria-hidden', 'true');
+  });
 });

--- a/apps/web/src/components/charts/CategoryPieChart.tsx
+++ b/apps/web/src/components/charts/CategoryPieChart.tsx
@@ -8,9 +8,15 @@
  *
  * @module components/charts/CategoryPieChart
  */
-import { type FC, useCallback, useEffect, useId, useRef, useState } from 'react';
+import { type FC, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import * as d3 from 'd3';
-import { CHART_COLORS, buildChartDescription, formatChartCurrency } from './chart-palette';
+import {
+  CHART_COLORS,
+  buildCategoryCaption,
+  buildChartDescription,
+  formatChartCurrency,
+  patternId,
+} from './chart-palette';
 import { AccessibleChartDataTable } from './chart-accessibility';
 import { ChartEmptyState } from './ChartEmptyState';
 import { useEffectiveMaskingMode } from '../../contexts/PrivacyModeContext';
@@ -25,6 +31,72 @@ export interface CategoryPieChartProps {
   width?: number;
   height?: number;
   title?: string;
+}
+
+/** Side length (user units) of a single texture tile. */
+const PATTERN_TILE = 8;
+
+/**
+ * SVG texture shapes for a given palette index, cycling through six distinct
+ * patterns (dots, diagonals, orthogonals, crosshatch). Layered over the slice's
+ * CVD-safe color they provide a secondary, color-independent encoding so
+ * adjacent slices remain distinguishable for low-vision / color-blind users
+ * (WCAG 1.4.1 Use of Color). Stroke uses a token so it adapts to light/dark.
+ */
+function TextureShapes({ index }: { index: number }): React.ReactElement {
+  const stroke = 'var(--semantic-background-primary, #FFFFFF)';
+  const strokeWidth = 1.3;
+  switch (index % 6) {
+    case 0:
+      return <circle cx={PATTERN_TILE / 2} cy={PATTERN_TILE / 2} r={1.4} fill={stroke} />;
+    case 1:
+      return (
+        <path
+          d={`M0 ${PATTERN_TILE} L${PATTERN_TILE} 0`}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+        />
+      );
+    case 2:
+      return (
+        <path
+          d={`M0 0 L${PATTERN_TILE} ${PATTERN_TILE}`}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+        />
+      );
+    case 3:
+      return (
+        <path
+          d={`M0 ${PATTERN_TILE / 2} L${PATTERN_TILE} ${PATTERN_TILE / 2}`}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+        />
+      );
+    case 4:
+      return (
+        <path
+          d={`M${PATTERN_TILE / 2} 0 L${PATTERN_TILE / 2} ${PATTERN_TILE}`}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+        />
+      );
+    default:
+      return (
+        <>
+          <path
+            d={`M0 0 L${PATTERN_TILE} ${PATTERN_TILE}`}
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+          />
+          <path
+            d={`M0 ${PATTERN_TILE} L${PATTERN_TILE} 0`}
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+          />
+        </>
+      );
+  }
 }
 
 export const CategoryPieChart: FC<CategoryPieChartProps> = ({
@@ -49,6 +121,24 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
   const reducedMotion =
     typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+  const caption = useMemo(
+    () =>
+      buildCategoryCaption(
+        data.map((d) => ({ name: d.name, value: d.value })),
+        currency,
+        maskingMode,
+      ),
+    [data, currency, maskingMode],
+  );
+  const formattedTotal = formatChartCurrency(total, currency, 'en-US', maskingMode);
+  // useId() can contain colons; strip them so the derived <pattern> ids are safe
+  // to reference from `fill: url(#…)`.
+  const patternPrefix = chartId.replace(/:/g, '');
+  const patternRef = useCallback(
+    (index: number) => `${patternPrefix}-${patternId(index)}`,
+    [patternPrefix],
+  );
+
   const renderChart = useCallback(() => {
     const svg = d3.select(svgRef.current);
     svg.selectAll('*').remove();
@@ -64,7 +154,10 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
       .value((d) => d.value)
       .sort(null)
       .padAngle(0.02);
-    const arc = d3.arc<d3.PieArcDatum<CategorySlice>>().innerRadius(0).outerRadius(radius);
+    const arc = d3
+      .arc<d3.PieArcDatum<CategorySlice>>()
+      .innerRadius(radius * 0.58)
+      .outerRadius(radius);
     const slices = g
       .selectAll<SVGPathElement, d3.PieArcDatum<CategorySlice>>('path')
       .data(pie(data))
@@ -78,7 +171,7 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
         (d) =>
           `${d.data.name}: ${formatChartCurrency(d.data.value, currency, 'en-US', maskingMode)} (${total > 0 ? ((d.data.value / total) * 100).toFixed(1) : '0.0'}%)`,
       )
-      .attr('fill', (_d, i) => CHART_COLORS[i % CHART_COLORS.length])
+      .attr('fill', (_d, i) => `url(#${patternRef(i)})`)
       .attr('stroke', 'var(--semantic-background-primary, #FFFFFF)')
       .attr('stroke-width', 2)
       .style('cursor', 'pointer')
@@ -106,7 +199,7 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
           return (t: number) => arc(i(t)) ?? '';
         });
     }
-  }, [data, currency, width, height, reducedMotion, total, maskingMode]);
+  }, [data, currency, width, height, reducedMotion, total, maskingMode, patternRef]);
 
   useEffect(() => {
     renderChart();
@@ -153,6 +246,11 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
       <h3 id={`${chartId}-title`} className="chart-title">
         {title}
       </h3>
+      {caption && (
+        <p className="chart-caption" aria-hidden="true">
+          {caption}
+        </p>
+      )}
       <p id={`${chartId}-desc`} className="sr-only">
         {description}
       </p>
@@ -166,26 +264,38 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
         {announcement}
       </div>
       <div className="pie-chart-layout">
-        <svg
-          ref={svgRef}
-          width={width}
-          height={height}
-          viewBox={`0 0 ${width} ${height}`}
-          role="img"
-          aria-labelledby={`${chartId}-title`}
-          aria-describedby={`${chartId}-desc`}
-          onKeyDown={handleKeyDown}
-        />
+        <div className="pie-chart-canvas">
+          <svg
+            ref={svgRef}
+            width={width}
+            height={height}
+            viewBox={`0 0 ${width} ${height}`}
+            role="img"
+            aria-labelledby={`${chartId}-title`}
+            aria-describedby={`${chartId}-desc`}
+            onKeyDown={handleKeyDown}
+          />
+          {total > 0 && (
+            <div className="pie-chart-center" aria-hidden="true">
+              <span className="pie-chart-center__value">{formattedTotal}</span>
+              <span className="pie-chart-center__label">Total</span>
+            </div>
+          )}
+        </div>
         <ul className="pie-chart-legend" aria-label="Category legend">
           {data.map((slice, i) => {
             const percent = total > 0 ? ((slice.value / total) * 100).toFixed(1) : '0.0';
             return (
               <li key={slice.name} className="pie-chart-legend__item">
-                <span
+                <svg
                   className="pie-chart-legend__swatch"
-                  style={{ backgroundColor: CHART_COLORS[i % CHART_COLORS.length] }}
+                  width={12}
+                  height={12}
                   aria-hidden="true"
-                />
+                  focusable="false"
+                >
+                  <rect width={12} height={12} rx={2} fill={`url(#${patternRef(i)})`} />
+                </svg>
                 <span className="pie-chart-legend__name">{slice.name}</span>
                 <span className="pie-chart-legend__value">
                   {formatChartCurrency(slice.value, currency, 'en-US', maskingMode)} ({percent}%)
@@ -207,6 +317,30 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
           rows={tableRows}
         />
       )}
+      {/* Shared, off-screen texture definitions referenced by both the pie
+          slices (via D3 `fill: url(#…)`) and the legend swatches, so the legend
+          maps 1:1 to slices even for low-vision / color-blind users. Rendered
+          last so the primary chart svg remains the first <svg> in the tree. */}
+      <svg width="0" height="0" aria-hidden="true" focusable="false" className="pie-chart-defs">
+        <defs>
+          {data.map((_slice, i) => (
+            <pattern
+              key={patternRef(i)}
+              id={patternRef(i)}
+              patternUnits="userSpaceOnUse"
+              width={PATTERN_TILE}
+              height={PATTERN_TILE}
+            >
+              <rect
+                width={PATTERN_TILE}
+                height={PATTERN_TILE}
+                fill={CHART_COLORS[i % CHART_COLORS.length]}
+              />
+              <TextureShapes index={i} />
+            </pattern>
+          ))}
+        </defs>
+      </svg>
     </div>
   );
 };

--- a/apps/web/src/components/charts/SpendingBarChart.test.tsx
+++ b/apps/web/src/components/charts/SpendingBarChart.test.tsx
@@ -139,4 +139,16 @@ describe('SpendingBarChart', () => {
     render(<SpendingBarChart data={[]} />);
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
+
+  // -- Visible caption (#3755) -----------------------------------------------
+
+  it('renders a compact visible caption beneath the title', () => {
+    const { container } = render(<SpendingBarChart data={sampleData} />);
+    const caption = container.querySelector('.chart-caption');
+    expect(caption).not.toBeNull();
+    expect(caption).toHaveTextContent('$800 across 3 categories');
+    expect(caption).toHaveTextContent('Food is largest at 56%');
+    // Marked aria-hidden so screen readers do not double-announce it.
+    expect(caption).toHaveAttribute('aria-hidden', 'true');
+  });
 });

--- a/apps/web/src/components/charts/SpendingBarChart.tsx
+++ b/apps/web/src/components/charts/SpendingBarChart.tsx
@@ -17,7 +17,12 @@ import {
   ResponsiveContainer,
   Cell,
 } from 'recharts';
-import { CHART_COLORS, buildChartDescription, formatChartCurrency } from './chart-palette';
+import {
+  CHART_COLORS,
+  buildCategoryCaption,
+  buildChartDescription,
+  formatChartCurrency,
+} from './chart-palette';
 import { AccessibleChartDataTable } from './chart-accessibility';
 import { ChartEmptyState } from './ChartEmptyState';
 import { useArrowKeyNavigation } from '../../accessibility/aria';
@@ -56,6 +61,16 @@ export const SpendingBarChart: FC<SpendingBarChartProps> = ({
       buildChartDescription(
         'Bar chart',
         data.map((d) => ({ label: d.name, value: d.amount })),
+        currency,
+        maskingMode,
+      ),
+    [data, currency, maskingMode],
+  );
+
+  const caption = useMemo(
+    () =>
+      buildCategoryCaption(
+        data.map((d) => ({ name: d.name, value: d.amount })),
         currency,
         maskingMode,
       ),
@@ -112,6 +127,11 @@ export const SpendingBarChart: FC<SpendingBarChartProps> = ({
       <h3 id={`${chartId}-title`} className="chart-title">
         {title}
       </h3>
+      {caption && (
+        <p className="chart-caption" aria-hidden="true">
+          {caption}
+        </p>
+      )}
       <p id={`${chartId}-desc`} className="sr-only">
         {description}
       </p>

--- a/apps/web/src/components/charts/SpendingTrendChart.tsx
+++ b/apps/web/src/components/charts/SpendingTrendChart.tsx
@@ -283,6 +283,16 @@ export const SpendingTrendChart: FC<SpendingTrendChartProps> = ({
 
   const { announcement, handleFocus, handleKeyDown } = useChartKeyboardNavigation(dataPointRows);
 
+  const caption = useMemo(() => {
+    if (data.length === 0) return '';
+    const total = data.reduce((sum, d) => sum + d.spending, 0);
+    const peak = data.reduce((max, d) => (d.spending > max.spending ? d : max), data[0]);
+    const noun = data.length === 1 ? 'point' : 'points';
+    // The period-over-period comparison is already shown visibly in the
+    // annotations row, so it is intentionally omitted here to avoid duplication.
+    return `${formatChartCurrency(total, currency, 'en-US', maskingMode)} over ${data.length} ${noun}; peak ${formatChartCurrency(peak.spending, currency, 'en-US', maskingMode)} on ${peak.label}.`;
+  }, [data, currency, maskingMode]);
+
   const chartColor = CHART_COLORS[0];
   const chartProps = {
     data,
@@ -400,6 +410,12 @@ export const SpendingTrendChart: FC<SpendingTrendChartProps> = ({
           <ViewToggle selected={viewType} onChange={onViewTypeChange} />
         </div>
       </div>
+
+      {caption && (
+        <p className="chart-caption" aria-hidden="true">
+          {caption}
+        </p>
+      )}
 
       <div className="spending-trend__annotations" aria-live="polite">
         {averageDailySpending != null && (

--- a/apps/web/src/components/charts/chart-palette.test.ts
+++ b/apps/web/src/components/charts/chart-palette.test.ts
@@ -10,6 +10,9 @@ import {
   patternId,
   formatChartCurrency,
   buildChartDescription,
+  buildCategoryCaption,
+  groupTopNCategories,
+  DEFAULT_TOP_N_CATEGORIES,
 } from './chart-palette';
 
 // ---------------------------------------------------------------------------
@@ -177,5 +180,86 @@ describe('buildChartDescription', () => {
     expect(desc).toContain('1 categories');
     expect(desc).toContain('$3,000');
     expect(desc).toContain('Savings: $3,000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupTopNCategories (#3757 — Top N + Other)
+// ---------------------------------------------------------------------------
+
+describe('groupTopNCategories', () => {
+  const many = [
+    { name: 'A', value: 10 },
+    { name: 'B', value: 90 },
+    { name: 'C', value: 30 },
+    { name: 'D', value: 80 },
+    { name: 'E', value: 20 },
+    { name: 'F', value: 70 },
+    { name: 'G', value: 40 },
+    { name: 'H', value: 60 },
+  ];
+
+  it('returns data sorted by value descending', () => {
+    const result = groupTopNCategories(many, 8);
+    expect(result.map((d) => d.value)).toEqual([90, 80, 70, 60, 40, 30, 20, 10]);
+  });
+
+  it('caps at topN and aggregates the remainder into a single "Other" entry', () => {
+    const result = groupTopNCategories(many, 3);
+    expect(result).toHaveLength(4);
+    expect(result.slice(0, 3).map((d) => d.name)).toEqual(['B', 'D', 'F']);
+    const other = result[result.length - 1];
+    expect(other.name).toBe('Other');
+    // Remaining values: 40 + 30 + 20 + 10 = 100.
+    expect(other.value).toBe(160);
+  });
+
+  it('preserves the grand total', () => {
+    const grandTotal = many.reduce((sum, d) => sum + d.value, 0);
+    const result = groupTopNCategories(many, 4);
+    const rolledTotal = result.reduce((sum, d) => sum + d.value, 0);
+    expect(rolledTotal).toBe(grandTotal);
+  });
+
+  it('does not add an "Other" entry when there are topN or fewer categories', () => {
+    const few = [
+      { name: 'A', value: 10 },
+      { name: 'B', value: 20 },
+    ];
+    const result = groupTopNCategories(few, 6);
+    expect(result).toHaveLength(2);
+    expect(result.some((d) => d.name === 'Other')).toBe(false);
+  });
+
+  it('defaults to a six-category cap', () => {
+    expect(DEFAULT_TOP_N_CATEGORIES).toBe(6);
+    const result = groupTopNCategories(many);
+    expect(result).toHaveLength(7); // 6 top + Other
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCategoryCaption (#3755 — visible captions)
+// ---------------------------------------------------------------------------
+
+describe('buildCategoryCaption', () => {
+  it('returns an empty string for no data', () => {
+    expect(buildCategoryCaption([])).toBe('');
+  });
+
+  it('summarises total, count, and largest category with its share', () => {
+    const caption = buildCategoryCaption([
+      { name: 'Groceries', value: 280 },
+      { name: 'Rent', value: 720 },
+    ]);
+    expect(caption).toContain('$1,000');
+    expect(caption).toContain('2 categories');
+    expect(caption).toContain('Rent is largest at 72%');
+  });
+
+  it('uses the singular noun for a single category', () => {
+    const caption = buildCategoryCaption([{ name: 'Rent', value: 500 }]);
+    expect(caption).toContain('1 category');
+    expect(caption).toContain('Rent is largest at 100%');
   });
 });

--- a/apps/web/src/components/charts/chart-palette.ts
+++ b/apps/web/src/components/charts/chart-palette.ts
@@ -60,6 +60,67 @@ export function patternId(index: number): string {
   return `chart-pattern-${index}`;
 }
 
+/**
+ * Default number of individual categories to surface in a categorical chart
+ * before the remainder is rolled into a single "Other" slice. Chosen to match
+ * the six-entry CVD-safe palette so every visible slice gets a unique color.
+ */
+export const DEFAULT_TOP_N_CATEGORIES = 6;
+
+/** Label applied to the aggregated remainder slice. */
+export const OTHER_CATEGORY_LABEL = 'Other';
+
+/** A named, numeric-valued slice used by the categorical charts. */
+export interface NamedValue {
+  name: string;
+  value: number;
+}
+
+/**
+ * Cap a categorical dataset at the largest `topN` entries and aggregate the
+ * remainder into a single "Other" entry that preserves the grand total.
+ *
+ * The result is deterministic: sorted by value descending, with the "Other"
+ * entry (when present) always last. When there are `topN` or fewer categories
+ * the data is returned sorted but otherwise unchanged (no "Other" entry).
+ */
+export function groupTopNCategories<T extends NamedValue>(
+  data: readonly T[],
+  topN: number = DEFAULT_TOP_N_CATEGORIES,
+  otherLabel: string = OTHER_CATEGORY_LABEL,
+): NamedValue[] {
+  const sorted = [...data]
+    .map(({ name, value }) => ({ name, value }))
+    .sort((left, right) => right.value - left.value);
+
+  if (topN <= 0 || sorted.length <= topN) {
+    return sorted;
+  }
+
+  const top = sorted.slice(0, topN);
+  const otherTotal = sorted.slice(topN).reduce((sum, entry) => sum + entry.value, 0);
+  return [...top, { name: otherLabel, value: otherTotal }];
+}
+
+/**
+ * Build a short, human-readable caption for a categorical chart, e.g.
+ * "$2,340 across 6 categories; Groceries is largest at 28%." Intended for a
+ * compact visible summary line; returns an empty string when there is no data.
+ */
+export function buildCategoryCaption(
+  dataPoints: readonly NamedValue[],
+  currency = 'USD',
+  maskingMode: MaskingMode = MaskingMode.Visible,
+): string {
+  if (dataPoints.length === 0) return '';
+  const total = dataPoints.reduce((sum, d) => sum + d.value, 0);
+  const largest = dataPoints.reduce((max, d) => (d.value > max.value ? d : max), dataPoints[0]);
+  const share = total > 0 ? Math.round((largest.value / total) * 100) : 0;
+  const noun = dataPoints.length === 1 ? 'category' : 'categories';
+  const totalText = formatChartCurrency(total, currency, 'en-US', maskingMode);
+  return `${totalText} across ${dataPoints.length} ${noun}; ${largest.name} is largest at ${share}%.`;
+}
+
 export function buildChartDescription(
   chartType: string,
   dataPoints: Array<{ label: string; value: number }>,

--- a/apps/web/src/components/dashboard/SpendingInsightCard.test.tsx
+++ b/apps/web/src/components/dashboard/SpendingInsightCard.test.tsx
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SpendingInsightCard } from './SpendingInsightCard';
+
+// Mock CurrencyDisplay so the card can be tested without the privacy/locale
+// providers; it simply echoes the (cents) amount for assertions.
+vi.mock('../common', () => ({
+  CurrencyDisplay: ({ amount }: { amount: number }) => (
+    <span data-testid="currency">{`$${Math.round(amount / 100)}`}</span>
+  ),
+}));
+
+describe('SpendingInsightCard', () => {
+  it('returns null when there is no top category and no comparison', () => {
+    const { container } = render(
+      <SpendingInsightCard topCategory={null} totalSpending={0} comparison={null} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null when the top category has zero value', () => {
+    const { container } = render(
+      <SpendingInsightCard
+        topCategory={{ name: 'Groceries', value: 0 }}
+        totalSpending={0}
+        comparison={null}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('surfaces the top category with amount and share', () => {
+    render(
+      <SpendingInsightCard
+        topCategory={{ name: 'Groceries', value: 420 }}
+        totalSpending={1500}
+        comparison={null}
+      />,
+    );
+    const card = screen.getByRole('article', { name: /spending insight/i });
+    expect(card).toHaveTextContent('Groceries is your top category');
+    expect(card).toHaveTextContent('$420');
+    expect(card).toHaveTextContent('(28%)');
+  });
+
+  it('describes an increase with a word and an icon, not color alone', () => {
+    render(
+      <SpendingInsightCard
+        topCategory={{ name: 'Groceries', value: 420 }}
+        totalSpending={1500}
+        comparison={{ percentChange: 15 }}
+      />,
+    );
+    const card = screen.getByRole('article', { name: /spending insight/i });
+    expect(card).toHaveTextContent('15% more than the previous period');
+    expect(card).toHaveTextContent('↑');
+  });
+
+  it('describes a decrease as "less"', () => {
+    render(
+      <SpendingInsightCard
+        topCategory={{ name: 'Groceries', value: 420 }}
+        totalSpending={1500}
+        comparison={{ percentChange: -22 }}
+      />,
+    );
+    const card = screen.getByRole('article', { name: /spending insight/i });
+    expect(card).toHaveTextContent('22% less than the previous period');
+    expect(card).toHaveTextContent('↓');
+  });
+
+  it('omits the comparison clause when the rounded change is flat (0%)', () => {
+    render(
+      <SpendingInsightCard
+        topCategory={{ name: 'Groceries', value: 420 }}
+        totalSpending={1500}
+        comparison={{ percentChange: 0.2 }}
+      />,
+    );
+    const card = screen.getByRole('article', { name: /spending insight/i });
+    expect(card).not.toHaveTextContent('than the previous period');
+  });
+});

--- a/apps/web/src/components/dashboard/SpendingInsightCard.tsx
+++ b/apps/web/src/components/dashboard/SpendingInsightCard.tsx
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * SpendingInsightCard — a compact, plain-language "what stands out" summary for
+ * the dashboard. Surfaces (a) the top spending category with its amount and
+ * share and (b) the period-over-period direction and magnitude, using the data
+ * already computed on the dashboard.
+ *
+ * Accessibility (WCAG 2.2 AA):
+ * - Directional change uses a word ("more"/"less") plus an icon glyph, never
+ *   color alone (1.4.1 Use of Color).
+ * - Currency respects the active masking mode via `CurrencyDisplay`.
+ * - Rendered as a self-contained `<article>` with an accessible label.
+ *
+ * References: issue #3756
+ *
+ * @module components/dashboard/SpendingInsightCard
+ */
+
+import { type FC } from 'react';
+import { CurrencyDisplay } from '../common';
+import './spending-insight-card.css';
+
+export interface SpendingInsightTopCategory {
+  /** Category display name. */
+  name: string;
+  /** Category spend in major currency units (dollars, not cents). */
+  value: number;
+}
+
+export interface SpendingInsightComparison {
+  /** Percentage change vs the previous period (positive = increase). */
+  percentChange: number;
+}
+
+export interface SpendingInsightCardProps {
+  /** Highest-spend category for the period, or `null` when unavailable. */
+  topCategory: SpendingInsightTopCategory | null;
+  /** Total spend across all categories in major units (for the share %). */
+  totalSpending: number;
+  /** Period-over-period comparison, or `null` when there is no prior period. */
+  comparison: SpendingInsightComparison | null;
+  /** ISO 4217 currency code for formatting. */
+  currency?: string;
+}
+
+/**
+ * A one-line spending insight card. Returns `null` when there is insufficient
+ * data (no top category and no comparison) so the dashboard stays uncluttered.
+ */
+export const SpendingInsightCard: FC<SpendingInsightCardProps> = ({
+  topCategory,
+  totalSpending,
+  comparison,
+  currency = 'USD',
+}) => {
+  const hasTopCategory = topCategory != null && topCategory.value > 0;
+  const hasComparison = comparison != null && Number.isFinite(comparison.percentChange);
+
+  if (!hasTopCategory && !hasComparison) {
+    return null;
+  }
+
+  const share =
+    hasTopCategory && totalSpending > 0
+      ? Math.round((topCategory.value / totalSpending) * 100)
+      : null;
+
+  const changeMagnitude = hasComparison ? Math.abs(Math.round(comparison.percentChange)) : 0;
+  const changeDirection = hasComparison && comparison.percentChange >= 0 ? 'more' : 'less';
+  const changeGlyph = changeDirection === 'more' ? '↑' : '↓';
+  // Suppress the comparison clause when the rounded magnitude is 0 ("flat"),
+  // which reads more naturally as no meaningful change.
+  const showComparison = hasComparison && changeMagnitude > 0;
+
+  return (
+    <article className="spending-insight-card" aria-label="Spending insight">
+      <span className="spending-insight-card__icon" aria-hidden="true">
+        💡
+      </span>
+      <p className="spending-insight-card__text">
+        {hasTopCategory && (
+          <span>
+            <strong>{topCategory.name}</strong> is your top category this period at{' '}
+            <CurrencyDisplay
+              amount={Math.round(topCategory.value * 100)}
+              currency={currency}
+              context={`${topCategory.name} category`}
+            />
+            {share !== null ? ` (${share}%)` : ''}.
+          </span>
+        )}{' '}
+        {showComparison && (
+          <span
+            className={`spending-insight-card__change spending-insight-card__change--${changeDirection}`}
+          >
+            <span aria-hidden="true">{changeGlyph}</span> You&rsquo;re spending {changeMagnitude}%{' '}
+            {changeDirection} than the previous period.
+          </span>
+        )}
+      </p>
+    </article>
+  );
+};
+
+export default SpendingInsightCard;

--- a/apps/web/src/components/dashboard/spending-insight-card.css
+++ b/apps/web/src/components/dashboard/spending-insight-card.css
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * SpendingInsightCard styles.
+ *
+ * A compact, single-line "what stands out" summary. Uses design tokens so it
+ * themes correctly in light/dark/high-contrast. References: issue #3756.
+ */
+
+.spending-insight-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  margin-bottom: var(--spacing-4);
+  background: var(--semantic-surface-primary, var(--card-background));
+  border: 1px solid var(--semantic-border-default, var(--card-border));
+  border-radius: var(--border-radius-lg, 12px);
+}
+
+.spending-insight-card__icon {
+  font-size: 1.25rem;
+  line-height: 1.5;
+  flex-shrink: 0;
+}
+
+.spending-insight-card__text {
+  margin: 0;
+  font-size: var(--type-scale-body-font-size, 0.9375rem);
+  line-height: 1.5;
+  color: var(--semantic-text-primary);
+}
+
+.spending-insight-card__change {
+  color: var(--semantic-text-secondary);
+}
+
+@media (prefers-contrast: more) {
+  .spending-insight-card {
+    border-width: 2px;
+  }
+}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -3,6 +3,9 @@
 import React, { Suspense, useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { TimePeriod, ViewType } from '../components/charts';
+import { ChartEmptyState } from '../components/charts/ChartEmptyState';
+import { groupTopNCategories } from '../components/charts/chart-palette';
+import { SpendingInsightCard } from '../components/dashboard/SpendingInsightCard';
 import { AccountPurposeFilterControl } from '../components/accounts';
 import { RecentTransactionsCard } from '../components/transactions';
 import {
@@ -633,9 +636,12 @@ export const DashboardPage: React.FC = () => {
   );
 
   const { trendData, barData, categoryData, hasChartData } = useMemo(() => {
-    const transformedCategoryData = buildCategoryData(
-      chartPrivacyRollup.visibleTransactions,
-      categoryNames,
+    // Cap the category charts at a readable Top N, rolling the remainder into a
+    // single "Other" entry that preserves the grand total (#3757). Beyond ~6-8
+    // categories a pie/bar becomes unreadable and the 6-color CVD-safe palette
+    // starts to repeat.
+    const transformedCategoryData = groupTopNCategories(
+      buildCategoryData(chartPrivacyRollup.visibleTransactions, categoryNames),
     );
 
     if (chartPrivacyRollup.protectedRollup !== null) {
@@ -726,6 +732,32 @@ export const DashboardPage: React.FC = () => {
   const visibleWidgetIds = useMemo(
     () => new Set(widgetLayout.visibleWidgets.map((widget) => widget.id)),
     [widgetLayout.visibleWidgets],
+  );
+  // Whether the user has any chart widget enabled via Customize. When true but
+  // there is no chart data we show a compact empty state instead of collapsing
+  // the section to nothing; when false the section stays absent (#3751).
+  const anyChartWidgetVisible = useMemo(
+    () =>
+      visibleWidgetIds.has('spending-trend') ||
+      visibleWidgetIds.has('spending-by-category') ||
+      visibleWidgetIds.has('category-pie'),
+    [visibleWidgetIds],
+  );
+  const chartsEmptyMessage = useMemo(() => {
+    const periodText: Record<TimePeriod, string> = {
+      '7d': 'last 7 days',
+      '30d': 'last 30 days',
+      '90d': 'last 90 days',
+      '1y': 'last year',
+      custom: 'selected period',
+    };
+    const filterClause =
+      selectedPurposeFilter !== 'all' ? ' under the current account-purpose filter' : '';
+    return `No spending in expense categories for the ${periodText[selectedPeriod]}${filterClause}. Add a transaction, widen the time period, or change the filter to see charts.`;
+  }, [selectedPeriod, selectedPurposeFilter]);
+  const topSpendingCategory = useMemo(
+    () => categoryData.find((slice) => slice.value > 0) ?? null,
+    [categoryData],
   );
   // Minimalist mode (#2122): hide a quick-access card when the user has hidden
   // the corresponding module. Sourced from layout-level context so the rich
@@ -1043,52 +1075,63 @@ export const DashboardPage: React.FC = () => {
                   fallbackCurrency={chartCurrency}
                 />
               </Suspense>
-              {hasChartData &&
-              (visibleWidgetIds.has('spending-trend') ||
-                visibleWidgetIds.has('spending-by-category') ||
-                visibleWidgetIds.has('category-pie')) ? (
+              {anyChartWidgetVisible ? (
                 <section className="page-section dashboard-charts" aria-label="Financial charts">
-                  {visibleWidgetIds.has('spending-trend') ? (
-                    <div className="chart-container" aria-label="Spending trend chart">
-                      <Suspense fallback={<ChartFallback />}>
-                        <SpendingTrendChart
-                          data={trendData}
-                          currency={chartCurrency}
-                          title="Spending Trend"
-                          selectedPeriod={selectedPeriod}
-                          onPeriodChange={handlePeriodChange}
-                          viewType={viewType}
-                          onViewTypeChange={handleViewTypeChange}
-                          averageDailySpending={averageDaily}
-                          comparison={comparison}
-                        />
-                      </Suspense>
+                  {hasChartData ? (
+                    <>
+                      <SpendingInsightCard
+                        topCategory={topSpendingCategory}
+                        totalSpending={totalSpending}
+                        comparison={comparison}
+                        currency={chartCurrency}
+                      />
+                      {visibleWidgetIds.has('spending-trend') ? (
+                        <div className="chart-container" aria-label="Spending trend chart">
+                          <Suspense fallback={<ChartFallback />}>
+                            <SpendingTrendChart
+                              data={trendData}
+                              currency={chartCurrency}
+                              title="Spending Trend"
+                              selectedPeriod={selectedPeriod}
+                              onPeriodChange={handlePeriodChange}
+                              viewType={viewType}
+                              onViewTypeChange={handleViewTypeChange}
+                              averageDailySpending={averageDaily}
+                              comparison={comparison}
+                            />
+                          </Suspense>
+                        </div>
+                      ) : null}
+                      {visibleWidgetIds.has('spending-by-category') ? (
+                        <div className="chart-container" aria-label="Category spending bar chart">
+                          <Suspense fallback={<ChartFallback />}>
+                            <SpendingBarChart
+                              data={barData}
+                              currency={chartCurrency}
+                              title="Spending by Category"
+                            />
+                          </Suspense>
+                        </div>
+                      ) : null}
+                      {visibleWidgetIds.has('category-pie') ? (
+                        <div className="chart-container" aria-label="Category share pie chart">
+                          <Suspense fallback={<ChartFallback />}>
+                            <CategoryPieChart
+                              data={categoryData}
+                              currency={chartCurrency}
+                              width={280}
+                              height={280}
+                              title="Category Share"
+                            />
+                          </Suspense>
+                        </div>
+                      ) : null}
+                    </>
+                  ) : (
+                    <div className="chart-container" aria-label="Financial charts empty state">
+                      <ChartEmptyState title="Financial charts" message={chartsEmptyMessage} />
                     </div>
-                  ) : null}
-                  {visibleWidgetIds.has('spending-by-category') ? (
-                    <div className="chart-container" aria-label="Category spending bar chart">
-                      <Suspense fallback={<ChartFallback />}>
-                        <SpendingBarChart
-                          data={barData}
-                          currency={chartCurrency}
-                          title="Spending by Category"
-                        />
-                      </Suspense>
-                    </div>
-                  ) : null}
-                  {visibleWidgetIds.has('category-pie') ? (
-                    <div className="chart-container" aria-label="Category share pie chart">
-                      <Suspense fallback={<ChartFallback />}>
-                        <CategoryPieChart
-                          data={categoryData}
-                          currency={chartCurrency}
-                          width={280}
-                          height={280}
-                          title="Category Share"
-                        />
-                      </Suspense>
-                    </div>
-                  ) : null}
+                  )}
                 </section>
               ) : null}
               <Suspense fallback={<SectionFallback label="Loading financial coach" />}>

--- a/apps/web/src/pages/InsightsPage.tsx
+++ b/apps/web/src/pages/InsightsPage.tsx
@@ -17,6 +17,7 @@ import { WeeklyDigest } from '../components/insights';
 import { RecommendationsFeed } from '../components/recommendations';
 import { WellnessOverview } from '../components/wellness';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import { CHART_COLORS } from '../components/charts';
 import { Checkbox } from '../components/common/Checkbox';
 import { AppIcon, type IconName } from '../components/icons';
 import { useInsights } from '../hooks/useInsights';
@@ -84,14 +85,11 @@ interface CategoryBarProps {
 }
 
 const CategoryBar: React.FC<CategoryBarProps> = ({ name, amount, percent, index, onDrillDown }) => {
-  const colors = [
-    'var(--semantic-status-info)',
-    'var(--semantic-status-positive)',
-    'var(--semantic-status-warning)',
-    'var(--semantic-status-negative)',
-    'var(--semantic-interactive-default)',
-  ];
-  const color = colors[index % colors.length];
+  // Use the shared CVD-safe categorical palette rather than semantic status
+  // tokens (info/positive/warning/negative). Status colors carry meaning
+  // (good/bad/warning) in this app, so cycling them by category index falsely
+  // implies a category is "good" or "bad". References: issue #3752.
+  const color = CHART_COLORS[index % CHART_COLORS.length];
 
   return (
     <div className="insights-category-bar" role="listitem">

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -1006,6 +1006,42 @@
   font-weight: var(--type-scale-title-font-weight);
   color: var(--semantic-text-primary);
 }
+/* Compact visible caption shown beneath a chart title. The full breakdown
+ * stays screen-reader only; this one-line takeaway is marked aria-hidden so it
+ * is not announced twice. References: issue #3755. */
+.chart-caption {
+  margin: calc(-1 * var(--spacing-3)) 0 var(--spacing-4);
+  font-size: var(--type-scale-body-font-size, 0.875rem);
+  line-height: 1.4;
+  color: var(--semantic-text-secondary);
+}
+/* Donut center total overlay for the category pie chart. References: #3754. */
+.pie-chart-canvas {
+  position: relative;
+  display: inline-flex;
+}
+.pie-chart-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-1);
+  pointer-events: none;
+  text-align: center;
+}
+.pie-chart-center__value {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight, 700);
+  color: var(--semantic-text-primary);
+}
+.pie-chart-center__label {
+  font-size: var(--type-scale-label-font-size, 0.75rem);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--semantic-text-secondary);
+}
 @media (prefers-color-scheme: dark) {
   html:not([data-theme='light']) .sidebar-nav__item[aria-current='page'],
   html:not([data-theme='light']) .sidebar-nav__item--active {


### PR DESCRIPTION
﻿## Summary

Web dashboard & charts improvements across `apps/web` (dashboard, charts, insights). Ten closely-related issues implemented in one cohesive PR.

### Changes
- **#3757** Group category chart data into **Top N + Other** via `groupTopNCategories()` in `chart-palette.ts`, applied in the dashboard category memo.
- **#3756** New `SpendingInsightCard` summarizing the top spending category (icon **+** word, not color alone; masking-aware via `CurrencyDisplay`).
- **#3755** Visible `aria-hidden` captions on the pie, bar and trend charts (full description stays `sr-only`).
- **#3754** `CategoryPieChart` converted to a **donut** with a center total overlay.
- **#3752** `InsightsPage` `CategoryBar` now uses `CHART_COLORS` instead of semantic status tokens.
- **#3751** Charts section shows `ChartEmptyState` when chart widgets are enabled but there is no data.
- **#3749** SVG **texture patterns** on pie slices and legend swatches for non-color differentiation.

### Verified already satisfied on `main` (closed by this PR)
- **#3753** header / RMD badge moved to CSS classes.
- **#3750** `SpendingBarChart` `AccessibleChartDataTable` (with tests).
- **#3748** `DashboardSkeleton` loading state.

### Testing
- `npx prettier --check .` — clean
- `npx eslint . --max-warnings 0` — clean
- `apps/web` vitest suite — all tests pass (added tests for the new helpers/components/captions).

Closes #3757
Closes #3756
Closes #3755
Closes #3754
Closes #3753
Closes #3752
Closes #3751
Closes #3750
Closes #3749
Closes #3748
