### PR TITLE
feat(ios): charts, investing, VoiceOver & low-noise UX batch (#2115 #2116 #2118 #2122 #2163 #2167)

### DIFF
--- a/apps/ios/Finance/Charts/InvestmentProjectionChart.swift
+++ b/apps/ios/Finance/Charts/InvestmentProjectionChart.swift
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// InvestmentProjectionChart.swift
+// Finance
+//
+// A compound-growth projection chart for a portfolio. Plots the projected total
+// balance as a solid line and the cumulative contributed principal as a dashed
+// line, so the shaded gap between them makes market growth legible at a glance.
+//
+// VoiceOver users step through each yearly point with the adjustable rotor
+// (swipe up/down) — no drag gesture required (#2115).
+//
+// References: #2118, #2116, #2115, #2113
+
+import Charts
+import SwiftUI
+
+/// A line chart of a compound-growth projection: total value versus contributed
+/// principal, sampled once per year. Values are in minor units.
+struct InvestmentProjectionChart: View {
+    let points: [ProjectionPoint]
+    let currencyCode: String
+
+    @State private var selectedIndex: Int?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Chart {
+                ForEach(points) { point in
+                    LineMark(
+                        x: .value(String(localized: "Year"), point.date),
+                        y: .value(String(localized: "Value"), Double(point.valueMinorUnits) / 100.0),
+                        series: .value(String(localized: "Series"), "value")
+                    )
+                    .foregroundStyle(ChartColorPalette.blue)
+                    .interpolationMethod(.monotone)
+
+                    AreaMark(
+                        x: .value(String(localized: "Year"), point.date),
+                        yStart: .value(String(localized: "Contributed"), Double(point.contributedMinorUnits) / 100.0),
+                        yEnd: .value(String(localized: "Value"), Double(point.valueMinorUnits) / 100.0)
+                    )
+                    .foregroundStyle(ChartColorPalette.blue.opacity(0.12))
+                    .accessibilityHidden(true)
+
+                    LineMark(
+                        x: .value(String(localized: "Year"), point.date),
+                        y: .value(String(localized: "Contributed"), Double(point.contributedMinorUnits) / 100.0),
+                        series: .value(String(localized: "Series"), "contributed")
+                    )
+                    .foregroundStyle(ChartColorPalette.gold)
+                    .lineStyle(StrokeStyle(lineWidth: 2, dash: [5, 4]))
+                }
+
+                if let index = selectedIndex, points.indices.contains(index) {
+                    let point = points[index]
+                    RuleMark(x: .value(String(localized: "Selected"), point.date))
+                        .foregroundStyle(.secondary)
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                        .accessibilityHidden(true)
+                    PointMark(
+                        x: .value(String(localized: "Year"), point.date),
+                        y: .value(String(localized: "Value"), Double(point.valueMinorUnits) / 100.0)
+                    )
+                    .symbolSize(60)
+                    .foregroundStyle(ChartColorPalette.blue)
+                    .accessibilityHidden(true)
+                }
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading) { value in
+                    AxisValueLabel {
+                        if let doubleValue = value.as(Double.self) {
+                            Text(formattedAxis(doubleValue))
+                                .font(.caption2)
+                        }
+                    }
+                    AxisGridLine()
+                }
+            }
+            .chartXAxis {
+                AxisMarks { _ in
+                    AxisValueLabel(format: .dateTime.year())
+                        .font(.caption2)
+                    AxisGridLine()
+                }
+            }
+            .frame(minHeight: 200)
+            .drawingGroup()
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(String(localized: "Investment growth projection chart"))
+            .accessibilityValue(accessibilityValueText)
+            .accessibilityHint(String(localized: "Swipe up or down with one finger to move through each projected year"))
+            .accessibilityAdjustableAction { direction in
+                stepSelection(direction)
+            }
+
+            ChartDataTable(
+                summary: chartSummary,
+                rows: chartRows,
+                tableLabel: String(localized: "Projection data table")
+            )
+        }
+    }
+
+    // MARK: - VoiceOver Navigation (#2115)
+
+    private var accessibilityValueText: String {
+        guard let index = selectedIndex, points.indices.contains(index) else {
+            return chartSummary
+        }
+        let point = points[index]
+        let value = formattedCurrency(point.valueMinorUnits)
+        let growth = formattedCurrency(point.growthMinorUnits)
+        return String(localized: "\(formattedYear(point.date)), value \(value), of which growth \(growth)")
+    }
+
+    private func stepSelection(_ direction: AccessibilityAdjustmentDirection) {
+        guard !points.isEmpty else { return }
+        switch direction {
+        case .increment:
+            selectedIndex = min((selectedIndex ?? -1) + 1, points.count - 1)
+        case .decrement:
+            selectedIndex = max((selectedIndex ?? 0) - 1, 0)
+        @unknown default:
+            break
+        }
+    }
+
+    // MARK: - Text Alternative (#2113)
+
+    private var chartSummary: String {
+        guard let first = points.first, let last = points.last, points.count > 1 else {
+            return String(localized: "No projection available.")
+        }
+        let startValue = formattedCurrency(first.valueMinorUnits)
+        let endValue = formattedCurrency(last.valueMinorUnits)
+        let contributed = formattedCurrency(last.contributedMinorUnits)
+        let growth = formattedCurrency(last.growthMinorUnits)
+        return String(localized: "Projection from \(startValue) to \(endValue) over \(points.count - 1) years, with \(contributed) contributed and \(growth) of projected growth.")
+    }
+
+    private var chartRows: [ChartDataRow] {
+        points.map { point in
+            ChartDataRow(
+                label: formattedYear(point.date),
+                value: String(localized: "\(formattedCurrency(point.valueMinorUnits)) (contributed \(formattedCurrency(point.contributedMinorUnits)))")
+            )
+        }
+    }
+
+    // MARK: - Formatting
+
+    private func formattedCurrency(_ minorUnits: Int64) -> String {
+        CurrencyLabel.formatted(minorUnits: minorUnits, currencyCode: currencyCode)
+    }
+
+    private func formattedAxis(_ value: Double) -> String {
+        let thousands = value / 1000.0
+        return "\(Int(thousands.rounded()))k"
+    }
+
+    private func formattedYear(_ date: Date) -> String {
+        date.formatted(.dateTime.year())
+    }
+}

--- a/apps/ios/Finance/Charts/NetWorthTrendChart.swift
+++ b/apps/ios/Finance/Charts/NetWorthTrendChart.swift
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// NetWorthTrendChart.swift
+// Finance
+//
+// A clean, minimalist net-worth growth chart with an optional forward
+// projection band. Reconstructed history is drawn as a solid line with a soft
+// area fill; the projection continues as a dashed line so the "known past" and
+// "estimated future" are visually distinct without relying on colour alone.
+//
+// VoiceOver users step through every point with the adjustable rotor (swipe
+// up/down) — no drag gesture required — satisfying #2115.
+//
+// References: #2116, #2115, #2113
+
+import Charts
+import SwiftUI
+
+/// A net-worth growth line chart with reconstructed history and a dashed
+/// forward projection. Values are supplied in minor units.
+struct NetWorthTrendChart: View {
+    let history: [NetWorthTrendPoint]
+    let projection: [NetWorthTrendPoint]
+    let currencyCode: String
+
+    @State private var selectedIndex: Int?
+
+    /// History followed by projection, in chart order, for point navigation.
+    private var orderedPoints: [NetWorthTrendPoint] { history + projection }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Chart {
+                ForEach(history) { point in
+                    LineMark(
+                        x: .value(String(localized: "Date"), point.date),
+                        y: .value(String(localized: "Net Worth"), Double(point.valueMinorUnits) / 100.0),
+                        series: .value(String(localized: "Series"), "history")
+                    )
+                    .foregroundStyle(ChartColorPalette.teal)
+                    .interpolationMethod(.catmullRom)
+
+                    AreaMark(
+                        x: .value(String(localized: "Date"), point.date),
+                        y: .value(String(localized: "Net Worth"), Double(point.valueMinorUnits) / 100.0)
+                    )
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [ChartColorPalette.teal.opacity(0.25), .clear],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .accessibilityHidden(true)
+                }
+
+                ForEach(projection) { point in
+                    LineMark(
+                        x: .value(String(localized: "Date"), point.date),
+                        y: .value(String(localized: "Net Worth"), Double(point.valueMinorUnits) / 100.0),
+                        series: .value(String(localized: "Series"), "projection")
+                    )
+                    .foregroundStyle(ChartColorPalette.purple)
+                    .lineStyle(StrokeStyle(lineWidth: 2, dash: [6, 4]))
+                }
+
+                if let index = selectedIndex, orderedPoints.indices.contains(index) {
+                    let point = orderedPoints[index]
+                    RuleMark(x: .value(String(localized: "Selected"), point.date))
+                        .foregroundStyle(.secondary)
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                        .accessibilityHidden(true)
+                    PointMark(
+                        x: .value(String(localized: "Date"), point.date),
+                        y: .value(String(localized: "Net Worth"), Double(point.valueMinorUnits) / 100.0)
+                    )
+                    .symbolSize(60)
+                    .foregroundStyle(point.isProjected ? ChartColorPalette.purple : ChartColorPalette.teal)
+                    .accessibilityHidden(true)
+                }
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading) { value in
+                    AxisValueLabel {
+                        if let doubleValue = value.as(Double.self) {
+                            Text(formattedAxis(doubleValue))
+                                .font(.caption2)
+                        }
+                    }
+                    AxisGridLine()
+                }
+            }
+            .chartXAxis {
+                AxisMarks { _ in
+                    AxisValueLabel(format: .dateTime.month(.abbreviated))
+                        .font(.caption2)
+                    AxisGridLine()
+                }
+            }
+            .frame(minHeight: 200)
+            .drawingGroup()
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(String(localized: "Net worth growth chart"))
+            .accessibilityValue(accessibilityValueText)
+            .accessibilityHint(String(localized: "Swipe up or down with one finger to move through months"))
+            .accessibilityAdjustableAction { direction in
+                stepSelection(direction)
+            }
+
+            ChartDataTable(
+                summary: chartSummary,
+                rows: chartRows,
+                tableLabel: String(localized: "Net worth data table")
+            )
+        }
+    }
+
+    // MARK: - VoiceOver Navigation (#2115)
+
+    private var accessibilityValueText: String {
+        guard let index = selectedIndex, orderedPoints.indices.contains(index) else {
+            return chartSummary
+        }
+        let point = orderedPoints[index]
+        let qualifier = point.isProjected
+            ? String(localized: "projected")
+            : String(localized: "actual")
+        return "\(formattedDate(point.date)), \(formattedCurrency(point.valueMinorUnits)), \(qualifier)"
+    }
+
+    private func stepSelection(_ direction: AccessibilityAdjustmentDirection) {
+        guard !orderedPoints.isEmpty else { return }
+        switch direction {
+        case .increment:
+            selectedIndex = min((selectedIndex ?? -1) + 1, orderedPoints.count - 1)
+        case .decrement:
+            selectedIndex = max((selectedIndex ?? 0) - 1, 0)
+        @unknown default:
+            break
+        }
+    }
+
+    // MARK: - Text Alternative (#2113)
+
+    private var chartSummary: String {
+        guard let first = history.first ?? projection.first,
+              let last = projection.last ?? history.last else {
+            return String(localized: "No net worth history available.")
+        }
+        let start = formattedCurrency(first.valueMinorUnits)
+        let end = formattedCurrency(last.valueMinorUnits)
+        let range = "\(formattedDate(first.date)) to \(formattedDate(last.date))"
+        if projection.isEmpty {
+            return String(localized: "Net worth from \(range), \(start) to \(end).")
+        }
+        return String(localized: "Net worth from \(range), \(start) to a projected \(end).")
+    }
+
+    private var chartRows: [ChartDataRow] {
+        orderedPoints.map { point in
+            ChartDataRow(
+                label: point.isProjected
+                    ? String(localized: "\(formattedDate(point.date)) (projected)")
+                    : formattedDate(point.date),
+                value: formattedCurrency(point.valueMinorUnits)
+            )
+        }
+    }
+
+    // MARK: - Formatting
+
+    private func formattedCurrency(_ minorUnits: Int64) -> String {
+        CurrencyLabel.formatted(minorUnits: minorUnits, currencyCode: currencyCode)
+    }
+
+    private func formattedAxis(_ value: Double) -> String {
+        let thousands = value / 1000.0
+        return "\(Int(thousands.rounded()))k"
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        date.formatted(.dateTime.month(.abbreviated).year())
+    }
+}

--- a/apps/ios/Finance/Charts/PredictionChart.swift
+++ b/apps/ios/Finance/Charts/PredictionChart.swift
@@ -19,6 +19,7 @@ struct PredictionChart: View {
     let currencyCode: String
 
     @State private var selectedDate: Date?
+    @State private var selectedIndex: Int?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -121,8 +122,13 @@ struct PredictionChart: View {
             }
             .frame(minHeight: 220)
             .drawingGroup()
-            .accessibilityElement(children: .contain)
+            .accessibilityElement(children: .ignore)
             .accessibilityLabel(String(localized: "Spending forecast chart with predictions"))
+            .accessibilityValue(accessibilityValueText)
+            .accessibilityHint(String(localized: "Swipe up or down with one finger to move through history and forecast points"))
+            .accessibilityAdjustableAction { direction in
+                stepSelection(direction)
+            }
 
             ChartDataTable(
                 summary: forecastSummary,
@@ -131,6 +137,64 @@ struct PredictionChart: View {
             )
         }
         .padding()
+    }
+
+    // MARK: - VoiceOver Point Navigation (#2115)
+    //
+    // VoiceOver users step through the combined history + forecast series with
+    // the adjustable rotor (swipe up/down) rather than the sighted drag gesture.
+
+    /// A navigable point: history and forecast values flattened in chart order.
+    private struct AccessiblePoint {
+        let date: Date
+        let label: String
+        let value: String
+    }
+
+    private var accessiblePoints: [AccessiblePoint] {
+        var points = historicalData.map {
+            AccessiblePoint(
+                date: $0.date,
+                label: formattedDate($0.date),
+                value: formattedCurrency($0.value)
+            )
+        }
+        points += predictions.map { prediction in
+            let predicted = formattedCurrency(Double(prediction.predictedMinorUnits) / 100.0)
+            let lower = formattedCurrency(Double(prediction.lowerBoundMinorUnits) / 100.0)
+            let upper = formattedCurrency(Double(prediction.upperBoundMinorUnits) / 100.0)
+            return AccessiblePoint(
+                date: prediction.date,
+                label: String(localized: "\(formattedDate(prediction.date)) predicted"),
+                value: String(localized: "\(predicted), range \(lower) to \(upper)")
+            )
+        }
+        return points
+    }
+
+    private var accessibilityValueText: String {
+        let points = accessiblePoints
+        guard let index = selectedIndex, points.indices.contains(index) else {
+            return forecastSummary
+        }
+        let point = points[index]
+        return "\(point.label), \(point.value)"
+    }
+
+    private func stepSelection(_ direction: AccessibilityAdjustmentDirection) {
+        let points = accessiblePoints
+        guard !points.isEmpty else { return }
+        switch direction {
+        case .increment:
+            selectedIndex = min((selectedIndex ?? -1) + 1, points.count - 1)
+        case .decrement:
+            selectedIndex = max((selectedIndex ?? 0) - 1, 0)
+        @unknown default:
+            break
+        }
+        if let index = selectedIndex, points.indices.contains(index) {
+            selectedDate = points[index].date
+        }
     }
 
     // MARK: - Text Alternative (#2113)

