### PR TITLE
feat(ios): iOS UX & accessibility batch - empty state, Reduce Transparency, offline banner, non-color cues, Dynamic Type, chart alternatives

### DIFF
--- a/apps/ios/Finance/Charts/BudgetProgressChart.swift
+++ b/apps/ios/Finance/Charts/BudgetProgressChart.swift
@@ -40,29 +40,49 @@ struct BudgetRing: View {
     let currencyCode: String
 
     var body: some View {
-        Gauge(value: progress.fraction) {
-            Text(progress.name)
-                .font(.caption)
-        } currentValueLabel: {
-            Text(percentText)
-                .font(.caption2)
-                .fontWeight(.semibold)
-        } minimumValueLabel: {
-            Text("0")
-                .font(.caption2)
-        } maximumValueLabel: {
-            Text(formattedCurrency(progress.budgeted))
-                .font(.caption2)
+        VStack(spacing: 4) {
+            Gauge(value: progress.fraction) {
+                Text(progress.name)
+                    .font(.caption)
+            } currentValueLabel: {
+                Text(percentText)
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+            } minimumValueLabel: {
+                Text("0")
+                    .font(.caption2)
+            } maximumValueLabel: {
+                Text(formattedCurrency(progress.budgeted))
+                    .font(.caption2)
+            }
+            .gaugeStyle(.accessoryCircular)
+            .tint(ringGradient)
+
+            if progress.isOverBudget {
+                Label(String(localized: "Over budget"), systemImage: "exclamationmark.triangle.fill")
+                    .labelStyle(.titleAndIcon)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(FinanceColors.statusNegative)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityHidden(true)
+            }
         }
-        .gaugeStyle(.accessoryCircular)
-        .tint(ringGradient)
+        .accessibilityElement(children: .ignore)
         .accessibilityLabel(progress.name)
-        .accessibilityValue(
-            String(localized: "\(percentText) spent, \(formattedCurrency(progress.spent)) of \(formattedCurrency(progress.budgeted))")
-        )
+        .accessibilityValue(accessibilityValueText)
     }
 
     // MARK: - Helpers
+
+    /// Spoken value that always states the over-budget condition in words, so
+    /// the state never depends on the ring color alone. (#2121)
+    private var accessibilityValueText: String {
+        let base = String(localized: "\(percentText) spent, \(formattedCurrency(progress.spent)) of \(formattedCurrency(progress.budgeted))")
+        if progress.isOverBudget {
+            return String(localized: "\(base). Over budget.")
+        }
+        return base
+    }
 
     private var percentText: String {
         let pct = Int((progress.fraction * 100).rounded())
@@ -71,7 +91,7 @@ struct BudgetRing: View {
 
     private var ringGradient: some ShapeStyle {
         if progress.isOverBudget {
-            return AnyShapeStyle(Color.red)
+            return AnyShapeStyle(FinanceColors.statusNegative)
         }
         return AnyShapeStyle(
             ChartColorPalette.color(at: progress.colorIndex)

--- a/apps/ios/Finance/Charts/CategoryBreakdownChart.swift
+++ b/apps/ios/Finance/Charts/CategoryBreakdownChart.swift
@@ -67,6 +67,12 @@ struct CategoryBreakdownChart: View {
 
             // Legend
             legendView
+
+            ChartDataTable(
+                summary: breakdownSummary,
+                rows: breakdownRows,
+                tableLabel: String(localized: "Category breakdown data table")
+            )
         }
         .padding()
         .onChange(of: selectedAngle) { _, newValue in
@@ -109,7 +115,7 @@ struct CategoryBreakdownChart: View {
 
                     Text(slice.category)
                         .font(.caption)
-                        .lineLimit(1)
+                        .fixedSize(horizontal: false, vertical: true)
 
                     Spacer()
 
@@ -126,6 +132,30 @@ struct CategoryBreakdownChart: View {
     }
 
     // MARK: - Helpers
+
+    /// Spoken summary of the breakdown: total spend, category count, and the
+    /// largest category, for VoiceOver users. (#2113)
+    private var breakdownSummary: String {
+        guard !data.isEmpty else {
+            return String(localized: "No spending data available.")
+        }
+        let total = formattedCurrency(totalSpending)
+        let largest = data.max { $0.amount < $1.amount }
+        if let largest {
+            return String(localized: "Spending across \(data.count) categories totalling \(total). Largest: \(largest.category) at \(formattedCurrency(largest.amount)), \(percentageText(for: largest)).")
+        }
+        return String(localized: "Spending across \(data.count) categories totalling \(total).")
+    }
+
+    /// One row per category slice, in the same order as the chart. (#2113)
+    private var breakdownRows: [ChartDataRow] {
+        data.map { slice in
+            ChartDataRow(
+                label: slice.category,
+                value: "\(formattedCurrency(slice.amount)) (\(percentageText(for: slice)))"
+            )
+        }
+    }
 
     private func percentageText(for slice: CategorySlice) -> String {
         guard totalSpending > 0 else { return "0%" }

--- a/apps/ios/Finance/Charts/PredictionChart.swift
+++ b/apps/ios/Finance/Charts/PredictionChart.swift
@@ -123,8 +123,55 @@ struct PredictionChart: View {
             .drawingGroup()
             .accessibilityElement(children: .contain)
             .accessibilityLabel(String(localized: "Spending forecast chart with predictions"))
+
+            ChartDataTable(
+                summary: forecastSummary,
+                rows: forecastRows,
+                tableLabel: String(localized: "Forecast data table")
+            )
         }
         .padding()
+    }
+
+    // MARK: - Text Alternative (#2113)
+
+    /// Spoken summary of the history and forecast ranges for VoiceOver users.
+    private var forecastSummary: String {
+        guard !historicalData.isEmpty || !predictions.isEmpty else {
+            return String(localized: "No forecast data available.")
+        }
+        var parts: [String] = []
+        if let firstH = historicalData.first, let lastH = historicalData.last {
+            parts.append(String(localized: "History from \(formattedDate(firstH.date)) to \(formattedDate(lastH.date)), latest \(formattedCurrency(lastH.value))."))
+        }
+        if let firstP = predictions.first, let lastP = predictions.last {
+            let firstVal = formattedCurrency(Double(firstP.predictedMinorUnits) / 100.0)
+            let lastVal = formattedCurrency(Double(lastP.predictedMinorUnits) / 100.0)
+            parts.append(String(localized: "Forecast from \(formattedDate(firstP.date)) to \(formattedDate(lastP.date)), predicted \(firstVal) to \(lastVal)."))
+        }
+        return parts.joined(separator: " ")
+    }
+
+    /// Historical points followed by predicted points (with confidence range),
+    /// in the same order as the chart. (#2113)
+    private var forecastRows: [ChartDataRow] {
+        var rows = historicalData.map { point in
+            ChartDataRow(label: formattedDate(point.date), value: formattedCurrency(point.value))
+        }
+        rows += predictions.map { prediction in
+            let predicted = formattedCurrency(Double(prediction.predictedMinorUnits) / 100.0)
+            let lower = formattedCurrency(Double(prediction.lowerBoundMinorUnits) / 100.0)
+            let upper = formattedCurrency(Double(prediction.upperBoundMinorUnits) / 100.0)
+            return ChartDataRow(
+                label: String(localized: "\(formattedDate(prediction.date)) (predicted)"),
+                value: String(localized: "\(predicted), range \(lower) to \(upper)")
+            )
+        }
+        return rows
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        date.formatted(.dateTime.month(.abbreviated).day())
     }
 
     // MARK: - Helpers

--- a/apps/ios/Finance/Charts/TrendChart.swift
+++ b/apps/ios/Finance/Charts/TrendChart.swift
@@ -136,8 +136,46 @@ struct TrendChart: View {
             .drawingGroup()  // Rasterise into a single Metal layer for 60 FPS scrolling
             .accessibilityElement(children: .contain)
             .accessibilityLabel(String(localized: "Financial trend line chart"))
+
+            ChartDataTable(
+                summary: chartSummary,
+                rows: chartRows,
+                tableLabel: String(localized: "Trend data table")
+            )
         }
         .padding()
+    }
+
+    // MARK: - Text Alternative (#2113)
+
+    /// Spoken summary describing the date range and, per series, the latest,
+    /// highest, and lowest values so VoiceOver users get the trend in text.
+    private var chartSummary: String {
+        guard let firstDate = data.map(\.date).min(),
+              let lastDate = data.map(\.date).max() else {
+            return String(localized: "No trend data available.")
+        }
+        let range = "\(formattedDate(firstDate)) to \(formattedDate(lastDate))"
+        let parts = seriesNames.map { name -> String in
+            let values = data.filter { $0.series == name }.map(\.value)
+            let latest = data.last(where: { $0.series == name })?.value ?? 0
+            let high = values.max() ?? 0
+            let low = values.min() ?? 0
+            return String(localized: "\(name): latest \(formattedCurrency(latest)), high \(formattedCurrency(high)), low \(formattedCurrency(low)).")
+        }
+        return String(localized: "Trend from \(range). ") + parts.joined(separator: " ")
+    }
+
+    /// One row per data point, kept in the same order as the chart.
+    private var chartRows: [ChartDataRow] {
+        data.map { point in
+            ChartDataRow(
+                label: seriesNames.count > 1
+                    ? "\(point.series), \(formattedDate(point.date))"
+                    : formattedDate(point.date),
+                value: formattedCurrency(point.value)
+            )
+        }
     }
 
     // MARK: - Helpers

--- a/apps/ios/Finance/Components/CardBackground.swift
+++ b/apps/ios/Finance/Components/CardBackground.swift
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CardBackground.swift
+// Finance
+//
+// A card surface background that respects the Reduce Transparency setting.
+// Refs #3586
+
+import SwiftUI
+
+// MARK: - Modifier
+
+/// Applies a card surface background that honors **Reduce Transparency**.
+///
+/// When `accessibilityReduceTransparency` is enabled, the translucent
+/// `.regularMaterial` is swapped for the opaque `FinanceColors.backgroundElevated`
+/// token so text layered on the card keeps sufficient contrast and legibility
+/// (WCAG-aligned). When the setting is off, the standard material look is
+/// preserved. (#3586)
+struct CardBackgroundModifier: ViewModifier {
+    let cornerRadius: CGFloat
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius)
+        if reduceTransparency {
+            content.background(FinanceColors.backgroundElevated, in: shape)
+        } else {
+            content.background(.regularMaterial, in: shape)
+        }
+    }
+}
+
+// MARK: - View Extension
+
+extension View {
+    /// Applies a rounded card background that falls back to an opaque token
+    /// color when **Reduce Transparency** is enabled, and uses the standard
+    /// translucent material otherwise. (#3586)
+    ///
+    /// Prefer this over `.background(.regularMaterial, in:)` for card surfaces
+    /// so overlaid text stays legible for users who reduce transparency.
+    func cardBackground(cornerRadius: CGFloat) -> some View {
+        modifier(CardBackgroundModifier(cornerRadius: cornerRadius))
+    }
+}

--- a/apps/ios/Finance/Components/ChartDataTable.swift
+++ b/apps/ios/Finance/Components/ChartDataTable.swift
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// ChartDataTable.swift
+// Finance
+//
+// A reusable, VoiceOver-friendly text alternative for charts: a spoken summary
+// plus a browsable data table so non-visual users get the same information a
+// chart conveys.
+// Refs #2113
+
+import SwiftUI
+
+// MARK: - Data Row
+
+/// A single labeled row in a chart's text-alternative data table.
+struct ChartDataRow: Identifiable, Sendable {
+    let id = UUID()
+    let label: String
+    let value: String
+
+    init(label: String, value: String) {
+        self.label = label
+        self.value = value
+    }
+}
+
+// MARK: - View
+
+/// A reusable text alternative for a chart.
+///
+/// Renders a spoken `summary` (date range, totals, extremes, forecast ranges,
+/// …) followed by a collapsible data table of `rows`. Sighted users can leave
+/// it collapsed; VoiceOver users get the full data in the **same swipe order**
+/// as the chart. This mirrors the existing report data-table pattern so every
+/// analytics and investment chart can offer a non-visual equivalent. (#2113)
+struct ChartDataTable: View {
+    let summary: String
+    let rows: [ChartDataRow]
+    var tableLabel: String
+
+    @State private var isExpanded = false
+
+    init(
+        summary: String,
+        rows: [ChartDataRow],
+        tableLabel: String = String(localized: "Chart data table")
+    ) {
+        self.summary = summary
+        self.rows = rows
+        self.tableLabel = tableLabel
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(summary)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityLabel(summary)
+
+            if !rows.isEmpty {
+                DisclosureGroup(isExpanded: $isExpanded) {
+                    VStack(spacing: 0) {
+                        ForEach(rows) { row in
+                            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                                Text(row.label)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                Spacer(minLength: 8)
+                                Text(row.value)
+                                    .font(.caption)
+                                    .fontWeight(.medium)
+                                    .multilineTextAlignment(.trailing)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            .padding(.vertical, 6)
+                            .accessibilityElement(children: .combine)
+                            .accessibilityLabel("\(row.label), \(row.value)")
+
+                            if row.id != rows.last?.id {
+                                Divider()
+                            }
+                        }
+                    }
+                    .padding(.top, 4)
+                } label: {
+                    Text(String(localized: "View data table"))
+                        .font(.footnote.weight(.medium))
+                }
+                .accessibilityLabel(tableLabel)
+                .accessibilityHint(String(localized: "Shows the underlying chart values as text"))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Chart Data Table") {
+    ChartDataTable(
+        summary: "Spending from Jan to Jun totalled $12,340. Highest: March at $2,510. Lowest: January at $1,420.",
+        rows: [
+            ChartDataRow(label: "January", value: "$1,420"),
+            ChartDataRow(label: "February", value: "$1,980"),
+            ChartDataRow(label: "March", value: "$2,510"),
+            ChartDataRow(label: "April", value: "$2,010"),
+            ChartDataRow(label: "May", value: "$2,000"),
+            ChartDataRow(label: "June", value: "$2,420"),
+        ]
+    )
+    .padding()
+}

--- a/apps/ios/Finance/Components/DebtPayoffCard.swift
+++ b/apps/ios/Finance/Components/DebtPayoffCard.swift
@@ -45,7 +45,7 @@ struct DebtPayoffCard: View {
             milestoneFooter
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(progress.name))
         .accessibilityValue(Text(accessibilitySummary))

--- a/apps/ios/Finance/Components/GainLossBadge.swift
+++ b/apps/ios/Finance/Components/GainLossBadge.swift
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// GainLossBadge.swift
+// Finance
+//
+// A compact badge that encodes gain/loss/flat state with an icon and text
+// label in addition to color, so financial direction never relies on red/green
+// alone.
+// Refs #2121
+
+import SwiftUI
+
+/// A compact pill that communicates gain/loss/flat state with **three**
+/// redundant cues — an SF Symbol, a text label, and a semantic color — so
+/// low-vision and color-blind users can read financial direction reliably.
+/// (#2121)
+struct GainLossBadge: View {
+    let state: GainLossState
+
+    /// When `false`, only the directional icon is shown (compact contexts).
+    var showLabel: Bool = true
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: state.symbolName)
+                .font(.caption2.weight(.bold))
+                .accessibilityHidden(true)
+
+            if showLabel {
+                Text(state.label)
+                    .font(.caption2.weight(.semibold))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .foregroundStyle(state.color)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(state.color.opacity(0.12), in: Capsule())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(state.label)
+    }
+}
+
+#Preview("Gain / Loss Badges") {
+    VStack(spacing: 12) {
+        GainLossBadge(state: .gain)
+        GainLossBadge(state: .loss)
+        GainLossBadge(state: .flat)
+        GainLossBadge(state: .gain, showLabel: false)
+    }
+    .padding()
+}

--- a/apps/ios/Finance/Components/OfflineAware.swift
+++ b/apps/ios/Finance/Components/OfflineAware.swift
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// OfflineAware.swift
+// Finance
+//
+// A shared modifier that renders the OfflineBanner above any primary data
+// screen whenever the device loses connectivity, and announces the change
+// to VoiceOver as a status.
+// Refs #3583
+
+import SwiftUI
+
+// MARK: - Modifier
+
+/// Prepends the shared ``OfflineBanner`` above a screen's content whenever the
+/// injected ``NetworkMonitor`` reports no connectivity, giving every primary
+/// data screen (Transactions, Accounts, Budgets, Goals, …) a single, consistent
+/// offline indicator instead of only the Dashboard. (#3583)
+///
+/// When connectivity drops, a VoiceOver announcement is posted so the change is
+/// conveyed as a status even when the banner is off-screen.
+struct OfflineAwareModifier: ViewModifier {
+    @Environment(NetworkMonitor.self) private var networkMonitor: NetworkMonitor?
+
+    private var isConnected: Bool { networkMonitor?.isConnected ?? true }
+
+    func body(content: Content) -> some View {
+        VStack(spacing: 0) {
+            if let monitor = networkMonitor, !monitor.isConnected {
+                OfflineBanner()
+                    .padding(.top, FinanceSpacing.sm)
+            }
+            content
+        }
+        .animation(.default, value: isConnected)
+        .onChange(of: isConnected) { _, connected in
+            guard !connected else { return }
+            AccessibilityNotification.Announcement(
+                String(localized: "You are offline. Some features may be limited.")
+            ).post()
+        }
+    }
+}
+
+// MARK: - View Extension
+
+extension View {
+    /// Renders the shared offline banner above this screen and announces
+    /// connectivity loss to VoiceOver as a status. Apply to primary data
+    /// screens for consistent offline feedback. (#3583)
+    func offlineAware() -> some View {
+        modifier(OfflineAwareModifier())
+    }
+}

--- a/apps/ios/Finance/Components/TransactionRowView.swift
+++ b/apps/ios/Finance/Components/TransactionRowView.swift
@@ -9,27 +9,48 @@ import SwiftUI
 struct TransactionRowView: View, Equatable {
     let transaction: TransactionItem
 
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     static func == (lhs: TransactionRowView, rhs: TransactionRowView) -> Bool { lhs.transaction == rhs.transaction }
 
+    private var amountLabel: some View {
+        CurrencyLabel(amountInMinorUnits: transaction.amountMinorUnits, currencyCode: transaction.currencyCode, font: .callout.bold())
+            .contentTransition(.numericText())
+    }
+
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             IconView(transaction.type.iconToken, size: 16)
                 .foregroundStyle(transaction.type.color)
                 .frame(width: 32, height: 32).background(transaction.type.color.opacity(0.1), in: Circle())
             VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 4) {
-                    Text(transaction.payee).font(.body).lineLimit(1)
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(transaction.payee)
+                        .font(.body)
+                        .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
+                        .fixedSize(horizontal: false, vertical: true)
                     if transaction.isRecurring { IconView(.recurring, size: 12).foregroundStyle(.secondary).accessibilityLabel(String(localized: "Recurring")) }
                     if transaction.status == .pending { Text(transaction.status.displayName).font(.caption2).foregroundStyle(FinanceColors.statusWarning).padding(.horizontal, 6).padding(.vertical, 2).background(FinanceColors.statusWarning.opacity(0.1), in: Capsule()) }
                 }
-                HStack(spacing: 4) { Text(transaction.category); Text("·"); Text(transaction.accountName) }.font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                HStack(spacing: 4) { Text(transaction.category); Text("·"); Text(transaction.accountName) }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
+                    .fixedSize(horizontal: false, vertical: true)
                 // Show up to 2 tags inline
                 if !transaction.tags.isEmpty {
                     TagsRow(tags: transaction.tags, maxVisible: 2)
                 }
+                // At accessibility text sizes the trailing amount would be
+                // cramped, so stack it below the details instead. (#2119)
+                if dynamicTypeSize.isAccessibilitySize {
+                    amountLabel
+                }
             }
-            Spacer()
-            CurrencyLabel(amountInMinorUnits: transaction.amountMinorUnits, currencyCode: transaction.currencyCode, font: .callout.bold()).contentTransition(.numericText())
+            if !dynamicTypeSize.isAccessibilitySize {
+                Spacer()
+                amountLabel
+            }
         }.padding(.vertical, 2).accessibilityElement(children: .combine)
         .accessibilityLabel(transaction.accessibilityRowLabel())
         .accessibilityHint(String(localized: "Tap to view details. Swipe for more actions."))

--- a/apps/ios/Finance/Models/InvestmentModels.swift
+++ b/apps/ios/Finance/Models/InvestmentModels.swift
@@ -11,6 +11,54 @@
 
 import SwiftUI
 
+// MARK: - Gain / Loss State
+
+/// Direction of an unrealised gain/loss, encoded with redundant non-color cues
+/// (icon + text label) so financial state never depends on red/green alone.
+/// (#2121)
+enum GainLossState: Sendable {
+    case gain
+    case loss
+    case flat
+
+    init(minorUnits: Int64) {
+        if minorUnits > 0 {
+            self = .gain
+        } else if minorUnits < 0 {
+            self = .loss
+        } else {
+            self = .flat
+        }
+    }
+
+    /// SF Symbol reinforcing the direction independently of color.
+    var symbolName: String {
+        switch self {
+        case .gain: "arrow.up.right"
+        case .loss: "arrow.down.right"
+        case .flat: "minus"
+        }
+    }
+
+    /// Short textual label for badges and VoiceOver.
+    var label: String {
+        switch self {
+        case .gain: String(localized: "Gain")
+        case .loss: String(localized: "Loss")
+        case .flat: String(localized: "No change")
+        }
+    }
+
+    /// WCAG-tuned semantic color token — never a raw system red/green.
+    var color: Color {
+        switch self {
+        case .gain: FinanceColors.amountPositive
+        case .loss: FinanceColors.amountNegative
+        case .flat: .primary
+        }
+    }
+}
+
 // MARK: - Asset Class
 
 /// Classification of an investment holding, mirroring KMP `AssetClass`.
@@ -93,12 +141,11 @@ struct HoldingItem: Identifiable, Hashable, Sendable {
         return (Double(currentValueMinorUnits - prev) / Double(prev)) * 100.0
     }
 
-    /// Color for the gain/loss indicator.
-    var gainLossColor: Color {
-        if gainLossMinorUnits > 0 { return .green }
-        if gainLossMinorUnits < 0 { return .red }
-        return .primary
-    }
+    /// Redundant, non-color state (icon + label) for the gain/loss indicator.
+    var gainLossState: GainLossState { GainLossState(minorUnits: gainLossMinorUnits) }
+
+    /// Color for the gain/loss indicator (semantic token, not raw red/green).
+    var gainLossColor: Color { gainLossState.color }
 }
 
 // MARK: - Portfolio Item
@@ -129,12 +176,11 @@ struct PortfolioItem: Identifiable, Sendable {
     /// Whether the portfolio is in overall profit.
     var isProfit: Bool { totalGainLossMinorUnits > 0 }
 
-    /// Color for the total gain/loss indicator.
-    var gainLossColor: Color {
-        if totalGainLossMinorUnits > 0 { return .green }
-        if totalGainLossMinorUnits < 0 { return .red }
-        return .primary
-    }
+    /// Redundant, non-color state (icon + label) for the total gain/loss.
+    var gainLossState: GainLossState { GainLossState(minorUnits: totalGainLossMinorUnits) }
+
+    /// Color for the total gain/loss indicator (semantic token, not raw red/green).
+    var gainLossColor: Color { gainLossState.color }
 }
 
 // MARK: - Allocation Slice

--- a/apps/ios/Finance/Navigation/DeepLinkHandler.swift
+++ b/apps/ios/Finance/Navigation/DeepLinkHandler.swift
@@ -107,6 +107,12 @@ final class DeepLinkHandler {
     /// The account ID to navigate to after switching to the Accounts tab.
     private(set) var pendingAccountId: String?
 
+    /// Set when another screen (e.g. the Dashboard first-run empty state)
+    /// requests that the Accounts tab open the "add account" flow. The
+    /// Accounts screen observes this and presents the create sheet, then
+    /// calls ``consumeAccountCreationRequest()``. (#3588)
+    var requestAccountCreation = false
+
     /// The transaction ID to navigate to after switching to the Transactions tab.
     private(set) var pendingTransactionId: String?
 
@@ -236,6 +242,12 @@ final class DeepLinkHandler {
         if case .account = currentDeepLink {
             currentDeepLink = nil
         }
+    }
+
+    /// Clears the "add account" request after the Accounts screen has
+    /// presented the create flow. (#3588)
+    func consumeAccountCreationRequest() {
+        requestAccountCreation = false
     }
 
     /// Clears the pending transaction navigation after the view has consumed it.
@@ -412,5 +424,6 @@ final class DeepLinkHandler {
         hasPendingQuickEntry = false
         pendingQuickEntryAction = nil
         pendingBudgetCategoryId = nil
+        requestAccountCreation = false
     }
 }

--- a/apps/ios/Finance/Screens/AccountsView.swift
+++ b/apps/ios/Finance/Screens/AccountsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 // MARK: - View
 
 struct AccountsView: View {
+    @Environment(DeepLinkHandler.self) private var deepLinkHandler: DeepLinkHandler?
     @State private var viewModel: AccountsViewModel
 
     init(viewModel: AccountsViewModel = AccountsViewModel(
@@ -38,6 +39,7 @@ struct AccountsView: View {
                     accountsList
                 }
             }
+            .offlineAware()
             .navigationTitle(String(localized: "Accounts"))
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
@@ -52,6 +54,10 @@ struct AccountsView: View {
             .sheet(isPresented: \$viewModel.showingAddAccount) { addAccountPlaceholder }
             .refreshable { await viewModel.loadAccounts() }
             .task { await viewModel.loadAccounts() }
+            .onAppear { handleAccountCreationRequest() }
+            .onChange(of: deepLinkHandler?.requestAccountCreation ?? false) { _, requested in
+                if requested { handleAccountCreationRequest() }
+            }
             .alert(String(localized: "Error"), isPresented: Binding(
                 get: { viewModel.showError },
                 set: { if !\$0 { viewModel.dismissError() } }
@@ -62,6 +68,14 @@ struct AccountsView: View {
                 Text(viewModel.errorMessage ?? "")
             }
         }
+    }
+
+    /// Opens the create-account flow when another screen (e.g. the Dashboard
+    /// first-run empty state) has requested it via ``DeepLinkHandler``. (#3588)
+    private func handleAccountCreationRequest() {
+        guard deepLinkHandler?.requestAccountCreation == true else { return }
+        viewModel.showingAddAccount = true
+        deepLinkHandler?.consumeAccountCreationRequest()
     }
 
     private var accountsList: some View {

--- a/apps/ios/Finance/Screens/AnalyticsView.swift
+++ b/apps/ios/Finance/Screens/AnalyticsView.swift
@@ -133,14 +133,14 @@ struct AnalyticsView: View {
                     title: String(localized: "Avg. Spending"),
                     value: viewModel.formatCurrency(summary.averageMonthlySpending),
                     icon: "arrow.up.right",
-                    color: .red
+                    color: FinanceColors.statusNegative
                 )
 
                 summaryCard(
                     title: String(localized: "Avg. Income"),
                     value: viewModel.formatCurrency(summary.averageMonthlyIncome),
                     icon: "arrow.down.left",
-                    color: .green
+                    color: FinanceColors.statusPositive
                 )
 
                 summaryCard(
@@ -154,7 +154,7 @@ struct AnalyticsView: View {
                     title: String(localized: "Savings Rate"),
                     value: String(format: "%.1f%%", summary.savingsRatePercent),
                     icon: "leaf",
-                    color: summary.savingsRatePercent >= 20 ? .green : .orange
+                    color: summary.savingsRatePercent >= 20 ? FinanceColors.statusPositive : FinanceColors.statusWarning
                 )
             }
         }
@@ -178,8 +178,7 @@ struct AnalyticsView: View {
             Text(value)
                 .font(.title3)
                 .fontWeight(.semibold)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
+                .fixedSize(horizontal: false, vertical: true)
 
             Text(title)
                 .font(.caption)

--- a/apps/ios/Finance/Screens/BillDetailView.swift
+++ b/apps/ios/Finance/Screens/BillDetailView.swift
@@ -64,7 +64,7 @@ struct BillDetailView: View {
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(bill.name), \(bill.payee)")
         .accessibilityValue(String(localized: "\(bill.frequency.displayName), \(bill.dueDateText)"))
@@ -114,7 +114,7 @@ struct BillDetailView: View {
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .cardBackground(cornerRadius: 12)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(title)
         .accessibilityValue(value)
@@ -143,7 +143,7 @@ struct BillDetailView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
     }
 
     private func detailRow(label: String, value: String) -> some View {
@@ -207,7 +207,7 @@ struct BillDetailView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
     }
 
     // MARK: - Actions

--- a/apps/ios/Finance/Screens/BillsListView.swift
+++ b/apps/ios/Finance/Screens/BillsListView.swift
@@ -148,7 +148,7 @@ struct BillsListView: View {
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(String(localized: "Bills summary"))
         .accessibilityValue(String(localized: "\(viewModel.bills.count) bills, \(viewModel.overdueBills.count) overdue"))
@@ -221,7 +221,7 @@ struct BillsListView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .cardBackground(cornerRadius: 12)
         .contextMenu {
             if bill.status != .paid {
                 Button {

--- a/apps/ios/Finance/Screens/BudgetsView.swift
+++ b/apps/ios/Finance/Screens/BudgetsView.swift
@@ -48,6 +48,7 @@ struct BudgetsView: View {
                     }
                 }
             }
+            .offlineAware()
             .navigationTitle(String(localized: "Budgets"))
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
@@ -145,7 +146,7 @@ struct BudgetsView: View {
             }
         }
         .frame(maxWidth: .infinity).padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(String(localized: "Overall budget summary"))
         .accessibilityValue(
@@ -187,7 +188,7 @@ struct BudgetsView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .cardBackground(cornerRadius: 12)
         .contentShape(RoundedRectangle(cornerRadius: 12))
         .onTapGesture { viewModel.editingBudget = budget }
         .accessibilityElement(children: .combine)

--- a/apps/ios/Finance/Screens/DashboardView.swift
+++ b/apps/ios/Finance/Screens/DashboardView.swift
@@ -14,7 +14,7 @@ struct DashboardView: View {
     @State private var viewModel: DashboardViewModel
     @State private var showingAskFinance = false
     @State private var showingSettings = false
-    @Environment(NetworkMonitor.self) private var networkMonitor: NetworkMonitor?
+    @Environment(DeepLinkHandler.self) private var deepLinkHandler: DeepLinkHandler?
 
     init(viewModel: DashboardViewModel = DashboardViewModel(
         accountRepository: RepositoryProvider.shared.accounts,
@@ -29,12 +29,11 @@ struct DashboardView: View {
             Group {
                 if viewModel.isLoading && viewModel.accounts.isEmpty {
                     DashboardSkeletonView()
+                } else if viewModel.accounts.isEmpty {
+                    dashboardEmptyState
                 } else {
                     ScrollView {
                         VStack(spacing: FinanceSpacing.lg) {
-                            if let monitor = networkMonitor, !monitor.isConnected {
-                                OfflineBanner()
-                            }
                             netWorthCard
                             savingsRateCard
                             spendingSummaryCard
@@ -47,6 +46,7 @@ struct DashboardView: View {
                     }
                 }
             }
+            .offlineAware()
             .navigationTitle(String(localized: "Dashboard"))
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
@@ -86,6 +86,27 @@ struct DashboardView: View {
         }
     }
 
+    // MARK: - First-Run Empty State (#3588)
+
+    /// Guiding empty state shown to brand-new users who have no accounts yet.
+    ///
+    /// Replaces the wall of zero-value cards with a welcoming message and a
+    /// working "Add Account" call to action that switches to the Accounts tab
+    /// and opens the create-account flow. Fully accessible via `EmptyStateView`.
+    private var dashboardEmptyState: some View {
+        EmptyStateView(
+            systemImage: "sparkles",
+            title: String(localized: "Welcome to Finance"),
+            message: String(localized: "Add your first account to see your net worth, spending, and budget health here."),
+            actionLabel: String(localized: "Add Account"),
+            action: {
+                deepLinkHandler?.selectedTab = .accounts
+                deepLinkHandler?.requestAccountCreation = true
+            }
+        )
+        .accessibilityIdentifier("dashboard_empty_state")
+    }
+
     // MARK: - Net Worth Card
 
     private var netWorthCard: some View {
@@ -104,7 +125,7 @@ struct DashboardView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, FinanceSpacing.xl)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl))
+        .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
         .accessibilityIdentifier("net_worth_card")
     }
 
@@ -170,7 +191,7 @@ struct DashboardView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+            .cardBackground(cornerRadius: 16)
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
@@ -218,7 +239,7 @@ struct DashboardView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl))
+        .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
         .accessibilityElement(children: .ignore)
         .accessibilityIdentifier("spending_summary_card")
         .accessibilityLabel(spendingSummaryAccessibilityLabel)
@@ -274,7 +295,7 @@ struct DashboardView: View {
         }
         .frame(width: 80)
         .padding(.vertical, FinanceSpacing.sm).padding(.horizontal, FinanceSpacing.xs)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.lg))
+        .cardBackground(cornerRadius: FinanceSpacing.Radius.lg)
         .accessibilityElement(children: .ignore)
     }
 
@@ -343,7 +364,7 @@ struct DashboardView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, FinanceSpacing.sm)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.lg))
+        .cardBackground(cornerRadius: FinanceSpacing.Radius.lg)
     }
 
     // MARK: - Recent Transactions
@@ -377,7 +398,7 @@ struct DashboardView: View {
                     }
                 }
                 .padding()
-                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl))
+                .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
             }
         }
     }

