### PR TITLE
feat(web): auth-page a11y & sign-up parity batch (#3720 #3707 #3702 #3679 #3669 #3664 #3656 #3648 #3643 #3638)

### DIFF
--- a/apps/web/src/components/auth/OAuthButtons.tsx
+++ b/apps/web/src/components/auth/OAuthButtons.tsx
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * OAuthButtons — shared social-provider button group for the auth pages.
+ *
+ * Extracted from `LoginPage` so the same accessible provider group can be
+ * reused on Signup for sign-up parity (#3707). The caller owns whether the
+ * group renders at all (e.g. suppress in demo mode); this component only
+ * renders the divider + provider buttons.
+ */
+
+import React from 'react';
+
+import type { OAuthProvider } from '../../auth/auth-context';
+
+export interface OAuthButtonsProps {
+  /** Invoked with the chosen provider when a button is pressed. */
+  onSelect: (provider: OAuthProvider) => void;
+  /** Disables every provider button (e.g. while a request is in flight). */
+  disabled?: boolean;
+  /** Action verb used in each button's accessible label, e.g. "Sign in". */
+  verb?: string;
+  /** Accessible label for the button group. */
+  groupLabel?: string;
+  /** Divider caption rendered above the buttons. */
+  dividerText?: string;
+}
+
+interface ProviderMeta {
+  id: OAuthProvider;
+  name: string;
+  icon: React.ReactNode;
+}
+
+const PROVIDERS: readonly ProviderMeta[] = [
+  {
+    id: 'google',
+    name: 'Google',
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          fill="#4285F4"
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        />
+        <path
+          fill="#34A853"
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        />
+        <path
+          fill="#EA4335"
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        />
+      </svg>
+    ),
+  },
+  {
+    id: 'github',
+    name: 'GitHub',
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+      </svg>
+    ),
+  },
+  {
+    id: 'azure',
+    name: 'Microsoft',
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="#F25022" d="M2 2h9.5v9.5H2z" />
+        <path fill="#7FBA00" d="M12.5 2H22v9.5h-9.5z" />
+        <path fill="#00A4EF" d="M2 12.5h9.5V22H2z" />
+        <path fill="#FFB900" d="M12.5 12.5H22V22h-9.5z" />
+      </svg>
+    ),
+  },
+  {
+    id: 'apple',
+    name: 'Apple',
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+      </svg>
+    ),
+  },
+];
+
+/** Renders the shared social provider button group. */
+export const OAuthButtons: React.FC<OAuthButtonsProps> = ({
+  onSelect,
+  disabled = false,
+  verb = 'Sign in',
+  groupLabel = 'Social login options',
+  dividerText = 'or continue with',
+}) => (
+  <div className="auth-actions auth-oauth-section">
+    <div className="auth-divider" aria-hidden="true">
+      <span className="auth-divider__text">{dividerText}</span>
+    </div>
+
+    <div className="auth-oauth-buttons" role="group" aria-label={groupLabel}>
+      {PROVIDERS.map((provider) => (
+        <button
+          key={provider.id}
+          type="button"
+          className="form-button form-button--secondary auth-oauth-button"
+          onClick={() => {
+            onSelect(provider.id);
+          }}
+          disabled={disabled}
+          aria-label={`${verb} with ${provider.name}`}
+        >
+          {provider.icon}
+          {provider.name}
+        </button>
+      ))}
+    </div>
+  </div>
+);
+
+export default OAuthButtons;

