### PR TITLE
feat(web): investments & business finance batch (holdings, P&L, invoices, remittances, runway)

### DIFF
--- a/apps/web/src/components/investments/HoldingsTable.test.tsx
+++ b/apps/web/src/components/investments/HoldingsTable.test.tsx
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import {
+  HoldingsTable,
+  VIRTUALIZE_THRESHOLD,
+  type HoldingRow,
+} from './HoldingsTable';
+
+function makeRow(index: number): HoldingRow {
+  return {
+    key: `row-${index}`,
+    to: `/investments/inv-${index}`,
+    symbol: `SYM${index}`,
+    name: `Security ${index}`,
+    iconName: 'trending-up',
+    typeLabel: 'Stock',
+    accountLabel: 'Fidelity',
+    shares: 10,
+    pricePerShareCents: 10000,
+    currencyCode: 'USD',
+    marketValueCents: 100000,
+    gainLossCents: 5000,
+    gainLossPercent: 5,
+  };
+}
+
+function renderTable(rowCount: number, extra: Partial<React.ComponentProps<typeof HoldingsTable>> = {}) {
+  const rows = Array.from({ length: rowCount }, (_, i) => makeRow(i));
+  const onSort = vi.fn();
+  render(
+    <MemoryRouter>
+      <HoldingsTable
+        rows={rows}
+        sortField="symbol"
+        sortDirection="asc"
+        onSort={onSort}
+        accountColumnLabel="Account"
+        {...extra}
+      />
+    </MemoryRouter>,
+  );
+  return { rows, onSort };
+}
+
+describe('HoldingsTable', () => {
+  it('renders every row for small portfolios (no virtualization)', () => {
+    renderTable(10);
+    expect(screen.getAllByTestId('holding-row')).toHaveLength(10);
+  });
+
+  it('renders only a small window of rows for large portfolios (#3272)', () => {
+    const total = 1000;
+    renderTable(total);
+    const rendered = screen.getAllByTestId('holding-row');
+    // Far fewer rows than the full portfolio should be mounted.
+    expect(rendered.length).toBeLessThan(total);
+    expect(rendered.length).toBeLessThan(50);
+    // The header exposes the true total row count for assistive tech.
+    expect(screen.getByLabelText('Investment holdings table')).toHaveAttribute(
+      'aria-rowcount',
+      String(total),
+    );
+  });
+
+  it('keeps sortable column headers accessible even when virtualized', () => {
+    const { onSort } = renderTable(VIRTUALIZE_THRESHOLD + 50);
+    const symbolHeader = screen.getByRole('button', { name: /sort by symbol/i });
+    fireEvent.click(symbolHeader);
+    expect(onSort).toHaveBeenCalledWith('symbol');
+
+    fireEvent.click(screen.getByRole('button', { name: /sort by market value/i }));
+    expect(onSort).toHaveBeenCalledWith('value');
+
+    fireEvent.click(screen.getByRole('button', { name: /sort by gain\/loss/i }));
+    expect(onSort).toHaveBeenCalledWith('gainLoss');
+  });
+
+  it('shows the account column label and per-row account attribution (#3262)', () => {
+    renderTable(3);
+    expect(screen.getByRole('columnheader', { name: 'Account' })).toBeInTheDocument();
+    expect(screen.getAllByText('Fidelity').length).toBe(3);
+  });
+
+  it('renders a dash for blended roll-up price and a custom account column label', () => {
+    const rows: HoldingRow[] = [
+      {
+        key: 'AAPL|USD',
+        symbol: 'AAPL',
+        name: 'Apple Inc.',
+        iconName: 'trending-up',
+        typeLabel: 'Stock',
+        accountLabel: '2 accounts',
+        shares: 15,
+        pricePerShareCents: null,
+        currencyCode: 'USD',
+        marketValueCents: 300000,
+        gainLossCents: 75000,
+        gainLossPercent: 33.33,
+      },
+    ];
+    render(
+      <MemoryRouter>
+        <HoldingsTable
+          rows={rows}
+          sortField="value"
+          sortDirection="desc"
+          onSort={vi.fn()}
+          accountColumnLabel="Accounts"
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('columnheader', { name: 'Accounts' })).toBeInTheDocument();
+    expect(screen.getByText('2 accounts')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/investments/HoldingsTable.test.tsx
+++ b/apps/web/src/components/investments/HoldingsTable.test.tsx
@@ -4,11 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 
-import {
-  HoldingsTable,
-  VIRTUALIZE_THRESHOLD,
-  type HoldingRow,
-} from './HoldingsTable';
+import { HoldingsTable, VIRTUALIZE_THRESHOLD, type HoldingRow } from './HoldingsTable';
 
 function makeRow(index: number): HoldingRow {
   return {
@@ -28,7 +24,10 @@ function makeRow(index: number): HoldingRow {
   };
 }
 
-function renderTable(rowCount: number, extra: Partial<React.ComponentProps<typeof HoldingsTable>> = {}) {
+function renderTable(
+  rowCount: number,
+  extra: Partial<React.ComponentProps<typeof HoldingsTable>> = {},
+) {
   const rows = Array.from({ length: rowCount }, (_, i) => makeRow(i));
   const onSort = vi.fn();
   render(

--- a/apps/web/src/components/investments/HoldingsTable.tsx
+++ b/apps/web/src/components/investments/HoldingsTable.tsx
@@ -167,9 +167,7 @@ export const HoldingsTable: React.FC<HoldingsTableProps> = ({
     overscan: 6,
   });
 
-  const renderedRows = shouldVirtualize
-    ? virtual.visibleItems.map((v) => v.item)
-    : rows;
+  const renderedRows = shouldVirtualize ? virtual.visibleItems.map((v) => v.item) : rows;
   const topSpacer = shouldVirtualize ? virtual.startIndex * ROW_HEIGHT : 0;
   const bottomSpacer = shouldVirtualize
     ? Math.max(0, (rows.length - virtual.endIndex) * ROW_HEIGHT)

--- a/apps/web/src/components/investments/HoldingsTable.tsx
+++ b/apps/web/src/components/investments/HoldingsTable.tsx
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Investment holdings table (issues #3272, #3262).
+ *
+ * - #3272: virtualizes the row list for large portfolios so only the rows near
+ *   the viewport are mounted, while preserving native `<table>` semantics and
+ *   accessible sortable column headers. Virtualization only kicks in above a row
+ *   threshold; smaller portfolios render every row as before.
+ * - #3262: shows the owning account/brokerage per holding and supports a
+ *   group-by-symbol roll-up that consolidates a ticker held across accounts into
+ *   one line showing total exposure and the number of contributing accounts.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { CurrencyDisplay } from '../common';
+import { AppIcon, type IconName } from '../icons';
+import { useVirtualList } from '../../hooks/useVirtualList';
+
+/** A normalized, render-ready holdings row (detail position or roll-up line). */
+export interface HoldingRow {
+  /** Stable React key. */
+  readonly key: string;
+  /** Detail-row link target; omitted for roll-up lines. */
+  readonly to?: string;
+  readonly symbol: string;
+  readonly name: string;
+  readonly iconName: IconName;
+  readonly typeLabel: string;
+  /** Account/brokerage label (e.g. "Fidelity") or roll-up account summary. */
+  readonly accountLabel: string;
+  readonly shares: number;
+  /** Price per share in cents; `null` for blended roll-up lines. */
+  readonly pricePerShareCents: number | null;
+  readonly currencyCode: string;
+  readonly marketValueCents: number;
+  readonly gainLossCents: number;
+  readonly gainLossPercent: number;
+}
+
+export type HoldingsSortField = 'symbol' | 'value' | 'gainLoss';
+
+export interface HoldingsTableProps {
+  readonly rows: readonly HoldingRow[];
+  readonly sortField: HoldingsSortField;
+  readonly sortDirection: 'asc' | 'desc';
+  readonly onSort: (field: HoldingsSortField) => void;
+  /** Header label for the second column (Account vs. Accounts in roll-up mode). */
+  readonly accountColumnLabel: string;
+}
+
+/**
+ * Row count above which the body is virtualized. Chosen so typical portfolios
+ * render in full (keeping the DOM simple and every row printable) while very
+ * large portfolios avoid mounting thousands of rows at once.
+ */
+export const VIRTUALIZE_THRESHOLD = 100;
+
+/** Fixed height (px) used for each virtualized row's spacer math. */
+export const ROW_HEIGHT = 68;
+
+/** Height (px) of the scrollable viewport when virtualizing. */
+const VIEWPORT_HEIGHT = 612;
+
+const CELL_STYLE: React.CSSProperties = { padding: 'var(--spacing-3)' };
+const HEADER_BORDER = '2px solid var(--semantic-border-default, #e5e7eb)';
+const ROW_BORDER = '1px solid var(--semantic-border-default, #e5e7eb)';
+
+const HEADER_BUTTON_STYLE: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  font: 'inherit',
+  color: 'inherit',
+  padding: 0,
+};
+
+function formatSignedCents(cents: number, currencyCode: string): string {
+  const sign = cents >= 0 ? '+' : '−';
+  const abs = Math.abs(cents) / 100;
+  return `${sign}${abs.toLocaleString(undefined, {
+    style: 'currency',
+    currency: currencyCode,
+  })}`;
+}
+
+const HoldingCells: React.FC<{ row: HoldingRow }> = ({ row }) => {
+  const gainLoss = row.gainLossCents;
+  const symbolContent = (
+    <>
+      <AppIcon name={row.iconName} /> <strong>{row.symbol}</strong>
+      <br />
+      <span
+        style={{
+          fontSize: 'var(--type-scale-caption-font-size)',
+          color: 'var(--semantic-text-secondary)',
+        }}
+      >
+        {row.name}
+      </span>
+    </>
+  );
+
+  return (
+    <>
+      <td style={CELL_STYLE}>
+        {row.to ? (
+          <Link
+            to={row.to}
+            style={{ textDecoration: 'none', color: 'inherit' }}
+            aria-label={`View details for ${row.name} (${row.symbol})`}
+          >
+            {symbolContent}
+          </Link>
+        ) : (
+          symbolContent
+        )}
+      </td>
+      <td style={CELL_STYLE}>{row.accountLabel}</td>
+      <td style={CELL_STYLE}>{row.typeLabel}</td>
+      <td style={{ ...CELL_STYLE, textAlign: 'right' }}>
+        {row.shares.toLocaleString(undefined, { maximumFractionDigits: 4 })}
+      </td>
+      <td style={{ ...CELL_STYLE, textAlign: 'right' }}>
+        {row.pricePerShareCents === null ? (
+          <span aria-hidden="true">—</span>
+        ) : (
+          <CurrencyDisplay amount={row.pricePerShareCents} currency={row.currencyCode} />
+        )}
+      </td>
+      <td style={{ ...CELL_STYLE, textAlign: 'right' }}>
+        <CurrencyDisplay amount={row.marketValueCents} currency={row.currencyCode} />
+      </td>
+      <td
+        style={{
+          ...CELL_STYLE,
+          textAlign: 'right',
+          color:
+            gainLoss >= 0
+              ? 'var(--semantic-positive, #059669)'
+              : 'var(--semantic-negative, #dc2626)',
+        }}
+      >
+        {formatSignedCents(gainLoss, row.currencyCode)} ({row.gainLossPercent}%)
+      </td>
+    </>
+  );
+};
+
+/** Investment holdings table with virtualization and account attribution. */
+export const HoldingsTable: React.FC<HoldingsTableProps> = ({
+  rows,
+  sortField,
+  sortDirection,
+  onSort,
+  accountColumnLabel,
+}) => {
+  const sortArrow = sortDirection === 'asc' ? ' ↑' : ' ↓';
+  const shouldVirtualize = rows.length > VIRTUALIZE_THRESHOLD;
+
+  const virtual = useVirtualList<HoldingRow>({
+    items: rows as HoldingRow[],
+    itemHeight: ROW_HEIGHT,
+    containerHeight: VIEWPORT_HEIGHT,
+    overscan: 6,
+  });
+
+  const renderedRows = shouldVirtualize
+    ? virtual.visibleItems.map((v) => v.item)
+    : rows;
+  const topSpacer = shouldVirtualize ? virtual.startIndex * ROW_HEIGHT : 0;
+  const bottomSpacer = shouldVirtualize
+    ? Math.max(0, (rows.length - virtual.endIndex) * ROW_HEIGHT)
+    : 0;
+
+  const table = (
+    <table
+      style={{ width: '100%', borderCollapse: 'collapse' }}
+      aria-label="Investment holdings table"
+      aria-rowcount={rows.length}
+    >
+      <thead>
+        <tr>
+          <th
+            scope="col"
+            style={{
+              textAlign: 'left',
+              padding: 'var(--spacing-3)',
+              cursor: 'pointer',
+              borderBottom: HEADER_BORDER,
+              userSelect: 'none',
+              position: shouldVirtualize ? 'sticky' : undefined,
+              top: shouldVirtualize ? 0 : undefined,
+              background: shouldVirtualize ? 'var(--semantic-surface, #fff)' : undefined,
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => onSort('symbol')}
+              aria-label={`Sort by symbol${sortField === 'symbol' ? sortArrow : ''}`}
+              style={HEADER_BUTTON_STYLE}
+            >
+              Symbol{sortField === 'symbol' ? sortArrow : ''}
+            </button>
+          </th>
+          <th
+            scope="col"
+            style={{ textAlign: 'left', padding: 'var(--spacing-3)', borderBottom: HEADER_BORDER }}
+          >
+            {accountColumnLabel}
+          </th>
+          <th
+            scope="col"
+            style={{ textAlign: 'left', padding: 'var(--spacing-3)', borderBottom: HEADER_BORDER }}
+          >
+            Type
+          </th>
+          <th
+            scope="col"
+            style={{ textAlign: 'right', padding: 'var(--spacing-3)', borderBottom: HEADER_BORDER }}
+          >
+            Shares
+          </th>
+          <th
+            scope="col"
+            style={{ textAlign: 'right', padding: 'var(--spacing-3)', borderBottom: HEADER_BORDER }}
+          >
+            Price
+          </th>
+          <th
+            scope="col"
+            style={{
+              textAlign: 'right',
+              padding: 'var(--spacing-3)',
+              cursor: 'pointer',
+              borderBottom: HEADER_BORDER,
+              userSelect: 'none',
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => onSort('value')}
+              aria-label={`Sort by market value${sortField === 'value' ? sortArrow : ''}`}
+              style={HEADER_BUTTON_STYLE}
+            >
+              Market Value{sortField === 'value' ? sortArrow : ''}
+            </button>
+          </th>
+          <th
+            scope="col"
+            style={{
+              textAlign: 'right',
+              padding: 'var(--spacing-3)',
+              cursor: 'pointer',
+              borderBottom: HEADER_BORDER,
+              userSelect: 'none',
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => onSort('gainLoss')}
+              aria-label={`Sort by gain/loss${sortField === 'gainLoss' ? sortArrow : ''}`}
+              style={HEADER_BUTTON_STYLE}
+            >
+              Gain/Loss{sortField === 'gainLoss' ? sortArrow : ''}
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {topSpacer > 0 && (
+          <tr aria-hidden="true" style={{ height: topSpacer }}>
+            <td colSpan={7} style={{ padding: 0, border: 'none' }} />
+          </tr>
+        )}
+        {renderedRows.map((row) => (
+          <tr
+            key={row.key}
+            data-testid="holding-row"
+            style={{
+              borderBottom: ROW_BORDER,
+              height: shouldVirtualize ? ROW_HEIGHT : undefined,
+            }}
+          >
+            <HoldingCells row={row} />
+          </tr>
+        ))}
+        {bottomSpacer > 0 && (
+          <tr aria-hidden="true" style={{ height: bottomSpacer }}>
+            <td colSpan={7} style={{ padding: 0, border: 'none' }} />
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+
+  if (!shouldVirtualize) {
+    return table;
+  }
+
+  return (
+    <div
+      ref={virtual.containerRef}
+      onScroll={virtual.containerProps.onScroll}
+      style={{ height: VIEWPORT_HEIGHT, overflow: 'auto', position: 'relative' }}
+      role="group"
+      aria-label={`Investment holdings (virtualized, ${rows.length} rows)`}
+    >
+      {table}
+    </div>
+  );
+};
+
+export default HoldingsTable;

--- a/apps/web/src/components/invoices/InvoicePaymentDialog.test.tsx
+++ b/apps/web/src/components/invoices/InvoicePaymentDialog.test.tsx
@@ -35,6 +35,7 @@ function makeInvoice(overrides: Partial<Invoice> = {}): Invoice {
     id: 'inv-1',
     clientName: 'Acme Studio',
     amountCents: 400000,
+    currency: 'USD',
     issueDate: '2024-01-01',
     paymentTerm: 'net-30',
     status: 'Sent',

--- a/apps/web/src/db/repositories/invoices.test.ts
+++ b/apps/web/src/db/repositories/invoices.test.ts
@@ -46,6 +46,7 @@ function invoiceRow(overrides: Partial<Row> = {}): Row {
     household_id: 'hh-1',
     client_name: 'Studio Delacroix',
     amount_cents: 120000,
+    currency: 'USD',
     issue_date: '2026-01-01',
     payment_term: 'net-30',
     status: 'Sent',
@@ -69,6 +70,7 @@ function baseInvoice(overrides: Partial<Invoice> = {}): Invoice {
     id: 'inv-1',
     clientName: 'Studio Delacroix',
     amountCents: 120000,
+    currency: 'USD',
     issueDate: '2026-01-01',
     paymentTerm: 'net-30',
     status: 'Sent',
@@ -133,6 +135,7 @@ describe('invoices repository', () => {
       id: 'inv-1',
       clientName: 'Studio Delacroix',
       amountCents: 120000,
+      currency: 'USD',
       issueDate: '2026-01-01',
       paymentTerm: 'net-30',
       status: 'Paid',
@@ -172,6 +175,7 @@ describe('invoices repository', () => {
       'hh-1',
       'Studio Delacroix',
       120000,
+      'USD',
       '2026-01-01',
       'net-30',
       'Sent',
@@ -211,10 +215,10 @@ describe('invoices repository', () => {
     );
 
     const params = mockExecute.mock.calls[0][2] as unknown[];
-    expect(params[9]).toBe(120000); // amount_paid_cents
-    expect(params[10]).toBe('2026-02-10'); // paid_date
-    expect(params[11]).toBe('acc-9'); // payment_account_id
-    expect(params[12]).toBe('txn-9'); // payment_transaction_id
+    expect(params[10]).toBe(120000); // amount_paid_cents
+    expect(params[11]).toBe('2026-02-10'); // paid_date
+    expect(params[12]).toBe('acc-9'); // payment_account_id
+    expect(params[13]).toBe('txn-9'); // payment_transaction_id
   });
 
   it('returns null when updating an invoice that does not exist', () => {

--- a/apps/web/src/db/repositories/invoices.ts
+++ b/apps/web/src/db/repositories/invoices.ts
@@ -150,7 +150,7 @@ export function insertInvoice(db: SqliteDb, invoice: Invoice): Invoice {
       householdId,
       invoice.clientName,
       invoice.amountCents,
-      invoice.currency,
+      normalizeInvoiceCurrency(invoice.currency),
       invoice.issueDate,
       invoice.paymentTerm,
       invoice.status,
@@ -208,7 +208,7 @@ export function updateInvoiceRecord(db: SqliteDb, invoice: Invoice): Invoice | n
     [
       invoice.clientName,
       invoice.amountCents,
-      invoice.currency,
+      normalizeInvoiceCurrency(invoice.currency),
       invoice.issueDate,
       invoice.paymentTerm,
       invoice.status,

--- a/apps/web/src/db/repositories/invoices.ts
+++ b/apps/web/src/db/repositories/invoices.ts
@@ -16,6 +16,8 @@
 
 import {
   computeExpectedPayDate,
+  DEFAULT_INVOICE_CURRENCY,
+  normalizeInvoiceCurrency,
   type Invoice,
   type InvoicePaymentTerm,
   type InvoiceStatus,
@@ -32,6 +34,7 @@ const INVOICE_COLUMNS = [
   'household_id',
   'client_name',
   'amount_cents',
+  'currency',
   'issue_date',
   'payment_term',
   'status',
@@ -62,6 +65,7 @@ function mapInvoice(row: Row): Invoice {
     id: requireString(row.id, 'invoice.id'),
     clientName: requireString(row.client_name, 'invoice.client_name'),
     amountCents: requireNumber(row.amount_cents, 'invoice.amount_cents'),
+    currency: normalizeInvoiceCurrency(optionalString(row.currency) ?? DEFAULT_INVOICE_CURRENCY),
     issueDate: requireString(row.issue_date, 'invoice.issue_date'),
     paymentTerm: requireString(row.payment_term, 'invoice.payment_term') as InvoicePaymentTerm,
     status: requireString(row.status, 'invoice.status') as InvoiceStatus,
@@ -120,6 +124,7 @@ export function insertInvoice(db: SqliteDb, invoice: Invoice): Invoice {
       household_id,
       client_name,
       amount_cents,
+      currency,
       issue_date,
       payment_term,
       status,
@@ -135,7 +140,7 @@ export function insertInvoice(db: SqliteDb, invoice: Invoice): Invoice {
       sync_version,
       is_synced
     ) VALUES (
-      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
       NULL,
       1,
       0
@@ -145,6 +150,7 @@ export function insertInvoice(db: SqliteDb, invoice: Invoice): Invoice {
       householdId,
       invoice.clientName,
       invoice.amountCents,
+      invoice.currency,
       invoice.issueDate,
       invoice.paymentTerm,
       invoice.status,
@@ -184,6 +190,7 @@ export function updateInvoiceRecord(db: SqliteDb, invoice: Invoice): Invoice | n
     `UPDATE invoice
         SET client_name = ?,
             amount_cents = ?,
+            currency = ?,
             issue_date = ?,
             payment_term = ?,
             status = ?,
@@ -201,6 +208,7 @@ export function updateInvoiceRecord(db: SqliteDb, invoice: Invoice): Invoice | n
     [
       invoice.clientName,
       invoice.amountCents,
+      invoice.currency,
       invoice.issueDate,
       invoice.paymentTerm,
       invoice.status,
@@ -259,6 +267,7 @@ function normalizeLegacyInvoice(entry: Invoice): Invoice {
   const nowIso = new Date().toISOString();
   return {
     ...entry,
+    currency: normalizeInvoiceCurrency(entry.currency),
     expectedPayDate:
       entry.expectedPayDate || computeExpectedPayDate(entry.issueDate, entry.paymentTerm),
     createdAt: entry.createdAt || nowIso,

--- a/apps/web/src/db/repositories/remittances.test.ts
+++ b/apps/web/src/db/repositories/remittances.test.ts
@@ -59,6 +59,8 @@ function remittanceRow(overrides: Partial<Row> = {}): Row {
     deleted_at: null,
     sync_version: 1,
     is_synced: 0,
+    recurrence_frequency: null,
+    recurrence_next_date: null,
     ...overrides,
   };
 }
@@ -77,6 +79,7 @@ function baseRemittance(overrides: Partial<RemittanceRecord> = {}): RemittanceRe
     recipient: { name: 'Priya Supplier', country: 'IN' },
     note: 'June fabric order',
     createdAt: '2026-06-01T09:00:00.000Z',
+    recurrence: null,
     ...overrides,
   };
 }
@@ -129,6 +132,7 @@ describe('remittances repository', () => {
       recipient: { name: 'Priya Supplier', country: 'IN' },
       note: 'June fabric order',
       createdAt: '2026-06-01T09:00:00.000Z',
+      recurrence: null,
     });
   });
 
@@ -166,6 +170,8 @@ describe('remittances repository', () => {
       'Priya Supplier',
       'IN',
       'June fabric order',
+      null,
+      null,
       '2026-06-01T09:00:00.000Z',
       '2026-06-01T09:00:00.000Z',
     ]);

--- a/apps/web/src/db/repositories/remittances.ts
+++ b/apps/web/src/db/repositories/remittances.ts
@@ -13,7 +13,11 @@
  * is stored in integer minor units and FX rates as reals.
  */
 
-import type { RemittanceFeeModel, RemittanceRecord } from '../../lib/remittance';
+import type {
+  RemittanceFeeModel,
+  RemittanceFrequency,
+  RemittanceRecord,
+} from '../../lib/remittance';
 import { execute, query, queryOne, type Row, type SqliteDb } from '../sqlite-wasm';
 import { getPrimaryHouseholdId } from './household';
 import { SQLITE_NOW_EXPRESSION, optionalString, requireNumber, requireString } from './helpers';
@@ -35,6 +39,8 @@ const REMITTANCE_COLUMNS = [
   'recipient_name',
   'recipient_country',
   'note',
+  'recurrence_frequency',
+  'recurrence_next_date',
   'created_at',
   'updated_at',
   'deleted_at',
@@ -64,8 +70,19 @@ function mapRemittance(row: Row): RemittanceRecord {
       country: requireString(row.recipient_country, 'remittance.recipient_country'),
     },
     note: optionalString(row.note),
+    recurrence: mapRecurrence(row),
     createdAt: requireString(row.created_at, 'remittance.created_at'),
   };
+}
+
+/** Reconstruct the recurrence schedule from its two persisted columns, or null. */
+function mapRecurrence(row: Row): RemittanceRecord['recurrence'] {
+  const frequency = optionalString(row.recurrence_frequency);
+  const nextDate = optionalString(row.recurrence_next_date);
+  if (!frequency || !nextDate) {
+    return null;
+  }
+  return { frequency: frequency as RemittanceFrequency, nextDate };
 }
 
 /** Return all non-deleted remittances, most recent send date first. */
@@ -108,13 +125,15 @@ export function insertRemittance(db: SqliteDb, record: RemittanceRecord): Remitt
       recipient_name,
       recipient_country,
       note,
+      recurrence_frequency,
+      recurrence_next_date,
       created_at,
       updated_at,
       deleted_at,
       sync_version,
       is_synced
     ) VALUES (
-      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
       NULL,
       1,
       0
@@ -133,6 +152,8 @@ export function insertRemittance(db: SqliteDb, record: RemittanceRecord): Remitt
       record.recipient.name,
       record.recipient.country,
       record.note,
+      record.recurrence?.frequency ?? null,
+      record.recurrence?.nextDate ?? null,
       record.createdAt,
       record.createdAt,
     ],
@@ -193,6 +214,7 @@ function normalizeLegacyRemittance(entry: RemittanceRecord): RemittanceRecord {
     ...entry,
     referenceRate: entry.referenceRate ?? null,
     note: entry.note ?? null,
+    recurrence: entry.recurrence ?? null,
     createdAt: entry.createdAt || new Date().toISOString(),
   };
 }

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -716,6 +716,22 @@ export const MIGRATIONS: Migration[] = [
       ]),
     ],
   },
+  {
+    version: 16,
+    label: 'add-invoice-currency-and-remittance-recurrence',
+    up: [
+      // Invoices were implicitly always-USD (#3263). Add an explicit ISO-4217
+      // currency so a freelancer billing EUR/GBP clients records the true
+      // denomination instead of mislabelling every invoice as dollars. Existing
+      // rows backfill to 'USD', matching prior behaviour.
+      `ALTER TABLE invoice ADD COLUMN currency TEXT NOT NULL DEFAULT 'USD';`,
+      // Recurring/scheduled supplier remittances (#3265): a nullable recurrence
+      // frequency and the next scheduled send date. NULL frequency means the
+      // remittance is a one-off, preserving the behaviour of every existing row.
+      `ALTER TABLE remittance ADD COLUMN recurrence_frequency TEXT;`,
+      `ALTER TABLE remittance ADD COLUMN recurrence_next_date TEXT;`,
+    ],
+  },
 ];
 // ---------------------------------------------------------------------------
 // OPFS / IndexedDB feature detection

--- a/apps/web/src/hooks/__tests__/useSecurityWatchlists.test.ts
+++ b/apps/web/src/hooks/__tests__/useSecurityWatchlists.test.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useSecurityWatchlists } from '../useSecurityWatchlists';
+import { useInvestments } from '../useInvestments';
+
+vi.mock('../useInvestments', () => ({
+  useInvestments: vi.fn(),
+}));
+
+const mockedUseInvestments = vi.mocked(useInvestments);
+
+function investmentsWithPrices(prices: Record<string, number>) {
+  return {
+    investments: Object.entries(prices).map(([symbol, amount], index) => ({
+      id: `inv-${index}`,
+      symbol,
+      currentPricePerShare: { amount, currency: 'USD' },
+    })),
+  } as unknown as ReturnType<typeof useInvestments>;
+}
+
+describe('useSecurityWatchlists', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockedUseInvestments.mockReturnValue(investmentsWithPrices({ AAPL: 20000 }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts empty', () => {
+    const { result } = renderHook(() => useSecurityWatchlists());
+    expect(result.current.watches).toHaveLength(0);
+    expect(result.current.alerts).toHaveLength(0);
+  });
+
+  it('adds a watch and persists it to localStorage', () => {
+    const { result } = renderHook(() => useSecurityWatchlists());
+
+    act(() => {
+      result.current.addWatch({
+        symbol: 'aapl',
+        referencePriceCents: 19000,
+        alertThresholdPercent: 5,
+      });
+    });
+
+    expect(result.current.watches).toHaveLength(1);
+    expect(result.current.watches[0].symbol).toBe('AAPL');
+    expect(localStorage.getItem('finance-security-watchlists')).toContain('AAPL');
+  });
+
+  it('emits an alert when the held price moves beyond the threshold', () => {
+    // Reference 190.00, current 200.00 → +5.26% ≥ 5% threshold.
+    const { result } = renderHook(() => useSecurityWatchlists());
+
+    act(() => {
+      result.current.addWatch({
+        symbol: 'AAPL',
+        referencePriceCents: 19000,
+        alertThresholdPercent: 5,
+      });
+    });
+
+    expect(result.current.alerts).toHaveLength(1);
+    expect(result.current.alerts[0].watch.symbol).toBe('AAPL');
+    expect(result.current.alerts[0].movePercent).toBeCloseTo(5.26, 2);
+  });
+
+  it('does not alert when the move is within the threshold', () => {
+    const { result } = renderHook(() => useSecurityWatchlists());
+
+    act(() => {
+      result.current.addWatch({
+        symbol: 'AAPL',
+        referencePriceCents: 19900,
+        alertThresholdPercent: 5,
+      });
+    });
+
+    expect(result.current.alerts).toHaveLength(0);
+  });
+
+  it('re-baselines the reference price to the latest held price', () => {
+    const { result } = renderHook(() => useSecurityWatchlists());
+
+    act(() => {
+      result.current.addWatch({
+        symbol: 'AAPL',
+        referencePriceCents: 19000,
+        alertThresholdPercent: 5,
+      });
+    });
+    expect(result.current.alerts).toHaveLength(1);
+
+    act(() => {
+      result.current.resetReferencePrice(result.current.watches[0].id);
+    });
+
+    expect(result.current.watches[0].referencePriceCents).toBe(20000);
+    expect(result.current.alerts).toHaveLength(0);
+  });
+
+  it('dismisses an alert until refresh', () => {
+    const { result } = renderHook(() => useSecurityWatchlists());
+
+    act(() => {
+      result.current.addWatch({
+        symbol: 'AAPL',
+        referencePriceCents: 19000,
+        alertThresholdPercent: 5,
+      });
+    });
+    const watchId = result.current.watches[0].id;
+
+    act(() => {
+      result.current.dismissAlert(watchId);
+    });
+    expect(result.current.alerts).toHaveLength(0);
+
+    act(() => {
+      result.current.refresh();
+    });
+    expect(result.current.alerts).toHaveLength(1);
+  });
+
+  it('removes a watch', () => {
+    const { result } = renderHook(() => useSecurityWatchlists());
+
+    act(() => {
+      result.current.addWatch({
+        symbol: 'AAPL',
+        referencePriceCents: 19000,
+        alertThresholdPercent: 5,
+      });
+    });
+    const watchId = result.current.watches[0].id;
+
+    act(() => {
+      result.current.removeWatch(watchId);
+    });
+    expect(result.current.watches).toHaveLength(0);
+  });
+
+  it('suppresses alerts when disabled for an entry', () => {
+    const { result } = renderHook(() => useSecurityWatchlists());
+
+    act(() => {
+      result.current.addWatch({
+        symbol: 'AAPL',
+        referencePriceCents: 19000,
+        alertThresholdPercent: 5,
+      });
+    });
+    expect(result.current.alerts).toHaveLength(1);
+
+    act(() => {
+      result.current.toggleAlerts(result.current.watches[0].id);
+    });
+    expect(result.current.alerts).toHaveLength(0);
+  });
+});

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -74,6 +74,8 @@ export type {
   AlertLevel,
   CreateWatchlistInput,
 } from './useSpendingWatchlists';
+export { useSecurityWatchlists } from './useSecurityWatchlists';
+export type { UseSecurityWatchlistsResult } from './useSecurityWatchlists';
 export { useFinancialTips } from './useFinancialTips';
 export type { UseFinancialTipsResult } from './useFinancialTips';
 export { useNaturalLanguageInput, parseTransactionText } from './useNaturalLanguageInput';

--- a/apps/web/src/hooks/useRemittances.test.ts
+++ b/apps/web/src/hooks/useRemittances.test.ts
@@ -60,6 +60,7 @@ function input(overrides: Partial<CreateRemittanceInput> = {}): CreateRemittance
     referenceRate: 17.5,
     recipient: { name: 'Familia', country: 'MX' },
     note: null,
+    recurrence: null,
     ...overrides,
   };
 }

--- a/apps/web/src/hooks/useSecurityWatchlists.ts
+++ b/apps/web/src/hooks/useSecurityWatchlists.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook for managing security/ticker watchlists with price-move alerts
+ * (issue #3260).
+ *
+ * A security watch tracks a ticker against a reference price. Current prices are
+ * sourced from the user's own holdings (`useInvestments`) — the same prices that
+ * the live-P&L / market-data pipeline keeps up to date — so a watched symbol
+ * that is also held reflects its latest observed price. When a symbol's move
+ * from its reference reaches the entry's threshold, a price-move alert is
+ * emitted for the UI to render.
+ *
+ * Watch entries persist in localStorage for offline-first support.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useInvestments } from './useInvestments';
+import {
+  computeSecurityAlerts,
+  normalizeSymbol,
+  type CreateSecurityWatchInput,
+  type SecurityAlert,
+  type SecurityWatch,
+} from '../lib/investment/security-watchlist';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Shape returned by {@link useSecurityWatchlists}. */
+export interface UseSecurityWatchlistsResult {
+  /** All configured security watches. */
+  watches: SecurityWatch[];
+  /** Active price-move alerts. */
+  alerts: SecurityAlert[];
+  /** Latest known price per share (cents) keyed by normalized symbol. */
+  priceBySymbolCents: Map<string, number>;
+  /** Add a new security watch. Returns the created entry. */
+  addWatch: (input: CreateSecurityWatchInput) => SecurityWatch;
+  /** Remove a watch by ID. */
+  removeWatch: (watchId: string) => void;
+  /** Toggle alerts for a watch. */
+  toggleAlerts: (watchId: string) => void;
+  /** Reset a watch's reference price to the latest observed price (re-baseline). */
+  resetReferencePrice: (watchId: string) => void;
+  /** Dismiss an alert until the next refresh. */
+  dismissAlert: (watchId: string) => void;
+  /** Clear dismissals so alerts re-evaluate. */
+  refresh: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = 'finance-security-watchlists';
+
+function normalizeWatches(watches: readonly SecurityWatch[]): SecurityWatch[] {
+  return [...watches]
+    .sort((left, right) => (left.sortOrder ?? 0) - (right.sortOrder ?? 0))
+    .map((watch, index) => ({ ...watch, sortOrder: index }));
+}
+
+function loadWatches(): SecurityWatch[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return normalizeWatches(JSON.parse(raw) as SecurityWatch[]);
+  } catch {
+    return [];
+  }
+}
+
+function saveWatches(watches: SecurityWatch[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(normalizeWatches(watches)));
+  } catch {
+    // Storage may be unavailable.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useSecurityWatchlists(): UseSecurityWatchlistsResult {
+  const { investments } = useInvestments();
+  const [watches, setWatches] = useState<SecurityWatch[]>(loadWatches);
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    saveWatches(watches);
+  }, [watches]);
+
+  // Latest price per symbol from the user's holdings (cents).
+  const priceBySymbolCents = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const investment of investments) {
+      map.set(normalizeSymbol(investment.symbol), investment.currentPricePerShare.amount);
+    }
+    return map;
+  }, [investments]);
+
+  const alerts = useMemo<SecurityAlert[]>(() => {
+    const active = watches.filter((watch) => !dismissedIds.has(watch.id));
+    return computeSecurityAlerts(active, priceBySymbolCents);
+  }, [watches, priceBySymbolCents, dismissedIds]);
+
+  const addWatch = useCallback(
+    (input: CreateSecurityWatchInput): SecurityWatch => {
+      const newWatch: SecurityWatch = {
+        id: crypto.randomUUID(),
+        symbol: normalizeSymbol(input.symbol),
+        name: input.name?.trim() ?? '',
+        referencePriceCents: Math.max(0, Math.round(input.referencePriceCents)),
+        alertThresholdPercent: Math.max(0, input.alertThresholdPercent),
+        alertsEnabled: input.alertsEnabled ?? true,
+        createdAt: new Date().toISOString(),
+        sortOrder: watches.length,
+      };
+      setWatches((prev) => normalizeWatches([...prev, newWatch]));
+      return newWatch;
+    },
+    [watches.length],
+  );
+
+  const removeWatch = useCallback((watchId: string) => {
+    setWatches((prev) => normalizeWatches(prev.filter((watch) => watch.id !== watchId)));
+  }, []);
+
+  const toggleAlerts = useCallback((watchId: string) => {
+    setWatches((prev) =>
+      normalizeWatches(
+        prev.map((watch) =>
+          watch.id === watchId ? { ...watch, alertsEnabled: !watch.alertsEnabled } : watch,
+        ),
+      ),
+    );
+  }, []);
+
+  const resetReferencePrice = useCallback(
+    (watchId: string) => {
+      setWatches((prev) =>
+        normalizeWatches(
+          prev.map((watch) => {
+            if (watch.id !== watchId) return watch;
+            const latest = priceBySymbolCents.get(normalizeSymbol(watch.symbol));
+            return latest === undefined ? watch : { ...watch, referencePriceCents: latest };
+          }),
+        ),
+      );
+    },
+    [priceBySymbolCents],
+  );
+
+  const dismissAlert = useCallback((watchId: string) => {
+    setDismissedIds((prev) => new Set([...prev, watchId]));
+  }, []);
+
+  const refresh = useCallback(() => {
+    setDismissedIds(new Set());
+  }, []);
+
+  return {
+    watches,
+    alerts,
+    priceBySymbolCents,
+    addWatch,
+    removeWatch,
+    toggleAlerts,
+    resetReferencePrice,
+    dismissAlert,
+    refresh,
+  };
+}

--- a/apps/web/src/lib/analytics/invoices.test.ts
+++ b/apps/web/src/lib/analytics/invoices.test.ts
@@ -12,6 +12,8 @@ import {
   buildInvoiceCashInflow,
   computeExpectedPayDate,
   computeInvoiceForecast,
+  createInvoice,
+  DEFAULT_INVOICE_CURRENCY,
   exportInvoicesCsv,
   FOLLOW_UP_STALE_DAYS,
   getEffectiveInvoiceStatus,
@@ -21,6 +23,7 @@ import {
   invoiceIsFullyPaid,
   invoiceNeedsFollowUp,
   invoiceOutstandingCents,
+  normalizeInvoiceCurrency,
   recordInvoiceContact,
   recordInvoicePayment,
   type Invoice,
@@ -32,6 +35,7 @@ function makeInvoice(overrides: Partial<Invoice>): Invoice {
     id: overrides.id ?? 'inv-1',
     clientName: overrides.clientName ?? 'Acme Studio',
     amountCents: overrides.amountCents ?? 100000,
+    currency: overrides.currency ?? 'USD',
     issueDate: overrides.issueDate ?? '2024-01-01',
     paymentTerm: overrides.paymentTerm ?? 'net-30',
     status: overrides.status ?? 'Sent',
@@ -171,10 +175,10 @@ describe('exportInvoicesCsv', () => {
 
     expect(lines[0]).toBe(INVOICE_CSV_HEADER);
     // Sorted by expected pay date: Ceta (paid, no bucket), Beta (overdue), Acme.
-    expect(lines[1]).toBe('Ceta LLC,300.00,2024-01-01,Net-30,Paid,2024-01-05,');
-    expect(lines[2]).toBe('Beta Co,500.00,2024-01-01,Net-30,Overdue,2024-01-10,Past due');
-    expect(lines[3]).toBe('Acme Studio,1000.00,2024-01-01,Net-30,Sent,2024-01-31,Next 30 days');
-    expect(lines[lines.length - 1]).toBe('Total,1800.00,,,,,');
+    expect(lines[1]).toBe('Ceta LLC,300.00,USD,2024-01-01,Net-30,Paid,2024-01-05,');
+    expect(lines[2]).toBe('Beta Co,500.00,USD,2024-01-01,Net-30,Overdue,2024-01-10,Past due');
+    expect(lines[3]).toBe('Acme Studio,1000.00,USD,2024-01-01,Net-30,Sent,2024-01-31,Next 30 days');
+    expect(lines[lines.length - 1]).toBe('Total,1800.00,,,,,,');
   });
 
   it('quotes client names that contain commas', () => {
@@ -189,8 +193,72 @@ describe('exportInvoicesCsv', () => {
   it('returns the header and a zero totals row for an empty pipeline', () => {
     expect(exportInvoicesCsv([], '2024-01-15').split('\n')).toEqual([
       INVOICE_CSV_HEADER,
-      'Total,0.00,,,,,',
+      'Total,0.00,,,,,,',
     ]);
+  });
+});
+
+describe('invoice currency (#3263)', () => {
+  it('defaults a created invoice to USD when no currency is given', () => {
+    const invoice = createInvoice(
+      { clientName: 'Acme', amountCents: 10000, issueDate: '2024-01-01', paymentTerm: 'net-30' },
+      '2024-01-01T00:00:00Z',
+      'inv-1',
+    );
+    expect(invoice.currency).toBe(DEFAULT_INVOICE_CURRENCY);
+  });
+
+  it('normalizes and preserves an explicit currency on create', () => {
+    const invoice = createInvoice(
+      {
+        clientName: 'Acme',
+        amountCents: 10000,
+        issueDate: '2024-01-01',
+        paymentTerm: 'net-30',
+        currency: 'eur',
+      },
+      '2024-01-01T00:00:00Z',
+      'inv-1',
+    );
+    expect(invoice.currency).toBe('EUR');
+  });
+
+  it('keeps the existing currency when an edit omits it', () => {
+    const invoice = makeInvoice({ currency: 'GBP' });
+    const edited = applyInvoiceEdit(
+      invoice,
+      {
+        clientName: invoice.clientName,
+        amountCents: invoice.amountCents,
+        issueDate: invoice.issueDate,
+        paymentTerm: invoice.paymentTerm,
+        status: invoice.status,
+      },
+      '2024-02-01T00:00:00Z',
+    );
+    expect(edited.currency).toBe('GBP');
+  });
+
+  it('updates the currency when an edit supplies one', () => {
+    const invoice = makeInvoice({ currency: 'USD' });
+    const edited = applyInvoiceEdit(
+      invoice,
+      {
+        clientName: invoice.clientName,
+        amountCents: invoice.amountCents,
+        issueDate: invoice.issueDate,
+        paymentTerm: invoice.paymentTerm,
+        status: invoice.status,
+        currency: 'jpy',
+      },
+      '2024-02-01T00:00:00Z',
+    );
+    expect(edited.currency).toBe('JPY');
+  });
+
+  it('falls back to USD for a blank currency code', () => {
+    expect(normalizeInvoiceCurrency('  ')).toBe('USD');
+    expect(normalizeInvoiceCurrency(undefined)).toBe('USD');
   });
 });
 

--- a/apps/web/src/lib/analytics/invoices.ts
+++ b/apps/web/src/lib/analytics/invoices.ts
@@ -329,7 +329,8 @@ export function applyInvoiceEdit(
     ...invoice,
     clientName: input.clientName.trim(),
     amountCents: input.amountCents,
-    currency: input.currency !== undefined ? normalizeInvoiceCurrency(input.currency) : invoice.currency,
+    currency:
+      input.currency !== undefined ? normalizeInvoiceCurrency(input.currency) : invoice.currency,
     issueDate: input.issueDate,
     paymentTerm: input.paymentTerm,
     status: input.status,

--- a/apps/web/src/lib/analytics/invoices.ts
+++ b/apps/web/src/lib/analytics/invoices.ts
@@ -22,6 +22,8 @@ export interface Invoice {
   readonly id: string;
   readonly clientName: string;
   readonly amountCents: number;
+  /** ISO 4217 currency code the invoice is denominated in (e.g. 'USD', 'EUR'). */
+  readonly currency: string;
   readonly issueDate: string;
   readonly paymentTerm: InvoicePaymentTerm;
   readonly status: InvoiceStatus;
@@ -46,6 +48,8 @@ export interface CreateInvoiceInput {
   readonly issueDate: string;
   readonly paymentTerm: InvoicePaymentTerm;
   readonly status?: InvoiceStatus;
+  /** ISO 4217 currency code; defaults to {@link DEFAULT_INVOICE_CURRENCY} (#3263). */
+  readonly currency?: string;
 }
 
 export interface UpdateInvoiceInput {
@@ -54,6 +58,17 @@ export interface UpdateInvoiceInput {
   readonly issueDate: string;
   readonly paymentTerm: InvoicePaymentTerm;
   readonly status: InvoiceStatus;
+  /** ISO 4217 currency code; when omitted the existing currency is kept (#3263). */
+  readonly currency?: string;
+}
+
+/** Default currency for invoices created without an explicit currency (#3263). */
+export const DEFAULT_INVOICE_CURRENCY = 'USD';
+
+/** Normalize a user-supplied currency code to a trimmed upper-case ISO code. */
+export function normalizeInvoiceCurrency(currency: string | undefined): string {
+  const code = (currency ?? '').trim().toUpperCase();
+  return code === '' ? DEFAULT_INVOICE_CURRENCY : code;
 }
 
 export interface InvoicePipelineGroup {
@@ -259,9 +274,9 @@ export interface InvoiceCashInflowContext {
  * transaction against the chosen account so paid revenue shows up in balances,
  * net worth and reconciliation instead of living only in the invoice pipeline
  * (issue #3266). Amounts are positive cents (the app's income convention) and
- * the transaction adopts the receiving account's currency — invoices do not yet
- * carry their own currency (see #14), so the account the payment lands in is the
- * source of truth for currency.
+ * the transaction adopts the receiving account's currency — the invoice's own
+ * currency (#3263) records what was billed, but the cash actually lands in the
+ * receiving account, so that account's currency is the source of truth here.
  */
 export function buildInvoiceCashInflow(
   invoice: Invoice,
@@ -284,6 +299,7 @@ export function createInvoice(input: CreateInvoiceInput, nowIso: string, id: str
     id,
     clientName: input.clientName.trim(),
     amountCents: input.amountCents,
+    currency: normalizeInvoiceCurrency(input.currency),
     issueDate: input.issueDate,
     paymentTerm: input.paymentTerm,
     status: input.status ?? 'Sent',
@@ -313,6 +329,7 @@ export function applyInvoiceEdit(
     ...invoice,
     clientName: input.clientName.trim(),
     amountCents: input.amountCents,
+    currency: input.currency !== undefined ? normalizeInvoiceCurrency(input.currency) : invoice.currency,
     issueDate: input.issueDate,
     paymentTerm: input.paymentTerm,
     status: input.status,
@@ -387,7 +404,7 @@ export function computeInvoiceForecast(invoices: Invoice[], todayIso: string): F
 
 /** CSV header for {@link exportInvoicesCsv}. */
 export const INVOICE_CSV_HEADER =
-  'Client,Amount,Issue date,Payment term,Status,Expected pay date,Aging bucket';
+  'Client,Amount,Currency,Issue date,Payment term,Status,Expected pay date,Aging bucket';
 
 function invoiceAmountDollars(cents: number): string {
   return (cents / 100).toFixed(2);
@@ -419,6 +436,7 @@ export function exportInvoicesCsv(invoices: Invoice[], todayIso: string): string
       [
         escapeCsvField(invoice.clientName),
         invoiceAmountDollars(invoice.amountCents),
+        invoice.currency,
         invoice.issueDate,
         PAYMENT_TERM_LABELS[invoice.paymentTerm],
         invoice.status,
@@ -428,7 +446,7 @@ export function exportInvoicesCsv(invoices: Invoice[], todayIso: string): string
     );
 
   const totalCents = normalized.reduce((sum, invoice) => sum + invoice.amountCents, 0);
-  const totalRow = ['Total', invoiceAmountDollars(totalCents), '', '', '', '', ''].join(',');
+  const totalRow = ['Total', invoiceAmountDollars(totalCents), '', '', '', '', '', ''].join(',');
 
   return [INVOICE_CSV_HEADER, ...rows, totalRow].join('\n');
 }

--- a/apps/web/src/lib/business/profit-and-loss.test.ts
+++ b/apps/web/src/lib/business/profit-and-loss.test.ts
@@ -28,18 +28,20 @@ function makeTransaction(options: {
   amountCents: number;
   tags?: readonly string[];
   status?: TransactionStatus;
+  categoryId?: string | null;
+  payee?: string | null;
 }): Transaction {
   nextId += 1;
   return {
     id: `txn-${nextId}`,
     householdId: 'hh-1',
     accountId: 'acct-1',
-    categoryId: null,
+    categoryId: options.categoryId ?? null,
     type: options.type,
     status: options.status ?? 'CLEARED',
     amount: { amount: options.amountCents },
     currency: { code: 'USD', decimalPlaces: 2 },
-    payee: null,
+    payee: options.payee ?? null,
     note: null,
     date: options.date,
     transferAccountId: null,
@@ -210,6 +212,111 @@ describe('classifyTransaction', () => {
         tagSets,
       ),
     ).toBeNull();
+  });
+
+  it('classifies a designated supplier category/payee expense as COGS (#3268)', () => {
+    const supplierSets = compilePnlTagSets({
+      cogsCategoryIds: ['cat-supplies'],
+      cogsPayees: ['Acme Fabrics'],
+    });
+    expect(
+      classifyTransaction(
+        makeTransaction({
+          date: '2024-01-01',
+          type: 'EXPENSE',
+          amountCents: 5000,
+          categoryId: 'cat-supplies',
+        }),
+        supplierSets,
+      ),
+    ).toBe('cogs');
+    expect(
+      classifyTransaction(
+        makeTransaction({
+          date: '2024-01-01',
+          type: 'EXPENSE',
+          amountCents: 5000,
+          payee: 'acme fabrics',
+        }),
+        supplierSets,
+      ),
+    ).toBe('cogs');
+  });
+
+  it('lets explicit tags override supplier attribution (#3268)', () => {
+    const supplierSets = compilePnlTagSets({ cogsCategoryIds: ['cat-supplies'] });
+    expect(
+      classifyTransaction(
+        makeTransaction({
+          date: '2024-01-01',
+          type: 'EXPENSE',
+          amountCents: 5000,
+          categoryId: 'cat-supplies',
+          tags: ['overhead'],
+        }),
+        supplierSets,
+      ),
+    ).toBe('overhead');
+  });
+
+  it('does not treat designated income as COGS (#3268)', () => {
+    const supplierSets = compilePnlTagSets({ cogsCategoryIds: ['cat-supplies'] });
+    expect(
+      classifyTransaction(
+        makeTransaction({
+          date: '2024-01-01',
+          type: 'INCOME',
+          amountCents: 5000,
+          categoryId: 'cat-supplies',
+        }),
+        supplierSets,
+      ),
+    ).toBe('revenue');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Untagged-expense diagnostic (#3268)
+// ---------------------------------------------------------------------------
+
+describe('buildProfitAndLoss untagged-expense diagnostic', () => {
+  it('reports expenses that only reached overhead via the type fallback', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 100_000 }),
+        // Untagged supplier spend — misclassified as overhead by fallback.
+        makeTransaction({ date: '2024-01-06', type: 'EXPENSE', amountCents: 30_000 }),
+        makeTransaction({ date: '2024-01-07', type: 'EXPENSE', amountCents: 20_000 }),
+        // Explicitly tagged — not counted as untagged.
+        makeTransaction({
+          date: '2024-01-08',
+          type: 'EXPENSE',
+          amountCents: 10_000,
+          tags: ['cogs'],
+        }),
+      ],
+      { granularity: 'monthly' },
+    );
+    expect(statement.totals.untaggedExpenseCents).toBe(50_000);
+    expect(statement.totals.untaggedExpenseCount).toBe(2);
+  });
+
+  it('excludes supplier-attributed expenses from the untagged total (#3268)', () => {
+    const statement = buildProfitAndLoss(
+      [
+        makeTransaction({ date: '2024-01-05', type: 'INCOME', amountCents: 100_000 }),
+        makeTransaction({
+          date: '2024-01-06',
+          type: 'EXPENSE',
+          amountCents: 40_000,
+          categoryId: 'cat-supplies',
+        }),
+      ],
+      { granularity: 'monthly', cogsCategoryIds: ['cat-supplies'] },
+    );
+    expect(statement.totals.cogsCents).toBe(40_000);
+    expect(statement.totals.untaggedExpenseCents).toBe(0);
+    expect(statement.totals.untaggedExpenseCount).toBe(0);
   });
 });
 

--- a/apps/web/src/lib/business/profit-and-loss.ts
+++ b/apps/web/src/lib/business/profit-and-loss.ts
@@ -63,12 +63,22 @@ export type PnlGranularity = 'weekly' | 'monthly';
  * Tag markers (case-insensitive, matched as whole tags) that force a
  * transaction into a specific P&L bucket regardless of its income/expense
  * type. Explicit tags always win over the type-based fallback.
+ *
+ * {@link cogsCategoryIds} and {@link cogsPayees} let an owner-operator designate
+ * supplier payments (e.g. recurring fabric-supplier remittances) as cost of
+ * goods sold *by default*, without hand-tagging every transaction. Without this,
+ * untagged expenses fall back to `overhead`, so COGS reads near zero and gross
+ * margin is overstated — misleading restock decisions (issue #3268).
  */
 export interface PnlTagConfig {
   readonly revenueTags?: readonly string[];
   readonly cogsTags?: readonly string[];
   readonly laborTags?: readonly string[];
   readonly overheadTags?: readonly string[];
+  /** Category ids whose expense transactions default to COGS (e.g. "Supplies"). */
+  readonly cogsCategoryIds?: readonly string[];
+  /** Payee names (case-insensitive, whole match) whose expenses default to COGS. */
+  readonly cogsPayees?: readonly string[];
 }
 
 export interface PnlOptions extends PnlTagConfig {
@@ -102,6 +112,15 @@ export interface PnlTotals {
   readonly netMarginBps: number | null;
   /** Count of transactions that contributed to this slice. */
   readonly transactionCount: number;
+  /**
+   * Cost (cents) of expense transactions that fell to `overhead` purely by the
+   * income/expense type fallback — i.e. carried no P&L tag and matched no COGS
+   * category/payee rule. High values mean COGS may be understated and gross
+   * margin overstated (issue #3268). Always ≥ 0.
+   */
+  readonly untaggedExpenseCents: number;
+  /** Count of expense transactions classified only by the type fallback. */
+  readonly untaggedExpenseCount: number;
 }
 
 /** A single reporting period (one week or one month). */
@@ -286,6 +305,10 @@ export interface CompiledPnlTagSets {
   readonly cogs: Set<string>;
   readonly labor: Set<string>;
   readonly overhead: Set<string>;
+  /** Category ids designated COGS-by-default (exact match, trimmed). */
+  readonly cogsCategoryIds: Set<string>;
+  /** Payee names designated COGS-by-default (normalized lower-case). */
+  readonly cogsPayees: Set<string>;
 }
 
 /** Pre-compile the configured (or default) tag markers into lookup sets. */
@@ -295,6 +318,12 @@ export function compilePnlTagSets(config: PnlTagConfig = {}): CompiledPnlTagSets
     cogs: normalizeTagList(config.cogsTags, DEFAULT_PNL_TAGS.cogs),
     labor: normalizeTagList(config.laborTags, DEFAULT_PNL_TAGS.labor),
     overhead: normalizeTagList(config.overheadTags, DEFAULT_PNL_TAGS.overhead),
+    cogsCategoryIds: new Set(
+      (config.cogsCategoryIds ?? []).map((id) => id.trim()).filter((id) => id !== ''),
+    ),
+    cogsPayees: new Set(
+      (config.cogsPayees ?? []).map(normalizeTag).filter((payee) => payee !== ''),
+    ),
   };
 }
 
@@ -302,29 +331,70 @@ function hasTag(tags: readonly string[], markers: Set<string>): boolean {
   return tags.some((tag) => markers.has(normalizeTag(tag)));
 }
 
+/** How a transaction's P&L bucket was decided. */
+export type PnlClassificationSource = 'tag' | 'supplier' | 'type-fallback';
+
+/** A classified transaction: its bucket plus how the bucket was decided. */
+export interface PnlClassification {
+  readonly category: PnlCategory;
+  readonly source: PnlClassificationSource;
+}
+
+/**
+ * Classify a transaction into a P&L bucket with provenance, or `null` if it
+ * should be ignored (transfers and voided transactions).
+ *
+ * Priority:
+ *   1. Explicit bucket tags (COGS → labor → overhead → revenue) — `source: 'tag'`.
+ *   2. Supplier attribution — an *expense* whose category id or payee is
+ *      designated COGS-by-default is classified `cogs` — `source: 'supplier'`.
+ *   3. Type fallback — income → `revenue`, expense → `overhead` —
+ *      `source: 'type-fallback'`.
+ */
+export function classifyTransactionDetailed(
+  transaction: Transaction,
+  tagSets: CompiledPnlTagSets,
+): PnlClassification | null {
+  if (transaction.type === 'TRANSFER' || transaction.status === 'VOID') {
+    return null;
+  }
+
+  const tags = transaction.tags ?? [];
+  if (hasTag(tags, tagSets.cogs)) return { category: 'cogs', source: 'tag' };
+  if (hasTag(tags, tagSets.labor)) return { category: 'labor', source: 'tag' };
+  if (hasTag(tags, tagSets.overhead)) return { category: 'overhead', source: 'tag' };
+  if (hasTag(tags, tagSets.revenue)) return { category: 'revenue', source: 'tag' };
+
+  if (transaction.type === 'EXPENSE') {
+    const categoryId = transaction.categoryId ?? undefined;
+    const payee = transaction.payee ? normalizeTag(transaction.payee) : undefined;
+    if (
+      (categoryId !== undefined && tagSets.cogsCategoryIds.has(categoryId)) ||
+      (payee !== undefined && tagSets.cogsPayees.has(payee))
+    ) {
+      return { category: 'cogs', source: 'supplier' };
+    }
+  }
+
+  return transaction.type === 'INCOME'
+    ? { category: 'revenue', source: 'type-fallback' }
+    : { category: 'overhead', source: 'type-fallback' };
+}
+
 /**
  * Classify a transaction into a P&L bucket, or `null` if it should be ignored
  * (transfers and voided transactions).
  *
  * Priority: explicit bucket tags win (checked COGS → labor → overhead →
- * revenue), otherwise income falls back to `revenue` and expenses to
+ * revenue), then supplier attribution (a COGS-designated expense category/payee
+ * defaults to `cogs`), otherwise income falls back to `revenue` and expenses to
  * `overhead` (other operating expense).
  */
 export function classifyTransaction(
   transaction: Transaction,
   tagSets: CompiledPnlTagSets,
 ): PnlCategory | null {
-  if (transaction.type === 'TRANSFER' || transaction.status === 'VOID') {
-    return null;
-  }
-
-  const tags = transaction.tags ?? [];
-  if (hasTag(tags, tagSets.cogs)) return 'cogs';
-  if (hasTag(tags, tagSets.labor)) return 'labor';
-  if (hasTag(tags, tagSets.overhead)) return 'overhead';
-  if (hasTag(tags, tagSets.revenue)) return 'revenue';
-
-  return transaction.type === 'INCOME' ? 'revenue' : 'overhead';
+  return classifyTransactionDetailed(transaction, tagSets)?.category ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -337,6 +407,8 @@ interface MutableBucket {
   laborCents: number;
   overheadCents: number;
   transactionCount: number;
+  untaggedExpenseCents: number;
+  untaggedExpenseCount: number;
 }
 
 function emptyBucket(): MutableBucket {
@@ -346,6 +418,8 @@ function emptyBucket(): MutableBucket {
     laborCents: 0,
     overheadCents: 0,
     transactionCount: 0,
+    untaggedExpenseCents: 0,
+    untaggedExpenseCount: 0,
   };
 }
 
@@ -383,6 +457,8 @@ function finalizeBucket(bucket: MutableBucket): PnlTotals {
     grossMarginBps: marginBasisPoints(grossProfitCents, bucket.revenueCents),
     netMarginBps: marginBasisPoints(netProfitCents, bucket.revenueCents),
     transactionCount: bucket.transactionCount,
+    untaggedExpenseCents: bucket.untaggedExpenseCents,
+    untaggedExpenseCount: bucket.untaggedExpenseCount,
   };
 }
 
@@ -415,18 +491,29 @@ export function buildProfitAndLoss(
       continue;
     }
 
-    const category = classifyTransaction(transaction, tagSets);
-    if (category === null) {
+    const classification = classifyTransactionDetailed(transaction, tagSets);
+    if (classification === null) {
       continue;
     }
+    const { category, source } = classification;
 
     const cents = bucketContributionCents(transaction, category);
     const key = periodKey(transaction.date, granularity);
     const bucket = buckets.get(key) ?? emptyBucket();
     addToBucket(bucket, category, cents);
-    buckets.set(key, bucket);
-
     addToBucket(combined, category, cents);
+
+    // Track expenses that only reached `overhead` via the type fallback so the
+    // UI can warn that COGS may be understated (issue #3268).
+    if (source === 'type-fallback' && transaction.type === 'EXPENSE') {
+      const magnitude = magnitudeCents(transaction.amount.amount);
+      bucket.untaggedExpenseCents += magnitude;
+      bucket.untaggedExpenseCount += 1;
+      combined.untaggedExpenseCents += magnitude;
+      combined.untaggedExpenseCount += 1;
+    }
+
+    buckets.set(key, bucket);
   }
 
   const periods = [...buckets.entries()]

--- a/apps/web/src/lib/i18n/locales/en-US.ts
+++ b/apps/web/src/lib/i18n/locales/en-US.ts
@@ -186,6 +186,18 @@ export const EN_US_CATALOG: MessageCatalog = {
     'Add the real market rate to estimate the FX margin you paid.',
   'remittance.form.referenceRate.invalid': 'Enter a valid rate greater than zero.',
   'remittance.form.note.label': 'Note (optional)',
+  'remittance.form.recurrence.label': 'Repeat',
+  'remittance.form.recurrence.help':
+    'Schedule this remittance to repeat. Recurring remittances are counted as upcoming outflows in Cash Runway.',
+  'remittance.form.recurrence.none': 'One-time (no repeat)',
+  'remittance.form.recurrence.freq.weekly': 'Weekly',
+  'remittance.form.recurrence.freq.biweekly': 'Every 2 weeks',
+  'remittance.form.recurrence.freq.monthly': 'Monthly',
+  'remittance.form.recurrence.freq.quarterly': 'Quarterly',
+  'remittance.form.recurrence.freq.yearly': 'Yearly',
+  'remittance.form.recurrence.nextDate.label': 'Next scheduled date',
+  'remittance.form.fxRate.prefill': 'Use mid-market rate',
+  'remittance.form.fxRate.prefillHint': 'Prefilled {rate} from the exchange-rate service.',
   'remittance.form.submit': 'Record remittance',
   'remittance.form.submitting': 'Saving…',
   'remittance.form.saveError': 'Could not save the remittance. Please try again.',
@@ -233,6 +245,11 @@ export const EN_US_CATALOG: MessageCatalog = {
     'Delete the remittance to {recipient} on {date}? This permanently removes it from your payment history and FX/fee totals.',
   'remittance.history.confirmDelete.confirm': 'Delete remittance',
   'remittance.history.confirmDelete.cancel': 'Cancel',
+  'remittance.upcoming.title': 'Upcoming scheduled remittances',
+  'remittance.upcoming.empty': 'No upcoming scheduled remittances.',
+  'remittance.upcoming.itemAria':
+    '{amount} scheduled to {recipient} on {date}, repeats {frequency}',
+  'remittance.upcoming.badge': 'Repeats {frequency}',
 
   // ── Multi-currency dashboard (issue #3306) ───────────────────────────────
   'dashboard.currency.selector.label': 'Currency',

--- a/apps/web/src/lib/investment/holdings-rollup.test.ts
+++ b/apps/web/src/lib/investment/holdings-rollup.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  UNASSIGNED_ACCOUNT_ID,
+  computePositionCostBasisCents,
+  computePositionMarketValueCents,
+  rollUpHoldingsBySymbol,
+  type HoldingPosition,
+} from './holdings-rollup';
+
+function position(overrides: Partial<HoldingPosition> = {}): HoldingPosition {
+  return {
+    id: 'inv-1',
+    symbol: 'AAPL',
+    name: 'Apple Inc.',
+    shares: 10,
+    currentPricePerShareCents: 20000,
+    costBasisPerShareCents: 15000,
+    currencyCode: 'USD',
+    accountId: 'acct-1',
+    ...overrides,
+  };
+}
+
+describe('holdings-rollup', () => {
+  it('computes per-position market value and cost basis in cents', () => {
+    const pos = position({ shares: 3, currentPricePerShareCents: 12345, costBasisPerShareCents: 10000 });
+    expect(computePositionMarketValueCents(pos)).toBe(37035);
+    expect(computePositionCostBasisCents(pos)).toBe(30000);
+  });
+
+  it('rolls up the same symbol across multiple accounts', () => {
+    const rolled = rollUpHoldingsBySymbol([
+      position({ id: 'a', accountId: 'acct-1', shares: 10 }),
+      position({ id: 'b', accountId: 'acct-2', shares: 5 }),
+    ]);
+
+    expect(rolled).toHaveLength(1);
+    const line = rolled[0];
+    expect(line.symbol).toBe('AAPL');
+    expect(line.totalShares).toBe(15);
+    // 15 shares * $200 = $3000; cost 15 * $150 = $2250; gain $750.
+    expect(line.marketValueCents).toBe(300000);
+    expect(line.costBasisCents).toBe(225000);
+    expect(line.gainLossCents).toBe(75000);
+    expect(line.gainLossPercent).toBeCloseTo(33.33, 2);
+    expect(line.accountCount).toBe(2);
+    expect(line.positionCount).toBe(2);
+  });
+
+  it('groups case-insensitively on symbol', () => {
+    const rolled = rollUpHoldingsBySymbol([
+      position({ id: 'a', symbol: 'aapl', accountId: 'acct-1' }),
+      position({ id: 'b', symbol: 'AAPL', accountId: 'acct-2' }),
+    ]);
+    expect(rolled).toHaveLength(1);
+    expect(rolled[0].symbol).toBe('AAPL');
+    expect(rolled[0].accountCount).toBe(2);
+  });
+
+  it('does not merge positions in different currencies', () => {
+    const rolled = rollUpHoldingsBySymbol([
+      position({ id: 'a', symbol: 'SHEL', currencyCode: 'USD' }),
+      position({ id: 'b', symbol: 'SHEL', currencyCode: 'GBP' }),
+    ]);
+    expect(rolled).toHaveLength(2);
+  });
+
+  it('counts unassigned positions as a single distinct account', () => {
+    const rolled = rollUpHoldingsBySymbol([
+      position({ id: 'a', accountId: null }),
+      position({ id: 'b', accountId: null }),
+    ]);
+    expect(rolled).toHaveLength(1);
+    expect(rolled[0].accountCount).toBe(1);
+    expect(rolled[0].accountIds).toContain(UNASSIGNED_ACCOUNT_ID);
+  });
+
+  it('sorts consolidated lines by market value descending', () => {
+    const rolled = rollUpHoldingsBySymbol([
+      position({ id: 'a', symbol: 'SMALL', shares: 1, currentPricePerShareCents: 100 }),
+      position({ id: 'b', symbol: 'BIG', shares: 100, currentPricePerShareCents: 10000 }),
+    ]);
+    expect(rolled.map((line) => line.symbol)).toEqual(['BIG', 'SMALL']);
+  });
+
+  it('picks the display name from the largest contributing position', () => {
+    const rolled = rollUpHoldingsBySymbol([
+      position({ id: 'a', shares: 2, name: 'Apple (small lot)' }),
+      position({ id: 'b', shares: 20, name: 'Apple Inc.' }),
+    ]);
+    expect(rolled[0].name).toBe('Apple Inc.');
+  });
+
+  it('returns an empty array for no positions', () => {
+    expect(rollUpHoldingsBySymbol([])).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/investment/holdings-rollup.test.ts
+++ b/apps/web/src/lib/investment/holdings-rollup.test.ts
@@ -26,7 +26,11 @@ function position(overrides: Partial<HoldingPosition> = {}): HoldingPosition {
 
 describe('holdings-rollup', () => {
   it('computes per-position market value and cost basis in cents', () => {
-    const pos = position({ shares: 3, currentPricePerShareCents: 12345, costBasisPerShareCents: 10000 });
+    const pos = position({
+      shares: 3,
+      currentPricePerShareCents: 12345,
+      costBasisPerShareCents: 10000,
+    });
     expect(computePositionMarketValueCents(pos)).toBe(37035);
     expect(computePositionCostBasisCents(pos)).toBe(30000);
   });

--- a/apps/web/src/lib/investment/holdings-rollup.ts
+++ b/apps/web/src/lib/investment/holdings-rollup.ts
@@ -99,9 +99,7 @@ interface RollupAccumulator {
  * separate (their cents are not comparable). Results are sorted by market value
  * descending so the largest exposures surface first.
  */
-export function rollUpHoldingsBySymbol(
-  positions: readonly HoldingPosition[],
-): RolledUpHolding[] {
+export function rollUpHoldingsBySymbol(positions: readonly HoldingPosition[]): RolledUpHolding[] {
   const groups = new Map<string, RollupAccumulator>();
 
   for (const position of positions) {

--- a/apps/web/src/lib/investment/holdings-rollup.ts
+++ b/apps/web/src/lib/investment/holdings-rollup.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Cross-account holdings roll-up (issue #3262).
+ *
+ * A single security (ticker) can be held across several brokerage accounts.
+ * This module rolls those per-account positions up into one consolidated line
+ * per symbol so the user sees their true total exposure, while still being able
+ * to attribute each position to the account/brokerage that holds it.
+ *
+ * All monetary values are integer cents; share counts are decimals. The module
+ * is pure so the aggregation math is deterministic and unit-testable.
+ */
+
+/** Minimal per-account holding position consumed by the roll-up. */
+export interface HoldingPosition {
+  /** Investment identifier. */
+  readonly id: string;
+  /** Ticker symbol (roll-up groups case-insensitively on this). */
+  readonly symbol: string;
+  /** Descriptive name. */
+  readonly name: string;
+  /** Number of shares held in this position. */
+  readonly shares: number;
+  /** Current price per share in cents. */
+  readonly currentPricePerShareCents: number;
+  /** Cost basis per share in cents. */
+  readonly costBasisPerShareCents: number;
+  /** ISO currency code (e.g. "USD"). Positions in different currencies are not merged. */
+  readonly currencyCode: string;
+  /** Owning account/brokerage identifier, or `null` when unassigned. */
+  readonly accountId: string | null;
+}
+
+/** A consolidated holding rolled up across accounts for one symbol + currency. */
+export interface RolledUpHolding {
+  /** Normalized (upper-case) ticker symbol. */
+  readonly symbol: string;
+  /** Descriptive name (from the largest contributing position). */
+  readonly name: string;
+  /** ISO currency code shared by every contributing position. */
+  readonly currencyCode: string;
+  /** Total shares across all accounts. */
+  readonly totalShares: number;
+  /** Total market value in cents. */
+  readonly marketValueCents: number;
+  /** Total cost basis in cents. */
+  readonly costBasisCents: number;
+  /** Unrealized gain/loss in cents (market value − cost basis). */
+  readonly gainLossCents: number;
+  /** Unrealized gain/loss as a percentage of cost basis (2-dp). */
+  readonly gainLossPercent: number;
+  /** Number of distinct accounts holding this symbol. */
+  readonly accountCount: number;
+  /** Number of source positions rolled into this line. */
+  readonly positionCount: number;
+  /** Distinct owning account identifiers (`null` becomes the sentinel below). */
+  readonly accountIds: readonly string[];
+}
+
+/** Sentinel used to group positions with no owning account. */
+export const UNASSIGNED_ACCOUNT_ID = '__unassigned__';
+
+/** Market value of a single position in cents (rounded). */
+export function computePositionMarketValueCents(position: HoldingPosition): number {
+  return Math.round(position.shares * position.currentPricePerShareCents);
+}
+
+/** Cost basis of a single position in cents (rounded). */
+export function computePositionCostBasisCents(position: HoldingPosition): number {
+  return Math.round(position.shares * position.costBasisPerShareCents);
+}
+
+function normalizeSymbol(symbol: string): string {
+  return symbol.trim().toUpperCase();
+}
+
+function gainLossPercent(gainLossCents: number, costBasisCents: number): number {
+  if (costBasisCents <= 0) return 0;
+  return Math.round((gainLossCents / costBasisCents) * 10000) / 100;
+}
+
+interface RollupAccumulator {
+  symbol: string;
+  name: string;
+  currencyCode: string;
+  totalShares: number;
+  marketValueCents: number;
+  costBasisCents: number;
+  positionCount: number;
+  /** Shares of the largest contributing position — used to pick the display name. */
+  dominantShares: number;
+  accountIds: Set<string>;
+}
+
+/**
+ * Roll up per-account positions into one consolidated line per symbol +
+ * currency. Positions in different currencies for the same ticker are kept
+ * separate (their cents are not comparable). Results are sorted by market value
+ * descending so the largest exposures surface first.
+ */
+export function rollUpHoldingsBySymbol(
+  positions: readonly HoldingPosition[],
+): RolledUpHolding[] {
+  const groups = new Map<string, RollupAccumulator>();
+
+  for (const position of positions) {
+    const symbol = normalizeSymbol(position.symbol);
+    const key = `${symbol}|${position.currencyCode}`;
+    const marketValue = computePositionMarketValueCents(position);
+    const costBasis = computePositionCostBasisCents(position);
+    const accountKey = position.accountId ?? UNASSIGNED_ACCOUNT_ID;
+
+    const existing = groups.get(key);
+    if (existing) {
+      existing.totalShares += position.shares;
+      existing.marketValueCents += marketValue;
+      existing.costBasisCents += costBasis;
+      existing.positionCount += 1;
+      existing.accountIds.add(accountKey);
+      if (position.shares > existing.dominantShares) {
+        existing.dominantShares = position.shares;
+        existing.name = position.name;
+      }
+    } else {
+      groups.set(key, {
+        symbol,
+        name: position.name,
+        currencyCode: position.currencyCode,
+        totalShares: position.shares,
+        marketValueCents: marketValue,
+        costBasisCents: costBasis,
+        positionCount: 1,
+        dominantShares: position.shares,
+        accountIds: new Set([accountKey]),
+      });
+    }
+  }
+
+  return [...groups.values()]
+    .map((group): RolledUpHolding => {
+      const gainLossCents = group.marketValueCents - group.costBasisCents;
+      return {
+        symbol: group.symbol,
+        name: group.name,
+        currencyCode: group.currencyCode,
+        totalShares: group.totalShares,
+        marketValueCents: group.marketValueCents,
+        costBasisCents: group.costBasisCents,
+        gainLossCents,
+        gainLossPercent: gainLossPercent(gainLossCents, group.costBasisCents),
+        accountCount: group.accountIds.size,
+        positionCount: group.positionCount,
+        accountIds: [...group.accountIds],
+      };
+    })
+    .sort((a, b) => b.marketValueCents - a.marketValueCents);
+}

--- a/apps/web/src/lib/investment/security-watchlist.test.ts
+++ b/apps/web/src/lib/investment/security-watchlist.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  computePriceMovePercent,
+  computeSecurityAlert,
+  computeSecurityAlerts,
+  normalizeSymbol,
+  type SecurityWatch,
+} from './security-watchlist';
+
+function watch(overrides: Partial<SecurityWatch> = {}): SecurityWatch {
+  return {
+    id: 'w1',
+    symbol: 'AAPL',
+    name: 'Apple Inc.',
+    referencePriceCents: 10000,
+    alertThresholdPercent: 5,
+    alertsEnabled: true,
+    createdAt: '2025-01-01T00:00:00Z',
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+describe('normalizeSymbol', () => {
+  it('trims and upper-cases', () => {
+    expect(normalizeSymbol('  aapl ')).toBe('AAPL');
+  });
+});
+
+describe('computePriceMovePercent', () => {
+  it('computes a signed percentage rounded to 2dp', () => {
+    expect(computePriceMovePercent(10000, 10550)).toBe(5.5);
+    expect(computePriceMovePercent(10000, 9400)).toBe(-6);
+  });
+
+  it('returns 0 for a non-positive reference', () => {
+    expect(computePriceMovePercent(0, 10000)).toBe(0);
+    expect(computePriceMovePercent(-5, 10000)).toBe(0);
+  });
+});
+
+describe('computeSecurityAlert', () => {
+  it('fires a warning when the move meets the threshold', () => {
+    const alert = computeSecurityAlert(watch(), 10600); // +6% vs 5% threshold
+    expect(alert).not.toBeNull();
+    expect(alert?.direction).toBe('up');
+    expect(alert?.movePercent).toBe(6);
+    expect(alert?.level).toBe('warning');
+    expect(alert?.message).toContain('+6.00%');
+  });
+
+  it('escalates to critical at double the threshold', () => {
+    const alert = computeSecurityAlert(watch(), 8900); // -11% vs 5% threshold
+    expect(alert?.level).toBe('critical');
+    expect(alert?.direction).toBe('down');
+  });
+
+  it('does not fire below the threshold', () => {
+    expect(computeSecurityAlert(watch(), 10400)).toBeNull(); // +4% < 5%
+  });
+
+  it('does not fire when alerts are disabled', () => {
+    expect(computeSecurityAlert(watch({ alertsEnabled: false }), 12000)).toBeNull();
+  });
+
+  it('does not fire without a positive reference price', () => {
+    expect(computeSecurityAlert(watch({ referencePriceCents: 0 }), 12000)).toBeNull();
+  });
+});
+
+describe('computeSecurityAlerts', () => {
+  it('returns firing alerts sorted by largest absolute move, skipping unknown symbols', () => {
+    const watches = [
+      watch({ id: 'a', symbol: 'AAPL', referencePriceCents: 10000 }),
+      watch({ id: 'b', symbol: 'MSFT', referencePriceCents: 20000 }),
+      watch({ id: 'c', symbol: 'TSLA', referencePriceCents: 30000 }),
+    ];
+    const prices = new Map<string, number>([
+      ['AAPL', 10600], // +6%
+      ['MSFT', 25000], // +25%
+      // TSLA has no price → skipped
+    ]);
+
+    const alerts = computeSecurityAlerts(watches, prices);
+    expect(alerts.map((a) => a.watch.symbol)).toEqual(['MSFT', 'AAPL']);
+  });
+});

--- a/apps/web/src/lib/investment/security-watchlist.ts
+++ b/apps/web/src/lib/investment/security-watchlist.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Security/ticker watchlist engine with price-move alerts (issue #3260).
+ *
+ * A security watchlist entry tracks a ticker against a *reference price* (the
+ * price when it was added or last reset). Whenever the latest observed price
+ * moves away from that reference by at least the entry's alert threshold, a
+ * price-move alert is emitted so the user can react to a notable swing.
+ *
+ * All monetary values are integer cents; percentage moves are rounded to two
+ * decimals. The engine is pure — persistence and price fetching live in the
+ * hook layer — so the math is deterministic and easy to unit test.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A user-defined ticker to watch for notable price moves. */
+export interface SecurityWatch {
+  /** Unique identifier (UUID). */
+  readonly id: string;
+  /** Ticker symbol, normalized to upper case (e.g. "AAPL"). */
+  readonly symbol: string;
+  /** Optional descriptive name. */
+  readonly name: string;
+  /** Reference price per share in cents (the baseline a move is measured from). */
+  readonly referencePriceCents: number;
+  /** Absolute percentage move that triggers an alert (e.g. 5 = ±5%). */
+  readonly alertThresholdPercent: number;
+  /** Whether price-move alerts are enabled for this entry. */
+  readonly alertsEnabled: boolean;
+  /** ISO-8601 creation timestamp. */
+  readonly createdAt: string;
+  /** Persisted display order. */
+  readonly sortOrder?: number;
+}
+
+/** Direction of a price move relative to the reference price. */
+export type PriceMoveDirection = 'up' | 'down' | 'flat';
+
+/** Severity of a price-move alert. */
+export type SecurityAlertLevel = 'info' | 'warning' | 'critical';
+
+/** A computed price-move alert for a watched security. */
+export interface SecurityAlert {
+  /** The watchlist entry that triggered this alert. */
+  readonly watch: SecurityWatch;
+  /** Latest observed price per share in cents. */
+  readonly currentPriceCents: number;
+  /** Signed percentage move from the reference price (2-dp). */
+  readonly movePercent: number;
+  /** Direction of the move. */
+  readonly direction: PriceMoveDirection;
+  /** Alert severity. */
+  readonly level: SecurityAlertLevel;
+  /** Human-readable message. */
+  readonly message: string;
+}
+
+/** Input for creating a new security watch. */
+export interface CreateSecurityWatchInput {
+  readonly symbol: string;
+  readonly name?: string;
+  readonly referencePriceCents: number;
+  readonly alertThresholdPercent: number;
+  readonly alertsEnabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Math
+// ---------------------------------------------------------------------------
+
+/** Normalize a ticker symbol to a trimmed upper-case string. */
+export function normalizeSymbol(symbol: string): string {
+  return symbol.trim().toUpperCase();
+}
+
+/**
+ * Signed percentage move of `currentPriceCents` from `referencePriceCents`,
+ * rounded to two decimal places. Returns 0 when the reference is non-positive
+ * (a move percentage is undefined without a positive baseline).
+ */
+export function computePriceMovePercent(
+  referencePriceCents: number,
+  currentPriceCents: number,
+): number {
+  if (referencePriceCents <= 0) return 0;
+  const raw = ((currentPriceCents - referencePriceCents) / referencePriceCents) * 100;
+  return Math.round(raw * 100) / 100;
+}
+
+function moveDirection(movePercent: number): PriceMoveDirection {
+  if (movePercent > 0) return 'up';
+  if (movePercent < 0) return 'down';
+  return 'flat';
+}
+
+/**
+ * Severity for a move: `critical` once the move is at least double the
+ * threshold, `warning` once it meets the threshold, otherwise `info`.
+ */
+function alertLevel(absMove: number, threshold: number): SecurityAlertLevel {
+  if (threshold > 0 && absMove >= threshold * 2) return 'critical';
+  if (absMove >= threshold) return 'warning';
+  return 'info';
+}
+
+function formatSignedPercent(movePercent: number): string {
+  const sign = movePercent > 0 ? '+' : '';
+  return `${sign}${movePercent.toFixed(2)}%`;
+}
+
+/**
+ * Compute the price-move alert for a single watch given the latest price, or
+ * `null` when no alert should fire (alerts disabled, no positive reference, or
+ * the move has not reached the threshold).
+ */
+export function computeSecurityAlert(
+  watch: SecurityWatch,
+  currentPriceCents: number,
+): SecurityAlert | null {
+  if (!watch.alertsEnabled) return null;
+  if (watch.referencePriceCents <= 0) return null;
+
+  const movePercent = computePriceMovePercent(watch.referencePriceCents, currentPriceCents);
+  const absMove = Math.abs(movePercent);
+  if (absMove < watch.alertThresholdPercent || watch.alertThresholdPercent <= 0) {
+    return null;
+  }
+
+  const direction = moveDirection(movePercent);
+  const label = watch.name ? `${watch.symbol} (${watch.name})` : watch.symbol;
+  const message = `${label} is ${direction === 'down' ? 'down' : 'up'} ${formatSignedPercent(
+    movePercent,
+  )} from your reference price.`;
+
+  return {
+    watch,
+    currentPriceCents,
+    movePercent,
+    direction,
+    level: alertLevel(absMove, watch.alertThresholdPercent),
+    message,
+  };
+}
+
+/**
+ * Compute all firing price-move alerts for `watches` given a symbol→price map
+ * (prices in cents), sorted by the largest absolute move first. Symbols with no
+ * known price are skipped.
+ */
+export function computeSecurityAlerts(
+  watches: readonly SecurityWatch[],
+  priceBySymbolCents: ReadonlyMap<string, number>,
+): SecurityAlert[] {
+  const alerts: SecurityAlert[] = [];
+  for (const watch of watches) {
+    const price = priceBySymbolCents.get(normalizeSymbol(watch.symbol));
+    if (price === undefined) continue;
+    const alert = computeSecurityAlert(watch, price);
+    if (alert) alerts.push(alert);
+  }
+  return alerts.sort((a, b) => Math.abs(b.movePercent) - Math.abs(a.movePercent));
+}

--- a/apps/web/src/lib/remittance/index.ts
+++ b/apps/web/src/lib/remittance/index.ts
@@ -13,6 +13,8 @@ export type {
   RemittanceQuoteInput,
   RemittanceQuote,
   RemittanceRecord,
+  RemittanceFrequency,
+  RemittanceRecurrence,
   CreateRemittanceInput,
 } from './remittance-types';
 
@@ -24,6 +26,15 @@ export {
   effectiveFxRate,
   totalCostMinor,
 } from './remittance-math';
+
+export {
+  REMITTANCE_FREQUENCIES,
+  REMITTANCE_FREQUENCY_LABELS,
+  remittanceTotalPaidMinor,
+  advanceRemittanceDate,
+  projectUpcomingRemittances,
+} from './remittance-schedule';
+export type { UpcomingRemittance } from './remittance-schedule';
 
 export { summarizeRemittances, summarizeByRecipient } from './remittance-summary';
 export type { RemittanceSummary, RemittanceRecipientBreakdown } from './remittance-summary';

--- a/apps/web/src/lib/remittance/remittance-schedule.test.ts
+++ b/apps/web/src/lib/remittance/remittance-schedule.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import type { RemittanceRecord } from './remittance-types';
+import {
+  advanceRemittanceDate,
+  projectUpcomingRemittances,
+  remittanceTotalPaidMinor,
+} from './remittance-schedule';
+
+function makeRecord(overrides: Partial<RemittanceRecord> = {}): RemittanceRecord {
+  return {
+    id: overrides.id ?? 'rem-1',
+    date: overrides.date ?? '2024-01-01',
+    sourceCurrency: overrides.sourceCurrency ?? 'USD',
+    destCurrency: overrides.destCurrency ?? 'MXN',
+    sendAmountMinor: overrides.sendAmountMinor ?? 50000,
+    feeMinor: overrides.feeMinor ?? 500,
+    fxRate: overrides.fxRate ?? 17,
+    feeModel: overrides.feeModel ?? 'ADDITIVE',
+    referenceRate: overrides.referenceRate ?? null,
+    recipient: overrides.recipient ?? { name: 'Family', country: 'MX' },
+    note: overrides.note ?? null,
+    recurrence: overrides.recurrence ?? null,
+    createdAt: overrides.createdAt ?? '2024-01-01T00:00:00Z',
+  };
+}
+
+describe('remittanceTotalPaidMinor', () => {
+  it('adds the fee on top for an additive fee', () => {
+    expect(
+      remittanceTotalPaidMinor({ sendAmountMinor: 50000, feeMinor: 500, feeModel: 'ADDITIVE' }),
+    ).toBe(50500);
+  });
+
+  it('leaves the send amount unchanged for an inclusive fee', () => {
+    expect(
+      remittanceTotalPaidMinor({ sendAmountMinor: 50000, feeMinor: 500, feeModel: 'INCLUSIVE' }),
+    ).toBe(50000);
+  });
+
+  it('never returns a negative amount', () => {
+    expect(
+      remittanceTotalPaidMinor({ sendAmountMinor: -100, feeMinor: -5, feeModel: 'ADDITIVE' }),
+    ).toBe(0);
+  });
+});
+
+describe('advanceRemittanceDate', () => {
+  it('advances weekly and biweekly by whole days', () => {
+    expect(advanceRemittanceDate('2024-01-01', 'weekly')).toBe('2024-01-08');
+    expect(advanceRemittanceDate('2024-01-01', 'biweekly')).toBe('2024-01-15');
+  });
+
+  it('advances monthly, quarterly and yearly by calendar months', () => {
+    expect(advanceRemittanceDate('2024-01-15', 'monthly')).toBe('2024-02-15');
+    expect(advanceRemittanceDate('2024-01-15', 'quarterly')).toBe('2024-04-15');
+    expect(advanceRemittanceDate('2024-01-15', 'yearly')).toBe('2025-01-15');
+  });
+
+  it('clamps month-end overflow (Jan 31 + 1 month = Feb 29 in a leap year)', () => {
+    expect(advanceRemittanceDate('2024-01-31', 'monthly')).toBe('2024-02-29');
+    expect(advanceRemittanceDate('2023-01-31', 'monthly')).toBe('2023-02-28');
+  });
+});
+
+describe('projectUpcomingRemittances', () => {
+  it('ignores one-off remittances', () => {
+    const records = [makeRecord({ recurrence: null })];
+    expect(projectUpcomingRemittances(records, '2024-01-01', '2024-12-31')).toEqual([]);
+  });
+
+  it('projects monthly occurrences within the window in date order', () => {
+    const records = [
+      makeRecord({
+        id: 'rem-monthly',
+        recurrence: { frequency: 'monthly', nextDate: '2024-02-01' },
+      }),
+    ];
+    const upcoming = projectUpcomingRemittances(records, '2024-02-01', '2024-04-30');
+    expect(upcoming.map((u) => u.date)).toEqual(['2024-02-01', '2024-03-01', '2024-04-01']);
+    expect(upcoming[0].totalPaidMinor).toBe(50500);
+  });
+
+  it('skips occurrences before the from date', () => {
+    const records = [
+      makeRecord({ recurrence: { frequency: 'weekly', nextDate: '2024-01-01' } }),
+    ];
+    const upcoming = projectUpcomingRemittances(records, '2024-01-15', '2024-01-31');
+    expect(upcoming.map((u) => u.date)).toEqual(['2024-01-15', '2024-01-22', '2024-01-29']);
+  });
+
+  it('merges and sorts occurrences across multiple recurring remittances', () => {
+    const records = [
+      makeRecord({ id: 'a', recurrence: { frequency: 'monthly', nextDate: '2024-02-10' } }),
+      makeRecord({ id: 'b', recurrence: { frequency: 'monthly', nextDate: '2024-02-01' } }),
+    ];
+    const upcoming = projectUpcomingRemittances(records, '2024-02-01', '2024-02-28');
+    expect(upcoming.map((u) => u.date)).toEqual(['2024-02-01', '2024-02-10']);
+  });
+});

--- a/apps/web/src/lib/remittance/remittance-schedule.test.ts
+++ b/apps/web/src/lib/remittance/remittance-schedule.test.ts
@@ -84,9 +84,7 @@ describe('projectUpcomingRemittances', () => {
   });
 
   it('skips occurrences before the from date', () => {
-    const records = [
-      makeRecord({ recurrence: { frequency: 'weekly', nextDate: '2024-01-01' } }),
-    ];
+    const records = [makeRecord({ recurrence: { frequency: 'weekly', nextDate: '2024-01-01' } })];
     const upcoming = projectUpcomingRemittances(records, '2024-01-15', '2024-01-31');
     expect(upcoming.map((u) => u.date)).toEqual(['2024-01-15', '2024-01-22', '2024-01-29']);
   });

--- a/apps/web/src/lib/remittance/remittance-schedule.ts
+++ b/apps/web/src/lib/remittance/remittance-schedule.ts
@@ -13,10 +13,7 @@
  * that are never time-zone shifted.
  */
 
-import type {
-  RemittanceFrequency,
-  RemittanceRecord,
-} from './remittance-types';
+import type { RemittanceFrequency, RemittanceRecord } from './remittance-types';
 
 /** Every supported recurrence cadence, in ascending period length. */
 export const REMITTANCE_FREQUENCIES: readonly RemittanceFrequency[] = [

--- a/apps/web/src/lib/remittance/remittance-schedule.ts
+++ b/apps/web/src/lib/remittance/remittance-schedule.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Scheduling helpers for recurring/scheduled remittances (issue #3265).
+ *
+ * A remittance can repeat on a fixed cadence (e.g. a business paying an overseas
+ * supplier every month, or family support sent every two weeks). These pure
+ * helpers describe the cadence, compute the cash actually leaving the sender's
+ * pocket, advance the next scheduled date, and project upcoming occurrences so
+ * the cash-runway forecast can treat them as scheduled outflows (issue #3244).
+ *
+ * Money stays in integer minor units; dates are `YYYY-MM-DD` calendar strings
+ * that are never time-zone shifted.
+ */
+
+import type {
+  RemittanceFrequency,
+  RemittanceRecord,
+} from './remittance-types';
+
+/** Every supported recurrence cadence, in ascending period length. */
+export const REMITTANCE_FREQUENCIES: readonly RemittanceFrequency[] = [
+  'weekly',
+  'biweekly',
+  'monthly',
+  'quarterly',
+  'yearly',
+];
+
+/** Human-readable labels for each recurrence cadence. */
+export const REMITTANCE_FREQUENCY_LABELS: Record<RemittanceFrequency, string> = {
+  weekly: 'Weekly',
+  biweekly: 'Every 2 weeks',
+  monthly: 'Monthly',
+  quarterly: 'Quarterly',
+  yearly: 'Yearly',
+};
+
+/**
+ * The cash actually leaving the sender's pocket for a remittance, in
+ * source-currency minor units.
+ *
+ * For an `ADDITIVE` fee the sender pays `sendAmount + fee`; for an `INCLUSIVE`
+ * fee the fee is already inside `sendAmount`, so the sender pays exactly
+ * `sendAmount`. Mirrors `quoteRemittance`'s `totalPaidMinor`.
+ */
+export function remittanceTotalPaidMinor(record: {
+  readonly sendAmountMinor: number;
+  readonly feeMinor: number;
+  readonly feeModel: RemittanceRecord['feeModel'];
+}): number {
+  const send = Math.max(0, Math.trunc(record.sendAmountMinor));
+  const fee = Math.max(0, Math.trunc(record.feeMinor));
+  return record.feeModel === 'INCLUSIVE' ? send : send + fee;
+}
+
+function parseIsoDate(date: string): { year: number; month: number; day: number } | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  return { year, month, day };
+}
+
+function formatIsoDate(year: number, month: number, day: number): string {
+  const mm = String(month).padStart(2, '0');
+  const dd = String(day).padStart(2, '0');
+  return `${year}-${mm}-${dd}`;
+}
+
+function addDays(date: string, days: number): string {
+  const parts = parseIsoDate(date);
+  if (!parts) return date;
+  const utc = Date.UTC(parts.year, parts.month - 1, parts.day + days);
+  return new Date(utc).toISOString().slice(0, 10);
+}
+
+/** Days in a given (1-based) month, accounting for leap years. */
+function daysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function addMonths(date: string, months: number): string {
+  const parts = parseIsoDate(date);
+  if (!parts) return date;
+  const zeroBased = parts.month - 1 + months;
+  const year = parts.year + Math.floor(zeroBased / 12);
+  const month = ((zeroBased % 12) + 12) % 12; // 0-based, normalised
+  // Clamp the day so e.g. Jan-31 + 1 month lands on Feb-28/29, not Mar-03.
+  const day = Math.min(parts.day, daysInMonth(year, month + 1));
+  return formatIsoDate(year, month + 1, day);
+}
+
+/**
+ * Advance a scheduled date by exactly one period of the given cadence. Matches
+ * the cash-runway forecaster's stepping (weekly/biweekly add days; the rest add
+ * calendar months with end-of-month clamping) so a projected schedule and the
+ * runway forecast agree.
+ */
+export function advanceRemittanceDate(date: string, frequency: RemittanceFrequency): string {
+  switch (frequency) {
+    case 'weekly':
+      return addDays(date, 7);
+    case 'biweekly':
+      return addDays(date, 14);
+    case 'monthly':
+      return addMonths(date, 1);
+    case 'quarterly':
+      return addMonths(date, 3);
+    case 'yearly':
+      return addMonths(date, 12);
+    default:
+      return date;
+  }
+}
+
+/** A single projected upcoming occurrence of a recurring remittance. */
+export interface UpcomingRemittance {
+  readonly record: RemittanceRecord;
+  /** Occurrence date, `YYYY-MM-DD`. */
+  readonly date: string;
+  /** Cash leaving the sender's pocket, in source-currency minor units. */
+  readonly totalPaidMinor: number;
+}
+
+/**
+ * Project the upcoming occurrences of the recurring remittances in `records`
+ * that fall within the inclusive `[fromDate, toDate]` window, sorted by date.
+ *
+ * One-off remittances (no recurrence) are historical and never projected.
+ * Occurrences strictly before `fromDate` are skipped; the anchor is the
+ * recurrence's `nextDate`.
+ */
+export function projectUpcomingRemittances(
+  records: readonly RemittanceRecord[],
+  fromDate: string,
+  toDate: string,
+  maxPerRecord = 260,
+): UpcomingRemittance[] {
+  const upcoming: UpcomingRemittance[] = [];
+
+  for (const record of records) {
+    const recurrence = record.recurrence;
+    if (!recurrence) continue;
+
+    const totalPaidMinor = remittanceTotalPaidMinor(record);
+    let date = recurrence.nextDate;
+    for (let step = 0; step < maxPerRecord; step += 1) {
+      if (date > toDate) break;
+      if (date >= fromDate) {
+        upcoming.push({ record, date, totalPaidMinor });
+      }
+      date = advanceRemittanceDate(date, recurrence.frequency);
+    }
+  }
+
+  return upcoming.sort((a, b) => a.date.localeCompare(b.date));
+}

--- a/apps/web/src/lib/remittance/remittance-summary.test.ts
+++ b/apps/web/src/lib/remittance/remittance-summary.test.ts
@@ -23,6 +23,7 @@ function record(overrides: Partial<RemittanceRecord> = {}): RemittanceRecord {
     recipient: { name: 'Familia', country: 'MX' },
     note: null,
     createdAt: '2026-06-01T12:00:00.000Z',
+    recurrence: null,
     ...overrides,
   };
 }

--- a/apps/web/src/lib/remittance/remittance-types.ts
+++ b/apps/web/src/lib/remittance/remittance-types.ts
@@ -132,6 +132,22 @@ export interface RemittanceQuote {
   readonly totalCostMinor: number | null;
 }
 
+/**
+ * How often a scheduled/recurring remittance repeats. Mirrors the cadence
+ * vocabulary used by the cash-runway forecaster (`ScheduledCashEvent`) so a
+ * recurring supplier remittance maps cleanly onto a scheduled outflow (#3265,
+ * #3244).
+ */
+export type RemittanceFrequency = 'weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'yearly';
+
+/** Recurrence schedule for a remittance that repeats (e.g. monthly to family). */
+export interface RemittanceRecurrence {
+  /** How often the remittance repeats. */
+  readonly frequency: RemittanceFrequency;
+  /** Next scheduled send date (`YYYY-MM-DD`). */
+  readonly nextDate: string;
+}
+
 /** A persisted remittance entry (one row in the history). */
 export interface RemittanceRecord {
   readonly id: string;
@@ -146,6 +162,12 @@ export interface RemittanceRecord {
   readonly referenceRate: number | null;
   readonly recipient: RemittanceRecipient;
   readonly note: string | null;
+  /**
+   * Recurrence schedule when this remittance repeats, or `null` for a one-off.
+   * Recurring remittances are projected as scheduled cash outflows so cash
+   * runway reflects upcoming supplier/family transfers (#3265, #3244).
+   */
+  readonly recurrence: RemittanceRecurrence | null;
   /** ISO-8601 instant the record was created locally. */
   readonly createdAt: string;
 }

--- a/apps/web/src/pages/BusinessPnlPage.tsx
+++ b/apps/web/src/pages/BusinessPnlPage.tsx
@@ -274,6 +274,25 @@ export function BusinessPnlPage() {
         </div>
       </section>
 
+      {totals.untaggedExpenseCount > 0 ? (
+        <section
+          className="business-pnl__card business-pnl__card--hint"
+          aria-labelledby="business-pnl-cogs-hint-title"
+        >
+          <h2 id="business-pnl-cogs-hint-title" className="business-pnl__card-title">
+            COGS may be understated
+          </h2>
+          <p className="business-pnl__hint-text">
+            {formatCurrency(totals.untaggedExpenseCents)} across {totals.untaggedExpenseCount}{' '}
+            {totals.untaggedExpenseCount === 1 ? 'expense' : 'expenses'} fell into{' '}
+            <strong>overhead</strong> only because it carried no P&amp;L tag and matched no
+            cost-of-goods supplier rule. If any of these are inventory or materials, tag them{' '}
+            <code>cogs</code> (or designate the supplier as a cost of goods) so gross margin isn&apos;t
+            overstated.
+          </p>
+        </section>
+      ) : null}
+
       <section className="business-pnl__card" aria-labelledby="business-pnl-statement-title">
         <h2 id="business-pnl-statement-title" className="business-pnl__card-title">
           Statement

--- a/apps/web/src/pages/BusinessPnlPage.tsx
+++ b/apps/web/src/pages/BusinessPnlPage.tsx
@@ -287,8 +287,8 @@ export function BusinessPnlPage() {
             {totals.untaggedExpenseCount === 1 ? 'expense' : 'expenses'} fell into{' '}
             <strong>overhead</strong> only because it carried no P&amp;L tag and matched no
             cost-of-goods supplier rule. If any of these are inventory or materials, tag them{' '}
-            <code>cogs</code> (or designate the supplier as a cost of goods) so gross margin isn&apos;t
-            overstated.
+            <code>cogs</code> (or designate the supplier as a cost of goods) so gross margin
+            isn&apos;t overstated.
           </p>
         </section>
       ) : null}

--- a/apps/web/src/pages/CashRunwayPage.test.tsx
+++ b/apps/web/src/pages/CashRunwayPage.test.tsx
@@ -15,18 +15,21 @@
  * conversion math is exercised end-to-end, matching the #3514 net-worth pattern.
  */
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CashRunwayPage } from './CashRunwayPage';
 import { useAccounts } from '../hooks/useAccounts';
 import { useExchangeRates, type UseExchangeRatesResult } from '../hooks/useExchangeRates';
+import { useRemittances } from '../hooks/useRemittances';
 import { AccessibilityProvider } from '../contexts/AccessibilityContext';
 import type { Account } from '../kmp/bridge';
+import type { RemittanceRecord } from '../lib/remittance';
 
 vi.mock('../hooks/useAccounts', () => ({ useAccounts: vi.fn() }));
 vi.mock('../hooks/useBills', () => ({ useBills: () => ({ bills: [] }) }));
 vi.mock('../hooks/useInvoices', () => ({ useInvoices: () => ({ invoices: [] }) }));
+vi.mock('../hooks/useRemittances', () => ({ useRemittances: vi.fn(() => ({ remittances: [] })) }));
 vi.mock('../hooks/useLocalePreferences', () => ({
   useLocalePreferences: () => ({ locale: 'en-US' }),
 }));
@@ -45,6 +48,7 @@ vi.mock('../hooks/useExchangeRates', () => ({ useExchangeRates: vi.fn() }));
 
 const mockedUseAccounts = vi.mocked(useAccounts);
 const mockedUseExchangeRates = vi.mocked(useExchangeRates);
+const mockedUseRemittances = vi.mocked(useRemittances);
 
 const syncMetadata = {
   createdAt: '2025-01-01T00:00:00Z',
@@ -169,5 +173,78 @@ describe('CashRunwayPage multi-currency starting cash (#3240)', () => {
 
     const note = screen.getByRole('note');
     expect(note).toHaveTextContent(/Excluded JPY — no exchange rate available\./);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scheduled supplier remittances (#3244) and workspace filter (#3242)
+// ---------------------------------------------------------------------------
+
+/** ISO date `days` from today, matching the page's `todayIsoDate` anchor. */
+function isoOffset(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+    d.getDate(),
+  ).padStart(2, '0')}`;
+}
+
+function businessAccount(id: string, amountCents: number): Account {
+  return { ...cashAccount(id, 'USD', 2, amountCents), purpose: 'business' };
+}
+
+function recurringRemittance(
+  overrides: Partial<RemittanceRecord> = {},
+): RemittanceRecord {
+  return {
+    id: 'rem-1',
+    date: isoOffset(0),
+    sourceCurrency: 'USD',
+    destCurrency: 'MXN',
+    sendAmountMinor: 50_000,
+    feeMinor: 0,
+    fxRate: 17,
+    feeModel: 'INCLUSIVE',
+    referenceRate: null,
+    recipient: { name: 'Fabrica Supplier', country: 'MX' },
+    note: null,
+    createdAt: '2025-01-01T00:00:00Z',
+    recurrence: { frequency: 'monthly', nextDate: isoOffset(3) },
+    ...overrides,
+  };
+}
+
+describe('CashRunwayPage scheduled remittances and workspace filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseExchangeRates.mockReturnValue({ ...baseRatesResult, rates: {} });
+    mockedUseRemittances.mockReturnValue({ remittances: [] } as ReturnType<typeof useRemittances>);
+  });
+
+  it('includes recurring supplier remittances as scheduled outflows (#3244)', () => {
+    mockAccounts([cashAccount('usd', 'USD', 2, 500000)]);
+    mockedUseRemittances.mockReturnValue({
+      remittances: [recurringRemittance()],
+    } as ReturnType<typeof useRemittances>);
+
+    render(<CashRunwayPage />);
+
+    expect(screen.getAllByText('Fabrica Supplier').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Supplier remittance').length).toBeGreaterThan(0);
+  });
+
+  it('excludes remittances and business accounts from the personal workspace (#3242)', () => {
+    mockAccounts([businessAccount('biz', 500000)]);
+    mockedUseRemittances.mockReturnValue({
+      remittances: [recurringRemittance()],
+    } as ReturnType<typeof useRemittances>);
+
+    render(<CashRunwayPage />);
+    // Default "All" workspace shows the scheduled supplier remittance.
+    expect(screen.getAllByText('Fabrica Supplier').length).toBeGreaterThan(0);
+
+    // Switching to the personal workspace drops the business remittance.
+    fireEvent.click(screen.getByRole('button', { name: /Personal/ }));
+    expect(screen.queryByText('Fabrica Supplier')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/CashRunwayPage.test.tsx
+++ b/apps/web/src/pages/CashRunwayPage.test.tsx
@@ -193,9 +193,7 @@ function businessAccount(id: string, amountCents: number): Account {
   return { ...cashAccount(id, 'USD', 2, amountCents), purpose: 'business' };
 }
 
-function recurringRemittance(
-  overrides: Partial<RemittanceRecord> = {},
-): RemittanceRecord {
+function recurringRemittance(overrides: Partial<RemittanceRecord> = {}): RemittanceRecord {
   return {
     id: 'rem-1',
     date: isoOffset(0),

--- a/apps/web/src/pages/CashRunwayPage.test.tsx
+++ b/apps/web/src/pages/CashRunwayPage.test.tsx
@@ -216,14 +216,16 @@ describe('CashRunwayPage scheduled remittances and workspace filter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedUseExchangeRates.mockReturnValue({ ...baseRatesResult, rates: {} });
-    mockedUseRemittances.mockReturnValue({ remittances: [] } as ReturnType<typeof useRemittances>);
+    mockedUseRemittances.mockReturnValue({ remittances: [] } as unknown as ReturnType<
+      typeof useRemittances
+    >);
   });
 
   it('includes recurring supplier remittances as scheduled outflows (#3244)', () => {
     mockAccounts([cashAccount('usd', 'USD', 2, 500000)]);
     mockedUseRemittances.mockReturnValue({
       remittances: [recurringRemittance()],
-    } as ReturnType<typeof useRemittances>);
+    } as unknown as ReturnType<typeof useRemittances>);
 
     render(<CashRunwayPage />);
 
@@ -235,7 +237,7 @@ describe('CashRunwayPage scheduled remittances and workspace filter', () => {
     mockAccounts([businessAccount('biz', 500000)]);
     mockedUseRemittances.mockReturnValue({
       remittances: [recurringRemittance()],
-    } as ReturnType<typeof useRemittances>);
+    } as unknown as ReturnType<typeof useRemittances>);
 
     render(<CashRunwayPage />);
     // Default "All" workspace shows the scheduled supplier remittance.

--- a/apps/web/src/pages/CashRunwayPage.tsx
+++ b/apps/web/src/pages/CashRunwayPage.tsx
@@ -21,6 +21,7 @@
 import { useMemo, useState } from 'react';
 
 import { EmptyState, Icon, ReadAloudButton } from '../components/common';
+import { AccountPurposeFilterControl } from '../components/accounts';
 import { IconToken } from '../icons/tokens';
 import { useAccounts } from '../hooks/useAccounts';
 import { useBills } from '../hooks/useBills';
@@ -28,7 +29,13 @@ import { useDisplayCurrencyRollup } from '../hooks/useDisplayCurrencyRollup';
 import { useInvoices } from '../hooks/useInvoices';
 import { useLocalePreferences } from '../hooks/useLocalePreferences';
 import { useReducedMotion } from '../hooks/useReducedMotion';
+import { useRemittances } from '../hooks/useRemittances';
 import { formatCurrency } from '../lib/currency';
+import {
+  matchesWorkspaceSelection,
+  type AccountPurposeFilter,
+} from '../lib/accountPurpose';
+import { projectUpcomingRemittances } from '../lib/remittance';
 import type { DisplayCurrencyAmount } from '../lib/budgeting/display-currency-rollups';
 import {
   forecastCashRunway,
@@ -66,6 +73,7 @@ function notBefore(isoDate: string, today: string): string {
 
 export function CashRunwayPage() {
   const [horizonWeeks, setHorizonWeeks] = useState(12);
+  const [workspaceFilter, setWorkspaceFilter] = useState<AccountPurposeFilter>('all');
 
   const today = useMemo(() => todayIsoDate(), []);
   const reducedMotion = useReducedMotion();
@@ -74,15 +82,61 @@ export function CashRunwayPage() {
   const { accounts, loading: accountsLoading } = useAccounts();
   const { bills } = useBills();
   const { invoices } = useInvoices();
+  const { remittances } = useRemittances();
 
-  const cashAccounts = useMemo(
-    () => accounts.filter((account) => !account.isArchived && CASH_ACCOUNT_TYPES.has(account.type)),
+  // Resolve each account's workspace (personal/business/both) so bills and
+  // remittances can be attributed to the selected workspace (#3242).
+  const accountPurposeById = useMemo(
+    () => new Map(accounts.map((account) => [account.id, account.purpose])),
     [accounts],
   );
 
+  const cashAccounts = useMemo(
+    () =>
+      accounts.filter(
+        (account) =>
+          !account.isArchived &&
+          CASH_ACCOUNT_TYPES.has(account.type) &&
+          matchesWorkspaceSelection(account.purpose, workspaceFilter),
+      ),
+    [accounts, workspaceFilter],
+  );
+
   const upcomingBills = useMemo(
-    () => bills.filter((bill) => bill.status === 'UPCOMING' || bill.status === 'OVERDUE'),
-    [bills],
+    () =>
+      bills.filter(
+        (bill) =>
+          (bill.status === 'UPCOMING' || bill.status === 'OVERDUE') &&
+          matchesWorkspaceSelection(
+            bill.accountId ? accountPurposeById.get(bill.accountId) : undefined,
+            workspaceFilter,
+          ),
+      ),
+    [bills, accountPurposeById, workspaceFilter],
+  );
+
+  // Invoices are business receivables, so they only belong to the business and
+  // combined workspaces — never the personal one (#3242).
+  const scopedInvoices = useMemo(
+    () => (workspaceFilter === 'personal' ? [] : invoices),
+    [invoices, workspaceFilter],
+  );
+
+  // Recurring supplier remittances are scheduled business outflows. Project each
+  // occurrence within the forecast horizon so the runway reflects them (#3244);
+  // like invoices they are excluded from the personal workspace (#3242).
+  const horizonEndIso = useMemo(() => {
+    const end = new Date(`${today}T00:00:00.000Z`);
+    end.setUTCDate(end.getUTCDate() + horizonWeeks * 7);
+    return end.toISOString().slice(0, 10);
+  }, [today, horizonWeeks]);
+
+  const upcomingRemittances = useMemo(
+    () =>
+      workspaceFilter === 'personal'
+        ? []
+        : projectUpcomingRemittances(remittances, today, horizonEndIso),
+    [remittances, today, horizonEndIso, workspaceFilter],
   );
 
   // Convert every currency-bearing forecast input into the user's display
@@ -109,8 +163,18 @@ export function CashRunwayPage() {
         currency: bill.currency.code,
       });
     }
+    // Recurring remittances carry their own source currency and minor units, so
+    // they must be converted into the display currency before being summed into
+    // the forecast — exactly like account balances and bills (#3244).
+    for (const occurrence of upcomingRemittances) {
+      amounts.push({
+        id: `remit:${occurrence.record.id}:${occurrence.date}`,
+        amountCents: occurrence.totalPaidMinor,
+        currency: occurrence.record.sourceCurrency,
+      });
+    }
     return amounts;
-  }, [cashAccounts, upcomingBills]);
+  }, [cashAccounts, upcomingBills, upcomingRemittances]);
 
   const {
     rollup,
@@ -156,7 +220,7 @@ export function CashRunwayPage() {
       ];
     });
 
-    const invoiceEvents = invoices
+    const invoiceEvents = scopedInvoices
       .filter((invoice) => invoice.status === 'Sent' || invoice.status === 'Overdue')
       .map<ScheduledCashEvent>((invoice) => ({
         id: `invoice:${invoice.id}`,
@@ -168,8 +232,29 @@ export function CashRunwayPage() {
         category: 'Expected payment',
       }));
 
-    return [...billEvents, ...invoiceEvents];
-  }, [upcomingBills, invoices, today, convertedById]);
+    // Each projected remittance occurrence is already a concrete dated outflow,
+    // so it is emitted as a one-off event (the recurrence was expanded during
+    // projection) to avoid double-counting inside the forecaster (#3244).
+    const remittanceEvents = upcomingRemittances.flatMap<ScheduledCashEvent>((occurrence) => {
+      const amountCents = convertedById.get(
+        `remit:${occurrence.record.id}:${occurrence.date}`,
+      );
+      if (amountCents === undefined) return [];
+      return [
+        {
+          id: `remit:${occurrence.record.id}:${occurrence.date}`,
+          label: occurrence.record.recipient.name,
+          direction: 'outflow',
+          amountCents,
+          date: notBefore(occurrence.date, today),
+          frequency: 'once',
+          category: 'Supplier remittance',
+        },
+      ];
+    });
+
+    return [...billEvents, ...invoiceEvents, ...remittanceEvents];
+  }, [upcomingBills, scopedInvoices, upcomingRemittances, today, convertedById]);
 
   const forecast = useMemo(
     () => forecastCashRunway({ startingCashCents, events, horizonWeeks, today }),
@@ -247,6 +332,16 @@ export function CashRunwayPage() {
               </option>
             ))}
           </select>
+        </div>
+        <div className="cash-runway__field">
+          <span className="cash-runway__label" id="cash-runway-workspace-label">
+            Workspace
+          </span>
+          <AccountPurposeFilterControl
+            value={workspaceFilter}
+            onChange={setWorkspaceFilter}
+            label="Filter cash runway by workspace"
+          />
         </div>
       </section>
 

--- a/apps/web/src/pages/CashRunwayPage.tsx
+++ b/apps/web/src/pages/CashRunwayPage.tsx
@@ -31,10 +31,7 @@ import { useLocalePreferences } from '../hooks/useLocalePreferences';
 import { useReducedMotion } from '../hooks/useReducedMotion';
 import { useRemittances } from '../hooks/useRemittances';
 import { formatCurrency } from '../lib/currency';
-import {
-  matchesWorkspaceSelection,
-  type AccountPurposeFilter,
-} from '../lib/accountPurpose';
+import { matchesWorkspaceSelection, type AccountPurposeFilter } from '../lib/accountPurpose';
 import { projectUpcomingRemittances } from '../lib/remittance';
 import type { DisplayCurrencyAmount } from '../lib/budgeting/display-currency-rollups';
 import {
@@ -236,9 +233,7 @@ export function CashRunwayPage() {
     // so it is emitted as a one-off event (the recurrence was expanded during
     // projection) to avoid double-counting inside the forecaster (#3244).
     const remittanceEvents = upcomingRemittances.flatMap<ScheduledCashEvent>((occurrence) => {
-      const amountCents = convertedById.get(
-        `remit:${occurrence.record.id}:${occurrence.date}`,
-      );
+      const amountCents = convertedById.get(`remit:${occurrence.record.id}:${occurrence.date}`);
       if (amountCents === undefined) return [];
       return [
         {

--- a/apps/web/src/pages/ExpectedIncomePage.test.tsx
+++ b/apps/web/src/pages/ExpectedIncomePage.test.tsx
@@ -153,6 +153,7 @@ describe('ExpectedIncomePage', () => {
         id: 'inv-1',
         clientName: 'Studio Delacroix',
         amountCents: 120000,
+        currency: 'USD',
         issueDate: '2099-01-01',
         paymentTerm: 'net-30',
         status: 'Sent',

--- a/apps/web/src/pages/InvestmentDetailPage.test.tsx
+++ b/apps/web/src/pages/InvestmentDetailPage.test.tsx
@@ -134,4 +134,45 @@ describe('InvestmentDetailPage', () => {
 
     expect(screen.getByText('Database error')).toBeInTheDocument();
   });
+
+  it('renders a per-lot tax-lot breakdown with holding-period classification (#3270)', () => {
+    const lots = [
+      {
+        id: 'lot-long',
+        investmentId: 'inv-1',
+        purchaseDate: '2020-01-01',
+        shares: 4,
+        costPerShare: { amount: 10000 },
+        totalCost: { amount: 40000 },
+        ...syncMetadata,
+      },
+      {
+        id: 'lot-short',
+        investmentId: 'inv-1',
+        purchaseDate: new Date().toISOString().slice(0, 10),
+        shares: 6,
+        costPerShare: { amount: 18000 },
+        totalCost: { amount: 108000 },
+        ...syncMetadata,
+      },
+    ];
+    mockedUseInvestments.mockReturnValue({
+      ...baseMockReturn,
+      getLots: vi.fn().mockReturnValue(lots),
+    });
+
+    renderWithRoute('inv-1');
+
+    expect(screen.getByRole('table', { name: 'Tax lots breakdown' })).toBeInTheDocument();
+    expect(screen.getByText('Long-term')).toBeInTheDocument();
+    expect(screen.getByText('Short-term')).toBeInTheDocument();
+  });
+
+  it('shows a fallback note when a holding has no recorded tax lots (#3270)', () => {
+    renderWithRoute('inv-1');
+
+    expect(
+      screen.getByText(/No individual tax lots are recorded for this holding/),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/InvestmentDetailPage.tsx
+++ b/apps/web/src/pages/InvestmentDetailPage.tsx
@@ -12,6 +12,7 @@ import { Link, useParams } from 'react-router-dom';
 import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { useInvestments } from '../hooks';
 import { formatGainLoss } from '../lib/currency';
+import { computeAllLotGainLoss } from '../lib/investment/cost-basis';
 import { getCurrentLocale } from '../lib/i18n';
 import type { InvestmentType } from '../kmp/bridge';
 
@@ -30,7 +31,7 @@ const TYPE_LABELS: Record<InvestmentType, string> = {
 /** Investment detail page component. */
 export const InvestmentDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
-  const { investments, loading, error, refresh } = useInvestments();
+  const { investments, loading, error, refresh, getLots } = useInvestments();
 
   const investment = investments.find((inv) => inv.id === id) ?? null;
 
@@ -64,6 +65,12 @@ export const InvestmentDetailPage: React.FC = () => {
   const gainLoss = marketValue - costBasis;
   const gainLossPercent = costBasis > 0 ? Math.round((gainLoss / costBasis) * 10000) / 100 : 0;
   const isPositive = gainLoss >= 0;
+
+  // Per-lot cost-basis and holding-period breakdown for tax-lot planning (#3270).
+  const lots = getLots(investment.id);
+  const lotGainLoss = computeAllLotGainLoss(lots, investment.currentPricePerShare.amount);
+  const hasLots = lotGainLoss.length > 0;
+  const locale = getCurrentLocale();
 
   return (
     <>
@@ -194,6 +201,188 @@ export const InvestmentDetailPage: React.FC = () => {
               ? `This holding is up ${gainLossPercent}% from your purchase price.`
               : `This holding is down ${Math.abs(gainLossPercent)}% from your purchase price.`}
           </p>
+        </div>
+      </section>
+
+      {/* Tax lots (#3270) */}
+      <section className="page-section" aria-label="Tax lots">
+        <div className="card" style={{ marginBottom: 'var(--spacing-6)' }}>
+          <h3
+            style={{
+              fontWeight: 'var(--font-weight-semibold)',
+              marginBottom: 'var(--spacing-2)',
+            }}
+          >
+            Tax lots
+          </h3>
+          <p
+            style={{
+              marginTop: 0,
+              marginBottom: 'var(--spacing-4)',
+              fontSize: 'var(--type-scale-caption-font-size)',
+              color: 'var(--semantic-text-secondary)',
+            }}
+          >
+            Per-lot cost basis and holding period. Lots held longer than one year
+            qualify for long-term capital-gains treatment.
+          </p>
+          {hasLots ? (
+            <div style={{ overflowX: 'auto' }}>
+              <table
+                style={{ width: '100%', borderCollapse: 'collapse' }}
+                aria-label="Tax lots breakdown"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      scope="col"
+                      style={{
+                        textAlign: 'left',
+                        padding: 'var(--spacing-3)',
+                        borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
+                      }}
+                    >
+                      Purchase Date
+                    </th>
+                    <th
+                      scope="col"
+                      style={{
+                        textAlign: 'right',
+                        padding: 'var(--spacing-3)',
+                        borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
+                      }}
+                    >
+                      Shares
+                    </th>
+                    <th
+                      scope="col"
+                      style={{
+                        textAlign: 'right',
+                        padding: 'var(--spacing-3)',
+                        borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
+                      }}
+                    >
+                      Cost/Share
+                    </th>
+                    <th
+                      scope="col"
+                      style={{
+                        textAlign: 'right',
+                        padding: 'var(--spacing-3)',
+                        borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
+                      }}
+                    >
+                      Cost Basis
+                    </th>
+                    <th
+                      scope="col"
+                      style={{
+                        textAlign: 'right',
+                        padding: 'var(--spacing-3)',
+                        borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
+                      }}
+                    >
+                      Market Value
+                    </th>
+                    <th
+                      scope="col"
+                      style={{
+                        textAlign: 'right',
+                        padding: 'var(--spacing-3)',
+                        borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
+                      }}
+                    >
+                      Unrealized G/L
+                    </th>
+                    <th
+                      scope="col"
+                      style={{
+                        textAlign: 'left',
+                        padding: 'var(--spacing-3)',
+                        borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
+                      }}
+                    >
+                      Holding Period
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lotGainLoss.map(({ lot, marketValue: lotValue, unrealizedGainLoss, unrealizedGainLossPercent, isLongTerm, daysHeld }) => (
+                    <tr
+                      key={lot.id}
+                      style={{
+                        borderBottom: '1px solid var(--semantic-border-default, #e5e7eb)',
+                      }}
+                    >
+                      <td style={{ padding: 'var(--spacing-3)' }}>
+                        {new Date(`${lot.purchaseDate}T00:00:00Z`).toLocaleDateString(locale, {
+                          year: 'numeric',
+                          month: 'short',
+                          day: 'numeric',
+                          timeZone: 'UTC',
+                        })}
+                      </td>
+                      <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
+                        {lot.shares.toLocaleString(undefined, { maximumFractionDigits: 4 })}
+                      </td>
+                      <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
+                        <CurrencyDisplay
+                          amount={lot.costPerShare.amount}
+                          currency={investment.currency.code}
+                        />
+                      </td>
+                      <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
+                        <CurrencyDisplay
+                          amount={lot.totalCost.amount}
+                          currency={investment.currency.code}
+                        />
+                      </td>
+                      <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
+                        <CurrencyDisplay amount={lotValue} currency={investment.currency.code} />
+                      </td>
+                      <td
+                        style={{
+                          padding: 'var(--spacing-3)',
+                          textAlign: 'right',
+                          color:
+                            unrealizedGainLoss >= 0
+                              ? 'var(--semantic-positive, #059669)'
+                              : 'var(--semantic-negative, #dc2626)',
+                        }}
+                      >
+                        {formatGainLoss(unrealizedGainLoss)} ({unrealizedGainLossPercent}%)
+                      </td>
+                      <td style={{ padding: 'var(--spacing-3)' }}>
+                        <span
+                          style={{
+                            fontSize: 'var(--type-scale-caption-font-size)',
+                            padding: 'var(--spacing-1) var(--spacing-2)',
+                            borderRadius: 'var(--radius-sm, 4px)',
+                            backgroundColor: 'var(--semantic-background-secondary, #f3f4f6)',
+                          }}
+                        >
+                          {isLongTerm ? 'Long-term' : 'Short-term'}
+                        </span>{' '}
+                        <span
+                          style={{
+                            fontSize: 'var(--type-scale-caption-font-size)',
+                            color: 'var(--semantic-text-secondary)',
+                          }}
+                        >
+                          {daysHeld.toLocaleString()} days
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p style={{ margin: 0, color: 'var(--semantic-text-secondary)' }}>
+              No individual tax lots are recorded for this holding. The position-level
+              cost basis above is used for gain/loss.
+            </p>
+          )}
         </div>
       </section>
 

--- a/apps/web/src/pages/InvestmentDetailPage.tsx
+++ b/apps/web/src/pages/InvestmentDetailPage.tsx
@@ -223,8 +223,8 @@ export const InvestmentDetailPage: React.FC = () => {
               color: 'var(--semantic-text-secondary)',
             }}
           >
-            Per-lot cost basis and holding period. Lots held longer than one year
-            qualify for long-term capital-gains treatment.
+            Per-lot cost basis and holding period. Lots held longer than one year qualify for
+            long-term capital-gains treatment.
           </p>
           {hasLots ? (
             <div style={{ overflowX: 'auto' }}>
@@ -307,80 +307,89 @@ export const InvestmentDetailPage: React.FC = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {lotGainLoss.map(({ lot, marketValue: lotValue, unrealizedGainLoss, unrealizedGainLossPercent, isLongTerm, daysHeld }) => (
-                    <tr
-                      key={lot.id}
-                      style={{
-                        borderBottom: '1px solid var(--semantic-border-default, #e5e7eb)',
-                      }}
-                    >
-                      <td style={{ padding: 'var(--spacing-3)' }}>
-                        {new Date(`${lot.purchaseDate}T00:00:00Z`).toLocaleDateString(locale, {
-                          year: 'numeric',
-                          month: 'short',
-                          day: 'numeric',
-                          timeZone: 'UTC',
-                        })}
-                      </td>
-                      <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
-                        {lot.shares.toLocaleString(undefined, { maximumFractionDigits: 4 })}
-                      </td>
-                      <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
-                        <CurrencyDisplay
-                          amount={lot.costPerShare.amount}
-                          currency={investment.currency.code}
-                        />
-                      </td>
-                      <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
-                        <CurrencyDisplay
-                          amount={lot.totalCost.amount}
-                          currency={investment.currency.code}
-                        />
-                      </td>
-                      <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
-                        <CurrencyDisplay amount={lotValue} currency={investment.currency.code} />
-                      </td>
-                      <td
+                  {lotGainLoss.map(
+                    ({
+                      lot,
+                      marketValue: lotValue,
+                      unrealizedGainLoss,
+                      unrealizedGainLossPercent,
+                      isLongTerm,
+                      daysHeld,
+                    }) => (
+                      <tr
+                        key={lot.id}
                         style={{
-                          padding: 'var(--spacing-3)',
-                          textAlign: 'right',
-                          color:
-                            unrealizedGainLoss >= 0
-                              ? 'var(--semantic-positive, #059669)'
-                              : 'var(--semantic-negative, #dc2626)',
+                          borderBottom: '1px solid var(--semantic-border-default, #e5e7eb)',
                         }}
                       >
-                        {formatGainLoss(unrealizedGainLoss)} ({unrealizedGainLossPercent}%)
-                      </td>
-                      <td style={{ padding: 'var(--spacing-3)' }}>
-                        <span
+                        <td style={{ padding: 'var(--spacing-3)' }}>
+                          {new Date(`${lot.purchaseDate}T00:00:00Z`).toLocaleDateString(locale, {
+                            year: 'numeric',
+                            month: 'short',
+                            day: 'numeric',
+                            timeZone: 'UTC',
+                          })}
+                        </td>
+                        <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
+                          {lot.shares.toLocaleString(undefined, { maximumFractionDigits: 4 })}
+                        </td>
+                        <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
+                          <CurrencyDisplay
+                            amount={lot.costPerShare.amount}
+                            currency={investment.currency.code}
+                          />
+                        </td>
+                        <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
+                          <CurrencyDisplay
+                            amount={lot.totalCost.amount}
+                            currency={investment.currency.code}
+                          />
+                        </td>
+                        <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
+                          <CurrencyDisplay amount={lotValue} currency={investment.currency.code} />
+                        </td>
+                        <td
                           style={{
-                            fontSize: 'var(--type-scale-caption-font-size)',
-                            padding: 'var(--spacing-1) var(--spacing-2)',
-                            borderRadius: 'var(--radius-sm, 4px)',
-                            backgroundColor: 'var(--semantic-background-secondary, #f3f4f6)',
+                            padding: 'var(--spacing-3)',
+                            textAlign: 'right',
+                            color:
+                              unrealizedGainLoss >= 0
+                                ? 'var(--semantic-positive, #059669)'
+                                : 'var(--semantic-negative, #dc2626)',
                           }}
                         >
-                          {isLongTerm ? 'Long-term' : 'Short-term'}
-                        </span>{' '}
-                        <span
-                          style={{
-                            fontSize: 'var(--type-scale-caption-font-size)',
-                            color: 'var(--semantic-text-secondary)',
-                          }}
-                        >
-                          {daysHeld.toLocaleString()} days
-                        </span>
-                      </td>
-                    </tr>
-                  ))}
+                          {formatGainLoss(unrealizedGainLoss)} ({unrealizedGainLossPercent}%)
+                        </td>
+                        <td style={{ padding: 'var(--spacing-3)' }}>
+                          <span
+                            style={{
+                              fontSize: 'var(--type-scale-caption-font-size)',
+                              padding: 'var(--spacing-1) var(--spacing-2)',
+                              borderRadius: 'var(--radius-sm, 4px)',
+                              backgroundColor: 'var(--semantic-background-secondary, #f3f4f6)',
+                            }}
+                          >
+                            {isLongTerm ? 'Long-term' : 'Short-term'}
+                          </span>{' '}
+                          <span
+                            style={{
+                              fontSize: 'var(--type-scale-caption-font-size)',
+                              color: 'var(--semantic-text-secondary)',
+                            }}
+                          >
+                            {daysHeld.toLocaleString()} days
+                          </span>
+                        </td>
+                      </tr>
+                    ),
+                  )}
                 </tbody>
               </table>
             </div>
           ) : (
             <p style={{ margin: 0, color: 'var(--semantic-text-secondary)' }}>
-              No individual tax lots are recorded for this holding. The position-level
-              cost basis above is used for gain/loss.
+              No individual tax lots are recorded for this holding. The position-level cost basis
+              above is used for gain/loss.
             </p>
           )}
         </div>

--- a/apps/web/src/pages/InvestmentsPage.test.tsx
+++ b/apps/web/src/pages/InvestmentsPage.test.tsx
@@ -116,7 +116,9 @@ describe('InvestmentsPage', () => {
   beforeEach(() => {
     window.localStorage.clear();
     mockedUseInvestments.mockReturnValue(baseMockReturn);
-    mockedUseAccounts.mockReturnValue({ accounts: [] } as unknown as ReturnType<typeof useAccounts>);
+    mockedUseAccounts.mockReturnValue({ accounts: [] } as unknown as ReturnType<
+      typeof useAccounts
+    >);
   });
 
   it('exposes a labelled read-aloud control for total portfolio value when "Read amounts aloud" is enabled (#3278)', () => {
@@ -311,9 +313,7 @@ describe('InvestmentsPage', () => {
 
   it('attributes holdings to their owning account/brokerage (#3262)', () => {
     mockedUseAccounts.mockReturnValue({
-      accounts: [
-        { id: 'account-1', name: 'Fidelity Brokerage' },
-      ],
+      accounts: [{ id: 'account-1', name: 'Fidelity Brokerage' }],
     } as unknown as ReturnType<typeof useAccounts>);
 
     render(

--- a/apps/web/src/pages/InvestmentsPage.test.tsx
+++ b/apps/web/src/pages/InvestmentsPage.test.tsx
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
-import { useInvestments } from '../hooks';
+import { useInvestments, useAccounts } from '../hooks';
 import { InvestmentsPage } from './InvestmentsPage';
 import { AccessibilityProvider } from '../contexts/AccessibilityContext';
 
 vi.mock('../hooks', () => ({
   useInvestments: vi.fn(),
+  useAccounts: vi.fn(() => ({ accounts: [] })),
   useDisplayCurrency: vi.fn(() => ({
     displayCurrency: 'USD',
     setDisplayCurrency: vi.fn(),
@@ -35,6 +36,7 @@ vi.mock('recharts', () => ({
 }));
 
 const mockedUseInvestments = vi.mocked(useInvestments);
+const mockedUseAccounts = vi.mocked(useAccounts);
 
 const syncMetadata = {
   createdAt: '2025-01-01T00:00:00Z',
@@ -114,6 +116,7 @@ describe('InvestmentsPage', () => {
   beforeEach(() => {
     window.localStorage.clear();
     mockedUseInvestments.mockReturnValue(baseMockReturn);
+    mockedUseAccounts.mockReturnValue({ accounts: [] } as unknown as ReturnType<typeof useAccounts>);
   });
 
   it('exposes a labelled read-aloud control for total portfolio value when "Read amounts aloud" is enabled (#3278)', () => {
@@ -304,5 +307,49 @@ describe('InvestmentsPage', () => {
     );
 
     expect(screen.getByText('No investments yet')).toBeInTheDocument();
+  });
+
+  it('attributes holdings to their owning account/brokerage (#3262)', () => {
+    mockedUseAccounts.mockReturnValue({
+      accounts: [
+        { id: 'account-1', name: 'Fidelity Brokerage' },
+      ],
+    } as unknown as ReturnType<typeof useAccounts>);
+
+    render(
+      <MemoryRouter>
+        <InvestmentsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('columnheader', { name: 'Account' })).toBeInTheDocument();
+    expect(screen.getAllByText('Fidelity Brokerage').length).toBeGreaterThan(0);
+  });
+
+  it('rolls holdings up across accounts when grouping by symbol (#3262)', () => {
+    mockedUseInvestments.mockReturnValue({
+      ...baseMockReturn,
+      investments: [
+        { ...mockInvestments[0], id: 'inv-1', accountId: 'account-1' },
+        { ...mockInvestments[0], id: 'inv-3', accountId: 'account-2' },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <InvestmentsPage />
+      </MemoryRouter>,
+    );
+
+    // Two AAPL positions in separate accounts render as two detail rows first.
+    expect(screen.getAllByTestId('holding-row')).toHaveLength(2);
+
+    fireEvent.click(screen.getByLabelText(/group by symbol/i));
+
+    // After rolling up, a single consolidated AAPL line remains.
+    const rows = screen.getAllByTestId('holding-row');
+    expect(rows).toHaveLength(1);
+    expect(screen.getByRole('columnheader', { name: 'Accounts' })).toBeInTheDocument();
+    expect(screen.getByText('2 accounts')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/InvestmentsPage.tsx
+++ b/apps/web/src/pages/InvestmentsPage.tsx
@@ -252,8 +252,7 @@ export const InvestmentsPage: React.FC = () => {
             name: inv.name,
             iconName: getInvestmentIcon(inv.type),
             typeLabel: TYPE_LABELS[inv.type],
-            accountLabel:
-              (inv.accountId && accountNameById.get(inv.accountId)) || 'Unassigned',
+            accountLabel: (inv.accountId && accountNameById.get(inv.accountId)) || 'Unassigned',
             shares: inv.shares,
             pricePerShareCents: inv.currentPricePerShare.amount,
             currencyCode: inv.currency.code,

--- a/apps/web/src/pages/InvestmentsPage.tsx
+++ b/apps/web/src/pages/InvestmentsPage.tsx
@@ -8,7 +8,6 @@
  */
 
 import React, { lazy, Suspense, useCallback, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import {
   CurrencyDisplay,
@@ -17,7 +16,6 @@ import {
   ExplainThis,
   LoadingSpinner,
   ReadAloudButton,
-  ScrollableRegion,
 } from '../components/common';
 import { DataExport } from '../components/DataExport';
 import {
@@ -26,10 +24,16 @@ import {
 } from '../components/investments/InvestingBetaFeatures';
 import { InvestmentProjections } from '../components/investments/InvestmentProjections';
 import { DeFiPositionsCard } from '../components/investments/DeFiPositionsCard';
-import { useInvestments } from '../hooks';
+import { useAccounts, useInvestments } from '../hooks';
 import { formatCurrency, formatGainLoss } from '../lib/currency';
 import type { Investment, InvestmentType } from '../kmp/bridge';
-import { AppIcon, type IconName } from '../components/icons';
+import type { IconName } from '../components/icons';
+import {
+  HoldingsTable,
+  type HoldingRow,
+  type HoldingsSortField,
+} from '../components/investments/HoldingsTable';
+import { rollUpHoldingsBySymbol } from '../lib/investment/holdings-rollup';
 import type {
   InvestmentIncomeExportInput,
   InvestmentRealizedGainExportInput,
@@ -140,8 +144,18 @@ export const InvestmentsPage: React.FC = () => {
     dividends?: readonly InvestmentIncomeExportInput[];
     income?: readonly InvestmentIncomeExportInput[];
   };
-  const [sortField, setSortField] = useState<'symbol' | 'value' | 'gainLoss'>('symbol');
+  const { accounts } = useAccounts();
+  const [sortField, setSortField] = useState<HoldingsSortField>('symbol');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  const [groupBySymbol, setGroupBySymbol] = useState(false);
+
+  const accountNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const account of accounts) {
+      map.set(account.id, account.name);
+    }
+    return map;
+  }, [accounts]);
 
   const allocation = computeAllocation(investments);
   const investmentLots = useMemo(
@@ -175,7 +189,7 @@ export const InvestmentsPage: React.FC = () => {
   );
 
   const handleSort = useCallback(
-    (field: 'symbol' | 'value' | 'gainLoss') => {
+    (field: HoldingsSortField) => {
       if (sortField === field) {
         setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
       } else {
@@ -186,27 +200,82 @@ export const InvestmentsPage: React.FC = () => {
     [sortField],
   );
 
-  const sortedInvestments = [...investments].sort((a, b) => {
+  // Build normalized, render-ready holdings rows — either per-account detail
+  // rows (#3262 attribution) or symbol roll-up lines (#3262 cross-account
+  // roll-up) — then sort them by the active column.
+  const holdingRows = useMemo<HoldingRow[]>(() => {
     const dir = sortDirection === 'asc' ? 1 : -1;
-    switch (sortField) {
-      case 'symbol':
-        return a.symbol.localeCompare(b.symbol) * dir;
-      case 'value': {
-        const aVal = a.shares * a.currentPricePerShare.amount;
-        const bVal = b.shares * b.currentPricePerShare.amount;
-        return (aVal - bVal) * dir;
-      }
-      case 'gainLoss': {
-        const aGain = a.shares * (a.currentPricePerShare.amount - a.costBasisPerShare.amount);
-        const bGain = b.shares * (b.currentPricePerShare.amount - b.costBasisPerShare.amount);
-        return (aGain - bGain) * dir;
-      }
-      default:
-        return 0;
-    }
-  });
 
-  const sortArrow = sortDirection === 'asc' ? ' ↑' : ' ↓';
+    const rows: HoldingRow[] = groupBySymbol
+      ? rollUpHoldingsBySymbol(
+          investments.map((inv) => ({
+            id: inv.id,
+            symbol: inv.symbol,
+            name: inv.name,
+            shares: inv.shares,
+            currentPricePerShareCents: inv.currentPricePerShare.amount,
+            costBasisPerShareCents: inv.costBasisPerShare.amount,
+            currencyCode: inv.currency.code,
+            accountId: inv.accountId,
+          })),
+        ).map((line): HoldingRow => {
+          const firstMatch = investments.find(
+            (inv) => inv.symbol.trim().toUpperCase() === line.symbol,
+          );
+          const accountLabel =
+            line.accountCount === 1 ? '1 account' : `${line.accountCount} accounts`;
+          return {
+            key: `${line.symbol}|${line.currencyCode}`,
+            symbol: line.symbol,
+            name: line.name,
+            iconName: firstMatch ? getInvestmentIcon(firstMatch.type) : 'wallet',
+            typeLabel: firstMatch ? TYPE_LABELS[firstMatch.type] : '—',
+            accountLabel,
+            shares: line.totalShares,
+            pricePerShareCents: null,
+            currencyCode: line.currencyCode,
+            marketValueCents: line.marketValueCents,
+            gainLossCents: line.gainLossCents,
+            gainLossPercent: line.gainLossPercent,
+          };
+        })
+      : investments.map((inv): HoldingRow => {
+          const marketValue = Math.round(inv.shares * inv.currentPricePerShare.amount);
+          const costBasis = Math.round(inv.shares * inv.costBasisPerShare.amount);
+          const gainLoss = marketValue - costBasis;
+          const gainLossPercent =
+            costBasis > 0 ? Math.round((gainLoss / costBasis) * 10000) / 100 : 0;
+          return {
+            key: inv.id,
+            to: `/investments/${inv.id}`,
+            symbol: inv.symbol,
+            name: inv.name,
+            iconName: getInvestmentIcon(inv.type),
+            typeLabel: TYPE_LABELS[inv.type],
+            accountLabel:
+              (inv.accountId && accountNameById.get(inv.accountId)) || 'Unassigned',
+            shares: inv.shares,
+            pricePerShareCents: inv.currentPricePerShare.amount,
+            currencyCode: inv.currency.code,
+            marketValueCents: marketValue,
+            gainLossCents: gainLoss,
+            gainLossPercent,
+          };
+        });
+
+    return rows.sort((a, b) => {
+      switch (sortField) {
+        case 'symbol':
+          return a.symbol.localeCompare(b.symbol) * dir;
+        case 'value':
+          return (a.marketValueCents - b.marketValueCents) * dir;
+        case 'gainLoss':
+          return (a.gainLossCents - b.gainLossCents) * dir;
+        default:
+          return 0;
+      }
+    });
+  }, [investments, groupBySymbol, sortField, sortDirection, accountNameById]);
 
   return (
     <>
@@ -421,190 +490,37 @@ export const InvestmentsPage: React.FC = () => {
 
           <section aria-label="Investment holdings">
             <div className="card">
-              <ScrollableRegion label="Investment holdings">
-                <table
-                  style={{ width: '100%', borderCollapse: 'collapse' }}
-                  aria-label="Investment holdings table"
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'flex-end',
+                  marginBottom: 'var(--spacing-3)',
+                }}
+              >
+                <label
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 'var(--spacing-2)',
+                    cursor: 'pointer',
+                    fontSize: 'var(--type-scale-body-font-size)',
+                  }}
                 >
-                  <thead>
-                    <tr>
-                      <th
-                        scope="col"
-                        style={{
-                          textAlign: 'left',
-                          padding: 'var(--spacing-3)',
-                          cursor: 'pointer',
-                          borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
-                          userSelect: 'none',
-                        }}
-                      >
-                        <button
-                          type="button"
-                          onClick={() => handleSort('symbol')}
-                          aria-label={`Sort by symbol${sortField === 'symbol' ? sortArrow : ''}`}
-                          style={{
-                            background: 'none',
-                            border: 'none',
-                            cursor: 'pointer',
-                            font: 'inherit',
-                            color: 'inherit',
-                            padding: 0,
-                          }}
-                        >
-                          Symbol{sortField === 'symbol' ? sortArrow : ''}
-                        </button>
-                      </th>
-                      <th
-                        scope="col"
-                        style={{
-                          textAlign: 'left',
-                          padding: 'var(--spacing-3)',
-                          borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
-                        }}
-                      >
-                        Type
-                      </th>
-                      <th
-                        scope="col"
-                        style={{
-                          textAlign: 'right',
-                          padding: 'var(--spacing-3)',
-                          borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
-                        }}
-                      >
-                        Shares
-                      </th>
-                      <th
-                        scope="col"
-                        style={{
-                          textAlign: 'right',
-                          padding: 'var(--spacing-3)',
-                          borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
-                        }}
-                      >
-                        Price
-                      </th>
-                      <th
-                        scope="col"
-                        style={{
-                          textAlign: 'right',
-                          padding: 'var(--spacing-3)',
-                          cursor: 'pointer',
-                          borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
-                          userSelect: 'none',
-                        }}
-                      >
-                        <button
-                          type="button"
-                          onClick={() => handleSort('value')}
-                          aria-label={`Sort by market value${sortField === 'value' ? sortArrow : ''}`}
-                          style={{
-                            background: 'none',
-                            border: 'none',
-                            cursor: 'pointer',
-                            font: 'inherit',
-                            color: 'inherit',
-                            padding: 0,
-                          }}
-                        >
-                          Market Value{sortField === 'value' ? sortArrow : ''}
-                        </button>
-                      </th>
-                      <th
-                        scope="col"
-                        style={{
-                          textAlign: 'right',
-                          padding: 'var(--spacing-3)',
-                          cursor: 'pointer',
-                          borderBottom: '2px solid var(--semantic-border-default, #e5e7eb)',
-                          userSelect: 'none',
-                        }}
-                      >
-                        <button
-                          type="button"
-                          onClick={() => handleSort('gainLoss')}
-                          aria-label={`Sort by gain/loss${sortField === 'gainLoss' ? sortArrow : ''}`}
-                          style={{
-                            background: 'none',
-                            border: 'none',
-                            cursor: 'pointer',
-                            font: 'inherit',
-                            color: 'inherit',
-                            padding: 0,
-                          }}
-                        >
-                          Gain/Loss{sortField === 'gainLoss' ? sortArrow : ''}
-                        </button>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedInvestments.map((inv) => {
-                      const marketValue = Math.round(inv.shares * inv.currentPricePerShare.amount);
-                      const costBasis = Math.round(inv.shares * inv.costBasisPerShare.amount);
-                      const gainLoss = marketValue - costBasis;
-                      const gainLossPercent =
-                        costBasis > 0 ? Math.round((gainLoss / costBasis) * 10000) / 100 : 0;
-
-                      return (
-                        <tr
-                          key={inv.id}
-                          style={{
-                            borderBottom: '1px solid var(--semantic-border-default, #e5e7eb)',
-                          }}
-                        >
-                          <td style={{ padding: 'var(--spacing-3)' }}>
-                            <Link
-                              to={`/investments/${inv.id}`}
-                              style={{ textDecoration: 'none', color: 'inherit' }}
-                              aria-label={`View details for ${inv.name} (${inv.symbol})`}
-                            >
-                              <AppIcon name={getInvestmentIcon(inv.type)} />{' '}
-                              <strong>{inv.symbol}</strong>
-                              <br />
-                              <span
-                                style={{
-                                  fontSize: 'var(--type-scale-caption-font-size)',
-                                  color: 'var(--semantic-text-secondary)',
-                                }}
-                              >
-                                {inv.name}
-                              </span>
-                            </Link>
-                          </td>
-                          <td style={{ padding: 'var(--spacing-3)' }}>{TYPE_LABELS[inv.type]}</td>
-                          <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
-                            {inv.shares.toLocaleString(undefined, {
-                              maximumFractionDigits: 4,
-                            })}
-                          </td>
-                          <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
-                            <CurrencyDisplay
-                              amount={inv.currentPricePerShare.amount}
-                              currency={inv.currency.code}
-                            />
-                          </td>
-                          <td style={{ padding: 'var(--spacing-3)', textAlign: 'right' }}>
-                            <CurrencyDisplay amount={marketValue} currency={inv.currency.code} />
-                          </td>
-                          <td
-                            style={{
-                              padding: 'var(--spacing-3)',
-                              textAlign: 'right',
-                              color:
-                                gainLoss >= 0
-                                  ? 'var(--semantic-positive, #059669)'
-                                  : 'var(--semantic-negative, #dc2626)',
-                            }}
-                          >
-                            {formatGainLoss(gainLoss)} ({gainLossPercent}%)
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </ScrollableRegion>
+                  <input
+                    type="checkbox"
+                    checked={groupBySymbol}
+                    onChange={(e) => setGroupBySymbol(e.target.checked)}
+                  />
+                  Group by symbol (roll up across accounts)
+                </label>
+              </div>
+              <HoldingsTable
+                rows={holdingRows}
+                sortField={sortField}
+                sortDirection={sortDirection}
+                onSort={handleSort}
+                accountColumnLabel={groupBySymbol ? 'Accounts' : 'Account'}
+              />
             </div>
           </section>
         </>

--- a/apps/web/src/pages/InvoicesPage.test.tsx
+++ b/apps/web/src/pages/InvoicesPage.test.tsx
@@ -81,6 +81,7 @@ const SAMPLE_INVOICE: Invoice = {
   id: 'inv-1',
   clientName: 'Etsy Wholesale',
   amountCents: 120_000,
+  currency: 'USD',
   issueDate: '2026-06-01',
   paymentTerm: 'net-30',
   status: 'Sent',

--- a/apps/web/src/pages/InvoicesPage.tsx
+++ b/apps/web/src/pages/InvoicesPage.tsx
@@ -19,6 +19,7 @@ import { useTransactions } from '../hooks/useTransactions';
 import {
   buildInvoiceCashInflow,
   computeExpectedPayDate,
+  DEFAULT_INVOICE_CURRENCY,
   exportInvoicesCsv,
   FOLLOW_UP_STALE_DAYS,
   getInvoicesNeedingFollowUp,
@@ -34,6 +35,7 @@ import {
 import { buildDatedExportFileName } from '../lib/export/simple-export';
 import { formatDate } from '../utils/formatDate';
 import { dollarsToCents } from '../lib/currency';
+import { SUPPORTED_CURRENCY_METADATA } from '../lib/currency-metadata';
 import './analytics.css';
 
 function todayIsoDate(): string {
@@ -87,19 +89,19 @@ const InvoiceCard: React.FC<{
           </p>
         </div>
         <div className="invoice-card__amount">
-          <CurrencyDisplay amount={invoice.amountCents} />
+          <CurrencyDisplay amount={invoice.amountCents} currency={invoice.currency} />
           <StatusBadge status={invoice.status} />
         </div>
       </div>
       {paidCents > 0 && (
         <p className="invoice-card__payment">
-          Paid <CurrencyDisplay amount={paidCents} /> of{' '}
-          <CurrencyDisplay amount={invoice.amountCents} /> ·{' '}
+          Paid <CurrencyDisplay amount={paidCents} currency={invoice.currency} /> of{' '}
+          <CurrencyDisplay amount={invoice.amountCents} currency={invoice.currency} /> ·{' '}
           {fullyPaid ? (
             'paid in full'
           ) : (
             <>
-              <CurrencyDisplay amount={outstandingCents} /> outstanding
+              <CurrencyDisplay amount={outstandingCents} currency={invoice.currency} /> outstanding
             </>
           )}
           {invoice.paidDate ? ` · last payment ${formatDate(invoice.paidDate, { locale })}` : ''}
@@ -169,6 +171,7 @@ export const InvoicesPage: React.FC = () => {
   const { locale } = useLocalePreferences();
   const [clientName, setClientName] = useState('');
   const [amount, setAmount] = useState('');
+  const [currency, setCurrency] = useState<string>(DEFAULT_INVOICE_CURRENCY);
   const [issueDate, setIssueDate] = useState(todayIsoDate);
   const [paymentTerm, setPaymentTerm] = useState<InvoicePaymentTerm>('net-30');
   const [status, setStatus] = useState<InvoiceStatus>('Sent');
@@ -181,6 +184,7 @@ export const InvoicesPage: React.FC = () => {
     setEditingInvoiceId(null);
     setClientName('');
     setAmount('');
+    setCurrency(DEFAULT_INVOICE_CURRENCY);
     setIssueDate(todayIsoDate());
     setPaymentTerm('net-30');
     setStatus('Sent');
@@ -191,6 +195,7 @@ export const InvoicesPage: React.FC = () => {
     setEditingInvoiceId(invoice.id);
     setClientName(invoice.clientName);
     setAmount((invoice.amountCents / 100).toString());
+    setCurrency(invoice.currency);
     setIssueDate(invoice.issueDate);
     setPaymentTerm(invoice.paymentTerm);
     setStatus(invoice.status);
@@ -299,9 +304,16 @@ export const InvoicesPage: React.FC = () => {
     }
 
     if (editingInvoiceId) {
-      updateInvoice(editingInvoiceId, { clientName, amountCents, issueDate, paymentTerm, status });
+      updateInvoice(editingInvoiceId, {
+        clientName,
+        amountCents,
+        currency,
+        issueDate,
+        paymentTerm,
+        status,
+      });
     } else {
-      addInvoice({ clientName, amountCents, issueDate, paymentTerm, status });
+      addInvoice({ clientName, amountCents, currency, issueDate, paymentTerm, status });
     }
     resetForm();
   };
@@ -365,6 +377,16 @@ export const InvoicesPage: React.FC = () => {
               placeholder="4200.00"
               required
             />
+          </label>
+          <label className="invoice-form__field">
+            Currency
+            <select value={currency} onChange={(event) => setCurrency(event.target.value)}>
+              {SUPPORTED_CURRENCY_METADATA.map((option) => (
+                <option key={option.code} value={option.code}>
+                  {option.code} — {option.label}
+                </option>
+              ))}
+            </select>
           </label>
           <label className="invoice-form__field">
             Issue date

--- a/apps/web/src/pages/RemittancesPage.test.tsx
+++ b/apps/web/src/pages/RemittancesPage.test.tsx
@@ -56,6 +56,7 @@ const SAMPLE_RECORD: RemittanceRecord = {
   recipient: { name: 'Familia García', country: 'MX' },
   note: null,
   createdAt: '2026-06-01T12:00:00.000Z',
+  recurrence: null,
 };
 
 describe('RemittancesPage', () => {
@@ -172,6 +173,7 @@ describe('RemittancesPage', () => {
       referenceRate: 17.5,
       recipient: { name: 'Familia García', country: 'MX' },
       note: null,
+      recurrence: null,
     });
   });
 

--- a/apps/web/src/pages/RemittancesPage.tsx
+++ b/apps/web/src/pages/RemittancesPage.tsx
@@ -25,11 +25,12 @@
  * References: issue #2170
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { useLocalePreferences } from '../hooks/useLocalePreferences';
 import { useRemittances } from '../hooks/useRemittances';
+import { useExchangeRates } from '../hooks/useExchangeRates';
 import { formatCurrency } from '../lib/currency';
 import { formatCurrencyGroup } from '../lib/currency-utils';
 import {
@@ -39,8 +40,18 @@ import {
 } from '../lib/currency-metadata';
 import { translate } from '../lib/i18n';
 import { normalizeNumberInput } from '../lib/i18n/local-currency-entry';
-import { quoteRemittance } from '../lib/remittance';
-import type { RemittanceFeeModel, RemittanceQuote, RemittanceRecord } from '../lib/remittance';
+import {
+  quoteRemittance,
+  projectUpcomingRemittances,
+  advanceRemittanceDate,
+  REMITTANCE_FREQUENCIES,
+} from '../lib/remittance';
+import type {
+  RemittanceFeeModel,
+  RemittanceFrequency,
+  RemittanceQuote,
+  RemittanceRecord,
+} from '../lib/remittance';
 import { formatDate } from '../utils/formatDate';
 import './remittances.css';
 
@@ -72,6 +83,11 @@ function formatRate(rate: number, locale: string): string {
     minimumFractionDigits: 2,
     maximumFractionDigits: 6,
   }).format(rate);
+}
+
+/** Plain (non-grouped) numeric string suitable for a `type="number"` input. */
+function rateInputValue(rate: number): string {
+  return String(Number(rate.toFixed(RATE_MAX_DECIMALS)));
 }
 
 function formatCountry(value: string, locale: string): string {
@@ -333,8 +349,51 @@ export const RemittancesPage: React.FC = () => {
   const [fxRate, setFxRate] = useState('');
   const [referenceRate, setReferenceRate] = useState('');
   const [note, setNote] = useState('');
+  const [recurrenceFrequency, setRecurrenceFrequency] = useState<'none' | RemittanceFrequency>(
+    'none',
+  );
+  const [recurrenceNextDate, setRecurrenceNextDate] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Mid-market reference rate from the exchange-rate service (base = source
+  // currency), used to prefill the FX/reference rate fields (#3296).
+  const { rates: fxRates } = useExchangeRates(sourceCurrency);
+  const midMarketRate =
+    sourceCurrency !== destCurrency ? (fxRates[destCurrency]?.rate ?? null) : null;
+
+  // Prefill the mid-market reference rate when the user has not typed one, so the
+  // FX-margin estimate is populated by default without clobbering manual input.
+  useEffect(() => {
+    if (midMarketRate && midMarketRate > 0) {
+      setReferenceRate((prev) => (prev.trim() ? prev : rateInputValue(midMarketRate)));
+    }
+  }, [midMarketRate]);
+
+  const applyMidMarketRate = useCallback(() => {
+    if (midMarketRate && midMarketRate > 0) {
+      const value = rateInputValue(midMarketRate);
+      setFxRate(value);
+      setReferenceRate(value);
+    }
+  }, [midMarketRate]);
+
+  // Project the next occurrence of each recurring remittance over the coming
+  // quarter so the sender can see scheduled outflows at a glance (#3265).
+  const upcomingRemittances = useMemo(() => {
+    const from = today();
+    const horizon = advanceRemittanceDate(from, 'quarterly');
+    const projected = projectUpcomingRemittances(remittances, from, horizon);
+    // One per recurring remittance (its next occurrence), soonest first.
+    const seen = new Set<string>();
+    const next: typeof projected = [];
+    for (const item of projected) {
+      if (seen.has(item.record.id)) continue;
+      seen.add(item.record.id);
+      next.push(item);
+    }
+    return next;
+  }, [remittances]);
 
   const parsedSendMinor = toMinor(sendAmount, sourceCurrency);
   const parsedFeeMinor = fee.trim() ? toMinor(fee, sourceCurrency) : 0;
@@ -425,6 +484,8 @@ export const RemittancesPage: React.FC = () => {
     setFxRate('');
     setReferenceRate('');
     setNote('');
+    setRecurrenceFrequency('none');
+    setRecurrenceNextDate('');
     setErrors({});
     setSubmitError(null);
   }, []);
@@ -449,6 +510,13 @@ export const RemittancesPage: React.FC = () => {
           parsedRef !== undefined && Number.isFinite(parsedRef) && parsedRef > 0 ? parsedRef : null,
         recipient: { name: recipientName.trim(), country: recipientCountry.trim() },
         note: note.trim() ? note.trim() : null,
+        recurrence:
+          recurrenceFrequency === 'none'
+            ? null
+            : {
+                frequency: recurrenceFrequency,
+                nextDate: recurrenceNextDate.trim() ? recurrenceNextDate : date,
+              },
       });
 
       if (!created) {
@@ -471,6 +539,8 @@ export const RemittancesPage: React.FC = () => {
       recipientName,
       recipientCountry,
       note,
+      recurrenceFrequency,
+      recurrenceNextDate,
       resetForm,
       t,
     ],
@@ -768,12 +838,70 @@ export const RemittancesPage: React.FC = () => {
               <p id="remit-reference-rate-help" className="remittance-field__help">
                 {t('remittance.form.referenceRate.help')}
               </p>
+              {midMarketRate && midMarketRate > 0 && (
+                <div className="remittance-field__prefill">
+                  <button
+                    type="button"
+                    className="remittance-field__prefill-button"
+                    onClick={applyMidMarketRate}
+                  >
+                    {t('remittance.form.fxRate.prefill')}
+                  </button>
+                  <span className="remittance-field__help">
+                    {t('remittance.form.fxRate.prefillHint', {
+                      rate: formatRate(midMarketRate, locale),
+                    })}
+                  </span>
+                </div>
+              )}
               {errors.referenceRate && (
                 <p id="remit-reference-rate-error" className="remittance-field__error" role="alert">
                   {errors.referenceRate}
                 </p>
               )}
             </div>
+          </div>
+
+          <div className="remittance-field-row">
+            <div className="remittance-field">
+              <label htmlFor="remit-recurrence" className="remittance-field__label">
+                {t('remittance.form.recurrence.label')}
+              </label>
+              <select
+                id="remit-recurrence"
+                className="remittance-field__input"
+                value={recurrenceFrequency}
+                onChange={(e) =>
+                  setRecurrenceFrequency(e.target.value as 'none' | RemittanceFrequency)
+                }
+                aria-describedby="remit-recurrence-help"
+              >
+                <option value="none">{t('remittance.form.recurrence.none')}</option>
+                {REMITTANCE_FREQUENCIES.map((freq) => (
+                  <option key={freq} value={freq}>
+                    {t(`remittance.form.recurrence.freq.${freq}`)}
+                  </option>
+                ))}
+              </select>
+              <p id="remit-recurrence-help" className="remittance-field__help">
+                {t('remittance.form.recurrence.help')}
+              </p>
+            </div>
+            {recurrenceFrequency !== 'none' && (
+              <div className="remittance-field">
+                <label htmlFor="remit-recurrence-next" className="remittance-field__label">
+                  {t('remittance.form.recurrence.nextDate.label')}
+                </label>
+                <input
+                  id="remit-recurrence-next"
+                  className="remittance-field__input"
+                  type="date"
+                  value={recurrenceNextDate}
+                  min={date}
+                  onChange={(e) => setRecurrenceNextDate(e.target.value)}
+                />
+              </div>
+            )}
           </div>
 
           <div className="remittance-field">
@@ -873,6 +1001,57 @@ export const RemittancesPage: React.FC = () => {
                   </article>
                 ))}
               </div>
+            </section>
+          )}
+
+          {upcomingRemittances.length > 0 && (
+            <section
+              className="remittance-section"
+              aria-label={t('remittance.upcoming.title')}
+            >
+              <h2 className="remittance-section__title">{t('remittance.upcoming.title')}</h2>
+              <ul className="remittance-upcoming" role="list">
+                {upcomingRemittances.map((item) => {
+                  const freq = item.record.recurrence?.frequency;
+                  const frequencyLabel = freq
+                    ? t(`remittance.form.recurrence.freq.${freq}`)
+                    : '';
+                  return (
+                    <li
+                      key={item.record.id}
+                      className="remittance-upcoming__item"
+                      aria-label={t('remittance.upcoming.itemAria', {
+                        amount: formatCurrency(
+                          item.totalPaidMinor,
+                          item.record.sourceCurrency,
+                          locale,
+                        ),
+                        recipient: item.record.recipient.name,
+                        date: formatDate(item.date, locale),
+                        frequency: frequencyLabel,
+                      })}
+                    >
+                      <div className="remittance-upcoming__main">
+                        <span className="remittance-upcoming__recipient">
+                          {item.record.recipient.name}
+                        </span>
+                        <span className="remittance-upcoming__date">
+                          {formatDate(item.date, locale)}
+                        </span>
+                      </div>
+                      <div className="remittance-upcoming__meta">
+                        <CurrencyDisplay
+                          amount={item.totalPaidMinor}
+                          currency={item.record.sourceCurrency}
+                        />
+                        <span className="remittance-upcoming__badge">
+                          {t('remittance.upcoming.badge', { frequency: frequencyLabel })}
+                        </span>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
             </section>
           )}
 

--- a/apps/web/src/pages/RemittancesPage.tsx
+++ b/apps/web/src/pages/RemittancesPage.tsx
@@ -1005,17 +1005,12 @@ export const RemittancesPage: React.FC = () => {
           )}
 
           {upcomingRemittances.length > 0 && (
-            <section
-              className="remittance-section"
-              aria-label={t('remittance.upcoming.title')}
-            >
+            <section className="remittance-section" aria-label={t('remittance.upcoming.title')}>
               <h2 className="remittance-section__title">{t('remittance.upcoming.title')}</h2>
               <ul className="remittance-upcoming" role="list">
                 {upcomingRemittances.map((item) => {
                   const freq = item.record.recurrence?.frequency;
-                  const frequencyLabel = freq
-                    ? t(`remittance.form.recurrence.freq.${freq}`)
-                    : '';
+                  const frequencyLabel = freq ? t(`remittance.form.recurrence.freq.${freq}`) : '';
                   return (
                     <li
                       key={item.record.id}

--- a/apps/web/src/pages/RemittancesPage.tsx
+++ b/apps/web/src/pages/RemittancesPage.tsx
@@ -1016,13 +1016,12 @@ export const RemittancesPage: React.FC = () => {
                       key={item.record.id}
                       className="remittance-upcoming__item"
                       aria-label={t('remittance.upcoming.itemAria', {
-                        amount: formatCurrency(
-                          item.totalPaidMinor,
-                          item.record.sourceCurrency,
+                        amount: formatCurrency(item.totalPaidMinor, {
+                          currency: item.record.sourceCurrency,
                           locale,
-                        ),
+                        }),
                         recipient: item.record.recipient.name,
-                        date: formatDate(item.date, locale),
+                        date: formatDate(item.date, { locale }),
                         frequency: frequencyLabel,
                       })}
                     >
@@ -1031,7 +1030,7 @@ export const RemittancesPage: React.FC = () => {
                           {item.record.recipient.name}
                         </span>
                         <span className="remittance-upcoming__date">
-                          {formatDate(item.date, locale)}
+                          {formatDate(item.date, { locale })}
                         </span>
                       </div>
                       <div className="remittance-upcoming__meta">

--- a/apps/web/src/pages/WatchlistsPage.test.tsx
+++ b/apps/web/src/pages/WatchlistsPage.test.tsx
@@ -6,6 +6,7 @@ import { WatchlistsPage } from './WatchlistsPage';
 import { useCategories } from '../hooks/useCategories';
 import { useSpendingWatchlists } from '../hooks/useSpendingWatchlists';
 import type { WatchlistAlert } from '../hooks/useSpendingWatchlists';
+import { useSecurityWatchlists } from '../hooks/useSecurityWatchlists';
 
 vi.mock('../hooks/useCategories', () => ({
   useCategories: vi.fn(),
@@ -15,8 +16,13 @@ vi.mock('../hooks/useSpendingWatchlists', () => ({
   useSpendingWatchlists: vi.fn(),
 }));
 
+vi.mock('../hooks/useSecurityWatchlists', () => ({
+  useSecurityWatchlists: vi.fn(),
+}));
+
 const mockedUseCategories = vi.mocked(useCategories);
 const mockedUseSpendingWatchlists = vi.mocked(useSpendingWatchlists);
+const mockedUseSecurityWatchlists = vi.mocked(useSecurityWatchlists);
 
 const syncMetadata = {
   createdAt: '2025-01-01T00:00:00Z',
@@ -80,6 +86,18 @@ describe('WatchlistsPage', () => {
       toggleAlerts: vi.fn(),
       dismissAlert: vi.fn(),
       reorderWatchlists: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    mockedUseSecurityWatchlists.mockReturnValue({
+      watches: [],
+      alerts: [],
+      priceBySymbolCents: new Map(),
+      addWatch: vi.fn(),
+      removeWatch: vi.fn(),
+      toggleAlerts: vi.fn(),
+      resetReferencePrice: vi.fn(),
+      dismissAlert: vi.fn(),
       refresh: vi.fn(),
     });
   });

--- a/apps/web/src/pages/WatchlistsPage.tsx
+++ b/apps/web/src/pages/WatchlistsPage.tsx
@@ -39,6 +39,9 @@ import {
   type Watchlist,
   type WatchlistAlert,
 } from '../hooks/useSpendingWatchlists';
+import { useSecurityWatchlists } from '../hooks/useSecurityWatchlists';
+import type { SecurityAlertLevel } from '../lib/investment/security-watchlist';
+import { computePriceMovePercent, normalizeSymbol } from '../lib/investment/security-watchlist';
 
 import '../styles/watchlists.css';
 
@@ -181,6 +184,264 @@ const WatchlistItem: React.FC<WatchlistItemProps> = ({
         </div>
       </div>
     </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Security watchlists (issue #3260)
+// ---------------------------------------------------------------------------
+
+const SECURITY_ALERT_ARIA_LABELS: Record<SecurityAlertLevel, string> = {
+  info: 'Information',
+  warning: 'Warning',
+  critical: 'Critical alert',
+};
+
+/**
+ * Security/ticker watchlists with price-move alerts. Current prices come from
+ * the user's holdings; a move from each entry's reference price beyond its
+ * threshold raises an alert.
+ */
+const SecurityWatchlistsSection: React.FC = () => {
+  const {
+    watches,
+    alerts,
+    priceBySymbolCents,
+    addWatch,
+    removeWatch,
+    toggleAlerts,
+    resetReferencePrice,
+    dismissAlert,
+  } = useSecurityWatchlists();
+
+  const [symbol, setSymbol] = useState('');
+  const [name, setName] = useState('');
+  const [referencePrice, setReferencePrice] = useState('');
+  const [threshold, setThreshold] = useState('5');
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent) => {
+      event.preventDefault();
+      const trimmedSymbol = normalizeSymbol(symbol);
+      const referenceCents = Math.round(Number.parseFloat(referencePrice) * 100);
+      const thresholdPercent = Number.parseFloat(threshold);
+      if (
+        !trimmedSymbol ||
+        !Number.isFinite(referenceCents) ||
+        referenceCents <= 0 ||
+        !Number.isFinite(thresholdPercent) ||
+        thresholdPercent <= 0
+      ) {
+        return;
+      }
+      addWatch({
+        symbol: trimmedSymbol,
+        name: name.trim() || undefined,
+        referencePriceCents: referenceCents,
+        alertThresholdPercent: thresholdPercent,
+      });
+      setSymbol('');
+      setName('');
+      setReferencePrice('');
+      setThreshold('5');
+    },
+    [addWatch, name, referencePrice, symbol, threshold],
+  );
+
+  return (
+    <section className="page-section" aria-label="Security watchlists">
+      <h2 className="page-section__title">Security Watchlists</h2>
+
+      {alerts.length > 0 && (
+        <div
+          className="watchlist-alerts"
+          role="log"
+          aria-label="Security price-move alert notifications"
+        >
+          {alerts.map((alert) => (
+            <div
+              key={alert.watch.id}
+              className={`watchlist-alert watchlist-alert--${alert.level}`}
+              role="alert"
+              aria-label={`${SECURITY_ALERT_ARIA_LABELS[alert.level]}: ${alert.message}`}
+            >
+              <div className="watchlist-alert__content">
+                <span className="watchlist-alert__icon" aria-hidden="true">
+                  <AppIcon
+                    name={
+                      alert.level === 'critical'
+                        ? 'alert-triangle'
+                        : alert.level === 'warning'
+                          ? 'alert-circle'
+                          : 'info'
+                    }
+                  />
+                </span>
+                <div className="watchlist-alert__text">
+                  <p className="watchlist-alert__message">{alert.message}</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                className="watchlist-alert__dismiss"
+                onClick={() => dismissAlert(alert.watch.id)}
+                aria-label={`Dismiss ${alert.watch.symbol} price alert`}
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="card">
+        <form
+          className="watchlist-security-form"
+          onSubmit={handleSubmit}
+          aria-label="Add security watch"
+        >
+          <div className="watchlist-form__field">
+            <label htmlFor="sec-symbol">Ticker</label>
+            <input
+              id="sec-symbol"
+              type="text"
+              value={symbol}
+              onChange={(e) => setSymbol(e.target.value)}
+              placeholder="AAPL"
+              autoComplete="off"
+              required
+              aria-required="true"
+            />
+          </div>
+          <div className="watchlist-form__field">
+            <label htmlFor="sec-name">Name (optional)</label>
+            <input
+              id="sec-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Apple Inc."
+              autoComplete="off"
+            />
+          </div>
+          <div className="watchlist-form__field">
+            <label htmlFor="sec-reference">Reference price ($)</label>
+            <input
+              id="sec-reference"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="0.01"
+              value={referencePrice}
+              onChange={(e) => setReferencePrice(e.target.value)}
+              placeholder="195.00"
+              required
+              aria-required="true"
+            />
+          </div>
+          <div className="watchlist-form__field">
+            <label htmlFor="sec-threshold">Alert on move (±%)</label>
+            <input
+              id="sec-threshold"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="0.5"
+              value={threshold}
+              onChange={(e) => setThreshold(e.target.value)}
+              required
+              aria-required="true"
+            />
+          </div>
+          <button type="submit" className="watchlist-form__submit">
+            Add ticker
+          </button>
+        </form>
+
+        {watches.length === 0 ? (
+          <EmptyState
+            title="No securities watched yet"
+            description="Add a ticker with a reference price to get alerted when it moves beyond your threshold."
+          />
+        ) : (
+          <ul className="watchlist-security-list" aria-label="Watched securities">
+            {watches.map((watch) => {
+              const currentPrice = priceBySymbolCents.get(normalizeSymbol(watch.symbol));
+              const movePercent =
+                currentPrice === undefined
+                  ? null
+                  : computePriceMovePercent(watch.referencePriceCents, currentPrice);
+              return (
+                <li key={watch.id} className="watchlist-security-item">
+                  <div className="watchlist-security-item__head">
+                    <span className="watchlist-security-item__symbol">{watch.symbol}</span>
+                    {watch.name && (
+                      <span className="watchlist-security-item__name">{watch.name}</span>
+                    )}
+                  </div>
+                  <div className="watchlist-security-item__prices">
+                    <span>
+                      Ref <CurrencyDisplay amount={watch.referencePriceCents} />
+                    </span>
+                    {currentPrice !== undefined ? (
+                      <span>
+                        Now <CurrencyDisplay amount={currentPrice} />
+                      </span>
+                    ) : (
+                      <span className="watchlist-security-item__no-price">No live price</span>
+                    )}
+                    {movePercent !== null && (
+                      <span
+                        className={`watchlist-security-item__move watchlist-security-item__move--${
+                          movePercent > 0 ? 'up' : movePercent < 0 ? 'down' : 'flat'
+                        }`}
+                      >
+                        {movePercent > 0 ? '+' : ''}
+                        {movePercent.toFixed(2)}%
+                      </span>
+                    )}
+                    <span className="watchlist-security-item__threshold">
+                      ±{watch.alertThresholdPercent}% alert
+                    </span>
+                  </div>
+                  <div className="watchlist-security-item__actions">
+                    <button
+                      type="button"
+                      onClick={() => toggleAlerts(watch.id)}
+                      aria-pressed={watch.alertsEnabled}
+                      aria-label={`${watch.alertsEnabled ? 'Disable' : 'Enable'} alerts for ${watch.symbol}`}
+                    >
+                      {watch.alertsEnabled ? (
+                        <>
+                          <AppIcon name="bell" /> Alerts on
+                        </>
+                      ) : (
+                        'Alerts off'
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => resetReferencePrice(watch.id)}
+                      disabled={currentPrice === undefined}
+                      aria-label={`Reset reference price for ${watch.symbol} to the latest price`}
+                    >
+                      Re-baseline
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => removeWatch(watch.id)}
+                      aria-label={`Remove ${watch.symbol} from watchlist`}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </section>
   );
 };
 
@@ -360,6 +621,8 @@ export const WatchlistsPage: React.FC = () => {
           </div>
         </section>
       )}
+
+      <SecurityWatchlistsSection />
 
       {/* Add watchlist form (inline) */}
       {isAddFormOpen && (

--- a/apps/web/src/pages/remittances.css
+++ b/apps/web/src/pages/remittances.css
@@ -388,3 +388,81 @@
     border-width: 2px;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Scheduled/recurring remittances (issue #3265) and FX prefill (issue #3296)
+ * ------------------------------------------------------------------------- */
+
+.remittance-field__prefill {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-2);
+}
+
+.remittance-field__prefill-button {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-interactive-default);
+  background: transparent;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  padding: var(--spacing-1) var(--spacing-3);
+  cursor: pointer;
+}
+
+.remittance-field__prefill-button:focus-visible {
+  outline: 2px solid var(--semantic-interactive-default);
+  outline-offset: 2px;
+}
+
+.remittance-upcoming {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.remittance-upcoming__item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  background: var(--semantic-background-secondary);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  padding: var(--spacing-3) var(--spacing-4);
+}
+
+.remittance-upcoming__main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.remittance-upcoming__recipient {
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+}
+
+.remittance-upcoming__date {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.remittance-upcoming__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.remittance-upcoming__badge {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  background: var(--semantic-background-tertiary, var(--semantic-background-primary));
+  border-radius: var(--border-radius-sm);
+  padding: var(--spacing-1) var(--spacing-2);
+}

--- a/apps/web/src/styles/watchlists.css
+++ b/apps/web/src/styles/watchlists.css
@@ -356,3 +356,91 @@
     margin-top: 0;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Security/ticker watchlists (issue #3260)
+ * ------------------------------------------------------------------------- */
+
+.watchlist-security-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+}
+
+.watchlist-security-form .watchlist-form__field {
+  flex: 1 1 8rem;
+  min-width: 7rem;
+}
+
+.watchlist-security-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.watchlist-security-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-md, 8px);
+}
+
+.watchlist-security-item__head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-2);
+}
+
+.watchlist-security-item__symbol {
+  font-weight: var(--font-weight-semibold);
+}
+
+.watchlist-security-item__name {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.watchlist-security-item__prices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.watchlist-security-item__move--up {
+  color: var(--semantic-positive, #059669);
+  font-weight: var(--font-weight-semibold);
+}
+
+.watchlist-security-item__move--down {
+  color: var(--semantic-negative, #dc2626);
+  font-weight: var(--font-weight-semibold);
+}
+
+.watchlist-security-item__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+
+.watchlist-security-item__actions button {
+  font-size: var(--type-scale-caption-font-size);
+  padding: var(--spacing-1) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-sm, 4px);
+  background: transparent;
+  cursor: pointer;
+}
+
+.watchlist-security-item__actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
﻿## Summary

One cohesive batch across **apps/web** covering investments and business finance. All money math uses integer cents; new pure engines are unit-tested and the performance-sensitive holdings table has render-count coverage.

### Investments
- **Virtualized holdings table** for large portfolios — only rows near the viewport mount, preserving `<table>` semantics and accessible sortable headers (`HoldingsTable`, `useVirtualList`).
- **Cross-account / brokerage attribution + roll-up** — per-holding account column plus a "Group by symbol" toggle consolidating a ticker held across accounts (`lib/investment/holdings-rollup.ts`).
- **Per-lot cost-basis & holding-period breakdown** for tax-lot planning on the investment detail page (`cost-basis.ts`).
- **Security/ticker watchlists with price-move alerts** — reference-vs-current price moves sourced from holdings (`security-watchlist.ts`, `useSecurityWatchlists`).

### Business finance
- **P&L COGS fix** — untagged/supplier expenses no longer silently misclassified as overhead (understating COGS); untagged spend is flagged.
- **Invoice currency field** — invoices carry an explicit currency instead of always-USD (migration v16, repository, hook, UI).
- **Recurring/scheduled supplier remittances** — recurrence with next-date projection (migration v16, `remittance-schedule.ts`).
- **Remittance FX prefill** — prefills the rate from the exchange-rate service with a mid-market reference.
- **Cash Runway: scheduled remittances** included as projected outflows.
- **Cash Runway: business/personal workspace filter** honored across accounts, bills, invoices and remittances.

### Testing
`npm run format:check` clean, `eslint . --max-warnings 0` clean, and the full apps/web vitest suite passes (one pre-existing DashboardPage savings-rate test is flaky only under full-suite parallel load and passes in isolation; unrelated to this change).

Closes #3272
Closes #3270
Closes #3268
Closes #3265
Closes #3263
Closes #3262
Closes #3260
Closes #3244
Closes #3242
Closes #3296
