### PR TITLE
feat(web): transactions register & filters batch (running balance, save-and-add-another, summary, filters)

### DIFF
--- a/apps/web/src/components/forms/TransactionForm.test.tsx
+++ b/apps/web/src/components/forms/TransactionForm.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Account, Category } from '../../kmp/bridge';
+import type { Account, Category, Transaction } from '../../kmp/bridge';
 import { validateTransactionSplits } from '../../lib/transactions/splits';
 import { TransactionForm, type TransactionFormProps } from './TransactionForm';
 
@@ -74,6 +74,43 @@ const categories: Category[] = [
     ...syncMetadata,
   },
 ];
+
+function makeEditTransaction(): Transaction {
+  return {
+    id: 'txn-edit-1',
+    householdId: 'household-1',
+    accountId: 'account-1',
+    categoryId: null,
+    type: 'EXPENSE',
+    status: 'CLEARED',
+    amount: { amount: -1234 },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    payee: 'Coffee Shop',
+    note: null,
+    date: '2025-06-10',
+    transferAccountId: null,
+    transferTransactionId: null,
+    isRecurring: false,
+    recurringRuleId: null,
+    tags: [],
+    merchantAddress: null,
+    merchantCity: null,
+    merchantState: null,
+    merchantZip: null,
+    merchantCountry: null,
+    externalReferenceId: null,
+    statementDescription: null,
+    customFields: null,
+    extraNotes: null,
+    counterpartyName: null,
+    counterpartyAccountId: null,
+    createdAt: '2025-06-10T00:00:00.000Z',
+    updatedAt: '2025-06-10T00:00:00.000Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  } as Transaction;
+}
 
 function renderTransactionForm(overrides: Partial<TransactionFormProps> = {}) {
   const onSubmit = overrides.onSubmit ?? vi.fn().mockResolvedValue(undefined);
@@ -220,6 +257,41 @@ describe('TransactionForm', () => {
         }),
       }),
     );
