### PR TITLE
feat(tokens): design tokens batch - ramps, scales, status, themes & chart palette

### DIFF
--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -6,17 +6,23 @@ Design tokens for the Finance app, defined in [DTCG](https://design-tokens.githu
 
 ```
 tokens/
-├── primitive/     # Raw values (colors, spacing, typography, shadows, motion, cognitive)
+├── primitive/     # Raw values (colors, spacing, radius, typography, shadows, motion, opacity, z-index, cognitive)
 ├── semantic/      # Purpose-mapped tokens with theme variants + accessibility modes
-│   ├── colors.light.json          # Light theme colors
-│   ├── colors.dark.json           # Dark theme colors
-│   ├── colors.dark-oled.json      # OLED dark theme (true black)
-│   ├── colors.high-contrast.json  # High-contrast theme (WCAG AAA)
-│   ├── typography.json            # Type scale (display → caption)
-│   ├── elevation.json             # Shadow elevation mapping
+│   ├── colors.light.json               # Light theme colors
+│   ├── colors.dark.json                # Dark theme colors
+│   ├── colors.dark-oled.json           # OLED dark theme (true black)
+│   ├── colors.high-contrast.json       # Light high-contrast theme (WCAG AAA)
+│   ├── colors.high-contrast-dark.json  # Dark high-contrast theme (WCAG AAA, near-black)
+│   ├── typography.json            # Type scale (display → caption → amount)
+│   ├── elevation.json             # Shadow elevation mapping (light default)
 │   ├── animation.json             # Motion purpose mapping
 │   ├── breakpoints.json           # Responsive layout breakpoints
+│   ├── state.json                 # Opacity states (disabled, scrim, hover)
+│   ├── layer.json                 # Stacking layers (modal, toast, tooltip…)
 │   └── cognitive.json             # Cognitive accessibility overrides
+├── override/      # Theme-scoped overrides layered after semantic + component (not auto-globbed)
+│   ├── elevation.dark.json        # Visible dark/OLED elevation (shadow.dark.*)
+│   └── chart.dark.json            # Dark/OLED CVD-safe chart series routing
 └── component/     # Component-specific tokens
     ├── button.json                # Button variants (primary, secondary, destructive)
     ├── card.json                  # Card container styling
@@ -28,6 +34,16 @@ tokens/
     └── cognitive.json             # Cognitive mode component overrides
 ```
 
+## Naming Conventions
+
+Token authors should follow these conventions so names stay predictable across the three tiers:
+
+- **Tiers**: `primitive` → `semantic` → `component`. Reference up the chain with `{group.subgroup.key}`; never hardcode a raw value in a semantic/component token.
+- **Casing**: token group and key names are `camelCase` (`borderRadius`, `fontSize`, `zIndex`, `positiveSubtle`, `typeScale`). Numeric scale steps use bare numbers as keys (`spacing.4`, `color.blue.500`, `opacity.40`).
+- **Scales**: color ramps run `50,100,…,900` (`950` where a deeper step is needed); `spacing` keys equal the multiplier of the 4px base (`spacing.6` = 24px); `borderRadius` uses t-shirt sizes (`sm`…`3xl`, plus `none`/`full`); `zIndex`/`opacity` use ordered numeric steps with gaps.
+- **Semantic status**: each status hue exposes a solid foreground (`status.positive`) and a low-emphasis background (`status.positiveSubtle`). Never convey financial state through color alone — always pair with an icon/label.
+- **Types**: use DTCG `$type` (`color`, `dimension`, `number`, `shadow`, `fontFamily`, `fontVariantNumeric`, `fontWeight`). Keep names stable — renames/removals are breaking changes.
+
 ## Build
 
 ```bash
@@ -37,22 +53,23 @@ npm run clean    # Remove build artifacts
 
 ### Output Platforms
 
-| Platform       | Path             | Files                                                                                                              |
-| -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Web (CSS)      | `build/web/`     | `tokens.css`, `tokens-dark.css`, `tokens-dark-oled.css`, `tokens-high-contrast.css`                                |
-| iOS (Swift)    | `build/ios/`     | `FinanceTokens.swift`, `FinanceTokensDark.swift`, `FinanceTokensDarkOLED.swift`, `FinanceTokensHighContrast.swift` |
-| Android (XML)  | `build/android/` | `colors.xml`, `dimens.xml`, `colors-night.xml`, `colors-night-oled.xml`, `colors-high-contrast.xml`                |
-| Windows (XAML) | `build/windows/` | `FinanceTokens.xaml`, `FinanceTokensBrushes.xaml` + dark/OLED/HC variants                                          |
-| Kotlin (KMP)   | `build/kotlin/`  | `FinanceBreakpoints.kt`                                                                                            |
+| Platform       | Path             | Files                                                                                                                                                     |
+| -------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Web (CSS)      | `build/web/`     | `tokens.css`, `tokens-dark.css`, `tokens-dark-oled.css`, `tokens-high-contrast.css`, `tokens-high-contrast-dark.css`                                      |
+| iOS (Swift)    | `build/ios/`     | `FinanceTokens.swift`, `FinanceTokensDark.swift`, `FinanceTokensDarkOLED.swift`, `FinanceTokensHighContrast.swift`, `FinanceTokensHighContrastDark.swift` |
+| Android (XML)  | `build/android/` | `colors.xml`, `dimens.xml`, `colors-night.xml`, `colors-night-oled.xml`, `colors-high-contrast.xml`, `colors-high-contrast-dark.xml`                      |
+| Windows (XAML) | `build/windows/` | `FinanceTokens.xaml`, `FinanceTokensBrushes.xaml` + dark/OLED/HC/HC-dark variants                                                                         |
+| Kotlin (KMP)   | `build/kotlin/`  | `FinanceBreakpoints.kt`                                                                                                                                   |
 
 ### Theme Coverage
 
-| Theme         | CSS Selector                   | Use Case                              |
-| ------------- | ------------------------------ | ------------------------------------- |
-| Light         | `:root`                        | Default theme                         |
-| Dark          | `[data-theme="dark"]`          | Standard dark mode                    |
-| Dark OLED     | `[data-theme="dark-oled"]`     | True black for AMOLED battery savings |
-| High Contrast | `[data-theme="high-contrast"]` | Low vision / `prefers-contrast: more` |
+| Theme              | CSS Selector                        | Use Case                                                                    |
+| ------------------ | ----------------------------------- | --------------------------------------------------------------------------- |
+| Light              | `:root`                             | Default theme                                                               |
+| Dark               | `[data-theme="dark"]`               | Standard dark mode                                                          |
+| Dark OLED          | `[data-theme="dark-oled"]`          | True black for AMOLED battery savings                                       |
+| High Contrast      | `[data-theme="high-contrast"]`      | Low vision / `prefers-contrast: more`                                       |
+| High Contrast Dark | `[data-theme="high-contrast-dark"]` | Low vision + dark (`prefers-contrast: more` + `prefers-color-scheme: dark`) |
 
 ## Usage
 

--- a/packages/design-tokens/config/style-dictionary.config.mjs
+++ b/packages/design-tokens/config/style-dictionary.config.mjs
@@ -13,12 +13,26 @@ const toGlob = (p) => p.replace(/\\/g, '/');
 const primitives = toGlob(join(root, 'tokens', 'primitive', '*.json'));
 const components = toGlob(join(root, 'tokens', 'component', '*.json'));
 
-/** Shared non-color semantic tokens (typography, elevation, breakpoints, animation) */
+/** Shared non-color semantic tokens (typography, elevation, breakpoints, animation, state, layer) */
 const semanticShared = [
   toGlob(join(root, 'tokens', 'semantic', 'typography.json')),
   toGlob(join(root, 'tokens', 'semantic', 'elevation.json')),
   toGlob(join(root, 'tokens', 'semantic', 'breakpoints.json')),
   toGlob(join(root, 'tokens', 'semantic', 'animation.json')),
+  toGlob(join(root, 'tokens', 'semantic', 'state.json')),
+  toGlob(join(root, 'tokens', 'semantic', 'layer.json')),
+];
+
+/**
+ * Dark-theme overrides layered AFTER shared semantic + components so dark/OLED
+ * builds get visible (theme-aware) elevation and the dark CVD-safe chart palette
+ * without affecting the light or light-high-contrast output. Kept in
+ * tokens/override/ (outside the primitive/component globs) so they only apply to
+ * the themes that explicitly include them.
+ */
+const darkOverrides = [
+  toGlob(join(root, 'tokens', 'override', 'elevation.dark.json')),
+  toGlob(join(root, 'tokens', 'override', 'chart.dark.json')),
 ];
 
 // ---------------------------------------------------------------------------
@@ -271,6 +285,7 @@ const darkSd = new StyleDictionary({
     toGlob(join(root, 'tokens', 'semantic', 'colors.dark.json')),
     ...semanticShared,
     components,
+    ...darkOverrides,
   ],
   usesDtcg: true,
   platforms: buildPlatforms({
@@ -297,6 +312,7 @@ const oledDarkSd = new StyleDictionary({
     toGlob(join(root, 'tokens', 'semantic', 'colors.dark-oled.json')),
     ...semanticShared,
     components,
+    ...darkOverrides,
   ],
   usesDtcg: true,
   platforms: buildPlatforms({
@@ -337,6 +353,36 @@ const highContrastSd = new StyleDictionary({
   }),
 });
 
+/**
+ * Build dark high-contrast theme — primitives + dark high-contrast semantic +
+ * shared semantic + components + dark overrides.
+ *
+ * Completes the accessibility matrix for users who need both high contrast AND a
+ * dark surface (Windows High Contrast dark, macOS Increase Contrast + Dark Mode,
+ * prefers-contrast: more + prefers-color-scheme: dark). Near-black base with
+ * near-white AAA text pairings and brightened borders (≥3:1 UI contrast). Reuses
+ * the dark elevation + dark CVD-safe chart overrides since it is a dark theme.
+ */
+const highContrastDarkSd = new StyleDictionary({
+  source: [
+    primitives,
+    toGlob(join(root, 'tokens', 'semantic', 'colors.high-contrast-dark.json')),
+    ...semanticShared,
+    components,
+    ...darkOverrides,
+  ],
+  usesDtcg: true,
+  platforms: buildPlatforms({
+    cssFile: 'tokens-high-contrast-dark.css',
+    cssSelector: '[data-theme="high-contrast-dark"]',
+    swiftFile: 'FinanceTokensHighContrastDark.swift',
+    swiftClass: 'FinanceTokensHighContrastDark',
+    androidColorsFile: 'colors-high-contrast-dark.xml',
+    xamlFile: 'FinanceTokensHighContrastDark.xaml',
+    xamlBrushFile: 'FinanceTokensHighContrastDarkBrushes.xaml',
+  }),
+});
+
 // ---------------------------------------------------------------------------
 // Build all themes
 // ---------------------------------------------------------------------------
@@ -346,7 +392,10 @@ try {
   await darkSd.buildAllPlatforms();
   await oledDarkSd.buildAllPlatforms();
   await highContrastSd.buildAllPlatforms();
-  console.log('✅ Design tokens built successfully (light + dark + dark-oled + high-contrast)!');
+  await highContrastDarkSd.buildAllPlatforms();
+  console.log(
+    '✅ Design tokens built successfully (light + dark + dark-oled + high-contrast + high-contrast-dark)!',
+  );
 } catch (err) {
   console.error('Build failed:', err.message);
   process.exit(1);

--- a/packages/design-tokens/tokens/override/chart.dark.json
+++ b/packages/design-tokens/tokens/override/chart.dark.json
@@ -1,0 +1,37 @@
+{
+  "$description": "Dark/OLED chart series override. Layered after component/chart.json so the dark and OLED themes route chart.series.1–6 to the lightened CVD-safe color.chart.dark.* palette (each ≥8:1 on near-black), while light and high-contrast (light) chart output is unchanged. Existing chart token names are stable. Charts MUST still pair color with labels/patterns.",
+  "chart": {
+    "series": {
+      "1": {
+        "$value": "{color.chart.dark.1}",
+        "$type": "color",
+        "$description": "Series 1 — dark-theme CVD-safe blue (#8CB4FF)"
+      },
+      "2": {
+        "$value": "{color.chart.dark.2}",
+        "$type": "color",
+        "$description": "Series 2 — dark-theme CVD-safe purple (#B99BFF)"
+      },
+      "3": {
+        "$value": "{color.chart.dark.3}",
+        "$type": "color",
+        "$description": "Series 3 — dark-theme CVD-safe magenta (#FF7EB6)"
+      },
+      "4": {
+        "$value": "{color.chart.dark.4}",
+        "$type": "color",
+        "$description": "Series 4 — dark-theme CVD-safe orange (#FF8D3F)"
+      },
+      "5": {
+        "$value": "{color.chart.dark.5}",
+        "$type": "color",
+        "$description": "Series 5 — dark-theme CVD-safe gold (#FFC933)"
+      },
+      "6": {
+        "$value": "{color.chart.dark.6}",
+        "$type": "color",
+        "$description": "Series 6 — dark-theme CVD-safe teal (#3DD6B0)"
+      }
+    }
+  }
+}

--- a/packages/design-tokens/tokens/override/elevation.dark.json
+++ b/packages/design-tokens/tokens/override/elevation.dark.json
@@ -1,0 +1,9 @@
+{
+  "$description": "Dark/OLED elevation override. Layered after the shared elevation.json so dark themes map to the stronger shadow.dark.* primitives instead of the faint black shadows that are invisible on near-black surfaces. Light and high-contrast (light) elevation are unchanged. Token names are stable — only the resolved shadow values differ per theme.",
+  "elevation": {
+    "none": { "$value": "{shadow.none}", "$type": "shadow" },
+    "low": { "$value": "{shadow.dark.sm}", "$type": "shadow" },
+    "medium": { "$value": "{shadow.dark.md}", "$type": "shadow" },
+    "high": { "$value": "{shadow.dark.lg}", "$type": "shadow" }
+  }
+}

--- a/packages/design-tokens/tokens/primitive/border-radius.json
+++ b/packages/design-tokens/tokens/primitive/border-radius.json
@@ -1,10 +1,13 @@
 {
   "borderRadius": {
+    "$description": "Corner-radius scale from square (none) to pill (full). 2xl/3xl support larger card and bottom-sheet surfaces.",
     "none": { "$value": "0px", "$type": "dimension" },
     "sm": { "$value": "4px", "$type": "dimension" },
     "md": { "$value": "8px", "$type": "dimension" },
     "lg": { "$value": "12px", "$type": "dimension" },
     "xl": { "$value": "16px", "$type": "dimension" },
+    "2xl": { "$value": "24px", "$type": "dimension" },
+    "3xl": { "$value": "32px", "$type": "dimension" },
     "full": { "$value": "9999px", "$type": "dimension" }
   }
 }

--- a/packages/design-tokens/tokens/primitive/colors.json
+++ b/packages/design-tokens/tokens/primitive/colors.json
@@ -26,22 +26,39 @@
     },
     "green": {
       "50": { "$value": "#F0FDF4", "$type": "color" },
+      "100": { "$value": "#DCFCE7", "$type": "color" },
+      "200": { "$value": "#BBF7D0", "$type": "color" },
+      "300": { "$value": "#86EFAC", "$type": "color" },
+      "400": { "$value": "#4ADE80", "$type": "color" },
       "500": { "$value": "#22C55E", "$type": "color" },
       "600": { "$value": "#16A34A", "$type": "color" },
-      "700": { "$value": "#15803D", "$type": "color" }
+      "700": { "$value": "#15803D", "$type": "color" },
+      "800": { "$value": "#166534", "$type": "color" },
+      "900": { "$value": "#14532D", "$type": "color" }
     },
     "amber": {
       "50": { "$value": "#FFFBEB", "$type": "color" },
+      "100": { "$value": "#FEF3C7", "$type": "color" },
+      "200": { "$value": "#FDE68A", "$type": "color" },
+      "300": { "$value": "#FCD34D", "$type": "color" },
+      "400": { "$value": "#FBBF24", "$type": "color" },
       "500": { "$value": "#F59E0B", "$type": "color" },
       "600": { "$value": "#D97706", "$type": "color" },
-      "700": { "$value": "#B45309", "$type": "color" }
+      "700": { "$value": "#B45309", "$type": "color" },
+      "800": { "$value": "#92400E", "$type": "color" },
+      "900": { "$value": "#78350F", "$type": "color" }
     },
     "red": {
       "50": { "$value": "#FEF2F2", "$type": "color" },
+      "100": { "$value": "#FEE2E2", "$type": "color" },
+      "200": { "$value": "#FECACA", "$type": "color" },
+      "300": { "$value": "#FCA5A5", "$type": "color" },
       "400": { "$value": "#F87171", "$type": "color" },
       "500": { "$value": "#EF4444", "$type": "color" },
       "600": { "$value": "#DC2626", "$type": "color" },
-      "700": { "$value": "#B91C1C", "$type": "color" }
+      "700": { "$value": "#B91C1C", "$type": "color" },
+      "800": { "$value": "#991B1B", "$type": "color" },
+      "900": { "$value": "#7F1D1D", "$type": "color" }
     },
     "neutral": {
       "0": { "$value": "#FFFFFF", "$type": "color" },
@@ -112,6 +129,39 @@
           "$value": "#005D5D",
           "$type": "color",
           "$description": "HC teal — 6.5:1 vs white (AA)"
+        }
+      },
+      "dark": {
+        "$description": "Dark-theme chart palette — lightened CVD-safe variants tuned for near-black surfaces. Each is ≥8:1 against #000000 (and the dark theme's #030712 base), preserving the IBM CVD-safe hue families so series stay distinguishable for deuteranopia/protanopia/tritanopia. Charts still MUST pair color with labels/patterns.",
+        "1": {
+          "$value": "#8CB4FF",
+          "$type": "color",
+          "$description": "Dark blue series — 10.1:1 vs #000000"
+        },
+        "2": {
+          "$value": "#B99BFF",
+          "$type": "color",
+          "$description": "Dark purple series — 9.2:1 vs #000000 (lightened from #785EF0)"
+        },
+        "3": {
+          "$value": "#FF7EB6",
+          "$type": "color",
+          "$description": "Dark magenta series — 8.9:1 vs #000000"
+        },
+        "4": {
+          "$value": "#FF8D3F",
+          "$type": "color",
+          "$description": "Dark orange series — 9.1:1 vs #000000"
+        },
+        "5": {
+          "$value": "#FFC933",
+          "$type": "color",
+          "$description": "Dark gold series — 13.6:1 vs #000000"
+        },
+        "6": {
+          "$value": "#3DD6B0",
+          "$type": "color",
+          "$description": "Dark teal series — 11.4:1 vs #000000"
         }
       }
     }

--- a/packages/design-tokens/tokens/primitive/opacity.json
+++ b/packages/design-tokens/tokens/primitive/opacity.json
@@ -1,0 +1,45 @@
+{
+  "opacity": {
+    "$description": "Alpha opacity scale (0–1) for disabled states, scrims, overlays, hover washes, skeletons, and press ripples. Centralizing these keeps every disabled control and every scrim at the same level and lets dark/high-contrast themes tune them from one place.",
+    "0": {
+      "$value": 0,
+      "$type": "number",
+      "$description": "Fully transparent"
+    },
+    "5": {
+      "$value": 0.05,
+      "$type": "number",
+      "$description": "Hover/skeleton wash — barely-there tint"
+    },
+    "10": {
+      "$value": 0.1,
+      "$type": "number",
+      "$description": "Subtle overlay / pressed ripple"
+    },
+    "20": {
+      "$value": 0.2,
+      "$type": "number",
+      "$description": "Light overlay / hover fill"
+    },
+    "40": {
+      "$value": 0.4,
+      "$type": "number",
+      "$description": "Disabled control dim level"
+    },
+    "60": {
+      "$value": 0.6,
+      "$type": "number",
+      "$description": "Modal scrim / backdrop darkness"
+    },
+    "80": {
+      "$value": 0.8,
+      "$type": "number",
+      "$description": "Heavy overlay / strong scrim"
+    },
+    "100": {
+      "$value": 1,
+      "$type": "number",
+      "$description": "Fully opaque"
+    }
+  }
+}

--- a/packages/design-tokens/tokens/primitive/shadows.json
+++ b/packages/design-tokens/tokens/primitive/shadows.json
@@ -40,6 +40,49 @@
         "color": "rgba(0,0,0,0.1)"
       },
       "$type": "shadow"
+    },
+    "dark": {
+      "$description": "Stronger, deeper shadows for dark/OLED themes. Faint black shadows (0.05–0.1 alpha) are invisible on near-black surfaces, so dark elevation uses higher-opacity black with larger blur/spread — combined with the lighter elevated surface tints already defined per dark theme — to restore depth cues between cards, modals, and popovers.",
+      "sm": {
+        "$value": {
+          "offsetX": "0px",
+          "offsetY": "1px",
+          "blur": "3px",
+          "spread": "0px",
+          "color": "rgba(0,0,0,0.5)"
+        },
+        "$type": "shadow"
+      },
+      "md": {
+        "$value": {
+          "offsetX": "0px",
+          "offsetY": "4px",
+          "blur": "8px",
+          "spread": "-1px",
+          "color": "rgba(0,0,0,0.55)"
+        },
+        "$type": "shadow"
+      },
+      "lg": {
+        "$value": {
+          "offsetX": "0px",
+          "offsetY": "10px",
+          "blur": "20px",
+          "spread": "-3px",
+          "color": "rgba(0,0,0,0.6)"
+        },
+        "$type": "shadow"
+      },
+      "xl": {
+        "$value": {
+          "offsetX": "0px",
+          "offsetY": "20px",
+          "blur": "30px",
+          "spread": "-5px",
+          "color": "rgba(0,0,0,0.65)"
+        },
+        "$type": "shadow"
+      }
     }
   }
 }

--- a/packages/design-tokens/tokens/primitive/spacing.json
+++ b/packages/design-tokens/tokens/primitive/spacing.json
@@ -1,5 +1,6 @@
 {
   "spacing": {
+    "$description": "4px base spacing scale. Keys equal the multiplier of the 4px base (e.g. 6 = 24px). The scale is intentionally sparse above 6 (only common layout steps are provided); use 7 (28px), 14 (56px), and 24 (96px) for the one-off gaps they fill rather than off-grid values.",
     "0": { "$value": "0px", "$type": "dimension" },
     "1": { "$value": "4px", "$type": "dimension" },
     "2": { "$value": "8px", "$type": "dimension" },
@@ -7,10 +8,13 @@
     "4": { "$value": "16px", "$type": "dimension" },
     "5": { "$value": "20px", "$type": "dimension" },
     "6": { "$value": "24px", "$type": "dimension" },
+    "7": { "$value": "28px", "$type": "dimension" },
     "8": { "$value": "32px", "$type": "dimension" },
     "10": { "$value": "40px", "$type": "dimension" },
     "12": { "$value": "48px", "$type": "dimension" },
+    "14": { "$value": "56px", "$type": "dimension" },
     "16": { "$value": "64px", "$type": "dimension" },
-    "20": { "$value": "80px", "$type": "dimension" }
+    "20": { "$value": "80px", "$type": "dimension" },
+    "24": { "$value": "96px", "$type": "dimension" }
   }
 }

--- a/packages/design-tokens/tokens/primitive/typography.json
+++ b/packages/design-tokens/tokens/primitive/typography.json
@@ -1,4 +1,35 @@
 {
+  "fontFamily": {
+    "$description": "Font-family stacks. Platform-native system fonts by default; numeric maps to the same sans face but is the intent hook for currency/amount styles that also apply tabular figures.",
+    "sans": {
+      "$value": "system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
+      "$type": "fontFamily",
+      "$description": "Default UI sans-serif stack"
+    },
+    "mono": {
+      "$value": "ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace",
+      "$type": "fontFamily",
+      "$description": "Monospace stack for code and fixed-width data"
+    },
+    "numeric": {
+      "$value": "system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
+      "$type": "fontFamily",
+      "$description": "Face used for currency/amount figures; pair with fontVariantNumeric.tabular so digits align in columns"
+    }
+  },
+  "fontVariantNumeric": {
+    "$description": "font-variant-numeric intent tokens. Consumers map tabular to CSS `font-variant-numeric: tabular-nums` (and the equivalent OpenType feature on native platforms).",
+    "normal": {
+      "$value": "normal",
+      "$type": "fontVariantNumeric",
+      "$description": "Default proportional figures"
+    },
+    "tabular": {
+      "$value": "tabular-nums",
+      "$type": "fontVariantNumeric",
+      "$description": "Fixed-width figures so monetary columns align vertically"
+    }
+  },
   "fontSize": {
     "xs": { "$value": "12px", "$type": "dimension" },
     "sm": { "$value": "14px", "$type": "dimension" },

--- a/packages/design-tokens/tokens/primitive/z-index.json
+++ b/packages/design-tokens/tokens/primitive/z-index.json
@@ -1,0 +1,50 @@
+{
+  "zIndex": {
+    "$description": "Stacking-order layering scale. Ordered integers with generous gaps so new layers can be inserted between existing ones without renumbering. Consumers should reference these instead of hardcoding z-index per platform to avoid overlap bugs (e.g. a toast under a modal, a tooltip clipped by a sticky header).",
+    "hide": {
+      "$value": -1,
+      "$type": "number",
+      "$description": "Send an element behind the base layer"
+    },
+    "base": {
+      "$value": 0,
+      "$type": "number",
+      "$description": "Default in-flow content"
+    },
+    "dropdown": {
+      "$value": 1000,
+      "$type": "number",
+      "$description": "Dropdown/select menus and comboboxes"
+    },
+    "sticky": {
+      "$value": 1100,
+      "$type": "number",
+      "$description": "Sticky headers, toolbars, and pinned rows"
+    },
+    "overlay": {
+      "$value": 1300,
+      "$type": "number",
+      "$description": "Full-screen scrim/backdrop behind modal surfaces"
+    },
+    "modal": {
+      "$value": 1400,
+      "$type": "number",
+      "$description": "Modal dialogs and drawers/sheets"
+    },
+    "popover": {
+      "$value": 1500,
+      "$type": "number",
+      "$description": "Popovers and context menus above modals"
+    },
+    "toast": {
+      "$value": 1600,
+      "$type": "number",
+      "$description": "Toast/snackbar notifications"
+    },
+    "tooltip": {
+      "$value": 1700,
+      "$type": "number",
+      "$description": "Tooltips — always on top"
+    }
+  }
+}

--- a/packages/design-tokens/tokens/semantic/colors.dark-oled.json
+++ b/packages/design-tokens/tokens/semantic/colors.dark-oled.json
@@ -99,6 +99,46 @@
         "$value": "{color.blue.400}",
         "$type": "color",
         "$description": "Info status — 8.3:1 vs #000000"
+      },
+      "pending": {
+        "$value": "{color.teal.400}",
+        "$type": "color",
+        "$description": "Pending/in-progress — teal.400, ~10:1 vs #000000. Pair with icon + label."
+      },
+      "neutral": {
+        "$value": "{color.neutral.400}",
+        "$type": "color",
+        "$description": "Neutral/uncategorized — neutral.400, 8.3:1 vs #000000. Pair with label."
+      },
+      "positiveSubtle": {
+        "$value": "{color.green.900}",
+        "$type": "color",
+        "$description": "Dark positive tint panel on true black. Pair with text.primary (AA text) or status.positive (≥3:1)."
+      },
+      "negativeSubtle": {
+        "$value": "{color.red.900}",
+        "$type": "color",
+        "$description": "Dark negative tint panel. Pair with text.primary or status.negative (≥3:1)."
+      },
+      "warningSubtle": {
+        "$value": "{color.amber.900}",
+        "$type": "color",
+        "$description": "Dark warning tint panel. Pair with text.primary or status.warning (≥3:1)."
+      },
+      "infoSubtle": {
+        "$value": "{color.blue.900}",
+        "$type": "color",
+        "$description": "Dark info tint panel. Pair with text.primary or status.info (≥3:1)."
+      },
+      "pendingSubtle": {
+        "$value": "{color.teal.900}",
+        "$type": "color",
+        "$description": "Dark pending pill panel. Pair with text.primary or status.pending (≥3:1)."
+      },
+      "neutralSubtle": {
+        "$value": "{color.neutral.800}",
+        "$type": "color",
+        "$description": "Dark neutral tint panel. Pair with text.primary (AA text)."
       }
     },
     "amount": {

--- a/packages/design-tokens/tokens/semantic/colors.dark.json
+++ b/packages/design-tokens/tokens/semantic/colors.dark.json
@@ -26,7 +26,47 @@
       "positive": { "$value": "{color.green.500}", "$type": "color" },
       "negative": { "$value": "{color.red.500}", "$type": "color" },
       "warning": { "$value": "{color.amber.500}", "$type": "color" },
-      "info": { "$value": "{color.blue.400}", "$type": "color" }
+      "info": { "$value": "{color.blue.400}", "$type": "color" },
+      "pending": {
+        "$value": "{color.teal.400}",
+        "$type": "color",
+        "$description": "Pending/in-progress — teal.400, ~10:1 on dark base. Distinct from info/warning; pair with icon + label."
+      },
+      "neutral": {
+        "$value": "{color.neutral.400}",
+        "$type": "color",
+        "$description": "Neutral/uncategorized — neutral.400, ~8:1 on dark base. Pair with label."
+      },
+      "positiveSubtle": {
+        "$value": "{color.green.900}",
+        "$type": "color",
+        "$description": "Dark positive tint panel. Pair with text.primary (≥12:1, AA text) or status.positive (≥3:1, graphical)."
+      },
+      "negativeSubtle": {
+        "$value": "{color.red.900}",
+        "$type": "color",
+        "$description": "Dark negative tint panel. Pair with text.primary or status.negative (≥3:1)."
+      },
+      "warningSubtle": {
+        "$value": "{color.amber.900}",
+        "$type": "color",
+        "$description": "Dark warning tint panel. Pair with text.primary or status.warning (≥3:1)."
+      },
+      "infoSubtle": {
+        "$value": "{color.blue.900}",
+        "$type": "color",
+        "$description": "Dark info tint panel. Pair with text.primary or status.info (≥3:1)."
+      },
+      "pendingSubtle": {
+        "$value": "{color.teal.900}",
+        "$type": "color",
+        "$description": "Dark pending pill panel. Pair with text.primary or status.pending (≥3:1)."
+      },
+      "neutralSubtle": {
+        "$value": "{color.neutral.800}",
+        "$type": "color",
+        "$description": "Dark neutral tint panel. Pair with text.primary (≥12:1, AA text)."
+      }
     },
     "amount": {
       "positive": { "$value": "{color.green.500}", "$type": "color" },

--- a/packages/design-tokens/tokens/semantic/colors.high-contrast-dark.json
+++ b/packages/design-tokens/tokens/semantic/colors.high-contrast-dark.json
@@ -1,0 +1,157 @@
+{
+  "$description": "Dark high-contrast theme semantic color tokens. Completes the accessibility matrix for users who need BOTH maximum contrast AND a dark surface (Windows High Contrast dark, macOS Increase Contrast + Dark Mode, prefers-contrast: more + prefers-color-scheme: dark). Near-black base with near-white text; text pairings target WCAG AAA (7:1+) and non-text UI (borders/focus) exceed 3:1 vs the base. Contrast ratios documented vs the #030712 base.",
+  "semantic": {
+    "background": {
+      "primary": {
+        "$value": "{color.neutral.950}",
+        "$type": "color",
+        "$description": "Near-black background (#030712) — maximum-contrast dark base"
+      },
+      "secondary": {
+        "$value": "{color.neutral.900}",
+        "$type": "color",
+        "$description": "Slightly lighter secondary surface (#111827) — clear separation from primary"
+      },
+      "elevated": {
+        "$value": "{color.neutral.800}",
+        "$type": "color",
+        "$description": "Elevated surface (#1F2937) with bright border for definition"
+      }
+    },
+    "text": {
+      "primary": {
+        "$value": "{color.neutral.0}",
+        "$type": "color",
+        "$description": "Pure white primary text — 20.9:1 vs base (AAA)"
+      },
+      "secondary": {
+        "$value": "{color.neutral.200}",
+        "$type": "color",
+        "$description": "Near-white secondary text (#E5E7EB) — 16.8:1 vs base (AAA)"
+      },
+      "disabled": {
+        "$value": "{color.neutral.400}",
+        "$type": "color",
+        "$description": "Medium gray disabled text (#9CA3AF) — 7.1:1 vs base (WCAG exempt for disabled)"
+      },
+      "inverse": {
+        "$value": "{color.neutral.950}",
+        "$type": "color",
+        "$description": "Near-black text for use on bright interactive surfaces"
+      }
+    },
+    "border": {
+      "default": {
+        "$value": "{color.neutral.300}",
+        "$type": "color",
+        "$description": "Bright default border (#D1D5DB) — 12.9:1 vs base, far exceeds 3:1 UI contrast"
+      },
+      "focus": {
+        "$value": "{color.blue.300}",
+        "$type": "color",
+        "$description": "Bright blue focus ring (#93C5FD) — 9.9:1 vs base, clearly visible"
+      },
+      "error": {
+        "$value": "{color.red.400}",
+        "$type": "color",
+        "$description": "Bright red error border (#F87171) — 6.0:1 vs base (exceeds 3:1 UI)"
+      }
+    },
+    "interactive": {
+      "default": {
+        "$value": "{color.blue.300}",
+        "$type": "color",
+        "$description": "Bright blue interactive (#93C5FD) — 9.9:1 vs base (AAA for text)"
+      },
+      "hover": {
+        "$value": "{color.blue.200}",
+        "$type": "color",
+        "$description": "Lighter blue on hover (#BFDBFE) — 13.4:1 vs base"
+      },
+      "pressed": {
+        "$value": "{color.blue.100}",
+        "$type": "color",
+        "$description": "Lightest blue pressed (#DBEAFE) — 16.5:1 vs base"
+      },
+      "disabled": {
+        "$value": "{color.neutral.600}",
+        "$type": "color",
+        "$description": "Disabled interactive — WCAG exempt for disabled controls"
+      }
+    },
+    "status": {
+      "positive": {
+        "$value": "{color.green.400}",
+        "$type": "color",
+        "$description": "Bright green positive (#4ADE80) — 11.6:1 vs base (AAA), used with icon+text"
+      },
+      "negative": {
+        "$value": "{color.red.400}",
+        "$type": "color",
+        "$description": "Bright red negative (#F87171) — 6.0:1 vs base, used with icon+text"
+      },
+      "warning": {
+        "$value": "{color.amber.400}",
+        "$type": "color",
+        "$description": "Bright amber warning (#FBBF24) — 11.6:1 vs base, used with icon+text"
+      },
+      "info": {
+        "$value": "{color.blue.300}",
+        "$type": "color",
+        "$description": "Bright blue info (#93C5FD) — 9.9:1 vs base (AAA)"
+      },
+      "pending": {
+        "$value": "{color.teal.300}",
+        "$type": "color",
+        "$description": "Bright teal pending (#5EEAD4) — 13.7:1 vs base (AAA). Pair with icon + label."
+      },
+      "neutral": {
+        "$value": "{color.neutral.300}",
+        "$type": "color",
+        "$description": "Bright gray neutral (#D1D5DB) — 12.9:1 vs base (AAA). Pair with label."
+      },
+      "positiveSubtle": {
+        "$value": "{color.green.900}",
+        "$type": "color",
+        "$description": "Dark positive tint panel. Pair with status.positive (green.400) or text.primary (≥12:1, AA/AAA)."
+      },
+      "negativeSubtle": {
+        "$value": "{color.red.900}",
+        "$type": "color",
+        "$description": "Dark negative tint panel. Pair with status.negative (red.400) or text.primary."
+      },
+      "warningSubtle": {
+        "$value": "{color.amber.900}",
+        "$type": "color",
+        "$description": "Dark warning tint panel. Pair with status.warning (amber.400) or text.primary."
+      },
+      "infoSubtle": {
+        "$value": "{color.blue.900}",
+        "$type": "color",
+        "$description": "Dark info tint panel. Pair with status.info (blue.300) or text.primary."
+      },
+      "pendingSubtle": {
+        "$value": "{color.teal.900}",
+        "$type": "color",
+        "$description": "Dark pending pill panel. Pair with status.pending (teal.300) or text.primary."
+      },
+      "neutralSubtle": {
+        "$value": "{color.neutral.800}",
+        "$type": "color",
+        "$description": "Dark neutral tint panel. Pair with text.primary (AA text)."
+      }
+    },
+    "amount": {
+      "positive": {
+        "$value": "{color.green.400}",
+        "$type": "color",
+        "$description": "Bright green for income — always paired with ↑ arrow icon"
+      },
+      "negative": {
+        "$value": "{color.red.400}",
+        "$type": "color",
+        "$description": "Bright red for expenses — always paired with ↓ arrow icon"
+      }
+    }
+  }
+}

--- a/packages/design-tokens/tokens/semantic/colors.high-contrast.json
+++ b/packages/design-tokens/tokens/semantic/colors.high-contrast.json
@@ -99,6 +99,46 @@
         "$value": "{color.blue.800}",
         "$type": "color",
         "$description": "Dark blue info — 8.6:1 vs white (AAA)"
+      },
+      "pending": {
+        "$value": "{color.teal.800}",
+        "$type": "color",
+        "$description": "Dark teal pending — ~7:1 vs white (AAA). Always paired with clock/spinner icon + label."
+      },
+      "neutral": {
+        "$value": "{color.neutral.700}",
+        "$type": "color",
+        "$description": "Dark gray neutral — 9.3:1 vs white (AAA). Paired with label."
+      },
+      "positiveSubtle": {
+        "$value": "{color.green.50}",
+        "$type": "color",
+        "$description": "Very light positive tint. Pair with status.positive (green.700) — ≥10:1 (AAA)."
+      },
+      "negativeSubtle": {
+        "$value": "{color.red.50}",
+        "$type": "color",
+        "$description": "Very light negative tint. Pair with status.negative (red.700) — ≥10:1 (AAA)."
+      },
+      "warningSubtle": {
+        "$value": "{color.amber.50}",
+        "$type": "color",
+        "$description": "Very light warning tint. Pair with status.warning (amber.700) — ≥8:1 (AAA)."
+      },
+      "infoSubtle": {
+        "$value": "{color.blue.50}",
+        "$type": "color",
+        "$description": "Very light info tint. Pair with status.info (blue.800) — ≥8:1 (AAA)."
+      },
+      "pendingSubtle": {
+        "$value": "{color.teal.50}",
+        "$type": "color",
+        "$description": "Very light pending tint. Pair with status.pending (teal.800) — ≥7:1 (AAA)."
+      },
+      "neutralSubtle": {
+        "$value": "{color.neutral.100}",
+        "$type": "color",
+        "$description": "Very light neutral tint. Pair with text.primary or status.neutral — ≥9:1 (AAA)."
       }
     },
     "amount": {

--- a/packages/design-tokens/tokens/semantic/colors.light.json
+++ b/packages/design-tokens/tokens/semantic/colors.light.json
@@ -26,7 +26,47 @@
       "positive": { "$value": "{color.green.600}", "$type": "color" },
       "negative": { "$value": "{color.red.600}", "$type": "color" },
       "warning": { "$value": "{color.amber.600}", "$type": "color" },
-      "info": { "$value": "{color.blue.600}", "$type": "color" }
+      "info": { "$value": "{color.blue.600}", "$type": "color" },
+      "pending": {
+        "$value": "{color.teal.700}",
+        "$type": "color",
+        "$description": "Pending/in-progress (authorizing, syncing, processing) — teal.700, 4.8:1 on white (AA). Distinct hue from info/warning; always pair with a clock/spinner icon + label, never color alone."
+      },
+      "neutral": {
+        "$value": "{color.neutral.500}",
+        "$type": "color",
+        "$description": "Neutral/uncategorized/cleared-unremarkable — neutral.500, 4.8:1 on white (AA). Pair with label, never color alone."
+      },
+      "positiveSubtle": {
+        "$value": "{color.green.100}",
+        "$type": "color",
+        "$description": "Low-emphasis positive background (badge/banner/row). Pair with status.positive (green.700) foreground — 6.3:1 (AA)."
+      },
+      "negativeSubtle": {
+        "$value": "{color.red.100}",
+        "$type": "color",
+        "$description": "Low-emphasis negative background. Pair with status.negative (red.700) — 6.5:1 (AA)."
+      },
+      "warningSubtle": {
+        "$value": "{color.amber.100}",
+        "$type": "color",
+        "$description": "Low-emphasis warning background. Pair with status.warning (amber.700) — 5.6:1 (AA)."
+      },
+      "infoSubtle": {
+        "$value": "{color.blue.100}",
+        "$type": "color",
+        "$description": "Low-emphasis info background. Pair with status.info (blue.700) — 6.9:1 (AA)."
+      },
+      "pendingSubtle": {
+        "$value": "{color.teal.100}",
+        "$type": "color",
+        "$description": "Low-emphasis pending pill background. Pair with status.pending (teal.700) — 5.7:1 (AA)."
+      },
+      "neutralSubtle": {
+        "$value": "{color.neutral.100}",
+        "$type": "color",
+        "$description": "Low-emphasis neutral background. Pair with text.primary or status.neutral — 4.8:1+ (AA)."
+      }
     },
     "amount": {
       "positive": { "$value": "{color.green.700}", "$type": "color" },

--- a/packages/design-tokens/tokens/semantic/layer.json
+++ b/packages/design-tokens/tokens/semantic/layer.json
@@ -1,0 +1,45 @@
+{
+  "$description": "Purpose-mapped stacking layers shared across themes. Each maps to a step in the primitive zIndex scale so consumers reference intent (layer.modal) rather than raw numbers.",
+  "layer": {
+    "base": {
+      "$value": "{zIndex.base}",
+      "$type": "number",
+      "$description": "Default in-flow content"
+    },
+    "dropdown": {
+      "$value": "{zIndex.dropdown}",
+      "$type": "number",
+      "$description": "Dropdown/select menus"
+    },
+    "sticky": {
+      "$value": "{zIndex.sticky}",
+      "$type": "number",
+      "$description": "Sticky headers and pinned rows"
+    },
+    "overlay": {
+      "$value": "{zIndex.overlay}",
+      "$type": "number",
+      "$description": "Modal scrim/backdrop"
+    },
+    "modal": {
+      "$value": "{zIndex.modal}",
+      "$type": "number",
+      "$description": "Modal dialogs and drawers"
+    },
+    "popover": {
+      "$value": "{zIndex.popover}",
+      "$type": "number",
+      "$description": "Popovers and context menus"
+    },
+    "toast": {
+      "$value": "{zIndex.toast}",
+      "$type": "number",
+      "$description": "Toast/snackbar notifications"
+    },
+    "tooltip": {
+      "$value": "{zIndex.tooltip}",
+      "$type": "number",
+      "$description": "Tooltips — topmost layer"
+    }
+  }
+}

--- a/packages/design-tokens/tokens/semantic/state.json
+++ b/packages/design-tokens/tokens/semantic/state.json
@@ -1,0 +1,22 @@
+{
+  "$description": "Purpose-mapped interaction/state tokens shared across themes. Opacity levels for disabled controls and scrims map to the primitive opacity scale.",
+  "state": {
+    "disabled": {
+      "$value": "{opacity.40}",
+      "$type": "number",
+      "$description": "Opacity applied to disabled controls"
+    }
+  },
+  "overlay": {
+    "scrim": {
+      "$value": "{opacity.60}",
+      "$type": "number",
+      "$description": "Backdrop darkness behind modals/drawers"
+    },
+    "hover": {
+      "$value": "{opacity.5}",
+      "$type": "number",
+      "$description": "Hover wash applied over interactive surfaces"
+    }
+  }
+}

--- a/packages/design-tokens/tokens/semantic/typography.json
+++ b/packages/design-tokens/tokens/semantic/typography.json
@@ -29,6 +29,17 @@
       "fontSize": { "$value": "{fontSize.xs}", "$type": "dimension" },
       "fontWeight": { "$value": "{fontWeight.regular}", "$type": "fontWeight" },
       "lineHeight": { "$value": "{lineHeight.normal}", "$type": "number" }
+    },
+    "amount": {
+      "$description": "Numeric/currency style for transaction lists, ledgers, and budgets. Uses tabular figures so digits align vertically for easy scanning and comparison. Always render with fontVariantNumeric = tabular-nums.",
+      "fontFamily": { "$value": "{fontFamily.numeric}", "$type": "fontFamily" },
+      "fontSize": { "$value": "{fontSize.base}", "$type": "dimension" },
+      "fontWeight": { "$value": "{fontWeight.medium}", "$type": "fontWeight" },
+      "lineHeight": { "$value": "{lineHeight.normal}", "$type": "number" },
+      "fontVariantNumeric": {
+        "$value": "{fontVariantNumeric.tabular}",
+        "$type": "fontVariantNumeric"
+      }
     }
   }
 }

--- a/tools/token-preview-generate.mjs
+++ b/tools/token-preview-generate.mjs
@@ -110,8 +110,17 @@ const PRIM = [
   'breakpoints.json',
   'motion.json',
   'shadows.json',
+  'opacity.json',
+  'z-index.json',
 ];
-const SEM_SHARED = ['typography.json', 'elevation.json', 'breakpoints.json', 'animation.json'];
+const SEM_SHARED = [
+  'typography.json',
+  'elevation.json',
+  'breakpoints.json',
+  'animation.json',
+  'state.json',
+  'layer.json',
+];
 const COMP = ['button.json', 'card.json', 'input.json', 'navigation.json', 'animation.json'];
 
 function loadDir(dir, files) {


### PR DESCRIPTION
﻿## Summary

A single cohesive design-tokens batch (DTCG sources + Style Dictionary config). All work edits token **sources**; generated `build/` outputs are produced via `npm run build:tokens` (the `build/` dir is gitignored in this repo, so only sources/config/docs are committed). Additive and backward-compatible — no existing token renamed or removed.

### What changed
- **Complete primitive ramps** — `green`/`amber`/`red` now expose the full `50–900` scale (Tailwind-family reference values), matching `blue`/`teal`/`neutral`. Existing steps unchanged. (#3663)
- **Spacing / radius / naming** — added `spacing.7/14/24` and `borderRadius.2xl/3xl`; documented the scale + a token **naming-convention** guide in the README. (#3711)
- **Opacity scale** — new `primitive/opacity.json` (`0–100`) plus semantic `state.disabled`, `overlay.scrim`, `overlay.hover`. (#3680)
- **z-index layering scale** — new `primitive/z-index.json` (ordered, gapped) plus semantic `layer.*` (dropdown → sticky → overlay → modal → popover → toast → tooltip). (#3675)
- **fontFamily + tabular numerals** — new `fontFamily` (sans/mono/numeric) and `fontVariantNumeric` primitives; new semantic `typeScale.amount` numeric style expressing tabular figures for currency columns. (#3670)
- **Pending / neutral status** — `status.pending` + `status.neutral` in **all** themes (light/dark/OLED/HC/HC-dark) with documented AA ratios; reminder to pair with icon/label. (#3704)
- **Subtle status backgrounds** — `status.*Subtle` (positive/negative/warning/info + pending/neutral) low-emphasis fills in every theme, with paired-foreground contrast documented. (#3657)
- **Theme-aware elevation** — new `shadow.dark.*` primitives + `override/elevation.dark.json` so dark/OLED express visible elevation; light/HC elevation output unchanged. (#3686)
- **Dark CVD-safe chart palette** — new `color.chart.dark.1–6` (>=8:1 on near-black) + `override/chart.dark.json` routing dark/OLED chart series without altering light output. (#3666)
- **Dark high-contrast theme** — new `colors.high-contrast-dark.json` (near-black base, AAA text, >=3:1 borders) + wired `[data-theme=\"high-contrast-dark\"]` build target across CSS/Swift/Android/XAML. (#3696)

### Verification (local only)
- `npm run build:tokens` builds light + dark + dark-oled + high-contrast + high-contrast-dark successfully.
- `npx prettier --check .` clean. `npx eslint . --max-warnings 0` clean.
- Confirmed light output unchanged for chart series + elevation; dark/OLED route to the dark palette/elevation; hc-dark target emitted.

Closes #3711
Closes #3704
Closes #3696
Closes #3686
Closes #3680
Closes #3675
Closes #3670
Closes #3666
Closes #3663
Closes #3657