--- a/apps/ios/Finance/Screens/DebtPayoffView.swift
+++ b/apps/ios/Finance/Screens/DebtPayoffView.swift
@@ -85,7 +85,7 @@ struct DebtPayoffView: View {
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20))
+        .cardBackground(cornerRadius: 20)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(String(localized: "All debts combined"))
         .accessibilityValue(String(localized: "\(portfolio.percentComplete) percent paid off"))

--- a/apps/ios/Finance/Screens/FinanceQueryView.swift
+++ b/apps/ios/Finance/Screens/FinanceQueryView.swift
@@ -150,7 +150,7 @@ struct FinanceQueryView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .cardBackground(cornerRadius: 12)
     }
 
     @ViewBuilder
@@ -176,7 +176,7 @@ struct FinanceQueryView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .cardBackground(cornerRadius: 12)
     }
 
     private var unrecognizedCard: some View {
@@ -185,7 +185,7 @@ struct FinanceQueryView: View {
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            .cardBackground(cornerRadius: 12)
     }
 
     // MARK: - Examples

--- a/apps/ios/Finance/Screens/GoalsView.swift
+++ b/apps/ios/Finance/Screens/GoalsView.swift
@@ -41,6 +41,7 @@ struct GoalsView: View {
                     }
                 }
             }