--- a/apps/ios/Finance/Charts/TrendChart.swift
+++ b/apps/ios/Finance/Charts/TrendChart.swift
@@ -33,6 +33,7 @@ struct TrendChart: View {
     let currencyCode: String
 
     @State private var selectedDate: Date?
+    @State private var selectedIndex: Int?
 
     /// Unique series names, preserving first-occurrence order.
     private var seriesNames: [String] {
@@ -134,8 +135,13 @@ struct TrendChart: View {
             }
             .frame(minHeight: 220)
             .drawingGroup()  // Rasterise into a single Metal layer for 60 FPS scrolling
-            .accessibilityElement(children: .contain)
+            .accessibilityElement(children: .ignore)
             .accessibilityLabel(String(localized: "Financial trend line chart"))
+            .accessibilityValue(accessibilityValueText)
+            .accessibilityHint(String(localized: "Swipe up or down with one finger to move through data points"))
+            .accessibilityAdjustableAction { direction in
+                stepSelection(direction)
+            }
 
             ChartDataTable(
                 summary: chartSummary,
@@ -144,6 +150,43 @@ struct TrendChart: View {
             )
         }
         .padding()
+    }
+
+    // MARK: - VoiceOver Point Navigation (#2115)
+    //
+    // VoiceOver users move point-by-point with the standard adjustable rotor
+    // (swipe up/down) instead of the touch-drag gesture, which is unusable
+    // without sight. Each step announces the date and value — and, for
+    // multi-series charts, the series — and mirrors the selection visually.
+
+    /// Spoken value for the chart: the current point when one is selected,
+    /// otherwise the full trend summary.
+    private var accessibilityValueText: String {
+        guard let index = selectedIndex, data.indices.contains(index) else {
+            return chartSummary
+        }
+        let point = data[index]
+        if seriesNames.count > 1 {
+            return "\(point.series), \(formattedDate(point.date)), \(formattedCurrency(point.value))"
+        }
+        return "\(formattedDate(point.date)), \(formattedCurrency(point.value))"
+    }
+
+    /// Advances or rewinds the selected point in response to the VoiceOver
+    /// adjustable action, keeping the visual selection in sync.
+    private func stepSelection(_ direction: AccessibilityAdjustmentDirection) {
+        guard !data.isEmpty else { return }
+        switch direction {
+        case .increment:
+            selectedIndex = min((selectedIndex ?? -1) + 1, data.count - 1)
+        case .decrement:
+            selectedIndex = max((selectedIndex ?? 0) - 1, 0)
+        @unknown default:
+            break
+        }
+        if let index = selectedIndex, data.indices.contains(index) {
+            selectedDate = data[index].date
+        }
     }
 
     // MARK: - Text Alternative (#2113)

--- a/apps/ios/Finance/Components/InvestmentProjectionCard.swift
+++ b/apps/ios/Finance/Components/InvestmentProjectionCard.swift
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// InvestmentProjectionCard.swift
+// Finance
+//
+// Contribution-aware growth projection section for the investment portfolio.
+// Lets a passive index-fund investor set a recurring monthly contribution,
+// pick a horizon and expected return, and see a trustworthy compound-growth
+// projection that separates contributed principal from market growth.
+//
+// The projection math lives in the pure, unit-tested `CompoundGrowthProjector`
+// (via `InvestmentViewModel`); this file only owns presentation and controls.
+//
+// References: #2118, #2116, #2115
+
+import SwiftUI
+
+/// A projection section with contribution/horizon/return controls, a compound
+/// growth chart, and a principal-versus-growth breakdown.
+struct InvestmentProjectionCard: View {
+    @Bindable var viewModel: InvestmentViewModel
+    let currencyCode: String
+
+    /// Monthly contribution adjustment step: $50.
+    private let contributionStepMinorUnits: Int64 = 5_000
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(String(localized: "Growth Projection"))
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            controls
+
+            InvestmentProjectionChart(
+                points: viewModel.projectionPoints,
+                currencyCode: currencyCode
+            )
+
+            breakdown
+
+            if !viewModel.contributions.isEmpty {
+                contributionsHistory
+            }
+        }
+        .padding()
+        .cardBackground(cornerRadius: 16)
+        .accessibilityIdentifier("investment_projection_card")
+    }
+
+    // MARK: - Controls
+
+    private var controls: some View {
+        VStack(spacing: 12) {
+            contributionStepper
+            horizonStepper
+            returnStepper
+        }
+    }
+
+    private var contributionStepper: some View {
+        Stepper {
+            controlLabel(
+                title: String(localized: "Monthly contribution"),
+                value: viewModel.formatCurrency(viewModel.monthlyContributionMinorUnits, currencyCode: currencyCode)
+            )
+        } onIncrement: {
+            Task { await viewModel.updateMonthlyContribution(viewModel.monthlyContributionMinorUnits + contributionStepMinorUnits) }
+        } onDecrement: {
+            Task { await viewModel.updateMonthlyContribution(viewModel.monthlyContributionMinorUnits - contributionStepMinorUnits) }
+        }
+        .accessibilityValue(viewModel.formatCurrency(viewModel.monthlyContributionMinorUnits, currencyCode: currencyCode))
+    }
+
+    private var horizonStepper: some View {
+        Stepper(value: $viewModel.projectionYears, in: 5...40, step: 5) {
+            controlLabel(
+                title: String(localized: "Horizon"),
+                value: String(localized: "\(viewModel.projectionYears) years")
+            )
+        }
+        .accessibilityValue(String(localized: "\(viewModel.projectionYears) years"))
+    }
+
+    private var returnStepper: some View {
+        Stepper(value: $viewModel.projectionAnnualReturnPercent, in: 1...12, step: 0.5) {
+            controlLabel(
+                title: String(localized: "Expected return"),
+                value: String(format: "%.1f%%", viewModel.projectionAnnualReturnPercent)
+            )
+        }
+        .accessibilityValue(String(format: "%.1f percent", viewModel.projectionAnnualReturnPercent))
+    }
+
+    private func controlLabel(title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+                .font(.subheadline)
+            Spacer()
+            Text(value)
+                .font(.subheadline.bold())
+                .monospacedDigit()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(title)
+    }
+
+    // MARK: - Breakdown
+
+    private var breakdown: some View {
+        HStack(spacing: 12) {
+            statColumn(
+                title: String(localized: "Contributed"),
+                value: viewModel.totalContributionsMinorUnits
+            )
+            Divider().frame(height: 40)
+            statColumn(
+                title: String(localized: "Market growth"),
+                value: viewModel.marketReturnMinorUnits,
+                showSign: true
+            )
+            Divider().frame(height: 40)
+            statColumn(
+                title: String(localized: "Projected"),
+                value: viewModel.projectedValueMinorUnits
+            )
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func statColumn(title: String, value: Int64, showSign: Bool = false) -> some View {
+        VStack(spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Text(viewModel.formatCurrency(value, currencyCode: currencyCode, showSign: showSign))
+                .font(.callout.bold())
+                .monospacedDigit()
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title), \(viewModel.formatCurrency(value, currencyCode: currencyCode, showSign: showSign))")
+    }
+
+    // MARK: - Contributions History
+
+    private var contributionsHistory: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "Recent Contributions"))
+                .font(.subheadline.bold())
+
+            ForEach(viewModel.contributions.prefix(5)) { record in
+                HStack {
+                    Text(record.date, style: .date)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(viewModel.formatCurrency(record.amountMinorUnits, currencyCode: currencyCode, showSign: true))
+                        .font(.caption.bold())
+                        .monospacedDigit()
+                }
+                .accessibilityElement(children: .combine)
+            }
+        }
+    }
+}

