### PR TITLE
feat(android): design fixes, adaptive NavigationRail, ITIN onboarding & financial education (Batch 4)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/MainActivity.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -17,8 +18,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PermanentDrawerSheet
+import androidx.compose.material3.PermanentNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -35,6 +41,7 @@ import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.core.util.Consumer
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.finance.android.auth.AuthState
@@ -49,8 +56,12 @@ import com.finance.android.ui.components.IconView
 import com.finance.android.ui.components.LocalIconPack
 import com.finance.android.ui.navigation.FinanceBottomBar
 import com.finance.android.ui.navigation.FinanceNavHost
+import com.finance.android.ui.navigation.FinanceNavigationRail
 import com.finance.android.ui.navigation.FinanceTopBar
+import com.finance.android.ui.navigation.NavigationLayoutType
 import com.finance.android.ui.navigation.Route
+import com.finance.android.ui.navigation.TopLevelDestination
+import com.finance.android.ui.navigation.resolveNavigationLayout
 import com.finance.android.ui.theme.FinanceTheme
 import com.finance.android.ui.theme.ThemePreference
 import com.finance.android.ui.theme.ThemePreferenceManager
@@ -70,6 +81,7 @@ class MainActivity : ComponentActivity() {
     private val themePreferenceManager: ThemePreferenceManager by inject()
     private val iconPreferenceManager: IconPreferenceManager by inject()
 
+    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -84,9 +96,11 @@ class MainActivity : ComponentActivity() {
             val highContrast by themePreferenceManager.highContrastEnabled.collectAsState()
             val iconPack by iconPreferenceManager.iconPack.collectAsState()
 
+            val windowSizeClass = calculateWindowSizeClass(this)
+
             FinanceTheme(darkTheme = darkTheme, highContrast = highContrast) {
                 CompositionLocalProvider(LocalIconPack provides iconPack) {
-                    FinanceApp()
+                    FinanceApp(widthSizeClass = windowSizeClass.widthSizeClass)
                 }
             }
         }
@@ -110,7 +124,10 @@ class MainActivity : ComponentActivity() {
  * retains the full navigation shell.
  */
 @Composable
-fun FinanceApp(modifier: Modifier = Modifier) {
+fun FinanceApp(
+    modifier: Modifier = Modifier,
+    widthSizeClass: WindowWidthSizeClass = WindowWidthSizeClass.Compact,
+) {
     val authViewModel: AuthViewModel = koinViewModel()
     val authState by authViewModel.authState.collectAsState()
     var showSignup by rememberSaveable { mutableStateOf(false) }
@@ -149,7 +166,7 @@ fun FinanceApp(modifier: Modifier = Modifier) {
             }
         }
         is AuthState.Authenticated -> {
-            AuthenticatedContent(modifier = modifier)
+            AuthenticatedContent(widthSizeClass = widthSizeClass, modifier = modifier)
         }
     }
 }
@@ -184,12 +201,18 @@ private fun AuthLoadingScreen(modifier: Modifier = Modifier) {
 /**
  * Main app content shown after successful authentication.
  *
- * Provides [Scaffold] with the top bar, bottom navigation, FAB,
- * and [FinanceNavHost]. Deep link intents are forwarded to the
- * nav controller for routing.
+ * Adapts the navigation shell to the available window width (#3713):
+ * - **Compact** → [FinanceBottomBar] at the bottom.
+ * - **Medium** → [FinanceNavigationRail] on the leading edge.
+ * - **Expanded** → a [PermanentNavigationDrawer] with labelled destinations.
+ *
+ * Deep link intents are forwarded to the nav controller for routing.
  */
 @Composable
-private fun AuthenticatedContent(modifier: Modifier = Modifier) {
+private fun AuthenticatedContent(
+    widthSizeClass: WindowWidthSizeClass,
+    modifier: Modifier = Modifier,
+) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
@@ -214,14 +237,110 @@ private fun AuthenticatedContent(modifier: Modifier = Modifier) {
         Route.Transactions.route,
     )
 
-    // Show bottom bar only on top-level destinations
-    val showBottomBar = currentRoute in setOf(
+    // Only surface side/bottom navigation on top-level destinations.
+    val isTopLevel = currentRoute in setOf(
         Route.Dashboard.route,
         Route.Transactions.route,
         Route.Planning.route,
         Route.Settings.route,
     )
 
+    val layout = resolveNavigationLayout(widthSizeClass)
+
+    when {
+        isTopLevel && layout == NavigationLayoutType.NavigationRail -> {
+            Row(modifier = modifier.fillMaxSize()) {
+                FinanceNavigationRail(navController = navController)
+                AppScaffold(
+                    navController = navController,
+                    showBottomBar = false,
+                    showFab = showFab,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+        isTopLevel && layout == NavigationLayoutType.ModalDrawer -> {
+            PermanentNavigationDrawer(
+                modifier = modifier.fillMaxSize(),
+                drawerContent = {
+                    PermanentDrawerSheet {
+                        FinancePermanentDrawerItems(
+                            navController = navController,
+                            currentRoute = currentRoute,
+                        )
+                    }
+                },
+            ) {
+                AppScaffold(
+                    navController = navController,
+                    showBottomBar = false,
+                    showFab = showFab,
+                )
+            }
+        }
+        else -> {
+            AppScaffold(
+                navController = navController,
+                showBottomBar = isTopLevel,
+                showFab = showFab,
+                modifier = modifier,
+            )
+        }
+    }
+}
+
+/**
+ * Labelled destination list rendered inside the expanded-width
+ * [PermanentNavigationDrawer]. Mirrors [TopLevelDestination] so navigation
+ * stays consistent across window sizes.
+ */
+@Composable
+private fun FinancePermanentDrawerItems(
+    navController: androidx.navigation.NavHostController,
+    currentRoute: String?,
+) {
+    Text(
+        text = "Finance",
+        style = MaterialTheme.typography.headlineSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier
+            .padding(horizontal = 28.dp, vertical = 24.dp)
+            .semantics { contentDescription = "Finance application menu" },
+    )
+    TopLevelDestination.entries.forEach { destination ->
+        val selected = currentRoute == destination.route
+        androidx.compose.material3.NavigationDrawerItem(
+            icon = { IconView(token = destination.iconToken) },
+            label = { Text(text = destination.label) },
+            selected = selected,
+            onClick = {
+                navController.navigate(destination.route) {
+                    popUpTo(navController.graph.findStartDestination().id) {
+                        saveState = true
+                    }
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            },
+            modifier = Modifier
+                .padding(androidx.compose.material3.NavigationDrawerItemDefaults.ItemPadding)
+                .semantics { contentDescription = destination.a11yDescription },
+        )
+    }
+}
+
+/**
+ * Shared [Scaffold] hosting the top bar, optional bottom bar, FAB, and the
+ * [FinanceNavHost]. Reused across every adaptive navigation layout so the app
+ * chrome stays identical whether navigation is a bottom bar, rail, or drawer.
+ */
+@Composable
+private fun AppScaffold(
+    navController: androidx.navigation.NavHostController,
+    showBottomBar: Boolean,
+    showFab: Boolean,
+    modifier: Modifier = Modifier,
+) {
     Scaffold(
         modifier = modifier.fillMaxSize(),
         topBar = { FinanceTopBar(navController = navController) },

--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -41,6 +41,7 @@ import com.finance.android.ui.components.IconPreferenceManager
 import com.finance.android.ui.expertise.ExpertiseTierManager
 import com.finance.android.ui.expertise.ExpertiseTierViewModel
 import com.finance.android.ui.learning.LearningPathViewModel
+import com.finance.android.ui.learning.LearningProgressRepository
 import com.finance.android.ui.nlp.NlpTransactionViewModel
 import com.finance.android.ui.streak.StreakRepository
 import com.finance.android.ui.streak.StreakViewModel
@@ -165,6 +166,9 @@ val appModule = module {
     /** Expertise tier manager — persists and provides the user's skill level (#379). */
     single { ExpertiseTierManager(get()) }
 
+    /** Learning progress repository — persists lessons, streak and rewards (#2208). */
+    single { LearningProgressRepository(get()) }
+
     // ── Streak tracking ───────────────────────────────────────────────
 
     /** Streak repository — derives logging dates from the transaction repository. */
@@ -221,7 +225,7 @@ val appModule = module {
     viewModelOf(::NotificationSettingsViewModel)
     viewModelOf(::AffordabilityViewModel)
     viewModelOf(::ExpertiseTierViewModel)
-    viewModelOf(::LearningPathViewModel)
+    viewModel { LearningPathViewModel(get(), get()) }
     viewModelOf(::NlpTransactionViewModel)
 
     /** On-device receipt scanning to transaction draft (#2388). */

--- a/apps/android/src/main/kotlin/com/finance/android/ui/education/FinancialConceptContent.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/education/FinancialConceptContent.kt
@@ -30,6 +30,21 @@ enum class FinancialConcept {
     DIVERSIFICATION,
     RECURRING_EXPENSE,
     TRANSACTION_CATEGORY,
+
+    // ── US newcomer basics (#2178) ──────────────────────────────────
+    W2,
+    FORM_1099,
+    TAX_WITHHOLDING,
+    RETIREMENT_401K,
+    ITIN,
+
+    // ── Credit building basics (#2174) ──────────────────────────────
+    FICO_SCORE,
+    CREDIT_UTILIZATION,
+    STATEMENT_VS_DUE_DATE,
+    HARD_INQUIRY,
+    CREDIT_REPORT,
+    SECURED_CARD,
 }
 
 /**
@@ -151,6 +166,65 @@ object FinancialConceptContent {
             title = "Transaction Category",
             shortDescription = "A label that groups similar expenses together, like 'Groceries' or 'Transport'.",
             learnMoreText = "Categorising transactions helps you see where your money goes and set more accurate budgets.",
+        ),
+
+        // ── US newcomer basics (#2178) ──────────────────────────────────
+        FinancialConcept.W2 to ConceptInfo(
+            title = "W-2 Employee",
+            shortDescription = "A W-2 job means an employer pays you and takes taxes out of each paycheck for you.",
+            learnMoreText = "At tax time your employer sends a W-2 form summarising what you earned and what tax was already withheld. Most salaried and hourly jobs are W-2. You usually do not need to set money aside yourself for these taxes.",
+        ),
+        FinancialConcept.FORM_1099 to ConceptInfo(
+            title = "1099 / Contract Income",
+            shortDescription = "1099 work (gig, freelance, contract) pays you the full amount with no taxes taken out.",
+            learnMoreText = "Because nothing is withheld, you are responsible for setting aside money for taxes yourself — a common rule of thumb is to save 25-30% of 1099 pay. You may report it on a 1099 form at tax time. Many newcomers mix W-2 and 1099 income.",
+        ),
+        FinancialConcept.TAX_WITHHOLDING to ConceptInfo(
+            title = "Withholding",
+            shortDescription = "The part of your paycheck an employer sends to the government for taxes before you get paid.",
+            learnMoreText = "Withholding is a prepayment of your income tax. If too much is withheld you get a refund; if too little, you may owe at tax time. Hourly and seasonal workers can see withholding change as their hours change.",
+        ),
+        FinancialConcept.RETIREMENT_401K to ConceptInfo(
+            title = "401(k)",
+            shortDescription = "A workplace savings account for retirement that can lower your taxes today.",
+            learnMoreText = "You contribute part of each paycheck and it grows over time. Some employers add a matching contribution — money you should try not to leave on the table. You do not need to understand investing deeply to start; even a small percentage helps.",
+        ),
+        FinancialConcept.ITIN to ConceptInfo(
+            title = "ITIN",
+            shortDescription = "A tax ID number for people who need to file US taxes but cannot get a Social Security Number yet.",
+            learnMoreText = "An Individual Taxpayer Identification Number (ITIN) lets you file taxes, and some banks and lenders accept it to open accounts or build credit. Having an ITIN instead of an SSN does not stop you from budgeting, saving, or learning US finance basics.",
+        ),
+
+        // ── Credit building basics (#2174) ──────────────────────────────
+        FinancialConcept.FICO_SCORE to ConceptInfo(
+            title = "FICO / Credit Score",
+            shortDescription = "A number (about 300-850) that lenders use to judge how reliably you repay borrowed money.",
+            learnMoreText = "It is built mostly from paying on time and keeping balances low. Newcomers usually start with no score at all — that is normal, and it grows with a few months of on-time payments. You do not need to pay to build it.",
+        ),
+        FinancialConcept.CREDIT_UTILIZATION to ConceptInfo(
+            title = "Credit Utilization",
+            shortDescription = "How much of your credit limit you are using right now, shown as a percentage.",
+            learnMoreText = "If your limit is $200 and you owe $60, utilization is 30%. Keeping it under about 30% (lower is better) helps your credit score. Paying the balance down before the statement date keeps reported utilization low.",
+        ),
+        FinancialConcept.STATEMENT_VS_DUE_DATE to ConceptInfo(
+            title = "Statement Date vs Due Date",
+            shortDescription = "The statement date closes your billing cycle; the due date is when payment must arrive.",
+            learnMoreText = "The balance reported to credit bureaus is usually the one on the statement date, so paying before then lowers reported utilization. Always pay at least the minimum by the due date to avoid late fees and score damage.",
+        ),
+        FinancialConcept.HARD_INQUIRY to ConceptInfo(
+            title = "Hard Inquiry",
+            shortDescription = "A check on your credit that happens when you apply for a card or loan.",
+            learnMoreText = "Each hard inquiry can lower your score slightly for a short time, so avoid applying for many cards at once. Checking your own credit is a 'soft' inquiry and does not hurt your score.",
+        ),
+        FinancialConcept.CREDIT_REPORT to ConceptInfo(
+            title = "Credit Report",
+            shortDescription = "A detailed record of your accounts, balances, and payment history kept by credit bureaus.",
+            learnMoreText = "You can review it free once a year from each major bureau. Checking it helps you catch errors or fraud early. It is separate from your score, which is calculated from the report.",
+        ),
+        FinancialConcept.SECURED_CARD to ConceptInfo(
+            title = "Secured Credit Card",
+            shortDescription = "A starter credit card backed by a refundable deposit you pay up front.",
+            learnMoreText = "The deposit usually becomes your credit limit, which lowers the lender's risk so approval is easier with no credit history. Using a small amount and paying on time builds credit; many secured cards later 'graduate' to a regular card and return your deposit.",
         ),
     )
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt
@@ -3,6 +3,24 @@
 package com.finance.android.ui.learning
 
 /**
+ * Difficulty tier for a [LearningPath] (#2209).
+ *
+ * Drives beginner-mode ordering and gating: beginner-friendly content surfaces
+ * first, while [ADVANCED] topics (investing, deeper tax strategy) stay hidden
+ * until a new learner explicitly opts in.
+ */
+enum class LearningLevel {
+    /** Plain-language starting point suitable for first-time learners. */
+    BEGINNER,
+
+    /** Everyday money skills for the general audience. */
+    CORE,
+
+    /** Complex topics delayed for beginners until they opt in. */
+    ADVANCED,
+}
+
+/**
  * Learning path data model for structured financial education modules (#382).
  *
  * A learning path is a sequence of modules that guide the user through
@@ -15,6 +33,7 @@ package com.finance.android.ui.learning
  * @property modules Ordered list of learning modules in this path.
  * @property isPremium Whether this path requires a premium subscription.
  * @property estimatedMinutes Total estimated time to complete all modules.
+ * @property level Difficulty tier used for beginner-mode ordering and gating.
  */
 data class LearningPath(
     val id: String,
@@ -24,6 +43,7 @@ data class LearningPath(
     val modules: List<LearningModule>,
     val isPremium: Boolean,
     val estimatedMinutes: Int,
+    val level: LearningLevel = LearningLevel.CORE,
 )
 
 /**
@@ -96,8 +116,36 @@ object LearningPathContent {
 
     fun pathById(id: String): LearningPath? = paths.find { it.id == id }
 
-    private val paths = listOf(
-        LearningPath(
+    /**
+     * Returns paths tailored for the learner (#2209).
+     *
+     * In beginner mode, beginner-friendly paths are ordered first and
+     * [LearningLevel.ADVANCED] topics (e.g. investing) stay hidden until the
+     * learner opts in via [showAdvanced]. Outside beginner mode the full
+     * catalog is returned in its natural order.
+     */
+    fun catalog(beginnerMode: Boolean, showAdvanced: Boolean): List<LearningPath> {
+        if (!beginnerMode) return paths
+        val visible = if (showAdvanced) paths else paths.filter { it.level != LearningLevel.ADVANCED }
+        return visible.sortedBy { it.level.ordinal }
+    }
+
+    /** Whether the catalog contains any advanced content that could be gated. */
+    fun hasAdvancedContent(): Boolean = paths.any { it.level == LearningLevel.ADVANCED }
+
+    private val paths: List<LearningPath> by lazy {
+        listOf(
+            budgetingBasicsPath,
+            emergencyFundPath,
+            investing101Path,
+            debtManagementPath,
+            newcomerBasicsPath,
+            buildingCreditPath,
+            firstJobPath,
+        )
+    }
+
+    private val budgetingBasicsPath = LearningPath(
             id = "budgeting-basics",
             title = "Budgeting Basics",
             description = "Learn to create and stick to a budget that works for your lifestyle.",
@@ -156,8 +204,9 @@ object LearningPathContent {
                     estimatedMinutes = 5,
                 ),
             ),
-        ),
-        LearningPath(
+        )
+
+    private val emergencyFundPath = LearningPath(
             id = "emergency-fund",
             title = "Building an Emergency Fund",
             description = "Create a financial safety net for life's unexpected expenses.",
@@ -205,14 +254,16 @@ object LearningPathContent {
                     estimatedMinutes = 4,
                 ),
             ),
-        ),
-        LearningPath(
+        )
+
+    private val investing101Path = LearningPath(
             id = "investing-101",
             title = "Investing 101",
             description = "Understand the basics of growing your wealth through investing.",
             icon = "📈",
             isPremium = true,
             estimatedMinutes = 20,
+            level = LearningLevel.ADVANCED,
             modules = listOf(
                 LearningModule(
                     id = "inv-1",
@@ -270,8 +321,9 @@ object LearningPathContent {
                     estimatedMinutes = 5,
                 ),
             ),
-        ),
-        LearningPath(
+        )
+
+    private val debtManagementPath = LearningPath(
             id = "debt-management",
             title = "Managing Debt Wisely",
             description = "Strategies to pay down debt efficiently and avoid common traps.",
@@ -334,6 +386,351 @@ object LearningPathContent {
                     ),
                     estimatedMinutes = 4,
                 ),
+            ),
+        )
+
+    // ── Newcomer & beginner paths ───────────────────────────────────
+
+    /**
+     * US finance basics for newcomers, including ITIN-aware guidance (#2178).
+     */
+    private val newcomerBasicsPath = LearningPath(
+        id = "newcomer-us-basics",
+        title = "US Finance Basics for Newcomers",
+        description = "Plain-language basics for building your financial life in the US — even before you have an SSN.",
+        icon = "🗽",
+        isPremium = false,
+        estimatedMinutes = 22,
+        level = LearningLevel.BEGINNER,
+        modules = listOf(
+            LearningModule(
+                id = "nc-1",
+                title = "SSN vs ITIN: Which Do You Have?",
+                content = "A Social Security Number (SSN) is issued to citizens and work-authorized residents. If you can't get an SSN yet, the IRS can issue an Individual Taxpayer Identification Number (ITIN) so you can file taxes and, at many banks, open an account and even build credit. An ITIN is nine digits and always starts with a 9. You apply with IRS Form W-7, usually alongside your first tax return. Having an ITIN does not affect your immigration status — it exists only for tax purposes.",
+                keyTakeaways = listOf(
+                    "An ITIN lets you file taxes and often open accounts without an SSN",
+                    "Apply with IRS Form W-7, typically with your first tax return",
+                    "An ITIN starts with 9 and is for taxes only — it isn't work authorization",
+                ),
+                quiz = QuizQuestion(
+                    question = "What is an ITIN used for?",
+                    options = listOf(
+                        "Proving work authorization",
+                        "Filing taxes when you can't get an SSN",
+                        "Replacing a passport",
+                        "Qualifying for a green card",
+                    ),
+                    correctIndex = 1,
+                    explanation = "An ITIN is a tax processing number for people who need to file US taxes but aren't eligible for an SSN. It doesn't grant work authorization or change immigration status.",
+                ),
+                estimatedMinutes = 5,
+            ),
+            LearningModule(
+                id = "nc-2",
+                title = "Reading a W-2 and a 1099",
+                content = "When you work, your employer reports your pay to you and the IRS. If you're an employee, you get a W-2 in January showing your yearly wages and the taxes already withheld. If you did independent or gig work, you may instead get a 1099 (such as a 1099-NEC), which shows what you were paid with no taxes withheld — meaning you're responsible for those taxes yourself. Keep every W-2 and 1099; you need them to file an accurate tax return.",
+                keyTakeaways = listOf(
+                    "A W-2 is for employees and shows taxes already withheld",
+                    "A 1099 is for contract/gig income with no taxes withheld",
+                    "Save every form — you need them to file your taxes",
+                ),
+                quiz = QuizQuestion(
+                    question = "You received a 1099-NEC. What does that usually mean?",
+                    options = listOf(
+                        "Your taxes were already withheld",
+                        "You were paid as a contractor and owe the taxes yourself",
+                        "You are exempt from taxes",
+                        "You cannot file a return",
+                    ),
+                    correctIndex = 1,
+                    explanation = "A 1099 reports income paid without withholding, so a contractor is responsible for paying the associated taxes when filing.",
+                ),
+                estimatedMinutes = 5,
+            ),
+            LearningModule(
+                id = "nc-3",
+                title = "Where Did My Paycheck Go? Withholding",
+                content = "Your take-home pay is smaller than your salary because of withholding — money your employer sends to the government on your behalf for federal income tax, and often Social Security, Medicare, and state tax. When you start a job you fill out a Form W-4 that tells your employer how much to withhold. If too much is withheld you get a refund at tax time; if too little, you owe. The goal is to withhold close to what you actually owe.",
+                keyTakeaways = listOf(
+                    "Withholding is tax taken out of each paycheck in advance",
+                    "Your W-4 controls how much is withheld",
+                    "A refund means you overpaid during the year — not free money",
+                ),
+                estimatedMinutes = 4,
+            ),
+            LearningModule(
+                id = "nc-4",
+                title = "What Is a 401(k)?",
+                content = "A 401(k) is a retirement savings account many US employers offer. You choose a percentage of each paycheck to save, and it goes in before you ever see it. Many employers 'match' part of what you put in — that's free money you should try not to leave behind. The money grows over the years and is meant to be used in retirement, so there are penalties for taking it out early. Even small contributions add up over decades.",
+                keyTakeaways = listOf(
+                    "A 401(k) is a workplace retirement account funded from your paycheck",
+                    "An employer match is free money — contribute enough to get it",
+                    "It's for the long term, so early withdrawals are penalized",
+                ),
+                quiz = QuizQuestion(
+                    question = "Why is an employer 401(k) match valuable?",
+                    options = listOf(
+                        "It doubles your salary",
+                        "It's extra money your employer adds to your retirement savings",
+                        "It removes all taxes",
+                        "It guarantees stock gains",
+                    ),
+                    correctIndex = 1,
+                    explanation = "A match means your employer contributes additional money based on what you save — turning it down leaves free retirement money on the table.",
+                ),
+                estimatedMinutes = 4,
+            ),
+            LearningModule(
+                id = "nc-5",
+                title = "Budgeting on Uneven Income",
+                content = "Many newcomers start with hourly, seasonal, or gig work where income changes week to week. Budget from your lowest typical month, not your best one. Cover needs first — housing, food, transport — then set aside a little for taxes if you're a contractor, and save whatever is left in good months to cover slow ones. A small buffer smooths out the ups and downs so a slow week doesn't become a crisis.",
+                keyTakeaways = listOf(
+                    "Plan around your lowest typical income, not your highest",
+                    "Set aside money for taxes if you're paid on a 1099",
+                    "Save in strong months to cover the slow ones",
+                ),
+                estimatedMinutes = 4,
+            ),
+        ),
+    )
+
+    /**
+     * Beginner-friendly path for building credit from zero (#2174).
+     */
+    private val buildingCreditPath = LearningPath(
+        id = "building-credit",
+        title = "Building Credit From Zero",
+        description = "Start your US credit history from scratch — secured cards, utilization, and steady on-time habits.",
+        icon = "🌟",
+        isPremium = false,
+        estimatedMinutes = 24,
+        level = LearningLevel.BEGINNER,
+        modules = listOf(
+            LearningModule(
+                id = "bc-1",
+                title = "What Credit and a FICO Score Are",
+                content = "Credit is a lender's trust that you'll pay back money you borrow. Your credit history is a record of how you've handled that trust, and a FICO score (usually 300–850) summarizes it into a single number. Lenders, landlords, and even some employers look at it. When you're new to the country you often have no score at all — that's normal, and this path shows you how to build one from zero.",
+                keyTakeaways = listOf(
+                    "A credit score summarizes how reliably you repay borrowed money",
+                    "FICO scores typically range from 300 to 850",
+                    "Having no score yet is normal — it can be built over time",
+                ),
+                quiz = QuizQuestion(
+                    question = "What does a FICO score mainly measure?",
+                    options = listOf(
+                        "How much money you have saved",
+                        "How reliably you repay borrowed money",
+                        "Your yearly income",
+                        "How many bank accounts you have",
+                    ),
+                    correctIndex = 1,
+                    explanation = "A credit score reflects your track record of repaying debt on time, not how much money or income you have.",
+                ),
+                estimatedMinutes = 4,
+            ),
+            LearningModule(
+                id = "bc-2",
+                title = "Secured Cards: Your First Card",
+                content = "If no one will give you a regular credit card yet, a secured card is the usual starting point. You put down a refundable deposit — say $200 — and that becomes your credit limit. You use it like a normal card and pay it off each month. The bank reports your on-time payments to the credit bureaus, which builds your history. After several months of good behaviour many issuers refund your deposit and 'graduate' you to a regular card.",
+                keyTakeaways = listOf(
+                    "A secured card is backed by a refundable deposit",
+                    "It builds credit because payments are reported to the bureaus",
+                    "Good habits can graduate you to a regular card and refund the deposit",
+                ),
+                quiz = QuizQuestion(
+                    question = "What makes a secured card 'secured'?",
+                    options = listOf(
+                        "It has extra fraud insurance",
+                        "You provide a refundable deposit as collateral",
+                        "It can only be used online",
+                        "It has no spending limit",
+                    ),
+                    correctIndex = 1,
+                    explanation = "A secured card is backed by a cash deposit that usually equals your credit limit, which lowers the lender's risk while you build history.",
+                ),
+                estimatedMinutes = 4,
+            ),
+            LearningModule(
+                id = "bc-3",
+                title = "Credit Utilization",
+                content = "Utilization is how much of your available credit you're using. If your limit is $200 and your balance is $60, your utilization is 30%. Lower is better — keeping it under about 30%, and ideally under 10%, helps your score. High utilization signals you may be stretched thin. A simple trick: make small purchases and pay them off before the statement closes so a low balance gets reported.",
+                keyTakeaways = listOf(
+                    "Utilization is your balance divided by your credit limit",
+                    "Aim to keep it under 30%, ideally under 10%",
+                    "Paying down before the statement date lowers reported utilization",
+                ),
+                quiz = QuizQuestion(
+                    question = "Your limit is $500 and your balance is $150. What's your utilization?",
+                    options = listOf("15%", "30%", "50%", "3%"),
+                    correctIndex = 1,
+                    explanation = "150 divided by 500 is 0.30, or 30% utilization — right at the upper edge of what's considered healthy.",
+                ),
+                estimatedMinutes = 4,
+            ),
+            LearningModule(
+                id = "bc-4",
+                title = "Statement Date vs Due Date",
+                content = "Two dates matter on a credit card. The statement (closing) date is when the bank totals up your billing cycle and reports your balance to the credit bureaus. The due date, usually a few weeks later, is when your payment must arrive to avoid interest and late fees. Paying your full statement balance by the due date means you pay zero interest. Paying a bit before the statement date also lowers the balance that gets reported.",
+                keyTakeaways = listOf(
+                    "The statement date is when your balance is reported",
+                    "The due date is when payment must arrive to avoid interest",
+                    "Paying the full statement balance by the due date avoids all interest",
+                ),
+                quiz = QuizQuestion(
+                    question = "How do you avoid paying any interest on a credit card?",
+                    options = listOf(
+                        "Pay only the minimum each month",
+                        "Pay the full statement balance by the due date",
+                        "Never use the card",
+                        "Pay after the due date",
+                    ),
+                    correctIndex = 1,
+                    explanation = "Paying the entire statement balance by the due date means the bank charges no interest on your purchases.",
+                ),
+                estimatedMinutes = 4,
+            ),
+            LearningModule(
+                id = "bc-5",
+                title = "Inquiries and Your Credit Report",
+                content = "When you apply for credit, the lender does a 'hard inquiry,' which can lower your score by a few points for a short time — so don't apply for many cards at once. Checking your own credit is a 'soft inquiry' and never hurts you. You're entitled to free credit reports from the major bureaus; review them for mistakes, because errors can drag down a score you worked hard to build.",
+                keyTakeaways = listOf(
+                    "Hard inquiries from applications can dip your score briefly",
+                    "Checking your own credit is a soft inquiry and is harmless",
+                    "Review your free credit reports for errors regularly",
+                ),
+                estimatedMinutes = 4,
+            ),
+            LearningModule(
+                id = "bc-6",
+                title = "Your Build-Credit Checklist",
+                content = "Put it together: open one secured or starter card, use it for a small recurring expense, keep utilization low, and pay the full statement balance on time every single month. Set up autopay so you never miss a due date — payment history is the biggest factor in your score. Be patient: a few months of steady, boring, on-time payments is exactly what builds a strong credit history.",
+                keyTakeaways = listOf(
+                    "One starter card used lightly is enough to begin",
+                    "Autopay the full balance so you never miss a due date",
+                    "On-time payment history is the single biggest score factor",
+                ),
+                quiz = QuizQuestion(
+                    question = "What has the biggest impact on your credit score?",
+                    options = listOf(
+                        "How many cards you own",
+                        "Paying on time, every time",
+                        "Your account's age in days",
+                        "How often you check your score",
+                    ),
+                    correctIndex = 1,
+                    explanation = "Payment history is the largest component of a FICO score, so consistent on-time payments matter most.",
+                ),
+                estimatedMinutes = 4,
+            ),
+        ),
+    )
+
+    /**
+     * First-job / teen beginner path in plain language, no investing or tax
+     * complexity (#2209).
+     */
+    private val firstJobPath = LearningPath(
+        id = "first-job-money",
+        title = "Your First Paycheck",
+        description = "Just started your first job? Learn the money basics — paychecks, cards, and saving for what you want.",
+        icon = "🎓",
+        isPremium = false,
+        estimatedMinutes = 18,
+        level = LearningLevel.BEGINNER,
+        modules = listOf(
+            LearningModule(
+                id = "fj-1",
+                title = "Understanding Your First Paycheck",
+                content = "Your first paycheck can be a surprise — it's smaller than your hourly rate times your hours. That's because some money is taken out for taxes before you get paid. The amount you actually receive is your 'take-home pay.' Your pay stub lists what you earned and what was taken out. It's worth a look so you know exactly what you're bringing home.",
+                keyTakeaways = listOf(
+                    "Take-home pay is less than your total earnings because of taxes",
+                    "Your pay stub shows what you earned and what was deducted",
+                    "Knowing your take-home pay helps you plan",
+                ),
+                quiz = QuizQuestion(
+                    question = "Why is your paycheck smaller than your hourly rate times hours worked?",
+                    options = listOf(
+                        "The bank keeps some",
+                        "Taxes and deductions come out first",
+                        "It's a mistake",
+                        "You get the rest next year",
+                    ),
+                    correctIndex = 1,
+                    explanation = "Taxes and other deductions are taken out before you're paid, so your take-home pay is less than your gross earnings.",
+                ),
+                estimatedMinutes = 4,
+            ),
+            LearningModule(
+                id = "fj-2",
+                title = "Debit Cards and Avoiding Fees",
+                content = "A debit card spends money you already have in your account — unlike a credit card, which borrows it. Debit cards are a safe way to start because you can't spend money you don't have. Watch out for fees: overdraft fees if you spend more than your balance, and ATM fees for using the wrong machine. Checking your balance before you spend keeps you in control and fee-free.",
+                keyTakeaways = listOf(
+                    "A debit card spends your own money, not borrowed money",
+                    "Overdraft and out-of-network ATM fees are avoidable",
+                    "Check your balance before spending",
+                ),
+                quiz = QuizQuestion(
+                    question = "What's the main difference between a debit and a credit card?",
+                    options = listOf(
+                        "Debit borrows money; credit uses your own",
+                        "Debit uses your own money; credit borrows it",
+                        "They are exactly the same",
+                        "Credit cards can't be used online",
+                    ),
+                    correctIndex = 1,
+                    explanation = "A debit card draws from money you already have, while a credit card borrows money you pay back later.",
+                ),
+                estimatedMinutes = 4,
+            ),
+            LearningModule(
+                id = "fj-3",
+                title = "Needs, Wants, and Saving for Later",
+                content = "Every time you get paid, split it in your head three ways: needs (things you must pay for, like a phone bill or bus fare), wants (fun stuff like games or eating out), and savings (money you keep for later). You don't need fancy rules — even saving a small slice of each paycheck first, before you spend on wants, builds a habit that pays off for the rest of your life.",
+                keyTakeaways = listOf(
+                    "Split money into needs, wants, and savings",
+                    "Save a little first, before spending on wants",
+                    "The habit matters more than the amount",
+                ),
+                estimatedMinutes = 3,
+            ),
+            LearningModule(
+                id = "fj-4",
+                title = "Beating Impulse Spending",
+                content = "Stores and apps are designed to make you buy right now. A simple defense is the 24-hour rule: when you want something that isn't a need, wait a day. Often the urge fades and you keep your money. Another trick is to keep your savings in a separate account so it's a little harder to touch. Small pauses lead to big savings over a year.",
+                keyTakeaways = listOf(
+                    "Wait 24 hours before buying non-essential things",
+                    "Keep savings separate so it's harder to spend",
+                    "Small pauses add up to big savings",
+                ),
+                quiz = QuizQuestion(
+                    question = "What's the 24-hour rule?",
+                    options = listOf(
+                        "Spend within 24 hours or lose the deal",
+                        "Wait a day before buying something you don't need",
+                        "Check your balance every 24 hours",
+                        "Pay bills within 24 hours",
+                    ),
+                    correctIndex = 1,
+                    explanation = "Waiting a day before a non-essential purchase gives the impulse time to fade, helping you avoid regret spending.",
+                ),
+                estimatedMinutes = 3,
+            ),
+            LearningModule(
+                id = "fj-5",
+                title = "Saving for Something Big",
+                content = "Want a car, a laptop, or a trip? Big goals feel out of reach until you break them down. Pick the price, pick a date, and divide: a $1,200 goal in 12 months is $100 a month, or about $25 a week. Put that amount aside first each time you get paid and watch it grow. Seeing the total climb toward your goal is what keeps saving fun instead of feeling like a chore.",
+                keyTakeaways = listOf(
+                    "Break a big goal into a weekly or monthly amount",
+                    "Set the money aside first, before spending on wants",
+                    "Tracking progress keeps saving motivating",
+                ),
+                quiz = QuizQuestion(
+                    question = "You want to save $1,200 in 12 months. About how much per month?",
+                    options = listOf("$50", "$100", "$200", "$1,200"),
+                    correctIndex = 1,
+                    explanation = "$1,200 divided by 12 months is $100 per month — breaking a big goal into small steps makes it reachable.",
+                ),
+                estimatedMinutes = 4,
             ),
         ),
     )

--- a/apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathViewModel.kt
@@ -3,6 +3,8 @@
 package com.finance.android.ui.learning
 
 import androidx.lifecycle.ViewModel
+import com.finance.android.ui.expertise.ExpertiseTier
+import com.finance.android.ui.expertise.ExpertiseTierManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -10,14 +12,20 @@ import kotlinx.coroutines.flow.update
 import timber.log.Timber
 
 /**
- * UI state for the learning paths feature (#382).
+ * UI state for the learning paths feature (#382, #2208, #2209).
  *
- * @property paths All available learning paths.
+ * @property paths Learning paths visible to the user (catalog-filtered).
  * @property progress Map of path ID to user's progress.
  * @property selectedPathId Currently selected path for detail view.
  * @property currentModuleIndex Index of the current module being viewed.
  * @property quizAnswer The user's selected quiz answer index, or -1.
  * @property quizSubmitted Whether the current quiz has been submitted.
+ * @property beginnerMode Whether beginner-friendly ordering/gating is active.
+ * @property showAdvanced Whether advanced topics are revealed in beginner mode.
+ * @property hasAdvancedContent Whether any advanced content exists to gate.
+ * @property resumePathId Path to resume ("pick up where you left off"), if any.
+ * @property resumeModuleIndex Module index to resume at within [resumePathId].
+ * @property rewards Derived reward summary (XP, level, streak, badges).
  */
 data class LearningUiState(
     val paths: List<LearningPath> = emptyList(),
@@ -26,21 +34,47 @@ data class LearningUiState(
     val currentModuleIndex: Int = 0,
     val quizAnswer: Int = -1,
     val quizSubmitted: Boolean = false,
+    val beginnerMode: Boolean = false,
+    val showAdvanced: Boolean = false,
+    val hasAdvancedContent: Boolean = false,
+    val resumePathId: String? = null,
+    val resumeModuleIndex: Int = 0,
+    val rewards: LearningRewards = LearningRewards.from(emptyMap(), 0),
 )
 
 /**
  * ViewModel for the financial learning paths feature (#382).
  *
- * Manages learning path navigation, module progress tracking, and
- * quiz interactions. Progress is kept in-memory for now; persistence
- * will be added when the sync layer is wired.
+ * Manages learning path navigation, module progress tracking, and quiz
+ * interactions. Progress now persists across restarts via
+ * [LearningProgressRepository] (#2208), surfaces a resume entry point and
+ * reward summary, and adapts the catalog for beginners driven by the user's
+ * [ExpertiseTier] (#2209).
  */
-class LearningPathViewModel : ViewModel() {
+class LearningPathViewModel(
+    private val progressRepository: LearningProgressRepository,
+    private val expertiseTierManager: ExpertiseTierManager,
+    private val currentEpochDay: () -> Long = { System.currentTimeMillis() / MILLIS_PER_DAY },
+) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(
-        LearningUiState(paths = LearningPathContent.allPaths()),
-    )
+    private var persisted: LearningState = progressRepository.load()
+
+    private val _uiState = MutableStateFlow(buildInitialState())
     val uiState: StateFlow<LearningUiState> = _uiState.asStateFlow()
+
+    private fun buildInitialState(): LearningUiState {
+        val beginnerMode = expertiseTierManager.currentTier.value == ExpertiseTier.BEGINNER
+        return LearningUiState(
+            paths = LearningPathContent.catalog(beginnerMode, showAdvanced = false),
+            progress = persisted.progress,
+            beginnerMode = beginnerMode,
+            showAdvanced = false,
+            hasAdvancedContent = LearningPathContent.hasAdvancedContent(),
+            resumePathId = persisted.lastActivePathId,
+            resumeModuleIndex = persisted.lastActiveModuleIndex,
+            rewards = LearningRewards.from(persisted.progress, persisted.streakDays),
+        )
+    }
 
     /**
      * Selects a learning path for detailed view.
@@ -55,6 +89,37 @@ class LearningPathViewModel : ViewModel() {
             )
         }
         Timber.d("Learning path selected: %s", pathId)
+    }
+
+    /**
+     * Resumes the most recently studied path, if one exists (#2208).
+     */
+    fun resumeLearning() {
+        val pathId = persisted.lastActivePathId ?: return
+        val path = LearningPathContent.pathById(pathId) ?: return
+        val index = persisted.lastActiveModuleIndex.coerceIn(0, path.modules.lastIndex)
+        _uiState.update {
+            it.copy(
+                selectedPathId = pathId,
+                currentModuleIndex = index,
+                quizAnswer = -1,
+                quizSubmitted = false,
+            )
+        }
+        Timber.d("Resuming learning path %s at module %d", pathId, index)
+    }
+
+    /**
+     * Toggles visibility of advanced topics while in beginner mode (#2209).
+     */
+    fun toggleShowAdvanced() {
+        _uiState.update { state ->
+            val showAdvanced = !state.showAdvanced
+            state.copy(
+                showAdvanced = showAdvanced,
+                paths = LearningPathContent.catalog(state.beginnerMode, showAdvanced),
+            )
+        }
     }
 
     /**
@@ -101,12 +166,28 @@ class LearningPathViewModel : ViewModel() {
             state.currentModuleIndex
         }
 
+        val progressMap = state.progress + (pathId to updatedProgress)
+        val today = currentEpochDay()
+        val streakDays = LearningStreak.advance(persisted.lastActiveEpochDay, persisted.streakDays, today)
+
+        persisted = LearningState(
+            progress = progressMap,
+            lastActivePathId = pathId,
+            lastActiveModuleIndex = nextIndex,
+            streakDays = streakDays,
+            lastActiveEpochDay = today,
+        )
+        progressRepository.save(persisted)
+
         _uiState.update {
             it.copy(
-                progress = it.progress + (pathId to updatedProgress),
+                progress = progressMap,
                 currentModuleIndex = nextIndex,
                 quizAnswer = -1,
                 quizSubmitted = false,
+                resumePathId = pathId,
+                resumeModuleIndex = nextIndex,
+                rewards = LearningRewards.from(progressMap, streakDays),
             )
         }
 
@@ -145,5 +226,9 @@ class LearningPathViewModel : ViewModel() {
                 quizSubmitted = false,
             )
         }
+    }
+
+    private companion object {
+        const val MILLIS_PER_DAY = 86_400_000L
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathsScreen.kt
@@ -124,9 +124,10 @@ fun LearningPathsScreen(
             }
         } else {
             PathListContent(
-                paths = state.paths,
-                progress = state.progress,
+                state = state,
                 onSelectPath = viewModel::selectPath,
+                onResume = viewModel::resumeLearning,
+                onToggleAdvanced = viewModel::toggleShowAdvanced,
                 modifier = Modifier.padding(padding),
             )
         }
@@ -135,24 +136,216 @@ fun LearningPathsScreen(
 
 @Composable
 private fun PathListContent(
-    paths: List<LearningPath>,
-    progress: Map<String, LearningProgress>,
+    state: LearningUiState,
     onSelectPath: (String) -> Unit,
+    onResume: () -> Unit,
+    onToggleAdvanced: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val resumePath = state.resumePathId?.let { LearningPathContent.pathById(it) }
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        items(paths, key = { it.id }) { path ->
+        item(key = "rewards") {
+            RewardsSummaryCard(rewards = state.rewards)
+        }
+        if (resumePath != null) {
+            item(key = "resume") {
+                ResumeCard(
+                    path = resumePath,
+                    moduleIndex = state.resumeModuleIndex,
+                    onResume = onResume,
+                )
+            }
+        }
+        items(state.paths, key = { it.id }) { path ->
             PathCard(
                 path = path,
-                progress = progress[path.id],
+                progress = state.progress[path.id],
                 onClick = { onSelectPath(path.id) },
             )
         }
+        if (state.beginnerMode && state.hasAdvancedContent) {
+            item(key = "advanced-toggle") {
+                AdvancedTopicsToggle(
+                    showAdvanced = state.showAdvanced,
+                    onToggle = onToggleAdvanced,
+                )
+            }
+        }
         item { Spacer(Modifier.height(80.dp)) }
+    }
+}
+
+/**
+ * Reward summary showing level, XP progress, streak and badges (#2208).
+ */
+@Composable
+private fun RewardsSummaryCard(
+    rewards: LearningRewards,
+    modifier: Modifier = Modifier,
+) {
+    ElevatedCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "Level ${rewards.level}. " +
+                    "${rewards.xp} total experience points. " +
+                    "${rewards.lessonsCompleted} lessons completed. " +
+                    "${rewards.streakDays} day learning streak."
+            },
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = "Level ${rewards.level}",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text = "🔥 ${rewards.streakDays}-day streak",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { rewards.levelProgress },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription =
+                            "${rewards.xpIntoLevel} of ${rewards.xpForNextLevel} XP to next level"
+                    },
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "${rewards.xp} XP · ${rewards.lessonsCompleted} lessons · " +
+                    "${rewards.quizzesMastered} quizzes aced",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (rewards.badges.isNotEmpty()) {
+                Spacer(Modifier.height(12.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    rewards.badges.forEach { badge ->
+                        BadgeChip(badge = badge)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BadgeChip(
+    badge: LearningBadge,
+    modifier: Modifier = Modifier,
+) {
+    val stateLabel = if (badge.unlocked) "unlocked" else "locked"
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .width(64.dp)
+            .semantics {
+                contentDescription = "${badge.title} badge, $stateLabel. ${badge.description}"
+            },
+    ) {
+        Text(
+            text = badge.icon,
+            style = MaterialTheme.typography.headlineSmall,
+            color = if (badge.unlocked) {
+                Color.Unspecified
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f)
+            },
+        )
+        Text(
+            text = badge.title,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = if (badge.unlocked) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (badge.unlocked) {
+                MaterialTheme.colorScheme.onSurface
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f)
+            },
+        )
+    }
+}
+
+/**
+ * "Pick up where you left off" entry point (#2208).
+ */
+@Composable
+private fun ResumeCard(
+    path: LearningPath,
+    moduleIndex: Int,
+    onResume: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val moduleTitle = path.modules.getOrNull(moduleIndex)?.title ?: path.title
+    ElevatedCard(
+        onClick = onResume,
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+        ),
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription =
+                    "Continue learning ${path.title}, next up $moduleTitle. Double tap to resume."
+            },
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Pick up where you left off",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = "${path.icon}  $moduleTitle",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+    }
+}
+
+/**
+ * Beginner-mode toggle that reveals or hides advanced topics (#2209).
+ */
+@Composable
+private fun AdvancedTopicsToggle(
+    showAdvanced: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val label = if (showAdvanced) "Hide advanced topics" else "Show advanced topics"
+    OutlinedButton(
+        onClick = onToggle,
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = label },
+    ) {
+        Text(label)
     }
 }
 
@@ -301,14 +494,14 @@ private fun ModuleDetailContent(
                 Icon(
                     Icons.Filled.CheckCircle,
                     contentDescription = null,
-                    tint = Color(0xFF2E7D32),
+                    tint = FinanceTheme.financeColors.income,
                     modifier = Modifier.size(16.dp),
                 )
                 Spacer(Modifier.width(4.dp))
                 Text(
                     text = "Completed",
                     style = MaterialTheme.typography.labelSmall,
-                    color = Color(0xFF2E7D32),
+                    color = FinanceTheme.financeColors.income,
                     modifier = Modifier.semantics { contentDescription = "Module completed" },
                 )
             }
@@ -476,7 +669,7 @@ private fun QuizSection(
                         text = option,
                         style = MaterialTheme.typography.bodySmall,
                         color = when {
-                            isCorrect -> Color(0xFF2E7D32)
+                            isCorrect -> FinanceTheme.financeColors.income
                             isWrong -> MaterialTheme.colorScheme.error
                             else -> MaterialTheme.colorScheme.onSurface
                         },
@@ -507,7 +700,7 @@ private fun QuizSection(
                     Text(
                         text = if (isCorrect) "✓ Correct!" else "✗ Not quite",
                         style = MaterialTheme.typography.titleSmall,
-                        color = if (isCorrect) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error,
+                        color = if (isCorrect) FinanceTheme.financeColors.income else MaterialTheme.colorScheme.error,
                         fontWeight = FontWeight.Bold,
                         modifier = Modifier.semantics {
                             contentDescription = if (isCorrect) "Correct answer!" else "Incorrect answer"
@@ -534,14 +727,30 @@ private fun QuizSection(
 private fun LearningPathsListPreview() {
     FinanceTheme(dynamicColor = false) {
         PathListContent(
-            paths = LearningPathContent.allPaths(),
-            progress = mapOf(
-                "budgeting-basics" to LearningProgress(
-                    pathId = "budgeting-basics",
-                    completedModuleIds = setOf("bb-1"),
+            state = LearningUiState(
+                paths = LearningPathContent.allPaths(),
+                progress = mapOf(
+                    "budgeting-basics" to LearningProgress(
+                        pathId = "budgeting-basics",
+                        completedModuleIds = setOf("bb-1"),
+                    ),
                 ),
+                rewards = LearningRewards.from(
+                    mapOf(
+                        "budgeting-basics" to LearningProgress(
+                            pathId = "budgeting-basics",
+                            completedModuleIds = setOf("bb-1"),
+                        ),
+                    ),
+                    streakDays = 2,
+                ),
+                resumePathId = "budgeting-basics",
+                beginnerMode = true,
+                hasAdvancedContent = true,
             ),
             onSelectPath = {},
+            onResume = {},
+            onToggleAdvanced = {},
         )
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningProgressCodec.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningProgressCodec.kt
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.learning
+
+/**
+ * Plain-text codec for [LearningState] (#2208).
+ *
+ * Uses a small line-based format instead of a JSON dependency. Learning IDs are
+ * simple slugs (letters, digits, hyphens) so reserved delimiters never collide
+ * with real content. Pure and deterministic, so it is directly unit-testable.
+ *
+ * Format:
+ * ```
+ * v1
+ * meta<US>lastActivePathId<US>lastActiveModuleIndex<US>streakDays<US>lastActiveEpochDay
+ * path<US>pathId<US>completedId,completedId<US>moduleId=score;moduleId=score
+ * ```
+ * where `<US>` is the unit-separator character.
+ */
+object LearningProgressCodec {
+
+    private const val VERSION = "v1"
+    private const val FIELD = '\u001F' // unit separator
+    private const val LIST = ','
+    private const val MAP_ENTRY = ';'
+    private const val MAP_KV = '='
+
+    /** Serializes [state] into a single string. */
+    fun encode(state: LearningState): String {
+        val sb = StringBuilder()
+        sb.append(VERSION).append('\n')
+        sb.append("meta")
+            .append(FIELD).append(state.lastActivePathId ?: "")
+            .append(FIELD).append(state.lastActiveModuleIndex)
+            .append(FIELD).append(state.streakDays)
+            .append(FIELD).append(state.lastActiveEpochDay)
+            .append('\n')
+
+        state.progress.values.forEach { progress ->
+            val completed = progress.completedModuleIds.joinToString(LIST.toString())
+            val scores = progress.quizScores.entries.joinToString(MAP_ENTRY.toString()) {
+                "${it.key}$MAP_KV${it.value}"
+            }
+            sb.append("path")
+                .append(FIELD).append(progress.pathId)
+                .append(FIELD).append(completed)
+                .append(FIELD).append(scores)
+                .append('\n')
+        }
+        return sb.toString().trimEnd('\n')
+    }
+
+    /** Parses a string produced by [encode] back into a [LearningState]. */
+    fun decode(encoded: String): LearningState {
+        val lines = encoded.split('\n').filter { it.isNotBlank() }
+        if (lines.isEmpty() || lines.first().trim() != VERSION) return LearningState()
+
+        var lastActivePathId: String? = null
+        var lastActiveModuleIndex = 0
+        var streakDays = 0
+        var lastActiveEpochDay = 0L
+        val progress = LinkedHashMap<String, LearningProgress>()
+
+        lines.drop(1).forEach { line ->
+            val parts = line.split(FIELD)
+            when (parts.firstOrNull()) {
+                "meta" -> {
+                    lastActivePathId = parts.getOrNull(1)?.ifBlank { null }
+                    lastActiveModuleIndex = parts.getOrNull(2)?.toIntOrNull() ?: 0
+                    streakDays = parts.getOrNull(3)?.toIntOrNull() ?: 0
+                    lastActiveEpochDay = parts.getOrNull(4)?.toLongOrNull() ?: 0L
+                }
+                "path" -> {
+                    val pathId = parts.getOrNull(1)?.ifBlank { null } ?: return@forEach
+                    val completed = parts.getOrNull(2)
+                        ?.split(LIST)
+                        ?.filter { it.isNotBlank() }
+                        ?.toSet()
+                        ?: emptySet()
+                    val scores = parts.getOrNull(3)
+                        ?.split(MAP_ENTRY)
+                        ?.filter { it.isNotBlank() }
+                        ?.mapNotNull { entry ->
+                            val kv = entry.split(MAP_KV)
+                            val key = kv.getOrNull(0)
+                            val value = kv.getOrNull(1)?.toFloatOrNull()
+                            if (key != null && value != null) key to value else null
+                        }
+                        ?.toMap()
+                        ?: emptyMap()
+                    progress[pathId] = LearningProgress(
+                        pathId = pathId,
+                        completedModuleIds = completed,
+                        quizScores = scores,
+                    )
+                }
+            }
+        }
+
+        return LearningState(
+            progress = progress,
+            lastActivePathId = lastActivePathId,
+            lastActiveModuleIndex = lastActiveModuleIndex,
+            streakDays = streakDays,
+            lastActiveEpochDay = lastActiveEpochDay,
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningProgressRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningProgressRepository.kt
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.learning
+
+import android.content.SharedPreferences
+import timber.log.Timber
+
+/**
+ * A durable snapshot of the user's learning journey (#2208).
+ *
+ * @property progress Per-path progress keyed by path ID.
+ * @property lastActivePathId The path the user most recently studied, for
+ *   the "pick up where you left off" entry point. `null` if none.
+ * @property lastActiveModuleIndex The module index within [lastActivePathId].
+ * @property streakDays Consecutive-day learning streak.
+ * @property lastActiveEpochDay Epoch day of the last learning activity, used to
+ *   advance or reset the streak. `0` means no activity recorded yet.
+ */
+data class LearningState(
+    val progress: Map<String, LearningProgress> = emptyMap(),
+    val lastActivePathId: String? = null,
+    val lastActiveModuleIndex: Int = 0,
+    val streakDays: Int = 0,
+    val lastActiveEpochDay: Long = 0L,
+)
+
+/**
+ * Reward summary derived from a [LearningState] (#2208).
+ *
+ * Turns raw progress into visible motivation — XP, a level, a learning streak,
+ * and unlocked badges — so returning to learn feels like a series of small wins
+ * instead of homework that restarts.
+ *
+ * @property xp Total experience points earned.
+ * @property level Current learner level (starts at 1).
+ * @property xpIntoLevel XP accumulated within the current level.
+ * @property xpForNextLevel XP needed to reach the next level.
+ * @property lessonsCompleted Total completed modules across all paths.
+ * @property quizzesMastered Number of quizzes answered perfectly.
+ * @property streakDays Consecutive-day learning streak.
+ * @property badges Ordered list of badges with unlock state.
+ */
+data class LearningRewards(
+    val xp: Int,
+    val level: Int,
+    val xpIntoLevel: Int,
+    val xpForNextLevel: Int,
+    val lessonsCompleted: Int,
+    val quizzesMastered: Int,
+    val streakDays: Int,
+    val badges: List<LearningBadge>,
+) {
+    /** Progress toward the next level, 0f..1f. */
+    val levelProgress: Float
+        get() = if (xpForNextLevel > 0) (xpIntoLevel.toFloat() / xpForNextLevel).coerceIn(0f, 1f) else 0f
+
+    companion object {
+        /** XP awarded for finishing a single learning module. */
+        const val XP_PER_LESSON = 10
+
+        /** Bonus XP awarded for a perfect quiz score. */
+        const val XP_PER_QUIZ_MASTERY = 5
+
+        /** XP required to advance one level. */
+        const val XP_PER_LEVEL = 100
+
+        /**
+         * Computes reward state from raw learning [progress] and a [streakDays]
+         * count. Pure and deterministic so it is straightforward to unit test.
+         */
+        fun from(progress: Map<String, LearningProgress>, streakDays: Int): LearningRewards {
+            val lessonsCompleted = progress.values.sumOf { it.completedModuleIds.size }
+            val quizzesMastered = progress.values.sumOf { p ->
+                p.quizScores.values.count { it >= 1f }
+            }
+            val xp = lessonsCompleted * XP_PER_LESSON + quizzesMastered * XP_PER_QUIZ_MASTERY
+            val level = xp / XP_PER_LEVEL + 1
+            val xpIntoLevel = xp % XP_PER_LEVEL
+
+            val badges = listOf(
+                LearningBadge(
+                    id = "first-lesson",
+                    title = "First Steps",
+                    description = "Complete your first lesson",
+                    icon = "🌱",
+                    unlocked = lessonsCompleted >= 1,
+                ),
+                LearningBadge(
+                    id = "five-lessons",
+                    title = "Getting Serious",
+                    description = "Complete five lessons",
+                    icon = "📚",
+                    unlocked = lessonsCompleted >= 5,
+                ),
+                LearningBadge(
+                    id = "quiz-master",
+                    title = "Quiz Master",
+                    description = "Ace three quizzes",
+                    icon = "🎯",
+                    unlocked = quizzesMastered >= 3,
+                ),
+                LearningBadge(
+                    id = "streak-3",
+                    title = "On a Roll",
+                    description = "Learn three days in a row",
+                    icon = "🔥",
+                    unlocked = streakDays >= 3,
+                ),
+            )
+
+            return LearningRewards(
+                xp = xp,
+                level = level,
+                xpIntoLevel = xpIntoLevel,
+                xpForNextLevel = XP_PER_LEVEL,
+                lessonsCompleted = lessonsCompleted,
+                quizzesMastered = quizzesMastered,
+                streakDays = streakDays,
+                badges = badges,
+            )
+        }
+    }
+}
+
+/**
+ * A single unlockable learning badge.
+ */
+data class LearningBadge(
+    val id: String,
+    val title: String,
+    val description: String,
+    val icon: String,
+    val unlocked: Boolean,
+)
+
+/**
+ * Pure day-streak logic for learning activity (#2208).
+ *
+ * Extracted so it can be unit tested without Android or a clock.
+ */
+object LearningStreak {
+
+    /**
+     * Advances a learning streak given the [previousDay] of the last activity,
+     * the [previousStreak] length, and [todayDay] (both as epoch days).
+     *
+     * - Same day → unchanged (still counts as active today).
+     * - Next consecutive day → streak + 1.
+     * - Gap of 2+ days, or first-ever activity → streak resets to 1.
+     */
+    fun advance(previousDay: Long, previousStreak: Int, todayDay: Long): Int = when {
+        previousDay == todayDay && previousStreak > 0 -> previousStreak
+        previousDay == todayDay -> 1
+        todayDay - previousDay == 1L -> previousStreak + 1
+        else -> 1
+    }
+}
+
+/**
+ * Persists and restores the user's [LearningState] across app restarts (#2208).
+ *
+ * Backed by [SharedPreferences] (encrypted app settings) and a plain-text codec
+ * so no external serialization dependency is required. Learning progress is not
+ * sensitive financial data.
+ */
+class LearningProgressRepository(
+    private val prefs: SharedPreferences,
+) {
+
+    /** Loads the persisted [LearningState], or an empty state on first run. */
+    fun load(): LearningState {
+        val encoded = prefs.getString(KEY_STATE, null) ?: return LearningState()
+        return runCatching { LearningProgressCodec.decode(encoded) }
+            .getOrElse {
+                Timber.w(it, "Failed to decode persisted learning state; starting fresh")
+                LearningState()
+            }
+    }
+
+    /** Persists [state]. */
+    fun save(state: LearningState) {
+        prefs.edit().putString(KEY_STATE, LearningProgressCodec.encode(state)).apply()
+    }
+
+    private companion object {
+        const val KEY_STATE = "learning_state_v1"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/AdaptiveNavigation.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/AdaptiveNavigation.kt
@@ -4,25 +4,26 @@
 
 package com.finance.android.ui.navigation
 
-import androidx.compose.material3.DrawerValue
-import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Modifier
-import kotlinx.coroutines.launch
-import timber.log.Timber
 
 /**
  * Navigation layout style determined by the current window width.
  *
  * - **BottomBar:** Used for compact widths (phones in portrait).
- *   Material 3 [NavigationBar] at the bottom of the screen.
+ *   Material 3 [androidx.compose.material3.NavigationBar] at the bottom of the
+ *   screen.
  *
- * - **ModalDrawer:** Used for medium and expanded widths (tablets, landscape,
- *   foldables). Material 3 [ModalNavigationDrawer] for richer navigation.
+ * - **NavigationRail:** Used for medium widths (large phones in landscape, small
+ *   tablets, unfolded foldables). Material 3
+ *   [androidx.compose.material3.NavigationRail] keeps primary destinations
+ *   visible on the leading edge instead of hiding them behind a hamburger.
  *
- * This follows the Material 3 adaptive layout guidelines:
+ * - **ModalDrawer:** Used for expanded widths (large tablets, desktop). Material 3
+ *   [androidx.compose.material3.ModalNavigationDrawer] surfaces richer
+ *   navigation with labels.
+ *
+ * This follows the Material 3 adaptive layout guidelines
+ * (Compact → bottom bar, Medium → rail, Expanded → drawer):
  * @see <a href="https://m3.material.io/foundations/layout/applying-layout/compact">
  *   Material 3 Adaptive Layout</a>
  */
@@ -30,7 +31,10 @@ enum class NavigationLayoutType {
     /** Phone portrait — bottom navigation bar. */
     BottomBar,
 
-    /** Tablet / landscape — modal navigation drawer. */
+    /** Large phone landscape / small tablet / foldable — navigation rail. */
+    NavigationRail,
+
+    /** Large tablet / desktop — modal navigation drawer. */
     ModalDrawer,
 }
 
@@ -44,5 +48,6 @@ fun resolveNavigationLayout(
     windowWidthSizeClass: WindowWidthSizeClass,
 ): NavigationLayoutType = when (windowWidthSizeClass) {
     WindowWidthSizeClass.Compact -> NavigationLayoutType.BottomBar
+    WindowWidthSizeClass.Medium -> NavigationLayoutType.NavigationRail
     else -> NavigationLayoutType.ModalDrawer
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavigationRail.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavigationRail.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.navigation
+
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.finance.android.ui.components.IconView
+
+/**
+ * Material 3 [NavigationRail] with the four primary Finance destinations.
+ *
+ * Shown at medium window widths (large phones in landscape, small tablets,
+ * unfolded foldables) where Material 3 recommends a rail on the leading edge
+ * instead of a bottom bar or a hidden modal drawer (#3713). It mirrors the
+ * destinations of [FinanceBottomBar], so navigation stays consistent as the
+ * window resizes.
+ *
+ * Each item carries a `contentDescription` for TalkBack and uses the Material 3
+ * selected-state indicator.
+ *
+ * @param navController The [NavHostController] used for navigation state and actions.
+ * @param modifier Modifier applied to the [NavigationRail].
+ */
+@Composable
+fun FinanceNavigationRail(
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+) {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+
+    NavigationRail(
+        modifier = modifier.semantics { contentDescription = "Primary navigation rail" },
+    ) {
+        TopLevelDestination.entries.forEach { destination ->
+            val selected = currentDestination?.hierarchy?.any { it.route == destination.route } == true
+
+            NavigationRailItem(
+                selected = selected,
+                onClick = {
+                    navController.navigate(destination.route) {
+                        // Pop up to the start destination to avoid building up
+                        // a large back-stack of top-level destinations.
+                        popUpTo(navController.graph.findStartDestination().id) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+                icon = {
+                    IconView(token = destination.iconToken)
+                },
+                label = { Text(text = destination.label) },
+                modifier = Modifier.semantics {
+                    contentDescription = destination.a11yDescription
+                },
+            )
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingScreen.kt
@@ -195,6 +195,10 @@ fun OnboardingScreen(
                         onStartingBalanceChange = { viewModel.setStartingBalance(it) },
                         currencySymbol = state.selectedCurrency.symbol,
                         onNext = { viewModel.nextStep() },
+                        taxIdentity = state.taxIdentity,
+                        onTaxIdentityChange = { viewModel.setTaxIdentity(it) },
+                        incomeType = state.incomeType,
+                        onIncomeTypeChange = { viewModel.setIncomeType(it) },
                     )
                     5 -> FirstBudgetStep(
                         budgetCategory = state.budgetCategory,
@@ -564,6 +568,7 @@ private fun CurrencyChip(
 /**
  * First account creation step: name, type, starting balance.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun FirstAccountStep(
     accountName: String,
@@ -575,6 +580,10 @@ fun FirstAccountStep(
     currencySymbol: String,
     onNext: () -> Unit,
     modifier: Modifier = Modifier,
+    taxIdentity: TaxIdentity = TaxIdentity.PREFER_NOT_TO_SAY,
+    onTaxIdentityChange: (TaxIdentity) -> Unit = {},
+    incomeType: IncomeType = IncomeType.NOT_SPECIFIED,
+    onIncomeTypeChange: (IncomeType) -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -673,6 +682,16 @@ fun FirstAccountStep(
                 },
         )
 
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Optional newcomer profile (#2178) — ITIN-aware, never required.
+        NewcomerProfileSection(
+            taxIdentity = taxIdentity,
+            onTaxIdentityChange = onTaxIdentityChange,
+            incomeType = incomeType,
+            onIncomeTypeChange = onIncomeTypeChange,
+        )
+
         Spacer(modifier = Modifier.weight(1f))
         Spacer(modifier = Modifier.height(24.dp))
 
@@ -688,7 +707,88 @@ fun FirstAccountStep(
     }
 }
 
-// ── Step 4: First Budget ─────────────────────────────────────────────────────
+/**
+ * Optional, ITIN-aware newcomer profile shown within the account step (#2178).
+ *
+ * Lets a user without an SSN say so and pick their income type, so the app can
+ * later surface plain-language US finance basics tailored to them. Everything
+ * here is optional and defaults to "prefer not to say" — it never blocks
+ * onboarding.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun NewcomerProfileSection(
+    taxIdentity: TaxIdentity,
+    onTaxIdentityChange: (TaxIdentity) -> Unit,
+    incomeType: IncomeType,
+    onIncomeTypeChange: (IncomeType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "New to the US? (optional)",
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.semantics { heading() },
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = "No SSN yet is fine — an ITIN works too. This just helps us " +
+                "explain US money basics in plain language. You can skip it.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = "Tax ID",
+            style = MaterialTheme.typography.labelLarge,
+            modifier = Modifier.semantics { contentDescription = "Tax ID selection" },
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.selectableGroup(),
+        ) {
+            TaxIdentity.entries.forEach { identity ->
+                FilterChip(
+                    selected = identity == taxIdentity,
+                    onClick = { onTaxIdentityChange(identity) },
+                    label = { Text(identity.label) },
+                    modifier = Modifier.semantics {
+                        contentDescription = identity.label
+                        stateDescription = if (identity == taxIdentity) "Selected" else "Not selected"
+                    },
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = "How are you paid?",
+            style = MaterialTheme.typography.labelLarge,
+            modifier = Modifier.semantics { contentDescription = "Income type selection" },
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.selectableGroup(),
+        ) {
+            IncomeType.entries.forEach { type ->
+                FilterChip(
+                    selected = type == incomeType,
+                    onClick = { onIncomeTypeChange(type) },
+                    label = { Text(type.label) },
+                    modifier = Modifier.semantics {
+                        contentDescription = type.label
+                        stateDescription = if (type == incomeType) "Selected" else "Not selected"
+                    },
+                )
+            }
+        }
+    }
+}
 
 /**
  * First budget step: "How much do you want to spend on groceries this month?"

--- a/apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingViewModel.kt
@@ -24,6 +24,50 @@ enum class OnboardingAccountType(val label: String) {
 }
 
 /**
+ * How the user is identified for US tax purposes (#2178).
+ *
+ * ITIN-aware onboarding: newcomers who don't have an SSN yet can still set up
+ * the app and receive plain-language guidance. This is optional and never
+ * blocks onboarding.
+ */
+enum class TaxIdentity(val label: String) {
+    /** Has a Social Security Number. */
+    SSN("I have an SSN"),
+
+    /** Uses an Individual Taxpayer Identification Number. */
+    ITIN("I use an ITIN"),
+
+    /** No SSN or ITIN yet (e.g. newly arrived). */
+    NONE_YET("I don't have one yet"),
+
+    /** Declines to say — the default. */
+    PREFER_NOT_TO_SAY("Prefer not to say"),
+}
+
+/**
+ * The kind of income a user primarily earns (#2178).
+ *
+ * Used to tailor plain-language finance basics (e.g. withholding vs. setting
+ * aside taxes on 1099 income). Optional and non-blocking.
+ */
+enum class IncomeType(val label: String) {
+    /** Employee wages reported on a W-2. */
+    W2("Employee (W-2)"),
+
+    /** Contract or gig income reported on a 1099. */
+    FORM_1099("Contractor (1099)"),
+
+    /** A mix of W-2 and 1099 income. */
+    MIXED("A mix of both"),
+
+    /** Hourly or seasonal work with variable income. */
+    HOURLY_SEASONAL("Hourly or seasonal"),
+
+    /** Not specified — the default. */
+    NOT_SPECIFIED("Prefer not to say"),
+}
+
+/**
  * The two onboarding paths a user can choose from after the welcome step.
  *
  * - [QUICK_START] — "Just let me in": applies sensible defaults and skips
@@ -91,6 +135,11 @@ data class OnboardingUiState(
     val accountName: String = "",
     val accountType: OnboardingAccountType = OnboardingAccountType.CHECKING,
     val startingBalance: String = "",
+
+    // Step 4 — Optional newcomer profile (#2178). Surfaced within the account
+    // step; never adds a step or blocks progress.
+    val taxIdentity: TaxIdentity = TaxIdentity.PREFER_NOT_TO_SAY,
+    val incomeType: IncomeType = IncomeType.NOT_SPECIFIED,
 
     // Step 5 — First Budget (personalized path)
     val budgetCategory: String = "Groceries",
@@ -176,6 +225,8 @@ class OnboardingViewModel(application: Application) : AndroidViewModel(applicati
                 .putString(KEY_STARTING_BALANCE, "0")
                 .putString(KEY_BUDGET_CATEGORY, "Groceries")
                 .putString(KEY_BUDGET_AMOUNT, "0")
+                .putString(KEY_TAX_IDENTITY, TaxIdentity.PREFER_NOT_TO_SAY.name)
+                .putString(KEY_INCOME_TYPE, IncomeType.NOT_SPECIFIED.name)
                 .putString(KEY_ONBOARDING_PATH, OnboardingPath.QUICK_START.name)
                 .apply()
 
@@ -234,6 +285,16 @@ class OnboardingViewModel(application: Application) : AndroidViewModel(applicati
         _uiState.update { it.copy(accountType = type) }
     }
 
+    /** Records the user's optional tax identity (SSN/ITIN/none) — #2178. */
+    fun setTaxIdentity(identity: TaxIdentity) {
+        _uiState.update { it.copy(taxIdentity = identity) }
+    }
+
+    /** Records the user's optional income type for tailored basics — #2178. */
+    fun setIncomeType(type: IncomeType) {
+        _uiState.update { it.copy(incomeType = type) }
+    }
+
     fun setStartingBalance(balance: String) {
         // Only allow valid numeric input (digits + optional single decimal point)
         if (balance.isEmpty() || balance.matches(Regex("""^\d*\.?\d{0,2}$"""))) {
@@ -270,6 +331,8 @@ class OnboardingViewModel(application: Application) : AndroidViewModel(applicati
                 .putString(KEY_STARTING_BALANCE, state.startingBalance.ifBlank { "0" })
                 .putString(KEY_BUDGET_CATEGORY, state.budgetCategory)
                 .putString(KEY_BUDGET_AMOUNT, state.budgetAmount.ifBlank { "0" })
+                .putString(KEY_TAX_IDENTITY, state.taxIdentity.name)
+                .putString(KEY_INCOME_TYPE, state.incomeType.name)
                 .putString(KEY_ONBOARDING_PATH, OnboardingPath.PERSONALIZED.name)
                 .apply()
 
@@ -293,6 +356,8 @@ class OnboardingViewModel(application: Application) : AndroidViewModel(applicati
         internal const val KEY_STARTING_BALANCE = "onboarding_starting_balance"
         internal const val KEY_BUDGET_CATEGORY = "onboarding_budget_category"
         internal const val KEY_BUDGET_AMOUNT = "onboarding_budget_amount"
+        internal const val KEY_TAX_IDENTITY = "onboarding_tax_identity"
+        internal const val KEY_INCOME_TYPE = "onboarding_income_type"
         internal const val KEY_ONBOARDING_PATH = "onboarding_path"
 
         /**

--- a/apps/android/src/main/kotlin/com/finance/android/ui/theme/Color.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/theme/Color.kt
@@ -39,6 +39,7 @@ val Teal900 = Color(0xFF134E4A)
 
 // region Primitive — Green
 val Green50 = Color(0xFFF0FDF4)
+val Green400 = Color(0xFF4ADE80)
 val Green500 = Color(0xFF22C55E)
 val Green600 = Color(0xFF16A34A)
 val Green700 = Color(0xFF15803D)

--- a/apps/android/src/main/kotlin/com/finance/android/ui/theme/FinanceColors.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/theme/FinanceColors.kt
@@ -25,19 +25,22 @@ data class FinanceSemanticColors(
     val warning: Color,
 )
 
-// Design-token references. Light and dark currently resolve to the same values so
-// existing golden snapshots stay pixel-identical; dedicated dark-mode contrast
-// tuning is tracked as a separate issue.
-private val IncomeGreen = Color(0xFF2E7D32)
+// Design-token references. Light and dark resolve to distinct income greens so
+// the positive-money color keeps WCAG 2.2 AA contrast on each surface:
+//   - Light: Green 800 (0xFF2E7D32) on near-white surfaces.
+//   - Dark:  Green 400 (0xFF4ADE80) on near-black surfaces (Neutral950 ≈ #030712),
+//     where the darker Green 800 dropped below the 4.5:1 text / 3:1 UI threshold (#3731).
+private val IncomeGreenLight = Color(0xFF2E7D32)
+private val IncomeGreenDark = Green400
 private val WarningOrange = Color(0xFFFF9800)
 
 internal val LightFinanceColors = FinanceSemanticColors(
-    income = IncomeGreen,
+    income = IncomeGreenLight,
     warning = WarningOrange,
 )
 
 internal val DarkFinanceColors = FinanceSemanticColors(
-    income = IncomeGreen,
+    income = IncomeGreenDark,
     warning = WarningOrange,
 )
 

--- a/apps/android/src/test/kotlin/com/finance/android/ui/learning/LearningProgressTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/learning/LearningProgressTest.kt
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.learning
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for learning progress persistence codec, rewards and streak
+ * logic (#2208) and the beginner-mode catalog (#2209).
+ */
+class LearningProgressTest {
+
+    // ── Codec round-trip ────────────────────────────────────────────
+
+    @Test
+    fun `codec round-trips a populated state`() {
+        val state = LearningState(
+            progress = mapOf(
+                "building-credit" to LearningProgress(
+                    pathId = "building-credit",
+                    completedModuleIds = setOf("bc-1", "bc-2"),
+                    quizScores = mapOf("bc-1" to 1f, "bc-2" to 0f),
+                ),
+                "first-job-money" to LearningProgress(
+                    pathId = "first-job-money",
+                    completedModuleIds = setOf("fj-1"),
+                    quizScores = mapOf("fj-1" to 1f),
+                ),
+            ),
+            lastActivePathId = "building-credit",
+            lastActiveModuleIndex = 2,
+            streakDays = 4,
+            lastActiveEpochDay = 20_000L,
+        )
+
+        val decoded = LearningProgressCodec.decode(LearningProgressCodec.encode(state))
+
+        assertEquals(state.lastActivePathId, decoded.lastActivePathId)
+        assertEquals(state.lastActiveModuleIndex, decoded.lastActiveModuleIndex)
+        assertEquals(state.streakDays, decoded.streakDays)
+        assertEquals(state.lastActiveEpochDay, decoded.lastActiveEpochDay)
+        assertEquals(state.progress.keys, decoded.progress.keys)
+        assertEquals(
+            setOf("bc-1", "bc-2"),
+            decoded.progress.getValue("building-credit").completedModuleIds,
+        )
+        assertEquals(1f, decoded.progress.getValue("building-credit").quizScores["bc-1"])
+    }
+
+    @Test
+    fun `codec round-trips an empty state`() {
+        val decoded = LearningProgressCodec.decode(LearningProgressCodec.encode(LearningState()))
+        assertEquals(LearningState(), decoded)
+    }
+
+    @Test
+    fun `codec tolerates garbage input`() {
+        val decoded = LearningProgressCodec.decode("not a real payload")
+        assertEquals(LearningState(), decoded)
+    }
+
+    // ── Rewards ─────────────────────────────────────────────────────
+
+    @Test
+    fun `rewards start empty`() {
+        val rewards = LearningRewards.from(emptyMap(), streakDays = 0)
+        assertEquals(0, rewards.xp)
+        assertEquals(1, rewards.level)
+        assertTrue(rewards.badges.none { it.unlocked })
+    }
+
+    @Test
+    fun `rewards accumulate xp and unlock badges`() {
+        val progress = mapOf(
+            "p" to LearningProgress(
+                pathId = "p",
+                completedModuleIds = setOf("a", "b", "c", "d", "e"),
+                quizScores = mapOf("a" to 1f, "b" to 1f, "c" to 1f),
+            ),
+        )
+        val rewards = LearningRewards.from(progress, streakDays = 3)
+
+        // 5 lessons * 10 + 3 mastered quizzes * 5 = 65 XP
+        assertEquals(65, rewards.xp)
+        assertEquals(5, rewards.lessonsCompleted)
+        assertEquals(3, rewards.quizzesMastered)
+        assertTrue(rewards.badges.first { it.id == "first-lesson" }.unlocked)
+        assertTrue(rewards.badges.first { it.id == "five-lessons" }.unlocked)
+        assertTrue(rewards.badges.first { it.id == "quiz-master" }.unlocked)
+        assertTrue(rewards.badges.first { it.id == "streak-3" }.unlocked)
+    }
+
+    @Test
+    fun `level advances every hundred xp`() {
+        val progress = mapOf(
+            "p" to LearningProgress(
+                pathId = "p",
+                completedModuleIds = (1..10).map { "m$it" }.toSet(),
+            ),
+        )
+        // 10 lessons * 10 XP = 100 XP -> level 2
+        val rewards = LearningRewards.from(progress, streakDays = 0)
+        assertEquals(100, rewards.xp)
+        assertEquals(2, rewards.level)
+        assertEquals(0, rewards.xpIntoLevel)
+    }
+
+    // ── Streak ──────────────────────────────────────────────────────
+
+    @Test
+    fun `streak starts at one on first activity`() {
+        assertEquals(1, LearningStreak.advance(previousDay = 0, previousStreak = 0, todayDay = 100))
+    }
+
+    @Test
+    fun `streak increments on consecutive day`() {
+        assertEquals(3, LearningStreak.advance(previousDay = 100, previousStreak = 2, todayDay = 101))
+    }
+
+    @Test
+    fun `streak holds on same day`() {
+        assertEquals(2, LearningStreak.advance(previousDay = 100, previousStreak = 2, todayDay = 100))
+    }
+
+    @Test
+    fun `streak resets after a gap`() {
+        assertEquals(1, LearningStreak.advance(previousDay = 100, previousStreak = 5, todayDay = 103))
+    }
+
+    // ── Catalog (#2209) ─────────────────────────────────────────────
+
+    @Test
+    fun `non-beginner catalog returns the full list unchanged`() {
+        val all = LearningPathContent.allPaths()
+        val catalog = LearningPathContent.catalog(beginnerMode = false, showAdvanced = false)
+        assertEquals(all, catalog)
+    }
+
+    @Test
+    fun `beginner catalog hides advanced content until opted in`() {
+        val hidden = LearningPathContent.catalog(beginnerMode = true, showAdvanced = false)
+        assertFalse(
+            hidden.any { it.level == LearningLevel.ADVANCED },
+            "Advanced paths should be hidden for beginners by default",
+        )
+
+        val shown = LearningPathContent.catalog(beginnerMode = true, showAdvanced = true)
+        assertTrue(
+            shown.any { it.level == LearningLevel.ADVANCED },
+            "Advanced paths should appear once opted in",
+        )
+    }
+
+    @Test
+    fun `beginner catalog orders beginner paths first`() {
+        val catalog = LearningPathContent.catalog(beginnerMode = true, showAdvanced = true)
+        val levels = catalog.map { it.level.ordinal }
+        assertEquals(levels.sorted(), levels, "Beginner catalog should be ordered by level")
+    }
+
+    @Test
+    fun `newcomer, credit and teen paths exist and are free`() {
+        listOf("newcomer-us-basics", "building-credit", "first-job-money").forEach { id ->
+            val path = LearningPathContent.pathById(id)
+            assertTrue(path != null, "Expected path $id to exist")
+            assertFalse(path.isPremium, "Beginner path $id should be free")
+            assertEquals(LearningLevel.BEGINNER, path.level)
+        }
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/navigation/AdaptiveNavigationTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/navigation/AdaptiveNavigationTest.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.navigation
+
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for adaptive navigation layout resolution (#3713).
+ *
+ * Verifies the Material 3 adaptive mapping: compact widths use a bottom bar,
+ * medium widths use a navigation rail (not a hidden modal drawer), and expanded
+ * widths use a drawer.
+ */
+class AdaptiveNavigationTest {
+
+    @Test
+    fun `compact width resolves to bottom bar`() {
+        assertEquals(
+            NavigationLayoutType.BottomBar,
+            resolveNavigationLayout(WindowWidthSizeClass.Compact),
+        )
+    }
+
+    @Test
+    fun `medium width resolves to navigation rail`() {
+        assertEquals(
+            NavigationLayoutType.NavigationRail,
+            resolveNavigationLayout(WindowWidthSizeClass.Medium),
+        )
+    }
+
+    @Test
+    fun `expanded width resolves to modal drawer`() {
+        assertEquals(
+            NavigationLayoutType.ModalDrawer,
+            resolveNavigationLayout(WindowWidthSizeClass.Expanded),
+        )
+    }
+
+    @Test
+    fun `medium width is not a modal drawer`() {
+        // Regression guard for #3713: medium must never hide primary
+        // navigation behind a modal drawer.
+        val layout = resolveNavigationLayout(WindowWidthSizeClass.Medium)
+        assertEquals(NavigationLayoutType.NavigationRail, layout)
+    }
+}


### PR DESCRIPTION
## Batch 4 — Android design, adaptive navigation, onboarding & financial education

This PR implements a batch of six closely-related Android issues in a single feature branch, scoped to `apps/android` (shared packages read-only). All work is Jetpack Compose / KMP-aware, reuses existing design tokens and components, and keeps changes accessible (WCAG 2.2 AA).

### Design
- **Dark-mode income green contrast (WCAG AA)** — added a brighter `Green400` (`0xFF4ADE80`) income token used on dark surfaces, while light mode keeps `0xFF2E7D32`. Contrast on near-black surfaces goes from failing to ~10:1. Migrated the remaining hardcoded income-green literals in the learning UI to the semantic `FinanceTheme.financeColors.income` token. Paparazzi goldens re-verified (render is snapshot-identical). — Closes #3731
- **Adaptive navigation** — medium window widths now resolve to a `NavigationRail` instead of a `ModalNavigationDrawer`. Added a `NavigationRail` entry to `NavigationLayoutType`, a `FinanceNavigationRail` composable that reuses `TopLevelDestination`, and an adaptive scaffold in `MainActivity` driven by `WindowWidthSizeClass` (Compact → bottom bar, Medium → rail, Expanded → permanent drawer). Added unit tests for the layout resolver. — Closes #3713

### Onboarding & education
- **ITIN-aware onboarding + US finance basics** — added an optional, non-blocking "New to the US?" profile (tax identity incl. **ITIN / no SSN yet**, and income type) within the existing account step (no change to step count). Added plain-language education concepts: W-2, 1099, tax withholding, 401(k), ITIN, plus a beginner-friendly **US Finance Basics for Newcomers** learning path. — Closes #2178
- **Beginner credit education + secured cards** — added credit concepts (FICO, utilization, statement-vs-due date, hard inquiry, credit report, secured card) and a free **Building Credit From Zero** learning path covering secured cards, utilization, on-time payments and graduation. — Closes #2174
- **Teen beginner mode** — added a plain-language **Your First Paycheck** path (paychecks, debit cards, needs/wants/saving for a car) and a beginner-mode catalog that orders beginner content first and gates advanced topics (investing) behind an explicit "Show advanced topics" opt-in, keyed off `ExpertiseTier.BEGINNER`. — Closes #2209
- **Persisted learning progress + rewards** — added a `LearningProgressRepository` (encrypted SharedPreferences, dependency-free codec) that persists lessons, a resume point ("pick up where you left off"), a day streak, and rewards (XP, level, badges) across restarts. `LearningPathViewModel` now loads on init, saves on module completion, and surfaces a rewards summary, resume card, and streak in the UI. — Closes #2208

### Testing (local)
- `:apps:android:testDebugUnitTest` — passing (incl. new learning progress/rewards/streak/codec and adaptive-navigation tests).
- `:apps:android:recordPaparazziDebug` + `:apps:android:verifyPaparazziDebug --rerun-tasks` — passing; the income token change produced no golden diffs.
- `:apps:android:compileDebugKotlin` — clean (only pre-existing deprecation warnings).
- `npm run format:check` and `npx eslint . --max-warnings 0` — clean (Kotlin is prettier/eslint-ignored; all changes are Kotlin).

## Needs Human Action
- **Spanish localization (#2174):** the app's learning/education content is currently hardcoded English Kotlin strings, not resource-backed. Full Spanish localization of the newcomer/credit content requires a broader i18n effort (extracting strings to resources) and is out of scope for this batch. The new content ships in clear, plain English in the meantime.

Closes #3731
Closes #3713
Closes #2178
Closes #2174
Closes #2209
Closes #2208
