### PR TITLE
feat(core): core recurrence & reminders batch

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/OfxExportSerializer.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/OfxExportSerializer.kt
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.models.Transaction
+import com.finance.models.TransactionType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Serializes transactions into an OFX (Open Financial Exchange) 1.0.2 SGML document.
+ *
+ * OFX is the de-facto interchange format accepted by Quicken, GnuCash, and most banking tools for
+ * importing transaction history. Unlike CSV it carries typed transaction records (amount, date,
+ * FITID, type, memo) that downstream finance software imports directly, supporting the repo's data
+ * portability / GDPR goals.
+ *
+ * The output is a well-formed `<OFX>` document with the standard `SIGNONMSGSRSV1` and
+ * `BANKMSGSRSV1` / `STMTTRNRS` aggregates and one `<STMTTRN>` per transaction. Amounts derive from
+ * integer [Cents] formatted to the currency's decimal places (no floating-point drift) with the
+ * sign implied by [TransactionType] (expenses/transfers debit negative, income credits positive).
+ * Dates use `kotlinx-datetime`. Output is deterministic: transactions are ordered by `(date, id)`.
+ *
+ * Pure logic — no platform dependencies.
+ */
+object OfxExportSerializer {
+
+    /** OFX `NAME` element maximum length (spec: 32 characters). */
+    private const val NAME_MAX_LENGTH = 32
+
+    /** OFX `MEMO` element maximum length (spec: 255 characters). */
+    private const val MEMO_MAX_LENGTH = 255
+
+    private const val LF = "\r\n"
+
+    /**
+     * Serialize [transactions] into an OFX 1.0.2 SGML document.
+     *
+     * @param transactions The transactions to export (deleted records should be pre-filtered).
+     * @param generatedAt Timestamp used for `DTSERVER` and, when [transactions] is empty, the
+     *   statement date range.
+     * @param currencyDefault Statement default currency (`CURDEF`). Defaults to the first
+     *   transaction's currency, or USD when there are none.
+     * @param accountId Bank account identifier emitted in `BANKACCTFROM/ACCTID`.
+     * @param bankId Routing/bank identifier emitted in `BANKACCTFROM/BANKID`.
+     * @param zone Time zone used to render [generatedAt] as an OFX datetime.
+     * @return A complete OFX document string.
+     */
+    fun serialize(
+        transactions: List<Transaction>,
+        generatedAt: Instant,
+        currencyDefault: Currency = transactions.firstOrNull()?.currency ?: Currency.USD,
+        accountId: String = "000000000",
+        bankId: String = "000000000",
+        zone: TimeZone = TimeZone.UTC,
+    ): String {
+        val ordered = transactions.sortedWith(compareBy({ it.date }, { it.id.value }))
+        val serverDateTime = formatDateTime(generatedAt, zone)
+        val startDate = ordered.firstOrNull()?.date
+        val endDate = ordered.lastOrNull()?.date
+        val dtStart = startDate?.let(::formatDate) ?: serverDateTime
+        val dtEnd = endDate?.let(::formatDate) ?: serverDateTime
+
+        val sb = StringBuilder()
+        appendHeader(sb)
+        sb.append("<OFX>").append(LF)
+
+        // ── Sign-on response ─────────────────────────────────────────
+        sb.append("<SIGNONMSGSRSV1>").append(LF)
+        sb.append("<SONRS>").append(LF)
+        appendStatusOk(sb)
+        appendLeaf(sb, "DTSERVER", serverDateTime)
+        appendLeaf(sb, "LANGUAGE", "ENG")
+        sb.append("</SONRS>").append(LF)
+        sb.append("</SIGNONMSGSRSV1>").append(LF)
+
+        // ── Bank statement response ──────────────────────────────────
+        sb.append("<BANKMSGSRSV1>").append(LF)
+        sb.append("<STMTTRNRS>").append(LF)
+        appendLeaf(sb, "TRNUID", "1")
+        appendStatusOk(sb)
+        sb.append("<STMTRS>").append(LF)
+        appendLeaf(sb, "CURDEF", currencyDefault.code)
+        sb.append("<BANKACCTFROM>").append(LF)
+        appendLeaf(sb, "BANKID", bankId)
+        appendLeaf(sb, "ACCTID", accountId)
+        appendLeaf(sb, "ACCTTYPE", "CHECKING")
+        sb.append("</BANKACCTFROM>").append(LF)
+
+        sb.append("<BANKTRANLIST>").append(LF)
+        appendLeaf(sb, "DTSTART", dtStart)
+        appendLeaf(sb, "DTEND", dtEnd)
+        for (txn in ordered) {
+            appendTransaction(sb, txn)
+        }
+        sb.append("</BANKTRANLIST>").append(LF)
+
+        sb.append("</STMTRS>").append(LF)
+        sb.append("</STMTTRNRS>").append(LF)
+        sb.append("</BANKMSGSRSV1>").append(LF)
+        sb.append("</OFX>").append(LF)
+
+        return sb.toString()
+    }
+
+    // ── Section builders ─────────────────────────────────────────────
+
+    private fun appendHeader(sb: StringBuilder) {
+        sb.append("OFXHEADER:100").append(LF)
+        sb.append("DATA:OFXSGML").append(LF)
+        sb.append("VERSION:102").append(LF)
+        sb.append("SECURITY:NONE").append(LF)
+        sb.append("ENCODING:USASCII").append(LF)
+        sb.append("CHARSET:1252").append(LF)
+        sb.append("COMPRESSION:NONE").append(LF)
+        sb.append("OLDFILEUID:NONE").append(LF)
+        sb.append("NEWFILEUID:NONE").append(LF)
+        sb.append(LF)
+    }
+
+    private fun appendStatusOk(sb: StringBuilder) {
+        sb.append("<STATUS>").append(LF)
+        appendLeaf(sb, "CODE", "0")
+        appendLeaf(sb, "SEVERITY", "INFO")
+        sb.append("</STATUS>").append(LF)
+    }
+
+    private fun appendTransaction(sb: StringBuilder, txn: Transaction) {
+        sb.append("<STMTTRN>").append(LF)
+        appendLeaf(sb, "TRNTYPE", trnType(txn.type))
+        appendLeaf(sb, "DTPOSTED", formatDate(txn.date))
+        appendLeaf(sb, "TRNAMT", formatSignedAmount(txn))
+        appendLeaf(sb, "FITID", txn.id.value)
+        val name = txn.payee?.takeIf { it.isNotBlank() }
+        if (name != null) {
+            appendLeaf(sb, "NAME", name.take(NAME_MAX_LENGTH))
+        }
+        val memo = txn.note?.takeIf { it.isNotBlank() }
+        if (memo != null) {
+            appendLeaf(sb, "MEMO", memo.take(MEMO_MAX_LENGTH))
+        }
+        sb.append("</STMTTRN>").append(LF)
+    }
+
+    private fun appendLeaf(sb: StringBuilder, tag: String, value: String) {
+        sb.append('<').append(tag).append('>').append(escape(value)).append(LF)
+    }
+
+    // ── Value helpers ────────────────────────────────────────────────
+
+    private fun trnType(type: TransactionType): String = when (type) {
+        TransactionType.EXPENSE -> "DEBIT"
+        TransactionType.INCOME -> "CREDIT"
+        TransactionType.TRANSFER -> "XFER"
+    }
+
+    /**
+     * Format the transaction amount for `TRNAMT` from integer [Cents], applying the OFX sign
+     * convention: income is a positive credit; expenses and transfers are negative debits.
+     */
+    private fun formatSignedAmount(txn: Transaction): String {
+        val magnitude = txn.amount.abs()
+        val signed = when (txn.type) {
+            TransactionType.INCOME -> magnitude
+            TransactionType.EXPENSE, TransactionType.TRANSFER -> Cents(-magnitude.amount)
+        }
+        return formatCentsDisplay(signed, txn.currency)
+    }
+
+    /** Format a [LocalDate] as OFX `YYYYMMDD`. */
+    private fun formatDate(date: LocalDate): String {
+        val month = date.monthNumber.toString().padStart(2, '0')
+        val day = date.dayOfMonth.toString().padStart(2, '0')
+        return "${date.year}$month$day"
+    }
+
+    /** Format an [Instant] as OFX `YYYYMMDDHHMMSS` in [zone]. */
+    private fun formatDateTime(instant: Instant, zone: TimeZone): String {
+        val dt = instant.toLocalDateTime(zone)
+        val month = dt.monthNumber.toString().padStart(2, '0')
+        val day = dt.dayOfMonth.toString().padStart(2, '0')
+        val hour = dt.hour.toString().padStart(2, '0')
+        val minute = dt.minute.toString().padStart(2, '0')
+        val second = dt.second.toString().padStart(2, '0')
+        return "${dt.year}$month$day$hour$minute$second"
+    }
+
+    /** Escape SGML markup characters in element values. */
+    private fun escape(value: String): String = value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminderEngine.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminderEngine.kt
@@ -26,8 +26,12 @@ object BillReminderEngine {
     /**
      * Calculate the next notification times for a set of bill reminders.
      *
-     * For each rule+reminder pair, computes when the notification should fire
-     * based on the rule's next due date and the reminder's offset.
+     * For each rule+reminder pair, computes when the notification should fire based on the rule's
+     * next due date and the reminder's offset. When the stored [RecurringTransactionRule.nextDueDate]
+     * is stale (in the past), the next due date on/after [today] is recomputed from the recurrence
+     * rule so an active, confirmed, enabled rule always produces a reminder. The notification date is
+     * clamped to [today] when the offset would otherwise place it in the past, so a fire-now reminder
+     * is still emitted for an imminent bill.
      *
      * @param rules Active recurring transaction rules.
      * @param reminders Bill reminder configurations keyed by rule ID.
@@ -47,21 +51,29 @@ object BillReminderEngine {
             val reminder = reminders[rule.id] ?: continue
             if (!reminder.isEnabled) continue
 
-            val notificationDate = rule.nextDueDate.minus(reminder.offsetDays, DateTimeUnit.DAY)
-
-            // Only include future or today's notifications
-            if (notificationDate >= today) {
-                notifications.add(
-                    ScheduledNotification(
-                        ruleId = rule.id,
-                        reminderId = reminder.id,
-                        dueDate = rule.nextDueDate,
-                        notificationDate = notificationDate,
-                        notificationTime = reminder.reminderTime,
-                        merchant = rule.merchant,
-                    ),
-                )
+            // Use the stored due date when it is still current; otherwise advance the recurrence to
+            // the next occurrence on/after today so a stale nextDueDate never drops the reminder.
+            val dueDate = if (rule.nextDueDate >= today) {
+                rule.nextDueDate
+            } else {
+                RecurringTransactionEngine.nextOccurrenceOnOrAfter(rule.recurrenceRule, today)
+                    ?: continue
             }
+
+            val rawNotificationDate = dueDate.minus(reminder.offsetDays, DateTimeUnit.DAY)
+            // Fire now (today) rather than dropping a reminder whose offset falls in the past.
+            val notificationDate = if (rawNotificationDate < today) today else rawNotificationDate
+
+            notifications.add(
+                ScheduledNotification(
+                    ruleId = rule.id,
+                    reminderId = reminder.id,
+                    dueDate = dueDate,
+                    notificationDate = notificationDate,
+                    notificationTime = reminder.reminderTime,
+                    merchant = rule.merchant,
+                ),
+            )
         }
 
         return notifications.sortedBy { it.notificationDate }
@@ -145,7 +157,7 @@ object BillReminderEngine {
                 val entry = BillCalendarEntry(
                     ruleId = rule.id,
                     merchant = rule.merchant,
-                    amount = rule.amount,
+                    amount = rule.amountFor(dueDate),
                     dueDate = dueDate,
                     isPaid = isPaid,
                     isOverdue = isOverdue,

--- a/packages/core/src/commonMain/kotlin/com/finance/core/recurring/RecurrenceRule.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/recurring/RecurrenceRule.kt
@@ -31,7 +31,16 @@ enum class RecurrenceFrequency {
  *   Clamped to the last day of shorter months (e.g., 31 → 28 for Feb in non-leap years).
  *   When `null`, the day-of-month of [startDate] is used as the recurrence anchor and is
  *   preserved across short months (e.g., a Jan-31 anchor still lands on Mar 31, not Mar 28).
- * @property dayOfWeek Optional day-of-week for WEEKLY/BIWEEKLY recurrences.
+ * @property dayOfWeek Optional day-of-week for WEEKLY/BIWEEKLY recurrences, and the target
+ *   weekday for positional MONTHLY recurrences (see [nthWeekday]). For WEEKLY/BIWEEKLY rules the
+ *   first emitted occurrence is aligned to this weekday on/after [startDate], and every subsequent
+ *   occurrence stays on this weekday exactly `interval` (×2 for biweekly) weeks apart.
+ * @property nthWeekday Optional RRULE `BYDAY`-style positional weekday selector for MONTHLY rules.
+ *   Combined with [dayOfWeek] it selects the *nth* weekday of each month: `1`..`4` pick the
+ *   1st–4th occurrence of [dayOfWeek]; `-1` (or `5`) picks the **last** occurrence. A requested
+ *   ordinal that does not exist in a given month (e.g. a 5th Friday) gracefully clamps to the last
+ *   occurrence of that weekday in the month. Requires [dayOfWeek] to be non-null and only applies
+ *   when [frequency] is [RecurrenceFrequency.MONTHLY]. When set, [dayOfMonth] is ignored.
  * @property count Optional RRULE-style occurrence cap: generate at most this many occurrences
  *   counting from [startDate] (inclusive). `null` means unbounded (subject to [endDate]).
  *   When both [count] and [endDate] are set, whichever limit is reached first wins.
@@ -50,6 +59,7 @@ data class RecurrenceRule(
     val endDate: LocalDate? = null,
     val dayOfMonth: Int? = null,
     val dayOfWeek: DayOfWeek? = null,
+    val nthWeekday: Int? = null,
     val count: Int? = null,
     val skipDates: Set<LocalDate> = emptySet(),
     val isPaused: Boolean = false,
@@ -58,6 +68,14 @@ data class RecurrenceRule(
         require(interval >= 1) { "Interval must be at least 1, was $interval" }
         if (dayOfMonth != null) {
             require(dayOfMonth in 1..31) { "dayOfMonth must be 1–31, was $dayOfMonth" }
+        }
+        if (nthWeekday != null) {
+            require(nthWeekday in 1..5 || nthWeekday == -1) {
+                "nthWeekday must be 1..5 or -1 (last), was $nthWeekday"
+            }
+            require(dayOfWeek != null) {
+                "nthWeekday positional recurrence requires a dayOfWeek"
+            }
         }
         if (endDate != null) {
             require(endDate >= startDate) { "endDate ($endDate) must be on or after startDate ($startDate)" }

--- a/packages/core/src/commonMain/kotlin/com/finance/core/recurring/RecurringCategorizer.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/recurring/RecurringCategorizer.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.models.Transaction
+import com.finance.models.types.SyncId
+
+/**
+ * Pure helpers for seeding the category of generated recurring transactions from historical
+ * occurrences (e.g. an auto-detected subscription).
+ *
+ * [SubscriptionDetector][com.finance.core.subscription.SubscriptionDetector] already infers the most
+ * common category for a detected pattern, but generated transactions only copy the template
+ * category. This bridge selects the category to stamp on generated transactions by choosing the
+ * dominant historical category, so auto-detected rules are pre-categorized.
+ *
+ * All functions are deterministic and side-effect-free.
+ */
+object RecurringCategorizer {
+
+    /**
+     * Select the dominant `categoryId` across [occurrences].
+     *
+     * The category assigned to the most occurrences wins. Ties are broken deterministically by the
+     * lexicographically smallest [SyncId.value], so the result never depends on input ordering.
+     * Occurrences without a category are ignored. Returns `null` when no occurrence carries a
+     * category.
+     *
+     * @param occurrences Historical transactions for a recurring pattern.
+     * @return The dominant category, or `null` if none is present.
+     */
+    fun dominantCategory(occurrences: List<Transaction>): SyncId? {
+        val counts = LinkedHashMap<SyncId, Int>()
+        for (txn in occurrences) {
+            val categoryId = txn.categoryId ?: continue
+            counts[categoryId] = (counts[categoryId] ?: 0) + 1
+        }
+        if (counts.isEmpty()) return null
+
+        val maxCount = counts.values.max()
+        return counts.entries
+            .filter { it.value == maxCount }
+            .minByOrNull { it.key.value }
+            ?.key
+    }
+
+    /**
+     * Determine the category to stamp on a transaction generated for a recurring rule.
+     *
+     * Prefers the dominant category inferred from [occurrences]; when the history carries no
+     * category, falls back to [templateCategory] (the recurring template's own category).
+     *
+     * @param occurrences Historical transactions for the pattern.
+     * @param templateCategory The recurring template's category, used as a fallback.
+     * @return The category to apply to generated transactions, or `null` when neither is available.
+     */
+    fun categoryForGenerated(
+        occurrences: List<Transaction>,
+        templateCategory: SyncId? = null,
+    ): SyncId? = dominantCategory(occurrences) ?: templateCategory
+
+    /**
+     * Return a copy of [template] whose `categoryId` is seeded from the dominant category of
+     * [occurrences] (falling back to the template's existing category when the history is
+     * uncategorized). All other fields — including the fixed integer `Cents` amount — are unchanged.
+     *
+     * @param template The recurring transaction template.
+     * @param occurrences Historical transactions for the pattern.
+     * @return A template carrying the resolved category.
+     */
+    fun applyDominantCategory(
+        template: Transaction,
+        occurrences: List<Transaction>,
+    ): Transaction {
+        val resolved = categoryForGenerated(occurrences, template.categoryId)
+        return if (resolved == template.categoryId) template else template.copy(categoryId = resolved)
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/recurring/RecurringTransactionEngine.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/recurring/RecurringTransactionEngine.kt
@@ -8,6 +8,7 @@ import com.finance.models.types.SyncId
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
 import kotlinx.datetime.number
 import kotlinx.datetime.plus
 
@@ -19,6 +20,14 @@ import kotlinx.datetime.plus
  * tested trivially and run on any KMP target.
  */
 object RecurringTransactionEngine {
+
+    private const val DAYS_PER_WEEK = 7
+
+    /** Default number of days before `today` that [getOverdueReminders] scans for overdue bills. */
+    const val DEFAULT_OVERDUE_LOOKBACK_DAYS: Int = 90
+
+    /** Default cap on overdue occurrences emitted per rule by [getOverdueReminders]. */
+    const val DEFAULT_OVERDUE_MAX_PER_RULE: Int = 50
 
     // ── Occurrence generation ────────────────────────────────────────
 
@@ -50,7 +59,7 @@ object RecurringTransactionEngine {
         }
 
         val dates = mutableListOf<LocalDate>()
-        var current = rule.startDate
+        var current = effectiveStart(rule)
         var occurrenceCount = 0
 
         while (current <= effectiveEnd) {
@@ -87,7 +96,7 @@ object RecurringTransactionEngine {
     ): LocalDate? {
         if (rule.isPaused) return null
 
-        var current = rule.startDate
+        var current = effectiveStart(rule)
         var occurrenceCount = 0
 
         while (true) {
@@ -141,26 +150,49 @@ object RecurringTransactionEngine {
     // ── Overdue detection ────────────────────────────────────────────
 
     /**
-     * For each rule + template pair, find every occurrence on or before [today]
+     * For each rule + template pair, find overdue occurrences on or before [today]
      * and emit a [Reminder] marked as overdue.
      *
-     * A reminder is overdue when the occurrence date ≤ [today].
+     * A reminder is overdue when the occurrence date ≤ [today]. To keep the result bounded for
+     * long-running rules (e.g. a DAILY rule started years ago), overdue detection only reaches back
+     * [lookbackDays] days from [today] and caps the number of overdue occurrences emitted per rule
+     * at [maxPerRule] (keeping the most recent ones). Occurrences already recorded/paid — identified
+     * by a `(ruleId, dueDate)` pair in [paidOccurrences] — are excluded.
+     *
      * This intentionally only returns *overdue* reminders; upcoming-but-not-yet-due
      * reminders should be built by combining [generateUpcoming] with a future window.
      *
      * @param rules Pairs of (recurrence rule, transaction template).
      * @param today The reference date (typically `Clock.System.todayIn(tz)`).
+     * @param lookbackDays How many days before [today] overdue detection reaches (default 90).
+     *   Must be non-negative.
+     * @param maxPerRule Maximum overdue occurrences emitted per rule (default 50), keeping the most
+     *   recent. Must be positive.
+     * @param paidOccurrences `(ruleId, dueDate)` pairs already recorded/paid; excluded from output.
      * @return List of [Reminder]s sorted by due date ascending.
      */
     fun getOverdueReminders(
         rules: List<Pair<RecurrenceRule, Transaction>>,
         today: LocalDate,
+        lookbackDays: Int = DEFAULT_OVERDUE_LOOKBACK_DAYS,
+        maxPerRule: Int = DEFAULT_OVERDUE_MAX_PER_RULE,
+        paidOccurrences: Set<Pair<SyncId, LocalDate>> = emptySet(),
     ): List<Reminder> {
+        require(lookbackDays >= 0) { "lookbackDays must be non-negative, was $lookbackDays" }
+        require(maxPerRule >= 1) { "maxPerRule must be at least 1, was $maxPerRule" }
+
+        val windowStart = today.minus(lookbackDays, DateTimeUnit.DAY)
+
         return rules.flatMap { (rule, template) ->
             // Rule hasn't started yet — no overdue occurrences possible.
             if (rule.startDate > today) return@flatMap emptyList()
 
-            generateUpcoming(rule, from = rule.startDate, to = today)
+            val from = if (rule.startDate > windowStart) rule.startDate else windowStart
+
+            generateUpcoming(rule, from = from, to = today)
+                .filter { dueDate -> Pair(rule.id, dueDate) !in paidOccurrences }
+                // Keep the most recent overdue occurrences when the window is dense.
+                .takeLast(maxPerRule)
                 .map { dueDate ->
                     val daysOverdue = daysBetween(dueDate, today)
                     Reminder(
@@ -195,11 +227,55 @@ object RecurringTransactionEngine {
                 advanceWeekly(current, rule.interval * 2, rule.dayOfWeek)
 
             RecurrenceFrequency.MONTHLY ->
-                advanceMonthly(current, rule.interval, anchorDay)
+                if (rule.nthWeekday != null && rule.dayOfWeek != null) {
+                    advanceMonthlyPositional(current, rule.interval, rule.dayOfWeek, rule.nthWeekday)
+                } else {
+                    advanceMonthly(current, rule.interval, anchorDay)
+                }
 
             RecurrenceFrequency.YEARLY ->
                 advanceYearly(current, rule.interval, anchorDay)
         }
+    }
+
+    /**
+     * Resolve the first concrete occurrence of [rule] (the date the series starts emitting from).
+     *
+     * For WEEKLY/BIWEEKLY rules with a [RecurrenceRule.dayOfWeek] the start is aligned forward to
+     * that weekday on/after [RecurrenceRule.startDate] so the first entry lands on the preferred
+     * weekday and every interval is a whole number of weeks. For positional MONTHLY rules
+     * (see [RecurrenceRule.nthWeekday]) the start is the nth weekday of the start month, advanced to
+     * the next eligible month when that date already precedes [RecurrenceRule.startDate]. All other
+     * rules start exactly on [RecurrenceRule.startDate].
+     */
+    internal fun effectiveStart(rule: RecurrenceRule): LocalDate {
+        val start = rule.startDate
+        return when (rule.frequency) {
+            RecurrenceFrequency.WEEKLY, RecurrenceFrequency.BIWEEKLY -> {
+                val dow = rule.dayOfWeek ?: return start
+                alignToWeekday(start, dow)
+            }
+
+            RecurrenceFrequency.MONTHLY -> {
+                val dow = rule.dayOfWeek
+                val nth = rule.nthWeekday
+                if (dow == null || nth == null) return start
+                val firstInMonth = nthWeekdayOfMonth(start.year, start.month.number, dow, nth)
+                if (firstInMonth >= start) {
+                    firstInMonth
+                } else {
+                    advanceMonthlyPositional(firstInMonth, rule.interval, dow, nth)
+                }
+            }
+
+            else -> start
+        }
+    }
+
+    /** Advance [date] forward (never backward) to the next occurrence of [target] weekday. */
+    private fun alignToWeekday(date: LocalDate, target: DayOfWeek): LocalDate {
+        val diff = ((target.ordinal - date.dayOfWeek.ordinal) + DAYS_PER_WEEK) % DAYS_PER_WEEK
+        return date.plus(diff, DateTimeUnit.DAY)
     }
 
     private fun advanceWeekly(
@@ -209,9 +285,52 @@ object RecurringTransactionEngine {
     ): LocalDate {
         val advanced = current.plus(weeks, DateTimeUnit.WEEK)
         if (preferredDay == null) return advanced
-        // Snap to the preferred day within the same ISO week.
-        val diff = preferredDay.ordinal - advanced.dayOfWeek.ordinal
-        return advanced.plus(diff, DateTimeUnit.DAY)
+        // Snap forward-only to the preferred day so an occurrence is never earlier than the
+        // previous one. When [current] is already aligned (the normal case) this is a no-op.
+        return alignToWeekday(advanced, preferredDay)
+    }
+
+    /**
+     * Advance a positional MONTHLY recurrence by [months] months and resolve the [nth] occurrence
+     * of [weekday] in the resulting month (see [RecurrenceRule.nthWeekday]).
+     */
+    private fun advanceMonthlyPositional(
+        current: LocalDate,
+        months: Int,
+        weekday: DayOfWeek,
+        nth: Int,
+    ): LocalDate {
+        val firstOfMonth = LocalDate(current.year, current.month.number, 1)
+        val nextMonth = firstOfMonth.plus(months, DateTimeUnit.MONTH)
+        return nthWeekdayOfMonth(nextMonth.year, nextMonth.month.number, weekday, nth)
+    }
+
+    /**
+     * Resolve the [nth] occurrence of [weekday] within [year]/[month].
+     *
+     * `nth` in `1..4` selects the 1st–4th occurrence; `-1` (or `5`) selects the last occurrence.
+     * A requested ordinal that does not exist in the month clamps to the last occurrence of
+     * [weekday] (e.g. a 5th Friday in a month with only four resolves to the 4th).
+     */
+    internal fun nthWeekdayOfMonth(
+        year: Int,
+        month: Int,
+        weekday: DayOfWeek,
+        nth: Int,
+    ): LocalDate {
+        val lastDay = lastDayOfMonth(year, month)
+        if (nth <= 0) {
+            // Last occurrence: walk back from month end to the target weekday.
+            val monthEnd = LocalDate(year, month, lastDay)
+            val back = ((monthEnd.dayOfWeek.ordinal - weekday.ordinal) + DAYS_PER_WEEK) % DAYS_PER_WEEK
+            return monthEnd.minus(back, DateTimeUnit.DAY)
+        }
+        val firstOfMonth = LocalDate(year, month, 1)
+        val offset = ((weekday.ordinal - firstOfMonth.dayOfWeek.ordinal) + DAYS_PER_WEEK) % DAYS_PER_WEEK
+        var day = 1 + offset + (nth - 1) * DAYS_PER_WEEK
+        // Clamp a non-existent ordinal (e.g. 5th weekday) back to the last real occurrence.
+        while (day > lastDay) day -= DAYS_PER_WEEK
+        return LocalDate(year, month, day)
     }
 
     /**

--- a/packages/core/src/commonMain/kotlin/com/finance/core/recurring/RecurringTransactionRule.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/recurring/RecurringTransactionRule.kt
@@ -21,7 +21,14 @@ import kotlinx.serialization.Serializable
  * @property ownerId Authenticated user who owns this rule.
  * @property householdId Household this rule belongs to.
  * @property merchant The payee/merchant name for this recurring bill.
- * @property amount Expected bill amount in cents.
+ * @property amount Expected bill amount in cents. For [isVariable] rules this is the *estimate*
+ *   used by forecasts when no per-occurrence override is known.
+ * @property isVariable `true` if the bill amount varies each cycle (e.g. utilities, credit-card
+ *   minimums). Forecasts fall back to [amount] as the estimate; a concrete [amountOverrides] entry
+ *   is used for an occurrence when known.
+ * @property amountOverrides Optional per-occurrence amount overrides keyed by the occurrence
+ *   [LocalDate]. Applied when stamping/forecasting that specific occurrence. Ignored unless
+ *   [isVariable] is `true`.
  * @property currency Currency for the bill amount.
  * @property accountId Account to charge/credit.
  * @property categoryId Category for generated transactions.
@@ -43,6 +50,8 @@ data class RecurringTransactionRule(
     val householdId: SyncId,
     val merchant: String,
     val amount: Cents,
+    val isVariable: Boolean = false,
+    val amountOverrides: Map<LocalDate, Cents> = emptyMap(),
     val currency: Currency,
     val accountId: SyncId,
     val categoryId: SyncId? = null,
@@ -61,4 +70,14 @@ data class RecurringTransactionRule(
         require(merchant.isNotBlank()) { "Merchant name cannot be blank" }
         require(amount.amount != 0L) { "Bill amount cannot be zero" }
     }
+
+    /**
+     * Resolve the amount to use for the occurrence on [date].
+     *
+     * Returns the per-occurrence override from [amountOverrides] when this rule [isVariable] and an
+     * override exists for that date; otherwise returns the estimate [amount]. Fixed (non-variable)
+     * rules always return [amount].
+     */
+    fun amountFor(date: LocalDate): Cents =
+        if (isVariable) amountOverrides[date] ?: amount else amount
 }

--- a/packages/core/src/commonMain/kotlin/com/finance/core/recurring/ReminderScheduling.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/recurring/ReminderScheduling.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+
+/**
+ * Resolves timezone-naive reminder data ([LocalDate] + [ReminderTime]) into an absolute [Instant]
+ * anchored to a user's [TimeZone], so reminders fire at the intended civil time even across time
+ * zone changes and daylight-saving-time (DST) transitions.
+ *
+ * `ReminderTime` carries only hour/minute and `ScheduledNotification.notificationDate` is a bare
+ * `LocalDate`; without a zone a reminder like "9:00 the day before" has no real instant. This
+ * object supplies that anchor.
+ *
+ * ## DST semantics
+ * Wall-clock resolution delegates to `kotlinx-datetime`'s [LocalDateTime.toInstant] and inherits its
+ * documented, deterministic behavior:
+ * - **Spring-forward gap** (a wall-clock time that does not exist, e.g. 02:30 when clocks jump
+ *   02:00 → 03:00): the time is shifted forward by the size of the gap, so the reminder fires at the
+ *   first valid instant after the requested time rather than being dropped.
+ * - **Fall-back overlap** (a wall-clock time that occurs twice, e.g. 01:30 when clocks fall
+ *   03:00 → 02:00... 01:00): the **earlier** of the two instants is chosen, so the reminder fires
+ *   once, at its first occurrence.
+ *
+ * All functions are pure `commonMain` and use no platform APIs.
+ */
+object ReminderScheduling {
+
+    /**
+     * Resolve a reminder [date] and wall-clock [time] in [zone] to an absolute [Instant].
+     *
+     * @param date The civil date the reminder should fire on.
+     * @param time The wall-clock time of day (hour/minute) in [zone].
+     * @param zone The user's time zone anchoring the wall-clock time.
+     * @return The absolute instant the reminder should fire, applying the DST semantics above.
+     */
+    fun resolveInstant(date: LocalDate, time: ReminderTime, zone: TimeZone): Instant {
+        val wallClock = LocalDateTime(
+            year = date.year,
+            monthNumber = date.monthNumber,
+            dayOfMonth = date.dayOfMonth,
+            hour = time.hour,
+            minute = time.minute,
+        )
+        return wallClock.toInstant(zone)
+    }
+
+    /**
+     * Resolve a computed [ScheduledNotification] to the absolute [Instant] it should fire at in
+     * [zone], combining its [ScheduledNotification.notificationDate] and
+     * [ScheduledNotification.notificationTime].
+     *
+     * @param notification The scheduled notification produced by [BillReminderEngine].
+     * @param zone The user's time zone.
+     * @return The absolute instant the notification should fire.
+     */
+    fun resolveInstant(notification: ScheduledNotification, zone: TimeZone): Instant =
+        resolveInstant(notification.notificationDate, notification.notificationTime, zone)
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/subscription/SubscriptionDetector.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/subscription/SubscriptionDetector.kt
@@ -116,7 +116,7 @@ object SubscriptionDetector {
 
         // Check amount consistency
         val amounts = sorted.map { it.amount.abs().amount }
-        val avgAmount = amounts.sum() / amounts.size
+        val avgAmount = roundHalfUp(amounts.sum(), amounts.size.toLong())
         val allSimilar = amounts.all { amount ->
             val diff = kotlin.math.abs(amount - avgAmount).toDouble()
             avgAmount == 0L || (diff / avgAmount) * 100.0 <= AMOUNT_TOLERANCE_PERCENT
@@ -170,35 +170,65 @@ object SubscriptionDetector {
             .trim()
     }
 
+    /**
+     * Classify the dominant cadence from an average inter-transaction interval in days.
+     *
+     * Ranges are contiguous across the common billing cadences so genuine subscriptions with
+     * ~21-day (every-three-weeks), semi-monthly (twice-a-month, ~15 days), and every-other-month
+     * (~35–80 day) cycles are no longer dropped as `null`. Semi-monthly is disambiguated from a true
+     * 14-day biweekly cycle by its slightly longer average interval. Returns `null` only for
+     * intervals outside every supported cadence band (e.g. sub-weekly noise or 100–350 day gaps).
+     */
     internal fun classifyFrequency(avgIntervalDays: Double): SubscriptionFrequency? {
         return when {
             avgIntervalDays in 5.0..9.0 -> SubscriptionFrequency.WEEKLY
-            avgIntervalDays in 12.0..17.0 -> SubscriptionFrequency.BIWEEKLY
+            avgIntervalDays in 12.0..14.0 -> SubscriptionFrequency.BIWEEKLY
+            avgIntervalDays > 14.0 && avgIntervalDays <= 17.0 -> SubscriptionFrequency.SEMI_MONTHLY
+            avgIntervalDays in 18.0..26.0 -> SubscriptionFrequency.EVERY_THREE_WEEKS
             avgIntervalDays in 27.0..34.0 -> SubscriptionFrequency.MONTHLY
-            avgIntervalDays in 85.0..100.0 -> SubscriptionFrequency.QUARTERLY
+            avgIntervalDays in 35.0..80.0 -> SubscriptionFrequency.BIMONTHLY
+            avgIntervalDays in 81.0..100.0 -> SubscriptionFrequency.QUARTERLY
             avgIntervalDays in 350.0..380.0 -> SubscriptionFrequency.YEARLY
             else -> null
         }
     }
 
     internal fun toMonthlyCost(amount: Cents, frequency: SubscriptionFrequency): Cents {
+        val cents = amount.amount
         return when (frequency) {
-            SubscriptionFrequency.WEEKLY -> Cents(amount.amount * 52 / 12)
-            SubscriptionFrequency.BIWEEKLY -> Cents(amount.amount * 26 / 12)
+            SubscriptionFrequency.WEEKLY -> Cents(roundHalfUp(cents * 52, 12))
+            SubscriptionFrequency.BIWEEKLY -> Cents(roundHalfUp(cents * 26, 12))
+            SubscriptionFrequency.SEMI_MONTHLY -> Cents(cents * 2)
+            SubscriptionFrequency.EVERY_THREE_WEEKS -> Cents(roundHalfUp(cents * 365, 21 * 12))
             SubscriptionFrequency.MONTHLY -> amount
-            SubscriptionFrequency.QUARTERLY -> Cents(amount.amount / 3)
-            SubscriptionFrequency.YEARLY -> Cents(amount.amount / 12)
+            SubscriptionFrequency.BIMONTHLY -> Cents(roundHalfUp(cents, 2))
+            SubscriptionFrequency.QUARTERLY -> Cents(roundHalfUp(cents, 3))
+            SubscriptionFrequency.YEARLY -> Cents(roundHalfUp(cents, 12))
         }
     }
 
     internal fun toAnnualCost(amount: Cents, frequency: SubscriptionFrequency): Cents {
+        val cents = amount.amount
         return when (frequency) {
-            SubscriptionFrequency.WEEKLY -> Cents(amount.amount * 52)
-            SubscriptionFrequency.BIWEEKLY -> Cents(amount.amount * 26)
-            SubscriptionFrequency.MONTHLY -> Cents(amount.amount * 12)
-            SubscriptionFrequency.QUARTERLY -> Cents(amount.amount * 4)
+            SubscriptionFrequency.WEEKLY -> Cents(cents * 52)
+            SubscriptionFrequency.BIWEEKLY -> Cents(cents * 26)
+            SubscriptionFrequency.SEMI_MONTHLY -> Cents(cents * 24)
+            SubscriptionFrequency.EVERY_THREE_WEEKS -> Cents(roundHalfUp(cents * 365, 21))
+            SubscriptionFrequency.MONTHLY -> Cents(cents * 12)
+            SubscriptionFrequency.BIMONTHLY -> Cents(cents * 6)
+            SubscriptionFrequency.QUARTERLY -> Cents(cents * 4)
             SubscriptionFrequency.YEARLY -> amount
         }
+    }
+
+    /**
+     * Round `numerator / denominator` to the nearest integer using round-half-up, staying in integer
+     * [Cents] math. [numerator] and [denominator] are expected to be non-negative (amounts are taken
+     * as absolute values before averaging/annualization).
+     */
+    internal fun roundHalfUp(numerator: Long, denominator: Long): Long {
+        require(denominator > 0) { "denominator must be positive, was $denominator" }
+        return (numerator + denominator / 2) / denominator
     }
 
     private fun computeConfidence(
@@ -217,7 +247,7 @@ object SubscriptionDetector {
 
 @Serializable
 enum class SubscriptionFrequency {
-    WEEKLY, BIWEEKLY, MONTHLY, QUARTERLY, YEARLY,
+    WEEKLY, BIWEEKLY, SEMI_MONTHLY, EVERY_THREE_WEEKS, MONTHLY, BIMONTHLY, QUARTERLY, YEARLY,
 }
 
 @Serializable

--- a/packages/core/src/commonMain/kotlin/com/finance/core/validation/DateInputValidator.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/validation/DateInputValidator.kt
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.validation
+
+import kotlinx.datetime.LocalDate
+
+/**
+ * Cross-platform date parsing and validation, mirroring the web app's
+ * `apps/web/src/utils/dateValidation.ts` so every platform (Android, iOS, Windows, and eventually
+ * web via the KMP-JS bridge) shares one implementation and one set of messages.
+ *
+ * It deliberately distinguishes the two failure modes that are easy to conflate:
+ * - **Malformed** — the text is not shaped like a supported date at all (e.g. `6/18/25`,
+ *   `2025.01.01`, `hello`). The user must fix the *format*.
+ * - **Invalid calendar date** — the text is well-formed (`MM/DD/YYYY` or ISO `YYYY-MM-DD`) but is
+ *   not a real day on the calendar (e.g. `12/33/2000`, `02/30/2024`, `02/29/2023`). The format is
+ *   fine; the *value* is wrong.
+ *
+ * Inclusive `min`/`max` range checks are handled here too, so every field applies the same boundary
+ * semantics and messaging. All functions are pure `commonMain`.
+ */
+object DateInputValidator {
+
+    /** Matches a display date shaped `MM/DD/YYYY` (two/two/four digits). */
+    val DISPLAY_DATE_PATTERN = Regex("""^(\d{2})/(\d{2})/(\d{4})$""")
+
+    /** Matches an ISO date shaped `YYYY-MM-DD`. */
+    val ISO_DATE_PATTERN = Regex("""^(\d{4})-(\d{2})-(\d{2})$""")
+
+    /** User-facing message for an empty-but-required value. */
+    const val MESSAGE_EMPTY = "Enter a date."
+
+    /** User-facing message for a value that is not shaped like a supported date. */
+    const val MESSAGE_MALFORMED = "Enter a date in MM/DD/YYYY format."
+
+    /** User-facing message for a well-formed value that is not a real calendar date. */
+    const val MESSAGE_INVALID_CALENDAR_DATE = "Not a valid calendar date — check the month and day."
+
+    /**
+     * Construct a [LocalDate], returning `null` when [year]/[month]/[day] is not a real calendar
+     * date (e.g. month 13, day 33, Feb 30, or Feb 29 in a non-leap year).
+     */
+    fun createCalendarDate(year: Int, month: Int, day: Int): LocalDate? =
+        try {
+            LocalDate(year, month, day)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+
+    /** Parse an ISO `YYYY-MM-DD` string, or `null` if it is not a well-formed, real calendar date. */
+    fun parseIsoDate(value: String): LocalDate? {
+        val match = ISO_DATE_PATTERN.matchEntire(value.trim()) ?: return null
+        val (year, month, day) = match.destructured
+        return createCalendarDate(year.toInt(), month.toInt(), day.toInt())
+    }
+
+    /** Parse a display `MM/DD/YYYY` string, or `null` if it is not a well-formed, real calendar date. */
+    fun parseDisplayDate(value: String): LocalDate? {
+        val match = DISPLAY_DATE_PATTERN.matchEntire(value.trim()) ?: return null
+        val (month, day, year) = match.destructured
+        return createCalendarDate(year.toInt(), month.toInt(), day.toInt())
+    }
+
+    /** Format a [LocalDate] as a display `MM/DD/YYYY` string. */
+    fun formatDisplayDate(date: LocalDate): String {
+        val month = date.monthNumber.toString().padStart(2, '0')
+        val day = date.dayOfMonth.toString().padStart(2, '0')
+        return "$month/$day/${date.year}"
+    }
+
+    /**
+     * Parse a user-entered date string, accepting either `MM/DD/YYYY` or ISO `YYYY-MM-DD`.
+     * Distinguishes malformed input from well-formed-but-invalid calendar dates so callers can
+     * surface an accurate message.
+     */
+    fun parse(rawValue: String): DateParseResult {
+        val trimmed = rawValue.trim()
+        if (trimmed.isEmpty()) {
+            return DateParseResult.Failure(DateValidationErrorKind.EMPTY, MESSAGE_EMPTY)
+        }
+
+        val isIso = ISO_DATE_PATTERN.matches(trimmed)
+        val isDisplay = DISPLAY_DATE_PATTERN.matches(trimmed)
+
+        // Not shaped like a supported date format at all.
+        if (!isIso && !isDisplay) {
+            return DateParseResult.Failure(DateValidationErrorKind.MALFORMED, MESSAGE_MALFORMED)
+        }
+
+        // Well-formed shape — now check it is a real calendar date.
+        val date = if (isIso) parseIsoDate(trimmed) else parseDisplayDate(trimmed)
+        return if (date == null) {
+            DateParseResult.Failure(
+                DateValidationErrorKind.INVALID_CALENDAR_DATE,
+                MESSAGE_INVALID_CALENDAR_DATE,
+            )
+        } else {
+            DateParseResult.Success(date)
+        }
+    }
+
+    /**
+     * Fully validate a user-entered date string: shape, calendar validity, and inclusive range.
+     *
+     * An empty value is [DateValidationResult.Valid] (with a `null` date) unless [required] is set.
+     * Both `MM/DD/YYYY` and ISO `YYYY-MM-DD` inputs are accepted.
+     *
+     * @param rawValue The raw user input.
+     * @param min Optional inclusive lower bound.
+     * @param max Optional inclusive upper bound.
+     * @param required When `true`, an empty value is invalid. Defaults to `false`.
+     */
+    fun validate(
+        rawValue: String,
+        min: LocalDate? = null,
+        max: LocalDate? = null,
+        required: Boolean = false,
+    ): DateValidationResult {
+        val trimmed = rawValue.trim()
+        if (trimmed.isEmpty()) {
+            return if (required) {
+                DateValidationResult.Invalid(DateValidationErrorKind.EMPTY, MESSAGE_EMPTY)
+            } else {
+                DateValidationResult.Valid(null)
+            }
+        }
+
+        val parsed = parse(trimmed)
+        val date = when (parsed) {
+            is DateParseResult.Success -> parsed.date
+            is DateParseResult.Failure ->
+                return DateValidationResult.Invalid(parsed.errorKind, parsed.message)
+        }
+
+        if (min != null && date < min) {
+            return DateValidationResult.Invalid(
+                DateValidationErrorKind.BEFORE_MIN,
+                "Date must be on or after ${formatDisplayDate(min)}.",
+            )
+        }
+        if (max != null && date > max) {
+            return DateValidationResult.Invalid(
+                DateValidationErrorKind.AFTER_MAX,
+                "Date must be on or before ${formatDisplayDate(max)}.",
+            )
+        }
+
+        return DateValidationResult.Valid(date)
+    }
+}
+
+/** The distinct reasons a date input can fail validation. */
+enum class DateValidationErrorKind {
+    EMPTY,
+    MALFORMED,
+    INVALID_CALENDAR_DATE,
+    BEFORE_MIN,
+    AFTER_MAX,
+}
+
+/** Result of [DateInputValidator.parse]. */
+sealed interface DateParseResult {
+    /** A well-formed, real calendar date. */
+    data class Success(val date: LocalDate) : DateParseResult
+
+    /** A parse failure with a distinct [errorKind] and user-facing [message]. */
+    data class Failure(
+        val errorKind: DateValidationErrorKind,
+        val message: String,
+    ) : DateParseResult
+}
+
+/** Result of [DateInputValidator.validate]. */
+sealed interface DateValidationResult {
+    /** A valid input. [date] is `null` for an accepted empty (non-required) value. */
+    data class Valid(val date: LocalDate?) : DateValidationResult
+
+    /** An invalid input with the specific [errorKind] and user-facing [message]. */
+    data class Invalid(
+        val errorKind: DateValidationErrorKind,
+        val message: String,
+    ) : DateValidationResult
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/export/OfxExportSerializerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/export/OfxExportSerializerTest.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.core.TestFixtures
+import com.finance.models.TransactionType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Tests for the OFX 1.0.2 export serializer (#3746). */
+class OfxExportSerializerTest {
+
+    private val generatedAt = Instant.parse("2024-06-15T12:00:00Z")
+
+    private fun expense() = TestFixtures.createTransaction(
+        id = SyncId("txn-b"),
+        type = TransactionType.EXPENSE,
+        amount = Cents(2500),
+        currency = Currency.USD,
+        payee = "Coffee Shop",
+        note = "Latte",
+        date = LocalDate(2024, 6, 10),
+    )
+
+    private fun income() = TestFixtures.createTransaction(
+        id = SyncId("txn-a"),
+        type = TransactionType.INCOME,
+        amount = Cents(500000),
+        currency = Currency.USD,
+        payee = "Employer",
+        date = LocalDate(2024, 6, 12),
+    )
+
+    @Test
+    fun producesWellFormedOfxHeaderAndEnvelope() {
+        val ofx = OfxExportSerializer.serialize(listOf(expense()), generatedAt = generatedAt)
+        assertTrue(ofx.startsWith("OFXHEADER:100"), "should start with OFX header")
+        assertTrue(ofx.contains("VERSION:102"))
+        assertTrue(ofx.contains("<OFX>") && ofx.contains("</OFX>"))
+        assertTrue(ofx.contains("<BANKTRANLIST>") && ofx.contains("</BANKTRANLIST>"))
+    }
+
+    @Test
+    fun emitsOneStmtTrnPerTransaction() {
+        val ofx = OfxExportSerializer.serialize(listOf(expense(), income()), generatedAt = generatedAt)
+        val count = Regex("<STMTTRN>").findAll(ofx).count()
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun expenseIsNegativeDebit_incomeIsPositiveCredit() {
+        val ofxExpense = OfxExportSerializer.serialize(listOf(expense()), generatedAt = generatedAt)
+        assertTrue(ofxExpense.contains("<TRNTYPE>DEBIT"))
+        assertTrue(ofxExpense.contains("<TRNAMT>-25.00"), "expense amount should be negative with 2 decimals")
+
+        val ofxIncome = OfxExportSerializer.serialize(listOf(income()), generatedAt = generatedAt)
+        assertTrue(ofxIncome.contains("<TRNTYPE>CREDIT"))
+        assertTrue(ofxIncome.contains("<TRNAMT>5000.00"), "income amount should be positive with 2 decimals")
+    }
+
+    @Test
+    fun includesFitidAndDatePostedAndName() {
+        val ofx = OfxExportSerializer.serialize(listOf(expense()), generatedAt = generatedAt)
+        assertTrue(ofx.contains("<FITID>txn-b"))
+        assertTrue(ofx.contains("<DTPOSTED>20240610"))
+        assertTrue(ofx.contains("<NAME>Coffee Shop"))
+        assertTrue(ofx.contains("<MEMO>Latte"))
+    }
+
+    @Test
+    fun orderingIsDeterministicByDateThenId() {
+        // income (06/12) after expense (06/10) regardless of input order.
+        val a = OfxExportSerializer.serialize(listOf(income(), expense()), generatedAt = generatedAt)
+        val b = OfxExportSerializer.serialize(listOf(expense(), income()), generatedAt = generatedAt)
+        assertEquals(a, b)
+        assertTrue(a.indexOf("txn-b") < a.indexOf("txn-a"), "earlier date should serialize first")
+    }
+
+    @Test
+    fun escapesMarkupCharactersInText() {
+        val txn = TestFixtures.createTransaction(
+            id = SyncId("txn-esc"),
+            type = TransactionType.EXPENSE,
+            amount = Cents(100),
+            payee = "Tom & Jerry <LLC>",
+            date = LocalDate(2024, 6, 10),
+        )
+        val ofx = OfxExportSerializer.serialize(listOf(txn), generatedAt = generatedAt)
+        assertTrue(ofx.contains("Tom &amp; Jerry &lt;LLC&gt;"))
+    }
+
+    @Test
+    fun emptyTransactions_stillProducesValidEnvelope() {
+        val ofx = OfxExportSerializer.serialize(emptyList(), generatedAt = generatedAt)
+        assertTrue(ofx.contains("<OFX>") && ofx.contains("</OFX>"))
+        assertEquals(0, Regex("<STMTTRN>").findAll(ofx).count())
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/recurring/BillReminderEngineTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/recurring/BillReminderEngineTest.kt
@@ -136,8 +136,10 @@ class BillReminderEngineTest {
     }
 
     @Test
-    fun scheduleNotifications_skipsPastNotifications() {
-        val rule = createRule(nextDueDate = LocalDate(2024, 6, 10)) // past due
+    fun scheduleNotifications_staleNextDueDate_advancesToNextOccurrence() {
+        // Stale stored nextDueDate in the past must not silently drop the reminder (#3714):
+        // the engine advances the recurrence to the next occurrence on/after today.
+        val rule = createRule(nextDueDate = LocalDate(2024, 6, 10)) // stale, in the past
         val reminder = createReminder(offsetDays = 3)
 
         val notifications = BillReminderEngine.scheduleNotifications(
@@ -146,7 +148,11 @@ class BillReminderEngineTest {
             today = today,
         )
 
-        assertEquals(0, notifications.size)
+        // Monthly rule anchored on the 15th → next occurrence on/after 2024-06-15 is 2024-06-15.
+        assertEquals(1, notifications.size)
+        assertEquals(LocalDate(2024, 6, 15), notifications[0].dueDate)
+        // Offset would land the notification in the past, so it is clamped to today (fire now).
+        assertEquals(today, notifications[0].notificationDate)
     }
 
     @Test

--- a/packages/core/src/commonTest/kotlin/com/finance/core/recurring/OverdueRemindersBoundedTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/recurring/OverdueRemindersBoundedTest.kt
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.core.TestFixtures
+import com.finance.models.types.SyncId
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+/** Tests for bounded, paid-aware overdue reminder detection (#3735). */
+class OverdueRemindersBoundedTest {
+
+    private fun dailyRule(id: String, start: LocalDate) = RecurrenceRule(
+        id = SyncId(id),
+        frequency = RecurrenceFrequency.DAILY,
+        startDate = start,
+    )
+
+    @Test
+    fun longRunningDailyRule_isBoundedByDefaultLookbackAndCap() {
+        val template = TestFixtures.createExpense()
+        val rule = dailyRule("daily", LocalDate(2020, 1, 1)) // started years ago
+        val today = LocalDate(2024, 6, 15)
+
+        val reminders = RecurringTransactionEngine.getOverdueReminders(
+            rules = listOf(rule to template),
+            today = today,
+        )
+
+        // Without bounding this would materialize ~1600 occurrences; the cap keeps it small.
+        assertEquals(RecurringTransactionEngine.DEFAULT_OVERDUE_MAX_PER_RULE, reminders.size)
+        assertTrue(reminders.all { it.isOverdue })
+        // Most-recent occurrences are kept; the newest is today.
+        assertEquals(today, reminders.last().dueDate)
+    }
+
+    @Test
+    fun customLookbackWindow_limitsHowFarBack() {
+        val template = TestFixtures.createExpense()
+        val rule = dailyRule("daily", LocalDate(2020, 1, 1))
+        val today = LocalDate(2024, 6, 15)
+
+        val reminders = RecurringTransactionEngine.getOverdueReminders(
+            rules = listOf(rule to template),
+            today = today,
+            lookbackDays = 5,
+            maxPerRule = 100,
+        )
+
+        // Window is [today-5, today] inclusive = 6 days.
+        assertEquals(6, reminders.size)
+        assertEquals(LocalDate(2024, 6, 10), reminders.first().dueDate)
+        assertEquals(today, reminders.last().dueDate)
+    }
+
+    @Test
+    fun paidOccurrences_areExcluded() {
+        val template = TestFixtures.createExpense()
+        val rule = dailyRule("daily", LocalDate(2024, 6, 10))
+        val today = LocalDate(2024, 6, 15)
+        val paid = setOf(
+            SyncId("daily") to LocalDate(2024, 6, 11),
+            SyncId("daily") to LocalDate(2024, 6, 13),
+        )
+
+        val reminders = RecurringTransactionEngine.getOverdueReminders(
+            rules = listOf(rule to template),
+            today = today,
+            paidOccurrences = paid,
+        )
+
+        val dueDates = reminders.map { it.dueDate }
+        assertFalse(LocalDate(2024, 6, 11) in dueDates)
+        assertFalse(LocalDate(2024, 6, 13) in dueDates)
+        assertEquals(4, reminders.size) // 10,12,14,15
+    }
+
+    @Test
+    fun capKeepsMostRecentOccurrences() {
+        val template = TestFixtures.createExpense()
+        val rule = dailyRule("daily", LocalDate(2024, 6, 1))
+        val today = LocalDate(2024, 6, 15)
+
+        val reminders = RecurringTransactionEngine.getOverdueReminders(
+            rules = listOf(rule to template),
+            today = today,
+            maxPerRule = 3,
+        )
+
+        assertEquals(3, reminders.size)
+        assertEquals(
+            listOf(LocalDate(2024, 6, 13), LocalDate(2024, 6, 14), LocalDate(2024, 6, 15)),
+            reminders.map { it.dueDate },
+        )
+    }
+
+    @Test
+    fun invalidArguments_areRejected() {
+        val template = TestFixtures.createExpense()
+        val rule = dailyRule("daily", LocalDate(2024, 6, 1))
+        val today = LocalDate(2024, 6, 15)
+
+        assertFailsWithNegativeLookback {
+            RecurringTransactionEngine.getOverdueReminders(
+                rules = listOf(rule to template), today = today, lookbackDays = -1,
+            )
+        }
+        assertFailsWithNonPositiveCap {
+            RecurringTransactionEngine.getOverdueReminders(
+                rules = listOf(rule to template), today = today, maxPerRule = 0,
+            )
+        }
+    }
+
+    private fun assertFailsWithNegativeLookback(block: () -> Unit) {
+        try {
+            block(); error("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message?.contains("lookbackDays") == true)
+        }
+    }
+
+    private fun assertFailsWithNonPositiveCap(block: () -> Unit) {
+        try {
+            block(); error("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message?.contains("maxPerRule") == true)
+        }
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/recurring/RecurrencePositionalWeekdayTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/recurring/RecurrencePositionalWeekdayTest.kt
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.models.types.SyncId
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Tests for RRULE-style positional weekday (BYDAY) monthly recurrences (#3747). */
+class RecurrencePositionalWeekdayTest {
+
+    private fun rule(
+        startDate: LocalDate,
+        dayOfWeek: DayOfWeek,
+        nthWeekday: Int,
+        interval: Int = 1,
+        endDate: LocalDate? = null,
+        count: Int? = null,
+    ) = RecurrenceRule(
+        id = SyncId("pos"),
+        frequency = RecurrenceFrequency.MONTHLY,
+        interval = interval,
+        startDate = startDate,
+        endDate = endDate,
+        dayOfWeek = dayOfWeek,
+        nthWeekday = nthWeekday,
+        count = count,
+    )
+
+    @Test
+    fun secondTuesday_resolvesAcrossMonths() {
+        val r = rule(LocalDate(2024, 1, 1), DayOfWeek.TUESDAY, 2)
+
+        val dates = RecurringTransactionEngine.generateUpcoming(
+            r, from = LocalDate(2024, 1, 1), to = LocalDate(2024, 4, 30),
+        )
+
+        assertEquals(
+            listOf(
+                LocalDate(2024, 1, 9),
+                LocalDate(2024, 2, 13),
+                LocalDate(2024, 3, 12),
+                LocalDate(2024, 4, 9),
+            ),
+            dates,
+        )
+    }
+
+    @Test
+    fun lastFriday_resolvesAcrossMonthsIncludingLeapFebruary() {
+        val r = rule(LocalDate(2024, 1, 1), DayOfWeek.FRIDAY, -1)
+
+        val dates = RecurringTransactionEngine.generateUpcoming(
+            r, from = LocalDate(2024, 1, 1), to = LocalDate(2024, 4, 30),
+        )
+
+        assertEquals(
+            listOf(
+                LocalDate(2024, 1, 26),
+                LocalDate(2024, 2, 23), // Feb 2024 is a leap year, last Friday is the 23rd
+                LocalDate(2024, 3, 29),
+                LocalDate(2024, 4, 26),
+            ),
+            dates,
+        )
+    }
+
+    @Test
+    fun fifthTuesday_clampsToLastWhenMonthHasOnlyFour() {
+        val r = rule(LocalDate(2024, 1, 1), DayOfWeek.TUESDAY, 5)
+
+        // Jan 2024 has five Tuesdays (2,9,16,23,30); Feb has four (6,13,20,27) → clamp to 27.
+        assertEquals(
+            LocalDate(2024, 1, 30),
+            RecurringTransactionEngine.nthWeekdayOfMonth(2024, 1, DayOfWeek.TUESDAY, 5),
+        )
+        assertEquals(
+            LocalDate(2024, 2, 27),
+            RecurringTransactionEngine.nthWeekdayOfMonth(2024, 2, DayOfWeek.TUESDAY, 5),
+        )
+
+        val dates = RecurringTransactionEngine.generateUpcoming(
+            r, from = LocalDate(2024, 1, 1), to = LocalDate(2024, 2, 29),
+        )
+        assertEquals(listOf(LocalDate(2024, 1, 30), LocalDate(2024, 2, 27)), dates)
+    }
+
+    @Test
+    fun firstOccurrenceAfterNthWeekdayAlreadyPassed_advancesToNextMonth() {
+        // Start on Jan 20 but the 2nd Tuesday (Jan 9) already passed → first occurrence is Feb.
+        val r = rule(LocalDate(2024, 1, 20), DayOfWeek.TUESDAY, 2)
+
+        val next = RecurringTransactionEngine.nextOccurrenceOnOrAfter(r, LocalDate(2024, 1, 20))
+        assertEquals(LocalDate(2024, 2, 13), next)
+    }
+
+    @Test
+    fun interoperatesWithInterval() {
+        // Every 2 months, 1st Monday.
+        val r = rule(LocalDate(2024, 1, 1), DayOfWeek.MONDAY, 1, interval = 2)
+
+        val dates = RecurringTransactionEngine.generateUpcoming(
+            r, from = LocalDate(2024, 1, 1), to = LocalDate(2024, 6, 30),
+        )
+        assertEquals(
+            listOf(
+                LocalDate(2024, 1, 1), // Jan 1 2024 is a Monday, the 1st Monday
+                LocalDate(2024, 3, 4),
+                LocalDate(2024, 5, 6),
+            ),
+            dates,
+        )
+    }
+
+    @Test
+    fun interoperatesWithCount() {
+        val r = rule(LocalDate(2024, 1, 1), DayOfWeek.WEDNESDAY, 3, count = 2)
+
+        val dates = RecurringTransactionEngine.generateUpcoming(
+            r, from = LocalDate(2024, 1, 1), to = LocalDate(2024, 12, 31),
+        )
+        assertEquals(2, dates.size)
+        assertTrue(dates.all { it.dayOfWeek == DayOfWeek.WEDNESDAY })
+    }
+
+    @Test
+    fun interoperatesWithEndDate() {
+        val r = rule(
+            LocalDate(2024, 1, 1), DayOfWeek.TUESDAY, 2,
+            endDate = LocalDate(2024, 2, 20),
+        )
+
+        val dates = RecurringTransactionEngine.generateUpcoming(
+            r, from = LocalDate(2024, 1, 1), to = LocalDate(2024, 12, 31),
+        )
+        assertEquals(listOf(LocalDate(2024, 1, 9), LocalDate(2024, 2, 13)), dates)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/recurring/RecurrenceWeeklyAlignmentTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/recurring/RecurrenceWeeklyAlignmentTest.kt
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.models.types.SyncId
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.daysUntil
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Tests for weekly/biweekly first-occurrence alignment and forward-only snapping (#3706). */
+class RecurrenceWeeklyAlignmentTest {
+
+    private fun rule(
+        frequency: RecurrenceFrequency,
+        startDate: LocalDate,
+        dayOfWeek: DayOfWeek?,
+        interval: Int = 1,
+    ) = RecurrenceRule(
+        id = SyncId("w"),
+        frequency = frequency,
+        interval = interval,
+        startDate = startDate,
+        dayOfWeek = dayOfWeek,
+    )
+
+    @Test
+    fun weekly_startOnDifferentWeekday_firstOccurrenceAlignedForward() {
+        // Start Friday 2024-07-05, preferred Monday → first occurrence is Monday 2024-07-08.
+        val r = rule(RecurrenceFrequency.WEEKLY, LocalDate(2024, 7, 5), DayOfWeek.MONDAY)
+
+        val dates = RecurringTransactionEngine.generateUpcoming(
+            r, from = LocalDate(2024, 7, 5), to = LocalDate(2024, 7, 31),
+        )
+
+        assertEquals(
+            listOf(
+                LocalDate(2024, 7, 8),
+                LocalDate(2024, 7, 15),
+                LocalDate(2024, 7, 22),
+                LocalDate(2024, 7, 29),
+            ),
+            dates,
+        )
+        assertTrue(dates.all { it.dayOfWeek == DayOfWeek.MONDAY })
+    }
+
+    @Test
+    fun weekly_backwardSnapRegression_neverGoesEarlierThanPrevious() {
+        // Regression: start Fri + WEEKLY + preferred MON must NOT yield a 3-day first interval.
+        val r = rule(RecurrenceFrequency.WEEKLY, LocalDate(2024, 7, 5), DayOfWeek.MONDAY)
+
+        val dates = RecurringTransactionEngine.generateUpcoming(
+            r, from = LocalDate(2024, 7, 5), to = LocalDate(2024, 8, 31),
+        )
+
+        // Every consecutive pair is exactly 7 days apart and strictly increasing.
+        dates.zipWithNext().forEach { (a, b) ->
+            assertEquals(7, a.daysUntil(b))
+            assertTrue(b > a)
+        }
+    }
+
+    @Test
+    fun biweekly_spacingIsAlwaysFourteenDaysOnPreferredWeekday() {
+        val r = rule(RecurrenceFrequency.BIWEEKLY, LocalDate(2024, 7, 3), DayOfWeek.MONDAY)
+
+        val dates = RecurringTransactionEngine.generateUpcoming(
+            r, from = LocalDate(2024, 7, 1), to = LocalDate(2024, 9, 30),
+        )
+
+        assertTrue(dates.isNotEmpty())
+        assertTrue(dates.all { it.dayOfWeek == DayOfWeek.MONDAY })
+        dates.zipWithNext().forEach { (a, b) -> assertEquals(14, a.daysUntil(b)) }
+        assertEquals(LocalDate(2024, 7, 8), dates.first()) // first Monday on/after Jul 3
+    }
+
+    @Test
+    fun weekly_withoutDayOfWeek_startsExactlyOnStartDate() {
+        val r = rule(RecurrenceFrequency.WEEKLY, LocalDate(2024, 7, 3), dayOfWeek = null)
+
+        val dates = RecurringTransactionEngine.generateUpcoming(
+            r, from = LocalDate(2024, 7, 3), to = LocalDate(2024, 7, 24),
+        )
+
+        assertEquals(LocalDate(2024, 7, 3), dates.first())
+        dates.zipWithNext().forEach { (a, b) -> assertEquals(7, a.daysUntil(b)) }
+    }
+
+    @Test
+    fun nextOccurrenceOnOrAfter_alignsToPreferredWeekday() {
+        val r = rule(RecurrenceFrequency.WEEKLY, LocalDate(2024, 7, 5), DayOfWeek.MONDAY)
+
+        val next = RecurringTransactionEngine.nextOccurrenceOnOrAfter(r, LocalDate(2024, 7, 5))
+        assertEquals(LocalDate(2024, 7, 8), next)
+        assertEquals(DayOfWeek.MONDAY, next?.dayOfWeek)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/recurring/RecurringCategorizerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/recurring/RecurringCategorizerTest.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.core.TestFixtures
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** Tests for auto-categorization of generated recurring transactions (#3743). */
+class RecurringCategorizerTest {
+
+    private fun txn(category: String?) = TestFixtures.createExpense(
+        amount = Cents(1000),
+        categoryId = category?.let { SyncId(it) },
+    )
+
+    @Test
+    fun dominantCategory_picksMostFrequent() {
+        val occurrences = listOf(txn("streaming"), txn("streaming"), txn("misc"))
+        assertEquals(SyncId("streaming"), RecurringCategorizer.dominantCategory(occurrences))
+    }
+
+    @Test
+    fun dominantCategory_tie_breaksDeterministicallyByIdAscending() {
+        // Even split between "aaa" and "zzz" — smallest id wins, regardless of order.
+        val occurrences = listOf(txn("zzz"), txn("aaa"), txn("aaa"), txn("zzz"))
+        assertEquals(SyncId("aaa"), RecurringCategorizer.dominantCategory(occurrences))
+
+        val reordered = listOf(txn("aaa"), txn("zzz"), txn("zzz"), txn("aaa"))
+        assertEquals(SyncId("aaa"), RecurringCategorizer.dominantCategory(reordered))
+    }
+
+    @Test
+    fun dominantCategory_emptyOrUncategorized_returnsNull() {
+        assertNull(RecurringCategorizer.dominantCategory(emptyList()))
+        assertNull(RecurringCategorizer.dominantCategory(listOf(txn(null), txn(null))))
+    }
+
+    @Test
+    fun categoryForGenerated_fallsBackToTemplateWhenHistoryUncategorized() {
+        val occurrences = listOf(txn(null), txn(null))
+        assertEquals(
+            SyncId("template-cat"),
+            RecurringCategorizer.categoryForGenerated(occurrences, SyncId("template-cat")),
+        )
+    }
+
+    @Test
+    fun categoryForGenerated_prefersDominantOverTemplate() {
+        val occurrences = listOf(txn("groceries"), txn("groceries"), txn("misc"))
+        assertEquals(
+            SyncId("groceries"),
+            RecurringCategorizer.categoryForGenerated(occurrences, SyncId("template-cat")),
+        )
+    }
+
+    @Test
+    fun applyDominantCategory_stampsCategoryAndKeepsAmount() {
+        val template = TestFixtures.createExpense(amount = Cents(2500), categoryId = SyncId("template-cat"))
+        val occurrences = listOf(txn("utilities"), txn("utilities"), txn("misc"))
+
+        val result = RecurringCategorizer.applyDominantCategory(template, occurrences)
+
+        assertEquals(SyncId("utilities"), result.categoryId)
+        assertEquals(Cents(2500), result.amount) // fixed integer Cents unchanged
+    }
+
+    @Test
+    fun applyDominantCategory_keepsTemplateCategoryWhenHistoryUncategorized() {
+        val template = TestFixtures.createExpense(amount = Cents(2500), categoryId = SyncId("template-cat"))
+        val result = RecurringCategorizer.applyDominantCategory(template, listOf(txn(null)))
+        assertEquals(SyncId("template-cat"), result.categoryId)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/recurring/ReminderSchedulingTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/recurring/ReminderSchedulingTest.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/** Tests for timezone/DST-aware reminder instant resolution (#3741). */
+class ReminderSchedulingTest {
+
+    private val newYork = TimeZone.of("America/New_York")
+
+    @Test
+    fun resolvesWallClockToInstantInUtc() {
+        val instant = ReminderScheduling.resolveInstant(
+            date = LocalDate(2024, 6, 15),
+            time = ReminderTime(9, 0),
+            zone = TimeZone.UTC,
+        )
+        assertEquals(Instant.parse("2024-06-15T09:00:00Z"), instant)
+    }
+
+    @Test
+    fun sameWallClockInDifferentZonesYieldsDifferentInstants() {
+        val date = LocalDate(2024, 6, 15)
+        val time = ReminderTime(9, 0)
+
+        val utc = ReminderScheduling.resolveInstant(date, time, TimeZone.UTC)
+        val ny = ReminderScheduling.resolveInstant(date, time, newYork)
+
+        assertNotEquals(utc, ny)
+        // New York is UTC-4 in June (EDT), so 09:00 local is 13:00 UTC.
+        assertEquals(Instant.parse("2024-06-15T13:00:00Z"), ny)
+    }
+
+    @Test
+    fun springForwardGap_shiftsForwardToFirstValidInstant() {
+        // 2024-03-10 02:30 does not exist in New York (clocks jump 02:00 -> 03:00).
+        val instant = ReminderScheduling.resolveInstant(
+            date = LocalDate(2024, 3, 10),
+            time = ReminderTime(2, 30),
+            zone = newYork,
+        )
+
+        // Shifted forward to 03:30 EDT (-04:00) = 07:30 UTC.
+        assertEquals(Instant.parse("2024-03-10T07:30:00Z"), instant)
+        val local = instant.toLocalDateTime(newYork)
+        assertEquals(3, local.hour)
+        assertEquals(30, local.minute)
+    }
+
+    @Test
+    fun fallBackOverlap_choosesEarlierInstant() {
+        // 2024-11-03 01:30 occurs twice in New York (clocks fall 02:00 -> 01:00).
+        val instant = ReminderScheduling.resolveInstant(
+            date = LocalDate(2024, 11, 3),
+            time = ReminderTime(1, 30),
+            zone = newYork,
+        )
+
+        // Earlier occurrence is EDT (-04:00) = 05:30 UTC (not the later EST 06:30 UTC).
+        assertEquals(Instant.parse("2024-11-03T05:30:00Z"), instant)
+    }
+
+    @Test
+    fun scheduledNotificationOverload_resolvesNotificationDateAndTime() {
+        val notification = ScheduledNotification(
+            ruleId = SyncId("rule-1"),
+            reminderId = SyncId("rem-1"),
+            dueDate = LocalDate(2024, 6, 18),
+            notificationDate = LocalDate(2024, 6, 15),
+            notificationTime = ReminderTime(8, 30),
+            merchant = "Netflix",
+        )
+
+        val instant = ReminderScheduling.resolveInstant(notification, newYork)
+        assertEquals(Instant.parse("2024-06-15T12:30:00Z"), instant) // 08:30 EDT = 12:30 UTC
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/recurring/VariableAmountRuleTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/recurring/VariableAmountRuleTest.kt
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Tests for variable-amount recurring rules and forecasts (#3729). */
+class VariableAmountRuleTest {
+
+    private val fixedInstant: Instant = Instant.parse("2024-06-15T12:00:00Z")
+
+    private fun rule(
+        estimate: Long,
+        isVariable: Boolean = false,
+        overrides: Map<LocalDate, Cents> = emptyMap(),
+        frequency: RecurrenceFrequency = RecurrenceFrequency.MONTHLY,
+        startDate: LocalDate = LocalDate(2024, 1, 15),
+    ) = RecurringTransactionRule(
+        id = SyncId("rule-1"),
+        ownerId = SyncId("owner-1"),
+        householdId = SyncId("household-1"),
+        merchant = "Electric Co",
+        amount = Cents(estimate),
+        isVariable = isVariable,
+        amountOverrides = overrides,
+        currency = Currency.USD,
+        accountId = SyncId("account-1"),
+        recurrenceRule = RecurrenceRule(
+            id = SyncId("rec-1"),
+            frequency = frequency,
+            startDate = startDate,
+            dayOfMonth = 15,
+        ),
+        nextDueDate = LocalDate(2024, 7, 15),
+        createdAt = fixedInstant,
+        updatedAt = fixedInstant,
+    )
+
+    @Test
+    fun fixedRule_alwaysReturnsEstimate() {
+        val r = rule(estimate = 5000, isVariable = false, overrides = mapOf(LocalDate(2024, 7, 15) to Cents(9999)))
+        // Non-variable rules ignore overrides entirely.
+        assertFalse(r.isVariable)
+        assertEquals(Cents(5000), r.amountFor(LocalDate(2024, 7, 15)))
+    }
+
+    @Test
+    fun variableRule_usesOverrideWhenPresent() {
+        val r = rule(
+            estimate = 5000,
+            isVariable = true,
+            overrides = mapOf(LocalDate(2024, 7, 15) to Cents(7350)),
+        )
+        assertEquals(Cents(7350), r.amountFor(LocalDate(2024, 7, 15)))
+    }
+
+    @Test
+    fun variableRule_fallsBackToEstimateWhenNoOverride() {
+        val r = rule(estimate = 5000, isVariable = true, overrides = mapOf(LocalDate(2024, 7, 15) to Cents(7350)))
+        assertEquals(Cents(5000), r.amountFor(LocalDate(2024, 8, 15)))
+    }
+
+    @Test
+    fun calendarForecast_usesOverridePerOccurrence() {
+        val r = rule(
+            estimate = 5000,
+            isVariable = true,
+            overrides = mapOf(LocalDate(2024, 7, 15) to Cents(8200)),
+        )
+
+        val calendar = BillReminderEngine.generateMonthlyCalendar(
+            rules = listOf(r),
+            year = 2024,
+            month = 7,
+            today = LocalDate(2024, 7, 1),
+        )
+
+        val entry = calendar.days.flatMap { it.bills }.single { it.dueDate == LocalDate(2024, 7, 15) }
+        assertEquals(Cents(8200), entry.amount)
+        assertEquals(Cents(8200), calendar.totalDue)
+    }
+
+    @Test
+    fun calendarForecast_usesEstimateWhenNoOverride() {
+        val r = rule(estimate = 5000, isVariable = true) // no overrides
+
+        val calendar = BillReminderEngine.generateMonthlyCalendar(
+            rules = listOf(r),
+            year = 2024,
+            month = 7,
+            today = LocalDate(2024, 7, 1),
+        )
+
+        val entry = calendar.days.flatMap { it.bills }.single { it.dueDate == LocalDate(2024, 7, 15) }
+        assertEquals(Cents(5000), entry.amount)
+    }
+
+    @Test
+    fun overridesStayInIntegerCents() {
+        val r = rule(estimate = 5000, isVariable = true, overrides = mapOf(LocalDate(2024, 7, 15) to Cents(12345)))
+        val amount = r.amountFor(LocalDate(2024, 7, 15))
+        assertTrue(amount.amount == 12345L)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/subscription/SubscriptionDetectorTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/subscription/SubscriptionDetectorTest.kt
@@ -324,7 +324,10 @@ class SubscriptionDetectorTest {
     fun classifyFrequency_correctRanges() {
         assertEquals(SubscriptionFrequency.WEEKLY, SubscriptionDetector.classifyFrequency(7.0))
         assertEquals(SubscriptionFrequency.BIWEEKLY, SubscriptionDetector.classifyFrequency(14.0))
+        assertEquals(SubscriptionFrequency.SEMI_MONTHLY, SubscriptionDetector.classifyFrequency(15.0))
+        assertEquals(SubscriptionFrequency.EVERY_THREE_WEEKS, SubscriptionDetector.classifyFrequency(21.0))
         assertEquals(SubscriptionFrequency.MONTHLY, SubscriptionDetector.classifyFrequency(30.0))
+        assertEquals(SubscriptionFrequency.BIMONTHLY, SubscriptionDetector.classifyFrequency(45.0))
         assertEquals(SubscriptionFrequency.QUARTERLY, SubscriptionDetector.classifyFrequency(91.0))
         assertEquals(SubscriptionFrequency.YEARLY, SubscriptionDetector.classifyFrequency(365.0))
     }
@@ -332,7 +335,7 @@ class SubscriptionDetectorTest {
     @Test
     fun classifyFrequency_outOfRange_returnsNull() {
         assertNull(SubscriptionDetector.classifyFrequency(3.0))
-        assertNull(SubscriptionDetector.classifyFrequency(45.0))
+        assertNull(SubscriptionDetector.classifyFrequency(10.5))
         assertNull(SubscriptionDetector.classifyFrequency(200.0))
     }
 

--- a/packages/core/src/commonTest/kotlin/com/finance/core/subscription/SubscriptionFrequencyRoundingTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/subscription/SubscriptionFrequencyRoundingTest.kt
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.subscription
+
+import com.finance.core.TestFixtures
+import com.finance.models.types.Cents
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.plus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for the expanded frequency bands (semi-monthly, every-three-weeks, bimonthly) and the
+ * round-half-up integer-Cents money math added in #3738.
+ */
+class SubscriptionFrequencyRoundingTest {
+
+    // ── New contiguous frequency bands ───────────────────────────────
+
+    @Test
+    fun classifiesSemiMonthlyCadence() {
+        assertEquals(SubscriptionFrequency.SEMI_MONTHLY, SubscriptionDetector.classifyFrequency(15.0))
+        assertEquals(SubscriptionFrequency.SEMI_MONTHLY, SubscriptionDetector.classifyFrequency(16.5))
+    }
+
+    @Test
+    fun classifiesEveryThreeWeeksCadence() {
+        assertEquals(SubscriptionFrequency.EVERY_THREE_WEEKS, SubscriptionDetector.classifyFrequency(21.0))
+    }
+
+    @Test
+    fun classifiesBimonthlyCadence() {
+        assertEquals(SubscriptionFrequency.BIMONTHLY, SubscriptionDetector.classifyFrequency(60.0))
+    }
+
+    @Test
+    fun bandsAreContiguous_noGapsBetweenBiweeklyAndQuarterly() {
+        // Every whole-day interval from 12..100 resolves to a cadence (no dropped gaps inside this
+        // supported span), and true out-of-range values stay null.
+        for (days in 12..100) {
+            val label = "interval=$days"
+            kotlin.test.assertNotNull(SubscriptionDetector.classifyFrequency(days.toDouble()), label)
+        }
+        kotlin.test.assertNull(SubscriptionDetector.classifyFrequency(4.0))
+        kotlin.test.assertNull(SubscriptionDetector.classifyFrequency(120.0))
+    }
+
+    // ── Detection no longer drops these cadences ─────────────────────
+
+    @Test
+    fun detectsEveryThreeWeeksSubscription() {
+        val transactions = listOf(0, 21, 42, 63).map { offset ->
+            TestFixtures.createExpense(
+                amount = Cents(500),
+                date = LocalDate(2024, 1, 1).plus(offset, DateTimeUnit.DAY),
+            ).copy(payee = "Weekly Box")
+        }
+        val sub = SubscriptionDetector.detect(transactions).single()
+        assertEquals(SubscriptionFrequency.EVERY_THREE_WEEKS, sub.frequency)
+    }
+
+    @Test
+    fun detectsSemiMonthlySubscription() {
+        // 1st and 16th of consecutive months → ~15–16 day intervals.
+        val dates = listOf(
+            LocalDate(2024, 1, 1),
+            LocalDate(2024, 1, 16),
+            LocalDate(2024, 2, 1),
+            LocalDate(2024, 2, 16),
+        )
+        val transactions = dates.map { d ->
+            TestFixtures.createExpense(amount = Cents(2000), date = d).copy(payee = "Gym")
+        }
+        val sub = SubscriptionDetector.detect(transactions).single()
+        assertEquals(SubscriptionFrequency.SEMI_MONTHLY, sub.frequency)
+    }
+
+    // ── Round-half-up average (integer Cents) ────────────────────────
+
+    @Test
+    fun averageAmountUsesRoundHalfUp() {
+        // Two occurrences 21 days apart; sum 2001 / 2 = 1000.5 → 1001 (round-half-up), not 1000.
+        val transactions = listOf(
+            TestFixtures.createExpense(amount = Cents(1000), date = LocalDate(2024, 1, 1)),
+            TestFixtures.createExpense(amount = Cents(1001), date = LocalDate(2024, 1, 22)),
+        ).map { it.copy(payee = "Rounding Co") }
+
+        val sub = SubscriptionDetector.detect(transactions).single()
+        assertEquals(Cents(1001), sub.averageAmount)
+    }
+
+    @Test
+    fun roundHalfUp_roundsHalvesUpAndStaysInteger() {
+        assertEquals(1L, SubscriptionDetector.roundHalfUp(1, 2)) // 0.5 → 1
+        assertEquals(2L, SubscriptionDetector.roundHalfUp(3, 2)) // 1.5 → 2
+        assertEquals(2L, SubscriptionDetector.roundHalfUp(5, 3)) // 1.67 → 2
+        assertEquals(1L, SubscriptionDetector.roundHalfUp(4, 3)) // 1.33 → 1
+        assertEquals(1001L, SubscriptionDetector.roundHalfUp(2001, 2))
+    }
+
+    // ── Cost conversions for the new frequencies ─────────────────────
+
+    @Test
+    fun semiMonthlyCostConversions() {
+        val amount = Cents(1000)
+        assertEquals(Cents(2000), SubscriptionDetector.toMonthlyCost(amount, SubscriptionFrequency.SEMI_MONTHLY))
+        assertEquals(Cents(24000), SubscriptionDetector.toAnnualCost(amount, SubscriptionFrequency.SEMI_MONTHLY))
+    }
+
+    @Test
+    fun everyThreeWeeksCostConversions() {
+        val amount = Cents(1000)
+        // Annual: 1000 * 365 / 21 = 17381.0 → round-half-up 17381.
+        assertEquals(Cents(17381), SubscriptionDetector.toAnnualCost(amount, SubscriptionFrequency.EVERY_THREE_WEEKS))
+        // Monthly: 1000 * 365 / 252 = 1448.4 → 1448.
+        assertEquals(Cents(1448), SubscriptionDetector.toMonthlyCost(amount, SubscriptionFrequency.EVERY_THREE_WEEKS))
+    }
+
+    @Test
+    fun bimonthlyCostConversions() {
+        val amount = Cents(1000)
+        assertEquals(Cents(500), SubscriptionDetector.toMonthlyCost(amount, SubscriptionFrequency.BIMONTHLY))
+        assertEquals(Cents(6000), SubscriptionDetector.toAnnualCost(amount, SubscriptionFrequency.BIMONTHLY))
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/validation/DateInputValidatorTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/validation/DateInputValidatorTest.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.validation
+
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+/** Boundary tests for the shared cross-platform date validator (#3564). */
+class DateInputValidatorTest {
+
+    // ── parse(): shape vs calendar validity ──────────────────────────
+
+    @Test
+    fun parse_validDisplayDate() {
+        val result = DateInputValidator.parse("06/15/2024")
+        assertIs<DateParseResult.Success>(result)
+        assertEquals(LocalDate(2024, 6, 15), result.date)
+    }
+
+    @Test
+    fun parse_validIsoDate() {
+        val result = DateInputValidator.parse("2024-06-15")
+        assertIs<DateParseResult.Success>(result)
+        assertEquals(LocalDate(2024, 6, 15), result.date)
+    }
+
+    @Test
+    fun parse_empty_isEmptyError() {
+        val result = DateInputValidator.parse("   ")
+        assertIs<DateParseResult.Failure>(result)
+        assertEquals(DateValidationErrorKind.EMPTY, result.errorKind)
+    }
+
+    @Test
+    fun parse_partialOrWrongShape_isMalformed() {
+        for (value in listOf("6/18/25", "2025.01.01", "hello", "2024-6-15", "1/2/2024")) {
+            val result = DateInputValidator.parse(value)
+            assertIs<DateParseResult.Failure>(result, "expected malformed for '$value'")
+            assertEquals(DateValidationErrorKind.MALFORMED, result.errorKind, "for '$value'")
+        }
+    }
+
+    @Test
+    fun parse_wellFormedButInvalidCalendarDate() {
+        for (value in listOf("12/33/2000", "02/30/2024", "13/01/2000", "00/00/0000", "02/29/2023")) {
+            val result = DateInputValidator.parse(value)
+            assertIs<DateParseResult.Failure>(result, "expected invalid-calendar for '$value'")
+            assertEquals(
+                DateValidationErrorKind.INVALID_CALENDAR_DATE,
+                result.errorKind,
+                "for '$value'",
+            )
+        }
+    }
+
+    @Test
+    fun parse_leapDay_validInLeapYear_invalidOtherwise() {
+        assertIs<DateParseResult.Success>(DateInputValidator.parse("02/29/2024"))
+        val invalid = DateInputValidator.parse("02/29/2023")
+        assertIs<DateParseResult.Failure>(invalid)
+        assertEquals(DateValidationErrorKind.INVALID_CALENDAR_DATE, invalid.errorKind)
+    }
+
+    @Test
+    fun parseIso_leapDay_invalidYear() {
+        assertNull(DateInputValidator.parseIsoDate("2023-02-29"))
+        assertEquals(LocalDate(2024, 2, 29), DateInputValidator.parseIsoDate("2024-02-29"))
+    }
+
+    // ── validate(): range + required ─────────────────────────────────
+
+    @Test
+    fun validate_emptyOptional_isValidWithNullDate() {
+        val result = DateInputValidator.validate("")
+        assertIs<DateValidationResult.Valid>(result)
+        assertNull(result.date)
+    }
+
+    @Test
+    fun validate_emptyRequired_isInvalid() {
+        val result = DateInputValidator.validate("", required = true)
+        assertIs<DateValidationResult.Invalid>(result)
+        assertEquals(DateValidationErrorKind.EMPTY, result.errorKind)
+    }
+
+    @Test
+    fun validate_beforeMin_isInvalid() {
+        val result = DateInputValidator.validate(
+            "01/01/2020",
+            min = LocalDate(2024, 1, 1),
+        )
+        assertIs<DateValidationResult.Invalid>(result)
+        assertEquals(DateValidationErrorKind.BEFORE_MIN, result.errorKind)
+    }
+
+    @Test
+    fun validate_afterMax_isInvalid() {
+        val result = DateInputValidator.validate(
+            "01/01/2030",
+            max = LocalDate(2024, 12, 31),
+        )
+        assertIs<DateValidationResult.Invalid>(result)
+        assertEquals(DateValidationErrorKind.AFTER_MAX, result.errorKind)
+    }
+
+    @Test
+    fun validate_boundsAreInclusive() {
+        val min = LocalDate(2024, 1, 1)
+        val max = LocalDate(2024, 12, 31)
+        assertIs<DateValidationResult.Valid>(
+            DateInputValidator.validate("01/01/2024", min = min, max = max),
+        )
+        assertIs<DateValidationResult.Valid>(
+            DateInputValidator.validate("12/31/2024", min = min, max = max),
+        )
+    }
+
+    @Test
+    fun validate_normalizesBothInputFormats() {
+        val fromDisplay = DateInputValidator.validate("06/15/2024")
+        val fromIso = DateInputValidator.validate("2024-06-15")
+        assertIs<DateValidationResult.Valid>(fromDisplay)
+        assertIs<DateValidationResult.Valid>(fromIso)
+        assertEquals(fromDisplay.date, fromIso.date)
+    }
+
+    @Test
+    fun formatDisplayDate_padsMonthAndDay() {
+        assertEquals("01/05/2024", DateInputValidator.formatDisplayDate(LocalDate(2024, 1, 5)))
+    }
+}


### PR DESCRIPTION
## Summary

Batch of core recurrence & reminder fixes and features in `packages/core` (KMP `commonMain`), implemented as pure functions with integer `Cents` money math and unit tests for all business logic. No JS/TS touched; no deployment.

### What's included

- **#3706 — weekly first-occurrence bug**: weekly recurrences now align to the first matching `dayOfWeek` on/after the start date (forward-only snap) instead of emitting the start date itself.
- **#3747 — nth-weekday / BYDAY**: `RecurrenceRule.nthWeekday` (1..5 or -1 for last) drives positional monthly recurrences (e.g. "2nd Tuesday", "last Friday"), with clamping for months lacking a 5th weekday.
- **#3714 — stale `nextDueDate`**: `BillReminderEngine.scheduleNotifications` uses the stored `nextDueDate` when still current, otherwise recomputes via `nextOccurrenceOnOrAfter`, and clamps a past notification date to today.
- **#3735 — unbounded overdue occurrences**: `getOverdueReminders` now bounds its window (`lookbackDays`, default 90), excludes already-paid occurrences, and caps results per rule (`maxPerRule`, default 50).
- **#3729 — variable-amount recurrences**: `RecurringTransactionRule` gains `isVariable` + `amountOverrides` and an `amountFor(date)` accessor; the bill calendar uses per-occurrence amounts.
- **#3743 — auto-categorize recurring txns**: new `RecurringCategorizer` seeds generated transactions from the dominant historical category (deterministic tie-break), falling back to the template category.
- **#3738 — SubscriptionDetector frequency & rounding**: contiguous frequency bands add `SEMI_MONTHLY`, `EVERY_THREE_WEEKS`, and `BIMONTHLY`; averages and monthly/annual cost conversions use round-half-up integer-Cents math.
- **#3741 — DST-aware reminder scheduling**: new `ReminderScheduling.resolveInstant` maps a reminder date + wall-clock time + zone to an absolute `Instant`, handling spring-forward gaps and fall-back overlaps deterministically.
- **#3746 — OFX export**: new `OfxExportSerializer` emits a well-formed OFX 1.0.2 SGML document (one `STMTTRN` per transaction, signed `TRNAMT` from integer Cents, deterministic ordering).
- **#3564 — shared date validation**: new `DateInputValidator` ports the web date-validation util into core, distinguishing malformed input from invalid calendar dates and applying inclusive min/max range checks.

### Testing

- `./gradlew :packages:core:jvmTest` — **BUILD SUCCESSFUL** (all commonTest suites pass).
- New unit tests cover every issue; existing subscription tests updated for the new contiguous frequency bands.

Closes #3747
Closes #3746
Closes #3743
Closes #3741
Closes #3738
Closes #3735
Closes #3729
Closes #3714
Closes #3706
Closes #3564
