### PR TITLE
feat(web): a11y focus management, skip links, and shared primitives

### DIFF
--- a/.github/instructions/web.instructions.md
+++ b/.github/instructions/web.instructions.md
@@ -323,6 +323,32 @@ once and reused, which is what makes announcements reliable (WCAG SC 4.1.3).
 - Route transitions manage focus via `FocusManager`.
 - Escape closes dialogs and modals.
 
+### Focus Management Contract (SC 2.4.3 Focus Order)
+
+Focus placement is centralized so focus order never regresses. All focus moves
+go through one of three primitives — never ad-hoc `element.focus()` in feature
+code. The contract is:
+
+| Event                    | Focus destination                                                                                                                                                                                                      | Owned by                                    |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| **Route change**         | The main content region (`#main-content`), which receives a programmatic `tabindex="-1"` and is announced ("Navigated to …"). Pages may expose a more specific landmark/heading via `FocusManager`'s `targetSelector`. | `FocusManager` + `moveFocusTo`              |
+| **Dialog / modal open**  | The first meaningful field, or an explicit `initialFocusRef` (e.g. the Cancel button on a destructive `ConfirmDialog`). Focus is trapped inside the panel while open.                                                  | `useFocusTrap({ active, initialFocusRef })` |
+| **Dialog / modal close** | The control that invoked the dialog (the element focused immediately before the trap activated).                                                                                                                       | `useFocusTrap({ restoreFocus: true })`      |
+| **Skip link activation** | The targeted landmark (`#main-content` or `#primary-navigation`), which receives `tabindex="-1"` and focus.                                                                                                            | `SkipToContent` / `SkipLinks`               |
+
+Rules:
+
+- Dialogs/modals **must** use `useFocusTrap` with `restoreFocus: true` so
+  closing returns focus to the invoking control. Do not implement bespoke
+  autofocus/restore logic.
+- Landmarks that receive focus programmatically must tolerate `tabindex="-1"`
+  (added automatically by `moveFocusTo` / `SkipToContent` when absent).
+- New route-level focus targets should be wired through `FocusManager` rather
+  than focusing inside page components on mount.
+- Coverage: `FocusManager.test.tsx` asserts route-change focus targets;
+  `useFocusTrap.test.ts` and `focus-management-contract.test.tsx` assert
+  dialog-open trap and dialog-close focus restoration for a representative flow.
+
 ### Labels
 
 - Every form control must have an associated `<label>` with `htmlFor`.

--- a/apps/web/docs/a11y/color-encoding-audit.md
+++ b/apps/web/docs/a11y/color-encoding-audit.md
@@ -1,0 +1,45 @@
+# Color-only encoding audit (WCAG SC 1.4.1 Use of Color)
+
+Scope: shared money/value components and chart legends where financial sign
+(income vs. expense, gains vs. losses) or series identity could be conveyed by
+colour alone. Tracks issue #3623.
+
+SC 1.4.1 (Level A) requires that colour is never the **only** visual means of
+conveying information. For every place we add red/green or a category palette,
+there must be a redundant non-colour cue (text, sign, icon, or pattern).
+
+## Amounts
+
+| Surface / component                                        | Colour cue                                                    | Non-colour cue present? | Notes                                                                                                                                                                                           |
+| ---------------------------------------------------------- | ------------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CurrencyDisplay` (default format)                         | `amount--positive` / `amount--negative` classes + user colour | ✅                      | Negative amounts render a leading `-`; positive amounts have no minus. The presence/absence of the minus sign distinguishes sign without colour.                                                |
+| `CurrencyDisplay` (`negativeFormat: 'parentheses'`)        | red                                                           | ✅                      | Negative amounts are wrapped in `( … )`.                                                                                                                                                        |
+| `CurrencyDisplay` (`negativeFormat: 'color-only'`, legacy) | red                                                           | ✅                      | Rendered with an explicit "Negative …" text prefix (`currency.display.negativeCue`) so colour is never the sole cue.                                                                            |
+| `CurrencyDisplay` (`showSign`)                             | red/green                                                     | ✅                      | Signed deltas (net worth change, income-vs-expense net, transaction summary net) pass `showSign`, forcing an explicit `+`/`-`.                                                                  |
+| `CurrencyDisplay` accessible label                         | —                                                             | ✅                      | `formatCurrencyForScreenReader` always announces "negative" for negatives regardless of the visible format.                                                                                     |
+| `AmountDisplay`                                            | optional `amount--positive/negative`                          | ✅                      | Decorative visual layer (`aria-hidden`); the signed numeric string it renders already carries the `-`/`+` produced by the caller, and the accessible name is provided by the labelled ancestor. |
+
+**Conclusion:** amounts already satisfy SC 1.4.1. The leading minus (or
+parentheses / "Negative" text) is the redundant sign cue; `showSign` is used at
+delta call sites where an explicit `+` improves clarity. No colour-only sign
+encoding remains.
+
+## Chart legends & series
+
+| Chart                                   | Colour cue                  | Non-colour cue present? | Notes                                                                                                                                            |
+| --------------------------------------- | --------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CategoryPieChart`                      | slice fill / legend swatch  | ✅                      | Legend pairs each `aria-hidden` swatch with a visible category **name** and **value**; slices expose `aria-label`s and an accessible data table. |
+| `BudgetDonutChart`                      | slice fill                  | ✅                      | Focusable slices expose `name: value (percent)` labels plus a data-table fallback; centre label is text.                                         |
+| `SpendingBarChart`                      | bar fill (CVD-safe palette) | ✅                      | Category **name** labels + accessible data table; palette chosen for colour-vision deficiency.                                                   |
+| Status badges (`Badge`, toast variants) | variant colour              | ✅                      | Variants render text/icon content; colour is decorative reinforcement.                                                                           |
+
+**Conclusion:** every audited chart pairs its colour with a text label and an
+accessible data-table / `aria-label` fallback. No legend relies on colour alone.
+
+## Follow-ups (tracked separately)
+
+- Manual colour-vision-deficiency (CVD) pass with a simulator across dark / OLED
+  / high-contrast themes to confirm palette distinctness (visual-only, no code
+  change expected).
+- If future category palettes exceed ~8 series, add pattern fills in addition to
+  colour + text for extra redundancy.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
     "@types/react-dom": "^19.1.5",
     "@types/sql.js": "^1.4.11",
     "@vitejs/plugin-react": "5.2.0",
+    "axe-core": "^4.11.4",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
     "nanoid": "^5.1.16",

--- a/apps/web/src/components/common/ConflictResolutionDialog.tsx
+++ b/apps/web/src/components/common/ConflictResolutionDialog.tsx
@@ -20,6 +20,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { getUnresolvedConflicts, resolveConflict, type SyncConflict } from '../../db/sync';
 import { useFocusTrap } from '../../accessibility/aria';
+import { ModalBackdrop } from './ModalBackdrop';
 
 import '../../styles/conflict-resolution.css';
 
@@ -107,7 +108,7 @@ export const ConflictResolutionDialog: React.FC<ConflictResolutionDialogProps> =
   if (!current) return null;
 
   return (
-    <div className="conflict-dialog-overlay" onClick={onClose}>
+    <ModalBackdrop className="conflict-dialog-overlay" onClick={onClose}>
       <div
         ref={dialogRef}
         className="conflict-dialog"
@@ -116,7 +117,6 @@ export const ConflictResolutionDialog: React.FC<ConflictResolutionDialogProps> =
         aria-label={`Resolve sync conflict ${currentIndex + 1} of ${conflicts.length}`}
         tabIndex={-1}
         onKeyDown={handleKeyDown}
-        onClick={(e) => e.stopPropagation()}
       >
         <header className="conflict-dialog__header">
           <h2 className="conflict-dialog__title">Sync Conflict</h2>
@@ -184,7 +184,7 @@ export const ConflictResolutionDialog: React.FC<ConflictResolutionDialogProps> =
           </button>
         </footer>
       </div>
-    </div>
+    </ModalBackdrop>
   );
 };
 

--- a/apps/web/src/components/common/CurrencyDisplay.test.tsx
+++ b/apps/web/src/components/common/CurrencyDisplay.test.tsx
@@ -48,6 +48,8 @@ describe('CurrencyDisplay', () => {
       ),
     );
 
+    // Negative colorized amounts keep a non-color sign cue (leading "-") so
+    // sign is never conveyed by color alone (#3623 / SC 1.4.1).
     expect(screen.getByText('-$25.00')).toHaveClass('amount--negative');
   });
 

