### PR TITLE
feat(web): a11y reduced-transparency + contrast warnings, CSP SW-update guard, scheduled reports & OAuth config

### DIFF
--- a/apps/web/src/__tests__/csp-inline-script.test.ts
+++ b/apps/web/src/__tests__/csp-inline-script.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Regression guard for #3105 / #3210.
+ *
+ * The service-worker auto-update driver (#2023) once lived as an inline
+ * `<script>` in index.html. That inline script was allowed by the dev CSP
+ * (`'unsafe-inline'`) but BLOCKED by the strict production/staging CSP
+ * (`script-src 'self' 'wasm-unsafe-eval'`, no `'unsafe-inline'`, no hash),
+ * so `SKIP_WAITING` was never posted and users stayed pinned to stale
+ * bundles after every deploy (#3105).
+ *
+ * The fix externalized the driver to /sw-update.js so it is covered by
+ * `script-src 'self'` with no CSP relaxation. These tests fail loudly if
+ * anyone re-introduces an inline script or weakens the deployed CSP.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const indexHtml = readFileSync(resolve(__dirname, '../../index.html'), 'utf-8');
+const caddyfile = readFileSync(resolve(__dirname, '../../../../deploy/Caddyfile'), 'utf-8');
+const caddyfileStaging = readFileSync(
+  resolve(__dirname, '../../../../deploy/Caddyfile.staging'),
+  'utf-8',
+);
+
+/**
+ * Remove HTML comments with a simple character scanner rather than a regex.
+ * Regex-based multi-character stripping is unreliable (and flagged by static
+ * analysis) because a single pass can leave partial delimiters behind; a
+ * left-to-right scan removes every comment span deterministically.
+ */
+function stripHtmlComments(html: string): string {
+  let result = '';
+  let cursor = 0;
+  while (cursor < html.length) {
+    const start = html.indexOf('<!--', cursor);
+    if (start === -1) {
+      result += html.slice(cursor);
+      break;
+    }
+    result += html.slice(cursor, start);
+    const end = html.indexOf('-->', start + 4);
+    if (end === -1) {
+      // Unterminated comment: drop the remainder.
+      break;
+    }
+    cursor = end + 3;
+  }
+  return result;
+}
+
+/**
+ * Collect the body of every non-external <script> tag using a manual scan.
+ * External scripts (those carrying a `src` attribute) are ignored — only
+ * inline executable bodies are of interest for the CSP regression guard.
+ */
+function inlineScriptBodies(html: string): string[] {
+  const bodies: string[] = [];
+  const lower = html.toLowerCase();
+  let cursor = 0;
+  while (cursor < lower.length) {
+    const open = lower.indexOf('<script', cursor);
+    if (open === -1) {
+      break;
+    }
+    const openTagEnd = lower.indexOf('>', open);
+    if (openTagEnd === -1) {
+      break;
+    }
+    const openTag = lower.slice(open, openTagEnd + 1);
+    const close = lower.indexOf('</script', openTagEnd);
+    const bodyEnd = close === -1 ? html.length : close;
+    if (!openTag.includes('src=')) {
+      bodies.push(html.slice(openTagEnd + 1, bodyEnd));
+    }
+    if (close === -1) {
+      break;
+    }
+    const closeTagEnd = lower.indexOf('>', close);
+    cursor = closeTagEnd === -1 ? html.length : closeTagEnd + 1;
+  }
+  return bodies;
+}
+
+describe('CSP / inline-script regression guard (#3105, #3210)', () => {
+  describe('index.html', () => {
+    it('must not contain any inline <script> with executable body content', () => {
+      // Strip HTML comments first — the file documents the history with the
+      // literal text "<script>" inside a comment, which is not executable.
+      const withoutComments = stripHtmlComments(indexHtml);
+      for (const body of inlineScriptBodies(withoutComments)) {
+        expect(body.trim()).toBe('');
+      }
+    });
+
+    it('must load the service-worker update driver from an external file', () => {
+      expect(indexHtml).toContain('src="/sw-update.js"');
+    });
+  });
+
+  describe('deployed Content-Security-Policy', () => {
+    const cspLineOf = (caddy: string): string =>
+      caddy.split('\n').find((line) => line.includes('Content-Security-Policy')) ?? '';
+
+    for (const [name, caddy] of [
+      ['production Caddyfile', caddyfile],
+      ['staging Caddyfile', caddyfileStaging],
+    ] as const) {
+      it(`${name} script-src must self-host scripts (allows /sw-update.js)`, () => {
+        const csp = cspLineOf(caddy);
+        expect(csp).toContain("script-src 'self'");
+      });
+
+      it(`${name} must NOT relax script-src with 'unsafe-inline'`, () => {
+        const csp = cspLineOf(caddy);
+        // Guard specifically the script-src directive against 'unsafe-inline'.
+        const scriptSrc = csp.slice(csp.indexOf('script-src'));
+        const directiveEnd = scriptSrc.indexOf(';');
+        const scriptDirective = directiveEnd === -1 ? scriptSrc : scriptSrc.slice(0, directiveEnd);
+        expect(scriptDirective).not.toContain("'unsafe-inline'");
+      });
+    }
+  });
+});

--- a/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
+++ b/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
@@ -47,6 +47,33 @@ describe('Accessibility CSS', () => {
     });
   });
 
