### PR TITLE
feat(windows): batch 7 — window bounds, sidebar wiring, shortcut focus, DeFi + tax + live-feed gate

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
@@ -34,15 +34,20 @@ import com.finance.desktop.navigation.SidebarNavigation
 import com.finance.desktop.screens.AccountsScreen
 import com.finance.desktop.screens.BudgetNegotiationScreen
 import com.finance.desktop.screens.BudgetsScreen
+import com.finance.desktop.screens.ComingSoonScreen
 import com.finance.desktop.screens.CurrencyConversionScreen
+import com.finance.desktop.screens.CryptoDashboardScreen
 import com.finance.desktop.screens.DashboardScreen
 import com.finance.desktop.screens.DiagnosticsScreen
 import com.finance.desktop.screens.FeedbackDialog
 import com.finance.desktop.screens.GamificationScreen
 import com.finance.desktop.screens.GoalsScreen
 import com.finance.desktop.screens.HealthScoreScreen
+import com.finance.desktop.screens.HouseholdScreen
+import com.finance.desktop.screens.InvestmentScreen
 import com.finance.desktop.screens.KeyboardShortcutsHelpDialog
 import com.finance.desktop.screens.LockScreen
+import com.finance.desktop.screens.ReferralScreen
 import com.finance.desktop.screens.ReportBuilderScreen
 import com.finance.desktop.screens.ReceiptOcrScreen
 import com.finance.desktop.screens.QuickAddTransactionDialog
