### PR TITLE
style(windows): adaptive semantic status colors, remove hardcoded status hex (#3815)

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/components/RecurringPreviewPanel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/components/RecurringPreviewPanel.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -92,7 +91,7 @@ private fun RecurringItemCard(
     onEdit: (String) -> Unit,
     onToggleNotify: (String, Boolean) -> Unit,
 ) {
-    val amountColor = if (item.isExpense) MaterialTheme.colorScheme.error else Color(0xFF2E7D32)
+    val amountColor = if (item.isExpense) MaterialTheme.colorScheme.error else FinanceDesktopTheme.status.positive
     var notifyEnabled by remember { mutableStateOf(item.notifyDaysBefore > 0) }
 
     Card(modifier = Modifier.fillMaxWidth().semantics { contentDescription = "${item.name}, ${item.amountFormatted}, next on ${item.nextDate}, ${item.frequency}" }) {

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/AccountsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/AccountsScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
@@ -420,7 +419,7 @@ private fun DetailChip(label: String, value: String) {
 @Composable
 private fun AccountTransactionRow(txn: Transaction) {
     val isExpense = txn.type == TransactionType.EXPENSE
-    val amountColor = if (isExpense) MaterialTheme.colorScheme.error else Color(0xFF2E7D32)
+    val amountColor = if (isExpense) MaterialTheme.colorScheme.error else FinanceDesktopTheme.status.positive
     val formattedAmount = CurrencyFormatter.format(txn.amount, txn.currency, showSign = true)
     val payee = txn.payee ?: "Unknown"
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/BudgetNegotiationScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/BudgetNegotiationScreen.kt
@@ -220,7 +220,7 @@ private fun ProposalList(
                 horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.md),
             ) {
                 StatusBadge("Pending", pendingCount, MaterialTheme.colorScheme.tertiary)
-                StatusBadge("Approved", approvedCount, Color(0xFF2E7D32))
+                StatusBadge("Approved", approvedCount, FinanceDesktopTheme.status.positive)
                 StatusBadge(
                     "Rejected",
                     proposals.count { it.status == ProposalStatus.REJECTED },
@@ -304,7 +304,7 @@ private fun ProposalListItem(
 ) {
     val statusColor = when (proposal.status) {
         ProposalStatus.PENDING -> MaterialTheme.colorScheme.tertiary
-        ProposalStatus.APPROVED -> Color(0xFF2E7D32)
+        ProposalStatus.APPROVED -> FinanceDesktopTheme.status.positive
         ProposalStatus.REJECTED -> MaterialTheme.colorScheme.error
         ProposalStatus.WITHDRAWN -> MaterialTheme.colorScheme.onSurfaceVariant
     }
@@ -374,7 +374,7 @@ private fun ProposalListItem(
                         text = " ($sign${proposal.changePercent}%)",
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = FontWeight.SemiBold,
-                        color = if (proposal.changePercent > 0) Color(0xFF2E7D32)
+                        color = if (proposal.changePercent > 0) FinanceDesktopTheme.status.positive
                         else MaterialTheme.colorScheme.error,
                     )
                 }
@@ -535,7 +535,7 @@ private fun ProposalDetail(
 
 @Composable
 private fun ProposalDetailHeader(proposal: BudgetProposal) {
-    val changeColor = if (proposal.changePercent >= 0) Color(0xFF2E7D32)
+    val changeColor = if (proposal.changePercent >= 0) FinanceDesktopTheme.status.positive
     else MaterialTheme.colorScheme.error
     val sign = if (proposal.changePercent >= 0) "+" else ""
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/BudgetsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/BudgetsScreen.kt
@@ -314,7 +314,7 @@ private fun BudgetCard(
 ) {
     val healthColor = when (budget.health) {
         BudgetHealth.OVER -> MaterialTheme.colorScheme.error
-        BudgetHealth.WARNING -> Color(0xFFFF9800)
+        BudgetHealth.WARNING -> FinanceDesktopTheme.status.warning
         BudgetHealth.HEALTHY -> MaterialTheme.colorScheme.primary
     }
     val healthLabel = when (budget.health) {

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/ConflictResolutionScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/ConflictResolutionScreen.kt
@@ -108,7 +108,7 @@ private fun ConflictListPanel(conflicts: List<SyncConflict>, selectedId: String?
                         colors = CardDefaults.cardColors(containerColor = bg)) {
                         Row(Modifier.fillMaxWidth().padding(FinanceDesktopTheme.spacing.md), verticalAlignment = Alignment.CenterVertically) {
                             Icon(if (conflict.resolution != null) Icons.Filled.CheckCircle else Icons.Filled.Warning, null,
-                                tint = if (conflict.resolution != null) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error, modifier = Modifier.size(20.dp))
+                                tint = if (conflict.resolution != null) FinanceDesktopTheme.status.positive else MaterialTheme.colorScheme.error, modifier = Modifier.size(20.dp))
                             Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
                             Column(Modifier.weight(1f)) {
                                 Text(conflict.entityName, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/DashboardScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/DashboardScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -309,7 +308,7 @@ private fun TransactionRow(transaction: Transaction) {
     val amountColor = if (isExpense) {
         MaterialTheme.colorScheme.error
     } else {
-        Color(0xFF2E7D32)
+        FinanceDesktopTheme.status.positive
     }
     val formattedAmount = CurrencyFormatter.format(
         transaction.amount,
@@ -419,7 +418,7 @@ private fun BudgetHealthSection(budgets: List<BudgetStatusUi>) {
 private fun DashboardBudgetCard(budget: BudgetStatusUi, modifier: Modifier = Modifier) {
     val healthColor = when (budget.health) {
         BudgetHealth.OVER -> MaterialTheme.colorScheme.error
-        BudgetHealth.WARNING -> Color(0xFFFF9800)
+        BudgetHealth.WARNING -> FinanceDesktopTheme.status.warning
         BudgetHealth.HEALTHY -> MaterialTheme.colorScheme.primary
     }
     val healthLabel = when (budget.health) {

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/GamificationScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/GamificationScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.semantics.contentDescription
@@ -335,7 +334,7 @@ private fun StreakCard(streak: StreakInfo) {
             Icon(
                 imageVector = Icons.Filled.LocalFireDepartment,
                 contentDescription = null,
-                tint = if (streak.isActiveToday) Color(0xFFFF6B35) else MaterialTheme.colorScheme.onSurfaceVariant,
+                tint = if (streak.isActiveToday) FinanceDesktopTheme.status.streak else MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(28.dp),
             )
             Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
@@ -356,7 +355,7 @@ private fun StreakCard(streak: StreakInfo) {
                     text = "${streak.currentStreak}",
                     style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.Bold,
-                    color = if (streak.isActiveToday) Color(0xFFFF6B35) else MaterialTheme.colorScheme.onSurface,
+                    color = if (streak.isActiveToday) FinanceDesktopTheme.status.streak else MaterialTheme.colorScheme.onSurface,
                 )
                 Text(
                     text = "days",
@@ -500,7 +499,7 @@ private fun RecentUnlockCard(achievement: Achievement) {
             Icon(
                 imageVector = Icons.Filled.Star,
                 contentDescription = null,
-                tint = Color(0xFFFFD700),
+                tint = FinanceDesktopTheme.status.premium,
                 modifier = Modifier.size(20.dp),
             )
         }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/GoalsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/GoalsScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
@@ -278,9 +277,9 @@ private fun GoalCard(
     onDelete: () -> Unit,
 ) {
     val progressColor = when {
-        goal.progress >= 0.75f -> Color(0xFF2E7D32)
+        goal.progress >= 0.75f -> FinanceDesktopTheme.status.positive
         goal.progress >= 0.40f -> MaterialTheme.colorScheme.primary
-        else -> Color(0xFFFF9800)
+        else -> FinanceDesktopTheme.status.warning
     }
     val progressPercent = (goal.progress * 100).toInt()
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/HealthScoreScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/HealthScoreScreen.kt
@@ -474,7 +474,7 @@ private fun DimensionCard(dimension: HealthDimension) {
                     text = compLabel,
                     style = MaterialTheme.typography.labelSmall,
                     fontWeight = FontWeight.SemiBold,
-                    color = if (comparison >= 0) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error,
+                    color = if (comparison >= 0) FinanceDesktopTheme.status.positive else MaterialTheme.colorScheme.error,
                 )
             }
 
@@ -504,8 +504,8 @@ private fun DimensionCard(dimension: HealthDimension) {
  */
 @Composable
 private fun scoreToColor(score: Int): Color = when {
-    score >= 80 -> Color(0xFF2E7D32) // Green
+    score >= 80 -> FinanceDesktopTheme.status.positive // Green
     score >= 60 -> MaterialTheme.colorScheme.primary // Blue
-    score >= 40 -> Color(0xFFFF9800) // Amber
+    score >= 40 -> FinanceDesktopTheme.status.warning // Amber
     else -> MaterialTheme.colorScheme.error // Red
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/ImportWizardScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/ImportWizardScreen.kt
@@ -188,7 +188,7 @@ private fun StepIndicator(currentStep: ImportStep) {
             val isCompleted = index < currentIndex
             val isCurrent = index == currentIndex
             val color = when {
-                isCompleted -> Color(0xFF2E7D32)
+                isCompleted -> FinanceDesktopTheme.status.positive
                 isCurrent -> MaterialTheme.colorScheme.primary
                 else -> MaterialTheme.colorScheme.outlineVariant
             }
@@ -246,7 +246,7 @@ private fun StepIndicator(currentStep: ImportStep) {
                         .height(2.dp)
                         .padding(horizontal = FinanceDesktopTheme.spacing.sm)
                         .background(
-                            if (index < currentIndex) Color(0xFF2E7D32)
+                            if (index < currentIndex) FinanceDesktopTheme.status.positive
                             else MaterialTheme.colorScheme.outlineVariant,
                         ),
                 )
@@ -552,7 +552,7 @@ private fun DuplicateDetectionStep(
                         Icons.Filled.CheckCircle,
                         contentDescription = null,
                         modifier = Modifier.size(48.dp),
-                        tint = Color(0xFF2E7D32),
+                        tint = FinanceDesktopTheme.status.positive,
                     )
                     Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
                     Text(
@@ -656,14 +656,14 @@ private fun DuplicateRow(
                 shape = RoundedCornerShape(12.dp),
                 color = if (duplicate.shouldSkip)
                     MaterialTheme.colorScheme.error.copy(alpha = 0.12f)
-                else Color(0xFF2E7D32).copy(alpha = 0.12f),
+                else FinanceDesktopTheme.status.positive.copy(alpha = 0.12f),
             ) {
                 Text(
                     text = if (duplicate.shouldSkip) "Skip" else "Import",
                     style = MaterialTheme.typography.labelSmall,
                     fontWeight = FontWeight.SemiBold,
                     color = if (duplicate.shouldSkip)
-                        MaterialTheme.colorScheme.error else Color(0xFF2E7D32),
+                        MaterialTheme.colorScheme.error else FinanceDesktopTheme.status.positive,
                     modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
                 )
             }
@@ -724,7 +724,7 @@ private fun ImportingStep(state: ImportWizardUiState) {
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly,
                 ) {
-                    ImportStatChip("Imported", "${progress.importedRows}", Color(0xFF2E7D32))
+                    ImportStatChip("Imported", "${progress.importedRows}", FinanceDesktopTheme.status.positive)
                     ImportStatChip("Skipped", "${progress.skippedRows}", MaterialTheme.colorScheme.tertiary)
                     ImportStatChip("Errors", "${progress.errorRows}", MaterialTheme.colorScheme.error)
                 }
@@ -773,7 +773,7 @@ private fun CompleteStep(
                     imageVector = Icons.Filled.CheckCircle,
                     contentDescription = null,
                     modifier = Modifier.size(64.dp),
-                    tint = Color(0xFF2E7D32),
+                    tint = FinanceDesktopTheme.status.positive,
                 )
                 Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
                 Text(
@@ -805,7 +805,7 @@ private fun CompleteStep(
                         horizontalArrangement = Arrangement.SpaceEvenly,
                     ) {
                         ImportStatChip("Total", "${progress.totalRows}", MaterialTheme.colorScheme.onSurface)
-                        ImportStatChip("Imported", "${progress.importedRows}", Color(0xFF2E7D32))
+                        ImportStatChip("Imported", "${progress.importedRows}", FinanceDesktopTheme.status.positive)
                         ImportStatChip("Skipped", "${progress.skippedRows}", MaterialTheme.colorScheme.tertiary)
                     }
                 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/InvestmentScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/InvestmentScreen.kt
@@ -240,7 +240,7 @@ private fun ChangeIndicator(
     changePercent: String,
     isPositive: Boolean,
 ) {
-    val color = if (isPositive) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
+    val color = if (isPositive) FinanceDesktopTheme.status.positive else MaterialTheme.colorScheme.error
     Column {
         Text(
             text = label,
@@ -308,7 +308,7 @@ private fun PerformanceChartCard(
             }
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
             // Canvas chart
-            val lineColor = if (isPositive) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
+            val lineColor = if (isPositive) FinanceDesktopTheme.status.positive else MaterialTheme.colorScheme.error
             val fillColor = lineColor.copy(alpha = 0.1f)
 
             val narration = remember(data, selectedRange) {
@@ -502,8 +502,8 @@ private fun HoldingsTableHeader() {
 
 @Composable
 private fun HoldingRow(holding: HoldingUi) {
-    val dayColor = if (holding.isPositive) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
-    val totalColor = if (holding.totalReturn.startsWith("+")) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
+    val dayColor = if (holding.isPositive) FinanceDesktopTheme.status.positive else MaterialTheme.colorScheme.error
+    val totalColor = if (holding.totalReturn.startsWith("+")) FinanceDesktopTheme.status.positive else MaterialTheme.colorScheme.error
 
     Card(
         modifier = Modifier

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/NaturalLanguageScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/NaturalLanguageScreen.kt
@@ -199,7 +199,7 @@ fun NaturalLanguageScreen(modifier: Modifier = Modifier) {
             ) {
                 Surface(
                     shape = RoundedCornerShape(8.dp),
-                    color = Color(0xFF2E7D32).copy(alpha = 0.12f),
+                    color = FinanceDesktopTheme.status.positive.copy(alpha = 0.12f),
                     modifier = Modifier
                         .fillMaxWidth()
                         .semantics { contentDescription = state.successMessage ?: "" },
@@ -208,12 +208,12 @@ fun NaturalLanguageScreen(modifier: Modifier = Modifier) {
                         modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Icon(Icons.Filled.Check, contentDescription = null, tint = Color(0xFF2E7D32))
+                        Icon(Icons.Filled.Check, contentDescription = null, tint = FinanceDesktopTheme.status.positive)
                         Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
                         Text(
                             text = state.successMessage ?: "",
                             style = MaterialTheme.typography.bodyMedium,
-                            color = Color(0xFF2E7D32),
+                            color = FinanceDesktopTheme.status.positive,
                         )
                     }
                 }
@@ -460,7 +460,7 @@ private fun ParsedPreviewCard(
     onEditCancel: () -> Unit,
 ) {
     val confidenceColor = when {
-        parsed.confidence >= 0.7f -> Color(0xFF2E7D32)
+        parsed.confidence >= 0.7f -> FinanceDesktopTheme.status.positive
         parsed.confidence >= 0.4f -> MaterialTheme.colorScheme.tertiary
         else -> MaterialTheme.colorScheme.error
     }
@@ -609,7 +609,7 @@ private fun ParsedPreviewCard(
                         shape = RoundedCornerShape(12.dp),
                         color = if (parsed.type == TransactionType.EXPENSE)
                             MaterialTheme.colorScheme.errorContainer
-                        else Color(0xFF2E7D32).copy(alpha = 0.12f),
+                        else FinanceDesktopTheme.status.positive.copy(alpha = 0.12f),
                         modifier = Modifier.clickable { onFieldClick(EditingField.TYPE) }
                             .semantics {
                                 contentDescription = "Transaction type: ${parsed.type.name}. Click to change."
@@ -627,7 +627,7 @@ private fun ParsedPreviewCard(
                                 fontWeight = FontWeight.SemiBold,
                                 color = if (parsed.type == TransactionType.EXPENSE)
                                     MaterialTheme.colorScheme.onErrorContainer
-                                else Color(0xFF2E7D32),
+                                else FinanceDesktopTheme.status.positive,
                             )
                             Spacer(Modifier.width(4.dp))
                             Icon(
@@ -636,7 +636,7 @@ private fun ParsedPreviewCard(
                                 modifier = Modifier.size(14.dp),
                                 tint = if (parsed.type == TransactionType.EXPENSE)
                                     MaterialTheme.colorScheme.onErrorContainer
-                                else Color(0xFF2E7D32),
+                                else FinanceDesktopTheme.status.positive,
                             )
                         }
                     }
@@ -764,7 +764,7 @@ private fun EditableParsedField(
                         Icons.Filled.Check,
                         contentDescription = null,
                         modifier = Modifier.size(16.dp),
-                        tint = Color(0xFF2E7D32),
+                        tint = FinanceDesktopTheme.status.positive,
                     )
                 }
                 IconButton(
@@ -816,8 +816,8 @@ private fun EditableParsedField(
 @Composable
 private fun ConfidenceDot(confidence: FieldConfidence) {
     val color = when (confidence) {
-        FieldConfidence.HIGH -> Color(0xFF2E7D32)
-        FieldConfidence.MEDIUM -> Color(0xFFF9A825)
+        FieldConfidence.HIGH -> FinanceDesktopTheme.status.positive
+        FieldConfidence.MEDIUM -> FinanceDesktopTheme.status.warning
         FieldConfidence.LOW -> MaterialTheme.colorScheme.error
         FieldConfidence.NONE -> MaterialTheme.colorScheme.outlineVariant
     }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/QuickAddTransactionDialog.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/QuickAddTransactionDialog.kt
@@ -102,7 +102,7 @@ fun QuickAddTransactionDialog(
                             Icon(
                                 Icons.AutoMirrored.Filled.TrendingUp,
                                 contentDescription = null,
-                                tint = if (!state.isExpense) Color(0xFF22C55E) else Color.Unspecified,
+                                tint = if (!state.isExpense) FinanceDesktopTheme.status.positive else Color.Unspecified,
                             )
                         },
                         modifier = Modifier.semantics {

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/ReferralScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/ReferralScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.semantics.Role
@@ -446,7 +445,7 @@ private fun RewardTierCard(
 @Composable
 private fun ReferralHistoryRow(referral: ReferralItemUi) {
     val statusColor = when (referral.status) {
-        ReferralStatus.ACTIVATED -> Color(0xFF2E7D32)
+        ReferralStatus.ACTIVATED -> FinanceDesktopTheme.status.positive
         ReferralStatus.SIGNED_UP -> MaterialTheme.colorScheme.primary
         ReferralStatus.PENDING -> MaterialTheme.colorScheme.tertiary
         ReferralStatus.EXPIRED -> MaterialTheme.colorScheme.outline
@@ -526,7 +525,7 @@ private fun ReferralHistoryRow(referral: ReferralItemUi) {
                     text = referral.rewardEarned,
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold,
-                    color = Color(0xFF2E7D32),
+                    color = FinanceDesktopTheme.status.positive,
                 )
             }
         }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/ReportBuilderScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/ReportBuilderScreen.kt
@@ -877,7 +877,7 @@ private fun ReportChartSection(chartData: List<ReportChartPoint>) {
                     BarDataPoint(
                         label = point.label,
                         value = point.value,
-                        color = if (point.isIncome) Color(0xFF2E7D32)
+                        color = if (point.isIncome) FinanceDesktopTheme.status.positive
                         else MaterialTheme.colorScheme.error,
                         formattedValue = point.formattedValue,
                     )
@@ -899,7 +899,7 @@ private fun ReportSummaryCards(summary: ReportSummary) {
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
     ) {
-        SummaryCard("Income", summary.totalIncome, Color(0xFF2E7D32), Modifier.weight(1f))
+        SummaryCard("Income", summary.totalIncome, FinanceDesktopTheme.status.positive, Modifier.weight(1f))
         SummaryCard("Expenses", summary.totalExpenses, MaterialTheme.colorScheme.error, Modifier.weight(1f))
         SummaryCard("Net", summary.netAmount, MaterialTheme.colorScheme.primary, Modifier.weight(1f))
         SummaryCard("Transactions", "${summary.transactionCount}", MaterialTheme.colorScheme.tertiary, Modifier.weight(1f))
@@ -939,7 +939,7 @@ private fun SummaryCard(
 
 @Composable
 private fun ReportDataRow(row: ReportPreviewRow) {
-    val color = if (row.isIncome) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
+    val color = if (row.isIncome) FinanceDesktopTheme.status.positive else MaterialTheme.colorScheme.error
     val pct = (row.percentage * 100).toInt()
 
     Card(

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/TransactionFormDialog.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/TransactionFormDialog.kt
@@ -300,7 +300,7 @@ private fun TransactionTypeToggle(
                     Icons.AutoMirrored.Filled.TrendingUp,
                     contentDescription = null,
                     tint = if (selectedType == TransactionType.INCOME)
-                        Color(0xFF2E7D32) else Color.Unspecified,
+                        FinanceDesktopTheme.status.positive else Color.Unspecified,
                     modifier = Modifier.size(16.dp),
                 )
             },

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/TransactionsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/TransactionsScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -447,7 +446,7 @@ private fun SortableColumnHeader(
 private fun TransactionTableRow(txn: Transaction) {
     val amountColor = when (txn.type) {
         TransactionType.EXPENSE -> MaterialTheme.colorScheme.error
-        TransactionType.INCOME -> Color(0xFF2E7D32)
+        TransactionType.INCOME -> FinanceDesktopTheme.status.positive
         TransactionType.TRANSFER -> MaterialTheme.colorScheme.tertiary
     }
     val typeIcon = when (txn.type) {

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/UpgradeScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/UpgradeScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -210,7 +209,7 @@ private fun PlanCard(
             Icon(
                 imageVector = if (isPremium) Icons.Filled.Diamond else Icons.Filled.Star,
                 contentDescription = null,
-                tint = if (isPremium) Color(0xFFFFD700) else MaterialTheme.colorScheme.onSurfaceVariant,
+                tint = if (isPremium) FinanceDesktopTheme.status.premium else MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(36.dp),
             )
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
@@ -288,7 +287,7 @@ private fun FeatureRow(
                 imageVector = if (status.isGranted) Icons.Filled.CheckCircle
                 else Icons.Filled.Lock,
                 contentDescription = null,
-                tint = if (status.isGranted) Color(0xFF22C55E)
+                tint = if (status.isGranted) FinanceDesktopTheme.status.positive
                 else MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(24.dp),
             )
@@ -333,7 +332,7 @@ private fun UpgradeDialog(
             Icon(
                 imageVector = Icons.Filled.Diamond,
                 contentDescription = null,
-                tint = Color(0xFFFFD700),
+                tint = FinanceDesktopTheme.status.premium,
                 modifier = Modifier.size(48.dp),
             )
         },

--- a/apps/windows/src/main/kotlin/com/finance/desktop/theme/FinanceDesktopTheme.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/theme/FinanceDesktopTheme.kt
@@ -41,6 +41,8 @@ private val Teal900 = Color(0xFF134E4A)
 // endregion
 
 // region Green
+private val Green400 = Color(0xFF4ADE80)
+private val Green700 = Color(0xFF15803D)
 // endregion
 
 // region Amber
@@ -48,6 +50,16 @@ private val Amber50 = Color(0xFFFFFBEB)
 private val Amber500 = Color(0xFFF59E0B)
 private val Amber600 = Color(0xFFD97706)
 private val Amber700 = Color(0xFFB45309)
+// endregion
+
+// region Orange
+private val Orange400 = Color(0xFFFB923C)
+private val Orange700 = Color(0xFFC2410B)
+// endregion
+
+// region Gold — premium/achievement accent
+private val Gold400 = Color(0xFFFBBF24)
+private val Gold700 = Color(0xFFA16207)
 // endregion
 
 // region Red
@@ -129,6 +141,49 @@ private val DarkColorScheme = darkColorScheme(
     outline = Neutral700,
     outlineVariant = Neutral700,
 )
+
+// =============================================================================
+// Semantic status colors — financial domain (positive/warning/streak/premium)
+//
+// These carry meaning that Material's role palette doesn't express directly
+// (income vs. expense, budget health, streaks, premium). Each has a light and
+// dark variant so the hue adapts the same way the Material roles do — a fixed
+// mid-tone green/amber fails the WCAG 4.5:1 body-text ratio on the near-black
+// dark surface, and amber-as-text fails it on white.
+// =============================================================================
+
+/**
+ * Semantic status colors for the finance domain, paired with the active theme
+ * so each hue stays legible on its background. Access via
+ * [FinanceDesktopTheme.status].
+ */
+@Immutable
+data class FinanceStatusColors(
+    /** Positive amounts, income, "on track" / success states. */
+    val positive: Color,
+    /** Cautionary states — approaching a budget limit, medium confidence. */
+    val warning: Color,
+    /** Active streak / momentum accent (e.g. the streak flame). */
+    val streak: Color,
+    /** Premium / achievement accent (crowns, trophies, upgrade stars). */
+    val premium: Color,
+)
+
+private val LightStatusColors = FinanceStatusColors(
+    positive = Green700,
+    warning = Amber700,
+    streak = Orange700,
+    premium = Gold700,
+)
+
+private val DarkStatusColors = FinanceStatusColors(
+    positive = Green400,
+    warning = Amber500,
+    streak = Orange400,
+    premium = Gold400,
+)
+
+val LocalStatusColors = staticCompositionLocalOf { LightStatusColors }
 
 // =============================================================================
 // Typography — Fluent Design uses Segoe UI (platform default on Windows)
@@ -227,8 +282,12 @@ fun FinanceDesktopTheme(
         standardLight = LightColorScheme,
         standardDark = DarkColorScheme,
     )
+    val statusColors = if (darkTheme) DarkStatusColors else LightStatusColors
 
-    CompositionLocalProvider(LocalSpacing provides Spacing()) {
+    CompositionLocalProvider(
+        LocalSpacing provides Spacing(),
+        LocalStatusColors provides statusColors,
+    ) {
         MaterialTheme(
             colorScheme = colorScheme,
             typography = FinanceTypography,
@@ -245,4 +304,10 @@ object FinanceDesktopTheme {
         @Composable
         @ReadOnlyComposable
         get() = LocalSpacing.current
+
+    /** Semantic finance status colors for the active theme. */
+    val status: FinanceStatusColors
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalStatusColors.current
 }


### PR DESCRIPTION
## Summary

Impeccable-quality design craft pass over the Windows Compose Desktop client (`apps/windows`) — the native counterpart to the web pass in #3812 / PR #3813. UI/design only, no behavior or business-logic changes. Semantic color meaning is preserved exactly.

## Audit findings

Audited every screen and reusable composable for the flagged `AI-generated UI` tells:

- **Side-stripe accent borders** — none found. The `drawRect`/`drawLine` uses are all legitimate chart data-viz (gauges, spark/line charts). ✅
- **Bounce / spring / elastic overshoot easing** — none found. No `DampingRatioHighBouncy`, no `0→1.3→0.9→1` overshoot; entrance motion uses `tween`/default specs. ✅
- **Gradient text, decorative glassmorphism** — none found. ✅
- **Color-only status signaling** — status is already paired with an icon and/or text label (budget health labels, streak semantics, confidence dots beside text). ✅

## What this PR fixes

The one real, systemic defect: **~49 hardcoded `Color(0xFF…)` status literals** scattered across screens that (a) duplicated magic values, (b) **failed WCAG 2.2 AA contrast**, and (c) didn't adapt light/dark like every other semantic color in the theme (which already uses Blue400/Red400 in dark mode):

- `Color(0xFF2E7D32)` (positive/income green) — fails the 4.5:1 body-text ratio in **dark mode** (~3.8:1 on the near-black dark surface).
- `Color(0xFFFF9800)` / `Color(0xFFF9A825)` (warning amber) used as **text** — only ~2.2:1 on white, a clear light-mode failure.
- Flame-orange and gold literals duplicated inline as magic values.

### Changes

- **`FinanceDesktopTheme.kt`** — new `FinanceStatusColors` (`positive`, `warning`, `streak`, `premium`) provided via a composition local, with contrast-correct **light and dark** variants, exposed as `FinanceDesktopTheme.status`.
- **18 screen/component files** — replaced the hardcoded status hex with the semantic tokens (background tints keep their `.copy(alpha = …)`). Removed 8 now-unused `Color` imports.
- **Intentionally left untouched:** categorical multi-series chart palettes (`InsightsScreen`, `InvestmentScreen`, `CryptoDashboardScreen`) — those are legitimate data-viz color sets, not status signaling.

## Testing

- [x] `./gradlew :apps:windows:build` — compile + unit tests green
- [x] Semantic color meaning preserved (green = positive, amber = warning); hues only shift tone by light/dark to meet contrast

## Issues

Closes #3815