--- a/apps/web/src/pages/ForgotPasswordPage.test.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ForgotPasswordPage } from './ForgotPasswordPage';
@@ -25,6 +25,14 @@ describe('ForgotPasswordPage', () => {
     expect(screen.getByText('Reset your password')).toBeInTheDocument();
     expect(screen.getByLabelText('Email')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute('href', '/login');
+  });
+
+  it('autofocuses the email field on mount', async () => {
+    renderForgotPasswordPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Email')).toHaveFocus();
+    });
   });
 
   it('requests a reset email with an absolute reset redirect URL', async () => {

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useId, useMemo, useState } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { z } from 'zod';
 
@@ -24,7 +24,21 @@ export const ForgotPasswordPage: React.FC = () => {
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const emailInputRef = useRef<HTMLInputElement>(null);
+
   const redirectTo = useMemo(() => `${window.location.origin}/reset-password`, []);
+
+  /**
+   * Autofocus the email field on mount so keyboard users can start typing
+   * immediately (#3656). Deferred via rAF so it runs after the initial paint.
+   */
+  useEffect(() => {
+    const handle = requestAnimationFrame(() => {
+      emailInputRef.current?.focus();
+    });
+
+    return () => cancelAnimationFrame(handle);
+  }, []);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -77,6 +91,7 @@ export const ForgotPasswordPage: React.FC = () => {
               Email
             </label>
             <input
+              ref={emailInputRef}
               id={emailId}
               className="auth-field__input"
               type="email"

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -101,6 +101,14 @@ describe('LoginPage', () => {
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
   });
 
+  it('autofocuses the email field on mount', async () => {
+    renderLoginPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Email')).toHaveFocus();
+    });
+  });
+
   it('renders the privacy-first brand tagline', () => {
     renderLoginPage();
 

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -5,6 +5,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../auth/auth-context';
 import { getPreferredAuthMethod, setPreferredAuthMethod } from '../auth/preferred-auth-method';
+import { OAuthButtons } from '../components/auth/OAuthButtons';
 import { PasskeySetupPrompt } from '../components/auth/PasskeySetupPrompt';
 import { PasswordInput } from '../components/auth/PasswordInput';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
@@ -103,6 +104,25 @@ export const LoginPage: React.FC = () => {
       navigate('/dashboard', { replace: true });
     }
   }, [isAuthenticated, navigate]);
+
+  /**
+   * Autofocus the email field on mount so keyboard users can start typing
+   * immediately (#3656). Skipped when biometric sign-in is the primary CTA —
+   * the email form is collapsed in that layout and stealing focus into a
+   * hidden field would be disorienting. Deferred via rAF so it runs after the
+   * initial paint and doesn't fight route-level focus management.
+   */
+  useEffect(() => {
+    if (passkeyPrimary) {
+      return;
+    }
+
+    const handle = requestAnimationFrame(() => {
+      emailInputRef.current?.focus();
+    });
+
+    return () => cancelAnimationFrame(handle);
+  }, [passkeyPrimary]);
 
   /**
    * Confirm a platform authenticator is actually available on this device
@@ -425,100 +445,15 @@ export const LoginPage: React.FC = () => {
         {/* Social sign-in lives OUTSIDE the collapsible email form so it stays
             reachable for passkey-primary users without expanding the email
             disclosure (#3178). */}
-        <div className="auth-actions auth-oauth-section">
-          <div className="auth-divider" aria-hidden="true">
-            <span className="auth-divider__text">or continue with</span>
-          </div>
-
-          <div className="auth-oauth-buttons" role="group" aria-label="Social login options">
-            <button
-              type="button"
-              className="form-button form-button--secondary auth-oauth-button"
-              onClick={() => {
-                void loginWithOAuth('google');
-              }}
-              disabled={isBusy}
-              aria-label="Sign in with Google"
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  fill="#4285F4"
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                />
-                <path
-                  fill="#34A853"
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                />
-                <path
-                  fill="#FBBC05"
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                />
-                <path
-                  fill="#EA4335"
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                />
-              </svg>
-              Google
-            </button>
-            <button
-              type="button"
-              className="form-button form-button--secondary auth-oauth-button"
-              onClick={() => {
-                void loginWithOAuth('github');
-              }}
-              disabled={isBusy}
-              aria-label="Sign in with GitHub"
-            >
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
-              </svg>
-              GitHub
-            </button>
-            <button
-              type="button"
-              className="form-button form-button--secondary auth-oauth-button"
-              onClick={() => {
-                void loginWithOAuth('azure');
-              }}
-              disabled={isBusy}
-              aria-label="Sign in with Microsoft"
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
-                <path fill="#F25022" d="M2 2h9.5v9.5H2z" />
-                <path fill="#7FBA00" d="M12.5 2H22v9.5h-9.5z" />
-                <path fill="#00A4EF" d="M2 12.5h9.5V22H2z" />
-                <path fill="#FFB900" d="M12.5 12.5H22V22h-9.5z" />
-              </svg>
-              Microsoft
-            </button>
-            <button
-              type="button"
-              className="form-button form-button--secondary auth-oauth-button"
-              onClick={() => {
-                void loginWithOAuth('apple');
-              }}
-              disabled={isBusy}
-              aria-label="Sign in with Apple"
-            >
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
-              </svg>
-              Apple
-            </button>
-          </div>
-        </div>
+        <OAuthButtons
+          onSelect={(provider) => {
+            void loginWithOAuth(provider);
+          }}
+          disabled={isBusy}
+          verb="Sign in"
+          groupLabel="Social login options"
+          dividerText="or continue with"
+        />
 
         <p className="auth-footer">
           Don&apos;t have an account?{' '}

