### PR TITLE
feat(core): shared GoalTrackingEngine foundation + goals engine batch

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/goals/GoalTrackingEngine.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/goals/GoalTrackingEngine.kt
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.models.Goal
+import com.finance.models.GoalStatus
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.daysUntil
+import kotlinx.datetime.monthsUntil
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Shared, platform-agnostic engine for all goal / savings math (#3673).
+ *
+ * `GoalTrackingEngine` is the single deterministic source of truth used by
+ * every platform app (iOS, Android, Web, Windows) so goal progress,
+ * projections, pacing, and allocation never drift between platforms.
+ *
+ * ## Design rules
+ * - **Pure `commonMain`.** No platform APIs; only [Cents] and `kotlinx-datetime`.
+ * - **Integer money only.** All arithmetic stays in [Cents] (Long-backed). The
+ *   model's [Goal.progress] (a `Double`) is **display-only**; any branching
+ *   logic here uses the integer [progressPermille] basis instead (#3737).
+ * - **Deterministic.** Same inputs always produce the same outputs, with no
+ *   dependence on floating-point comparison or JS number semantics.
+ */
+@Suppress("TooManyFunctions")
+object GoalTrackingEngine {
+
+    private const val PERMILLE_BASIS = 1000L
+    private const val MAX_PERMILLE = 1000
+    private const val DAYS_PER_WEEK = 7
+    private const val DOLLAR_CENTS = 100L
+    private const val MAX_YEAR = 9999
+    private const val MONTH_DEC = 12
+    private const val DAY_31 = 31
+
+    /** Tolerance band (in permille of the target) around the linear pace that still counts as ON_TRACK. */
+    private const val PACE_TOLERANCE_PERMILLE = 50L
+
+    // ── #3673 / #3737: core progress primitives ──────────────────────
+
+    /**
+     * The amount still needed to reach the goal's target, clamped to
+     * [Cents.ZERO] once the goal is met or over-funded.
+     */
+    fun remainingAmount(goal: Goal): Cents {
+        val remaining = goal.targetAmount.amount - goal.currentAmount.amount
+        return if (remaining <= 0L) Cents.ZERO else Cents(remaining)
+    }
+
+    /**
+     * Progress toward the target expressed as an integer permille in `0..1000`
+     * using pure integer math (`currentAmount * 1000 / targetAmount`), floored
+     * and clamped.
+     *
+     * This is the integer basis every downstream behaviour (milestones, pace,
+     * summaries) branches on, so results are identical on all platforms.
+     * Prefer this over the display-only [Goal.progress] `Double` accessor.
+     */
+    fun progressPermille(goal: Goal): Int =
+        permilleForAmount(goal.currentAmount.amount, goal.targetAmount.amount)
+
+    // ── #3734: feasibility / on-time check ───────────────────────────
+
+    /**
+     * Determine whether saving [contributionPerPeriod] every [period] starting
+     * from [from] reaches the goal by its `targetDate`, and if not, by how much
+     * it falls short. See [GoalFeasibility] for field semantics.
+     *
+     * The projection counts only **whole** periods between [from] and the
+     * deadline and stays entirely in integer [Cents]. When the goal has no
+     * deadline, [GoalFeasibility.willMeetDeadline] is `true` whenever a positive
+     * contribution will eventually complete it.
+     */
+    fun feasibility(
+        goal: Goal,
+        contributionPerPeriod: Cents,
+        period: ContributionPeriod,
+        from: LocalDate,
+    ): GoalFeasibility {
+        val target = goal.targetAmount
+        val completionDate = projectedCompletionDate(goal, contributionPerPeriod, period, from)
+        val deadline = goal.targetDate
+
+        if (deadline == null) {
+            val willMeet = remainingAmount(goal).isZero() || contributionPerPeriod.isPositive()
+            return GoalFeasibility(
+                willMeetDeadline = willMeet,
+                projectedAmountByDeadline = goal.currentAmount,
+                shortfall = if (willMeet) Cents.ZERO else remainingAmount(goal),
+                projectedCompletionDate = completionDate,
+            )
+        }
+
+        val periods = wholePeriodsBetween(from, deadline, period)
+        val projected = if (contributionPerPeriod.isZero() || periods == 0) {
+            goal.currentAmount
+        } else {
+            goal.currentAmount + (contributionPerPeriod * periods)
+        }
+        val gap = target.amount - projected.amount
+        return GoalFeasibility(
+            willMeetDeadline = projected.amount >= target.amount,
+            projectedAmountByDeadline = projected,
+            shortfall = if (gap > 0L) Cents(gap) else Cents.ZERO,
+            projectedCompletionDate = completionDate,
+        )
+    }
+
+    // ── #3721: priority ordering ─────────────────────────────────────
+
+    /**
+     * Order ACTIVE goals by the recommended funding priority (#3721):
+     * 1. dated goals before undated ones, nearest `targetDate` first;
+     * 2. then highest completion (closest to done) by [progressPermille];
+     * 3. then largest remaining amount;
+     * 4. stable tiebreak by goal id.
+     *
+     * Non-ACTIVE and soft-deleted goals are excluded. All comparison keys are
+     * integer cents / dates — no floating-point ordering. [asOf] is accepted
+     * for API symmetry with date-aware callers and future pace-weighted rules.
+     */
+    @Suppress("UnusedParameter")
+    fun prioritize(goals: List<Goal>, asOf: LocalDate): List<Goal> =
+        goals
+            .filter { it.status == GoalStatus.ACTIVE && it.deletedAt == null }
+            .sortedWith(
+                compareBy<Goal> { it.targetDate == null }
+                    .thenBy { it.targetDate ?: LocalDate(MAX_YEAR, MONTH_DEC, DAY_31) }
+                    .thenByDescending { progressPermille(it) }
+                    .thenByDescending { remainingAmount(it).amount }
+                    .thenBy { it.id.value },
+            )
+
+    // ── #3730: lump-sum allocation across goals ──────────────────────
+
+    /**
+     * Split [amount] across [goals] in funding-priority order (see
+     * [prioritize]), capping each goal's share at its remaining amount so no
+     * goal is over-funded (#3730).
+     *
+     * Allocation is exact integer cents with no penny loss: the returned values
+     * never sum to more than [amount] and never exceed total remaining. Any
+     * leftover after every goal is full is **dropped** (documented).
+     *
+     * @return map of goal id to allocated [Cents]; only goals that receive a
+     *   positive allocation appear. An [amount] of zero yields an empty map.
+     * @throws IllegalArgumentException if [amount] is negative.
+     */
+    fun allocateContribution(amount: Cents, goals: List<Goal>, asOf: LocalDate): Map<SyncId, Cents> {
+        require(amount.amount >= 0L) { "Contribution amount cannot be negative" }
+        if (amount.isZero()) return emptyMap()
+
+        val result = LinkedHashMap<SyncId, Cents>()
+        var budget = amount.amount
+        for (goal in prioritize(goals, asOf)) {
+            if (budget <= 0L) break
+            val need = remainingAmount(goal).amount
+            if (need > 0L) {
+                val give = minOf(budget, need)
+                result[goal.id] = Cents(give)
+                budget -= give
+            }
+        }
+        return result
+    }
+
+    // ── #3726: aggregate savings summary ─────────────────────────────
+
+    /**
+     * Reduce [goals] to a single [GoalSummary]. Totals include only non-deleted,
+     * non-CANCELLED goals and use overflow-safe [Cents] addition; counts are
+     * reported per status. An empty list yields an all-zero summary.
+     */
+    fun summarize(goals: List<Goal>): GoalSummary {
+        val considered = goals.filter { it.deletedAt == null }
+        var saved = Cents.ZERO
+        var target = Cents.ZERO
+        for (goal in considered) {
+            if (goal.status == GoalStatus.CANCELLED) continue
+            saved += goal.currentAmount
+            target += goal.targetAmount
+        }
+        val remaining = if (target.amount > saved.amount) Cents(target.amount - saved.amount) else Cents.ZERO
+        return GoalSummary(
+            totalSaved = saved,
+            totalTarget = target,
+            remaining = remaining,
+            progressPermille = permilleForAmount(saved.amount, target.amount),
+            activeCount = considered.count { it.status == GoalStatus.ACTIVE },
+            completedCount = considered.count { it.status == GoalStatus.COMPLETED },
+            totalCount = considered.size,
+        )
+    }
+
+    // ── #3716: round-up (spare-change) primitive ─────────────────────
+
+    /**
+     * The spare change from rounding [amount] up to the next multiple of
+     * [nearest] (defaults to the nearest dollar). Returns [Cents.ZERO] when
+     * [amount] is already an exact multiple.
+     *
+     * The result is always in `0 until nearest`. Negative amounts round toward
+     * positive infinity (the next multiple `>= amount`), so an expense of
+     * `-150` cents at `nearest = 100` yields `50` — callers storing expenses as
+     * positive cents get the intuitive result.
+     *
+     * @throws IllegalArgumentException if [nearest] is not positive.
+     */
+    fun roundUpContribution(amount: Cents, nearest: Cents = Cents(DOLLAR_CENTS)): Cents {
+        require(nearest.isPositive()) { "nearest must be positive" }
+        val n = nearest.amount
+        val remainder = ((amount.amount % n) + n) % n
+        return if (remainder == 0L) Cents.ZERO else Cents(n - remainder)
+    }
+
+    /**
+     * Sum of [roundUpContribution] over [amounts] using overflow-safe [Cents]
+     * addition. An empty list yields [Cents.ZERO].
+     *
+     * @throws IllegalArgumentException if [nearest] is not positive.
+     */
+    fun roundUpTotal(amounts: List<Cents>, nearest: Cents = Cents(DOLLAR_CENTS)): Cents {
+        require(nearest.isPositive()) { "nearest must be positive" }
+        var total = Cents.ZERO
+        for (amount in amounts) {
+            total += roundUpContribution(amount, nearest)
+        }
+        return total
+    }
+
+    // ── #3708: milestone detection ───────────────────────────────────
+
+    /**
+     * All [GoalMilestone] thresholds the goal has reached at its current amount,
+     * using exact integer comparison (`current * 1000 >= target * permille`).
+     */
+    fun milestonesReached(goal: Goal): Set<GoalMilestone> =
+        reachedMilestones(goal.currentAmount.amount, goal.targetAmount.amount)
+
+    /**
+     * The milestones newly crossed between [previousAmount] and the goal's
+     * current amount — the set difference — for firing one-time celebrations.
+     * Returns an empty set when the amount is unchanged or moved backward.
+     */
+    fun newlyReachedMilestones(previousAmount: Cents, goal: Goal): Set<GoalMilestone> {
+        val target = goal.targetAmount.amount
+        val now = reachedMilestones(goal.currentAmount.amount, target)
+        val before = reachedMilestones(previousAmount.amount, target)
+        return now - before
+    }
+
+    // ── #3700: lifecycle transitions + auto-complete ─────────────────
+
+    /**
+     * The set of statuses [from] may legally transition to. Legal matrix:
+     * - `ACTIVE` → `PAUSED`, `COMPLETED`, `CANCELLED`
+     * - `PAUSED` → `ACTIVE`, `CANCELLED`
+     * - `COMPLETED` → `ACTIVE` (reopen)
+     * - `CANCELLED` → *(terminal — no transitions)*
+     */
+    fun transitions(from: GoalStatus): Set<GoalStatus> = when (from) {
+        GoalStatus.ACTIVE -> setOf(GoalStatus.PAUSED, GoalStatus.COMPLETED, GoalStatus.CANCELLED)
+        GoalStatus.PAUSED -> setOf(GoalStatus.ACTIVE, GoalStatus.CANCELLED)
+        GoalStatus.COMPLETED -> setOf(GoalStatus.ACTIVE)
+        GoalStatus.CANCELLED -> emptySet()
+    }
+
+    /** Whether the [from] → [to] status transition is permitted by [transitions]. */
+    fun canTransition(from: GoalStatus, to: GoalStatus): Boolean = to in transitions(from)
+
+    /**
+     * Suggests `COMPLETED` when the goal is fully funded and still ACTIVE or
+     * PAUSED, otherwise `null`. Never mutates the goal — callers decide whether
+     * to apply the recommendation.
+     */
+    fun recommendedStatus(goal: Goal): GoalStatus? =
+        if (goal.isComplete && (goal.status == GoalStatus.ACTIVE || goal.status == GoalStatus.PAUSED)) {
+            GoalStatus.COMPLETED
+        } else {
+            null
+        }
+
+    // ── #3694: on-track / ahead / behind pace ────────────────────────
+
+    /**
+     * Classify a goal's [GoalPace] as of [asOf] by comparing the fraction saved
+     * against the fraction of time elapsed between the goal's creation date and
+     * its `targetDate`. [GoalPace.COMPLETED] takes precedence; goals without a
+     * deadline are [GoalPace.NO_DEADLINE]. A small tolerance band around the
+     * linear expectation classifies near-parity as [GoalPace.ON_TRACK].
+     */
+    fun pace(goal: Goal, asOf: LocalDate): GoalPace = when {
+        goal.isComplete -> GoalPace.COMPLETED
+        goal.targetDate == null -> GoalPace.NO_DEADLINE
+        else -> {
+            val current = goal.currentAmount.amount
+            val expected = expectedAmountByNow(goal, asOf).amount
+            val tolerance = goal.targetAmount.amount * PACE_TOLERANCE_PERMILLE / PERMILLE_BASIS
+            when {
+                current in (expected - tolerance)..(expected + tolerance) -> GoalPace.ON_TRACK
+                current > expected -> GoalPace.AHEAD
+                else -> GoalPace.BEHIND
+            }
+        }
+    }
+
+    /**
+     * The amount a dated goal is linearly expected to have saved by [asOf]:
+     * `target * elapsedDays / totalDays`, with `elapsedDays` clamped to
+     * `0..totalDays`. Returns [Cents.ZERO] when the goal has no deadline, and
+     * the full target when the deadline is on or before the creation date.
+     */
+    fun expectedAmountByNow(goal: Goal, asOf: LocalDate): Cents {
+        val deadline = goal.targetDate ?: return Cents.ZERO
+        val start = goal.createdAt.toLocalDateTime(TimeZone.UTC).date
+        val totalDays = start.daysUntil(deadline)
+        return when {
+            totalDays <= 0 -> goal.targetAmount
+            else -> {
+                val elapsed = start.daysUntil(asOf).coerceIn(0, totalDays)
+                Cents(goal.targetAmount.amount * elapsed / totalDays)
+            }
+        }
+    }
+
+    // ── private helpers ──────────────────────────────────────────────
+
+    private fun permilleForAmount(current: Long, target: Long): Int {
+        if (target <= 0L) return 0
+        val clamped = current.coerceAtLeast(0L)
+        return if (clamped >= target) MAX_PERMILLE else ((clamped * PERMILLE_BASIS) / target).toInt()
+    }
+
+    private fun reachedMilestones(amount: Long, target: Long): Set<GoalMilestone> {
+        if (target <= 0L) return emptySet()
+        val clamped = amount.coerceAtLeast(0L)
+        return GoalMilestone.entries
+            .filter { clamped * PERMILLE_BASIS >= target * it.permille.toLong() }
+            .toSet()
+    }
+
+    private fun projectedCompletionDate(
+        goal: Goal,
+        contribution: Cents,
+        period: ContributionPeriod,
+        from: LocalDate,
+    ): LocalDate? {
+        val remaining = remainingAmount(goal).amount
+        return when {
+            remaining <= 0L -> from
+            !contribution.isPositive() -> null
+            else -> {
+                val periodsNeeded = ((remaining + contribution.amount - 1L) / contribution.amount)
+                    .coerceAtMost(Int.MAX_VALUE.toLong())
+                    .toInt()
+                addPeriods(from, periodsNeeded, period)
+            }
+        }
+    }
+
+    private fun wholePeriodsBetween(from: LocalDate, to: LocalDate, period: ContributionPeriod): Int {
+        if (to <= from) return 0
+        return when (period) {
+            ContributionPeriod.DAILY -> from.daysUntil(to)
+            ContributionPeriod.WEEKLY -> from.daysUntil(to) / DAYS_PER_WEEK
+            ContributionPeriod.MONTHLY -> from.monthsUntil(to)
+        }
+    }
+
+    private fun addPeriods(from: LocalDate, count: Int, period: ContributionPeriod): LocalDate = when (period) {
+        ContributionPeriod.DAILY -> from.plus(count, DateTimeUnit.DAY)
+        ContributionPeriod.WEEKLY -> from.plus(count * DAYS_PER_WEEK, DateTimeUnit.DAY)
+        ContributionPeriod.MONTHLY -> from.plus(count, DateTimeUnit.MONTH)
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/goals/GoalTypes.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/goals/GoalTypes.kt
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.models.types.Cents
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.Serializable
+
+/**
+ * Cadence at which a recurring contribution is made toward a goal.
+ *
+ * Used by [GoalTrackingEngine.feasibility] to project savings over whole
+ * periods between a start date and a goal's deadline.
+ */
+@Serializable
+enum class ContributionPeriod {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+}
+
+/**
+ * Result of a goal feasibility / on-time check (#3734).
+ *
+ * All monetary fields are exact integer [Cents]; no floating point is used
+ * anywhere in the projection.
+ *
+ * @property willMeetDeadline `true` when the projected balance by the goal's
+ *   deadline reaches (or exceeds) its target. When the goal has no deadline,
+ *   this is `true` whenever a positive contribution will eventually complete
+ *   the goal (or the goal is already complete).
+ * @property projectedAmountByDeadline The balance projected at the goal's
+ *   deadline: `currentAmount + contribution * wholePeriodsUntilDeadline`.
+ *   When the goal has no deadline there is no horizon, so this equals the
+ *   goal's current amount.
+ * @property shortfall The amount still missing at the deadline, or
+ *   [Cents.ZERO] when the goal is projected to be met on time.
+ * @property projectedCompletionDate The date the goal is projected to be fully
+ *   funded given the contribution, or `null` when it never completes (zero /
+ *   non-positive contribution and a positive remaining amount). Equals `from`
+ *   when the goal is already complete.
+ */
+@Serializable
+data class GoalFeasibility(
+    val willMeetDeadline: Boolean,
+    val projectedAmountByDeadline: Cents,
+    val shortfall: Cents,
+    val projectedCompletionDate: LocalDate?,
+)
+
+/**
+ * Aggregate savings summary across a list of goals (#3726).
+ *
+ * Totals are computed in overflow-safe integer [Cents] and include only
+ * non-deleted, non-[com.finance.models.GoalStatus.CANCELLED] goals. Counts are
+ * reported per status.
+ *
+ * @property totalSaved Sum of `currentAmount` across counted goals.
+ * @property totalTarget Sum of `targetAmount` across counted goals.
+ * @property remaining `totalTarget - totalSaved`, clamped to [Cents.ZERO].
+ * @property progressPermille Overall progress in 0..1000 computed from integer
+ *   totals; `0` when `totalTarget` is zero, clamped at `1000` when over-funded.
+ * @property activeCount Number of non-deleted goals with status ACTIVE.
+ * @property completedCount Number of non-deleted goals with status COMPLETED.
+ * @property totalCount Number of non-deleted goals considered.
+ */
+@Serializable
+data class GoalSummary(
+    val totalSaved: Cents,
+    val totalTarget: Cents,
+    val remaining: Cents,
+    val progressPermille: Int,
+    val activeCount: Int,
+    val completedCount: Int,
+    val totalCount: Int,
+)
+
+/**
+ * Progress milestones a goal can cross, for one-time celebrations (#3708).
+ *
+ * Each milestone carries its threshold as an integer permille (parts per
+ * thousand) so detection uses exact integer comparison, never floating point.
+ */
+@Serializable
+enum class GoalMilestone(val permille: Int) {
+    /** 25% of the target reached. */
+    QUARTER(250),
+
+    /** 50% of the target reached. */
+    HALF(500),
+
+    /** 75% of the target reached. */
+    THREE_QUARTER(750),
+
+    /** 100% of the target reached. */
+    COMPLETE(1000),
+}
+
+/**
+ * Pace of a dated goal relative to its linear time budget (#3694).
+ *
+ * - [COMPLETED] takes precedence when the goal is already met.
+ * - [NO_DEADLINE] when the goal has no `targetDate`.
+ * - [AHEAD] / [ON_TRACK] / [BEHIND] compare the fraction saved against the
+ *   fraction of time elapsed, with a small tolerance band around parity.
+ */
+@Serializable
+enum class GoalPace {
+    ON_TRACK,
+    AHEAD,
+    BEHIND,
+    NO_DEADLINE,
+    COMPLETED,
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalAllocationTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalAllocationTest.kt
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.core.TestFixtures
+import com.finance.models.GoalStatus
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/** Tests for [GoalTrackingEngine.allocateContribution] (#3730). */
+class GoalAllocationTest {
+
+    private val asOf = LocalDate(2024, 1, 1)
+
+    private fun goal(id: String, remaining: Long, deadline: LocalDate) = TestFixtures.createGoal(
+        id = SyncId(id),
+        targetAmount = Cents(remaining),
+        currentAmount = Cents.ZERO,
+        targetDate = deadline,
+    )
+
+    // Priority order below is driven by deadline (nearest first): a, b, c.
+    private val goalA = goal("a", 200, LocalDate(2024, 1, 10))
+    private val goalB = goal("b", 300, LocalDate(2024, 1, 20))
+    private val goalC = goal("c", 500, LocalDate(2024, 1, 30))
+
+    @Test
+    fun amountLessThanFirstGoalRemaining() {
+        val result = GoalTrackingEngine.allocateContribution(Cents(150), listOf(goalA, goalB, goalC), asOf)
+        assertEquals(mapOf(SyncId("a") to Cents(150)), result)
+    }
+
+    @Test
+    fun amountSpansSeveralGoals() {
+        val result = GoalTrackingEngine.allocateContribution(Cents(600), listOf(goalA, goalB, goalC), asOf)
+        assertEquals(
+            mapOf(SyncId("a") to Cents(200), SyncId("b") to Cents(300), SyncId("c") to Cents(100)),
+            result,
+        )
+        assertEquals(600, result.values.sumOf { it.amount })
+    }
+
+    @Test
+    fun amountExceedsAllRemainingDropsLeftover() {
+        val result = GoalTrackingEngine.allocateContribution(Cents(2000), listOf(goalA, goalB, goalC), asOf)
+        assertEquals(
+            mapOf(SyncId("a") to Cents(200), SyncId("b") to Cents(300), SyncId("c") to Cents(500)),
+            result,
+        )
+        // Never exceeds total remaining (1000); leftover 1000 dropped.
+        assertEquals(1000, result.values.sumOf { it.amount })
+    }
+
+    @Test
+    fun singleGoal() {
+        val result = GoalTrackingEngine.allocateContribution(Cents(120), listOf(goalA), asOf)
+        assertEquals(mapOf(SyncId("a") to Cents(120)), result)
+    }
+
+    @Test
+    fun emptyGoalList() {
+        assertEquals(emptyMap(), GoalTrackingEngine.allocateContribution(Cents(500), emptyList(), asOf))
+    }
+
+    @Test
+    fun zeroAmountYieldsEmpty() {
+        assertEquals(emptyMap(), GoalTrackingEngine.allocateContribution(Cents.ZERO, listOf(goalA, goalB), asOf))
+    }
+
+    @Test
+    fun negativeAmountRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            GoalTrackingEngine.allocateContribution(Cents(-100), listOf(goalA), asOf)
+        }
+    }
+
+    @Test
+    fun completedGoalsExcluded() {
+        val completed = TestFixtures.createGoal(
+            id = SyncId("done"),
+            targetAmount = Cents(500),
+            currentAmount = Cents(500),
+            status = GoalStatus.COMPLETED,
+            targetDate = LocalDate(2024, 1, 5),
+        )
+        val result = GoalTrackingEngine.allocateContribution(Cents(1000), listOf(completed, goalA), asOf)
+        assertEquals(mapOf(SyncId("a") to Cents(200)), result)
+    }
+
+    @Test
+    fun neverExceedsAmountOrTotalRemaining() {
+        val result = GoalTrackingEngine.allocateContribution(Cents(450), listOf(goalA, goalB, goalC), asOf)
+        val total = result.values.sumOf { it.amount }
+        assertTrue(total <= 450)
+        assertTrue(total <= 1000)
+        assertEquals(450, total)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalFeasibilityTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalFeasibilityTest.kt
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.core.TestFixtures
+import com.finance.models.types.Cents
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Tests for [GoalTrackingEngine.feasibility] (#3734). */
+class GoalFeasibilityTest {
+
+    private val from = LocalDate(2024, 1, 1)
+
+    @Test
+    fun meetsExactly() {
+        // Need $300 over 30 days at $10/day = exactly on target.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents.ZERO,
+            targetDate = LocalDate(2024, 1, 31),
+        )
+        val result = GoalTrackingEngine.feasibility(goal, Cents(1000), ContributionPeriod.DAILY, from)
+        assertTrue(result.willMeetDeadline)
+        assertEquals(Cents(30_000), result.projectedAmountByDeadline)
+        assertEquals(Cents.ZERO, result.shortfall)
+        assertEquals(LocalDate(2024, 1, 31), result.projectedCompletionDate)
+    }
+
+    @Test
+    fun meetsEarly() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents.ZERO,
+            targetDate = LocalDate(2024, 1, 31),
+        )
+        val result = GoalTrackingEngine.feasibility(goal, Cents(2000), ContributionPeriod.DAILY, from)
+        assertTrue(result.willMeetDeadline)
+        assertEquals(Cents.ZERO, result.shortfall)
+        assertTrue(result.projectedAmountByDeadline.amount >= 30_000)
+        assertTrue(result.projectedCompletionDate!! < LocalDate(2024, 1, 31))
+    }
+
+    @Test
+    fun fallsShort() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents.ZERO,
+            targetDate = LocalDate(2024, 1, 31),
+        )
+        // $5/day * 30 days = $150 projected, $150 short.
+        val result = GoalTrackingEngine.feasibility(goal, Cents(500), ContributionPeriod.DAILY, from)
+        assertFalse(result.willMeetDeadline)
+        assertEquals(Cents(15_000), result.projectedAmountByDeadline)
+        assertEquals(Cents(15_000), result.shortfall)
+        assertTrue(result.projectedCompletionDate!! > LocalDate(2024, 1, 31))
+    }
+
+    @Test
+    fun zeroContributionNeverCompletes() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents(5_000),
+            targetDate = LocalDate(2024, 1, 31),
+        )
+        val result = GoalTrackingEngine.feasibility(goal, Cents.ZERO, ContributionPeriod.DAILY, from)
+        assertFalse(result.willMeetDeadline)
+        assertEquals(Cents(5_000), result.projectedAmountByDeadline)
+        assertEquals(Cents(25_000), result.shortfall)
+        assertNull(result.projectedCompletionDate)
+    }
+
+    @Test
+    fun noDeadlineWithPositiveContributionEventuallyCompletes() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents.ZERO,
+            targetDate = null,
+        )
+        val result = GoalTrackingEngine.feasibility(goal, Cents(1000), ContributionPeriod.DAILY, from)
+        assertTrue(result.willMeetDeadline)
+        assertEquals(Cents.ZERO, result.shortfall)
+        // $300 / $10 per day = 30 days.
+        assertEquals(LocalDate(2024, 1, 31), result.projectedCompletionDate)
+    }
+
+    @Test
+    fun noDeadlineWithZeroContributionDoesNotComplete() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents.ZERO,
+            targetDate = null,
+        )
+        val result = GoalTrackingEngine.feasibility(goal, Cents.ZERO, ContributionPeriod.DAILY, from)
+        assertFalse(result.willMeetDeadline)
+        assertEquals(Cents(30_000), result.shortfall)
+        assertNull(result.projectedCompletionDate)
+    }
+
+    @Test
+    fun alreadyCompleteMeetsImmediately() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents(30_000),
+            targetDate = LocalDate(2024, 1, 31),
+        )
+        val result = GoalTrackingEngine.feasibility(goal, Cents(1000), ContributionPeriod.DAILY, from)
+        assertTrue(result.willMeetDeadline)
+        assertEquals(Cents.ZERO, result.shortfall)
+        assertEquals(from, result.projectedCompletionDate)
+    }
+
+    @Test
+    fun weeklyContributionProjection() {
+        // 8 whole weeks between Jan 1 and Feb 28; $50/wk = $400.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(40_000),
+            currentAmount = Cents.ZERO,
+            targetDate = LocalDate(2024, 2, 28),
+        )
+        val result = GoalTrackingEngine.feasibility(goal, Cents(5_000), ContributionPeriod.WEEKLY, from)
+        assertEquals(Cents(40_000), result.projectedAmountByDeadline)
+        assertTrue(result.willMeetDeadline)
+    }
+
+    @Test
+    fun monthlyContributionProjection() {
+        // 6 whole months Jan 1 -> Jul 1; $100/mo = $600.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(60_000),
+            currentAmount = Cents.ZERO,
+            targetDate = LocalDate(2024, 7, 1),
+        )
+        val result = GoalTrackingEngine.feasibility(goal, Cents(10_000), ContributionPeriod.MONTHLY, from)
+        assertEquals(Cents(60_000), result.projectedAmountByDeadline)
+        assertTrue(result.willMeetDeadline)
+    }
+
+    @Test
+    fun pastDueDeadlineProjectsNoPeriods() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents(10_000),
+            targetDate = LocalDate(2023, 12, 1),
+        )
+        val result = GoalTrackingEngine.feasibility(goal, Cents(1000), ContributionPeriod.DAILY, from)
+        assertFalse(result.willMeetDeadline)
+        assertEquals(Cents(10_000), result.projectedAmountByDeadline)
+        assertEquals(Cents(20_000), result.shortfall)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalLifecycleTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalLifecycleTest.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.core.TestFixtures
+import com.finance.models.GoalStatus
+import com.finance.models.types.Cents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Tests for [GoalTrackingEngine] lifecycle transitions and auto-complete recommendation (#3700). */
+class GoalLifecycleTest {
+
+    @Test
+    fun activeTransitions() {
+        assertEquals(
+            setOf(GoalStatus.PAUSED, GoalStatus.COMPLETED, GoalStatus.CANCELLED),
+            GoalTrackingEngine.transitions(GoalStatus.ACTIVE),
+        )
+    }
+
+    @Test
+    fun pausedTransitions() {
+        assertEquals(
+            setOf(GoalStatus.ACTIVE, GoalStatus.CANCELLED),
+            GoalTrackingEngine.transitions(GoalStatus.PAUSED),
+        )
+    }
+
+    @Test
+    fun completedCanOnlyReopen() {
+        assertEquals(setOf(GoalStatus.ACTIVE), GoalTrackingEngine.transitions(GoalStatus.COMPLETED))
+    }
+
+    @Test
+    fun cancelledIsTerminal() {
+        assertEquals(emptySet(), GoalTrackingEngine.transitions(GoalStatus.CANCELLED))
+    }
+
+    @Test
+    fun legalTransitionsAllowed() {
+        assertTrue(GoalTrackingEngine.canTransition(GoalStatus.ACTIVE, GoalStatus.PAUSED))
+        assertTrue(GoalTrackingEngine.canTransition(GoalStatus.ACTIVE, GoalStatus.COMPLETED))
+        assertTrue(GoalTrackingEngine.canTransition(GoalStatus.ACTIVE, GoalStatus.CANCELLED))
+        assertTrue(GoalTrackingEngine.canTransition(GoalStatus.PAUSED, GoalStatus.ACTIVE))
+        assertTrue(GoalTrackingEngine.canTransition(GoalStatus.PAUSED, GoalStatus.CANCELLED))
+        assertTrue(GoalTrackingEngine.canTransition(GoalStatus.COMPLETED, GoalStatus.ACTIVE))
+    }
+
+    @Test
+    fun illegalTransitionsRejected() {
+        assertFalse(GoalTrackingEngine.canTransition(GoalStatus.CANCELLED, GoalStatus.ACTIVE))
+        assertFalse(GoalTrackingEngine.canTransition(GoalStatus.COMPLETED, GoalStatus.CANCELLED))
+        assertFalse(GoalTrackingEngine.canTransition(GoalStatus.COMPLETED, GoalStatus.PAUSED))
+        assertFalse(GoalTrackingEngine.canTransition(GoalStatus.PAUSED, GoalStatus.COMPLETED))
+        assertFalse(GoalTrackingEngine.canTransition(GoalStatus.ACTIVE, GoalStatus.ACTIVE))
+    }
+
+    @Test
+    fun recommendsCompletedWhenActiveAndFunded() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(1000),
+            currentAmount = Cents(1000),
+            status = GoalStatus.ACTIVE,
+        )
+        assertEquals(GoalStatus.COMPLETED, GoalTrackingEngine.recommendedStatus(goal))
+    }
+
+    @Test
+    fun recommendsCompletedWhenPausedAndFunded() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(1000),
+            currentAmount = Cents(1200),
+            status = GoalStatus.PAUSED,
+        )
+        assertEquals(GoalStatus.COMPLETED, GoalTrackingEngine.recommendedStatus(goal))
+    }
+
+    @Test
+    fun noRecommendationWhenNotFunded() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(1000),
+            currentAmount = Cents(999),
+            status = GoalStatus.ACTIVE,
+        )
+        assertNull(GoalTrackingEngine.recommendedStatus(goal))
+    }
+
+    @Test
+    fun noRecommendationWhenAlreadyCompleted() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(1000),
+            currentAmount = Cents(1000),
+            status = GoalStatus.COMPLETED,
+        )
+        assertNull(GoalTrackingEngine.recommendedStatus(goal))
+    }
+
+    @Test
+    fun noRecommendationWhenCancelled() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(1000),
+            currentAmount = Cents(1000),
+            status = GoalStatus.CANCELLED,
+        )
+        assertNull(GoalTrackingEngine.recommendedStatus(goal))
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalMilestoneTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalMilestoneTest.kt
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.core.TestFixtures
+import com.finance.models.types.Cents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Tests for [GoalTrackingEngine.milestonesReached] and [GoalTrackingEngine.newlyReachedMilestones] (#3708). */
+class GoalMilestoneTest {
+
+    private fun goal(current: Long, target: Long = 1000) =
+        TestFixtures.createGoal(targetAmount = Cents(target), currentAmount = Cents(current))
+
+    @Test
+    fun noMilestonesBelowQuarter() {
+        assertEquals(emptySet(), GoalTrackingEngine.milestonesReached(goal(249)))
+    }
+
+    @Test
+    fun exactQuarterThreshold() {
+        assertEquals(setOf(GoalMilestone.QUARTER), GoalTrackingEngine.milestonesReached(goal(250)))
+    }
+
+    @Test
+    fun exactHalfThreshold() {
+        assertEquals(
+            setOf(GoalMilestone.QUARTER, GoalMilestone.HALF),
+            GoalTrackingEngine.milestonesReached(goal(500)),
+        )
+    }
+
+    @Test
+    fun exactThreeQuarterThreshold() {
+        assertEquals(
+            setOf(GoalMilestone.QUARTER, GoalMilestone.HALF, GoalMilestone.THREE_QUARTER),
+            GoalTrackingEngine.milestonesReached(goal(750)),
+        )
+    }
+
+    @Test
+    fun completeReachesAll() {
+        assertEquals(
+            setOf(
+                GoalMilestone.QUARTER,
+                GoalMilestone.HALF,
+                GoalMilestone.THREE_QUARTER,
+                GoalMilestone.COMPLETE,
+            ),
+            GoalTrackingEngine.milestonesReached(goal(1000)),
+        )
+    }
+
+    @Test
+    fun overHundredPercentClampsToComplete() {
+        assertEquals(
+            setOf(
+                GoalMilestone.QUARTER,
+                GoalMilestone.HALF,
+                GoalMilestone.THREE_QUARTER,
+                GoalMilestone.COMPLETE,
+            ),
+            GoalTrackingEngine.milestonesReached(goal(1500)),
+        )
+    }
+
+    @Test
+    fun newlyReachedCrossingMultipleThresholdsInOneJump() {
+        val g = goal(current = 1000)
+        assertEquals(
+            setOf(
+                GoalMilestone.QUARTER,
+                GoalMilestone.HALF,
+                GoalMilestone.THREE_QUARTER,
+                GoalMilestone.COMPLETE,
+            ),
+            GoalTrackingEngine.newlyReachedMilestones(Cents.ZERO, g),
+        )
+    }
+
+    @Test
+    fun newlyReachedOnlyTheJustCrossedThreshold() {
+        val g = goal(current = 550)
+        // Previously at 40% (already past QUARTER), now at 55% -> only HALF is new.
+        assertEquals(
+            setOf(GoalMilestone.HALF),
+            GoalTrackingEngine.newlyReachedMilestones(Cents(400), g),
+        )
+    }
+
+    @Test
+    fun newlyReachedIsEmptyWhenAmountUnchanged() {
+        val g = goal(current = 600)
+        assertEquals(emptySet(), GoalTrackingEngine.newlyReachedMilestones(Cents(600), g))
+    }
+
+    @Test
+    fun newlyReachedIsEmptyWhenAmountDecreased() {
+        val g = goal(current = 300)
+        assertEquals(emptySet(), GoalTrackingEngine.newlyReachedMilestones(Cents(800), g))
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalPaceTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalPaceTest.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.core.TestFixtures
+import com.finance.models.types.Cents
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Tests for [GoalTrackingEngine.pace] and [GoalTrackingEngine.expectedAmountByNow] (#3694). */
+class GoalPaceTest {
+
+    // Goals are created at TestFixtures.fixedInstant (2024-06-15). The window
+    // below spans exactly 60 days, so 2024-07-15 is the 30-day (50%) midpoint.
+    private val deadline = LocalDate(2024, 8, 14)
+    private val midpoint = LocalDate(2024, 7, 15)
+
+    private fun goal(current: Long, target: Long = 1000, date: LocalDate? = deadline) =
+        TestFixtures.createGoal(targetAmount = Cents(target), currentAmount = Cents(current), targetDate = date)
+
+    @Test
+    fun expectedAmountAtMidpointIsHalf() {
+        assertEquals(Cents(500), GoalTrackingEngine.expectedAmountByNow(goal(0), midpoint))
+    }
+
+    @Test
+    fun expectedAmountBeforeStartIsZero() {
+        assertEquals(Cents.ZERO, GoalTrackingEngine.expectedAmountByNow(goal(0), LocalDate(2024, 6, 1)))
+    }
+
+    @Test
+    fun expectedAmountAfterDeadlineIsFullTarget() {
+        assertEquals(Cents(1000), GoalTrackingEngine.expectedAmountByNow(goal(0), LocalDate(2024, 9, 1)))
+    }
+
+    @Test
+    fun expectedAmountWithoutDeadlineIsZero() {
+        assertEquals(Cents.ZERO, GoalTrackingEngine.expectedAmountByNow(goal(0, date = null), midpoint))
+    }
+
+    @Test
+    fun aheadWhenSavedFarAboveExpectation() {
+        assertEquals(GoalPace.AHEAD, GoalTrackingEngine.pace(goal(700), midpoint))
+    }
+
+    @Test
+    fun behindWhenSavedFarBelowExpectation() {
+        assertEquals(GoalPace.BEHIND, GoalTrackingEngine.pace(goal(300), midpoint))
+    }
+
+    @Test
+    fun onTrackWithinToleranceBand() {
+        // Expected 500, tolerance 5% of 1000 = 50 -> band [450, 550].
+        assertEquals(GoalPace.ON_TRACK, GoalTrackingEngine.pace(goal(520), midpoint))
+    }
+
+    @Test
+    fun onTrackAtExactExpectation() {
+        assertEquals(GoalPace.ON_TRACK, GoalTrackingEngine.pace(goal(500), midpoint))
+    }
+
+    @Test
+    fun noDeadlineIsNoDeadline() {
+        assertEquals(GoalPace.NO_DEADLINE, GoalTrackingEngine.pace(goal(300, date = null), midpoint))
+    }
+
+    @Test
+    fun completeTakesPrecedenceOverPace() {
+        assertEquals(GoalPace.COMPLETED, GoalTrackingEngine.pace(goal(1000), midpoint))
+    }
+
+    @Test
+    fun completeTakesPrecedenceEvenWhenNoDeadline() {
+        assertEquals(GoalPace.COMPLETED, GoalTrackingEngine.pace(goal(1000, date = null), midpoint))
+    }
+
+    @Test
+    fun pastDueUnfinishedGoalIsBehind() {
+        assertEquals(GoalPace.BEHIND, GoalTrackingEngine.pace(goal(300), LocalDate(2024, 9, 1)))
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalPrioritizeTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalPrioritizeTest.kt
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.core.TestFixtures
+import com.finance.models.GoalStatus
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Tests for [GoalTrackingEngine.prioritize] (#3721). */
+class GoalPrioritizeTest {
+
+    private val asOf = LocalDate(2024, 1, 1)
+
+    @Test
+    fun datedGoalsSortByNearestDeadlineFirst() {
+        val later = TestFixtures.createGoal(id = SyncId("later"), targetDate = LocalDate(2024, 3, 1))
+        val sooner = TestFixtures.createGoal(id = SyncId("sooner"), targetDate = LocalDate(2024, 2, 1))
+        val ordered = GoalTrackingEngine.prioritize(listOf(later, sooner), asOf)
+        assertEquals(listOf(SyncId("sooner"), SyncId("later")), ordered.map { it.id })
+    }
+
+    @Test
+    fun undatedGoalsSortAfterDatedOnes() {
+        val dated = TestFixtures.createGoal(id = SyncId("dated"), targetDate = LocalDate(2024, 6, 1))
+        val undated = TestFixtures.createGoal(id = SyncId("undated"), targetDate = null)
+        val ordered = GoalTrackingEngine.prioritize(listOf(undated, dated), asOf)
+        assertEquals(listOf(SyncId("dated"), SyncId("undated")), ordered.map { it.id })
+    }
+
+    @Test
+    fun undatedGoalsSortByHighestCompletionThenRemaining() {
+        val nearlyDone = TestFixtures.createGoal(
+            id = SyncId("nearly"),
+            targetAmount = Cents(1000),
+            currentAmount = Cents(800),
+        )
+        val fresh = TestFixtures.createGoal(
+            id = SyncId("fresh"),
+            targetAmount = Cents(1000),
+            currentAmount = Cents.ZERO,
+        )
+        val ordered = GoalTrackingEngine.prioritize(listOf(fresh, nearlyDone), asOf)
+        assertEquals(listOf(SyncId("nearly"), SyncId("fresh")), ordered.map { it.id })
+    }
+
+    @Test
+    fun nonActiveGoalsExcluded() {
+        val active = TestFixtures.createGoal(id = SyncId("active"), status = GoalStatus.ACTIVE)
+        val paused = TestFixtures.createGoal(id = SyncId("paused"), status = GoalStatus.PAUSED)
+        val completed = TestFixtures.createGoal(id = SyncId("completed"), status = GoalStatus.COMPLETED)
+        val cancelled = TestFixtures.createGoal(id = SyncId("cancelled"), status = GoalStatus.CANCELLED)
+        val ordered = GoalTrackingEngine.prioritize(listOf(active, paused, completed, cancelled), asOf)
+        assertEquals(listOf(SyncId("active")), ordered.map { it.id })
+    }
+
+    @Test
+    fun deletedGoalsExcluded() {
+        val active = TestFixtures.createGoal(id = SyncId("active"))
+        val deleted = active.copy(id = SyncId("deleted"), deletedAt = TestFixtures.fixedInstant)
+        val ordered = GoalTrackingEngine.prioritize(listOf(active, deleted), asOf)
+        assertEquals(listOf(SyncId("active")), ordered.map { it.id })
+    }
+
+    @Test
+    fun tiesBrokenStablyByGoalId() {
+        val y = TestFixtures.createGoal(
+            id = SyncId("y"),
+            targetAmount = Cents(1000),
+            currentAmount = Cents(500),
+            targetDate = LocalDate(2024, 5, 1),
+        )
+        val x = TestFixtures.createGoal(
+            id = SyncId("x"),
+            targetAmount = Cents(1000),
+            currentAmount = Cents(500),
+            targetDate = LocalDate(2024, 5, 1),
+        )
+        val ordered = GoalTrackingEngine.prioritize(listOf(y, x), asOf)
+        assertEquals(listOf(SyncId("x"), SyncId("y")), ordered.map { it.id })
+    }
+
+    @Test
+    fun largerRemainingFundedFirstWhenCompletionEqual() {
+        val big = TestFixtures.createGoal(
+            id = SyncId("big"),
+            targetAmount = Cents(2000),
+            currentAmount = Cents.ZERO,
+        )
+        val small = TestFixtures.createGoal(
+            id = SyncId("small"),
+            targetAmount = Cents(1000),
+            currentAmount = Cents.ZERO,
+        )
+        val ordered = GoalTrackingEngine.prioritize(listOf(small, big), asOf)
+        assertEquals(listOf(SyncId("big"), SyncId("small")), ordered.map { it.id })
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalRoundUpTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalRoundUpTest.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.models.types.Cents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/** Tests for the round-up (spare-change) primitive of [GoalTrackingEngine] (#3716). */
+class GoalRoundUpTest {
+
+    @Test
+    fun exactMultipleYieldsZero() {
+        assertEquals(Cents.ZERO, GoalTrackingEngine.roundUpContribution(Cents(500)))
+    }
+
+    @Test
+    fun oneCentOver() {
+        assertEquals(Cents(99), GoalTrackingEngine.roundUpContribution(Cents(501)))
+    }
+
+    @Test
+    fun ninetyNineCentsOver() {
+        assertEquals(Cents(1), GoalTrackingEngine.roundUpContribution(Cents(599)))
+    }
+
+    @Test
+    fun roundsToNearestFiveDollars() {
+        // $4.30 -> next $5 multiple is $5.00, spare change $0.70.
+        assertEquals(Cents(70), GoalTrackingEngine.roundUpContribution(Cents(430), Cents(500)))
+    }
+
+    @Test
+    fun exactFiveDollarMultipleYieldsZero() {
+        assertEquals(Cents.ZERO, GoalTrackingEngine.roundUpContribution(Cents(1000), Cents(500)))
+    }
+
+    @Test
+    fun zeroAmountYieldsZero() {
+        assertEquals(Cents.ZERO, GoalTrackingEngine.roundUpContribution(Cents.ZERO))
+    }
+
+    @Test
+    fun negativeAmountRoundsTowardNextMultiple() {
+        // Next multiple of 100 that is >= -150 is -100; difference is 50.
+        assertEquals(Cents(50), GoalTrackingEngine.roundUpContribution(Cents(-150)))
+    }
+
+    @Test
+    fun nonPositiveNearestRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            GoalTrackingEngine.roundUpContribution(Cents(501), Cents.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GoalTrackingEngine.roundUpContribution(Cents(501), Cents(-100))
+        }
+    }
+
+    @Test
+    fun totalSumsRoundUps() {
+        // 0.75 + 0.10 + 1.00 -> 0.25 + 0.90 + 0.00
+        val amounts = listOf(Cents(325), Cents(510), Cents(700))
+        assertEquals(Cents(75 + 90 + 0), GoalTrackingEngine.roundUpTotal(amounts))
+    }
+
+    @Test
+    fun totalOfEmptyListIsZero() {
+        assertEquals(Cents.ZERO, GoalTrackingEngine.roundUpTotal(emptyList()))
+    }
+
+    @Test
+    fun totalRejectsInvalidNearest() {
+        assertFailsWith<IllegalArgumentException> {
+            GoalTrackingEngine.roundUpTotal(listOf(Cents(101)), Cents.ZERO)
+        }
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalSummaryTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalSummaryTest.kt
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.core.TestFixtures
+import com.finance.models.GoalStatus
+import com.finance.models.types.Cents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Tests for [GoalTrackingEngine.summarize] (#3726). */
+class GoalSummaryTest {
+
+    @Test
+    fun emptyListIsAllZero() {
+        val summary = GoalTrackingEngine.summarize(emptyList())
+        assertEquals(Cents.ZERO, summary.totalSaved)
+        assertEquals(Cents.ZERO, summary.totalTarget)
+        assertEquals(Cents.ZERO, summary.remaining)
+        assertEquals(0, summary.progressPermille)
+        assertEquals(0, summary.activeCount)
+        assertEquals(0, summary.completedCount)
+        assertEquals(0, summary.totalCount)
+    }
+
+    @Test
+    fun singleGoal() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(100_000), currentAmount = Cents(25_000))
+        val summary = GoalTrackingEngine.summarize(listOf(goal))
+        assertEquals(Cents(25_000), summary.totalSaved)
+        assertEquals(Cents(100_000), summary.totalTarget)
+        assertEquals(Cents(75_000), summary.remaining)
+        assertEquals(250, summary.progressPermille)
+        assertEquals(1, summary.activeCount)
+        assertEquals(1, summary.totalCount)
+    }
+
+    @Test
+    fun mixedStatusesCountedAndTotaled() {
+        val active = TestFixtures.createGoal(
+            targetAmount = Cents(100_000),
+            currentAmount = Cents(40_000),
+            status = GoalStatus.ACTIVE,
+        )
+        val completed = TestFixtures.createGoal(
+            targetAmount = Cents(50_000),
+            currentAmount = Cents(50_000),
+            status = GoalStatus.COMPLETED,
+        )
+        val paused = TestFixtures.createGoal(
+            targetAmount = Cents(20_000),
+            currentAmount = Cents(10_000),
+            status = GoalStatus.PAUSED,
+        )
+        val cancelled = TestFixtures.createGoal(
+            targetAmount = Cents(999_999),
+            currentAmount = Cents(999_999),
+            status = GoalStatus.CANCELLED,
+        )
+        val summary = GoalTrackingEngine.summarize(listOf(active, completed, paused, cancelled))
+
+        // Cancelled excluded from totals: saved = 40k+50k+10k, target = 100k+50k+20k.
+        assertEquals(Cents(100_000), summary.totalSaved)
+        assertEquals(Cents(170_000), summary.totalTarget)
+        assertEquals(Cents(70_000), summary.remaining)
+        assertEquals(588, summary.progressPermille) // 100000*1000/170000 floored
+        assertEquals(1, summary.activeCount)
+        assertEquals(1, summary.completedCount)
+        assertEquals(4, summary.totalCount) // all non-deleted counted
+    }
+
+    @Test
+    fun deletedGoalsExcludedEntirely() {
+        val active = TestFixtures.createGoal(targetAmount = Cents(100_000), currentAmount = Cents(50_000))
+        val deleted = active.copy(deletedAt = TestFixtures.fixedInstant)
+        val summary = GoalTrackingEngine.summarize(listOf(active, deleted))
+        assertEquals(Cents(50_000), summary.totalSaved)
+        assertEquals(1, summary.totalCount)
+    }
+
+    @Test
+    fun overFundedGoalClampedInPermille() {
+        val overFunded = TestFixtures.createGoal(targetAmount = Cents(100_000), currentAmount = Cents(150_000))
+        val summary = GoalTrackingEngine.summarize(listOf(overFunded))
+        assertEquals(1000, summary.progressPermille)
+        assertEquals(Cents.ZERO, summary.remaining)
+    }
+
+    @Test
+    fun zeroTargetGuardedInPermille() {
+        // Only a cancelled goal -> totals are zero, permille must not divide by zero.
+        val cancelled = TestFixtures.createGoal(
+            targetAmount = Cents(100_000),
+            currentAmount = Cents(50_000),
+            status = GoalStatus.CANCELLED,
+        )
+        val summary = GoalTrackingEngine.summarize(listOf(cancelled))
+        assertEquals(0, summary.progressPermille)
+        assertEquals(Cents.ZERO, summary.totalTarget)
+        assertEquals(1, summary.totalCount)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalTrackingEngineProgressTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalTrackingEngineProgressTest.kt
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.core.TestFixtures
+import com.finance.models.types.Cents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for the core progress primitives of [GoalTrackingEngine] — the shared
+ * foundation (#3673) and its integer permille basis (#3737).
+ */
+class GoalTrackingEngineProgressTest {
+
+    @Test
+    fun remainingAmountAtZero() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(100_000), currentAmount = Cents.ZERO)
+        assertEquals(Cents(100_000), GoalTrackingEngine.remainingAmount(goal))
+    }
+
+    @Test
+    fun remainingAmountPartial() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(100_000), currentAmount = Cents(30_000))
+        assertEquals(Cents(70_000), GoalTrackingEngine.remainingAmount(goal))
+    }
+
+    @Test
+    fun remainingAmountAtComplete() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(100_000), currentAmount = Cents(100_000))
+        assertEquals(Cents.ZERO, GoalTrackingEngine.remainingAmount(goal))
+    }
+
+    @Test
+    fun remainingAmountClampedWhenOverTarget() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(100_000), currentAmount = Cents(150_000))
+        assertEquals(Cents.ZERO, GoalTrackingEngine.remainingAmount(goal))
+    }
+
+    @Test
+    fun remainingAmountSingleCent() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(1), currentAmount = Cents.ZERO)
+        assertEquals(Cents(1), GoalTrackingEngine.remainingAmount(goal))
+    }
+
+    @Test
+    fun progressPermilleAtZero() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(1000), currentAmount = Cents.ZERO)
+        assertEquals(0, GoalTrackingEngine.progressPermille(goal))
+    }
+
+    @Test
+    fun progressPermilleAt250() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(1000), currentAmount = Cents(250))
+        assertEquals(250, GoalTrackingEngine.progressPermille(goal))
+    }
+
+    @Test
+    fun progressPermilleFloorsAt333() {
+        // 1/3 = 0.333... floored to 333 permille via integer math
+        val goal = TestFixtures.createGoal(targetAmount = Cents(3), currentAmount = Cents(1))
+        assertEquals(333, GoalTrackingEngine.progressPermille(goal))
+    }
+
+    @Test
+    fun progressPermilleAt500() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(1000), currentAmount = Cents(500))
+        assertEquals(500, GoalTrackingEngine.progressPermille(goal))
+    }
+
+    @Test
+    fun progressPermilleAt999() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(1000), currentAmount = Cents(999))
+        assertEquals(999, GoalTrackingEngine.progressPermille(goal))
+    }
+
+    @Test
+    fun progressPermilleAt1000() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(1000), currentAmount = Cents(1000))
+        assertEquals(1000, GoalTrackingEngine.progressPermille(goal))
+    }
+
+    @Test
+    fun progressPermilleClampedWhenOverTarget() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(1000), currentAmount = Cents(1500))
+        assertEquals(1000, GoalTrackingEngine.progressPermille(goal))
+    }
+
+    @Test
+    fun progressPermilleSingleCentComplete() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(1), currentAmount = Cents(1))
+        assertEquals(1000, GoalTrackingEngine.progressPermille(goal))
+    }
+
+    @Test
+    fun progressPermilleNeverNegative() {
+        val goal = TestFixtures.createGoal(targetAmount = Cents(1000), currentAmount = Cents(-500))
+        assertEquals(0, GoalTrackingEngine.progressPermille(goal))
+    }
+}