--- a/apps/ios/Finance/Components/NetWorthTrendCard.swift
+++ b/apps/ios/Finance/Components/NetWorthTrendCard.swift
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// NetWorthTrendCard.swift
+// Finance
+//
+// Dashboard card presenting a clean net-worth growth chart with a range
+// selector and a one-line forward projection. Keeps the Dashboard screen thin
+// by owning the trend section's layout, range picker, and projection summary.
+//
+// References: #2116, #2115
+
+import SwiftUI
+
+/// A dashboard section showing the net-worth growth chart, a range selector,
+/// and a compact projection summary.
+struct NetWorthTrendCard: View {
+    @Bindable var viewModel: DashboardViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
+            header
+
+            NetWorthTrendChart(
+                history: viewModel.netWorthTrendPoints,
+                projection: viewModel.netWorthProjectionPoints,
+                currencyCode: viewModel.currencyCode
+            )
+
+            projectionSummary
+        }
+        .padding()
+        .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
+        .accessibilityIdentifier("net_worth_trend_card")
+    }
+
+    private var header: some View {
+        HStack {
+            Text(String(localized: "Net Worth Growth"))
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+            Spacer()
+            rangePicker
+        }
+    }
+
+    private var rangePicker: some View {
+        Picker(String(localized: "Range"), selection: $viewModel.netWorthTrendRange) {
+            ForEach(NetWorthTrendRange.allCases) { range in
+                Text(range.shortLabel).tag(range)
+            }
+        }
+        .pickerStyle(.segmented)
+        .frame(maxWidth: 200)
+        .accessibilityLabel(String(localized: "Trend range"))
+        .accessibilityHint(String(localized: "Choose how far back the net worth chart looks"))
+    }
+
+    /// One-line, non-colour-dependent projection callout.
+    private var projectionSummary: some View {
+        let projected = CurrencyLabel.formatted(
+            minorUnits: viewModel.projectedNetWorthMinorUnits,
+            currencyCode: viewModel.currencyCode
+        )
+        let pace = CurrencyLabel.formatted(
+            minorUnits: viewModel.averageMonthlySavingsMinorUnits,
+            currencyCode: viewModel.currencyCode
+        )
+        return HStack(spacing: 6) {
+            Image(systemName: "chart.line.uptrend.xyaxis")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text(String(localized: "Projected \(projected) in 12 months at \(pace) per month"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(localized: "Projected net worth \(projected) in twelve months, saving \(pace) per month"))
+    }
+}

--- a/apps/ios/Finance/Components/QuickAddExpenseSheet.swift
+++ b/apps/ios/Finance/Components/QuickAddExpenseSheet.swift
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// QuickAddExpenseSheet.swift
+// Finance
+//
+// One-thumb quick expense capture. A floating action button on the
+// Transactions screen opens this compact sheet: tap a preset (coffee, lunch,
+// transit, …), type an amount, and save — with the last-used account and
+// category remembered so repeat capture is fast.
+//
+// Composition + remembered defaults live in the pure, unit-tested
+// `QuickExpenseComposer`; this file owns only presentation.
+//
+// References: #2167
+
+import SwiftUI
+
+// MARK: - Floating Action Button
+
+/// A large, thumb-reachable button that triggers quick expense capture.
+struct QuickAddExpenseButton: View {
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "plus")
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(.white)
+                .frame(width: 60, height: 60)
+                .background(Color.accentColor, in: Circle())
+                .shadow(radius: 6, y: 3)
+        }
+        .accessibilityIdentifier("quick_add_fab")
+        .accessibilityLabel(String(localized: "Quick add expense"))
+        .accessibilityHint(String(localized: "Log an expense in a few taps"))
+    }
+}
+
+// MARK: - Quick Add Sheet
+
+/// A minimal expense-entry sheet optimised for speed and one-handed use.
+struct QuickAddExpenseSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    private let transactionRepository: TransactionRepository
+    private let accountRepository: AccountRepository
+    private let categoryRepository: CategoryRepository
+    private let onSaved: () -> Void
+
+    @State private var amountText = ""
+    @State private var payee = ""
+    @State private var accounts: [AccountItem] = []
+    @State private var categories: [CategoryItem] = []
+    @State private var selectedAccountId: String = ""
+    @State private var selectedCategoryId: String = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+    @FocusState private var amountFocused: Bool
+
+    init(
+        transactionRepository: TransactionRepository = RepositoryProvider.shared.transactions,
+        accountRepository: AccountRepository = RepositoryProvider.shared.accounts,
+        categoryRepository: CategoryRepository = RepositoryProvider.shared.categories,
+        onSaved: @escaping () -> Void = {}
+    ) {
+        self.transactionRepository = transactionRepository
+        self.accountRepository = accountRepository
+        self.categoryRepository = categoryRepository
+        self.onSaved = onSaved
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                presetsSection
+                amountSection
+                detailsSection
+            }
+            .navigationTitle(String(localized: "Quick Expense"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Cancel")) { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "Save")) {
+                        Task { await save() }
+                    }
+                    .disabled(!canSave || isSaving)
+                    .accessibilityIdentifier("quick_add_save")
+                }
+            }
+            .task { await load() }
+            .alert(
+                String(localized: "Couldn't Save"),
+                isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
+                Button(String(localized: "OK"), role: .cancel) { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    // MARK: - Sections
+
+    private var presetsSection: some View {
+        Section {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(QuickExpenseComposer.presets) { preset in
+                        presetChip(preset)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        } header: {
+            Text(String(localized: "Quick Picks"))
+        }
+    }
+
+    private func presetChip(_ preset: QuickExpensePreset) -> some View {
+        Button {
+            apply(preset)
+        } label: {
+            VStack(spacing: 6) {
+                Image(systemName: preset.systemImage)
+                    .font(.title3)
+                Text(preset.label)
+                    .font(.caption)
+            }
+            .frame(width: 70, height: 60)
+            .background(Color.accentColor.opacity(selectedCategoryId == preset.categoryId ? 0.2 : 0.08), in: RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(preset.label)
+        .accessibilityHint(String(localized: "Fills the category and payee, then enter an amount"))
+    }
+
+    private var amountSection: some View {
+        Section {
+            TextField(String(localized: "0.00"), text: $amountText)
+                .keyboardType(.decimalPad)
+                .font(.largeTitle.bold())
+                .focused($amountFocused)
+                .accessibilityLabel(String(localized: "Amount"))
+                .accessibilityHint(String(localized: "Enter the expense amount"))
+        } header: {
+            Text(String(localized: "Amount"))
+        }
+    }
+
+    private var detailsSection: some View {
+        Section {
+            TextField(String(localized: "Payee (optional)"), text: $payee)
+                .accessibilityLabel(String(localized: "Payee"))
+
+            Picker(String(localized: "Category"), selection: $selectedCategoryId) {
+                ForEach(categories) { category in
+                    Text(category.name).tag(category.id)
+                }
+            }
+            .accessibilityLabel(String(localized: "Category"))
+
+            Picker(String(localized: "Account"), selection: $selectedAccountId) {
+                ForEach(accounts) { account in
+                    Text(account.name).tag(account.id)
+                }
+            }
+            .accessibilityLabel(String(localized: "Account"))
+        }
+    }
+
+    // MARK: - Logic
+
+    private var parsedMinorUnits: Int64? {
+        let trimmed = amountText.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, let value = Decimal(string: trimmed) else { return nil }
+        let cents = NSDecimalNumber(decimal: value * 100).int64Value
+        return cents > 0 ? cents : nil
+    }
+
+    private var canSave: Bool {
+        parsedMinorUnits != nil && !selectedAccountId.isEmpty && !selectedCategoryId.isEmpty
+    }
+
+    private func apply(_ preset: QuickExpensePreset) {
+        payee = preset.defaultPayee
+        if categories.contains(where: { $0.id == preset.categoryId }) {
+            selectedCategoryId = preset.categoryId
+        }
+        amountFocused = true
+    }
+
+    private func load() async {
+        do {
+            async let loadedAccounts = accountRepository.getAccounts()
+            async let loadedCategories = categoryRepository.getCategories()
+            accounts = try await loadedAccounts
+            categories = try await loadedCategories
+
+            selectedAccountId = QuickExpenseComposer.lastAccountId().flatMap { id in
+                accounts.contains(where: { $0.id == id }) ? id : nil
+            } ?? accounts.first?.id ?? ""
+
+            selectedCategoryId = QuickExpenseComposer.lastCategoryId().flatMap { id in
+                categories.contains(where: { $0.id == id }) ? id : nil
+            } ?? categories.first?.id ?? ""
+
+            amountFocused = true
+        } catch {
+            errorMessage = String(localized: "Couldn't load your accounts and categories.")
+        }
+    }
+
+    private func save() async {
+        guard let minorUnits = parsedMinorUnits,
+              let account = accounts.first(where: { $0.id == selectedAccountId }),
+              let category = categories.first(where: { $0.id == selectedCategoryId }) else {
+            return
+        }
+        isSaving = true
+        defer { isSaving = false }
+
+        let transaction = QuickExpenseComposer.makeTransaction(
+            amountMinorUnits: minorUnits,
+            payee: payee,
+            categoryName: category.name,
+            accountName: account.name,
+            currencyCode: account.currencyCode
+        )
+
+        do {
+            try await transactionRepository.createTransaction(transaction)
+            QuickExpenseComposer.setLastAccountId(account.id)
+            QuickExpenseComposer.setLastCategoryId(category.id)
+            onSaved()
+            dismiss()
+        } catch {
+            errorMessage = String(localized: "Couldn't save the expense. Please try again.")
+        }
+    }
+}

--- a/apps/ios/Finance/Models/InvestmentModels.swift
+++ b/apps/ios/Finance/Models/InvestmentModels.swift
@@ -158,11 +158,24 @@ struct PortfolioItem: Identifiable, Sendable {
     let currencyCode: String
     let createdAt: Date
 
+    /// Recurring monthly contribution the investor adds to this portfolio, in
+    /// minor units. Powers compound-growth projections for passive investors.
+    /// (#2118)
+    var monthlyContributionMinorUnits: Int64 = 0
+
     /// Total portfolio value in minor units.
     var totalValueMinorUnits: Int64 { holdings.reduce(0) { $0 + $1.currentValueMinorUnits } }
 
     /// Total cost basis in minor units.
     var totalCostBasisMinorUnits: Int64 { holdings.reduce(0) { $0 + $1.costBasisMinorUnits } }
+
+    /// Money the investor has actually put in (cost basis). Contribution-aware
+    /// metric distinguishing invested principal from market growth. (#2118)
+    var totalContributionsMinorUnits: Int64 { totalCostBasisMinorUnits }
+
+    /// Growth attributable to the market (value minus contributed principal).
+    /// (#2118)
+    var marketReturnMinorUnits: Int64 { totalGainLossMinorUnits }
 
     /// Total unrealised gain/loss in minor units.
     var totalGainLossMinorUnits: Int64 { totalValueMinorUnits - totalCostBasisMinorUnits }
@@ -200,4 +213,21 @@ struct PerformanceDataPoint: Identifiable, Sendable {
     let id = UUID()
     let date: Date
     let valueMinorUnits: Int64
+}
+
+// MARK: - Contribution Record
+
+/// A single recorded contribution (deposit) into a portfolio. Persisted so the
+/// investor can see and trust the money they have actually added over time.
+/// (#2118)
+struct ContributionRecord: Identifiable, Codable, Sendable, Hashable {
+    let id: String
+    let date: Date
+    let amountMinorUnits: Int64
+
+    init(id: String = UUID().uuidString, date: Date, amountMinorUnits: Int64) {
+        self.id = id
+        self.date = date
+        self.amountMinorUnits = amountMinorUnits
+    }
 }

--- a/apps/ios/Finance/Navigation/MainTabView.swift
+++ b/apps/ios/Finance/Navigation/MainTabView.swift
@@ -19,6 +19,10 @@ struct MainTabView: View {
     /// (e.g. deep links) to switch tabs programmatically.
     @Binding var selectedTab: Tab
 
+    // Low-noise mode: optional tabs the user can hide. (#2122)
+    @AppStorage(FeatureVisibility.budgetsTabKey) private var showBudgetsTab = true
+    @AppStorage(FeatureVisibility.goalsTabKey) private var showGoalsTab = true
+
     init(selectedTab: Binding<Tab> = .constant(.dashboard)) {
         _selectedTab = selectedTab
     }
@@ -79,25 +83,29 @@ struct MainTabView: View {
                 .accessibilityLabel(Tab.transactions.title)
                 .accessibilityHint(String(localized: "Shows all your transactions"))
 
-            BudgetsView()
-                .tabItem {
-                    IconView(Tab.budgets.iconToken)
-                    Text(Tab.budgets.title)
-                }
-                .tag(Tab.budgets)
-                .accessibilityIdentifier("tab_budgets")
-                .accessibilityLabel(Tab.budgets.title)
-                .accessibilityHint(String(localized: "Shows your budget categories and spending"))
+            if showBudgetsTab {
+                BudgetsView()
+                    .tabItem {
+                        IconView(Tab.budgets.iconToken)
+                        Text(Tab.budgets.title)
+                    }
+                    .tag(Tab.budgets)
+                    .accessibilityIdentifier("tab_budgets")
+                    .accessibilityLabel(Tab.budgets.title)
+                    .accessibilityHint(String(localized: "Shows your budget categories and spending"))
+            }
 
-            GoalsView()
-                .tabItem {
-                    IconView(Tab.goals.iconToken)
-                    Text(Tab.goals.title)
-                }
-                .tag(Tab.goals)
-                .accessibilityIdentifier("tab_goals")
-                .accessibilityLabel(Tab.goals.title)
-                .accessibilityHint(String(localized: "Shows your financial goals and progress"))
+            if showGoalsTab {
+                GoalsView()
+                    .tabItem {
+                        IconView(Tab.goals.iconToken)
+                        Text(Tab.goals.title)
+                    }
+                    .tag(Tab.goals)
+                    .accessibilityIdentifier("tab_goals")
+                    .accessibilityLabel(Tab.goals.title)
+                    .accessibilityHint(String(localized: "Shows your financial goals and progress"))
+            }
         }
     }
 }

--- a/apps/ios/Finance/Repositories/InvestmentRepository.swift
+++ b/apps/ios/Finance/Repositories/InvestmentRepository.swift
@@ -32,6 +32,30 @@ protocol InvestmentRepository: Sendable {
     /// Returns simulated performance history for a portfolio.
     func getPerformanceHistory(portfolioId: String, months: Int) async throws -> [PerformanceDataPoint]
 
+    /// Returns the recurring monthly contribution for a portfolio, in minor units.
+    func getMonthlyContributionMinorUnits(portfolioId: String) async throws -> Int64
+
+    /// Persists the recurring monthly contribution for a portfolio.
+    func setMonthlyContributionMinorUnits(_ amountMinorUnits: Int64, portfolioId: String) async throws
+
+    /// Records a one-off contribution (deposit) into a portfolio.
+    func recordContribution(_ amountMinorUnits: Int64, portfolioId: String, date: Date) async throws
+
+    /// Returns the recorded contribution history for a portfolio, newest first.
+    func getContributions(portfolioId: String) async throws -> [ContributionRecord]
+
     /// Permanently deletes all investment data. Used for GDPR "Delete Everything".
     func deleteAllInvestments() async throws
+}
+
+// MARK: - Default Contribution Handling
+
+/// Default no-op contribution handling so repositories that do not track
+/// contributions (e.g. the mock) conform without extra boilerplate. Persisted
+/// implementations override these.
+extension InvestmentRepository {
+    func getMonthlyContributionMinorUnits(portfolioId: String) async throws -> Int64 { 0 }
+    func setMonthlyContributionMinorUnits(_ amountMinorUnits: Int64, portfolioId: String) async throws {}
+    func recordContribution(_ amountMinorUnits: Int64, portfolioId: String, date: Date) async throws {}
+    func getContributions(portfolioId: String) async throws -> [ContributionRecord] { [] }
 }

--- a/apps/ios/Finance/Repositories/PersistedInvestmentRepository.swift
+++ b/apps/ios/Finance/Repositories/PersistedInvestmentRepository.swift
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// PersistedInvestmentRepository.swift
+// Finance
+//
+// Persistence-backed investment repository. Replaces the always-hardcoded mock
+// with real data that survives app restarts: portfolios, holdings, a recurring
+// monthly contribution, and a contribution history are encoded to UserDefaults
+// as JSON. On first launch it seeds a realistic, editable passive index-fund
+// starter portfolio (VTI / VXUS / BND) so index-fund investors see trustworthy,
+// contribution-aware numbers instead of throwaway sample tickers.
+//
+// Performance history is reconstructed deterministically from the current
+// portfolio value and the recurring contribution — no random noise — so the
+// same inputs always render the same trend.
+//
+// References: #2118
+
+import Foundation
+import os
+
+/// UserDefaults-backed implementation of ``InvestmentRepository``.
+final class PersistedInvestmentRepository: InvestmentRepository, @unchecked Sendable {
+
+    // MARK: - Storage
+
+    private let defaults: UserDefaults
+    private let storageKey: String
+    private let seededKey: String
+    private let lock = NSLock()
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "PersistedInvestmentRepository"
+    )
+
+    /// Deterministic monthly growth assumption used to reconstruct history.
+    private static let monthlyGrowthRate = 0.005
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = "investments.persisted.v1",
+        seededKey: String = "investments.seeded.v1",
+        seedIfEmpty: Bool = true
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+        self.seededKey = seededKey
+        if seedIfEmpty {
+            seedIfNeeded()
+        }
+    }
+
+    // MARK: - InvestmentRepository
+
+    func getPortfolios() async throws -> [PortfolioItem] {
+        load().portfolios.map { $0.toDomain() }
+    }
+
+    func getPortfolio(id: String) async throws -> PortfolioItem? {
+        load().portfolios.first { $0.id == id }?.toDomain()
+    }
+
+    func getHoldings(portfolioId: String) async throws -> [HoldingItem] {
+        load().portfolios.first { $0.id == portfolioId }?.toDomain().holdings ?? []
+    }
+
+    func getHolding(id: String) async throws -> HoldingItem? {
+        for portfolio in load().portfolios {
+            if let match = portfolio.holdings.first(where: { $0.id == id }) {
+                return match.toDomain()
+            }
+        }
+        return nil
+    }
+
+    func getPerformanceHistory(portfolioId: String, months: Int) async throws -> [PerformanceDataPoint] {
+        guard let stored = load().portfolios.first(where: { $0.id == portfolioId }) else { return [] }
+        let portfolio = stored.toDomain()
+        let count = max(1, months)
+        let calendar = Calendar.current
+        let now = Date.now
+        let contribution = Double(portfolio.monthlyContributionMinorUnits)
+
+        // Walk backwards from the current value, removing one month's growth and
+        // contribution at each step, then reverse to oldest-first.
+        var value = Double(portfolio.totalValueMinorUnits)
+        var reversed: [PerformanceDataPoint] = []
+        for offset in 0..<count {
+            let date = calendar.date(byAdding: .month, value: -offset, to: now) ?? now
+            reversed.append(PerformanceDataPoint(date: date, valueMinorUnits: Int64(max(0, value).rounded())))
+            value = (value - contribution) / (1.0 + Self.monthlyGrowthRate)
+        }
+        return reversed.reversed()
+    }
+
+    func getMonthlyContributionMinorUnits(portfolioId: String) async throws -> Int64 {
+        load().portfolios.first { $0.id == portfolioId }?.monthlyContributionMinorUnits ?? 0
+    }
+
+    func setMonthlyContributionMinorUnits(_ amountMinorUnits: Int64, portfolioId: String) async throws {
+        mutate { data in
+            guard let index = data.portfolios.firstIndex(where: { $0.id == portfolioId }) else { return }
+            data.portfolios[index].monthlyContributionMinorUnits = max(0, amountMinorUnits)
+        }
+    }
+
+    func recordContribution(_ amountMinorUnits: Int64, portfolioId: String, date: Date) async throws {
+        mutate { data in
+            guard let index = data.portfolios.firstIndex(where: { $0.id == portfolioId }) else { return }
+            let record = ContributionRecord(date: date, amountMinorUnits: amountMinorUnits)
+            data.portfolios[index].contributions.append(record)
+        }
+    }
+
+    func getContributions(portfolioId: String) async throws -> [ContributionRecord] {
+        (load().portfolios.first { $0.id == portfolioId }?.contributions ?? [])
+            .sorted { $0.date > $1.date }
+    }
+
+    func deleteAllInvestments() async throws {
+        lock.lock()
+        defer { lock.unlock() }
+        defaults.removeObject(forKey: storageKey)
+        defaults.removeObject(forKey: seededKey)
+    }
+
+    // MARK: - Persistence Helpers
+
+    private func load() -> StoredData {
+        lock.lock()
+        defer { lock.unlock() }
+        return decode()
+    }
+
+    private func mutate(_ transform: (inout StoredData) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        var data = decode()
+        transform(&data)
+        encode(data)
+    }
+
+    private func decode() -> StoredData {
+        guard let raw = defaults.data(forKey: storageKey) else { return StoredData(portfolios: []) }
+        do {
+            return try JSONDecoder().decode(StoredData.self, from: raw)
+        } catch {
+            Self.logger.error("Failed to decode investments: \(error.localizedDescription, privacy: .public)")
+            return StoredData(portfolios: [])
+        }
+    }
+
+    private func encode(_ data: StoredData) {
+        do {
+            let raw = try JSONEncoder().encode(data)
+            defaults.set(raw, forKey: storageKey)
+        } catch {
+            Self.logger.error("Failed to encode investments: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func seedIfNeeded() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard defaults.data(forKey: storageKey) == nil, !defaults.bool(forKey: seededKey) else { return }
+        encode(StoredData(portfolios: [Self.starterPortfolio()]))
+        defaults.set(true, forKey: seededKey)
+        Self.logger.info("Seeded starter index-fund portfolio")
+    }
+
+    // MARK: - Seed Data
+
+    private static func starterPortfolio() -> StoredPortfolio {
+        let created = Calendar.current.date(byAdding: .year, value: -3, to: .now) ?? .now
+        let holdings: [StoredHolding] = [
+            StoredHolding(
+                id: "vti", portfolioId: "main", symbol: "VTI", name: "Vanguard Total Stock Market ETF",
+                assetClass: AssetClassUI.stocks.rawValue, quantity: 120,
+                costBasisMinorUnits: 2_400_000, currentValueMinorUnits: 3_180_000,
+                previousCloseMinorUnits: 3_165_000, currencyCode: "USD", lastUpdated: .now
+            ),
+            StoredHolding(
+                id: "vxus", portfolioId: "main", symbol: "VXUS", name: "Vanguard Total International Stock ETF",
+                assetClass: AssetClassUI.stocks.rawValue, quantity: 200,
+                costBasisMinorUnits: 1_100_000, currentValueMinorUnits: 1_260_000,
+                previousCloseMinorUnits: 1_255_000, currencyCode: "USD", lastUpdated: .now
+            ),
+            StoredHolding(
+                id: "bnd", portfolioId: "main", symbol: "BND", name: "Vanguard Total Bond Market ETF",
+                assetClass: AssetClassUI.bonds.rawValue, quantity: 150,
+                costBasisMinorUnits: 1_120_000, currentValueMinorUnits: 1_095_000,
+                previousCloseMinorUnits: 1_098_000, currencyCode: "USD", lastUpdated: .now
+            ),
+        ]
+        return StoredPortfolio(
+            id: "main", name: String(localized: "Index Portfolio"),
+            holdings: holdings, currencyCode: "USD", createdAt: created,
+            monthlyContributionMinorUnits: 100_000, contributions: []
+        )
+    }
+}
+
+// MARK: - Codable Storage DTOs
+
+private struct StoredData: Codable {
+    var portfolios: [StoredPortfolio]
+}
+
+private struct StoredPortfolio: Codable {
+    let id: String
+    let name: String
+    let holdings: [StoredHolding]
+    let currencyCode: String
+    let createdAt: Date
+    var monthlyContributionMinorUnits: Int64
+    var contributions: [ContributionRecord]
+
+    func toDomain() -> PortfolioItem {
+        PortfolioItem(
+            id: id,
+            name: name,
+            holdings: holdings.map { $0.toDomain() },
+            currencyCode: currencyCode,
+            createdAt: createdAt,
+            monthlyContributionMinorUnits: monthlyContributionMinorUnits
+        )
+    }
+}
+
+private struct StoredHolding: Codable {
+    let id: String
+    let portfolioId: String
+    let symbol: String
+    let name: String
+    let assetClass: String
+    let quantity: Int64
+    let costBasisMinorUnits: Int64
+    let currentValueMinorUnits: Int64
+    let previousCloseMinorUnits: Int64?
+    let currencyCode: String
+    let lastUpdated: Date
+
+    func toDomain() -> HoldingItem {
+        HoldingItem(
+            id: id,
+            portfolioId: portfolioId,
+            symbol: symbol,
+            name: name,
+            assetClass: AssetClassUI(rawValue: assetClass) ?? .other,
+            quantity: quantity,
+            costBasisMinorUnits: costBasisMinorUnits,
+            currentValueMinorUnits: currentValueMinorUnits,
+            previousCloseMinorUnits: previousCloseMinorUnits,
+            currencyCode: currencyCode,
+            lastUpdated: lastUpdated
+        )
+    }
+}

--- a/apps/ios/Finance/Repositories/RepositoryProvider.swift
+++ b/apps/ios/Finance/Repositories/RepositoryProvider.swift
@@ -83,7 +83,7 @@ final class RepositoryProvider: @unchecked Sendable {
     ///   - budgets:      Budget repository (defaults to Swift Export bridged).
     ///   - goals:        Goal repository (defaults to Swift Export bridged).
     ///   - categories:   Category repository (defaults to Swift Export bridged).
-    ///   - investments:  Investment repository (defaults to mock — KMP bridge pending).
+    ///   - investments:  Investment repository (defaults to persisted store — #2118).
     ///   - bills:        Bill repository (defaults to mock — KMP bridge pending).
     ///
     /// Since Sprint 7, the default implementations delegate through the
@@ -97,7 +97,7 @@ final class RepositoryProvider: @unchecked Sendable {
         budgets: any BudgetRepository = BridgedBudgetRepository(),
         goals: any GoalRepository = BridgedGoalRepository(),
         categories: any CategoryRepository = BridgedCategoryRepository(),
-        investments: any InvestmentRepository = MockInvestmentRepository(),
+        investments: any InvestmentRepository = PersistedInvestmentRepository(),
         bills: any BillRepository = MockBillRepository()
     ) {
         self.accounts = accounts

--- a/apps/ios/Finance/Screens/DashboardView.swift
+++ b/apps/ios/Finance/Screens/DashboardView.swift
@@ -16,6 +16,11 @@ struct DashboardView: View {
     @State private var showingSettings = false
     @Environment(DeepLinkHandler.self) private var deepLinkHandler: DeepLinkHandler?
 
+    // Low-noise mode: quick-access cards the user can hide. (#2122)
+    @AppStorage(FeatureVisibility.investmentsKey) private var showInvestments = true
+    @AppStorage(FeatureVisibility.billsKey) private var showBills = true
+    @AppStorage(FeatureVisibility.reportsKey) private var showReports = true
+
     init(viewModel: DashboardViewModel = DashboardViewModel(
         accountRepository: RepositoryProvider.shared.accounts,
         transactionRepository: RepositoryProvider.shared.transactions,
@@ -35,6 +40,7 @@ struct DashboardView: View {
                     ScrollView {
                         VStack(spacing: FinanceSpacing.lg) {
                             netWorthCard
+                            netWorthTrendSection
                             savingsRateCard
                             spendingSummaryCard
                             budgetHealthSection
@@ -133,6 +139,17 @@ struct DashboardView: View {
     /// not visually identical to a positive balance. (#3593)
     private var netWorthColor: Color {
         viewModel.netWorth < 0 ? FinanceColors.amountNegative : .primary
+    }
+
+    // MARK: - Net Worth Trend (#2116)
+
+    /// Clean net-worth growth chart with projection, shown on the primary
+    /// surface right below the headline net-worth figure.
+    @ViewBuilder
+    private var netWorthTrendSection: some View {
+        if viewModel.hasNetWorthTrend {
+            NetWorthTrendCard(viewModel: viewModel)
+        }
     }
 
     /// Spoken label for the net-worth amount so VoiceOver conveys the figure
@@ -301,52 +318,67 @@ struct DashboardView: View {
 
     // MARK: - Quick Access
 
+    /// Whether any quick-access card is visible. When the user hides them all
+    /// in low-noise mode, the whole section (and its heading) disappears. (#2122)
+    private var hasVisibleQuickAccess: Bool {
+        showInvestments || showBills || showReports
+    }
+
+    @ViewBuilder
     private var quickAccessSection: some View {
-        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
-            Text(String(localized: "More"))
-                .font(.headline)
-                .accessibilityAddTraits(.isHeader)
+        if hasVisibleQuickAccess {
+            VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
+                Text(String(localized: "More"))
+                    .font(.headline)
+                    .accessibilityAddTraits(.isHeader)
 
-            LazyVGrid(columns: [
-                GridItem(.flexible()),
-                GridItem(.flexible()),
-                GridItem(.flexible()),
-            ], spacing: FinanceSpacing.sm) {
-                NavigationLink {
-                    InvestmentPortfolioView()
-                } label: {
-                    quickAccessCard(
-                        title: String(localized: "Investments"),
-                        iconToken: .investment,
-                        color: .blue
-                    )
-                }
-                .accessibilityLabel(String(localized: "Investments"))
-                .accessibilityHint(String(localized: "Opens your investment portfolio"))
+                LazyVGrid(columns: [
+                    GridItem(.flexible()),
+                    GridItem(.flexible()),
+                    GridItem(.flexible()),
+                ], spacing: FinanceSpacing.sm) {
+                    if showInvestments {
+                        NavigationLink {
+                            InvestmentPortfolioView()
+                        } label: {
+                            quickAccessCard(
+                                title: String(localized: "Investments"),
+                                iconToken: .investment,
+                                color: .blue
+                            )
+                        }
+                        .accessibilityLabel(String(localized: "Investments"))
+                        .accessibilityHint(String(localized: "Opens your investment portfolio"))
+                    }
 
-                NavigationLink {
-                    BillsListView()
-                } label: {
-                    quickAccessCard(
-                        title: String(localized: "Bills"),
-                        iconToken: .bill,
-                        color: .orange
-                    )
-                }
-                .accessibilityLabel(String(localized: "Bills"))
-                .accessibilityHint(String(localized: "Opens your bill reminders"))
+                    if showBills {
+                        NavigationLink {
+                            BillsListView()
+                        } label: {
+                            quickAccessCard(
+                                title: String(localized: "Bills"),
+                                iconToken: .bill,
+                                color: .orange
+                            )
+                        }
+                        .accessibilityLabel(String(localized: "Bills"))
+                        .accessibilityHint(String(localized: "Opens your bill reminders"))
+                    }
 
-                NavigationLink {
-                    ReportBuilderView()
-                } label: {
-                    quickAccessCard(
-                        title: String(localized: "Reports"),
-                        iconToken: .reports,
-                        color: .purple
-                    )
+                    if showReports {
+                        NavigationLink {
+                            ReportBuilderView()
+                        } label: {
+                            quickAccessCard(
+                                title: String(localized: "Reports"),
+                                iconToken: .reports,
+                                color: .purple
+                            )
+                        }
+                        .accessibilityLabel(String(localized: "Reports"))
+                        .accessibilityHint(String(localized: "Opens the custom report builder"))
+                    }
                 }
-                .accessibilityLabel(String(localized: "Reports"))
-                .accessibilityHint(String(localized: "Opens the custom report builder"))
             }
         }
     }

--- a/apps/ios/Finance/Screens/InvestmentPortfolioView.swift
+++ b/apps/ios/Finance/Screens/InvestmentPortfolioView.swift
@@ -67,6 +67,7 @@ struct InvestmentPortfolioView: View {
             VStack(spacing: 20) {
                 portfolioSummaryCard(portfolio)
                 performanceChart
+                InvestmentProjectionCard(viewModel: viewModel, currencyCode: portfolio.currencyCode)
                 allocationSection
                 holdingsList(portfolio)
             }

--- a/apps/ios/Finance/Screens/MinimalistModeScreen.swift
+++ b/apps/ios/Finance/Screens/MinimalistModeScreen.swift
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// MinimalistModeScreen.swift
+// Finance
+//
+// Low-noise / minimalist mode. Lets a FIRE-minded minimalist hide features they
+// don't use — Dashboard quick-access cards, optional tabs, and experimental
+// extras — so the app surfaces only what matters to them. Preferences are
+// stored via `FeatureVisibility` keys and observed live by the affected
+// surfaces (Dashboard and the tab bar).
+//
+// References: #2122
+
+import SwiftUI
+
+/// Configuration screen for low-noise mode: per-feature visibility toggles plus
+/// one-tap presets.
+struct MinimalistModeScreen: View {
+    @AppStorage(FeatureVisibility.investmentsKey) private var showInvestments = true
+    @AppStorage(FeatureVisibility.billsKey) private var showBills = true
+    @AppStorage(FeatureVisibility.reportsKey) private var showReports = true
+    @AppStorage(FeatureVisibility.budgetsTabKey) private var showBudgetsTab = true
+    @AppStorage(FeatureVisibility.goalsTabKey) private var showGoalsTab = true
+    @AppStorage(FeatureVisibility.moodTagsKey) private var moodTagsEnabled = false
+    @AppStorage(FeatureVisibility.minimalistModeEngagedKey) private var engaged = false
+
+    /// Whether at least one feature is currently hidden.
+    private var anyHidden: Bool {
+        !showInvestments || !showBills || !showReports || !showBudgetsTab || !showGoalsTab
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Text(String(localized: "Turn off anything you don't use. The app stays fully featured — hidden items simply disappear from your Dashboard and tab bar, and you can bring them back any time."))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                Toggle(String(localized: "Investments card"), isOn: $showInvestments)
+                Toggle(String(localized: "Bills card"), isOn: $showBills)
+                Toggle(String(localized: "Reports card"), isOn: $showReports)
+            } header: {
+                Text(String(localized: "Dashboard"))
+            } footer: {
+                Text(String(localized: "Quick-access cards shown under your net worth."))
+            }
+
+            Section {
+                Toggle(String(localized: "Budgets tab"), isOn: $showBudgetsTab)
+                Toggle(String(localized: "Goals tab"), isOn: $showGoalsTab)
+            } header: {
+                Text(String(localized: "Tabs"))
+            } footer: {
+                Text(String(localized: "Dashboard, Accounts, and Transactions always stay."))
+            }
+
+            Section {
+                Toggle(String(localized: "Mood tags on transactions"), isOn: $moodTagsEnabled)
+            } header: {
+                Text(String(localized: "Extras"))
+            }
+
+            Section {
+                Button {
+                    applyFirePreset()
+                } label: {
+                    Label(String(localized: "Apply FIRE preset"), systemImage: "flame")
+                }
+                .accessibilityHint(String(localized: "Hides bills, reports, and mood tags; keeps investments, budgets, and goals"))
+
+                Button {
+                    showEverything()
+                } label: {
+                    Label(String(localized: "Show everything"), systemImage: "square.grid.2x2")
+                }
+                .accessibilityHint(String(localized: "Restores all features"))
+            } header: {
+                Text(String(localized: "Presets"))
+            }
+        }
+        .navigationTitle(String(localized: "Focus Mode"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onChange(of: anyHidden) { _, hidden in
+            if hidden { engaged = true }
+        }
+    }
+
+    // MARK: - Presets
+
+    private func applyFirePreset() {
+        showInvestments = true
+        showBudgetsTab = true
+        showGoalsTab = true
+        showBills = false
+        showReports = false
+        moodTagsEnabled = false
+    }
+
+    private func showEverything() {
+        showInvestments = true
+        showBills = true
+        showReports = true
+        showBudgetsTab = true
+        showGoalsTab = true
+    }
+}
+
+#Preview {
+    NavigationStack {
+        MinimalistModeScreen()
+    }
+}

--- a/apps/ios/Finance/Screens/NotificationSettingsView.swift
+++ b/apps/ios/Finance/Screens/NotificationSettingsView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct NotificationSettingsView: View {
     @State private var viewModel: NotificationSettingsViewModel
+    @Environment(\.openURL) private var openURL
 
     init(
         budgetRepository: BudgetRepository,
@@ -27,8 +28,11 @@ struct NotificationSettingsView: View {
 
     var body: some View {
         List {
+            summarySection
             permissionSection
             schedulesSection
+            budgetThresholdSection
+            quietHoursSection
             smartAlertsSection
         }
         .navigationTitle(String(localized: "Notifications"))
@@ -49,6 +53,24 @@ struct NotificationSettingsView: View {
             Button(String(localized: "OK"), role: .cancel) {}
         } message: {
             Text(viewModel.errorMessage ?? "")
+        }
+    }
+
+    // MARK: - Summary Section (#2163)
+
+    @ViewBuilder
+    private var summarySection: some View {
+        Section {
+            HStack {
+                Image(systemName: "bell.badge")
+                    .foregroundStyle(.accent)
+                    .accessibilityHidden(true)
+                Text(viewModel.stateSummary)
+                    .font(.subheadline)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(String(localized: "Alert center status"))
+            .accessibilityValue(viewModel.stateSummary)
         }
     }
 
@@ -155,6 +177,78 @@ struct NotificationSettingsView: View {
         .accessibilityHint(schedule.type.description)
     }
 
+    // MARK: - Budget Threshold Section (#2163)
+
+    @ViewBuilder
+    private var budgetThresholdSection: some View {
+        Section {
+            Picker(
+                selection: Binding(
+                    get: { viewModel.budgetThresholdPercent },
+                    set: { newValue in
+                        Task { await viewModel.setBudgetThreshold(newValue) }
+                    }
+                )
+            ) {
+                ForEach(NotificationSettingsViewModel.budgetThresholdOptions, id: \.self) { percent in
+                    Text(String(localized: "\(Int(percent))% of budget"))
+                        .tag(percent)
+                }
+            } label: {
+                Text(String(localized: "Alert me at"))
+            }
+            .accessibilityLabel(String(localized: "Budget alert threshold"))
+            .accessibilityHint(String(localized: "How much of a budget you can spend before being alerted"))
+        } header: {
+            Text(String(localized: "Budget Threshold"))
+                .accessibilityAddTraits(.isHeader)
+        } footer: {
+            Text(String(localized: "Trigger budget alerts when spending reaches this share of a category's limit."))
+        }
+    }
+
+    // MARK: - Quiet Hours Section (#2163)
+
+    @ViewBuilder
+    private var quietHoursSection: some View {
+        Section {
+            Toggle(isOn: $viewModel.quietHoursEnabled) {
+                Label(String(localized: "Quiet Hours"), systemImage: "moon")
+            }
+            .accessibilityLabel(String(localized: "Quiet hours"))
+            .accessibilityHint(String(localized: "Silences alerts during the selected window"))
+
+            if viewModel.quietHoursEnabled {
+                Picker(
+                    String(localized: "From"),
+                    selection: $viewModel.quietHoursStartHour
+                ) {
+                    ForEach(0..<24, id: \.self) { hour in
+                        Text(NotificationSettingsViewModel.formatHour(hour)).tag(hour)
+                    }
+                }
+                .accessibilityLabel(String(localized: "Quiet hours start"))
+
+                Picker(
+                    String(localized: "To"),
+                    selection: $viewModel.quietHoursEndHour
+                ) {
+                    ForEach(0..<24, id: \.self) { hour in
+                        Text(NotificationSettingsViewModel.formatHour(hour)).tag(hour)
+                    }
+                }
+                .accessibilityLabel(String(localized: "Quiet hours end"))
+            }
+        } header: {
+            Text(String(localized: "Quiet Hours"))
+                .accessibilityAddTraits(.isHeader)
+        } footer: {
+            Text(viewModel.quietHoursEnabled
+                ? String(localized: "Alerts are silenced \(viewModel.quietHoursSummary).")
+                : String(localized: "Silence non-urgent alerts overnight."))
+        }
+    }
+
     // MARK: - Smart Alerts Section
 
     @ViewBuilder
@@ -180,7 +274,33 @@ struct NotificationSettingsView: View {
         }
     }
 
+    @ViewBuilder
     private func smartAlertRow(_ alert: SmartAlert) -> some View {
+        if let urlString = alert.actionURL, let url = URL(string: urlString) {
+            Button {
+                openURL(url)
+            } label: {
+                smartAlertRowContent(alert, actionable: true)
+            }
+            .buttonStyle(.plain)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(alert.title)
+            .accessibilityValue(
+                String(localized: "\(alert.priority.displayName) priority. \(alert.body)")
+            )
+            .accessibilityHint(String(localized: "Double tap to open"))
+            .accessibilityAddTraits(.isButton)
+        } else {
+            smartAlertRowContent(alert, actionable: false)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(alert.title)
+                .accessibilityValue(
+                    String(localized: "\(alert.priority.displayName) priority. \(alert.body)")
+                )
+        }
+    }
+
+    private func smartAlertRowContent(_ alert: SmartAlert, actionable: Bool) -> some View {
         HStack(spacing: 12) {
             Circle()
                 .fill(alert.priority.color)
@@ -191,6 +311,7 @@ struct NotificationSettingsView: View {
                 Text(alert.title)
                     .font(.subheadline)
                     .fontWeight(.medium)
+                    .foregroundStyle(.primary)
 
                 Text(alert.body)
                     .font(.caption)
@@ -206,12 +327,14 @@ struct NotificationSettingsView: View {
                 .padding(.vertical, 2)
                 .background(alert.priority.color.opacity(0.15))
                 .clipShape(Capsule())
+
+            if actionable {
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+            }
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(alert.title)
-        .accessibilityValue(
-            String(localized: "\(alert.priority.displayName) priority. \(alert.body)")
-        )
     }
 }
 

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
                 accountSection
                 generalSection
                 appearanceSection
+                focusSection
                 notificationsSection
                 accessibilitySection
                 securitySection
@@ -165,10 +166,36 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - Focus (#2122)
+
+    private var focusSection: some View {
+        Section(String(localized: "Focus")) {
+            NavigationLink {
+                MinimalistModeScreen()
+            } label: {
+                Label(String(localized: "Focus Mode"), systemImage: "moon.stars")
+            }
+            .accessibilityLabel(String(localized: "Focus Mode"))
+            .accessibilityHint(String(localized: "Hide features you don't use for a low-noise app"))
+        }
+    }
+
     // MARK: - Notifications
 
     private var notificationsSection: some View {
         Section(String(localized: "Notifications")) {
+            NavigationLink {
+                NotificationSettingsView(
+                    budgetRepository: RepositoryProvider.shared.budgets,
+                    transactionRepository: RepositoryProvider.shared.transactions,
+                    goalRepository: RepositoryProvider.shared.goals
+                )
+            } label: {
+                Label(String(localized: "Alert Center"), systemImage: "bell.badge")
+            }
+            .accessibilityLabel(String(localized: "Alert Center"))
+            .accessibilityHint(String(localized: "Manage alerts, schedules, and quiet hours"))
+
             Toggle(isOn: $viewModel.notificationsEnabled) {
                 Label(String(localized: "Enable Notifications"), systemImage: "bell")
             }

--- a/apps/ios/Finance/Screens/TransactionsView.swift
+++ b/apps/ios/Finance/Screens/TransactionsView.swift
@@ -14,6 +14,7 @@ struct TransactionsView: View {
     @Environment(DeepLinkHandler.self) private var deepLinkHandler
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var viewModel: TransactionsViewModel
+    @State private var showingQuickAdd = false
 
     init(viewModel: TransactionsViewModel = TransactionsViewModel(
         repository: RepositoryProvider.shared.transactions
@@ -43,6 +44,12 @@ struct TransactionsView: View {
                 } else {
                     transactionsList
                 }
+            }
+            .overlay(alignment: .bottomTrailing) {
+                // One-thumb quick expense capture (#2167).
+                QuickAddExpenseButton { showingQuickAdd = true }
+                    .padding(.trailing, 20)
+                    .padding(.bottom, 20)
             }
             .offlineAware()
             .navigationTitle(String(localized: "Transactions"))
@@ -109,6 +116,13 @@ struct TransactionsView: View {
                 Task { await viewModel.loadTransactions() }
             }) {
                 NlpInputView()
+            }
+            .sheet(isPresented: $showingQuickAdd, onDismiss: {
+                Task { await viewModel.loadTransactions() }
+            }) {
+                QuickAddExpenseSheet(onSaved: {
+                    Task { await viewModel.loadTransactions() }
+                })
             }
             .sheet(isPresented: $viewModel.showingFilterSheet) {
                 TransactionFilterSheet(

--- a/apps/ios/Finance/Services/CompoundGrowthProjector.swift
+++ b/apps/ios/Finance/Services/CompoundGrowthProjector.swift
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CompoundGrowthProjector.swift
+// Finance
+//
+// Pure, deterministic compound-growth math for long-term investment and
+// net-worth projections. Kept free of SwiftUI so it is fully unit-testable
+// and can be reused by the investment portfolio and net-worth surfaces.
+//
+// All monetary values are in minor units (cents). Monthly compounding with
+// end-of-month contributions models a passive index-fund investor who adds a
+// fixed amount every month.
+//
+// References: #2118, #2116
+
+import Foundation
+
+// MARK: - Projection Point
+
+/// A single point on a compound-growth projection curve.
+struct ProjectionPoint: Identifiable, Sendable {
+    let id = UUID()
+
+    /// The date this point represents.
+    let date: Date
+
+    /// Projected total balance in minor units.
+    let valueMinorUnits: Int64
+
+    /// Cumulative principal (starting balance + contributions made so far),
+    /// in minor units. The gap between `valueMinorUnits` and this value is
+    /// growth from market returns.
+    let contributedMinorUnits: Int64
+
+    /// Whether this point is a future projection (`true`) or the present
+    /// starting balance (`false`).
+    let isProjected: Bool
+
+    /// Projected market growth (value minus contributed principal).
+    var growthMinorUnits: Int64 { valueMinorUnits - contributedMinorUnits }
+}
+
+// MARK: - Projector
+
+/// Deterministic compound-growth projector using monthly compounding with
+/// end-of-month contributions.
+enum CompoundGrowthProjector {
+
+    /// A reasonable default long-run annual return for a diversified,
+    /// low-cost index portfolio (nominal, before inflation).
+    static let defaultAnnualReturnRate = 0.07
+
+    /// Projects a balance forward month-by-month and samples one point per
+    /// year (plus the starting point at year 0).
+    ///
+    /// - Parameters:
+    ///   - currentMinorUnits: Starting balance in minor units.
+    ///   - monthlyContributionMinorUnits: Fixed contribution added at the end
+    ///     of every month, in minor units.
+    ///   - annualReturnRate: Expected nominal annual return (e.g. `0.07`).
+    ///   - years: Projection horizon in whole years (clamped to `0...80`).
+    ///   - startDate: The date of the year-0 point.
+    ///   - calendar: Calendar used to advance the sample dates.
+    /// - Returns: `years + 1` points, oldest first.
+    static func project(
+        currentMinorUnits: Int64,
+        monthlyContributionMinorUnits: Int64,
+        annualReturnRate: Double = defaultAnnualReturnRate,
+        years: Int,
+        startDate: Date = .now,
+        calendar: Calendar = .current
+    ) -> [ProjectionPoint] {
+        let horizon = max(0, min(years, 80))
+        let monthlyRate = annualReturnRate / 12.0
+
+        var balance = Double(currentMinorUnits)
+        var contributed = Double(currentMinorUnits)
+
+        var points: [ProjectionPoint] = [
+            ProjectionPoint(
+                date: startDate,
+                valueMinorUnits: currentMinorUnits,
+                contributedMinorUnits: currentMinorUnits,
+                isProjected: false
+            )
+        ]
+
+        guard horizon > 0 else { return points }
+
+        for year in 1...horizon {
+            for _ in 0..<12 {
+                balance = balance * (1.0 + monthlyRate) + Double(monthlyContributionMinorUnits)
+                contributed += Double(monthlyContributionMinorUnits)
+            }
+            let date = calendar.date(byAdding: .year, value: year, to: startDate) ?? startDate
+            points.append(
+                ProjectionPoint(
+                    date: date,
+                    valueMinorUnits: Int64(balance.rounded()),
+                    contributedMinorUnits: Int64(contributed.rounded()),
+                    isProjected: true
+                )
+            )
+        }
+
+        return points
+    }
+
+    /// Returns the projected future value after a whole number of `months`.
+    static func futureValue(
+        currentMinorUnits: Int64,
+        monthlyContributionMinorUnits: Int64,
+        annualReturnRate: Double = defaultAnnualReturnRate,
+        months: Int
+    ) -> Int64 {
+        let count = max(0, months)
+        let monthlyRate = annualReturnRate / 12.0
+        var balance = Double(currentMinorUnits)
+        for _ in 0..<count {
+            balance = balance * (1.0 + monthlyRate) + Double(monthlyContributionMinorUnits)
+        }
+        return Int64(balance.rounded())
+    }
+}

--- a/apps/ios/Finance/Services/FeatureVisibility.swift
+++ b/apps/ios/Finance/Services/FeatureVisibility.swift
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FeatureVisibility.swift
+// Finance
+//
+// Central registry of user-controllable feature-visibility flags powering the
+// low-noise / minimalist mode. Flags default to visible when unset, so the app
+// is fully featured until the user opts to hide something.
+//
+// Views observe these keys with `@AppStorage`; this type owns the key
+// constants and the preset logic so the behaviour is unit-testable without
+// SwiftUI.
+//
+// References: #2122
+
+import Foundation
+
+/// Namespace of feature-visibility preference keys and presets.
+enum FeatureVisibility {
+
+    // MARK: - Keys
+
+    /// Investments quick-access card on the Dashboard.
+    static let investmentsKey = "feature.investments.visible"
+    /// Bills quick-access card on the Dashboard.
+    static let billsKey = "feature.bills.visible"
+    /// Reports quick-access card on the Dashboard.
+    static let reportsKey = "feature.reports.visible"
+    /// Budgets tab in the main tab bar.
+    static let budgetsTabKey = "feature.budgetsTab.visible"
+    /// Goals tab in the main tab bar.
+    static let goalsTabKey = "feature.goalsTab.visible"
+    /// Mood tags on transactions (shared with the experimental setting).
+    static let moodTagsKey = "experimental.moodTags.enabled"
+
+    /// Master flag: whether minimalist mode has been switched on at least once.
+    /// Used purely to badge the Settings entry point.
+    static let minimalistModeEngagedKey = "feature.minimalistMode.engaged"
+
+    /// All boolean visibility keys that default to `true` (visible).
+    static let visibilityKeys: [String] = [
+        investmentsKey, billsKey, reportsKey, budgetsTabKey, goalsTabKey,
+    ]
+
+    // MARK: - Reads
+
+    /// Returns whether a visibility-keyed feature is visible, treating an unset
+    /// value as visible (`true`).
+    static func isVisible(_ key: String, defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: key) == nil ? true : defaults.bool(forKey: key)
+    }
+
+    // MARK: - Presets
+
+    /// FIRE / minimalist preset: keep savings-rate, net-worth, investments,
+    /// budgets and goals; hide bills, reports and mood tags.
+    static func firePreset() -> [String: Bool] {
+        [
+            investmentsKey: true,
+            budgetsTabKey: true,
+            goalsTabKey: true,
+            billsKey: false,
+            reportsKey: false,
+            moodTagsKey: false,
+        ]
+    }
+
+    /// Full preset: everything visible (restores defaults).
+    static func fullPreset() -> [String: Bool] {
+        var preset: [String: Bool] = [:]
+        for key in visibilityKeys { preset[key] = true }
+        return preset
+    }
+
+    /// Applies a preset dictionary to a defaults store.
+    static func apply(_ preset: [String: Bool], to defaults: UserDefaults = .standard) {
+        for (key, value) in preset {
+            defaults.set(value, forKey: key)
+        }
+    }
+
+    /// Whether any feature is currently hidden.
+    static func hasHiddenFeatures(defaults: UserDefaults = .standard) -> Bool {
+        visibilityKeys.contains { !isVisible($0, defaults: defaults) }
+    }
+}

--- a/apps/ios/Finance/Services/NetWorthTrendCalculator.swift
+++ b/apps/ios/Finance/Services/NetWorthTrendCalculator.swift
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// NetWorthTrendCalculator.swift
+// Finance
+//
+// Pure, deterministic reconstruction of a net-worth trend line from the
+// current net worth plus historical transaction flows, and a simple
+// forward projection based on recent savings pace. Kept free of SwiftUI so
+// it is fully unit-testable and reusable across the Dashboard and Accounts
+// surfaces.
+//
+// Net worth today is a known quantity (sum of account balances). Working
+// backwards, net worth at the end of an earlier month equals today's net
+// worth minus every income/expense flow that happened after that month.
+// Transfers move money between accounts and so do not change net worth.
+//
+// References: #2116
+
+import Foundation
+
+// MARK: - Net Worth Trend Point
+
+/// A single point on the net-worth trend line.
+struct NetWorthTrendPoint: Identifiable, Sendable {
+    let id = UUID()
+    let date: Date
+    let valueMinorUnits: Int64
+    /// Whether the point is a forward projection rather than reconstructed history.
+    let isProjected: Bool
+}
+
+// MARK: - Range
+
+/// Selectable look-back windows for the net-worth trend.
+enum NetWorthTrendRange: String, CaseIterable, Identifiable, Sendable {
+    case threeMonths
+    case sixMonths
+    case oneYear
+    case all
+
+    var id: String { rawValue }
+
+    /// Number of trailing months to show, or `nil` for "all available".
+    var months: Int? {
+        switch self {
+        case .threeMonths: 3
+        case .sixMonths: 6
+        case .oneYear: 12
+        case .all: nil
+        }
+    }
+
+    var shortLabel: String {
+        switch self {
+        case .threeMonths: String(localized: "3M")
+        case .sixMonths: String(localized: "6M")
+        case .oneYear: String(localized: "1Y")
+        case .all: String(localized: "All")
+        }
+    }
+}
+
+// MARK: - Calculator
+
+enum NetWorthTrendCalculator {
+
+    /// Reconstructs a monthly net-worth history ending at the current value.
+    ///
+    /// - Parameters:
+    ///   - currentNetWorthMinorUnits: Today's net worth.
+    ///   - transactions: All available transactions (any order).
+    ///   - months: Number of trailing months to produce, including the current
+    ///     month. Values below 1 are treated as 1.
+    ///   - now: The reference "today" date.
+    ///   - calendar: Calendar used for month bucketing.
+    /// - Returns: One point per month, oldest first, ending at `now`.
+    static func history(
+        currentNetWorthMinorUnits: Int64,
+        transactions: [TransactionItem],
+        months: Int,
+        now: Date = .now,
+        calendar: Calendar = .current
+    ) -> [NetWorthTrendPoint] {
+        let monthCount = max(1, months)
+        let startOfThisMonth = calendar.date(
+            from: calendar.dateComponents([.year, .month], from: now)
+        ) ?? now
+
+        // Month-start dates, oldest first, one per requested month.
+        let monthStarts: [Date] = (0..<monthCount).reversed().compactMap { offset in
+            calendar.date(byAdding: .month, value: -offset, to: startOfThisMonth)
+        }
+
+        // Net flow (income + signed expenses, excluding transfers) per month start.
+        var flowByMonth: [Date: Int64] = [:]
+        for txn in transactions where txn.type != .transfer {
+            let monthStart = calendar.date(
+                from: calendar.dateComponents([.year, .month], from: txn.date)
+            ) ?? txn.date
+            flowByMonth[monthStart, default: 0] += txn.amountMinorUnits
+        }
+
+        // Walk backwards from the current month subtracting each month's flow.
+        var runningValue = currentNetWorthMinorUnits
+        var reversed: [NetWorthTrendPoint] = []
+        for (index, monthStart) in monthStarts.enumerated().reversed() {
+            reversed.append(
+                NetWorthTrendPoint(
+                    date: monthStart,
+                    valueMinorUnits: runningValue,
+                    isProjected: false
+                )
+            )
+            // Subtract this month's flow to get the previous month's ending value,
+            // unless this is the oldest point we need.
+            if index > 0 {
+                let flow = flowByMonth[monthStart] ?? 0
+                runningValue -= flow
+            }
+        }
+
+        return reversed.reversed()
+    }
+
+    /// Average monthly net savings (income minus spending, excluding transfers)
+    /// over the trailing `months`, in minor units. Used to set a projection pace.
+    static func averageMonthlySavings(
+        transactions: [TransactionItem],
+        months: Int,
+        now: Date = .now,
+        calendar: Calendar = .current
+    ) -> Int64 {
+        let monthCount = max(1, months)
+        let startOfThisMonth = calendar.date(
+            from: calendar.dateComponents([.year, .month], from: now)
+        ) ?? now
+        let cutoff = calendar.date(byAdding: .month, value: -(monthCount - 1), to: startOfThisMonth) ?? startOfThisMonth
+
+        let total = transactions
+            .filter { $0.type != .transfer && $0.date >= cutoff }
+            .reduce(Int64(0)) { $0 + $1.amountMinorUnits }
+
+        return total / Int64(monthCount)
+    }
+
+    /// Builds a forward projection continuing from the last history point at a
+    /// fixed monthly savings pace (linear — no market growth assumption, since
+    /// net worth includes cash and debt).
+    ///
+    /// - Returns: `months` future points (does not repeat the anchor point).
+    static func projection(
+        from anchor: NetWorthTrendPoint,
+        monthlySavingsMinorUnits: Int64,
+        months: Int,
+        calendar: Calendar = .current
+    ) -> [NetWorthTrendPoint] {
+        guard months > 0 else { return [] }
+        var points: [NetWorthTrendPoint] = []
+        var value = anchor.valueMinorUnits
+        for step in 1...months {
+            value += monthlySavingsMinorUnits
+            let date = calendar.date(byAdding: .month, value: step, to: anchor.date) ?? anchor.date
+            points.append(
+                NetWorthTrendPoint(date: date, valueMinorUnits: value, isProjected: true)
+            )
+        }
+        return points
+    }
+}

--- a/apps/ios/Finance/Services/QuickExpenseComposer.swift
+++ b/apps/ios/Finance/Services/QuickExpenseComposer.swift
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// QuickExpenseComposer.swift
+// Finance
+//
+// Pure logic backing one-thumb quick expense capture: the instant-log presets,
+// remembered last-used account/category defaults, and construction of a
+// `TransactionItem` from a minimal quick-add form. Kept free of SwiftUI so it
+// is fully unit-testable.
+//
+// References: #2167
+
+import Foundation
+
+// MARK: - Preset
+
+/// An instant-log preset for common on-the-go expenses.
+struct QuickExpensePreset: Identifiable, Sendable, Equatable {
+    let id: String
+    let label: String
+    let systemImage: String
+    /// Category id (matching the app's built-in category options).
+    let categoryId: String
+    /// Suggested payee text (may be cleared by the user for true on-the-go capture).
+    let defaultPayee: String
+}
+
+// MARK: - Composer
+
+/// Builds quick-add transactions and remembers the last-used account/category
+/// so repeat capture is one-thumb fast.
+enum QuickExpenseComposer {
+
+    // MARK: Presets
+
+    /// Fast presets tuned for a city spender: coffee, lunch, transit, cash.
+    static let presets: [QuickExpensePreset] = [
+        QuickExpensePreset(id: "coffee", label: String(localized: "Coffee"), systemImage: "cup.and.saucer.fill", categoryId: "c2", defaultPayee: String(localized: "Coffee")),
+        QuickExpensePreset(id: "lunch", label: String(localized: "Lunch"), systemImage: "fork.knife", categoryId: "c2", defaultPayee: String(localized: "Lunch")),
+        QuickExpensePreset(id: "transit", label: String(localized: "Transit"), systemImage: "tram.fill", categoryId: "c3", defaultPayee: String(localized: "Transit")),
+        QuickExpensePreset(id: "groceries", label: String(localized: "Groceries"), systemImage: "cart.fill", categoryId: "c1", defaultPayee: String(localized: "Groceries")),
+        QuickExpensePreset(id: "cash", label: String(localized: "Cash"), systemImage: "banknote.fill", categoryId: "c5", defaultPayee: ""),
+    ]
+
+    // MARK: Remembered Defaults
+
+    private static let lastAccountKey = "quickadd.lastAccountId"
+    private static let lastCategoryKey = "quickadd.lastCategoryId"
+
+    /// The last account id used for quick add, if any.
+    static func lastAccountId(defaults: UserDefaults = .standard) -> String? {
+        defaults.string(forKey: lastAccountKey)
+    }
+
+    /// Persists the last account id used for quick add.
+    static func setLastAccountId(_ id: String?, defaults: UserDefaults = .standard) {
+        if let id, !id.isEmpty {
+            defaults.set(id, forKey: lastAccountKey)
+        } else {
+            defaults.removeObject(forKey: lastAccountKey)
+        }
+    }
+
+    /// The last category id used for quick add, if any.
+    static func lastCategoryId(defaults: UserDefaults = .standard) -> String? {
+        defaults.string(forKey: lastCategoryKey)
+    }
+
+    /// Persists the last category id used for quick add.
+    static func setLastCategoryId(_ id: String?, defaults: UserDefaults = .standard) {
+        if let id, !id.isEmpty {
+            defaults.set(id, forKey: lastCategoryKey)
+        } else {
+            defaults.removeObject(forKey: lastCategoryKey)
+        }
+    }
+
+    // MARK: Construction
+
+    /// Builds an expense `TransactionItem` from the minimal quick-add inputs.
+    ///
+    /// - Parameters:
+    ///   - amountMinorUnits: Positive amount in minor units; stored as a
+    ///     negative (expense) figure on the resulting transaction.
+    ///   - payee: Optional payee; when empty a neutral "Quick expense" label is used.
+    ///   - categoryName: Resolved category display name.
+    ///   - accountName: Resolved account display name.
+    ///   - currencyCode: ISO currency code.
+    ///   - date: Transaction date (defaults to now).
+    static func makeTransaction(
+        amountMinorUnits: Int64,
+        payee: String,
+        categoryName: String,
+        accountName: String,
+        currencyCode: String,
+        date: Date = .now
+    ) -> TransactionItem {
+        let trimmedPayee = payee.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedPayee = trimmedPayee.isEmpty ? String(localized: "Quick expense") : trimmedPayee
+        return TransactionItem(
+            id: UUID().uuidString,
+            payee: resolvedPayee,
+            category: categoryName,
+            accountName: accountName,
+            amountMinorUnits: -abs(amountMinorUnits),
+            currencyCode: currencyCode,
+            date: date,
+            type: .expense,
+            status: .cleared
+        )
+    }
+}

--- a/apps/ios/Finance/ViewModels/DashboardViewModel.swift
+++ b/apps/ios/Finance/ViewModels/DashboardViewModel.swift
@@ -47,6 +47,58 @@ final class DashboardViewModel {
     /// Net worth computed via the Swift Export aggregator module.
     var netWorth: Int64 { aggregator.netWorth(accounts: accounts) }
 
+    // MARK: - Net Worth Trend (#2116)
+    //
+    // A minimalist net-worth growth line reconstructed from the current net
+    // worth and historical flows, plus a straight-line forward projection at
+    // the recent savings pace. All heavy math lives in the pure, unit-tested
+    // `NetWorthTrendCalculator`; these are thin, cached-input accessors.
+
+    /// Selected look-back window for the net-worth trend chart.
+    var netWorthTrendRange: NetWorthTrendRange = .sixMonths
+
+    /// Months of history shown when the "All" range is selected.
+    private static let netWorthAllMonths = 24
+
+    /// Months projected forward past today.
+    private static let netWorthProjectionMonths = 12
+
+    /// Reconstructed monthly net-worth history for the selected range.
+    var netWorthTrendPoints: [NetWorthTrendPoint] {
+        NetWorthTrendCalculator.history(
+            currentNetWorthMinorUnits: netWorth,
+            transactions: savingsRateTransactions,
+            months: netWorthTrendRange.months ?? Self.netWorthAllMonths
+        )
+    }
+
+    /// Average monthly net savings over the trailing six months, used to set
+    /// the projection pace.
+    var averageMonthlySavingsMinorUnits: Int64 {
+        NetWorthTrendCalculator.averageMonthlySavings(
+            transactions: savingsRateTransactions,
+            months: 6
+        )
+    }
+
+    /// Forward net-worth projection continuing from the latest history point.
+    var netWorthProjectionPoints: [NetWorthTrendPoint] {
+        guard let anchor = netWorthTrendPoints.last else { return [] }
+        return NetWorthTrendCalculator.projection(
+            from: anchor,
+            monthlySavingsMinorUnits: averageMonthlySavingsMinorUnits,
+            months: Self.netWorthProjectionMonths
+        )
+    }
+
+    /// Projected net worth a year out, in minor units.
+    var projectedNetWorthMinorUnits: Int64 {
+        netWorthProjectionPoints.last?.valueMinorUnits ?? netWorth
+    }
+
+    /// Whether there is enough data to show the trend chart.
+    var hasNetWorthTrend: Bool { !accounts.isEmpty }
+
     // MARK: - Cached Aggregations
     //
     // These values are pre-computed when data loads rather than being

--- a/apps/ios/Finance/ViewModels/InvestmentViewModel.swift
+++ b/apps/ios/Finance/ViewModels/InvestmentViewModel.swift
@@ -34,6 +34,44 @@ final class InvestmentViewModel {
     var isLoading = false
     var errorMessage: String?
 
+    // MARK: - Contributions & Projection (#2118)
+
+    /// Recurring monthly contribution for the selected portfolio, in minor units.
+    var monthlyContributionMinorUnits: Int64 = 0
+
+    /// Recorded contribution history for the selected portfolio, newest first.
+    var contributions: [ContributionRecord] = []
+
+    /// Projection horizon in whole years (adjustable by the investor).
+    var projectionYears: Int = 20
+
+    /// Expected nominal annual return, as a percentage (adjustable).
+    var projectionAnnualReturnPercent: Double = 7
+
+    /// Total money the investor has put in (cost basis) for the selected portfolio.
+    var totalContributionsMinorUnits: Int64 { selectedPortfolio?.totalContributionsMinorUnits ?? 0 }
+
+    /// Market growth (value minus contributed principal) for the selected portfolio.
+    var marketReturnMinorUnits: Int64 { selectedPortfolio?.marketReturnMinorUnits ?? 0 }
+
+    /// Compound-growth projection curve for the selected portfolio using the
+    /// current balance, recurring monthly contribution, and adjustable
+    /// return/horizon inputs.
+    var projectionPoints: [ProjectionPoint] {
+        guard let portfolio = selectedPortfolio else { return [] }
+        return CompoundGrowthProjector.project(
+            currentMinorUnits: portfolio.totalValueMinorUnits,
+            monthlyContributionMinorUnits: monthlyContributionMinorUnits,
+            annualReturnRate: projectionAnnualReturnPercent / 100.0,
+            years: projectionYears
+        )
+    }
+
+    /// The projected balance at the end of the projection horizon, in minor units.
+    var projectedValueMinorUnits: Int64 {
+        projectionPoints.last?.valueMinorUnits ?? (selectedPortfolio?.totalValueMinorUnits ?? 0)
+    }
+
     /// Whether an error alert should be presented.
     var showError: Bool { errorMessage != nil }
 
@@ -68,11 +106,49 @@ final class InvestmentViewModel {
                 selectedPortfolio = first
                 computeAllocation(for: first)
                 await loadPerformanceHistory(for: first.id)
+                await loadContributionData(for: first.id)
             }
         } catch {
             errorMessage = String(localized: "Failed to load investment data. Please try again.")
             Self.logger.error("Investment load failed: \(error.localizedDescription, privacy: .public)")
             portfolios = []
+        }
+    }
+
+    /// Loads the recurring monthly contribution and contribution history for a
+    /// portfolio. Failures are non-fatal — projections simply fall back to a
+    /// zero contribution. (#2118)
+    func loadContributionData(for portfolioId: String) async {
+        do {
+            monthlyContributionMinorUnits = try await repository.getMonthlyContributionMinorUnits(portfolioId: portfolioId)
+            contributions = try await repository.getContributions(portfolioId: portfolioId)
+        } catch {
+            Self.logger.error("Contribution load failed: \(error.localizedDescription, privacy: .public)")
+            monthlyContributionMinorUnits = 0
+            contributions = []
+        }
+    }
+
+    /// Persists a new recurring monthly contribution and refreshes projections.
+    func updateMonthlyContribution(_ amountMinorUnits: Int64) async {
+        guard let portfolioId = selectedPortfolio?.id else { return }
+        let sanitised = max(0, amountMinorUnits)
+        monthlyContributionMinorUnits = sanitised
+        do {
+            try await repository.setMonthlyContributionMinorUnits(sanitised, portfolioId: portfolioId)
+        } catch {
+            Self.logger.error("Failed to save monthly contribution: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Records a one-off contribution and reloads the contribution history.
+    func recordContribution(_ amountMinorUnits: Int64, date: Date = .now) async {
+        guard amountMinorUnits > 0, let portfolioId = selectedPortfolio?.id else { return }
+        do {
+            try await repository.recordContribution(amountMinorUnits, portfolioId: portfolioId, date: date)
+            contributions = try await repository.getContributions(portfolioId: portfolioId)
+        } catch {
+            Self.logger.error("Failed to record contribution: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/apps/ios/Finance/ViewModels/NotificationSettingsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/NotificationSettingsViewModel.swift
@@ -19,6 +19,7 @@ final class NotificationSettingsViewModel {
     private let budgetRepository: BudgetRepository
     private let transactionRepository: TransactionRepository
     private let goalRepository: GoalRepository
+    private let defaults: UserDefaults
 
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
@@ -37,6 +38,32 @@ final class NotificationSettingsViewModel {
     var showError: Bool { errorMessage != nil }
     func dismissError() { errorMessage = nil }
 
+    // MARK: - Quiet Hours (#2163)
+
+    private enum PrefKey {
+        static let quietHoursEnabled = "notifications.quietHours.enabled"
+        static let quietHoursStart = "notifications.quietHours.startHour"
+        static let quietHoursEnd = "notifications.quietHours.endHour"
+    }
+
+    /// Whether quiet hours suppress alerts overnight.
+    var quietHoursEnabled: Bool {
+        didSet { defaults.set(quietHoursEnabled, forKey: PrefKey.quietHoursEnabled) }
+    }
+
+    /// Hour (0–23) quiet hours begin.
+    var quietHoursStartHour: Int {
+        didSet { defaults.set(quietHoursStartHour, forKey: PrefKey.quietHoursStart) }
+    }
+
+    /// Hour (0–23) quiet hours end.
+    var quietHoursEndHour: Int {
+        didSet { defaults.set(quietHoursEndHour, forKey: PrefKey.quietHoursEnd) }
+    }
+
+    /// Budget-alert threshold options offered in the UI.
+    static let budgetThresholdOptions: [Double] = [75, 90, 100]
+
     /// Default schedules for initial setup.
     static let defaultSchedules: [NotificationSchedule] = NotificationType.allCases.map { type in
         NotificationSchedule(
@@ -53,13 +80,87 @@ final class NotificationSettingsViewModel {
         scheduler: NotificationSchedulerProtocol = NotificationSchedulerService.shared,
         budgetRepository: BudgetRepository,
         transactionRepository: TransactionRepository,
-        goalRepository: GoalRepository
+        goalRepository: GoalRepository,
+        defaults: UserDefaults = .standard
     ) {
         self.scheduler = scheduler
         self.budgetRepository = budgetRepository
         self.transactionRepository = transactionRepository
         self.goalRepository = goalRepository
+        self.defaults = defaults
         self.schedules = Self.defaultSchedules
+        self.quietHoursEnabled = defaults.bool(forKey: PrefKey.quietHoursEnabled)
+        self.quietHoursStartHour = defaults.object(forKey: PrefKey.quietHoursStart) as? Int ?? 22
+        self.quietHoursEndHour = defaults.object(forKey: PrefKey.quietHoursEnd) as? Int ?? 7
+    }
+
+    // MARK: - Alert Center Summary (#2163)
+
+    /// Number of enabled alert schedules.
+    var enabledScheduleCount: Int { schedules.filter(\.isEnabled).count }
+
+    /// Current budget-alert threshold percentage.
+    var budgetThresholdPercent: Double {
+        schedules.first(where: { $0.type == .budgetAlert })?.thresholdPercent ?? 80
+    }
+
+    /// A one-line summary of the alert center state for the entry point.
+    var stateSummary: String {
+        let alertsPart = String(localized: "\(enabledScheduleCount) alerts on")
+        let quietPart = quietHoursEnabled
+            ? String(localized: "quiet hours \(quietHoursSummary)")
+            : String(localized: "quiet hours off")
+        return "\(alertsPart) · \(quietPart)"
+    }
+
+    /// Human-readable quiet-hours window, e.g. "10 PM – 7 AM".
+    var quietHoursSummary: String {
+        "\(Self.formatHour(quietHoursStartHour)) – \(Self.formatHour(quietHoursEndHour))"
+    }
+
+    /// Whether a given hour of day falls inside the quiet-hours window.
+    /// Correctly handles windows that wrap past midnight.
+    func isWithinQuietHours(hour: Int) -> Bool {
+        guard quietHoursEnabled else { return false }
+        let start = quietHoursStartHour
+        let end = quietHoursEndHour
+        if start == end { return false }
+        if start < end { return hour >= start && hour < end }
+        return hour >= start || hour < end
+    }
+
+    /// Formats a 24-hour value as a localized 12-hour label.
+    static func formatHour(_ hour: Int) -> String {
+        let clamped = ((hour % 24) + 24) % 24
+        var components = DateComponents()
+        components.hour = clamped
+        let date = Calendar.current.date(from: components) ?? Date()
+        return date.formatted(.dateTime.hour())
+    }
+
+    /// Updates the budget-alert threshold and reschedules if enabled.
+    func setBudgetThreshold(_ percent: Double) async {
+        guard let index = schedules.firstIndex(where: { $0.type == .budgetAlert }) else { return }
+        let schedule = schedules[index]
+        let updated = NotificationSchedule(
+            id: schedule.id,
+            type: schedule.type,
+            isEnabled: schedule.isEnabled,
+            frequency: schedule.frequency,
+            scheduledHour: schedule.scheduledHour,
+            scheduledMinute: schedule.scheduledMinute,
+            thresholdPercent: percent,
+            createdAt: schedule.createdAt
+        )
+        schedules[index] = updated
+
+        if updated.isEnabled {
+            do {
+                try await scheduler.scheduleNotification(updated)
+            } catch {
+                errorMessage = String(localized: "Failed to update budget threshold.")
+            }
+        }
     }
 
     // MARK: - Permission

--- a/apps/ios/Tests/CompoundGrowthProjectorTests.swift
+++ b/apps/ios/Tests/CompoundGrowthProjectorTests.swift
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CompoundGrowthProjectorTests.swift
+// FinanceTests
+//
+// Tests for the pure compound-growth projection math (#2118, #2116).
+
+import XCTest
+@testable import FinanceApp
+
+final class CompoundGrowthProjectorTests: XCTestCase {
+
+    func testProjectReturnsYearsPlusOnePoints() {
+        let points = CompoundGrowthProjector.project(
+            currentMinorUnits: 100_000,
+            monthlyContributionMinorUnits: 10_000,
+            annualReturnRate: 0.07,
+            years: 10
+        )
+        XCTAssertEqual(points.count, 11)
+    }
+
+    func testFirstPointIsPresentBalance() {
+        let points = CompoundGrowthProjector.project(
+            currentMinorUnits: 250_000,
+            monthlyContributionMinorUnits: 0,
+            annualReturnRate: 0.07,
+            years: 5
+        )
+        let first = points.first!
+        XCTAssertFalse(first.isProjected)
+        XCTAssertEqual(first.valueMinorUnits, 250_000)
+        XCTAssertEqual(first.contributedMinorUnits, 250_000)
+        XCTAssertEqual(first.growthMinorUnits, 0)
+    }
+
+    func testZeroReturnAccumulatesContributionsOnly() {
+        let points = CompoundGrowthProjector.project(
+            currentMinorUnits: 0,
+            monthlyContributionMinorUnits: 100,
+            annualReturnRate: 0.0,
+            years: 1
+        )
+        let last = points.last!
+        // 12 months * 100 = 1200, no market growth.
+        XCTAssertEqual(last.valueMinorUnits, 1_200)
+        XCTAssertEqual(last.contributedMinorUnits, 1_200)
+        XCTAssertEqual(last.growthMinorUnits, 0)
+    }
+
+    func testPositiveReturnProducesGrowth() {
+        let points = CompoundGrowthProjector.project(
+            currentMinorUnits: 100_000,
+            monthlyContributionMinorUnits: 5_000,
+            annualReturnRate: 0.08,
+            years: 20
+        )
+        let last = points.last!
+        XCTAssertTrue(last.isProjected)
+        XCTAssertGreaterThan(last.valueMinorUnits, last.contributedMinorUnits)
+        XCTAssertGreaterThan(last.growthMinorUnits, 0)
+    }
+
+    func testYearsClampedToZeroReturnsSinglePoint() {
+        let points = CompoundGrowthProjector.project(
+            currentMinorUnits: 100_000,
+            monthlyContributionMinorUnits: 1_000,
+            annualReturnRate: 0.07,
+            years: -5
+        )
+        XCTAssertEqual(points.count, 1)
+    }
+
+    func testFutureValueMatchesProjectAtHorizon() {
+        let years = 3
+        let points = CompoundGrowthProjector.project(
+            currentMinorUnits: 500_000,
+            monthlyContributionMinorUnits: 20_000,
+            annualReturnRate: 0.06,
+            years: years
+        )
+        let fv = CompoundGrowthProjector.futureValue(
+            currentMinorUnits: 500_000,
+            monthlyContributionMinorUnits: 20_000,
+            annualReturnRate: 0.06,
+            months: years * 12
+        )
+        XCTAssertEqual(points.last!.valueMinorUnits, fv)
+    }
+
+    func testFutureValueZeroMonthsReturnsCurrent() {
+        let fv = CompoundGrowthProjector.futureValue(
+            currentMinorUnits: 123_456,
+            monthlyContributionMinorUnits: 1_000,
+            annualReturnRate: 0.07,
+            months: 0
+        )
+        XCTAssertEqual(fv, 123_456)
+    }
+}

--- a/apps/ios/Tests/DashboardViewModelTests.swift
+++ b/apps/ios/Tests/DashboardViewModelTests.swift
@@ -230,4 +230,46 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertEqual(vm.recentTransactions.count, 5,
                        "Dashboard should show at most 5 recent transactions")
     }
+
+    // MARK: - Net Worth Trend (#2116)
+
+    @MainActor
+    func testNetWorthTrendPointsEndAtCurrentNetWorth() async {
+        let vm = makeDashboardVM()
+
+        await vm.loadDashboard()
+
+        XCTAssertTrue(vm.hasNetWorthTrend)
+        XCTAssertFalse(vm.netWorthTrendPoints.isEmpty)
+        XCTAssertEqual(vm.netWorthTrendPoints.last?.valueMinorUnits, vm.netWorth)
+    }
+
+    @MainActor
+    func testNetWorthTrendRangeControlsPointCount() async {
+        let vm = makeDashboardVM()
+        await vm.loadDashboard()
+
+        vm.netWorthTrendRange = .threeMonths
+        XCTAssertEqual(vm.netWorthTrendPoints.count, 3)
+
+        vm.netWorthTrendRange = .oneYear
+        XCTAssertEqual(vm.netWorthTrendPoints.count, 12)
+    }
+
+    @MainActor
+    func testNetWorthProjectionExtendsFromHistory() async {
+        let vm = makeDashboardVM()
+        await vm.loadDashboard()
+
+        XCTAssertEqual(vm.netWorthProjectionPoints.count, 12)
+        XCTAssertTrue(vm.netWorthProjectionPoints.allSatisfy(\.isProjected))
+    }
+
+    @MainActor
+    func testNoNetWorthTrendWithoutAccounts() async {
+        let vm = makeDashboardVM(accounts: [], transactions: [], budgets: [])
+        await vm.loadDashboard()
+
+        XCTAssertFalse(vm.hasNetWorthTrend)
+    }
 }

--- a/apps/ios/Tests/FeatureVisibilityTests.swift
+++ b/apps/ios/Tests/FeatureVisibilityTests.swift
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FeatureVisibilityTests.swift
+// FinanceTests
+//
+// Tests for the low-noise / minimalist mode visibility store (#2122).
+
+import XCTest
+@testable import FinanceApp
+
+final class FeatureVisibilityTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private let suiteName = "FeatureVisibilityTests.suite"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func testUnsetKeyDefaultsToVisible() {
+        XCTAssertTrue(FeatureVisibility.isVisible(FeatureVisibility.investmentsKey, defaults: defaults))
+    }
+
+    func testExplicitFalseHidesFeature() {
+        defaults.set(false, forKey: FeatureVisibility.billsKey)
+        XCTAssertFalse(FeatureVisibility.isVisible(FeatureVisibility.billsKey, defaults: defaults))
+    }
+
+    func testFirePresetHidesBillsReportsAndMoodTags() {
+        FeatureVisibility.apply(FeatureVisibility.firePreset(), to: defaults)
+
+        XCTAssertTrue(FeatureVisibility.isVisible(FeatureVisibility.investmentsKey, defaults: defaults))
+        XCTAssertTrue(FeatureVisibility.isVisible(FeatureVisibility.budgetsTabKey, defaults: defaults))
+        XCTAssertTrue(FeatureVisibility.isVisible(FeatureVisibility.goalsTabKey, defaults: defaults))
+        XCTAssertFalse(FeatureVisibility.isVisible(FeatureVisibility.billsKey, defaults: defaults))
+        XCTAssertFalse(FeatureVisibility.isVisible(FeatureVisibility.reportsKey, defaults: defaults))
+        XCTAssertFalse(defaults.bool(forKey: FeatureVisibility.moodTagsKey))
+    }
+
+    func testFullPresetRestoresEverything() {
+        FeatureVisibility.apply(FeatureVisibility.firePreset(), to: defaults)
+        FeatureVisibility.apply(FeatureVisibility.fullPreset(), to: defaults)
+
+        for key in FeatureVisibility.visibilityKeys {
+            XCTAssertTrue(FeatureVisibility.isVisible(key, defaults: defaults), "\(key) should be visible")
+        }
+        XCTAssertFalse(FeatureVisibility.hasHiddenFeatures(defaults: defaults))
+    }
+
+    func testHasHiddenFeatures() {
+        XCTAssertFalse(FeatureVisibility.hasHiddenFeatures(defaults: defaults))
+        defaults.set(false, forKey: FeatureVisibility.reportsKey)
+        XCTAssertTrue(FeatureVisibility.hasHiddenFeatures(defaults: defaults))
+    }
+}

--- a/apps/ios/Tests/InvestmentViewModelTests.swift
+++ b/apps/ios/Tests/InvestmentViewModelTests.swift
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// InvestmentViewModelTests.swift
+// FinanceTests
+//
+// Tests for InvestmentViewModel — portfolio loading, allocation, contributions,
+// and compound-growth projections (#1103, #2118).
+
+import XCTest
+@testable import FinanceApp
+
+// MARK: - Stub Formatter
+
+private struct StubFormatter: SwiftExportFormatterModule {
+    func format(amountMinorUnits: Int64, currencyCode: String, showSign: Bool) -> String {
+        "\(amountMinorUnits)"
+    }
+
+    func formatCompact(amountMinorUnits: Int64, currencyCode: String) -> String {
+        "\(amountMinorUnits)"
+    }
+}
+
+final class InvestmentViewModelTests: XCTestCase {
+
+    @MainActor
+    private func makeViewModel(
+        portfolios: [PortfolioItem] = [SampleData.samplePortfolio],
+        monthlyContribution: Int64 = 1_000_00,
+        contributions: [ContributionRecord] = [],
+        error: Error? = nil
+    ) -> (InvestmentViewModel, StubInvestmentRepository) {
+        let repo = StubInvestmentRepository()
+        repo.portfoliosToReturn = portfolios
+        repo.errorToThrow = error
+        if let first = portfolios.first {
+            repo.monthlyContributionByPortfolio[first.id] = monthlyContribution
+            repo.contributionsByPortfolio[first.id] = contributions
+        }
+        let vm = InvestmentViewModel(repository: repo, formatter: StubFormatter())
+        return (vm, repo)
+    }
+
+    @MainActor
+    func testLoadPortfoliosSelectsFirst() async {
+        let (vm, _) = makeViewModel()
+
+        await vm.loadPortfolios()
+
+        XCTAssertEqual(vm.portfolios.count, 1)
+        XCTAssertEqual(vm.selectedPortfolio?.id, "p1")
+        XCTAssertFalse(vm.isLoading)
+        XCTAssertNil(vm.errorMessage)
+    }
+
+    @MainActor
+    func testLoadPortfoliosComputesAllocation() async {
+        let (vm, _) = makeViewModel()
+
+        await vm.loadPortfolios()
+
+        XCTAssertFalse(vm.allocationSlices.isEmpty)
+        let total = vm.allocationSlices.reduce(0.0) { $0 + $1.percentage }
+        XCTAssertEqual(total, 100.0, accuracy: 0.01)
+    }
+
+    @MainActor
+    func testLoadPortfoliosLoadsContributionData() async {
+        let record = ContributionRecord(date: .now, amountMinorUnits: 500_00)
+        let (vm, _) = makeViewModel(contributions: [record])
+
+        await vm.loadPortfolios()
+
+        XCTAssertEqual(vm.monthlyContributionMinorUnits, 1_000_00)
+        XCTAssertEqual(vm.contributions.count, 1)
+    }
+
+    @MainActor
+    func testLoadPortfoliosError() async {
+        let (vm, _) = makeViewModel(error: TestError.simulated)
+
+        await vm.loadPortfolios()
+
+        XCTAssertNotNil(vm.errorMessage)
+        XCTAssertTrue(vm.portfolios.isEmpty)
+    }
+
+    @MainActor
+    func testProjectionPointsUseContributionAndHorizon() async {
+        let (vm, _) = makeViewModel()
+        await vm.loadPortfolios()
+
+        vm.projectionYears = 10
+        vm.projectionAnnualReturnPercent = 7
+
+        let points = vm.projectionPoints
+        XCTAssertEqual(points.count, 11)
+        XCTAssertGreaterThan(vm.projectedValueMinorUnits, vm.selectedPortfolio!.totalValueMinorUnits)
+    }
+
+    @MainActor
+    func testProjectionEmptyWithoutPortfolio() {
+        let (vm, _) = makeViewModel(portfolios: [])
+        XCTAssertTrue(vm.projectionPoints.isEmpty)
+    }
+
+    @MainActor
+    func testUpdateMonthlyContributionPersistsSanitised() async {
+        let (vm, repo) = makeViewModel()
+        await vm.loadPortfolios()
+
+        await vm.updateMonthlyContribution(-50)
+
+        XCTAssertEqual(vm.monthlyContributionMinorUnits, 0)
+        XCTAssertEqual(repo.setContributionCalls.last?.amount, 0)
+    }
+
+    @MainActor
+    func testUpdateMonthlyContributionStoresValue() async {
+        let (vm, repo) = makeViewModel()
+        await vm.loadPortfolios()
+
+        await vm.updateMonthlyContribution(2_000_00)
+
+        XCTAssertEqual(vm.monthlyContributionMinorUnits, 2_000_00)
+        XCTAssertEqual(repo.setContributionCalls.last?.amount, 2_000_00)
+    }
+
+    @MainActor
+    func testRecordContributionAddsToHistory() async {
+        let (vm, repo) = makeViewModel()
+        await vm.loadPortfolios()
+
+        await vm.recordContribution(750_00)
+
+        XCTAssertEqual(repo.recordedContributions.last?.amount, 750_00)
+        XCTAssertEqual(vm.contributions.first?.amountMinorUnits, 750_00)
+    }
+
+    @MainActor
+    func testRecordContributionIgnoresNonPositive() async {
+        let (vm, repo) = makeViewModel()
+        await vm.loadPortfolios()
+
+        await vm.recordContribution(0)
+
+        XCTAssertTrue(repo.recordedContributions.isEmpty)
+    }
+
+    @MainActor
+    func testContributionMetrics() async {
+        let (vm, _) = makeViewModel()
+        await vm.loadPortfolios()
+
+        // p1: cost basis 25_000_00, value 29_100_00 → growth 4_100_00.
+        XCTAssertEqual(vm.totalContributionsMinorUnits, 25_000_00)
+        XCTAssertEqual(vm.marketReturnMinorUnits, 4_100_00)
+    }
+
+    @MainActor
+    func testSortedHoldingsDescending() async {
+        let (vm, _) = makeViewModel()
+        await vm.loadPortfolios()
+
+        let sorted = vm.sortedHoldings(for: vm.selectedPortfolio!)
+        XCTAssertEqual(sorted.first?.symbol, "VTI")
+    }
+
+    @MainActor
+    func testDismissError() {
+        let (vm, _) = makeViewModel()
+        vm.errorMessage = "oops"
+        XCTAssertTrue(vm.showError)
+        vm.dismissError()
+        XCTAssertFalse(vm.showError)
+    }
+}

--- a/apps/ios/Tests/NetWorthTrendCalculatorTests.swift
+++ b/apps/ios/Tests/NetWorthTrendCalculatorTests.swift
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// NetWorthTrendCalculatorTests.swift
+// FinanceTests
+//
+// Tests for the pure net-worth trend reconstruction and projection (#2116).
+
+import XCTest
+@testable import FinanceApp
+
+final class NetWorthTrendCalculatorTests: XCTestCase {
+
+    private var calendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var comps = DateComponents()
+        comps.year = year
+        comps.month = month
+        comps.day = day
+        return calendar.date(from: comps)!
+    }
+
+    private func txn(
+        amount: Int64,
+        date: Date,
+        type: TransactionTypeUI = .expense
+    ) -> TransactionItem {
+        TransactionItem(
+            id: UUID().uuidString,
+            payee: "x",
+            category: "y",
+            accountName: "z",
+            amountMinorUnits: amount,
+            currencyCode: "USD",
+            date: date,
+            type: type,
+            status: .cleared
+        )
+    }
+
+    func testHistoryHasRequestedNumberOfPoints() {
+        let points = NetWorthTrendCalculator.history(
+            currentNetWorthMinorUnits: 100_000,
+            transactions: [],
+            months: 6,
+            now: date(2023, 11, 15),
+            calendar: calendar
+        )
+        XCTAssertEqual(points.count, 6)
+    }
+
+    func testHistoryEndsAtCurrentNetWorth() {
+        let points = NetWorthTrendCalculator.history(
+            currentNetWorthMinorUnits: 100_000,
+            transactions: [],
+            months: 3,
+            now: date(2023, 11, 15),
+            calendar: calendar
+        )
+        XCTAssertEqual(points.last?.valueMinorUnits, 100_000)
+        // No flows means a flat line.
+        XCTAssertTrue(points.allSatisfy { $0.valueMinorUnits == 100_000 })
+    }
+
+    func testHistorySubtractsCurrentMonthIncomeGoingBackwards() {
+        let now = date(2023, 11, 15)
+        let points = NetWorthTrendCalculator.history(
+            currentNetWorthMinorUnits: 100_000,
+            transactions: [txn(amount: 5_000, date: date(2023, 11, 10), type: .income)],
+            months: 3,
+            now: now,
+            calendar: calendar
+        )
+        // Current month gained 5_000, so the prior months sit 5_000 lower.
+        XCTAssertEqual(points.last?.valueMinorUnits, 100_000)
+        XCTAssertEqual(points.first?.valueMinorUnits, 95_000)
+    }
+
+    func testTransfersAreIgnored() {
+        let now = date(2023, 11, 15)
+        let points = NetWorthTrendCalculator.history(
+            currentNetWorthMinorUnits: 100_000,
+            transactions: [txn(amount: -50_000, date: date(2023, 11, 10), type: .transfer)],
+            months: 3,
+            now: now,
+            calendar: calendar
+        )
+        XCTAssertTrue(points.allSatisfy { $0.valueMinorUnits == 100_000 })
+    }
+
+    func testAverageMonthlySavings() {
+        let now = date(2023, 11, 15)
+        let avg = NetWorthTrendCalculator.averageMonthlySavings(
+            transactions: [txn(amount: 6_000, date: date(2023, 11, 10), type: .income)],
+            months: 3,
+            now: now,
+            calendar: calendar
+        )
+        XCTAssertEqual(avg, 2_000)
+    }
+
+    func testProjectionIsLinearAtSavingsPace() {
+        let anchor = NetWorthTrendPoint(
+            date: date(2023, 11, 1),
+            valueMinorUnits: 100_000,
+            isProjected: false
+        )
+        let projection = NetWorthTrendCalculator.projection(
+            from: anchor,
+            monthlySavingsMinorUnits: 2_000,
+            months: 3,
+            calendar: calendar
+        )
+        XCTAssertEqual(projection.count, 3)
+        XCTAssertEqual(projection.map(\.valueMinorUnits), [102_000, 104_000, 106_000])
+        XCTAssertTrue(projection.allSatisfy(\.isProjected))
+    }
+
+    func testProjectionZeroMonthsIsEmpty() {
+        let anchor = NetWorthTrendPoint(
+            date: date(2023, 11, 1),
+            valueMinorUnits: 100_000,
+            isProjected: false
+        )
+        let projection = NetWorthTrendCalculator.projection(
+            from: anchor,
+            monthlySavingsMinorUnits: 2_000,
+            months: 0,
+            calendar: calendar
+        )
+        XCTAssertTrue(projection.isEmpty)
+    }
+
+    func testRangeMonthsMapping() {
+        XCTAssertEqual(NetWorthTrendRange.threeMonths.months, 3)
+        XCTAssertEqual(NetWorthTrendRange.sixMonths.months, 6)
+        XCTAssertEqual(NetWorthTrendRange.oneYear.months, 12)
+        XCTAssertNil(NetWorthTrendRange.all.months)
+    }
+}

--- a/apps/ios/Tests/NotificationSettingsViewModelTests.swift
+++ b/apps/ios/Tests/NotificationSettingsViewModelTests.swift
@@ -204,6 +204,99 @@ final class NotificationSettingsViewModelTests: XCTestCase {
         vm.dismissError()
         XCTAssertFalse(vm.showError)
     }
+
+    // MARK: - Alert Center: Quiet Hours & Threshold (#2163)
+
+    @MainActor
+    private func makeViewModelWithDefaults(
+        suiteName: String
+    ) -> (NotificationSettingsViewModel, UserDefaults) {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let vm = NotificationSettingsViewModel(
+            scheduler: StubNotificationScheduler(),
+            budgetRepository: StubBudgetRepository(),
+            transactionRepository: StubTransactionRepository(),
+            goalRepository: StubGoalRepository(),
+            defaults: defaults
+        )
+        return (vm, defaults)
+    }
+
+    @MainActor
+    func testQuietHoursDefaults() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "quiet.defaults")
+        defer { defaults.removePersistentDomain(forName: "quiet.defaults") }
+
+        XCTAssertFalse(vm.quietHoursEnabled)
+        XCTAssertEqual(vm.quietHoursStartHour, 22)
+        XCTAssertEqual(vm.quietHoursEndHour, 7)
+    }
+
+    @MainActor
+    func testQuietHoursPersist() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "quiet.persist")
+        defer { defaults.removePersistentDomain(forName: "quiet.persist") }
+
+        vm.quietHoursEnabled = true
+        vm.quietHoursStartHour = 21
+        vm.quietHoursEndHour = 6
+
+        let vm2 = NotificationSettingsViewModel(
+            scheduler: StubNotificationScheduler(),
+            budgetRepository: StubBudgetRepository(),
+            transactionRepository: StubTransactionRepository(),
+            goalRepository: StubGoalRepository(),
+            defaults: defaults
+        )
+        XCTAssertTrue(vm2.quietHoursEnabled)
+        XCTAssertEqual(vm2.quietHoursStartHour, 21)
+        XCTAssertEqual(vm2.quietHoursEndHour, 6)
+    }
+
+    @MainActor
+    func testQuietHoursWrapAroundMidnight() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "quiet.wrap")
+        defer { defaults.removePersistentDomain(forName: "quiet.wrap") }
+
+        vm.quietHoursEnabled = true
+        vm.quietHoursStartHour = 22
+        vm.quietHoursEndHour = 7
+
+        XCTAssertTrue(vm.isWithinQuietHours(hour: 23))
+        XCTAssertTrue(vm.isWithinQuietHours(hour: 2))
+        XCTAssertFalse(vm.isWithinQuietHours(hour: 12))
+    }
+
+    @MainActor
+    func testQuietHoursDisabledNeverMatches() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "quiet.off")
+        defer { defaults.removePersistentDomain(forName: "quiet.off") }
+
+        vm.quietHoursEnabled = false
+        XCTAssertFalse(vm.isWithinQuietHours(hour: 3))
+    }
+
+    @MainActor
+    func testSetBudgetThresholdUpdatesSchedule() async {
+        let scheduler = StubNotificationScheduler()
+        let (vm, _) = makeViewModel(scheduler: scheduler)
+
+        await vm.setBudgetThreshold(90)
+
+        XCTAssertEqual(vm.budgetThresholdPercent, 90)
+    }
+
+    @MainActor
+    func testBudgetThresholdOptions() {
+        XCTAssertEqual(NotificationSettingsViewModel.budgetThresholdOptions, [75, 90, 100])
+    }
+
+    @MainActor
+    func testStateSummaryReflectsEnabledCount() {
+        let (vm, _) = makeViewModel()
+        XCTAssertTrue(vm.stateSummary.contains("\(vm.enabledScheduleCount)"))
+    }
 }
 
 // MARK: - Notification Model Tests

--- a/apps/ios/Tests/PersistedInvestmentRepositoryTests.swift
+++ b/apps/ios/Tests/PersistedInvestmentRepositoryTests.swift
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// PersistedInvestmentRepositoryTests.swift
+// FinanceTests
+//
+// Tests for the UserDefaults-backed investment repository, including seeding,
+// contribution tracking, and deterministic performance history (#2118).
+
+import XCTest
+@testable import FinanceApp
+
+final class PersistedInvestmentRepositoryTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private let suiteName = "PersistedInvestmentRepositoryTests.suite"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    private func makeRepo(seedIfEmpty: Bool = true) -> PersistedInvestmentRepository {
+        PersistedInvestmentRepository(
+            defaults: defaults,
+            storageKey: "test.investments",
+            seededKey: "test.investments.seeded",
+            seedIfEmpty: seedIfEmpty
+        )
+    }
+
+    func testSeedsStarterPortfolioOnFirstLaunch() async throws {
+        let repo = makeRepo()
+        let portfolios = try await repo.getPortfolios()
+
+        XCTAssertEqual(portfolios.count, 1)
+        let portfolio = portfolios.first!
+        XCTAssertEqual(portfolio.id, "main")
+        XCTAssertFalse(portfolio.holdings.isEmpty)
+        XCTAssertGreaterThan(portfolio.monthlyContributionMinorUnits, 0)
+    }
+
+    func testNoSeedWhenDisabled() async throws {
+        let repo = makeRepo(seedIfEmpty: false)
+        let portfolios = try await repo.getPortfolios()
+        XCTAssertTrue(portfolios.isEmpty)
+    }
+
+    func testSetMonthlyContributionPersists() async throws {
+        let repo = makeRepo()
+        try await repo.setMonthlyContributionMinorUnits(250_00, portfolioId: "main")
+
+        let value = try await repo.getMonthlyContributionMinorUnits(portfolioId: "main")
+        XCTAssertEqual(value, 250_00)
+    }
+
+    func testNegativeContributionClampedToZero() async throws {
+        let repo = makeRepo()
+        try await repo.setMonthlyContributionMinorUnits(-500, portfolioId: "main")
+        let value = try await repo.getMonthlyContributionMinorUnits(portfolioId: "main")
+        XCTAssertEqual(value, 0)
+    }
+
+    func testRecordContributionAppearsNewestFirst() async throws {
+        let repo = makeRepo()
+        let older = Date(timeIntervalSince1970: 1_600_000_000)
+        let newer = Date(timeIntervalSince1970: 1_700_000_000)
+
+        try await repo.recordContribution(100_00, portfolioId: "main", date: older)
+        try await repo.recordContribution(200_00, portfolioId: "main", date: newer)
+
+        let contributions = try await repo.getContributions(portfolioId: "main")
+        XCTAssertEqual(contributions.count, 2)
+        XCTAssertEqual(contributions.first?.amountMinorUnits, 200_00)
+        XCTAssertEqual(contributions.last?.amountMinorUnits, 100_00)
+    }
+
+    func testPerformanceHistoryHasRequestedMonths() async throws {
+        let repo = makeRepo()
+        let history = try await repo.getPerformanceHistory(portfolioId: "main", months: 12)
+        XCTAssertEqual(history.count, 12)
+        // Oldest first; last point equals current total value.
+        let portfolio = try await repo.getPortfolio(id: "main")!
+        XCTAssertEqual(history.last?.valueMinorUnits, portfolio.totalValueMinorUnits)
+    }
+
+    func testPersistenceSurvivesNewInstance() async throws {
+        let repo = makeRepo()
+        try await repo.setMonthlyContributionMinorUnits(999_00, portfolioId: "main")
+
+        let repo2 = makeRepo()
+        let value = try await repo2.getMonthlyContributionMinorUnits(portfolioId: "main")
+        XCTAssertEqual(value, 999_00)
+    }
+
+    func testDeleteAllClearsData() async throws {
+        let repo = makeRepo()
+        try await repo.deleteAllInvestments()
+
+        // A fresh instance with seeding disabled should now see nothing.
+        let repo2 = makeRepo(seedIfEmpty: false)
+        let portfolios = try await repo2.getPortfolios()
+        XCTAssertTrue(portfolios.isEmpty)
+    }
+}

--- a/apps/ios/Tests/QuickExpenseComposerTests.swift
+++ b/apps/ios/Tests/QuickExpenseComposerTests.swift
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// QuickExpenseComposerTests.swift
+// FinanceTests
+//
+// Tests for one-thumb quick expense composition and remembered defaults (#2167).
+
+import XCTest
+@testable import FinanceApp
+
+final class QuickExpenseComposerTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private let suiteName = "QuickExpenseComposerTests.suite"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func testPresetsAreNonEmptyWithUniqueIds() {
+        let presets = QuickExpenseComposer.presets
+        XCTAssertFalse(presets.isEmpty)
+        XCTAssertEqual(Set(presets.map(\.id)).count, presets.count)
+        for preset in presets {
+            XCTAssertFalse(preset.label.isEmpty)
+            XCTAssertFalse(preset.categoryId.isEmpty)
+            XCTAssertFalse(preset.systemImage.isEmpty)
+        }
+    }
+
+    func testMakeTransactionStoresNegativeExpenseAmount() {
+        let txn = QuickExpenseComposer.makeTransaction(
+            amountMinorUnits: 12_50,
+            payee: "Blue Bottle",
+            categoryName: "Dining Out",
+            accountName: "Main Checking",
+            currencyCode: "USD"
+        )
+        XCTAssertEqual(txn.amountMinorUnits, -12_50)
+        XCTAssertEqual(txn.type, .expense)
+        XCTAssertEqual(txn.payee, "Blue Bottle")
+        XCTAssertEqual(txn.category, "Dining Out")
+        XCTAssertEqual(txn.accountName, "Main Checking")
+    }
+
+    func testMakeTransactionNegativeInputStillStoredNegative() {
+        let txn = QuickExpenseComposer.makeTransaction(
+            amountMinorUnits: -500,
+            payee: "x",
+            categoryName: "c",
+            accountName: "a",
+            currencyCode: "USD"
+        )
+        XCTAssertEqual(txn.amountMinorUnits, -500)
+    }
+
+    func testMakeTransactionEmptyPayeeFallsBack() {
+        let txn = QuickExpenseComposer.makeTransaction(
+            amountMinorUnits: 300,
+            payee: "   ",
+            categoryName: "Cash",
+            accountName: "Wallet",
+            currencyCode: "USD"
+        )
+        XCTAssertFalse(txn.payee.isEmpty)
+    }
+
+    func testRememberedAccountRoundTrips() {
+        XCTAssertNil(QuickExpenseComposer.lastAccountId(defaults: defaults))
+        QuickExpenseComposer.setLastAccountId("a1", defaults: defaults)
+        XCTAssertEqual(QuickExpenseComposer.lastAccountId(defaults: defaults), "a1")
+        QuickExpenseComposer.setLastAccountId(nil, defaults: defaults)
+        XCTAssertNil(QuickExpenseComposer.lastAccountId(defaults: defaults))
+    }
+
+    func testRememberedCategoryRoundTrips() {
+        QuickExpenseComposer.setLastCategoryId("c2", defaults: defaults)
+        XCTAssertEqual(QuickExpenseComposer.lastCategoryId(defaults: defaults), "c2")
+        QuickExpenseComposer.setLastCategoryId("", defaults: defaults)
+        XCTAssertNil(QuickExpenseComposer.lastCategoryId(defaults: defaults))
+    }
+}

--- a/apps/ios/Tests/TestHelpers.swift
+++ b/apps/ios/Tests/TestHelpers.swift
@@ -243,6 +243,79 @@ final class StubBiometricAuthManager: BiometricAuthManaging, @unchecked Sendable
     }
 }
 
+// MARK: - Stub Investment Repository
+
+/// Configurable stub for `InvestmentRepository`. Returns pre-set portfolios /
+/// performance history and tracks contribution mutations for verification.
+final class StubInvestmentRepository: InvestmentRepository, @unchecked Sendable {
+    var portfoliosToReturn: [PortfolioItem] = []
+    var performanceToReturn: [PerformanceDataPoint] = []
+    var errorToThrow: Error?
+
+    var monthlyContributionByPortfolio: [String: Int64] = [:]
+    var contributionsByPortfolio: [String: [ContributionRecord]] = [:]
+
+    private(set) var recordedContributions: [(amount: Int64, portfolioId: String, date: Date)] = []
+    private(set) var setContributionCalls: [(amount: Int64, portfolioId: String)] = []
+    private(set) var deleteAllCalled = false
+
+    func getPortfolios() async throws -> [PortfolioItem] {
+        if let error = errorToThrow { throw error }
+        return portfoliosToReturn
+    }
+
+    func getPortfolio(id: String) async throws -> PortfolioItem? {
+        if let error = errorToThrow { throw error }
+        return portfoliosToReturn.first { $0.id == id }
+    }
+
+    func getHoldings(portfolioId: String) async throws -> [HoldingItem] {
+        if let error = errorToThrow { throw error }
+        return portfoliosToReturn.first { $0.id == portfolioId }?.holdings ?? []
+    }
+
+    func getHolding(id: String) async throws -> HoldingItem? {
+        if let error = errorToThrow { throw error }
+        return portfoliosToReturn.flatMap(\.holdings).first { $0.id == id }
+    }
+
+    func getPerformanceHistory(portfolioId: String, months: Int) async throws -> [PerformanceDataPoint] {
+        if let error = errorToThrow { throw error }
+        return performanceToReturn
+    }
+
+    func getMonthlyContributionMinorUnits(portfolioId: String) async throws -> Int64 {
+        if let error = errorToThrow { throw error }
+        return monthlyContributionByPortfolio[portfolioId] ?? 0
+    }
+
+    func setMonthlyContributionMinorUnits(_ amountMinorUnits: Int64, portfolioId: String) async throws {
+        if let error = errorToThrow { throw error }
+        setContributionCalls.append((amount: amountMinorUnits, portfolioId: portfolioId))
+        monthlyContributionByPortfolio[portfolioId] = amountMinorUnits
+    }
+
+    func recordContribution(_ amountMinorUnits: Int64, portfolioId: String, date: Date) async throws {
+        if let error = errorToThrow { throw error }
+        recordedContributions.append((amount: amountMinorUnits, portfolioId: portfolioId, date: date))
+        let record = ContributionRecord(date: date, amountMinorUnits: amountMinorUnits)
+        contributionsByPortfolio[portfolioId, default: []].insert(record, at: 0)
+    }
+
+    func getContributions(portfolioId: String) async throws -> [ContributionRecord] {
+        if let error = errorToThrow { throw error }
+        return contributionsByPortfolio[portfolioId] ?? []
+    }
+
+    func deleteAllInvestments() async throws {
+        if let error = errorToThrow { throw error }
+        deleteAllCalled = true
+        portfoliosToReturn = []
+        monthlyContributionByPortfolio = [:]
+        contributionsByPortfolio = [:]
+    }
+}
+
 // MARK: - Sample Data Factory
 
 /// Deterministic sample data for use across all test files.
@@ -404,4 +477,36 @@ enum SampleData {
     static let allCategories: [CategoryItem] = [
         groceriesCategory, diningCategory, transportCategory,
     ]
+
+    // MARK: Investments
+
+    static let vtiHolding = HoldingItem(
+        id: "h1", portfolioId: "p1", symbol: "VTI",
+        name: "Vanguard Total Stock Market ETF",
+        assetClass: .stocks, quantity: 100,
+        costBasisMinorUnits: 20_000_00,
+        currentValueMinorUnits: 24_000_00,
+        previousCloseMinorUnits: 23_800_00,
+        currencyCode: "USD",
+        lastUpdated: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+
+    static let bndHolding = HoldingItem(
+        id: "h2", portfolioId: "p1", symbol: "BND",
+        name: "Vanguard Total Bond Market ETF",
+        assetClass: .bonds, quantity: 50,
+        costBasisMinorUnits: 5_000_00,
+        currentValueMinorUnits: 5_100_00,
+        previousCloseMinorUnits: 5_090_00,
+        currencyCode: "USD",
+        lastUpdated: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+
+    static let samplePortfolio = PortfolioItem(
+        id: "p1", name: "Index Portfolio",
+        holdings: [vtiHolding, bndHolding],
+        currencyCode: "USD",
+        createdAt: Date(timeIntervalSince1970: 1_650_000_000),
+        monthlyContributionMinorUnits: 1_000_00
+    )
 }


### PR DESCRIPTION
﻿## Summary

A cohesive batch of iOS SwiftUI improvements focused on **charts, investing surfaces, VoiceOver reachability, and low-noise UX**. All work is confined to `apps/ios` (shared packages read-only). Compute logic lives in pure, unit-tested Services/Models; new UI is built as Chart/Card/Sheet/Screen/Button components.

### #2115 - VoiceOver: chart details reachable without drag gestures
- `TrendChart`/`PredictionChart` (and the two new charts) expose an **adjustable accessibility action**: swipe up/down to step through every data point, announcing date, value, and actual-vs-projected - no drag required. Each chart is a single ignore-children element with a live accessibility value plus a text-table alternative.

### #2118 - Trustworthy investment tracking with compound-growth projections
- New `PersistedInvestmentRepository` (UserDefaults-backed) replaces always-mock data: seeds a realistic index-fund starter portfolio, tracks a recurring monthly contribution + contribution history, deterministic performance history.
- New pure `CompoundGrowthProjector` (monthly compounding, end-of-month contributions).
- `InvestmentProjectionCard` + `InvestmentProjectionChart`: adjust contribution/horizon/return; projected value separates contributed principal from market growth.

### #2116 - Clean net-worth growth chart & projection on the primary surface
- New pure `NetWorthTrendCalculator` reconstructs monthly net worth from balances + transaction flows (transfers excluded) and projects forward at recent savings pace.
- `NetWorthTrendCard` + `NetWorthTrendChart` on the Dashboard with range selector, dashed projection, and projection summary.

### #2122 - Low-noise minimalist mode
- New `FeatureVisibility` store (visible-by-default keys, FIRE/full presets) and `MinimalistModeScreen`, reachable from a Focus section in Settings. Dashboard quick-access cards and optional Budgets/Goals tabs are gated on these keys.

### #2167 - One-thumb quick expense logging
- A thumb-reachable FAB on Transactions opens a compact quick-add sheet: preset chips, decimal-pad amount, optional payee, remembered last-used account/category. Pure `QuickExpenseComposer` owns composition + defaults.

### #2163 - Real in-app alert center
- Notifications promoted from buried toggles to a dedicated Alert Center linked from Settings: state summary, per-type schedules, quiet hours (persisted, midnight-wrapping), budget-alert threshold picker, and actionable smart-alert rows that open deep links.

## Accessibility
Adjustable chart navigation (no drag), redundant non-color cues, VoiceOver labels/hints/values, >=44pt targets, Dynamic Type-friendly layouts (WCAG 2.2 AA / Apple guidance).

## Testing
New unit tests: CompoundGrowthProjectorTests, NetWorthTrendCalculatorTests, FeatureVisibilityTests, QuickExpenseComposerTests, PersistedInvestmentRepositoryTests, InvestmentViewModelTests; plus extensions to DashboardViewModelTests and NotificationSettingsViewModelTests. StubInvestmentRepository + sample portfolio added to test helpers. Repo format:check and eslint --max-warnings 0 pass (Swift is prettier/eslint-ignored). iOS build/test/coverage validated by macOS CI.

Closes #2115
Closes #2118
Closes #2116
Closes #2122
Closes #2167
Closes #2163