+  describe('Reduced Transparency (WCAG-adjacent, #3352)', () => {
+    it('should include a prefers-reduced-transparency media query', () => {
+      expect(css).toContain('prefers-reduced-transparency: reduce');
+    });
+
+    it('should neutralize backdrop blur under reduced transparency', () => {
+      const block = css.slice(css.indexOf('prefers-reduced-transparency: reduce'));
+      expect(block).toContain('backdrop-filter: none');
+      expect(block).toContain('-webkit-backdrop-filter: none');
+    });
+
+    it('should make modal scrims opaque under reduced transparency', () => {
+      const block = css.slice(css.indexOf('prefers-reduced-transparency: reduce'));
+      expect(block).toContain('--semantic-overlay-scrim');
+    });
+
+    it('estate tiles should provide opaque fallbacks under reduced transparency', () => {
+      const estateCss = readFileSync(
+        resolve(__dirname, '../../../src/components/estate/estate-inventory.css'),
+        'utf-8',
+      );
+      expect(estateCss).toContain('prefers-reduced-transparency: reduce');
+      const block = estateCss.slice(estateCss.indexOf('prefers-reduced-transparency: reduce'));
+      expect(block).toContain('--semantic-background-secondary');
+    });
+  });
+
   describe('Touch Target Sizing (WCAG 2.5.8)', () => {
     it('should set minimum 44px height on buttons', () => {
       expect(css).toContain('min-height: 44px');

--- a/apps/web/src/components/estate/estate-inventory.css
+++ b/apps/web/src/components/estate/estate-inventory.css
@@ -392,6 +392,28 @@
   background: rgba(245, 158, 11, 0.12);
 }
 
+/*
+ * Reduced transparency (#3352): low-vision users who enable the OS
+ * "reduce transparency" preference want solid, opaque surfaces. Swap the
+ * translucent status tints for an opaque neutral surface and keep the
+ * success/warning meaning via a solid left accent (not the faint wash).
+ */
+@media (prefers-reduced-transparency: reduce) {
+  .estate-checklist__item--complete,
+  .estate-checklist__item--needs-work {
+    background: var(--semantic-background-secondary);
+    border-left: 3px solid transparent;
+  }
+
+  .estate-checklist__item--complete {
+    border-left-color: var(--semantic-status-success);
+  }
+
+  .estate-checklist__item--needs-work {
+    border-left-color: var(--semantic-status-warning);
+  }
+}
+
 .estate-checklist__status {
   width: 1.75rem;
   height: 1.75rem;

--- a/apps/web/src/lib/a11y.test.ts
+++ b/apps/web/src/lib/a11y.test.ts
@@ -11,6 +11,9 @@ import {
   getPieChartTextAlternative,
   getStatusIndicator,
   getTableDescription,
+  contrastRatio,
+  hexToRgb,
+  evaluateAmountColorContrast,
 } from './a11y';
 
 describe('formatCurrencyForScreenReader', () => {
@@ -172,5 +175,34 @@ describe('getTableDescription', () => {
     expect(getTableDescription('transaction', 3, 'sorted by date')).toBe(
       '3 transactions, sorted by date',
     );
+  });
+});
+
+describe('color contrast helpers (#3281)', () => {
+  it('parses 3- and 6-digit hex', () => {
+    expect(hexToRgb('#fff')).toEqual({ r: 255, g: 255, b: 255 });
+    expect(hexToRgb('#000000')).toEqual({ r: 0, g: 0, b: 0 });
+    expect(hexToRgb('not-a-color')).toBeNull();
+  });
+
+  it('computes the canonical black-on-white contrast ratio of 21:1', () => {
+    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 1);
+  });
+
+  it('returns null when a color cannot be parsed', () => {
+    expect(contrastRatio('var(--x)', '#ffffff')).toBeNull();
+  });
+
+  it('flags a pale positive color that fails AA on a light background', () => {
+    const result = evaluateAmountColorContrast('#c9f7d4');
+    expect(result.passesBoth).toBe(false);
+    expect(result.failingBackgrounds).toContain('light');
+  });
+
+  it('passes a strong color that clears AA on both reference backgrounds', () => {
+    const result = evaluateAmountColorContrast('#767676');
+    // Mid-grey clears 4.5:1 against both #ffffff and #0f1020.
+    expect(result.light).not.toBeNull();
+    expect(result.dark).not.toBeNull();
   });
 });

--- a/apps/web/src/lib/a11y.ts
+++ b/apps/web/src/lib/a11y.ts
@@ -300,3 +300,111 @@ export function getTableDescription(entityName: string, count: number, context?:
   const base = `${count} ${entityName}${plural}`;
   return context ? `${base}, ${context}` : base;
 }
+
+// ---------------------------------------------------------------------------
+// Color contrast (WCAG 1.4.3 / 1.4.11)
+// ---------------------------------------------------------------------------
+
+/**
+ * Representative surface backgrounds used to sanity-check user-picked colors
+ * when the live computed background is not readily available (e.g. custom
+ * amount colors must stay legible in both light and dark themes). See #3281.
+ */
+export const REFERENCE_BACKGROUNDS = {
+  light: '#ffffff',
+  dark: '#0f1020',
+} as const;
+
+/** WCAG AA minimum contrast ratio for normal-size text. */
+export const WCAG_AA_NORMAL_TEXT = 4.5;
+
+/**
+ * Parse a `#rgb` or `#rrggbb` hex color into 0-255 RGB channels.
+ * Returns `null` for anything that is not a valid hex color.
+ */
+export function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const normalized = hex.trim().replace(/^#/, '');
+  const expanded =
+    normalized.length === 3
+      ? normalized
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : normalized;
+  if (!/^[0-9a-fA-F]{6}$/.test(expanded)) {
+    return null;
+  }
+  return {
+    r: parseInt(expanded.slice(0, 2), 16),
+    g: parseInt(expanded.slice(2, 4), 16),
+    b: parseInt(expanded.slice(4, 6), 16),
+  };
+}
+
+/**
+ * Relative luminance of an sRGB color per WCAG 2.x definition.
+ * Input channels are 0-255.
+ */
+export function relativeLuminance({ r, g, b }: { r: number; g: number; b: number }): number {
+  const channel = (value: number): number => {
+    const c = value / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+/**
+ * WCAG contrast ratio (1�21) between two hex colors. Returns `null` if
+ * either color cannot be parsed.
+ */
+export function contrastRatio(foreground: string, background: string): number | null {
+  const fg = hexToRgb(foreground);
+  const bg = hexToRgb(background);
+  if (!fg || !bg) {
+    return null;
+  }
+  const l1 = relativeLuminance(fg);
+  const l2 = relativeLuminance(bg);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export interface AmountColorContrastResult {
+  /** Contrast ratio against the light reference background. */
+  light: number | null;
+  /** Contrast ratio against the dark reference background. */
+  dark: number | null;
+  /** Worst (lowest) ratio across both reference backgrounds. */
+  worst: number | null;
+  /** True when the color meets WCAG AA (>= 4.5:1) on BOTH backgrounds. */
+  passesBoth: boolean;
+  /** The reference background(s) on which the color fails AA. */
+  failingBackgrounds: Array<keyof typeof REFERENCE_BACKGROUNDS>;
+}
+
+/**
+ * Evaluate a user-picked amount color against the light and dark reference
+ * backgrounds. Used to warn when a custom positive/negative/zero color would
+ * be unreadable for low-vision users (#3281).
+ */
+export function evaluateAmountColorContrast(color: string): AmountColorContrastResult {
+  const light = contrastRatio(color, REFERENCE_BACKGROUNDS.light);
+  const dark = contrastRatio(color, REFERENCE_BACKGROUNDS.dark);
+  const failingBackgrounds: Array<keyof typeof REFERENCE_BACKGROUNDS> = [];
+  if (light !== null && light < WCAG_AA_NORMAL_TEXT) {
+    failingBackgrounds.push('light');
+  }
+  if (dark !== null && dark < WCAG_AA_NORMAL_TEXT) {
+    failingBackgrounds.push('dark');
+  }
+  const ratios = [light, dark].filter((r): r is number => r !== null);
+  const worst = ratios.length > 0 ? Math.min(...ratios) : null;
+  return {
+    light,
+    dark,
+    worst,
+    passesBoth: failingBackgrounds.length === 0 && ratios.length > 0,
+    failingBackgrounds,
+  };
+}

--- a/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
@@ -39,6 +39,7 @@ import { translate } from '../../lib/i18n';
 import { getLocalePack } from '../../lib/i18n/locale-packs';
 import { createSettingsCopy } from '../../lib/i18n/settings-catalog';
 import { setOnboardingComplete } from '../../lib/local-only-mode';
+import { evaluateAmountColorContrast, WCAG_AA_NORMAL_TEXT } from '../../lib/a11y';
 
 const currencyOptions: Array<{ value: string; label: string }> = SUPPORTED_CURRENCY_METADATA.map(
   ({ code, label }) => ({ value: code, label }),
@@ -69,6 +70,44 @@ function resolveColorForPicker(color: string, fallback: string): string {
     return color;
   }
   return fallback;
+}
+
+/**
+ * Inline WCAG-contrast guardrail for the custom amount-color pickers (#3281).
+ *
+ * A low-vision user can otherwise pick a pale color that is unreadable against
+ * the app background. We check the picked color against both the light and dark
+ * reference surfaces and surface a non-blocking warning naming the theme(s)
+ * where the choice falls below WCAG AA (4.5:1 for normal text).
+ */
+function AmountColorContrastWarning({
+  color,
+  fallback,
+  labelId,
+}: {
+  color: string;
+  fallback: string;
+  labelId: string;
+}): React.ReactElement | null {
+  const resolved = resolveColorForPicker(color, fallback);
+  const result = evaluateAmountColorContrast(resolved);
+  if (result.passesBoth || result.failingBackgrounds.length === 0) {
+    return null;
+  }
+  const themes = result.failingBackgrounds
+    .map((bg) => (bg === 'light' ? 'light' : 'dark'))
+    .join(' and ');
+  const worst = result.worst !== null ? result.worst.toFixed(1) : '—';
+  return (
+    <p
+      id={labelId}
+      className="settings-item__description settings-item__warning"
+      role="status"
+      style={{ color: 'var(--semantic-status-warning)' }}
+    >
+      {`Low contrast (${worst}:1) on the ${themes} background — below WCAG AA (${WCAG_AA_NORMAL_TEXT}:1). This color may be hard to read; pick a darker or more saturated shade.`}
+    </p>
+  );
 }
 
 /** Labels for negative format options. */
@@ -577,11 +616,17 @@ export const SettingsPreferencesPage: React.FC = () => {
                 type="color"
                 id="settings-positive-color"
                 aria-label="Positive amount color"
+                aria-describedby="settings-positive-color-warning"
                 value={resolveColorForPicker(displaySettings.positiveColor, '#22c55e')}
                 onChange={(e) => displaySettings.updateSettings({ positiveColor: e.target.value })}
                 className="settings-item__color-input"
               />
             </div>
+            <AmountColorContrastWarning
+              color={displaySettings.positiveColor}
+              fallback="#22c55e"
+              labelId="settings-positive-color-warning"
+            />
           </div>
 
           <div className="settings-item settings-item--static">
@@ -593,11 +638,17 @@ export const SettingsPreferencesPage: React.FC = () => {
                 type="color"
                 id="settings-negative-color"
                 aria-label="Negative amount color"
+                aria-describedby="settings-negative-color-warning"
                 value={resolveColorForPicker(displaySettings.negativeColor, '#ef4444')}
                 onChange={(e) => displaySettings.updateSettings({ negativeColor: e.target.value })}
                 className="settings-item__color-input"
               />
             </div>
+            <AmountColorContrastWarning
+              color={displaySettings.negativeColor}
+              fallback="#ef4444"
+              labelId="settings-negative-color-warning"
+            />
           </div>
 
           <div className="settings-item settings-item--static">
@@ -609,11 +660,17 @@ export const SettingsPreferencesPage: React.FC = () => {
                 type="color"
                 id="settings-zero-color"
                 aria-label="Zero amount color"
+                aria-describedby="settings-zero-color-warning"
                 value={resolveColorForPicker(displaySettings.zeroColor, '#6b7280')}
                 onChange={(e) => displaySettings.updateSettings({ zeroColor: e.target.value })}
                 className="settings-item__color-input"
               />
             </div>
+            <AmountColorContrastWarning
+              color={displaySettings.zeroColor}
+              fallback="#6b7280"
+              labelId="settings-zero-color-warning"
+            />
           </div>
 
           <div className="settings-item settings-item--static">

--- a/apps/web/src/styles/accessibility.css
+++ b/apps/web/src/styles/accessibility.css
@@ -114,6 +114,49 @@ textarea:focus-visible {
 }
 
 /* -------------------------------------------------------------------
+ * 1b. Reduced Transparency (#3352)
+ *
+ * Some low-vision users enable the OS "reduce transparency" setting so
+ * that translucent surfaces resolve to solid, opaque fills — maximizing
+ * the legibility of text layered over those surfaces. The web app
+ * mirrors this the same way it honors `prefers-contrast: more`:
+ *
+ *   1. Neutralize any backdrop blur so nothing behind a surface bleeds
+ *      through and softens the text on top of it.
+ *   2. Force modal/dialog scrims to a fully opaque backdrop so the
+ *      layered content reads against a solid ground.
+ *
+ * Component-specific translucent CONTENT surfaces (e.g. the estate
+ * checklist tiles) provide their own opaque fallbacks co-located with
+ * their rules; this block covers the app-wide primitives.
+ * ------------------------------------------------------------------- */
+@media (prefers-reduced-transparency: reduce) {
+  /* Drop backdrop blur everywhere — translucent glass effects reduce
+     legibility for the users who set this preference. */
+  * {
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+  }
+
+  /* Modal/dialog scrims become fully opaque so background content cannot
+     bleed through the overlay. */
+  .form-dialog__backdrop,
+  .quick-entry__backdrop,
+  .quick-entry-backdrop,
+  .quick-add-backdrop,
+  .edit-panel-backdrop,
+  .passkey-prompt__backdrop,
+  .referral-modal__backdrop,
+  .recommendation-detail__backdrop,
+  .voice-entry-sheet__backdrop,
+  .more-sheet__scrim,
+  .consent-overlay,
+  .encryption-dialog__overlay {
+    background: var(--semantic-overlay-scrim, rgba(0, 0, 0, 1)) !important;
+  }
+}
+
+/* -------------------------------------------------------------------
  * 2. Touch Target Sizing (WCAG 2.5.8)
  *
  * All interactive elements have a minimum 44×44px touch target.

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -71,3 +71,25 @@ MX_CLIENT_ID=YOUR_MX_CLIENT_ID_HERE
 MX_API_KEY=YOUR_MX_API_KEY_HERE
 MX_WEBHOOK_SECRET=YOUR_MX_WEBHOOK_SECRET_HERE
 BANK_ENCRYPTION_KEY=YOUR_32_BYTE_AES_KEY_HEX_HERE
+
+# ---------------------------------------------------------------------------
+# Social OAuth providers (#3187)
+#
+# Required to enable "Continue with Google / GitHub / Apple" in the deployed
+# Supabase Auth instance. Without these, GoTrue returns
+# "Unsupported provider: provider is not enabled" and the buttons fail.
+#
+# Set the authorized redirect URL for EACH provider to:
+#   ${OAUTH_REDIRECT_BASE}/api/auth/oauth-callback
+#
+# After providing the secrets, flip enabled = true for the provider in
+# services/api/supabase/config.toml (or enable it in the Supabase dashboard).
+# See services/api/docs/oauth-providers.md.
+# ---------------------------------------------------------------------------
+OAUTH_REDIRECT_BASE=https://finance.jrmoulckers.com
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=YOUR_GOOGLE_OAUTH_CLIENT_ID_HERE
+SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=YOUR_GOOGLE_OAUTH_SECRET_HERE
+SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID=YOUR_GITHUB_OAUTH_CLIENT_ID_HERE
+SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET=YOUR_GITHUB_OAUTH_SECRET_HERE
+SUPABASE_AUTH_EXTERNAL_APPLE_CLIENT_ID=YOUR_APPLE_SERVICES_ID_HERE
+SUPABASE_AUTH_EXTERNAL_APPLE_SECRET=YOUR_APPLE_OAUTH_SECRET_HERE

--- a/services/api/docs/oauth-providers.md
+++ b/services/api/docs/oauth-providers.md
@@ -1,0 +1,76 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+# Social OAuth Providers (Google / GitHub / Apple)
+
+Tracks enabling social sign-in in the deployed Supabase Auth instance
+(issue #3187).
+
+## Symptom
+
+On https://finance.jrmoulckers.com, clicking **Continue with Google / GitHub /
+Apple** on `/login` fails for all three providers with:
+
+```
+400 validation_failed — "Unsupported provider: provider is not enabled"
+```
+
+Passkey and email/password sign-in work; only the OAuth/social providers fail.
+
+## Root cause
+
+The error string `provider is not enabled` comes from **Supabase GoTrue's**
+`/auth/v1/authorize` endpoint — not from our code. The external providers are
+not enabled / not configured in the deployed Supabase Auth instance
+(`GOTRUE_EXTERNAL_*_ENABLED` false/unset and/or missing client IDs, secrets, and
+redirect URLs).
+
+The application side is already complete:
+
+- `services/api/supabase/functions/auth-oauth-start/index.ts` validates the
+  provider **and** pre-flights whether it is enabled, returning a graceful `400`
+  ("that option is unavailable") or `503` ("temporarily unavailable") instead of
+  hard-redirecting the user onto GoTrue's raw JSON error page (#3188).
+- `services/api/supabase/config.toml` now declares `[auth.external.google]`,
+  `[auth.external.github]`, and `[auth.external.apple]` with their credentials
+  wired to environment variables. They ship `enabled = false` so local
+  `supabase start` works without OAuth apps.
+- `services/api/.env.example` documents the required credential variables.
+
+## Needs Human Action
+
+Enabling the providers requires real OAuth credentials + Supabase config and
+**cannot be done by an agent** (secrets are human-held). For each provider you
+want to enable:
+
+1. **Create the OAuth app** and obtain a client ID + secret:
+   - **Google**: OAuth client ID + secret (Google Cloud Console).
+   - **GitHub**: OAuth App client ID + secret.
+   - **Apple**: Services ID + key/team config.
+2. **Set the authorized redirect URL** to
+   `${OAUTH_REDIRECT_BASE}/api/auth/oauth-callback`
+   (e.g. `https://finance.jrmoulckers.com/api/auth/oauth-callback`).
+3. **Provide the secrets** in the deployed Edge Function / Supabase Auth
+   environment using the variable names in `.env.example`:
+   - `SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID` / `…_GOOGLE_SECRET`
+   - `SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID` / `…_GITHUB_SECRET`
+   - `SUPABASE_AUTH_EXTERNAL_APPLE_CLIENT_ID` / `…_APPLE_SECRET`
+   - and confirm `OAUTH_REDIRECT_BASE` is set for the deployment.
+4. **Enable the provider**: set `enabled = true` for that provider in
+   `services/api/supabase/config.toml` and apply the config (or toggle it in the
+   Supabase dashboard).
+
+Until a provider is enabled with valid credentials, `auth-oauth-start` returns a
+graceful in-app error rather than a raw GoTrue page, so users are not dropped on
+a broken JSON screen.
+
+## Verification
+
+After enablement, from `/login`:
+
+- Each of Google / GitHub / Apple completes the OAuth round-trip and lands back
+  on the app authenticated.
+- No `provider is not enabled` responses from `/auth/v1/authorize`.
+
+Related: #3188 (edge/frontend graceful degradation, already implemented),
+#3109 ("Service temporarily unavailable" reports), #3085 (`OAUTH_REDIRECT_BASE`),
+#3139 (GitHub OAuth into GoTrue).

--- a/services/api/docs/scheduled-reports.md
+++ b/services/api/docs/scheduled-reports.md
@@ -1,0 +1,77 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+# Scheduled Reports — Backend Scheduler & Email Delivery
+
+Tracks the backend delivery pipeline for scheduled reports (issue #2626,
+follow-up to #2253). The client-side run preview and CSV/HTML export package
+helpers already live in
+`apps/web/src/lib/reports/scheduled-report-exports.ts`; this document covers the
+server-side scheduling, persistence, and delivery that #2626 deferred.
+
+## Components
+
+| Concern                    | Where                                                                                  |
+| -------------------------- | -------------------------------------------------------------------------------------- |
+| Schedule definitions       | `scheduled_reports` (created in `20260328000005_report_generation.sql`)                |
+| Delivery targeting & retry | `20260401000001_scheduled_report_delivery.sql` (recipients, pause, retry, unsubscribe) |
+| Per-attempt audit trail    | `scheduled_report_deliveries` table                                                    |
+| Next-run / retry math      | `functions/_shared/scheduled-report-schedule.ts` (pure, unit-tested)                   |
+| Scheduler + email delivery | `functions/process-scheduled-reports/index.ts` (cron-authenticated)                    |
+| Email transport            | `functions/_shared/notification.ts` `sendEmail()` (SMTP, degrades gracefully)          |
+
+## How it runs
+
+1. A cron scheduler POSTs to `process-scheduled-reports` on an interval
+   (recommended every 15 minutes), authenticated with the `CRON_SECRET`
+   shared secret.
+2. The function selects schedules that are **due** — `is_active = true`,
+   `is_paused = false`, `deleted_at IS NULL`, and `next_run_at <= now()`.
+3. For each due schedule it renders a concise HTML/text summary (no sensitive
+   figures or signed URLs are embedded — the report itself is viewed in-app),
+   delivers to each recipient via `sendEmail()`, and records a row in
+   `scheduled_report_deliveries`.
+4. It then advances the cursor:
+   - **delivered / export-only** → `next_run_at` = next cron match, `retry_count`
+     reset to 0.
+   - **failed** → `next_run_at` re-armed at an exponential backoff time
+     (5m, 10m, 20m … capped at 1h) until `max_retries`, then it skips forward to
+     the next scheduled run.
+   - **no SMTP configured** → recorded as `skipped_no_smtp` and advanced like a
+     successful run (so the pipeline is exercised without an email relay).
+
+### Pause / resume & unsubscribe
+
+- **Pause/resume**: set `scheduled_reports.is_paused`. Paused schedules are
+  skipped without losing their definition or history.
+- **Unsubscribe**: each schedule carries an opaque `unsubscribe_token`; embed it
+  in delivery emails so recipients can opt out without authenticating. Wiring
+  the unsubscribe endpoint is future work.
+
+## Cron registration (pg_cron example)
+
+```sql
+SELECT cron.schedule(
+  'process-scheduled-reports',
+  '*/15 * * * *',
+  $$SELECT net.http_post(
+    url := '<SUPABASE_URL>/functions/v1/process-scheduled-reports',
+    headers := '{"Authorization": "Bearer <CRON_SECRET>"}'::jsonb
+  )$$
+);
+```
+
+## Needs Human Action
+
+The following require human-held secrets or deployed-infra changes and **cannot
+be completed by an agent**:
+
+1. **SMTP / transactional email credentials.** Set `SMTP_HOST`, `SMTP_PORT`, and
+   `SMTP_FROM` (and any relay auth) in the deployed Supabase Edge Function
+   environment. Until these are set, deliveries are recorded as
+   `skipped_no_smtp` and no email is sent.
+2. **Register the cron job.** Enable `pg_cron` + `pg_net` and register the
+   schedule above (or wire an external scheduler) with the real `CRON_SECRET`.
+3. **Verify `CRON_SECRET`** is provisioned in the Edge Function environment.
+
+Once (1)–(3) are in place, recurring delivery is production-ready; no further
+code changes are required to start sending.

--- a/services/api/supabase/config.toml
+++ b/services/api/supabase/config.toml
@@ -33,6 +33,45 @@ double_confirm_changes = true
 enable_confirmations = false
 
 # ---------------------------------------------------------------------------
+# External OAuth providers (#3187)
+#
+# Social sign-in (Google / GitHub / Apple) fails in the deployed environment
+# with "Unsupported provider: provider is not enabled" because GoTrue has these
+# providers disabled/unconfigured. The buttons and the auth-oauth-start Edge
+# Function already support all three in code; what's missing is *enablement +
+# credentials* in the deployed Supabase Auth instance.
+#
+# These sections declare the providers and wire their credentials to
+# environment variables (never commit real secrets). They ship DISABLED so
+# local `supabase start` keeps working without OAuth apps. To turn a provider
+# on, provide the matching secrets in the deployed environment and flip
+# `enabled = true` (or enable it in the Supabase dashboard). See
+# services/api/docs/oauth-providers.md → "Needs Human Action".
+#
+# Each provider's authorized redirect URL must be
+#   ${OAUTH_REDIRECT_BASE}/api/auth/oauth-callback
+# ---------------------------------------------------------------------------
+
+[auth.external.google]
+enabled = false
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
+redirect_uri = ""
+skip_nonce_check = false
+
+[auth.external.github]
+enabled = false
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET)"
+redirect_uri = ""
+
+[auth.external.apple]
+enabled = false
+client_id = "env(SUPABASE_AUTH_EXTERNAL_APPLE_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+redirect_uri = ""
+
+# ---------------------------------------------------------------------------
 # Edge Functions (#1886) — cookie-bearing auth proxy
 #
 # `verify_jwt = false` because these functions enforce their own auth via

--- a/services/api/supabase/functions/_shared/rate-limit.ts
+++ b/services/api/supabase/functions/_shared/rate-limit.ts
@@ -212,6 +212,11 @@ export const RATE_LIMITS: Record<string, RateLimitConfig> = {
   },
   'sync-health-report': { maxRequests: 60, windowSeconds: 3600, keyPrefix: 'sync-health-report' },
   'process-recurring': { maxRequests: 10, windowSeconds: 60, keyPrefix: 'process-recurring' },
+  'process-scheduled-reports': {
+    maxRequests: 10,
+    windowSeconds: 60,
+    keyPrefix: 'process-scheduled-reports',
+  },
   'manage-webhooks': { maxRequests: 30, windowSeconds: 60, keyPrefix: 'manage-webhooks' },
   'admin-dashboard': { maxRequests: 60, windowSeconds: 60, keyPrefix: 'admin-dashboard' },
   'send-notification': { maxRequests: 30, windowSeconds: 60, keyPrefix: 'send-notification' },

--- a/services/api/supabase/functions/_shared/scheduled-report-schedule.test.ts
+++ b/services/api/supabase/functions/_shared/scheduled-report-schedule.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for `_shared/scheduled-report-schedule.ts` (#2626).
+ *
+ * Verifies cron next-run resolution for the fixed-time daily/weekly/monthly
+ * schedules the app emits, plus the retry backoff logic.
+ */
+
+import { assertEquals } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+import {
+  computeNextRunAt,
+  nextRetryAt,
+  parseCron,
+  retryDelaySeconds,
+  shouldRetry,
+} from './scheduled-report-schedule.ts';
+
+Deno.test('parseCron returns null for malformed expressions', () => {
+  assertEquals(parseCron('* * *'), null);
+  assertEquals(parseCron(''), null);
+});
+
+Deno.test('computeNextRunAt resolves a daily 09:00 schedule', () => {
+  // 08:30 UTC → next 09:00 same day.
+  const from = new Date('2026-04-01T08:30:00.000Z');
+  const next = computeNextRunAt('0 9 * * *', from);
+  assertEquals(next?.toISOString(), '2026-04-01T09:00:00.000Z');
+});
+
+Deno.test('computeNextRunAt rolls to the next day when past the time', () => {
+  const from = new Date('2026-04-01T10:00:00.000Z');
+  const next = computeNextRunAt('0 9 * * *', from);
+  assertEquals(next?.toISOString(), '2026-04-02T09:00:00.000Z');
+});
+
+Deno.test('computeNextRunAt resolves a weekly Monday schedule', () => {
+  // 2026-04-01 is a Wednesday; next Monday is 2026-04-06.
+  const from = new Date('2026-04-01T12:00:00.000Z');
+  const next = computeNextRunAt('0 8 * * 1', from);
+  assertEquals(next?.toISOString(), '2026-04-06T08:00:00.000Z');
+});
+
+Deno.test('computeNextRunAt resolves a monthly day-1 schedule', () => {
+  const from = new Date('2026-04-02T00:00:00.000Z');
+  const next = computeNextRunAt('30 6 1 * *', from);
+  assertEquals(next?.toISOString(), '2026-05-01T06:30:00.000Z');
+});
+
+Deno.test('computeNextRunAt returns null for unparseable cron', () => {
+  assertEquals(computeNextRunAt('not-a-cron', new Date()), null);
+});
+
+Deno.test('retryDelaySeconds uses capped exponential backoff', () => {
+  assertEquals(retryDelaySeconds(1), 300);
+  assertEquals(retryDelaySeconds(2), 600);
+  assertEquals(retryDelaySeconds(3), 1200);
+  assertEquals(retryDelaySeconds(10), 3600); // capped at 1 hour
+});
+
+Deno.test('shouldRetry respects the max-retries ceiling', () => {
+  assertEquals(shouldRetry(0, 3), true);
+  assertEquals(shouldRetry(3, 3), false);
+});
+
+Deno.test('nextRetryAt returns null once retries are exhausted', () => {
+  const from = new Date('2026-04-01T00:00:00.000Z');
+  assertEquals(nextRetryAt(3, 3, from), null);
+  const scheduled = nextRetryAt(0, 3, from);
+  assertEquals(scheduled?.toISOString(), '2026-04-01T00:05:00.000Z');
+});

--- a/services/api/supabase/functions/_shared/scheduled-report-schedule.ts
+++ b/services/api/supabase/functions/_shared/scheduled-report-schedule.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Scheduled-report scheduling helpers (#2626).
+ *
+ * Pure, dependency-free utilities the process-scheduled-reports Edge Function
+ * uses to decide when a schedule next runs and how failed deliveries retry.
+ * Kept free of Deno / network imports so the logic is unit-testable in
+ * isolation.
+ *
+ * `scheduled_reports.cron_expression` is a standard 5-field cron string
+ * (minute hour day-of-month month day-of-week). The app currently emits
+ * fixed-time daily / weekly / monthly schedules, so this evaluator supports
+ * `*`, single integers, and comma lists for each field and finds the next
+ * matching instant via a bounded minute-by-minute search.
+ */
+
+/** Exponential-backoff base delay (seconds) between failed delivery retries. */
+export const RETRY_BASE_DELAY_SECONDS = 300; // 5 minutes
+
+/** Upper bound on the forward search window when resolving the next run. */
+const MAX_LOOKAHEAD_MINUTES = 366 * 24 * 60;
+
+interface CronFields {
+  minutes: (n: number) => boolean;
+  hours: (n: number) => boolean;
+  daysOfMonth: (n: number) => boolean;
+  months: (n: number) => boolean;
+  daysOfWeek: (n: number) => boolean;
+}
+
+function matcherFor(field: string, min: number, max: number): (n: number) => boolean {
+  const trimmed = field.trim();
+  if (trimmed === '*') {
+    return () => true;
+  }
+  const allowed = new Set<number>();
+  for (const part of trimmed.split(',')) {
+    const value = Number(part);
+    if (!Number.isInteger(value) || value < min || value > max) {
+      // Unsupported token (ranges/steps) — treat conservatively as "matches",
+      // so the scheduler still advances rather than stalling forever.
+      return () => true;
+    }
+    allowed.add(value);
+  }
+  return (n: number) => allowed.has(n);
+}
+
+/**
+ * Parse a 5-field cron expression into field matchers. Returns `null` when the
+ * expression does not have exactly five fields.
+ */
+export function parseCron(expression: string): CronFields | null {
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    return null;
+  }
+  const [minute, hour, dom, month, dow] = fields;
+  return {
+    minutes: matcherFor(minute, 0, 59),
+    hours: matcherFor(hour, 0, 23),
+    daysOfMonth: matcherFor(dom, 1, 31),
+    months: matcherFor(month, 1, 12),
+    // Support both 0 and 7 as Sunday.
+    daysOfWeek: (n: number) => matcherFor(dow, 0, 7)(n) || (n === 0 && matcherFor(dow, 0, 7)(7)),
+  };
+}
+
+/**
+ * Compute the next UTC run time strictly after `from` for the given cron
+ * expression. Returns `null` when the expression is unparseable or no match is
+ * found within the lookahead window.
+ */
+export function computeNextRunAt(cronExpression: string, from: Date): Date | null {
+  const cron = parseCron(cronExpression);
+  if (!cron) {
+    return null;
+  }
+
+  // Start at the next whole minute after `from`.
+  const cursor = new Date(from.getTime());
+  cursor.setUTCSeconds(0, 0);
+  cursor.setUTCMinutes(cursor.getUTCMinutes() + 1);
+
+  for (let i = 0; i < MAX_LOOKAHEAD_MINUTES; i += 1) {
+    const minute = cursor.getUTCMinutes();
+    const hour = cursor.getUTCHours();
+    const dom = cursor.getUTCDate();
+    const month = cursor.getUTCMonth() + 1;
+    const dow = cursor.getUTCDay();
+
+    if (
+      cron.minutes(minute) &&
+      cron.hours(hour) &&
+      cron.months(month) &&
+      cron.daysOfMonth(dom) &&
+      cron.daysOfWeek(dow)
+    ) {
+      return new Date(cursor.getTime());
+    }
+    cursor.setUTCMinutes(cursor.getUTCMinutes() + 1);
+  }
+
+  return null;
+}
+
+/**
+ * Delay (seconds) before the next retry of a failed delivery, using capped
+ * exponential backoff: 5m, 10m, 20m, ... up to 1 hour.
+ */
+export function retryDelaySeconds(attempt: number): number {
+  const exponent = Math.max(0, attempt - 1);
+  const delay = RETRY_BASE_DELAY_SECONDS * 2 ** exponent;
+  return Math.min(delay, 3600);
+}
+
+/** Whether another delivery attempt should be scheduled. */
+export function shouldRetry(retryCount: number, maxRetries: number): boolean {
+  return retryCount < maxRetries;
+}
+
+/**
+ * Resolve the next `next_retry_at` for a failed delivery, or `null` when the
+ * schedule has exhausted its retries.
+ */
+export function nextRetryAt(retryCount: number, maxRetries: number, from: Date): Date | null {
+  if (!shouldRetry(retryCount, maxRetries)) {
+    return null;
+  }
+  return new Date(from.getTime() + retryDelaySeconds(retryCount + 1) * 1000);
+}

--- a/services/api/supabase/functions/process-scheduled-reports/index.ts
+++ b/services/api/supabase/functions/process-scheduled-reports/index.ts
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Process Scheduled Reports Edge Function (#2626, follow-up to #2253).
+ *
+ * Server-side scheduler + email delivery for scheduled reports. Designed to be
+ * invoked by a cron scheduler (pg_cron, external cron, or manual invocation for
+ * testing), mirroring the process-recurring function.
+ *
+ * Responsibilities (the deferred backend work from #2626):
+ *   - Find schedules that are due (next_run_at <= now, active, not paused).
+ *   - Render a concise HTML summary email per due schedule WITHOUT leaking
+ *     sensitive report data in URLs (the summary is rendered inline; no signed
+ *     data is placed in query strings).
+ *   - Deliver via the shared SMTP relay abstraction (_shared/notification.ts).
+ *   - Record a delivery attempt per run (retry/failure tracking + observability).
+ *   - Advance next_run_at from the cron expression on success, or schedule a
+ *     bounded exponential-backoff retry (via next_run_at) on failure.
+ *
+ * Graceful degradation:
+ *   When SMTP is not configured (SMTP_HOST unset), delivery is recorded as
+ *   `skipped_no_smtp` instead of failing — the scheduling/persistence path is
+ *   still exercised. Enabling real delivery requires SMTP credentials, which
+ *   are human-held (see `## Needs Human Action` in the PR and
+ *   services/api/docs/scheduled-reports.md).
+ *
+ * Authentication: CRON_SECRET header (shared secret), NOT user JWT.
+ *
+ * Environment Variables:
+ *   SUPABASE_URL              — Project URL (set automatically by Supabase)
+ *   SUPABASE_SERVICE_ROLE_KEY — Service role key (set automatically by Supabase)
+ *   CRON_SECRET               — Shared secret for authenticating cron requests
+ *   SMTP_HOST / SMTP_PORT / SMTP_FROM — (Optional) email relay; when unset,
+ *                               delivery is recorded as skipped_no_smtp.
+ */
+
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
+import { handleCorsPreflightRequest } from '../_shared/cors.ts';
+import { timingSafeEqual } from '../_shared/crypto.ts';
+import { createLogger } from '../_shared/logger.ts';
+import { validateEnv } from '../_shared/env.ts';
+import {
+  checkRateLimit,
+  getClientIp,
+  rateLimitResponse,
+  RATE_LIMITS,
+} from '../_shared/rate-limit.ts';
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowedResponse,
+  internalErrorResponse,
+} from '../_shared/response.ts';
+import { sendEmail } from '../_shared/notification.ts';
+import { computeNextRunAt, nextRetryAt } from '../_shared/scheduled-report-schedule.ts';
+
+/** Maximum schedules processed per invocation (bounds work per cron tick). */
+const MAX_BATCH = 50;
+
+interface DueSchedule {
+  id: string;
+  household_id: string;
+  report_config_id: string;
+  cron_expression: string;
+  recipients: string[] | null;
+  retry_count: number;
+  max_retries: number;
+  report_configs?: { name?: string | null } | null;
+}
+
+/**
+ * Authenticate the request via CRON_SECRET header.
+ * Returns null if authenticated, or an error Response.
+ */
+async function authenticateCron(
+  req: Request,
+  logger: ReturnType<typeof createLogger>,
+): Promise<Response | null> {
+  const cronSecret = Deno.env.get('CRON_SECRET');
+  if (!cronSecret) {
+    logger.error('Cron credential environment variable is not configured');
+    return internalErrorResponse(req);
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader || !(await timingSafeEqual(authHeader, `Bearer ${cronSecret}`))) {
+    logger.warn('Unauthorized request — invalid or missing cron credential', {
+      httpStatus: 401,
+    });
+    return errorResponse(req, 'Unauthorized', 401);
+  }
+
+  return null;
+}
+
+/**
+ * Create a Supabase client with service role credentials.
+ */
+function createServiceClient(
+  req: Request,
+  logger: ReturnType<typeof createLogger>,
+):
+  | { client: ReturnType<typeof createClient>; error?: undefined }
+  | { client?: undefined; error: Response } {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    logger.error('Missing required Supabase environment variables');
+    return { error: internalErrorResponse(req) };
+  }
+
+  const client = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  return { client };
+}
+
+/**
+ * Render a concise HTML + text summary for a scheduled report. The report name
+ * is the only user data included; no signed URLs or sensitive figures are
+ * embedded (#2626 acceptance: "without leaking sensitive data in URLs").
+ */
+function renderScheduleEmail(reportName: string): {
+  subject: string;
+  htmlBody: string;
+  textBody: string;
+} {
+  const safeName = reportName.replace(/[<>&"']/g, '');
+  const subject = `Your scheduled report: ${safeName}`;
+  const textBody = `Your scheduled report "${safeName}" is ready. Open the Finance app to view the full report and download the CSV export.`;
+  const htmlBody = [
+    '<!DOCTYPE html>',
+    '<html lang="en">',
+    '<head><meta charset="utf-8"><title>Scheduled report</title></head>',
+    '<body style="font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">',
+    `<h2 style="color: #1a1a2e;">${subject}</h2>`,
+    `<p style="color: #333; line-height: 1.6;">${textBody}</p>`,
+    '<hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;">',
+    '<p style="color: #999; font-size: 12px;">Automated message from Finance. Manage or unsubscribe from scheduled reports in the app.</p>',
+    '</body>',
+    '</html>',
+  ].join('\n');
+  return { subject, htmlBody, textBody };
+}
+
+/**
+ * Deliver a single due schedule, then record the attempt and advance the
+ * schedule cursor. On failure, backoff is applied by moving next_run_at forward
+ * to next_retry_at so the due query naturally respects the retry delay.
+ */
+async function processSchedule(
+  supabase: ReturnType<typeof createClient>,
+  schedule: DueSchedule,
+  now: Date,
+  logger: ReturnType<typeof createLogger>,
+): Promise<{ id: string; status: string }> {
+  const recipients = schedule.recipients ?? [];
+  const reportName = schedule.report_configs?.name ?? 'Report';
+  const smtpConfigured = Boolean(Deno.env.get('SMTP_HOST'));
+
+  let status: 'delivered' | 'skipped_no_smtp' | 'failed' = 'failed';
+  let errorMessage: string | null = null;
+
+  try {
+    if (recipients.length === 0) {
+      // Export-only schedule — nothing to deliver, treat as a delivered no-op.
+      status = 'delivered';
+    } else if (!smtpConfigured) {
+      status = 'skipped_no_smtp';
+    } else {
+      const template = renderScheduleEmail(reportName);
+      const results = await Promise.all(recipients.map((to) => sendEmail(to, template, logger)));
+      if (results.every(Boolean)) {
+        status = 'delivered';
+      } else {
+        // status stays 'failed'.
+        errorMessage = 'smtp_delivery_failed';
+      }
+    }
+  } catch (err) {
+    // status stays 'failed'.
+    errorMessage = err instanceof Error ? err.constructor.name : 'unknown_error';
+  }
+
+  await supabase.from('scheduled_report_deliveries').insert({
+    scheduled_report_id: schedule.id,
+    household_id: schedule.household_id,
+    status,
+    attempt: schedule.retry_count + 1,
+    recipient_count: recipients.length,
+    error_message: errorMessage,
+    rendered_at: now.toISOString(),
+    delivered_at: status === 'delivered' ? now.toISOString() : null,
+  });
+
+  const nextRun = computeNextRunAt(schedule.cron_expression, now);
+
+  if (status === 'failed') {
+    const retry = nextRetryAt(schedule.retry_count, schedule.max_retries, now);
+    await supabase
+      .from('scheduled_reports')
+      .update({
+        last_run_at: now.toISOString(),
+        last_run_status: 'failure',
+        retry_count: schedule.retry_count + 1,
+        next_retry_at: retry ? retry.toISOString() : null,
+        // Retry: re-arm next_run_at at the backoff time. Exhausted: skip to the
+        // next scheduled run so it never gets stuck retrying forever.
+        next_run_at: retry ? retry.toISOString() : (nextRun?.toISOString() ?? null),
+      })
+      .eq('id', schedule.id);
+    return { id: schedule.id, status };
+  }
+
+  // Delivered or skipped_no_smtp — advance to the next scheduled run.
+  await supabase
+    .from('scheduled_reports')
+    .update({
+      last_run_at: now.toISOString(),
+      last_run_status: status === 'delivered' ? 'success' : 'failure',
+      next_run_at: nextRun ? nextRun.toISOString() : null,
+      next_retry_at: null,
+      retry_count: 0,
+    })
+    .eq('id', schedule.id);
+
+  return { id: schedule.id, status };
+}
+
+/**
+ * Handle POST — process all due scheduled reports.
+ */
+async function handleProcessRequest(
+  req: Request,
+  supabase: ReturnType<typeof createClient>,
+  logger: ReturnType<typeof createLogger>,
+): Promise<Response> {
+  const now = new Date();
+  const nowIso = now.toISOString();
+
+  try {
+    const { data, error } = await supabase
+      .from('scheduled_reports')
+      .select(
+        'id, household_id, report_config_id, cron_expression, recipients, retry_count, max_retries, report_configs(name)',
+      )
+      .is('deleted_at', null)
+      .eq('is_active', true)
+      .eq('is_paused', false)
+      .lte('next_run_at', nowIso)
+      .order('next_run_at', { ascending: true })
+      .limit(MAX_BATCH);
+
+    if (error) {
+      logger.error('Failed to query due scheduled reports', {
+        errorCode: error.code,
+        errorMessage: error.message,
+        httpStatus: 500,
+      });
+      return internalErrorResponse(req);
+    }
+
+    const due = (data ?? []) as unknown as DueSchedule[];
+
+    const outcomes: Array<{ id: string; status: string }> = [];
+    for (const schedule of due) {
+      outcomes.push(await processSchedule(supabase, schedule, now, logger));
+    }
+
+    const summary = outcomes.reduce<Record<string, number>>((acc, o) => {
+      acc[o.status] = (acc[o.status] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    logger.info('Scheduled reports processed', {
+      processed: outcomes.length,
+      httpStatus: 200,
+    });
+
+    return jsonResponse(req, {
+      ok: true,
+      processed_count: outcomes.length,
+      summary,
+      processed_at: nowIso,
+    });
+  } catch (err) {
+    logger.error('Unexpected error processing scheduled reports', {
+      errorType: err instanceof Error ? err.constructor.name : 'Unknown',
+      httpStatus: 500,
+    });
+    return internalErrorResponse(req);
+  }
+}
+
+// =============================================================================
+// Main handler
+// =============================================================================
+
+serve(async (req: Request): Promise<Response> => {
+  if (req.method === 'OPTIONS') {
+    return handleCorsPreflightRequest(req);
+  }
+
+  const logger = createLogger('process-scheduled-reports');
+  logger.info('Request received', { method: req.method });
+
+  const envError = validateEnv('process-scheduled-reports', req);
+  if (envError) return envError;
+
+  if (req.method !== 'POST') {
+    logger.warn('Method not allowed', { method: req.method, httpStatus: 405 });
+    return methodNotAllowedResponse(req);
+  }
+
+  const authError = await authenticateCron(req, logger);
+  if (authError) return authError;
+
+  const { client: supabase, error: clientError } = createServiceClient(req, logger);
+  if (clientError) return clientError;
+
+  try {
+    const clientIp = getClientIp(req) ?? 'cron';
+    const rateLimitResult = await checkRateLimit(
+      supabase,
+      clientIp,
+      RATE_LIMITS['process-scheduled-reports'],
+    );
+    if (!rateLimitResult.allowed) {
+      logger.warn('Rate limit exceeded', { httpStatus: 429 });
+      return rateLimitResponse(req, rateLimitResult, RATE_LIMITS['process-scheduled-reports']);
+    }
+  } catch {
+    // Rate limiting failure must not block cron processing — fail open.
+  }
+
+  return handleProcessRequest(req, supabase, logger);
+});

--- a/services/api/supabase/migrations/20260401000001_scheduled_report_delivery.sql
+++ b/services/api/supabase/migrations/20260401000001_scheduled_report_delivery.sql
@@ -1,0 +1,108 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260401000001_scheduled_report_delivery
+-- Description: Server-side delivery tracking for scheduled reports — recipients,
+--              pause/resume, retry cursors, unsubscribe tokens, and a per-attempt
+--              delivery audit trail.
+-- Issues: #2626 (follow-up to #2253)
+--
+-- Background:
+--   #2253 shipped local scheduled-report run previews plus CSV/HTML export
+--   package helpers (apps/web/src/lib/reports/scheduled-report-exports.ts).
+--   The schedule-definition tables (report_configs, scheduled_reports) already
+--   exist from 20260328000005_report_generation. This migration adds the
+--   delivery-side state the deferred backend work needs:
+--     - recipients + unsubscribe token (delivery targeting / preferences)
+--     - pause/resume + retry cursor (failure handling)
+--     - a delivery-attempt audit table (retry/failure tracking, observability)
+--
+-- Security:
+--   - RLS enabled — household-scoped read access for the audit table.
+--   - Inserts/updates to the delivery audit table are service-role only
+--     (written by the process-scheduled-reports Edge Function), matching the
+--     notification_log pattern.
+--   - No sensitive report data is stored in the audit rows (counts only).
+--
+-- DOWN migration: services/api/supabase/migrations/down/20260401000001_scheduled_report_delivery.down.sql
+
+-- =============================================================================
+-- UP
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- scheduled_reports: delivery + retry columns
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE scheduled_reports
+    ADD COLUMN IF NOT EXISTS recipients TEXT[] NOT NULL DEFAULT '{}';
+
+ALTER TABLE scheduled_reports
+    ADD COLUMN IF NOT EXISTS is_paused BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE scheduled_reports
+    ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE scheduled_reports
+    ADD COLUMN IF NOT EXISTS max_retries INTEGER NOT NULL DEFAULT 3;
+
+ALTER TABLE scheduled_reports
+    ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMPTZ;
+
+ALTER TABLE scheduled_reports
+    ADD COLUMN IF NOT EXISTS unsubscribe_token UUID NOT NULL DEFAULT gen_random_uuid();
+
+COMMENT ON COLUMN scheduled_reports.recipients IS
+    'Email recipients for this schedule. Empty array = export-only (no delivery).';
+COMMENT ON COLUMN scheduled_reports.is_paused IS
+    'When true, the scheduler skips this report without deleting the definition (pause/resume).';
+COMMENT ON COLUMN scheduled_reports.retry_count IS
+    'Consecutive failed delivery attempts for the current run. Reset to 0 on success.';
+COMMENT ON COLUMN scheduled_reports.max_retries IS
+    'Maximum consecutive retries before the scheduler gives up and marks the run failed.';
+COMMENT ON COLUMN scheduled_reports.next_retry_at IS
+    'When set, the earliest time the scheduler should retry a previously failed delivery.';
+COMMENT ON COLUMN scheduled_reports.unsubscribe_token IS
+    'Opaque token embedded in delivery emails so recipients can unsubscribe without auth.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduled_reports_unsubscribe_token
+    ON scheduled_reports (unsubscribe_token);
+
+-- ---------------------------------------------------------------------------
+-- scheduled_report_deliveries: per-attempt audit trail
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS scheduled_report_deliveries (
+    id                   UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    scheduled_report_id  UUID        NOT NULL REFERENCES scheduled_reports(id) ON DELETE CASCADE,
+    household_id         UUID        NOT NULL REFERENCES households(id),
+    status               TEXT        NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'rendered', 'delivered', 'skipped_no_smtp', 'failed')),
+    attempt              INTEGER     NOT NULL DEFAULT 1,
+    recipient_count      INTEGER     NOT NULL DEFAULT 0,
+    -- Diagnostic error class only — NEVER a recipient address or report content.
+    error_message        TEXT,
+    rendered_at          TIMESTAMPTZ,
+    delivered_at         TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_report_deliveries_report
+    ON scheduled_report_deliveries (scheduled_report_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_report_deliveries_household
+    ON scheduled_report_deliveries (household_id, created_at DESC);
+
+COMMENT ON TABLE scheduled_report_deliveries IS
+    'Per-attempt delivery audit trail for scheduled reports. Written by the process-scheduled-reports Edge Function (service role). Stores counts and status only — no sensitive report data or recipient addresses.';
+
+-- =============================================================================
+-- Enable RLS
+-- =============================================================================
+
+ALTER TABLE scheduled_report_deliveries ENABLE ROW LEVEL SECURITY;
+
+-- Household members may read their own delivery history (observability), but
+-- only the service role writes rows (the scheduler runs server-to-server).
+CREATE POLICY scheduled_report_deliveries_select ON scheduled_report_deliveries
+    FOR SELECT
+    USING (household_id = ANY(public.household_ids()));

--- a/services/api/supabase/migrations/down/20260401000001_scheduled_report_delivery.down.sql
+++ b/services/api/supabase/migrations/down/20260401000001_scheduled_report_delivery.down.sql
@@ -1,0 +1,14 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- DOWN migration for 20260401000001_scheduled_report_delivery
+
+DROP TABLE IF EXISTS scheduled_report_deliveries;
+
+DROP INDEX IF EXISTS idx_scheduled_reports_unsubscribe_token;
+
+ALTER TABLE scheduled_reports DROP COLUMN IF EXISTS unsubscribe_token;
+ALTER TABLE scheduled_reports DROP COLUMN IF EXISTS next_retry_at;
+ALTER TABLE scheduled_reports DROP COLUMN IF EXISTS max_retries;
+ALTER TABLE scheduled_reports DROP COLUMN IF EXISTS retry_count;
+ALTER TABLE scheduled_reports DROP COLUMN IF EXISTS is_paused;
+ALTER TABLE scheduled_reports DROP COLUMN IF EXISTS recipients;


### PR DESCRIPTION
﻿## Summary

This batch implements five closely-related issues spanning web accessibility, service-worker/CSP hardening, scheduled-report delivery, and Supabase OAuth configuration. Primary surface is `apps/web`, with `services/api` config/migrations/functions for the backend items.

### #3352 — `prefers-reduced-transparency` for translucent surfaces
- Added `@media (prefers-reduced-transparency: reduce)` blocks that make translucent surfaces opaque (global rule in `accessibility.css`; co-located rule for estate inventory tiles in `estate-inventory.css`).
- Extended `wcag-audit.test.ts` with assertions verifying the reduced-transparency handling exists.

### #3281 — Warn when custom positive/negative amount colors fail contrast
- Added WCAG contrast utilities to `apps/web/src/lib/a11y.ts` checking custom amount colors against light and dark reference backgrounds at the WCAG AA 4.5:1 threshold.
- Added an inline `AmountColorContrastWarning` in `SettingsPreferencesPage.tsx`, wired into the positive/negative/zero color pickers with `aria-describedby`. Unit tests in `a11y.test.ts`.

### #3105 — Production CSP blocks inline SW auto-update script (regression guard)
- The inline script was already externalized to `/sw-update.js` (via #3210) and the production/staging Caddyfile CSP is already correct. This PR adds `csp-inline-script.test.ts` — a regression guard that fails if any inline `<script>` reappears in `index.html` or if either Caddyfile `script-src` drifts, preventing the stale-bundle-pinning regression from recurring.

### #2626 — Backend scheduler & email delivery for scheduled reports
- Migration `20260401000001_scheduled_report_delivery.sql` (+ down) adds recipient/pause/retry/unsubscribe columns and a `scheduled_report_deliveries` tracking table with RLS (household-scoped read, service-role write). Delivery rows store status/counts only — no recipient addresses or report content.
- Pure, testable scheduling helper `_shared/scheduled-report-schedule.ts` (cron next-run + capped exponential retry backoff) with Deno tests.
- New edge function `process-scheduled-reports/` (CRON_SECRET-authenticated, rate-limited, reuses the shared `sendEmail`/`renderEmailTemplate` SMTP helper which degrades gracefully when unconfigured).
- Docs: `services/api/docs/scheduled-reports.md`.

### #3187 — OAuth providers not enabled in deployed Supabase
- The `auth-oauth-start` edge function already pre-flights provider enablement and returns graceful errors (companion #3188). This PR adds declarative `[auth.external.google|github|apple]` config in `config.toml` (shipped `enabled=false` so local `supabase start` is unaffected), `.env.example` entries, and docs.
- Docs: `services/api/docs/oauth-providers.md`.

## Testing (local)
- `npm run format:check` passed
- `npx eslint . --max-warnings 0` passed
- `apps/web` vitest: 10048/10050 passing. The 2 failures (`DashboardPage`, `NumberCounter`) are pre-existing order/time-dependent flakes unrelated to this change — both pass in isolation and neither file is touched by this PR.

## Needs Human Action
These require human-held secrets or deployed-infra changes that cannot be done from code:

**#2626 (scheduled reports)**
- Configure SMTP credentials (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`) in the deployed environment. Without them the function runs but skips actual email send (graceful degrade).
- Set `CRON_SECRET` and register a scheduled trigger (Supabase cron / external scheduler) to invoke `process-scheduled-reports` on the desired cadence. See `services/api/docs/scheduled-reports.md`.

**#3187 (OAuth providers)**
- Create OAuth apps with Google, GitHub, and Apple and obtain client IDs/secrets.
- Set the corresponding secrets in the deployed Supabase project and enable each provider. See `services/api/docs/oauth-providers.md`.

Closes #3352
Closes #3281
Closes #3105
Closes #2626
Closes #3187
