### PR TITLE
fix(core,web): currency/FX correctness & related financial data bugs

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -116,6 +116,9 @@ jobs:
       - name: Prettier
         run: npx prettier --check .
 
+      - name: Validate financial-terminology glossary
+        run: node scripts/i18n/validate-glossary.js
+
   pr-title:
     name: Semantic PR Title
     needs: changes

--- a/apps/web/src/db/repositories/goals.test.ts
+++ b/apps/web/src/db/repositories/goals.test.ts
@@ -11,6 +11,7 @@ import {
   getActiveGoals,
   getAllGoals,
   getGoalById,
+  getGoalProgressContributions,
   reorderGoals,
   updateGoal,
   type CreateGoalInput,
@@ -894,6 +895,59 @@ describe('goals repository', () => {
 
       const sql = mockExecute.mock.calls[0][1];
       expect(sql).not.toContain("id = 'goal-1'");
+    });
+  });
+
+  describe('getGoalProgressContributions', () => {
+    it('maps rows and computes a cumulative running total (#3381)', () => {
+      mockQuery.mockReturnValue({
+        columns: [],
+        rows: [
+          { amount: 10000, contributed_at: '2024-01-01T00:00:00Z' },
+          { amount: 25000, contributed_at: '2024-02-01T00:00:00Z' },
+          { amount: 15000, contributed_at: '2024-03-01T00:00:00Z' },
+        ],
+      });
+
+      const contributions = getGoalProgressContributions(mockDb, 'goal-1');
+
+      expect(contributions).toEqual([
+        { date: '2024-01-01T00:00:00Z', amountCents: 10000, runningTotalCents: 10000 },
+        { date: '2024-02-01T00:00:00Z', amountCents: 25000, runningTotalCents: 35000 },
+        { date: '2024-03-01T00:00:00Z', amountCents: 15000, runningTotalCents: 50000 },
+      ]);
+    });
+
+    it('queries oldest-first, scoped to the goal and non-deleted rows', () => {
+      mockQuery.mockReturnValue({ columns: [], rows: [] });
+
+      getGoalProgressContributions(mockDb, 'goal-42');
+
+      const [, sql, params] = mockQuery.mock.calls[0];
+      expect(sql).toContain('FROM goal_progress_contribution');
+      expect(sql).toContain('goal_id = ?');
+      expect(sql).toContain('deleted_at IS NULL');
+      expect(sql).toContain('ORDER BY contributed_at ASC');
+      expect(params).toEqual(['goal-42']);
+    });
+
+    it('handles a withdrawal (negative amount) in the running total', () => {
+      mockQuery.mockReturnValue({
+        columns: [],
+        rows: [
+          { amount: 50000, contributed_at: '2024-01-01T00:00:00Z' },
+          { amount: -20000, contributed_at: '2024-02-01T00:00:00Z' },
+        ],
+      });
+
+      const contributions = getGoalProgressContributions(mockDb, 'goal-1');
+
+      expect(contributions[1].runningTotalCents).toBe(30000);
+    });
+
+    it('returns an empty array when there is no history', () => {
+      mockQuery.mockReturnValue({ columns: [], rows: [] });
+      expect(getGoalProgressContributions(mockDb, 'goal-1')).toEqual([]);
     });
   });
 });

--- a/apps/web/src/db/repositories/goals.ts
+++ b/apps/web/src/db/repositories/goals.ts
@@ -76,6 +76,16 @@ export interface GoalContributionInput {
   note?: string | null;
 }
 
