### PR TITLE
style(ios): semantic status colors, drop gradient glyph, guard reduce-motion (#3817)

### DIFF
--- a/apps/ios/Finance/Charts/CategoryBreakdownChart.swift
+++ b/apps/ios/Finance/Charts/CategoryBreakdownChart.swift
@@ -33,6 +33,8 @@ struct CategoryBreakdownChart: View {
 
     @State private var selectedCategory: String?
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private var totalSpending: Double {
         data.reduce(0) { $0 + $1.amount }
     }
@@ -68,7 +70,7 @@ struct CategoryBreakdownChart: View {
         }
         .padding()
         .onChange(of: selectedAngle) { _, newValue in
-            withAnimation(.easeInOut(duration: 0.15)) {
+            withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.15)) {
                 selectedCategory = categoryForAngle(newValue)
             }
         }

--- a/apps/ios/Finance/Components/AnomalyCard.swift
+++ b/apps/ios/Finance/Components/AnomalyCard.swift
@@ -34,7 +34,7 @@ struct AnomalyCard: View {
                     Text(formatCurrency(anomaly.actualMinorUnits))
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundStyle(anomaly.isOverspend ? .red : .green)
+                        .foregroundStyle(anomaly.isOverspend ? FinanceColors.statusNegative : FinanceColors.statusPositive)
                 }
 
                 HStack(spacing: 4) {

--- a/apps/ios/Finance/Components/CategorySuggestionCard.swift
+++ b/apps/ios/Finance/Components/CategorySuggestionCard.swift
@@ -135,7 +135,7 @@ struct CategorySuggestionCard: View {
     private var resolvedBody: some View {
         HStack(spacing: 10) {
             Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
+                .foregroundStyle(FinanceColors.statusPositive)
                 .accessibilityHidden(true)
             Text(resolvedLabel)
                 .font(.subheadline)

--- a/apps/ios/Finance/Components/ConfidenceIndicatorView.swift
+++ b/apps/ios/Finance/Components/ConfidenceIndicatorView.swift
@@ -14,10 +14,10 @@ import SwiftUI
 /// Displays the confidence level of an NLP parse result as a progress bar
 /// with an icon and text label.
 ///
-/// Colours follow CVD-safe palette conventions:
-/// - High: system green
-/// - Medium: system orange
-/// - Low/VeryLow: system red
+/// Colours follow the semantic status tokens (``FinanceColors``):
+/// - High: positive (green)
+/// - Medium: warning (amber)
+/// - Low/VeryLow: negative (red)
 struct ConfidenceIndicatorView: View {
     let confidence: NlpConfidence
 
@@ -50,10 +50,10 @@ struct ConfidenceIndicatorView: View {
 
     private var confidenceColor: Color {
         switch confidence {
-        case .high: .green
-        case .medium: .orange
-        case .low: .red
-        case .veryLow: .red
+        case .high: FinanceColors.statusPositive
+        case .medium: FinanceColors.statusWarning
+        case .low: FinanceColors.statusNegative
+        case .veryLow: FinanceColors.statusNegative
         }
     }
 }

--- a/apps/ios/Finance/Components/DebtPayoffCard.swift
+++ b/apps/ios/Finance/Components/DebtPayoffCard.swift
@@ -57,9 +57,9 @@ struct DebtPayoffCard: View {
         HStack(spacing: 12) {
             Image(systemName: "percent")
                 .font(.title3)
-                .foregroundStyle(.green)
+                .foregroundStyle(FinanceColors.statusPositive)
                 .frame(width: 40, height: 40)
-                .background(Color.green.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+                .background(FinanceColors.statusPositive.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 2) {
                 Text(progress.name)
@@ -119,10 +119,10 @@ struct DebtPayoffCard: View {
         if progress.isPaidOff {
             Label(String(localized: "Paid off — ring closed!"), systemImage: "checkmark.seal.fill")
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.green)
+                .foregroundStyle(FinanceColors.statusPositive)
         } else if let interestSaved, interestSaved > 0 {
             HStack(spacing: 4) {
-                Image(systemName: "bolt.fill").font(.caption2).foregroundStyle(.orange)
+                Image(systemName: "bolt.fill").font(.caption2).foregroundStyle(FinanceColors.statusWarning)
                     .accessibilityHidden(true)
                 Text(String(localized: "Pay")).font(.caption).foregroundStyle(.secondary)
                 CurrencyLabel(

--- a/apps/ios/Finance/Components/DebtPayoffRing.swift
+++ b/apps/ios/Finance/Components/DebtPayoffRing.swift
@@ -47,7 +47,7 @@ struct DebtPayoffRing: View {
                     .lineLimit(1)
                 if progress.isPaidOff {
                     Image(systemName: "checkmark.seal.fill")
-                        .foregroundStyle(.green)
+                        .foregroundStyle(FinanceColors.statusPositive)
                         .font(.caption)
                 } else {
                     Text(String(localized: "paid off"))

--- a/apps/ios/Finance/Components/ParsedFieldTag.swift
+++ b/apps/ios/Finance/Components/ParsedFieldTag.swift
@@ -39,7 +39,7 @@ struct ParsedFieldTag: View {
             if field.isUncertain {
                 Image(systemName: "questionmark.circle.fill")
                     .font(.caption2)
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(FinanceColors.statusWarning)
             }
         }
         .padding(.horizontal, 10)
@@ -48,7 +48,7 @@ struct ParsedFieldTag: View {
         .overlay(
             RoundedRectangle(cornerRadius: 8)
                 .strokeBorder(
-                    field.isUncertain ? Color.orange : tagColor.opacity(0.3),
+                    field.isUncertain ? FinanceColors.statusWarning : tagColor.opacity(0.3),
                     style: field.isUncertain
                         ? StrokeStyle(lineWidth: 1, dash: [4, 2])
                         : StrokeStyle(lineWidth: 1)

--- a/apps/ios/Finance/Components/TransactionRowView.swift
+++ b/apps/ios/Finance/Components/TransactionRowView.swift
@@ -20,7 +20,7 @@ struct TransactionRowView: View, Equatable {
                 HStack(spacing: 4) {
                     Text(transaction.payee).font(.body).lineLimit(1)
                     if transaction.isRecurring { IconView(.recurring, size: 12).foregroundStyle(.secondary).accessibilityLabel(String(localized: "Recurring")) }
-                    if transaction.status == .pending { Text(transaction.status.displayName).font(.caption2).foregroundStyle(.orange).padding(.horizontal, 6).padding(.vertical, 2).background(.orange.opacity(0.1), in: Capsule()) }
+                    if transaction.status == .pending { Text(transaction.status.displayName).font(.caption2).foregroundStyle(FinanceColors.statusWarning).padding(.horizontal, 6).padding(.vertical, 2).background(FinanceColors.statusWarning.opacity(0.1), in: Capsule()) }
                 }
                 HStack(spacing: 4) { Text(transaction.category); Text("·"); Text(transaction.accountName) }.font(.caption).foregroundStyle(.secondary).lineLimit(1)
                 // Show up to 2 tags inline

--- a/apps/ios/Finance/Models/AnalyticsModels.swift
+++ b/apps/ios/Finance/Models/AnalyticsModels.swift
@@ -65,9 +65,9 @@ enum AnomalySeverity: String, Sendable {
 
     var color: Color {
         switch self {
-        case .low: .yellow
+        case .low: FinanceColors.statusWarning
         case .medium: .orange
-        case .high: .red
+        case .high: FinanceColors.statusNegative
         }
     }
 

--- a/apps/ios/Finance/Models/BillModels.swift
+++ b/apps/ios/Finance/Models/BillModels.swift
@@ -52,9 +52,9 @@ enum BillStatus: String, CaseIterable, Hashable, Sendable {
 
     var color: Color {
         switch self {
-        case .upcoming: .blue
-        case .overdue: .red
-        case .paid: .green
+        case .upcoming: FinanceColors.statusInfo
+        case .overdue: FinanceColors.statusNegative
+        case .paid: FinanceColors.statusPositive
         }
     }
 

--- a/apps/ios/Finance/Models/GoalItem.swift
+++ b/apps/ios/Finance/Models/GoalItem.swift
@@ -25,10 +25,10 @@ enum GoalStatusUI: String, CaseIterable, Hashable, Sendable {
 
     var color: Color {
         switch self {
-        case .active: .blue
-        case .paused: .orange
-        case .completed: .green
-        case .cancelled: .gray
+        case .active: FinanceColors.statusInfo
+        case .paused: FinanceColors.statusWarning
+        case .completed: FinanceColors.statusPositive
+        case .cancelled: .secondary
         }
     }
 

--- a/apps/ios/Finance/Models/HealthScoreModels.swift
+++ b/apps/ios/Finance/Models/HealthScoreModels.swift
@@ -48,10 +48,10 @@ struct HealthScoreComponent: Identifiable, Sendable {
     /// Color indicating component health.
     var color: Color {
         let pct = percentage
-        if pct >= 80 { return .green }
-        if pct >= 60 { return .yellow }
+        if pct >= 80 { return FinanceColors.statusPositive }
+        if pct >= 60 { return FinanceColors.statusWarning }
         if pct >= 40 { return .orange }
-        return .red
+        return FinanceColors.statusNegative
     }
 }
 
@@ -70,11 +70,11 @@ enum HealthGrade: String, Sendable {
 
     var color: Color {
         switch self {
-        case .aPlus, .a: .green
-        case .bPlus, .b: .blue
-        case .cPlus, .c: .yellow
+        case .aPlus, .a: FinanceColors.statusPositive
+        case .bPlus, .b: FinanceColors.statusInfo
+        case .cPlus, .c: FinanceColors.statusWarning
         case .d: .orange
-        case .f: .red
+        case .f: FinanceColors.statusNegative
         }
     }
 
@@ -131,8 +131,8 @@ enum TipImpact: String, Sendable {
     var color: Color {
         switch self {
         case .low: .secondary
-        case .medium: .blue
-        case .high: .green
+        case .medium: FinanceColors.statusInfo
+        case .high: FinanceColors.statusPositive
         }
     }
 }

--- a/apps/ios/Finance/Models/NotificationModels.swift
+++ b/apps/ios/Finance/Models/NotificationModels.swift
@@ -164,9 +164,9 @@ enum AlertPriority: String, Sendable, Comparable {
     var color: Color {
         switch self {
         case .low: .secondary
-        case .normal: .blue
-        case .high: .orange
-        case .urgent: .red
+        case .normal: FinanceColors.statusInfo
+        case .high: FinanceColors.statusWarning
+        case .urgent: FinanceColors.statusNegative
         }
     }
 

--- a/apps/ios/Finance/Models/TransactionItem.swift
+++ b/apps/ios/Finance/Models/TransactionItem.swift
@@ -40,9 +40,9 @@ enum TransactionTypeUI: String, CaseIterable, Hashable, Sendable {
 
     var color: Color {
         switch self {
-        case .expense: .red
-        case .income: .green
-        case .transfer: .blue
+        case .expense: FinanceColors.statusNegative
+        case .income: FinanceColors.statusPositive
+        case .transfer: FinanceColors.statusInfo
         }
     }
 }

--- a/apps/ios/Finance/Screens/AuthGateView.swift
+++ b/apps/ios/Finance/Screens/AuthGateView.swift
@@ -38,6 +38,8 @@ struct AuthGateView: View {
     /// showing login UI before we know the definitive auth state.
     @State private var hasCompletedInitialCheck = false
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
         category: "AuthGateView"
@@ -72,7 +74,7 @@ struct AuthGateView: View {
                     .transition(.opacity)
             }
         }
-        .animation(.easeInOut(duration: 0.3), value: resolvedState)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: resolvedState)
         .task {
             await authService.checkExistingSession()
             hasCompletedInitialCheck = true

--- a/apps/ios/Finance/Screens/SubscriptionView.swift
+++ b/apps/ios/Finance/Screens/SubscriptionView.swift
@@ -76,13 +76,7 @@ struct SubscriptionView: View {
         VStack(spacing: 16) {
             Image(systemName: "crown.fill")
                 .font(.system(size: 48))
-                .foregroundStyle(
-                    LinearGradient(
-                        colors: [.yellow, .orange],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
+                .foregroundStyle(FinanceColors.statusWarning)
                 .accessibilityHidden(true)
 
             Text(String(localized: "Finance Premium"))

--- a/apps/ios/FinanceClip/QuickTransactionView.swift
+++ b/apps/ios/FinanceClip/QuickTransactionView.swift
@@ -14,6 +14,7 @@ struct QuickTransactionView: View {
     @State private var showAppStoreOverlay = false
     @State private var store = ClipTransactionStore()
     @FocusState private var isAmountFocused: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let categoryColumns = [GridItem(.adaptive(minimum: 80, maximum: 120), spacing: 12)]
     var body: some View {
         if isSaved { confirmationView } else { transactionFormView }
@@ -51,7 +52,7 @@ struct QuickTransactionView: View {
     }
     private func categoryButton(for category: TransactionCategory) -> some View {
         let isSelected = selectedCategory == category
-        return Button { withAnimation(.easeInOut(duration: 0.2)) { selectedCategory = category } } label: {
+        return Button { withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.2)) { selectedCategory = category } } label: {
             VStack(spacing: 6) {
                 Image(systemName: category.systemImage).font(.title3).frame(width: 32, height: 32).accessibilityHidden(true)
                 Text(category.displayName).font(.caption).lineLimit(1)
@@ -112,9 +113,9 @@ struct QuickTransactionView: View {
         let saved = store.save(transaction)
         if saved { playSuccessHaptic(); View.announceForAccessibility(String(localized: "Expense saved")) }
         else { playErrorHaptic() }
-        withAnimation(.easeInOut(duration: 0.3)) { isSaved = true }
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.3)) { isSaved = true }
     }
-    private func resetForm() { withAnimation(.easeInOut(duration: 0.3)) { amountText = ""; selectedCategory = nil; payeeText = ""; isSaved = false }; isAmountFocused = true }
+    private func resetForm() { withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.3)) { amountText = ""; selectedCategory = nil; payeeText = ""; isSaved = false }; isAmountFocused = true }
     private func prefillFromURL() {
         if let m = initialAmountMinorUnits, m > 0 { amountText = NSDecimalNumber(decimal: Decimal(m) / 100).stringValue }
         if let c = initialCategoryId { selectedCategory = TransactionCategory.quickCategories.first { $0.id == c } }


### PR DESCRIPTION
## Summary

Native (SwiftUI) counterpart to the web `impeccable` craft pass (#3812 / PR #3813). Removes the most recognizable "AI-generated UI" tells from `apps/ios` while preserving every semantic color meaning and all behavior. **Visual/design only — no logic changes.**

Unlike web, iOS has **no side-stripe accent borders and no spring/bounce easing** — every animation already uses `easeOut`/`easeInOut`, and there are no one-sided colored stripes. So this pass targets the tells that *do* exist here: raw system status colors bypassing the WCAG-tuned design tokens, a decorative gradient glyph, and a few reduce-motion gaps.

## Changes

**Status color → semantic `FinanceColors` tokens (contrast + dark-mode + consistency)**

The design system already standardizes on `FinanceColors` semantic tokens for most model color props (`InsightModels`, `FinancialTip`, `GamificationModels`, `InvestmentModels`). A handful of stragglers still used raw system colors. System `.green` (~1.5:1) and `.yellow` (~1.1:1) as foreground **fail WCAG 2.2 AA contrast** and don't adapt for dark mode; the semantic tokens are darker/adaptive. Migrating them completes the established pattern and fixes contrast — meaning and tier ordering preserved.

- Models: `TransactionItem`, `BillModels`, `NotificationModels`, `GoalItem`, `HealthScoreModels`, `AnalyticsModels` (`.red`→`statusNegative`, `.green`→`statusPositive`, `.orange`/`.yellow`→`statusWarning`, `.blue`→`statusInfo`, `.gray`→`.secondary`).
- Shared components: `AnomalyCard`, `CategorySuggestionCard`, `DebtPayoffCard`, `DebtPayoffRing`, `ConfidenceIndicatorView`, `TransactionRowView`, `ParsedFieldTag`.
- Multi-tier **sequential** health/severity scales stay sequential — only their unreadable `.yellow` step moves to the design-token amber; a distinct middle `.orange` step is kept so the 4-tier gradient still reads.

**Gradient glyph → solid color**

- `SubscriptionView`: the Premium `crown.fill` `LinearGradient([.yellow, .orange])` fill (a "premium badge" tell) → solid `FinanceColors.statusWarning` (semantic gold/amber).

**Reduce-motion guards**

- Added `@Environment(\.accessibilityReduceMotion)` guards to the remaining unguarded animations: `CategoryBreakdownChart` (slice selection), `AuthGateView` (state crossfade), and App Clip `QuickTransactionView` (category select / save / reset).

## Intentional — not changed

- CVD-safe chart `AreaMark`/`BarMark` gradient *fills* (net-worth, portfolio, spending-trend) — legitimate data-viz depth, not gradient text.
- Celebratory achievement-badge / level `Color.gradient` sheens — appropriate for a rewards surface.
- Categorical (non-status) palettes: `TagView` hash palette, `HouseholdModels` CVD chart palette, `CategoryItem` user hex, `ParsedFieldTag` field-type colors, `AchievementTier` medal hexes.
- Watch-target complication providers keep raw colors (the `FinanceColors` token set is in the `FinanceApp` target, not the Watch target).

## Verification

- [x] Every touched file keeps its VoiceOver labels and Dynamic Type support; status is always paired with an icon or text label (WCAG use-of-color).
- [x] No behavior/logic changes — pure `Color`/animation/`foregroundStyle` swaps.
- [x] All `FinanceColors` references are within the `FinanceApp` target (path `Finance/`); App Clip edits are reduce-motion only.
- [ ] iOS build / tests via remote CI (no Swift toolchain on the authoring host; `*.swift` is `.prettierignore`d so JS/TS format+lint is a no-op for this diff).

Closes #3817
