### PR TITLE
feat(core): core budgeting batch - 10 issues

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetCalculator.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetCalculator.kt
@@ -5,9 +5,6 @@ package com.finance.core.budget
 import com.finance.models.*
 import com.finance.models.types.*
 import com.finance.core.money.MoneyOperations
-import com.finance.models.util.DateTimeUtil.endOfMonth
-import com.finance.models.util.DateTimeUtil.startOfMonth
-import com.finance.models.util.DateTimeUtil.startOfWeek
 import kotlinx.datetime.*
 import kotlinx.serialization.Serializable
 
@@ -18,6 +15,11 @@ object BudgetCalculator {
 
     /**
      * Calculate budget status for a given budget and its transactions.
+     *
+     * The reported [BudgetStatus.isWithinBudgetDates] reflects whether
+     * [referenceDate] falls inside the budget's active window
+     * `[startDate, endDate]` (see [isActiveOn]); an ended budget still reports
+     * its last period's numbers but is flagged as inactive (#3632).
      */
     fun calculateStatus(
         budget: Budget,
@@ -25,13 +27,7 @@ object BudgetCalculator {
         referenceDate: LocalDate,
     ): BudgetStatus {
         val period = getCurrentPeriod(budget.period, budget.startDate, referenceDate)
-        val periodTransactions = transactions.filter { txn ->
-            txn.categoryId == budget.categoryId &&
-                txn.currency == budget.currency &&
-                txn.date >= period.start && txn.date <= period.end &&
-                txn.deletedAt == null &&
-                txn.type == TransactionType.EXPENSE
-        }
+        val periodTransactions = periodExpenses(budget, transactions, period)
 
         val spent = Cents(periodTransactions.sumOf { it.amount.abs().amount })
         val remaining = budget.amount - spent
@@ -46,11 +42,87 @@ object BudgetCalculator {
             remaining = remaining,
             utilization = utilization,
             isOverBudget = spent.amount > budget.amount.amount,
+            isWithinBudgetDates = isActiveOn(budget, referenceDate),
         )
     }
 
     /**
+     * Break a shared/household budget's spend down by member (`ownerId`) for the
+     * period containing [referenceDate] (#3690).
+     *
+     * The same category / currency / date-window / soft-delete / expense-only
+     * filters as [calculateStatus] are applied, so [BudgetMemberBreakdown.totalSpent]
+     * reconciles exactly with [BudgetStatus.spent]. Members with no qualifying
+     * spend in the period do not appear in [BudgetMemberBreakdown.byMember]; use
+     * [BudgetMemberBreakdown.spendFor] to read a zero for absent members.
+     */
+    fun calculateMemberBreakdown(
+        budget: Budget,
+        transactions: List<Transaction>,
+        referenceDate: LocalDate,
+    ): BudgetMemberBreakdown {
+        val period = getCurrentPeriod(budget.period, budget.startDate, referenceDate)
+        val periodTransactions = periodExpenses(budget, transactions, period)
+
+        val byMember = LinkedHashMap<SyncId, Cents>()
+        for (txn in periodTransactions) {
+            val current = byMember[txn.ownerId] ?: Cents.ZERO
+            byMember[txn.ownerId] = current + txn.amount.abs()
+        }
+        val total = Cents(periodTransactions.sumOf { it.amount.abs().amount })
+
+        return BudgetMemberBreakdown(
+            budget = budget,
+            period = period,
+            totalSpent = total,
+            byMember = byMember,
+        )
+    }
+
+    /**
+     * Whether [referenceDate] falls inside the budget's active window (#3632).
+     *
+     * A budget is active on any date in `[startDate, endDate]`. When
+     * [Budget.endDate] is `null` the budget is open-ended and active on every
+     * date on or after [Budget.startDate].
+     */
+    fun isActiveOn(budget: Budget, referenceDate: LocalDate): Boolean {
+        val endDate = budget.endDate
+        return referenceDate >= budget.startDate &&
+            (endDate == null || referenceDate <= endDate)
+    }
+
+    /**
+     * Expenses that count against [budget] within [period]: matching category and
+     * currency, inside the date window, not soft-deleted, and of expense type.
+     */
+    private fun periodExpenses(
+        budget: Budget,
+        transactions: List<Transaction>,
+        period: DatePeriod,
+    ): List<Transaction> = transactions.filter { txn ->
+        txn.categoryId == budget.categoryId &&
+            txn.currency == budget.currency &&
+            txn.date >= period.start && txn.date <= period.end &&
+            txn.deletedAt == null &&
+            txn.type == TransactionType.EXPENSE
+    }
+
+    /**
      * Get the current period boundaries for a budget.
+     *
+     * ## Anchoring rule (#3595)
+     * Every period type is anchored to the budget's [startDate] rather than to
+     * calendar boundaries, so a cycle that begins on the 15th (or a Thursday)
+     * stays on that cadence:
+     *  - **WEEKLY / BIWEEKLY** — fixed 7- / 14-day windows counted from [startDate].
+     *  - **MONTHLY / QUARTERLY / YEARLY** — 1- / 3- / 12-month windows counted
+     *    from [startDate], preserving its day-of-month (clamped for short months
+     *    by `kotlinx-datetime`).
+     *
+     * Because a `startDate` on the 1st of a month that is also an ISO Monday
+     * coincides with the calendar grid, calendar-aligned budgets are unaffected.
+     * Reference dates before [startDate] resolve to the correct earlier period.
      */
     fun getCurrentPeriod(
         period: BudgetPeriod,
@@ -58,37 +130,58 @@ object BudgetCalculator {
         referenceDate: LocalDate,
     ): DatePeriod {
         return when (period) {
-            BudgetPeriod.WEEKLY -> {
-                val start = referenceDate.startOfWeek()
-                DatePeriod(start, start.plus(6, DateTimeUnit.DAY))
-            }
-            BudgetPeriod.BIWEEKLY -> {
-                val daysSinceStart = startDate.daysUntil(referenceDate)
-                // Floor division so dates before startDate bucket into the
-                // correct (earlier) period rather than truncating toward zero.
-                val periodIndex = floorDiv(daysSinceStart, BIWEEKLY_DAYS)
-                val periodStart = startDate.plus(periodIndex * BIWEEKLY_DAYS, DateTimeUnit.DAY)
-                DatePeriod(periodStart, periodStart.plus(BIWEEKLY_DAYS - 1, DateTimeUnit.DAY))
-            }
-            BudgetPeriod.MONTHLY -> {
-                val start = referenceDate.startOfMonth()
-                DatePeriod(start, referenceDate.endOfMonth())
-            }
-            BudgetPeriod.QUARTERLY -> {
-                val quarterMonth = ((referenceDate.monthNumber - 1) / 3) * 3 + 1
-                val start = LocalDate(referenceDate.year, quarterMonth, 1)
-                val endMonth = quarterMonth + 2
-                val end = LocalDate(referenceDate.year, endMonth, 1)
-                    .plus(1, DateTimeUnit.MONTH)
-                    .minus(1, DateTimeUnit.DAY)
-                DatePeriod(start, end)
-            }
-            BudgetPeriod.YEARLY -> {
-                val start = LocalDate(referenceDate.year, 1, 1)
-                val end = LocalDate(referenceDate.year, 12, 31)
-                DatePeriod(start, end)
-            }
+            BudgetPeriod.WEEKLY -> alignedDayPeriod(startDate, referenceDate, DAYS_PER_WEEK)
+            BudgetPeriod.BIWEEKLY -> alignedDayPeriod(startDate, referenceDate, BIWEEKLY_DAYS)
+            BudgetPeriod.MONTHLY -> alignedMonthPeriod(startDate, referenceDate, MONTHS_PER_MONTH)
+            BudgetPeriod.QUARTERLY -> alignedMonthPeriod(startDate, referenceDate, MONTHS_PER_QUARTER)
+            BudgetPeriod.YEARLY -> alignedMonthPeriod(startDate, referenceDate, MONTHS_PER_YEAR)
         }
+    }
+
+    /**
+     * A fixed-length day window (7 or 14 days) anchored at [startDate]. Uses
+     * floor division so reference dates before [startDate] bucket into the
+     * correct earlier period rather than truncating toward zero.
+     */
+    private fun alignedDayPeriod(
+        startDate: LocalDate,
+        referenceDate: LocalDate,
+        lengthDays: Int,
+    ): DatePeriod {
+        val daysSinceStart = startDate.daysUntil(referenceDate)
+        val periodIndex = floorDiv(daysSinceStart, lengthDays)
+        val periodStart = startDate.plus(periodIndex * lengthDays, DateTimeUnit.DAY)
+        return DatePeriod(periodStart, periodStart.plus(lengthDays - 1, DateTimeUnit.DAY))
+    }
+
+    /**
+     * A month-based window anchored at [startDate], where [monthsPerPeriod] is 1
+     * (monthly), 3 (quarterly) or 12 (yearly). The window preserves the
+     * [startDate] day-of-month; each period boundary is computed by adding whole
+     * months to [startDate] (never by compounding) to avoid drift across short
+     * months.
+     */
+    private fun alignedMonthPeriod(
+        startDate: LocalDate,
+        referenceDate: LocalDate,
+        monthsPerPeriod: Int,
+    ): DatePeriod {
+        val totalMonths = startDate.monthsUntil(referenceDate)
+        var index = floorDiv(totalMonths, monthsPerPeriod)
+        var start = startDate.plus(index * monthsPerPeriod, DateTimeUnit.MONTH)
+        // monthsUntil truncates by day-of-month, so correct the bucket until
+        // referenceDate lies within [start, nextStart).
+        while (referenceDate < start) {
+            index -= 1
+            start = startDate.plus(index * monthsPerPeriod, DateTimeUnit.MONTH)
+        }
+        var nextStart = startDate.plus((index + 1) * monthsPerPeriod, DateTimeUnit.MONTH)
+        while (referenceDate >= nextStart) {
+            index += 1
+            start = nextStart
+            nextStart = startDate.plus((index + 1) * monthsPerPeriod, DateTimeUnit.MONTH)
+        }
+        return DatePeriod(start, nextStart.minus(1, DateTimeUnit.DAY))
     }
 
     /**
@@ -156,6 +249,14 @@ object BudgetCalculator {
     /** Number of days in a biweekly budget period. */
     private const val BIWEEKLY_DAYS = 14
 
+    /** Number of days in a weekly budget period. */
+    private const val DAYS_PER_WEEK = 7
+
+    /** Months per monthly / quarterly / yearly period, used to anchor on startDate. */
+    private const val MONTHS_PER_MONTH = 1
+    private const val MONTHS_PER_QUARTER = 3
+    private const val MONTHS_PER_YEAR = 12
+
     /**
      * Integer floor division (rounds toward negative infinity), unlike Kotlin's
      * `/` which truncates toward zero. Ensures negative day offsets bucket into
@@ -185,6 +286,11 @@ data class DatePeriod(
 
 /**
  * Current status of a budget for its active period.
+ *
+ * @property isWithinBudgetDates Whether the evaluated reference date fell inside
+ *   the budget's `[startDate, endDate]` window. `false` means the status is for
+ *   a date outside the budget's life (e.g. after its `endDate`) and is reported
+ *   for reference only (#3632).
  */
 data class BudgetStatus(
     val budget: Budget,
@@ -194,13 +300,19 @@ data class BudgetStatus(
     /** Fraction of budget spent (0.0 to unbounded). >1.0 means over budget. */
     val utilization: Double,
     val isOverBudget: Boolean,
+    val isWithinBudgetDates: Boolean = true,
 ) {
-    /** Health level: HEALTHY (< 75%), WARNING (75-100%), OVER (> 100%) */
-    val healthLevel: BudgetHealth get() = when {
-        utilization > 1.0 -> BudgetHealth.OVER
-        utilization > 0.75 -> BudgetHealth.WARNING
-        else -> BudgetHealth.HEALTHY
-    }
+    /**
+     * Health level using the default thresholds (WARNING > 75%, OVER > 100%).
+     * For custom sensitivity use [healthLevel] with explicit [BudgetThresholds].
+     */
+    val healthLevel: BudgetHealth get() = BudgetThresholds.DEFAULT.classify(utilization)
+
+    /**
+     * Health level classified against caller-supplied [thresholds] (#3678).
+     * Passing [BudgetThresholds.DEFAULT] is identical to the [healthLevel] property.
+     */
+    fun healthLevel(thresholds: BudgetThresholds): BudgetHealth = thresholds.classify(utilization)
 }
 
 enum class BudgetHealth { HEALTHY, WARNING, OVER }

--- a/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetMemberBreakdown.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetMemberBreakdown.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.models.Budget
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+
+/**
+ * Per-member spend attribution for a shared/household budget within a single
+ * period (#3690).
+ *
+ * Produced by [BudgetCalculator.calculateMemberBreakdown]. The sum of
+ * [byMember] values always equals [totalSpent], which in turn reconciles with
+ * [BudgetStatus.spent] for the same budget, transactions and reference date.
+ *
+ * @property budget The budget the breakdown was computed for.
+ * @property period The period boundaries the spend was attributed within.
+ * @property totalSpent Total qualifying expense across all members (in cents).
+ * @property byMember Spend per member `ownerId`, in insertion order. Members
+ *   with no qualifying spend in the period are omitted — use [spendFor] to read
+ *   a defaulted zero for any owner.
+ */
+data class BudgetMemberBreakdown(
+    val budget: Budget,
+    val period: DatePeriod,
+    val totalSpent: Cents,
+    val byMember: Map<SyncId, Cents>,
+) {
+    /** Spend attributed to [ownerId], or [Cents.ZERO] when the member has none. */
+    fun spendFor(ownerId: SyncId): Cents = byMember[ownerId] ?: Cents.ZERO
+
+    /** The `ownerId`s that contributed any spend to this budget in the period. */
+    val members: Set<SyncId> get() = byMember.keys
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetRolloverCalculator.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetRolloverCalculator.kt
@@ -90,8 +90,18 @@ object BudgetRolloverCalculator {
     }
 
     /**
-     * Compute the effective budget for [referenceDate], incorporating any rollover
-     * from the immediately preceding period.
+     * Compute the effective budget for [referenceDate] from **only the
+     * immediately preceding period** (#3653).
+     *
+     * ## Scope — single-period only
+     * This function looks back exactly one period and recomputes that period's
+     * rollover as `base - previousSpent`; it deliberately assumes the previous
+     * period itself carried **no** inherited rollover. It is therefore correct
+     * only for a budget that is at most one period old, or for callers that only
+     * track a single prior period. For a budget that has been rolling over for
+     * several periods, rollover compounds — use [effectiveBudgetCumulative] (or
+     * [calculateCumulativeRollover]) instead, which chains carry across every
+     * prior period. For a budget exactly one period old the two agree.
      *
      * If [Budget.isRollover] is `false`, the effective amount equals the base amount.
      *
@@ -99,6 +109,8 @@ object BudgetRolloverCalculator {
      * @param currentPeriodTransactions Transactions in the *current* period (used for status only, not rollover).
      * @param previousPeriodTransactions Transactions in the *previous* period (used to compute rollover).
      * @param referenceDate The date for which the effective budget is evaluated.
+     * @param policy How to bound the carry-forward (#3649). Defaults to
+     *   [RolloverPolicy.UNLIMITED], preserving the historical behaviour.
      * @return An [EffectiveBudget] with the base, rollover, and effective amounts.
      */
     fun calculateEffectiveBudget(
@@ -106,6 +118,7 @@ object BudgetRolloverCalculator {
         @Suppress("unused") currentPeriodTransactions: List<Transaction>,
         previousPeriodTransactions: List<Transaction>,
         referenceDate: LocalDate,
+        policy: RolloverPolicy = RolloverPolicy.UNLIMITED,
     ): EffectiveBudget {
         val currentPeriod = BudgetCalculator.getCurrentPeriod(budget.period, budget.startDate, referenceDate)
 
@@ -122,7 +135,7 @@ object BudgetRolloverCalculator {
         val previousPeriodDate = currentPeriod.start.minus(1, DateTimeUnit.DAY)
         val previousPeriod = BudgetCalculator.getCurrentPeriod(budget.period, budget.startDate, previousPeriodDate)
         val previousSpent = sumExpenses(previousPeriodTransactions, previousPeriod)
-        val rolloverCarry = budget.amount - previousSpent
+        val rolloverCarry = policy.apply(budget.amount - previousSpent, budget.amount)
         val effectiveAmount = budget.amount + rolloverCarry
 
         return EffectiveBudget(
@@ -135,20 +148,58 @@ object BudgetRolloverCalculator {
     }
 
     /**
+     * Compute the effective budget for [referenceDate] by **chaining** rollover
+     * across every prior period (#3653) — the correct entry point for budgets
+     * older than one period.
+     *
+     * This is the cumulative counterpart to [calculateEffectiveBudget]; its
+     * [EffectiveBudget.rolloverCarry] equals [calculateCumulativeRollover] for
+     * the same inputs. For a budget exactly one period old, it agrees with
+     * [calculateEffectiveBudget].
+     *
+     * @param budget The budget definition.
+     * @param transactionsByPeriod Map of period start dates to that period's transactions.
+     * @param referenceDate The date for which the effective budget is evaluated.
+     * @param policy How to bound each period's carry (#3649). Defaults to [RolloverPolicy.UNLIMITED].
+     */
+    fun effectiveBudgetCumulative(
+        budget: Budget,
+        transactionsByPeriod: Map<LocalDate, List<Transaction>>,
+        referenceDate: LocalDate,
+        policy: RolloverPolicy = RolloverPolicy.UNLIMITED,
+    ): EffectiveBudget {
+        val currentPeriod = BudgetCalculator.getCurrentPeriod(budget.period, budget.startDate, referenceDate)
+        val carry = calculateCumulativeRollover(budget, transactionsByPeriod, referenceDate, policy)
+        return EffectiveBudget(
+            budget = budget,
+            period = currentPeriod,
+            baseAmount = budget.amount,
+            rolloverCarry = carry,
+            effectiveAmount = budget.amount + carry,
+        )
+    }
+
+    /**
      * Calculate the effective budget by chaining rollover across multiple consecutive periods.
      *
      * This is useful when an audit trail is needed for several periods. The rollover
      * accumulates: period 1 surplus -> period 2 effective, period 2 surplus -> period 3 effective, etc.
      *
+     * Rollover chaining never extends past [Budget.endDate]: periods that begin
+     * after the budget has ended contribute no carry (#3632).
+     *
      * @param budget The budget definition.
      * @param transactionsByPeriod Map of period start dates to the transactions in that period.
      * @param referenceDate The target date whose effective budget is returned.
+     * @param policy How to bound each period's carry before it compounds into the
+     *   next (#3649). Defaults to [RolloverPolicy.UNLIMITED].
      * @return The cumulative rollover amount to apply to the period containing [referenceDate].
      */
     fun calculateCumulativeRollover(
         budget: Budget,
         transactionsByPeriod: Map<LocalDate, List<Transaction>>,
         referenceDate: LocalDate,
+        policy: RolloverPolicy = RolloverPolicy.UNLIMITED,
     ): Cents {
         if (!budget.isRollover) return Cents.ZERO
 
@@ -162,7 +213,7 @@ object BudgetRolloverCalculator {
             val txns = transactionsByPeriod[period.start] ?: emptyList()
             val spent = sumExpenses(txns, period)
             val effectiveForPeriod = budget.amount + cumulativeRollover
-            cumulativeRollover = effectiveForPeriod - spent
+            cumulativeRollover = policy.apply(effectiveForPeriod - spent, budget.amount)
         }
         return cumulativeRollover
     }
@@ -199,6 +250,10 @@ object BudgetRolloverCalculator {
     /**
      * Build a chain of consecutive periods from the budget start up to (but not including)
      * [currentPeriod]. Used for cumulative rollover computation.
+     *
+     * The walk stops at [Budget.endDate]: a period whose start falls after the
+     * budget has ended does not contribute rollover (#3632). An open-ended budget
+     * ([Budget.endDate] == `null`) is unaffected.
      */
     @Suppress("LoopWithTooManyJumpStatements")
     private fun buildPeriodChain(budget: Budget, currentPeriod: DatePeriod): List<DatePeriod> {
@@ -208,8 +263,10 @@ object BudgetRolloverCalculator {
         // Safety limit to prevent runaway iteration.
         val maxIterations = 1_000
         var iterations = 0
+        val endDate = budget.endDate
 
         while (period.start < currentPeriod.start && iterations < maxIterations) {
+            if (endDate != null && period.start > endDate) break
             chain.add(period)
             val nextStart = period.end.plus(1, DateTimeUnit.DAY)
             period = BudgetCalculator.getCurrentPeriod(budget.period, budget.startDate, nextStart)

--- a/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetTemplate.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetTemplate.kt
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.core.money.MoneyOperations
+import com.finance.models.types.Cents
+
+/**
+ * A single named allocation within a [BudgetTemplate] (#3684).
+ *
+ * @property name Human-readable name for the allocation (e.g. "Needs").
+ * @property ratio Relative weight used to split income across allocations.
+ *   Must be positive. Absolute percentages are expressed as weights too
+ *   (e.g. 50/30/20).
+ */
+data class BudgetAllocation(
+    val name: String,
+    val ratio: Int,
+) {
+    init {
+        require(name.isNotBlank()) { "Allocation name cannot be blank" }
+        require(ratio > 0) { "Allocation ratio must be positive, was $ratio" }
+    }
+}
+
+/**
+ * A proposed budget amount produced by applying a [BudgetTemplate] to an income
+ * figure (#3684).
+ *
+ * @property name The allocation name this amount corresponds to.
+ * @property amount The proposed budget amount in [Cents].
+ */
+data class BudgetProposal(
+    val name: String,
+    val amount: Cents,
+)
+
+/**
+ * A reusable budget template describing how to split an income figure into named
+ * allocations by ratio (#3684).
+ *
+ * Applying a template ([applyTemplate]) uses [MoneyOperations.allocateByRatio],
+ * so the proposed amounts always sum **exactly** to the input income — no cents
+ * are lost or created, and any indivisible remainder is distributed
+ * deterministically to the largest-weight allocations first.
+ *
+ * @property name Template name (e.g. "50/30/20").
+ * @property allocations Ordered allocations; must be non-empty.
+ */
+data class BudgetTemplate(
+    val name: String,
+    val allocations: List<BudgetAllocation>,
+) {
+    init {
+        require(name.isNotBlank()) { "Template name cannot be blank" }
+        require(allocations.isNotEmpty()) { "Template must have at least one allocation" }
+    }
+
+    /**
+     * Split [income] across this template's [allocations] by ratio.
+     *
+     * @param income The income to allocate; must be positive.
+     * @return One [BudgetProposal] per allocation, in the same order as
+     *   [allocations]. The proposed [BudgetProposal.amount]s sum exactly to
+     *   [income].
+     * @throws IllegalArgumentException if [income] is not positive.
+     */
+    fun applyTemplate(income: Cents): List<BudgetProposal> {
+        require(income.isPositive()) { "Income must be positive to apply a template, was ${income.amount}" }
+        val amounts = MoneyOperations.allocateByRatio(income, allocations.map { it.ratio })
+        return allocations.mapIndexed { index, allocation ->
+            BudgetProposal(name = allocation.name, amount = amounts[index])
+        }
+    }
+
+    companion object {
+        /**
+         * The classic 50/30/20 rule: 50% needs, 30% wants, 20% savings/debt.
+         */
+        val FIFTY_THIRTY_TWENTY = BudgetTemplate(
+            name = "50/30/20",
+            allocations = listOf(
+                BudgetAllocation(name = "Needs", ratio = 50),
+                BudgetAllocation(name = "Wants", ratio = 30),
+                BudgetAllocation(name = "Savings", ratio = 20),
+            ),
+        )
+
+        /**
+         * Build a **zero-based** template from explicit named weights, where every
+         * dollar of income is assigned to a category (the allocations sum to the
+         * whole income by construction). Order is preserved.
+         *
+         * @param allocations Ordered (name, weight) pairs; must be non-empty and
+         *   every weight must be positive.
+         * @param name Optional template name.
+         * @throws IllegalArgumentException if [allocations] is empty.
+         */
+        fun zeroBased(
+            allocations: List<Pair<String, Int>>,
+            name: String = "Zero-based",
+        ): BudgetTemplate {
+            require(allocations.isNotEmpty()) { "Zero-based template needs at least one allocation" }
+            return BudgetTemplate(
+                name = name,
+                allocations = allocations.map { (label, weight) -> BudgetAllocation(label, weight) },
+            )
+        }
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetThresholds.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetThresholds.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+/**
+ * Configurable utilization thresholds for classifying [BudgetHealth] (#3678).
+ *
+ * Utilization is the fraction of the budget spent (`spent / amount`), where
+ * `1.0` means exactly at the limit. A budget is classified as:
+ *  - [BudgetHealth.OVER] when utilization is strictly greater than [over];
+ *  - [BudgetHealth.WARNING] when utilization is strictly greater than [warning]
+ *    (but not over);
+ *  - [BudgetHealth.HEALTHY] otherwise.
+ *
+ * Different categories warrant different sensitivity — e.g. warn at 90% for
+ * rent but 50% for discretionary spend. The [DEFAULT] preserves the historical
+ * behaviour (warn above 75%, over above 100%) exactly.
+ *
+ * @property warning Fraction above which the budget is a warning. Must be in
+ *   `0.0..1.0` and strictly less than [over].
+ * @property over Fraction above which the budget is over. Must be in `0.0..1.0`.
+ *   Defaults to `1.0` (the budget amount itself).
+ */
+data class BudgetThresholds(
+    val warning: Double,
+    val over: Double = DEFAULT_OVER,
+) {
+    init {
+        require(warning in 0.0..1.0) { "warning threshold must be within 0.0..1.0, was $warning" }
+        require(over in 0.0..1.0) { "over threshold must be within 0.0..1.0, was $over" }
+        require(warning < over) { "warning ($warning) must be strictly less than over ($over)" }
+    }
+
+    /**
+     * Classify [utilization] against these thresholds. Boundaries are exclusive:
+     * a utilization exactly equal to [warning] or [over] does not cross into the
+     * higher band (matching the original `> 0.75` / `> 1.0` semantics).
+     */
+    fun classify(utilization: Double): BudgetHealth = when {
+        utilization > over -> BudgetHealth.OVER
+        utilization > warning -> BudgetHealth.WARNING
+        else -> BudgetHealth.HEALTHY
+    }
+
+    companion object {
+        /** Default warning band: 75% of the budget. */
+        const val DEFAULT_WARNING = 0.75
+
+        /** Default over band: 100% of the budget. */
+        const val DEFAULT_OVER = 1.0
+
+        /** The historical default thresholds (warn above 75%, over above 100%). */
+        val DEFAULT = BudgetThresholds(DEFAULT_WARNING, DEFAULT_OVER)
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/budget/CategoryBudgetRollup.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/budget/CategoryBudgetRollup.kt
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.models.Budget
+import com.finance.models.Category
+import com.finance.models.Transaction
+import com.finance.models.TransactionType
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.datetime.LocalDate
+
+/**
+ * Hierarchical (category-group) budget rollup (#3662).
+ *
+ * `Category` models a tree via [Category.parentId]. A budget defined on a parent
+ * category (e.g. "Food") should account for spend categorised against any of its
+ * descendants ("Groceries", "Restaurants"). These helpers resolve the descendant
+ * set (cycle-safe) and sum spend across the whole group.
+ *
+ * All money math stays in [Cents]; no floating point is used for spend totals.
+ */
+object CategoryBudgetRollup {
+
+    /**
+     * Resolve the set of category ids in the subtree rooted at [rootId] —
+     * including [rootId] itself — following [Category.parentId] links.
+     *
+     * Guards against cycles in the parent references: each category is visited
+     * at most once, so a malformed tree (A→B→A) terminates instead of looping
+     * forever. Soft-deleted categories are excluded from the resolved set.
+     *
+     * @param rootId The budget category whose group is being resolved.
+     * @param categories All known categories (any household/order).
+     * @return The [rootId] plus every non-deleted descendant id.
+     */
+    fun resolveCategoryGroup(rootId: SyncId, categories: List<Category>): Set<SyncId> {
+        val childrenByParent = HashMap<SyncId, MutableList<SyncId>>()
+        for (category in categories) {
+            val parent = category.parentId
+            if (parent == null || category.deletedAt != null) continue
+            childrenByParent.getOrPut(parent) { mutableListOf() }.add(category.id)
+        }
+
+        val resolved = LinkedHashSet<SyncId>()
+        val stack = ArrayDeque<SyncId>()
+        stack.addLast(rootId)
+        while (stack.isNotEmpty()) {
+            val current = stack.removeLast()
+            // `add` returns false when already present → prevents cyclic re-visits.
+            if (!resolved.add(current)) continue
+            childrenByParent[current]?.forEach { stack.addLast(it) }
+        }
+        return resolved
+    }
+
+    /**
+     * Calculate a [BudgetStatus] whose spend rolls up across the budget's
+     * category and all of its descendants (#3662).
+     *
+     * Uses the same currency / date-window / soft-delete / expense-only filters
+     * as [BudgetCalculator.calculateStatus], but matches any transaction whose
+     * `categoryId` is in the resolved [resolveCategoryGroup] set instead of the
+     * single budget category. When the budget category has no children the
+     * result is equivalent to [BudgetCalculator.calculateStatus].
+     */
+    fun calculateGroupStatus(
+        budget: Budget,
+        categories: List<Category>,
+        transactions: List<Transaction>,
+        referenceDate: LocalDate,
+    ): BudgetStatus {
+        val period = BudgetCalculator.getCurrentPeriod(budget.period, budget.startDate, referenceDate)
+        val groupIds = resolveCategoryGroup(budget.categoryId, categories)
+
+        val spentAmount = transactions
+            .filter { txn ->
+                txn.categoryId in groupIds &&
+                    txn.currency == budget.currency &&
+                    txn.date >= period.start && txn.date <= period.end &&
+                    txn.deletedAt == null &&
+                    txn.type == TransactionType.EXPENSE
+            }
+            .sumOf { it.amount.abs().amount }
+
+        val spent = Cents(spentAmount)
+        val remaining = budget.amount - spent
+        val utilization = if (budget.amount.amount > 0) {
+            (spent.amount.toDouble() / budget.amount.amount).coerceIn(0.0, Double.MAX_VALUE)
+        } else 0.0
+
+        return BudgetStatus(
+            budget = budget,
+            period = period,
+            spent = spent,
+            remaining = remaining,
+            utilization = utilization,
+            isOverBudget = spent.amount > budget.amount.amount,
+            isWithinBudgetDates = BudgetCalculator.isActiveOn(budget, referenceDate),
+        )
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/budget/Envelope.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/budget/Envelope.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.serialization.Serializable
+
+/**
+ * A persistent-balance "envelope" for YNAB-style envelope budgeting (#3658).
+ *
+ * Unlike a calendar-reset [com.finance.models.Budget], an envelope is a running
+ * balance that persists across periods: you explicitly *fund* it (allocate money
+ * in) and *spend* from it, and there is no automatic per-period reset. The
+ * [balance] can go negative when overspent and must be covered from another
+ * envelope via [EnvelopeOperations.transfer].
+ *
+ * This is an **additive alternative** to period budgets — it does not replace
+ * [BudgetCalculator]/[BudgetRolloverCalculator]. All arithmetic is exact
+ * integer [Cents]; no floating point is involved.
+ *
+ * @property id Stable identifier for the envelope.
+ * @property name Human-readable envelope name.
+ * @property funded Total money allocated into the envelope over its lifetime.
+ * @property spent Total money spent from the envelope over its lifetime.
+ */
+@Serializable
+data class Envelope(
+    val id: SyncId,
+    val name: String,
+    val funded: Cents = Cents.ZERO,
+    val spent: Cents = Cents.ZERO,
+) {
+    init {
+        require(name.isNotBlank()) { "Envelope name cannot be blank" }
+    }
+
+    /** The current balance: [funded] minus [spent]. Negative when overspent. */
+    val balance: Cents get() = funded - spent
+
+    /** Whether the envelope is overspent (its [balance] is negative). */
+    val isOverspent: Boolean get() = balance.isNegative()
+}
+
+/**
+ * Pure, deterministic operations over [Envelope] balances (#3658).
+ *
+ * Every function returns a new [Envelope] (or pair) — inputs are never mutated —
+ * and all math stays in integer [Cents].
+ */
+object EnvelopeOperations {
+
+    /**
+     * Allocate [amount] of new money into [envelope], increasing its [Envelope.funded].
+     *
+     * @throws IllegalArgumentException if [amount] is not positive.
+     */
+    fun fund(envelope: Envelope, amount: Cents): Envelope {
+        require(amount.isPositive()) { "Funding amount must be positive, was ${amount.amount}" }
+        return envelope.copy(funded = envelope.funded + amount)
+    }
+
+    /**
+     * Record a spend of [amount] from [envelope], increasing its [Envelope.spent].
+     *
+     * Spending is permitted even when it drives the [Envelope.balance] negative
+     * (an overspend to be covered later); the resulting balance simply reflects
+     * the shortfall.
+     *
+     * @throws IllegalArgumentException if [amount] is not positive.
+     */
+    fun spend(envelope: Envelope, amount: Cents): Envelope {
+        require(amount.isPositive()) { "Spend amount must be positive, was ${amount.amount}" }
+        return envelope.copy(spent = envelope.spent + amount)
+    }
+
+    /**
+     * Move [amount] of funding from [from] to [to] — e.g. to cover an overspent
+     * envelope. Decreases the source's [Envelope.funded] and increases the
+     * destination's by the same amount, so total funded across the pair is
+     * conserved.
+     *
+     * @return the updated `(from, to)` pair, in that order.
+     * @throws IllegalArgumentException if [amount] is not positive or if [from]
+     *   and [to] are the same envelope.
+     */
+    fun transfer(from: Envelope, to: Envelope, amount: Cents): Pair<Envelope, Envelope> {
+        require(amount.isPositive()) { "Transfer amount must be positive, was ${amount.amount}" }
+        require(from.id != to.id) { "Cannot transfer an envelope to itself" }
+        return from.copy(funded = from.funded - amount) to to.copy(funded = to.funded + amount)
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/budget/RolloverPolicy.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/budget/RolloverPolicy.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.models.types.Cents
+
+/**
+ * Policy for bounding budget rollover carry-forward (#3649).
+ *
+ * A single unbounded formula is a poor fit for real envelope/rollover systems: a
+ * catastrophic overspend would suppress the next period's budget indefinitely,
+ * and an untouched budget would accumulate surplus without limit. This policy
+ * lets callers choose how each period's carry is clamped before it is applied to
+ * the next period.
+ *
+ * The [UNLIMITED] default preserves the historical behaviour exactly.
+ */
+enum class RolloverPolicy {
+    /** No bounding — carry forward the full surplus or deficit (historical default). */
+    UNLIMITED,
+
+    /** Floor negative carry at zero so one bad period never buries the next; surplus is unbounded. */
+    RESET_NEGATIVE,
+
+    /** Clamp carry to `[-base, +base]` — at most one period's worth of surplus or deficit carries. */
+    CAP_AT_BASE,
+    ;
+
+    /**
+     * Apply this policy to a raw [carry] given the period's [base] budget amount.
+     *
+     * @param carry The unbounded carry (`effective - spent`) for a period.
+     * @param base The budget's base amount for the period; used as the cap
+     *   magnitude for [CAP_AT_BASE]. Assumed non-negative (budget amounts are
+     *   validated positive).
+     */
+    fun apply(carry: Cents, base: Cents): Cents = when (this) {
+        UNLIMITED -> carry
+        RESET_NEGATIVE -> if (carry.isNegative()) Cents.ZERO else carry
+        CAP_AT_BASE -> Cents(carry.amount.coerceIn(-base.amount, base.amount))
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/goals/GoalTrackingEngine.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/goals/GoalTrackingEngine.kt
@@ -330,12 +330,51 @@ object GoalTrackingEngine {
         }
     }
 
-    // ── private helpers ──────────────────────────────────────────────
+    // ── #3689: required per-period contribution to hit a goal on time ─
+
+    /**
+     * The amount that must be contributed every [period], starting from [from],
+     * to reach the goal's `targetAmount` by its `targetDate` (#3689).
+     *
+     * Uses **ceiling** division in integer [Cents] so that applying the returned
+     * amount each whole period always reaches or exceeds the remaining amount by
+     * the deadline — the schedule never falls short. When fewer than one whole
+     * period remains before the (future) deadline, the entire remaining amount is
+     * required in a single contribution.
+     *
+     * @param goal The goal to fund.
+     * @param period The contribution cadence.
+     * @param from The date the contribution schedule starts.
+     * @return The per-period amount, or [Cents.ZERO] when the goal is already met.
+     * @throws IllegalArgumentException if the goal has no `targetDate`, or the
+     *   `targetDate` is on or before [from] (i.e. not in the future).
+     */
+    fun requiredContribution(goal: Goal, period: ContributionPeriod, from: LocalDate): Cents {
+        val remaining = remainingAmount(goal)
+        if (remaining.isZero()) return Cents.ZERO
+
+        val deadline = goal.targetDate
+        requireNotNull(deadline) { "Goal ${goal.id.value} has no target date" }
+        require(deadline > from) {
+            "Goal target date $deadline is not in the future relative to $from"
+        }
+
+        // A future deadline with < 1 whole period left still needs the full amount now.
+        val periods = wholePeriodsBetween(from, deadline, period).coerceAtLeast(1)
+        return Cents(ceilDiv(remaining.amount, periods.toLong()))
+    }
 
     private fun permilleForAmount(current: Long, target: Long): Int {
         if (target <= 0L) return 0
         val clamped = current.coerceAtLeast(0L)
         return if (clamped >= target) MAX_PERMILLE else ((clamped * PERMILLE_BASIS) / target).toInt()
+    }
+
+    /** Ceiling division for non-negative integers: the smallest `q` with `q * divisor >= numerator`. */
+    private fun ceilDiv(numerator: Long, divisor: Long): Long {
+        require(divisor > 0L) { "divisor must be positive" }
+        if (numerator <= 0L) return 0L
+        return (numerator + divisor - 1L) / divisor
     }
 
     private fun reachedMilestones(amount: Long, target: Long): Set<GoalMilestone> {

--- a/packages/core/src/commonTest/kotlin/com/finance/core/BudgetUtilizationTrackingTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/BudgetUtilizationTrackingTest.kt
@@ -295,14 +295,16 @@ class BudgetUtilizationTrackingTest {
 
     @Test
     fun weeklyPeriodBoundaries() {
-        // June 15, 2024 is a Saturday; week starts Monday June 10
+        // #3595: weekly periods anchor on the budget startDate (Sat June 1, 2024),
+        // not the calendar Monday. June 15 is exactly two 7-day periods later,
+        // so the active week is June 15-21.
         val period = BudgetCalculator.getCurrentPeriod(
             BudgetPeriod.WEEKLY,
             LocalDate(2024, 6, 1),
             LocalDate(2024, 6, 15),
         )
-        assertEquals(LocalDate(2024, 6, 10), period.start)
-        assertEquals(LocalDate(2024, 6, 16), period.end)
+        assertEquals(LocalDate(2024, 6, 15), period.start)
+        assertEquals(LocalDate(2024, 6, 21), period.end)
         assertEquals(7, period.daysTotal)
     }
 

--- a/packages/core/src/commonTest/kotlin/com/finance/core/TestFixtures.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/TestFixtures.kt
@@ -99,6 +99,8 @@ object TestFixtures {
         date: LocalDate = fixedDate,
         categoryId: SyncId? = SyncId("category-1"),
         accountId: SyncId = SyncId("account-1"),
+        ownerId: SyncId = SyncId("owner-1"),
+        currency: Currency = Currency.USD,
         status: TransactionStatus = TransactionStatus.CLEARED,
         deletedAt: Instant? = null,
     ): Transaction = createTransaction(
@@ -107,6 +109,8 @@ object TestFixtures {
         date = date,
         categoryId = categoryId,
         accountId = accountId,
+        ownerId = ownerId,
+        currency = currency,
         status = status,
         deletedAt = deletedAt,
     )
@@ -141,6 +145,7 @@ object TestFixtures {
         currency: Currency = Currency.USD,
         period: BudgetPeriod = BudgetPeriod.MONTHLY,
         startDate: LocalDate = LocalDate(2024, 6, 1),
+        endDate: LocalDate? = null,
         isRollover: Boolean = false,
         createdAt: Instant = fixedInstant,
         updatedAt: Instant = fixedInstant,
@@ -154,9 +159,35 @@ object TestFixtures {
         currency = currency,
         period = period,
         startDate = startDate,
+        endDate = endDate,
         isRollover = isRollover,
         createdAt = createdAt,
         updatedAt = updatedAt,
+    )
+
+    // ── Category Factory ─────────────────────────────────────────────
+
+    @Suppress("LongParameterList")
+    fun createCategory(
+        id: SyncId = nextId(),
+        householdId: SyncId = SyncId("household-1"),
+        ownerId: SyncId = SyncId("owner-1"),
+        name: String = "Test Category",
+        parentId: SyncId? = null,
+        isIncome: Boolean = false,
+        createdAt: Instant = fixedInstant,
+        updatedAt: Instant = fixedInstant,
+        deletedAt: Instant? = null,
+    ): Category = Category(
+        id = id,
+        householdId = householdId,
+        ownerId = ownerId,
+        name = name,
+        parentId = parentId,
+        isIncome = isIncome,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        deletedAt = deletedAt,
     )
 
     // ── Goal Factory ─────────────────────────────────────────────────

--- a/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetEndDateTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetEndDateTest.kt
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.core.TestFixtures
+import com.finance.models.BudgetPeriod
+import com.finance.models.types.Cents
+import kotlinx.datetime.LocalDate
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for #3632 — budget `endDate` must be honoured: status flags a
+ * date outside the window and rollover chaining stops at `endDate`.
+ */
+class BudgetEndDateTest {
+
+    @BeforeTest
+    fun setup() {
+        TestFixtures.reset()
+    }
+
+    // ── isActiveOn / isWithinBudgetDates ───────────────────────────────
+
+    @Test
+    fun isActiveOn_withinWindow_true() {
+        val budget = TestFixtures.createBudget(
+            startDate = LocalDate(2024, 1, 1),
+            endDate = LocalDate(2024, 12, 31),
+        )
+        assertTrue(BudgetCalculator.isActiveOn(budget, LocalDate(2024, 6, 15)))
+        assertTrue(BudgetCalculator.isActiveOn(budget, LocalDate(2024, 1, 1)))
+        assertTrue(BudgetCalculator.isActiveOn(budget, LocalDate(2024, 12, 31)))
+    }
+
+    @Test
+    fun isActiveOn_afterEndDate_false() {
+        val budget = TestFixtures.createBudget(
+            startDate = LocalDate(2024, 1, 1),
+            endDate = LocalDate(2024, 6, 30),
+        )
+        assertFalse(BudgetCalculator.isActiveOn(budget, LocalDate(2024, 7, 1)))
+    }
+
+    @Test
+    fun isActiveOn_beforeStartDate_false() {
+        val budget = TestFixtures.createBudget(startDate = LocalDate(2024, 6, 1))
+        assertFalse(BudgetCalculator.isActiveOn(budget, LocalDate(2024, 5, 31)))
+    }
+
+    @Test
+    fun isActiveOn_nullEndDate_openEnded() {
+        val budget = TestFixtures.createBudget(
+            startDate = LocalDate(2024, 1, 1),
+            endDate = null,
+        )
+        assertTrue(BudgetCalculator.isActiveOn(budget, LocalDate(2030, 1, 1)))
+    }
+
+    @Test
+    fun calculateStatus_afterEndDate_flaggedInactive() {
+        val budget = TestFixtures.createBudget(
+            amount = Cents(50000),
+            period = BudgetPeriod.MONTHLY,
+            startDate = LocalDate(2024, 1, 1),
+            endDate = LocalDate(2024, 6, 30),
+        )
+        val status = BudgetCalculator.calculateStatus(budget, emptyList(), LocalDate(2024, 9, 15))
+        assertFalse(status.isWithinBudgetDates, "reference date after endDate is not active")
+    }
+
+    @Test
+    fun calculateStatus_withinWindow_active() {
+        val budget = TestFixtures.createBudget(
+            startDate = LocalDate(2024, 1, 1),
+            endDate = LocalDate(2024, 12, 31),
+        )
+        val status = BudgetCalculator.calculateStatus(budget, emptyList(), LocalDate(2024, 6, 15))
+        assertTrue(status.isWithinBudgetDates)
+    }
+
+    @Test
+    fun calculateStatus_nullEndDate_alwaysActive() {
+        val budget = TestFixtures.createBudget(startDate = LocalDate(2024, 1, 1))
+        val status = BudgetCalculator.calculateStatus(budget, emptyList(), LocalDate(2027, 3, 3))
+        assertTrue(status.isWithinBudgetDates)
+    }
+
+    // ── Rollover chaining stops at endDate ─────────────────────────────
+
+    @Test
+    fun cumulativeRollover_doesNotExtendPastEndDate() {
+        // Budget ends Feb 29; only Jan and Feb should contribute. A big surplus
+        // is provided for a period after endDate which must be ignored.
+        val budget = TestFixtures.createBudget(
+            amount = Cents(50000), // $500/month
+            period = BudgetPeriod.MONTHLY,
+            startDate = LocalDate(2024, 1, 1),
+            endDate = LocalDate(2024, 2, 29),
+            isRollover = true,
+        )
+        val transactionsByPeriod = mapOf(
+            LocalDate(2024, 1, 1) to listOf(
+                TestFixtures.createExpense(amount = Cents(40000), date = LocalDate(2024, 1, 15)),
+            ),
+            LocalDate(2024, 2, 1) to listOf(
+                TestFixtures.createExpense(amount = Cents(30000), date = LocalDate(2024, 2, 15)),
+            ),
+            // This period is entirely after endDate and must NOT be chained.
+            LocalDate(2024, 3, 1) to listOf(
+                TestFixtures.createExpense(amount = Cents(10000), date = LocalDate(2024, 3, 15)),
+            ),
+        )
+
+        // Only Jan (+$100) and Feb (eff $600 - $300 = +$300) count → $300 into a later ref.
+        val cumulative = BudgetRolloverCalculator.calculateCumulativeRollover(
+            budget = budget,
+            transactionsByPeriod = transactionsByPeriod,
+            referenceDate = LocalDate(2024, 6, 15),
+        )
+        assertEquals(Cents(30000), cumulative, "periods after endDate are excluded from chaining")
+    }
+
+    @Test
+    fun cumulativeRollover_openEnded_chainsNormally() {
+        val budget = TestFixtures.createBudget(
+            amount = Cents(50000),
+            period = BudgetPeriod.MONTHLY,
+            startDate = LocalDate(2024, 1, 1),
+            endDate = null,
+            isRollover = true,
+        )
+        val transactionsByPeriod = mapOf(
+            LocalDate(2024, 1, 1) to listOf(
+                TestFixtures.createExpense(amount = Cents(40000), date = LocalDate(2024, 1, 15)),
+            ),
+            LocalDate(2024, 2, 1) to listOf(
+                TestFixtures.createExpense(amount = Cents(30000), date = LocalDate(2024, 2, 15)),
+            ),
+        )
+        val cumulative = BudgetRolloverCalculator.calculateCumulativeRollover(
+            budget = budget,
+            transactionsByPeriod = transactionsByPeriod,
+            referenceDate = LocalDate(2024, 3, 15),
+        )
+        assertEquals(Cents(30000), cumulative)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetMemberBreakdownTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetMemberBreakdownTest.kt
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.core.TestFixtures
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.datetime.LocalDate
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for #3690 — per-member attribution for shared/household budgets.
+ */
+class BudgetMemberBreakdownTest {
+
+    @BeforeTest
+    fun setup() {
+        TestFixtures.reset()
+    }
+
+    private val alice = SyncId("owner-alice")
+    private val bob = SyncId("owner-bob")
+    private val carol = SyncId("owner-carol")
+
+    @Test
+    fun breakdown_multipleMembers_sumsReconcileWithTotal() {
+        val budget = TestFixtures.createBudget(amount = Cents(50000), startDate = LocalDate(2024, 6, 1))
+        val txns = listOf(
+            TestFixtures.createExpense(amount = Cents(10000), date = LocalDate(2024, 6, 5), ownerId = alice),
+            TestFixtures.createExpense(amount = Cents(5000), date = LocalDate(2024, 6, 10), ownerId = alice),
+            TestFixtures.createExpense(amount = Cents(8000), date = LocalDate(2024, 6, 12), ownerId = bob),
+        )
+
+        val breakdown = BudgetCalculator.calculateMemberBreakdown(budget, txns, LocalDate(2024, 6, 15))
+        val status = BudgetCalculator.calculateStatus(budget, txns, LocalDate(2024, 6, 15))
+
+        assertEquals(Cents(15000), breakdown.spendFor(alice))
+        assertEquals(Cents(8000), breakdown.spendFor(bob))
+        assertEquals(Cents(23000), breakdown.totalSpent)
+        assertEquals(status.spent, breakdown.totalSpent, "member total reconciles with BudgetStatus.spent")
+
+        val summed = breakdown.byMember.values.fold(Cents.ZERO) { acc, c -> acc + c }
+        assertEquals(breakdown.totalSpent, summed, "per-member sums add up to the total")
+    }
+
+    @Test
+    fun breakdown_singleMember() {
+        val budget = TestFixtures.createBudget(amount = Cents(50000), startDate = LocalDate(2024, 6, 1))
+        val txns = listOf(
+            TestFixtures.createExpense(amount = Cents(12000), date = LocalDate(2024, 6, 5), ownerId = alice),
+        )
+        val breakdown = BudgetCalculator.calculateMemberBreakdown(budget, txns, LocalDate(2024, 6, 15))
+
+        assertEquals(setOf(alice), breakdown.members)
+        assertEquals(Cents(12000), breakdown.totalSpent)
+    }
+
+    @Test
+    fun breakdown_noSpend_isEmpty() {
+        val budget = TestFixtures.createBudget(amount = Cents(50000), startDate = LocalDate(2024, 6, 1))
+        val breakdown = BudgetCalculator.calculateMemberBreakdown(budget, emptyList(), LocalDate(2024, 6, 15))
+
+        assertTrue(breakdown.byMember.isEmpty())
+        assertEquals(Cents.ZERO, breakdown.totalSpent)
+        assertEquals(Cents.ZERO, breakdown.spendFor(carol), "absent member reads zero")
+    }
+
+    @Test
+    fun breakdown_appliesSameFiltersAsStatus() {
+        val budget = TestFixtures.createBudget(amount = Cents(50000), startDate = LocalDate(2024, 6, 1))
+        val txns = listOf(
+            TestFixtures.createExpense(amount = Cents(10000), date = LocalDate(2024, 6, 5), ownerId = alice),
+            // Deleted → excluded
+            TestFixtures.createExpense(
+                amount = Cents(9999), date = LocalDate(2024, 6, 6), ownerId = alice,
+                deletedAt = TestFixtures.fixedInstant,
+            ),
+            // Out of period → excluded
+            TestFixtures.createExpense(amount = Cents(7777), date = LocalDate(2024, 7, 1), ownerId = bob),
+            // Income → excluded
+            TestFixtures.createIncome(amount = Cents(20000), date = LocalDate(2024, 6, 7)),
+        )
+        val breakdown = BudgetCalculator.calculateMemberBreakdown(budget, txns, LocalDate(2024, 6, 15))
+
+        assertEquals(Cents(10000), breakdown.totalSpent)
+        assertEquals(setOf(alice), breakdown.members)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetPeriodAnchoringTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetPeriodAnchoringTest.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.models.BudgetPeriod
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression tests for #3595 — budget period anchoring must honour `startDate`
+ * for WEEKLY / MONTHLY / QUARTERLY / YEARLY, not just BIWEEKLY.
+ */
+class BudgetPeriodAnchoringTest {
+
+    // ── WEEKLY anchored to startDate's day-of-week (not ISO Monday) ────
+
+    @Test
+    fun weekly_anchorsOnStartDayOfWeek_notMonday() {
+        // 2024-06-06 is a Thursday. A weekly budget anchored here should run
+        // Thu → Wed, NOT Mon → Sun.
+        val start = LocalDate(2024, 6, 6)
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.WEEKLY, start, LocalDate(2024, 6, 10))
+
+        assertEquals(LocalDate(2024, 6, 6), period.start, "week anchored on the Thursday startDate")
+        assertEquals(LocalDate(2024, 6, 12), period.end, "week ends the following Wednesday")
+        assertEquals(7, period.daysTotal)
+    }
+
+    @Test
+    fun weekly_secondWeekFromStart() {
+        val start = LocalDate(2024, 6, 6) // Thursday
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.WEEKLY, start, LocalDate(2024, 6, 15))
+
+        assertEquals(LocalDate(2024, 6, 13), period.start)
+        assertEquals(LocalDate(2024, 6, 19), period.end)
+    }
+
+    // ── MONTHLY anchored to startDate's day-of-month ───────────────────
+
+    @Test
+    fun monthly_anchorsOnStartDayOfMonth_15th() {
+        // Pay-cycle budget: the 15th to the 14th.
+        val start = LocalDate(2024, 1, 15)
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.MONTHLY, start, LocalDate(2024, 6, 20))
+
+        assertEquals(LocalDate(2024, 6, 15), period.start)
+        assertEquals(LocalDate(2024, 7, 14), period.end)
+    }
+
+    @Test
+    fun monthly_referenceBeforeAnchorDay_fallsInPriorPeriod() {
+        val start = LocalDate(2024, 1, 15)
+        // June 10 is before the 15th, so it belongs to the May 15 – Jun 14 period.
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.MONTHLY, start, LocalDate(2024, 6, 10))
+
+        assertEquals(LocalDate(2024, 5, 15), period.start)
+        assertEquals(LocalDate(2024, 6, 14), period.end)
+    }
+
+    @Test
+    fun monthly_onExactAnchorDay() {
+        val start = LocalDate(2024, 1, 15)
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.MONTHLY, start, LocalDate(2024, 6, 15))
+
+        assertEquals(LocalDate(2024, 6, 15), period.start)
+        assertEquals(LocalDate(2024, 7, 14), period.end)
+    }
+
+    @Test
+    fun monthly_endOfMonthAnchor_clampsForShortMonths() {
+        // Anchored on Jan 31: February has no 31st, so the Feb period starts on
+        // the clamped Feb 29 (2024 is a leap year).
+        val start = LocalDate(2024, 1, 31)
+        val febPeriod = BudgetCalculator.getCurrentPeriod(BudgetPeriod.MONTHLY, start, LocalDate(2024, 2, 15))
+
+        assertEquals(LocalDate(2024, 1, 31), febPeriod.start)
+        assertEquals(LocalDate(2024, 2, 28), febPeriod.end)
+    }
+
+    // ── QUARTERLY anchored to startDate ────────────────────────────────
+
+    @Test
+    fun quarterly_anchorsOnStartDate() {
+        // Starts Feb 15 → quarters are Feb15–May14, May15–Aug14, ...
+        val start = LocalDate(2024, 2, 15)
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.QUARTERLY, start, LocalDate(2024, 3, 1))
+
+        assertEquals(LocalDate(2024, 2, 15), period.start)
+        assertEquals(LocalDate(2024, 5, 14), period.end)
+    }
+
+    @Test
+    fun quarterly_secondQuarterFromStart() {
+        val start = LocalDate(2024, 2, 15)
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.QUARTERLY, start, LocalDate(2024, 6, 1))
+
+        assertEquals(LocalDate(2024, 5, 15), period.start)
+        assertEquals(LocalDate(2024, 8, 14), period.end)
+    }
+
+    // ── YEARLY anchored to startDate ───────────────────────────────────
+
+    @Test
+    fun yearly_anchorsOnStartDate() {
+        // Fiscal year starting Apr 6.
+        val start = LocalDate(2023, 4, 6)
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.YEARLY, start, LocalDate(2024, 1, 1))
+
+        assertEquals(LocalDate(2023, 4, 6), period.start)
+        assertEquals(LocalDate(2024, 4, 5), period.end)
+    }
+
+    @Test
+    fun yearly_referenceAfterAnchor_nextYear() {
+        val start = LocalDate(2023, 4, 6)
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.YEARLY, start, LocalDate(2024, 6, 1))
+
+        assertEquals(LocalDate(2024, 4, 6), period.start)
+        assertEquals(LocalDate(2025, 4, 5), period.end)
+    }
+
+    // ── Calendar-aligned budgets remain on the calendar grid ───────────
+
+    @Test
+    fun monthly_calendarAlignedStart_unchanged() {
+        // startDate on the 1st still yields calendar months.
+        val start = LocalDate(2024, 1, 1)
+        val period = BudgetCalculator.getCurrentPeriod(BudgetPeriod.MONTHLY, start, LocalDate(2024, 6, 15))
+
+        assertEquals(LocalDate(2024, 6, 1), period.start)
+        assertEquals(LocalDate(2024, 6, 30), period.end)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetRolloverPolicyTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetRolloverPolicyTest.kt
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.core.TestFixtures
+import com.finance.models.BudgetPeriod
+import com.finance.models.Transaction
+import com.finance.models.types.Cents
+import kotlinx.datetime.LocalDate
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for #3649 (rollover cap/floor policy) and #3653 (reconciling
+ * single-period `calculateEffectiveBudget` with the cumulative chain).
+ */
+class BudgetRolloverPolicyTest {
+
+    @BeforeTest
+    fun setup() {
+        TestFixtures.reset()
+    }
+
+    private fun monthlyRollover() = TestFixtures.createBudget(
+        amount = Cents(50000), // $500/month
+        period = BudgetPeriod.MONTHLY,
+        startDate = LocalDate(2024, 1, 1),
+        isRollover = true,
+    )
+
+    // ── #3653: single-period vs cumulative reconciliation ──────────────
+
+    @Test
+    fun reconcile_singlePeriodOld_effectiveMatchesCumulative() {
+        val budget = monthlyRollover()
+        val janTxns = listOf(TestFixtures.createExpense(amount = Cents(40000), date = LocalDate(2024, 1, 15)))
+
+        // Reference February → exactly one prior period (January).
+        val single = BudgetRolloverCalculator.calculateEffectiveBudget(
+            budget = budget,
+            currentPeriodTransactions = emptyList(),
+            previousPeriodTransactions = janTxns,
+            referenceDate = LocalDate(2024, 2, 15),
+        )
+        val cumulative = BudgetRolloverCalculator.effectiveBudgetCumulative(
+            budget = budget,
+            transactionsByPeriod = mapOf(LocalDate(2024, 1, 1) to janTxns),
+            referenceDate = LocalDate(2024, 2, 15),
+        )
+
+        assertEquals(single.rolloverCarry, cumulative.rolloverCarry, "agree for a one-period-old budget")
+        assertEquals(single.effectiveAmount, cumulative.effectiveAmount)
+        assertEquals(Cents(10000), cumulative.rolloverCarry)
+    }
+
+    @Test
+    fun reconcile_multiPeriod_cumulativeEffectiveMatchesCumulativeCarry() {
+        val budget = monthlyRollover()
+        val txnsByPeriod = mapOf(
+            LocalDate(2024, 1, 1) to listOf(TestFixtures.createExpense(amount = Cents(40000), date = LocalDate(2024, 1, 15))),
+            LocalDate(2024, 2, 1) to listOf(TestFixtures.createExpense(amount = Cents(30000), date = LocalDate(2024, 2, 15))),
+        )
+        val carry = BudgetRolloverCalculator.calculateCumulativeRollover(budget, txnsByPeriod, LocalDate(2024, 3, 15))
+        val effective = BudgetRolloverCalculator.effectiveBudgetCumulative(budget, txnsByPeriod, LocalDate(2024, 3, 15))
+
+        // Jan +$100 → Feb eff $600 - $300 = +$300.
+        assertEquals(Cents(30000), carry)
+        assertEquals(carry, effective.rolloverCarry, "cumulative effective uses the chained carry")
+        assertEquals(Cents(80000), effective.effectiveAmount, "$500 base + $300 carry")
+    }
+
+    // ── #3649: RolloverPolicy floor / cap ──────────────────────────────
+
+    @Test
+    fun policy_default_isUnlimited_preservesBehaviour() {
+        val budget = monthlyRollover()
+        val txnsByPeriod = mapOf(
+            LocalDate(2024, 1, 1) to listOf(TestFixtures.createExpense(amount = Cents(70000), date = LocalDate(2024, 1, 15))),
+            LocalDate(2024, 2, 1) to listOf(TestFixtures.createExpense(amount = Cents(10000), date = LocalDate(2024, 2, 15))),
+        )
+        val defaultCarry = BudgetRolloverCalculator.calculateCumulativeRollover(budget, txnsByPeriod, LocalDate(2024, 3, 15))
+        val explicitUnlimited = BudgetRolloverCalculator.calculateCumulativeRollover(
+            budget, txnsByPeriod, LocalDate(2024, 3, 15), RolloverPolicy.UNLIMITED,
+        )
+        // Jan -$200 → Feb eff $300 - $100 = +$200.
+        assertEquals(Cents(20000), defaultCarry)
+        assertEquals(defaultCarry, explicitUnlimited)
+    }
+
+    @Test
+    fun policy_resetNegative_floorsOverspendAtZero() {
+        val budget = monthlyRollover()
+        val txnsByPeriod = mapOf(
+            // Jan overspend by $200 → raw carry -$200, reset to $0.
+            LocalDate(2024, 1, 1) to listOf(TestFixtures.createExpense(amount = Cents(70000), date = LocalDate(2024, 1, 15))),
+            // Feb eff $500 (carry reset), spent $100 → +$400.
+            LocalDate(2024, 2, 1) to listOf(TestFixtures.createExpense(amount = Cents(10000), date = LocalDate(2024, 2, 15))),
+        )
+        val carry = BudgetRolloverCalculator.calculateCumulativeRollover(
+            budget, txnsByPeriod, LocalDate(2024, 3, 15), RolloverPolicy.RESET_NEGATIVE,
+        )
+        assertEquals(Cents(40000), carry, "one bad month does not bury the next")
+    }
+
+    @Test
+    fun policy_capAtBase_capsPositiveCarry() {
+        val budget = monthlyRollover()
+        val txnsByPeriod = mapOf(
+            // Jan spent nothing → raw carry +$500, capped at base $500.
+            LocalDate(2024, 1, 1) to emptyList<Transaction>(),
+            // Feb eff $1000 raw, but carry capped again at base $500.
+            LocalDate(2024, 2, 1) to emptyList<Transaction>(),
+        )
+        val carry = BudgetRolloverCalculator.calculateCumulativeRollover(
+            budget, txnsByPeriod, LocalDate(2024, 3, 15), RolloverPolicy.CAP_AT_BASE,
+        )
+        assertEquals(Cents(50000), carry, "savings carry capped at one month's base")
+    }
+
+    @Test
+    fun policy_capAtBase_floorsNegativeAtNegativeBase() {
+        val budget = monthlyRollover()
+        val txnsByPeriod = mapOf(
+            // Jan overspend by $1000 → raw -$1000, floored at -base = -$500.
+            LocalDate(2024, 1, 1) to listOf(TestFixtures.createExpense(amount = Cents(150000), date = LocalDate(2024, 1, 15))),
+        )
+        val carry = BudgetRolloverCalculator.calculateCumulativeRollover(
+            budget, txnsByPeriod, LocalDate(2024, 2, 15), RolloverPolicy.CAP_AT_BASE,
+        )
+        assertEquals(Cents(-50000), carry)
+    }
+
+    @Test
+    fun policy_appliesToSinglePeriodEffective() {
+        val budget = monthlyRollover()
+        // Previous period overspent by $200.
+        val prev = listOf(TestFixtures.createExpense(amount = Cents(70000), date = LocalDate(2024, 1, 15)))
+        val reset = BudgetRolloverCalculator.calculateEffectiveBudget(
+            budget = budget,
+            currentPeriodTransactions = emptyList(),
+            previousPeriodTransactions = prev,
+            referenceDate = LocalDate(2024, 2, 15),
+            policy = RolloverPolicy.RESET_NEGATIVE,
+        )
+        assertEquals(Cents.ZERO, reset.rolloverCarry, "negative carry reset to zero")
+        assertEquals(Cents(50000), reset.effectiveAmount)
+    }
+
+    // ── RolloverPolicy.apply unit checks ───────────────────────────────
+
+    @Test
+    fun rolloverPolicy_apply_matrix() {
+        val base = Cents(500)
+        assertEquals(Cents(-200), RolloverPolicy.UNLIMITED.apply(Cents(-200), base))
+        assertEquals(Cents.ZERO, RolloverPolicy.RESET_NEGATIVE.apply(Cents(-200), base))
+        assertEquals(Cents(200), RolloverPolicy.RESET_NEGATIVE.apply(Cents(200), base))
+        assertEquals(Cents(500), RolloverPolicy.CAP_AT_BASE.apply(Cents(800), base))
+        assertEquals(Cents(-500), RolloverPolicy.CAP_AT_BASE.apply(Cents(-800), base))
+        assertEquals(Cents(300), RolloverPolicy.CAP_AT_BASE.apply(Cents(300), base))
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetTemplateTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetTemplateTest.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.models.types.Cents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Tests for #3684 — budget templates (50/30/20, zero-based).
+ */
+class BudgetTemplateTest {
+
+    @Test
+    fun fiftyThirtyTwenty_divisibleIncome_exactSplit() {
+        val proposals = BudgetTemplate.FIFTY_THIRTY_TWENTY.applyTemplate(Cents(1_000_000)) // $10,000
+        assertEquals(3, proposals.size)
+        assertEquals(Cents(500_000), proposals[0].amount) // Needs 50%
+        assertEquals(Cents(300_000), proposals[1].amount) // Wants 30%
+        assertEquals(Cents(200_000), proposals[2].amount) // Savings 20%
+        assertEquals(listOf("Needs", "Wants", "Savings"), proposals.map { it.name })
+    }
+
+    @Test
+    fun applyTemplate_allocationsSumExactlyToIncome() {
+        // Non-divisible income exercises remainder distribution.
+        val income = Cents(100_001)
+        val proposals = BudgetTemplate.FIFTY_THIRTY_TWENTY.applyTemplate(income)
+        val total = proposals.fold(Cents.ZERO) { acc, p -> acc + p.amount }
+        assertEquals(income, total, "no cents lost or created")
+    }
+
+    @Test
+    fun fiftyThirtyTwenty_nonDivisible_remainderIsDeterministic() {
+        // income = 101 cents; 50/30/20 → 50/30/20 base = 50,30,20 (sum 100),
+        // remainder 1 goes to the largest ratio (Needs).
+        val proposals = BudgetTemplate.FIFTY_THIRTY_TWENTY.applyTemplate(Cents(101))
+        assertEquals(Cents(51), proposals[0].amount)
+        assertEquals(Cents(30), proposals[1].amount)
+        assertEquals(Cents(20), proposals[2].amount)
+        assertEquals(Cents(101), proposals.fold(Cents.ZERO) { a, p -> a + p.amount })
+    }
+
+    @Test
+    fun zeroBased_customAllocations_sumExactly() {
+        val template = BudgetTemplate.zeroBased(
+            listOf("Rent" to 40, "Food" to 20, "Transport" to 15, "Fun" to 10, "Savings" to 15),
+        )
+        val income = Cents(333_333)
+        val proposals = template.applyTemplate(income)
+        assertEquals(5, proposals.size)
+        assertEquals(income, proposals.fold(Cents.ZERO) { a, p -> a + p.amount })
+    }
+
+    @Test
+    fun applyTemplate_nonPositiveIncome_rejected() {
+        assertFailsWith<IllegalArgumentException> {
+            BudgetTemplate.FIFTY_THIRTY_TWENTY.applyTemplate(Cents.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            BudgetTemplate.FIFTY_THIRTY_TWENTY.applyTemplate(Cents(-100))
+        }
+    }
+
+    @Test
+    fun template_validation() {
+        assertFailsWith<IllegalArgumentException> { BudgetTemplate(name = "", allocations = listOf(BudgetAllocation("A", 1))) }
+        assertFailsWith<IllegalArgumentException> { BudgetTemplate(name = "x", allocations = emptyList()) }
+        assertFailsWith<IllegalArgumentException> { BudgetAllocation(name = "A", ratio = 0) }
+        assertFailsWith<IllegalArgumentException> { BudgetAllocation(name = "", ratio = 1) }
+        assertFailsWith<IllegalArgumentException> { BudgetTemplate.zeroBased(emptyList()) }
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetThresholdsTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/budget/BudgetThresholdsTest.kt
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.core.TestFixtures
+import com.finance.models.types.Cents
+import kotlinx.datetime.LocalDate
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Tests for #3678 — configurable over-budget warning thresholds.
+ */
+class BudgetThresholdsTest {
+
+    @BeforeTest
+    fun setup() {
+        TestFixtures.reset()
+    }
+
+    private fun statusAtUtilization(spent: Long): BudgetStatus {
+        val budget = TestFixtures.createBudget(amount = Cents(10000), startDate = LocalDate(2024, 6, 1))
+        val txns = listOf(TestFixtures.createExpense(amount = Cents(spent), date = LocalDate(2024, 6, 10)))
+        return BudgetCalculator.calculateStatus(budget, txns, LocalDate(2024, 6, 15))
+    }
+
+    // ── Default behaviour unchanged ────────────────────────────────────
+
+    @Test
+    fun default_thresholds_matchLegacyBehaviour() {
+        assertEquals(BudgetHealth.HEALTHY, statusAtUtilization(7500).healthLevel, "exactly 75% is healthy")
+        assertEquals(BudgetHealth.WARNING, statusAtUtilization(7501).healthLevel, "just over 75% warns")
+        assertEquals(BudgetHealth.WARNING, statusAtUtilization(10000).healthLevel, "exactly 100% is warning")
+        assertEquals(BudgetHealth.OVER, statusAtUtilization(10001).healthLevel, "just over 100% is over")
+    }
+
+    @Test
+    fun defaultThresholds_classifyMatchesProperty() {
+        val status = statusAtUtilization(8000)
+        assertEquals(status.healthLevel, status.healthLevel(BudgetThresholds.DEFAULT))
+    }
+
+    // ── Custom thresholds change classification ────────────────────────
+
+    @Test
+    fun conservativeThreshold_warnsEarlier() {
+        // Warn at 50% for discretionary spend.
+        val thresholds = BudgetThresholds(warning = 0.5)
+        assertEquals(BudgetHealth.HEALTHY, statusAtUtilization(4900).healthLevel(thresholds))
+        assertEquals(BudgetHealth.WARNING, statusAtUtilization(5001).healthLevel(thresholds))
+    }
+
+    @Test
+    fun lenientThreshold_warnsLater() {
+        // Warn at 90% for rent.
+        val thresholds = BudgetThresholds(warning = 0.9)
+        assertEquals(BudgetHealth.HEALTHY, statusAtUtilization(8000).healthLevel(thresholds))
+        assertEquals(BudgetHealth.WARNING, statusAtUtilization(9500).healthLevel(thresholds))
+    }
+
+    @Test
+    fun customOverThreshold_belowOne() {
+        // Treat 80% as "over".
+        val thresholds = BudgetThresholds(warning = 0.5, over = 0.8)
+        assertEquals(BudgetHealth.WARNING, statusAtUtilization(7000).healthLevel(thresholds))
+        assertEquals(BudgetHealth.OVER, statusAtUtilization(8100).healthLevel(thresholds))
+    }
+
+    // ── Validation ─────────────────────────────────────────────────────
+
+    @Test
+    fun invalid_warningNotLessThanOver_rejected() {
+        assertFailsWith<IllegalArgumentException> { BudgetThresholds(warning = 1.0, over = 1.0) }
+        assertFailsWith<IllegalArgumentException> { BudgetThresholds(warning = 0.9, over = 0.8) }
+    }
+
+    @Test
+    fun invalid_warningOutOfRange_rejected() {
+        assertFailsWith<IllegalArgumentException> { BudgetThresholds(warning = -0.1) }
+        assertFailsWith<IllegalArgumentException> { BudgetThresholds(warning = 1.5, over = 2.0) }
+    }
+
+    @Test
+    fun invalid_overOutOfRange_rejected() {
+        assertFailsWith<IllegalArgumentException> { BudgetThresholds(warning = 0.5, over = 1.5) }
+    }
+
+    @Test
+    fun classify_directly() {
+        val thresholds = BudgetThresholds(warning = 0.6, over = 0.95)
+        assertEquals(BudgetHealth.HEALTHY, thresholds.classify(0.6))
+        assertEquals(BudgetHealth.WARNING, thresholds.classify(0.61))
+        assertEquals(BudgetHealth.WARNING, thresholds.classify(0.95))
+        assertEquals(BudgetHealth.OVER, thresholds.classify(0.96))
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/budget/CategoryBudgetRollupTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/budget/CategoryBudgetRollupTest.kt
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.core.TestFixtures
+import com.finance.models.Category
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.datetime.LocalDate
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for #3662 — hierarchical / category-group budget rollup.
+ */
+class CategoryBudgetRollupTest {
+
+    @BeforeTest
+    fun setup() {
+        TestFixtures.reset()
+    }
+
+    private val food = SyncId("cat-food")
+    private val groceries = SyncId("cat-groceries")
+    private val restaurants = SyncId("cat-restaurants")
+    private val fastFood = SyncId("cat-fastfood")
+    private val rent = SyncId("cat-rent")
+
+    private fun tree(): List<Category> = listOf(
+        TestFixtures.createCategory(id = food, name = "Food"),
+        TestFixtures.createCategory(id = groceries, name = "Groceries", parentId = food),
+        TestFixtures.createCategory(id = restaurants, name = "Restaurants", parentId = food),
+        TestFixtures.createCategory(id = fastFood, name = "Fast Food", parentId = restaurants),
+        TestFixtures.createCategory(id = rent, name = "Rent"),
+    )
+
+    // ── resolveCategoryGroup ───────────────────────────────────────────
+
+    @Test
+    fun resolve_singleLevel() {
+        val group = CategoryBudgetRollup.resolveCategoryGroup(restaurants, tree())
+        assertEquals(setOf(restaurants, fastFood), group)
+    }
+
+    @Test
+    fun resolve_multiLevel_includesAllDescendantsAndRoot() {
+        val group = CategoryBudgetRollup.resolveCategoryGroup(food, tree())
+        assertEquals(setOf(food, groceries, restaurants, fastFood), group)
+    }
+
+    @Test
+    fun resolve_leaf_returnsOnlyItself() {
+        val group = CategoryBudgetRollup.resolveCategoryGroup(rent, tree())
+        assertEquals(setOf(rent), group)
+    }
+
+    @Test
+    fun resolve_cyclicParents_terminatesSafely() {
+        // A → B → A cycle plus a self-loop C → C.
+        val a = SyncId("A")
+        val b = SyncId("B")
+        val c = SyncId("C")
+        val cyclic = listOf(
+            TestFixtures.createCategory(id = a, name = "A", parentId = b),
+            TestFixtures.createCategory(id = b, name = "B", parentId = a),
+            TestFixtures.createCategory(id = c, name = "C", parentId = c),
+        )
+        val group = CategoryBudgetRollup.resolveCategoryGroup(a, cyclic)
+        // Must include A and its descendant B, and must not loop forever.
+        assertTrue(a in group)
+        assertTrue(b in group)
+    }
+
+    // ── calculateGroupStatus ───────────────────────────────────────────
+
+    @Test
+    fun groupStatus_rollsUpSpendFromDescendants() {
+        val budget = TestFixtures.createBudget(
+            categoryId = food,
+            amount = Cents(50000),
+            startDate = LocalDate(2024, 6, 1),
+        )
+        val txns = listOf(
+            TestFixtures.createExpense(amount = Cents(10000), date = LocalDate(2024, 6, 5), categoryId = groceries),
+            TestFixtures.createExpense(amount = Cents(6000), date = LocalDate(2024, 6, 8), categoryId = restaurants),
+            TestFixtures.createExpense(amount = Cents(4000), date = LocalDate(2024, 6, 9), categoryId = fastFood),
+            TestFixtures.createExpense(amount = Cents(3000), date = LocalDate(2024, 6, 10), categoryId = food),
+            // Unrelated category → excluded
+            TestFixtures.createExpense(amount = Cents(9999), date = LocalDate(2024, 6, 11), categoryId = rent),
+        )
+
+        val status = CategoryBudgetRollup.calculateGroupStatus(budget, tree(), txns, LocalDate(2024, 6, 15))
+        assertEquals(Cents(23000), status.spent, "groceries + restaurants + fastfood + food")
+        assertEquals(Cents(27000), status.remaining)
+    }
+
+    @Test
+    fun groupStatus_noChildren_matchesPlainStatus() {
+        val budget = TestFixtures.createBudget(
+            categoryId = rent,
+            amount = Cents(50000),
+            startDate = LocalDate(2024, 6, 1),
+        )
+        val txns = listOf(
+            TestFixtures.createExpense(amount = Cents(12000), date = LocalDate(2024, 6, 5), categoryId = rent),
+        )
+        val group = CategoryBudgetRollup.calculateGroupStatus(budget, tree(), txns, LocalDate(2024, 6, 15))
+        val plain = BudgetCalculator.calculateStatus(budget, txns, LocalDate(2024, 6, 15))
+        assertEquals(plain.spent, group.spent)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/budget/EnvelopeTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/budget/EnvelopeTest.kt
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.budget
+
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for #3658 — envelope budgeting with persistent balances.
+ */
+class EnvelopeTest {
+
+    private fun envelope(
+        funded: Long = 0,
+        spent: Long = 0,
+        id: String = "env-1",
+    ) = Envelope(id = SyncId(id), name = "Groceries", funded = Cents(funded), spent = Cents(spent))
+
+    @Test
+    fun balance_isFundedMinusSpent() {
+        assertEquals(Cents(7000), envelope(funded = 10000, spent = 3000).balance)
+    }
+
+    @Test
+    fun fund_increasesFundedAndBalance() {
+        val funded = EnvelopeOperations.fund(envelope(funded = 5000), Cents(2500))
+        assertEquals(Cents(7500), funded.funded)
+        assertEquals(Cents(7500), funded.balance)
+    }
+
+    @Test
+    fun spend_increasesSpentAndReducesBalance() {
+        val spent = EnvelopeOperations.spend(envelope(funded = 10000, spent = 2000), Cents(3000))
+        assertEquals(Cents(5000), spent.spent)
+        assertEquals(Cents(5000), spent.balance)
+    }
+
+    @Test
+    fun spend_canOverspend_negativeBalance() {
+        val overspent = EnvelopeOperations.spend(envelope(funded = 5000), Cents(8000))
+        assertEquals(Cents(-3000), overspent.balance)
+        assertTrue(overspent.isOverspent)
+    }
+
+    @Test
+    fun transfer_movesFundingAndConservesTotal() {
+        val from = envelope(funded = 10000, id = "from")
+        val to = envelope(funded = 2000, spent = 5000, id = "to") // overspent by 3000
+        val (newFrom, newTo) = EnvelopeOperations.transfer(from, to, Cents(3000))
+
+        assertEquals(Cents(7000), newFrom.funded)
+        assertEquals(Cents(5000), newTo.funded)
+        assertEquals(Cents.ZERO, newTo.balance, "transfer covers the overspend exactly")
+        assertFalse(newTo.isOverspent)
+        // Total funded conserved.
+        assertEquals(from.funded + to.funded, newFrom.funded + newTo.funded)
+    }
+
+    @Test
+    fun fund_nonPositive_rejected() {
+        assertFailsWith<IllegalArgumentException> { EnvelopeOperations.fund(envelope(), Cents.ZERO) }
+        assertFailsWith<IllegalArgumentException> { EnvelopeOperations.fund(envelope(), Cents(-1)) }
+    }
+
+    @Test
+    fun spend_nonPositive_rejected() {
+        assertFailsWith<IllegalArgumentException> { EnvelopeOperations.spend(envelope(), Cents(-1)) }
+    }
+
+    @Test
+    fun transfer_toSelf_rejected() {
+        val e = envelope(funded = 5000, id = "same")
+        assertFailsWith<IllegalArgumentException> { EnvelopeOperations.transfer(e, e, Cents(100)) }
+    }
+
+    @Test
+    fun transfer_nonPositive_rejected() {
+        assertFailsWith<IllegalArgumentException> {
+            EnvelopeOperations.transfer(envelope(id = "a"), envelope(id = "b"), Cents(0))
+        }
+    }
+
+    @Test
+    fun blankName_rejected() {
+        assertFailsWith<IllegalArgumentException> { Envelope(id = SyncId("x"), name = " ") }
+    }
+
+    @Test
+    fun operations_areImmutable() {
+        val original = envelope(funded = 5000)
+        EnvelopeOperations.fund(original, Cents(1000))
+        EnvelopeOperations.spend(original, Cents(1000))
+        assertEquals(Cents(5000), original.funded, "original envelope unchanged")
+        assertEquals(Cents.ZERO, original.spent)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalRequiredContributionTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalRequiredContributionTest.kt
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.core.TestFixtures
+import com.finance.models.GoalStatus
+import com.finance.models.types.Cents
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/** Tests for [GoalTrackingEngine.requiredContribution] (#3689). */
+class GoalRequiredContributionTest {
+
+    private val from = LocalDate(2024, 1, 1)
+
+    @Test
+    fun exactDivision_perPeriodIsExact() {
+        // Need $300 over 3 whole months → exactly $100/month.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents.ZERO,
+            targetDate = LocalDate(2024, 4, 1),
+        )
+        val required = GoalTrackingEngine.requiredContribution(goal, ContributionPeriod.MONTHLY, from)
+        assertEquals(Cents(10_000), required)
+    }
+
+    @Test
+    fun remainderRoundsUp_scheduleNeverFallsShort() {
+        // Need $100 over 3 whole months → ceil(10000/3) = 3334/month.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(10_000),
+            currentAmount = Cents.ZERO,
+            targetDate = LocalDate(2024, 4, 1),
+        )
+        val required = GoalTrackingEngine.requiredContribution(goal, ContributionPeriod.MONTHLY, from)
+        assertEquals(Cents(3_334), required)
+        // Applying it each of the 3 periods reaches or exceeds the target.
+        assertTrue(required.amount * 3 >= 10_000)
+    }
+
+    @Test
+    fun accountsForCurrentAmount() {
+        // Target $500, already saved $200 → remaining $300 over 3 months = $100.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(50_000),
+            currentAmount = Cents(20_000),
+            targetDate = LocalDate(2024, 4, 1),
+        )
+        val required = GoalTrackingEngine.requiredContribution(goal, ContributionPeriod.MONTHLY, from)
+        assertEquals(Cents(10_000), required)
+    }
+
+    @Test
+    fun completeGoal_returnsZero() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(10_000),
+            currentAmount = Cents(10_000),
+            targetDate = LocalDate(2024, 4, 1),
+            status = GoalStatus.ACTIVE,
+        )
+        assertEquals(Cents.ZERO, GoalTrackingEngine.requiredContribution(goal, ContributionPeriod.MONTHLY, from))
+    }
+
+    @Test
+    fun overfundedGoal_returnsZero() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(10_000),
+            currentAmount = Cents(12_000),
+            targetDate = LocalDate(2024, 4, 1),
+        )
+        assertEquals(Cents.ZERO, GoalTrackingEngine.requiredContribution(goal, ContributionPeriod.MONTHLY, from))
+    }
+
+    @Test
+    fun singlePeriodRemaining_requiresFullRemaining() {
+        // Exactly one whole week between from and deadline.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(25_000),
+            currentAmount = Cents.ZERO,
+            targetDate = LocalDate(2024, 1, 8),
+        )
+        val required = GoalTrackingEngine.requiredContribution(goal, ContributionPeriod.WEEKLY, from)
+        assertEquals(Cents(25_000), required)
+    }
+
+    @Test
+    fun lessThanOnePeriodRemaining_requiresFullRemaining() {
+        // 3 days before deadline but weekly cadence → still need it all in one contribution.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(25_000),
+            currentAmount = Cents.ZERO,
+            targetDate = LocalDate(2024, 1, 4),
+        )
+        val required = GoalTrackingEngine.requiredContribution(goal, ContributionPeriod.WEEKLY, from)
+        assertEquals(Cents(25_000), required)
+    }
+
+    @Test
+    fun weeklyExactDivision() {
+        // Need $280 over 4 whole weeks → $70/week.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(28_000),
+            currentAmount = Cents.ZERO,
+            targetDate = LocalDate(2024, 1, 29), // 28 days = 4 weeks
+        )
+        val required = GoalTrackingEngine.requiredContribution(goal, ContributionPeriod.WEEKLY, from)
+        assertEquals(Cents(7_000), required)
+    }
+
+    @Test
+    fun nullTargetDate_throws() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(10_000),
+            currentAmount = Cents.ZERO,
+            targetDate = null,
+        )
+        assertFailsWith<IllegalArgumentException> {
+            GoalTrackingEngine.requiredContribution(goal, ContributionPeriod.MONTHLY, from)
+        }
+    }
+
+    @Test
+    fun targetDateInPast_throws() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(10_000),
+            currentAmount = Cents.ZERO,
+            targetDate = LocalDate(2023, 12, 1),
+        )
+        assertFailsWith<IllegalArgumentException> {
+            GoalTrackingEngine.requiredContribution(goal, ContributionPeriod.MONTHLY, from)
+        }
+    }
+
+    @Test
+    fun targetDateEqualsFrom_throws() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(10_000),
+            currentAmount = Cents.ZERO,
+            targetDate = from,
+        )
+        assertFailsWith<IllegalArgumentException> {
+            GoalTrackingEngine.requiredContribution(goal, ContributionPeriod.MONTHLY, from)
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary

Implements a cohesive batch of core budgeting features and bug fixes in `packages/core` (KMP shared financial-logic). All money math uses integer `Cents`; all logic is pure functions with comprehensive `commonTest` coverage.

### Features
- **Per-member attribution for shared/household budgets** (#3690): `BudgetCalculator.calculateMemberBreakdown` + `BudgetMemberBreakdown` splits period spend by transaction owner.
- **Budget templates** (#3684): `BudgetTemplate` with `FIFTY_THIRTY_TWENTY` and `zeroBased(...)`, allocating income via integer ratio math (no remainder loss).
- **Configurable over-budget thresholds** (#3678): `BudgetThresholds(warning, over)` with validation and `classify`; `BudgetStatus.healthLevel` delegates to defaults with a `healthLevel(thresholds)` overload.
- **Hierarchical/category-group rollup** (#3662): `CategoryBudgetRollup` resolves a category subtree (cycle-safe, excludes soft-deleted) and rolls spend up.
- **Envelope budgeting persistent balances** (#3658): `Envelope` + `EnvelopeOperations.fund/spend/transfer`, immutable and validated.
- **Required per-period goal contribution** (#3689): `GoalTrackingEngine.requiredContribution` (ceiling division; ZERO when complete; validates target date).
- **Rollover cap/floor policy** (#3649): `RolloverPolicy { UNLIMITED, RESET_NEGATIVE, CAP_AT_BASE }` applied per period in cumulative and single-period rollover.

### Bug fixes (with regression tests)
- **Period anchoring on startDate** (#3595): weekly/biweekly/monthly/quarterly/yearly periods now anchor on the budget''s `startDate` instead of the calendar boundary.
- **Honor budget endDate** (#3632): status window and rollover chaining stop at `endDate`.
- **Reconcile effective vs cumulative rollover** (#3653): `calculateEffectiveBudget` documented as single-period; new `effectiveBudgetCumulative` uses the cumulative chain, resolving the multi-period disagreement.

### Testing
- `./gradlew :packages:core:jvmTest` — all tests pass (2698).
- `./gradlew detekt` — clean for all new/changed files.

Closes #3690
Closes #3684
Closes #3678
Closes #3662
Closes #3658
Closes #3653
Closes #3649
Closes #3632
Closes #3595
Closes #3689
