### PR TITLE
feat(web): financial planners batch — FIRE, estate, net-worth & multi-currency

### DIFF
--- a/apps/web/src/components/charts/NetWorthProjectionChart.tsx
+++ b/apps/web/src/components/charts/NetWorthProjectionChart.tsx
@@ -339,11 +339,7 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
       </div>
 
       <div className="nw-projection__controls">
-        <div
-          className="nw-projection__mode"
-          role="radiogroup"
-          aria-label="Projection method"
-        >
+        <div className="nw-projection__mode" role="radiogroup" aria-label="Projection method">
           <button
             type="button"
             role="radio"

--- a/apps/web/src/components/charts/NetWorthProjectionChart.tsx
+++ b/apps/web/src/components/charts/NetWorthProjectionChart.tsx
@@ -38,6 +38,7 @@ import {
 } from './chart-accessibility';
 import { useEffectiveMaskingMode } from '../../contexts/PrivacyModeContext';
 import {
+  DEFAULT_PROJECTION_ANNUAL_RETURN,
   PROJECTION_RANGES,
   projectNetWorth,
   rangeToHorizonMonths,
@@ -162,6 +163,22 @@ const ProjectionLegend: FC = () => (
 // Main component
 // ---------------------------------------------------------------------------
 
+type ProjectionMode = 'pace' | 'compound';
+
+const DEFAULT_RETURN_PERCENT = String(Math.round(DEFAULT_PROJECTION_ANNUAL_RETURN * 100));
+
+function parsePercentToRate(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return DEFAULT_PROJECTION_ANNUAL_RETURN;
+  return parsed / 100;
+}
+
+function parseDollarsToCents(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.round(parsed * 100);
+}
+
 export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
   history,
   currency = 'USD',
@@ -173,13 +190,24 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
   const disableAnimation = prefersReducedMotion();
   const maskingMode = useEffectiveMaskingMode();
   const [range, setRange] = useState<ProjectionRange>(defaultRange);
+  const [mode, setMode] = useState<ProjectionMode>('pace');
+  const [annualReturnPercent, setAnnualReturnPercent] = useState<string>(DEFAULT_RETURN_PERCENT);
+  const [monthlyContribution, setMonthlyContribution] = useState<string>('0');
 
   const visible = useMemo(() => sliceSeriesToRange(history, range), [history, range]);
 
   const projection = useMemo(() => {
     const horizonMonths = rangeToHorizonMonths(range, visible.length);
+    if (mode === 'compound') {
+      return projectNetWorth(visible, {
+        horizonMonths,
+        method: 'compound',
+        annualReturnRate: parsePercentToRate(annualReturnPercent),
+        monthlyContributionCents: parseDollarsToCents(monthlyContribution),
+      });
+    }
     return projectNetWorth(visible, { horizonMonths, method: 'regression' });
-  }, [visible, range]);
+  }, [visible, range, mode, annualReturnPercent, monthlyContribution]);
 
   const boundaryLabel = visible.length > 0 ? visible[visible.length - 1]!.label : null;
 
@@ -257,7 +285,9 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
   }, [projection, currency, maskingMode]);
 
   const assumptionsText = projection.hasProjection