+  });
+
+  it('keeps the dialog open and preserves account context on "Save and add another" (#3650)', async () => {
+    const { onSubmit, onCancel } = renderTransactionForm();
+
+    const amountInput = screen.getByLabelText('Amount');
+    fireEvent.keyDown(amountInput, { key: '1' });
+    fireEvent.keyDown(amountInput, { key: '2' });
+    fireEvent.keyDown(amountInput, { key: '3' });
+    fireEvent.keyDown(amountInput, { key: '4' });
+
+    fireEvent.change(screen.getByLabelText('Payee'), { target: { value: 'Coffee Shop' } });
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-1' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save and add another' }));
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: 'account-1', payee: 'Coffee Shop' }),
+      { addAnother: true },
+    );
+    // Dialog stays open (parent close callback not invoked) and the account is
+    // preserved while amount/payee reset for the next entry.
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog', { name: 'New Transaction' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Account')).toHaveValue('account-1');
+    expect(screen.getByLabelText('Payee')).toHaveValue('');
+    expect(screen.getByText(/ready to add another/i)).toBeInTheDocument();
+  });
+
+  it('does not render "Save and add another" in edit mode (#3650)', () => {
+    renderTransactionForm({ initialData: makeEditTransaction() });
+    expect(screen.queryByRole('button', { name: 'Save and add another' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Update Transaction' })).toBeInTheDocument();
   });
 
   it('submits retirement contribution tagging fields', async () => {

--- a/apps/web/src/components/forms/TransactionForm.tsx
+++ b/apps/web/src/components/forms/TransactionForm.tsx
@@ -123,8 +123,13 @@ const TRANSACTION_STATUSES: readonly { value: TransactionStatus; label: string }
 
 /** Props for {@link TransactionForm}. */
 export interface TransactionFormProps {
-  /** Callback invoked with validated form data when the user submits. */
-  onSubmit: (data: CreateTransactionInput) => Promise<void>;
+  /**
+   * Callback invoked with validated form data when the user submits. The
+   * optional `options.addAnother` flag is set when the user chose "Save and add
+   * another" so the caller can keep the dialog open for fast batch entry
+   * (#3650).
+   */
+  onSubmit: (data: CreateTransactionInput, options?: { addAnother?: boolean }) => Promise<void>;
   /** Callback invoked when the user cancels or presses Escape. */
   onCancel: () => void;
   /** Available accounts to choose from. */
@@ -416,6 +421,10 @@ export function TransactionForm({
   const panelRef = useRef<HTMLDivElement>(null);
   const firstInputRef = useRef<HTMLInputElement>(null);
   const errorSummaryRef = useRef<HTMLDivElement>(null);
+  // Tracks which submit button was used so a successful create can either close
+  // the dialog ("Save") or keep it open for the next entry ("Save and add
+  // another", #3650).
+  const submitModeRef = useRef<'close' | 'add-another'>('close');
 
   // -- state ---------------------------------------------------------------
   const [transactionType, setTransactionType] = useState<TransactionType>('EXPENSE');
@@ -470,6 +479,9 @@ export function TransactionForm({
   const [errors, setErrors] = useState<FormErrors>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  // Polite confirmation announced after "Save and add another" so assistive
+  // tech users know the entry saved and the form is ready for the next (#3650).
+  const [addAnotherStatus, setAddAnotherStatus] = useState('');
   const [suggestion, setSuggestion] = useState<CategorySuggestion | null>(null);
   const [counterpartyName, setCounterpartyName] = useState('');
   const [merchantMatch, setMerchantMatch] = useState<MerchantMatchResult | null>(null);
@@ -585,6 +597,7 @@ export function TransactionForm({
   // -- autofocus first field ------------------------------------------------
   useEffect(() => {
     if (isOpen) {
+      setAddAnotherStatus('');
       const id = requestAnimationFrame(() => {
         firstInputRef.current?.focus();
       });
@@ -817,6 +830,11 @@ export function TransactionForm({
     async (e: FormEvent) => {
       e.preventDefault();
 
+      // Capture and reset the requested submit mode immediately so it cannot
+      // leak into a later submission if this one bails out on validation.
+      const addAnother = !isEditMode && submitModeRef.current === 'add-another';
+      submitModeRef.current = 'close';
+
       const normalizedAmountCents = normalizeTransactionAmount(amountInput.cents, transactionType);
       const fieldErrors = validate(
         normalizedAmountCents,
@@ -963,7 +981,11 @@ export function TransactionForm({
       setSubmitError(null);
 
       try {
-        await onSubmit(input);
+        if (addAnother) {
+          await onSubmit(input, { addAnother: true });
+        } else {
+          await onSubmit(input);
+        }
 
         if (categoryId && description.trim()) {
           learnFromFeedback({
@@ -974,20 +996,14 @@ export function TransactionForm({
           });
         }
 
-        // Reset form on success
+        // Reset form on success. "Save and add another" keeps sensible context
+        // (account, date, type, status, currency) for the next entry (#3650);
+        // "Save" resets everything before the dialog closes.
         amountInput.reset(0);
         amountInput.setSign('negative');
         setDescription('');
-        setTransactionType('EXPENSE');
-        setStatus('PENDING');
         setCategoryId('');
         setSplitRows([]);
-        setAccountId('');
-        setCurrencyCode('');
-        setCurrencyTouched(false);
-        setExchangeRateInput('');
-        setRateCapturedAt(null);
-        setDate(todayISO());
         setNotes('');
         setTagsInput('');
         setIsRetirementContribution(false);
@@ -1011,6 +1027,22 @@ export function TransactionForm({
         setLocalTime(captureNow(getBrowserTimeZone()).localDateTime);
         setLocalTimeZone(getBrowserTimeZone());
         setAdditionalOpen(false);
+
+        if (!addAnother) {
+          setTransactionType('EXPENSE');
+          setStatus('PENDING');
+          setAccountId('');
+          setCurrencyCode('');
+          setCurrencyTouched(false);
+          setExchangeRateInput('');
+          setRateCapturedAt(null);
+          setDate(todayISO());
+        } else {
+          // Keep the dialog open, return focus to the first field, and confirm
+          // the save to assistive tech for the next fast entry.
+          setAddAnotherStatus('Transaction saved. Ready to add another.');
+          requestAnimationFrame(() => firstInputRef.current?.focus());
+        }
       } catch (err) {
         setSubmitError(err instanceof Error ? err.message : submitFailureMessage);
       } finally {
@@ -1021,6 +1053,7 @@ export function TransactionForm({
       amountInput,
       description,
       accountId,
+      isEditMode,
       baseCurrency,
       entryCurrency,
       isForeignEntry,
@@ -1990,12 +2023,35 @@ export function TransactionForm({
             </div>
           )}
 
+          <div className="sr-only" aria-live="polite">
+            {addAnotherStatus}
+          </div>
+
           {/* Actions */}
           <div className="form-actions">
             <Button type="button" variant="secondary" onClick={handleCancel} disabled={submitting}>
               Cancel
             </Button>
-            <Button type="submit" variant="primary" loading={submitting}>
+            {!isEditMode && (
+              <Button
+                type="submit"
+                variant="secondary"
+                loading={submitting}
+                onClick={() => {
+                  submitModeRef.current = 'add-another';
+                }}
+              >
+                Save and add another
+              </Button>
+            )}
+            <Button
+              type="submit"
+              variant="primary"
+              loading={submitting}
+              onClick={() => {
+                submitModeRef.current = 'close';
+              }}
+            >
               {submitting ? submittingLabel : submitButtonLabel}
             </Button>
           </div>

--- a/apps/web/src/components/transactions/TransactionShortcutsLegend.test.tsx
+++ b/apps/web/src/components/transactions/TransactionShortcutsLegend.test.tsx
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for TransactionShortcutsLegend.
+ * References: issue #3654
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { TransactionShortcutsLegend } from './TransactionShortcutsLegend';
+
+describe('TransactionShortcutsLegend', () => {
+  it('is collapsed by default with an accessible trigger', () => {
+    render(<TransactionShortcutsLegend />);
+    const trigger = screen.getByRole('button', {
+      name: /keyboard shortcuts for the transaction list/i,
+    });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the legend and lists the transaction-list shortcuts', () => {
+    render(<TransactionShortcutsLegend />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /keyboard shortcuts for the transaction list/i }),
+    );
+    const dialog = screen.getByRole('dialog', { name: /transaction list keyboard shortcuts/i });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText('Next item')).toBeInTheDocument();
+    expect(screen.getByText('Select all visible items')).toBeInTheDocument();
+    expect(screen.getByText('Edit active item')).toBeInTheDocument();
+  });
+
+  it('closes on Escape and restores focus to the trigger', () => {
+    render(<TransactionShortcutsLegend />);
+    const trigger = screen.getByRole('button', {
+      name: /keyboard shortcuts for the transaction list/i,
+    });
+    fireEvent.click(trigger);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/apps/web/src/components/transactions/TransactionShortcutsLegend.tsx
+++ b/apps/web/src/components/transactions/TransactionShortcutsLegend.tsx
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * TransactionShortcutsLegend — a discoverable, on-screen affordance that
+ * surfaces the transaction-list keyboard shortcuts wired up by
+ * `useKeyboardShortcuts`. Without it the shortcuts (J/K navigate, X toggle,
+ * A select-all, E edit, Delete, Enter open) are effectively invisible (#3654).
+ *
+ * Renders a compact "?" button that toggles a small, dismissible legend. The
+ * legend is keyboard reachable, closes on Escape, and returns focus to the
+ * trigger. Styling uses design tokens and respects reduced-motion.
+ *
+ * @module components/transactions/TransactionShortcutsLegend
+ */
+
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+
+import { SHORTCUT_CATEGORIES } from '../../hooks/useKeyboardShortcuts';
+
+import './transaction-shortcuts-legend.css';
+
+const TRANSACTION_LIST_SHORTCUTS =
+  SHORTCUT_CATEGORIES.find((category) => category.title === 'Transaction List')?.shortcuts ?? [];
+
+export function TransactionShortcutsLegend(): React.ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const legendRef = useRef<HTMLDivElement>(null);
+  const legendId = useId();
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+      }
+    };
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (legendRef.current?.contains(target) || triggerRef.current?.contains(target)) {
+        return;
+      }
+      setIsOpen(false);
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('mousedown', handlePointerDown);
+    };
+  }, [isOpen, close]);
+
+  return (
+    <div className="transaction-shortcuts-legend">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="transaction-shortcuts-legend__trigger"
+        aria-label="Keyboard shortcuts for the transaction list"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? legendId : undefined}
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        <span aria-hidden="true">?</span>
+      </button>
+
+      {isOpen && (
+        <div
+          ref={legendRef}
+          id={legendId}
+          role="dialog"
+          aria-label="Transaction list keyboard shortcuts"
+          className="transaction-shortcuts-legend__panel"
+        >
+          <p className="transaction-shortcuts-legend__title">Keyboard shortcuts</p>
+          <dl className="transaction-shortcuts-legend__list">
+            {TRANSACTION_LIST_SHORTCUTS.map((shortcut) => (
+              <div className="transaction-shortcuts-legend__row" key={shortcut.keys}>
+                <dt className="transaction-shortcuts-legend__keys">
+                  <kbd>{shortcut.keys}</kbd>
+                </dt>
+                <dd className="transaction-shortcuts-legend__action">{shortcut.description}</dd>
+              </div>
+            ))}
+          </dl>
+          <p className="transaction-shortcuts-legend__hint">
+            Shortcuts work when focus is outside text fields. Press <kbd>?</kbd> anywhere for the
+            full list.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TransactionShortcutsLegend;

--- a/apps/web/src/components/transactions/TransactionsSummaryBar.test.tsx
+++ b/apps/web/src/components/transactions/TransactionsSummaryBar.test.tsx
@@ -39,16 +39,18 @@ describe('TransactionsSummaryBar', () => {
     expect(screen.getAllByText(/4 transactions/).length).toBeGreaterThan(0);
   });
 
-  it('renders a single net total', () => {
+  it('renders income, expense, and net totals', () => {
     render(
       <TransactionsSummaryBar
         summary={summary({
           count: 3,
-          totalsByCurrency: [{ currency: 'USD', net: 2500 }],
-          singleCurrencyNet: { currency: 'USD', net: 2500 },
+          totalsByCurrency: [{ currency: 'USD', income: 5000, expenses: 2500, net: 2500 }],
+          singleCurrencyNet: { currency: 'USD', income: 5000, expenses: 2500, net: 2500 },
         })}
       />,
     );
+    expect(screen.getByText('USD 5000')).toBeInTheDocument();
+    expect(screen.getByText('USD -2500')).toBeInTheDocument();
     expect(screen.getByText('USD 2500')).toBeInTheDocument();
   });
 
@@ -59,32 +61,32 @@ describe('TransactionsSummaryBar', () => {
           count: 2,
           isMixedCurrency: true,
           totalsByCurrency: [
-            { currency: 'EUR', net: -700 },
-            { currency: 'USD', net: 600 },
+            { currency: 'EUR', income: 0, expenses: 700, net: -700 },
+            { currency: 'USD', income: 600, expenses: 0, net: 600 },
           ],
         })}
       />,
     );
-    expect(screen.getByText('EUR -700')).toBeInTheDocument();
-    expect(screen.getByText('USD 600')).toBeInTheDocument();
+    expect(screen.getAllByText('EUR -700').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('USD 600').length).toBeGreaterThan(0);
   });
 
-  it('announces the net total in a live region for screen readers', () => {
+  it('announces income, expense, and net totals in a live region for screen readers', () => {
     render(
       <TransactionsSummaryBar
         summary={summary({
           count: 3,
-          totalsByCurrency: [{ currency: 'USD', net: -1500 }],
-          singleCurrencyNet: { currency: 'USD', net: -1500 },
+          totalsByCurrency: [{ currency: 'USD', income: 500, expenses: 2000, net: -1500 }],
+          singleCurrencyNet: { currency: 'USD', income: 500, expenses: 2000, net: -1500 },
         })}
       />,
     );
     const status = screen.getByRole('status');
     expect(status).toHaveTextContent('3 transactions');
-    expect(status).toHaveTextContent(/net total negative 15\.00 USD/i);
+    expect(status).toHaveTextContent(/net negative 15\.00 USD/i);
   });
 
-  it('omits the net when there are no net-contributing transactions', () => {
+  it('omits the totals when there are no net-contributing transactions', () => {
     render(<TransactionsSummaryBar summary={summary({ count: 2 })} />);
     expect(screen.queryByTestId('currency')).not.toBeInTheDocument();
   });

--- a/apps/web/src/components/transactions/TransactionsSummaryBar.tsx
+++ b/apps/web/src/components/transactions/TransactionsSummaryBar.tsx
@@ -1,21 +1,22 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * TransactionsSummaryBar — at-a-glance count and net total for the visible
- * ledger. Renders a visible summary and mirrors it in a polite live region so
- * screen-reader users hear the totals update as filters and search change.
+ * TransactionsSummaryBar — at-a-glance count plus income, expense, and net
+ * totals for the visible ledger. Renders a visible summary and mirrors it in a
+ * polite live region so screen-reader users hear the totals update as filters
+ * and search change.
  *
  * Net total = income − expenses; transfers are excluded. When the visible set
- * spans multiple currencies each currency's net is listed separately so unlike
- * currencies are never summed into a misleading single figure.
+ * spans multiple currencies each currency's totals are listed separately so
+ * unlike currencies are never summed into a misleading single figure.
  *
- * References: issue #3772
+ * References: issues #3772, #3605
  * @module components/transactions/TransactionsSummaryBar
  */
 
 import React from 'react';
 
-import type { TransactionSummary } from '../../lib/transactions/summary';
+import type { CurrencyTotal, TransactionSummary } from '../../lib/transactions/summary';
 import { CurrencyDisplay } from '../common';
 
 import './transactions-summary-bar.css';
@@ -29,42 +30,77 @@ function countLabel(count: number): string {
   return `${count} ${count === 1 ? 'transaction' : 'transactions'}`;
 }
 
-function netScreenReaderText(summary: TransactionSummary): string {
+function amountWords(cents: number): string {
+  const magnitude = (Math.abs(cents) / 100).toFixed(2);
+  const sign = cents < 0 ? 'negative ' : '';
+  return `${sign}${magnitude}`;
+}
+
+function screenReaderText(summary: TransactionSummary): string {
   if (summary.totalsByCurrency.length === 0) {
     return '';
   }
-  const parts = summary.totalsByCurrency.map((total) => {
-    const magnitude = (Math.abs(total.net) / 100).toFixed(2);
-    const sign = total.net < 0 ? 'negative ' : '';
-    return `${sign}${magnitude} ${total.currency}`;
-  });
-  return `. Net total ${parts.join(', ')}`;
+  const parts = summary.totalsByCurrency.map(
+    (total) =>
+      `Income ${amountWords(total.income)}, expenses ${amountWords(total.expenses)}, ` +
+      `net ${amountWords(total.net)} ${total.currency}`,
+  );
+  return `. ${parts.join('. ')}`;
+}
+
+function CurrencyTotals({ total }: { total: CurrencyTotal }): React.ReactElement {
+  return (
+    <span className="transactions-summary-bar__currency" aria-hidden="true">
+      <span className="transactions-summary-bar__metric transactions-summary-bar__metric--income">
+        <span className="transactions-summary-bar__metric-label">Income</span>
+        <CurrencyDisplay
+          className="transactions-summary-bar__amount"
+          amount={total.income}
+          currency={total.currency}
+          colorize
+          showSign
+        />
+      </span>
+      <span className="transactions-summary-bar__metric transactions-summary-bar__metric--expense">
+        <span className="transactions-summary-bar__metric-label">Expenses</span>
+        <CurrencyDisplay
+          className="transactions-summary-bar__amount"
+          amount={-total.expenses}
+          currency={total.currency}
+          colorize
+          showSign
+        />
+      </span>
+      <span className="transactions-summary-bar__metric transactions-summary-bar__metric--net">
+        <span className="transactions-summary-bar__metric-label">Net</span>
+        <CurrencyDisplay
+          className="transactions-summary-bar__amount"
+          amount={total.net}
+          currency={total.currency}
+          colorize
+          showSign
+        />
+      </span>
+    </span>
+  );
 }
 
 export const TransactionsSummaryBar: React.FC<TransactionsSummaryBarProps> = ({ summary }) => {
-  const hasNet = summary.totalsByCurrency.length > 0;
+  const hasTotals = summary.totalsByCurrency.length > 0;
 
   return (
     <div className="transactions-summary-bar">
       <span className="transactions-summary-bar__count">{countLabel(summary.count)}</span>
-      {hasNet && (
-        <span className="transactions-summary-bar__net" aria-hidden="true">
-          <span className="transactions-summary-bar__net-label">Net</span>
+      {hasTotals && (
+        <span className="transactions-summary-bar__totals">
           {summary.totalsByCurrency.map((total) => (
-            <CurrencyDisplay
-              key={total.currency}
-              className="transactions-summary-bar__amount"
-              amount={total.net}
-              currency={total.currency}
-              colorize
-              showSign
-            />
+            <CurrencyTotals key={total.currency} total={total} />
           ))}
         </span>
       )}
       <span className="sr-only" role="status" aria-live="polite">
         {countLabel(summary.count)}
-        {netScreenReaderText(summary)}
+        {screenReaderText(summary)}
       </span>
     </div>
   );

--- a/apps/web/src/components/transactions/index.ts
+++ b/apps/web/src/components/transactions/index.ts
@@ -18,3 +18,4 @@ export { CounterpartyInput } from './CounterpartyInput';
 export type { CounterpartyInputProps } from './CounterpartyInput';
 export { TransactionsSummaryBar } from './TransactionsSummaryBar';
 export type { TransactionsSummaryBarProps } from './TransactionsSummaryBar';
+export { TransactionShortcutsLegend } from './TransactionShortcutsLegend';

--- a/apps/web/src/components/transactions/transaction-shortcuts-legend.css
+++ b/apps/web/src/components/transactions/transaction-shortcuts-legend.css
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for TransactionShortcutsLegend — a discoverable "?" trigger and its
+ * small pop-over legend of transaction-list keyboard shortcuts (#3654). Uses
+ * design tokens and respects reduced-motion.
+ */
+
+.transaction-shortcuts-legend {
+  position: relative;
+  display: inline-flex;
+}
+
+.transaction-shortcuts-legend__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-full, 999px);
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-text-secondary);
+  font-weight: var(--font-weight-semibold, 600);
+  font-size: var(--type-scale-body-font-size, 0.9375rem);
+  cursor: pointer;
+  transition: background-color var(--duration-fast, 120ms) ease;
+}
+
+.transaction-shortcuts-legend__trigger:hover {
+  background: var(--semantic-background-tertiary, var(--semantic-background-secondary));
+  color: var(--semantic-text-primary);
+}
+
+.transaction-shortcuts-legend__trigger:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, var(--color-primary, currentColor));
+  outline-offset: 2px;
+}
+
+.transaction-shortcuts-legend__panel {
+  position: absolute;
+  top: calc(100% + var(--spacing-2));
+  right: 0;
+  z-index: var(--z-index-popover, 60);
+  min-width: 16rem;
+  padding: var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary, var(--semantic-background-secondary));
+  box-shadow: var(--shadow-md, 0 4px 12px rgb(0 0 0 / 15%));
+  animation: transaction-shortcuts-legend-in var(--duration-fast, 120ms) ease;
+}
+
+.transaction-shortcuts-legend__title {
+  margin: 0 0 var(--spacing-2);
+  font-size: var(--type-scale-caption-font-size, 0.8125rem);
+  font-weight: var(--font-weight-semibold, 600);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--semantic-text-tertiary, var(--semantic-text-secondary));
+}
+
+.transaction-shortcuts-legend__list {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--spacing-1) var(--spacing-3);
+}
+
+.transaction-shortcuts-legend__row {
+  display: contents;
+}
+
+.transaction-shortcuts-legend__keys {
+  margin: 0;
+}
+
+.transaction-shortcuts-legend__keys kbd,
+.transaction-shortcuts-legend__hint kbd {
+  display: inline-block;
+  padding: 0 var(--spacing-1);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm, 4px);
+  background: var(--semantic-background-secondary);
+  font-family: var(--font-family-mono, monospace);
+  font-size: var(--type-scale-caption-font-size, 0.8125rem);
+  color: var(--semantic-text-primary);
+}
+
+.transaction-shortcuts-legend__action {
+  margin: 0;
+  font-size: var(--type-scale-body-font-size, 0.9375rem);
+  color: var(--semantic-text-secondary);
+}
+
+.transaction-shortcuts-legend__hint {
+  margin: var(--spacing-3) 0 0;
+  font-size: var(--type-scale-caption-font-size, 0.8125rem);
+  color: var(--semantic-text-tertiary, var(--semantic-text-secondary));
+}
+
+@keyframes transaction-shortcuts-legend-in {
+  from {
+    opacity: 0;
+    transform: translateY(-0.25rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .transaction-shortcuts-legend__panel {
+    animation: none;
+  }
+}

--- a/apps/web/src/components/transactions/transactions-summary-bar.css
+++ b/apps/web/src/components/transactions/transactions-summary-bar.css
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: BUSL-1.1 */
 
 /**
- * Styles for TransactionsSummaryBar — the at-a-glance count + net total shown
- * above the transactions ledger. Uses design tokens for consistent theming.
- * References: issue #3772
+ * Styles for TransactionsSummaryBar — the at-a-glance count + income / expense
+ * / net totals shown above the transactions ledger. Uses design tokens for
+ * consistent theming. References: issues #3772, #3605
  */
 
 .transactions-summary-bar {
@@ -25,14 +25,27 @@
   color: var(--semantic-text-secondary);
 }
 
-.transactions-summary-bar__net {
+.transactions-summary-bar__totals {
   display: inline-flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: var(--spacing-2);
+  gap: var(--spacing-2) var(--spacing-4);
 }
 
-.transactions-summary-bar__net-label {
+.transactions-summary-bar__currency {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--spacing-2) var(--spacing-4);
+}
+
+.transactions-summary-bar__metric {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--spacing-1);
+}
+
+.transactions-summary-bar__metric-label {
   font-size: var(--type-scale-caption-font-size, 0.8125rem);
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;

--- a/apps/web/src/lib/transactions/filter-sort.test.ts
+++ b/apps/web/src/lib/transactions/filter-sort.test.ts
@@ -179,6 +179,50 @@ describe('applyAdvancedFilters', () => {
 
     expect(result.map((t) => t.id)).toEqual(['mid']);
   });
+
+  it('ignores non-numeric amount bounds instead of hiding every row (#3639)', () => {
+    const small = makeTransaction({ id: 'small', amount: { amount: 500 } });
+    const large = makeTransaction({ id: 'large', amount: { amount: 9000 } });
+
+    const nanMin = applyAdvancedFilters([small, large], {
+      ...EMPTY_FILTERS,
+      amountMin: 'abc',
+    });
+    expect(nanMin.map((t) => t.id)).toEqual(['small', 'large']);
+
+    const nanMax = applyAdvancedFilters([small, large], {
+      ...EMPTY_FILTERS,
+      amountMax: 'not-a-number',
+    });
+    expect(nanMax.map((t) => t.id)).toEqual(['small', 'large']);
+  });
+
+  it('treats an empty amount range as no bound', () => {
+    const small = makeTransaction({ id: 'small', amount: { amount: 500 } });
+    const large = makeTransaction({ id: 'large', amount: { amount: 9000 } });
+
+    const result = applyAdvancedFilters([small, large], {
+      ...EMPTY_FILTERS,
+      amountMin: '   ',
+      amountMax: '',
+    });
+
+    expect(result.map((t) => t.id)).toEqual(['small', 'large']);
+  });
+
+  it('swaps an inverted amount range instead of returning an empty list (#3639)', () => {
+    const small = makeTransaction({ id: 'small', amount: { amount: 500 } }); // $5
+    const mid = makeTransaction({ id: 'mid', amount: { amount: -2500 } }); // $25
+    const large = makeTransaction({ id: 'large', amount: { amount: 9000 } }); // $90
+
+    const result = applyAdvancedFilters([small, mid, large], {
+      ...EMPTY_FILTERS,
+      amountMin: '50',
+      amountMax: '10',
+    });
+
+    expect(result.map((t) => t.id)).toEqual(['mid']);
+  });
 });
 
 describe('matchesTransactionQuery', () => {

--- a/apps/web/src/lib/transactions/filter-sort.ts
+++ b/apps/web/src/lib/transactions/filter-sort.ts
@@ -69,6 +69,21 @@ export function sortTransactions(
 // Advanced filters (category / account / amount range / type / status)
 // ---------------------------------------------------------------------------
 
+/**
+ * Parse an amount-range bound (major units) into integer cents.
+ *
+ * Returns `null` for empty, whitespace-only, or non-numeric input so a
+ * malformed bound is treated as "no bound" instead of producing a `NaN`
+ * comparison that hides every row (#3639).
+ */
+function parseAmountBoundCents(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  const value = Number(trimmed);
+  if (!Number.isFinite(value)) return null;
+  return Math.round(value * 100);
+}
+
 /** Apply the advanced filter set (AND semantics) on top of an existing list. */
 export function applyAdvancedFilters(
   transactions: readonly Transaction[],
@@ -86,14 +101,21 @@ export function applyAdvancedFilters(
     result = result.filter((t) => filters.accountIds.includes(t.accountId));
   }
 
-  if (filters.amountMin) {
-    const minCents = Math.round(parseFloat(filters.amountMin) * 100);
-    result = result.filter((t) => Math.abs(t.amount.amount) >= minCents);
+  // Amount range: parse both bounds up front, ignore non-numeric input, and
+  // swap an inverted (min > max) range so malformed or shareable URL params
+  // never silently hide every row (#3639).
+  let minCents = parseAmountBoundCents(filters.amountMin);
+  let maxCents = parseAmountBoundCents(filters.amountMax);
+  if (minCents !== null && maxCents !== null && minCents > maxCents) {
+    [minCents, maxCents] = [maxCents, minCents];
   }
 
-  if (filters.amountMax) {
-    const maxCents = Math.round(parseFloat(filters.amountMax) * 100);
-    result = result.filter((t) => Math.abs(t.amount.amount) <= maxCents);
+  if (minCents !== null) {
+    result = result.filter((t) => Math.abs(t.amount.amount) >= minCents!);
+  }
+
+  if (maxCents !== null) {
+    result = result.filter((t) => Math.abs(t.amount.amount) <= maxCents!);
   }
 
   if (filters.types.length > 0) {

--- a/apps/web/src/lib/transactions/summary.test.ts
+++ b/apps/web/src/lib/transactions/summary.test.ts
@@ -66,7 +66,12 @@ describe('summarizeTransactions', () => {
       makeTransaction({ type: 'EXPENSE', amount: 2000 }),
       makeTransaction({ type: 'EXPENSE', amount: 500 }),
     ]);
-    expect(summary.singleCurrencyNet).toEqual({ currency: 'USD', net: 2500 });
+    expect(summary.singleCurrencyNet).toEqual({
+      currency: 'USD',
+      income: 5000,
+      expenses: 2500,
+      net: 2500,
+    });
     expect(summary.isMixedCurrency).toBe(false);
   });
 
@@ -75,7 +80,12 @@ describe('summarizeTransactions', () => {
       makeTransaction({ type: 'EXPENSE', amount: -3000 }),
       makeTransaction({ type: 'INCOME', amount: 1000 }),
     ]);
-    expect(summary.singleCurrencyNet).toEqual({ currency: 'USD', net: -2000 });
+    expect(summary.singleCurrencyNet).toEqual({
+      currency: 'USD',
+      income: 1000,
+      expenses: 3000,
+      net: -2000,
+    });
   });
 
   it('excludes transfers from the net total', () => {
@@ -83,7 +93,12 @@ describe('summarizeTransactions', () => {
       makeTransaction({ type: 'INCOME', amount: 1000 }),
       makeTransaction({ type: 'TRANSFER', amount: 50000 }),
     ]);
-    expect(summary.singleCurrencyNet).toEqual({ currency: 'USD', net: 1000 });
+    expect(summary.singleCurrencyNet).toEqual({
+      currency: 'USD',
+      income: 1000,
+      expenses: 0,
+      net: 1000,
+    });
   });
 
   it('reports per-currency totals and flags mixed currencies', () => {
@@ -95,8 +110,8 @@ describe('summarizeTransactions', () => {
     expect(summary.isMixedCurrency).toBe(true);
     expect(summary.singleCurrencyNet).toBeNull();
     expect(summary.totalsByCurrency).toEqual([
-      { currency: 'EUR', net: -700 },
-      { currency: 'USD', net: 600 },
+      { currency: 'EUR', income: 0, expenses: 700, net: -700 },
+      { currency: 'USD', income: 1000, expenses: 400, net: 600 },
     ]);
   });
 

--- a/apps/web/src/lib/transactions/summary.ts
+++ b/apps/web/src/lib/transactions/summary.ts
@@ -4,7 +4,8 @@
  * Transaction summary helpers.
  *
  * Produces at-a-glance totals for a set of transactions so the ledger can
- * surface a results summary (count + net total) and per-day subtotals.
+ * surface a results summary (count + income / expense / net totals) and
+ * per-day subtotals.
  *
  * Net total = income − expenses. Transfers are excluded from the net because
  * they move money between the user's own accounts and are not spend or income.
@@ -17,10 +18,14 @@
 
 import type { Transaction } from '../../kmp/bridge';
 
-/** Net total (in integer cents) for a single currency. */
+/** Income, expense, and net totals (in integer cents) for a single currency. */
 export interface CurrencyTotal {
   /** ISO 4217 currency code. */
   readonly currency: string;
+  /** Total income in integer cents (positive magnitude). */
+  readonly income: number;
+  /** Total expenses in integer cents (positive magnitude). */
+  readonly expenses: number;
   /** Net amount in integer cents (income positive, expenses negative). */
   readonly net: number;
 }
@@ -41,41 +46,42 @@ export interface TransactionSummary {
   readonly singleCurrencyNet: CurrencyTotal | null;
 }
 
-/**
- * Signed contribution of a transaction to a net total, in integer cents.
- * Expenses are negative, income positive, transfers contribute nothing.
- */
-function netContribution(transaction: Transaction): number {
-  switch (transaction.type) {
-    case 'EXPENSE':
-      return -Math.abs(transaction.amount.amount);
-    case 'INCOME':
-      return Math.abs(transaction.amount.amount);
-    default:
-      return 0;
-  }
+/** Running income/expense tallies for one currency, in integer cents. */
+interface CurrencyTally {
+  income: number;
+  expenses: number;
 }
 
 /**
- * Summarize a set of transactions into a count and per-currency net totals.
+ * Summarize a set of transactions into a count and per-currency income,
+ * expense, and net totals.
  *
  * @param transactions Transactions to summarize (order-independent).
  * @returns A {@link TransactionSummary}.
  */
 export function summarizeTransactions(transactions: readonly Transaction[]): TransactionSummary {
-  const netByCurrency = new Map<string, number>();
+  const tallyByCurrency = new Map<string, CurrencyTally>();
 
   for (const transaction of transactions) {
     if (transaction.type === 'TRANSFER') {
       continue;
     }
     const code = transaction.currency.code;
-    netByCurrency.set(code, (netByCurrency.get(code) ?? 0) + netContribution(transaction));
+    const tally = tallyByCurrency.get(code) ?? { income: 0, expenses: 0 };
+    const magnitude = Math.abs(transaction.amount.amount);
+    if (transaction.type === 'INCOME') {
+      tally.income += magnitude;
+    } else if (transaction.type === 'EXPENSE') {
+      tally.expenses += magnitude;
+    }
+    tallyByCurrency.set(code, tally);
   }
 
-  const totalsByCurrency: CurrencyTotal[] = Array.from(netByCurrency, ([currency, net]) => ({
+  const totalsByCurrency: CurrencyTotal[] = Array.from(tallyByCurrency, ([currency, tally]) => ({
     currency,
-    net,
+    income: tally.income,
+    expenses: tally.expenses,
+    net: tally.income - tally.expenses,
   })).sort((a, b) => a.currency.localeCompare(b.currency));
 
   const isMixedCurrency = totalsByCurrency.length > 1;

--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -216,6 +216,7 @@ vi.mock('../components/transactions', () => ({
     statuses: [],
   },
   DEFAULT_SORT: { field: 'date', direction: 'desc' },
+  TransactionShortcutsLegend: () => <div data-testid="transaction-shortcuts-legend" />,
 }));
 
 const mockedUseTransactions = vi.mocked(useTransactions);

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -44,6 +44,7 @@ import {
   TransactionSort,
   TransactionEditPanel,
   TransactionsSummaryBar,
+  TransactionShortcutsLegend,
   LazyReceiptImage,
   DEFAULT_SORT,
 } from '../components/transactions';
@@ -676,7 +677,47 @@ export const TransactionsPage: React.FC = () => {
     [transactions],
   );
 
-  // Filter/Sort handlers
+  // Running balance (#3659): a register/ledger balance after each transaction
+  // only makes sense when the visible set is scoped to a single account and
+  // ordered by date. It is accumulated from that account's full loaded history
+  // (rawTransactions) in chronological order so each row reflects the true
+  // balance even when a date/amount filter hides earlier rows. When the view
+  // mixes accounts the balance is meaningless, so it is hidden entirely.
+  const runningBalanceAccountId = useMemo(() => {
+    if (transactions.length === 0) return null;
+    let accountId: string | null = null;
+    for (const transaction of transactions) {
+      if (accountId === null) {
+        accountId = transaction.accountId;
+      } else if (accountId !== transaction.accountId) {
+        return null;
+      }
+    }
+    return accountId;
+  }, [transactions]);
+
+  const showRunningBalance = sortConfig.field === 'date' && runningBalanceAccountId !== null;
+
+  const runningBalanceById = useMemo(() => {
+    const balances = new Map<string, number>();
+    if (runningBalanceAccountId === null) return balances;
+
+    const accountHistory = rawTransactions
+      .filter((transaction) => transaction.accountId === runningBalanceAccountId)
+      .sort((a, b) => {
+        const byDate = a.date.localeCompare(b.date);
+        if (byDate !== 0) return byDate;
+        return a.createdAt.localeCompare(b.createdAt);
+      });
+
+    let runningTotal = 0;
+    for (const transaction of accountHistory) {
+      runningTotal += getTransactionDisplayAmount(transaction);
+      balances.set(transaction.id, runningTotal);
+    }
+    return balances;
+  }, [rawTransactions, runningBalanceAccountId]);
+
   const handleFiltersChange = useCallback(
     (newFilters: AdvancedFilters) => {
       const params = { ...filtersToParams(newFilters) };
@@ -762,7 +803,7 @@ export const TransactionsPage: React.FC = () => {
   }, []);
 
   const handleTransactionSubmit = useCallback(
-    async (data: CreateTransactionInput): Promise<void> => {
+    async (data: CreateTransactionInput, options?: { addAnother?: boolean }): Promise<void> => {
       if (editingTransaction !== null) {
         const result = updateTransaction(editingTransaction.id, data);
         if (result === null) {
@@ -779,7 +820,11 @@ export const TransactionsPage: React.FC = () => {
       }
 
       recordPwaMeaningfulAction();
-      handleFormCancel();
+      // "Save and add another" keeps the dialog open for the next entry (#3650);
+      // a regular save closes it as before.
+      if (!options?.addAnother) {
+        handleFormCancel();
+      }
       refreshTransactions();
     },
     [
@@ -1274,6 +1319,18 @@ export const TransactionsPage: React.FC = () => {
                 showSign
               />
             </div>
+            {showRunningBalance && runningBalanceById.has(transaction.id) ? (
+              <div className="transaction-list-item__running-balance">
+                <span className="transaction-list-item__running-balance-label" aria-hidden="true">
+                  Balance
+                </span>
+                <CurrencyDisplay
+                  amount={runningBalanceById.get(transaction.id)!}
+                  currency={transaction.currency.code}
+                  context={`running balance after ${transactionLabel}`}
+                />
+              </div>
+            ) : null}
             <div className="transaction-item__actions" aria-label="Transaction actions">
               <button
                 type="button"
@@ -1304,6 +1361,8 @@ export const TransactionsPage: React.FC = () => {
       handleEditTransaction,
       handleTransactionSelection,
       transactions.length,
+      showRunningBalance,
+      runningBalanceById,
     ],
   );
 
@@ -1428,7 +1487,7 @@ export const TransactionsPage: React.FC = () => {
             <input
               type="search"
               className="search-bar__input"
-              placeholder="Search..."
+              placeholder="Search payee, category, amount, tag…"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               aria-label="Search transactions"
@@ -1538,6 +1597,7 @@ export const TransactionsPage: React.FC = () => {
                 {hasActiveFilters ? ' match your filters' : ''}
               </p>
             ) : null}
+            {!isSimplified && <TransactionShortcutsLegend />}
           </div>
 
           {!isLoading && !resolvedError && transactions.length > 0 && (

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -1200,6 +1200,22 @@
 .transaction-list-item__amount {
   text-align: right;
 }
+.transaction-list-item__running-balance {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  min-width: 5.5rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--semantic-text-secondary);
+}
+.transaction-list-item__running-balance-label {
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  font-weight: var(--font-weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--semantic-text-tertiary, var(--semantic-text-secondary));
+}
 .transaction-item__actions {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
﻿## Summary

A cohesive batch of transactions register & filter improvements for `apps/web`, covering the transactions list/register: running balance, save-and-add-another, income/expense/net summary bar, richer search placeholder & clear button, an amount-range filter bug fix, debounced search, keyboard-shortcut discoverability, and empty-state CTAs.

### Newly implemented in this PR
- **Running balance** (#3659): per-account chronological running balance column in the register, shown when sorted by date within a single account, computed from the full unfiltered set and privacy-aware.
- **Save and add another** (#3650): secondary submit on the create form keeps the dialog open, preserves context (account, date, type, status, currency), clears entry-specific fields, refocuses the first input, and announces readiness. Hidden in edit mode.
- **Income / expenses / net summary bar** (#3605): the summary bar now breaks each currency into income, expenses, and net instead of only net.
- **Descriptive search placeholder** (#3644): placeholder now names the searchable fields (payee, category, amount, tag).
- **Amount-range filter bug** (#3639): non-numeric bounds are ignored instead of matching nothing; an inverted min>max range is swapped.
- **Keyboard-shortcut discoverability** (#3654): a visible `?` trigger in the results header opens a dismissible legend listing the Transaction List shortcuts (Escape/outside-click close, focus restored).

### Verified already satisfied on `main` (closed via this PR)
- **Debounced search** (#3608): `useDebouncedSearch` already wired.
- **Search clear (x) button** (#3613): `search-bar__clear` already present.
- **Add transaction CTA on empty state** (#3625): already implemented.
- **Clear all filters on filtered empty state** (#3621): `NoResultsEmptyState` `onClearFilters` already implemented.

## Testing (local only)
- `npm run format` + `npx eslint . --fix`; verified `npm run format:check` and `npx eslint . --max-warnings 0` clean.
- Full `apps/web` unit suite: 9856 tests across 902 files passing.
- `apps/web` production build succeeds.

Closes #3659
Closes #3650
Closes #3605
Closes #3644
Closes #3639
Closes #3613
Closes #3608
Closes #3654
Closes #3625
Closes #3621