+/** A single recorded goal-progress contribution, oldest-first friendly. */
+export interface GoalContributionRecord {
+  /** ISO-8601 timestamp the contribution was recorded. */
+  readonly date: string;
+  /** Signed contribution amount in cents (negative for withdrawals). */
+  readonly amountCents: number;
+  /** Cumulative saved amount in cents after this contribution. */
+  readonly runningTotalCents: number;
+}
+
 function mapGoal(row: Row): Goal {
   return {
     id: requireString(row.id, 'goal.id'),
@@ -391,4 +401,40 @@ export function getCompletedGoals(db: SqliteDb): Goal[] {
     `${GOAL_BASE_QUERY} AND status = ? ORDER BY sort_order ASC, updated_at DESC, name ASC`,
     ['COMPLETED'],
   ).rows.map(mapGoal);
+}
+
+/**
+ * Return a goal's real contribution history, oldest first, with a cumulative
+ * running total.
+ *
+ * These are the actual rows written by {@link contributeToGoal} into
+ * `goal_progress_contribution`. Consumers use the timestamps and per-entry
+ * amounts to compute a genuine monthly pace and projected completion date,
+ * rather than fabricating a single lump-sum contribution from the goal's
+ * current balance (#3381).
+ */
+export function getGoalProgressContributions(
+  db: SqliteDb,
+  goalId: SyncId,
+): GoalContributionRecord[] {
+  const rows = query<Row>(
+    db,
+    `SELECT amount, contributed_at
+       FROM goal_progress_contribution
+      WHERE goal_id = ?
+        AND deleted_at IS NULL
+      ORDER BY contributed_at ASC, created_at ASC`,
+    [goalId],
+  ).rows;
+
+  let runningTotalCents = 0;
+  return rows.map((row) => {
+    const amountCents = requireNumber(row.amount, 'goal_progress_contribution.amount');
+    runningTotalCents += amountCents;
+    return {
+      date: requireString(row.contributed_at, 'goal_progress_contribution.contributed_at'),
+      amountCents,
+      runningTotalCents,
+    };
+  });
 }

--- a/apps/web/src/hooks/useLinkedGoals.ts
+++ b/apps/web/src/hooks/useLinkedGoals.ts
@@ -17,6 +17,8 @@
 import { useMemo } from 'react';
 import { useGoals } from './useGoals';
 import { useAccounts } from './useAccounts';
+import { useDatabase } from '../db/DatabaseProvider';
+import { getGoalProgressContributions } from '../db/repositories/goals';
 import { buildLinkedGoal, type LinkedGoal, type GoalContribution } from '../lib/planning';
 
 // ---------------------------------------------------------------------------
@@ -41,6 +43,7 @@ export interface UseLinkedGoalsResult {
 
 /** Load savings goals with linked-account progress tracking. */
 export function useLinkedGoals(): UseLinkedGoalsResult {
+  const db = useDatabase();
   const { goals, loading: goalsLoading, error: goalsError, refresh: refreshGoals } = useGoals();
   const { accounts, loading: accountsLoading, refresh: refreshAccounts } = useAccounts();
 
@@ -51,15 +54,16 @@ export function useLinkedGoals(): UseLinkedGoalsResult {
         ? (accounts.find((a) => a.id === goal.accountId) ?? null)
         : null;
 
-      // Derive contribution history from goal progress (simplified)
-      // In production, this would come from transaction history
-      const contributions: GoalContribution[] = [];
-      if (goal.currentAmount.amount > 0) {
-        contributions.push({
-          date: goal.createdAt,
-          amountCents: goal.currentAmount.amount,
-          runningTotalCents: goal.currentAmount.amount,
-        });
+      // Use the goal's real, dated contribution history from
+      // `goal_progress_contribution` so pace and projection reflect how the
+      // balance actually accumulated over time — not a single lump sum synthesised
+      // from the current balance (#3381). buildLinkedGoal treats fewer than two
+      // contributions as insufficient history.
+      let contributions: GoalContribution[];
+      try {
+        contributions = getGoalProgressContributions(db, goal.id);
+      } catch {
+        contributions = [];
       }
 
       return buildLinkedGoal(
@@ -75,7 +79,7 @@ export function useLinkedGoals(): UseLinkedGoalsResult {
         contributions,
       );
     });
-  }, [goals, accounts]);
+  }, [db, goals, accounts]);
 
   const refresh = () => {
     refreshGoals();

--- a/apps/web/src/lib/education/glossary-canonical.test.ts
+++ b/apps/web/src/lib/education/glossary-canonical.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Consumes and validates the canonical financial-terminology glossary
+ * (config/i18n/glossary.json) from the web app so terminology drift is caught
+ * by the web test suite in addition to the standalone CI validator.
+ *
+ * References: issue #3318
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import canonicalGlossary from '../../../../../config/i18n/glossary.json';
+import canonicalLocales from '../../../../../config/i18n/locales.json';
+
+import { financialGlossary } from './glossary';
+
+interface GlossaryTerm {
+  concept: string;
+  doNotUse?: Record<string, string[]>;
+  [locale: string]: unknown;
+}
+
+interface CanonicalGlossary {
+  sourceLocale: string;
+  locales: string[];
+  terms: GlossaryTerm[];
+}
+
+interface LocaleMeta {
+  locales: { id: string; enforced?: boolean }[];
+}
+
+const glossary = canonicalGlossary as unknown as CanonicalGlossary;
+
+const localeMeta = canonicalLocales as unknown as LocaleMeta;
+
+describe('canonical financial-terminology glossary (#3318)', () => {
+  it('declares a valid locale set with the source locale included', () => {
+    expect(Array.isArray(glossary.locales)).toBe(true);
+    expect(glossary.locales.length).toBeGreaterThan(0);
+    expect(glossary.locales).toContain(glossary.sourceLocale);
+  });
+
+  it('supplies a non-blank value for every locale on every concept', () => {
+    for (const term of glossary.terms) {
+      expect(term.concept, JSON.stringify(term)).toBeTruthy();
+      for (const locale of glossary.locales) {
+        const value = term[locale];
+        expect(typeof value, `${term.concept} / ${locale}`).toBe('string');
+        expect((value as string).trim().length, `${term.concept} / ${locale}`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('has unique concept keys', () => {
+    const concepts = glossary.terms.map((t) => t.concept);
+    expect(new Set(concepts).size).toBe(concepts.length);
+  });
+
+  it('never lists a chosen translation in its own doNotUse set', () => {
+    for (const term of glossary.terms) {
+      if (!term.doNotUse) continue;
+      for (const [locale, banned] of Object.entries(term.doNotUse)) {
+        const chosen = String(term[locale] ?? '')
+          .trim()
+          .toLowerCase();
+        for (const bad of banned) {
+          expect(bad.trim().toLowerCase(), `${term.concept} / ${locale}`).not.toBe(chosen);
+        }
+      }
+    }
+  });
+
+  it('covers every enforced locale from config/i18n/locales.json', () => {
+    const enforced = localeMeta.locales.filter((l) => l.enforced).map((l) => l.id);
+    for (const id of enforced) {
+      expect(glossary.locales, `enforced locale ${id}`).toContain(id);
+    }
+  });
+
+  it('keeps the in-app English glossary wording consistent with canonical terms', () => {
+    const collapse = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+    const inAppByCollapsed = new Map<string, string>();
+    for (const entry of Object.values(financialGlossary)) {
+      inAppByCollapsed.set(collapse(entry.term), entry.term);
+    }
+
+    const en = glossary.sourceLocale;
+    let overlaps = 0;
+    for (const term of glossary.terms) {
+      const canonical = String(term[en] ?? '');
+      const key = collapse(canonical);
+      const inApp = inAppByCollapsed.get(key);
+      if (inApp === undefined) continue;
+      overlaps += 1;
+      // Case/spacing may differ per surface, but the words must match.
+      expect(collapse(inApp), term.concept).toBe(key);
+    }
+    // At least the shared terms (Budget, Net worth, Exchange rate) overlap.
+    expect(overlaps).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/lib/planning/life-events/education-planner.test.ts
+++ b/apps/web/src/lib/planning/life-events/education-planner.test.ts
@@ -265,4 +265,37 @@ describe('analyzeEducationFund', () => {
     expect(result.fundingGapCents).toBeGreaterThanOrEqual(0);
     expect(result.requiredMonthlyContributionCents).toBeGreaterThan(0);
   });
+
+  it('reports a non-zero surplus for an overfunded plan (#3484)', () => {
+    // Massively overfund: a huge balance and contribution guarantee the
+    // projected balance exceeds the projected cost.
+    const result = analyzeEducationFund({
+      ...baseParams,
+      currentBalanceCents: 50_000_000, // $500,000
+      monthlyContributionCents: 200_000, // $2,000/mo
+    });
+
+    expect(result.fundingGapCents).toBe(0);
+    // Surplus must reflect the actual overage, not $0.00.
+    expect(result.surplusCents).toBeGreaterThan(0);
+    expect(result.surplusCents).toBe(result.projectedBalanceCents - result.totalProjectedCostCents);
+  });
+
+  it('reports zero surplus and a positive gap when underfunded (#3484)', () => {
+    const result = analyzeEducationFund({
+      ...baseParams,
+      currentBalanceCents: 0,
+      monthlyContributionCents: 0,
+    });
+
+    expect(result.fundingGapCents).toBeGreaterThan(0);
+    expect(result.surplusCents).toBe(0);
+  });
+
+  it('never reports both a surplus and a gap simultaneously (#3484)', () => {
+    for (const currentBalanceCents of [0, 2_000_000, 50_000_000]) {
+      const result = analyzeEducationFund({ ...baseParams, currentBalanceCents });
+      expect(Math.min(result.surplusCents, result.fundingGapCents)).toBe(0);
+    }
+  });
 });

--- a/apps/web/src/lib/planning/life-events/education-planner.ts
+++ b/apps/web/src/lib/planning/life-events/education-planner.ts
@@ -288,6 +288,9 @@ export function analyzeEducationFund(params: EducationFundParams): EducationFund
   );
 
   const fundingGapCents = Math.max(0, totalProjectedCostCents - projectedBalanceCents);
+  // Mirror of the funding gap: how far the projected balance exceeds the cost
+  // when the plan is overfunded. At most one of the two is ever non-zero (#3484).
+  const surplusCents = Math.max(0, projectedBalanceCents - totalProjectedCostCents);
 
   const coverageRatioBps =
     totalProjectedCostCents > 0
@@ -320,6 +323,7 @@ export function analyzeEducationFund(params: EducationFundParams): EducationFund
     totalProjectedCostCents,
     projectedBalanceCents,
     fundingGapCents,
+    surplusCents,
     coverageRatioBps,
     requiredMonthlyContributionCents,
     projectionPoints,

--- a/apps/web/src/lib/planning/life-events/types.ts
+++ b/apps/web/src/lib/planning/life-events/types.ts
@@ -111,6 +111,13 @@ export interface EducationFundResult {
   readonly projectedBalanceCents: number;
   /** Funding gap (cost - projected balance), 0 if fully funded. */
   readonly fundingGapCents: number;
+  /**
+   * Surplus (projected balance - cost) in cents when the plan is *overfunded*,
+   * 0 otherwise. This is the mirror of {@link fundingGapCents}: at most one of
+   * the two is non-zero. Surfaced so an overfunded 529 shows how much it is
+   * ahead instead of a misleading $0.00 (#3484).
+   */
+  readonly surplusCents: number;
   /** Funding coverage ratio in basis points (balance / cost × 10000). */
   readonly coverageRatioBps: number;
   /** Monthly contribution needed to fully fund, in cents. */

--- a/apps/web/src/lib/planning/savings-goals.test.ts
+++ b/apps/web/src/lib/planning/savings-goals.test.ts
@@ -188,4 +188,72 @@ describe('buildLinkedGoal', () => {
     expect(result.accountId).toBeNull();
     expect(result.progressPercent).toBe(50);
   });
+
+  // #3381 — projections must be based on real, multi-point contribution history
+  // rather than a single lump sum fabricated from the current balance.
+
+  it('does not project from a single contribution (#3381)', () => {
+    const result = buildLinkedGoal(
+      {
+        id: 'g3',
+        name: 'New Car',
+        targetCents: 2000000,
+        currentCents: 500000,
+        accountId: null,
+      },
+      null,
+      null,
+      // Only one dated contribution — insufficient to establish a pace.
+      [{ date: '2024-01-01', amountCents: 500000, runningTotalCents: 500000 }],
+    );
+
+    expect(result.hasSufficientHistory).toBe(false);
+    expect(result.monthlyPaceCents).toBe(0);
+    expect(result.projectedCompletionDate).toBeNull();
+  });
+
+  it('projects from two or more real contributions (#3381)', () => {
+    const contributions: GoalContribution[] = [
+      { date: '2024-01-01', amountCents: 100000, runningTotalCents: 100000 },
+      { date: '2024-02-01', amountCents: 100000, runningTotalCents: 200000 },
+      { date: '2024-03-01', amountCents: 100000, runningTotalCents: 300000 },
+    ];
+
+    const result = buildLinkedGoal(
+      {
+        id: 'g4',
+        name: 'House Deposit',
+        targetCents: 1000000,
+        currentCents: 300000,
+        accountId: null,
+      },
+      null,
+      null,
+      contributions,
+    );
+
+    expect(result.hasSufficientHistory).toBe(true);
+    // ~$100k/month over the two-month span.
+    expect(result.monthlyPaceCents).toBeGreaterThan(0);
+    expect(result.projectedCompletionDate).toBeTruthy();
+  });
+
+  it('still reports completion for a finished goal with sparse history (#3381)', () => {
+    const result = buildLinkedGoal(
+      {
+        id: 'g5',
+        name: 'Done Goal',
+        targetCents: 100000,
+        currentCents: 100000,
+        accountId: null,
+      },
+      null,
+      null,
+      // Even with a single contribution, an already-complete goal has a date.
+      [{ date: '2024-01-01', amountCents: 100000, runningTotalCents: 100000 }],
+    );
+
+    expect(result.progressPercent).toBe(100);
+    expect(result.projectedCompletionDate).toBeTruthy();
+  });
 });

--- a/apps/web/src/lib/planning/savings-goals.ts
+++ b/apps/web/src/lib/planning/savings-goals.ts
@@ -138,6 +138,14 @@ export function projectCompletionDate(
 }
 
 /**
+ * Minimum number of dated contributions required to compute a trustworthy
+ * pace/projection. A single data point cannot establish a rate over time —
+ * projecting from it (as the old lump-sum shim did) produces a meaningless
+ * completion date (#3381).
+ */
+const MIN_CONTRIBUTIONS_FOR_PACE = 2;
+
+/**
  * Build a complete LinkedGoal from raw goal and account data.
  *
  * @param goal - Goal metadata
@@ -161,7 +169,12 @@ export function buildLinkedGoal(
   // Use account balance as current progress if linked
   const currentCents = accountBalance ?? goal.currentCents;
   const progressPercent = calculateProgress(currentCents, goal.targetCents);
-  const monthlyPaceCents = calculateMonthlyPace(contributions);
+  // A pace/projection is only meaningful with at least two real, dated
+  // contributions. With fewer, we report zero pace and let the projection fall
+  // through to null (unless the goal is already complete) rather than inventing
+  // an optimistic completion date from a single point (#3381).
+  const hasSufficientHistory = contributions.length >= MIN_CONTRIBUTIONS_FOR_PACE;
+  const monthlyPaceCents = hasSufficientHistory ? calculateMonthlyPace(contributions) : 0;
   const projectedCompletionDate = projectCompletionDate(
     currentCents,
     goal.targetCents,
@@ -179,6 +192,7 @@ export function buildLinkedGoal(
     progressPercent,
     projectedCompletionDate,
     monthlyPaceCents,
+    hasSufficientHistory,
     contributions: [...contributions],
     milestones,
   };

--- a/apps/web/src/lib/planning/types.ts
+++ b/apps/web/src/lib/planning/types.ts
@@ -181,6 +181,15 @@ export interface LinkedGoal {
   readonly projectedCompletionDate: string | null;
   /** Monthly contribution pace in cents (based on recent history). */
   readonly monthlyPaceCents: number;
+  /**
+   * Whether there is enough real contribution history (at least two dated
+   * contributions) to compute a trustworthy pace and projection. When `false`,
+   * {@link monthlyPaceCents} is 0 and {@link projectedCompletionDate} is `null`
+   * (unless the goal is already complete), so the UI can say "not enough
+   * history" instead of showing a projection fabricated from a single lump
+   * sum (#3381).
+   */
+  readonly hasSufficientHistory: boolean;
   /** Contribution history entries. */
   readonly contributions: readonly GoalContribution[];
   /** Milestones with completion status. */

--- a/apps/web/src/pages/AccountsPage.test.tsx
+++ b/apps/web/src/pages/AccountsPage.test.tsx
@@ -320,6 +320,48 @@ describe('AccountsPage', () => {
     expect(screen.queryByText('$22,310.79')).not.toBeInTheDocument();
   });
 
+  it('excludes archived accounts from the net-worth total but still lists them (#3469)', () => {
+    // Same active accounts as the $20,964.81 scenario, plus a large archived
+    // savings account. The /net-worth page skips archived accounts, so the
+    // Accounts total must too — otherwise the two pages disagree.
+    mockedUseAccounts.mockReturnValue({
+      accounts: [
+        makeMockAccount({ id: 'a-checking', name: 'Checking', type: 'CHECKING', balance: 956405 }),
+        makeMockAccount({ id: 'a-savings', name: 'Savings', type: 'SAVINGS', balance: 1200000 }),
+        makeMockAccount({ id: 'a-cash', name: 'Cash', type: 'CASH', balance: 7375 }),
+        makeMockAccount({ id: 'a-card', name: 'Credit Card', type: 'CREDIT_CARD', balance: 67299 }),
+        makeMockAccount({
+          id: 'a-archived',
+          name: 'Old Savings',
+          type: 'SAVINGS',
+          balance: 5000000,
+          isArchived: true,
+        }),
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      createAccount: vi.fn(),
+      updateAccount: vi.fn(),
+      deleteAccount: vi.fn(),
+    });
+
+    render(
+      <PrivacyModeProvider initialValue={false}>
+        <MemoryRouter>
+          <AccountsPage />
+        </MemoryRouter>
+      </PrivacyModeProvider>,
+    );
+
+    // Total still nets to $20,964.81 — the $50,000 archived account is excluded.
+    expect(screen.getAllByText('$20,964.81').length).toBeGreaterThanOrEqual(1);
+    // The figure that would include the archived account must never appear.
+    expect(screen.queryByText('$70,964.81')).not.toBeInTheDocument();
+    // ...but the archived account is still shown in the list.
+    expect(screen.getByText('Old Savings')).toBeInTheDocument();
+  });
+
   it('shows multi-currency indicator when accounts have different currencies', async () => {
     mockedUseAccounts.mockReturnValue({
       accounts: [

--- a/apps/web/src/pages/AccountsPage.tsx
+++ b/apps/web/src/pages/AccountsPage.tsx
@@ -66,12 +66,18 @@ const MultiCurrencyTotal: React.FC<{
     type: AccountType;
     currentBalance: { amount: number };
     currency: { code: string };
+    isArchived?: boolean;
   }>;
   colorize?: boolean;
   readAloud?: boolean;
 }> = ({ accounts, colorize = false, readAloud = false }) => {
   const maskingMode = useEffectiveMaskingMode();
-  const currencyItems = accounts.map((acc) => ({
+  // Archived accounts are excluded from every total so the Accounts page agrees
+  // with the dedicated Net Worth page (`computeCurrentNetWorth`), which also
+  // skips archived accounts. They are still rendered in the account list, just
+  // not counted toward the net-worth figure (#3469).
+  const activeAccounts = accounts.filter((acc) => !acc.isArchived);
+  const currencyItems = activeAccounts.map((acc) => ({
     currency: acc.currency.code,
   }));
 
@@ -79,7 +85,7 @@ const MultiCurrencyTotal: React.FC<{
 
   if (!isMixed) {
     const singleCurrency = getSingleCurrency(currencyItems);
-    const total = accounts.reduce((sum, acc) => sum + netWorthContribution(acc), 0);
+    const total = activeAccounts.reduce((sum, acc) => sum + netWorthContribution(acc), 0);
     return (
       <>
         <CurrencyDisplay amount={total} currency={singleCurrency ?? 'USD'} colorize={colorize} />
@@ -94,7 +100,7 @@ const MultiCurrencyTotal: React.FC<{
     );
   }
 
-  const amounts = accounts.map((acc) => ({
+  const amounts = activeAccounts.map((acc) => ({
     amount: netWorthContribution(acc),
     currency: acc.currency.code,
   }));
@@ -142,22 +148,24 @@ export const AccountsPage: React.FC = () => {
     [accounts],
   );
 
-  // Check if accounts use multiple currencies
+  // Check if accounts use multiple currencies (archived accounts are excluded
+  // from net-worth totals, so they should not drive the converted-total UI — #3469).
+  const activeAccounts = useMemo(() => accounts.filter((a) => !a.isArchived), [accounts]);
   const currencyCodes = useMemo(
-    () => [...new Set(accounts.map((a) => a.currency.code))],
-    [accounts],
+    () => [...new Set(activeAccounts.map((a) => a.currency.code))],
+    [activeAccounts],
   );
   const isMultiCurrency = currencyCodes.length > 1;
 
   // Compute converted total when multi-currency
   const computeConvertedTotal = useCallback(async () => {
-    if (!isMultiCurrency || accounts.length === 0) {
+    if (!isMultiCurrency || activeAccounts.length === 0) {
       setConvertedTotal(null);
       return;
     }
     try {
       let total = 0;
-      for (const account of accounts) {
+      for (const account of activeAccounts) {
         // Liabilities subtract from the converted net-worth total, matching
         // the single-currency path and the Net Worth page.
         const contribution = netWorthContribution(account);
@@ -172,7 +180,7 @@ export const AccountsPage: React.FC = () => {
     } catch {
       setConvertedTotal(null);
     }
-  }, [accounts, convert, isMultiCurrency]);
+  }, [activeAccounts, convert, isMultiCurrency]);
 
   useEffect(() => {
     void computeConvertedTotal();

--- a/apps/web/src/pages/PlanningPage.tsx
+++ b/apps/web/src/pages/PlanningPage.tsx
@@ -705,6 +705,11 @@ const GoalProgressCard: React.FC<{ goal: LinkedGoal }> = ({ goal }) => (
         Projected completion: {new Date(goal.projectedCompletionDate).toLocaleDateString()}
       </p>
     )}
+    {!goal.projectedCompletionDate && !goal.hasSufficientHistory && goal.progressPercent < 100 && (
+      <p className="goal-progress__meta" aria-live="polite">
+        Not enough contribution history yet to project a completion date.
+      </p>
+    )}
     <div className="milestone-list" role="list" aria-label="Milestones">
       {goal.milestones.map((m) => (
         <div
@@ -2377,7 +2382,9 @@ const EducationPanel: React.FC = () => {
           </article>
           <article className="planning-metric" aria-label={fullyFunded ? 'Surplus' : 'Shortfall'}>
             <p className="planning-metric__label">{fullyFunded ? 'Surplus' : 'Shortfall'}</p>
-            <p className="planning-metric__value">{formatCurrency(result.fundingGapCents)}</p>
+            <p className="planning-metric__value">
+              {formatCurrency(fullyFunded ? result.surplusCents : result.fundingGapCents)}
+            </p>
           </article>
           <article
             className="planning-metric"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "type-check": "turbo run type-check",
     "format": "npx prettier --write .",
     "format:check": "npx prettier --check .",
+    "i18n:validate-glossary": "node scripts/i18n/validate-glossary.js",
+    "i18n:validate": "node scripts/i18n/validate-locale-catalogs.js && node scripts/i18n/validate-glossary.js",
     "ci:check": "npm run format:check && npm run lint && npm run type-check",
     "ci:check:quick": "node tools/ci-check-quick.js",
     "ready-for-pr": "node tools/ready-for-pr.js",

--- a/packages/core/src/commonMain/kotlin/com/finance/core/analytics/ReportGenerator.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/analytics/ReportGenerator.kt
@@ -308,10 +308,31 @@ object ReportGenerator {
                 previousMonth = previous,
                 percentChange = percentChange,
                 trend = trend,
+                isNew = previous.isZero() && current.amount > 0,
             )
-        }.sortedByDescending { insight ->
-            insight.percentChange?.let { kotlin.math.abs(it) } ?: 0.0
-        }
+        }.sortedWith(
+            // Brand-new spending (0 → X) has an undefined percent change but is the
+            // most important thing to surface, so it ranks at the very top; among
+            // new categories the larger current spend comes first. Everything else
+            // is ranked by magnitude of change — a vanished category (X → 0) is a
+            // 100% decrease and thus outranks minor wiggles (#3744). Ties break by
+            // category id for deterministic ordering.
+            compareByDescending<SpendingInsight> { insightSortMagnitude(it) }
+                .thenByDescending { it.currentMonth.amount }
+                .thenBy { it.categoryId.value },
+        )
+    }
+
+    /**
+     * Ranking magnitude for [spendingInsights]. New spending is treated as a
+     * maximal change so it sorts above every finite percentage change; otherwise
+     * the absolute percent change is used, with an undefined (`null`) change
+     * ranked lowest.
+     */
+    private fun insightSortMagnitude(insight: SpendingInsight): Double = when {
+        insight.isNew -> Double.MAX_VALUE
+        insight.percentChange != null -> kotlin.math.abs(insight.percentChange)
+        else -> 0.0
     }
 
     // ── Helpers ───────────────────────────────────────────────────────

--- a/packages/core/src/commonMain/kotlin/com/finance/core/analytics/SpendingInsight.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/analytics/SpendingInsight.kt
@@ -16,6 +16,11 @@ enum class Trend { UP, DOWN, STABLE }
  * [percentChange] is the relative change expressed as a percentage (e.g., 25.0 means +25 %).
  * Positive values mean spending increased; negative values mean it decreased.
  * When the previous month has zero spending, [percentChange] is `null` (division undefined).
+ *
+ * [isNew] flags **brand-new spending** — a category with zero spending last month and
+ * positive spending this month (0 → X). Percent change is mathematically undefined for
+ * this case (so [percentChange] stays `null`), but it is often the single most important
+ * insight, so it is surfaced explicitly and ranked at the top (#3744).
  */
 data class SpendingInsight(
     val categoryId: SyncId,
@@ -23,6 +28,7 @@ data class SpendingInsight(
     val previousMonth: Cents,
     val percentChange: Double?,
     val trend: Trend,
+    val isNew: Boolean = false,
 ) {
     init {
         require(currentMonth.amount >= 0) { "Current month spending cannot be negative" }

--- a/packages/core/src/commonMain/kotlin/com/finance/core/currency/CurrencyConverter.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/currency/CurrencyConverter.kt
@@ -5,6 +5,7 @@ package com.finance.core.currency
 import com.finance.models.types.Cents
 import com.finance.models.types.Currency
 import com.finance.core.money.MoneyOperations
+import kotlinx.datetime.Instant
 import kotlin.math.pow
 
 /**
@@ -14,7 +15,7 @@ class CurrencyConverter(
     private val rateProvider: ExchangeRateProvider,
 ) {
     /**
-     * Convert an amount from one currency to another.
+     * Convert an amount from one currency to another using the **current** rate.
      * Uses banker's rounding for the conversion.
      */
     suspend fun convert(amount: Cents, from: Currency, to: Currency): ConversionResult {
@@ -23,6 +24,38 @@ class CurrencyConverter(
         val rate = rateProvider.getRate(from, to)
             ?: throw CurrencyConversionException("No exchange rate available for ${from.code} -> ${to.code}")
 
+        return convertWithRate(amount, from, to, rate)
+    }
+
+    /**
+     * Convert an amount using the exchange rate that was in effect on [at]
+     * (#3728). This resolves the rate via the timestamped
+     * [ExchangeRateProvider.getRate] overload so a past-dated transaction is
+     * valued at its historical rate rather than today's — essential for
+     * accurate P&L, net-worth history, and category trends over time.
+     *
+     * The returned [ConversionResult.rateUsed] reflects the historical rate and
+     * its timestamp. Minor-unit rescaling (#3460) and banker's rounding are
+     * applied identically to the non-dated [convert]; same-currency conversions
+     * short-circuit with no rate lookup.
+     */
+    suspend fun convert(amount: Cents, from: Currency, to: Currency, at: Instant): ConversionResult {
+        if (from == to) return ConversionResult(amount, amount, null)
+
+        val rate = rateProvider.getRate(from, to, at)
+            ?: throw CurrencyConversionException(
+                "No exchange rate available for ${from.code} -> ${to.code} at $at",
+            )
+
+        return convertWithRate(amount, from, to, rate)
+    }
+
+    private fun convertWithRate(
+        amount: Cents,
+        from: Currency,
+        to: Currency,
+        rate: ExchangeRate,
+    ): ConversionResult {
         // `amount` is in the source currency's minor units, but `rate` converts
         // *major* units (e.g. 1 USD = 149.5 JPY). Rescale by the minor-unit
         // delta (10^(toDecimals - fromDecimals)) so converting to/from

--- a/packages/core/src/commonMain/kotlin/com/finance/core/currency/CurrencyFormatter.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/currency/CurrencyFormatter.kt
@@ -11,19 +11,30 @@ import kotlin.math.abs
  * Respects currency-specific decimal places and symbols.
  */
 object CurrencyFormatter {
-    private val symbols = mapOf(
-        "USD" to "$", "EUR" to "€", "GBP" to "£", "JPY" to "¥",
-        "CAD" to "CA$", "AUD" to "A$", "CHF" to "CHF ",
-        "CNY" to "¥", "KRW" to "₩", "INR" to "₹",
-        "BRL" to "R$", "MXN" to "MX$", "SEK" to "kr",
+    // Extra display symbols for a few currencies whose glyphs differ from the
+    // canonical catalog's compact symbol, plus a trailing space where the code
+    // is used as a symbol (e.g. "CHF "). Anything not overridden here falls back
+    // to the single canonical source of truth ([CurrencyCatalog]) so symbols and
+    // decimal places never diverge (#3736).
+    private val symbolOverrides = mapOf(
+        "CHF" to "CHF ",
     )
+
+    /**
+     * Resolve the display symbol for [code], preferring an override, then the
+     * canonical [CurrencyCatalog], then the raw code with a trailing space.
+     */
+    private fun symbolFor(code: String): String =
+        symbolOverrides[code]
+            ?: com.finance.core.multicurrency.CurrencyCatalog.get(code)?.symbol
+            ?: "$code "
 
     /**
      * Format cents as a human-readable currency string.
      * Examples: "$12.50", "€1,234.56", "¥1,235" (no decimals for JPY)
      */
     fun format(amount: Cents, currency: Currency, showSign: Boolean = false): String {
-        val symbol = symbols[currency.code] ?: "${currency.code} "
+        val symbol = symbolFor(currency.code)
         val decimals = currency.decimalPlaces
         val isNegative = amount.isNegative()
         val absAmount = amount.abs().amount
@@ -51,7 +62,7 @@ object CurrencyFormatter {
      * Uses multiplatform-safe string formatting (no String.format).
      */
     fun formatCompact(amount: Cents, currency: Currency): String {
-        val symbol = symbols[currency.code] ?: "${currency.code} "
+        val symbol = symbolFor(currency.code)
         val dollars = amount.amount.toDouble() / pow10(currency.decimalPlaces)
         val isNeg = dollars < 0
         val absDollars = abs(dollars)

--- a/packages/core/src/commonMain/kotlin/com/finance/core/goals/GoalTrackingEngine.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/goals/GoalTrackingEngine.kt
@@ -85,7 +85,7 @@ object GoalTrackingEngine {
         from: LocalDate,
     ): GoalFeasibility {
         val target = goal.targetAmount
-        val completionDate = projectedCompletionDate(goal, contributionPerPeriod, period, from)
+        val completionDate = feasibilityCompletionDate(goal, contributionPerPeriod, period, from)
         val deadline = goal.targetDate
 
         if (deadline == null) {
@@ -385,7 +385,7 @@ object GoalTrackingEngine {
             .toSet()
     }
 
-    private fun projectedCompletionDate(
+    private fun feasibilityCompletionDate(
         goal: Goal,
         contribution: Cents,
         period: ContributionPeriod,
@@ -402,6 +402,35 @@ object GoalTrackingEngine {
                 addPeriods(from, periodsNeeded, period)
             }
         }
+    }
+
+    // ── #3681: projected completion date from a contribution rate ─────
+
+    /**
+     * Project the date a goal will be fully funded if [contributionPerPeriod] is
+     * contributed every [period], starting from [from] (#3681).
+     *
+     * Uses **ceiling** division on the remaining cents so the returned date is
+     * the first date the target is met or exceeded — the projection never
+     * underestimates. All arithmetic stays in integer [Cents]; day/period
+     * arithmetic uses `kotlinx-datetime`.
+     *
+     * @return the projected completion date, or `null` when the goal is already
+     *   complete (nothing to project) or the contribution is zero/negative
+     *   (never completes — no divide-by-zero).
+     */
+    fun projectedCompletionDate(
+        goal: Goal,
+        contributionPerPeriod: Cents,
+        period: ContributionPeriod,
+        from: LocalDate,
+    ): LocalDate? {
+        val remaining = remainingAmount(goal).amount
+        if (remaining <= 0L || !contributionPerPeriod.isPositive()) return null
+        val periodsNeeded = ceilDiv(remaining, contributionPerPeriod.amount)
+            .coerceAtMost(Int.MAX_VALUE.toLong())
+            .toInt()
+        return addPeriods(from, periodsNeeded, period)
     }
 
     private fun wholePeriodsBetween(from: LocalDate, to: LocalDate, period: ContributionPeriod): Int {

--- a/packages/core/src/commonMain/kotlin/com/finance/core/multicurrency/MultiCurrencyEngine.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/multicurrency/MultiCurrencyEngine.kt
@@ -5,6 +5,7 @@ package com.finance.core.multicurrency
 import com.finance.models.types.Cents
 import com.finance.models.types.Currency
 import com.finance.core.money.MoneyOperations
+import kotlin.math.abs
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
@@ -15,24 +16,18 @@ import kotlinx.serialization.Serializable
  */
 object MultiCurrencyEngine {
 
-    val currencyCatalog: Map<String, CurrencyInfo> = mapOf(
-        "USD" to CurrencyInfo("USD", "US Dollar", "$", 2),
-        "EUR" to CurrencyInfo("EUR", "Euro", "\u20AC", 2),
-        "GBP" to CurrencyInfo("GBP", "British Pound", "\u00A3", 2),
-        "JPY" to CurrencyInfo("JPY", "Japanese Yen", "\u00A5", 0),
-        "CAD" to CurrencyInfo("CAD", "Canadian Dollar", "CA$", 2),
-        "AUD" to CurrencyInfo("AUD", "Australian Dollar", "A$", 2),
-        "CHF" to CurrencyInfo("CHF", "Swiss Franc", "CHF", 2),
-        "CNY" to CurrencyInfo("CNY", "Chinese Yuan", "\u00A5", 2),
-        "INR" to CurrencyInfo("INR", "Indian Rupee", "\u20B9", 2),
-        "MXN" to CurrencyInfo("MXN", "Mexican Peso", "MX$", 2),
-        "BRL" to CurrencyInfo("BRL", "Brazilian Real", "R$", 2),
-        "KRW" to CurrencyInfo("KRW", "South Korean Won", "\u20A9", 0),
-        "SEK" to CurrencyInfo("SEK", "Swedish Krona", "kr", 2),
-        "BHD" to CurrencyInfo("BHD", "Bahraini Dinar", "BD", 3),
-        "KWD" to CurrencyInfo("KWD", "Kuwaiti Dinar", "KD", 3),
-        "OMR" to CurrencyInfo("OMR", "Omani Rial", "OMR", 3),
-    )
+    /**
+     * ISO 4217 catalog with display metadata.
+     *
+     * Derived from the single canonical [CurrencyCatalog] so decimal places,
+     * symbols, and names never diverge from the rest of the app (#3736). The
+     * per-currency `decimalPlaces` therefore always agrees with
+     * [Currency.decimalPlaces] (asserted by a consistency test).
+     */
+    val currencyCatalog: Map<String, CurrencyInfo> =
+        CurrencyCatalog.all.mapValues { (_, def) ->
+            CurrencyInfo(def.code, def.name, def.symbol, def.decimalPlaces)
+        }
 
     fun currencyInfo(currency: Currency): CurrencyInfo? = currencyCatalog[currency.code]
 
@@ -50,6 +45,40 @@ object MultiCurrencyEngine {
             cache[cacheKey(from, to)]?.let { if (!isStale(it, now)) return it.rate }
             cache[cacheKey(to, from)]?.let { if (!isStale(it, now)) return 1.0 / it.rate }
             return null
+        }
+
+        /**
+         * Resolve a `from → to` rate, falling back to **triangulation** through a
+         * [pivot] currency (default USD) when no direct or inverse rate is cached
+         * (#3733).
+         *
+         * Rate feeds commonly quote everything against a single base (e.g. USD),
+         * so a user holding EUR and JPY may have `USD→EUR` and `USD→JPY` but no
+         * direct `EUR→JPY`. This derives the missing cross rate as
+         * `rate(from→pivot) * rate(pivot→to)`.
+         *
+         * Resolution order:
+         * 1. A direct or inverse rate (via [get]) always takes precedence.
+         * 2. Otherwise both legs `from→pivot` and `pivot→to` are looked up (each
+         *    may itself be a direct or inverse cache hit) and multiplied.
+         *
+         * @return the resolved rate, or `null` when neither a direct/inverse rate
+         *   nor both triangulation legs are available (fresh) at [now].
+         */
+        @Suppress("ReturnCount")
+        fun getTriangulated(
+            from: Currency,
+            to: Currency,
+            pivot: Currency = Currency.USD,
+            now: Instant = Clock.System.now(),
+        ): Double? {
+            get(from, to, now)?.let { return it }
+            // If either endpoint *is* the pivot, the missing leg equals the
+            // direct lookup already attempted above — triangulation adds nothing.
+            if (from == pivot || to == pivot) return null
+            val firstLeg = get(from, pivot, now) ?: return null
+            val secondLeg = get(pivot, to, now) ?: return null
+            return firstLeg * secondLeg
         }
 
         /**
@@ -98,6 +127,29 @@ object MultiCurrencyEngine {
         return ConversionResult(amount, convert(amount, rate), from, to, rate)
     }
 
+    /**
+     * Convert [amount] from [from] to [to], deriving the rate via
+     * [ExchangeRateCache.getTriangulated] through [pivot] when no direct/inverse
+     * rate is cached (#3733). The converted amount is computed in integer
+     * [Cents] with banker's rounding (via [convert]).
+     *
+     * @return a [ConversionResult] whose `rateUsed` is the (possibly
+     *   triangulated) rate, or `null` when the rate cannot be resolved.
+     */
+    @Suppress("ReturnCount")
+    fun convertWithTriangulation(
+        amount: Cents,
+        from: Currency,
+        to: Currency,
+        cache: ExchangeRateCache,
+        pivot: Currency = Currency.USD,
+        now: Instant = Clock.System.now(),
+    ): ConversionResult? {
+        if (from == to) return ConversionResult(amount, amount, from, to, 1.0)
+        val rate = cache.getTriangulated(from, to, pivot, now) ?: return null
+        return ConversionResult(amount, convert(amount, rate), from, to, rate)
+    }
+
     fun aggregate(amounts: List<CurrencyAmount>, targetCurrency: Currency, cache: ExchangeRateCache, now: Instant = Clock.System.now()): AggregationResult? {
         val conversions = mutableListOf<ConversionResult>(); var total = Cents.ZERO
         for (ca in amounts) {
@@ -110,8 +162,17 @@ object MultiCurrencyEngine {
     @Suppress("ReturnCount")
     fun currencyBreakdown(amounts: List<CurrencyAmount>, targetCurrency: Currency, cache: ExchangeRateCache, now: Instant = Clock.System.now()): Map<Currency, Double>? {
         val result = aggregate(amounts, targetCurrency, cache, now) ?: return null
-        if (result.totalAmount.isZero()) return emptyMap()
-        return result.conversions.groupBy { it.fromCurrency }.mapValues { (_, convs) -> (convs.sumOf { it.convertedAmount.amount }.toDouble() / result.totalAmount.amount) * 100.0 }
+        // Base the breakdown on the sum of **absolute** converted magnitudes, not
+        // the signed net total. A signed denominator is meaningless for mixed-sign
+        // data (income + expense): it can be small, zero, or negative, producing
+        // percentages that explode, go negative, or fail to sum to 100% (#3745).
+        val totalMagnitude = result.conversions.sumOf { abs(it.convertedAmount.amount) }
+        if (totalMagnitude == 0L) return emptyMap()
+        return result.conversions
+            .groupBy { it.fromCurrency }
+            .mapValues { (_, convs) ->
+                (convs.sumOf { abs(it.convertedAmount.amount) }.toDouble() / totalMagnitude) * 100.0
+            }
     }
 }
 

--- a/packages/core/src/commonTest/kotlin/com/finance/core/analytics/ReportsInsightsVerificationTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/analytics/ReportsInsightsVerificationTest.kt
@@ -280,8 +280,61 @@ class ReportsInsightsVerificationTest {
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // Net worth calculation across accounts
+    // #3744 — brand-new spending categories rank at the top, not the bottom
     // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun spendingInsights_newCategory_rankedFirst() {
+        val existing = SyncId("cat-existing")
+        val brandNew = SyncId("cat-new")
+        val transactions = listOf(
+            // Existing category with a modest +10% change.
+            TestFixtures.createExpense(amount = Cents(10000), categoryId = existing, date = LocalDate(2024, 5, 15)),
+            TestFixtures.createExpense(amount = Cents(11000), categoryId = existing, date = LocalDate(2024, 6, 15)),
+            // Brand-new category: nothing last month, $50 this month.
+            TestFixtures.createExpense(amount = Cents(5000), categoryId = brandNew, date = LocalDate(2024, 6, 20)),
+        )
+
+        val insights = ReportGenerator.spendingInsights(transactions, referenceDate = LocalDate(2024, 6, 15))
+
+        assertEquals(brandNew, insights.first().categoryId, "Brand-new spending should rank first")
+        assertTrue(insights.first().isNew)
+        assertNull(insights.first().percentChange, "New category has undefined percent change")
+    }
+
+    @Test
+    fun spendingInsights_multipleNewCategories_orderedByCurrentSpendDesc() {
+        val small = SyncId("cat-new-small")
+        val big = SyncId("cat-new-big")
+        val transactions = listOf(
+            TestFixtures.createExpense(amount = Cents(3000), categoryId = small, date = LocalDate(2024, 6, 10)),
+            TestFixtures.createExpense(amount = Cents(8000), categoryId = big, date = LocalDate(2024, 6, 12)),
+        )
+
+        val insights = ReportGenerator.spendingInsights(transactions, referenceDate = LocalDate(2024, 6, 15))
+
+        assertTrue(insights[0].isNew && insights[1].isNew)
+        assertEquals(big, insights[0].categoryId, "Larger new spend ranks ahead of smaller new spend")
+        assertEquals(small, insights[1].categoryId)
+    }
+
+    @Test
+    fun spendingInsights_vanishedCategory_outranksMinorChange() {
+        val minor = SyncId("cat-minor")
+        val vanished = SyncId("cat-vanished")
+        val transactions = listOf(
+            // Minor +1% wiggle.
+            TestFixtures.createExpense(amount = Cents(10000), categoryId = minor, date = LocalDate(2024, 5, 15)),
+            TestFixtures.createExpense(amount = Cents(10100), categoryId = minor, date = LocalDate(2024, 6, 15)),
+            // Category that vanished (X → 0) — a 100% decrease.
+            TestFixtures.createExpense(amount = Cents(10000), categoryId = vanished, date = LocalDate(2024, 5, 15)),
+        )
+
+        val insights = ReportGenerator.spendingInsights(transactions, referenceDate = LocalDate(2024, 6, 15))
+
+        assertEquals(vanished, insights.first().categoryId, "A 100% drop should outrank a 1% wiggle")
+        assertFalse(insights.first().isNew, "A vanished category is not new")
+    }
 
     @Test
     fun netWorth_checkingAndSavings_sumsPositive() {

--- a/packages/core/src/commonTest/kotlin/com/finance/core/currency/CurrencyConverterTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/currency/CurrencyConverterTest.kt
@@ -349,4 +349,90 @@ class CurrencyConverterTest {
         val gbpResult = converter.convert(Cents(10000), Currency.USD, Currency.GBP)
         assertEquals(Cents(7900), gbpResult.convertedAmount)
     }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // #3728 — date-aware historical conversion. A past-dated transaction must
+    // be valued at the rate in effect on its date, not today's rate.
+    // ═══════════════════════════════════════════════════════════════════
+
+    /** Rate provider that returns a different rate depending on the [at] date. */
+    private class DatedFakeRateProvider(
+        private val byDate: Map<Instant, ExchangeRate>,
+        private val current: ExchangeRate? = null,
+    ) : ExchangeRateProvider {
+        override suspend fun getRate(from: Currency, to: Currency): ExchangeRate? = current
+        override suspend fun getRate(from: Currency, to: Currency, at: Instant): ExchangeRate? = byDate[at]
+        override suspend fun getAvailableCurrencies(): Set<Currency> =
+            (byDate.values + listOfNotNull(current)).flatMap { listOf(it.from, it.to) }.toSet()
+    }
+
+    @Test
+    fun convertWithDate_usesRateInEffectOnThatDate() = runTest {
+        val jan = Instant.parse("2024-01-15T00:00:00Z")
+        val jun = Instant.parse("2024-06-15T00:00:00Z")
+        val janRate = ExchangeRate(Currency.USD, Currency.EUR, 0.90, jan)
+        val junRate = ExchangeRate(Currency.USD, Currency.EUR, 0.95, jun)
+        val converter = CurrencyConverter(
+            DatedFakeRateProvider(
+                byDate = mapOf(jan to janRate, jun to junRate),
+                current = ExchangeRate(Currency.USD, Currency.EUR, 0.99, timestamp),
+            ),
+        )
+
+        // $100.00 valued on Jan 15 uses 0.90 → €90.00, not today's 0.99.
+        val janResult = converter.convert(Cents(10000), Currency.USD, Currency.EUR, jan)
+        assertEquals(Cents(9000), janResult.convertedAmount)
+        assertEquals(janRate, janResult.rateUsed)
+
+        // The same amount valued on Jun 15 uses 0.95 → €95.00.
+        val junResult = converter.convert(Cents(10000), Currency.USD, Currency.EUR, jun)
+        assertEquals(Cents(9500), junResult.convertedAmount)
+        assertEquals(junRate, junResult.rateUsed)
+    }
+
+    @Test
+    fun convertWithDate_differsFromCurrentRate() = runTest {
+        val jan = Instant.parse("2024-01-15T00:00:00Z")
+        val janRate = ExchangeRate(Currency.USD, Currency.EUR, 0.90, jan)
+        val currentRate = ExchangeRate(Currency.USD, Currency.EUR, 0.99, timestamp)
+        val converter = CurrencyConverter(
+            DatedFakeRateProvider(byDate = mapOf(jan to janRate), current = currentRate),
+        )
+
+        val historical = converter.convert(Cents(10000), Currency.USD, Currency.EUR, jan)
+        val today = converter.convert(Cents(10000), Currency.USD, Currency.EUR)
+        assertEquals(Cents(9000), historical.convertedAmount)
+        assertEquals(Cents(9900), today.convertedAmount)
+        assertTrue(historical.convertedAmount.amount != today.convertedAmount.amount)
+    }
+
+    @Test
+    fun convertWithDate_sameCurrency_noRateLookup() = runTest {
+        val converter = CurrencyConverter(DatedFakeRateProvider(emptyMap()))
+        val result = converter.convert(Cents(10000), Currency.USD, Currency.USD, timestamp)
+        assertEquals(Cents(10000), result.convertedAmount)
+        assertNull(result.rateUsed)
+    }
+
+    @Test
+    fun convertWithDate_rescalesMinorUnits() = runTest {
+        val jan = Instant.parse("2024-01-15T00:00:00Z")
+        val rate = ExchangeRate(Currency.USD, Currency.JPY, 149.50, jan)
+        val converter = CurrencyConverter(DatedFakeRateProvider(mapOf(jan to rate)))
+
+        // $100.00 (10000 US cents) at 149.50 → ¥14,950 (JPY 0 decimals).
+        val result = converter.convert(Cents(10000), Currency.USD, Currency.JPY, jan)
+        assertEquals(Cents(14950), result.convertedAmount)
+    }
+
+    @Test
+    fun convertWithDate_missingRate_throwsWithDate() = runTest {
+        val jan = Instant.parse("2024-01-15T00:00:00Z")
+        val converter = CurrencyConverter(DatedFakeRateProvider(emptyMap()))
+        val exception = assertFailsWith<CurrencyConversionException> {
+            converter.convert(Cents(10000), Currency.USD, Currency.EUR, jan)
+        }
+        assertTrue(exception.message!!.contains("USD"))
+        assertTrue(exception.message!!.contains("EUR"))
+    }
 }

--- a/packages/core/src/commonTest/kotlin/com/finance/core/currency/CurrencyFormatterTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/currency/CurrencyFormatterTest.kt
@@ -158,9 +158,44 @@ class CurrencyFormatterTest {
 
     @Test
     fun format_unknownCurrency_usesCodeAsPrefix() {
-        val nzd = Currency("NZD")
-        // Unknown symbol fallback: "NZD " prefix
-        assertEquals("NZD 10.00", CurrencyFormatter.format(Cents(1000), nzd))
+        // XAF is intentionally absent from the canonical CurrencyCatalog, so the
+        // formatter falls back to the "<CODE> " prefix. (NZD and friends now
+        // resolve their real symbol via the canonical catalog — #3736.)
+        val unknown = Currency("XAF")
+        assertEquals("XAF 10.00", CurrencyFormatter.format(Cents(1000), unknown))
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Consolidated currency metadata (#3736) — symbols + decimal places for
+    // currencies previously missing from the formatter's own symbol map.
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun format_bhd_threeDecimals_withSymbol() {
+        // Bahraini Dinar: 3 decimal places, "BD" symbol from the canonical catalog.
+        assertEquals("BD1.234", CurrencyFormatter.format(Cents(1234), Currency("BHD")))
+    }
+
+    @Test
+    fun format_kwd_threeDecimals_withSymbol() {
+        assertEquals("KD1.500", CurrencyFormatter.format(Cents(1500), Currency("KWD")))
+    }
+
+    @Test
+    fun format_omr_threeDecimals_withSymbol() {
+        assertEquals("OMR1.005", CurrencyFormatter.format(Cents(1005), Currency("OMR")))
+    }
+
+    @Test
+    fun format_vnd_zeroDecimals_withSymbol() {
+        // Vietnamese Dong: 0 decimal places, "₫" symbol.
+        assertEquals("₫1,000", CurrencyFormatter.format(Cents(1000), Currency("VND")))
+    }
+
+    @Test
+    fun format_clp_zeroDecimals() {
+        // Chilean Peso: 0 decimal places (canonical), "CL$" symbol.
+        assertEquals("CL$5,000", CurrencyFormatter.format(Cents(5000), Currency("CLP")))
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalProjectedCompletionDateTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/goals/GoalProjectedCompletionDateTest.kt
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.goals
+
+import com.finance.core.TestFixtures
+import com.finance.models.types.Cents
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Tests for the public [GoalTrackingEngine.projectedCompletionDate] (#3681):
+ * projecting when a goal will be fully funded from a contribution rate.
+ */
+class GoalProjectedCompletionDateTest {
+
+    private val from = LocalDate(2024, 1, 1)
+
+    @Test
+    fun exactFit_returnsExactDate() {
+        // $300 remaining, $10/day → exactly 30 days → Jan 31.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents.ZERO,
+            targetDate = null,
+        )
+        assertEquals(
+            LocalDate(2024, 1, 31),
+            GoalTrackingEngine.projectedCompletionDate(goal, Cents(1000), ContributionPeriod.DAILY, from),
+        )
+    }
+
+    @Test
+    fun remainder_roundsUpToNextWholePeriod() {
+        // $300 remaining, $7/day → ceil(42.857) = 43 days → Feb 13. The projection
+        // never underestimates: 42 days would leave the goal a few cents short.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents.ZERO,
+            targetDate = null,
+        )
+        assertEquals(
+            LocalDate(2024, 2, 13),
+            GoalTrackingEngine.projectedCompletionDate(goal, Cents(700), ContributionPeriod.DAILY, from),
+        )
+    }
+
+    @Test
+    fun accountsForExistingProgress() {
+        // $250 already saved, $50 remaining, $10/day → 5 days → Jan 6.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents(25_000),
+            targetDate = null,
+        )
+        assertEquals(
+            LocalDate(2024, 1, 6),
+            GoalTrackingEngine.projectedCompletionDate(goal, Cents(1000), ContributionPeriod.DAILY, from),
+        )
+    }
+
+    @Test
+    fun monthlyContribution_projectsMonths() {
+        // $600 remaining, $100/month → 6 months → Jul 1.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(60_000),
+            currentAmount = Cents.ZERO,
+            targetDate = null,
+        )
+        assertEquals(
+            LocalDate(2024, 7, 1),
+            GoalTrackingEngine.projectedCompletionDate(goal, Cents(10_000), ContributionPeriod.MONTHLY, from),
+        )
+    }
+
+    @Test
+    fun weeklyContribution_projectsWeeks() {
+        // $200 remaining, $50/week → 4 weeks → Jan 29.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(20_000),
+            currentAmount = Cents.ZERO,
+            targetDate = null,
+        )
+        assertEquals(
+            LocalDate(2024, 1, 29),
+            GoalTrackingEngine.projectedCompletionDate(goal, Cents(5000), ContributionPeriod.WEEKLY, from),
+        )
+    }
+
+    @Test
+    fun alreadyComplete_returnsNull() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents(30_000),
+            targetDate = null,
+        )
+        assertNull(GoalTrackingEngine.projectedCompletionDate(goal, Cents(1000), ContributionPeriod.DAILY, from))
+    }
+
+    @Test
+    fun overFunded_returnsNull() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents(45_000),
+            targetDate = null,
+        )
+        assertNull(GoalTrackingEngine.projectedCompletionDate(goal, Cents(1000), ContributionPeriod.DAILY, from))
+    }
+
+    @Test
+    fun zeroContribution_returnsNull() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents.ZERO,
+            targetDate = null,
+        )
+        assertNull(GoalTrackingEngine.projectedCompletionDate(goal, Cents.ZERO, ContributionPeriod.DAILY, from))
+    }
+
+    @Test
+    fun negativeContribution_returnsNull() {
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(30_000),
+            currentAmount = Cents.ZERO,
+            targetDate = null,
+        )
+        assertNull(GoalTrackingEngine.projectedCompletionDate(goal, Cents(-1000), ContributionPeriod.DAILY, from))
+    }
+
+    @Test
+    fun largeAmount_usesIntegerMathWithoutOverflow() {
+        // $10,000,000,000 remaining at $1,000,000/day → 10,000 days. Exercises
+        // large integer-cents division without precision loss or overflow.
+        val goal = TestFixtures.createGoal(
+            targetAmount = Cents(1_000_000_000_000L),
+            currentAmount = Cents.ZERO,
+            targetDate = null,
+        )
+        val result = GoalTrackingEngine.projectedCompletionDate(
+            goal, Cents(100_000_000), ContributionPeriod.DAILY, from,
+        )
+        // from + 10,000 days = 2051-05-19.
+        assertEquals(LocalDate(2051, 5, 19), result)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/multicurrency/CurrencyMetadataConsistencyTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/multicurrency/CurrencyMetadataConsistencyTest.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.multicurrency
+
+import com.finance.models.types.Currency
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for #3736: the app previously carried **three** divergent
+ * sources of currency decimal-place metadata (Currency.decimalPlaces, the
+ * MultiCurrencyEngine catalog, and CurrencyFormatter's own map), which drifted
+ * out of sync (e.g. CLP was treated as 2-decimal in some paths and 0 in
+ * others). These tests pin every source to the single canonical
+ * [Currency.decimalPlaces].
+ */
+class CurrencyMetadataConsistencyTest {
+
+    @Test
+    fun catalog_decimalPlaces_matchCanonicalCurrency() {
+        for ((code, def) in CurrencyCatalog.all) {
+            assertEquals(
+                Currency(code).decimalPlaces,
+                def.decimalPlaces,
+                "CurrencyCatalog[$code].decimalPlaces disagrees with Currency.decimalPlaces",
+            )
+        }
+    }
+
+    @Test
+    fun engineCatalog_decimalPlaces_matchCanonicalCurrency() {
+        for ((code, info) in MultiCurrencyEngine.currencyCatalog) {
+            assertEquals(
+                Currency(code).decimalPlaces,
+                info.decimalPlaces,
+                "MultiCurrencyEngine.currencyCatalog[$code].decimalPlaces disagrees with Currency",
+            )
+        }
+    }
+
+    @Test
+    fun engineCatalog_isDerivedFromCanonicalCatalog() {
+        // The engine catalog must expose exactly the canonical catalog's codes
+        // (it is derived from it), so nothing can silently fall out of sync.
+        assertEquals(CurrencyCatalog.all.keys, MultiCurrencyEngine.currencyCatalog.keys)
+    }
+
+    @Test
+    fun clp_isZeroDecimal_everywhere() {
+        // CLP (Chilean Peso) has no minor unit; this was the concrete drift bug.
+        assertEquals(0, Currency("CLP").decimalPlaces)
+        assertEquals(0, CurrencyCatalog.get("CLP")!!.decimalPlaces)
+        assertEquals(0, MultiCurrencyEngine.currencyCatalog["CLP"]!!.decimalPlaces)
+    }
+
+    @Test
+    fun zeroDecimalCurrencies_areConsistent() {
+        for (code in listOf("JPY", "KRW", "CLP", "VND")) {
+            assertEquals(0, Currency(code).decimalPlaces, "$code should be zero-decimal")
+        }
+    }
+
+    @Test
+    fun threeDecimalCurrencies_areConsistent() {
+        for (code in listOf("BHD", "KWD", "OMR")) {
+            assertEquals(3, Currency(code).decimalPlaces, "$code should be three-decimal")
+            assertEquals(3, CurrencyCatalog.get(code)!!.decimalPlaces)
+        }
+    }
+
+    @Test
+    fun catalog_hasNoBlankSymbolsOrNames() {
+        for ((code, def) in CurrencyCatalog.all) {
+            assertTrue(def.symbol.isNotBlank(), "$code has a blank symbol")
+            assertTrue(def.name.isNotBlank(), "$code has a blank name")
+        }
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/multicurrency/MultiCurrencyEngineTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/multicurrency/MultiCurrencyEngineTest.kt
@@ -38,4 +38,90 @@ class MultiCurrencyEngineTest {
 
     @Test fun breakdown() { val c = MultiCurrencyEngine.ExchangeRateCache(); c.put(Currency.EUR, Currency.USD, 1.0, now); val b = MultiCurrencyEngine.currencyBreakdown(listOf(CurrencyAmount(Cents(75000), Currency.USD), CurrencyAmount(Cents(25000), Currency.EUR)), Currency.USD, c, now)!!; assertEquals(75.0, b[Currency.USD]!!, 0.01); assertEquals(25.0, b[Currency.EUR]!!, 0.01) }
     @Test fun breakdown_missingRate() { assertNull(MultiCurrencyEngine.currencyBreakdown(listOf(CurrencyAmount(Cents(50000), Currency.USD), CurrencyAmount(Cents(50000), Currency.EUR)), Currency.USD, MultiCurrencyEngine.ExchangeRateCache(), now)) }
+
+    // ── #3745: percentages over absolute magnitudes for mixed-sign totals ──
+    @Test
+    fun breakdown_mixedSign_usesAbsoluteMagnitudes() {
+        // Currency A +1000, Currency B -900 → signed net = 100. The old code
+        // divided by the signed net, so A showed 1000%. Now shares are computed
+        // over |1000| + |900| = 1900 and must sum to ~100%.
+        val cache = MultiCurrencyEngine.ExchangeRateCache()
+        cache.put(Currency.EUR, Currency.USD, 1.0, now)
+        val b = MultiCurrencyEngine.currencyBreakdown(
+            listOf(
+                CurrencyAmount(Cents(100_000), Currency.USD),
+                CurrencyAmount(Cents(-90_000), Currency.EUR),
+            ),
+            Currency.USD, cache, now,
+        )!!
+        assertEquals(100_000.0 / 190_000.0 * 100.0, b[Currency.USD]!!, 0.01)
+        assertEquals(90_000.0 / 190_000.0 * 100.0, b[Currency.EUR]!!, 0.01)
+        assertEquals(100.0, b.values.sum(), 0.01)
+    }
+
+    @Test
+    fun breakdown_signedNetZero_stillProducesValidShares() {
+        // +500 and -500 → signed net 0 (would divide-by-zero before #3745).
+        val cache = MultiCurrencyEngine.ExchangeRateCache()
+        cache.put(Currency.EUR, Currency.USD, 1.0, now)
+        val b = MultiCurrencyEngine.currencyBreakdown(
+            listOf(
+                CurrencyAmount(Cents(50_000), Currency.USD),
+                CurrencyAmount(Cents(-50_000), Currency.EUR),
+            ),
+            Currency.USD, cache, now,
+        )!!
+        assertEquals(50.0, b[Currency.USD]!!, 0.01)
+        assertEquals(50.0, b[Currency.EUR]!!, 0.01)
+        assertEquals(100.0, b.values.sum(), 0.01)
+    }
+
+    @Test
+    fun breakdown_zeroMagnitude_returnsEmptyMap() {
+        val b = MultiCurrencyEngine.currencyBreakdown(
+            listOf(CurrencyAmount(Cents.ZERO, Currency.USD)),
+            Currency.USD, MultiCurrencyEngine.ExchangeRateCache(), now,
+        )!!
+        assertTrue(b.isEmpty())
+    }
+
+    // ── #3733: cross-currency triangulation via a pivot currency ──────────
+    @Test
+    fun triangulate_directRateTakesPrecedence() {
+        val cache = MultiCurrencyEngine.ExchangeRateCache()
+        cache.put(Currency.EUR, Currency.JPY, 160.0, now) // direct
+        cache.put(Currency.USD, Currency.EUR, 0.9, now)
+        cache.put(Currency.USD, Currency.JPY, 150.0, now)
+        // Direct EUR→JPY (160) must win over triangulated (150/0.9 ≈ 166.7).
+        assertEquals(160.0, cache.getTriangulated(Currency.EUR, Currency.JPY, Currency.USD, now)!!, 0.0001)
+    }
+
+    @Test
+    fun triangulate_derivesViaPivotWhenNoDirect() {
+        val cache = MultiCurrencyEngine.ExchangeRateCache()
+        cache.put(Currency.USD, Currency.EUR, 0.90, now) // USD→EUR
+        cache.put(Currency.USD, Currency.JPY, 150.0, now) // USD→JPY
+        // EUR→JPY = EUR→USD * USD→JPY = (1/0.9) * 150 = 166.666...
+        val rate = cache.getTriangulated(Currency.EUR, Currency.JPY, Currency.USD, now)!!
+        assertEquals((1.0 / 0.90) * 150.0, rate, 0.0001)
+    }
+
+    @Test
+    fun triangulate_oneLegMissing_returnsNull() {
+        val cache = MultiCurrencyEngine.ExchangeRateCache()
+        cache.put(Currency.USD, Currency.EUR, 0.90, now) // only one leg
+        assertNull(cache.getTriangulated(Currency.EUR, Currency.JPY, Currency.USD, now))
+    }
+
+    @Test
+    fun triangulate_convertUsesIntegerCents() {
+        val cache = MultiCurrencyEngine.ExchangeRateCache()
+        cache.put(Currency.USD, Currency.EUR, 0.90, now)
+        cache.put(Currency.USD, Currency.GBP, 0.80, now)
+        // EUR→GBP = (1/0.9) * 0.8 = 0.8888...; €100.00 (10000 cents) → 8889 (banker's rounding)
+        val result = MultiCurrencyEngine.convertWithTriangulation(
+            Cents(10_000), Currency.EUR, Currency.GBP, cache, Currency.USD, now,
+        )!!
+        assertEquals(Cents(8889), result.convertedAmount)
+    }
 }

--- a/packages/models/src/commonMain/kotlin/com/finance/models/types/Currency.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/models/types/Currency.kt
@@ -17,9 +17,16 @@ value class Currency(val code: String) {
         }
     }
 
-    /** Number of decimal places for this currency's minor unit. */
+    /**
+     * Number of decimal places for this currency's minor unit.
+     *
+     * This is the **single canonical source of truth** for money precision
+     * (#3736). Every other catalog ([CurrencyCatalog], the multi-currency
+     * engine catalog, and the formatter) must agree with the values here — a
+     * consistency test enforces it.
+     */
     val decimalPlaces: Int get() = when (code) {
-        "JPY", "KRW", "VND" -> 0
+        "JPY", "KRW", "VND", "CLP" -> 0
         "BHD", "KWD", "OMR" -> 3
         else -> 2
     }

--- a/scripts/i18n/validate-glossary.js
+++ b/scripts/i18n/validate-glossary.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+// validate-glossary.js
+//
+// Validates the canonical financial-terminology glossary
+// (config/i18n/glossary.json) — the single source of truth for translated
+// financial terms across every localized surface (Android, iOS, web, shared
+// KMP Strings). A mistranslated or drifted financial term is a correctness
+// bug, not polish, so these invariants are enforced in CI (#3318).
+//
+// Checks performed:
+//   1. Structure    — top-level `locales` is a non-empty string array and
+//                     `sourceLocale` is one of them.
+//   2. Completeness — every term supplies a non-blank value for every locale
+//                     listed in `locales`.
+//   3. Uniqueness   — `concept` keys are unique.
+//   4. doNotUse     — a term never appears in its own locale's doNotUse list
+//                     (a "do not use" entry that equals the chosen translation
+//                     is self-contradictory).
+//   5. Enforcement  — every enforced locale in config/i18n/locales.json is
+//                     covered by the glossary's `locales` (an enforced locale
+//                     with no canonical terminology cannot be validated).
+//   6. In-app sync  — the in-app English glossary
+//                     (apps/web/src/lib/education/glossary.ts) must not use
+//                     different wording from the canonical en-US term for any
+//                     overlapping concept. Comparison is case- and
+//                     whitespace-insensitive: individual surfaces may apply
+//                     their own display casing (e.g. the "Net Worth" heading),
+//                     but the underlying words must match.
+//
+// Usage:
+//   node scripts/i18n/validate-glossary.js
+//
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const glossaryPath = path.join(repoRoot, 'config', 'i18n', 'glossary.json');
+const localesPath = path.join(repoRoot, 'config', 'i18n', 'locales.json');
+const inAppGlossaryPath = path.join(
+  repoRoot,
+  'apps',
+  'web',
+  'src',
+  'lib',
+  'education',
+  'glossary.ts',
+);
+
+const errors = [];
+const err = (msg) => errors.push(msg);
+
+function readJson(file, label) {
+  if (!fs.existsSync(file)) {
+    err(`Missing ${label}: ${path.relative(repoRoot, file)}`);
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (e) {
+    err(`Invalid JSON in ${label}: ${e.message}`);
+    return null;
+  }
+}
+
+const glossary = readJson(glossaryPath, 'glossary');
+const localeMeta = readJson(localesPath, 'locale metadata');
+
+if (glossary) {
+  const locales = glossary.locales;
+
+  // 1. Structure.
+  if (
+    !Array.isArray(locales) ||
+    locales.length === 0 ||
+    !locales.every((l) => typeof l === 'string')
+  ) {
+    err('glossary.locales must be a non-empty array of locale id strings.');
+  } else {
+    if (typeof glossary.sourceLocale !== 'string' || !locales.includes(glossary.sourceLocale)) {
+      err(`glossary.sourceLocale (${glossary.sourceLocale}) must be one of glossary.locales.`);
+    }
+  }
+
+  const terms = Array.isArray(glossary.terms) ? glossary.terms : [];
+  if (terms.length === 0) {
+    err('glossary.terms must be a non-empty array.');
+  }
+
+  const seenConcepts = new Set();
+  const localeList = Array.isArray(locales) ? locales : [];
+
+  for (const term of terms) {
+    const concept = term && term.concept;
+    if (typeof concept !== 'string' || concept.trim() === '') {
+      err(`A term is missing a non-blank "concept": ${JSON.stringify(term)}`);
+      continue;
+    }
+
+    // 3. Uniqueness.
+    if (seenConcepts.has(concept)) {
+      err(`Duplicate concept: "${concept}".`);
+    }
+    seenConcepts.add(concept);
+
+    // 2. Completeness.
+    for (const locale of localeList) {
+      const value = term[locale];
+      if (typeof value !== 'string' || value.trim() === '') {
+        err(`Concept "${concept}" is missing a non-blank value for locale "${locale}".`);
+      }
+    }
+
+    // 4. doNotUse must not contain the chosen translation.
+    if (term.doNotUse && typeof term.doNotUse === 'object') {
+      for (const [locale, banned] of Object.entries(term.doNotUse)) {
+        if (!Array.isArray(banned)) {
+          err(`Concept "${concept}" doNotUse[${locale}] must be an array.`);
+          continue;
+        }
+        const chosen = typeof term[locale] === 'string' ? term[locale].trim().toLowerCase() : null;
+        for (const bad of banned) {
+          if (chosen !== null && typeof bad === 'string' && bad.trim().toLowerCase() === chosen) {
+            err(
+              `Concept "${concept}" lists its own ${locale} translation "${term[locale]}" in doNotUse.`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // 5. Enforced locales must be covered by the glossary.
+  if (localeMeta && Array.isArray(localeMeta.locales)) {
+    const enforced = localeMeta.locales.filter((l) => l && l.enforced).map((l) => l.id);
+    for (const id of enforced) {
+      if (!localeList.includes(id)) {
+        err(`Enforced locale "${id}" (config/i18n/locales.json) is not covered by the glossary.`);
+      }
+    }
+  }
+
+  // 6. In-app English glossary must not use different wording from canonical.
+  // Casing/whitespace is normalized away — surfaces apply their own display
+  // casing — so only genuine wording drift is reported.
+  if (fs.existsSync(inAppGlossaryPath)) {
+    const src = fs.readFileSync(inAppGlossaryPath, 'utf8');
+    const norm = (s) => s.trim().replace(/\s+/g, ' ').toLowerCase();
+    // Extract `term: '...'` string literals (single or double quoted).
+    const inAppTerms = new Map(); // normalized -> original
+    const re = /\bterm:\s*(['"])((?:\\.|(?!\1).)*)\1/g;
+    let m;
+    while ((m = re.exec(src)) !== null) {
+      const value = m[2].replace(/\\(['"])/g, '$1');
+      inAppTerms.set(norm(value), value);
+    }
+
+    const canonicalEn = glossary.sourceLocale || 'en-US';
+    let overlaps = 0;
+    for (const term of terms) {
+      const canonical = typeof term[canonicalEn] === 'string' ? term[canonicalEn] : null;
+      if (!canonical) continue;
+      const key = norm(canonical);
+      // Also detect wording drift: an in-app term whose collapsed alphanumeric
+      // form matches but whose spacing/words differ from canonical.
+      if (inAppTerms.has(key)) {
+        overlaps += 1;
+        continue;
+      }
+      const collapse = (s) => s.replace(/[^a-z0-9]/g, '');
+      const canonicalCollapsed = collapse(key);
+      for (const [inAppKey, inAppOriginal] of inAppTerms) {
+        if (collapse(inAppKey) === canonicalCollapsed && inAppKey !== key) {
+          err(
+            `In-app glossary term "${inAppOriginal}" uses different wording from ` +
+              `canonical en-US "${canonical}" (concept "${term.concept}"). ` +
+              `Align apps/web/src/lib/education/glossary.ts.`,
+          );
+        }
+      }
+    }
+    if (overlaps === 0) {
+      console.warn(
+        'WARN: no overlapping concepts found between the canonical glossary and ' +
+          'the in-app education glossary — cross-consistency was not exercised.',
+      );
+    }
+  } else {
+    err(`Missing in-app glossary: ${path.relative(repoRoot, inAppGlossaryPath)}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Glossary validation FAILED:');
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+
+const conceptCount = Array.isArray(glossary.terms) ? glossary.terms.length : 0;
+console.log(
+  `Glossary validation passed: ${conceptCount} concept(s) across ${glossary.locales.length} locale(s).`,
+);


### PR DESCRIPTION
## Summary

Batch fix for core currency/FX correctness and related financial-data bugs across `packages/core`, `packages/models`, and `apps/web`. All money math uses integer/Cents; new logic is in pure functions with unit/regression tests for every bug.

### Core (packages/core, packages/models)
- **#3745** `currencyBreakdown` percentages were wrong for mixed-sign totals — the denominator now sums the **absolute** magnitudes (with a zero guard) so shares are always in `[0, 100]`.
- **#3744** `spendingInsights` ranked brand-new categories last — added `SpendingInsight.isNew` and a ranking that surfaces new spend at the top, then by magnitude of change.
- **#3736** consolidated divergent currency metadata — `Currency.decimalPlaces` is now the canonical source; the catalog/formatter derive from it (added `CLP=0`) with a consistency test.
- **#3733** cross-currency triangulation via a pivot currency when no direct pair exists.
- **#3728** date-aware historical FX — `CurrencyConverter.convert(..., at: Instant)` selects the rate effective at a point in time.
- **#3681** public `projectedCompletionDate` from the contribution rate (null when already complete).

### Web (apps/web)
- **#3469** Accounts vs `/net-worth` archived-account inconsistency — archived accounts are excluded from all Accounts totals to match `/net-worth`.
- **#3484** 529 planner Surplus card always `$0.00` for overfunded plans — `EducationFundResult.surplusCents` is computed and rendered.
- **#3381** savings-goal monthly pace/projection was faked as one lump sum — pace/projection now derive from real `goal_progress_contribution` rows (requires ≥2 contributions; otherwise shows a "not enough history" note).

### Shared / i18n
- **#3318** consume/validate the canonical financial-terminology glossary — new `scripts/i18n/validate-glossary.js` (invariants: full locale coverage, no blanks, no self-referential `doNotUse`, unique concepts, enforced-locale coverage, in-app wording consistency), wired into CI (`ci-lint.yml`) and exercised by a web unit test.

## Testing
- KMP: `:packages:core:jvmTest` and `:packages:models:jvmTest` — BUILD SUCCESSFUL.
- Web: affected vitest suites pass (AccountsPage, education-planner, savings-goals, goals repo, PlanningPage, glossary consistency).
- `node scripts/i18n/validate-glossary.js` passes.
- `npm run format:check` and `npx eslint . --max-warnings 0` are clean; web `tsc --noEmit` clean.

Closes #3745
Closes #3744
Closes #3736
Closes #3733
Closes #3728
Closes #3681
Closes #3318
Closes #3469
Closes #3484
Closes #3381

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