+            .offlineAware()
             .navigationTitle(String(localized: "Goals"))
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
@@ -151,7 +152,7 @@ struct GoalsView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
         .contentShape(RoundedRectangle(cornerRadius: 16))
         .onTapGesture { viewModel.editingGoal = goal }
         .accessibilityElement(children: .combine)

--- a/apps/ios/Finance/Screens/InsightsView.swift
+++ b/apps/ios/Finance/Screens/InsightsView.swift
@@ -129,8 +129,7 @@ struct InsightsView: View {
             Text(value)
                 .font(.title3)
                 .fontWeight(.semibold)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
+                .fixedSize(horizontal: false, vertical: true)
 
             Text(title)
                 .font(.caption)
@@ -179,6 +178,12 @@ struct InsightsView: View {
                 .accessibilityLabel(String(localized: "Spending breakdown chart"))
                 .accessibilityHint(String(localized: "Shows spending distribution across categories"))
 
+                Text(spendingBreakdownSummary(summary))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityLabel(spendingBreakdownSummary(summary))
+
                 // Legend
                 ForEach(summary.spendingBreakdown) { item in
                     HStack(spacing: 8) {
@@ -214,6 +219,22 @@ struct InsightsView: View {
                 }
             }
         }
+    }
+
+    /// Spoken summary of the spending breakdown (total and largest category)
+    /// so VoiceOver users get the gist before browsing the per-category list.
+    /// (#2113)
+    private func spendingBreakdownSummary(_ summary: InsightsSummary) -> String {
+        let items = summary.spendingBreakdown
+        guard !items.isEmpty else {
+            return String(localized: "No spending data available.")
+        }
+        let total = items.reduce(Int64(0)) { $0 + $1.amountMinorUnits }
+        let totalText = viewModel.formatCurrency(total)
+        if let largest = items.max(by: { $0.amountMinorUnits < $1.amountMinorUnits }) {
+            return String(localized: "Spending across \(items.count) categories totalling \(totalText). Largest: \(largest.categoryName) at \(viewModel.formatCurrency(largest.amountMinorUnits)), \(String(format: "%.1f", largest.percentOfTotal)) percent.")
+        }
+        return String(localized: "Spending across \(items.count) categories totalling \(totalText).")
     }
 
     // MARK: - Trend Chart

--- a/apps/ios/Finance/Screens/InvestmentDetailView.swift
+++ b/apps/ios/Finance/Screens/InvestmentDetailView.swift
@@ -55,6 +55,8 @@ struct InvestmentDetailView: View {
             )
 
             HStack(spacing: 12) {
+                GainLossBadge(state: holding.gainLossState)
+
                 CurrencyLabel(
                     amountInMinorUnits: holding.gainLossMinorUnits,
                     currencyCode: holding.currencyCode,
@@ -70,14 +72,24 @@ struct InvestmentDetailView: View {
             }
 
             if let dailyPct = holding.dailyReturnPercent {
-                Text(String(localized: "Today: \(String(format: "%+.2f%%", dailyPct))"))
-                    .font(.caption)
-                    .foregroundStyle(dailyPct >= 0 ? Color.green : Color.red)
+                let dailyState = GainLossState(minorUnits: Int64(dailyPct * 100))
+                HStack(spacing: 4) {
+                    Image(systemName: dailyState.symbolName)
+                        .font(.caption2.weight(.bold))
+                        .accessibilityHidden(true)
+                    Text(String(localized: "Today: \(String(format: "%+.2f%%", dailyPct))"))
+                        .font(.caption)
+                }
+                .foregroundStyle(dailyState.color)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(
+                    String(localized: "Today: \(dailyState.label), \(String(format: "%.2f", abs(dailyPct))) percent")
+                )
             }
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(holding.symbol), \(holding.name)")
         .accessibilityValue(
@@ -130,12 +142,11 @@ struct InvestmentDetailView: View {
             Text(value)
                 .font(.callout)
                 .fontWeight(.medium)
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .cardBackground(cornerRadius: 12)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(title)
         .accessibilityValue(value)
@@ -184,10 +195,43 @@ struct InvestmentDetailView: View {
                 .drawingGroup()
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel(String(localized: "Price history line chart for \(holding.symbol)"))
+
+                ChartDataTable(
+                    summary: priceHistorySummary,
+                    rows: priceHistoryRows,
+                    tableLabel: String(localized: "Price history data table")
+                )
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
+    }
+
+    /// Spoken summary of the price-history chart for VoiceOver users. (#2113)
+    private var priceHistorySummary: String {
+        let history = viewModel.performanceHistory
+        guard let first = history.first, let last = history.last else {
+            return String(localized: "No price history available.")
+        }
+        let start = viewModel.formatCurrency(first.valueMinorUnits, currencyCode: holding.currencyCode)
+        let end = viewModel.formatCurrency(last.valueMinorUnits, currencyCode: holding.currencyCode)
+        let highValue = history.map(\.valueMinorUnits).max() ?? last.valueMinorUnits
+        let lowValue = history.map(\.valueMinorUnits).min() ?? first.valueMinorUnits
+        let high = viewModel.formatCurrency(highValue, currencyCode: holding.currencyCode)
+        let low = viewModel.formatCurrency(lowValue, currencyCode: holding.currencyCode)
+        let startDate = first.date.formatted(.dateTime.month(.abbreviated).day())
+        let endDate = last.date.formatted(.dateTime.month(.abbreviated).day())
+        return String(localized: "Price history for \(holding.symbol) from \(startDate) to \(endDate). Started at \(start), ended at \(end). High \(high), low \(low).")
+    }
+
+    /// Row-per-point data table backing the price-history chart. (#2113)
+    private var priceHistoryRows: [ChartDataRow] {
+        viewModel.performanceHistory.map { point in
+            ChartDataRow(
+                label: point.date.formatted(.dateTime.year().month(.abbreviated).day()),
+                value: viewModel.formatCurrency(point.valueMinorUnits, currencyCode: holding.currencyCode)
+            )
+        }
     }
 
     // MARK: - Holding Info
@@ -224,7 +268,7 @@ struct InvestmentDetailView: View {
             )
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
     }
 
     private func detailRow(label: String, value: String) -> some View {

--- a/apps/ios/Finance/Screens/InvestmentPortfolioView.swift
+++ b/apps/ios/Finance/Screens/InvestmentPortfolioView.swift
@@ -95,6 +95,7 @@ struct InvestmentPortfolioView: View {
                     Text(String(localized: "Total Gain/Loss"))
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    GainLossBadge(state: portfolio.gainLossState)
                     CurrencyLabel(
                         amountInMinorUnits: portfolio.totalGainLossMinorUnits,
                         currencyCode: portfolio.currencyCode,
@@ -117,7 +118,7 @@ struct InvestmentPortfolioView: View {
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(String(localized: "Portfolio summary"))
         .accessibilityValue(
@@ -185,7 +186,7 @@ struct InvestmentPortfolioView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
     }
 
     // MARK: - Asset Allocation
@@ -228,7 +229,7 @@ struct InvestmentPortfolioView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
     }
 
     // MARK: - Holdings List
@@ -287,7 +288,7 @@ struct InvestmentPortfolioView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .cardBackground(cornerRadius: 12)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(holding.symbol), \(holding.name)")
         .accessibilityValue(

--- a/apps/ios/Finance/Screens/NlpInputView.swift
+++ b/apps/ios/Finance/Screens/NlpInputView.swift
@@ -188,7 +188,7 @@ struct NlpInputView: View {
                 ConfidenceIndicatorView(confidence: result.confidence)
             }
             .padding()
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            .cardBackground(cornerRadius: 12)
             .accessibilityElement(children: .contain)
             .accessibilityLabel(String(localized: "Parsed transaction preview"))
             .accessibilityIdentifier("parsed_preview_section")

--- a/apps/ios/Finance/Screens/ReportResultView.swift
+++ b/apps/ios/Finance/Screens/ReportResultView.swift
@@ -56,7 +56,7 @@ struct ReportResultView: View {
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(String(localized: "\(result.configuration.reportType.displayName) report"))
         .accessibilityValue(String(localized: "Period: \(result.configuration.dateRange.displayName)"))
@@ -117,7 +117,7 @@ struct ReportResultView: View {
                                 .frame(width: 10, height: 10)
                             Text(entry.categoryName)
                                 .font(.caption)
-                                .lineLimit(1)
+                                .fixedSize(horizontal: false, vertical: true)
                         }
                         .accessibilityElement(children: .combine)
                         .accessibilityLabel(entry.categoryName)
@@ -127,7 +127,7 @@ struct ReportResultView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
     }
 
     private var incomeVsExpenseChart: some View {
@@ -178,7 +178,7 @@ struct ReportResultView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
     }
 
     private var netWorthChart: some View {
@@ -234,7 +234,7 @@ struct ReportResultView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
     }
 
     private var emptyChartPlaceholder: some View {
@@ -304,7 +304,7 @@ struct ReportResultView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
     }
 
     private var monthlyDataTable: some View {
@@ -373,7 +373,7 @@ struct ReportResultView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
     }
 
     private var netWorthDataTable: some View {
@@ -410,7 +410,7 @@ struct ReportResultView: View {
             }
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .cardBackground(cornerRadius: 16)
     }
 }
 

--- a/apps/ios/Finance/Screens/TransactionsView.swift
+++ b/apps/ios/Finance/Screens/TransactionsView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct TransactionsView: View {
     @Environment(BiometricAuthManager.self) private var biometricManager
     @Environment(DeepLinkHandler.self) private var deepLinkHandler
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var viewModel: TransactionsViewModel
 
     init(viewModel: TransactionsViewModel = TransactionsViewModel(
@@ -43,6 +44,7 @@ struct TransactionsView: View {
                     transactionsList
                 }
             }
+            .offlineAware()
             .navigationTitle(String(localized: "Transactions"))
             .searchable(text: $viewModel.searchText, prompt: String(localized: "Search by payee, category, or account"))
             .toolbar {
@@ -236,14 +238,17 @@ struct TransactionsView: View {
     }
 
     private func transactionRow(_ transaction: TransactionItem) -> some View {
-        HStack(spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             IconView(transaction.type.iconToken, size: 16)
                 .foregroundStyle(transaction.type.color)
                 .frame(width: 32, height: 32)
                 .background(transaction.type.color.opacity(0.1), in: Circle())
             VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 4) {
-                    Text(transaction.payee).font(.body).lineLimit(1)
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(transaction.payee)
+                        .font(.body)
+                        .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
+                        .fixedSize(horizontal: false, vertical: true)
                     if transaction.status == .pending {
                         Text(transaction.status.displayName)
                             .font(.caption2).foregroundStyle(.orange)
@@ -256,7 +261,9 @@ struct TransactionsView: View {
                     Text("·")
                     Text(transaction.accountName)
                 }
-                .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                .font(.caption).foregroundStyle(.secondary)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
+                .fixedSize(horizontal: false, vertical: true)
 
                 // Tags row (show up to 2 tag chips)
                 if !transaction.tags.isEmpty {
@@ -266,9 +273,16 @@ struct TransactionsView: View {
                         onTagTap: { tag in viewModel.filterByTag(tag) }
                     )
                 }
+                // At accessibility text sizes stack the amount below the
+                // details so nothing is truncated. (#2119)
+                if dynamicTypeSize.isAccessibilitySize {
+                    CurrencyLabel(amountInMinorUnits: transaction.amountMinorUnits, currencyCode: transaction.currencyCode, font: .callout.bold())
+                }
             }
-            Spacer()
-            CurrencyLabel(amountInMinorUnits: transaction.amountMinorUnits, currencyCode: transaction.currencyCode, font: .callout.bold())
+            if !dynamicTypeSize.isAccessibilitySize {
+                Spacer()
+                CurrencyLabel(amountInMinorUnits: transaction.amountMinorUnits, currencyCode: transaction.currencyCode, font: .callout.bold())
+            }
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)


### PR DESCRIPTION
﻿## Summary

Batch of closely-related iOS (SwiftUI) UX & accessibility improvements, all scoped to `apps/ios` (shared packages read-only). Targets WCAG 2.2 AA and Apple accessibility guidance.

### #3588 - Guiding first-run empty state
Brand-new users no longer see zero-value cards. When the Dashboard has no accounts, a welcoming EmptyStateView is shown with a working Add Account CTA that routes to the Accounts tab and opens account creation via a new DeepLinkHandler.requestAccountCreation flag.

### #3586 - Card surfaces honor Reduce Transparency
New .cardBackground(cornerRadius:) modifier swaps translucent .regularMaterial for the opaque FinanceColors.backgroundElevated token when Reduce Transparency is enabled, preserving the material look otherwise. Migrated 36 material card surfaces across 12 files.

### #3583 - OfflineBanner across all data screens
New .offlineAware() modifier reads NetworkMonitor and renders the shared OfflineBanner with a VoiceOver status announcement on connectivity loss. Applied to Dashboard, Accounts, Transactions, Budgets and Goals (previously Dashboard-only).

### #2121 - Financial state uses more than red/green
New GainLossBadge (SF Symbol arrow + text label + semantic color pill) and GainLossState type. Raw red/green replaced with semantic amount/status tokens for holdings, portfolio, analytics and daily-return. Budget rings gained an explicit Over budget icon + text label.

### #2119 - Fully respect AX Dynamic Type sizes
Removed lineLimit(1)/minimumScaleFactor on critical values; payee, category, legend and metric text now wrap. Transaction rows stack the amount below details at accessibility text sizes.

### #2113 - VoiceOver text alternative for every financial chart
New reusable ChartDataTable (spoken summary + browsable, collapsible data table). Paired with the Trend, Prediction, Category Breakdown, Insights spending-breakdown and Investment price-history charts.

## New shared components
- Components/CardBackground.swift
- Components/OfflineAware.swift
- Components/ChartDataTable.swift
- Components/GainLossBadge.swift

## Testing
- npm run format:check - pass
- npx eslint . --max-warnings 0 - pass
- Swift is prettier-ignored; no local Swift/Xcode toolchain in this environment, so Swift changes were validated by manual review and brace/paren balance checks. CI performs the Swift build.

Closes #3588
Closes #3586
Closes #3583
Closes #2121
Closes #2119
Closes #2113
