### PR TITLE
feat(windows): Windows desktop UX and accessibility batch (10 issues)

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
@@ -56,6 +56,8 @@ import com.finance.desktop.screens.WidgetBoardScreen
 import com.finance.desktop.data.repository.AppSettings
 import com.finance.desktop.data.repository.SettingsRepository
 import com.finance.desktop.theme.FinanceDesktopTheme
+import com.finance.desktop.theme.HighContrastMode
+import com.finance.desktop.theme.resolveHighContrast
 import com.finance.desktop.tray.FinanceSystemTray
 import com.finance.desktop.ui.components.IconPackProvider
 import com.finance.desktop.tray.QuickAddTransactionManager
@@ -100,6 +102,8 @@ import com.finance.desktop.viewmodel.LoginViewModel
  *   window's [onPreviewKeyEvent], enabling Ctrl+1 through Ctrl+8 shortcuts.
  * @param quickAddManager Manager for system tray quick-add transaction.
  * @param systemTray The system tray integration for notifications.
+ * @param onTitleChange Callback to update the OS window title for the active
+ *   screen (#3693). Receives the full title string, e.g. "Transactions - Finance".
  */
 @Composable
 @Suppress("CyclomaticComplexMethod") // Top-level navigation routing composable
@@ -107,6 +111,7 @@ fun FinanceApp(
     shortcutHandler: ShortcutHandler,
     quickAddManager: QuickAddTransactionManager,
     systemTray: FinanceSystemTray,
+    onTitleChange: (String) -> Unit = {},
 ) {
     val authViewModel = koinGet<AuthViewModel>()
     val authState by authViewModel.uiState.collectAsState()
@@ -141,7 +146,10 @@ fun FinanceApp(
         },
     )
 
-    FinanceDesktopTheme {
+    FinanceDesktopTheme(
+        highContrast = resolveHighContrast(HighContrastMode.fromStorage(appSettings.highContrastMode)),
+        compact = appSettings.compactDensity,
+    ) {
         IconPackProvider(iconPackId = appSettings.iconPackId) {
             Surface(
                 modifier = Modifier
@@ -152,12 +160,14 @@ fun FinanceApp(
                 // ── Layer 0: Splash screen while auth state resolves ──
                 // Prevents flash of login screen during startup
                 if (authState.isAuthenticating && !authState.isAuthenticated && !sessionAuthenticated) {
+                    LaunchedEffect(Unit) { onTitleChange("Finance") }
                     SplashLoadingScreen()
                     return@Surface
                 }
 
                 // ── Layer 1: GDPR consent dialog (first run) ──
                 if (gdprState.showConsentDialog) {
+                    LaunchedEffect(Unit) { onTitleChange("Finance") }
                     GdprConsentDialog(
                         onAcceptAll = { gdprViewModel.acceptAll() },
                         onAcceptRequired = { gdprViewModel.acceptRequiredOnly() },
@@ -173,17 +183,20 @@ fun FinanceApp(
                 val isFullyAuthenticated = authState.isAuthenticated || sessionAuthenticated
 
                 if (!isFullyAuthenticated && authState.requiresAuth) {
+                    LaunchedEffect(Unit) { onTitleChange("Finance") }
                     AuthGateContent(authState = authState, authViewModel = authViewModel)
                 } else {
                     MainAppContent(
                         shortcutHandler = shortcutHandler,
                         quickAddManager = quickAddManager,
                         systemTray = systemTray,
+                        onTitleChange = onTitleChange,
                     )
                 }
 
                 // ── Global dialogs (rendered above everything) ──
                 GlobalDialogs(
+                    shortcutHandler = shortcutHandler,
                     showNewTransactionDialog = showNewTransactionDialog,
                     showFeedbackDialog = showFeedbackDialog,
                     showShortcutsHelp = showShortcutsHelp,
@@ -265,6 +278,7 @@ private fun MainAppContent(
     shortcutHandler: ShortcutHandler,
     quickAddManager: QuickAddTransactionManager,
     systemTray: FinanceSystemTray,
+    onTitleChange: (String) -> Unit = {},
 ) {
     val loginViewModel = koinGet<LoginViewModel>()
     var showSignInScreen by remember { mutableStateOf(false) }
@@ -277,6 +291,7 @@ private fun MainAppContent(
         SidebarNavigation(
             shortcutHandler = shortcutHandler,
             onAccountSelected = { /* Settings shows the Account section. */ },
+            onScreenChange = { screen -> onTitleChange("${screen.label} - Finance") },
         ) { screen ->
             when (screen) {
                 Screen.Dashboard -> DashboardScreen()
@@ -325,6 +340,7 @@ private fun MainAppContent(
  */
 @Composable
 private fun GlobalDialogs(
+    shortcutHandler: ShortcutHandler,
     showNewTransactionDialog: Boolean,
     showFeedbackDialog: Boolean,
     showShortcutsHelp: Boolean,
@@ -354,6 +370,7 @@ private fun GlobalDialogs(
 
     if (showShortcutsHelp) {
         KeyboardShortcutsHelpDialog(
+            shortcutHandler = shortcutHandler,
             onDismiss = onDismissShortcutsHelp,
         )
     }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -2,6 +2,10 @@
 
 package com.finance.desktop
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -73,6 +77,10 @@ fun main() {
 
         val shortcutHandler = rememberShortcutHandler()
 
+        // Window title reflects the active screen (#3693); defaults to "Finance"
+        // for auth/splash and updates to "<Screen> - Finance" once navigating.
+        var windowTitle by remember { mutableStateOf("Finance") }
+
         // Initialise tray with action handler
         timed("tray_init") {
             systemTray.initialise(
@@ -110,11 +118,16 @@ fun main() {
                 stopKoin()
                 exitApplication()
             },
-            title = "Finance",
+            title = windowTitle,
             state = windowState,
             onPreviewKeyEvent = { shortcutHandler.onKeyEvent(it) },
         ) {
-            FinanceApp(shortcutHandler, quickAddManager, systemTray)
+            FinanceApp(
+                shortcutHandler,
+                quickAddManager,
+                systemTray,
+                onTitleChange = { windowTitle = it },
+            )
         }
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/accessibility/KeyboardNavigation.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/accessibility/KeyboardNavigation.kt
@@ -2,14 +2,23 @@
 
 package com.finance.desktop.accessibility
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -19,6 +28,7 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 
 // =============================================================================
 // Keyboard Navigation Utilities for Windows Desktop Accessibility
@@ -33,6 +43,48 @@ import androidx.compose.ui.semantics.semantics
 //
 // Every screen should use these utilities to manage focus order and provide
 // consistent keyboard interaction patterns.
+
+/**
+ * Width of the keyboard focus ring drawn by [focusVisible].
+ */
+private val FocusRingWidth = 2.dp
+
+/**
+ * Reusable focus-visible modifier that draws a clearly visible outline when the
+ * element receives keyboard focus (WCAG 2.4.7 Focus Visible, #3715).
+ *
+ * Custom interactive composables built with `clickable { }` only expose ripple
+ * and hover indication, so sighted keyboard users cannot tell what is focused
+ * when tabbing. Apply this modifier *before* the `clickable`/`focusable` in the
+ * chain so it observes the downstream focus target:
+ *
+ * ```
+ * Modifier
+ *     .background(bg, shape)
+ *     .focusVisible(shape)
+ *     .clickable { onClick() }
+ * ```
+ *
+ * The ring uses [MaterialTheme.colorScheme.primary] by default, which is chosen
+ * per-theme to meet contrast requirements in light, dark, and high-contrast
+ * schemes (bright yellow / dark blue in the high-contrast palettes).
+ *
+ * @param shape Shape of the focus ring; should match the element's background.
+ * @param color Ring color; defaults to the theme primary.
+ * @return A [Modifier] that renders a focus outline while keyboard-focused.
+ */
+@Composable
+fun Modifier.focusVisible(
+    shape: Shape = RoundedCornerShape(8.dp),
+    color: Color = MaterialTheme.colorScheme.primary,
+): Modifier {
+    var isFocused by remember { mutableStateOf(false) }
+    return this
+        .onFocusChanged { isFocused = it.isFocused }
+        .then(
+            if (isFocused) Modifier.border(FocusRingWidth, color, shape) else Modifier,
+        )
+}
 
 /**
  * Creates and remembers a [FocusRequester] that automatically requests

--- a/apps/windows/src/main/kotlin/com/finance/desktop/components/ListStateViews.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/components/ListStateViews.kt
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+@file:Suppress("MatchingDeclarationName") // File hosts several list-state composables
+
+package com.finance.desktop.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.theme.FinanceDesktopTheme
+
+/**
+ * Full-screen error state with a human-readable message and a Retry action
+ * (#3685). Screens should render this when a repository load fails, instead of
+ * leaving a permanent spinner or a misleading empty state.
+ *
+ * The message is exposed as a polite live region so Narrator announces the
+ * failure, and the Retry button is keyboard reachable and labeled.
+ *
+ * @param message Human-readable description of what went wrong.
+ * @param onRetry Invoked when the user activates Retry; should re-trigger the load.
+ * @param title Short heading shown above the message.
+ */
+@Composable
+fun ListErrorState(
+    message: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+    title: String = "Something went wrong",
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .semantics {
+                liveRegion = LiveRegionMode.Polite
+                contentDescription = "$title. $message"
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .widthIn(max = 420.dp)
+                .padding(FinanceDesktopTheme.spacing.xxl),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.ErrorOutline,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(56.dp),
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xl))
+            Button(
+                onClick = onRetry,
+                modifier = Modifier.semantics { contentDescription = "Retry loading" },
+            ) {
+                Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.height(0.dp))
+                Text(
+                    text = "Retry",
+                    modifier = Modifier.padding(start = FinanceDesktopTheme.spacing.sm),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Full-screen empty state with an optional primary call-to-action (#3677).
+ *
+ * Empty list screens are dead-ends without a way forward; providing a primary
+ * CTA (e.g. "Create goal") makes the primary task discoverable on first run.
+ *
+ * @param icon Decorative illustration icon.
+ * @param title Short heading (e.g. "No savings goals yet").
+ * @param message Supporting sentence describing what to do.
+ * @param ctaLabel Label for the primary action button; when null no CTA renders.
+ * @param onCta Invoked when the CTA is activated.
+ * @param ctaIcon Leading icon for the CTA button.
+ */
+@Composable
+fun ListEmptyState(
+    icon: ImageVector,
+    title: String,
+    message: String,
+    modifier: Modifier = Modifier,
+    ctaLabel: String? = null,
+    onCta: () -> Unit = {},
+    ctaIcon: ImageVector = Icons.Filled.Add,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .widthIn(max = 420.dp)
+                .padding(FinanceDesktopTheme.spacing.xxl),
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.semantics { contentDescription = title },
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            if (ctaLabel != null) {
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.xl))
+                Button(
+                    onClick = onCta,
+                    modifier = Modifier.semantics { contentDescription = ctaLabel },
+                ) {
+                    Icon(ctaIcon, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Text(
+                        text = ctaLabel,
+                        modifier = Modifier.padding(start = FinanceDesktopTheme.spacing.sm),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/SettingsRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/SettingsRepository.kt
@@ -23,6 +23,10 @@ data class AppSettings(
     val darkMode: Boolean = false,
     val language: String = "English",
     val accentColor: String = "Blue",
+    /** High-contrast preference: "Auto", "On", or "Off" (#3665). */
+    val highContrastMode: String = "Auto",
+    /** Compact information-density mode for list-heavy screens (#3722). */
+    val compactDensity: Boolean = false,
     @SerialName(ICON_PACK_PREFERENCE_KEY)
     val iconPackId: String = FLUENT_REGULAR,
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
@@ -19,12 +19,15 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.filled.AccountBalance
@@ -55,6 +58,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -67,12 +71,14 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.finance.desktop.accessibility.focusVisible
 import com.finance.desktop.components.KeyboardShortcut
 import com.finance.desktop.data.repository.AuthAccount
 import com.finance.desktop.data.repository.AuthRepository
@@ -82,36 +88,55 @@ import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
 
 /**
+ * Logical grouping for sidebar destinations (#3655).
+ *
+ * Grouping a flat 19+ item list into a small set of labelled sections reduces
+ * cognitive load and surfaces the primary tasks. [PRIMARY] has no visible
+ * header (it is the default landing set); the others render a group header with
+ * proper Narrator heading semantics.
+ *
+ * @param header Visible/Narrator section label, or empty for [PRIMARY].
+ */
+enum class NavGroup(val header: String) {
+    PRIMARY(""),
+    INSIGHTS("Insights"),
+    TOOLS("Tools"),
+    MORE("More"),
+}
+
+/**
  * Desktop navigation destinations.
  *
- * Each entry carries its icon, label, and keyboard shortcut key (Ctrl+1 … Ctrl+6).
+ * Each entry carries its icon, label, keyboard shortcut key, and the
+ * [NavGroup] it belongs to in the grouped sidebar information architecture.
  */
 enum class Screen(
     val label: String,
     val icon: ImageVector,
     val shortcutKey: Key,
     val shortcutLabel: String,
+    val group: NavGroup,
 ) {
-    Dashboard("Dashboard", Icons.Filled.Dashboard, Key.One, "Ctrl+1"),
-    Accounts("Accounts", Icons.Filled.AccountBalance, Key.Two, "Ctrl+2"),
-    Transactions("Transactions", Icons.Filled.Receipt, Key.Three, "Ctrl+3"),
-    Budgets("Budgets", Icons.Filled.PieChart, Key.Four, "Ctrl+4"),
-    Goals("Goals", Icons.Filled.Star, Key.Five, "Ctrl+5"),
-    Upgrade("Upgrade", Icons.Filled.WorkspacePremium, Key.Six, "Ctrl+6"),
-    Tips("Tips", Icons.Filled.Lightbulb, Key.T, "Ctrl+T"),
-    Investments("Investments", Icons.AutoMirrored.Filled.ShowChart, Key.F1, "Ctrl+F1"),
-    Household("Household", Icons.Filled.Group, Key.H, "Ctrl+H"),
-    Widgets("Widgets", Icons.Filled.Widgets, Key.Seven, "Ctrl+7"),
-    HealthScore("Health Score", Icons.Filled.Favorite, Key.Eight, "Ctrl+8"),
-    Reports("Reports", Icons.Filled.Assessment, Key.Nine, "Ctrl+9"),
-    QuickAdd("Quick Add", Icons.Filled.AutoAwesome, Key.Q, "Ctrl+Q"),
-    Import("Import", Icons.Filled.FileUpload, Key.I, "Ctrl+I"),
-    Referral("Referral", Icons.Filled.Share, Key.R, "Ctrl+R"),
-    Negotiate("Negotiate", Icons.Filled.Groups, Key.N, "Ctrl+N"),
-    Currency("Currency", Icons.Filled.CurrencyExchange, Key.F2, "Ctrl+F2"),
-    Diagnostics("Diagnostics", Icons.Filled.Speed, Key.D, "Ctrl+D"),
-    Achievements("Achievements", Icons.Filled.EmojiEvents, Key.A, "Ctrl+A"),
-    Settings("Settings", Icons.Filled.Settings, Key.Zero, "Ctrl+0"),
+    Dashboard("Dashboard", Icons.Filled.Dashboard, Key.One, "Ctrl+1", NavGroup.PRIMARY),
+    Accounts("Accounts", Icons.Filled.AccountBalance, Key.Two, "Ctrl+2", NavGroup.PRIMARY),
+    Transactions("Transactions", Icons.Filled.Receipt, Key.Three, "Ctrl+3", NavGroup.PRIMARY),
+    Budgets("Budgets", Icons.Filled.PieChart, Key.Four, "Ctrl+4", NavGroup.PRIMARY),
+    Goals("Goals", Icons.Filled.Star, Key.Five, "Ctrl+5", NavGroup.PRIMARY),
+    Reports("Reports", Icons.Filled.Assessment, Key.Nine, "Ctrl+9", NavGroup.PRIMARY),
+    HealthScore("Health Score", Icons.Filled.Favorite, Key.Eight, "Ctrl+8", NavGroup.INSIGHTS),
+    Investments("Investments", Icons.AutoMirrored.Filled.ShowChart, Key.F1, "Ctrl+F1", NavGroup.INSIGHTS),
+    Achievements("Achievements", Icons.Filled.EmojiEvents, Key.A, "Ctrl+A", NavGroup.INSIGHTS),
+    Tips("Tips", Icons.Filled.Lightbulb, Key.T, "Ctrl+T", NavGroup.INSIGHTS),
+    Household("Household", Icons.Filled.Group, Key.H, "Ctrl+H", NavGroup.TOOLS),
+    Import("Import", Icons.Filled.FileUpload, Key.I, "Ctrl+I", NavGroup.TOOLS),
+    Widgets("Widgets", Icons.Filled.Widgets, Key.Seven, "Ctrl+7", NavGroup.TOOLS),
+    Currency("Currency", Icons.Filled.CurrencyExchange, Key.F2, "Ctrl+F2", NavGroup.TOOLS),
+    Negotiate("Negotiate", Icons.Filled.Groups, Key.N, "Ctrl+N", NavGroup.TOOLS),
+    QuickAdd("Quick Add", Icons.Filled.AutoAwesome, Key.Q, "Ctrl+Q", NavGroup.TOOLS),
+    Upgrade("Upgrade", Icons.Filled.WorkspacePremium, Key.Six, "Ctrl+6", NavGroup.MORE),
+    Referral("Referral", Icons.Filled.Share, Key.R, "Ctrl+R", NavGroup.MORE),
+    Diagnostics("Diagnostics", Icons.Filled.Speed, Key.D, "Ctrl+D", NavGroup.MORE),
+    Settings("Settings", Icons.Filled.Settings, Key.Zero, "Ctrl+0", NavGroup.MORE),
 }
 
 /** Width of the sidebar when expanded. */
@@ -136,6 +161,7 @@ private val SIDEBAR_COLLAPSED_WIDTH = 64.dp
 fun SidebarNavigation(
     shortcutHandler: ShortcutHandler,
     onAccountSelected: () -> Unit = {},
+    onScreenChange: (Screen) -> Unit = {},
     content: @Composable (Screen) -> Unit,
 ) {
     var currentScreen by rememberSaveable { mutableStateOf(Screen.Dashboard) }
@@ -144,7 +170,10 @@ fun SidebarNavigation(
     val account by authRepository.currentAccount.collectAsState()
     val isSignedIn by authRepository.isAuthenticated.collectAsState()
 
-    // Register keyboard shortcuts (Ctrl+1 … Ctrl+6)
+    // Notify the host (window title, etc.) of the active screen (#3693).
+    LaunchedEffect(currentScreen) { onScreenChange(currentScreen) }
+
+    // Register keyboard shortcuts (one per destination)
     KeyboardShortcutEffect(shortcutHandler) {
         Screen.entries.map { screen ->
             KeyboardShortcut(
@@ -239,31 +268,49 @@ private fun SidebarPanel(
             )
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
 
-            // Navigation items — all except Settings
-            Screen.entries
-                .filter { it != Screen.Settings }
-                .forEach { screen ->
-                    SidebarItem(
-                        screen = screen,
-                        isSelected = currentScreen == screen,
-                        isExpanded = isExpanded,
-                        onClick = { onScreenSelected(screen) },
-                    )
+            // Scrollable navigation list (#3592) — takes remaining height so the
+            // account row + Settings stay pinned and reachable on short windows /
+            // high DPI. Destinations are grouped by NavGroup (#3655) with
+            // Narrator heading semantics on each section label.
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .semantics { contentDescription = "Primary navigation" },
+            ) {
+                val grouped = Screen.entries
+                    .filter { it != Screen.Settings }
+                    .groupBy { it.group }
+                NavGroup.entries.forEach { group ->
+                    val screens = grouped[group].orEmpty()
+                    if (screens.isEmpty()) return@forEach
+                    if (group != NavGroup.PRIMARY) {
+                        SidebarGroupHeader(title = group.header, isExpanded = isExpanded)
+                    }
+                    screens.forEach { screen ->
+                        SidebarItem(
+                            screen = screen,
+                            isSelected = currentScreen == screen,
+                            isExpanded = isExpanded,
+                            onClick = { onScreenSelected(screen) },
+                        )
+                    }
                 }
+            }
 
-            Spacer(Modifier.weight(1f))
-
-            // Account status and settings at bottom
+            // Account status and settings pinned at bottom
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = FinanceDesktopTheme.spacing.sm),
+                color = MaterialTheme.colorScheme.outlineVariant,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
             AccountStatusItem(
                 account = account,
                 isSignedIn = isSignedIn,
                 isExpanded = isExpanded,
                 onClick = onAccountSelected,
-            )
-            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
-            HorizontalDivider(
-                modifier = Modifier.padding(horizontal = FinanceDesktopTheme.spacing.sm),
-                color = MaterialTheme.colorScheme.outlineVariant,
             )
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
             SidebarItem(
@@ -274,6 +321,46 @@ private fun SidebarPanel(
             )
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
         }
+    }
+}
+
+/**
+ * Section header for a [NavGroup] in the sidebar (#3655).
+ *
+ * When expanded it shows the group label with a Narrator heading role. When
+ * collapsed to the icon rail it renders a thin divider so the grouping is still
+ * visually communicated without labels.
+ */
+@Composable
+private fun SidebarGroupHeader(title: String, isExpanded: Boolean) {
+    if (isExpanded) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .padding(
+                    start = FinanceDesktopTheme.spacing.lg,
+                    end = FinanceDesktopTheme.spacing.sm,
+                    top = FinanceDesktopTheme.spacing.md,
+                    bottom = FinanceDesktopTheme.spacing.xs,
+                )
+                .semantics {
+                    heading()
+                    contentDescription = "$title section"
+                },
+        )
+    } else {
+        HorizontalDivider(
+            modifier = Modifier.padding(
+                horizontal = FinanceDesktopTheme.spacing.md,
+                vertical = FinanceDesktopTheme.spacing.xs,
+            ),
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f),
+        )
     }
 }
 
@@ -302,6 +389,7 @@ private fun AccountStatusItem(
                 else Modifier.width(SIDEBAR_COLLAPSED_WIDTH - FinanceDesktopTheme.spacing.lg),
             )
             .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
+            .focusVisible(shape = RoundedCornerShape(8.dp))
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = ripple(),
@@ -398,6 +486,7 @@ private fun SidebarItem(
                 else Modifier.width(SIDEBAR_COLLAPSED_WIDTH - FinanceDesktopTheme.spacing.lg),
             )
             .background(backgroundColor, RoundedCornerShape(8.dp))
+            .focusVisible(shape = RoundedCornerShape(8.dp))
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = ripple(),

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/AccountsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/AccountsScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.finance.core.currency.CurrencyFormatter
+import com.finance.desktop.components.ListErrorState
 import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
 import com.finance.desktop.viewmodel.AccountsViewModel
@@ -120,6 +121,16 @@ fun AccountsScreen(modifier: Modifier = Modifier) {
                 },
             )
         }
+        return
+    }
+
+    if (state.errorMessage != null) {
+        ListErrorState(
+            message = state.errorMessage!!,
+            onRetry = { viewModel.retry() },
+            title = "Couldn't load accounts",
+            modifier = modifier,
+        )
         return
     }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/BudgetsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/BudgetsScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.finance.core.budget.BudgetHealth
+import com.finance.desktop.components.ListErrorState
 import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
 import com.finance.desktop.viewmodel.BudgetItemUi
@@ -103,6 +104,16 @@ fun BudgetsScreen(modifier: Modifier = Modifier) {
                 },
             )
         }
+        return
+    }
+
+    if (state.errorMessage != null) {
+        ListErrorState(
+            message = state.errorMessage!!,
+            onRetry = { viewModel.retry() },
+            title = "Couldn't load budgets",
+            modifier = modifier,
+        )
         return
     }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/GoalsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/GoalsScreen.kt
@@ -21,11 +21,13 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.automirrored.filled.TrendingUp
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -48,6 +50,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.finance.desktop.components.ListEmptyState
+import com.finance.desktop.components.ListErrorState
 import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
 import com.finance.desktop.viewmodel.GoalItemUi
@@ -93,9 +97,21 @@ fun GoalsScreen(modifier: Modifier = Modifier) {
         return
     }
 
-    // ── Edit Dialog ──
-    if (state.editingGoalId != null) {
+    if (state.errorMessage != null) {
+        ListErrorState(
+            message = state.errorMessage!!,
+            onRetry = { viewModel.retry() },
+            title = "Couldn't load goals",
+            modifier = modifier,
+        )
+        return
+    }
+
+    // ── Edit / Create Dialog ──
+    if (state.editingGoalId != null || state.isCreating) {
         GoalEditDialog(
+            title = if (state.isCreating) "New Goal" else "Edit Goal",
+            confirmLabel = if (state.isCreating) "Create" else "Save",
             name = state.editName,
             targetAmount = state.editTargetAmount,
             currentAmount = state.editCurrentAmount,
@@ -140,52 +156,50 @@ fun GoalsScreen(modifier: Modifier = Modifier) {
             .padding(FinanceDesktopTheme.spacing.xxl)
             .semantics { contentDescription = "Goals screen" },
     ) {
-        Text(
-            text = "Savings Goals",
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.semantics {
-                heading()
-                contentDescription = "Savings Goals heading"
-            },
-        )
-        Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
-        Text(
-            text = "Track progress toward your financial goals",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Savings Goals",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.semantics {
+                        heading()
+                        contentDescription = "Savings Goals heading"
+                    },
+                )
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+                Text(
+                    text = "Track progress toward your financial goals",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Button(
+                onClick = { viewModel.startCreate() },
+                modifier = Modifier.semantics { contentDescription = "New goal" },
+            ) {
+                Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+                Text(
+                    text = "New Goal",
+                    modifier = Modifier.padding(start = FinanceDesktopTheme.spacing.sm),
+                )
+            }
+        }
 
         Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
 
         if (state.goals.isEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        imageVector = Icons.Filled.Star,
-                        contentDescription = null,
-                        modifier = Modifier.size(64.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
-                    Text(
-                        text = "No savings goals yet",
-                        style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.semantics {
-                            contentDescription = "No savings goals yet"
-                        },
-                    )
-                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
-                    Text(
-                        text = "Create a goal to start saving toward something",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
+            ListEmptyState(
+                icon = Icons.Filled.Star,
+                title = "No savings goals yet",
+                message = "Create a goal to start saving toward something",
+                ctaLabel = "Create goal",
+                onCta = { viewModel.startCreate() },
+            )
         } else {
             LazyVerticalGrid(
                 columns = GridCells.Adaptive(minSize = 320.dp),
@@ -221,10 +235,12 @@ private fun GoalEditDialog(
     onCurrentAmountChange: (String) -> Unit,
     onSave: () -> Unit,
     onDismiss: () -> Unit,
+    title: String = "Edit Goal",
+    confirmLabel: String = "Save",
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Edit Goal") },
+        title = { Text(title) },
         text = {
             Column(
                 modifier = Modifier.semantics {
@@ -257,7 +273,7 @@ private fun GoalEditDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = onSave) { Text("Save") }
+            TextButton(onClick = onSave) { Text(confirmLabel) }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) { Text("Cancel") }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/KeyboardShortcutsHelpDialog.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/KeyboardShortcutsHelpDialog.kt
@@ -24,12 +24,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.finance.desktop.components.KeyboardShortcut
+import com.finance.desktop.components.ShortcutHandler
 import com.finance.desktop.theme.FinanceDesktopTheme
 
 /**
@@ -44,42 +47,109 @@ data class ShortcutHelpEntry(
 )
 
 /**
+ * Prefix used by navigation shortcut descriptions registered in
+ * `SidebarNavigation` — used to categorise entries in the help dialog.
+ */
+private const val NAV_PREFIX = "Navigate to "
+
+/**
+ * Formats a [KeyboardShortcut]'s key combination into a readable label such as
+ * "Ctrl+Shift+N" or "Escape".
+ */
+fun formatShortcutKeys(shortcut: KeyboardShortcut): String {
+    val parts = buildList {
+        if (shortcut.ctrl) add("Ctrl")
+        if (shortcut.shift) add("Shift")
+        add(keyDisplayName(shortcut.key))
+    }
+    return parts.joinToString("+")
+}
+
+/**
+ * Maps a Compose [Key] to a short, user-facing display name. Falls back to a
+ * cleaned-up form of the key's default string for anything not explicitly
+ * handled, so the list never renders raw internal identifiers.
+ */
+@Suppress("CyclomaticComplexMethod") // Exhaustive key-to-label mapping
+fun keyDisplayName(key: Key): String = when (key) {
+    Key.Zero -> "0"
+    Key.One -> "1"
+    Key.Two -> "2"
+    Key.Three -> "3"
+    Key.Four -> "4"
+    Key.Five -> "5"
+    Key.Six -> "6"
+    Key.Seven -> "7"
+    Key.Eight -> "8"
+    Key.Nine -> "9"
+    Key.A -> "A"
+    Key.D -> "D"
+    Key.F -> "F"
+    Key.H -> "H"
+    Key.I -> "I"
+    Key.N -> "N"
+    Key.Q -> "Q"
+    Key.R -> "R"
+    Key.T -> "T"
+    Key.Escape -> "Escape"
+    Key.Enter -> "Enter"
+    Key.Spacebar -> "Space"
+    Key.F1 -> "F1"
+    Key.F2 -> "F2"
+    else -> key.toString().substringAfterLast(' ').trimEnd(')')
+}
+
+/**
+ * Builds the grouped help sections purely from the currently-registered
+ * [shortcuts], so the dialog can never advertise a shortcut that isn't real and
+ * automatically stays correct as bindings change (#3660).
+ *
+ * Navigation shortcuts (description prefixed with "Navigate to ") are grouped
+ * separately from action/app shortcuts. Each section is sorted for stable,
+ * scannable output.
+ */
+fun buildShortcutHelpSections(
+    shortcuts: List<KeyboardShortcut>,
+): List<Pair<String, List<ShortcutHelpEntry>>> {
+    val (navigation, actions) = shortcuts
+        .distinctBy { formatShortcutKeys(it) }
+        .partition { it.description.startsWith(NAV_PREFIX) }
+
+    val navEntries = navigation
+        .map { ShortcutHelpEntry(formatShortcutKeys(it), "Go to " + it.description.removePrefix(NAV_PREFIX)) }
+        .sortedBy { it.description }
+
+    val actionEntries = actions
+        .map { ShortcutHelpEntry(formatShortcutKeys(it), it.description) }
+        .sortedBy { it.description }
+
+    return buildList {
+        if (navEntries.isNotEmpty()) add("Navigation" to navEntries)
+        if (actionEntries.isNotEmpty()) add("Actions" to actionEntries)
+    }
+}
+
+/**
  * Keyboard shortcuts reference dialog.
  *
- * Shows all available keyboard shortcuts grouped by category.
- * Accessible via F1 or Ctrl+? (Ctrl+Shift+/).
+ * The content is derived from [ShortcutHandler.allShortcuts] — the exact set of
+ * shortcuts registered at runtime — rather than a hand-maintained list. This
+ * guarantees every listed shortcut is real (no phantom entries) and that the
+ * list stays accurate as navigation/global bindings change (#3660).
  *
- * Narrator: each shortcut entry reads as "keys: description".
- * Section headings are marked as headings. The dialog itself
- * is announced with its purpose.
+ * Narrator: each shortcut entry reads as "keys: description". Section headings
+ * are marked as headings. The dialog itself is announced with its purpose.
  *
+ * @param shortcutHandler The active handler whose registered shortcuts drive the list.
  * @param onDismiss Callback to close the dialog.
  */
 @Composable
-fun KeyboardShortcutsHelpDialog(onDismiss: () -> Unit) {
-    val sections = remember {
-        listOf(
-            "Navigation" to listOf(
-                ShortcutHelpEntry("Ctrl+1", "Go to Dashboard"),
-                ShortcutHelpEntry("Ctrl+2", "Go to Accounts"),
-                ShortcutHelpEntry("Ctrl+3", "Go to Transactions"),
-                ShortcutHelpEntry("Ctrl+4", "Go to Budgets"),
-                ShortcutHelpEntry("Ctrl+5", "Go to Goals"),
-            ),
-            "Actions" to listOf(
-                ShortcutHelpEntry("Ctrl+Shift+N", "New transaction"),
-                ShortcutHelpEntry("Ctrl+F", "Focus search"),
-                ShortcutHelpEntry("/", "Focus search (alternative)"),
-                ShortcutHelpEntry("Delete", "Delete selected item"),
-                ShortcutHelpEntry("Enter", "Open selected item"),
-                ShortcutHelpEntry("Escape", "Close dialog / go back"),
-            ),
-            "App" to listOf(
-                ShortcutHelpEntry("F1", "Show keyboard shortcuts"),
-                ShortcutHelpEntry("Ctrl+Shift+F", "Report bug / send feedback"),
-                ShortcutHelpEntry("Ctrl+Shift+V", "Voice transaction entry"),
-            ),
-        )
+fun KeyboardShortcutsHelpDialog(
+    shortcutHandler: ShortcutHandler,
+    onDismiss: () -> Unit,
+) {
+    val sections = remember(shortcutHandler.allShortcuts()) {
+        buildShortcutHelpSections(shortcutHandler.allShortcuts())
     }
 
     AlertDialog(

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/LockScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/LockScreen.kt
@@ -27,8 +27,12 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.liveRegion
@@ -37,6 +41,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.finance.desktop.accessibility.activateOnEnterOrSpace
 import com.finance.desktop.theme.FinanceDesktopTheme
 
 /**
@@ -72,6 +77,20 @@ fun LockScreen(
     onContinueWithoutAuthentication: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
+    // Default keyboard focus lands on the primary action so keyboard/Narrator
+    // users can authenticate with Enter/Space immediately (#3709).
+    val unlockFocus = remember { FocusRequester() }
+    val fallbackFocus = remember { FocusRequester() }
+    LaunchedEffect(isAuthenticating, isWindowsHelloAvailable) {
+        if (isAuthenticating) return@LaunchedEffect
+        runCatching {
+            if (isWindowsHelloAvailable) {
+                unlockFocus.requestFocus()
+            } else if (onContinueWithoutAuthentication != null) {
+                fallbackFocus.requestFocus()
+            }
+        }
+    }
     Surface(
         modifier = modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background,
@@ -168,6 +187,8 @@ fun LockScreen(
                         modifier = Modifier
                             .width(280.dp)
                             .height(48.dp)
+                            .focusRequester(unlockFocus)
+                            .activateOnEnterOrSpace(onAuthenticate)
                             .semantics {
                                 contentDescription =
                                     "Unlock with Windows Hello. Uses fingerprint, face recognition, or PIN."
@@ -204,6 +225,8 @@ fun LockScreen(
                                 modifier = Modifier
                                     .width(280.dp)
                                     .height(48.dp)
+                                    .focusRequester(fallbackFocus)
+                                    .activateOnEnterOrSpace(onContinueWithoutAuthentication)
                                     .semantics {
                                         contentDescription =
                                             "Continue without authentication. Windows Hello is not configured."

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/SettingsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/SettingsScreen.kt
@@ -180,6 +180,10 @@ fun SettingsScreen(
                 AppearanceSettingsScreen(
                     selectedIconPackId = state.iconPackId,
                     onIconPackSelected = viewModel::setIconPack,
+                    highContrastMode = state.highContrastMode,
+                    onHighContrastModeSelected = viewModel::setHighContrastMode,
+                    compactDensity = state.compactDensity,
+                    onCompactDensityChange = viewModel::setCompactDensity,
                 )
             }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/TransactionsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/TransactionsScreen.kt
@@ -59,6 +59,7 @@ import com.finance.desktop.components.filter.FilterBar
 import com.finance.desktop.components.tags.TagChip
 import com.finance.desktop.components.tags.TagList
 import com.finance.desktop.components.tags.TagSize
+import com.finance.desktop.components.ListErrorState
 import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
 import com.finance.desktop.viewmodel.TransactionsViewModel
@@ -117,6 +118,16 @@ fun TransactionsScreen(modifier: Modifier = Modifier) {
                 },
             )
         }
+        return
+    }
+
+    if (state.errorMessage != null) {
+        ListErrorState(
+            message = state.errorMessage!!,
+            onRetry = { viewModel.retry() },
+            title = "Couldn't load transactions",
+            modifier = modifier,
+        )
         return
     }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/settings/AppearanceSettingsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/settings/AppearanceSettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -20,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -35,11 +37,148 @@ import com.finance.desktop.ui.components.LocalIconPack
 fun AppearanceSettingsScreen(
     selectedIconPackId: String,
     onIconPackSelected: (String) -> Unit,
+    highContrastMode: String = "Auto",
+    onHighContrastModeSelected: (String) -> Unit = {},
+    compactDensity: Boolean = false,
+    onCompactDensityChange: (Boolean) -> Unit = {},
 ) {
-    IconStyleCard(
-        selectedIconPackId = selectedIconPackId,
-        onIconPackSelected = onIconPackSelected,
-    )
+    Column(verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg)) {
+        IconStyleCard(
+            selectedIconPackId = selectedIconPackId,
+            onIconPackSelected = onIconPackSelected,
+        )
+        HighContrastCard(
+            selectedMode = highContrastMode,
+            onModeSelected = onHighContrastModeSelected,
+        )
+        DensityCard(
+            compact = compactDensity,
+            onCompactChange = onCompactDensityChange,
+        )
+    }
+}
+
+/**
+ * High Contrast preference card (#3665): Auto / On / Off radio options.
+ */
+@Composable
+private fun HighContrastCard(
+    selectedMode: String,
+    onModeSelected: (String) -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = "High contrast settings" },
+    ) {
+        Column(
+            modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+        ) {
+            Text(
+                text = "High Contrast",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = "System detection is unreliable — force high contrast on or off.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            listOf(
+                "Auto" to "Follow the Windows high-contrast setting",
+                "On" to "Always use a high-contrast color scheme",
+                "Off" to "Never use a high-contrast color scheme",
+            ).forEach { (value, description) ->
+                RadioOptionRow(
+                    label = value,
+                    description = description,
+                    selected = selectedMode.equals(value, ignoreCase = true),
+                    onSelected = { onModeSelected(value) },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Information-density card (#3722): Comfortable / Compact radio options.
+ */
+@Composable
+private fun DensityCard(
+    compact: Boolean,
+    onCompactChange: (Boolean) -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = "Density settings" },
+    ) {
+        Column(
+            modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.md),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Compact density",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = "Tighter spacing shows more rows per screen on list views.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = compact,
+                    onCheckedChange = onCompactChange,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Compact density, ${if (compact) "enabled" else "disabled"}"
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RadioOptionRow(
+    label: String,
+    description: String,
+    selected: Boolean,
+    onSelected: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                onClick = onSelected,
+                role = Role.RadioButton,
+            )
+            .padding(vertical = FinanceDesktopTheme.spacing.xs)
+            .semantics {
+                contentDescription = "$label. $description"
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.md),
+    ) {
+        RadioButton(selected = selected, onClick = onSelected)
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = label, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
 }
 
 @Composable

--- a/apps/windows/src/main/kotlin/com/finance/desktop/theme/FinanceDesktopTheme.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/theme/FinanceDesktopTheme.kt
@@ -254,7 +254,35 @@ data class Spacing(
     val epic: Dp = 80.dp,
 )
 
-val LocalSpacing = staticCompositionLocalOf { Spacing() }
+/**
+ * Comfortable (default) spacing scale — the standard Android-mirrored density.
+ */
+val ComfortableSpacing = Spacing()
+
+/**
+ * Compact spacing scale for information-dense desktop layouts (#3722).
+ *
+ * Paddings and gaps are reduced to roughly 60–70% of [ComfortableSpacing] so
+ * list-heavy screens show meaningfully more rows per screen. Values never drop
+ * below what keeps touch/click targets usable, and Narrator semantics are
+ * unaffected because only spacing — not element presence — changes.
+ */
+val CompactSpacing = Spacing(
+    none = 0.dp,
+    xs = 2.dp,
+    sm = 6.dp,
+    md = 8.dp,
+    lg = 12.dp,
+    xl = 14.dp,
+    xxl = 16.dp,
+    xxxl = 20.dp,
+    huge = 28.dp,
+    massive = 32.dp,
+    colossal = 44.dp,
+    epic = 56.dp,
+)
+
+val LocalSpacing = staticCompositionLocalOf { ComfortableSpacing }
 
 // =============================================================================
 // Theme composable
@@ -269,11 +297,16 @@ val LocalSpacing = staticCompositionLocalOf { Spacing() }
  *
  * Typography uses [FontFamily.Default] which resolves to Segoe UI on Windows,
  * aligning with Fluent Design system conventions.
+ *
+ * @param darkTheme Whether to use the dark color scheme.
+ * @param highContrast Whether to use a high-contrast color scheme (#3665).
+ * @param compact Whether to apply the [CompactSpacing] density scale (#3722).
  */
 @Composable
 fun FinanceDesktopTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     highContrast: Boolean = isHighContrastEnabled(),
+    compact: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     val colorScheme = resolveColorScheme(
@@ -283,9 +316,10 @@ fun FinanceDesktopTheme(
         standardDark = DarkColorScheme,
     )
     val statusColors = if (darkTheme) DarkStatusColors else LightStatusColors
+    val spacing = if (compact) CompactSpacing else ComfortableSpacing
 
     CompositionLocalProvider(
-        LocalSpacing provides Spacing(),
+        LocalSpacing provides spacing,
         LocalStatusColors provides statusColors,
     ) {
         MaterialTheme(

--- a/apps/windows/src/main/kotlin/com/finance/desktop/theme/HighContrastTheme.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/theme/HighContrastTheme.kt
@@ -142,6 +142,48 @@ fun isHighContrastEnabled(): Boolean {
 }
 
 /**
+ * User-facing high-contrast preference (#3665).
+ *
+ * System detection via [isHighContrastEnabled] is best-effort and frequently
+ * returns nothing under Compose Desktop, so users can force the behaviour:
+ * - [AUTO] preserves the current system-detection behaviour.
+ * - [ON] always uses a high-contrast scheme.
+ * - [OFF] never uses a high-contrast scheme.
+ */
+enum class HighContrastMode {
+    AUTO,
+    ON,
+    OFF,
+    ;
+
+    companion object {
+        /**
+         * Parses a persisted string value, falling back to [AUTO] for unknown
+         * or null input so a corrupt setting never breaks theming.
+         */
+        fun fromStorage(value: String?): HighContrastMode =
+            entries.firstOrNull { it.name.equals(value, ignoreCase = true) } ?: AUTO
+    }
+}
+
+/**
+ * Resolves whether high contrast should be active given the user's [mode] and
+ * the best-effort [systemDetected] flag from [isHighContrastEnabled].
+ *
+ * @param mode The user's explicit preference.
+ * @param systemDetected Whether the OS appears to have high contrast enabled.
+ * @return true if a high-contrast color scheme should be applied.
+ */
+fun resolveHighContrast(
+    mode: HighContrastMode,
+    systemDetected: Boolean = isHighContrastEnabled(),
+): Boolean = when (mode) {
+    HighContrastMode.ON -> true
+    HighContrastMode.OFF -> false
+    HighContrastMode.AUTO -> systemDetected
+}
+
+/**
  * Returns the appropriate color scheme based on system accessibility settings.
  *
  * Priority:

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/AccountsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/AccountsViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 data class AccountGroupUi(val type: AccountType, val displayName: String, val accounts: List<Account>, val totalBalanceFormatted: String)
-data class AccountsUiState(val isLoading: Boolean = true, val groups: List<AccountGroupUi> = emptyList(), val selectedAccount: Account? = null, val selectedAccountTransactions: List<Transaction> = emptyList())
+data class AccountsUiState(val isLoading: Boolean = true, val groups: List<AccountGroupUi> = emptyList(), val errorMessage: String? = null, val selectedAccount: Account? = null, val selectedAccountTransactions: List<Transaction> = emptyList())
 
 class AccountsViewModel(
     private val accountRepository: AccountRepository,
@@ -26,15 +26,22 @@ class AccountsViewModel(
             _uiState.value = _uiState.value.copy(selectedAccount = account, selectedAccountTransactions = txns)
         }
     }
+    /** Retries loading after an error (#3685). */
+    fun retry() { loadAccounts() }
     private fun loadAccounts() {
         viewModelScope.launch {
-            val accounts = accountRepository.observeAll(hid).first()
-            val currency = Currency.USD
-            val groups = accounts.groupBy { it.type }.entries.map { (type, accts) ->
-                val total = Cents(accts.sumOf { it.currentBalance.amount })
-                AccountGroupUi(type, type.name.lowercase().replaceFirstChar { it.uppercase() }, accts.sortedBy { it.sortOrder }, CurrencyFormatter.format(total, currency))
+            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+            try {
+                val accounts = accountRepository.observeAll(hid).first()
+                val currency = Currency.USD
+                val groups = accounts.groupBy { it.type }.entries.map { (type, accts) ->
+                    val total = Cents(accts.sumOf { it.currentBalance.amount })
+                    AccountGroupUi(type, type.name.lowercase().replaceFirstChar { it.uppercase() }, accts.sortedBy { it.sortOrder }, CurrencyFormatter.format(total, currency))
+                }
+                _uiState.value = AccountsUiState(isLoading = false, groups = groups)
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(isLoading = false, errorMessage = e.message ?: "Unable to load accounts. Please try again.")
             }
-            _uiState.value = AccountsUiState(isLoading = false, groups = groups)
         }
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/BudgetsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/BudgetsViewModel.kt
@@ -42,6 +42,7 @@ data class BudgetItemUi(
 data class BudgetsUiState(
     val isLoading: Boolean = true,
     val budgets: List<BudgetItemUi> = emptyList(),
+    val errorMessage: String? = null,
     val editingBudgetId: String? = null,
     val deletingBudgetId: String? = null,
     val editName: String = "",
@@ -78,55 +79,69 @@ class BudgetsViewModel(
 
     private fun loadBudgets() {
         viewModelScope.launch {
-            val budgets = budgetRepository.observeAll(hid).first()
-            rawBudgets = budgets
-            val transactions = transactionRepository.observeAll(hid).first()
-            val today = Clock.System.now()
-                .toLocalDateTime(TimeZone.currentSystemDefault()).date
-            val currency = Currency.USD
+            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+            try {
+                val budgets = budgetRepository.observeAll(hid).first()
+                rawBudgets = budgets
+                val transactions = transactionRepository.observeAll(hid).first()
+                val today = Clock.System.now()
+                    .toLocalDateTime(TimeZone.currentSystemDefault()).date
+                val currency = Currency.USD
 
-            val items = budgets.map { budget ->
-                val categoryTransactions = transactions.filter {
-                    it.categoryId == budget.categoryId
+                val items = budgets.map { budget ->
+                    val categoryTransactions = transactions.filter {
+                        it.categoryId == budget.categoryId
+                    }
+                    val status = BudgetCalculator.calculateStatus(
+                        budget, categoryTransactions, today,
+                    )
+                    val spentFormatted = CurrencyFormatter.format(status.spent, currency)
+                    val limitFormatted = CurrencyFormatter.format(budget.amount, currency)
+                    val utilization = status.utilization.toFloat().coerceIn(0f, 1.5f)
+                    val isOver = status.healthLevel == BudgetHealth.OVER
+                    val remainingCents = budget.amount.amount - status.spent.amount
+                    val remainingFormatted = if (remainingCents >= 0) {
+                        "${CurrencyFormatter.format(
+                            com.finance.models.types.Cents(remainingCents),
+                            currency,
+                        )} left"
+                    } else {
+                        "${CurrencyFormatter.format(
+                            com.finance.models.types.Cents(-remainingCents),
+                            currency,
+                        )} over"
+                    }
+
+                    BudgetItemUi(
+                        id = budget.id.value,
+                        name = budget.name,
+                        spent = spentFormatted,
+                        limit = limitFormatted,
+                        remaining = remainingFormatted,
+                        utilization = utilization,
+                        isOver = isOver,
+                        period = budget.period.displayName(),
+                        health = status.healthLevel,
+                    )
                 }
-                val status = BudgetCalculator.calculateStatus(
-                    budget, categoryTransactions, today,
+
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    budgets = items,
+                    errorMessage = null,
                 )
-                val spentFormatted = CurrencyFormatter.format(status.spent, currency)
-                val limitFormatted = CurrencyFormatter.format(budget.amount, currency)
-                val utilization = status.utilization.toFloat().coerceIn(0f, 1.5f)
-                val isOver = status.healthLevel == BudgetHealth.OVER
-                val remainingCents = budget.amount.amount - status.spent.amount
-                val remainingFormatted = if (remainingCents >= 0) {
-                    "${CurrencyFormatter.format(
-                        com.finance.models.types.Cents(remainingCents),
-                        currency,
-                    )} left"
-                } else {
-                    "${CurrencyFormatter.format(
-                        com.finance.models.types.Cents(-remainingCents),
-                        currency,
-                    )} over"
-                }
-
-                BudgetItemUi(
-                    id = budget.id.value,
-                    name = budget.name,
-                    spent = spentFormatted,
-                    limit = limitFormatted,
-                    remaining = remainingFormatted,
-                    utilization = utilization,
-                    isOver = isOver,
-                    period = budget.period.displayName(),
-                    health = status.healthLevel,
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    errorMessage = e.message ?: "Unable to load budgets. Please try again.",
                 )
             }
-
-            _uiState.value = _uiState.value.copy(
-                isLoading = false,
-                budgets = items,
-            )
         }
+    }
+
+    /** Retries loading after an error (#3685). */
+    fun retry() {
+        loadBudgets()
     }
 
     /**

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/GoalsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/GoalsViewModel.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import java.util.UUID
 
 /**
  * UI model for a single savings goal card in the Goals screen.
@@ -33,7 +35,9 @@ data class GoalItemUi(
 data class GoalsUiState(
     val isLoading: Boolean = true,
     val goals: List<GoalItemUi> = emptyList(),
+    val errorMessage: String? = null,
     val editingGoalId: String? = null,
+    val isCreating: Boolean = false,
     val deletingGoalId: String? = null,
     val editName: String = "",
     val editTargetAmount: String = "",
@@ -67,31 +71,45 @@ class GoalsViewModel(
 
     private fun loadGoals() {
         viewModelScope.launch {
-            val goals = goalRepository.observeAll(hid).first()
-            rawGoals = goals
-            val currency = Currency.USD
+            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+            try {
+                val goals = goalRepository.observeAll(hid).first()
+                rawGoals = goals
+                val currency = Currency.USD
 
-            val items = goals.map { goal ->
-                GoalItemUi(
-                    id = goal.id.value,
-                    name = goal.name,
-                    currentAmount = CurrencyFormatter.format(
-                        goal.currentAmount, currency,
-                    ),
-                    targetAmount = CurrencyFormatter.format(
-                        goal.targetAmount, currency,
-                    ),
-                    progress = goal.progress.toFloat(),
-                    deadline = goal.targetDate?.toString(),
-                    status = goal.status,
+                val items = goals.map { goal ->
+                    GoalItemUi(
+                        id = goal.id.value,
+                        name = goal.name,
+                        currentAmount = CurrencyFormatter.format(
+                            goal.currentAmount, currency,
+                        ),
+                        targetAmount = CurrencyFormatter.format(
+                            goal.targetAmount, currency,
+                        ),
+                        progress = goal.progress.toFloat(),
+                        deadline = goal.targetDate?.toString(),
+                        status = goal.status,
+                    )
+                }
+
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    goals = items,
+                    errorMessage = null,
+                )
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    errorMessage = e.message ?: "Unable to load goals. Please try again.",
                 )
             }
-
-            _uiState.value = _uiState.value.copy(
-                isLoading = false,
-                goals = items,
-            )
         }
+    }
+
+    /** Retries loading after an error (#3685). */
+    fun retry() {
+        loadGoals()
     }
 
     /**
@@ -107,9 +125,22 @@ class GoalsViewModel(
         )
     }
 
-    /** Cancels the edit dialog. */
+    /**
+     * Opens the create dialog with empty fields for a new savings goal (#3677).
+     */
+    fun startCreate() {
+        _uiState.value = _uiState.value.copy(
+            isCreating = true,
+            editingGoalId = null,
+            editName = "",
+            editTargetAmount = "",
+            editCurrentAmount = "",
+        )
+    }
+
+    /** Cancels the edit or create dialog. */
     fun cancelEdit() {
-        _uiState.value = _uiState.value.copy(editingGoalId = null)
+        _uiState.value = _uiState.value.copy(editingGoalId = null, isCreating = false)
     }
 
     /** Updates the edit form name field. */
@@ -127,17 +158,41 @@ class GoalsViewModel(
         _uiState.value = _uiState.value.copy(editCurrentAmount = amount)
     }
 
-    /** Saves the edited goal to the repository. */
+    /** Saves the edited goal to the repository, or creates a new one. */
     fun saveEdit() {
-        val editingId = _uiState.value.editingGoalId ?: return
+        val state = _uiState.value
+        val targetCents = ((state.editTargetAmount.toDoubleOrNull() ?: 0.0) * 100).toLong()
+        val currentCents = ((state.editCurrentAmount.toDoubleOrNull() ?: 0.0) * 100).toLong()
+
+        if (state.isCreating) {
+            if (state.editName.isBlank() || targetCents <= 0L) return
+            val now = Clock.System.now()
+            val newGoal = Goal(
+                id = SyncId(UUID.randomUUID().toString()),
+                householdId = hid,
+                ownerId = SyncId("owner-1"),
+                name = state.editName.trim(),
+                targetAmount = com.finance.models.types.Cents(targetCents),
+                currentAmount = com.finance.models.types.Cents(currentCents),
+                currency = Currency.USD,
+                createdAt = now,
+                updatedAt = now,
+            )
+            viewModelScope.launch {
+                goalRepository.insert(newGoal)
+                _uiState.value = _uiState.value.copy(isCreating = false)
+                loadGoals()
+            }
+            return
+        }
+
+        val editingId = state.editingGoalId ?: return
         val goal = rawGoals.find { it.id.value == editingId } ?: return
-        val targetCents = ((_uiState.value.editTargetAmount.toDoubleOrNull() ?: 0.0) * 100).toLong()
-        val currentCents = ((_uiState.value.editCurrentAmount.toDoubleOrNull() ?: 0.0) * 100).toLong()
 
         viewModelScope.launch {
             goalRepository.update(
                 goal.copy(
-                    name = _uiState.value.editName,
+                    name = state.editName,
                     targetAmount = com.finance.models.types.Cents(targetCents),
                     currentAmount = com.finance.models.types.Cents(currentCents),
                 ),

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/SettingsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/SettingsViewModel.kt
@@ -29,6 +29,8 @@ data class SettingsUiState(
     val darkMode: Boolean = false,
     val language: String = "English",
     val accentColor: String = "Blue",
+    val highContrastMode: String = "Auto",
+    val compactDensity: Boolean = false,
     val iconPackId: String = FLUENT_REGULAR,
 
     // ── Security ──
@@ -91,6 +93,12 @@ class SettingsViewModel(
     fun setLanguage(language: String) = updateAndSave { it.copy(language = language) }
 
     fun setAccentColor(color: String) = updateAndSave { it.copy(accentColor = color) }
+
+    /** Sets the high-contrast preference ("Auto", "On", or "Off") (#3665). */
+    fun setHighContrastMode(mode: String) = updateAndSave { it.copy(highContrastMode = mode) }
+
+    /** Toggles the compact information-density mode (#3722). */
+    fun setCompactDensity(enabled: Boolean) = updateAndSave { it.copy(compactDensity = enabled) }
 
     fun setIconPack(iconPackId: String) = updateAndSave { state ->
         val supportedPack = IconPacks.forPlatform(Platform.WINDOWS).firstOrNull { it.id == iconPackId }
@@ -270,6 +278,8 @@ private fun AppSettings.toUiState(): SettingsUiState = SettingsUiState(
     darkMode = darkMode,
     language = language,
     accentColor = accentColor,
+    highContrastMode = highContrastMode,
+    compactDensity = compactDensity,
     iconPackId = iconPackId,
     windowsHelloEnabled = windowsHelloEnabled,
     autoLockEnabled = autoLockEnabled,
@@ -286,6 +296,8 @@ private fun SettingsUiState.toAppSettings(): AppSettings = AppSettings(
     darkMode = darkMode,
     language = language,
     accentColor = accentColor,
+    highContrastMode = highContrastMode,
+    compactDensity = compactDensity,
     iconPackId = iconPackId,
     windowsHelloEnabled = windowsHelloEnabled,
     autoLockEnabled = autoLockEnabled,

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/TransactionsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/TransactionsViewModel.kt
@@ -37,6 +37,7 @@ data class TransactionFilter(
 data class TransactionsUiState(
     val isLoading: Boolean = true,
     val transactions: List<Transaction> = emptyList(),
+    val errorMessage: String? = null,
     val filter: TransactionFilter = TransactionFilter(),
     val advancedFilter: AdvancedFilter = AdvancedFilter(),
     val sortConfig: SortConfig = SortConfig(),
@@ -140,13 +141,32 @@ class TransactionsViewModel(
         }
     }
 
+    /** Retries loading after an error (#3685). */
+    fun retry() {
+        loadTransactions()
+    }
+
     /**
      * Loads transactions from the repository, applies all advanced filters,
      * and sorts the result according to the current sort configuration.
      */
-    @Suppress("CyclomaticComplexity") // Multi-field search predicate
     private fun loadTransactions() {
         viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(errorMessage = null)
+            try {
+                loadTransactionsInternal()
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    errorMessage = e.message ?: "Unable to load transactions. Please try again.",
+                )
+            }
+        }
+    }
+
+    @Suppress("CyclomaticComplexity") // Multi-field search predicate
+    private suspend fun loadTransactionsInternal() {
+        run {
             val all = transactionRepository.observeAll(hid).first()
             val filter = _uiState.value.advancedFilter
             val sortConfig = _uiState.value.sortConfig

--- a/apps/windows/src/test/kotlin/com/finance/desktop/screens/ShortcutHelpTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/screens/ShortcutHelpTest.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.screens
+
+import androidx.compose.ui.input.key.Key
+import com.finance.desktop.components.KeyboardShortcut
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the derived keyboard-shortcuts help content (#3660).
+ *
+ * These pin the key-formatting and section-grouping logic so the help dialog
+ * always reflects the real registered shortcuts, with no phantom entries.
+ */
+class ShortcutHelpTest {
+
+    private fun shortcut(
+        key: Key,
+        description: String,
+        ctrl: Boolean = true,
+        shift: Boolean = false,
+    ) = KeyboardShortcut(key = key, ctrl = ctrl, shift = shift, description = description, action = {})
+
+    @Test
+    fun `formatShortcutKeys renders modifiers in order`() {
+        assertEquals("Ctrl+Shift+N", formatShortcutKeys(shortcut(Key.N, "New transaction", ctrl = true, shift = true)))
+        assertEquals("Ctrl+D", formatShortcutKeys(shortcut(Key.D, "Go to dashboard")))
+        assertEquals("F1", formatShortcutKeys(shortcut(Key.F1, "Show shortcuts", ctrl = false)))
+        assertEquals("Escape", formatShortcutKeys(shortcut(Key.Escape, "Close dialog", ctrl = false)))
+    }
+
+    @Test
+    fun `sections split navigation from actions and rewrite nav labels`() {
+        val shortcuts = listOf(
+            shortcut(Key.D, "Navigate to Dashboard"),
+            shortcut(Key.T, "Navigate to Transactions"),
+            shortcut(Key.N, "New transaction", shift = true),
+            shortcut(Key.F1, "Show keyboard shortcuts", ctrl = false),
+        )
+
+        val sections = buildShortcutHelpSections(shortcuts)
+
+        assertEquals(listOf("Navigation", "Actions"), sections.map { it.first })
+
+        val nav = sections.first { it.first == "Navigation" }.second
+        assertTrue(nav.any { it.description == "Go to Dashboard" })
+        assertTrue(nav.any { it.description == "Go to Transactions" })
+
+        val actions = sections.first { it.first == "Actions" }.second
+        assertTrue(actions.any { it.description == "New transaction" })
+        assertTrue(actions.any { it.description == "Show keyboard shortcuts" })
+    }
+
+    @Test
+    fun `duplicate key combos are collapsed`() {
+        val shortcuts = listOf(
+            shortcut(Key.N, "New transaction", shift = true),
+            shortcut(Key.N, "New transaction", shift = true),
+        )
+        val actions = buildShortcutHelpSections(shortcuts).first { it.first == "Actions" }.second
+        assertEquals(1, actions.size)
+    }
+
+    @Test
+    fun `empty shortcut list yields no sections`() {
+        assertTrue(buildShortcutHelpSections(emptyList()).isEmpty())
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/theme/DensityAndContrastTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/theme/DensityAndContrastTest.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.theme
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the density spacing scales (#3722) and the high-contrast
+ * resolution logic (#3665). Pure logic — no Compose runtime involved.
+ */
+class DensityAndContrastTest {
+
+    @Test
+    fun `compact spacing is strictly denser than comfortable for key tokens`() {
+        assertTrue(CompactSpacing.xs.value < ComfortableSpacing.xs.value)
+        assertTrue(CompactSpacing.sm.value < ComfortableSpacing.sm.value)
+        assertTrue(CompactSpacing.md.value < ComfortableSpacing.md.value)
+        assertTrue(CompactSpacing.lg.value < ComfortableSpacing.lg.value)
+        assertTrue(CompactSpacing.xxl.value < ComfortableSpacing.xxl.value)
+        assertTrue(CompactSpacing.epic.value < ComfortableSpacing.epic.value)
+    }
+
+    @Test
+    fun `compact spacing keeps a sane monotonic scale`() {
+        assertTrue(CompactSpacing.xs.value <= CompactSpacing.sm.value)
+        assertTrue(CompactSpacing.sm.value <= CompactSpacing.md.value)
+        assertTrue(CompactSpacing.md.value <= CompactSpacing.lg.value)
+        assertTrue(CompactSpacing.lg.value <= CompactSpacing.xxl.value)
+        assertTrue(CompactSpacing.none.value == 0f)
+    }
+
+    @Test
+    fun `high contrast mode parses stored strings and defaults to auto`() {
+        assertEquals(HighContrastMode.ON, HighContrastMode.fromStorage("On"))
+        assertEquals(HighContrastMode.OFF, HighContrastMode.fromStorage("off"))
+        assertEquals(HighContrastMode.AUTO, HighContrastMode.fromStorage("AUTO"))
+        assertEquals(HighContrastMode.AUTO, HighContrastMode.fromStorage(null))
+        assertEquals(HighContrastMode.AUTO, HighContrastMode.fromStorage("garbage"))
+    }
+
+    @Test
+    fun `resolveHighContrast honours explicit user choice over system state`() {
+        assertTrue(resolveHighContrast(HighContrastMode.ON, systemDetected = false))
+        assertFalse(resolveHighContrast(HighContrastMode.OFF, systemDetected = true))
+    }
+
+    @Test
+    fun `resolveHighContrast follows system when auto`() {
+        assertTrue(resolveHighContrast(HighContrastMode.AUTO, systemDetected = true))
+        assertFalse(resolveHighContrast(HighContrastMode.AUTO, systemDetected = false))
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/viewmodel/GoalsViewModelTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/viewmodel/GoalsViewModelTest.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.viewmodel
+
+import com.finance.desktop.data.repository.GoalRepository
+import com.finance.models.Goal
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [GoalsViewModel] error/retry (#3685) and create (#3677) flows.
+ *
+ * Uses a controllable fake [GoalRepository] so the load can be made to fail and
+ * then recover on retry, and a created goal can be observed as persisted.
+ */
+class GoalsViewModelTest {
+
+    private class FakeGoalRepository(
+        @Volatile var shouldFail: Boolean = false,
+    ) : GoalRepository {
+        val stored = mutableListOf<Goal>()
+
+        override fun observeAll(householdId: SyncId): Flow<List<Goal>> =
+            if (shouldFail) {
+                flow { throw IllegalStateException("network down") }
+            } else {
+                flowOf(stored.toList())
+            }
+
+        override fun observeActive(householdId: SyncId): Flow<List<Goal>> = observeAll(householdId)
+        override suspend fun updateProgress(id: SyncId, currentAmount: Cents) = Unit
+        override suspend fun insert(entity: Goal) { stored.add(entity) }
+        override suspend fun update(entity: Goal) {
+            val idx = stored.indexOfFirst { it.id == entity.id }
+            if (idx >= 0) stored[idx] = entity
+        }
+        override suspend fun delete(id: SyncId) { stored.removeAll { it.id == id } }
+    }
+
+    private fun sampleGoal() = Goal(
+        id = SyncId("g1"),
+        householdId = SyncId("d1"),
+        ownerId = SyncId("owner-1"),
+        name = "Emergency Fund",
+        targetAmount = Cents(1000000),
+        currentAmount = Cents(250000),
+        currency = Currency.USD,
+        createdAt = Clock.System.now(),
+        updatedAt = Clock.System.now(),
+    )
+
+    private fun waitUntil(timeoutMs: Long = 3000, predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return
+            Thread.sleep(10)
+        }
+        throw AssertionError("Condition not met within ${timeoutMs}ms")
+    }
+
+    @Test
+    fun `load failure surfaces an error message and stops loading`() {
+        val repo = FakeGoalRepository(shouldFail = true)
+        val vm = GoalsViewModel(repo)
+
+        waitUntil { !vm.uiState.value.isLoading }
+        assertNotNull(vm.uiState.value.errorMessage)
+    }
+
+    @Test
+    fun `retry after recovery clears the error and loads goals`() {
+        val repo = FakeGoalRepository(shouldFail = true)
+        repo.stored.add(sampleGoal())
+        val vm = GoalsViewModel(repo)
+
+        waitUntil { vm.uiState.value.errorMessage != null }
+
+        repo.shouldFail = false
+        vm.retry()
+
+        waitUntil { !vm.uiState.value.isLoading && vm.uiState.value.errorMessage == null }
+        assertNull(vm.uiState.value.errorMessage)
+        assertEquals(1, vm.uiState.value.goals.size)
+    }
+
+    @Test
+    fun `create flow inserts a new goal and refreshes the list`() {
+        val repo = FakeGoalRepository()
+        val vm = GoalsViewModel(repo)
+        waitUntil { !vm.uiState.value.isLoading }
+
+        vm.startCreate()
+        assertTrue(vm.uiState.value.isCreating)
+        vm.updateEditName("Vacation")
+        vm.updateEditTargetAmount("500")
+        vm.updateEditCurrentAmount("0")
+        vm.saveEdit()
+
+        waitUntil { vm.uiState.value.goals.isNotEmpty() }
+        assertEquals(1, repo.stored.size)
+        assertEquals("Vacation", repo.stored.first().name)
+        assertTrue(!vm.uiState.value.isCreating)
+    }
+
+    @Test
+    fun `create is rejected when name blank or target not positive`() {
+        val repo = FakeGoalRepository()
+        val vm = GoalsViewModel(repo)
+        waitUntil { !vm.uiState.value.isLoading }
+
+        vm.startCreate()
+        vm.updateEditName("   ")
+        vm.updateEditTargetAmount("100")
+        vm.saveEdit()
+
+        // Nothing persisted for a blank name.
+        assertEquals(0, repo.stored.size)
+    }
+}


### PR DESCRIPTION
﻿## Summary

A single cohesive batch of 10 closely-related improvements to the Windows Compose Desktop app (apps/windows), focused on information density, accessibility (WCAG), navigation/IA, and list-state resilience. All work mirrors the existing Android/Compose + Koin DI + ViewModel/Repository architecture.

### What changed

- **Compact information-density mode (#3722)** - New Comfortable/Compact spacing scales; FinanceDesktopTheme(compact) selects the scale, persisted via a new Appearance setting.
- **Visible keyboard focus indicator (#3715)** - Modifier.focusVisible() draws a WCAG 2.4.7-compliant focus ring on custom clickables (sidebar items, account status).
- **Lock screen default focus + Enter-to-authenticate (#3709)** - The unlock button requests focus on show and activates on Enter/Space.
- **Window title reflects active screen (#3693)** - The window title updates to "<Screen> - Finance" as the user navigates.
- **List error state + retry (#3685)** - Goals/Accounts/Transactions/Budgets load paths are wrapped with error handling and a reusable retryable error state.
- **Empty-state primary CTA (#3677)** - Empty Goals screen offers a primary Create goal CTA plus a New Goal toolbar action, backed by a full create flow.
- **User-facing High Contrast toggle (#3665)** - HighContrastMode (Auto/On/Off) with resolveHighContrast(), surfaced in Appearance settings.
- **Accurate keyboard-shortcuts help dialog (#3660)** - The dialog is derived from the live ShortcutHandler.allShortcuts(), so it can never advertise a shortcut that isn't registered.
- **Sidebar grouping/IA (#3655)** - The 19+ flat destinations are grouped into Primary/Insights/Tools sections with headings.
- **Scrollable sidebar nav list (#3592)** - The nav list scrolls and no longer clips on short windows; account + Settings stay pinned.

### Testing

- ./gradlew :apps:windows:compileKotlin - PASS
- ./gradlew :apps:windows:test - PASS (full suite, incl. new tests)
- New unit tests: density spacing, high-contrast resolution, shortcut key formatting/section grouping, and Goals error/retry + create flow (fake repository).
- No JS/TS touched; Prettier ignores *.kt, Kotlin lint is detekt (non-blocking).

Closes #3722
Closes #3715
Closes #3709
Closes #3693
Closes #3685
Closes #3677
Closes #3665
Closes #3660
Closes #3655
Closes #3592
