### PR TITLE
feat(android): transaction list & entry UX batch (real repos, undo, sticky headers, AmountInput, reduced motion, skeletons)

### DIFF
--- a/apps/android/src/androidTest/kotlin/com/finance/android/e2e/robot/TransactionRobot.kt
+++ b/apps/android/src/androidTest/kotlin/com/finance/android/e2e/robot/TransactionRobot.kt
@@ -34,18 +34,18 @@ class TransactionRobot(
      */
     fun assertAmountStepVisible() {
         rule.waitUntil(timeoutMillis = 5_000) {
-            rule.onAllNodes(hasContentDescription("Amount in dollars"))
+            rule.onAllNodes(hasContentDescription("Amount input", substring = true))
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
         rule.waitForIdle()
-        rule.onNodeWithContentDescription("Amount in dollars")
+        rule.onNode(hasContentDescription("Amount input", substring = true))
             .assertIsDisplayed()
     }
 
     /** Enter the given [amount] into the Amount field. */
     fun enterAmount(amount: String) {
-        rule.onNodeWithContentDescription("Amount in dollars")
+        rule.onNode(hasContentDescription("Amount input", substring = true))
             .performTextInput(amount)
     }
 

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
@@ -14,6 +14,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
@@ -25,6 +27,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.navDeepLink
+import com.finance.android.ui.accessibility.CognitiveAccessibilityManager
 import com.finance.android.ui.screens.AccountCreateScreen
 import com.finance.android.ui.screens.AccountEditScreen
 import com.finance.android.ui.screens.AccountsScreen
@@ -56,6 +59,7 @@ import com.finance.android.ui.screens.referral.ReferralScreen
 import com.finance.android.ui.screens.report.ReportBuilderScreen
 import com.finance.android.ui.screens.currency.CurrencyConversionScreen
 import com.finance.android.ui.screens.currency.CurrencyPickerScreen
+import org.koin.compose.koinInject
 import timber.log.Timber
 
 /** Base URI for all deep link patterns declared in AndroidManifest.xml. */
@@ -227,14 +231,16 @@ fun FinanceNavHost(
     navController: NavHostController,
     modifier: Modifier = Modifier,
 ) {
+    val cognitiveManager: CognitiveAccessibilityManager = koinInject()
+    val reducedAnimations by cognitiveManager.reducedAnimations.collectAsState()
     NavHost(
         navController = navController,
         startDestination = Route.Dashboard.route,
         modifier = modifier,
-        enterTransition = NavTransitions.enterTransition,
-        exitTransition = NavTransitions.exitTransition,
-        popEnterTransition = NavTransitions.popEnterTransition,
-        popExitTransition = NavTransitions.popExitTransition,
+        enterTransition = if (reducedAnimations) NavTransitions.reducedEnterTransition else NavTransitions.enterTransition,
+        exitTransition = if (reducedAnimations) NavTransitions.reducedExitTransition else NavTransitions.exitTransition,
+        popEnterTransition = if (reducedAnimations) NavTransitions.reducedEnterTransition else NavTransitions.popEnterTransition,
+        popExitTransition = if (reducedAnimations) NavTransitions.reducedExitTransition else NavTransitions.popExitTransition,
     ) {
         // ── Top-level tabs ──────────────────────────────────────────
         composable(

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/NavTransitions.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/NavTransitions.kt
@@ -95,4 +95,22 @@ object NavTransitions {
     val tabExitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = {
         fadeOut(animationSpec = tween(DURATION_MS))
     }
+
+    // ── Reduced-motion transitions (accessibility) ──────────────────
+
+    /**
+     * Crossfade-only enter used when the user has enabled the
+     * **reduced animations** preference (#3717). Replaces directional
+     * slides to respect WCAG 2.2 (2.3.3 Animation from Interactions).
+     */
+    val reducedEnterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = {
+        fadeIn(animationSpec = tween(DURATION_MS))
+    }
+
+    /**
+     * Crossfade-only exit counterpart to [reducedEnterTransition].
+     */
+    val reducedExitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = {
+        fadeOut(animationSpec = tween(DURATION_MS))
+    }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/DashboardScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/DashboardScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material.icons.filled.TrendingDown
 import androidx.compose.material.icons.filled.TrendingUp
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
@@ -56,6 +55,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.finance.android.ui.data.SampleData
+import com.finance.android.ui.components.states.DashboardSkeleton
 import com.finance.android.ui.quickactions.QuickActionsSection
 import com.finance.android.ui.theme.FinanceTheme
 import com.finance.android.ui.tips.TipsSection
@@ -90,9 +90,8 @@ fun DashboardScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     if (state.isLoading) {
-        Box(modifier = modifier.fillMaxSize().semantics { contentDescription = "Loading dashboard" },
-            contentAlignment = Alignment.Center) {
-            CircularProgressIndicator(modifier = Modifier.semantics { contentDescription = "Loading indicator" })
+        Box(modifier = modifier.fillMaxSize().semantics { contentDescription = "Loading dashboard" }) {
+            DashboardSkeleton(Modifier.fillMaxSize())
         }
         return
     }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt
@@ -4,6 +4,8 @@ package com.finance.android.ui.screens
 
 import android.content.SharedPreferences
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
@@ -25,7 +27,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.Check
@@ -86,6 +87,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.finance.android.ui.data.SampleData
+import com.finance.android.ui.accessibility.CognitiveAccessibilityManager
+import com.finance.android.ui.components.AmountInput
 import com.finance.android.ui.feedback.rememberHapticFeedbackAvailable
 import com.finance.android.ui.feedback.rememberTransactionHapticFeedback
 import com.finance.android.ui.theme.FinanceTheme
@@ -94,8 +97,10 @@ import org.koin.compose.viewmodel.koinViewModel
 import com.finance.android.ui.viewmodel.CreateStep
 import com.finance.android.ui.viewmodel.TransactionCreateUiState
 import com.finance.android.ui.viewmodel.TransactionCreateViewModel
+import com.finance.core.multicurrency.CurrencyCatalog
 import com.finance.models.Category
 import com.finance.models.TransactionType
+import com.finance.models.types.Currency
 import com.finance.models.types.SyncId
 
 /**
@@ -113,6 +118,8 @@ fun TransactionCreateScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     val prefs: SharedPreferences = koinInject()
+    val cognitiveManager: CognitiveAccessibilityManager = koinInject()
+    val reducedAnimations by cognitiveManager.reducedAnimations.collectAsState()
     val hapticsAvailable = rememberHapticFeedbackAvailable()
     val hapticFeedbackEnabled = prefs.getBoolean(HAPTIC_FEEDBACK_PREF_KEY, hapticsAvailable)
     val hapticFeedback = rememberTransactionHapticFeedback(
@@ -151,15 +158,21 @@ fun TransactionCreateScreen(
             StepIndicator(state.currentStep, Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
             if (state.errors.isNotEmpty()) ErrorMessages(state.errors, Modifier.padding(horizontal = 16.dp))
             AnimatedContent(state.currentStep, transitionSpec = {
-                val forward = targetState.index > initialState.index
-                if (forward) {
-                    slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+                if (reducedAnimations) {
+                    // Honor the reduced-animations preference (#3717): crossfade instead
+                    // of a directional slide for users with vestibular sensitivity.
+                    fadeIn() togetherWith fadeOut()
                 } else {
-                    slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
+                    val forward = targetState.index > initialState.index
+                    if (forward) {
+                        slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+                    } else {
+                        slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
+                    }
                 }
             }, label = "step", modifier = Modifier.weight(1f).fillMaxWidth()) { step ->
                 when (step) {
-                    CreateStep.AMOUNT -> AmountStep(state, viewModel::updateAmount, viewModel::updatePayee,
+                    CreateStep.AMOUNT -> AmountStep(state, viewModel::updateAmountCents, viewModel::updatePayee,
                         viewModel::selectPayeeSuggestion, viewModel::updateTransactionType,
                         viewModel::setBnplLiabilityEnabled, viewModel::updateBnplInstallmentCount)
                     CreateStep.CATEGORY -> CategoryStep(state, viewModel::selectCategory, viewModel::selectAccount,
@@ -202,9 +215,12 @@ private fun ErrorMessages(errors: List<String>, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun AmountStep(state: TransactionCreateUiState, onAmt: (String) -> Unit, onPayee: (String) -> Unit,
+private fun AmountStep(state: TransactionCreateUiState, onAmtCents: (Long) -> Unit, onPayee: (String) -> Unit,
     onSugg: (String) -> Unit, onType: (TransactionType) -> Unit,
     onBnplChanged: (Boolean) -> Unit, onInstallmentCountChanged: (String) -> Unit) {
+    val currency = state.accounts.firstOrNull { it.id == state.selectedAccountId }?.currency
+        ?: Currency.USD
+    val currencySymbol = CurrencyCatalog.get(currency.code)?.symbol ?: "$"
     LazyColumn(Modifier.fillMaxSize(), contentPadding = PaddingValues(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
         item(key = "type") {
             Text("Transaction Type", style = MaterialTheme.typography.labelLarge,
@@ -226,10 +242,14 @@ private fun AmountStep(state: TransactionCreateUiState, onAmt: (String) -> Unit,
         item(key = "amount") {
             Text("Amount", style = MaterialTheme.typography.labelLarge, modifier = Modifier.semantics { heading() })
             Spacer(Modifier.height(8.dp))
-            OutlinedTextField(state.amountText, onAmt, Modifier.fillMaxWidth().semantics { contentDescription = "Amount in dollars" },
-                label = { Text("Amount") }, placeholder = { Text("0.00") },
-                leadingIcon = { Icon(Icons.Filled.AttachMoney, null) },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal), singleLine = true)
+            AmountInput(
+                amountCents = state.amountCents,
+                onAmountChange = onAmtCents,
+                currencySymbol = currencySymbol,
+                decimalPlaces = currency.decimalPlaces,
+                label = "Amount",
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
         item(key = "payee") {
             Text("Payee", style = MaterialTheme.typography.labelLarge, modifier = Modifier.semantics { heading() })

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionsScreen.kt
@@ -2,6 +2,7 @@
 
 package com.finance.android.ui.screens
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -26,9 +27,14 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import com.finance.android.ui.components.IconView
+import com.finance.android.ui.components.states.TransactionListSkeleton
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
@@ -40,6 +46,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -53,6 +60,7 @@ import androidx.compose.ui.unit.dp
 import com.finance.android.ui.data.SampleData
 import com.finance.android.ui.theme.FinanceTheme
 import com.finance.android.ui.viewmodel.TransactionDateGroup
+import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 import com.finance.android.ui.viewmodel.TransactionFilter
 import com.finance.android.ui.viewmodel.TransactionsUiState
@@ -78,56 +86,77 @@ fun TransactionsScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     if (state.isLoading && state.dateGroups.isEmpty()) {
-        Box(modifier.fillMaxSize().semantics { contentDescription = "Loading transactions" },
-            contentAlignment = Alignment.Center) {
-            CircularProgressIndicator(Modifier.semantics { contentDescription = "Loading indicator" })
+        Box(modifier.fillMaxSize().semantics { contentDescription = "Loading transactions" }) {
+            TransactionListSkeleton(Modifier.fillMaxSize())
         }
         return
     }
     TransactionsContent(state, viewModel::refresh, viewModel::updateSearch, viewModel::toggleSearch,
         viewModel::setTypeFilter, viewModel::clearFilters, viewModel::loadMore,
-        viewModel::deleteTransaction, onEditTransaction, onTransactionClick, modifier)
+        viewModel::deleteTransaction, onEditTransaction, onTransactionClick, viewModel::undoDelete, modifier)
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 internal fun TransactionsContent(
     state: TransactionsUiState, onRefresh: () -> Unit, onSearch: (String) -> Unit,
     onToggleSearch: () -> Unit, onTypeFilter: (TransactionType?) -> Unit,
     onClearFilters: () -> Unit, onLoadMore: () -> Unit,
     onDelete: (SyncId) -> Unit, onEdit: (SyncId) -> Unit,
-    onTransactionClick: (SyncId) -> Unit, modifier: Modifier = Modifier,
+    onTransactionClick: (SyncId) -> Unit, onUndoDelete: () -> Unit = {}, modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
     val shouldLoad by remember { derivedStateOf {
         val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()
         last != null && last.index >= listState.layoutInfo.totalItemsCount - 3
     }}
     LaunchedEffect(shouldLoad) { if (shouldLoad && state.hasMore && !state.isLoadingMore) onLoadMore() }
 
-    PullToRefreshBox(isRefreshing = state.isRefreshing, onRefresh = onRefresh, modifier = modifier.fillMaxSize()) {
-        LazyColumn(state = listState, modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
-            item(key = "search") {
-                SearchFilterBar(state.isSearchActive, state.filter.searchQuery, state.filter,
-                    onSearch, onToggleSearch, onTypeFilter, onClearFilters)
-                Spacer(Modifier.height(8.dp))
-            }
-            if (state.isEmpty) { item(key = "empty") { TxnEmptyState(state.filter != TransactionFilter()) } }
-            state.dateGroups.forEach { group ->
-                item(key = "hdr-${group.date}") { DateHeader(group.dateLabel) }
-                items(group.transactions, key = { it.id.value }) { txn ->
-                    SwipeableTxnItem(txn, { onDelete(txn.id) }, { onEdit(txn.id) }, { onTransactionClick(txn.id) })
+    // Delete via swipe, then surface an Undo snackbar so an accidental swipe is
+    // recoverable. TalkBack announces the snackbar message and the Undo action (#3688).
+    val onDeleteWithUndo: (SyncId) -> Unit = { id ->
+        onDelete(id)
+        scope.launch {
+            val result = snackbarHostState.showSnackbar(
+                message = "Transaction deleted",
+                actionLabel = "Undo",
+                withDismissAction = true,
+                duration = SnackbarDuration.Short,
+            )
+            if (result == SnackbarResult.ActionPerformed) onUndoDelete()
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        PullToRefreshBox(isRefreshing = state.isRefreshing, onRefresh = onRefresh,
+            modifier = Modifier.fillMaxSize()) {
+            LazyColumn(state = listState, modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
+                item(key = "search") {
+                    SearchFilterBar(state.isSearchActive, state.filter.searchQuery, state.filter,
+                        onSearch, onToggleSearch, onTypeFilter, onClearFilters)
                     Spacer(Modifier.height(8.dp))
                 }
+                if (state.isEmpty) { item(key = "empty") { TxnEmptyState(state.filter != TransactionFilter()) } }
+                state.dateGroups.forEach { group ->
+                    stickyHeader(key = "hdr-${group.date}") { DateHeader(group.dateLabel) }
+                    items(group.transactions, key = { it.id.value }) { txn ->
+                        SwipeableTxnItem(txn, state.categoryNames, state.accountNames,
+                            { onDeleteWithUndo(txn.id) }, { onEdit(txn.id) }, { onTransactionClick(txn.id) })
+                        Spacer(Modifier.height(8.dp))
+                    }
+                }
+                if (state.isLoadingMore) {
+                    item(key = "more") { Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator(Modifier.size(24.dp).semantics { contentDescription = "Loading more" }, strokeWidth = 2.dp)
+                    }}
+                }
+                item(key = "spacer") { Spacer(Modifier.height(80.dp)) }
             }
-            if (state.isLoadingMore) {
-                item(key = "more") { Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator(Modifier.size(24.dp).semantics { contentDescription = "Loading more" }, strokeWidth = 2.dp)
-                }}
-            }
-            item(key = "spacer") { Spacer(Modifier.height(80.dp)) }
         }
+        SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
     }
 }
 
@@ -175,12 +204,20 @@ private fun SearchFilterBar(active: Boolean, query: String, filter: TransactionF
 private fun DateHeader(label: String) {
     Text(label, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).semantics { heading(); contentDescription = "Transactions for $label" })
+        modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface)
+            .padding(vertical = 8.dp).semantics { heading(); contentDescription = "Transactions for $label" })
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SwipeableTxnItem(txn: Transaction, onDelete: () -> Unit, onEdit: () -> Unit, onClick: () -> Unit) {
+private fun SwipeableTxnItem(
+    txn: Transaction,
+    categoryNames: Map<SyncId, String>,
+    accountNames: Map<SyncId, String>,
+    onDelete: () -> Unit,
+    onEdit: () -> Unit,
+    onClick: () -> Unit,
+) {
     val dismiss = rememberSwipeToDismissBoxState(confirmValueChange = { v ->
         when (v) { SwipeToDismissBoxValue.StartToEnd -> { onEdit(); false }
             SwipeToDismissBoxValue.EndToStart -> { onDelete(); true }
@@ -200,17 +237,24 @@ private fun SwipeableTxnItem(txn: Transaction, onDelete: () -> Unit, onEdit: () 
         Box(Modifier.fillMaxSize().background(bg, MaterialTheme.shapes.medium).padding(horizontal = 20.dp), contentAlignment = align) {
             IconView(token = iconToken, tint = tint)
         }
-    }, modifier = Modifier.semantics { contentDescription = buildTxnDesc(txn) }) { TxnListItem(txn, onClick) }
+    }, modifier = Modifier.semantics { contentDescription = buildTxnDesc(txn) }) {
+        TxnListItem(txn, categoryNames, accountNames, onClick)
+    }
 }
 
 @Composable
-private fun TxnListItem(txn: Transaction, onClick: () -> Unit) {
+private fun TxnListItem(
+    txn: Transaction,
+    categoryNames: Map<SyncId, String>,
+    accountNames: Map<SyncId, String>,
+    onClick: () -> Unit,
+) {
     val amt = CurrencyFormatter.format(txn.amount, txn.currency, showSign = true)
     val color = when (txn.type) { TransactionType.EXPENSE -> MaterialTheme.colorScheme.error
         TransactionType.INCOME -> FinanceTheme.financeColors.income; TransactionType.TRANSFER -> MaterialTheme.colorScheme.tertiary }
     val payee = txn.payee ?: "Unknown"
-    val cat = SampleData.categoryMap[txn.categoryId]?.name ?: "Uncategorized"
-    val acct = SampleData.accountMap[txn.accountId]?.name ?: "Unknown"
+    val cat = txn.categoryId?.let { categoryNames[it] } ?: "Uncategorized"
+    val acct = accountNames[txn.accountId] ?: "Unknown"
     Card(
         Modifier
             .fillMaxWidth()
@@ -279,7 +323,9 @@ private fun TransactionsPreview() {
             TransactionsUiState(isLoading = false, dateGroups = listOf(
                 TransactionDateGroup(kotlinx.datetime.LocalDate(2025, 3, 6), "Today", SampleData.transactions.take(3)),
                 TransactionDateGroup(kotlinx.datetime.LocalDate(2025, 3, 5), "Yesterday", SampleData.transactions.drop(3).take(3))),
-                filter = TransactionFilter(), totalCount = 20),
+                filter = TransactionFilter(), totalCount = 20,
+                categoryNames = SampleData.categoryMap.mapValues { it.value.name },
+                accountNames = SampleData.accountMap.mapValues { it.value.name }),
             {}, {}, {}, {}, {}, {}, {}, {}, {})
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModel.kt
@@ -214,6 +214,18 @@ class TransactionCreateViewModel(
         _uiState.update { it.copy(amountText = limited, amountCents = cents, errors = emptyList()) }
     }
 
+    /**
+     * Updates the amount from a raw cents value produced by the currency AmountInput
+     * component (#3724). Keeps [amountText] in sync for validation and edit pre-fill.
+     */
+    fun updateAmountCents(cents: Long) {
+        val safe = cents.coerceAtLeast(0L)
+        val whole = safe / 100L
+        val frac = safe % 100L
+        val text = "$whole.${frac.toString().padStart(2, '0')}"
+        _uiState.update { it.copy(amountCents = safe, amountText = text, errors = emptyList()) }
+    }
+
     fun updatePayee(payee: String) {
         val suggestions = if (payee.length >= 2)
             payeeHistory.filter { it.lowercase().contains(payee.lowercase()) }.take(5)

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionsViewModel.kt
@@ -5,6 +5,7 @@ package com.finance.android.ui.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.AccountRepository
 import com.finance.android.data.repository.CategoryRepository
 import com.finance.android.data.repository.TransactionRepository
 import com.finance.models.Transaction
@@ -49,6 +50,8 @@ data class TransactionsUiState(
     val hasMore: Boolean = false,
     val isLoadingMore: Boolean = false,
     val totalCount: Int = 0,
+    val categoryNames: Map<SyncId, String> = emptyMap(),
+    val accountNames: Map<SyncId, String> = emptyMap(),
 )
 
 /**
@@ -56,17 +59,23 @@ data class TransactionsUiState(
  *
  * @param householdIdProvider Provides the authenticated user's household ID.
  * @param transactionRepository Source for transaction data.
- * @param categoryRepository Source for category data used in search-by-category-name.
+ * @param categoryRepository Source for category data used in search-by-category-name
+ *   and for resolving row category labels.
+ * @param accountRepository Source for account data used to resolve row account labels.
  */
 class TransactionsViewModel(
     private val householdIdProvider: HouseholdIdProvider,
     private val transactionRepository: TransactionRepository,
     private val categoryRepository: CategoryRepository,
+    private val accountRepository: AccountRepository,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(TransactionsUiState())
     val uiState: StateFlow<TransactionsUiState> = _uiState.asStateFlow()
     private val pageSize = 20
     private var currentPage = 0
+
+    /** The most recently deleted transaction, retained so it can be restored via Undo. */
+    private var lastDeleted: Transaction? = null
 
     init { loadTransactions() }
 
@@ -113,7 +122,23 @@ class TransactionsViewModel(
 
     fun deleteTransaction(id: SyncId) {
         viewModelScope.launch {
+            lastDeleted = transactionRepository.getById(id)
             transactionRepository.delete(id)
+            currentPage = 0; loadData()
+        }
+    }
+
+    /**
+     * Restores the most recently deleted transaction (via the Undo snackbar).
+     *
+     * Re-inserts the retained [Transaction] with its original fields so the row
+     * reappears in the list. No-op if nothing was deleted or it was already undone.
+     */
+    fun undoDelete() {
+        val restored = lastDeleted ?: return
+        lastDeleted = null
+        viewModelScope.launch {
+            transactionRepository.insert(restored)
             currentPage = 0; loadData()
         }
     }
@@ -136,7 +161,10 @@ class TransactionsViewModel(
         }
         val allTransactions = transactionRepository.observeAll(householdId).first()
         val categories = categoryRepository.observeAll(householdId).first()
+        val accounts = accountRepository.observeAll(householdId).first()
         val categoryMap = categories.associateBy { it.id }
+        val categoryNames = categories.associate { it.id to it.name }
+        val accountNames = accounts.associate { it.id to it.name }
 
         var filtered = allTransactions
         if (filter.searchQuery.isNotBlank()) {
@@ -163,7 +191,8 @@ class TransactionsViewModel(
             }
         _uiState.update {
             it.copy(dateGroups = groups, isEmpty = if (!append) groups.isEmpty() else it.isEmpty,
-                hasMore = end < total, totalCount = total)
+                hasMore = end < total, totalCount = total,
+                categoryNames = categoryNames, accountNames = accountNames)
         }
     }
 

--- a/apps/android/src/test/kotlin/com/finance/android/ui/navigation/NavTransitionsTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/navigation/NavTransitionsTest.kt
@@ -42,4 +42,14 @@ class NavTransitionsTest {
     fun `tabExitTransition is defined`() {
         assertNotNull(NavTransitions.tabExitTransition)
     }
+
+    @Test
+    fun `reducedEnterTransition is defined`() {
+        assertNotNull(NavTransitions.reducedEnterTransition)
+    }
+
+    @Test
+    fun `reducedExitTransition is defined`() {
+        assertNotNull(NavTransitions.reducedExitTransition)
+    }
 }

--- a/apps/android/src/test/kotlin/com/finance/android/ui/snapshot/TransactionsSnapshotTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/snapshot/TransactionsSnapshotTest.kt
@@ -39,6 +39,8 @@ class TransactionsSnapshotTest {
         ),
         filter = TransactionFilter(),
         totalCount = 20,
+        categoryNames = SampleData.categoryMap.mapValues { it.value.name },
+        accountNames = SampleData.accountMap.mapValues { it.value.name },
     )
 
     private val noOpSyncId: (com.finance.models.types.SyncId) -> Unit = {}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/TransactionsViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/TransactionsViewModelTest.kt
@@ -3,8 +3,11 @@
 package com.finance.android.ui.viewmodel
 
 import com.finance.android.auth.TestHouseholdIdProvider
+import com.finance.android.data.repository.AccountRepository
 import com.finance.android.data.repository.CategoryRepository
 import com.finance.android.data.repository.TransactionRepository
+import com.finance.models.Account
+import com.finance.models.AccountType
 import com.finance.models.Category
 import com.finance.models.Transaction
 import com.finance.models.TransactionStatus
@@ -114,6 +117,21 @@ class TransactionsViewModelTest {
         updatedAt = now,
     )
 
+    private fun createAccount(
+        id: String,
+        name: String,
+    ) = Account(
+        id = SyncId(id),
+        householdId = householdId,
+        ownerId = householdId,
+        name = name,
+        type = AccountType.CHECKING,
+        currency = Currency.USD,
+        currentBalance = Cents(0),
+        createdAt = now,
+        updatedAt = now,
+    )
+
     // ── Test Repositories ──────────────────────────────────────────────
 
     private class TestTransactionRepository(
@@ -211,14 +229,64 @@ class TransactionsViewModelTest {
         override suspend fun markSynced(ids: List<SyncId>) { /* No-op */ }
     }
 
+    private class TestAccountRepository(
+        initial: List<Account> = emptyList(),
+    ) : AccountRepository {
+        private val _accounts = MutableStateFlow(initial)
+
+        override fun observeAll(householdId: SyncId): Flow<List<Account>> =
+            _accounts.map { list -> list.filter { it.deletedAt == null } }
+
+        override fun observeById(id: SyncId): Flow<Account?> =
+            _accounts.map { list -> list.find { it.id == id } }
+
+        override suspend fun getById(id: SyncId): Account? =
+            _accounts.value.find { it.id == id }
+
+        override fun observeActive(householdId: SyncId): Flow<List<Account>> =
+            _accounts.map { list -> list.filter { !it.isArchived && it.deletedAt == null } }
+
+        override suspend fun updateBalance(id: SyncId, newBalance: Cents) {
+            _accounts.value = _accounts.value.map {
+                if (it.id == id) it.copy(currentBalance = newBalance) else it
+            }
+        }
+
+        override suspend fun archive(id: SyncId) {
+            _accounts.value = _accounts.value.map {
+                if (it.id == id) it.copy(isArchived = true) else it
+            }
+        }
+
+        override suspend fun insert(entity: Account) {
+            _accounts.value = _accounts.value + entity
+        }
+
+        override suspend fun update(entity: Account) {
+            _accounts.value =
+                _accounts.value.map { if (it.id == entity.id) entity else it }
+        }
+
+        override suspend fun delete(id: SyncId) {
+            _accounts.value = _accounts.value.map {
+                if (it.id == id) it.copy(deletedAt = Clock.System.now()) else it
+            }
+        }
+
+        override suspend fun getUnsynced(householdId: SyncId): List<Account> = emptyList()
+        override suspend fun markSynced(ids: List<SyncId>) { /* No-op */ }
+    }
+
     private fun createViewModel(
         transactions: List<Transaction> = emptyList(),
         categories: List<Category> = emptyList(),
+        accounts: List<Account> = emptyList(),
         householdIdProvider: TestHouseholdIdProvider = TestHouseholdIdProvider(),
     ) = TransactionsViewModel(
         householdIdProvider = householdIdProvider,
         transactionRepository = TestTransactionRepository(transactions),
         categoryRepository = TestCategoryRepository(categories),
+        accountRepository = TestAccountRepository(accounts),
     )
 
     // ═══════════════════════════════════════════════════════════════════
@@ -670,6 +738,41 @@ class TransactionsViewModelTest {
         advanceUntilIdle()
 
         assertEquals(1, vm.uiState.value.totalCount, "Should have 1 transaction after deletion")
+    }
+
+    @Test
+    fun `undoDelete restores the deleted transaction`() = runTest {
+        val txns = listOf(
+            createTransaction("txn-1", payee = "Keep"),
+            createTransaction("txn-2", payee = "Delete"),
+        )
+
+        val vm = createViewModel(transactions = txns)
+        advanceUntilIdle()
+
+        vm.deleteTransaction(SyncId("txn-2"))
+        advanceUntilIdle()
+        assertEquals(1, vm.uiState.value.totalCount)
+
+        vm.undoDelete()
+        advanceUntilIdle()
+        assertEquals(2, vm.uiState.value.totalCount, "Undo should restore the transaction")
+    }
+
+    @Test
+    fun `resolves category and account names from repositories`() = runTest {
+        val txns = listOf(
+            createTransaction("txn-1", payee = "Coffee",
+                categoryId = "cat-1", accountId = "acct-1"),
+        )
+        val cats = listOf(createCategory("cat-1", "Dining"))
+        val accts = listOf(createAccount("acct-1", "Checking"))
+
+        val vm = createViewModel(transactions = txns, categories = cats, accounts = accts)
+        advanceUntilIdle()
+
+        assertEquals("Dining", vm.uiState.value.categoryNames[SyncId("cat-1")])
+        assertEquals("Checking", vm.uiState.value.accountNames[SyncId("acct-1")])
     }
 
     // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
﻿## Summary

Batch of closely-related Android (`apps/android`) transaction list & entry UX improvements. Scoped entirely to `apps/android`; shared packages are consumed read-only.

## Changes by issue

### Closes #3683 — Transaction list shows real category & account names
- `TransactionsViewModel` now injects `AccountRepository` (in addition to `CategoryRepository`) and builds `categoryNames`/`accountNames` maps from the repositories during `loadData`, exposing them on `TransactionsUiState`.
- `TransactionsScreen` rows resolve labels from those maps instead of the `SampleData` mock.

### Closes #3688 — Undo for swipe-to-delete
- `deleteTransaction` retains the deleted `Transaction`; new `undoDelete()` re-inserts it.
- The screen shows a "Transaction deleted" snackbar with an **Undo** action (TalkBack-announced) via a `SnackbarHost`, so an accidental swipe is recoverable.

### Closes #3718 — Sticky date-group headers
- Date-group headers now use `stickyHeader` and paint an opaque `surface` background so they pin while scrolling.

### Closes #3727 — SkeletonLoader loading states
- Replaced bare `CircularProgressIndicator` initial-load states with the shipped `TransactionListSkeleton` (transactions) and `DashboardSkeleton` (dashboard).

### Closes #3724 — Currency AmountInput in create flow
- The create wizard's amount step now uses the shared currency `AmountInput` component, deriving the currency symbol and decimal places from the selected account's currency (fallback USD).
- Added `TransactionCreateViewModel.updateAmountCents(Long)` to accept the component's cents value (existing `updateAmount(String)` retained for compatibility).

### Closes #3717 — Honor `reducedAnimations`
- Added crossfade-only reduced-motion `NavHost` transitions; `FinanceNavHost` selects them live from `CognitiveAccessibilityManager.reducedAnimations`.
- The create wizard's `AnimatedContent` step transition switches to a crossfade when the preference is enabled. Respects WCAG 2.2 (2.3.3 Animation from Interactions).

## Testing
- Updated unit tests (`TransactionsViewModelTest`: undo restores the transaction; names resolved from repositories), snapshot state (`TransactionsSnapshotTest` populated with repository-derived name maps to keep goldens stable), nav transition tests, and the e2e amount-field robot locator.

> **Note on local verification:** this cloud session has no Android SDK, so the `:apps:android` module is skipped by `settings.gradle` locally and cannot be compiled/tested or have Paparazzi goldens re-recorded here. Kotlin is prettier-ignored and covered by detekt in CI. The snackbar was implemented as a `Box`+`SnackbarHost` overlay (not a `Scaffold`) and the sticky header background matches the snapshot wrapper's `surface` color specifically to avoid shifting existing Paparazzi goldens. CI builds/tests/verifies the Android module.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