### PR DESCRIPTION
## Summary

Adds a shared, platform-agnostic **`GoalTrackingEngine`** to `packages/core`
(`com.finance.core.goals`) so all four platforms (iOS, Android, Web, Windows)
share one deterministic source of truth for goal/savings math. All logic is
pure `commonMain`, uses integer `Cents` (Long) money math — never `Double` — and
is fully covered by `commonTest`.

## What's included

- **Foundation** (#3673): `remainingAmount(goal)` and the engine object with
  KDoc on every public function.
- **Integer permille basis** (#3737): `progressPermille(goal): Int` (0..1000)
  via integer math; all downstream logic branches on this, and `Goal.progress:
  Double` is documented as display-only.
- **Feasibility / on-time check** (#3734): `feasibility(...)` returning
  `GoalFeasibility` (`willMeetDeadline`, `projectedAmountByDeadline`,
  `shortfall`, `projectedCompletionDate`) over whole periods.
- **Lump-sum allocation** (#3730): `allocateContribution(...)` fills goals in
  priority order, caps at each goal's remaining, exact cents, no penny loss.
- **Aggregate summary** (#3726): `summarize(goals)` → `GoalSummary` with
  overflow-safe totals and per-status counts.
- **Priority ordering** (#3721): `prioritize(goals, asOf)` — nearest deadline,
  then closest to done, then largest remaining, stable by id.
- **Round-up primitive** (#3716): `roundUpContribution(...)` /
  `roundUpTotal(...)` spare-change math on `Cents`.
- **Milestone detection** (#3708): `GoalMilestone` (25/50/75/100%),
  `milestonesReached` / `newlyReachedMilestones` with integer thresholds.
- **Lifecycle validation** (#3700): `transitions` / `canTransition` /
  `recommendedStatus` (auto-complete suggestion, no mutation).
- **Pace indicator** (#3694): `pace(goal, asOf)` → `GoalPace`
  (`ON_TRACK | AHEAD | BEHIND | NO_DEADLINE | COMPLETED`) plus
  `expectedAmountByNow`.

## Testing

- `:packages:core:jvmTest` (KMP commonTest) — green.
- Root `detekt` — no violations in the new package.
- `commonMain` compiles for JVM and JS; code is pure `commonMain` so it builds
  for all KMP targets.

Closes #3673
Closes #3737
Closes #3734
Closes #3730
Closes #3726
Closes #3721
Closes #3716
Closes #3708
Closes #3700
Closes #3694
