### PR TITLE
style(android): remove color-only bill status tell and fix low-contrast labels (#3816)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/bills/BillRemindersScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/bills/BillRemindersScreen.kt
@@ -31,8 +31,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.EventAvailable
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Receipt
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -51,7 +53,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
@@ -313,6 +314,13 @@ private fun BillCard(
         bill.daysUntilDue <= 3 -> Color(0xFFFF9800)
         else -> MaterialTheme.colorScheme.primary
     }
+    // Pair each status hue with a distinct icon shape so the state is never
+    // conveyed by colour alone (WCAG 2.2 AA / 1.4.1 Use of Color).
+    val statusIcon = when {
+        bill.isOverdue -> Icons.Filled.Warning
+        bill.daysUntilDue <= 3 -> Icons.Filled.Schedule
+        else -> Icons.Filled.EventAvailable
+    }
 
     Card(
         modifier = Modifier
@@ -326,12 +334,14 @@ private fun BillCard(
             modifier = Modifier.fillMaxWidth().padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // Status indicator
-            Box(
-                modifier = Modifier
-                    .size(8.dp)
-                    .clip(CircleShape)
-                    .background(statusColor),
+            // Status indicator — icon shape differs per state so status is
+            // not conveyed by colour alone. Decorative for TalkBack because
+            // the card's merged description already states the due status.
+            Icon(
+                imageVector = statusIcon,
+                contentDescription = null,
+                tint = statusColor,
+                modifier = Modifier.size(20.dp),
             )
             Spacer(Modifier.width(12.dp))
 

--- a/apps/android/src/main/kotlin/com/finance/android/ui/streak/StreakCard.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/streak/StreakCard.kt
@@ -181,7 +181,7 @@ fun StreakCardContent(
                     Text(
                         text = "Longest: ${state.longestStreak} days",
                         style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.5f),
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
                         modifier = Modifier.semantics {
                             contentDescription = "Your longest streak is ${state.longestStreak} days"
                         },

--- a/apps/android/src/main/kotlin/com/finance/android/ui/tips/TipsSection.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/tips/TipsSection.kt
@@ -211,7 +211,7 @@ internal fun TipCard(
             Text(
                 text = tipCategoryLabel(tip.category),
                 style = MaterialTheme.typography.labelSmall,
-                color = contentColor.copy(alpha = 0.5f),
+                color = contentColor,
             )
         }
     }


### PR DESCRIPTION
## Summary

Impeccable-quality craft pass over `apps/android` — the native counterpart to the web pass merged in PR #3813 (#3812), which removed AI-slop design tells from `apps/web`. Same craft standards, translated to Jetpack Compose / Material 3. UI/design only — no behaviour or business-logic changes.

## Audit result

Android is already largely clean of the web pass's two headline tells:

- **No bounce / spring overshoot easing.** Navigation uses `tween` shared-axis transitions; micro-interactions use `tween` / default (non-bouncy) springs. No `DampingRatioHighBouncy`, no `scale 0 -> 1.3 -> 0.9 -> 1` keyframes.
- **No one-sided accent-stripe borders.** Status is expressed with container tints + icons, never a leading colored bar or asymmetric border.

So this is a focused pass on the genuine defects found.

## Changes

**Color-only status signaling → shape + color (WCAG 2.2 AA / 1.4.1)**

- `BillRemindersScreen` `BillCard` encoded overdue / due-soon / upcoming state with a bare colored dot (color alone). Replaced with a **status-differentiated icon** — `Warning` / `Schedule` / `EventAvailable` — tinted in the same status hue, so the state now reads by shape *and* color. Icon is decorative for TalkBack because the card's merged description already states the due status. Dropped the now-unused `clip` import.

**Muted-text contrast → container on-color (WCAG 1.4.3)**

- `TipsSection` category label and `StreakCard` `Longest` footer sat at `alpha = 0.5` on tinted containers (a sub-4.5:1 muted-gray-on-tint risk). Raised both to the container's full designed on-color; visual hierarchy is preserved by type scale (`labelSmall` vs the title/body).

## Intentionally kept

- **Chart legend color dots** (Insights / Investment / Report) — always paired with a text label, so not color-only.
- **Referral celebration particles** — literal, celebratory motion; reduced-motion-neutral and behind a reserved feature path.
- **Shimmer skeleton loaders** — standard low-amplitude loading affordance.
- **AffordabilityScreen / Insights trends / Gamification badges** — already pair color with an icon + text label.

## Follow-up (not in scope here)

- The semantic warning hue `0xFFFF9800` (Orange 500) is low-contrast as text/icon on a light surface across the app. Fixing it is a **design-token** change (owned by @design-engineer) that also touches golden-snapshot screens, so it belongs in its own PR rather than this surgical pass. The color-only *tell* is already resolved by the icon shape.

## Scope / risk

Edits target **non-golden** surfaces (BillReminders, Tips, Streak) to avoid Paparazzi pixel-diff churn on the Accounts/Budgets/Goals/Settings/Transactions goldens. Kotlin lint is detekt (CI); `.prettierignore` skips `*.kt`. `:apps:android` detekt is skipped locally (no Android SDK) — remote CI is the source of truth.

Closes #3816