@@ -302,15 +307,19 @@ private fun MainAppContent(
                 Screen.Widgets -> WidgetBoardScreen()
                 Screen.Upgrade -> UpgradeScreen()
                 Screen.Tips -> TipsScreen()
-                Screen.Investments -> {} // placeholder
-                Screen.Household -> {} // placeholder
+                Screen.Investments -> InvestmentScreen()
+                Screen.Household -> HouseholdScreen()
                 Screen.Achievements -> GamificationScreen()
                 Screen.Diagnostics -> DiagnosticsScreen()
                 Screen.HealthScore -> HealthScoreScreen()
                 Screen.Reports -> ReportBuilderScreen()
-                Screen.QuickAdd -> {} // handled by dialog
+                Screen.QuickAdd -> ComingSoonScreen(
+                    title = "Quick Add",
+                    description = "Use Ctrl+Shift+N or the system tray to quickly add a transaction.",
+                )
                 Screen.Import -> ReceiptOcrScreen()
-                Screen.Referral -> {} // placeholder
+                Screen.Referral -> ReferralScreen()
+                Screen.Crypto -> CryptoDashboardScreen()
                 Screen.Negotiate -> BudgetNegotiationScreen()
                 Screen.Currency -> CurrencyConversionScreen()
                 Screen.Settings -> SettingsScreen(onSignInRequested = openSignIn)

--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -2,17 +2,13 @@
 
 package com.finance.desktop
 
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
-import androidx.compose.ui.window.rememberWindowState
 import com.finance.desktop.components.rememberShortcutHandler
 import com.finance.desktop.data.storage.UserDataPaths
 import com.finance.desktop.di.SupabaseConfig
@@ -28,6 +24,7 @@ import com.finance.desktop.widgets.WidgetRegistrationManager
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
+import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 import javax.swing.JOptionPane
 import kotlin.system.exitProcess
@@ -70,10 +67,9 @@ fun main() {
     PerformanceTracker.recordFirstInteractive()
 
     application {
-        val windowState = rememberWindowState(
-            size = DpSize(width = 1280.dp, height = 800.dp),
-            position = WindowPosition(Alignment.Center),
-        )
+        // Restore the last window size/position (or a centered default on first
+        // run) and continuously persist bounds changes (#3589).
+        val windowState = rememberPersistedWindowState()
 
         val shortcutHandler = rememberShortcutHandler()
 
@@ -99,6 +95,7 @@ fun main() {
                     }
                 },
                 onQuit = {
+                    WindowStatePersistence.save(windowState)
                     PerformanceMonitor.stop()
                     systemTray.dispose()
                     widgetManager.dispose()
@@ -111,6 +108,7 @@ fun main() {
 
         Window(
             onCloseRequest = {
+                WindowStatePersistence.save(windowState)
                 PerformanceMonitor.stop()
                 systemTray.dispose()
                 widgetManager.dispose()
@@ -122,6 +120,14 @@ fun main() {
             state = windowState,
             onPreviewKeyEvent = { shortcutHandler.onKeyEvent(it) },
         ) {
+            // Prevent the window from shrinking below a usable size (#3589) so the
+            // sidebar + content never collapse.
+            LaunchedEffect(window) {
+                window.minimumSize = Dimension(
+                    WindowStatePersistence.MIN_WIDTH.value.toInt(),
+                    WindowStatePersistence.MIN_HEIGHT.value.toInt(),
+                )
+            }
             FinanceApp(
                 shortcutHandler,
                 quickAddManager,

--- a/apps/windows/src/main/kotlin/com/finance/desktop/WindowStatePersistence.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/WindowStatePersistence.kt
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
+import androidx.compose.ui.window.rememberWindowState
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import java.util.prefs.Preferences
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Window bounds persistence — Issue #3589
+//
+// Standard desktop apps restore their last window size/position and prevent the
+// window from being resized so small the layout collapses. Persistence uses
+// java.util.prefs.Preferences so no new dependency is introduced, and all logic
+// is contained in apps/windows.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Persists and restores the main window's size and position across launches.
+ *
+ * Values are stored under the user's [Preferences] tree. Missing or malformed
+ * entries fall back to a sensible, centered default (first-run behaviour).
+ */
+object WindowStatePersistence {
+
+    /** Minimum usable width; below this the sidebar + content collapse. */
+    val MIN_WIDTH = 960.dp
+
+    /** Minimum usable height. */
+    val MIN_HEIGHT = 640.dp
+
+    /** Default width on first run. */
+    val DEFAULT_WIDTH = 1280.dp
+
+    /** Default height on first run. */
+    val DEFAULT_HEIGHT = 800.dp
+
+    private const val NODE = "com/finance/desktop/window"
+    private const val KEY_WIDTH = "width"
+    private const val KEY_HEIGHT = "height"
+    private const val KEY_X = "x"
+    private const val KEY_Y = "y"
+    private const val KEY_MAXIMIZED = "maximized"
+    private const val UNSET = Float.MIN_VALUE
+
+    private val prefs: Preferences get() = Preferences.userRoot().node(NODE)
+
+    /** Snapshot of persisted window bounds. */
+    data class SavedBounds(
+        val size: DpSize,
+        val x: Float,
+        val y: Float,
+        val hasPosition: Boolean,
+        val maximized: Boolean,
+    )
+
+    /**
+     * Loads the last-saved bounds, clamped to the minimum size. Returns `null`
+     * when nothing has been persisted yet so the caller centers a default window.
+     */
+    fun load(): SavedBounds? {
+        val p = prefs
+        val width = p.getFloat(KEY_WIDTH, UNSET)
+        val height = p.getFloat(KEY_HEIGHT, UNSET)
+        if (width == UNSET || height == UNSET) return null
+
+        val x = p.getFloat(KEY_X, UNSET)
+        val y = p.getFloat(KEY_Y, UNSET)
+        val hasPosition = x != UNSET && y != UNSET
+        return SavedBounds(
+            size = DpSize(
+                width = maxOf(width, MIN_WIDTH.value).dp,
+                height = maxOf(height, MIN_HEIGHT.value).dp,
+            ),
+            x = x,
+            y = y,
+            hasPosition = hasPosition,
+            maximized = p.getBoolean(KEY_MAXIMIZED, false),
+        )
+    }
+
+    /** Persists the current [state] so the next launch restores it. */
+    fun save(state: WindowState) {
+        val p = prefs
+        val maximized = state.placement == WindowPlacement.Maximized
+        p.putBoolean(KEY_MAXIMIZED, maximized)
+        // Only persist size/position while in a normal (floating) placement so a
+        // maximized/fullscreen session doesn't clobber the restorable bounds.
+        if (!maximized && state.placement == WindowPlacement.Floating) {
+            p.putFloat(KEY_WIDTH, state.size.width.value)
+            p.putFloat(KEY_HEIGHT, state.size.height.value)
+            val position = state.position
+            if (position is WindowPosition.Absolute) {
+                p.putFloat(KEY_X, position.x.value)
+                p.putFloat(KEY_Y, position.y.value)
+            }
+        }
+        p.flush()
+    }
+}
+
+/**
+ * Builds a [WindowState] restored from [WindowStatePersistence], falling back to
+ * a centered default on first run, and continuously persists size/position and
+ * placement changes (debounced to avoid thrashing the prefs store during a
+ * drag/resize).
+ */
+@Composable
+@OptIn(FlowPreview::class)
+fun rememberPersistedWindowState(): WindowState {
+    val saved = WindowStatePersistence.load()
+    val windowState = rememberWindowState(
+        size = saved?.size ?: DpSize(
+            WindowStatePersistence.DEFAULT_WIDTH,
+            WindowStatePersistence.DEFAULT_HEIGHT,
+        ),
+        position = if (saved?.hasPosition == true) {
+            WindowPosition.Absolute(saved.x.dp, saved.y.dp)
+        } else {
+            WindowPosition(androidx.compose.ui.Alignment.Center)
+        },
+        placement = if (saved?.maximized == true) {
+            WindowPlacement.Maximized
+        } else {
+            WindowPlacement.Floating
+        },
+    )
+
+    LaunchedEffect(windowState) {
+        snapshotFlow { Triple(windowState.size, windowState.position, windowState.placement) }
+            .debounce(300)
+            .collect { WindowStatePersistence.save(windowState) }
+    }
+
+    return windowState
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/components/AmountTextField.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/components/AmountTextField.kt
@@ -105,7 +105,7 @@ fun AmountTextField(
             val filtered = newValue.filter { it.isDigit() }.take(12)
             onRawDigitsChange(filtered)
         },
-        modifier = modifier.semantics {
+        modifier = modifier.trackTextInputFocus().semantics {
             contentDescription = "Amount field. " +
                 "Type digits to enter amount. Currently ${formatForAccessibility(rawDigits, currencySymbol)}"
         },

--- a/apps/windows/src/main/kotlin/com/finance/desktop/components/KeyboardShortcuts.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/components/KeyboardShortcuts.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -13,6 +15,70 @@ import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Classifies a [KeyboardShortcut] so the dispatcher can decide whether it may
+ * fire while a text input is focused (#3585).
+ */
+enum class ShortcutCategory {
+    /**
+     * Sidebar/global navigation (e.g. Ctrl+A → Achievements). These MUST NOT
+     * fire while a text field is focused, otherwise they hijack standard
+     * editing combos like Ctrl+A (Select All).
+     */
+    NAVIGATION,
+
+    /**
+     * Discrete actions (new transaction, help, close dialog). These are safe to
+     * fire regardless of focus because they don't collide with text editing.
+     */
+    ACTION,
+}
+
+/**
+ * Tracks how many text inputs currently hold focus so the global
+ * [ShortcutHandler] can suppress navigation shortcuts while the user is typing
+ * (#3585). Backed by an [AtomicInteger] because focus callbacks and key-event
+ * dispatch can interleave.
+ */
+object TextInputFocusTracker {
+    private val focusedCount = AtomicInteger(0)
+
+    /** True when at least one text input is focused. */
+    val isTextInputFocused: Boolean get() = focusedCount.get() > 0
+
+    /** Called by [trackTextInputFocus] when a field gains focus. */
+    fun onFocusGained() {
+        focusedCount.incrementAndGet()
+    }
+
+    /** Called by [trackTextInputFocus] when a field loses focus. */
+    fun onFocusLost() {
+        focusedCount.updateAndGet { if (it > 0) it - 1 else 0 }
+    }
+
+    /** Test hook to reset state between cases. */
+    fun reset() {
+        focusedCount.set(0)
+    }
+}
+
+/**
+ * Marks a text-input composable so global navigation shortcuts are suppressed
+ * while it is focused (#3585). Apply to every editable field:
+ *
+ * ```
+ * OutlinedTextField(..., modifier = Modifier.trackTextInputFocus())
+ * ```
+ */
+fun Modifier.trackTextInputFocus(): Modifier = this.onFocusChanged { focusState ->
+    if (focusState.isFocused) {
+        TextInputFocusTracker.onFocusGained()
+    } else {
+        TextInputFocusTracker.onFocusLost()
+    }
+}
 
 /**
  * Represents a keyboard shortcut binding.
@@ -21,6 +87,9 @@ import androidx.compose.ui.input.key.type
  * @param ctrl Whether Ctrl must be held. Defaults to `true` (most desktop shortcuts use Ctrl).
  * @param shift Whether Shift must be held. Defaults to `false`.
  * @param description Human-readable label for accessibility and tooltip display.
+ * @param category Whether this is a [ShortcutCategory.NAVIGATION] or
+ *   [ShortcutCategory.ACTION] binding; navigation bindings are suppressed while
+ *   a text field is focused (#3585).
  * @param action The callback to invoke when the shortcut is triggered.
  */
 @Stable
@@ -29,6 +98,7 @@ data class KeyboardShortcut(
     val ctrl: Boolean = true,
     val shift: Boolean = false,
     val description: String,
+    val category: ShortcutCategory = ShortcutCategory.ACTION,
     val action: () -> Unit,
 )
 
@@ -68,20 +138,45 @@ class ShortcutHandler {
      *
      * Call this from `onPreviewKeyEvent` on the application [Window] so that
      * shortcuts fire before any child composable consumes the event.
+     *
+     * While a text input is focused (see [TextInputFocusTracker]),
+     * [ShortcutCategory.NAVIGATION] bindings are NOT consumed so standard editing
+     * combos like Ctrl+A (Select All) reach the focused field (#3585).
      */
     @Suppress("ReturnCount") // Keyboard shortcut dispatch logic
     fun onKeyEvent(event: KeyEvent): Boolean {
         if (event.type != KeyEventType.KeyDown) return false
+        return dispatch(event.key, event.isCtrlPressed, event.isShiftPressed)
+    }
+
+    /**
+     * Pure dispatch decision, split out from [onKeyEvent] so the focus-aware
+     * suppression can be unit-tested without constructing platform [KeyEvent]s
+     * (whose backing native type is not test-constructible). Returns `true` when
+     * a shortcut consumed the combination.
+     *
+     * While a text input is focused (see [TextInputFocusTracker]),
+     * [ShortcutCategory.NAVIGATION] bindings are NOT consumed so standard editing
+     * combos like Ctrl+A (Select All) reach the focused field (#3585).
+     */
+    @Suppress("ReturnCount") // Keyboard shortcut dispatch logic
+    fun dispatch(key: Key, ctrl: Boolean, shift: Boolean): Boolean {
         val match = shortcuts.firstOrNull { shortcut ->
-            event.key == shortcut.key &&
-                event.isCtrlPressed == shortcut.ctrl &&
-                event.isShiftPressed == shortcut.shift
+            key == shortcut.key &&
+                ctrl == shortcut.ctrl &&
+                shift == shortcut.shift
+        } ?: return false
+
+        // Let editing combos through to a focused text field instead of
+        // hijacking them for navigation (#3585).
+        if (match.category == ShortcutCategory.NAVIGATION &&
+            TextInputFocusTracker.isTextInputFocused
+        ) {
+            return false
         }
-        if (match != null) {
-            match.action()
-            return true
-        }
-        return false
+
+        match.action()
+        return true
     }
 }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoRefreshScheduler.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoRefreshScheduler.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Near-real-time refresh scheduler — Issue #2702
+//
+// Drives periodic refreshes for the Windows crypto ViewModel with cooperative
+// cancellation and exponential rate-limit backoff. The backoff maths lives in a
+// pure helper so it is unit-testable without spinning up coroutines.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Raised by a price source when the provider signals HTTP 429 / throttling. */
+class RateLimitException(message: String = "Rate limited by market-data provider") :
+    Exception(message)
+
+/**
+ * Pure backoff calculator. On success the interval resets to [baseIntervalMs];
+ * on a rate-limit hit it doubles up to [maxIntervalMs].
+ */
+object RefreshBackoff {
+    /** Next delay after a successful refresh. */
+    fun onSuccess(baseIntervalMs: Long): Long = baseIntervalMs
+
+    /** Next delay after a rate-limit hit, given the [current] delay. */
+    fun onRateLimited(current: Long, baseIntervalMs: Long, maxIntervalMs: Long): Long {
+        val doubled = (maxOf(current, baseIntervalMs)) * 2
+        return doubled.coerceAtMost(maxIntervalMs)
+    }
+}
+
+/**
+ * Schedules repeated invocations of a suspending refresh block on [scope].
+ *
+ * Cancellation is cooperative: [stop] cancels the running [Job], and the loop
+ * also exits when the scope is cancelled (e.g. ViewModel `onCleared`). A
+ * [RateLimitException] triggers exponential backoff; other exceptions are
+ * reported via [onError] and retried at the base interval.
+ *
+ * @param scope Coroutine scope the polling loop runs in.
+ * @param baseIntervalMs Delay between successful refreshes.
+ * @param maxIntervalMs Upper bound for backoff.
+ * @param onError Callback for surfaced errors (logging / stale-state UI).
+ */
+class CryptoRefreshScheduler(
+    private val scope: CoroutineScope,
+    private val baseIntervalMs: Long = MarketDataConfig.DEFAULT_REFRESH_INTERVAL_MS,
+    private val maxIntervalMs: Long = 5 * 60_000L,
+    private val onError: (Throwable) -> Unit = {},
+) {
+    private var job: Job? = null
+
+    /** True while the polling loop is active. */
+    val isRunning: Boolean get() = job?.isActive == true
+
+    /**
+     * Starts (or restarts) the polling loop. [block] is invoked immediately and
+     * then once per interval until [stop] is called or the scope is cancelled.
+     */
+    fun start(block: suspend () -> Unit) {
+        stop()
+        job = scope.launch {
+            var interval = baseIntervalMs
+            while (isActive) {
+                interval = try {
+                    block()
+                    RefreshBackoff.onSuccess(baseIntervalMs)
+                } catch (cancellation: CancellationException) {
+                    throw cancellation
+                } catch (rateLimit: RateLimitException) {
+                    onError(rateLimit)
+                    RefreshBackoff.onRateLimited(interval, baseIntervalMs, maxIntervalMs)
+                } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+                    onError(error)
+                    baseIntervalMs
+                }
+                delay(interval)
+            }
+        }
+    }
+
+    /** Cancels the polling loop. Safe to call repeatedly. */
+    fun stop() {
+        job?.cancel()
+        job = null
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoTaxEngine.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/crypto/CryptoTaxEngine.kt
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chain-aware cost basis + taxable-event tracking — Issue #2168
+//
+// Crypto-heavy users have hundreds of swaps, bridges and reward events across
+// chains. This pure engine models taxable crypto events explicitly, preserves
+// wallet/chain provenance so basis survives cross-chain and self-transfer
+// activity, supports FIFO / HIFO / wallet-aware specific identification, and
+// classifies airdrops and staking rewards as income while still tracking later
+// capital gains on disposal.
+//
+// No Compose / Koin / coroutines / network — deterministic and unit-testable.
+// Money is carried as Long cents; quantities as Double.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The economic nature of a crypto event for tax purposes. */
+enum class TaxEventType(val displayName: String) {
+    BUY("Buy"),
+    SELL("Sell"),
+    SWAP("Swap"),
+    BRIDGE("Bridge"),
+    WRAP("Wrap"),
+    UNWRAP("Unwrap"),
+    GAS_FEE("Gas Fee"),
+    STAKING_REWARD("Staking Reward"),
+    AIRDROP("Airdrop"),
+    INCOME_RECEIPT("Income Receipt"),
+    ;
+
+    /** Rewards/airdrops/income are taxed as ordinary income at fair value on receipt. */
+    val isIncomeOnReceipt: Boolean
+        get() = this == STAKING_REWARD || this == AIRDROP || this == INCOME_RECEIPT
+
+    /** Disposals realize capital gains (proceeds minus basis). */
+    val isDisposal: Boolean
+        get() = this == SELL || this == SWAP
+
+    /**
+     * Non-taxable movements that MUST preserve cost basis across the change of
+     * wallet/chain/wrapper rather than realizing a gain.
+     */
+    val preservesBasis: Boolean
+        get() = this == BRIDGE || this == WRAP || this == UNWRAP
+}
+
+/** Lot-selection method for choosing which basis to relieve on disposal. */
+enum class LotMethod(val displayName: String) {
+    /** Oldest lots first. */
+    FIFO("First-In, First-Out"),
+
+    /** Highest cost-per-unit first (minimizes gains). */
+    HIFO("Highest-In, First-Out"),
+
+    /** Caller supplies explicit lot IDs (wallet-aware specific identification). */
+    SPECIFIC_ID("Specific Identification"),
+}
+
+/**
+ * A taxable (or basis-affecting) crypto event with full wallet/chain provenance.
+ *
+ * @param walletId Source wallet identifier (provenance for specific-id + bridges).
+ * @param chain Chain the event occurred on (source chain for bridges).
+ * @param assetSymbol The primary asset moved.
+ * @param assetQuantity Units of [assetSymbol] moved.
+ * @param valueCents Fair market value of the primary asset at the event, in cents.
+ *   For BUY this is the purchase cost; for SELL the proceeds; for SWAP the value
+ *   of the leg disposed of; for income the FMV received.
+ * @param feeCents Fees paid (gas/bridge), in cents.
+ * @param counterAssetSymbol For SWAP/WRAP/UNWRAP, the asset received.
+ * @param counterAssetQuantity Units of [counterAssetSymbol] received.
+ * @param destinationChain For BRIDGE, the chain funds move to.
+ * @param destinationWalletId For BRIDGE/transfer, the receiving wallet.
+ * @param specificLotIds For [LotMethod.SPECIFIC_ID] disposals, the lots to relieve.
+ */
+data class CryptoTaxEvent(
+    val id: String,
+    val type: TaxEventType,
+    val timestampEpochMs: Long,
+    val walletId: String,
+    val chain: Chain,
+    val assetSymbol: String,
+    val assetQuantity: Double,
+    val valueCents: Long,
+    val feeCents: Long = 0L,
+    val counterAssetSymbol: String? = null,
+    val counterAssetQuantity: Double = 0.0,
+    val destinationChain: Chain? = null,
+    val destinationWalletId: String? = null,
+    val specificLotIds: List<String> = emptyList(),
+)
+
+/** An open tax lot with remaining quantity and its acquisition basis. */
+data class TaxLot(
+    val id: String,
+    val walletId: String,
+    val chain: Chain,
+    val symbol: String,
+    val originalQuantity: Double,
+    val remainingQuantity: Double,
+    val costBasisCents: Long,
+    val acquiredEpochMs: Long,
+) {
+    /** Cost basis per remaining unit, in cents. */
+    val costPerUnitCents: Double
+        get() = if (originalQuantity == 0.0) 0.0 else costBasisCents.toDouble() / originalQuantity
+}
+
+/** A realized capital gain (or loss) from a disposal. */
+data class RealizedGain(
+    val eventId: String,
+    val symbol: String,
+    val quantity: Double,
+    val proceedsCents: Long,
+    val costBasisCents: Long,
+    val gainCents: Long,
+    val isLongTerm: Boolean,
+)
+
+/** Ordinary income recognized on receipt of a reward/airdrop. */
+data class IncomeEvent(
+    val eventId: String,
+    val type: TaxEventType,
+    val symbol: String,
+    val fairMarketValueCents: Long,
+    val timestampEpochMs: Long,
+)
+
+/** A non-fatal issue encountered while processing (e.g. selling with no basis). */
+data class TaxWarning(val eventId: String, val message: String)
+
+/** The full tax report produced by [CryptoTaxEngine.process]. */
+data class TaxReport(
+    val method: LotMethod,
+    val realizedGains: List<RealizedGain>,
+    val incomeEvents: List<IncomeEvent>,
+    val openLots: List<TaxLot>,
+    val warnings: List<TaxWarning>,
+    val totalProceedsCents: Long,
+    val totalCostBasisCents: Long,
+    val totalRealizedGainCents: Long,
+    val shortTermGainCents: Long,
+    val longTermGainCents: Long,
+    val totalIncomeCents: Long,
+    val totalFeesCents: Long,
+) {
+    companion object {
+        val EMPTY = TaxReport(
+            method = LotMethod.FIFO,
+            realizedGains = emptyList(),
+            incomeEvents = emptyList(),
+            openLots = emptyList(),
+            warnings = emptyList(),
+            totalProceedsCents = 0L,
+            totalCostBasisCents = 0L,
+            totalRealizedGainCents = 0L,
+            shortTermGainCents = 0L,
+            longTermGainCents = 0L,
+            totalIncomeCents = 0L,
+            totalFeesCents = 0L,
+        )
+    }
+}
+
+/**
+ * Processes a chronological stream of [CryptoTaxEvent]s into a [TaxReport],
+ * maintaining per-(wallet, chain, symbol) lot inventories.
+ */
+object CryptoTaxEngine {
+
+    /** ~1 year holding period boundary between short- and long-term gains. */
+    const val LONG_TERM_THRESHOLD_MS: Long = 365L * 24 * 60 * 60 * 1000
+
+    private data class LotKey(val walletId: String, val chain: Chain, val symbol: String)
+
+    @Suppress("LongMethod", "CyclomaticComplexMethod") // Cohesive tax state machine.
+    fun process(events: List<CryptoTaxEvent>, method: LotMethod = LotMethod.FIFO): TaxReport {
+        if (events.isEmpty()) return TaxReport.EMPTY.copy(method = method)
+
+        val inventory = HashMap<LotKey, MutableList<TaxLot>>()
+        val realized = mutableListOf<RealizedGain>()
+        val income = mutableListOf<IncomeEvent>()
+        val warnings = mutableListOf<TaxWarning>()
+        var totalFees = 0L
+        var lotSeq = 0
+
+        fun addLot(walletId: String, chain: Chain, symbol: String, qty: Double, basisCents: Long, at: Long) {
+            if (qty <= 0.0) return
+            val key = LotKey(walletId, chain, symbol.uppercase())
+            inventory.getOrPut(key) { mutableListOf() }.add(
+                TaxLot(
+                    id = "lot-${lotSeq++}",
+                    walletId = walletId,
+                    chain = chain,
+                    symbol = symbol.uppercase(),
+                    originalQuantity = qty,
+                    remainingQuantity = qty,
+                    costBasisCents = basisCents,
+                    acquiredEpochMs = at,
+                ),
+            )
+        }
+
+        // Relieves [qty] of basis from the inventory, returning basis consumed and
+        // the acquisition time of the earliest lot touched (for holding period).
+        fun relieveBasis(
+            event: CryptoTaxEvent,
+            symbol: String,
+            qty: Double,
+        ): Pair<Long, Long> {
+            val key = LotKey(event.walletId, event.chain, symbol.uppercase())
+            val lots = inventory[key]
+            if (lots.isNullOrEmpty()) {
+                warnings += TaxWarning(event.id, "No basis lots for $symbol on ${event.chain.displayName}; basis treated as 0.")
+                return 0L to event.timestampEpochMs
+            }
+            val ordered = when (method) {
+                LotMethod.FIFO -> lots.sortedBy { it.acquiredEpochMs }
+                LotMethod.HIFO -> lots.sortedByDescending { it.costPerUnitCents }
+                LotMethod.SPECIFIC_ID -> {
+                    val chosen = lots.filter { it.id in event.specificLotIds }
+                    if (chosen.isEmpty()) lots.sortedBy { it.acquiredEpochMs } else chosen
+                }
+            }
+            var remaining = qty
+            var basisConsumed = 0L
+            var earliestAcquired = Long.MAX_VALUE
+            for (lot in ordered) {
+                if (remaining <= 1e-12) break
+                val take = minOf(lot.remainingQuantity, remaining)
+                if (take <= 0.0) continue
+                val lotBasis = Math.round(lot.costPerUnitCents * take)
+                basisConsumed += lotBasis
+                earliestAcquired = minOf(earliestAcquired, lot.acquiredEpochMs)
+                val idx = lots.indexOfFirst { it.id == lot.id }
+                if (idx >= 0) {
+                    lots[idx] = lots[idx].copy(remainingQuantity = lots[idx].remainingQuantity - take)
+                }
+                remaining -= take
+            }
+            lots.removeAll { it.remainingQuantity <= 1e-9 }
+            if (remaining > 1e-9) {
+                warnings += TaxWarning(event.id, "Disposed more $symbol than tracked basis; excess treated as zero-basis.")
+            }
+            if (earliestAcquired == Long.MAX_VALUE) earliestAcquired = event.timestampEpochMs
+            return basisConsumed to earliestAcquired
+        }
+
+        fun recordDisposal(event: CryptoTaxEvent, symbol: String, qty: Double, proceedsCents: Long) {
+            val (basis, acquiredAt) = relieveBasis(event, symbol, qty)
+            val isLongTerm = (event.timestampEpochMs - acquiredAt) >= LONG_TERM_THRESHOLD_MS
+            realized += RealizedGain(
+                eventId = event.id,
+                symbol = symbol.uppercase(),
+                quantity = qty,
+                proceedsCents = proceedsCents,
+                costBasisCents = basis,
+                gainCents = proceedsCents - basis,
+                isLongTerm = isLongTerm,
+            )
+        }
+
+        for (event in events.sortedBy { it.timestampEpochMs }) {
+            totalFees += event.feeCents
+            when (event.type) {
+                TaxEventType.BUY ->
+                    addLot(event.walletId, event.chain, event.assetSymbol, event.assetQuantity, event.valueCents + event.feeCents, event.timestampEpochMs)
+
+                TaxEventType.STAKING_REWARD, TaxEventType.AIRDROP, TaxEventType.INCOME_RECEIPT -> {
+                    income += IncomeEvent(event.id, event.type, event.assetSymbol.uppercase(), event.valueCents, event.timestampEpochMs)
+                    // Income establishes basis equal to FMV so later disposal only
+                    // taxes the subsequent capital move.
+                    addLot(event.walletId, event.chain, event.assetSymbol, event.assetQuantity, event.valueCents, event.timestampEpochMs)
+                }
+
+                TaxEventType.SELL ->
+                    recordDisposal(event, event.assetSymbol, event.assetQuantity, event.valueCents - event.feeCents)
+
+                TaxEventType.SWAP -> {
+                    // Dispose the outgoing leg, then acquire the incoming leg with
+                    // basis equal to the disposed leg's fair market value.
+                    recordDisposal(event, event.assetSymbol, event.assetQuantity, event.valueCents - event.feeCents)
+                    val recvSymbol = event.counterAssetSymbol
+                    if (recvSymbol != null && event.counterAssetQuantity > 0.0) {
+                        addLot(event.walletId, event.chain, recvSymbol, event.counterAssetQuantity, event.valueCents, event.timestampEpochMs)
+                    }
+                }
+
+                TaxEventType.BRIDGE ->
+                    moveBasis(
+                        inventory = inventory,
+                        event = event,
+                        fromKey = LotKey(event.walletId, event.chain, event.assetSymbol.uppercase()),
+                        toKey = LotKey(
+                            event.destinationWalletId ?: event.walletId,
+                            event.destinationChain ?: event.chain,
+                            event.assetSymbol.uppercase(),
+                        ),
+                        symbol = event.assetSymbol,
+                        qty = event.assetQuantity,
+                        warnings = warnings,
+                    )
+
+                TaxEventType.WRAP, TaxEventType.UNWRAP -> {
+                    // Wrapping preserves basis; migrate lots to the wrapped symbol.
+                    val target = event.counterAssetSymbol ?: event.assetSymbol
+                    moveBasis(
+                        inventory = inventory,
+                        event = event,
+                        fromKey = LotKey(event.walletId, event.chain, event.assetSymbol.uppercase()),
+                        toKey = LotKey(event.walletId, event.chain, target.uppercase()),
+                        symbol = event.assetSymbol,
+                        qty = event.assetQuantity,
+                        warnings = warnings,
+                        retargetSymbol = target,
+                        retargetQuantity = event.counterAssetQuantity.takeIf { it > 0.0 },
+                    )
+                }
+
+                TaxEventType.GAS_FEE -> Unit // Captured via totalFees.
+            }
+        }
+
+        val openLots = inventory.values.flatten().filter { it.remainingQuantity > 1e-9 }
+            .sortedBy { it.acquiredEpochMs }
+        val shortTerm = realized.filterNot { it.isLongTerm }.sumOf { it.gainCents }
+        val longTerm = realized.filter { it.isLongTerm }.sumOf { it.gainCents }
+
+        return TaxReport(
+            method = method,
+            realizedGains = realized,
+            incomeEvents = income,
+            openLots = openLots,
+            warnings = warnings,
+            totalProceedsCents = realized.sumOf { it.proceedsCents },
+            totalCostBasisCents = realized.sumOf { it.costBasisCents },
+            totalRealizedGainCents = realized.sumOf { it.gainCents },
+            shortTermGainCents = shortTerm,
+            longTermGainCents = longTerm,
+            totalIncomeCents = income.sumOf { it.fairMarketValueCents },
+            totalFeesCents = totalFees,
+        )
+    }
+
+    @Suppress("LongParameterList")
+    private fun moveBasis(
+        inventory: HashMap<LotKey, MutableList<TaxLot>>,
+        event: CryptoTaxEvent,
+        fromKey: LotKey,
+        toKey: LotKey,
+        symbol: String,
+        qty: Double,
+        warnings: MutableList<TaxWarning>,
+        retargetSymbol: String? = null,
+        retargetQuantity: Double? = null,
+    ) {
+        val source = inventory[fromKey]
+        if (source.isNullOrEmpty()) {
+            warnings += TaxWarning(event.id, "No basis to move for $symbol; movement recorded without basis.")
+            return
+        }
+        val ordered = source.sortedBy { it.acquiredEpochMs }
+        var remaining = qty
+        var movedBasis = 0L
+        var movedQty = 0.0
+        var earliest = Long.MAX_VALUE
+        for (lot in ordered) {
+            if (remaining <= 1e-12) break
+            val take = minOf(lot.remainingQuantity, remaining)
+            if (take <= 0.0) continue
+            movedBasis += Math.round(lot.costPerUnitCents * take)
+            movedQty += take
+            earliest = minOf(earliest, lot.acquiredEpochMs)
+            val idx = source.indexOfFirst { it.id == lot.id }
+            if (idx >= 0) source[idx] = source[idx].copy(remainingQuantity = source[idx].remainingQuantity - take)
+            remaining -= take
+        }
+        source.removeAll { it.remainingQuantity <= 1e-9 }
+        if (movedQty <= 0.0) return
+
+        // Preserve the acquisition date so the holding period survives the move.
+        val destSymbol = (retargetSymbol ?: toKey.symbol).uppercase()
+        val destQty = retargetQuantity ?: movedQty
+        val destList = inventory.getOrPut(toKey.copy(symbol = destSymbol)) { mutableListOf() }
+        destList.add(
+            TaxLot(
+                id = "lot-move-${event.id}",
+                walletId = toKey.walletId,
+                chain = toKey.chain,
+                symbol = destSymbol,
+                originalQuantity = destQty,
+                remainingQuantity = destQty,
+                costBasisCents = movedBasis,
+                acquiredEpochMs = if (earliest == Long.MAX_VALUE) event.timestampEpochMs else earliest,
+            ),
+        )
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/crypto/DeFiPosition.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/crypto/DeFiPosition.kt
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DeFi position model + aggregation — Issue #2172
+//
+// Yield farmers hold a large part of their portfolio in staking, LP tokens,
+// lending markets and farming positions. Wallet balance alone is not their true
+// exposure, and pending rewards + unlock dates change usable net worth. This
+// pure model tracks those contract positions SEPARATELY from spot holdings and
+// aggregates them without any Compose / Koin / network dependency so the maths
+// is fully unit-testable.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The kind of DeFi engagement a position represents. */
+enum class DeFiPositionType(val displayName: String) {
+    STAKING("Staking"),
+    LIQUIDITY_POOL("Liquidity Pool"),
+    LENDING("Lending"),
+    FARMING("Yield Farming"),
+}
+
+/** Whether the underlying asset is currently withdrawable. */
+enum class LockState(val displayName: String) {
+    /** Freely withdrawable. */
+    LIQUID("Liquid"),
+
+    /** Locked until [DeFiPosition.unlockEpochMs]. */
+    LOCKED("Locked"),
+
+    /** In an unbonding/cooldown window before it becomes liquid. */
+    UNBONDING("Unbonding"),
+}
+
+/**
+ * A blockchain a position or lot lives on. Chain provenance is first-class so
+ * cost basis can survive cross-chain activity (#2168) and exposure can be
+ * grouped by chain (#2172).
+ */
+enum class Chain(val displayName: String, val nativeSymbol: String) {
+    ETHEREUM("Ethereum", "ETH"),
+    ARBITRUM("Arbitrum", "ARB"),
+    OPTIMISM("Optimism", "OP"),
+    POLYGON("Polygon", "MATIC"),
+    BASE("Base", "ETH"),
+    BNB("BNB Chain", "BNB"),
+    AVALANCHE("Avalanche", "AVAX"),
+    SOLANA("Solana", "SOL"),
+    COSMOS("Cosmos", "ATOM"),
+    UNKNOWN("Unknown", "?"),
+}
+
+/**
+ * A single DeFi position (staked asset, LP token, lending deposit or farm).
+ *
+ * @param assetSymbol The principal asset symbol (e.g. `"ETH"`).
+ * @param quantity Units committed to the position (may be fractional).
+ * @param valueCents Current market value of the principal, in cents.
+ * @param costBasisCents Amount originally committed, in cents.
+ * @param apyPercent Advertised/estimated annual percentage yield.
+ * @param rewardSymbol Token pending rewards are paid in.
+ * @param pendingRewardsCents Value of unclaimed rewards, in cents.
+ * @param unlockEpochMs When a [LockState.LOCKED]/[LockState.UNBONDING] position
+ *   becomes liquid, or `null` when already liquid / open-ended.
+ */
+data class DeFiPosition(
+    val id: String,
+    val protocol: String,
+    val chain: Chain,
+    val type: DeFiPositionType,
+    val assetSymbol: String,
+    val quantity: Double,
+    val valueCents: Long,
+    val costBasisCents: Long,
+    val apyPercent: Double,
+    val rewardSymbol: String,
+    val pendingRewardsCents: Long,
+    val lockState: LockState,
+    val unlockEpochMs: Long? = null,
+) {
+    /** Market value plus unclaimed rewards, in cents. */
+    val totalValueCents: Long get() = valueCents + pendingRewardsCents
+
+    /** Market value minus cost basis, in cents. */
+    val unrealizedPnlCents: Long get() = valueCents - costBasisCents
+}
+
+/** Value + share of the DeFi book attributable to a [Chain]. */
+data class ChainAllocation(val chain: Chain, val valueCents: Long, val percent: Double)
+
+/** Value + share of the DeFi book attributable to a [DeFiPositionType]. */
+data class TypeAllocation(val type: DeFiPositionType, val valueCents: Long, val percent: Double)
+
+/**
+ * Aggregated view of all DeFi positions.
+ *
+ * @param weightedApyPercent Value-weighted APY across positions.
+ */
+data class DeFiPortfolioSummary(
+    val totalValueCents: Long,
+    val totalPendingRewardsCents: Long,
+    val totalCostCents: Long,
+    val totalUnrealizedPnlCents: Long,
+    val totalUnrealizedPnlPercent: Double,
+    val weightedApyPercent: Double,
+    val positions: List<DeFiPosition>,
+    val byChain: List<ChainAllocation>,
+    val byType: List<TypeAllocation>,
+) {
+    val hasData: Boolean get() = positions.isNotEmpty()
+
+    companion object {
+        val EMPTY = DeFiPortfolioSummary(
+            totalValueCents = 0L,
+            totalPendingRewardsCents = 0L,
+            totalCostCents = 0L,
+            totalUnrealizedPnlCents = 0L,
+            totalUnrealizedPnlPercent = 0.0,
+            weightedApyPercent = 0.0,
+            positions = emptyList(),
+            byChain = emptyList(),
+            byType = emptyList(),
+        )
+    }
+}
+
+/**
+ * Portfolio composition splitting liquid spot value from value locked in
+ * contracts plus unclaimed rewards, so net-worth views stop under-reporting
+ * where money actually is (#2172).
+ */
+data class PortfolioComposition(
+    val spotValueCents: Long,
+    val lockedValueCents: Long,
+    val pendingRewardsCents: Long,
+) {
+    /** True total exposure = spot + locked principal + pending rewards. */
+    val totalValueCents: Long get() = spotValueCents + lockedValueCents + pendingRewardsCents
+
+    val spotPercent: Double get() = percentOf(spotValueCents, totalValueCents)
+    val lockedPercent: Double get() = percentOf(lockedValueCents, totalValueCents)
+    val rewardsPercent: Double get() = percentOf(pendingRewardsCents, totalValueCents)
+
+    private fun percentOf(part: Long, whole: Long): Double =
+        if (whole == 0L) 0.0 else (part.toDouble() / whole.toDouble()) * 100.0
+}
+
+/**
+ * Pure aggregation of DeFi positions. Deterministic function of its inputs.
+ */
+object DeFiPortfolioAggregator {
+
+    /** Aggregates [positions] into a [DeFiPortfolioSummary]. */
+    fun aggregate(positions: List<DeFiPosition>): DeFiPortfolioSummary {
+        if (positions.isEmpty()) return DeFiPortfolioSummary.EMPTY
+
+        val totalValue = positions.sumOf { it.valueCents }
+        val totalRewards = positions.sumOf { it.pendingRewardsCents }
+        val totalCost = positions.sumOf { it.costBasisCents }
+        val totalPnl = totalValue - totalCost
+
+        val weightedApy = if (totalValue > 0L) {
+            positions.sumOf { it.apyPercent * it.valueCents } / totalValue.toDouble()
+        } else {
+            0.0
+        }
+
+        val byChain = positions
+            .groupBy { it.chain }
+            .map { (chain, group) ->
+                val value = group.sumOf { it.valueCents }
+                ChainAllocation(chain, value, percentOf(value, totalValue))
+            }
+            .sortedByDescending { it.valueCents }
+
+        val byType = positions
+            .groupBy { it.type }
+            .map { (type, group) ->
+                val value = group.sumOf { it.valueCents }
+                TypeAllocation(type, value, percentOf(value, totalValue))
+            }
+            .sortedByDescending { it.valueCents }
+
+        return DeFiPortfolioSummary(
+            totalValueCents = totalValue,
+            totalPendingRewardsCents = totalRewards,
+            totalCostCents = totalCost,
+            totalUnrealizedPnlCents = totalPnl,
+            totalUnrealizedPnlPercent = percentOf(totalPnl, totalCost),
+            weightedApyPercent = weightedApy,
+            positions = positions.sortedByDescending { it.totalValueCents },
+            byChain = byChain,
+            byType = byType,
+        )
+    }
+
+    /**
+     * Splits total exposure into spot (liquid wallet) value versus value locked
+     * in DeFi contracts plus unclaimed rewards.
+     */
+    fun compose(spotValueCents: Long, defi: DeFiPortfolioSummary): PortfolioComposition =
+        PortfolioComposition(
+            spotValueCents = spotValueCents,
+            lockedValueCents = defi.totalValueCents,
+            pendingRewardsCents = defi.totalPendingRewardsCents,
+        )
+
+    private fun percentOf(part: Long, whole: Long): Double =
+        if (whole == 0L) 0.0 else (part.toDouble() / whole.toDouble()) * 100.0
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/crypto/DeFiTaxSources.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/crypto/DeFiTaxSources.kt
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DeFi position + tax-event sources — Issues #2172, #2168, #2702
+//
+// Abstracts where DeFi positions and taxable crypto events come from so the
+// live SQLDelight-backed path can be swapped in without touching the ViewModel
+// or UI. Until the #2702 pipeline + credentials land, deterministic offline
+// samples supply clearly-labelled illustrative data with NO network access.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Supplies the user's DeFi positions (staking, LP, lending, farming). */
+interface DeFiHoldingsSource {
+    suspend fun positions(): List<DeFiPosition>
+}
+
+/** Supplies the user's taxable crypto events across wallets and chains. */
+interface CryptoTaxEventSource {
+    suspend fun events(): List<CryptoTaxEvent>
+}
+
+/**
+ * Deterministic, offline DeFi positions used until real holdings are wired
+ * (#2702). Figures are illustrative, not financial advice.
+ */
+class SampleDeFiHoldingsSource : DeFiHoldingsSource {
+    override suspend fun positions(): List<DeFiPosition> = listOf(
+        DeFiPosition(
+            id = "d-eth-lido",
+            protocol = "Lido",
+            chain = Chain.ETHEREUM,
+            type = DeFiPositionType.STAKING,
+            assetSymbol = "stETH",
+            quantity = 4.20,
+            valueCents = 1_476_000L,
+            costBasisCents = 1_180_000L,
+            apyPercent = 3.4,
+            rewardSymbol = "stETH",
+            pendingRewardsCents = 12_400L,
+            lockState = LockState.LIQUID,
+        ),
+        DeFiPosition(
+            id = "d-usdc-aave",
+            protocol = "Aave v3",
+            chain = Chain.ARBITRUM,
+            type = DeFiPositionType.LENDING,
+            assetSymbol = "USDC",
+            quantity = 12_500.0,
+            valueCents = 1_250_000L,
+            costBasisCents = 1_250_000L,
+            apyPercent = 5.1,
+            rewardSymbol = "ARB",
+            pendingRewardsCents = 8_900L,
+            lockState = LockState.LIQUID,
+        ),
+        DeFiPosition(
+            id = "d-eth-usdc-uni",
+            protocol = "Uniswap v3",
+            chain = Chain.OPTIMISM,
+            type = DeFiPositionType.LIQUIDITY_POOL,
+            assetSymbol = "ETH/USDC",
+            quantity = 1.0,
+            valueCents = 940_000L,
+            costBasisCents = 900_000L,
+            apyPercent = 18.7,
+            rewardSymbol = "OP",
+            pendingRewardsCents = 21_500L,
+            lockState = LockState.LIQUID,
+        ),
+        DeFiPosition(
+            id = "d-dot-stake",
+            protocol = "Polkadot",
+            chain = Chain.UNKNOWN,
+            type = DeFiPositionType.STAKING,
+            assetSymbol = "DOT",
+            quantity = 940.0,
+            valueCents = 770_800L,
+            costBasisCents = 810_000L,
+            apyPercent = 14.2,
+            rewardSymbol = "DOT",
+            pendingRewardsCents = 15_600L,
+            lockState = LockState.UNBONDING,
+            unlockEpochMs = 0L,
+        ),
+        DeFiPosition(
+            id = "d-cake-farm",
+            protocol = "PancakeSwap",
+            chain = Chain.BNB,
+            type = DeFiPositionType.FARMING,
+            assetSymbol = "CAKE-BNB",
+            quantity = 320.0,
+            valueCents = 512_000L,
+            costBasisCents = 600_000L,
+            apyPercent = 42.5,
+            rewardSymbol = "CAKE",
+            pendingRewardsCents = 9_800L,
+            lockState = LockState.LOCKED,
+            unlockEpochMs = 0L,
+        ),
+    )
+}
+
+/**
+ * Deterministic, offline taxable-event history spanning buys, swaps, a bridge,
+ * a wrap, staking rewards and an airdrop across multiple chains and wallets, so
+ * the chain-aware cost-basis engine (#2168) can be demonstrated and tested.
+ */
+class SampleCryptoTaxEventSource : CryptoTaxEventSource {
+    private val day = 24L * 60 * 60 * 1000
+
+    override suspend fun events(): List<CryptoTaxEvent> = listOf(
+        CryptoTaxEvent(
+            id = "t1", type = TaxEventType.BUY, timestampEpochMs = 0L,
+            walletId = "hot", chain = Chain.ETHEREUM,
+            assetSymbol = "ETH", assetQuantity = 5.0, valueCents = 900_000L, feeCents = 1_200L,
+        ),
+        CryptoTaxEvent(
+            id = "t2", type = TaxEventType.AIRDROP, timestampEpochMs = 30 * day,
+            walletId = "hot", chain = Chain.ARBITRUM,
+            assetSymbol = "ARB", assetQuantity = 1_250.0, valueCents = 137_500L,
+        ),
+        CryptoTaxEvent(
+            id = "t3", type = TaxEventType.STAKING_REWARD, timestampEpochMs = 60 * day,
+            walletId = "hot", chain = Chain.ETHEREUM,
+            assetSymbol = "ETH", assetQuantity = 0.15, valueCents = 33_000L,
+        ),
+        CryptoTaxEvent(
+            id = "t4", type = TaxEventType.BRIDGE, timestampEpochMs = 90 * day,
+            walletId = "hot", chain = Chain.ETHEREUM,
+            assetSymbol = "ETH", assetQuantity = 2.0, valueCents = 460_000L, feeCents = 900L,
+            destinationChain = Chain.OPTIMISM, destinationWalletId = "hot",
+        ),
+        CryptoTaxEvent(
+            id = "t5", type = TaxEventType.SWAP, timestampEpochMs = 120 * day,
+            walletId = "hot", chain = Chain.OPTIMISM,
+            assetSymbol = "ETH", assetQuantity = 1.0, valueCents = 250_000L, feeCents = 400L,
+            counterAssetSymbol = "USDC", counterAssetQuantity = 2_500.0,
+        ),
+        CryptoTaxEvent(
+            id = "t6", type = TaxEventType.SELL, timestampEpochMs = 400 * day,
+            walletId = "hot", chain = Chain.ETHEREUM,
+            assetSymbol = "ETH", assetQuantity = 1.0, valueCents = 300_000L, feeCents = 500L,
+        ),
+    )
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/crypto/MarketDataConfig.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/crypto/MarketDataConfig.kt
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Market-data configuration gate — Issue #2702
+//
+// The near-real-time Windows market-data pipeline is blocked on provider
+// credentials, API terms, and Windows desktop packaging constraints. Rather
+// than hardcode any secret, the live path is gated behind an explicit feature
+// flag AND the presence of credentials in the environment. When either is
+// absent the app stays on the deterministic offline mock — no network, no keys.
+//
+// See the "## Needs Human Action" section of the batch PR for the manual
+// credential-provisioning step required to switch this on.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Provider credentials for the live market-data feed. */
+data class MarketDataCredentials(
+    val apiKey: String,
+    val baseUrl: String,
+)
+
+/**
+ * Resolved market-data settings.
+ *
+ * @param isLiveFlagEnabled Whether the operator opted into the live pipeline.
+ * @param credentials Provider credentials, or `null` when unset.
+ * @param refreshIntervalMs Polling interval for the refresh scheduler.
+ */
+data class MarketDataSettings(
+    val isLiveFlagEnabled: Boolean,
+    val credentials: MarketDataCredentials?,
+    val refreshIntervalMs: Long,
+) {
+    /**
+     * The live feed is used ONLY when the operator both enabled the flag and
+     * supplied credentials; otherwise the offline mock is used.
+     */
+    val useLiveFeed: Boolean get() = isLiveFlagEnabled && credentials != null
+
+    /** Human-readable explanation shown in diagnostics/UI. */
+    val statusLabel: String
+        get() = when {
+            useLiveFeed -> "Live market data enabled"
+            isLiveFlagEnabled -> "Live flag on but credentials missing — using offline data"
+            else -> "Offline sample data (live feed disabled)"
+        }
+}
+
+/** Reads [MarketDataSettings] from the process environment. */
+object MarketDataConfig {
+    const val ENABLE_ENV = "FINANCE_MARKET_DATA_ENABLED"
+    const val API_KEY_ENV = "FINANCE_MARKET_DATA_API_KEY"
+    const val BASE_URL_ENV = "FINANCE_MARKET_DATA_URL"
+    const val REFRESH_INTERVAL_ENV = "FINANCE_MARKET_DATA_REFRESH_MS"
+
+    /** Default polling interval when unset (30 s). */
+    const val DEFAULT_REFRESH_INTERVAL_MS: Long = 30_000L
+
+    /** Lower bound to protect provider rate limits (5 s). */
+    const val MIN_REFRESH_INTERVAL_MS: Long = 5_000L
+
+    /**
+     * Resolves settings from [env] (defaults to the real environment). Pure and
+     * side-effect free so it is fully unit-testable.
+     */
+    fun fromEnvironment(env: (String) -> String? = System::getenv): MarketDataSettings {
+        val flag = env(ENABLE_ENV)?.trim()?.lowercase()
+        val enabled = flag == "true" || flag == "1" || flag == "yes"
+
+        val apiKey = env(API_KEY_ENV)?.trim().orEmpty()
+        val baseUrl = env(BASE_URL_ENV)?.trim().orEmpty()
+        val credentials = if (apiKey.isNotEmpty() && baseUrl.isNotEmpty()) {
+            MarketDataCredentials(apiKey, baseUrl)
+        } else {
+            null
+        }
+
+        val interval = env(REFRESH_INTERVAL_ENV)?.trim()?.toLongOrNull()
+            ?.coerceAtLeast(MIN_REFRESH_INTERVAL_MS)
+            ?: DEFAULT_REFRESH_INTERVAL_MS
+
+        return MarketDataSettings(
+            isLiveFlagEnabled = enabled,
+            credentials = credentials,
+            refreshIntervalMs = interval,
+        )
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
@@ -41,4 +41,11 @@ val viewModelModule = module {
     single { GamificationViewModel(get(), get()) }
     single { CurrencyViewModel(get(), get()) }
     single { NaturalLanguageViewModel(get(), get()) }
+    // Previously-blank sidebar destinations (#3587) — now wired to real screens.
+    single { InvestmentViewModel(get()) }
+    single { HouseholdViewModel(get()) }
+    single { ReferralViewModel() }
+    // Crypto / DeFi dashboard (#2172, #2168, #2702) — offline sources + env-gated
+    // live feed are resolved via constructor defaults.
+    single { CryptoDashboardViewModel() }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.filled.AccountBalance
 import androidx.compose.material.icons.filled.Assessment
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CurrencyExchange
+import androidx.compose.material.icons.filled.CurrencyBitcoin
 import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FileUpload
@@ -80,6 +81,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.finance.desktop.accessibility.focusVisible
 import com.finance.desktop.components.KeyboardShortcut
+import com.finance.desktop.components.ShortcutCategory
 import com.finance.desktop.data.repository.AuthAccount
 import com.finance.desktop.data.repository.AuthRepository
 import com.finance.desktop.components.KeyboardShortcutEffect
@@ -125,6 +127,7 @@ enum class Screen(
     Reports("Reports", Icons.Filled.Assessment, Key.Nine, "Ctrl+9", NavGroup.PRIMARY),
     HealthScore("Health Score", Icons.Filled.Favorite, Key.Eight, "Ctrl+8", NavGroup.INSIGHTS),
     Investments("Investments", Icons.AutoMirrored.Filled.ShowChart, Key.F1, "Ctrl+F1", NavGroup.INSIGHTS),
+    Crypto("Crypto & DeFi", Icons.Filled.CurrencyBitcoin, Key.F3, "Ctrl+F3", NavGroup.INSIGHTS),
     Achievements("Achievements", Icons.Filled.EmojiEvents, Key.A, "Ctrl+A", NavGroup.INSIGHTS),
     Tips("Tips", Icons.Filled.Lightbulb, Key.T, "Ctrl+T", NavGroup.INSIGHTS),
     Household("Household", Icons.Filled.Group, Key.H, "Ctrl+H", NavGroup.TOOLS),
@@ -179,6 +182,7 @@ fun SidebarNavigation(
             KeyboardShortcut(
                 key = screen.shortcutKey,
                 description = "Navigate to ${screen.label}",
+                category = ShortcutCategory.NAVIGATION,
             ) { currentScreen = screen }
         }
     }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/ComingSoonScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/ComingSoonScreen.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Construction
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * Clear placeholder for a navigable destination whose feature is not yet
+ * implemented (#3587).
+ *
+ * Previously several sidebar destinations rendered a completely blank content
+ * pane, which looked like a crash and announced nothing to Narrator. This
+ * placeholder shows an icon, a heading (with proper heading semantics so
+ * Narrator announces it), and a short description so the user always knows the
+ * app is working.
+ *
+ * @param title Destination name, rendered as an accessible heading.
+ * @param description Short explanation of what the destination will offer.
+ * @param icon Illustrative icon; defaults to a "construction" glyph.
+ */
+@Composable
+fun ComingSoonScreen(
+    title: String,
+    description: String,
+    icon: ImageVector = Icons.Filled.Construction,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp)
+            .semantics { contentDescription = "$title. Coming soon. $description" },
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.semantics { heading() },
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = "Coming soon",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.widthIn(max = 420.dp),
+        )
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/CryptoDashboardScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/CryptoDashboardScreen.kt
@@ -36,10 +36,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.FilterChip
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -53,10 +55,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.finance.desktop.crypto.DashboardLayout
+import com.finance.desktop.crypto.LotMethod
+import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
+import com.finance.desktop.viewmodel.CompositionUi
 import com.finance.desktop.viewmodel.CryptoDashboardUiState
 import com.finance.desktop.viewmodel.CryptoDashboardViewModel
 import com.finance.desktop.viewmodel.CryptoPositionUi
+import com.finance.desktop.viewmodel.DeFiPositionUi
+import com.finance.desktop.viewmodel.TaxSummaryUi
 
 // =============================================================================
 // Crypto Portfolio Dashboard — Issue #2176
@@ -82,11 +89,9 @@ private val AllocationPalette = listOf(
 
 @Composable
 fun CryptoDashboardScreen(modifier: Modifier = Modifier) {
-    // Self-contained construction: the offline mock source ships today; the live
-    // adapter is injected here once #2702 (market-data credentials) lands.
-    // TODO(human): Replace with the live CryptoPriceSource + real holdings source
-    // (DI-provided) when the #2702 refresh pipeline and credentials are available.
-    val viewModel = remember { CryptoDashboardViewModel() }
+    // DI-provided so the offline sources / env-gated live feed and the refresh
+    // scheduler are shared and survive recomposition (#2702).
+    val viewModel = koinGet<CryptoDashboardViewModel>()
     val state by viewModel.uiState.collectAsState()
 
     if (state.isLoading) {
@@ -108,13 +113,18 @@ fun CryptoDashboardScreen(modifier: Modifier = Modifier) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .verticalScroll(rememberScrollState())
                 .padding(FinanceDesktopTheme.spacing.xxl)
                 .semantics { contentDescription = "Crypto portfolio dashboard" },
             verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.xxl),
         ) {
             DashboardHeader(state, onRefresh = viewModel::refresh)
 
+            LiveFeedBanner(state)
+
             SummaryStatsGrid(state, columns = summaryColumns)
+
+            state.composition?.let { CompositionPanel(it) }
 
             if (multiPanel) {
                 Row(
@@ -135,7 +145,325 @@ fun CryptoDashboardScreen(modifier: Modifier = Modifier) {
                 HoldingsPanel(state = state, columns = holdingsColumns)
                 AllocationPanel(state = state)
             }
+
+            DeFiPositionsPanel(state)
+
+            state.taxSummary?.let { tax ->
+                TaxSummaryPanel(
+                    tax = tax,
+                    selectedMethod = state.selectedLotMethod,
+                    onMethodSelected = viewModel::setLotMethod,
+                )
+            }
         }
+    }
+}
+
+// ─── Live feed status (#2702) ────────────────────────────────────────────────
+
+@Composable
+private fun LiveFeedBanner(state: CryptoDashboardUiState) {
+    if (state.liveFeedStatus.isBlank()) return
+    val label = buildString {
+        append(state.liveFeedStatus)
+        if (state.autoRefreshEnabled) append(" · auto-refresh on")
+    }
+    AssistChip(
+        onClick = {},
+        enabled = false,
+        label = { Text(label, style = MaterialTheme.typography.labelMedium) },
+        leadingIcon = { Icon(Icons.Filled.Refresh, contentDescription = null, Modifier.size(18.dp)) },
+        modifier = Modifier.semantics {
+            contentDescription = "Market data feed: $label"
+            liveRegion = LiveRegionMode.Polite
+        },
+    )
+}
+
+// ─── Composition: spot vs locked vs rewards (#2172) ──────────────────────────
+
+@Composable
+private fun CompositionPanel(composition: CompositionUi) {
+    Column {
+        Text(
+            text = "Portfolio composition",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Portfolio composition: spot versus DeFi"
+            },
+        )
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+        ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+                CompositionRow(
+                    label = "Spot holdings",
+                    value = composition.spotValue,
+                    percent = composition.spotPercent,
+                    swatch = AllocationPalette[0],
+                )
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+                CompositionRow(
+                    label = "DeFi (locked / staked)",
+                    value = composition.lockedValue,
+                    percent = composition.lockedPercent,
+                    swatch = AllocationPalette[3],
+                )
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+                CompositionRow(
+                    label = "Pending rewards",
+                    value = composition.pendingRewards,
+                    percent = composition.rewardsPercent,
+                    swatch = AllocationPalette[1],
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CompositionRow(label: String, value: String, percent: Float, swatch: Color) {
+    val pctLabel = "${(percent * 100).toInt()}%"
+    Column(
+        modifier = Modifier.semantics {
+            contentDescription = "$label: $value, $pctLabel of portfolio"
+        },
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .clip(CircleShape)
+                    .background(swatch),
+            )
+            Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.weight(1f),
+            )
+            Text(text = value, style = MaterialTheme.typography.bodyMedium)
+            Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+            Text(
+                text = pctLabel,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+        LinearProgressIndicator(
+            progress = { percent },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .clip(RoundedCornerShape(3.dp)),
+            color = swatch,
+        )
+    }
+}
+
+// ─── DeFi positions (#2172) ──────────────────────────────────────────────────
+
+@Composable
+private fun DeFiPositionsPanel(state: CryptoDashboardUiState) {
+    Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "DeFi positions",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier
+                    .weight(1f)
+                    .semantics {
+                        heading()
+                        contentDescription = "DeFi positions, tracked separately from spot holdings"
+                    },
+            )
+            if (state.defiPositions.isNotEmpty()) {
+                AssistChip(
+                    onClick = {},
+                    enabled = false,
+                    label = { Text("APY ${state.defiWeightedApy}%") },
+                )
+            }
+        }
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+        if (state.defiPositions.isEmpty()) {
+            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = "No DeFi positions. Staking, LP, and lending positions appear here separately from spot holdings.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
+                )
+            }
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.md)) {
+                state.defiPositions.forEach { DeFiPositionCard(it) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeFiPositionCard(position: DeFiPositionUi) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = position.accessibilityLabel },
+    ) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = position.protocol,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                AssistChip(onClick = {}, enabled = false, label = { Text(position.chain) })
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.xs))
+                AssistChip(onClick = {}, enabled = false, label = { Text(position.type) })
+                Spacer(Modifier.weight(1f))
+                if (position.isLocked) {
+                    AssistChip(
+                        onClick = {},
+                        enabled = false,
+                        label = { Text(position.lockState) },
+                        leadingIcon = {
+                            Icon(Icons.Filled.Warning, contentDescription = null, Modifier.size(16.dp))
+                        },
+                    )
+                }
+            }
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+            Text(
+                text = "${position.value} · ${position.quantity} ${position.asset}",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "APY ${position.apy}%",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                Text(
+                    text = "Rewards ${position.pendingRewards} ${position.rewardSymbol}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                DirectionIcon(position.isPnlPositive)
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.xs))
+                Text(
+                    text = "P/L ${position.pnl}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = position.isPnlPositive.toAmountColor(),
+                )
+            }
+        }
+    }
+}
+
+// ─── Tax summary (#2168) ─────────────────────────────────────────────────────
+
+@Composable
+private fun TaxSummaryPanel(
+    tax: TaxSummaryUi,
+    selectedMethod: LotMethod,
+    onMethodSelected: (LotMethod) -> Unit,
+) {
+    Column {
+        Text(
+            text = "Cost basis & taxable events",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Chain-aware cost basis and taxable events"
+            },
+        )
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+        ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+                    modifier = Modifier.semantics {
+                        contentDescription = "Lot relief method"
+                    },
+                ) {
+                    Text(
+                        text = "Method",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    LotMethod.entries.forEach { method ->
+                        FilterChip(
+                            selected = method == selectedMethod,
+                            onClick = { onMethodSelected(method) },
+                            label = { Text(method.displayName) },
+                        )
+                    }
+                }
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+                TaxRow("Realized gain / loss", tax.realizedGain, tax.isGainPositive)
+                TaxRow("Short-term", tax.shortTermGain, null)
+                TaxRow("Long-term", tax.longTermGain, null)
+                TaxRow("Income (airdrops / staking)", tax.totalIncome, null)
+                TaxRow("Fees", tax.totalFees, null)
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+                Text(
+                    text = "${tax.eventCount} taxable events · ${tax.openLotCount} open lots",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                tax.warnings.forEach { warning ->
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Filled.Warning,
+                            contentDescription = "Warning",
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                        Spacer(Modifier.width(FinanceDesktopTheme.spacing.xs))
+                        Text(
+                            text = warning,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TaxRow(label: String, value: String, positive: Boolean?) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = FinanceDesktopTheme.spacing.xs)
+            .semantics { contentDescription = "$label: $value" },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            color = positive.toAmountColor(),
+        )
     }
 }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/FeedbackDialog.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/FeedbackDialog.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.finance.desktop.components.trackTextInputFocus
 import com.finance.desktop.theme.FinanceDesktopTheme
 
 /**
@@ -154,6 +155,7 @@ fun FeedbackDialog(
                     maxLines = 8,
                     modifier = Modifier
                         .fillMaxWidth()
+                        .trackTextInputFocus()
                         .semantics {
                             contentDescription = "Feedback description. " +
                                 "Describe the bug, feedback, or suggestion in detail."

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/GoalsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/GoalsScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.finance.desktop.components.ListEmptyState
 import com.finance.desktop.components.ListErrorState
+import com.finance.desktop.components.trackTextInputFocus
 import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
 import com.finance.desktop.viewmodel.GoalItemUi
@@ -252,7 +253,7 @@ private fun GoalEditDialog(
                     onValueChange = onNameChange,
                     label = { Text("Goal Name") },
                     singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth().trackTextInputFocus(),
                 )
                 Spacer(Modifier.height(12.dp))
                 OutlinedTextField(
@@ -260,7 +261,7 @@ private fun GoalEditDialog(
                     onValueChange = onTargetAmountChange,
                     label = { Text("Target Amount ($)") },
                     singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth().trackTextInputFocus(),
                 )
                 Spacer(Modifier.height(12.dp))
                 OutlinedTextField(
@@ -268,7 +269,7 @@ private fun GoalEditDialog(
                     onValueChange = onCurrentAmountChange,
                     label = { Text("Current Amount ($)") },
                     singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth().trackTextInputFocus(),
                 )
             }
         },

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/QuickAddTransactionDialog.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/QuickAddTransactionDialog.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.finance.desktop.components.trackTextInputFocus
 import com.finance.desktop.theme.FinanceDesktopTheme
 import com.finance.desktop.tray.FinanceSystemTray
 import com.finance.desktop.tray.QuickAddTransactionManager
@@ -122,6 +123,7 @@ fun QuickAddTransactionDialog(
                     singleLine = true,
                     modifier = Modifier
                         .fillMaxWidth()
+                        .trackTextInputFocus()
                         .semantics {
                             contentDescription = "Payee name"
                         },
@@ -138,6 +140,7 @@ fun QuickAddTransactionDialog(
                     singleLine = true,
                     modifier = Modifier
                         .fillMaxWidth()
+                        .trackTextInputFocus()
                         .semantics {
                             contentDescription = "Transaction amount in dollars"
                         },

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/CryptoDashboardViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/CryptoDashboardViewModel.kt
@@ -7,8 +7,21 @@ import com.finance.desktop.crypto.CryptoFormat
 import com.finance.desktop.crypto.CryptoHoldingsSource
 import com.finance.desktop.crypto.CryptoPortfolioAggregator
 import com.finance.desktop.crypto.CryptoPriceSource
+import com.finance.desktop.crypto.CryptoRefreshScheduler
+import com.finance.desktop.crypto.CryptoTaxEngine
+import com.finance.desktop.crypto.CryptoTaxEventSource
+import com.finance.desktop.crypto.DeFiHoldingsSource
+import com.finance.desktop.crypto.DeFiPortfolioAggregator
+import com.finance.desktop.crypto.LockState
+import com.finance.desktop.crypto.LotMethod
+import com.finance.desktop.crypto.MarketDataConfig
+import com.finance.desktop.crypto.MarketDataSettings
 import com.finance.desktop.crypto.MockCryptoPriceSource
+import com.finance.desktop.crypto.PortfolioComposition
 import com.finance.desktop.crypto.SampleCryptoHoldingsSource
+import com.finance.desktop.crypto.SampleCryptoTaxEventSource
+import com.finance.desktop.crypto.SampleDeFiHoldingsSource
+import com.finance.desktop.crypto.TaxReport
 import com.finance.models.types.Cents
 import com.finance.models.types.Currency
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -46,6 +59,50 @@ data class CryptoPositionUi(
     val accessibilityLabel: String,
 )
 
+/** UI projection of a single DeFi position (#2172). */
+data class DeFiPositionUi(
+    val id: String,
+    val protocol: String,
+    val chain: String,
+    val type: String,
+    val asset: String,
+    val quantity: String,
+    val value: String,
+    val apy: String,
+    val pendingRewards: String,
+    val rewardSymbol: String,
+    val lockState: String,
+    val isLocked: Boolean,
+    val pnl: String,
+    val isPnlPositive: Boolean,
+    val accessibilityLabel: String,
+)
+
+/** UI projection of portfolio composition: spot vs locked vs rewards (#2172). */
+data class CompositionUi(
+    val spotValue: String,
+    val lockedValue: String,
+    val pendingRewards: String,
+    val totalValue: String,
+    val spotPercent: Float,
+    val lockedPercent: Float,
+    val rewardsPercent: Float,
+)
+
+/** UI projection of the crypto tax summary (#2168). */
+data class TaxSummaryUi(
+    val method: String,
+    val realizedGain: String,
+    val isGainPositive: Boolean,
+    val shortTermGain: String,
+    val longTermGain: String,
+    val totalIncome: String,
+    val totalFees: String,
+    val openLotCount: Int,
+    val eventCount: Int,
+    val warnings: List<String>,
+)
+
 data class CryptoDashboardUiState(
     val isLoading: Boolean = true,
     val isRefreshing: Boolean = false,
@@ -63,20 +120,41 @@ data class CryptoDashboardUiState(
     val stalenessLabel: String = "",
     val missingSymbols: List<String> = emptyList(),
     val errorMessage: String? = null,
+    // ── DeFi separation (#2172) ──
+    val defiPositions: List<DeFiPositionUi> = emptyList(),
+    val defiTotalValue: String = "",
+    val defiPendingRewards: String = "",
+    val defiWeightedApy: String = "",
+    val composition: CompositionUi? = null,
+    // ── Chain-aware cost basis + tax (#2168) ──
+    val taxSummary: TaxSummaryUi? = null,
+    val selectedLotMethod: LotMethod = LotMethod.FIFO,
+    // ── Live pipeline gate (#2702) ──
+    val liveFeedStatus: String = "",
+    val autoRefreshEnabled: Boolean = false,
 )
 
 /**
- * Loads crypto holdings, values them against the injected [priceSource], and
- * exposes a formatted [uiState].
+ * Loads crypto holdings, values them against the injected [priceSource], tracks
+ * DeFi positions separately from spot holdings (#2172), computes chain-aware
+ * cost-basis / taxable-event summaries (#2168), and drives a gated near-real-time
+ * refresh loop (#2702).
  *
- * @param holdingsSource Where positions come from (offline sample by default).
+ * @param holdingsSource Where spot positions come from (offline sample by default).
  * @param priceSource Near-real-time prices (offline mock by default).
+ * @param defiSource DeFi positions source (offline sample by default).
+ * @param taxEventSource Taxable crypto event history (offline sample by default).
+ * @param settings Market-data gate; when live is disabled/unconfigured the
+ *   offline sources are used (#2702).
  * @param clock Supplies "now" for staleness + relative-time labels.
  * @param currency Display currency for all monetary formatting.
  */
 class CryptoDashboardViewModel(
     private val holdingsSource: CryptoHoldingsSource = SampleCryptoHoldingsSource(),
     private val priceSource: CryptoPriceSource = MockCryptoPriceSource(),
+    private val defiSource: DeFiHoldingsSource = SampleDeFiHoldingsSource(),
+    private val taxEventSource: CryptoTaxEventSource = SampleCryptoTaxEventSource(),
+    private val settings: MarketDataSettings = MarketDataConfig.fromEnvironment(),
     private val clock: () -> Long = { System.currentTimeMillis() },
     private val currency: Currency = Currency.USD,
 ) : DesktopViewModel() {
@@ -84,8 +162,51 @@ class CryptoDashboardViewModel(
     private val _uiState = MutableStateFlow(CryptoDashboardUiState())
     val uiState: StateFlow<CryptoDashboardUiState> = _uiState.asStateFlow()
 
+    private var lotMethod: LotMethod = LotMethod.FIFO
+
+    private val scheduler = CryptoRefreshScheduler(
+        scope = viewModelScope,
+        baseIntervalMs = settings.refreshIntervalMs,
+        onError = { error ->
+            _uiState.value = _uiState.value.copy(
+                isStale = true,
+                stalenessLabel = "Prices may be out of date",
+                errorMessage = error.message,
+            )
+        },
+    )
+
     init {
         refresh()
+        // The gated live pipeline (#2702): only auto-poll when a live feed is
+        // configured. The offline mock is loaded once and does not self-poll to
+        // avoid pointless churn.
+        if (settings.useLiveFeed) {
+            startAutoRefresh()
+        }
+    }
+
+    /** Starts the near-real-time polling loop (#2702). */
+    fun startAutoRefresh() {
+        scheduler.start { refreshSuspending() }
+        _uiState.value = _uiState.value.copy(autoRefreshEnabled = true)
+    }
+
+    /** Stops the near-real-time polling loop. */
+    fun stopAutoRefresh() {
+        scheduler.stop()
+        _uiState.value = _uiState.value.copy(autoRefreshEnabled = false)
+    }
+
+    /** Recomputes the tax report under a different [method] (#2168). */
+    fun setLotMethod(method: LotMethod) {
+        lotMethod = method
+        refresh()
+    }
+
+    override fun onCleared() {
+        scheduler.stop()
+        super.onCleared()
     }
 
     /**
@@ -98,89 +219,170 @@ class CryptoDashboardViewModel(
      * "## Needs Human Action" section of the PR for details.
      */
     fun refresh() {
-        viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isRefreshing = true, errorMessage = null)
-            try {
-                val holdings = holdingsSource.holdings()
-                val symbols = holdings.map { it.symbol }
-                val prices = priceSource.latestPrices(symbols)
-                val now = clock()
-                val summary = CryptoPortfolioAggregator.aggregate(
-                    holdings = holdings,
-                    prices = prices,
-                    nowEpochMs = now,
-                )
+        viewModelScope.launch { refreshSuspending() }
+    }
 
-                val positions = summary.positions.map { p ->
-                    val directionWord = CryptoFormat.directionWord(p.change24hPercent)
-                    val pnlWord = if (p.unrealizedPnlCents >= 0) "gain" else "loss"
-                    CryptoPositionUi(
-                        id = p.id,
-                        symbol = p.symbol,
-                        name = p.name,
-                        quantity = formatQuantity(p.quantity),
-                        price = CurrencyFormatter.format(Cents(p.priceCents), currency),
-                        value = CurrencyFormatter.format(Cents(p.marketValueCents), currency),
-                        allocationPercent = (p.allocationPercent / 100.0).toFloat(),
-                        allocationLabel = CryptoFormat.signedPercent(p.allocationPercent)
-                            .removePrefix("+"),
-                        change24h = CurrencyFormatter.format(
-                            Cents(p.change24hCents), currency, showSign = true,
-                        ),
-                        change24hPercent = CryptoFormat.signedPercent(p.change24hPercent),
-                        is24hPositive = p.change24hCents >= 0,
-                        pnl = CurrencyFormatter.format(
-                            Cents(p.unrealizedPnlCents), currency, showSign = true,
-                        ),
-                        pnlPercent = CryptoFormat.signedPercent(p.unrealizedPnlPercent),
-                        isPnlPositive = p.unrealizedPnlCents >= 0,
-                        isStale = p.isPriceStale,
-                        accessibilityLabel = buildString {
-                            append("${p.name}, ${formatQuantity(p.quantity)} ${p.symbol}, ")
-                            append("worth ${CurrencyFormatter.format(Cents(p.marketValueCents), currency)}, ")
-                            append("$directionWord ${CryptoFormat.signedPercent(p.change24hPercent).trimStart('+', '-')} ")
-                            append("over 24 hours, ")
-                            append("$pnlWord of ${CurrencyFormatter.format(Cents(p.unrealizedPnlCents).abs(), currency)}")
-                            if (p.isPriceStale) append(", price may be out of date")
-                        },
-                    )
-                }
+    @Suppress("LongMethod") // Cohesive mapping of the full dashboard snapshot.
+    private suspend fun refreshSuspending() {
+        _uiState.value = _uiState.value.copy(isRefreshing = true, errorMessage = null)
+        try {
+            val holdings = holdingsSource.holdings()
+            val symbols = holdings.map { it.symbol }
+            val prices = priceSource.latestPrices(symbols)
+            val now = clock()
+            val summary = CryptoPortfolioAggregator.aggregate(
+                holdings = holdings,
+                prices = prices,
+                nowEpochMs = now,
+            )
 
-                val deltaMs = now - summary.oldestPriceEpochMs
-                _uiState.value = CryptoDashboardUiState(
-                    isLoading = false,
-                    isRefreshing = false,
-                    totalValue = CurrencyFormatter.format(Cents(summary.totalValueCents), currency),
-                    totalPnl = CurrencyFormatter.format(
-                        Cents(summary.totalPnlCents), currency, showSign = true,
+            val positions = summary.positions.map { p ->
+                val directionWord = CryptoFormat.directionWord(p.change24hPercent)
+                val pnlWord = if (p.unrealizedPnlCents >= 0) "gain" else "loss"
+                CryptoPositionUi(
+                    id = p.id,
+                    symbol = p.symbol,
+                    name = p.name,
+                    quantity = formatQuantity(p.quantity),
+                    price = CurrencyFormatter.format(Cents(p.priceCents), currency),
+                    value = CurrencyFormatter.format(Cents(p.marketValueCents), currency),
+                    allocationPercent = (p.allocationPercent / 100.0).toFloat(),
+                    allocationLabel = CryptoFormat.signedPercent(p.allocationPercent)
+                        .removePrefix("+"),
+                    change24h = CurrencyFormatter.format(
+                        Cents(p.change24hCents), currency, showSign = true,
                     ),
-                    totalPnlPercent = CryptoFormat.signedPercent(summary.totalPnlPercent),
-                    isPnlPositive = summary.totalPnlCents >= 0,
-                    total24hChange = CurrencyFormatter.format(
-                        Cents(summary.total24hChangeCents), currency, showSign = true,
+                    change24hPercent = CryptoFormat.signedPercent(p.change24hPercent),
+                    is24hPositive = p.change24hCents >= 0,
+                    pnl = CurrencyFormatter.format(
+                        Cents(p.unrealizedPnlCents), currency, showSign = true,
                     ),
-                    total24hChangePercent = CryptoFormat.signedPercent(summary.total24hChangePercent),
-                    is24hPositive = summary.total24hChangeCents >= 0,
-                    positions = positions,
-                    sourceName = priceSource.sourceName,
-                    lastUpdatedLabel = if (summary.hasData) {
-                        CryptoFormat.relativeUpdated(deltaMs)
-                    } else {
-                        "No price data"
+                    pnlPercent = CryptoFormat.signedPercent(p.unrealizedPnlPercent),
+                    isPnlPositive = p.unrealizedPnlCents >= 0,
+                    isStale = p.isPriceStale,
+                    accessibilityLabel = buildString {
+                        append("${p.name}, ${formatQuantity(p.quantity)} ${p.symbol}, ")
+                        append("worth ${CurrencyFormatter.format(Cents(p.marketValueCents), currency)}, ")
+                        append("$directionWord ${CryptoFormat.signedPercent(p.change24hPercent).trimStart('+', '-')} ")
+                        append("over 24 hours, ")
+                        append("$pnlWord of ${CurrencyFormatter.format(Cents(p.unrealizedPnlCents).abs(), currency)}")
+                        if (p.isPriceStale) append(", price may be out of date")
                     },
-                    isStale = summary.isStale,
-                    stalenessLabel = if (summary.isStale) "Prices may be out of date" else "Live",
-                    missingSymbols = summary.missingPriceSymbols,
-                )
-            } catch (e: IllegalStateException) {
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    isRefreshing = false,
-                    errorMessage = e.message ?: "Could not refresh prices",
                 )
             }
+
+            // ── DeFi separation (#2172) ──
+            val defiSummary = DeFiPortfolioAggregator.aggregate(defiSource.positions())
+            val composition = DeFiPortfolioAggregator.compose(summary.totalValueCents, defiSummary)
+            val defiPositions = defiSummary.positions.map { mapDeFiPosition(it) }
+
+            // ── Chain-aware cost basis + tax (#2168) ──
+            val taxReport = CryptoTaxEngine.process(taxEventSource.events(), lotMethod)
+
+            val deltaMs = now - summary.oldestPriceEpochMs
+            _uiState.value = CryptoDashboardUiState(
+                isLoading = false,
+                isRefreshing = false,
+                totalValue = CurrencyFormatter.format(Cents(summary.totalValueCents), currency),
+                totalPnl = CurrencyFormatter.format(
+                    Cents(summary.totalPnlCents), currency, showSign = true,
+                ),
+                totalPnlPercent = CryptoFormat.signedPercent(summary.totalPnlPercent),
+                isPnlPositive = summary.totalPnlCents >= 0,
+                total24hChange = CurrencyFormatter.format(
+                    Cents(summary.total24hChangeCents), currency, showSign = true,
+                ),
+                total24hChangePercent = CryptoFormat.signedPercent(summary.total24hChangePercent),
+                is24hPositive = summary.total24hChangeCents >= 0,
+                positions = positions,
+                sourceName = priceSource.sourceName,
+                lastUpdatedLabel = if (summary.hasData) {
+                    CryptoFormat.relativeUpdated(deltaMs)
+                } else {
+                    "No price data"
+                },
+                isStale = summary.isStale,
+                stalenessLabel = if (summary.isStale) "Prices may be out of date" else "Live",
+                missingSymbols = summary.missingPriceSymbols,
+                defiPositions = defiPositions,
+                defiTotalValue = CurrencyFormatter.format(Cents(defiSummary.totalValueCents), currency),
+                defiPendingRewards = CurrencyFormatter.format(
+                    Cents(defiSummary.totalPendingRewardsCents), currency,
+                ),
+                defiWeightedApy = CryptoFormat.signedPercent(defiSummary.weightedApyPercent)
+                    .removePrefix("+"),
+                composition = mapComposition(composition),
+                taxSummary = mapTaxSummary(taxReport),
+                selectedLotMethod = lotMethod,
+                liveFeedStatus = settings.statusLabel,
+                autoRefreshEnabled = scheduler.isRunning,
+            )
+        } catch (e: IllegalStateException) {
+            _uiState.value = _uiState.value.copy(
+                isLoading = false,
+                isRefreshing = false,
+                errorMessage = e.message ?: "Could not refresh prices",
+            )
         }
     }
+
+    private fun mapDeFiPosition(p: com.finance.desktop.crypto.DeFiPosition): DeFiPositionUi {
+        val pnlWord = if (p.unrealizedPnlCents >= 0) "gain" else "loss"
+        return DeFiPositionUi(
+            id = p.id,
+            protocol = p.protocol,
+            chain = p.chain.displayName,
+            type = p.type.displayName,
+            asset = p.assetSymbol,
+            quantity = formatQuantity(p.quantity),
+            value = CurrencyFormatter.format(Cents(p.valueCents), currency),
+            apy = CryptoFormat.signedPercent(p.apyPercent).removePrefix("+"),
+            pendingRewards = CurrencyFormatter.format(Cents(p.pendingRewardsCents), currency),
+            rewardSymbol = p.rewardSymbol,
+            lockState = p.lockState.displayName,
+            isLocked = p.lockState != LockState.LIQUID,
+            pnl = CurrencyFormatter.format(Cents(p.unrealizedPnlCents), currency, showSign = true),
+            isPnlPositive = p.unrealizedPnlCents >= 0,
+            accessibilityLabel = buildString {
+                append("${p.protocol} ${p.type.displayName} on ${p.chain.displayName}, ")
+                append("${formatQuantity(p.quantity)} ${p.assetSymbol} ")
+                append("worth ${CurrencyFormatter.format(Cents(p.valueCents), currency)}, ")
+                append("${p.apyPercent} percent APY, ")
+                append("${p.lockState.displayName}, ")
+                append("pending rewards ${CurrencyFormatter.format(Cents(p.pendingRewardsCents), currency)} ${p.rewardSymbol}, ")
+                append("$pnlWord of ${CurrencyFormatter.format(Cents(p.unrealizedPnlCents).abs(), currency)}")
+            },
+        )
+    }
+
+    private fun mapComposition(c: PortfolioComposition): CompositionUi = CompositionUi(
+        spotValue = CurrencyFormatter.format(Cents(c.spotValueCents), currency),
+        lockedValue = CurrencyFormatter.format(Cents(c.lockedValueCents), currency),
+        pendingRewards = CurrencyFormatter.format(Cents(c.pendingRewardsCents), currency),
+        totalValue = CurrencyFormatter.format(Cents(c.totalValueCents), currency),
+        spotPercent = (c.spotPercent / 100.0).toFloat(),
+        lockedPercent = (c.lockedPercent / 100.0).toFloat(),
+        rewardsPercent = (c.rewardsPercent / 100.0).toFloat(),
+    )
+
+    private fun mapTaxSummary(report: TaxReport): TaxSummaryUi = TaxSummaryUi(
+        method = report.method.displayName,
+        realizedGain = CurrencyFormatter.format(
+            Cents(report.totalRealizedGainCents), currency, showSign = true,
+        ),
+        isGainPositive = report.totalRealizedGainCents >= 0,
+        shortTermGain = CurrencyFormatter.format(
+            Cents(report.shortTermGainCents), currency, showSign = true,
+        ),
+        longTermGain = CurrencyFormatter.format(
+            Cents(report.longTermGainCents), currency, showSign = true,
+        ),
+        totalIncome = CurrencyFormatter.format(Cents(report.totalIncomeCents), currency),
+        totalFees = CurrencyFormatter.format(Cents(report.totalFeesCents), currency),
+        openLotCount = report.openLots.size,
+        eventCount = report.realizedGains.size + report.incomeEvents.size,
+        warnings = report.warnings.map { it.message },
+    )
 
     private fun formatQuantity(quantity: Double): String {
         // Trim trailing zeros while keeping small fractional crypto amounts readable.

--- a/apps/windows/src/test/kotlin/com/finance/desktop/components/KeyboardShortcutFocusTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/components/KeyboardShortcutFocusTest.kt
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.components
+
+import androidx.compose.ui.input.key.Key
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that global NAVIGATION shortcuts stop hijacking editing combos like
+ * Ctrl+A (Select All) while a text field is focused (#3585), while ACTION
+ * shortcuts and un-focused navigation continue to fire.
+ *
+ * Exercises [ShortcutHandler.dispatch] — the pure focus-aware decision split out
+ * of `onKeyEvent` so it can be tested without constructing platform key events.
+ */
+class KeyboardShortcutFocusTest {
+
+    @BeforeTest
+    fun resetFocus() {
+        TextInputFocusTracker.reset()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        TextInputFocusTracker.reset()
+    }
+
+    @Test
+    fun `navigation shortcut fires when no text field is focused`() {
+        val handler = ShortcutHandler()
+        var fired = false
+        handler.register(
+            KeyboardShortcut(
+                key = Key.A,
+                ctrl = true,
+                description = "Achievements",
+                category = ShortcutCategory.NAVIGATION,
+            ) { fired = true },
+        )
+
+        val consumed = handler.dispatch(Key.A, ctrl = true, shift = false)
+
+        assertTrue(consumed)
+        assertTrue(fired)
+    }
+
+    @Test
+    fun `navigation shortcut is suppressed while a text field is focused`() {
+        val handler = ShortcutHandler()
+        var fired = false
+        handler.register(
+            KeyboardShortcut(
+                key = Key.A,
+                ctrl = true,
+                description = "Achievements",
+                category = ShortcutCategory.NAVIGATION,
+            ) { fired = true },
+        )
+
+        TextInputFocusTracker.onFocusGained()
+        val consumed = handler.dispatch(Key.A, ctrl = true, shift = false)
+
+        // Ctrl+A must reach the focused field (Select All), not navigate.
+        assertFalse(consumed)
+        assertFalse(fired)
+    }
+
+    @Test
+    fun `action shortcut still fires while a text field is focused`() {
+        val handler = ShortcutHandler()
+        var fired = false
+        handler.register(
+            KeyboardShortcut(
+                key = Key.N,
+                ctrl = true,
+                shift = true,
+                description = "New transaction",
+                category = ShortcutCategory.ACTION,
+            ) { fired = true },
+        )
+
+        TextInputFocusTracker.onFocusGained()
+        val consumed = handler.dispatch(Key.N, ctrl = true, shift = true)
+
+        assertTrue(consumed)
+        assertTrue(fired)
+    }
+
+    @Test
+    fun `navigation fires again after the field loses focus`() {
+        val handler = ShortcutHandler()
+        var count = 0
+        handler.register(
+            KeyboardShortcut(
+                key = Key.A,
+                ctrl = true,
+                description = "Achievements",
+                category = ShortcutCategory.NAVIGATION,
+            ) { count++ },
+        )
+
+        TextInputFocusTracker.onFocusGained()
+        handler.dispatch(Key.A, ctrl = true, shift = false)
+        TextInputFocusTracker.onFocusLost()
+        handler.dispatch(Key.A, ctrl = true, shift = false)
+
+        assertTrue(count == 1)
+    }
+
+    @Test
+    fun `nested focus requires all fields to blur before navigation resumes`() {
+        TextInputFocusTracker.onFocusGained()
+        TextInputFocusTracker.onFocusGained()
+        TextInputFocusTracker.onFocusLost()
+        assertTrue(TextInputFocusTracker.isTextInputFocused)
+        TextInputFocusTracker.onFocusLost()
+        assertFalse(TextInputFocusTracker.isTextInputFocused)
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/crypto/CryptoTaxEngineTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/crypto/CryptoTaxEngineTest.kt
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the chain-aware cost-basis / taxable-event engine
+ * ([CryptoTaxEngine]) — #2168.
+ *
+ * Pins FIFO/HIFO lot relief, airdrop/staking income classification, basis
+ * preservation across bridges/wraps, short-vs-long-term treatment and swap
+ * disposal + acquisition. Pure and deterministic — no UI, no network.
+ */
+class CryptoTaxEngineTest {
+
+    private val day = 24L * 60 * 60 * 1000
+
+    private fun buy(id: String, at: Long, symbol: String, qty: Double, cents: Long, wallet: String = "w", chain: Chain = Chain.ETHEREUM) =
+        CryptoTaxEvent(id, TaxEventType.BUY, at, wallet, chain, symbol, qty, cents)
+
+    private fun sell(id: String, at: Long, symbol: String, qty: Double, cents: Long, wallet: String = "w", chain: Chain = Chain.ETHEREUM) =
+        CryptoTaxEvent(id, TaxEventType.SELL, at, wallet, chain, symbol, qty, cents)
+
+    @Test
+    fun `empty events produce an empty report`() {
+        val report = CryptoTaxEngine.process(emptyList(), LotMethod.FIFO)
+        assertEquals(0L, report.totalRealizedGainCents)
+        assertTrue(report.realizedGains.isEmpty())
+        assertEquals(LotMethod.FIFO, report.method)
+    }
+
+    @Test
+    fun `FIFO relieves the oldest lot first`() {
+        val events = listOf(
+            buy("b1", 0L, "ETH", 1.0, 100_000L),
+            buy("b2", 10 * day, "ETH", 1.0, 300_000L),
+            sell("s1", 20 * day, "ETH", 1.0, 250_000L),
+        )
+        val report = CryptoTaxEngine.process(events, LotMethod.FIFO)
+        // FIFO relieves the 100k lot → gain = 250k - 100k = 150k.
+        assertEquals(150_000L, report.totalRealizedGainCents)
+        assertEquals(1, report.realizedGains.size)
+        // One 300k lot remains open.
+        assertEquals(1, report.openLots.size)
+        assertEquals(300_000L, report.openLots.first().costBasisCents)
+    }
+
+    @Test
+    fun `HIFO relieves the highest-cost lot first`() {
+        val events = listOf(
+            buy("b1", 0L, "ETH", 1.0, 100_000L),
+            buy("b2", 10 * day, "ETH", 1.0, 300_000L),
+            sell("s1", 20 * day, "ETH", 1.0, 250_000L),
+        )
+        val report = CryptoTaxEngine.process(events, LotMethod.HIFO)
+        // HIFO relieves the 300k lot → loss = 250k - 300k = -50k.
+        assertEquals(-50_000L, report.totalRealizedGainCents)
+        assertEquals(100_000L, report.openLots.first().costBasisCents)
+    }
+
+    @Test
+    fun `airdrops and staking rewards are ordinary income at fair value`() {
+        val events = listOf(
+            CryptoTaxEvent("a1", TaxEventType.AIRDROP, 0L, "w", Chain.ARBITRUM, "ARB", 1_000.0, 100_000L),
+            CryptoTaxEvent("r1", TaxEventType.STAKING_REWARD, day, "w", Chain.ETHEREUM, "ETH", 0.1, 20_000L),
+        )
+        val report = CryptoTaxEngine.process(events, LotMethod.FIFO)
+        assertEquals(120_000L, report.totalIncomeCents)
+        assertEquals(2, report.incomeEvents.size)
+        // Income establishes basis so later disposal only taxes the capital move.
+        assertEquals(2, report.openLots.size)
+    }
+
+    @Test
+    fun `income basis means a later sale at same price yields zero gain`() {
+        val events = listOf(
+            CryptoTaxEvent("a1", TaxEventType.AIRDROP, 0L, "w", Chain.ARBITRUM, "ARB", 1_000.0, 100_000L),
+            sell("s1", day, "ARB", 1_000.0, 100_000L, chain = Chain.ARBITRUM),
+        )
+        val report = CryptoTaxEngine.process(events, LotMethod.FIFO)
+        assertEquals(100_000L, report.totalIncomeCents)
+        assertEquals(0L, report.totalRealizedGainCents)
+    }
+
+    @Test
+    fun `bridge preserves basis and holding period across chains`() {
+        val events = listOf(
+            buy("b1", 0L, "ETH", 2.0, 400_000L, chain = Chain.ETHEREUM),
+            CryptoTaxEvent(
+                "br1", TaxEventType.BRIDGE, 10 * day, "w", Chain.ETHEREUM,
+                "ETH", 2.0, 460_000L,
+                destinationChain = Chain.OPTIMISM, destinationWalletId = "w",
+            ),
+            // Sell on the destination chain 400 days after the ORIGINAL buy.
+            sell("s1", 400 * day, "ETH", 2.0, 500_000L, chain = Chain.OPTIMISM),
+        )
+        val report = CryptoTaxEngine.process(events, LotMethod.FIFO)
+        // Bridge is not a disposal; basis (400k) carries to Optimism.
+        assertEquals(100_000L, report.totalRealizedGainCents)
+        // Holding period survived the bridge → long-term.
+        assertTrue(report.realizedGains.single().isLongTerm)
+        assertEquals(0L, report.shortTermGainCents)
+    }
+
+    @Test
+    fun `swap disposes the outgoing leg and acquires the incoming leg`() {
+        val events = listOf(
+            buy("b1", 0L, "ETH", 1.0, 100_000L),
+            CryptoTaxEvent(
+                "sw1", TaxEventType.SWAP, 5 * day, "w", Chain.ETHEREUM,
+                "ETH", 1.0, 250_000L,
+                counterAssetSymbol = "USDC", counterAssetQuantity = 2_500.0,
+            ),
+            sell("s1", 6 * day, "USDC", 2_500.0, 250_000L),
+        )
+        val report = CryptoTaxEngine.process(events, LotMethod.FIFO)
+        // Swap realizes 250k - 100k = 150k; USDC acquired at 250k basis, sold at
+        // 250k → 0 gain. Net realized = 150k.
+        assertEquals(150_000L, report.totalRealizedGainCents)
+    }
+
+    @Test
+    fun `disposing more than tracked basis warns and treats excess as zero-basis`() {
+        val events = listOf(
+            buy("b1", 0L, "ETH", 1.0, 100_000L),
+            sell("s1", day, "ETH", 2.0, 400_000L),
+        )
+        val report = CryptoTaxEngine.process(events, LotMethod.FIFO)
+        // Only 100k basis available → gain = 400k - 100k = 300k, plus a warning.
+        assertEquals(300_000L, report.totalRealizedGainCents)
+        assertTrue(report.warnings.isNotEmpty())
+    }
+
+    @Test
+    fun `short term disposal within a year is classified short term`() {
+        val events = listOf(
+            buy("b1", 0L, "ETH", 1.0, 100_000L),
+            sell("s1", 30 * day, "ETH", 1.0, 150_000L),
+        )
+        val report = CryptoTaxEngine.process(events, LotMethod.FIFO)
+        assertEquals(50_000L, report.shortTermGainCents)
+        assertEquals(0L, report.longTermGainCents)
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/crypto/DeFiPortfolioAggregatorTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/crypto/DeFiPortfolioAggregatorTest.kt
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the pure DeFi aggregation ([DeFiPortfolioAggregator]) — #2172.
+ *
+ * Pins the spot-vs-locked separation, value-weighted APY, chain/type grouping
+ * and composition maths the DeFi panel depends on. No UI, no network.
+ */
+class DeFiPortfolioAggregatorTest {
+
+    private fun position(
+        id: String,
+        chain: Chain,
+        type: DeFiPositionType,
+        valueCents: Long,
+        costBasisCents: Long = valueCents,
+        apy: Double = 0.0,
+        rewardsCents: Long = 0L,
+        lock: LockState = LockState.LIQUID,
+    ) = DeFiPosition(
+        id = id,
+        protocol = "p-$id",
+        chain = chain,
+        type = type,
+        assetSymbol = "ASSET",
+        quantity = 1.0,
+        valueCents = valueCents,
+        costBasisCents = costBasisCents,
+        apyPercent = apy,
+        rewardSymbol = "R",
+        pendingRewardsCents = rewardsCents,
+        lockState = lock,
+    )
+
+    @Test
+    fun `empty positions produce the EMPTY summary`() {
+        val summary = DeFiPortfolioAggregator.aggregate(emptyList())
+        assertEquals(DeFiPortfolioSummary.EMPTY, summary)
+        assertFalse(summary.hasData)
+    }
+
+    @Test
+    fun `totals sum value, rewards, cost and pnl`() {
+        val summary = DeFiPortfolioAggregator.aggregate(
+            listOf(
+                position("a", Chain.ETHEREUM, DeFiPositionType.STAKING, valueCents = 100_000L, costBasisCents = 80_000L, rewardsCents = 5_000L),
+                position("b", Chain.ARBITRUM, DeFiPositionType.LENDING, valueCents = 300_000L, costBasisCents = 300_000L, rewardsCents = 2_000L),
+            ),
+        )
+        assertEquals(400_000L, summary.totalValueCents)
+        assertEquals(7_000L, summary.totalPendingRewardsCents)
+        assertEquals(380_000L, summary.totalCostCents)
+        assertEquals(20_000L, summary.totalUnrealizedPnlCents)
+    }
+
+    @Test
+    fun `weighted apy is value-weighted not simple average`() {
+        val summary = DeFiPortfolioAggregator.aggregate(
+            listOf(
+                position("a", Chain.ETHEREUM, DeFiPositionType.STAKING, valueCents = 900_000L, apy = 2.0),
+                position("b", Chain.BNB, DeFiPositionType.FARMING, valueCents = 100_000L, apy = 42.0),
+            ),
+        )
+        // (0.9*2 + 0.1*42) = 6.0, not the simple mean of 22.0
+        assertEquals(6.0, summary.weightedApyPercent, 0.001)
+    }
+
+    @Test
+    fun `groups by chain and type sorted by value`() {
+        val summary = DeFiPortfolioAggregator.aggregate(
+            listOf(
+                position("a", Chain.ETHEREUM, DeFiPositionType.STAKING, valueCents = 100_000L),
+                position("b", Chain.ETHEREUM, DeFiPositionType.LENDING, valueCents = 400_000L),
+                position("c", Chain.ARBITRUM, DeFiPositionType.STAKING, valueCents = 250_000L),
+            ),
+        )
+        val eth = summary.byChain.first { it.chain == Chain.ETHEREUM }
+        assertEquals(500_000L, eth.valueCents)
+        // Highest-value chain sorts first.
+        assertEquals(Chain.ETHEREUM, summary.byChain.first().chain)
+        val staking = summary.byType.first { it.type == DeFiPositionType.STAKING }
+        assertEquals(350_000L, staking.valueCents)
+    }
+
+    @Test
+    fun `compose separates spot from locked value and rewards`() {
+        val defi = DeFiPortfolioAggregator.aggregate(
+            listOf(
+                position("a", Chain.ETHEREUM, DeFiPositionType.STAKING, valueCents = 300_000L, rewardsCents = 10_000L),
+            ),
+        )
+        val composition = DeFiPortfolioAggregator.compose(spotValueCents = 700_000L, defi = defi)
+        assertEquals(700_000L, composition.spotValueCents)
+        assertEquals(300_000L, composition.lockedValueCents)
+        assertEquals(10_000L, composition.pendingRewardsCents)
+        assertEquals(1_010_000L, composition.totalValueCents)
+        // Spot ~ 69.3%, locked ~ 29.7%, rewards ~ 0.99%.
+        assertEquals(100.0, composition.spotPercent + composition.lockedPercent + composition.rewardsPercent, 0.001)
+        assertTrue(composition.spotPercent > composition.lockedPercent)
+    }
+
+    @Test
+    fun `positions ordered by total value including rewards`() {
+        val summary = DeFiPortfolioAggregator.aggregate(
+            listOf(
+                position("small", Chain.ETHEREUM, DeFiPositionType.STAKING, valueCents = 100_000L, rewardsCents = 0L),
+                position("big", Chain.BNB, DeFiPositionType.FARMING, valueCents = 90_000L, rewardsCents = 50_000L),
+            ),
+        )
+        // big has 140k total (value+rewards) vs small's 100k.
+        assertEquals("big", summary.positions.first().id)
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/crypto/MarketDataConfigTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/crypto/MarketDataConfigTest.kt
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the market-data gate ([MarketDataConfig]) — #2702.
+ *
+ * The live feed must only engage when the operator BOTH enables the flag AND
+ * supplies credentials; otherwise the deterministic offline path is used. Pure
+ * function of an injected environment lookup — no real env access.
+ */
+class MarketDataConfigTest {
+
+    private fun env(vararg pairs: Pair<String, String>): (String) -> String? {
+        val map = pairs.toMap()
+        return { key -> map[key] }
+    }
+
+    @Test
+    fun `disabled by default when nothing is set`() {
+        val settings = MarketDataConfig.fromEnvironment(env())
+        assertFalse(settings.useLiveFeed)
+        assertNull(settings.credentials)
+        assertFalse(settings.isLiveFlagEnabled)
+    }
+
+    @Test
+    fun `flag on but no credentials stays offline`() {
+        val settings = MarketDataConfig.fromEnvironment(
+            env(MarketDataConfig.ENABLE_ENV to "true"),
+        )
+        assertTrue(settings.isLiveFlagEnabled)
+        assertFalse(settings.useLiveFeed)
+        assertTrue(settings.statusLabel.contains("credentials missing"))
+    }
+
+    @Test
+    fun `credentials present but flag off stays offline`() {
+        val settings = MarketDataConfig.fromEnvironment(
+            env(
+                MarketDataConfig.API_KEY_ENV to "k",
+                MarketDataConfig.BASE_URL_ENV to "https://api.example.com",
+            ),
+        )
+        assertFalse(settings.useLiveFeed)
+    }
+
+    @Test
+    fun `flag on plus credentials enables the live feed`() {
+        val settings = MarketDataConfig.fromEnvironment(
+            env(
+                MarketDataConfig.ENABLE_ENV to "true",
+                MarketDataConfig.API_KEY_ENV to "secret",
+                MarketDataConfig.BASE_URL_ENV to "https://api.example.com",
+            ),
+        )
+        assertTrue(settings.useLiveFeed)
+        assertEquals("secret", settings.credentials?.apiKey)
+        assertTrue(settings.statusLabel.contains("Live"))
+    }
+
+    @Test
+    fun `refresh interval is clamped to the minimum`() {
+        val settings = MarketDataConfig.fromEnvironment(
+            env(MarketDataConfig.REFRESH_INTERVAL_ENV to "10"),
+        )
+        assertEquals(MarketDataConfig.MIN_REFRESH_INTERVAL_MS, settings.refreshIntervalMs)
+    }
+
+    @Test
+    fun `refresh interval falls back to default when unparseable`() {
+        val settings = MarketDataConfig.fromEnvironment(
+            env(MarketDataConfig.REFRESH_INTERVAL_ENV to "not-a-number"),
+        )
+        assertEquals(MarketDataConfig.DEFAULT_REFRESH_INTERVAL_MS, settings.refreshIntervalMs)
+    }
+
+    @Test
+    fun `accepts alternate truthy flag spellings`() {
+        listOf("1", "yes", "TRUE").forEach { value ->
+            val settings = MarketDataConfig.fromEnvironment(env(MarketDataConfig.ENABLE_ENV to value))
+            assertTrue(settings.isLiveFlagEnabled, "expected '$value' to enable the flag")
+        }
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/crypto/RefreshBackoffTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/crypto/RefreshBackoffTest.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the pure rate-limit backoff maths ([RefreshBackoff]) — #2702.
+ *
+ * The scheduler doubles its delay on each rate-limit hit up to a ceiling, and
+ * snaps back to the base interval after a successful refresh.
+ */
+class RefreshBackoffTest {
+
+    private val base = 30_000L
+    private val max = 300_000L
+
+    @Test
+    fun `success resets to the base interval`() {
+        assertEquals(base, RefreshBackoff.onSuccess(base))
+    }
+
+    @Test
+    fun `first rate limit doubles the base interval`() {
+        assertEquals(60_000L, RefreshBackoff.onRateLimited(base, base, max))
+    }
+
+    @Test
+    fun `repeated rate limits keep doubling`() {
+        var current = base
+        current = RefreshBackoff.onRateLimited(current, base, max)
+        assertEquals(60_000L, current)
+        current = RefreshBackoff.onRateLimited(current, base, max)
+        assertEquals(120_000L, current)
+        current = RefreshBackoff.onRateLimited(current, base, max)
+        assertEquals(240_000L, current)
+    }
+
+    @Test
+    fun `backoff never exceeds the ceiling`() {
+        var current = base
+        repeat(20) { current = RefreshBackoff.onRateLimited(current, base, max) }
+        assertEquals(max, current)
+        assertTrue(current <= max)
+    }
+
+    @Test
+    fun `a current below base still doubles from base`() {
+        assertEquals(60_000L, RefreshBackoff.onRateLimited(1_000L, base, max))
+    }
+}


### PR DESCRIPTION
## Batch 7 — Windows desktop platform + crypto/DeFi tracking

Implements six closely-related Windows (Compose Desktop / KMP) issues in a single feature branch. All changes stay within `apps/windows`; shared packages are read-only. Windows mirrors the Android architecture (Koin DI → ViewModel → Repository / pure domain models).

### What's included

**#3589 — Persist window size/position + enforce a minimum size**
- `WindowStatePersistence` (backed by `java.util.prefs.Preferences`, no new deps) restores the last size/position on launch and clamps to a minimum (960×640) so the sidebar + content never collapse.
- `rememberPersistedWindowState()` debounces persistence on resize/move; `Main.kt` sets `window.minimumSize` and saves on close / tray-quit.

**#3587 — Investments, Household, Referral rendered blank**
- Registered `InvestmentViewModel`, `HouseholdViewModel`, `ReferralViewModel` in Koin and mapped their sidebar destinations to the existing screens (previously `{}` placeholders).
- Added an accessible `ComingSoonScreen` placeholder for QuickAdd and a new **Crypto & DeFi** destination.

**#3585 — Global shortcuts hijack Ctrl+A etc. inside text fields**
- Shortcuts are now classified `NAVIGATION` vs `ACTION`. A global `TextInputFocusTracker` + `Modifier.trackTextInputFocus()` suppress `NAVIGATION` bindings while a text input is focused, so `Ctrl+A` (Select All) and other editing combos reach the field.
- Editable fields (amount, goals, feedback, quick-add) opt in. Unit-tested via the extracted `ShortcutHandler.dispatch` seam.

**#2172 — DeFi positions tracked separately from spot holdings**
- Pure `DeFiPosition` model + `DeFiPortfolioAggregator`: separates liquid spot value from value locked in staking/LP/lending/farming plus pending rewards, with value-weighted APY and chain/type breakdowns.
- Dashboard now shows a DeFi positions panel and a spot-vs-locked composition panel. Aggregator unit tests included.

**#2168 — Chain-aware cost basis + taxable-event tracking**
- Pure `CryptoTaxEngine` models buys/sells/swaps/bridges/wraps/staking/airdrops across wallets and chains. Supports FIFO / HIFO / specific-id lot relief, preserves basis and holding period across bridges/wraps, classifies airdrops & staking as ordinary income, and splits short- vs long-term gains.
- Dashboard shows a tax summary with a lot-method selector. Engine unit tests included.

**#2702 — Real-time refresh pipeline behind a credential/flag gate**
- `MarketDataConfig` gate enables the live feed only when the operator both sets the feature flag **and** supplies credentials; otherwise deterministic offline sources are used.
- `CryptoRefreshScheduler` adds cooperative cancellation and exponential rate-limit backoff, wired into the crypto dashboard ViewModel. Config + backoff unit tests included.

### Testing (local)
- `./gradlew :apps:windows:test` — **all 148 tests pass** (includes new DeFi aggregator, tax engine, market-data config, backoff, and shortcut-focus tests).
- `./gradlew :apps:windows:compileKotlin` — succeeds.
- Lint gate: `npm run format:check` and `npx eslint . --max-warnings 0` both pass (Kotlin is prettier-ignored / detekt-linted in CI).

## Needs Human Action

The near-real-time market-data pipeline (#2702) is intentionally gated off and ships on deterministic offline sample data. To enable the live feed, provision provider credentials (out of band — no secrets are committed) and set these environment variables for the Windows app process:

| Variable | Purpose |
| --- | --- |
| `FINANCE_MARKET_DATA_ENABLED` | `true`/`1`/`yes` to opt into the live pipeline |
| `FINANCE_MARKET_DATA_API_KEY` | Provider API key |
| `FINANCE_MARKET_DATA_URL` | Provider base URL |
| `FINANCE_MARKET_DATA_REFRESH_MS` | (optional) poll interval; clamped to ≥ 5s, default 30s |

The live feed engages only when the flag is on **and** both credentials are present. The `TODO(human)` markers in `CryptoDashboardViewModel`/`CryptoDashboardScreen` note where the live `CryptoPriceSource` + real SQLDelight-backed holdings source are swapped in once credentials exist and the crypto/DeFi holdings are persisted.

Closes #3589
Closes #3587
Closes #3585
Closes #2702
Closes #2172
Closes #2168