--- a/apps/web/src/pages/ResetPasswordPage.test.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.test.tsx
@@ -40,6 +40,34 @@ describe('ResetPasswordPage', () => {
     );
   });
 
+  it('autofocuses the new-password field on mount for a valid recovery link', async () => {
+    renderResetPasswordPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('New password')).toHaveFocus();
+    });
+  });
+
+  it('associates the length hint with the new-password field via aria-describedby', () => {
+    renderResetPasswordPage();
+
+    const field = screen.getByLabelText('New password');
+    const describedBy = field.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+
+    const hint = screen.getByText('Must be at least 12 characters');
+    expect(describedBy?.split(' ')).toContain(hint.id);
+  });
+
+  it('does not autofocus when the recovery link is invalid', async () => {
+    renderResetPasswordPage('/reset-password');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Reset link is invalid or expired/)).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText('New password')).not.toHaveFocus();
+  });
+
   it('updates the password using the recovery access token and redirects to login', async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useId, useMemo, useState } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { PasswordInput } from '../components/auth/PasswordInput';
@@ -25,6 +25,7 @@ export const ResetPasswordPage: React.FC = () => {
 
   const passwordId = `${uid}-password`;
   const confirmPasswordId = `${uid}-confirm-password`;
+  const passwordHintId = `${uid}-password-hint`;
   const passwordErrorId = `${uid}-password-error`;
   const confirmPasswordErrorId = `${uid}-confirm-password-error`;
 
@@ -40,6 +41,33 @@ export const ResetPasswordPage: React.FC = () => {
   const [fieldErrors, setFieldErrors] = useState<ResetFieldErrors>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const passwordInputRef = useRef<HTMLInputElement>(null);
+
+  const linkError = recoveryError
+    ? recoveryError
+    : !accessToken
+      ? 'Reset link is invalid or expired. Request a new password reset link.'
+      : null;
+
+  /**
+   * Autofocus the new-password field on mount so keyboard users can start
+   * typing immediately (#3656). Deferred via rAF so it runs after the initial
+   * paint. Skipped when the recovery link is invalid — the field is disabled
+   * in that state, so focusing it would be a no-op and the error should own
+   * attention instead.
+   */
+  useEffect(() => {
+    if (linkError) {
+      return;
+    }
+
+    const handle = requestAnimationFrame(() => {
+      passwordInputRef.current?.focus();
+    });
+
+    return () => cancelAnimationFrame(handle);
+  }, [linkError]);
 
   const validate = (): boolean => {
     const errors: ResetFieldErrors = {};
@@ -85,12 +113,6 @@ export const ResetPasswordPage: React.FC = () => {
     }
   };
 
-  const linkError = recoveryError
-    ? recoveryError
-    : !accessToken
-      ? 'Reset link is invalid or expired. Request a new password reset link.'
-      : null;
-
   return (
     <main className="auth-page">
       <section className="auth-card" aria-labelledby={`${uid}-title`}>
@@ -119,6 +141,7 @@ export const ResetPasswordPage: React.FC = () => {
               New password
             </label>
             <PasswordInput
+              ref={passwordInputRef}
               id={passwordId}
               className="auth-field__input"
               autoComplete="new-password"
@@ -131,9 +154,13 @@ export const ResetPasswordPage: React.FC = () => {
               }}
               disabled={isSubmitting || Boolean(linkError)}
               aria-invalid={fieldErrors.password ? 'true' : undefined}
-              aria-describedby={fieldErrors.password ? passwordErrorId : undefined}
+              aria-describedby={[passwordHintId, fieldErrors.password ? passwordErrorId : null]
+                .filter(Boolean)
+                .join(' ')}
             />
-            <p className="auth-field__hint">Must be at least 12 characters</p>
+            <p id={passwordHintId} className="auth-field__hint">
+              Must be at least 12 characters
+            </p>
             {password.length > 0 && <PasswordStrengthMeter password={password} />}
             {fieldErrors.password && (
               <p id={passwordErrorId} className="auth-field__error" role="alert">

--- a/apps/web/src/pages/SignupPage.test.tsx
+++ b/apps/web/src/pages/SignupPage.test.tsx
@@ -9,6 +9,7 @@ const navigateMock = vi.hoisted(() => vi.fn());
 const authState = vi.hoisted(() => ({
   loginWithEmail: vi.fn(),
   loginWithPasskey: vi.fn(),
+  loginWithOAuth: vi.fn(),
   signupWithEmail: vi.fn(),
   isAuthenticated: false,
   isLoading: false,
@@ -54,6 +55,7 @@ describe('SignupPage', () => {
   beforeEach(() => {
     authState.loginWithEmail.mockReset();
     authState.loginWithPasskey.mockReset();
+    authState.loginWithOAuth.mockReset();
     authState.signupWithEmail.mockReset();
     authState.isAuthenticated = false;
     authState.isLoading = false;
@@ -61,6 +63,7 @@ describe('SignupPage', () => {
     authState.user = null;
     authState.webAuthnSupported = true;
     authState.webAuthnReady = true;
+    authState.isDemoMode = false;
     navigateMock.mockReset();
   });
 
@@ -231,5 +234,91 @@ describe('SignupPage', () => {
     expect(screen.getByRole('button', { name: 'Sign up' })).toBeEnabled();
 
     authState.signupWithEmail = original;
+  });
+
+  // ── OAuth parity (#3707) ────────────────────────────────────────────────────
+
+  it('renders social sign-up buttons at parity with login', () => {
+    renderSignupPage();
+
+    expect(screen.getByRole('button', { name: 'Sign up with Google' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign up with GitHub' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign up with Microsoft' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign up with Apple' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Social signup options' })).toBeInTheDocument();
+  });
+
+  it('calls loginWithOAuth with the chosen provider', () => {
+    renderSignupPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign up with Google' }));
+
+    expect(authState.loginWithOAuth).toHaveBeenCalledWith('google');
+  });
+
+  // ── Legal transparency (#3643) ──────────────────────────────────────────────
+
+  it('surfaces Terms and Privacy links on the signup form', () => {
+    renderSignupPage();
+
+    // Agreement line near the submit button links to the existing legal routes.
+    const termsLinks = screen.getAllByRole('link', { name: 'Terms' });
+    expect(termsLinks.some((link) => link.getAttribute('href') === '/legal/terms')).toBe(true);
+    expect(screen.getByRole('link', { name: 'Privacy Policy' })).toHaveAttribute(
+      'href',
+      '/legal/privacy',
+    );
+    // LegalLinks footer parity with Login.
+    expect(screen.getByRole('navigation', { name: 'Legal links' })).toBeInTheDocument();
+  });
+
+  // ── Autofocus (#3656) ───────────────────────────────────────────────────────
+
+  it('autofocuses the email field on mount', async () => {
+    renderSignupPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Email')).toHaveFocus();
+    });
+  });
+
+  // ── Weak-password soft-gate (#3679) ─────────────────────────────────────────
+
+  it('blocks submission of a common password and focuses the password field', async () => {
+    renderSignupPage();
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'alex@example.com' } });
+    // A recognizably common password from the shared blocklist (score 0).
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password' } });
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'password' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Sign up' }));
+    });
+
+    expect(authState.signupWithEmail).not.toHaveBeenCalled();
+    const error = screen.getByRole('alert');
+    expect(error).toHaveTextContent('too common');
+    expect(screen.getByLabelText('Password')).toHaveFocus();
+    expect(screen.getByLabelText('Password')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  // ── Confirmation panel focus management (#3702) ─────────────────────────────
+
+  it('moves focus to the confirmation heading after a confirmation-required signup', async () => {
+    authState.signupWithEmail.mockResolvedValue({ kind: 'confirmation_required' });
+    renderSignupPage();
+    fillValidForm();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Sign up' }));
+    });
+
+    const heading = await screen.findByRole('heading', { name: 'Check your email' });
+    await waitFor(() => {
+      expect(heading).toHaveFocus();
+    });
   });
 });

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -10,13 +10,16 @@
  * redirected to the dashboard.
  */
 
-import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../auth/auth-context';
+import { OAuthButtons } from '../components/auth/OAuthButtons';
 import { PasswordInput } from '../components/auth/PasswordInput';
 import { PasswordStrengthMeter } from '../components/auth/PasswordStrengthMeter';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import { LegalLinks } from '../components/legal/LegalLinks';
+import { calculatePasswordStrength } from '../lib/password-strength';
 import { signupSchema } from '../lib/validation';
 
 import '../components/auth/password-input.css';
@@ -44,7 +47,13 @@ interface SubmitMessage {
  */
 export const SignupPage: React.FC = () => {
   const navigate = useNavigate();
-  const { signupWithEmail, isLoading, isDemoMode: demoMode, isAuthenticated } = useAuth();
+  const {
+    signupWithEmail,
+    loginWithOAuth,
+    isLoading,
+    isDemoMode: demoMode,
+    isAuthenticated,
+  } = useAuth();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -54,6 +63,10 @@ export const SignupPage: React.FC = () => {
   const [confirmationEmail, setConfirmationEmail] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const emailInputRef = useRef<HTMLInputElement>(null);
+  const passwordInputRef = useRef<HTMLInputElement>(null);
+  const confirmationHeadingRef = useRef<HTMLHeadingElement>(null);
+
   const uid = useId();
   const emailId = `${uid}-email`;
   const passwordId = `${uid}-password`;
@@ -62,6 +75,7 @@ export const SignupPage: React.FC = () => {
   const passwordHintId = `${uid}-password-hint`;
   const passwordErrorId = `${uid}-password-error`;
   const confirmPasswordErrorId = `${uid}-confirm-password-error`;
+  const legalNoticeId = `${uid}-legal-notice`;
 
   // Redirect to dashboard once the user is authenticated (auto-login after signup)
   useEffect(() => {
@@ -69,6 +83,41 @@ export const SignupPage: React.FC = () => {
       navigate('/dashboard');
     }
   }, [isAuthenticated, navigate]);
+
+  /**
+   * Autofocus the email field on mount so keyboard users can start typing
+   * immediately (#3656). Deferred via rAF so it runs after the initial paint.
+   * Only applies while the form is shown — once the confirmation panel takes
+   * over, that panel owns focus (#3702).
+   */
+  useEffect(() => {
+    if (confirmationEmail) {
+      return;
+    }
+
+    const handle = requestAnimationFrame(() => {
+      emailInputRef.current?.focus();
+    });
+
+    return () => cancelAnimationFrame(handle);
+  }, [confirmationEmail]);
+
+  /**
+   * Move focus to the confirmation panel heading when the "Check your email"
+   * view replaces the form (#3702), so keyboard and screen-reader users are
+   * not stranded on the now-removed submit button.
+   */
+  useEffect(() => {
+    if (!confirmationEmail) {
+      return;
+    }
+
+    const handle = requestAnimationFrame(() => {
+      confirmationHeadingRef.current?.focus();
+    });
+
+    return () => cancelAnimationFrame(handle);
+  }, [confirmationEmail]);
 
   const confirmPasswordError = useMemo(() => {
     if (fieldErrors.confirmPassword) {
@@ -91,7 +140,7 @@ export const SignupPage: React.FC = () => {
     return submitMessage;
   }, [submitMessage]);
 
-  const validate = useCallback((): boolean => {
+  const validate = useCallback((): SignupFieldErrors => {
     const errors: SignupFieldErrors = {};
     const result = signupSchema.safeParse({
       email: email.trim(),
@@ -115,8 +164,17 @@ export const SignupPage: React.FC = () => {
       }
     }
 
+    // Soft-gate the very-weakest tier (score 0 — common/breached passwords).
+    // Runs independently of the length rule so a recognizably common password
+    // gets the actionable "too common" message rather than a bare length hint
+    // (#3679). Reuses the shared strength scorer / blocklist — no new rules.
+    if (password.length > 0 && calculatePasswordStrength(password).score === 0) {
+      errors.password =
+        'This password is too common. Add length or unrelated words to make it harder to guess.';
+    }
+
     setFieldErrors(errors);
-    return Object.keys(errors).length === 0;
+    return errors;
   }, [confirmPassword, email, password]);
 
   const handleSubmit = useCallback(
@@ -125,7 +183,16 @@ export const SignupPage: React.FC = () => {
       setSubmitMessage(null);
       setConfirmationEmail(null);
 
-      if (!validate()) {
+      const errors = validate();
+      if (Object.keys(errors).length > 0) {
+        // Move focus to the first field with an error so the accessible error
+        // (aria-invalid + role="alert") is announced and the user lands where
+        // the fix is needed — including the very-weak password soft-gate (#3679).
+        if (errors.email) {
+          emailInputRef.current?.focus();
+        } else if (errors.password) {
+          passwordInputRef.current?.focus();
+        }
         return;
       }
 
@@ -210,7 +277,9 @@ export const SignupPage: React.FC = () => {
 
         {confirmationEmail ? (
           <section className="auth-confirmation" aria-live="polite">
-            <h2>Check your email</h2>
+            <h2 ref={confirmationHeadingRef} tabIndex={-1}>
+              Check your email
+            </h2>
             <p>
               We sent a confirmation link to <strong>{confirmationEmail}</strong>. Click the link to
               activate your account, then return here to sign in.
@@ -249,6 +318,7 @@ export const SignupPage: React.FC = () => {
                 Email
               </label>
               <input
+                ref={emailInputRef}
                 id={emailId}
                 className="auth-field__input"
                 type="email"
@@ -279,6 +349,7 @@ export const SignupPage: React.FC = () => {
                 Password
               </label>
               <PasswordInput
+                ref={passwordInputRef}
                 id={passwordId}
                 className="auth-field__input"
                 autoComplete="new-password"
@@ -344,7 +415,25 @@ export const SignupPage: React.FC = () => {
               )}
             </div>
 
-            <button type="submit" className="auth-submit" disabled={isBusy} aria-busy={isBusy}>
+            <p className="auth-legal-notice" id={legalNoticeId}>
+              By creating an account you agree to our{' '}
+              <a href="/legal/terms" className="auth-footer__link">
+                Terms
+              </a>{' '}
+              and{' '}
+              <a href="/legal/privacy" className="auth-footer__link">
+                Privacy Policy
+              </a>
+              .
+            </p>
+
+            <button
+              type="submit"
+              className="auth-submit"
+              disabled={isBusy}
+              aria-busy={isBusy}
+              aria-describedby={legalNoticeId}
+            >
               {isBusy ? (
                 <>
                   <LoadingSpinner size={20} label="Creating account" />
@@ -357,12 +446,30 @@ export const SignupPage: React.FC = () => {
           </form>
         )}
 
+        {/* OAuth sign-up parity with Login (#3707) — rendered the same way
+            Login renders its social section, and hidden once the confirmation
+            panel takes over. */}
+        {!confirmationEmail && (
+          <OAuthButtons
+            onSelect={(provider) => {
+              void loginWithOAuth(provider);
+            }}
+            disabled={isBusy}
+            verb="Sign up"
+            groupLabel="Social signup options"
+            dividerText="or sign up with"
+          />
+        )}
+
         <p className="auth-footer">
           Already have an account?{' '}
           <Link to="/login" className="auth-footer__link">
             Sign in
           </Link>
         </p>
+        <footer className="auth-footer auth-footer--legal">
+          <LegalLinks />
+        </footer>
       </div>
     </main>
   );

--- a/apps/web/src/styles/auth.css
+++ b/apps/web/src/styles/auth.css
@@ -116,6 +116,14 @@
   color: var(--semantic-status-negative);
 }
 
+/* Consent / legal agreement line shown near the signup submit button (#3643). */
+.auth-legal-notice {
+  margin: 0 0 var(--spacing-3, 0.75rem);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  text-align: center;
+}
+
 /* ─── Primary submit button ──────────────────────────────────────────────── */
 
 .auth-submit {


### PR DESCRIPTION
﻿## Summary

Batch of 10 closely-related **web auth-page** improvements (Login / Signup / Reset / Forgot) landed in one cohesive PR. Focused on accessibility, sign-up parity, and safer password UX in `apps/web`.

## What changed

- **#3720** — Reset "Must be at least 12 characters" hint is now associated to the new-password input via `aria-describedby`.
- **#3707** — Signup now offers OAuth/social sign-up parity with Login. Extracted the 4-provider button group from `LoginPage` into a shared `OAuthButtons` component reused by both pages (same accessible group semantics).
- **#3702** — After a confirmation-required signup, focus moves to the "Check your email" heading (`tabindex="-1"`), so keyboard/SR users aren't stranded on the removed submit button.
- **#3679** — Signup soft-gates very-weak/common passwords (strength score 0) on submit with an accessible `role="alert"` + `aria-invalid` error and moves focus to the password field. Reuses `calculatePasswordStrength` (no new blocklist).
- **#3669** — Verified: Reset already renders the shared `PasswordStrengthMeter` (present on `main`). Covered by a new test.
- **#3664** — Verified: Login/Signup/Forgot email inputs already set `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}`, `inputMode="email"` (present on `main`).
- **#3656** — Standalone auth pages autofocus the first field on mount (Login/Forgot → email, Signup → email, Reset → new-password), via `requestAnimationFrame`, respecting Reset's invalid-link disabled state. Covered by `toHaveFocus()` tests.
- **#3648** — Verified: `PasswordInput` already shows a Caps Lock warning (`role="status"`, `getModifierState('CapsLock')`, clears on blur) — present on `main`.
- **#3643** — Signup surfaces a Terms/Privacy agreement line near the submit button and a `LegalLinks` footer for parity with Login.
- **#3638** — Verified: `PasswordInput` already provides an accessible show/hide toggle (`aria-pressed` + `aria-label`) used across Login/Signup/Reset — present on `main`.

Four issues (#3669, #3664, #3648, #3638) were already satisfied on `main` by the earlier `PasswordInput` / `PasswordStrengthMeter` extraction; they are verified here with tests and closed via this PR.

## Testing

- `npm run format:check` + `npx eslint . --max-warnings 0` — clean
- `apps/web` unit tests for the four auth pages + auth components/flows — all passing (new a11y tests added)
- `npm run build` (apps/web) — succeeds

Closes #3720
Closes #3707
Closes #3702
Closes #3679
Closes #3669
Closes #3664
Closes #3656
Closes #3648
Closes #3643
Closes #3638