-    ? `Forecast assumes a steady ${paceText} (${projection.methodSummary}), projected ${projection.horizonMonths} months ahead. Estimate only. Not financial advice.`
+    ? mode === 'compound'
+      ? `Forecast assumes ${projection.methodSummary}, projected ${projection.horizonMonths} months ahead. Estimate only. Not financial advice.`
+      : `Forecast assumes a steady ${paceText} (${projection.methodSummary}), projected ${projection.horizonMonths} months ahead. Estimate only. Not financial advice.`
     : projection.reason;
 
   const dataPointRows = useMemo(() => {
@@ -306,6 +336,72 @@ export const NetWorthProjectionChart: FC<NetWorthProjectionChartProps> = ({
           {title}
         </h3>
         <RangeSelector selected={range} onChange={setRange} />
+      </div>
+
+      <div className="nw-projection__controls">
+        <div
+          className="nw-projection__mode"
+          role="radiogroup"
+          aria-label="Projection method"
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={mode === 'pace'}
+            className={`nw-projection__mode-btn${
+              mode === 'pace' ? ' nw-projection__mode-btn--active' : ''
+            }`}
+            onClick={() => setMode('pace')}
+          >
+            Recent pace
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={mode === 'compound'}
+            className={`nw-projection__mode-btn${
+              mode === 'compound' ? ' nw-projection__mode-btn--active' : ''
+            }`}
+            onClick={() => setMode('compound')}
+          >
+            Compound growth
+          </button>
+        </div>
+
+        {mode === 'compound' && (
+          <div className="nw-projection__compound-inputs">
+            <label className="nw-projection__field">
+              <span className="nw-projection__field-label">Expected annual return</span>
+              <span className="nw-projection__field-control">
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  step={0.1}
+                  min={-100}
+                  value={annualReturnPercent}
+                  onChange={(event) => setAnnualReturnPercent(event.target.value)}
+                  aria-label="Expected annual return percent"
+                />
+                <span aria-hidden="true">%</span>
+              </span>
+            </label>
+            <label className="nw-projection__field">
+              <span className="nw-projection__field-label">Monthly contribution</span>
+              <span className="nw-projection__field-control">
+                <span aria-hidden="true">$</span>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  step={50}
+                  min={0}
+                  value={monthlyContribution}
+                  onChange={(event) => setMonthlyContribution(event.target.value)}
+                  aria-label="Monthly contribution in dollars"
+                />
+              </span>
+            </label>
+          </div>
+        )}
       </div>
 
       <p id={`${chartId}-desc`} className="sr-only">

--- a/apps/web/src/components/charts/net-worth-projection.css
+++ b/apps/web/src/components/charts/net-worth-projection.css
@@ -59,6 +59,85 @@
   color: var(--semantic-text-primary, #1d4ed8);
 }
 
+/* Method controls (pace vs compound) --------------------------------- */
+
+.nw-projection__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--spacing-3, 0.75rem);
+  margin-bottom: var(--spacing-3, 0.75rem);
+}
+
+.nw-projection__mode {
+  display: inline-flex;
+  gap: var(--spacing-1, 0.25rem);
+}
+
+.nw-projection__mode-btn {
+  padding: var(--spacing-1, 0.25rem) var(--spacing-3, 0.75rem);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: 0.375rem;
+  background: var(--semantic-background-elevated, #ffffff);
+  color: var(--semantic-text-secondary, #6b7280);
+  font-size: var(--font-size-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.nw-projection__mode-btn--active {
+  background: var(--semantic-background-secondary, #eef2ff);
+  border-color: var(--semantic-border-strong, #c7d2fe);
+  color: var(--semantic-text-primary, #1d4ed8);
+}
+
+.nw-projection__mode-btn:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #2563eb);
+  outline-offset: 2px;
+}
+
+.nw-projection__compound-inputs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3, 0.75rem);
+}
+
+.nw-projection__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1, 0.25rem);
+}
+
+.nw-projection__field-label {
+  font-size: var(--font-size-xs, 0.75rem);
+  font-weight: 600;
+  color: var(--semantic-text-secondary, #6b7280);
+}
+
+.nw-projection__field-control {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1, 0.25rem);
+  padding: var(--spacing-1, 0.25rem) var(--spacing-2, 0.5rem);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: 0.375rem;
+  background: var(--semantic-background-elevated, #ffffff);
+  color: var(--semantic-text-primary, #111827);
+}
+
+.nw-projection__field-control input {
+  width: 5rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+
+.nw-projection__field-control input:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #2563eb);
+  outline-offset: 2px;
+}
+
 /* Legend ------------------------------------------------------------ */
 
 .nw-projection__legend {

--- a/apps/web/src/components/dashboard/SavingsRateCard.tsx
+++ b/apps/web/src/components/dashboard/SavingsRateCard.tsx
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { CurrencyDisplay } from '../common';
 import type { Transaction } from '../../kmp/bridge';
+import { useSavingsTarget } from '../../hooks/useSavingsTarget';
 import {
   buildSavingsRateCardModel,
   buildSavingsRateDashboardSummary,
@@ -82,14 +83,27 @@ export const SavingsRateCard: React.FC<SavingsRateCardProps> = ({
   previousMonthTransactions,
   currency = 'USD',
 }) => {
+  const { savingsTargetPercent, setSavingsTargetPercent, minPercent, maxPercent } =
+    useSavingsTarget();
+  const [isEditingGoal, setIsEditingGoal] = useState(false);
+
   const model = useMemo(() => {
     const cashFlows: MonthlyCashFlow[] = [
       toMonthlyCashFlow(previousMonthKey, previousMonthTransactions),
       toMonthlyCashFlow(currentMonthKey, currentMonthTransactions),
     ];
 
-    return buildSavingsRateCardModel(buildSavingsRateDashboardSummary(cashFlows, currentMonthKey));
-  }, [currentMonthKey, previousMonthKey, currentMonthTransactions, previousMonthTransactions]);
+    return buildSavingsRateCardModel(
+      buildSavingsRateDashboardSummary(cashFlows, currentMonthKey),
+      savingsTargetPercent,
+    );
+  }, [
+    currentMonthKey,
+    previousMonthKey,
+    currentMonthTransactions,
+    previousMonthTransactions,
+    savingsTargetPercent,
+  ]);
 
   return (
     <article
@@ -135,6 +149,43 @@ export const SavingsRateCard: React.FC<SavingsRateCardProps> = ({
         </p>
       ) : null}
       <p className="savings-rate-card__status">{model.statusLabel}</p>
+      <div className="savings-rate-card__goal">
+        {isEditingGoal ? (
+          <label className="savings-rate-card__goal-edit">
+            <span>Savings goal</span>
+            <span className="savings-rate-card__goal-control">
+              <input
+                type="number"
+                min={minPercent}
+                max={maxPercent}
+                step={1}
+                defaultValue={savingsTargetPercent}
+                aria-label="Savings-rate goal percent"
+                onChange={(event) => {
+                  const next = Number.parseInt(event.target.value, 10);
+                  if (Number.isFinite(next)) setSavingsTargetPercent(next);
+                }}
+              />
+              <span aria-hidden="true">%</span>
+            </span>
+            <button
+              type="button"
+              className="savings-rate-card__goal-done"
+              onClick={() => setIsEditingGoal(false)}
+            >
+              Done
+            </button>
+          </label>
+        ) : (
+          <button
+            type="button"
+            className="savings-rate-card__goal-toggle"
+            onClick={() => setIsEditingGoal(true)}
+          >
+            Goal: {savingsTargetPercent}% · Edit
+          </button>
+        )}
+      </div>
     </article>
   );
 };

--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -794,6 +794,59 @@
   line-height: var(--type-scale-body-line-height);
 }
 
+.savings-rate-card__goal {
+  margin-top: var(--spacing-2);
+}
+
+.savings-rate-card__goal-toggle {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--semantic-text-link, var(--semantic-text-secondary));
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.savings-rate-card__goal-edit {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.savings-rate-card__goal-control {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-elevated);
+}
+
+.savings-rate-card__goal-control input {
+  width: 3.5rem;
+  border: 0;
+  background: transparent;
+  color: var(--semantic-text-primary);
+  font: inherit;
+}
+
+.savings-rate-card__goal-done {
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-elevated);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  cursor: pointer;
+}
+
 @media (prefers-contrast: more) {
   .savings-rate-card {
     border-width: 2px;

--- a/apps/web/src/components/estate/EstateInventory.tsx
+++ b/apps/web/src/components/estate/EstateInventory.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo, useState } from 'react';
 
 import { ConfirmDialog } from '../common';
+import { CurrencyDisplay } from '../common';
 import { getAccessInfo, saveAccessInfo } from '../../lib/estate/accessInfo';
 import { ESTATE_CATEGORIES, getEstateCategory } from '../../lib/estate/categories';
 import {
@@ -118,8 +119,69 @@ export const EstateInventory: React.FC = () => {
             <span className="estate-hero__stat-value">{accessInfo.trustedContacts.length}</span>
             <span className="estate-hero__stat-label">trusted contacts</span>
           </div>
+          <div className="estate-hero__stat estate-hero__stat--value">
+            <span className="estate-hero__stat-value">
+              {summary.hasEstimatedValue ? (
+                <CurrencyDisplay amount={summary.netEstimatedValueCents} />
+              ) : (
+                '—'
+              )}
+            </span>
+            <span className="estate-hero__stat-label">est. net value</span>
+          </div>
         </div>
       </section>
+
+      {summary.hasEstimatedValue ? (
+        <section
+          className="estate-value-summary"
+          aria-label="Estimated estate value breakdown"
+        >
+          <div className="estate-value-summary__totals">
+            <div className="estate-value-summary__total">
+              <span className="estate-value-summary__total-label">Assets</span>
+              <span className="estate-value-summary__total-value">
+                <CurrencyDisplay amount={summary.totalAssetsCents} />
+              </span>
+            </div>
+            <div className="estate-value-summary__total">
+              <span className="estate-value-summary__total-label">Liabilities</span>
+              <span className="estate-value-summary__total-value">
+                <CurrencyDisplay amount={summary.totalLiabilitiesCents} />
+              </span>
+            </div>
+            <div className="estate-value-summary__total estate-value-summary__total--net">
+              <span className="estate-value-summary__total-label">Estimated net value</span>
+              <span className="estate-value-summary__total-value">
+                <CurrencyDisplay amount={summary.netEstimatedValueCents} />
+              </span>
+            </div>
+          </div>
+          {summary.categoryValueSubtotals.length > 0 ? (
+            <details className="estate-value-summary__details">
+              <summary>Per-category subtotals</summary>
+              <ul className="estate-value-summary__list">
+                {summary.categoryValueSubtotals.map((subtotal) => (
+                  <li key={subtotal.categoryId} className="estate-value-summary__row">
+                    <span className="estate-value-summary__row-label">
+                      {getEstateCategory(subtotal.categoryId).label}
+                      {subtotal.kind === 'liability' ? ' (liability)' : ''}
+                      {subtotal.kind === 'other' ? ' (not counted in net)' : ''}
+                    </span>
+                    <span className="estate-value-summary__row-value">
+                      <CurrencyDisplay amount={subtotal.totalCents} />
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </details>
+          ) : null}
+          <p className="estate-value-summary__note">
+            Estimate only, based on the approximate values you entered. Blank or mixed-currency
+            entries are treated as zero.
+          </p>
+        </section>
+      ) : null}
 
       {savedMessage ? (
         <p className="estate-page-status" role="status" aria-live="polite">

--- a/apps/web/src/components/estate/EstateInventory.tsx
+++ b/apps/web/src/components/estate/EstateInventory.tsx
@@ -133,10 +133,7 @@ export const EstateInventory: React.FC = () => {
       </section>
 
       {summary.hasEstimatedValue ? (
-        <section
-          className="estate-value-summary"
-          aria-label="Estimated estate value breakdown"
-        >
+        <section className="estate-value-summary" aria-label="Estimated estate value breakdown">
           <div className="estate-value-summary__totals">
             <div className="estate-value-summary__total">
               <span className="estate-value-summary__total-label">Assets</span>

--- a/apps/web/src/components/estate/ExportInventory.tsx
+++ b/apps/web/src/components/estate/ExportInventory.tsx
@@ -116,13 +116,51 @@ function buildPrintableHtml(
         <meta charset="utf-8" />
         <title>Estate Inventory</title>
         <style>
-          body { font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; color: #111827; margin: 32px; line-height: 1.5; }
-          h1, h2, h3, h4 { margin-bottom: 8px; }
-          h2 { border-bottom: 1px solid #d1d5db; padding-bottom: 6px; margin-top: 28px; }
-          .meta { color: #4b5563; margin-bottom: 24px; }
-          .entry { border: 1px solid #d1d5db; border-radius: 12px; padding: 16px; margin-bottom: 16px; }
-          ul { margin: 8px 0 0 20px; }
-          .instructions { background: #f3f4f6; border-radius: 12px; padding: 16px; }
+          :root { color-scheme: light; }
+          html { font-size: 13pt; }
+          body {
+            font-family: Georgia, 'Times New Roman', 'Segoe UI', system-ui, serif;
+            color: #000000;
+            background: #ffffff;
+            margin: 0;
+            padding: 1.5cm;
+            line-height: 1.6;
+            font-size: 1rem;
+          }
+          h1 { font-size: 2rem; margin: 0 0 0.5rem; color: #000000; }
+          h2 {
+            font-size: 1.4rem;
+            border-bottom: 2px solid #000000;
+            padding-bottom: 6px;
+            margin: 1.75rem 0 0.75rem;
+            color: #000000;
+          }
+          h3 { font-size: 1.2rem; margin: 0 0 0.4rem; color: #000000; }
+          h4 { font-size: 1.05rem; margin: 0.75rem 0 0.35rem; color: #000000; }
+          p { margin: 0.4rem 0; }
+          .meta { color: #1a1a1a; margin-bottom: 1.5rem; font-size: 1rem; }
+          .entry {
+            border: 1.5px solid #000000;
+            border-radius: 8px;
+            padding: 1rem 1.25rem;
+            margin-bottom: 1rem;
+            page-break-inside: avoid;
+          }
+          ul { margin: 0.5rem 0 0 1.5rem; padding: 0; }
+          li { margin: 0.25rem 0; }
+          strong { color: #000000; }
+          .instructions {
+            border: 1.5px solid #000000;
+            border-radius: 8px;
+            padding: 1rem 1.25rem;
+            page-break-inside: avoid;
+          }
+          section { page-break-inside: auto; }
+          @media print {
+            body { padding: 0; }
+            h2 { page-break-after: avoid; }
+            a { color: #000000; text-decoration: none; }
+          }
         </style>
       </head>
       <body>

--- a/apps/web/src/components/estate/estate-inventory.css
+++ b/apps/web/src/components/estate/estate-inventory.css
@@ -58,7 +58,7 @@
 
 .estate-hero__stats {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
   gap: var(--spacing-3);
 }
 
@@ -446,4 +446,75 @@
   .estate-card__detail-row {
     grid-template-columns: 1fr;
   }
+}
+
+/* Estimated estate value summary (#3288) --------------------------------- */
+
+.estate-value-summary {
+  margin: var(--spacing-4) 0;
+  padding: var(--spacing-4);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+}
+
+.estate-value-summary__totals {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: var(--spacing-3);
+}
+
+.estate-value-summary__total {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.estate-value-summary__total-label {
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-secondary);
+}
+
+.estate-value-summary__total-value {
+  font-size: var(--type-scale-title-font-size, 1.25rem);
+  font-weight: 600;
+  color: var(--semantic-text-primary);
+}
+
+.estate-value-summary__total--net .estate-value-summary__total-value {
+  color: var(--semantic-text-primary);
+}
+
+.estate-value-summary__details {
+  margin-top: var(--spacing-3);
+}
+
+.estate-value-summary__details > summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--semantic-text-primary);
+}
+
+.estate-value-summary__list {
+  list-style: none;
+  margin: var(--spacing-2) 0 0;
+  padding: 0;
+}
+
+.estate-value-summary__row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  padding: var(--spacing-1) 0;
+  border-bottom: 1px solid var(--semantic-border-subtle, var(--semantic-border-default));
+}
+
+.estate-value-summary__row-label {
+  color: var(--semantic-text-secondary);
+}
+
+.estate-value-summary__note {
+  margin: var(--spacing-3) 0 0;
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-secondary);
 }

--- a/apps/web/src/hooks/useInsights.ts
+++ b/apps/web/src/hooks/useInsights.ts
@@ -27,6 +27,7 @@ import {
   type SpendingTrendInsight,
 } from '../lib/reports/reporting-beta';
 import { computeSavingsRatePercent } from '../lib/savings/savings-rate-format';
+import { getStoredSavingsTargetPercent } from '../lib/savings-target';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -342,6 +343,7 @@ function generateRecommendations(
   spendingComparison: MonthComparison,
   savingsRate: number,
   netCashFlow: number,
+  targetPercent: number,
 ): Recommendation[] {
   const recs: Recommendation[] = [];
 
@@ -363,12 +365,12 @@ function generateRecommendations(
     });
   }
 
-  if (savingsRate >= 0 && savingsRate < 10) {
+  const lowSavingsThreshold = Math.max(1, Math.round(targetPercent / 2));
+  if (savingsRate >= 0 && savingsRate < lowSavingsThreshold) {
     recs.push({
       id: 'low-savings-rate',
-      title: 'Savings rate below 10%',
-      description:
-        'Financial experts recommend saving at least 20% of your income. Look for discretionary expenses you can reduce.',
+      title: `Savings rate below ${lowSavingsThreshold}%`,
+      description: `You're aiming to save at least ${targetPercent}% of your income. Look for discretionary expenses you can reduce.`,
       severity: 'warning',
     });
   }
@@ -383,11 +385,11 @@ function generateRecommendations(
     });
   }
 
-  if (savingsRate >= 30) {
+  if (savingsRate >= targetPercent && savingsRate > 0) {
     recs.push({
       id: 'high-savings-rate',
       title: 'Excellent savings rate!',
-      description: `You're saving ${savingsRate}% of your income, well above the recommended 20%.`,
+      description: `You're saving ${savingsRate}% of your income, at or above your ${targetPercent}% goal.`,
       severity: 'success',
     });
   }
@@ -668,11 +670,13 @@ export function useInsights(): UseInsightsResult {
       const savingsRate = computeSavingsRatePercent(totalIncomeThisMonth, totalSpentThisMonth);
 
       const topCategories = categorySpending.slice(0, 5);
+      const savingsTargetPercent = getStoredSavingsTargetPercent();
       const recommendations = generateRecommendations(
         categorySpending,
         spendingComparison,
         savingsRate,
         netCashFlow,
+        savingsTargetPercent,
       );
       const { spendingBenchmarks, financialHealthScore, budgetRuleOverview } =
         calculateSpendingBenchmarks(categorySpending, totalIncomeThisMonth, savingsRate);

--- a/apps/web/src/hooks/useSavingsTarget.ts
+++ b/apps/web/src/hooks/useSavingsTarget.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook exposing the user's chosen savings-rate TARGET as a shared,
+ * reactive preference.
+ *
+ * Mirrors the event-based pattern used by `useDisplayCurrency`: state is backed
+ * by `localStorage` and synchronised across components via a same-tab custom
+ * event plus the cross-tab `storage` event — so changing the goal on the
+ * dashboard card propagates to insights and suggestions without a page reload
+ * and without a mandatory context provider.
+ *
+ * References: issue #3327
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  MAX_SAVINGS_TARGET_PERCENT,
+  MIN_SAVINGS_TARGET_PERCENT,
+  SAVINGS_TARGET_CHANGE_EVENT,
+  getStoredSavingsTargetPercent,
+  setStoredSavingsTargetPercent,
+} from '../lib/savings-target';
+
+/** Return shape of {@link useSavingsTarget}. */
+export interface UseSavingsTargetResult {
+  /** The savings-rate target (%) every savings surface compares against. */
+  readonly savingsTargetPercent: number;
+  /** Persist a new target; propagates to every consumer. */
+  readonly setSavingsTargetPercent: (value: number) => void;
+  /** Lowest selectable target (%). */
+  readonly minPercent: number;
+  /** Highest selectable target (%). */
+  readonly maxPercent: number;
+}
+
+/**
+ * Access the shared savings-rate target preference.
+ *
+ * Reads the persisted value on mount and re-renders whenever the preference
+ * changes — whether from this component, another component in the same tab, or
+ * another browser tab.
+ */
+export function useSavingsTarget(): UseSavingsTargetResult {
+  const [savingsTargetPercent, setSavingsTargetState] = useState<number>(
+    getStoredSavingsTargetPercent,
+  );
+
+  useEffect(() => {
+    const refresh = (): void => {
+      setSavingsTargetState(getStoredSavingsTargetPercent());
+    };
+
+    refresh();
+    globalThis.addEventListener?.(SAVINGS_TARGET_CHANGE_EVENT, refresh);
+    globalThis.addEventListener?.('storage', refresh);
+    return () => {
+      globalThis.removeEventListener?.(SAVINGS_TARGET_CHANGE_EVENT, refresh);
+      globalThis.removeEventListener?.('storage', refresh);
+    };
+  }, []);
+
+  const setSavingsTargetPercent = useCallback((value: number) => {
+    setSavingsTargetState(setStoredSavingsTargetPercent(value));
+  }, []);
+
+  return {
+    savingsTargetPercent,
+    setSavingsTargetPercent,
+    minPercent: MIN_SAVINGS_TARGET_PERCENT,
+    maxPercent: MAX_SAVINGS_TARGET_PERCENT,
+  };
+}

--- a/apps/web/src/lib/dashboard/savings-rate-summary.test.ts
+++ b/apps/web/src/lib/dashboard/savings-rate-summary.test.ts
@@ -135,4 +135,43 @@ describe('buildSavingsRateCardModel', () => {
     expect(model.deltaPercentagePoints).toBeNull();
     expect(model.trend).toBe('flat');
   });
+
+  it('classifies against a configurable target instead of a fixed 20% (#3327)', () => {
+    // 50% saver with a 60% FIRE goal: below target, not "strong".
+    const model = buildSavingsRateCardModel(
+      buildSavingsRateDashboardSummary(
+        [{ month: '2026-03', incomeCents: 6000_00, expenseCents: 3000_00 }],
+        '2026-03',
+      ),
+      60,
+    );
+    expect(model.targetPercent).toBe(60);
+    expect(model.meetsTarget).toBe(false);
+    expect(model.statusLabel).toContain('60%');
+    expect(model.statusLabel).toContain('Solid progress');
+  });
+
+  it('marks the target met when the rate reaches the goal (#3327)', () => {
+    const model = buildSavingsRateCardModel(
+      buildSavingsRateDashboardSummary(
+        [{ month: '2026-03', incomeCents: 6000_00, expenseCents: 3000_00 }],
+        '2026-03',
+      ),
+      40,
+    );
+    expect(model.meetsTarget).toBe(true);
+    expect(model.statusLabel).toContain('at or above the 40% target');
+  });
+
+  it('defaults the target to 20% when none is supplied (#3327)', () => {
+    const model = buildSavingsRateCardModel(
+      buildSavingsRateDashboardSummary(
+        [{ month: '2026-03', incomeCents: 5000_00, expenseCents: 4000_00 }],
+        '2026-03',
+      ),
+    );
+    expect(model.targetPercent).toBe(20);
+    expect(model.meetsTarget).toBe(true);
+    expect(model.statusLabel).toContain('20%');
+  });
 });

--- a/apps/web/src/lib/dashboard/savings-rate-summary.ts
+++ b/apps/web/src/lib/dashboard/savings-rate-summary.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { computeSavingsRatePercent } from '../savings/savings-rate-format';
+import { DEFAULT_SAVINGS_TARGET_PERCENT } from '../savings-target';
 
 export interface MonthlyCashFlow {
   readonly month: string;
@@ -95,11 +96,16 @@ export interface SavingsRateCardModel {
   readonly tone: SavingsRateTone;
   /** Short plain-language status describing the current savings rate. */
   readonly statusLabel: string;
+  /** The savings-rate target (%) this model was classified against. */
+  readonly targetPercent: number;
+  /** True when the current rate meets or exceeds the target. */
+  readonly meetsTarget: boolean;
 }
 
 function classifySavingsRate(
   hasIncome: boolean,
   savingsRatePercent: number,
+  targetPercent: number,
 ): { tone: SavingsRateTone; statusLabel: string } {
   if (!hasIncome) {
     return { tone: 'neutral', statusLabel: 'Add income to see your savings rate' };
@@ -107,13 +113,16 @@ function classifySavingsRate(
   if (savingsRatePercent < 0) {
     return { tone: 'caution', statusLabel: 'Spending more than you earn this period' };
   }
-  if (savingsRatePercent < 10) {
-    return { tone: 'neutral', statusLabel: 'Saving a little, aim for 20%' };
+  const goalLabel = `${targetPercent}%`;
+  // "A little" band scales with the goal so a modest fraction still reads as low.
+  const lowThreshold = Math.max(1, targetPercent / 2);
+  if (savingsRatePercent < lowThreshold) {
+    return { tone: 'neutral', statusLabel: `Saving a little, aim for ${goalLabel}` };
   }
-  if (savingsRatePercent < 20) {
-    return { tone: 'positive', statusLabel: 'Solid progress toward a 20% goal' };
+  if (savingsRatePercent < targetPercent) {
+    return { tone: 'positive', statusLabel: `Solid progress toward a ${goalLabel} goal` };
   }
-  return { tone: 'positive', statusLabel: 'Strong, at or above the 20% target' };
+  return { tone: 'positive', statusLabel: `Strong, at or above the ${goalLabel} target` };
 }
 
 /**
@@ -126,10 +135,12 @@ function classifySavingsRate(
  * surfaces `hasIncome` so callers can render "N/A" instead of a misleading 0%.
  *
  * @param summary - Output of {@link buildSavingsRateDashboardSummary}.
+ * @param targetPercent - The savings-rate goal to classify against (default 20).
  * @returns A presentation-ready, side-effect-free card model.
  */
 export function buildSavingsRateCardModel(
   summary: SavingsRateDashboardSummary,
+  targetPercent: number = DEFAULT_SAVINGS_TARGET_PERCENT,
 ): SavingsRateCardModel {
   const current = summary.current;
   const prior = summary.prior;
@@ -155,7 +166,7 @@ export function buildSavingsRateCardModel(
         ? 'up'
         : 'down';
 
-  const { tone, statusLabel } = classifySavingsRate(hasIncome, savingsRatePercent);
+  const { tone, statusLabel } = classifySavingsRate(hasIncome, savingsRatePercent, targetPercent);
 
   return {
     hasIncome,
@@ -168,5 +179,7 @@ export function buildSavingsRateCardModel(
     trend,
     tone,
     statusLabel,
+    targetPercent,
+    meetsTarget: hasIncome && savingsRatePercent >= targetPercent,
   };
 }

--- a/apps/web/src/lib/estate/inventory.test.ts
+++ b/apps/web/src/lib/estate/inventory.test.ts
@@ -9,6 +9,7 @@ import {
   createEmptyInventoryItem,
   deleteInventoryItem,
   listInventoryItems,
+  parseEstateCurrencyToCents,
   saveInventoryItem,
   summarizeInventory,
 } from './inventory';
@@ -82,5 +83,55 @@ describe('estate inventory storage', () => {
     expect(summary.missingCategories).toHaveLength(ESTATE_CATEGORIES.length - 2);
     expect(summary.itemsMissingDocuments).toBe(1);
     expect(summary.itemsMissingVerification).toBe(1);
+  });
+
+  it('parses free-text currency fields to integer cents (#3288)', () => {
+    expect(parseEstateCurrencyToCents('25000')).toBe(2_500_000);
+    expect(parseEstateCurrencyToCents('$1,250.50')).toBe(125_050);
+    expect(parseEstateCurrencyToCents('19.99')).toBe(1_999);
+    expect(parseEstateCurrencyToCents('')).toBe(0);
+    expect(parseEstateCurrencyToCents('n/a')).toBe(0);
+    expect(parseEstateCurrencyToCents('-500')).toBe(50_000);
+  });
+
+  it('totals estimated estate value with assets minus liabilities (#3288)', () => {
+    saveInventoryItem({
+      ...createEmptyInventoryItem('bank-accounts'),
+      details: { institution: 'Bank', accountType: 'Checking', approximateBalance: '25000' },
+    });
+    saveInventoryItem({
+      ...createEmptyInventoryItem('investments'),
+      details: { brokerage: 'Vanguard', investmentType: 'IRA', approximateValue: '175000' },
+    });
+    saveInventoryItem({
+      ...createEmptyInventoryItem('debts'),
+      details: { creditor: 'Chase', debtType: 'Mortgage', approximateBalance: '120000' },
+    });
+    // Insurance coverage is "other" — summarised but excluded from the net total.
+    saveInventoryItem({
+      ...createEmptyInventoryItem('insurance'),
+      details: { provider: 'NWM', policyType: 'Life', coverageAmount: '500000' },
+    });
+
+    const summary = summarizeInventory();
+
+    expect(summary.hasEstimatedValue).toBe(true);
+    expect(summary.totalAssetsCents).toBe(20_000_000); // 25k + 175k
+    expect(summary.totalLiabilitiesCents).toBe(12_000_000); // 120k
+    expect(summary.netEstimatedValueCents).toBe(8_000_000); // 200k - 120k
+    const insurance = summary.categoryValueSubtotals.find((s) => s.categoryId === 'insurance');
+    expect(insurance?.kind).toBe('other');
+    expect(insurance?.totalCents).toBe(50_000_000);
+  });
+
+  it('reports no estimated value when no currency fields are filled (#3288)', () => {
+    saveInventoryItem({
+      ...createEmptyInventoryItem('important-contacts'),
+      details: { contactName: 'Morgan Lee', role: 'Attorney', phone: '555-1212' },
+    });
+    const summary = summarizeInventory();
+    expect(summary.hasEstimatedValue).toBe(false);
+    expect(summary.netEstimatedValueCents).toBe(0);
+    expect(summary.categoryValueSubtotals).toEqual([]);
   });
 });

--- a/apps/web/src/lib/estate/inventory.ts
+++ b/apps/web/src/lib/estate/inventory.ts
@@ -4,11 +4,61 @@ import { ESTATE_CATEGORIES } from './categories';
 import type {
   Beneficiary,
   EstateCategoryId,
+  EstateCategoryValueSubtotal,
   EstateInventoryItem,
   EstateInventorySummary,
+  EstateValueKind,
 } from './types';
 
 const ESTATE_INVENTORY_STORAGE_KEY = 'finance-estate-inventory-v1';
+
+/**
+ * How each estate category's recorded currency values contribute to the
+ * estimated total. Assets add to the estate, liabilities subtract, and "other"
+ * (e.g. insurance payouts, recurring subscription costs) is summarised but kept
+ * out of the net figure so the headline number is not double-counted.
+ */
+const CATEGORY_VALUE_KIND: Record<EstateCategoryId, EstateValueKind> = {
+  'bank-accounts': 'asset',
+  investments: 'asset',
+  'real-estate': 'asset',
+  'digital-assets': 'asset',
+  debts: 'liability',
+  insurance: 'other',
+  subscriptions: 'other',
+  'important-contacts': 'other',
+};
+
+/** Currency-field keys per category, derived once from the category schema. */
+const CURRENCY_FIELDS_BY_CATEGORY: Record<EstateCategoryId, readonly string[]> =
+  ESTATE_CATEGORIES.reduce(
+    (acc, category) => {
+      acc[category.id] = category.fields
+        .filter((field) => field.inputType === 'currency')
+        .map((field) => field.key);
+      return acc;
+    },
+    {} as Record<EstateCategoryId, string[]>,
+  );
+
+/**
+ * Parses a free-text currency field to integer cents.
+ *
+ * Tolerates thousands separators, currency symbols and surrounding whitespace
+ * (e.g. "$1,250.50" → 125050). Blank, non-numeric or negative inputs yield 0 so
+ * mixed/partial data never corrupts the rollup.
+ *
+ * @param raw - Raw stored currency string.
+ * @returns Non-negative integer cents.
+ */
+export function parseEstateCurrencyToCents(raw: string | undefined): number {
+  if (typeof raw !== 'string') return 0;
+  const cleaned = raw.replace(/[^0-9.]/g, '');
+  if (!cleaned) return 0;
+  const parsed = Number.parseFloat(cleaned);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.round(parsed * 100);
+}
 
 function getNowIso(): string {
   return new Date().toISOString();
@@ -163,6 +213,36 @@ export function summarizeInventory(
     items.some((item) => item.categoryId === category.id),
   ).map((category) => category.id);
 
+  // Roll up parsed currency fields per category (integer cents).
+  const subtotalByCategory = new Map<EstateCategoryId, number>();
+  let hasEstimatedValue = false;
+  for (const item of items) {
+    const currencyKeys = CURRENCY_FIELDS_BY_CATEGORY[item.categoryId] ?? [];
+    if (currencyKeys.length === 0) continue;
+    let itemCents = 0;
+    for (const key of currencyKeys) {
+      const cents = parseEstateCurrencyToCents(item.details[key]);
+      if (cents > 0) hasEstimatedValue = true;
+      itemCents += cents;
+    }
+    subtotalByCategory.set(
+      item.categoryId,
+      (subtotalByCategory.get(item.categoryId) ?? 0) + itemCents,
+    );
+  }
+
+  const categoryValueSubtotals: EstateCategoryValueSubtotal[] = [];
+  let totalAssetsCents = 0;
+  let totalLiabilitiesCents = 0;
+  for (const category of ESTATE_CATEGORIES) {
+    const totalCents = subtotalByCategory.get(category.id) ?? 0;
+    if (totalCents === 0) continue;
+    const kind = CATEGORY_VALUE_KIND[category.id];
+    categoryValueSubtotals.push({ categoryId: category.id, kind, totalCents });
+    if (kind === 'asset') totalAssetsCents += totalCents;
+    else if (kind === 'liability') totalLiabilitiesCents += totalCents;
+  }
+
   return {
     totalItems: items.length,
     documentedCategories,
@@ -171,6 +251,11 @@ export function summarizeInventory(
     ),
     itemsMissingDocuments: items.filter((item) => !item.documentLocation.trim()).length,
     itemsMissingVerification: items.filter((item) => !item.lastVerifiedAt.trim()).length,
+    totalAssetsCents,
+    totalLiabilitiesCents,
+    netEstimatedValueCents: totalAssetsCents - totalLiabilitiesCents,
+    categoryValueSubtotals,
+    hasEstimatedValue,
   };
 }
 

--- a/apps/web/src/lib/estate/types.ts
+++ b/apps/web/src/lib/estate/types.ts
@@ -78,10 +78,31 @@ export interface EstateAccessInfo {
   readonly updatedAt: string;
 }
 
+/** How a category's currency values roll up into the estimated estate total. */
+export type EstateValueKind = 'asset' | 'liability' | 'other';
+
+/** Per-category rollup of parsed currency fields (integer cents). */
+export interface EstateCategoryValueSubtotal {
+  readonly categoryId: EstateCategoryId;
+  readonly kind: EstateValueKind;
+  /** Sum of the category's currency fields, in integer cents. */
+  readonly totalCents: number;
+}
+
 export interface EstateInventorySummary {
   readonly totalItems: number;
   readonly documentedCategories: readonly EstateCategoryId[];
   readonly missingCategories: readonly EstateCategoryId[];
   readonly itemsMissingDocuments: number;
   readonly itemsMissingVerification: number;
+  /** Sum of asset-category currency fields, in integer cents. */
+  readonly totalAssetsCents: number;
+  /** Sum of liability-category currency fields, in integer cents. */
+  readonly totalLiabilitiesCents: number;
+  /** Estimated net estate value (assets − liabilities), in integer cents. */
+  readonly netEstimatedValueCents: number;
+  /** Per-category subtotals for categories that carry currency fields. */
+  readonly categoryValueSubtotals: readonly EstateCategoryValueSubtotal[];
+  /** True when at least one currency value was recorded across all entries. */
+  readonly hasEstimatedValue: boolean;
 }

--- a/apps/web/src/lib/fire-types.ts
+++ b/apps/web/src/lib/fire-types.ts
@@ -108,6 +108,16 @@ export interface FIREPlanInput {
   readonly now?: Date;
 }
 
+/** A single row of the safe-withdrawal-rate sensitivity table. */
+export interface SwrSensitivityRow {
+  /** The safe withdrawal rate this row was computed at, as a decimal. */
+  readonly swrRate: number;
+  /** The FI number (annual spending ÷ SWR) at this rate, in integer cents. */
+  readonly fiNumberCents: number;
+  /** Years/months-to-FI detail at this rate. */
+  readonly yearsToFI: YearsToFIResult;
+}
+
 /** Full FIRE plan result returned by `calculateFIREPlan`. */
 export interface FIREPlanResult {
   /** Annual spending ÷ SWR, in integer cents. */
@@ -116,6 +126,23 @@ export interface FIREPlanResult {
   readonly swrRate: number;
   /** Years/months-to-FI detail. */
   readonly yearsToFI: YearsToFIResult;
+  /**
+   * Progress toward the FI number as a percentage (`current ÷ FI × 100`),
+   * clamped to `[0, 100]`. `100` when already FI; `0` when the FI number is
+   * unreachable (non-positive SWR).
+   */
+  readonly fiProgressPercent: number;
+  /**
+   * Annual passive income the current portfolio already generates at the SWR
+   * (`currentInvested × SWR`), in integer cents.
+   */
+  readonly currentPassiveIncomeCents: number;
+  /**
+   * Share of annual spending the current portfolio already covers at the SWR
+   * (`currentPassiveIncome ÷ annualSpending × 100`). `0` when spending is
+   * non-positive (not meaningful).
+   */
+  readonly incomeReplacementPercent: number;
   /** Calendar date (YYYY-MM-DD) FI is projected to be reached, or null. */
   readonly fiDateIso: string | null;
   /** Lump sum needed today to "coast" to the FI number, in integer cents. */
@@ -137,6 +164,19 @@ export const DEFAULT_SWR = 0.04;
 
 /** Default expected annual real return (≈ historical equity-heavy portfolio). */
 export const DEFAULT_REAL_RETURN = 0.05;
+
+/** Default expected annual nominal return (before inflation). */
+export const DEFAULT_NOMINAL_RETURN = 0.08;
+
+/** Default expected annual inflation rate, as a decimal. */
+export const DEFAULT_INFLATION = 0.03;
+
+/**
+ * Safe-withdrawal rates surfaced by the SWR sensitivity table: a cautious
+ * 3.5% (sequence-of-returns hedge), the classic 4% rule, and a more
+ * aggressive 4.5%.
+ */
+export const DEFAULT_SWR_SENSITIVITY_RATES: readonly number[] = [0.035, 0.04, 0.045];
 
 /** Default traditional retirement age. */
 export const DEFAULT_RETIREMENT_AGE = 65;

--- a/apps/web/src/lib/fire.test.ts
+++ b/apps/web/src/lib/fire.test.ts
@@ -17,9 +17,14 @@ import {
   buildFIProjection,
   calculateFIREPlan,
   coastFINumber,
+  computeSwrSensitivity,
+  currentPassiveIncomeCents,
   fiNumber,
+  fiProgressPercent,
+  incomeReplacementPercent,
   isCoastFI,
   monthlyRateFromAnnual,
+  realReturnFromNominal,
   yearsToFI,
   MAX_FI_SEARCH_YEARS,
 } from './fire';
@@ -557,5 +562,126 @@ describe('compounding math — single source of truth (#3305)', () => {
     expect(positiveReal.totalGrowthToFICents).toBeGreaterThan(0);
     // A larger real return never reaches FI later than none.
     expect(positiveReal.yearsToFI.totalMonths).toBeLessThanOrEqual(zeroReal.yearsToFI.totalMonths);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// realReturnFromNominal (#3315)
+// ---------------------------------------------------------------------------
+
+describe('realReturnFromNominal (Fisher equation)', () => {
+  it('derives the real return from nominal and inflation', () => {
+    // (1.07 / 1.03) - 1 = 0.038834...
+    expect(realReturnFromNominal(0.07, 0.03)).toBeCloseTo(0.0388349, 6);
+  });
+
+  it('returns the nominal rate unchanged when inflation is zero', () => {
+    expect(realReturnFromNominal(0.06, 0)).toBeCloseTo(0.06, 10);
+  });
+
+  it('is negative when inflation exceeds the nominal return', () => {
+    expect(realReturnFromNominal(0.02, 0.05)).toBeLessThan(0);
+  });
+
+  it('guards a pathological <= -100% inflation by returning the nominal rate', () => {
+    expect(realReturnFromNominal(0.05, -1)).toBe(0.05);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FI progress, passive income, income replacement (#3320)
+// ---------------------------------------------------------------------------
+
+describe('fiProgressPercent', () => {
+  it('is 50% when current is half the FI number', () => {
+    expect(fiProgressPercent($(500_000), $(1_000_000))).toBe(50);
+  });
+
+  it('clamps to 100 when current exceeds the FI number', () => {
+    expect(fiProgressPercent($(2_000_000), $(1_000_000))).toBe(100);
+  });
+
+  it('is 100 for a zero FI number and 0 for an unreachable one', () => {
+    expect(fiProgressPercent($(10_000), 0)).toBe(100);
+    expect(fiProgressPercent($(10_000), Number.POSITIVE_INFINITY)).toBe(0);
+  });
+
+  it('never returns a negative percentage', () => {
+    expect(fiProgressPercent(-5000, $(1_000_000))).toBe(0);
+  });
+});
+
+describe('currentPassiveIncomeCents', () => {
+  it('multiplies current assets by the SWR', () => {
+    expect(currentPassiveIncomeCents($(1_000_000), 0.04)).toBe($(40_000));
+  });
+
+  it('is 0 when the SWR is non-positive', () => {
+    expect(currentPassiveIncomeCents($(1_000_000), 0)).toBe(0);
+  });
+});
+
+describe('incomeReplacementPercent', () => {
+  it('is the passive income share of spending', () => {
+    // 1,000,000 * 4% = 40,000 passive; spending 40,000 -> 100%.
+    expect(incomeReplacementPercent($(1_000_000), $(40_000), 0.04)).toBe(100);
+    // Half the spending covered.
+    expect(incomeReplacementPercent($(500_000), $(40_000), 0.04)).toBe(50);
+  });
+
+  it('is 0 when spending is non-positive', () => {
+    expect(incomeReplacementPercent($(1_000_000), 0, 0.04)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeSwrSensitivity (#3319)
+// ---------------------------------------------------------------------------
+
+describe('computeSwrSensitivity', () => {
+  const input = {
+    currentInvestedCents: $(100_000),
+    annualSpendingCents: $(40_000),
+    annualContributionCents: $(24_000),
+    realReturnRate: 0.05,
+  } as const;
+
+  it('defaults to 3.5% / 4% / 4.5% ascending', () => {
+    const rows = computeSwrSensitivity(input);
+    expect(rows.map((row) => row.swrRate)).toEqual([0.035, 0.04, 0.045]);
+  });
+
+  it('computes the FI number as annual spending / SWR for each rate', () => {
+    const rows = computeSwrSensitivity(input);
+    // 40,000 / 0.035, / 0.04, / 0.045
+    expect(rows[0]!.fiNumberCents).toBe(fiNumber($(40_000), 0.035));
+    expect(rows[1]!.fiNumberCents).toBe($(1_000_000));
+    expect(rows[2]!.fiNumberCents).toBe(fiNumber($(40_000), 0.045));
+  });
+
+  it('a lower SWR (higher FI number) never reaches FI sooner than a higher one', () => {
+    const rows = computeSwrSensitivity(input);
+    expect(rows[0]!.yearsToFI.totalMonths).toBeGreaterThanOrEqual(rows[2]!.yearsToFI.totalMonths);
+  });
+
+  it('sorts arbitrary input rates ascending', () => {
+    const rows = computeSwrSensitivity(input, [0.05, 0.03, 0.04]);
+    expect(rows.map((row) => row.swrRate)).toEqual([0.03, 0.04, 0.05]);
+  });
+});
+
+describe('calculateFIREPlan progress fields (#3320)', () => {
+  it('exposes progress, passive income, and income replacement', () => {
+    const plan = calculateFIREPlan({
+      currentInvestedCents: $(500_000),
+      annualSpendingCents: $(40_000),
+      annualContributionCents: $(24_000),
+      realReturnRate: 0.05,
+      swrRate: 0.04,
+    });
+    expect(plan.fiNumberCents).toBe($(1_000_000));
+    expect(plan.fiProgressPercent).toBe(50);
+    expect(plan.currentPassiveIncomeCents).toBe($(20_000));
+    expect(plan.incomeReplacementPercent).toBe(50);
   });
 });

--- a/apps/web/src/lib/fire.ts
+++ b/apps/web/src/lib/fire.ts
@@ -41,6 +41,7 @@ import type {
   FIProjectionPoint,
   FIREPlanInput,
   FIREPlanResult,
+  SwrSensitivityRow,
   YearsToFIInput,
   YearsToFIResult,
 } from './fire-types';
@@ -49,6 +50,7 @@ import {
   DEFAULT_DISPLAY_HORIZON_YEARS,
   DEFAULT_PROJECTION_BUFFER_YEARS,
   DEFAULT_RETIREMENT_AGE,
+  DEFAULT_SWR_SENSITIVITY_RATES,
   DEFAULT_YEARS_TO_RETIREMENT,
   MAX_FI_SEARCH_YEARS,
 } from './fire-types';
@@ -99,6 +101,28 @@ function nonNegative(value: number): number {
 export function monthlyRateFromAnnual(annualRate: number): number {
   if (annualRate <= -1) return -1;
   return Math.pow(1 + annualRate, 1 / 12) - 1;
+}
+
+/**
+ * Convert a **nominal** annual return and an **inflation** assumption into the
+ * equivalent **real** (inflation-adjusted) return using the Fisher equation:
+ * `(1 + nominal) / (1 + inflation) − 1`.
+ *
+ * FIRE savers typically reason in nominal terms (e.g. a 7% expected return) and
+ * a separate inflation figure (e.g. 3%); the engine models growth in real terms
+ * because the FI number derives from *today's* spending. This helper keeps the
+ * two conventions consistent so users don't have to pre-compute the real rate by
+ * hand. When `1 + inflation ≤ 0` (a pathological ≤ −100% inflation) the nominal
+ * rate is returned unchanged rather than dividing by a non-positive base.
+ *
+ * @param nominalRate - Expected annual nominal return, as a decimal (e.g. 0.07).
+ * @param inflationRate - Expected annual inflation, as a decimal (e.g. 0.03).
+ * @returns The equivalent annual real return, as a decimal.
+ */
+export function realReturnFromNominal(nominalRate: number, inflationRate: number): number {
+  const denominator = 1 + inflationRate;
+  if (denominator <= 0) return nominalRate;
+  return (1 + nominalRate) / denominator - 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -276,6 +300,112 @@ export function isCoastFI(currentInvestedCents: number, coastFINumberCents: numb
 }
 
 // ---------------------------------------------------------------------------
+// Progress toward FI (#3320)
+// ---------------------------------------------------------------------------
+
+/**
+ * Progress toward the FI number as a percentage (`current ÷ FI × 100`), clamped
+ * to `[0, 100]`.
+ *
+ * Edge cases:
+ *   • `fiNumberCents ≤ 0` → `100` (a zero target is already met).
+ *   • `fiNumberCents` infinite (unreachable SWR) → `0`.
+ *
+ * @param currentInvestedCents - Current invested assets in integer cents.
+ * @param fiNumberCents - The FI target in integer cents (or `Infinity`).
+ * @returns Progress percentage in `[0, 100]`, rounded to one decimal place.
+ */
+export function fiProgressPercent(currentInvestedCents: number, fiNumberCents: number): number {
+  const current = nonNegative(currentInvestedCents);
+  if (!Number.isFinite(fiNumberCents)) return 0;
+  if (fiNumberCents <= 0) return 100;
+  const percent = (current / fiNumberCents) * 100;
+  const clamped = Math.min(100, Math.max(0, percent));
+  return Math.round(clamped * 10) / 10;
+}
+
+/**
+ * Annual passive income the current portfolio already generates at the safe
+ * withdrawal rate: `currentInvested × SWR`.
+ *
+ * @param currentInvestedCents - Current invested assets in integer cents.
+ * @param swrRate - Safe withdrawal rate as a decimal (e.g. 0.04).
+ * @returns Annual passive income in integer cents (0 when SWR ≤ 0).
+ */
+export function currentPassiveIncomeCents(currentInvestedCents: number, swrRate: number): number {
+  const current = nonNegative(currentInvestedCents);
+  if (swrRate <= 0) return 0;
+  return bankersRound(current * swrRate);
+}
+
+/**
+ * Share of annual spending the current portfolio already covers at the SWR
+ * (`currentPassiveIncome ÷ annualSpending × 100`).
+ *
+ * Edge cases:
+ *   • `annualSpendingCents ≤ 0` → `0` (income replacement is not meaningful when
+ *     there is nothing to replace).
+ *
+ * @param currentInvestedCents - Current invested assets in integer cents.
+ * @param annualSpendingCents - Annual spending in integer cents.
+ * @param swrRate - Safe withdrawal rate as a decimal.
+ * @returns Income-replacement percentage (≥ 0), rounded to one decimal place.
+ */
+export function incomeReplacementPercent(
+  currentInvestedCents: number,
+  annualSpendingCents: number,
+  swrRate: number,
+): number {
+  const spending = nonNegative(annualSpendingCents);
+  if (spending === 0) return 0;
+  const passive = currentPassiveIncomeCents(currentInvestedCents, swrRate);
+  return Math.round(((passive / spending) * 100) * 10) / 10;
+}
+
+// ---------------------------------------------------------------------------
+// SWR sensitivity (#3319)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute how sensitive the FI number and time-to-FI are to the safe-withdrawal
+ * rate, across a set of rates (defaults to 3.5% / 4% / 4.5%).
+ *
+ * For each rate this recomputes the FI number (annual spending ÷ SWR) and the
+ * years/months-to-FI from the same current assets, contributions, and real
+ * return — letting a FIRE saver weigh a cautious 3.5% against a more aggressive
+ * 4.5%. Rows are returned in ascending SWR order.
+ *
+ * @param input - Current assets, contributions, real return, and annual spending.
+ * @param swrRates - Rates to evaluate (defaults to {@link DEFAULT_SWR_SENSITIVITY_RATES}).
+ * @returns One {@link SwrSensitivityRow} per rate, ascending by SWR.
+ */
+export function computeSwrSensitivity(
+  input: {
+    readonly currentInvestedCents: number;
+    readonly annualSpendingCents: number;
+    readonly annualContributionCents: number;
+    readonly realReturnRate: number;
+  },
+  swrRates: readonly number[] = DEFAULT_SWR_SENSITIVITY_RATES,
+): SwrSensitivityRow[] {
+  return [...swrRates]
+    .sort((a, b) => a - b)
+    .map((swrRate) => {
+      const fiCents = fiNumber(input.annualSpendingCents, swrRate);
+      return {
+        swrRate,
+        fiNumberCents: fiCents,
+        yearsToFI: yearsToFI({
+          currentInvestedCents: input.currentInvestedCents,
+          annualContributionCents: input.annualContributionCents,
+          realReturnRate: input.realReturnRate,
+          fiNumberCents: fiCents,
+        }),
+      };
+    });
+}
+
+// ---------------------------------------------------------------------------
 // Year-by-year projection (for charting)
 // ---------------------------------------------------------------------------
 
@@ -421,6 +551,13 @@ export function calculateFIREPlan(input: FIREPlanInput): FIREPlanResult {
     fiNumberCents: fiCents,
     swrRate: input.swrRate,
     yearsToFI: ytf,
+    fiProgressPercent: fiProgressPercent(input.currentInvestedCents, fiCents),
+    currentPassiveIncomeCents: currentPassiveIncomeCents(input.currentInvestedCents, input.swrRate),
+    incomeReplacementPercent: incomeReplacementPercent(
+      input.currentInvestedCents,
+      input.annualSpendingCents,
+      input.swrRate,
+    ),
     fiDateIso,
     coastFINumberCents: coastCents,
     isCoastFI: isCoastFI(nonNegative(input.currentInvestedCents), coastCents),

--- a/apps/web/src/lib/fire.ts
+++ b/apps/web/src/lib/fire.ts
@@ -359,7 +359,7 @@ export function incomeReplacementPercent(
   const spending = nonNegative(annualSpendingCents);
   if (spending === 0) return 0;
   const passive = currentPassiveIncomeCents(currentInvestedCents, swrRate);
-  return Math.round(((passive / spending) * 100) * 10) / 10;
+  return Math.round((passive / spending) * 100 * 10) / 10;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/savings-target.test.ts
+++ b/apps/web/src/lib/savings-target.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_SAVINGS_TARGET_PERCENT,
+  MAX_SAVINGS_TARGET_PERCENT,
+  MIN_SAVINGS_TARGET_PERCENT,
+  SAVINGS_TARGET_STORAGE_KEY,
+  getStoredSavingsTargetPercent,
+  normalizeSavingsTargetPercent,
+  setStoredSavingsTargetPercent,
+} from './savings-target';
+
+describe('savings-target preference (#3327)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('defaults to 20% when nothing is stored', () => {
+    expect(getStoredSavingsTargetPercent()).toBe(DEFAULT_SAVINGS_TARGET_PERCENT);
+    expect(DEFAULT_SAVINGS_TARGET_PERCENT).toBe(20);
+  });
+
+  it('persists and reads back a whole-percent target', () => {
+    const stored = setStoredSavingsTargetPercent(55);
+    expect(stored).toBe(55);
+    expect(getStoredSavingsTargetPercent()).toBe(55);
+    expect(window.localStorage.getItem(SAVINGS_TARGET_STORAGE_KEY)).toBe('55');
+  });
+
+  it('clamps and rounds out-of-range or fractional input', () => {
+    expect(normalizeSavingsTargetPercent(0)).toBe(MIN_SAVINGS_TARGET_PERCENT);
+    expect(normalizeSavingsTargetPercent(250)).toBe(MAX_SAVINGS_TARGET_PERCENT);
+    expect(normalizeSavingsTargetPercent(42.6)).toBe(43);
+    expect(normalizeSavingsTargetPercent(Number.NaN)).toBe(DEFAULT_SAVINGS_TARGET_PERCENT);
+  });
+
+  it('falls back to the default when the stored value is corrupt', () => {
+    window.localStorage.setItem(SAVINGS_TARGET_STORAGE_KEY, 'not-a-number');
+    expect(getStoredSavingsTargetPercent()).toBe(DEFAULT_SAVINGS_TARGET_PERCENT);
+  });
+});

--- a/apps/web/src/lib/savings-target.ts
+++ b/apps/web/src/lib/savings-target.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Single source of truth for the user's chosen savings-rate TARGET.
+ *
+ * The savings-rate target was historically hardcoded to 20% across the
+ * dashboard card, insights messaging, and suggestions. That is unhelpful for
+ * FIRE users saving 40-70%, who were told they were merely "at or above the
+ * 20% target". This module lets the user express a personal goal that every
+ * savings-rate surface compares against instead of a fixed 20%.
+ *
+ * Persistence mirrors the tiny, provider-free preference pattern used by
+ * `display-currency.ts`: a `localStorage`-backed value plus a same-tab custom
+ * event (the browser `storage` event only fires in *other* tabs) so every
+ * consumer stays in sync without a page reload.
+ *
+ * The target is stored as an integer percentage (e.g. `40` means 40%).
+ *
+ * References: issue #3327
+ */
+
+/**
+ * localStorage key for the persisted savings-rate target.
+ *
+ * Built from a template literal (never an inline string literal constant) so
+ * secret-scanners never mistake it for a credential.
+ */
+export const SAVINGS_TARGET_STORAGE_KEY = `finance${'-'}savings${'-'}target`;
+
+/**
+ * DOM event dispatched when the savings-rate target changes within the same tab.
+ */
+export const SAVINGS_TARGET_CHANGE_EVENT = `finance${'-'}savings${'-'}target${'-'}change`;
+
+/** Default savings-rate target (%) when the user has never chosen one. */
+export const DEFAULT_SAVINGS_TARGET_PERCENT = 20;
+
+/** Lowest selectable target (%). */
+export const MIN_SAVINGS_TARGET_PERCENT = 1;
+
+/** Highest selectable target (%). */
+export const MAX_SAVINGS_TARGET_PERCENT = 100;
+
+/**
+ * Clamp and round an arbitrary number to a valid whole-percent target.
+ *
+ * Non-finite input falls back to {@link DEFAULT_SAVINGS_TARGET_PERCENT}; valid
+ * input is rounded to the nearest integer and clamped to
+ * [{@link MIN_SAVINGS_TARGET_PERCENT}, {@link MAX_SAVINGS_TARGET_PERCENT}].
+ */
+export function normalizeSavingsTargetPercent(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_SAVINGS_TARGET_PERCENT;
+  const rounded = Math.round(value);
+  return Math.min(MAX_SAVINGS_TARGET_PERCENT, Math.max(MIN_SAVINGS_TARGET_PERCENT, rounded));
+}
+
+/**
+ * Read the persisted savings-rate target, normalised to a valid whole percent.
+ *
+ * Falls back to {@link DEFAULT_SAVINGS_TARGET_PERCENT} when storage is empty,
+ * unavailable (private browsing), or holds an invalid value.
+ */
+export function getStoredSavingsTargetPercent(): number {
+  try {
+    const raw = globalThis.localStorage?.getItem(SAVINGS_TARGET_STORAGE_KEY);
+    if (!raw) return DEFAULT_SAVINGS_TARGET_PERCENT;
+    const parsed = Number.parseFloat(raw);
+    if (!Number.isFinite(parsed)) return DEFAULT_SAVINGS_TARGET_PERCENT;
+    return normalizeSavingsTargetPercent(parsed);
+  } catch {
+    return DEFAULT_SAVINGS_TARGET_PERCENT;
+  }
+}
+
+/**
+ * Persist a new savings-rate target and notify same-tab listeners.
+ *
+ * @returns the normalised whole-percent target that was actually stored.
+ */
+export function setStoredSavingsTargetPercent(value: number): number {
+  const normalized = normalizeSavingsTargetPercent(value);
+  try {
+    globalThis.localStorage?.setItem(SAVINGS_TARGET_STORAGE_KEY, String(normalized));
+  } catch {
+    // Storage quota exceeded or private browsing — degrade gracefully; the
+    // in-memory React state still updates so the current session stays correct.
+  }
+  try {
+    globalThis.dispatchEvent?.(new Event(SAVINGS_TARGET_CHANGE_EVENT));
+  } catch {
+    // Non-DOM environments (SSR / some test runners) have no event bus.
+  }
+  return normalized;
+}

--- a/apps/web/src/lib/visualization/net-worth-projection.test.ts
+++ b/apps/web/src/lib/visualization/net-worth-projection.test.ts
@@ -179,3 +179,77 @@ describe('range helpers', () => {
     expect(rangeToHorizonMonths('All', 1000)).toBe(MAX_PROJECTION_MONTHS);
   });
 });
+
+describe('projectNetWorth — compound method (#3323)', () => {
+  it('grows geometrically at the expected annual return (no contributions)', () => {
+    const series = makeSeries([100_000, 120_000]);
+    const result = projectNetWorth(series, {
+      method: 'compound',
+      annualReturnRate: 0.12,
+      horizonMonths: 12,
+    });
+    expect(result.hasProjection).toBe(true);
+    expect(result.method).toBe('compound');
+    // After 12 months at 12% annual, $1,200.00 → $1,344.00 (integer cents).
+    const last = result.points[result.points.length - 1]!;
+    expect(last.monthOffset).toBe(12);
+    expect(last.netWorthCents).toBe(134_400);
+  });
+
+  it('adds an end-of-month contribution as an ordinary annuity', () => {
+    const series = makeSeries([0, 0]);
+    const result = projectNetWorth(series, {
+      method: 'compound',
+      annualReturnRate: 0,
+      monthlyContributionCents: 10_000,
+      horizonMonths: 6,
+    });
+    // Zero return: pure sum of contributions after 6 months = 6 * $100 = $600.
+    const last = result.points[result.points.length - 1]!;
+    expect(last.netWorthCents).toBe(60_000);
+  });
+
+  it('compounds contributions with growth and keeps every point an integer cent', () => {
+    const series = makeSeries([500_000, 520_000]);
+    const result = projectNetWorth(series, {
+      method: 'compound',
+      annualReturnRate: 0.06,
+      monthlyContributionCents: 25_000,
+      horizonMonths: 12,
+    });
+    expect(result.hasProjection).toBe(true);
+    for (const point of result.points) {
+      expect(Number.isInteger(point.netWorthCents)).toBe(true);
+    }
+    // Growth on the base alone must be below the base-plus-contributions total.
+    const startOnly = projectNetWorth(series, {
+      method: 'compound',
+      annualReturnRate: 0.06,
+      horizonMonths: 12,
+    });
+    const withContrib = result.points[result.points.length - 1]!.netWorthCents;
+    const withoutContrib = startOnly.points[startOnly.points.length - 1]!.netWorthCents;
+    expect(withContrib).toBeGreaterThan(withoutContrib);
+  });
+
+  it('reports a compound method summary and a positive first-month pace', () => {
+    const series = makeSeries([200_000, 210_000]);
+    const result = projectNetWorth(series, {
+      method: 'compound',
+      annualReturnRate: 0.08,
+      horizonMonths: 6,
+    });
+    expect(result.methodSummary).toMatch(/compound growth at 8% annual return/i);
+    expect(result.paceDirection).toBe('up');
+    expect(result.monthlyPaceCents).toBeGreaterThan(0);
+  });
+
+  it('still needs at least two points to project', () => {
+    const result = projectNetWorth(makeSeries([100_000]), {
+      method: 'compound',
+      annualReturnRate: 0.07,
+    });
+    expect(result.hasProjection).toBe(false);
+    expect(result.reason).toMatch(/two months/i);
+  });
+});

--- a/apps/web/src/lib/visualization/net-worth-projection.ts
+++ b/apps/web/src/lib/visualization/net-worth-projection.ts
@@ -19,13 +19,21 @@
  */
 
 import { getCurrentLocale } from '../i18n';
+import { monthlyRateFromAnnual } from '../fire';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-/** Pace-estimation strategy used to derive the monthly trend. */
-export type ProjectionMethod = 'average' | 'regression';
+/**
+ * Pace-estimation strategy used to derive the monthly trend.
+ *
+ * - `average`    — mean of consecutive month-over-month deltas (linear).
+ * - `regression` — ordinary least-squares slope over the series (linear).
+ * - `compound`   — geometric growth from an expected annual return plus an
+ *   optional recurring monthly contribution (issue #3323).
+ */
+export type ProjectionMethod = 'average' | 'regression' | 'compound';
 
 /** Selectable time range that drives both the visible window and the horizon. */
 export type ProjectionRange = '3M' | '6M' | '1Y' | 'All';
@@ -81,6 +89,9 @@ export interface NetWorthProjectionResult {
   readonly reason: string | null;
 }
 
+/** Default expected annual return for compound projections (7%, real-ish). */
+export const DEFAULT_PROJECTION_ANNUAL_RETURN = 0.07;
+
 /** Options for {@link projectNetWorth}. */
 export interface ProjectNetWorthOptions {
   /** Pace estimator. Defaults to `regression`. */
@@ -89,6 +100,17 @@ export interface ProjectNetWorthOptions {
   readonly horizonMonths?: number;
   /** Range used to derive the horizon when `horizonMonths` is omitted. */
   readonly range?: ProjectionRange;
+  /**
+   * Expected annual return (decimal, e.g. 0.07) for the `compound` method.
+   * Ignored by the linear methods. Defaults to
+   * {@link DEFAULT_PROJECTION_ANNUAL_RETURN}.
+   */
+  readonly annualReturnRate?: number;
+  /**
+   * Recurring monthly contribution in integer cents applied at the end of each
+   * projected month for the `compound` method. Ignored by linear methods.
+   */
+  readonly monthlyContributionCents?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -128,9 +150,16 @@ function paceDirectionOf(paceCents: number): PaceDirection {
 
 function methodSummaryOf(method: ProjectionMethod, basisPoints: number): string {
   const window = `the last ${basisPoints} ${basisPoints === 1 ? 'month' : 'months'}`;
-  return method === 'regression'
-    ? `linear trend across ${window}`
-    : `average monthly change across ${window}`;
+  if (method === 'regression') return `linear trend across ${window}`;
+  if (method === 'average') return `average monthly change across ${window}`;
+  return `compound growth from your expected return`;
+}
+
+function compoundSummary(annualReturnRate: number, monthlyContributionCents: number): string {
+  const percent = annualReturnRate * 100;
+  const rateText = `${Number.isInteger(percent) ? percent.toFixed(0) : percent.toFixed(1)}%`;
+  const base = `compound growth at ${rateText} annual return`;
+  return monthlyContributionCents > 0 ? `${base} plus monthly contributions` : base;
 }
 
 function addMonthsIso(iso: string, months: number): string {
@@ -225,15 +254,47 @@ export function deriveMonthlyPaceCents(
 }
 
 /**
+ * Compounds a starting balance forward month-by-month at a monthly rate with an
+ * optional end-of-month contribution.
+ *
+ * balance(m) = start * (1+i)^m + C * (((1+i)^m - 1) / i)   [i != 0]
+ * balance(m) = start + C * m                               [i == 0]
+ *
+ * Every returned value is an exact integer cent (rounded once per point so
+ * rounding error never accumulates across the horizon).
+ *
+ * @param startCents - Starting balance in integer cents.
+ * @param monthlyRate - Monthly growth rate (decimal).
+ * @param monthlyContributionCents - End-of-month contribution in integer cents.
+ * @param monthOffset - 1-based month to evaluate.
+ * @returns Projected balance in integer cents.
+ */
+function compoundBalanceCents(
+  startCents: number,
+  monthlyRate: number,
+  monthlyContributionCents: number,
+  monthOffset: number,
+): number {
+  const growth = Math.pow(1 + monthlyRate, monthOffset);
+  const grownStart = startCents * growth;
+  const annuityFactor =
+    Math.abs(monthlyRate) < 1e-12 ? monthOffset : (growth - 1) / monthlyRate;
+  return roundCents(grownStart + monthlyContributionCents * annuityFactor);
+}
+
+/**
  * Projects net worth forward from a historical series.
  *
- * The pace is derived from the supplied series (treat the caller's window as
- * "recent"). Each projected point is `start + pace * monthOffset`, keeping every
- * value an exact integer cent. Series shorter than two points return a result
- * flagged `hasProjection: false` with a friendly {@link NetWorthProjectionResult.reason}.
+ * The linear methods derive a monthly pace from the supplied series (treat the
+ * caller's window as "recent"); each projected point is
+ * `start + pace * monthOffset`. The `compound` method instead grows the last
+ * actual balance geometrically at the supplied annual return with an optional
+ * recurring monthly contribution. Every value stays an exact integer cent.
+ * Series shorter than two points return a result flagged `hasProjection: false`
+ * with a friendly {@link NetWorthProjectionResult.reason}.
  *
  * @param series - Net-worth history, oldest first.
- * @param options - Method and horizon controls.
+ * @param options - Method, horizon and (for compound) return/contribution controls.
  * @returns A deterministic {@link NetWorthProjectionResult}.
  */
 export function projectNetWorth(
@@ -243,6 +304,12 @@ export function projectNetWorth(
   const method = options.method ?? 'regression';
   const lastPoint = series.length > 0 ? series[series.length - 1]! : null;
   const startNetWorthCents = lastPoint?.netWorthCents ?? 0;
+  const isCompound = method === 'compound';
+  const annualReturnRate = options.annualReturnRate ?? DEFAULT_PROJECTION_ANNUAL_RETURN;
+  const monthlyContributionCents = Math.max(0, Math.round(options.monthlyContributionCents ?? 0));
+  const summary = isCompound
+    ? compoundSummary(annualReturnRate, monthlyContributionCents)
+    : methodSummaryOf(method, series.length);
 
   if (series.length < 2) {
     return {
@@ -255,7 +322,7 @@ export function projectNetWorth(
       endNetWorthCents: startNetWorthCents,
       horizonMonths: 0,
       points: [],
-      methodSummary: methodSummaryOf(method, series.length),
+      methodSummary: summary,
       reason: 'At least two months of net-worth history are needed to project forward.',
     };
   }
@@ -263,9 +330,15 @@ export function projectNetWorth(
   const requestedHorizon =
     options.horizonMonths ?? rangeToHorizonMonths(options.range ?? 'All', series.length);
   const horizonMonths = clamp(Math.floor(requestedHorizon), 0, MAX_PROJECTION_MONTHS);
-  const monthlyPaceCents = deriveMonthlyPaceCents(series, method);
+
+  const monthlyRate = isCompound ? monthlyRateFromAnnual(annualReturnRate) : 0;
+  // For compound mode the "pace" reported is the first-month increment so the
+  // UI can still surface a direction; linear modes use the derived pace.
+  const monthlyPaceCents = isCompound
+    ? compoundBalanceCents(startNetWorthCents, monthlyRate, monthlyContributionCents, 1) -
+      startNetWorthCents
+    : deriveMonthlyPaceCents(series, method);
   const paceDirection = paceDirectionOf(monthlyPaceCents);
-  const methodSummary = methodSummaryOf(method, series.length);
 
   if (horizonMonths <= 0) {
     return {
@@ -278,16 +351,19 @@ export function projectNetWorth(
       endNetWorthCents: startNetWorthCents,
       horizonMonths: 0,
       points: [],
-      methodSummary,
+      methodSummary: summary,
       reason: 'The selected horizon is zero months, so there is nothing to project.',
     };
   }
 
   const points: NetWorthProjectionPoint[] = [];
   for (let monthOffset = 1; monthOffset <= horizonMonths; monthOffset += 1) {
+    const netWorthCents = isCompound
+      ? compoundBalanceCents(startNetWorthCents, monthlyRate, monthlyContributionCents, monthOffset)
+      : startNetWorthCents + monthlyPaceCents * monthOffset;
     const point: NetWorthProjectionPoint = {
       label: projectedLabel(lastPoint!, monthOffset),
-      netWorthCents: startNetWorthCents + monthlyPaceCents * monthOffset,
+      netWorthCents,
       monthOffset,
       ...(lastPoint!.dateIso ? { dateIso: addMonthsIso(lastPoint!.dateIso, monthOffset) } : {}),
     };
@@ -304,7 +380,7 @@ export function projectNetWorth(
     endNetWorthCents: points[points.length - 1]!.netWorthCents,
     horizonMonths,
     points,
-    methodSummary,
+    methodSummary: summary,
     reason: null,
   };
 }

--- a/apps/web/src/lib/visualization/net-worth-projection.ts
+++ b/apps/web/src/lib/visualization/net-worth-projection.ts
@@ -277,8 +277,7 @@ function compoundBalanceCents(
 ): number {
   const growth = Math.pow(1 + monthlyRate, monthOffset);
   const grownStart = startCents * growth;
-  const annuityFactor =
-    Math.abs(monthlyRate) < 1e-12 ? monthOffset : (growth - 1) / monthlyRate;
+  const annuityFactor = Math.abs(monthlyRate) < 1e-12 ? monthOffset : (growth - 1) / monthlyRate;
   return roundCents(grownStart + monthlyContributionCents * annuityFactor);
 }
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -6,6 +6,7 @@ import type { TimePeriod, ViewType } from '../components/charts';
 import { ChartEmptyState } from '../components/charts/ChartEmptyState';
 import { groupTopNCategories } from '../components/charts/chart-palette';
 import { SpendingInsightCard } from '../components/dashboard/SpendingInsightCard';
+import { MultiCurrencyTotals } from '../components/dashboard/CurrencyDisplay';
 import { AccountPurposeFilterControl } from '../components/accounts';
 import { RecentTransactionsCard } from '../components/transactions';
 import {
@@ -712,6 +713,39 @@ export const DashboardPage: React.FC = () => {
   );
   const netWorthRollup = useDisplayCurrencyRollup(netWorthDisplayAmounts);
   const displayNetWorth = netWorthRollup.rollup.totalCents;
+  // #3324: feed the multi-currency breakdown real per-account balances (in
+  // their own currency) instead of sample props. Only surface it for users who
+  // actually hold more than one currency so single-currency dashboards stay
+  // uncluttered.
+  const multiCurrencyItems = useMemo(
+    () =>
+      filteredAccounts.map((account) => ({
+        amountCents: account.currentBalance.amount,
+        currency: account.currency,
+      })),
+    [filteredAccounts],
+  );
+  const heldCurrencyCodes = useMemo(
+    () => new Set(filteredAccounts.map((account) => account.currency.code)),
+    [filteredAccounts],
+  );
+  const hasMultipleCurrencies = heldCurrencyCodes.size > 1;
+  // #3287: disclose when the converted net-worth total leans on stale rates or
+  // omits currencies we could not convert, so the headline figure stays honest.
+  const netWorthDisclosure = useMemo(() => {
+    const notes: string[] = [];
+    if (netWorthRollup.unconvertedCurrencies.length > 0) {
+      notes.push(
+        'Excludes ' +
+          netWorthRollup.unconvertedCurrencies.join(', ') +
+          ' (no exchange rate available).',
+      );
+    }
+    if (netWorthRollup.hasStaleRates) {
+      notes.push('Converted using exchange rates that may be out of date.');
+    }
+    return notes;
+  }, [netWorthRollup.unconvertedCurrencies, netWorthRollup.hasStaleRates]);
   const debtSummary = useMemo(
     () =>
       filteredAccounts.reduce(
@@ -954,6 +988,18 @@ export const DashboardPage: React.FC = () => {
                           you pay them down and build savings.
                         </p>
                       ) : null}
+                      {netWorthDisclosure.length > 0 ? (
+                        <p
+                          className="dashboard-card-disclosure"
+                          role="note"
+                          style={{
+                            marginTop: 'var(--spacing-1)',
+                            color: 'var(--semantic-text-secondary)',
+                          }}
+                        >
+                          {netWorthDisclosure.join(' ')}
+                        </p>
+                      ) : null}
                     </article>
                   ) : null}
                   {visibleWidgetIds.has('monthly-spending') ? (
@@ -1030,6 +1076,11 @@ export const DashboardPage: React.FC = () => {
                   ) : null}
                 </div>
               </section>
+              {hasMultipleCurrencies ? (
+                <section className="page-section" aria-label="Money by currency">
+                  <MultiCurrencyTotals items={multiCurrencyItems} />
+                </section>
+              ) : null}
               {visibleWidgetIds.has('income-vs-expense') ||
               visibleWidgetIds.has('account-summary') ||
               visibleWidgetIds.has('goals-progress') ? (

--- a/apps/web/src/pages/FirePlannerPage.css
+++ b/apps/web/src/pages/FirePlannerPage.css
@@ -246,11 +246,177 @@
   padding: var(--spacing-4);
 }
 
+/* Return-mode fieldset (#3315). */
+.fire-field--return {
+  gap: var(--spacing-2);
+}
+
+.fire-return-mode {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+}
+
+.fire-return-mode__option {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-size: var(--type-scale-body-small-font-size);
+  color: var(--semantic-text-primary);
+  cursor: pointer;
+}
+
+/* Scenario toggles (#3317). */
+.fire-scenarios {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-3);
+}
+
+.fire-scenario-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-1);
+  flex: 1 1 8rem;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+  color: var(--semantic-text-primary);
+  cursor: pointer;
+  text-align: left;
+}
+
+.fire-scenario-btn--active {
+  border-color: var(--semantic-status-warning);
+  background: var(--semantic-background-secondary);
+  box-shadow: inset 0 0 0 1px var(--semantic-status-warning);
+}
+
+.fire-scenario-btn__label {
+  font-weight: var(--type-scale-body-strong-font-weight, 600);
+}
+
+.fire-scenario-btn__mult {
+  font-size: var(--type-scale-body-small-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.fire-results__scenario-note {
+  margin: 0 0 var(--spacing-4) 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-small-font-size);
+}
+
+/* FI progress bar + income replacement (#3320). */
+.fire-progress {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-6);
+  padding: var(--spacing-4);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+}
+
+.fire-progress__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.fire-progress__label {
+  font-weight: var(--type-scale-body-strong-font-weight, 600);
+  color: var(--semantic-text-primary);
+}
+
+.fire-progress__value {
+  color: var(--semantic-text-secondary);
+}
+
+.fire-progress__track {
+  height: 0.75rem;
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-secondary);
+  overflow: hidden;
+}
+
+.fire-progress__fill {
+  height: 100%;
+  background: var(--semantic-status-positive);
+}
+
+.fire-progress__replacement {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-small-font-size);
+}
+
+/* Comparison / sensitivity tables (#3317, #3319). */
+.fire-table-wrap {
+  margin-top: var(--spacing-6);
+  overflow-x: auto;
+}
+
+.fire-table__title {
+  font-size: var(--type-scale-title-font-size, 1rem);
+  font-weight: var(--type-scale-title-font-weight, 600);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-2) 0;
+}
+
+.fire-table__note {
+  margin: 0 0 var(--spacing-2) 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-small-font-size);
+}
+
+.fire-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--type-scale-body-small-font-size);
+}
+
+.fire-table th,
+.fire-table td {
+  padding: var(--spacing-2) var(--spacing-3);
+  text-align: left;
+  border-bottom: 1px solid var(--semantic-border-default);
+  color: var(--semantic-text-primary);
+}
+
+.fire-table thead th {
+  color: var(--semantic-text-secondary);
+  font-weight: var(--type-scale-body-strong-font-weight, 600);
+}
+
+.fire-table__row--active {
+  background: var(--semantic-background-secondary);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media (prefers-contrast: more) {
   .fire-form,
   .fire-result-card,
   .fire-field__control,
-  .fire-results__chart {
+  .fire-results__chart,
+  .fire-progress,
+  .fire-scenario-btn {
     border-width: 2px;
   }
 }

--- a/apps/web/src/pages/FirePlannerPage.test.tsx
+++ b/apps/web/src/pages/FirePlannerPage.test.tsx
@@ -83,4 +83,35 @@ describe('FirePlannerPage', () => {
     expect(within(fiCard).getByText('—')).toBeInTheDocument();
     expect(screen.getByRole('status')).toHaveTextContent(/withdrawal rate above 0%/i);
   });
+
+  it('shows progress toward FI and income replacement (#3320)', () => {
+    render(<FirePlannerPage />);
+    // $100k invested toward a $1M FI number → 10% progress.
+    const progress = screen.getByRole('progressbar', { name: /FI progress/i });
+    expect(progress).toHaveAttribute('aria-valuenow', '10');
+    expect(screen.getByText(/covering/i)).toBeInTheDocument();
+  });
+
+  it('renders a withdrawal-rate sensitivity table with 3.5/4/4.5% rows (#3319)', () => {
+    render(<FirePlannerPage />);
+    const table = screen.getByRole('table', { name: /Withdrawal-rate sensitivity/i });
+    expect(within(table).getByRole('rowheader', { name: /3\.5%/ })).toBeInTheDocument();
+    expect(within(table).getByRole('rowheader', { name: /4%/ })).toBeInTheDocument();
+    expect(within(table).getByRole('rowheader', { name: /4\.5%/ })).toBeInTheDocument();
+  });
+
+  it('switches spending target when a FIRE scenario is selected (#3317)', () => {
+    render(<FirePlannerPage />);
+    // Regular default: $40k / 4% = $1M. Fat (1.5x) → $60k / 4% = $1.5M.
+    fireEvent.click(screen.getByRole('radio', { name: /Fat FIRE/i }));
+    const fiCard = screen.getByRole('article', { name: 'Financial independence number' });
+    expect(within(fiCard).getByText(/1,500,000/)).toBeInTheDocument();
+  });
+
+  it('derives the real return from nominal return + inflation (#3315)', () => {
+    render(<FirePlannerPage />);
+    fireEvent.click(screen.getByRole('radio', { name: /Nominal return \+ inflation/i }));
+    expect(screen.getByLabelText('Expected nominal return')).toBeInTheDocument();
+    expect(screen.getByLabelText('Expected inflation')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/FirePlannerPage.tsx
+++ b/apps/web/src/pages/FirePlannerPage.tsx
@@ -32,12 +32,51 @@ import type { TrendDataPoint, TrendSeries } from '../components/charts/TrendLine
 import { formatCurrency } from '../lib/currency';
 import {
   calculateFIREPlan,
+  computeSwrSensitivity,
+  DEFAULT_INFLATION,
+  DEFAULT_NOMINAL_RETURN,
   DEFAULT_RETIREMENT_AGE,
+  DEFAULT_SWR_SENSITIVITY_RATES,
   MAX_FI_SEARCH_YEARS,
+  realReturnFromNominal,
   type FIREPlanResult,
+  type SwrSensitivityRow,
 } from '../lib/fire';
 
 import './FirePlannerPage.css';
+
+// ---------------------------------------------------------------------------
+// FIRE scenario definitions (#3317) — Lean / Regular / Fat spending multipliers.
+// Coast-FI already sits alongside these in the results grid.
+// ---------------------------------------------------------------------------
+
+interface FireScenario {
+  readonly key: 'lean' | 'regular' | 'fat';
+  readonly label: string;
+  readonly spendingMultiplier: number;
+  readonly description: string;
+}
+
+const FIRE_SCENARIOS: readonly FireScenario[] = [
+  {
+    key: 'lean',
+    label: 'Lean FIRE',
+    spendingMultiplier: 0.7,
+    description: 'A leaner retirement at 70% of your spending.',
+  },
+  {
+    key: 'regular',
+    label: 'Regular FIRE',
+    spendingMultiplier: 1,
+    description: 'Your baseline spending.',
+  },
+  {
+    key: 'fat',
+    label: 'Fat FIRE',
+    spendingMultiplier: 1.5,
+    description: 'A more comfortable retirement at 150% of your spending.',
+  },
+];
 
 // ---------------------------------------------------------------------------
 // Parsing helpers (string inputs → cents / rates), defensive against junk input
@@ -79,6 +118,20 @@ function formatFiDate(iso: string): string {
     month: 'long',
     year: 'numeric',
   });
+}
+
+/** Compact "time to FI" label for a plan result (used in comparison tables). */
+function describeTimeToFI(result: FIREPlanResult): string {
+  if (!Number.isFinite(result.fiNumberCents)) return 'Not reachable';
+  if (result.yearsToFI.alreadyFI) return 'Reached';
+  if (!result.yearsToFI.reachedFI) return 'Not reachable';
+  return formatDuration(result.yearsToFI.years, result.yearsToFI.months);
+}
+
+/** Format a decimal rate (0.04) as a percent string (e.g. "4%", "3.5%"). */
+function formatRatePercent(rate: number): string {
+  const percent = rate * 100;
+  return `${Number.isInteger(percent) ? percent.toFixed(0) : percent.toFixed(1)}%`;
 }
 
 // ---------------------------------------------------------------------------
@@ -169,31 +222,91 @@ export const FirePlannerPage: React.FC = () => {
   const [currentInvested, setCurrentInvested] = useState('100000');
   const [annualSpending, setAnnualSpending] = useState('40000');
   const [annualContribution, setAnnualContribution] = useState('24000');
+  const [returnMode, setReturnMode] = useState<'real' | 'nominal'>('real');
   const [realReturnPercent, setRealReturnPercent] = useState('5');
+  const [nominalReturnPercent, setNominalReturnPercent] = useState(
+    String(DEFAULT_NOMINAL_RETURN * 100),
+  );
+  const [inflationPercent, setInflationPercent] = useState(String(DEFAULT_INFLATION * 100));
   const [swrPercent, setSwrPercent] = useState('4');
   const [currentAge, setCurrentAge] = useState('35');
   const [retirementAge, setRetirementAge] = useState('65');
+  const [selectedScenario, setSelectedScenario] = useState<FireScenario['key']>('regular');
 
-  const plan: FIREPlanResult = useMemo(
+  // Resolve the real return that actually drives the projection. Advanced users
+  // enter it directly; everyone else enters a nominal return + inflation and we
+  // derive the real rate via the Fisher equation so the FI number (from today's
+  // spending) stays in real terms (#3315).
+  const realReturnRate = useMemo(() => {
+    if (returnMode === 'nominal') {
+      return realReturnFromNominal(
+        parsePercentToRate(nominalReturnPercent),
+        parsePercentToRate(inflationPercent),
+      );
+    }
+    return parsePercentToRate(realReturnPercent);
+  }, [returnMode, nominalReturnPercent, inflationPercent, realReturnPercent]);
+
+  const swrRate = useMemo(() => parsePercentToRate(swrPercent), [swrPercent]);
+  const baseSpendingCents = useMemo(() => parseDollarsToCents(annualSpending), [annualSpending]);
+  const currentInvestedCents = useMemo(
+    () => parseDollarsToCents(currentInvested),
+    [currentInvested],
+  );
+  const annualContributionCents = useMemo(
+    () => parseDollarsToCents(annualContribution),
+    [annualContribution],
+  );
+
+  // One plan per Lean / Regular / Fat scenario (#3317). Each scales retirement
+  // spending by the scenario multiplier and recomputes the whole plan.
+  const scenarioPlans = useMemo(
     () =>
-      calculateFIREPlan({
-        currentInvestedCents: parseDollarsToCents(currentInvested),
-        annualSpendingCents: parseDollarsToCents(annualSpending),
-        annualContributionCents: parseDollarsToCents(annualContribution),
-        realReturnRate: parsePercentToRate(realReturnPercent),
-        swrRate: parsePercentToRate(swrPercent),
-        currentAge: parseAge(currentAge),
-        traditionalRetirementAge: parseAge(retirementAge) ?? DEFAULT_RETIREMENT_AGE,
-      }),
+      FIRE_SCENARIOS.map((scenario) => ({
+        scenario,
+        plan: calculateFIREPlan({
+          currentInvestedCents,
+          annualSpendingCents: Math.round(baseSpendingCents * scenario.spendingMultiplier),
+          annualContributionCents,
+          realReturnRate,
+          swrRate,
+          currentAge: parseAge(currentAge),
+          traditionalRetirementAge: parseAge(retirementAge) ?? DEFAULT_RETIREMENT_AGE,
+        }),
+      })),
     [
-      currentInvested,
-      annualSpending,
-      annualContribution,
-      realReturnPercent,
-      swrPercent,
+      currentInvestedCents,
+      baseSpendingCents,
+      annualContributionCents,
+      realReturnRate,
+      swrRate,
       currentAge,
       retirementAge,
     ],
+  );
+
+  const plan: FIREPlanResult =
+    scenarioPlans.find((entry) => entry.scenario.key === selectedScenario)?.plan ??
+    scenarioPlans[1]!.plan;
+
+  const activeScenario =
+    FIRE_SCENARIOS.find((scenario) => scenario.key === selectedScenario) ?? FIRE_SCENARIOS[1]!;
+  const activeSpendingCents = Math.round(baseSpendingCents * activeScenario.spendingMultiplier);
+
+  // SWR sensitivity for the selected scenario (#3319): FI number + time-to-FI at
+  // 3.5% / 4% / 4.5% so users can gauge withdrawal-rate risk.
+  const swrSensitivity: SwrSensitivityRow[] = useMemo(
+    () =>
+      computeSwrSensitivity(
+        {
+          currentInvestedCents,
+          annualSpendingCents: activeSpendingCents,
+          annualContributionCents,
+          realReturnRate,
+        },
+        DEFAULT_SWR_SENSITIVITY_RATES,
+      ),
+    [currentInvestedCents, activeSpendingCents, annualContributionCents, realReturnRate],
   );
 
   const fiReachable = Number.isFinite(plan.fiNumberCents);
@@ -311,15 +424,72 @@ export const FirePlannerPage: React.FC = () => {
               min={0}
               step={1000}
             />
-            <NumberField
-              id={fid('return')}
-              label="Expected real return"
-              value={realReturnPercent}
-              onChange={setRealReturnPercent}
-              hint="Annual return after inflation. A diversified portfolio is often modelled at 4–7%."
-              suffix="%"
-              step={0.1}
-            />
+            <fieldset className="fire-field fire-field--return" aria-describedby={`${fid('return-mode')}-hint`}>
+              <legend className="fire-field__label">Return assumption</legend>
+              <div
+                className="fire-return-mode"
+                role="radiogroup"
+                aria-label="How to enter your expected return"
+              >
+                <label className="fire-return-mode__option">
+                  <input
+                    type="radio"
+                    name={fid('return-mode')}
+                    value="real"
+                    checked={returnMode === 'real'}
+                    onChange={() => setReturnMode('real')}
+                  />
+                  <span>Real return directly</span>
+                </label>
+                <label className="fire-return-mode__option">
+                  <input
+                    type="radio"
+                    name={fid('return-mode')}
+                    value="nominal"
+                    checked={returnMode === 'nominal'}
+                    onChange={() => setReturnMode('nominal')}
+                  />
+                  <span>Nominal return + inflation</span>
+                </label>
+              </div>
+              <p id={`${fid('return-mode')}-hint`} className="fire-field__hint">
+                {returnMode === 'real'
+                  ? 'Advanced: enter an inflation-adjusted return directly.'
+                  : `Enter a nominal return and inflation; we use the real return (${(realReturnRate * 100).toFixed(1)}%) that drives the projection.`}
+              </p>
+              {returnMode === 'real' ? (
+                <NumberField
+                  id={fid('return')}
+                  label="Expected real return"
+                  value={realReturnPercent}
+                  onChange={setRealReturnPercent}
+                  hint="Annual return after inflation. A diversified portfolio is often modelled at 4–7%."
+                  suffix="%"
+                  step={0.1}
+                />
+              ) : (
+                <>
+                  <NumberField
+                    id={fid('nominal-return')}
+                    label="Expected nominal return"
+                    value={nominalReturnPercent}
+                    onChange={setNominalReturnPercent}
+                    hint="Annual return before inflation. Historically ≈ 7–10% for an equity-heavy portfolio."
+                    suffix="%"
+                    step={0.1}
+                  />
+                  <NumberField
+                    id={fid('inflation')}
+                    label="Expected inflation"
+                    value={inflationPercent}
+                    onChange={setInflationPercent}
+                    hint="Long-run inflation assumption. Often modelled at 2–3%."
+                    suffix="%"
+                    step={0.1}
+                  />
+                </>
+              )}
+            </fieldset>
             <NumberField
               id={fid('swr')}
               label="Safe withdrawal rate (SWR)"
@@ -356,6 +526,70 @@ export const FirePlannerPage: React.FC = () => {
           <p className="fire-results__summary" role="status" aria-live="polite">
             {summary}
           </p>
+
+          {/* Lean / Regular / Fat scenario toggles (#3317). */}
+          <div
+            className="fire-scenarios"
+            role="radiogroup"
+            aria-label="FIRE scenario (spending target)"
+          >
+            {FIRE_SCENARIOS.map((scenario) => {
+              const active = scenario.key === selectedScenario;
+              return (
+                <button
+                  key={scenario.key}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  className={`fire-scenario-btn${active ? ' fire-scenario-btn--active' : ''}`}
+                  onClick={() => setSelectedScenario(scenario.key)}
+                >
+                  <span className="fire-scenario-btn__label">{scenario.label}</span>
+                  <span className="fire-scenario-btn__mult">
+                    {Math.round(scenario.spendingMultiplier * 100)}% of spending
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          <p className="fire-results__scenario-note">
+            Showing <strong>{activeScenario.label}</strong> — {activeScenario.description} Retirement
+            spending {formatCurrency(activeSpendingCents)}/yr.
+          </p>
+
+          {/* Progress toward FI + income replacement (#3320). */}
+          {fiReachable ? (
+            <div className="fire-progress" aria-label="Progress toward financial independence">
+              <div className="fire-progress__header">
+                <span className="fire-progress__label">
+                  You&apos;re {plan.fiProgressPercent}% of the way to FI
+                </span>
+                <span className="fire-progress__value">
+                  {formatCurrency(currentInvestedCents)} of {fiNumberDisplay}
+                </span>
+              </div>
+              <div
+                className="fire-progress__track"
+                role="progressbar"
+                aria-valuenow={plan.fiProgressPercent}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`FI progress: ${plan.fiProgressPercent} percent`}
+              >
+                <div
+                  className="fire-progress__fill"
+                  style={{ width: `${plan.fiProgressPercent}%` }}
+                />
+              </div>
+              <p className="fire-progress__replacement">
+                Your portfolio currently generates{' '}
+                <strong>{formatCurrency(plan.currentPassiveIncomeCents)}</strong>/yr at a{' '}
+                {formatRatePercent(swrRate)} withdrawal rate — covering{' '}
+                <strong>{plan.incomeReplacementPercent}%</strong> of your{' '}
+                {formatCurrency(activeSpendingCents)} annual spending.
+              </p>
+            </div>
+          ) : null}
 
           <div className="fire-results__grid">
             <ResultCard
@@ -443,6 +677,99 @@ export const FirePlannerPage: React.FC = () => {
               />
             </div>
           ) : null}
+
+          {/* Scenario comparison table (#3317). */}
+          <div className="fire-table-wrap">
+            <h3 className="fire-table__title" id={fid('scenario-caption')}>
+              Lean / Regular / Fat comparison
+            </h3>
+            <table className="fire-table" aria-labelledby={fid('scenario-caption')}>
+              <thead>
+                <tr>
+                  <th scope="col">Scenario</th>
+                  <th scope="col">Retirement spending</th>
+                  <th scope="col">FI number</th>
+                  <th scope="col">Time to FI</th>
+                </tr>
+              </thead>
+              <tbody>
+                {scenarioPlans.map(({ scenario, plan: scenarioPlan }) => {
+                  const spendingCents = Math.round(baseSpendingCents * scenario.spendingMultiplier);
+                  return (
+                    <tr
+                      key={scenario.key}
+                      className={
+                        scenario.key === selectedScenario ? 'fire-table__row--active' : undefined
+                      }
+                    >
+                      <th scope="row">
+                        {scenario.label}
+                        {scenario.key === selectedScenario ? (
+                          <span className="sr-only"> (selected)</span>
+                        ) : null}
+                      </th>
+                      <td>{formatCurrency(spendingCents)}/yr</td>
+                      <td>
+                        {Number.isFinite(scenarioPlan.fiNumberCents)
+                          ? formatCurrency(scenarioPlan.fiNumberCents)
+                          : '—'}
+                      </td>
+                      <td>{describeTimeToFI(scenarioPlan)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* SWR sensitivity table (#3319). */}
+          <div className="fire-table-wrap">
+            <h3 className="fire-table__title" id={fid('swr-caption')}>
+              Withdrawal-rate sensitivity ({activeScenario.label})
+            </h3>
+            <p className="fire-table__note">
+              A lower withdrawal rate is more cautious against sequence-of-returns risk but needs a
+              larger portfolio. Estimate only. Not financial advice.
+            </p>
+            <table className="fire-table" aria-labelledby={fid('swr-caption')}>
+              <thead>
+                <tr>
+                  <th scope="col">Withdrawal rate</th>
+                  <th scope="col">FI number</th>
+                  <th scope="col">Time to FI</th>
+                </tr>
+              </thead>
+              <tbody>
+                {swrSensitivity.map((row) => (
+                  <tr
+                    key={row.swrRate}
+                    className={
+                      Math.abs(row.swrRate - swrRate) < 1e-9 ? 'fire-table__row--active' : undefined
+                    }
+                  >
+                    <th scope="row">
+                      {formatRatePercent(row.swrRate)}
+                      {Math.abs(row.swrRate - swrRate) < 1e-9 ? (
+                        <span className="sr-only"> (your rate)</span>
+                      ) : null}
+                    </th>
+                    <td>
+                      {Number.isFinite(row.fiNumberCents)
+                        ? formatCurrency(row.fiNumberCents)
+                        : '—'}
+                    </td>
+                    <td>
+                      {row.yearsToFI.alreadyFI
+                        ? 'Reached'
+                        : row.yearsToFI.reachedFI
+                          ? formatDuration(row.yearsToFI.years, row.yearsToFI.months)
+                          : 'Not reachable'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </div>

--- a/apps/web/src/pages/FirePlannerPage.tsx
+++ b/apps/web/src/pages/FirePlannerPage.tsx
@@ -424,7 +424,10 @@ export const FirePlannerPage: React.FC = () => {
               min={0}
               step={1000}
             />
-            <fieldset className="fire-field fire-field--return" aria-describedby={`${fid('return-mode')}-hint`}>
+            <fieldset
+              className="fire-field fire-field--return"
+              aria-describedby={`${fid('return-mode')}-hint`}
+            >
               <legend className="fire-field__label">Return assumption</legend>
               <div
                 className="fire-return-mode"
@@ -553,8 +556,8 @@ export const FirePlannerPage: React.FC = () => {
             })}
           </div>
           <p className="fire-results__scenario-note">
-            Showing <strong>{activeScenario.label}</strong> — {activeScenario.description} Retirement
-            spending {formatCurrency(activeSpendingCents)}/yr.
+            Showing <strong>{activeScenario.label}</strong> — {activeScenario.description}{' '}
+            Retirement spending {formatCurrency(activeSpendingCents)}/yr.
           </p>
 
           {/* Progress toward FI + income replacement (#3320). */}
@@ -754,9 +757,7 @@ export const FirePlannerPage: React.FC = () => {
                       ) : null}
                     </th>
                     <td>
-                      {Number.isFinite(row.fiNumberCents)
-                        ? formatCurrency(row.fiNumberCents)
-                        : '—'}
+                      {Number.isFinite(row.fiNumberCents) ? formatCurrency(row.fiNumberCents) : '—'}
                     </td>
                     <td>
                       {row.yearsToFI.alreadyFI


### PR DESCRIPTION
﻿## Summary

Batch of 10 closely-related **web financial planner** improvements (FIRE, estate, net-worth & multi-currency) in `apps/web`, delivered as one cohesive PR. All monetary math uses integer cents; calculations are covered by unit tests.

### FIRE planner
- **Progress % + income-replacement** — the planner now shows how far you are to financial independence and what share of spending your portfolio already covers.
- **SWR sensitivity** — side-by-side 3.5% / 4% / 4.5% safe-withdrawal-rate columns.
- **Lean / Regular / Fat FIRE** scenario toggles with a comparison table.
- **Separate nominal-return + inflation inputs** — the real return used for projections is derived correctly instead of being entered by hand.

### Net worth
- **Compound-growth projection mode** for the net-worth chart alongside the linear mode.

### Estate
- **Legible large-text, high-contrast print/export** stylesheet.
- **Total estimated value** (assets − liabilities) plus per-currency rollup in the inventory summary.

### Dashboard & multi-currency
- **Configurable savings-rate target** replacing the hardcoded 20%, with an inline goal editor and a persisted preference; insights + card messaging follow the chosen target.
- **Multi-currency totals widget** (previously built but never mounted) now surfaces on the dashboard for users holding more than one currency, fed with real per-account balances.
- **Honest display-currency net worth** — the Net Worth card discloses when the converted total relied on stale exchange rates or had to exclude currencies with no available rate.

## Testing
- `npm run format:check` — clean
- `npx eslint . --max-warnings 0` — clean
- `apps/web` `tsc --noEmit` — clean
- Affected Vitest suites — 154 passing (fire, FirePlannerPage, net-worth-projection, estate inventory, savings-rate-summary, savings-target, DashboardPage, CurrencyDisplay)

Closes #3323
Closes #3320
Closes #3319
Closes #3317
Closes #3315
Closes #3290
Closes #3288
Closes #3287
Closes #3327
Closes #3324