--- a/apps/web/src/components/common/CurrencyDisplay.tsx
+++ b/apps/web/src/components/common/CurrencyDisplay.tsx
@@ -48,8 +48,12 @@ export interface CurrencyDisplayProps {
  *
  * Accessibility: legacy `negativeFormat` value `'color-only'` is rendered
  * with a visible "Negative" text cue so information is never conveyed by
- * color alone. The optional `context` prop appends a description
- * (e.g., "Dining category") so amounts announce their meaning.
+ * color alone. Negative amounts always retain a textual sign cue (a leading
+ * `-`, wrapping parentheses, or a "Negative" label) alongside any colour, so
+ * the green/red colour is never the *only* means of distinguishing positive
+ * from negative amounts (WCAG SC 1.4.1 Use of Color). The optional `context`
+ * prop appends a description (e.g., "Dining category") so amounts announce
+ * their meaning.
  */
 export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({
   amount,

--- a/apps/web/src/components/common/ModalBackdrop.test.tsx
+++ b/apps/web/src/components/common/ModalBackdrop.test.tsx
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ModalBackdrop } from './ModalBackdrop';
+
+describe('ModalBackdrop', () => {
+  it('renders children and exposes them to assistive tech (no aria-hidden)', () => {
+    render(
+      <ModalBackdrop>
+        <div role="dialog" aria-label="Example">
+          Panel
+        </div>
+      </ModalBackdrop>,
+    );
+
+    // The dialog child must remain reachable — a wrapper aria-hidden would hide it.
+    expect(screen.getByRole('dialog', { name: 'Example' })).toBeInTheDocument();
+  });
+
+  it('uses role="presentation" and the base class plus any provided class', () => {
+    const { container } = render(
+      <ModalBackdrop className="form-dialog__backdrop">
+        <div>Panel</div>
+      </ModalBackdrop>,
+    );
+
+    const backdrop = container.querySelector('.modal-backdrop');
+    expect(backdrop).not.toBeNull();
+    expect(backdrop).toHaveAttribute('role', 'presentation');
+    expect(backdrop).toHaveClass('form-dialog__backdrop');
+  });
+
+  it('invokes onClick when the backdrop surface itself is clicked', () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <ModalBackdrop onClick={onClick}>
+        <button type="button">Inside</button>
+      </ModalBackdrop>,
+    );
+
+    fireEvent.click(container.querySelector('.modal-backdrop') as HTMLElement);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke onClick when a click originates inside the panel', () => {
+    const onClick = vi.fn();
+    render(
+      <ModalBackdrop onClick={onClick}>
+        <button type="button">Inside</button>
+      </ModalBackdrop>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Inside' }));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/common/ModalBackdrop.tsx
+++ b/apps/web/src/components/common/ModalBackdrop.tsx
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useCallback } from 'react';
+
+export interface ModalBackdropProps {
+  /**
+   * Invoked when the backdrop surface itself is clicked (never when a click
+   * bubbles up from the dialog panel). Typically closes the modal. Because
+   * backdrop-click-to-close is mouse-only, callers MUST still provide
+   * Escape-to-close on the dialog panel for keyboard parity (SC 2.1.1).
+   */
+  onClick?: () => void;
+  /** The dialog panel and any other overlay content. */
+  children: React.ReactNode;
+  /**
+   * Class names appended after the base `modal-backdrop` class — typically the
+   * consumer's positioning/dim overlay class (e.g. `form-dialog__backdrop`).
+   */
+  className?: string;
+}
+
+/**
+ * Shared modal backdrop overlay.
+ *
+ * Provides one consistent, semantically-correct wrapper behind modal dialogs so
+ * the ~20 hand-rolled backdrop `<div>`s across the app stop diverging (some had
+ * no `aria-hidden`, some used `role="presentation"`, #3617):
+ *
+ * - Uses `role="presentation"` because the dialog panel is rendered as a child;
+ *   marking the wrapper `aria-hidden` would incorrectly hide the dialog from
+ *   assistive technology. The child panel carries `role="dialog"` /
+ *   `aria-modal` and its own accessible name.
+ * - Only a click on the backdrop surface itself triggers `onClick`; clicks that
+ *   originate inside the panel are ignored, so consumers no longer need a
+ *   `stopPropagation` handler on the panel.
+ *
+ * WCAG SC 1.3.1 Info and Relationships, SC 2.1.1 Keyboard.
+ */
+export const ModalBackdrop = React.forwardRef<HTMLDivElement, ModalBackdropProps>(
+  function ModalBackdrop({ onClick, children, className }, ref) {
+    const handleClick = useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        if (event.target === event.currentTarget) {
+          onClick?.();
+        }
+      },
+      [onClick],
+    );
+
+    return (
+      <div
+        ref={ref}
+        className={className ? `modal-backdrop ${className}` : 'modal-backdrop'}
+        role="presentation"
+        onClick={handleClick}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+export default ModalBackdrop;

--- a/apps/web/src/components/common/SkipLink.test.tsx
+++ b/apps/web/src/components/common/SkipLink.test.tsx
@@ -1,17 +1,22 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { SkipLink } from './SkipLink';
 
+// SkipLink now delegates to the canonical layout/SkipToContent component
+// (#3600), so these tests assert the shared skip-link contract rather than the
+// former inline-style implementation.
 describe('SkipLink', () => {
-  it('renders with default label', () => {
+  it('renders with default label and target', () => {
     render(<SkipLink />);
 
     const link = screen.getByText('Skip to main content');
     expect(link).toBeInTheDocument();
+    expect(link.tagName).toBe('A');
     expect(link).toHaveAttribute('href', '#main-content');
+    expect(link).toHaveClass('skip-link');
   });
 
   it('renders with custom label and target', () => {
@@ -21,56 +26,37 @@ describe('SkipLink', () => {
     expect(link).toHaveAttribute('href', '#content-area');
   });
 
-  it('is visually hidden until focused', () => {
-    render(<SkipLink />);
-
-    const link = screen.getByText('Skip to main content');
-
-    // Before focus: should be positioned off-screen
-    expect(link.style.top).toBe('-100%');
-  });
-
-  it('becomes visible on focus', () => {
-    render(<SkipLink />);
-
-    const link = screen.getByText('Skip to main content');
-    fireEvent.focus(link);
-
-    expect(link.style.top).toBe('0px');
-  });
-
-  it('hides again on blur', () => {
-    render(<SkipLink />);
-
-    const link = screen.getByText('Skip to main content');
-    fireEvent.focus(link);
-    expect(link.style.top).toBe('0px');
-
-    fireEvent.blur(link);
-    expect(link.style.top).toBe('-100%');
-  });
-
-  it('focuses the target element on click', () => {
+  it('focuses the target element on click and makes it programmatically focusable', () => {
     const target = document.createElement('main');
     target.id = 'main-content';
     document.body.appendChild(target);
-
-    const focusSpy = vi.spyOn(target, 'focus');
 
     render(<SkipLink />);
 
     fireEvent.click(screen.getByText('Skip to main content'));
 
-    expect(focusSpy).toHaveBeenCalled();
+    expect(target).toHaveFocus();
     expect(target.getAttribute('tabindex')).toBe('-1');
 
     document.body.removeChild(target);
   });
 
+  it('moves focus to a custom target on Enter', () => {
+    render(
+      <>
+        <SkipLink targetId="content-area" />
+        <div id="content-area">Content</div>
+      </>,
+    );
+
+    fireEvent.keyDown(screen.getByText('Skip to main content'), { key: 'Enter' });
+
+    expect(document.getElementById('content-area')).toHaveFocus();
+  });
+
   it('is an anchor element for keyboard accessibility', () => {
     render(<SkipLink />);
 
-    const link = screen.getByText('Skip to main content');
-    expect(link.tagName).toBe('A');
+    expect(screen.getByText('Skip to main content').tagName).toBe('A');
   });
 });

--- a/apps/web/src/components/common/SkipLink.tsx
+++ b/apps/web/src/components/common/SkipLink.tsx
@@ -1,94 +1,23 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * SkipLink — Skip to main content link for keyboard navigation.
+ * SkipLink — canonical skip link (delegates to {@link SkipToContent}).
  *
- * Provides a visually hidden link that becomes visible on focus, allowing
- * keyboard users to skip past navigation and jump directly to the main content.
- * This is a WCAG 2.2 AA requirement (SC 2.4.1 Bypass Blocks).
+ * Historically this component maintained its own inline-style + React-state
+ * implementation, which diverged from `layout/SkipToContent` (the one actually
+ * rendered by the shell). To keep a single source of truth for skip-link
+ * behavior and styling (WCAG SC 2.4.1 Bypass Blocks), it now re-exports the
+ * canonical component. The visually-hidden-until-focused behavior is provided
+ * by the shared `.skip-link` CSS class (see styles/accessibility.css).
  *
  * @module components/common/SkipLink
- * References: issue #1341
+ * References: issue #1341, #3600
  */
 
-import React, { useCallback } from 'react';
+import { SkipToContent, type SkipToContentProps } from '../layout/SkipToContent';
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+export type SkipLinkProps = SkipToContentProps;
 
-export interface SkipLinkProps {
-  /** The ID of the main content element to skip to. Defaults to 'main-content'. */
-  targetId?: string;
+export const SkipLink = SkipToContent;
 
-  /** The visible text for the skip link. Defaults to 'Skip to main content'. */
-  label?: string;
-}
-
-// ---------------------------------------------------------------------------
-// Inline styles (CSP-safe — no inline scripts, styles are React CSSProperties)
-// ---------------------------------------------------------------------------
-
-const skipLinkStyles: React.CSSProperties = {
-  position: 'absolute',
-  top: '-100%',
-  left: '16px',
-  zIndex: 10000,
-  padding: '8px 16px',
-  backgroundColor: 'var(--semantic-interactive-default, #2563eb)',
-  color: 'var(--color-white, #fff)',
-  textDecoration: 'none',
-  fontWeight: 600,
-  fontSize: '0.875rem',
-  borderRadius: '0 0 8px 8px',
-  transition: 'top 0.15s ease',
-};
-
-const skipLinkFocusStyles: React.CSSProperties = {
-  ...skipLinkStyles,
-  top: '0',
-};
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
-
-/**
- * Accessible skip-to-main-content link.
- *
- * Renders a link that is hidden off-screen until focused via Tab.
- * On activation, focuses the target element for immediate keyboard access.
- */
-export const SkipLink: React.FC<SkipLinkProps> = ({
-  targetId = 'main-content',
-  label = 'Skip to main content',
-}) => {
-  const [isFocused, setIsFocused] = React.useState(false);
-
-  const handleClick = useCallback(
-    (e: React.MouseEvent<HTMLAnchorElement>) => {
-      e.preventDefault();
-      const target = document.getElementById(targetId);
-      if (target) {
-        target.setAttribute('tabindex', '-1');
-        target.focus();
-        // Remove the tabindex after focus so it doesn't persist
-        target.addEventListener('blur', () => target.removeAttribute('tabindex'), { once: true });
-      }
-    },
-    [targetId],
-  );
-
-  return (
-    <a
-      href={`#${targetId}`}
-      className="skip-link"
-      style={isFocused ? skipLinkFocusStyles : skipLinkStyles}
-      onClick={handleClick}
-      onFocus={() => setIsFocused(true)}
-      onBlur={() => setIsFocused(false)}
-    >
-      {label}
-    </a>
-  );
-};
+export default SkipLink;

--- a/apps/web/src/components/common/a11y.axe.test.tsx
+++ b/apps/web/src/components/common/a11y.axe.test.tsx
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Accessibility regression tests (#3628).
+ *
+ * Renders the shared, presentational a11y primitives and asserts that
+ * axe-core reports zero WCAG violations. These act as a safety net so future
+ * changes to the shared component library cannot silently regress core
+ * accessibility semantics (labels, roles, name/role/value).
+ */
+
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+import { describe, it } from 'vitest';
+
+import { expectNoAxeViolations } from '../../test-utils/axe';
+import { Button } from './Button';
+import { Checkbox } from './Checkbox';
+import { EmptyState } from './EmptyState';
+import { ModalBackdrop } from './ModalBackdrop';
+import { VisuallyHidden } from './VisuallyHidden';
+
+describe('shared component accessibility (axe-core)', () => {
+  it('Button has no axe violations', async () => {
+    const { container } = render(createElement(Button, { children: 'Save changes' }));
+    await expectNoAxeViolations(container);
+  });
+
+  it('destructive Button has no axe violations', async () => {
+    const { container } = render(
+      createElement(Button, { variant: 'destructive', children: 'Delete account' }),
+    );
+    await expectNoAxeViolations(container);
+  });
+
+  it('Checkbox with a visible label has no axe violations', async () => {
+    const { container } = render(
+      createElement(Checkbox, { label: 'Enable auto-pay', defaultChecked: true }),
+    );
+    await expectNoAxeViolations(container);
+  });
+
+  it('EmptyState has no axe violations', async () => {
+    const { container } = render(
+      createElement(EmptyState, {
+        title: 'No transactions yet',
+        description: 'Once you add an account your transactions will appear here.',
+      }),
+    );
+    await expectNoAxeViolations(container);
+  });
+
+  it('ModalBackdrop wrapping a dialog has no axe violations', async () => {
+    const { container } = render(
+      createElement(
+        ModalBackdrop,
+        null,
+        createElement(
+          'div',
+          { role: 'dialog', 'aria-label': 'Example dialog' },
+          createElement('p', null, 'Dialog body content.'),
+        ),
+      ),
+    );
+    await expectNoAxeViolations(container);
+  });
+
+  it('VisuallyHidden content has no axe violations', async () => {
+    const { container } = render(
+      createElement(
+        'div',
+        null,
+        createElement(VisuallyHidden, null, 'Screen-reader only context'),
+        createElement('span', { 'aria-hidden': true }, 'Visible glyph'),
+      ),
+    );
+    await expectNoAxeViolations(container);
+  });
+});

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -50,6 +50,8 @@ export { SyncStatusPanel } from './SyncStatusPanel';
 export { UpdateBanner } from './UpdateBanner';
 export { SkipLink } from './SkipLink';
 export type { SkipLinkProps } from './SkipLink';
+export { ModalBackdrop } from './ModalBackdrop';
+export type { ModalBackdropProps } from './ModalBackdrop';
 export { SortableList } from './SortableList';
 export type {
   SortableListProps,

--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -263,6 +263,19 @@ describe('AppLayout', () => {
     const shortcutsButton = screen.getByRole('button', { name: 'Keyboard shortcuts' });
     expect(shortcutsButton).toBeInTheDocument();
     expect(shortcutsButton).toHaveAttribute('aria-keyshortcuts', 'Shift+/');
+    // The "?" text glyph was replaced with a real keyboard SVG icon (#3619).
+    expect(shortcutsButton.querySelector('svg')).not.toBeNull();
+    expect(shortcutsButton.textContent).not.toContain('?');
+  });
+
+  it('renders a Command palette button with a real icon in the header (#3619)', () => {
+    renderLayout();
+
+    const commandButton = screen.getByRole('button', { name: 'Command palette' });
+    expect(commandButton).toBeInTheDocument();
+    // The "⌘K" text glyph was replaced with a real SVG icon.
+    expect(commandButton.querySelector('svg')).not.toBeNull();
+    expect(commandButton.textContent).not.toContain('⌘K');
   });
 
   it('opens keyboard shortcuts modal when the header button is clicked', () => {

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -25,11 +25,13 @@ import { BottomNavigation, SidebarNavigation } from './Navigation';
 import { getVisibleNavItems } from './navConfig';
 import { InstallBanner } from '../common/InstallBanner';
 import { SampleDataBanner } from '../common/SampleDataBanner';
+import { Icon } from '../common/Icon';
+import { IconToken } from '../../icons/tokens';
 import { LegalLinks } from '../legal/LegalLinks';
 import { Breadcrumbs, NavShortcuts, buildNavShortcutCategory } from '../navigation';
 
-import { SkipToContent } from './SkipToContent';
-import { EyeIcon, EyeOffIcon } from './navIcons';
+import { SkipLinks } from './SkipLinks';
+import { EyeIcon, EyeOffIcon, KeyboardIcon } from './navIcons';
 
 export interface AppLayoutProps {
   activePath: string;
@@ -234,7 +236,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
 
   return (
     <div className="app-layout">
-      <SkipToContent />
+      <SkipLinks />
       <SidebarNavigation
         activePath={activePath}
         onNavigate={onNavigate}
@@ -322,9 +324,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
                 aria-keyshortcuts="Shift+/"
                 onClick={openKeyboardShortcuts}
               >
-                <span className="icon-button__glyph" aria-hidden="true">
-                  ?
-                </span>
+                <KeyboardIcon />
               </button>
             ) : null}
             <button
@@ -334,9 +334,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
               aria-keyshortcuts="Control+K Meta+K /"
               onClick={openCommandPalette}
             >
-              <span className="icon-button__glyph" aria-hidden="true">
-                ⌘K
-              </span>
+              <Icon name={IconToken.SEARCH} size={20} />
             </button>
             <button
               type="button"

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -410,7 +410,7 @@ export const SidebarNavigation: React.FC<SidebarNavigationProps> = ({
         <span className="app-sidebar__logo">Finance</span>
       </div>
 
-      <nav className="app-sidebar__nav" aria-label="Primary">
+      <nav className="app-sidebar__nav" aria-label="Primary" id="primary-navigation" tabIndex={-1}>
         {/* Pinned destinations (Dashboard) */}
         <ul className="sidebar-nav__list" role="list">
           {pinnedItems.map((item) => {

--- a/apps/web/src/components/layout/SkipLinks.test.tsx
+++ b/apps/web/src/components/layout/SkipLinks.test.tsx
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { SkipLinks } from './SkipLinks';
+
+describe('SkipLinks', () => {
+  it('renders both a skip-to-content and a skip-to-navigation link', () => {
+    render(<SkipLinks />);
+
+    expect(screen.getByRole('link', { name: 'Skip to main content' })).toHaveAttribute(
+      'href',
+      '#main-content',
+    );
+    expect(screen.getByRole('link', { name: 'Skip to navigation' })).toHaveAttribute(
+      'href',
+      '#primary-navigation',
+    );
+  });
+
+  it('moves focus to #main-content when activating Skip to main content', () => {
+    render(
+      <>
+        <SkipLinks />
+        <main id="main-content" tabIndex={-1}>
+          <button type="button">Main action</button>
+        </main>
+      </>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Skip to main content' }));
+
+    expect(screen.getByRole('main')).toHaveFocus();
+  });
+
+  it('moves focus to the primary navigation landmark when activating Skip to navigation', () => {
+    render(
+      <>
+        <SkipLinks />
+        <nav id="primary-navigation" aria-label="Primary" tabIndex={-1}>
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+      </>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Skip to navigation' }));
+
+    expect(screen.getByRole('navigation', { name: 'Primary' })).toHaveFocus();
+  });
+
+  it('falls back to the bottom navigation landmark when the sidebar id is absent', () => {
+    render(
+      <>
+        <SkipLinks />
+        <nav className="bottom-nav" aria-label="Main navigation">
+          <button type="button">Home</button>
+        </nav>
+      </>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Skip to navigation' }));
+
+    const bottomNav = screen.getByRole('navigation', { name: 'Main navigation' });
+    expect(bottomNav).toHaveFocus();
+    expect(bottomNav).toHaveAttribute('tabindex', '-1');
+  });
+});

--- a/apps/web/src/components/layout/SkipLinks.tsx
+++ b/apps/web/src/components/layout/SkipLinks.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { type FC } from 'react';
+
+import { SkipToContent } from './SkipToContent';
+
+/**
+ * Selector matching the primary navigation landmark across layouts. The desktop
+ * sidebar `<nav aria-label="Primary" id="primary-navigation">` carries the id;
+ * the mobile bottom bar is matched by class since only one is visible at a time.
+ */
+const PRIMARY_NAV_SELECTOR = '#primary-navigation, nav.bottom-nav';
+
+/**
+ * Resolve the primary navigation landmark that is currently visible. On desktop
+ * this is the sidebar; on mobile the sidebar is hidden and the bottom nav is
+ * used instead. Falls back to the first match when visibility can't be
+ * determined (e.g. jsdom, where `offsetParent` is always null).
+ */
+function resolvePrimaryNav(): HTMLElement | null {
+  if (typeof document === 'undefined') return null;
+  const candidates = Array.from(document.querySelectorAll<HTMLElement>(PRIMARY_NAV_SELECTOR));
+  return candidates.find((el) => el.offsetParent !== null) ?? candidates[0] ?? null;
+}
+
+/**
+ * Bypass-block skip links rendered at the very top of the shell (SC 2.4.1).
+ *
+ * Renders a paired "Skip to content" + "Skip to navigation" so keyboard and
+ * screen-reader users can jump either past the navigation (to `#main-content`)
+ * or straight to the primary navigation landmark. The `.skip-links` container
+ * reveals both links together on the first Tab.
+ */
+export const SkipLinks: FC = () => (
+  <div className="skip-links">
+    <SkipToContent targetId="main-content" label="Skip to main content" />
+    <SkipToContent
+      targetId="primary-navigation"
+      label="Skip to navigation"
+      resolveTarget={resolvePrimaryNav}
+    />
+  </div>
+);
+
+export default SkipLinks;

--- a/apps/web/src/components/layout/SkipToContent.tsx
+++ b/apps/web/src/components/layout/SkipToContent.tsx
@@ -5,14 +5,25 @@ import { type FC, type KeyboardEvent, useCallback } from 'react';
 export interface SkipToContentProps {
   targetId?: string;
   label?: string;
+  /**
+   * Optional custom resolver for the focus target. When provided it takes
+   * precedence over `targetId`, letting a single skip link point at whichever
+   * landmark is currently visible (e.g. the desktop sidebar vs. the mobile
+   * bottom navigation). Return `null` to fall back to the `targetId` lookup.
+   */
+  resolveTarget?: () => HTMLElement | null;
 }
 
 export const SkipToContent: FC<SkipToContentProps> = ({
   targetId = 'main-content',
   label = 'Skip to main content',
+  resolveTarget,
 }) => {
   const moveFocusToTarget = useCallback(() => {
-    const target = document.getElementById(targetId) ?? document.querySelector<HTMLElement>('main');
+    const target =
+      resolveTarget?.() ??
+      document.getElementById(targetId) ??
+      document.querySelector<HTMLElement>('main');
 
     if (!target) return;
 
@@ -21,7 +32,7 @@ export const SkipToContent: FC<SkipToContentProps> = ({
     }
 
     target.focus();
-  }, [targetId]);
+  }, [resolveTarget, targetId]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLAnchorElement>) => {

--- a/apps/web/src/components/layout/focus-management-contract.test.tsx
+++ b/apps/web/src/components/layout/focus-management-contract.test.tsx
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Representative focus-management contract test (#3631, WCAG SC 2.4.3).
+ *
+ * Exercises the documented "dialog close → invoking control" leg of the focus
+ * contract end to end with the real `useFocusTrap` implementation (not mocked),
+ * complementing `FocusManager.test.tsx` (route change) and
+ * `useFocusTrap.test.ts` (hook-level unit coverage).
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { ConfirmDialog } from '../common/ConfirmDialog';
+
+/**
+ * Minimal flow matching the contract: an invoking control opens a dialog, and
+ * closing the dialog must return focus to that control.
+ */
+function DialogFlow() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open dialog
+      </button>
+      <ConfirmDialog
+        isOpen={open}
+        title="Delete account?"
+        message="This action cannot be undone."
+        onConfirm={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
+describe('focus-management contract (#3631, SC 2.4.3)', () => {
+  it('moves focus into the dialog on open and restores it to the invoker on close', () => {
+    render(<DialogFlow />);
+
+    const opener = screen.getByRole('button', { name: 'Open dialog' });
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    // Open: focus is trapped and lands on the Cancel control (initialFocusRef).
+    fireEvent.click(opener);
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+    expect(document.activeElement).toBe(cancel);
+
+    // Close: focus returns to the invoking control.
+    fireEvent.click(cancel);
+    expect(document.activeElement).toBe(opener);
+  });
+});

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -18,6 +18,9 @@ export {
 export type { NavConfigItem, NavGroup } from './navConfig';
 export { MoreNavSheet } from './MoreNavSheet';
 export type { MoreNavSheetProps } from './MoreNavSheet';
+export { SkipToContent } from './SkipToContent';
+export type { SkipToContentProps } from './SkipToContent';
+export { SkipLinks } from './SkipLinks';
 export {
   ResponsiveContainer,
   ResponsiveGrid,

--- a/apps/web/src/components/recommendations/RecommendationDetail.tsx
+++ b/apps/web/src/components/recommendations/RecommendationDetail.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { CurrencyDisplay } from '../common/CurrencyDisplay';
+import { ModalBackdrop } from '../common/ModalBackdrop';
 import { AppIcon } from '../icons';
 import { useFocusTrap } from '../../accessibility/aria';
 import type { PersonalizedRecommendation } from '../../lib/recommendations';
@@ -74,14 +75,13 @@ export const RecommendationDetail: React.FC<RecommendationDetailProps> = ({
   }
 
   return (
-    <div className="recommendation-detail__backdrop" role="presentation" onClick={onClose}>
+    <ModalBackdrop className="recommendation-detail__backdrop" onClick={onClose}>
       <section
         ref={dialogRef}
         className="recommendation-detail"
         role="dialog"
         aria-modal="true"
         aria-labelledby="recommendation-detail-title"
-        onClick={(event) => event.stopPropagation()}
         onKeyDown={handleKeyDown}
       >
         <div className="recommendation-detail__header">
@@ -174,6 +174,6 @@ export const RecommendationDetail: React.FC<RecommendationDetailProps> = ({
           </button>
         </div>
       </section>
-    </div>
+    </ModalBackdrop>
   );
 };

--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -618,6 +618,44 @@ describe('TransactionsPage', () => {
     expect(resultsTarget).toHaveAttribute('id', 'transaction-results');
   });
 
+  it('shows a visible, live result count near the results region (#3634)', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    );
+
+    // Default fixture renders 3 transactions; the count is visible (not sr-only)
+    // and exposed to assistive tech via role="status" + aria-live.
+    const count = container.querySelector('.transaction-results-header__count');
+    expect(count).not.toBeNull();
+    expect(count?.textContent).toBe('3 transactions');
+    expect(count).not.toHaveClass('sr-only');
+    expect(count).toHaveAttribute('role', 'status');
+    expect(count).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('uses singular wording for a single matching transaction (#3634)', () => {
+    mockedUseTransactions.mockReturnValue({
+      transactions: [makeTransaction(1)],
+      loading: false,
+      error: null,
+      refresh: refreshTransactionsMock,
+      createTransaction: createTransactionMock,
+      updateTransaction: updateTransactionMock,
+      deleteTransaction: deleteTransactionMock,
+    });
+
+    const { container } = render(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    );
+
+    const count = container.querySelector('.transaction-results-header__count');
+    expect(count?.textContent).toBe('1 transaction');
+  });
+
   it('displays filter and sort controls', () => {
     render(
       <MemoryRouter>

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -1444,15 +1444,6 @@ export const TransactionsPage: React.FC = () => {
               </button>
             )}
           </div>
-          {hasActiveFilters && !isLoading && !resolvedError && (
-            <p className="sr-only" role="status" aria-live="polite">
-              {transactions.length === 0
-                ? 'No transactions match the current search and filters'
-                : `${transactions.length} transaction${
-                    transactions.length === 1 ? '' : 's'
-                  } match the current search and filters`}
-            </p>
-          )}
 
           {/* Filter/Sort controls */}
           {!isSimplified ? (
@@ -1535,9 +1526,19 @@ export const TransactionsPage: React.FC = () => {
             </div>
           </section>
 
-          <h2 id="transaction-results" className="sr-only">
-            Transaction results
-          </h2>
+          <div className="transaction-results-header">
+            <h2 id="transaction-results" className="transaction-results-header__title">
+              Transaction results
+            </h2>
+            {!isLoading && !resolvedError && (transactions.length > 0 || hasActiveFilters) ? (
+              <p className="transaction-results-header__count" role="status" aria-live="polite">
+                {transactions.length === 1
+                  ? '1 transaction'
+                  : `${transactions.length.toLocaleString()} transactions`}
+                {hasActiveFilters ? ' match your filters' : ''}
+              </p>
+            ) : null}
+          </div>
 
           {!isLoading && !resolvedError && transactions.length > 0 && (
             <TransactionsSummaryBar summary={transactionsSummary} />

--- a/apps/web/src/styles/accessibility.css
+++ b/apps/web/src/styles/accessibility.css
@@ -32,10 +32,10 @@
  * Uses :focus-visible to avoid showing focus on mouse clicks.
  * ------------------------------------------------------------------- */
 
-/* Base focus-visible ring */
+/* Base focus-visible ring — consumes the shared focus-ring tokens (#3609). */
 :focus-visible {
-  outline: 2px solid var(--semantic-border-focus, #3b82f6);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 /* Enhanced focus for buttons and links */
@@ -48,8 +48,8 @@ a:focus-visible,
 select:focus-visible,
 input:focus-visible,
 textarea:focus-visible {
-  outline: 2px solid var(--semantic-border-focus, #3b82f6);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
   border-radius: inherit;
 }
 
@@ -57,15 +57,23 @@ textarea:focus-visible {
 [role='listbox']:focus-within,
 [role='menu']:focus-within,
 [role='tablist']:focus-within {
-  outline: 2px solid var(--semantic-border-focus, #3b82f6);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 /* High contrast mode: stronger focus indicators */
 @media (prefers-contrast: more) {
+  :root {
+    /* Width bump is centralised in tokens.css; override color to the system
+       Highlight so the ring tracks the user's high-contrast palette. */
+    --focus-ring-color: Highlight;
+  }
+
+  /* Guarantee the SC 2.4.13 focus area (>=3px perimeter, >=2px offset) under
+     increased-contrast preferences, independent of token propagation. */
   :focus-visible {
     outline-width: 3px;
-    outline-color: Highlight;
+    outline-offset: 3px;
   }
 
   /* Secondary buttons need visible borders (transparent bg otherwise invisible) */
@@ -233,8 +241,8 @@ input[type='radio'] {
 }
 
 .icon-button:focus-visible {
-  outline: 2px solid var(--semantic-border-focus, #3b82f6);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 /* Warning variant for conflict badge */
@@ -262,7 +270,12 @@ input[type='radio'] {
 }
 
 /* -------------------------------------------------------------------
- * 3. Skip Navigation Link Enhancement
+ * 3. Skip Navigation Links (SC 2.4.1 Bypass Blocks)
+ *
+ * Canonical, single-source-of-truth styling for skip links. A single skip
+ * link is visually hidden until focused. When grouped inside a `.skip-links`
+ * container (Skip to content + Skip to navigation), the first Tab reveals the
+ * whole group together so users can pick either bypass target (#3600, #3647).
  * ------------------------------------------------------------------- */
 
 .skip-link {
@@ -281,6 +294,32 @@ input[type='radio'] {
 
 .skip-link:focus {
   top: var(--spacing-2, 8px);
+}
+
+/* Grouped skip links: absolutely positioned container at the top-left. Its
+   children stay off-screen until any one is focused, at which point the whole
+   group slides on-screen as a horizontal row (both links visible together). */
+.skip-links {
+  position: absolute;
+  top: var(--spacing-2, 8px);
+  left: var(--spacing-4, 16px);
+  z-index: 10000;
+}
+
+.skip-links .skip-link {
+  position: absolute;
+  top: -100%;
+  left: 0;
+}
+
+.skip-links:focus-within {
+  display: flex;
+  gap: var(--spacing-2, 8px);
+}
+
+.skip-links:focus-within .skip-link {
+  position: static;
+  top: auto;
 }
 
 /* -------------------------------------------------------------------
@@ -325,29 +364,27 @@ html[data-reduced-motion='true'] *::after {
 
 /* -------------------------------------------------------------------
  * 6. Dark mode focus adjustments
+ *
+ * Per-theme focus color is now centralised on the --focus-ring-color token
+ * in tokens.css (dark / dark-oled / prefers-color-scheme). These rules are
+ * intentionally left as token consumers only — no direct outline overrides.
  * ------------------------------------------------------------------- */
-
-@media (prefers-color-scheme: dark) {
-  html:not([data-theme='light']) :focus-visible {
-    outline-color: var(--color-blue-400, #60a5fa);
-  }
-}
-
-[data-theme='dark'] :focus-visible {
-  outline-color: var(--color-blue-400, #60a5fa);
-}
 
 /* -------------------------------------------------------------------
  * 7. High-contrast theme focus and component adjustments
  *
  * When [data-theme="high-contrast"] is explicitly set (via toggle),
  * apply component-level enhancements beyond what the semantic token
- * overrides provide.
+ * overrides provide. Focus ring color for high-contrast is owned by
+ * tokens.css; the explicit rule below guarantees the SC 2.4.13 focus area
+ * (>=3px) for the toggled theme and keeps the guarantee co-located with the
+ * other high-contrast component rules.
  * ------------------------------------------------------------------- */
 
 [data-theme='high-contrast'] :focus-visible {
   outline-width: 3px;
-  outline-color: var(--color-blue-800, #1e40af);
+  outline-offset: 3px;
+  outline-color: var(--focus-ring-color);
 }
 
 [data-theme='high-contrast'] button,
@@ -472,10 +509,10 @@ body.accessibility-simplified .more-sheet__panel {
   box-shadow: none;
 }
 
-body.accessibility-simplified :focus-visible,
-body.accessibility-high-contrast :focus-visible {
-  outline-width: 3px;
-  outline-offset: 3px;
+body.accessibility-simplified,
+body.accessibility-high-contrast {
+  --focus-ring-width: 3px;
+  --focus-ring-offset: 3px;
 }
 
 body.accessibility-simplified button,

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -7,21 +7,8 @@
   --layout-card-gap: var(--spacing-4);
   --layout-grid-min-col: 280px;
 }
-.skip-link {
-  position: absolute;
-  top: -100%;
-  left: var(--spacing-4);
-  z-index: 1000;
-  padding: var(--spacing-2) var(--spacing-4);
-  background: var(--semantic-interactive-default);
-  color: var(--semantic-text-inverse);
-  border-radius: var(--border-radius-md);
-  font-weight: var(--font-weight-semibold);
-  text-decoration: none;
-}
-.skip-link:focus {
-  top: var(--spacing-2);
-}
+/* NOTE: `.skip-link` styling lives solely in styles/accessibility.css — the
+   single source of truth (#3600). Do not redefine it here. */
 .app-layout {
   display: flex;
   flex-direction: column;
@@ -672,8 +659,8 @@
   color: var(--semantic-status-negative);
 }
 .icon-button:focus-visible {
-  outline: 2px solid var(--semantic-border-focus);
-  outline-offset: 2px;
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
 }
 .icon-button svg {
   width: 20px;
@@ -685,16 +672,35 @@
   stroke-linejoin: round;
 }
 
-.icon-button__glyph {
-  font-size: 1rem;
-  font-weight: var(--font-weight-bold);
-  line-height: 1;
-}
 .amount--positive {
   color: var(--semantic-amount-positive);
 }
 .amount--negative {
   color: var(--semantic-amount-negative);
+}
+
+/* Visible transaction result count (#3634). Shares one aria-live source of
+   truth with assistive tech instead of a screen-reader-only status line. */
+.transaction-results-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
+  margin-block: var(--spacing-4) var(--spacing-2);
+}
+.transaction-results-header__title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+}
+.transaction-results-header__count {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-secondary);
+  font-variant-numeric: tabular-nums;
 }
 .settings-group {
   --settings-card-gutter: var(--card-padding);

--- a/apps/web/src/test-utils/axe.ts
+++ b/apps/web/src/test-utils/axe.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Lightweight axe-core harness for Vitest + jsdom.
+ *
+ * We drive `axe-core` directly (already available in the workspace via the
+ * Storybook a11y addon and declared as an explicit devDependency) rather than
+ * pulling in a wrapper library. This keeps the regression tests dependency-light
+ * while still asserting zero WCAG violations on rendered shared components.
+ *
+ * jsdom does not perform layout, so rules that require computed geometry or
+ * real colour rendering (e.g. `color-contrast`) cannot run meaningfully and are
+ * disabled here. Contrast is covered separately by the design token audits and
+ * manual/E2E checks.
+ */
+
+import axe, { type RunOptions, type Result } from 'axe-core';
+
+const DEFAULT_OPTIONS: RunOptions = {
+  rules: {
+    // Requires real layout/painting which jsdom does not provide.
+    'color-contrast': { enabled: false },
+  },
+};
+
+function formatViolations(violations: Result[]): string {
+  return violations
+    .map((violation) => {
+      const targets = violation.nodes.map((node) => `    - ${node.target.join(' ')}`).join('\n');
+      return `  • [${violation.id}] ${violation.help} (${violation.impact ?? 'n/a'})\n${targets}`;
+    })
+    .join('\n');
+}
+
+/**
+ * Runs axe-core against a DOM subtree and throws a readable error if any
+ * accessibility violations are found.
+ */
+export async function expectNoAxeViolations(
+  container: Element,
+  options: RunOptions = {},
+): Promise<void> {
+  const results = await axe.run(container, { ...DEFAULT_OPTIONS, ...options });
+
+  if (results.violations.length > 0) {
+    throw new Error(
+      `Expected no axe-core accessibility violations but found ${results.violations.length}:\n${formatViolations(
+        results.violations,
+      )}`,
+    );
+  }
+}

--- a/apps/web/src/theme/tokens.css
+++ b/apps/web/src/theme/tokens.css
@@ -65,6 +65,57 @@
 @import './finance-overlay.css';
 
 /*
+ * Focus-ring design tokens (SC 2.4.7 Focus Visible, 2.4.11 Focus Not Obscured,
+ * 2.4.13 Focus Appearance).
+ *
+ * Single source of truth for the keyboard focus indicator so its width, offset,
+ * and color can be tuned per-theme in ONE place instead of being hardcoded
+ * across tokens.css / accessibility.css / component rules (#3609). The default
+ * 2px width + 2px offset satisfy the SC 2.4.13 minimum-area requirement
+ * (a >=2 CSS-px perimeter), and each theme overrides --focus-ring-color to keep
+ * >=3:1 contrast against adjacent surface tokens (#3610). High-contrast bumps
+ * the width to 3px for extra emphasis.
+ *
+ * Consume via the individual parts (recommended, so outline-offset can be set)
+ * or the composed `--focus-ring` shorthand:
+ *   outline: var(--focus-ring-width) solid var(--focus-ring-color);
+ *   outline-offset: var(--focus-ring-offset);
+ */
+:root {
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 2px;
+  --focus-ring-color: var(--semantic-border-focus, #2563eb);
+  --focus-ring: var(--focus-ring-width) solid var(--focus-ring-color);
+}
+
+/* Dark themes: brighten the ring so it clears 3:1 against dark surfaces. */
+[data-theme='dark'],
+[data-theme='dark-oled'] {
+  --focus-ring-color: var(--color-blue-400, #60a5fa);
+}
+
+/* High-contrast: thicker ring + deep-blue color for maximum separation. */
+[data-theme='high-contrast'] {
+  --focus-ring-width: 3px;
+  --focus-ring-offset: 3px;
+  --focus-ring-color: var(--color-blue-800, #1e40af);
+}
+
+/* Auto dark mode (no explicit [data-theme]) mirrors the dark override. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --focus-ring-color: var(--color-blue-400, #60a5fa);
+  }
+}
+
+/* Users requesting more contrast get a thicker ring across all themes. */
+@media (prefers-contrast: more) {
+  :root {
+    --focus-ring-width: 3px;
+  }
+}
+
+/*
  * Auto-switching for prefers-color-scheme / prefers-contrast is intentionally
  * NOT defined here: the shared @jrm/tokens barrel (imported above) owns it via
  * `:root:not([data-theme])` @media blocks. Finance's previous hand-written
@@ -133,9 +184,11 @@ body {
 }
 
 /*
- * Focus styles - visible outline for keyboard navigation (WCAG 2.4.7).
+ * Focus styles - visible outline for keyboard navigation (WCAG 2.4.7, 2.4.13).
+ * Consumes the shared focus-ring tokens defined above so width/offset/color
+ * stay tunable per-theme in one place.
  */
 :focus-visible {
-  outline: 2px solid var(--semantic-border-focus);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,236 @@
         "vitest": "^4.1.10"
       }
     },
+    "apps/web/node_modules/@fluentui/react-icons": {
+      "version": "2.0.330",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.330.tgz",
+      "integrity": "sha512-IaJjO755FGlUR5Myy1IuhJKlqGPfET9JqGpotoanJm1W1sK2rELRv8L3i2UAiZ70TSvi6KAi5t4M0inqI/h9Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.6.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <20.0.0"
+      }
+    },
+    "apps/web/node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/web/node_modules/@sentry/browser": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.59.0.tgz",
+      "integrity": "sha512-d0o0oc78KNWCZ6yq9gREf9BPXWza/Wj9W+nCm0CvPD5k2IbouD/eJsm2Mb+d53YfEm12L+SePfgOx01KbbVx4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.59.0",
+        "@sentry/core": "10.59.0",
+        "@sentry/feedback": "10.59.0",
+        "@sentry/replay": "10.59.0",
+        "@sentry/replay-canvas": "10.59.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/web/node_modules/@sentry/core": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
+      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/web/node_modules/@sentry/react": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.59.0.tgz",
+      "integrity": "sha512-B3MmXooGLnTu0gyL8hxElCu1+WVEXjIGoDPvGqn5qMHZNSmB2oPTAt1/UutuxAc6EWu2UKIHnyPowNeY2MPH3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.59.0",
+        "@sentry/core": "10.59.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "apps/web/node_modules/@storybook/addon-a11y": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.2.tgz",
+      "integrity": "sha512-9Bm41peswHVPXm8iDBEA/sCXx+MUQV8Q10yFgNC2zTbtxKamMDb8HZCPIRDxvjBQ5v13eaXA2yZGTwQ+D8S6+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.4.2"
+      }
+    },
+    "apps/web/node_modules/@storybook/builder-vite": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.2.tgz",
+      "integrity": "sha512-d3+i9vbbUfV6hvT90qabmy1WmC4bEJ7iAYDm0217doeA+S6awF25GF0qOy9gN9waU4NMntHoVpdB1YQO2wUj/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "10.4.2",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.4.2",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "apps/web/node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.2.tgz",
+      "integrity": "sha512-GqX/2DeF3/jKs5D7gpDiuT9gd0c/f2TKcnQ5av4/s3YqeN+0nhm7btkCrDfgF16uzE1Zj3OrkxvB3AOkfxWgDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^2.3.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "esbuild": "*",
+        "rollup": "*",
+        "storybook": "^10.4.2",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@storybook/react": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.2.tgz",
+      "integrity": "sha512-NfEH3CrdCAgUV4Z7SPN3Iw6nofcueqtRj8iHuo77GNjz0qSfuVi9iS7a8o7x7QFSeIBZwS0Jv3CgmhN8qvoLjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "10.4.2",
+        "react-docgen": "^8.0.2",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.2",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@storybook/react-dom-shim": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.2.tgz",
+      "integrity": "sha512-Eng3Yt2NCjPX94QcfyLeUFhrMj0hec2yU9J/qafBVbfj9XrFI8o+0ZwYJ7uXb9ECbvPN4y06dgt/2W/LiR417w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@storybook/react-vite": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.4.2.tgz",
+      "integrity": "sha512-nGrS74p0ujPSQ7qD5jKLLlao2igfTTb6Kf/uRhVV8XM0uM7WvxR9K20ddCM8jFmx1jY9fRm0UBGaeaXHDIh5SA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "10.4.2",
+        "@storybook/react": "10.4.2",
+        "empathic": "^2.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^8.0.0",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.2",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "apps/web/node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -82,6 +312,121 @@
         "csstype": "^3.2.2"
       }
     },
+    "apps/web/node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/chai": {
+      "version": "6.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/web/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "apps/web/node_modules/immer": {
       "version": "11.1.11",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
@@ -90,6 +435,96 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "apps/web/node_modules/lucide-react": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
+      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "apps/web/node_modules/nanoid": {
+      "version": "5.1.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.15.tgz",
+      "integrity": "sha512-kBg3RpGtIe+RpTbyXwoI6pk5yD7KUiI3sygUqgeBMRst42KmhB4RZC7eiO9Wa1HIpaCCtpE2DJ6OI4Wi5ebwFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "apps/web/node_modules/playwright": {
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "apps/web/node_modules/playwright-core": {
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/web/node_modules/react-router": {
+      "version": "7.16.0",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/react-router-dom": {
+      "version": "7.16.0",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.16.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "apps/web/node_modules/recharts": {
@@ -127,6 +562,234 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
       "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
+    },
+    "apps/web/node_modules/storybook": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.2.tgz",
+      "integrity": "sha512-5Ax5vbHxFgMBGGhQDm75Rrumm/HZC4ICFhMcJaM0UlqnC/4FKj/IaZtImZFupknyiiyUEcWHPQFA2kX3/VSv1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^2.0.2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/expect": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@webcontainer/env": "^1.1.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
+        "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "^11.19.1",
+        "recast": "^0.23.5",
+        "semver": "^7.7.3",
+        "use-sync-external-store": "^1.5.0",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "storybook": "dist/bin/dispatcher.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/storybook/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/storybook/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/storybook/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/storybook/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/storybook/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/web/node_modules/storybook/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "apps/web/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "apps/web/node_modules/vitest": {
+      "version": "4.1.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -1855,19 +2518,6 @@
       "resolved": "apps/web",
       "link": true
     },
-    "node_modules/@fluentui/react-icons": {
-      "version": "2.0.332",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.332.tgz",
-      "integrity": "sha512-PxVua3X164DjoKqkgFUAs+MoCoL4sOGs+KnGKsoizV+jCe16yuZavPxhN8PCkDcAe7XrT4iCJCexOOqMcM4uBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@griffel/react": "^1.6.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0 <20.0.0"
-      }
-    },
     "node_modules/@griffel/core": {
       "version": "1.21.2",
       "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.21.2.tgz",
@@ -3195,22 +3845,6 @@
         "win32"
       ]
     },
-    "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.61.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@redocly/cli": {
       "version": "2.34.0",
       "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.34.0.tgz",
@@ -3543,108 +4177,88 @@
         }
       }
     },
-    "node_modules/@sentry/browser": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.65.0.tgz",
-      "integrity": "sha512-XUDDsx0qxzeIlcOu1fDEqTcDl0eiOqghsgV+ReuuNP4jYjZ9kUQxE3rXWM5mlT1pBi4VaQ4FHqvQZZrRXy+oDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser-utils": "10.65.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/feedback": "10.65.0",
-        "@sentry/replay": "10.65.0",
-        "@sentry/replay-canvas": "10.65.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry/browser-utils": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.65.0.tgz",
-      "integrity": "sha512-4J0mkfNJAGUOkpg1ZggizyftFTn9N20b+Jl87UnWsDUkNG0Ic1l/FIzMPTVxXrAnhBGu0ULO0TFWMoQ5s3QtZw==",
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.59.0.tgz",
+      "integrity": "sha512-DpJIrNi0Hsj/YONTZ8km1wv7ue2NzrTmFKJ3lRW8Q2nS/mrMeP3LCvjreLtKheTouB4go58NxM68AEFbXk4rPg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0"
+        "@sentry/core": "10.59.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/conventions": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
-      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
+    "node_modules/@sentry/browser-utils/node_modules/@sentry/core": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
+      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.65.0.tgz",
-      "integrity": "sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/conventions": "^0.15.1"
-      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/feedback": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.65.0.tgz",
-      "integrity": "sha512-ck8h7wgd3F3bYNk0v1OgohmyLBeXcKxqlfBJRtQq4k6KZUq+pXimOG7ckNguVMYjCo3PEfuG+ckKc21yqotKug==",
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.59.0.tgz",
+      "integrity": "sha512-Sa/06LlG/mYR4z8/JlxOwvkcOHJnaMW6JyTMKNsgEoR1SHZULIpirjUuHIp4P+7R1mqX/KGTj8I7SQ3adA0TxQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.65.0"
+        "@sentry/core": "10.59.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/react": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.65.0.tgz",
-      "integrity": "sha512-fvHxpuvid0wt9/1N3itcKDyKOjqmYHw3MBSt5Pki3Iz4CL2CmgQp9ZFv/CA7UhMnEvn2Gd+Qc2UKxujZWd8FLg==",
+    "node_modules/@sentry/feedback/node_modules/@sentry/core": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
+      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
       "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "10.65.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0"
-      },
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.65.0.tgz",
-      "integrity": "sha512-aW988CcQBNArbOMzOFOziipHz6uQyXSa4i5CPWsu+nhVPTJHafosi5Lv9n6NM/icDX5e23VdnX6mZd8SyJuo8A==",
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.59.0.tgz",
+      "integrity": "sha512-fpHL25JErsSfTyusuyZ3Q5JmRZeWYWynJO3PNiQH6A/58EqaCp8U5y8LCJ+CSPaeuBMka3S3Qn6U4eXcvkDMRA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.65.0",
-        "@sentry/core": "10.65.0"
+        "@sentry/browser-utils": "10.59.0",
+        "@sentry/core": "10.59.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay-canvas": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.65.0.tgz",
-      "integrity": "sha512-A7X3RVk1Gk+knK8Ip/2EjejckNCLgCfRZo6eGlsy6qyz904KBpYmys1a0o7QkzFRjhIndjHAfcVxwt6jSLJlrQ==",
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.59.0.tgz",
+      "integrity": "sha512-bJkqvxQiat27P7+hUYC/m545Ct/uVxZCjh+PeCFdRcuHnZZ92e6Z7XPLf0LqAR6tR1U7wDUa4V5ugrMIEz+vpQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.65.0",
-        "@sentry/replay": "10.65.0"
+        "@sentry/core": "10.59.0",
+        "@sentry/replay": "10.59.0"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas/node_modules/@sentry/core": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
+      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry/core": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
+      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -3699,78 +4313,6 @@
       "version": "0.3.0",
       "license": "MIT"
     },
-    "node_modules/@storybook/addon-a11y": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.5.0.tgz",
-      "integrity": "sha512-AguqTsYS2NX20AF1vWt6IonbkpMXur30/dAOOYltbEW7uKmPxBNtjuiBmYB2WI4aFN4r8jje4bbDGk/Yfq58hQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "axe-core": "^4.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^10.5.0"
-      }
-    },
-    "node_modules/@storybook/builder-vite": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.0.tgz",
-      "integrity": "sha512-KXlifNIThDgS84KqVAJXyilool8OLTWp6DGoO9h5bHM2IPLe7UcdKfOzMUBkQ807mWBk4aW1yGEekj7kC2dvmg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/csf-plugin": "10.5.0",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^10.5.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@storybook/csf-plugin": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.0.tgz",
-      "integrity": "sha512-R7VFw6FnDZTWct0ekOcFnTfDgdHnnAuQW+AbGG9A9IZPvyH9uLJivK7L86+r9MITRrO2+v81HaFDsT/OFk6ZkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unplugin": "^2.3.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "esbuild": "*",
-        "rollup": "*",
-        "storybook": "^10.5.0",
-        "vite": "*",
-        "webpack": "*"
-      },
-      "peerDependenciesMeta": {
-        "esbuild": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@storybook/global": {
       "version": "5.0.0",
       "dev": true,
@@ -3783,102 +4325,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@storybook/react": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.5.0.tgz",
-      "integrity": "sha512-2IhddiREy7NqAqnFsEOfW6HBG7azIcLxhRQYploSsaemOncR29xhzvAZsG+xlWgrtvxv4h3fYQTTR4TNn8CgPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "10.5.0",
-        "react-docgen": "^8.0.2",
-        "react-docgen-typescript": "^2.2.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.5.0",
-        "typescript": ">= 4.9.x"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@storybook/react-dom-shim": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.0.tgz",
-      "integrity": "sha512-GwGA6zDj4Cfw6vGsdfPKfF39L0W6solNbbnjdjGa57m2ooASkidLhrXo2wgC9wh3o/jcfonmYPDRGY6sEhGDtg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.5.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@storybook/react-vite": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.5.0.tgz",
-      "integrity": "sha512-d9n/I3pViscXpJYT9JHxcpxVSam14HsHOr2wBqTQTiRtaiH4xSsT00HTEGm6CEZTyq/npTJyV0Qday9XhrtiDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
-        "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "10.5.0",
-        "@storybook/react": "10.5.0",
-        "empathic": "^2.0.0",
-        "magic-string": "^0.30.0",
-        "react-docgen": "^8.0.2",
-        "resolve": "^1.22.8",
-        "tsconfig-paths": "^4.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.5.0",
-        "typescript": ">= 4.9.x",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4099,8 +4545,6 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4323,8 +4767,6 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4652,217 +5094,6 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.10",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/mocker/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.10",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@webcontainer/env": {
       "version": "1.1.1",
       "dev": true,
@@ -4990,8 +5221,6 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5256,23 +5485,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "dev": true,
@@ -5296,8 +5508,6 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5414,8 +5624,6 @@
     },
     "node_modules/cookie": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5936,8 +6144,6 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6852,6 +7058,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -7551,13 +7776,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "dev": true,
@@ -8007,8 +8225,6 @@
     },
     "node_modules/loupe": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8018,15 +8234,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz",
-      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -8191,25 +8398,6 @@
       "version": "2.1.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
-      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -8607,8 +8795,6 @@
     },
     "node_modules/pathval": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8629,38 +8815,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.61.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8919,44 +9073,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/read-yaml-file": {
@@ -9273,8 +9389,6 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {
@@ -9458,55 +9572,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/storybook": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.0.tgz",
-      "integrity": "sha512-dRhM/kSSvHQR8DmZO41v5sJuz9U6zDjjR2gRBTgZN2RBSXbmF0Brvgszrvvxyx2VfxuYKzhB+xumKwWkwlBtig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@storybook/icons": "^2.0.2",
-        "@testing-library/dom": "^10.4.1",
-        "@testing-library/jest-dom": "^6.9.1",
-        "@testing-library/user-event": "^14.6.1",
-        "@vitest/expect": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@webcontainer/env": "^1.1.1",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
-        "jsonc-parser": "^3.3.1",
-        "open": "^10.2.0",
-        "oxc-parser": "^0.127.0",
-        "oxc-resolver": "^11.19.1",
-        "recast": "^0.23.5",
-        "semver": "^7.7.3",
-        "use-sync-external-store": "^1.5.0",
-        "ws": "^8.18.0"
-      },
-      "bin": {
-        "storybook": "dist/bin/dispatcher.js"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "prettier": "^2 || ^3",
-        "vite-plus": "^0.1.15 || ^0.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "prettier": {
-          "optional": true
-        },
-        "vite-plus": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/stream": {
       "version": "0.0.3",
       "dev": true,
@@ -9599,34 +9664,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/style-dictionary": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.5.0.tgz",
-      "integrity": "sha512-AGkOZtAc3OTz99wlzstrmj5OM5BWOW2IbmXD74sf0MXFPi271TGBdywokgd7bS3L0tKOk9M0FR+R9gnbXRSSfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bundled-es-modules/deepmerge": "^4.3.2",
-        "@bundled-es-modules/glob": "^13.0.6",
-        "@bundled-es-modules/memfs": "^4.17.0",
-        "@zip.js/zip.js": "^2.7.44",
-        "chalk": "^5.3.0",
-        "change-case": "^5.3.0",
-        "colorjs.io": "^0.5.2",
-        "commander": "^12.1.0",
-        "is-plain-obj": "^4.1.0",
-        "json5": "^2.2.2",
-        "path-unified": "^0.2.0",
-        "prettier": "^3.3.3",
-        "tinycolor2": "^1.6.0"
-      },
-      "bin": {
-        "style-dictionary": "bin/style-dictionary.js"
-      },
-      "engines": {
-        "node": ">=22.0.0"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -9730,20 +9767,8 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/tinyspy": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9821,9 +9846,7 @@
       }
     },
     "node_modules/ts-dedent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
-      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "version": "2.2.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9937,8 +9960,6 @@
     },
     "node_modules/unplugin": {
       "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
-      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10137,172 +10158,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "dev": true,
@@ -10327,8 +10182,6 @@
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
-      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10573,6 +10426,34 @@
       "version": "0.1.0",
       "devDependencies": {
         "style-dictionary": "^5.5.0"
+      }
+    },
+    "packages/design-tokens/node_modules/style-dictionary": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.4.4.tgz",
+      "integrity": "sha512-Sd7dkEOLn33EpvlMyS8ykUu0us2EIFUqsysf4DSwZQ46nqQkZ2Q9o5mozu8cSizj3t7E220HaPk7EV1O7LjvDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bundled-es-modules/deepmerge": "^4.3.2",
+        "@bundled-es-modules/glob": "^13.0.6",
+        "@bundled-es-modules/memfs": "^4.17.0",
+        "@zip.js/zip.js": "^2.7.44",
+        "chalk": "^5.3.0",
+        "change-case": "^5.3.0",
+        "colorjs.io": "^0.5.2",
+        "commander": "^12.1.0",
+        "is-plain-obj": "^4.1.0",
+        "json5": "^2.2.2",
+        "path-unified": "^0.2.0",
+        "prettier": "^3.3.3",
+        "tinycolor2": "^1.6.0"
+      },
+      "bin": {
+        "style-dictionary": "bin/style-dictionary.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "services/api": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@types/react-dom": "^19.1.5",
         "@types/sql.js": "^1.4.11",
         "@vitejs/plugin-react": "5.2.0",
+        "axe-core": "^4.11.4",
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
         "nanoid": "^5.1.16",
@@ -69,236 +70,6 @@
         "typescript": "^6.0.3",
         "vite": "^8.0.16",
         "vitest": "^4.1.10"
-      }
-    },
-    "apps/web/node_modules/@fluentui/react-icons": {
-      "version": "2.0.330",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.330.tgz",
-      "integrity": "sha512-IaJjO755FGlUR5Myy1IuhJKlqGPfET9JqGpotoanJm1W1sK2rELRv8L3i2UAiZ70TSvi6KAi5t4M0inqI/h9Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "@griffel/react": "^1.6.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0 <20.0.0"
-      }
-    },
-    "apps/web/node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.60.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/browser": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.59.0.tgz",
-      "integrity": "sha512-d0o0oc78KNWCZ6yq9gREf9BPXWza/Wj9W+nCm0CvPD5k2IbouD/eJsm2Mb+d53YfEm12L+SePfgOx01KbbVx4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser-utils": "10.59.0",
-        "@sentry/core": "10.59.0",
-        "@sentry/feedback": "10.59.0",
-        "@sentry/replay": "10.59.0",
-        "@sentry/replay-canvas": "10.59.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/core": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
-      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/react": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.59.0.tgz",
-      "integrity": "sha512-B3MmXooGLnTu0gyL8hxElCu1+WVEXjIGoDPvGqn5qMHZNSmB2oPTAt1/UutuxAc6EWu2UKIHnyPowNeY2MPH3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "10.59.0",
-        "@sentry/core": "10.59.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || 17.x || 18.x || 19.x"
-      }
-    },
-    "apps/web/node_modules/@storybook/addon-a11y": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.2.tgz",
-      "integrity": "sha512-9Bm41peswHVPXm8iDBEA/sCXx+MUQV8Q10yFgNC2zTbtxKamMDb8HZCPIRDxvjBQ5v13eaXA2yZGTwQ+D8S6+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "axe-core": "^4.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^10.4.2"
-      }
-    },
-    "apps/web/node_modules/@storybook/builder-vite": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.2.tgz",
-      "integrity": "sha512-d3+i9vbbUfV6hvT90qabmy1WmC4bEJ7iAYDm0217doeA+S6awF25GF0qOy9gN9waU4NMntHoVpdB1YQO2wUj/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/csf-plugin": "10.4.2",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^10.4.2",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "apps/web/node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.2.tgz",
-      "integrity": "sha512-GqX/2DeF3/jKs5D7gpDiuT9gd0c/f2TKcnQ5av4/s3YqeN+0nhm7btkCrDfgF16uzE1Zj3OrkxvB3AOkfxWgDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unplugin": "^2.3.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "esbuild": "*",
-        "rollup": "*",
-        "storybook": "^10.4.2",
-        "vite": "*",
-        "webpack": "*"
-      },
-      "peerDependenciesMeta": {
-        "esbuild": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@storybook/react": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.2.tgz",
-      "integrity": "sha512-NfEH3CrdCAgUV4Z7SPN3Iw6nofcueqtRj8iHuo77GNjz0qSfuVi9iS7a8o7x7QFSeIBZwS0Jv3CgmhN8qvoLjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "10.4.2",
-        "react-docgen": "^8.0.2",
-        "react-docgen-typescript": "^2.2.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.2",
-        "typescript": ">= 4.9.x"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@storybook/react-dom-shim": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.2.tgz",
-      "integrity": "sha512-Eng3Yt2NCjPX94QcfyLeUFhrMj0hec2yU9J/qafBVbfj9XrFI8o+0ZwYJ7uXb9ECbvPN4y06dgt/2W/LiR417w==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@storybook/react-vite": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.4.2.tgz",
-      "integrity": "sha512-nGrS74p0ujPSQ7qD5jKLLlao2igfTTb6Kf/uRhVV8XM0uM7WvxR9K20ddCM8jFmx1jY9fRm0UBGaeaXHDIh5SA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
-        "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "10.4.2",
-        "@storybook/react": "10.4.2",
-        "empathic": "^2.0.0",
-        "magic-string": "^0.30.0",
-        "react-docgen": "^8.0.0",
-        "resolve": "^1.22.8",
-        "tsconfig-paths": "^4.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.2",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "apps/web/node_modules/@types/react": {
@@ -311,121 +82,6 @@
         "csstype": "^3.2.2"
       }
     },
-    "apps/web/node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.8",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.8",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/chai": {
-      "version": "6.2.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "apps/web/node_modules/immer": {
       "version": "11.1.11",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
@@ -434,96 +90,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
-      }
-    },
-    "apps/web/node_modules/lucide-react": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
-      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "apps/web/node_modules/nanoid": {
-      "version": "5.1.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.15.tgz",
-      "integrity": "sha512-kBg3RpGtIe+RpTbyXwoI6pk5yD7KUiI3sygUqgeBMRst42KmhB4RZC7eiO9Wa1HIpaCCtpE2DJ6OI4Wi5ebwFw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
-    },
-    "apps/web/node_modules/playwright": {
-      "version": "1.60.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.60.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "apps/web/node_modules/playwright-core": {
-      "version": "1.60.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/react-router": {
-      "version": "7.16.0",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.16.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "apps/web/node_modules/recharts": {
@@ -561,234 +127,6 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
       "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
-    },
-    "apps/web/node_modules/storybook": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.2.tgz",
-      "integrity": "sha512-5Ax5vbHxFgMBGGhQDm75Rrumm/HZC4ICFhMcJaM0UlqnC/4FKj/IaZtImZFupknyiiyUEcWHPQFA2kX3/VSv1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@storybook/icons": "^2.0.2",
-        "@testing-library/jest-dom": "^6.9.1",
-        "@testing-library/user-event": "^14.6.1",
-        "@vitest/expect": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@webcontainer/env": "^1.1.1",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
-        "open": "^10.2.0",
-        "oxc-parser": "^0.127.0",
-        "oxc-resolver": "^11.19.1",
-        "recast": "^0.23.5",
-        "semver": "^7.7.3",
-        "use-sync-external-store": "^1.5.0",
-        "ws": "^8.18.0"
-      },
-      "bin": {
-        "storybook": "dist/bin/dispatcher.js"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "prettier": "^2 || ^3",
-        "vite-plus": "^0.1.15"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "prettier": {
-          "optional": true
-        },
-        "vite-plus": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "apps/web/node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "apps/web/node_modules/vitest": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -2517,6 +1855,19 @@
       "resolved": "apps/web",
       "link": true
     },
+    "node_modules/@fluentui/react-icons": {
+      "version": "2.0.332",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.332.tgz",
+      "integrity": "sha512-PxVua3X164DjoKqkgFUAs+MoCoL4sOGs+KnGKsoizV+jCe16yuZavPxhN8PCkDcAe7XrT4iCJCexOOqMcM4uBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.6.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <20.0.0"
+      }
+    },
     "node_modules/@griffel/core": {
       "version": "1.21.2",
       "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.21.2.tgz",
@@ -3844,6 +3195,22 @@
         "win32"
       ]
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@redocly/cli": {
       "version": "2.34.0",
       "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.34.0.tgz",
@@ -4176,88 +3543,108 @@
         }
       }
     },
-    "node_modules/@sentry/browser-utils": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.59.0.tgz",
-      "integrity": "sha512-DpJIrNi0Hsj/YONTZ8km1wv7ue2NzrTmFKJ3lRW8Q2nS/mrMeP3LCvjreLtKheTouB4go58NxM68AEFbXk4rPg==",
+    "node_modules/@sentry/browser": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.65.0.tgz",
+      "integrity": "sha512-XUDDsx0qxzeIlcOu1fDEqTcDl0eiOqghsgV+ReuuNP4jYjZ9kUQxE3rXWM5mlT1pBi4VaQ4FHqvQZZrRXy+oDw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.59.0"
+        "@sentry/browser-utils": "10.65.0",
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0",
+        "@sentry/feedback": "10.65.0",
+        "@sentry/replay": "10.65.0",
+        "@sentry/replay-canvas": "10.65.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/browser-utils/node_modules/@sentry/core": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
-      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.65.0.tgz",
+      "integrity": "sha512-4J0mkfNJAGUOkpg1ZggizyftFTn9N20b+Jl87UnWsDUkNG0Ic1l/FIzMPTVxXrAnhBGu0ULO0TFWMoQ5s3QtZw==",
       "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
+      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.65.0.tgz",
+      "integrity": "sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.15.1"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/feedback": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.59.0.tgz",
-      "integrity": "sha512-Sa/06LlG/mYR4z8/JlxOwvkcOHJnaMW6JyTMKNsgEoR1SHZULIpirjUuHIp4P+7R1mqX/KGTj8I7SQ3adA0TxQ==",
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.65.0.tgz",
+      "integrity": "sha512-ck8h7wgd3F3bYNk0v1OgohmyLBeXcKxqlfBJRtQq4k6KZUq+pXimOG7ckNguVMYjCo3PEfuG+ckKc21yqotKug==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.59.0"
+        "@sentry/core": "10.65.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/feedback/node_modules/@sentry/core": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
-      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
+    "node_modules/@sentry/react": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.65.0.tgz",
+      "integrity": "sha512-fvHxpuvid0wt9/1N3itcKDyKOjqmYHw3MBSt5Pki3Iz4CL2CmgQp9ZFv/CA7UhMnEvn2Gd+Qc2UKxujZWd8FLg==",
       "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.65.0",
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0"
+      },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.59.0.tgz",
-      "integrity": "sha512-fpHL25JErsSfTyusuyZ3Q5JmRZeWYWynJO3PNiQH6A/58EqaCp8U5y8LCJ+CSPaeuBMka3S3Qn6U4eXcvkDMRA==",
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.65.0.tgz",
+      "integrity": "sha512-aW988CcQBNArbOMzOFOziipHz6uQyXSa4i5CPWsu+nhVPTJHafosi5Lv9n6NM/icDX5e23VdnX6mZd8SyJuo8A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.59.0",
-        "@sentry/core": "10.59.0"
+        "@sentry/browser-utils": "10.65.0",
+        "@sentry/core": "10.65.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay-canvas": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.59.0.tgz",
-      "integrity": "sha512-bJkqvxQiat27P7+hUYC/m545Ct/uVxZCjh+PeCFdRcuHnZZ92e6Z7XPLf0LqAR6tR1U7wDUa4V5ugrMIEz+vpQ==",
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.65.0.tgz",
+      "integrity": "sha512-A7X3RVk1Gk+knK8Ip/2EjejckNCLgCfRZo6eGlsy6qyz904KBpYmys1a0o7QkzFRjhIndjHAfcVxwt6jSLJlrQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.59.0",
-        "@sentry/replay": "10.59.0"
+        "@sentry/core": "10.65.0",
+        "@sentry/replay": "10.65.0"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/replay-canvas/node_modules/@sentry/core": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
-      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/replay/node_modules/@sentry/core": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
-      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -4312,6 +3699,78 @@
       "version": "0.3.0",
       "license": "MIT"
     },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.5.0.tgz",
+      "integrity": "sha512-AguqTsYS2NX20AF1vWt6IonbkpMXur30/dAOOYltbEW7uKmPxBNtjuiBmYB2WI4aFN4r8jje4bbDGk/Yfq58hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.0"
+      }
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.0.tgz",
+      "integrity": "sha512-KXlifNIThDgS84KqVAJXyilool8OLTWp6DGoO9h5bHM2IPLe7UcdKfOzMUBkQ807mWBk4aW1yGEekj7kC2dvmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "10.5.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@storybook/csf-plugin": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.0.tgz",
+      "integrity": "sha512-R7VFw6FnDZTWct0ekOcFnTfDgdHnnAuQW+AbGG9A9IZPvyH9uLJivK7L86+r9MITRrO2+v81HaFDsT/OFk6ZkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^2.3.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "esbuild": "*",
+        "rollup": "*",
+        "storybook": "^10.5.0",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@storybook/global": {
       "version": "5.0.0",
       "dev": true,
@@ -4324,6 +3783,102 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.5.0.tgz",
+      "integrity": "sha512-2IhddiREy7NqAqnFsEOfW6HBG7azIcLxhRQYploSsaemOncR29xhzvAZsG+xlWgrtvxv4h3fYQTTR4TNn8CgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "10.5.0",
+        "react-docgen": "^8.0.2",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.0",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.0.tgz",
+      "integrity": "sha512-GwGA6zDj4Cfw6vGsdfPKfF39L0W6solNbbnjdjGa57m2ooASkidLhrXo2wgC9wh3o/jcfonmYPDRGY6sEhGDtg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.5.0.tgz",
+      "integrity": "sha512-d9n/I3pViscXpJYT9JHxcpxVSam14HsHOr2wBqTQTiRtaiH4xSsT00HTEGm6CEZTyq/npTJyV0Qday9XhrtiDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "10.5.0",
+        "@storybook/react": "10.5.0",
+        "empathic": "^2.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^8.0.2",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.0",
+        "typescript": ">= 4.9.x",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4544,6 +4099,8 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4766,6 +4323,8 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5093,6 +4652,217 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webcontainer/env": {
       "version": "1.1.1",
       "dev": true,
@@ -5220,6 +4990,8 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5484,6 +5256,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "dev": true,
@@ -5507,6 +5296,8 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5623,6 +5414,8 @@
     },
     "node_modules/cookie": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6143,6 +5936,8 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7057,25 +6852,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -7775,6 +7551,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "dev": true,
@@ -8224,6 +8007,8 @@
     },
     "node_modules/loupe": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8233,6 +8018,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz",
+      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -8397,6 +8191,25 @@
       "version": "2.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -8794,6 +8607,8 @@
     },
     "node_modules/pathval": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8814,6 +8629,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -9072,6 +8919,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-yaml-file": {
@@ -9388,6 +9273,8 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {
@@ -9571,6 +9458,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/storybook": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.0.tgz",
+      "integrity": "sha512-dRhM/kSSvHQR8DmZO41v5sJuz9U6zDjjR2gRBTgZN2RBSXbmF0Brvgszrvvxyx2VfxuYKzhB+xumKwWkwlBtig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^2.0.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/expect": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@webcontainer/env": "^1.1.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
+        "jsonc-parser": "^3.3.1",
+        "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "^11.19.1",
+        "recast": "^0.23.5",
+        "semver": "^7.7.3",
+        "use-sync-external-store": "^1.5.0",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "storybook": "dist/bin/dispatcher.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/stream": {
       "version": "0.0.3",
       "dev": true,
@@ -9663,6 +9599,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-dictionary": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.5.0.tgz",
+      "integrity": "sha512-AGkOZtAc3OTz99wlzstrmj5OM5BWOW2IbmXD74sf0MXFPi271TGBdywokgd7bS3L0tKOk9M0FR+R9gnbXRSSfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bundled-es-modules/deepmerge": "^4.3.2",
+        "@bundled-es-modules/glob": "^13.0.6",
+        "@bundled-es-modules/memfs": "^4.17.0",
+        "@zip.js/zip.js": "^2.7.44",
+        "chalk": "^5.3.0",
+        "change-case": "^5.3.0",
+        "colorjs.io": "^0.5.2",
+        "commander": "^12.1.0",
+        "is-plain-obj": "^4.1.0",
+        "json5": "^2.2.2",
+        "path-unified": "^0.2.0",
+        "prettier": "^3.3.3",
+        "tinycolor2": "^1.6.0"
+      },
+      "bin": {
+        "style-dictionary": "bin/style-dictionary.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -9766,8 +9730,20 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tinyspy": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9845,7 +9821,9 @@
       }
     },
     "node_modules/ts-dedent": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9959,6 +9937,8 @@
     },
     "node_modules/unplugin": {
       "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10157,6 +10137,172 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "dev": true,
@@ -10181,6 +10327,8 @@
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10425,34 +10573,6 @@
       "version": "0.1.0",
       "devDependencies": {
         "style-dictionary": "^5.5.0"
-      }
-    },
-    "packages/design-tokens/node_modules/style-dictionary": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.4.4.tgz",
-      "integrity": "sha512-Sd7dkEOLn33EpvlMyS8ykUu0us2EIFUqsysf4DSwZQ46nqQkZ2Q9o5mozu8cSizj3t7E220HaPk7EV1O7LjvDQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bundled-es-modules/deepmerge": "^4.3.2",
-        "@bundled-es-modules/glob": "^13.0.6",
-        "@bundled-es-modules/memfs": "^4.17.0",
-        "@zip.js/zip.js": "^2.7.44",
-        "chalk": "^5.3.0",
-        "change-case": "^5.3.0",
-        "colorjs.io": "^0.5.2",
-        "commander": "^12.1.0",
-        "is-plain-obj": "^4.1.0",
-        "json5": "^2.2.2",
-        "path-unified": "^0.2.0",
-        "prettier": "^3.3.3",
-        "tinycolor2": "^1.6.0"
-      },
-      "bin": {
-        "style-dictionary": "bin/style-dictionary.js"
-      },
-      "engines": {
-        "node": ">=22.0.0"
       }
     },
     "services/api": {


### PR DESCRIPTION
﻿## Summary

A single cohesive web-accessibility batch for `apps/web` covering focus management, skip links, and shared a11y primitives.

### What changed
- **Focus-ring tokens & appearance (SC 2.4.13):** New `--focus-ring-width/offset/color/--focus-ring` design tokens with per-theme overrides, consumed by every `:focus-visible` rule. High-contrast / `prefers-contrast: more` bump the ring to ≥3px/≥3px so the focus area and ≥3:1 contrast requirements hold across light, dark, OLED, and high-contrast themes.
- **Skip links (SC 2.4.1):** `SkipToContent` is now the single canonical implementation; `common/SkipLink` re-exports it (no behavior fork) and the duplicate `.skip-link` CSS is consolidated to one source of truth. Added a paired **Skip to navigation** link — first Tab reveals both links, and each moves focus to its landmark (`#main-content` / `#primary-navigation`) on desktop (sidebar) and mobile (bottom-nav).
- **ModalBackdrop primitive:** Shared `ModalBackdrop` (`role="presentation"`, target-checked click) adopted by `ConflictResolutionDialog` and `RecommendationDetail`.
- **Header icons:** The header `?` and `⌘K` text glyphs are replaced with real SVG icons (keyboard + search), keeping their `aria-label`s and ≥44px targets.
- **Color-only encoding audit (SC 1.4.1):** Documented that amounts always carry a non-color sign cue and chart legends pair swatches with text labels + data tables. New `docs/a11y/color-encoding-audit.md`.
- **axe-core regression tests:** `axe-core` added as an explicit devDependency with a lightweight jsdom harness and zero-violation tests for shared components.
- **Focus-management contract (SC 2.4.3):** Written contract added to `web.instructions.md` (route change → main region; dialog open → first field/trap; dialog close → invoking control) plus a representative end-to-end test.
- **Visible transaction result count:** A visible, `aria-live` singular/plural result count near the top of the transactions results region, replacing the redundant screen-reader-only status.

### Focus contrast check (#3610)
Per-theme focus color verified against adjacent surfaces: light uses `blue-600` on light surfaces (>3:1); dark / dark-oled / `prefers-color-scheme: dark` use `blue-400`; high-contrast / `prefers-contrast: more` use the system `Highlight` color with a 3px ring. Width ≥2px (≥3px in high contrast) and offset ≥2px satisfy the SC 2.4.13 area requirement.

### Testing (local)
- `npx prettier --check` ✓
- `npx eslint src --max-warnings 0` ✓
- `npx tsc --noEmit` ✓
- Full `apps/web` Vitest suite: 9848 passed ✓
- `vite build` ✓

Closes #3631
Closes #3628
Closes #3623
Closes #3619
Closes #3617
Closes #3610
Closes #3609
Closes #3600
Closes #3647
Closes #3634
