### PR TITLE
feat(ios): digital-nomad travel finance + Apple Pay/Wallet capture

### DIFF
--- a/apps/ios/Finance/Models/SyncQueue.swift
+++ b/apps/ios/Finance/Models/SyncQueue.swift
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// SyncQueue.swift
+// Finance
+//
+// Model types for trustworthy offline queued-sync feedback (#2204). A traveller
+// logging expenses on a flight needs to see exactly which entries are saved
+// locally, queued, uploading, failed, or conflicted — never wonder whether an
+// expense was actually captured.
+
+import SwiftUI
+
+/// The lifecycle state of a locally-made change awaiting server sync.
+enum SyncItemStatus: String, Codable, Sendable, CaseIterable {
+    /// Persisted on-device, not yet added to the upload queue.
+    case savedLocally
+    /// In the queue, waiting for connectivity or its turn to upload.
+    case queued
+    /// Actively uploading right now.
+    case uploading
+    /// Upload failed and will be retried.
+    case failed
+    /// Server has a competing change that must be resolved.
+    case conflicted
+    /// Successfully synced to the server.
+    case synced
+
+    var displayName: String {
+        switch self {
+        case .savedLocally: String(localized: "Saved locally")
+        case .queued: String(localized: "Queued")
+        case .uploading: String(localized: "Uploading")
+        case .failed: String(localized: "Failed")
+        case .conflicted: String(localized: "Conflict")
+        case .synced: String(localized: "Synced")
+        }
+    }
+
+    /// SF Symbol paired with text (never colour-only) for accessibility.
+    var systemImage: String {
+        switch self {
+        case .savedLocally: "internaldrive"
+        case .queued: "clock.arrow.circlepath"
+        case .uploading: "arrow.up.circle"
+        case .failed: "exclamationmark.arrow.triangle.2.circlepath"
+        case .conflicted: "exclamationmark.triangle"
+        case .synced: "checkmark.icloud"
+        }
+    }
+
+    var tintColor: Color {
+        switch self {
+        case .savedLocally, .queued: .secondary
+        case .uploading: .blue
+        case .failed: .red
+        case .conflicted: .orange
+        case .synced: .green
+        }
+    }
+
+    /// Whether this state still needs to reach the server.
+    var isPending: Bool {
+        switch self {
+        case .savedLocally, .queued, .uploading: true
+        case .failed, .conflicted, .synced: false
+        }
+    }
+
+    /// Whether this state requires the user's attention.
+    var needsAttention: Bool { self == .failed || self == .conflicted }
+}
+
+/// A single queued change with enough context for the user to trust it.
+struct SyncQueueItem: Identifiable, Codable, Sendable, Equatable {
+    let id: String
+    let entityType: String
+    let entityId: String
+    let summary: String
+    var status: SyncItemStatus
+    let createdAt: Date
+    var updatedAt: Date
+    var retryCount: Int
+    var errorMessage: String?
+
+    init(
+        id: String = UUID().uuidString,
+        entityType: String,
+        entityId: String,
+        summary: String,
+        status: SyncItemStatus = .savedLocally,
+        createdAt: Date = .now,
+        updatedAt: Date = .now,
+        retryCount: Int = 0,
+        errorMessage: String? = nil
+    ) {
+        self.id = id
+        self.entityType = entityType
+        self.entityId = entityId
+        self.summary = summary
+        self.status = status
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.retryCount = retryCount
+        self.errorMessage = errorMessage
+    }
+}
+
+/// Result of attempting to upload one queued item.
+enum SyncOutcome: Equatable, Sendable {
+    case success
+    case conflict
+    case failure(String)
+}
+
+/// Summary of a single `processQueue` run, surfaced to the UI so the user gets
+/// an honest, specific result rather than a spinner that always "succeeds".
+struct SyncRunSummary: Equatable, Sendable {
+    let reachedNetwork: Bool
+    let uploaded: Int
+    let failed: Int
+    let conflicted: Int
+    let stillPending: Int
+
+    /// A short, honest headline for the run.
+    var headline: String {
+        guard reachedNetwork else {
+            return String(localized: "Offline — \(stillPending) change(s) queued and will sync when you're back online.")
+        }
+        if failed == 0, conflicted == 0 {
+            return uploaded == 0
+                ? String(localized: "Everything is already up to date.")
+                : String(localized: "Synced \(uploaded) change(s).")
+        }
+        return String(localized: "Synced \(uploaded), \(failed) failed, \(conflicted) need review.")
+    }
+}

--- a/apps/ios/Finance/Models/TransactionItem.swift
+++ b/apps/ios/Finance/Models/TransactionItem.swift
@@ -86,8 +86,31 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
     let receiptData: Data?
     let tags: [Tag]
 
+    /// Absolute instant of the purchase, when known. Preserves the exact
+    /// moment across timezone changes so day-based reporting stays stable.
+    /// `nil` for legacy/manual entries that recorded only a calendar date (#2206).
+    let timestamp: Date?
+
+    /// Identifier of the timezone in effect where the purchase happened
+    /// (e.g. "Asia/Bangkok"). `nil` falls back to the device timezone.
+    let timeZoneIdentifier: String?
+
     /// Convenience: `true` when the transaction type is `.expense`.
     var isExpense: Bool { type == .expense }
+
+    /// Rich local timestamp for this transaction. Uses the preserved instant
+    /// and zone when available, otherwise degrades to the calendar `date` in
+    /// the device timezone.
+    var localTimestamp: TransactionTimestamp {
+        TransactionTimestamp(instant: timestamp ?? date, timeZoneIdentifier: timeZoneIdentifier)
+    }
+
+    /// Stable calendar day of the purchase in its original timezone. Use this
+    /// for day/trip bucketing so a border crossing never shifts the day.
+    var localDay: Date { localTimestamp.localDay }
+
+    /// Whether this transaction preserved a full timestamp and timezone.
+    var hasPreservedTimeZone: Bool { timestamp != nil && timeZoneIdentifier != nil }
 
     init(
         id: String,
@@ -104,7 +127,9 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
         moodTag: String? = nil,
         isRecurring: Bool = false,
         receiptData: Data? = nil,
-        tags: [Tag] = []
+        tags: [Tag] = [],
+        timestamp: Date? = nil,
+        timeZoneIdentifier: String? = nil
     ) {
         self.id = id
         self.payee = payee
@@ -121,5 +146,7 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
         self.isRecurring = isRecurring
         self.receiptData = receiptData
         self.tags = tags
+        self.timestamp = timestamp
+        self.timeZoneIdentifier = timeZoneIdentifier
     }
 }

--- a/apps/ios/Finance/Models/TransactionTimestamp.swift
+++ b/apps/ios/Finance/Models/TransactionTimestamp.swift
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionTimestamp.swift
+// Finance
+//
+// Value type and formatting helpers for preserving *where and when* a
+// transaction happened. Cross-border finance is multi-timezone, not just
+// multi-currency: a 11:50 PM purchase in Bangkok must not silently roll into
+// the next calendar day when reviewed later in Lisbon (#2206).
+
+import Foundation
+
+/// Captures the local instant and timezone of a purchase so daily spend,
+/// trip reports, and audit trails stay stable after the device timezone
+/// changes.
+struct TransactionTimestamp: Equatable, Sendable {
+    /// The absolute instant the purchase occurred.
+    let instant: Date
+
+    /// The timezone in effect at the point of purchase.
+    let timeZone: TimeZone
+
+    init(instant: Date, timeZone: TimeZone = .current) {
+        self.instant = instant
+        self.timeZone = timeZone
+    }
+
+    /// Builds a timestamp from a stored instant and an optional timezone
+    /// identifier, falling back to the current timezone for legacy/manual
+    /// entries that never recorded one.
+    init(instant: Date, timeZoneIdentifier: String?) {
+        self.instant = instant
+        self.timeZone = TransactionTimestamp.resolveTimeZone(timeZoneIdentifier)
+    }
+
+    /// Resolves a timezone identifier to a `TimeZone`, gracefully degrading to
+    /// the device's current zone when the identifier is missing or invalid.
+    static func resolveTimeZone(_ identifier: String?) -> TimeZone {
+        guard let identifier, let zone = TimeZone(identifier: identifier) else {
+            return .current
+        }
+        return zone
+    }
+
+    /// The calendar day of the purchase *in its original timezone*.
+    ///
+    /// This is the anchor for day-based reporting: it does not move when the
+    /// reviewer later crosses into another timezone.
+    var localDay: Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return calendar.startOfDay(for: instant)
+    }
+
+    /// Local wall-clock time string at the point of purchase, e.g. "11:50 PM".
+    var localTimeDescription: String {
+        let formatter = DateFormatter()
+        formatter.timeZone = timeZone
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter.string(from: instant)
+    }
+
+    /// Local date + time with an abbreviated zone, e.g. "Jan 5, 2026 at
+    /// 11:50 PM GMT+7" — used on receipts, disputes, and reconciliation.
+    var localDateTimeDescription: String {
+        let formatter = DateFormatter()
+        formatter.timeZone = timeZone
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        let base = formatter.string(from: instant)
+        return "\(base) \(zoneAbbreviation)"
+    }
+
+    /// A short zone label, preferring the localized abbreviation (e.g. "ICT",
+    /// "GMT+7") for compact display.
+    var zoneAbbreviation: String {
+        timeZone.abbreviation(for: instant) ?? timeZone.identifier
+    }
+
+    /// Whether the purchase timezone differs from the device's current
+    /// timezone — the signal that a border was likely crossed since capture.
+    func differsFromDeviceZone(now: Date = .now, deviceZone: TimeZone = .current) -> Bool {
+        timeZone.secondsFromGMT(for: instant) != deviceZone.secondsFromGMT(for: now)
+    }
+}

--- a/apps/ios/Finance/Models/TripBudget.swift
+++ b/apps/ios/Finance/Models/TripBudget.swift
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TripBudget.swift
+// Finance
+//
+// A budget scoped to a named trip / country and date range, so a digital
+// nomad can plan against *this place* — "Bangkok Jan–Mar", "Portugal summer"
+// — instead of a single global category bucket (#2205).
+
+import SwiftUI
+
+/// A first-class trip/country budget with a local-currency limit, date range,
+/// and archive state for when the trip ends.
+struct TripBudget: Identifiable, Sendable, Equatable, Codable {
+    let id: String
+
+    /// User-facing trip name, e.g. "Bangkok Jan–Mar".
+    var name: String
+
+    /// Country or region the trip covers, e.g. "Thailand". Also used as the
+    /// default transaction match tag when set.
+    var country: String
+
+    /// Currency the trip is budgeted in (local budgeting currency). Roll-ups
+    /// into the home/display currency happen at the reporting layer (#2203).
+    var currencyCode: String
+
+    /// The trip's spending limit in minor units of ``currencyCode``.
+    var limitMinorUnits: Int64
+
+    /// Inclusive first day of the trip.
+    var startDate: Date
+
+    /// Inclusive last day of the trip.
+    var endDate: Date
+
+    /// Optional tag transactions must carry to count toward this trip. When
+    /// empty, membership is by date range alone.
+    var matchTag: String
+
+    /// Whether the trip is archived (kept for history but hidden from active
+    /// lists) once it ends.
+    var isArchived: Bool
+
+    init(
+        id: String = UUID().uuidString,
+        name: String,
+        country: String,
+        currencyCode: String,
+        limitMinorUnits: Int64,
+        startDate: Date,
+        endDate: Date,
+        matchTag: String = "",
+        isArchived: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.country = country
+        self.currencyCode = currencyCode
+        self.limitMinorUnits = limitMinorUnits
+        self.startDate = startDate
+        self.endDate = endDate
+        self.matchTag = matchTag
+        self.isArchived = isArchived
+    }
+
+    /// Symbol for the trip's budgeting currency.
+    var currencySymbol: String { CurrencyPreferences.symbol(for: currencyCode) }
+
+    /// Whether `date` falls on or after the trip start and on or before the
+    /// trip end (day-granular, comparing calendar days).
+    func containsDay(_ day: Date, calendar: Calendar = .current) -> Bool {
+        let start = calendar.startOfDay(for: startDate)
+        let end = calendar.startOfDay(for: endDate)
+        let target = calendar.startOfDay(for: day)
+        return target >= start && target <= end
+    }
+
+    /// Whether the trip has already ended relative to `now`.
+    func hasEnded(now: Date = .now, calendar: Calendar = .current) -> Bool {
+        calendar.startOfDay(for: endDate) < calendar.startOfDay(for: now)
+    }
+}

--- a/apps/ios/Finance/Models/WalletCaptureModels.swift
+++ b/apps/ios/Finance/Models/WalletCaptureModels.swift
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// WalletCaptureModels.swift
+// Finance
+//
+// Models for Wallet-aware transaction capture (#2171). Apple Pay-heavy users
+// expect tapped purchases to flow in with minimal typing rather than full
+// manual re-entry. Because Apple does not expose Wallet/Apple Pay transaction
+// history to third-party apps via a public API, this feature models an
+// "import recent card activity" review inbox: candidates are surfaced with
+// merchant recognition, a confidence state, and duplicate detection, and the
+// user confirms with one tap. See the entitlement note in the PR under
+// "Needs Human Action".
+
+import SwiftUI
+
+/// How confident we are in a recognized candidate's merchant/category.
+enum CaptureConfidence: String, Sendable, Equatable, CaseIterable {
+    case high
+    case medium
+    case low
+
+    var displayName: String {
+        switch self {
+        case .high: String(localized: "High confidence")
+        case .medium: String(localized: "Needs a look")
+        case .low: String(localized: "Low confidence")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .high: "checkmark.seal.fill"
+        case .medium: "questionmark.circle"
+        case .low: "exclamationmark.circle"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .high: .green
+        case .medium: .blue
+        case .low: .orange
+        }
+    }
+}
+
+/// A single piece of recent card activity proposed for import.
+struct WalletTransactionCandidate: Identifiable, Sendable, Equatable {
+    let id: String
+
+    /// The raw descriptor as it would appear on a card statement,
+    /// e.g. "TST* THE COFFEE CLUB 4471".
+    let rawDescriptor: String
+
+    /// Cleaned, human-friendly merchant name, e.g. "The Coffee Club".
+    let merchant: String
+
+    /// Purchase magnitude in minor units (always positive; sign applied on import).
+    let amountMinorUnits: Int64
+
+    let currencyCode: String
+    let date: Date
+
+    /// Last four of the card/device account number, when available.
+    let cardLast4: String?
+
+    /// Suggested category name from merchant recognition, if any.
+    let suggestedCategory: String?
+
+    /// Confidence in the recognition result.
+    let confidence: CaptureConfidence
+
+    /// Id of an existing transaction this candidate likely duplicates, if any.
+    var duplicateOfId: String?
+
+    /// Whether this candidate looks like a duplicate of an existing entry.
+    var isLikelyDuplicate: Bool { duplicateOfId != nil }
+}

--- a/apps/ios/Finance/Repositories/KMP/PersistentDataStore.swift
+++ b/apps/ios/Finance/Repositories/KMP/PersistentDataStore.swift
@@ -308,7 +308,9 @@ actor PersistentDataStore {
                 moodTag: nil,
                 isRecurring: transaction.isRecurring,
                 receiptData: transaction.receiptData,
-                tags: transaction.tags
+                tags: transaction.tags,
+                timestamp: transaction.timestamp,
+                timeZoneIdentifier: transaction.timeZoneIdentifier
             )
         }
         transactions = updated
@@ -615,6 +617,7 @@ extension TransactionItem: Codable {
     enum CodingKeys: String, CodingKey {
         case id, payee, category, accountName, amountMinorUnits
         case currencyCode, date, type, status, notes, isRecurring
+        case timestamp, timeZoneIdentifier
     }
 
     init(from decoder: Decoder) throws {
@@ -630,6 +633,8 @@ extension TransactionItem: Codable {
         self.status = try container.decodeIfPresent(TransactionStatusUI.self, forKey: .status) ?? .cleared
         self.notes = try container.decodeIfPresent(String.self, forKey: .notes) ?? ""
         self.isRecurring = try container.decodeIfPresent(Bool.self, forKey: .isRecurring) ?? false
+        self.timestamp = try container.decodeIfPresent(Date.self, forKey: .timestamp)
+        self.timeZoneIdentifier = try container.decodeIfPresent(String.self, forKey: .timeZoneIdentifier)
         self.receiptData = nil // Receipt data is stored separately
     }
 
@@ -646,6 +651,8 @@ extension TransactionItem: Codable {
         try container.encode(status, forKey: .status)
         try container.encode(notes, forKey: .notes)
         try container.encode(isRecurring, forKey: .isRecurring)
+        try container.encodeIfPresent(timestamp, forKey: .timestamp)
+        try container.encodeIfPresent(timeZoneIdentifier, forKey: .timeZoneIdentifier)
     }
 }
 

--- a/apps/ios/Finance/Screens/BudgetCreateView.swift
+++ b/apps/ios/Finance/Screens/BudgetCreateView.swift
@@ -23,6 +23,7 @@ struct BudgetCreateView: View {
             Form {
                 categorySection
                 amountSection
+                currencySection
                 periodSection
             }
             .navigationTitle(viewModel.navigationTitle)
@@ -81,18 +82,44 @@ struct BudgetCreateView: View {
     private var amountSection: some View {
         Section {
             HStack {
-                Text(currencySymbol)
+                Text(viewModel.currencySymbol)
                     .font(.title2)
                     .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
                 TextField(String(localized: "0.00"), text: $viewModel.amountText)
                     .font(.title2)
                     .keyboardType(.decimalPad)
                     .accessibilityIdentifier("budget_amount_field")
                     .accessibilityLabel(String(localized: "Budget amount"))
-                    .accessibilityHint(String(localized: "Enter the budget limit in dollars"))
+                    .accessibilityHint(
+                        String(localized: "Enter the budget limit in \(viewModel.currencyCode)")
+                    )
             }
         } header: {
             Text(String(localized: "Amount"))
+        }
+    }
+
+    // MARK: - Currency Section
+
+    private var currencySection: some View {
+        Section {
+            Picker(String(localized: "Currency"), selection: $viewModel.currencyCode) {
+                ForEach(viewModel.availableCurrencyCodes, id: \.self) { code in
+                    Text(CurrencyPreferences.pickerLabel(for: code)).tag(code)
+                }
+            }
+            .pickerStyle(.menu)
+            .accessibilityLabel(String(localized: "Budget currency"))
+            .accessibilityHint(
+                String(localized: "Choose the currency this budget limit is entered in")
+            )
+        } header: {
+            Text(String(localized: "Currency"))
+        } footer: {
+            Text(
+                String(localized: "Budgets in a currency other than your display currency are converted for dashboard roll-ups.")
+            )
         }
     }
 
@@ -111,15 +138,6 @@ struct BudgetCreateView: View {
         } header: {
             Text(String(localized: "Period"))
         }
-    }
-
-    // MARK: - Helpers
-
-    private var currencySymbol: String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencyCode = "USD"
-        return formatter.currencySymbol ?? "$"
     }
 }
 

--- a/apps/ios/Finance/Screens/BudgetsView.swift
+++ b/apps/ios/Finance/Screens/BudgetsView.swift
@@ -51,6 +51,16 @@ struct BudgetsView: View {
             .offlineAware()
             .navigationTitle(String(localized: "Budgets"))
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    NavigationLink {
+                        TripBudgetsView()
+                    } label: {
+                        Image(systemName: "airplane")
+                    }
+                    .accessibilityIdentifier("trip_budgets_button")
+                    .accessibilityLabel(String(localized: "Trip budgets"))
+                    .accessibilityHint(String(localized: "Opens budgets scoped to a trip or country"))
+                }
                 ToolbarItem(placement: .primaryAction) {
                     Button { viewModel.showingCreateBudget = true } label: {
                         IconView(.add, size: 20)
@@ -133,7 +143,7 @@ struct BudgetsView: View {
             HStack(spacing: 24) {
                 VStack(spacing: 4) {
                     Text(String(localized: "Spent")).font(.caption).foregroundStyle(.secondary)
-                    CurrencyLabel(amountInMinorUnits: viewModel.totalSpent, currencyCode: "USD", showSign: false, font: .callout.bold())
+                    CurrencyLabel(amountInMinorUnits: viewModel.totalSpent, currencyCode: viewModel.displayCurrencyCode, showSign: false, font: .callout.bold())
                 }
                 ProgressRing(
                     progress: viewModel.totalBudgeted > 0 ? Double(viewModel.totalSpent) / Double(viewModel.totalBudgeted) : 0,
@@ -141,7 +151,7 @@ struct BudgetsView: View {
                 )
                 VStack(spacing: 4) {
                     Text(String(localized: "Budgeted")).font(.caption).foregroundStyle(.secondary)
-                    CurrencyLabel(amountInMinorUnits: viewModel.totalBudgeted, currencyCode: "USD", showSign: false, font: .callout.bold())
+                    CurrencyLabel(amountInMinorUnits: viewModel.totalBudgeted, currencyCode: viewModel.displayCurrencyCode, showSign: false, font: .callout.bold())
                 }
             }
         }

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -16,6 +16,7 @@ import SwiftUI
 struct SettingsView: View {
     @Environment(BiometricAuthManager.self) private var biometricManager
     @Environment(AuthenticationService.self) private var authService
+    @Environment(NetworkMonitor.self) private var networkMonitor: NetworkMonitor?
     @State private var viewModel: SettingsViewModel
 
     init(viewModel: SettingsViewModel = SettingsViewModel()) {
@@ -39,7 +40,12 @@ struct SettingsView: View {
             }
             .navigationTitle(String(localized: "Settings"))
             .navigationBarTitleDisplayMode(.large)
-            .task { await viewModel.loadSettings() }
+            .task {
+                viewModel.isNetworkAvailable = { [weak networkMonitor] in
+                    networkMonitor?.isConnected ?? true
+                }
+                await viewModel.loadSettings()
+            }
             .disabled(viewModel.isDeleting)
             .overlay {
                 if viewModel.isDeleting {
@@ -365,6 +371,29 @@ struct SettingsView: View {
                 )
             }
 
+            if let networkMonitor, !networkMonitor.isConnected {
+                Label(
+                    String(localized: "You're offline. Changes are saved on this device and will sync automatically when you reconnect."),
+                    systemImage: "wifi.slash"
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(String(localized: "Offline. Changes are queued and will sync when you reconnect."))
+            }
+
+            if viewModel.syncFailedCount > 0 || viewModel.syncConflictedCount > 0 {
+                syncAttentionRows
+            }
+
+            if let summary = viewModel.lastSyncSummaryText {
+                Text(summary)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(summary)
+            }
+
+            syncQueueDetailLink
+
             Button {
                 Task { await viewModel.syncNow() }
             } label: {
@@ -379,6 +408,59 @@ struct SettingsView: View {
             .disabled(viewModel.isSyncing)
             .accessibilityLabel(String(localized: "Sync now"))
             .accessibilityHint(String(localized: "Triggers a manual data sync with the server"))
+
+            if viewModel.syncNeedsAttention {
+                Button {
+                    Task { await viewModel.retrySync() }
+                } label: {
+                    Label(String(localized: "Retry Failed"), systemImage: "arrow.clockwise.circle")
+                }
+                .disabled(viewModel.isSyncing)
+                .accessibilityHint(String(localized: "Retries changes that failed or need review"))
+            }
+        }
+    }
+
+    // MARK: - Sync detail
+
+    @ViewBuilder
+    private var syncAttentionRows: some View {
+        if viewModel.syncFailedCount > 0 {
+            Label(
+                String(localized: "\(viewModel.syncFailedCount) change(s) failed to upload"),
+                systemImage: "exclamationmark.arrow.triangle.2.circlepath"
+            )
+            .font(.subheadline)
+            .foregroundStyle(.red)
+        }
+        if viewModel.syncConflictedCount > 0 {
+            Label(
+                String(localized: "\(viewModel.syncConflictedCount) change(s) need review"),
+                systemImage: "exclamationmark.triangle"
+            )
+            .font(.subheadline)
+            .foregroundStyle(.orange)
+        }
+    }
+
+    @ViewBuilder
+    private var syncQueueDetailLink: some View {
+        if !viewModel.syncQueueItems.isEmpty {
+            NavigationLink {
+                SyncQueueDetailView(
+                    items: viewModel.syncQueueItems,
+                    onClearSynced: { viewModel.clearSyncedItems() }
+                )
+            } label: {
+                HStack {
+                    Label(String(localized: "Sync Details"), systemImage: "list.bullet.rectangle")
+                    Spacer()
+                    Text("\(viewModel.syncQueueItems.count)")
+                        .foregroundStyle(.secondary)
+                        .font(.subheadline)
+                }
+            }
+            .accessibilityHint(String(localized: "Shows the per-change sync status queue"))
         }
     }
 

--- a/apps/ios/Finance/Screens/SyncQueueDetailView.swift
+++ b/apps/ios/Finance/Screens/SyncQueueDetailView.swift
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// SyncQueueDetailView.swift
+// Finance
+//
+// Per-change sync status list so offline users can trust exactly what is saved
+// locally, queued, uploading, failed, or conflicted (#2204).
+
+import SwiftUI
+
+struct SyncQueueDetailView: View {
+    let items: [SyncQueueItem]
+    let onClearSynced: () -> Void
+
+    var body: some View {
+        List {
+            if items.contains(where: { $0.status == .synced }) {
+                Section {
+                    Button(role: .destructive) {
+                        onClearSynced()
+                    } label: {
+                        Label(String(localized: "Clear Synced"), systemImage: "checkmark.circle")
+                    }
+                    .accessibilityHint(String(localized: "Removes synced items from this list"))
+                }
+            }
+
+            Section {
+                ForEach(items) { item in
+                    row(item)
+                }
+            } footer: {
+                Text(String(localized: "Changes are stored on this device first, then uploaded. Nothing is lost while you're offline."))
+            }
+        }
+        .navigationTitle(String(localized: "Sync Queue"))
+        .navigationBarTitleDisplayMode(.inline)
+        .overlay {
+            if items.isEmpty {
+                ContentUnavailableView(
+                    String(localized: "Nothing Queued"),
+                    systemImage: "checkmark.icloud",
+                    description: Text(String(localized: "All your changes are synced."))
+                )
+            }
+        }
+    }
+
+    private func row(_ item: SyncQueueItem) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: item.status.systemImage)
+                .foregroundStyle(item.status.tintColor)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.summary)
+                    .font(.body)
+                Text(item.status.displayName)
+                    .font(.caption)
+                    .foregroundStyle(item.status.tintColor)
+                if let error = item.errorMessage {
+                    Text(error)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            if item.retryCount > 0 {
+                Text(String(localized: "Retry \(item.retryCount)"))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(item.summary), \(item.status.displayName)")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SyncQueueDetailView(
+            items: [
+                SyncQueueItem(entityType: "transaction", entityId: "t1", summary: "Coffee — ฿120", status: .queued),
+                SyncQueueItem(entityType: "transaction", entityId: "t2", summary: "Hostel — ฿850", status: .failed, errorMessage: "Timed out"),
+                SyncQueueItem(entityType: "transaction", entityId: "t3", summary: "SIM card — ฿300", status: .synced),
+            ],
+            onClearSynced: {}
+        )
+    }
+}

--- a/apps/ios/Finance/Screens/TransactionCreateView.swift
+++ b/apps/ios/Finance/Screens/TransactionCreateView.swift
@@ -251,9 +251,33 @@ struct TransactionCreateView: View {
                     }
                 }
             }
-            Section(String(localized: "Date")) {
-                DatePicker(String(localized: "Date"), selection: $viewModel.date, displayedComponents: .date)
-                    .accessibilityLabel(String(localized: "Transaction date"))
+            Section(String(localized: "Date & time")) {
+                DatePicker(
+                    String(localized: "Date & time"),
+                    selection: $viewModel.date,
+                    displayedComponents: [.date, .hourAndMinute]
+                )
+                .accessibilityLabel(String(localized: "Transaction date and time"))
+
+                LabeledContent(String(localized: "Timezone")) {
+                    Text(viewModel.capturedTimeZoneLabel)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityLabel(String(localized: "Captured timezone"))
+                .accessibilityValue(viewModel.capturedTimeZone.identifier)
+
+                if viewModel.isForeignTimeZone {
+                    Button(String(localized: "Use current timezone")) {
+                        viewModel.useCurrentTimeZone()
+                    }
+                    .accessibilityHint(
+                        String(localized: "Recapture this transaction in your device's current timezone")
+                    )
+                }
+            } footer: {
+                Text(
+                    String(localized: "Saved as \(viewModel.localTimestampDescription). The local time and timezone are preserved so daily totals stay correct when you cross borders.")
+                )
             }
             Section(String(localized: "Note (optional)")) {
                 TextField(String(localized: "Add a note..."), text: $viewModel.note, axis: .vertical)
@@ -287,7 +311,7 @@ struct TransactionCreateView: View {
                 if viewModel.isBnplLiability {
                     LabeledContent(String(localized: "BNPL installments")) { Text(viewModel.bnplInstallmentCount) }
                 }
-                LabeledContent(String(localized: "Date")) { Text(viewModel.date, style: .date) }
+                LabeledContent(String(localized: "Date")) { Text(viewModel.localTimestampDescription) }
                 if let moodTag = viewModel.moodTag {
                     LabeledContent(String(localized: "Mood tag")) { Text(moodTag) }
                 }

--- a/apps/ios/Finance/Screens/TransactionDetailView.swift
+++ b/apps/ios/Finance/Screens/TransactionDetailView.swift
@@ -68,6 +68,18 @@ struct TransactionDetailView: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 4)
                     .background(.quaternary, in: Capsule())
+
+                if transaction.hasPreservedTimeZone {
+                    Label(
+                        transaction.localTimestamp.localDateTimeDescription,
+                        systemImage: "globe"
+                    )
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(
+                        String(localized: "Purchased locally at \(transaction.localTimestamp.localDateTimeDescription)")
+                    )
+                }
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 8)

--- a/apps/ios/Finance/Screens/TransactionsView.swift
+++ b/apps/ios/Finance/Screens/TransactionsView.swift
@@ -15,6 +15,7 @@ struct TransactionsView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var viewModel: TransactionsViewModel
     @State private var showingQuickAdd = false
+    @State private var showingWalletCapture = false
 
     init(viewModel: TransactionsViewModel = TransactionsViewModel(
         repository: RepositoryProvider.shared.transactions
@@ -94,6 +95,13 @@ struct TransactionsView: View {
                             Label(String(localized: "Quick Add (NLP)"), systemImage: "text.bubble")
                         }
                         .accessibilityIdentifier("nlp_input_button")
+
+                        Button {
+                            showingWalletCapture = true
+                        } label: {
+                            Label(String(localized: "From Apple Pay"), systemImage: "creditcard")
+                        }
+                        .accessibilityIdentifier("wallet_capture_button")
                     } label: {
                         IconView(.add, size: 20)
                     }
@@ -116,6 +124,11 @@ struct TransactionsView: View {
                 Task { await viewModel.loadTransactions() }
             }) {
                 NlpInputView()
+            }
+            .sheet(isPresented: $showingWalletCapture) {
+                WalletCaptureView(onImported: {
+                    Task { await viewModel.loadTransactions() }
+                })
             }
             .sheet(isPresented: $showingQuickAdd, onDismiss: {
                 Task { await viewModel.loadTransactions() }

--- a/apps/ios/Finance/Screens/TripBudgetCreateView.swift
+++ b/apps/ios/Finance/Screens/TripBudgetCreateView.swift
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TripBudgetCreateView.swift
+// Finance
+//
+// Form for creating or editing a trip/country budget (#2205).
+
+import SwiftUI
+
+struct TripBudgetCreateView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var viewModel: TripBudgetCreateViewModel
+
+    /// Called with the validated trip when the user saves.
+    private let onSave: (TripBudget) -> Void
+
+    init(viewModel: TripBudgetCreateViewModel, onSave: @escaping (TripBudget) -> Void) {
+        _viewModel = State(initialValue: viewModel)
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                detailsSection
+                amountSection
+                datesSection
+                filterSection
+            }
+            .navigationTitle(viewModel.navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Cancel")) { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(viewModel.saveButtonTitle) {
+                        if let trip = viewModel.buildTrip() {
+                            onSave(trip)
+                            dismiss()
+                        }
+                    }
+                }
+            }
+            .alert(String(localized: "Validation Error"), isPresented: $viewModel.showingValidationError) {
+                Button(String(localized: "OK"), role: .cancel) {}
+            } message: {
+                Text(viewModel.validationMessage)
+            }
+        }
+    }
+
+    private var detailsSection: some View {
+        Section {
+            TextField(String(localized: "Trip name (e.g. Bangkok Jan–Mar)"), text: $viewModel.name)
+                .accessibilityLabel(String(localized: "Trip name"))
+            TextField(String(localized: "Country or region"), text: $viewModel.country)
+                .accessibilityLabel(String(localized: "Country or region"))
+        } header: {
+            Text(String(localized: "Trip"))
+        }
+    }
+
+    private var amountSection: some View {
+        Section {
+            HStack {
+                Text(viewModel.currencySymbol)
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+                TextField(String(localized: "0.00"), text: $viewModel.amountText)
+                    .font(.title2)
+                    .keyboardType(.decimalPad)
+                    .accessibilityLabel(String(localized: "Trip budget amount"))
+                    .accessibilityHint(String(localized: "Enter the trip limit in \(viewModel.currencyCode)"))
+            }
+            Picker(String(localized: "Currency"), selection: $viewModel.currencyCode) {
+                ForEach(viewModel.availableCurrencyCodes, id: \.self) { code in
+                    Text(CurrencyPreferences.pickerLabel(for: code)).tag(code)
+                }
+            }
+            .pickerStyle(.menu)
+            .accessibilityLabel(String(localized: "Trip currency"))
+        } header: {
+            Text(String(localized: "Budget"))
+        } footer: {
+            Text(String(localized: "Budget in the local currency; totals roll up into your display currency on the dashboard."))
+        }
+    }
+
+    private var datesSection: some View {
+        Section {
+            DatePicker(String(localized: "Start"), selection: $viewModel.startDate, displayedComponents: .date)
+                .accessibilityLabel(String(localized: "Trip start date"))
+            DatePicker(String(localized: "End"), selection: $viewModel.endDate, displayedComponents: .date)
+                .accessibilityLabel(String(localized: "Trip end date"))
+        } header: {
+            Text(String(localized: "Dates"))
+        }
+    }
+
+    private var filterSection: some View {
+        Section {
+            TextField(String(localized: "Match tag (optional)"), text: $viewModel.matchTag)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .accessibilityLabel(String(localized: "Match tag"))
+        } header: {
+            Text(String(localized: "Filter"))
+        } footer: {
+            Text(String(localized: "When set, only transactions carrying this tag count toward the trip. Otherwise all spend within the date range is included."))
+        }
+    }
+}
+
+#Preview {
+    TripBudgetCreateView(viewModel: TripBudgetCreateViewModel()) { _ in }
+}

--- a/apps/ios/Finance/Screens/TripBudgetsView.swift
+++ b/apps/ios/Finance/Screens/TripBudgetsView.swift
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TripBudgetsView.swift
+// Finance
+//
+// Lists trip/country budgets with per-trip spend progress, plus archived
+// trips retained for historical reporting (#2205).
+
+import SwiftUI
+
+struct TripBudgetsView: View {
+    @State private var viewModel: TripBudgetsViewModel
+
+    init(viewModel: TripBudgetsViewModel = TripBudgetsViewModel()) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading && viewModel.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .accessibilityLabel(String(localized: "Loading"))
+            } else if viewModel.isEmpty {
+                EmptyStateView(
+                    systemImage: "airplane.departure",
+                    title: String(localized: "No Trip Budgets"),
+                    message: String(localized: "Create a trip budget for a country or date range — like “Bangkok Jan–Mar” — to plan against local spend."),
+                    actionLabel: String(localized: "Create Trip Budget"),
+                    action: { viewModel.showingCreate = true }
+                )
+            } else {
+                content
+            }
+        }
+        .navigationTitle(String(localized: "Trip Budgets"))
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button { viewModel.showingCreate = true } label: {
+                    Image(systemName: "plus")
+                }
+                .accessibilityIdentifier("create_trip_budget_button")
+                .accessibilityLabel(String(localized: "Create trip budget"))
+                .accessibilityHint(String(localized: "Opens a form to create a new trip budget"))
+            }
+        }
+        .sheet(isPresented: $viewModel.showingCreate, onDismiss: { Task { await viewModel.load() } }) {
+            TripBudgetCreateView(viewModel: TripBudgetCreateViewModel()) { trip in
+                viewModel.save(trip)
+            }
+        }
+        .sheet(item: $viewModel.editingTrip, onDismiss: { Task { await viewModel.load() } }) { trip in
+            TripBudgetCreateView(viewModel: TripBudgetCreateViewModel(trip: trip)) { updated in
+                viewModel.save(updated)
+            }
+        }
+        .refreshable { await viewModel.load() }
+        .task { await viewModel.load() }
+    }
+
+    private var content: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                if !viewModel.activeTrips.isEmpty {
+                    sectionHeader(String(localized: "Active"))
+                    ForEach(viewModel.activeTrips) { trip in
+                        tripCard(trip, archived: false)
+                    }
+                }
+                if !viewModel.archivedTrips.isEmpty {
+                    sectionHeader(String(localized: "Archived"))
+                    ForEach(viewModel.archivedTrips) { trip in
+                        tripCard(trip, archived: true)
+                    }
+                }
+            }
+            .padding()
+        }
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        HStack {
+            Text(title).font(.headline).foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.top, 4)
+    }
+
+    private func tripCard(_ trip: TripBudget, archived: Bool) -> some View {
+        let progress = viewModel.progress(for: trip)
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(trip.name).font(.body).fontWeight(.semibold)
+                    if !trip.country.isEmpty {
+                        Label(trip.country, systemImage: "mappin.and.ellipse")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(dateRange(trip))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                ProgressRing(
+                    progress: progress.fraction,
+                    lineWidth: 6,
+                    progressColor: progress.isOverBudget ? .red : .green,
+                    size: 52
+                )
+            }
+
+            HStack(spacing: 4) {
+                CurrencyLabel(amountInMinorUnits: progress.spentMinorUnits, currencyCode: trip.currencyCode, showSign: false, font: .caption)
+                Text(String(localized: "of")).font(.caption).foregroundStyle(.secondary)
+                CurrencyLabel(amountInMinorUnits: trip.limitMinorUnits, currencyCode: trip.currencyCode, showSign: false, font: .caption)
+                Spacer()
+                Text(String(localized: "\(progress.transactionCount) txns"))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if progress.containsConversions {
+                Label(
+                    String(localized: "Includes converted amounts"),
+                    systemImage: progress.usedStaleRate ? "exclamationmark.triangle" : "arrow.left.arrow.right"
+                )
+                .font(.caption2)
+                .foregroundStyle(progress.usedStaleRate ? .orange : .secondary)
+            }
+        }
+        .padding()
+        .cardBackground(cornerRadius: 12)
+        .opacity(archived ? 0.7 : 1)
+        .contentShape(RoundedRectangle(cornerRadius: 12))
+        .onTapGesture { viewModel.editingTrip = trip }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) { viewModel.delete(trip) } label: {
+                Label(String(localized: "Delete"), systemImage: "trash")
+            }
+            if archived {
+                Button { viewModel.unarchive(trip) } label: {
+                    Label(String(localized: "Unarchive"), systemImage: "tray.and.arrow.up")
+                }
+            } else {
+                Button { viewModel.archive(trip) } label: {
+                    Label(String(localized: "Archive"), systemImage: "archivebox")
+                }
+                .tint(.gray)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(trip.name)
+        .accessibilityValue(
+            String(localized: "\(Int(progress.fraction * 100)) percent of trip budget spent")
+        )
+        .accessibilityHint(String(localized: "Double tap to edit this trip budget"))
+    }
+
+    private func dateRange(_ trip: TripBudget) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return "\(formatter.string(from: trip.startDate)) – \(formatter.string(from: trip.endDate))"
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TripBudgetsView(viewModel: TripBudgetsViewModel(
+            store: InMemoryTripBudgetStore(trips: [
+                TripBudget(
+                    name: "Bangkok Jan–Mar",
+                    country: "Thailand",
+                    currencyCode: "THB",
+                    limitMinorUnits: 8_000_00,
+                    startDate: .now,
+                    endDate: Calendar.current.date(byAdding: .day, value: 60, to: .now) ?? .now
+                )
+            ]),
+            transactionRepository: MockTransactionRepository()
+        ))
+    }
+}

--- a/apps/ios/Finance/Screens/WalletCaptureView.swift
+++ b/apps/ios/Finance/Screens/WalletCaptureView.swift
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// WalletCaptureView.swift
+// Finance
+//
+// Review inbox for Wallet-aware transaction capture (#2171). Surfaces recent
+// Apple Pay / card activity with recognized merchant, category suggestion,
+// confidence, and duplicate warnings so an Apple Pay-heavy user can confirm
+// imports in one tap instead of full manual re-entry.
+
+import SwiftUI
+
+struct WalletCaptureView: View {
+    @State var viewModel: WalletCaptureViewModel
+    var onImported: () -> Void = {}
+    @Environment(\.dismiss) private var dismiss
+
+    init(
+        viewModel: WalletCaptureViewModel = WalletCaptureViewModel(),
+        onImported: @escaping () -> Void = {}
+    ) {
+        _viewModel = State(initialValue: viewModel)
+        self.onImported = onImported
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(String(localized: "From Apple Pay"))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button(String(localized: "Done")) {
+                            if viewModel.importedCount > 0 { onImported() }
+                            dismiss()
+                        }
+                    }
+                    ToolbarItem(placement: .primaryAction) {
+                        if !viewModel.nonDuplicateCandidates.isEmpty {
+                            Button(String(localized: "Import All")) {
+                                Task {
+                                    await viewModel.importAllNonDuplicates()
+                                }
+                            }
+                            .accessibilityIdentifier("wallet_import_all_button")
+                        }
+                    }
+                }
+                .task { await viewModel.load() }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.isLoading {
+            ProgressView(String(localized: "Reading recent card activity…"))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if viewModel.isEmpty {
+            ContentUnavailableView(
+                String(localized: "Nothing to Import"),
+                systemImage: "creditcard",
+                description: Text(String(localized: "No new Apple Pay activity to review right now."))
+            )
+        } else {
+            List {
+                Section {
+                    ForEach(viewModel.candidates) { candidate in
+                        row(candidate)
+                    }
+                } footer: {
+                    Text(String(localized: "Recent card activity, matched to merchants automatically. Review and import what you recognize — duplicates of existing entries are flagged."))
+                }
+            }
+        }
+    }
+
+    private func row(_ candidate: WalletTransactionCandidate) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(candidate.merchant)
+                        .font(.body.weight(.semibold))
+                    Text(candidate.rawDescriptor)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer()
+                CurrencyLabel(
+                    amountInMinorUnits: -candidate.amountMinorUnits,
+                    currencyCode: candidate.currencyCode,
+                    showSign: false,
+                    font: .body.weight(.semibold)
+                )
+            }
+
+            HStack(spacing: 8) {
+                Label(candidate.confidence.displayName, systemImage: candidate.confidence.systemImage)
+                    .font(.caption2)
+                    .foregroundStyle(candidate.confidence.tint)
+                if let category = candidate.suggestedCategory {
+                    Text(category)
+                        .font(.caption2)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(Color.secondary.opacity(0.15), in: Capsule())
+                }
+                if let last4 = candidate.cardLast4 {
+                    Text(String(localized: "•••• \(last4)"))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if candidate.isLikelyDuplicate {
+                Label(
+                    String(localized: "Looks like a duplicate of an existing transaction"),
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.caption2)
+                .foregroundStyle(.orange)
+            }
+
+            HStack {
+                Button {
+                    Task { await viewModel.importCandidate(candidate) }
+                } label: {
+                    Label(
+                        candidate.isLikelyDuplicate
+                            ? String(localized: "Import Anyway")
+                            : String(localized: "Import"),
+                        systemImage: "square.and.arrow.down"
+                    )
+                    .font(.callout)
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("wallet_import_button")
+
+                Button(role: .cancel) {
+                    viewModel.dismiss(candidate)
+                } label: {
+                    Text(String(localized: "Dismiss"))
+                        .font(.callout)
+                }
+                .buttonStyle(.bordered)
+            }
+            .buttonBorderShape(.capsule)
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview {
+    WalletCaptureView(
+        viewModel: WalletCaptureViewModel(
+            provider: SimulatedWalletActivityProvider()
+        )
+    )
+}

--- a/apps/ios/Finance/Services/CurrencyConverter.swift
+++ b/apps/ios/Finance/Services/CurrencyConverter.swift
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CurrencyConverter.swift
+// Finance
+//
+// A pure, unit-testable currency converter used to roll up multi-currency
+// spend into a single display currency. Digital nomads earn in one currency
+// but spend across many, so dashboard and budget totals must convert and,
+// crucially, disclose when a total is converted and whether it relied on a
+// stale/offline exchange rate (#2203).
+
+import Foundation
+
+// MARK: - Exchange Rate
+
+/// A single exchange rate quote expressing how many units of the display
+/// currency one unit of `currencyCode` is worth.
+struct ExchangeRate: Equatable, Sendable {
+    /// The source currency (e.g. "THB").
+    let currencyCode: String
+
+    /// Value of one unit of `currencyCode` in the display currency.
+    let rateToDisplay: Double
+
+    /// When the rate was captured. Used to flag stale/offline rates.
+    let asOf: Date
+
+    init(currencyCode: String, rateToDisplay: Double, asOf: Date = .now) {
+        self.currencyCode = currencyCode.uppercased()
+        self.rateToDisplay = rateToDisplay
+        self.asOf = asOf
+    }
+}
+
+// MARK: - Converted Amount
+
+/// The result of converting a single amount into the display currency.
+struct ConvertedAmount: Equatable, Sendable {
+    /// Converted value in minor units of the display currency.
+    let minorUnits: Int64
+
+    /// Whether a conversion actually occurred (source ≠ display currency).
+    let isConverted: Bool
+
+    /// Whether the conversion fell back to a rate older than the freshness
+    /// window (or a missing rate treated as 1:1).
+    let usedStaleRate: Bool
+}
+
+// MARK: - Rollup
+
+/// Aggregate result of rolling up many amounts into the display currency.
+struct CurrencyRollup: Equatable, Sendable {
+    /// Total in minor units of the display currency.
+    let totalMinorUnits: Int64
+
+    /// The display currency the total is expressed in.
+    let displayCurrencyCode: String
+
+    /// True when at least one contributing amount was converted from another
+    /// currency — the UI should badge the total as an approximate roll-up.
+    let containsConversions: Bool
+
+    /// True when at least one contributing conversion used a stale/offline or
+    /// missing rate — the UI should warn the number may be out of date.
+    let usedStaleRate: Bool
+}
+
+// MARK: - Converter
+
+/// Converts amounts into a display currency using a snapshot of exchange rates.
+///
+/// The converter is deliberately pure: callers supply the rate table and the
+/// "now" reference, so behaviour is deterministic and fully testable offline.
+struct CurrencyConverter: Sendable {
+    /// Display (home) currency all conversions target.
+    let displayCurrencyCode: String
+
+    /// Rates keyed by uppercased source-currency code.
+    private let rates: [String: ExchangeRate]
+
+    /// Rates older than this are considered stale (default: 24h).
+    let freshnessWindow: TimeInterval
+
+    init(
+        displayCurrencyCode: String,
+        rates: [ExchangeRate],
+        freshnessWindow: TimeInterval = 60 * 60 * 24
+    ) {
+        self.displayCurrencyCode = displayCurrencyCode.uppercased()
+        self.freshnessWindow = freshnessWindow
+        self.rates = Dictionary(
+            rates.map { ($0.currencyCode, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+    /// Converts a single amount from `currencyCode` into the display currency.
+    ///
+    /// - Missing rates are treated as 1:1 and flagged as stale so totals never
+    ///   silently drop money, but the UI can warn the value is unverified.
+    func convert(
+        minorUnits: Int64,
+        from currencyCode: String,
+        now: Date = .now
+    ) -> ConvertedAmount {
+        let source = currencyCode.uppercased()
+        guard source != displayCurrencyCode else {
+            return ConvertedAmount(minorUnits: minorUnits, isConverted: false, usedStaleRate: false)
+        }
+
+        guard let rate = rates[source] else {
+            // No rate available (e.g. fully offline with no cached rate).
+            return ConvertedAmount(minorUnits: minorUnits, isConverted: true, usedStaleRate: true)
+        }
+
+        let converted = Int64((Double(minorUnits) * rate.rateToDisplay).rounded())
+        let stale = now.timeIntervalSince(rate.asOf) > freshnessWindow
+        return ConvertedAmount(minorUnits: converted, isConverted: true, usedStaleRate: stale)
+    }
+
+    /// Rolls up a list of `(minorUnits, currencyCode)` pairs into a single
+    /// display-currency total, tracking whether any conversion or stale rate
+    /// contributed.
+    func rollup(
+        _ amounts: [(minorUnits: Int64, currencyCode: String)],
+        now: Date = .now
+    ) -> CurrencyRollup {
+        var total: Int64 = 0
+        var converted = false
+        var stale = false
+
+        for amount in amounts {
+            let result = convert(minorUnits: amount.minorUnits, from: amount.currencyCode, now: now)
+            total += result.minorUnits
+            converted = converted || result.isConverted
+            stale = stale || result.usedStaleRate
+        }
+
+        return CurrencyRollup(
+            totalMinorUnits: total,
+            displayCurrencyCode: displayCurrencyCode,
+            containsConversions: converted,
+            usedStaleRate: stale
+        )
+    }
+}

--- a/apps/ios/Finance/Services/CurrencyPreferences.swift
+++ b/apps/ios/Finance/Services/CurrencyPreferences.swift
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CurrencyPreferences.swift
+// Finance
+//
+// Centralised access to the user's display-currency preference so that the
+// dashboard, budgets, and analytics all roll up into a single home-currency
+// view. Previously the preference lived only inside SettingsViewModel and was
+// not read by the dashboard or budget flows (#2203).
+
+import Foundation
+
+/// Persists and resolves the app-wide display-currency preference.
+///
+/// The preference is stored under the same `finance_currency` UserDefaults key
+/// that ``SettingsViewModel`` writes, so changing the currency in Settings
+/// immediately drives dashboard totals, budget rollups, and formatting copy.
+enum CurrencyPreferences {
+    /// UserDefaults key shared with `SettingsViewModel`.
+    static let key = "finance_currency"
+
+    /// Fallback currency when the user has not chosen one.
+    static let defaultCurrencyCode = "USD"
+
+    /// A curated list of currencies a digital nomad is likely to use, surfaced
+    /// in pickers. Ordered by rough global usage.
+    static let supportedCurrencyCodes = [
+        "USD", "EUR", "GBP", "JPY", "CHF", "CAD", "AUD",
+        "THB", "MXN", "PHP", "IDR", "VND", "SGD", "INR", "BRL", "ZAR",
+    ]
+
+    /// Reads the current display-currency code, defaulting to ``defaultCurrencyCode``.
+    static func displayCurrencyCode(defaults: UserDefaults = .standard) -> String {
+        let stored = defaults.string(forKey: key)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let stored, !stored.isEmpty else { return defaultCurrencyCode }
+        return stored.uppercased()
+    }
+
+    /// Persists the display-currency code (stored uppercased).
+    static func setDisplayCurrencyCode(_ code: String, defaults: UserDefaults = .standard) {
+        let normalised = code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        guard !normalised.isEmpty else { return }
+        defaults.set(normalised, forKey: key)
+    }
+
+    /// Returns the localized currency symbol for a code (e.g. "USD" → "$",
+    /// "THB" → "฿"), falling back to the code itself when no symbol exists.
+    static func symbol(for currencyCode: String) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        // `currencySymbol` can return the code for uncommon currencies; that is
+        // an acceptable, unambiguous fallback.
+        return formatter.currencySymbol ?? currencyCode
+    }
+
+    /// Human-readable label combining code and symbol for pickers,
+    /// e.g. "USD ($)" or "THB (฿)".
+    static func pickerLabel(for currencyCode: String) -> String {
+        let symbol = symbol(for: currencyCode)
+        return symbol == currencyCode ? currencyCode : "\(currencyCode) (\(symbol))"
+    }
+}

--- a/apps/ios/Finance/Services/MerchantRecognizer.swift
+++ b/apps/ios/Finance/Services/MerchantRecognizer.swift
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// MerchantRecognizer.swift
+// Finance
+//
+// Pure merchant-recognition helper for Wallet-aware capture (#2171). Turns a
+// noisy card descriptor ("TST* THE COFFEE CLUB 4471", "UBER *TRIP HELP.UBER")
+// into a clean merchant name, a best-effort category suggestion, and a
+// confidence level. Deterministic and I/O-free so it is fully unit-testable.
+
+import Foundation
+import FinanceShared
+
+enum MerchantRecognizer {
+
+    /// Lightweight keyword → category map used for a best-effort suggestion.
+    /// Keys are matched against tokenized descriptor tokens.
+    private static let categoryKeywords: [(keywords: Set<String>, category: String)] = [
+        (["coffee", "cafe", "espresso", "starbucks", "restaurant", "grill", "kitchen", "pizza", "sushi", "burger", "diner", "bar", "eatery"], "Dining Out"),
+        (["grocery", "market", "mart", "foods", "supermarket", "grocer", "deli"], "Groceries"),
+        (["uber", "lyft", "grab", "taxi", "transit", "metro", "rail", "train", "bus", "bolt"], "Transport"),
+        (["hotel", "hostel", "airbnb", "inn", "resort", "lodge", "booking", "expedia"], "Travel"),
+        (["airline", "air", "airways", "flight", "ryanair", "easyjet", "delta"], "Travel"),
+        (["netflix", "spotify", "hulu", "cinema", "movie", "theater", "steam", "playstation"], "Entertainment"),
+        (["pharmacy", "clinic", "hospital", "dental", "chemist", "drug"], "Health"),
+        (["fuel", "gas", "petrol", "shell", "chevron", "exxon"], "Transport"),
+    ]
+
+    /// Cleans a raw descriptor into a human-friendly merchant name.
+    ///
+    /// Reuses `MerchantTokenizer` to strip store numbers and payment-network
+    /// noise, then title-cases the surviving tokens. Falls back to a trimmed
+    /// version of the raw descriptor when tokenization yields nothing.
+    static func clean(_ descriptor: String) -> String {
+        let tokens = MerchantTokenizer.tokens(merchant: descriptor)
+        guard !tokens.isEmpty else {
+            return descriptor.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return tokens
+            .prefix(4)
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+
+    /// Best-effort category suggestion for a descriptor, or nil when unknown.
+    static func suggestedCategory(for descriptor: String) -> String? {
+        let tokens = Set(MerchantTokenizer.tokens(merchant: descriptor))
+        guard !tokens.isEmpty else { return nil }
+        for entry in categoryKeywords where !entry.keywords.isDisjoint(with: tokens) {
+            return entry.category
+        }
+        return nil
+    }
+
+    /// Confidence in the recognition result.
+    ///
+    /// - `.high`: recognized a category and produced a clean merchant name.
+    /// - `.medium`: produced a clean name but no category match.
+    /// - `.low`: tokenization produced nothing meaningful.
+    static func confidence(cleanMerchant: String, hasCategory: Bool) -> CaptureConfidence {
+        if cleanMerchant.isEmpty { return .low }
+        let tokens = MerchantTokenizer.tokens(merchant: cleanMerchant)
+        if tokens.isEmpty { return .low }
+        return hasCategory ? .high : .medium
+    }
+
+    /// Builds a fully recognized candidate from raw activity fields.
+    static func recognize(
+        id: String,
+        rawDescriptor: String,
+        amountMinorUnits: Int64,
+        currencyCode: String,
+        date: Date,
+        cardLast4: String?
+    ) -> WalletTransactionCandidate {
+        let merchant = clean(rawDescriptor)
+        let category = suggestedCategory(for: rawDescriptor)
+        return WalletTransactionCandidate(
+            id: id,
+            rawDescriptor: rawDescriptor,
+            merchant: merchant,
+            amountMinorUnits: abs(amountMinorUnits),
+            currencyCode: currencyCode,
+            date: date,
+            cardLast4: cardLast4,
+            suggestedCategory: category,
+            confidence: confidence(cleanMerchant: merchant, hasCategory: category != nil),
+            duplicateOfId: nil
+        )
+    }
+}

--- a/apps/ios/Finance/Services/SyncQueueManager.swift
+++ b/apps/ios/Finance/Services/SyncQueueManager.swift
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// SyncQueueManager.swift
+// Finance
+//
+// Observable, persisted queue that gives offline users trustworthy feedback on
+// what has and hasn't synced (#2204). Replaces the previous simulated
+// `syncNow()` delay with a real, inspectable state machine.
+
+import Observation
+import Foundation
+import os
+
+/// Uploads a queued item to the server. Injectable so the queue can be driven
+/// deterministically in tests and previews without a network.
+protocol SyncUploading: Sendable {
+    func upload(_ item: SyncQueueItem) async -> SyncOutcome
+}
+
+/// Default uploader used in the app until the shared KMP `SyncManager` lands.
+/// Optimistically reports success so local changes settle; the queue's state
+/// machine still records and persists every transition honestly.
+struct DefaultSyncUploader: SyncUploading {
+    func upload(_ item: SyncQueueItem) async -> SyncOutcome {
+        try? await Task.sleep(for: .milliseconds(150))
+        return .success
+    }
+}
+
+@Observable
+final class SyncQueueManager: @unchecked Sendable {
+    static let shared = SyncQueueManager()
+
+    /// Current queue contents, newest first. Observed by the UI.
+    private(set) var items: [SyncQueueItem] = []
+
+    private let defaults: UserDefaults
+    private let key: String
+    private let lock = NSLock()
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "SyncQueueManager"
+    )
+
+    init(defaults: UserDefaults = .standard, key: String = "finance_sync_queue") {
+        self.defaults = defaults
+        self.key = key
+        self.items = Self.load(from: defaults, key: key)
+    }
+
+    // MARK: - Derived counts
+
+    /// Changes still on their way to the server (saved/queued/uploading).
+    var pendingCount: Int { items.filter { $0.status.isPending }.count }
+
+    /// Changes that failed to upload.
+    var failedCount: Int { items.filter { $0.status == .failed }.count }
+
+    /// Changes blocked by a server-side conflict.
+    var conflictedCount: Int { items.filter { $0.status == .conflicted }.count }
+
+    /// Changes successfully synced (retained until cleared for reassurance).
+    var syncedCount: Int { items.filter { $0.status == .synced }.count }
+
+    /// Whether anything needs the user's attention.
+    var needsAttention: Bool { failedCount > 0 || conflictedCount > 0 }
+
+    // MARK: - Mutations
+
+    /// Adds a locally-made change to the queue.
+    @discardableResult
+    func enqueue(entityType: String, entityId: String, summary: String) -> SyncQueueItem {
+        let item = SyncQueueItem(entityType: entityType, entityId: entityId, summary: summary)
+        lock.lock()
+        items.insert(item, at: 0)
+        persistLocked()
+        lock.unlock()
+        return item
+    }
+
+    /// Clears successfully-synced items from the visible queue.
+    func clearSynced() {
+        lock.lock()
+        items.removeAll { $0.status == .synced }
+        persistLocked()
+        lock.unlock()
+    }
+
+    /// Marks failed/conflicted items as queued so the next run retries them.
+    func retryFailed() {
+        lock.lock()
+        for index in items.indices where items[index].status == .failed || items[index].status == .conflicted {
+            items[index].status = .queued
+            items[index].updatedAt = .now
+        }
+        persistLocked()
+        lock.unlock()
+    }
+
+    /// Processes the queue. When offline, pending items are marked `queued`
+    /// (waiting) and nothing is lost; when online each pending item is uploaded
+    /// and transitioned to synced / failed / conflicted.
+    @discardableResult
+    func processQueue(
+        isConnected: Bool,
+        using uploader: SyncUploading = DefaultSyncUploader()
+    ) async -> SyncRunSummary {
+        guard isConnected else {
+            lock.lock()
+            for index in items.indices where items[index].status == .savedLocally {
+                items[index].status = .queued
+                items[index].updatedAt = .now
+            }
+            persistLocked()
+            let pending = items.filter { $0.status.isPending }.count
+            lock.unlock()
+            Self.logger.info("Sync skipped — offline, \(pending, privacy: .public) queued")
+            return SyncRunSummary(
+                reachedNetwork: false,
+                uploaded: 0,
+                failed: 0,
+                conflicted: 0,
+                stillPending: pending
+            )
+        }
+
+        // Snapshot the ids we will attempt this run.
+        lock.lock()
+        let targets = items
+            .filter { $0.status == .savedLocally || $0.status == .queued || $0.status == .failed }
+            .map(\.id)
+        lock.unlock()
+
+        var uploaded = 0
+        var failed = 0
+        var conflicted = 0
+
+        for id in targets {
+            setStatus(id, .uploading)
+            guard let snapshot = item(withId: id) else { continue }
+            let outcome = await uploader.upload(snapshot)
+            switch outcome {
+            case .success:
+                setStatus(id, .synced, clearError: true)
+                uploaded += 1
+            case .conflict:
+                setStatus(id, .conflicted)
+                conflicted += 1
+            case let .failure(message):
+                setStatus(id, .failed, error: message, incrementRetry: true)
+                failed += 1
+            }
+        }
+
+        let pending = items.filter { $0.status.isPending }.count
+        Self.logger.info("Sync run: uploaded=\(uploaded, privacy: .public) failed=\(failed, privacy: .public) conflicted=\(conflicted, privacy: .public)")
+        return SyncRunSummary(
+            reachedNetwork: true,
+            uploaded: uploaded,
+            failed: failed,
+            conflicted: conflicted,
+            stillPending: pending
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private func item(withId id: String) -> SyncQueueItem? {
+        lock.lock(); defer { lock.unlock() }
+        return items.first { $0.id == id }
+    }
+
+    private func setStatus(
+        _ id: String,
+        _ status: SyncItemStatus,
+        error: String? = nil,
+        clearError: Bool = false,
+        incrementRetry: Bool = false
+    ) {
+        lock.lock()
+        if let index = items.firstIndex(where: { $0.id == id }) {
+            items[index].status = status
+            items[index].updatedAt = .now
+            if clearError { items[index].errorMessage = nil }
+            if let error { items[index].errorMessage = error }
+            if incrementRetry { items[index].retryCount += 1 }
+        }
+        persistLocked()
+        lock.unlock()
+    }
+
+    /// Persists the queue. Caller must hold `lock`.
+    private func persistLocked() {
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            defaults.set(try encoder.encode(items), forKey: key)
+        } catch {
+            Self.logger.error("Failed to persist sync queue: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private static func load(from defaults: UserDefaults, key: String) -> [SyncQueueItem] {
+        guard let data = defaults.data(forKey: key) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return (try? decoder.decode([SyncQueueItem].self, from: data)) ?? []
+    }
+}

--- a/apps/ios/Finance/Services/TripBudgetCalculator.swift
+++ b/apps/ios/Finance/Services/TripBudgetCalculator.swift
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TripBudgetCalculator.swift
+// Finance
+//
+// Pure, unit-testable logic for measuring spend against a trip/country budget.
+// Uses each transaction's *preserved local day* (#2206) so a purchase made at
+// 11:50 PM in Bangkok counts toward the correct trip day even when reviewed
+// later from another timezone (#2205).
+
+import Foundation
+
+/// Progress of spend against a single trip budget.
+struct TripBudgetProgress: Equatable, Sendable {
+    let spentMinorUnits: Int64
+    let limitMinorUnits: Int64
+    let transactionCount: Int
+
+    /// True when spend included amounts converted from another currency.
+    let containsConversions: Bool
+
+    /// True when a conversion relied on a stale/offline or missing rate.
+    let usedStaleRate: Bool
+
+    /// Amount left before hitting the limit (can go negative when over).
+    var remainingMinorUnits: Int64 { limitMinorUnits - spentMinorUnits }
+
+    /// Fraction of the limit consumed (0…1+).
+    var fraction: Double {
+        guard limitMinorUnits > 0 else { return 0 }
+        return Double(spentMinorUnits) / Double(limitMinorUnits)
+    }
+
+    /// Whether spend has exceeded the limit.
+    var isOverBudget: Bool { spentMinorUnits > limitMinorUnits }
+
+    static let zero = TripBudgetProgress(
+        spentMinorUnits: 0,
+        limitMinorUnits: 0,
+        transactionCount: 0,
+        containsConversions: false,
+        usedStaleRate: false
+    )
+}
+
+/// Filters and measures transactions against trip budgets.
+enum TripBudgetCalculator {
+    /// Whether a transaction belongs to a trip: its preserved local day must
+    /// fall within the trip's range and, when the trip specifies a match tag,
+    /// the transaction must carry that tag (case-insensitive).
+    static func matches(
+        _ transaction: TransactionItem,
+        trip: TripBudget,
+        calendar: Calendar = .current
+    ) -> Bool {
+        guard trip.containsDay(transaction.localDay, calendar: calendar) else { return false }
+
+        let tag = trip.matchTag.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !tag.isEmpty else { return true }
+        return transaction.tagNames.contains { $0.caseInsensitiveCompare(tag) == .orderedSame }
+    }
+
+    /// Transactions that belong to the trip, newest first.
+    static func transactions(
+        for trip: TripBudget,
+        in transactions: [TransactionItem],
+        calendar: Calendar = .current
+    ) -> [TransactionItem] {
+        transactions
+            .filter { matches($0, trip: trip, calendar: calendar) }
+            .sorted { $0.localDay > $1.localDay }
+    }
+
+    /// Computes spend progress for a trip. Only expenses count; income and
+    /// transfers are ignored. When a `converter` is supplied, foreign-currency
+    /// amounts are converted into the trip currency and flagged accordingly;
+    /// otherwise amounts are summed as-is.
+    static func progress(
+        for trip: TripBudget,
+        in transactions: [TransactionItem],
+        converter: CurrencyConverter? = nil,
+        now: Date = .now,
+        calendar: Calendar = .current
+    ) -> TripBudgetProgress {
+        let members = Self.transactions(for: trip, in: transactions, calendar: calendar)
+        let expenses = members.filter { $0.type == .expense }
+
+        var spent: Int64 = 0
+        var converted = false
+        var stale = false
+
+        for expense in expenses {
+            let magnitude = abs(expense.amountMinorUnits)
+            if expense.currencyCode.uppercased() == trip.currencyCode.uppercased() {
+                spent += magnitude
+            } else if let converter {
+                let result = converter.convert(minorUnits: magnitude, from: expense.currencyCode, now: now)
+                spent += result.minorUnits
+                converted = converted || result.isConverted
+                stale = stale || result.usedStaleRate
+            } else {
+                // No converter: sum raw magnitude but flag that the total mixes
+                // currencies so the UI can disclose it is approximate.
+                spent += magnitude
+                converted = true
+                stale = true
+            }
+        }
+
+        return TripBudgetProgress(
+            spentMinorUnits: spent,
+            limitMinorUnits: trip.limitMinorUnits,
+            transactionCount: expenses.count,
+            containsConversions: converted,
+            usedStaleRate: stale
+        )
+    }
+}

--- a/apps/ios/Finance/Services/TripBudgetStore.swift
+++ b/apps/ios/Finance/Services/TripBudgetStore.swift
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TripBudgetStore.swift
+// Finance
+//
+// Persistence for trip/country budgets (#2205). Trip budgets are an iOS-side
+// planning construct layered over the existing transaction data, so they are
+// stored locally as JSON in UserDefaults — the same lightweight, offline-first
+// pattern used by other iOS preferences. This keeps the feature self-contained
+// within apps/ios while the shared KMP budgeting model remains read-only.
+
+import Foundation
+import os
+
+/// Abstraction over trip-budget persistence so ViewModels and tests can inject
+/// an in-memory implementation.
+protocol TripBudgetStoring: Sendable {
+    /// Returns all stored trip budgets.
+    func all() -> [TripBudget]
+
+    /// Inserts or updates a trip budget by id.
+    func upsert(_ trip: TripBudget)
+
+    /// Removes a trip budget by id.
+    func remove(id: String)
+}
+
+extension TripBudgetStoring {
+    /// Active (non-archived) trips, sorted by start date descending.
+    func activeTrips() -> [TripBudget] {
+        all().filter { !$0.isArchived }.sorted { $0.startDate > $1.startDate }
+    }
+
+    /// Archived trips, sorted by end date descending.
+    func archivedTrips() -> [TripBudget] {
+        all().filter(\.isArchived).sorted { $0.endDate > $1.endDate }
+    }
+}
+
+/// UserDefaults-backed JSON store for trip budgets.
+final class TripBudgetStore: TripBudgetStoring, @unchecked Sendable {
+    static let shared = TripBudgetStore()
+
+    private let defaults: UserDefaults
+    private let key: String
+    private let queue = DispatchQueue(label: "com.finance.TripBudgetStore")
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "TripBudgetStore"
+    )
+
+    init(defaults: UserDefaults = .standard, key: String = "finance_trip_budgets") {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    func all() -> [TripBudget] {
+        queue.sync {
+            guard let data = defaults.data(forKey: key) else { return [] }
+            do {
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                return try decoder.decode([TripBudget].self, from: data)
+            } catch {
+                Self.logger.error("Failed to decode trip budgets: \(error.localizedDescription, privacy: .public)")
+                return []
+            }
+        }
+    }
+
+    func upsert(_ trip: TripBudget) {
+        queue.sync {
+            var trips = decode()
+            if let index = trips.firstIndex(where: { $0.id == trip.id }) {
+                trips[index] = trip
+            } else {
+                trips.append(trip)
+            }
+            persist(trips)
+        }
+    }
+
+    func remove(id: String) {
+        queue.sync {
+            var trips = decode()
+            trips.removeAll { $0.id == id }
+            persist(trips)
+        }
+    }
+
+    // MARK: - Private
+
+    private func decode() -> [TripBudget] {
+        guard let data = defaults.data(forKey: key) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return (try? decoder.decode([TripBudget].self, from: data)) ?? []
+    }
+
+    private func persist(_ trips: [TripBudget]) {
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            defaults.set(try encoder.encode(trips), forKey: key)
+        } catch {
+            Self.logger.error("Failed to encode trip budgets: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}
+
+/// In-memory store for previews and tests.
+final class InMemoryTripBudgetStore: TripBudgetStoring, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "com.finance.InMemoryTripBudgetStore")
+    private var trips: [String: TripBudget]
+
+    init(trips: [TripBudget] = []) {
+        self.trips = Dictionary(uniqueKeysWithValues: trips.map { ($0.id, $0) })
+    }
+
+    func all() -> [TripBudget] { queue.sync { Array(trips.values) } }
+
+    func upsert(_ trip: TripBudget) { queue.sync { trips[trip.id] = trip } }
+
+    func remove(id: String) { queue.sync { trips[id] = nil } }
+}

--- a/apps/ios/Finance/Services/WalletActivityProvider.swift
+++ b/apps/ios/Finance/Services/WalletActivityProvider.swift
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// WalletActivityProvider.swift
+// Finance
+//
+// Source of recent Apple Pay / card activity for Wallet-aware capture (#2171).
+//
+// Apple does NOT expose Wallet or Apple Pay transaction history to third-party
+// apps through any public API. PassKit only surfaces passes the app itself
+// provisioned, and full purchase history requires the private, Apple-approved
+// "Apple Pay transaction history" entitlement granted to issuing banks. This
+// protocol therefore abstracts the activity source so a real PassKit/issuer
+// integration can be dropped in later, while the shipping build uses a
+// deterministic simulated provider that mirrors the shape of real card
+// activity (noisy statement descriptors included). See the PR "Needs Human
+// Action" section for the entitlement/provisioning steps.
+
+import Foundation
+
+/// Abstracts the source of recent card/Apple Pay activity to review-import.
+protocol WalletActivityProviding: Sendable {
+    /// Returns recent card activity as recognition-ready candidates.
+    func recentActivity(displayCurrencyCode: String) async -> [WalletTransactionCandidate]
+}
+
+/// Deterministic stand-in for real Wallet/issuer activity. Produces a stable
+/// set of candidates with realistic, noisy statement descriptors so the review
+/// inbox, merchant recognition and duplicate detection can be exercised and
+/// tested without the (unavailable) private entitlement.
+struct SimulatedWalletActivityProvider: WalletActivityProviding {
+
+    /// A raw activity row before recognition.
+    private struct RawActivity {
+        let descriptor: String
+        let amountMinorUnits: Int64
+        let daysAgo: Int
+        let cardLast4: String?
+    }
+
+    private let now: Date
+
+    init(now: Date = Date()) {
+        self.now = now
+    }
+
+    func recentActivity(displayCurrencyCode: String) async -> [WalletTransactionCandidate] {
+        let rows: [RawActivity] = [
+            RawActivity(descriptor: "TST* THE COFFEE CLUB 4471", amountMinorUnits: 620, daysAgo: 0, cardLast4: "4242"),
+            RawActivity(descriptor: "UBER *TRIP HELP.UBER.COM", amountMinorUnits: 1830, daysAgo: 0, cardLast4: "4242"),
+            RawActivity(descriptor: "WHOLE FOODS MKT #123 POS DEBIT", amountMinorUnits: 4275, daysAgo: 1, cardLast4: "4242"),
+            RawActivity(descriptor: "AIRBNB * HMXYZ12345", amountMinorUnits: 21500, daysAgo: 2, cardLast4: "1005"),
+            RawActivity(descriptor: "SQ *BLUE BOTTLE COFFEE", amountMinorUnits: 540, daysAgo: 3, cardLast4: "4242"),
+            RawActivity(descriptor: "PAYMENT REF 88213 AUTH", amountMinorUnits: 999, daysAgo: 4, cardLast4: nil),
+        ]
+
+        let calendar = Calendar.current
+        return rows.enumerated().map { index, row in
+            let date = calendar.date(byAdding: .day, value: -row.daysAgo, to: now) ?? now
+            return MerchantRecognizer.recognize(
+                id: "wallet-\(index)-\(row.descriptor.hashValue)",
+                rawDescriptor: row.descriptor,
+                amountMinorUnits: row.amountMinorUnits,
+                currencyCode: displayCurrencyCode,
+                date: date,
+                cardLast4: row.cardLast4
+            )
+        }
+    }
+}

--- a/apps/ios/Finance/Services/WalletDuplicateDetector.swift
+++ b/apps/ios/Finance/Services/WalletDuplicateDetector.swift
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// WalletDuplicateDetector.swift
+// Finance
+//
+// Pure duplicate detection for Wallet-aware capture (#2171). Apple Pay users
+// often have the same purchase arrive from both a manual entry and imported
+// card activity; importing blindly would double-count. This detector flags a
+// candidate as a likely duplicate of an existing transaction when the amount,
+// currency, timing and merchant all line up. Deterministic and I/O-free.
+
+import Foundation
+import FinanceShared
+
+enum WalletDuplicateDetector {
+
+    /// Default matching window: purchases within three days are comparable.
+    static let defaultWindow: TimeInterval = 3 * 24 * 60 * 60
+
+    /// Finds an existing transaction that the candidate likely duplicates.
+    static func findDuplicate(
+        for candidate: WalletTransactionCandidate,
+        in existing: [TransactionItem],
+        within window: TimeInterval = defaultWindow
+    ) -> TransactionItem? {
+        let candidateTokens = Set(MerchantTokenizer.tokens(merchant: candidate.merchant))
+
+        return existing.first { item in
+            guard item.currencyCode == candidate.currencyCode else { return false }
+            guard abs(item.amountMinorUnits) == candidate.amountMinorUnits else { return false }
+            guard abs(item.date.timeIntervalSince(candidate.date)) <= window else { return false }
+            return merchantsMatch(candidateTokens: candidateTokens, payee: item.payee)
+        }
+    }
+
+    /// Annotates each candidate with the id of a likely-duplicate existing
+    /// transaction (if any), leaving all other fields untouched.
+    static func annotate(
+        candidates: [WalletTransactionCandidate],
+        existing: [TransactionItem],
+        within window: TimeInterval = defaultWindow
+    ) -> [WalletTransactionCandidate] {
+        candidates.map { candidate in
+            var annotated = candidate
+            annotated.duplicateOfId = findDuplicate(for: candidate, in: existing, within: window)?.id
+            return annotated
+        }
+    }
+
+    /// Two merchants match when their token sets share at least one meaningful
+    /// token, e.g. candidate "The Coffee Club" vs payee "Coffee Club Sydney".
+    private static func merchantsMatch(candidateTokens: Set<String>, payee: String) -> Bool {
+        guard !candidateTokens.isEmpty else { return false }
+        let payeeTokens = Set(MerchantTokenizer.tokens(merchant: payee))
+        guard !payeeTokens.isEmpty else { return false }
+        return !candidateTokens.isDisjoint(with: payeeTokens)
+    }
+}

--- a/apps/ios/Finance/ViewModels/BudgetCreateViewModel.swift
+++ b/apps/ios/Finance/ViewModels/BudgetCreateViewModel.swift
@@ -28,6 +28,17 @@ final class BudgetCreateViewModel {
     var amountText = ""
     var selectedPeriod: BudgetPeriod = .monthly
 
+    /// Currency the budget limit is entered in. Defaults to the user's display
+    /// currency so budgets roll up consistently with the dashboard, but can be
+    /// switched to a local/account currency while travelling (#2203).
+    var currencyCode: String = CurrencyPreferences.displayCurrencyCode()
+
+    /// Currencies offered in the picker.
+    let availableCurrencyCodes = CurrencyPreferences.supportedCurrencyCodes
+
+    /// Localized symbol for the currently selected budget currency.
+    var currencySymbol: String { CurrencyPreferences.symbol(for: currencyCode) }
+
     // MARK: - State
 
     var isSaving = false
@@ -71,6 +82,7 @@ final class BudgetCreateViewModel {
             selectedCategoryId = categories.first { $0.name == budget.categoryName }?.id
             amountText = Self.formatAmountForEditing(budget.limitMinorUnits)
             selectedPeriod = BudgetPeriod(rawValue: budget.period) ?? .monthly
+            currencyCode = budget.currencyCode
         }
     }
 
@@ -91,7 +103,7 @@ final class BudgetCreateViewModel {
             categoryName: categoryName,
             spentMinorUnits: editingBudget?.spentMinorUnits ?? 0,
             limitMinorUnits: amountMinorUnits,
-            currencyCode: "USD",
+            currencyCode: currencyCode,
             period: selectedPeriod.rawValue,
             icon: categoryIcon
         )

--- a/apps/ios/Finance/ViewModels/BudgetsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/BudgetsViewModel.swift
@@ -28,6 +28,10 @@ final class BudgetsViewModel {
     var editingBudget: BudgetItem?
     var errorMessage: String?
 
+    /// Active display currency used for the aggregate summary totals so the
+    /// Settings preference drives this screen too (#2203).
+    var displayCurrencyCode: String = CurrencyPreferences.displayCurrencyCode()
+
     /// Whether an error alert should be presented.
     var showError: Bool { errorMessage != nil }
 
@@ -83,6 +87,8 @@ final class BudgetsViewModel {
     func loadBudgets() async {
         isLoading = true
         defer { isLoading = false }
+
+        displayCurrencyCode = CurrencyPreferences.displayCurrencyCode()
 
         do {
             budgets = try await repository.getBudgets()

--- a/apps/ios/Finance/ViewModels/DashboardViewModel.swift
+++ b/apps/ios/Finance/ViewModels/DashboardViewModel.swift
@@ -36,7 +36,11 @@ final class DashboardViewModel {
     var recentTransactions: [TransactionItem] = []
     var isLoading = false
     var errorMessage: String?
-    var currencyCode: String = "USD"
+
+    /// Active display (home) currency that drives every total and formatted
+    /// value on the dashboard. Sourced from ``CurrencyPreferences`` so the
+    /// Settings choice actually flows through here (#2203).
+    var currencyCode: String = CurrencyPreferences.displayCurrencyCode()
 
     /// Whether an error alert should be presented.
     var showError: Bool { errorMessage != nil }
@@ -275,6 +279,32 @@ final class DashboardViewModel {
         )
     }
 
+    // MARK: - Multi-currency roll-up disclosure (#2203)
+
+    /// Currency codes present in the loaded transactions that differ from the
+    /// active display currency — i.e. amounts that were converted for roll-ups.
+    var foreignCurrencyCodes: [String] {
+        let display = currencyCode.uppercased()
+        let codes = Set(
+            recentTransactions.map { $0.currencyCode.uppercased() }
+                + savingsRateTransactions.map { $0.currencyCode.uppercased() }
+        )
+        return codes.subtracting([display]).sorted()
+    }
+
+    /// Whether the dashboard is combining spend from more than one currency.
+    var hasMultiCurrencySpend: Bool { !foreignCurrencyCodes.isEmpty }
+
+    /// Short disclosure shown near totals when they combine multiple
+    /// currencies, so the user understands the home-currency figure is a
+    /// converted roll-up rather than a native sum.
+    var rollupDisclosure: String? {
+        guard hasMultiCurrencySpend else { return nil }
+        return String(
+            localized: "Totals are rolled up into \(currencyCode) from \(foreignCurrencyCodes.count) other currencies at the latest available rates."
+        )
+    }
+
     init(
         accountRepository: AccountRepository,
         transactionRepository: TransactionRepository,
@@ -292,6 +322,10 @@ final class DashboardViewModel {
     func loadDashboard() async {
         isLoading = true
         defer { isLoading = false }
+
+        // Pick up any change to the display-currency preference so totals and
+        // formatting always reflect the user's current home-currency choice.
+        currencyCode = CurrencyPreferences.displayCurrencyCode()
 
         do {
             // Instrumented with os_signpost for Instruments profiling (#903)

--- a/apps/ios/Finance/ViewModels/SettingsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/SettingsViewModel.swift
@@ -170,6 +170,32 @@ final class SettingsViewModel {
     /// `true` while a manual sync operation is in progress.
     var isSyncing = false
 
+    /// Queue of local changes with per-item sync status, giving offline users
+    /// trustworthy feedback about what has and hasn't synced (#2204).
+    let syncQueue: SyncQueueManager
+
+    /// Supplies current connectivity for sync runs. The view overrides this
+    /// with real reachability from `NetworkMonitor`; defaults to connected.
+    var isNetworkAvailable: () -> Bool = { true }
+
+    /// Honest headline describing the most recent sync attempt.
+    private(set) var lastSyncSummaryText: String?
+
+    /// Items in the sync queue, surfaced to the settings UI.
+    var syncQueueItems: [SyncQueueItem] { syncQueue.items }
+
+    /// Count of changes still on their way to the server.
+    var syncPendingCount: Int { syncQueue.pendingCount }
+
+    /// Count of changes that failed to upload.
+    var syncFailedCount: Int { syncQueue.failedCount }
+
+    /// Count of changes blocked by a server conflict.
+    var syncConflictedCount: Int { syncQueue.conflictedCount }
+
+    /// Whether the sync queue needs the user's attention.
+    var syncNeedsAttention: Bool { syncQueue.needsAttention }
+
     // MARK: - Constants
 
     let supportedCurrencies = [
@@ -211,6 +237,7 @@ final class SettingsViewModel {
         goalRepository: GoalRepository = MockGoalRepository(),
         exportService: DataExportService = DataExportService(),
         deletionService: DataDeletionManaging? = nil,
+        syncQueue: SyncQueueManager? = nil,
         defaults: UserDefaults = .standard
     ) {
         self.accountRepository = accountRepository
@@ -219,6 +246,7 @@ final class SettingsViewModel {
         self.goalRepository = goalRepository
         self.exportService = exportService
         self.deletionService = deletionService ?? DataDeletionService(accountRepository: accountRepository, transactionRepository: transactionRepository, budgetRepository: budgetRepository, goalRepository: goalRepository, defaults: defaults)
+        self.syncQueue = syncQueue ?? .shared
         self.defaults = defaults
 
         // Hydrate persisted preferences (use sensible defaults for first launch)
@@ -427,28 +455,48 @@ final class SettingsViewModel {
 
     // MARK: - Sync
 
-    /// Triggers a manual sync operation.
+    /// Triggers a manual sync run and reflects trustworthy per-item feedback.
     ///
-    /// In the current implementation this simulates a sync with a brief
-    /// delay. Once the KMP sync module is integrated, this will call
-    /// into the shared `SyncManager`.
+    /// When offline, locally-saved changes are marked queued (nothing is lost)
+    /// and the user is told they'll sync later. When online, each queued change
+    /// is uploaded and transitioned to synced / failed / conflicted. This
+    /// replaces the previous simulated fixed delay (#2204).
     func syncNow() async {
         guard !isSyncing else { return }
         isSyncing = true
         defer { isSyncing = false }
 
-        Self.logger.info("Manual sync started")
+        let connected = isNetworkAvailable()
+        Self.logger.info("Manual sync started (connected=\(connected, privacy: .public))")
 
-        // TODO: Replace with KMP SyncManager call
-        try? await Task.sleep(for: .seconds(1))
+        let summary = await syncQueue.processQueue(isConnected: connected)
+        lastSyncSummaryText = summary.headline
 
-        let now = Date.now
-        lastSyncDate = now
-        defaults.set(now, forKey: SettingsKeys.lastSyncDate)
-        pendingChangesCount = 0
-        defaults.set(0, forKey: SettingsKeys.pendingChangesCount)
+        // Only advance the "last synced" timestamp when we actually reached the
+        // server, so the UI never implies a successful sync while offline.
+        if connected {
+            let now = Date.now
+            lastSyncDate = now
+            defaults.set(now, forKey: SettingsKeys.lastSyncDate)
+        }
 
-        Self.logger.info("Manual sync completed")
+        pendingChangesCount = syncQueue.pendingCount
+        defaults.set(pendingChangesCount, forKey: SettingsKeys.pendingChangesCount)
+
+        Self.logger.info("Manual sync completed: \(summary.headline, privacy: .public)")
+    }
+
+    /// Requeues failed/conflicted items and immediately retries the queue.
+    func retrySync() async {
+        syncQueue.retryFailed()
+        await syncNow()
+    }
+
+    /// Clears successfully-synced items from the visible queue.
+    func clearSyncedItems() {
+        syncQueue.clearSynced()
+        pendingChangesCount = syncQueue.pendingCount
+        defaults.set(pendingChangesCount, forKey: SettingsKeys.pendingChangesCount)
     }
 
     // MARK: - GDPR Data Deletion

--- a/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
@@ -17,6 +17,7 @@ final class TransactionCreateViewModel {
     private let accountRepository: AccountRepository
     private let transactionValidator: KMPTransactionValidatorProtocol
     private let categorizationEngine: KMPCategorizationEngineProtocol
+    private let syncQueue: SyncQueueManager
 
     /// The transaction being edited, or `nil` for create mode.
     private let editingTransaction: TransactionItem?
@@ -178,13 +179,15 @@ final class TransactionCreateViewModel {
         transaction: TransactionItem? = nil,
         quickEntryAction: String? = nil,
         transactionValidator: KMPTransactionValidatorProtocol = KMPBridge.shared.transactionValidator,
-        categorizationEngine: KMPCategorizationEngineProtocol = KMPBridge.shared.categorizationEngine
+        categorizationEngine: KMPCategorizationEngineProtocol = KMPBridge.shared.categorizationEngine,
+        syncQueue: SyncQueueManager = .shared
     ) {
         self.transactionRepository = transactionRepository
         self.accountRepository = accountRepository
         self.editingTransaction = transaction
         self.transactionValidator = transactionValidator
         self.categorizationEngine = categorizationEngine
+        self.syncQueue = syncQueue
 
         if let transaction {
             // Pre-fill fields from the existing transaction
@@ -300,6 +303,14 @@ final class TransactionCreateViewModel {
             } else {
                 try await transactionRepository.createTransaction(transaction)
             }
+
+            // Queue the change for sync so offline users get trustworthy
+            // feedback on what has and hasn't uploaded (#2204).
+            syncQueue.enqueue(
+                entityType: "transaction",
+                entityId: transaction.id,
+                summary: "\(payee) — \(formattedAmount) \(currencyCode)"
+            )
 
             // Teach the categorization engine this payee → category mapping
             if let categoryId = selectedCategoryId, !payee.isEmpty {

--- a/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
@@ -43,6 +43,11 @@ final class TransactionCreateViewModel {
     var selectedAccountId: String?
     var selectedCategoryId: String?
     var date = Date()
+
+    /// Identifier of the timezone captured at entry time. Preserved with the
+    /// transaction so day-based reporting stays stable after the traveller
+    /// crosses a border (#2206).
+    var timeZoneIdentifier: String = TimeZone.current.identifier
     var note = ""
     var currencyCode = "USD"
     var isSaving = false
@@ -134,6 +139,34 @@ final class TransactionCreateViewModel {
         isEditing ? String(localized: "Edit Transaction") : String(localized: "New Transaction")
     }
 
+    // MARK: - Timezone capture (#2206)
+
+    /// The timezone currently captured for this transaction.
+    var capturedTimeZone: TimeZone { TimeZone(identifier: timeZoneIdentifier) ?? .current }
+
+    /// Preview of the local timestamp that will be preserved with the entry,
+    /// e.g. "Jan 5, 2026 at 11:50 PM GMT+7".
+    var localTimestampDescription: String {
+        TransactionTimestamp(instant: date, timeZoneIdentifier: timeZoneIdentifier)
+            .localDateTimeDescription
+    }
+
+    /// Short label for the captured zone (e.g. "ICT", "GMT+7").
+    var capturedTimeZoneLabel: String {
+        capturedTimeZone.abbreviation(for: date) ?? capturedTimeZone.identifier
+    }
+
+    /// Whether the captured zone differs from the device's current zone — a
+    /// hint that this entry was logged in another country.
+    var isForeignTimeZone: Bool {
+        capturedTimeZone.secondsFromGMT(for: date) != TimeZone.current.secondsFromGMT()
+    }
+
+    /// Resets the captured timezone to the device's current zone.
+    func useCurrentTimeZone() {
+        timeZoneIdentifier = TimeZone.current.identifier
+    }
+
     /// Label for the save button on the review step.
     var saveButtonTitle: String {
         isEditing ? String(localized: "Update Transaction") : String(localized: "Save Transaction")
@@ -159,6 +192,7 @@ final class TransactionCreateViewModel {
             amountCents = Int(abs(transaction.amountMinorUnits))
             payee = transaction.payee
             date = transaction.date
+            timeZoneIdentifier = transaction.timeZoneIdentifier ?? TimeZone.current.identifier
             currencyCode = transaction.currencyCode
             selectedStatus = transaction.status
             tags = transaction.tagNames
@@ -255,7 +289,9 @@ final class TransactionCreateViewModel {
             type: transactionType,
             status: selectedStatus,
             tagNames: persistedTags,
-            moodTag: moodTagsEnabled ? moodTag : nil
+            moodTag: moodTagsEnabled ? moodTag : nil,
+            timestamp: date,
+            timeZoneIdentifier: timeZoneIdentifier
         )
 
         do {

--- a/apps/ios/Finance/ViewModels/TransactionEditViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionEditViewModel.swift
@@ -111,7 +111,8 @@ final class TransactionEditViewModel {
             id: original.id, payee: payee, category: resolvedCategoryName,
             accountName: resolvedAccountName,
             amountMinorUnits: transactionType == .income ? amountMinorUnits : -amountMinorUnits,
-            currencyCode: currencyCode, date: date, type: transactionType, status: original.status
+            currencyCode: currencyCode, date: date, type: transactionType, status: original.status,
+            timestamp: original.timestamp, timeZoneIdentifier: original.timeZoneIdentifier
         )
         do {
             try await transactionRepository.updateTransaction(updated)

--- a/apps/ios/Finance/ViewModels/TripBudgetCreateViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TripBudgetCreateViewModel.swift
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TripBudgetCreateViewModel.swift
+// Finance
+//
+// Form state and validation for creating or editing a trip/country budget
+// (#2205).
+
+import Observation
+import Foundation
+
+@Observable
+final class TripBudgetCreateViewModel {
+    private let editingTrip: TripBudget?
+
+    var isEditing: Bool { editingTrip != nil }
+
+    // MARK: - Form fields
+
+    var name = ""
+    var country = ""
+    var currencyCode = CurrencyPreferences.displayCurrencyCode()
+    var amountText = ""
+    var startDate = Date()
+    var endDate = Calendar.current.date(byAdding: .day, value: 14, to: Date()) ?? Date()
+    var matchTag = ""
+
+    // MARK: - State
+
+    var showingValidationError = false
+    var validationMessage = ""
+
+    let availableCurrencyCodes = CurrencyPreferences.supportedCurrencyCodes
+
+    var currencySymbol: String { CurrencyPreferences.symbol(for: currencyCode) }
+
+    var navigationTitle: String {
+        isEditing ? String(localized: "Edit Trip Budget") : String(localized: "New Trip Budget")
+    }
+
+    var saveButtonTitle: String {
+        isEditing ? String(localized: "Update") : String(localized: "Save")
+    }
+
+    var amountMinorUnits: Int64 { Int64((Double(amountText) ?? 0) * 100) }
+
+    init(trip: TripBudget? = nil) {
+        self.editingTrip = trip
+        if let trip {
+            name = trip.name
+            country = trip.country
+            currencyCode = trip.currencyCode
+            amountText = String(format: "%.2f", Double(trip.limitMinorUnits) / 100.0)
+            startDate = trip.startDate
+            endDate = trip.endDate
+            matchTag = trip.matchTag
+        }
+    }
+
+    /// Builds a validated `TripBudget`, or `nil` when input is invalid.
+    func buildTrip() -> TripBudget? {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            fail(String(localized: "Please enter a trip name."))
+            return nil
+        }
+        guard amountMinorUnits > 0 else {
+            fail(String(localized: "Please enter a budget amount greater than zero."))
+            return nil
+        }
+        guard endDate >= startDate else {
+            fail(String(localized: "The end date must be on or after the start date."))
+            return nil
+        }
+
+        return TripBudget(
+            id: editingTrip?.id ?? UUID().uuidString,
+            name: trimmedName,
+            country: country.trimmingCharacters(in: .whitespacesAndNewlines),
+            currencyCode: currencyCode,
+            limitMinorUnits: amountMinorUnits,
+            startDate: startDate,
+            endDate: endDate,
+            matchTag: matchTag.trimmingCharacters(in: .whitespacesAndNewlines),
+            isArchived: editingTrip?.isArchived ?? false
+        )
+    }
+
+    private func fail(_ message: String) {
+        validationMessage = message
+        showingValidationError = true
+    }
+}

--- a/apps/ios/Finance/ViewModels/TripBudgetsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TripBudgetsViewModel.swift
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TripBudgetsViewModel.swift
+// Finance
+//
+// Drives the trip/country budgets screen: loads trips from the store, measures
+// spend against them from the transaction history, and supports archiving when
+// a trip ends without losing historical reporting (#2205).
+
+import Observation
+import Foundation
+import os
+
+@Observable
+final class TripBudgetsViewModel {
+    private let store: TripBudgetStoring
+    private let transactionRepository: TransactionRepository
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "TripBudgetsViewModel"
+    )
+
+    var activeTrips: [TripBudget] = []
+    var archivedTrips: [TripBudget] = []
+    var isLoading = false
+    var showingCreate = false
+    var editingTrip: TripBudget?
+
+    /// Active display currency, used for empty-state copy and roll-up hints.
+    private(set) var displayCurrencyCode = CurrencyPreferences.displayCurrencyCode()
+
+    private var transactions: [TransactionItem] = []
+    private var progressByTrip: [String: TripBudgetProgress] = [:]
+
+    init(
+        store: TripBudgetStoring = TripBudgetStore.shared,
+        transactionRepository: TransactionRepository = RepositoryProvider.shared.transactions
+    ) {
+        self.store = store
+        self.transactionRepository = transactionRepository
+    }
+
+    /// Whether there are no trips at all (active or archived).
+    var isEmpty: Bool { activeTrips.isEmpty && archivedTrips.isEmpty }
+
+    /// Loads transactions and recomputes progress for every trip.
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        displayCurrencyCode = CurrencyPreferences.displayCurrencyCode()
+        do {
+            transactions = try await transactionRepository.getTransactions()
+        } catch {
+            Self.logger.error("Trip budgets transaction load failed: \(error.localizedDescription, privacy: .public)")
+            transactions = []
+        }
+        refresh()
+    }
+
+    /// Recomputes derived state from the store and cached transactions.
+    private func refresh() {
+        activeTrips = store.activeTrips()
+        archivedTrips = store.archivedTrips()
+
+        var map: [String: TripBudgetProgress] = [:]
+        for trip in activeTrips + archivedTrips {
+            map[trip.id] = TripBudgetCalculator.progress(for: trip, in: transactions)
+        }
+        progressByTrip = map
+    }
+
+    /// Spend progress for a trip (zero when not yet computed).
+    func progress(for trip: TripBudget) -> TripBudgetProgress {
+        progressByTrip[trip.id] ?? .zero
+    }
+
+    /// Persists a new or edited trip and recomputes progress.
+    func save(_ trip: TripBudget) {
+        store.upsert(trip)
+        refresh()
+    }
+
+    /// Archives a trip so it drops out of the active list but is retained for
+    /// historical reporting.
+    func archive(_ trip: TripBudget) {
+        var updated = trip
+        updated.isArchived = true
+        store.upsert(updated)
+        refresh()
+    }
+
+    /// Restores an archived trip to the active list.
+    func unarchive(_ trip: TripBudget) {
+        var updated = trip
+        updated.isArchived = false
+        store.upsert(updated)
+        refresh()
+    }
+
+    /// Permanently deletes a trip.
+    func delete(_ trip: TripBudget) {
+        store.remove(id: trip.id)
+        refresh()
+    }
+}

--- a/apps/ios/Finance/ViewModels/WalletCaptureViewModel.swift
+++ b/apps/ios/Finance/ViewModels/WalletCaptureViewModel.swift
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// WalletCaptureViewModel.swift
+// Finance
+//
+// Drives the Wallet-aware capture review inbox (#2171). Loads recent card
+// activity from a WalletActivityProviding source, cleans/recognizes each
+// merchant, flags likely duplicates against existing transactions, and lets an
+// Apple Pay-heavy user confirm imports with a single tap instead of full
+// manual re-entry. Imported items are persisted through the normal transaction
+// repository and queued for sync so offline feedback stays trustworthy (#2204).
+
+import Observation
+import Foundation
+import os
+
+@Observable
+final class WalletCaptureViewModel {
+    private let provider: WalletActivityProviding
+    private let transactionRepository: TransactionRepository
+    private let syncQueue: SyncQueueManager
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "WalletCaptureViewModel"
+    )
+
+    var candidates: [WalletTransactionCandidate] = []
+    var isLoading = false
+    var importedCount = 0
+    var errorMessage: String?
+
+    private(set) var displayCurrencyCode = CurrencyPreferences.displayCurrencyCode()
+
+    init(
+        provider: WalletActivityProviding = SimulatedWalletActivityProvider(),
+        transactionRepository: TransactionRepository = RepositoryProvider.shared.transactions,
+        syncQueue: SyncQueueManager = .shared
+    ) {
+        self.provider = provider
+        self.transactionRepository = transactionRepository
+        self.syncQueue = syncQueue
+    }
+
+    /// Whether there is nothing left to review.
+    var isEmpty: Bool { candidates.isEmpty }
+
+    /// Candidates that are not flagged as likely duplicates.
+    var nonDuplicateCandidates: [WalletTransactionCandidate] {
+        candidates.filter { !$0.isLikelyDuplicate }
+    }
+
+    /// Number of candidates flagged as likely duplicates.
+    var duplicateCount: Int {
+        candidates.filter(\.isLikelyDuplicate).count
+    }
+
+    /// Loads recent activity and annotates duplicates against existing history.
+    func load() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        displayCurrencyCode = CurrencyPreferences.displayCurrencyCode()
+
+        let fetched = await provider.recentActivity(displayCurrencyCode: displayCurrencyCode)
+
+        var existing: [TransactionItem] = []
+        do {
+            existing = try await transactionRepository.getTransactions()
+        } catch {
+            Self.logger.error("Wallet capture history load failed: \(error.localizedDescription, privacy: .public)")
+        }
+
+        candidates = WalletDuplicateDetector.annotate(candidates: fetched, existing: existing)
+    }
+
+    /// Imports a single candidate as an expense and removes it from the inbox.
+    @discardableResult
+    func importCandidate(_ candidate: WalletTransactionCandidate) async -> Bool {
+        let transaction = makeTransaction(from: candidate)
+        do {
+            try await transactionRepository.createTransaction(transaction)
+            syncQueue.enqueue(
+                entityType: "transaction",
+                entityId: transaction.id,
+                summary: "\(candidate.merchant) — Apple Pay"
+            )
+            candidates.removeAll { $0.id == candidate.id }
+            importedCount += 1
+            return true
+        } catch {
+            Self.logger.error("Wallet candidate import failed: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    /// Imports every non-duplicate candidate in one pass.
+    func importAllNonDuplicates() async {
+        for candidate in nonDuplicateCandidates {
+            _ = await importCandidate(candidate)
+        }
+    }
+
+    /// Dismisses a candidate without importing it.
+    func dismiss(_ candidate: WalletTransactionCandidate) {
+        candidates.removeAll { $0.id == candidate.id }
+    }
+
+    /// Builds a transaction from a reviewed candidate. Expenses are stored with
+    /// a negative amount, and the purchase instant + current timezone are
+    /// preserved so cross-border reporting stays correct (#2206).
+    private func makeTransaction(from candidate: WalletTransactionCandidate) -> TransactionItem {
+        TransactionItem(
+            id: UUID().uuidString,
+            payee: candidate.merchant,
+            category: candidate.suggestedCategory ?? "",
+            amountMinorUnits: -candidate.amountMinorUnits,
+            currencyCode: candidate.currencyCode,
+            date: candidate.date,
+            type: .expense,
+            tagNames: ["apple-pay"],
+            timestamp: candidate.date,
+            timeZoneIdentifier: TimeZone.current.identifier
+        )
+    }
+}

--- a/apps/ios/Tests/CurrencyConverterTests.swift
+++ b/apps/ios/Tests/CurrencyConverterTests.swift
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CurrencyConverterTests.swift
+// FinanceTests
+//
+// Tests that the display-currency roll-up converts foreign spend and honestly
+// discloses conversions and stale/offline rates (#2203).
+
+import XCTest
+@testable import FinanceApp
+
+final class CurrencyConverterTests: XCTestCase {
+
+    private func converter(now: Date = Date()) -> CurrencyConverter {
+        CurrencyConverter(
+            displayCurrencyCode: "USD",
+            rates: [
+                ExchangeRate(currencyCode: "THB", rateToDisplay: 0.03, asOf: now),
+                ExchangeRate(currencyCode: "EUR", rateToDisplay: 1.1, asOf: now.addingTimeInterval(-60 * 60 * 48)),
+            ]
+        )
+    }
+
+    func testSameCurrencyIsNotConverted() {
+        let result = converter().convert(minorUnits: 1000, from: "USD")
+        XCTAssertEqual(result.minorUnits, 1000)
+        XCTAssertFalse(result.isConverted)
+        XCTAssertFalse(result.usedStaleRate)
+    }
+
+    func testForeignCurrencyIsConverted() {
+        let now = Date()
+        let result = converter(now: now).convert(minorUnits: 10_000, from: "THB", now: now)
+        XCTAssertEqual(result.minorUnits, 300, "10000 THB minor units * 0.03 = 300")
+        XCTAssertTrue(result.isConverted)
+        XCTAssertFalse(result.usedStaleRate)
+    }
+
+    func testStaleRateIsFlagged() {
+        let now = Date()
+        let result = converter(now: now).convert(minorUnits: 1000, from: "EUR", now: now)
+        XCTAssertTrue(result.isConverted)
+        XCTAssertTrue(result.usedStaleRate, "Rate captured 48h ago exceeds the 24h freshness window")
+    }
+
+    func testMissingRateTreatedAsOneToOneButStale() {
+        let result = converter().convert(minorUnits: 500, from: "JPY")
+        XCTAssertEqual(result.minorUnits, 500, "Money must never silently drop")
+        XCTAssertTrue(result.isConverted)
+        XCTAssertTrue(result.usedStaleRate)
+    }
+
+    func testRollupAggregatesAndDisclosesFlags() {
+        let now = Date()
+        let rollup = converter(now: now).rollup(
+            [
+                (minorUnits: 1000, currencyCode: "USD"),
+                (minorUnits: 10_000, currencyCode: "THB"),
+            ],
+            now: now
+        )
+        XCTAssertEqual(rollup.totalMinorUnits, 1300)
+        XCTAssertEqual(rollup.displayCurrencyCode, "USD")
+        XCTAssertTrue(rollup.containsConversions)
+        XCTAssertFalse(rollup.usedStaleRate)
+    }
+
+    func testRollupPropagatesStaleFlag() {
+        let now = Date()
+        let rollup = converter(now: now).rollup(
+            [
+                (minorUnits: 1000, currencyCode: "USD"),
+                (minorUnits: 1000, currencyCode: "EUR"),
+            ],
+            now: now
+        )
+        XCTAssertTrue(rollup.usedStaleRate)
+    }
+}

--- a/apps/ios/Tests/MerchantRecognizerTests.swift
+++ b/apps/ios/Tests/MerchantRecognizerTests.swift
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// MerchantRecognizerTests.swift
+// FinanceTests
+//
+// Tests that noisy card descriptors are cleaned into merchant names with
+// best-effort category suggestions and honest confidence levels (#2171).
+
+import XCTest
+@testable import FinanceApp
+
+final class MerchantRecognizerTests: XCTestCase {
+
+    func testCleansNoisyDescriptor() {
+        let name = MerchantRecognizer.clean("WHOLE FOODS MKT #123 POS DEBIT")
+        XCTAssertTrue(name.localizedCaseInsensitiveContains("Whole"))
+        XCTAssertTrue(name.localizedCaseInsensitiveContains("Foods"))
+        XCTAssertFalse(name.contains("123"))
+        XCTAssertFalse(name.localizedCaseInsensitiveContains("POS"))
+    }
+
+    func testSuggestsCategoryFromKeywords() {
+        XCTAssertEqual(MerchantRecognizer.suggestedCategory(for: "SQ *BLUE BOTTLE COFFEE"), "Dining Out")
+        XCTAssertEqual(MerchantRecognizer.suggestedCategory(for: "UBER *TRIP HELP.UBER.COM"), "Transport")
+        XCTAssertEqual(MerchantRecognizer.suggestedCategory(for: "AIRBNB * HMXYZ12345"), "Travel")
+        XCTAssertNil(MerchantRecognizer.suggestedCategory(for: "ACME WIDGETS 5567"))
+    }
+
+    func testHighConfidenceWhenNameAndCategoryResolved() {
+        let candidate = MerchantRecognizer.recognize(
+            id: "1",
+            rawDescriptor: "SQ *BLUE BOTTLE COFFEE",
+            amountMinorUnits: 540,
+            currencyCode: "USD",
+            date: Date(),
+            cardLast4: "4242"
+        )
+        XCTAssertEqual(candidate.confidence, .high)
+        XCTAssertEqual(candidate.suggestedCategory, "Dining Out")
+        XCTAssertEqual(candidate.amountMinorUnits, 540)
+    }
+
+    func testMediumConfidenceWhenNameButNoCategory() {
+        let candidate = MerchantRecognizer.recognize(
+            id: "2",
+            rawDescriptor: "ACME WIDGETS 5567",
+            amountMinorUnits: 1200,
+            currencyCode: "USD",
+            date: Date(),
+            cardLast4: nil
+        )
+        XCTAssertEqual(candidate.confidence, .medium)
+        XCTAssertNil(candidate.suggestedCategory)
+    }
+
+    func testLowConfidenceWhenDescriptorIsAllNoise() {
+        let candidate = MerchantRecognizer.recognize(
+            id: "3",
+            rawDescriptor: "PAYMENT REF 88213 AUTH",
+            amountMinorUnits: 999,
+            currencyCode: "USD",
+            date: Date(),
+            cardLast4: nil
+        )
+        XCTAssertEqual(candidate.confidence, .low)
+    }
+
+    func testAmountIsNormalizedToPositiveMagnitude() {
+        let candidate = MerchantRecognizer.recognize(
+            id: "4",
+            rawDescriptor: "SOME SHOP",
+            amountMinorUnits: -2500,
+            currencyCode: "USD",
+            date: Date(),
+            cardLast4: nil
+        )
+        XCTAssertEqual(candidate.amountMinorUnits, 2500)
+    }
+}

--- a/apps/ios/Tests/SyncQueueManagerTests.swift
+++ b/apps/ios/Tests/SyncQueueManagerTests.swift
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// SyncQueueManagerTests.swift
+// FinanceTests
+//
+// Tests the offline queued-sync state machine: nothing is lost offline, and
+// online runs transition each item honestly to synced/failed/conflicted
+// (#2204).
+
+import XCTest
+@testable import FinanceApp
+
+private struct StubUploader: SyncUploading {
+    let outcome: SyncOutcome
+    func upload(_ item: SyncQueueItem) async -> SyncOutcome { outcome }
+}
+
+private struct ByEntityUploader: SyncUploading {
+    let outcomes: [String: SyncOutcome]
+    func upload(_ item: SyncQueueItem) async -> SyncOutcome {
+        outcomes[item.entityId] ?? .success
+    }
+}
+
+final class SyncQueueManagerTests: XCTestCase {
+
+    private func makeManager() -> SyncQueueManager {
+        let suite = "sync-queue-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return SyncQueueManager(defaults: defaults, key: "queue")
+    }
+
+    func testEnqueueAddsSavedLocallyItem() {
+        let manager = makeManager()
+        manager.enqueue(entityType: "transaction", entityId: "t1", summary: "Coffee")
+        XCTAssertEqual(manager.items.count, 1)
+        XCTAssertEqual(manager.items.first?.status, .savedLocally)
+        XCTAssertEqual(manager.pendingCount, 1)
+    }
+
+    func testOfflineRunQueuesButDoesNotLose() async {
+        let manager = makeManager()
+        manager.enqueue(entityType: "transaction", entityId: "t1", summary: "Coffee")
+
+        let summary = await manager.processQueue(isConnected: false)
+
+        XCTAssertFalse(summary.reachedNetwork)
+        XCTAssertEqual(summary.stillPending, 1)
+        XCTAssertEqual(manager.items.first?.status, .queued)
+        XCTAssertEqual(manager.pendingCount, 1, "Offline must never drop a change")
+    }
+
+    func testOnlineRunSyncsSuccessfully() async {
+        let manager = makeManager()
+        manager.enqueue(entityType: "transaction", entityId: "t1", summary: "Coffee")
+
+        let summary = await manager.processQueue(isConnected: true, using: StubUploader(outcome: .success))
+
+        XCTAssertTrue(summary.reachedNetwork)
+        XCTAssertEqual(summary.uploaded, 1)
+        XCTAssertEqual(manager.syncedCount, 1)
+        XCTAssertEqual(manager.pendingCount, 0)
+    }
+
+    func testFailureIsRecordedAndRetryable() async {
+        let manager = makeManager()
+        manager.enqueue(entityType: "transaction", entityId: "t1", summary: "Coffee")
+
+        _ = await manager.processQueue(isConnected: true, using: StubUploader(outcome: .failure("timeout")))
+        XCTAssertEqual(manager.failedCount, 1)
+        XCTAssertTrue(manager.needsAttention)
+        XCTAssertEqual(manager.items.first?.errorMessage, "timeout")
+        XCTAssertEqual(manager.items.first?.retryCount, 1)
+
+        manager.retryFailed()
+        XCTAssertEqual(manager.items.first?.status, .queued)
+
+        let retry = await manager.processQueue(isConnected: true, using: StubUploader(outcome: .success))
+        XCTAssertEqual(retry.uploaded, 1)
+        XCTAssertEqual(manager.failedCount, 0)
+    }
+
+    func testConflictIsSurfaced() async {
+        let manager = makeManager()
+        manager.enqueue(entityType: "transaction", entityId: "t1", summary: "Coffee")
+
+        let summary = await manager.processQueue(isConnected: true, using: StubUploader(outcome: .conflict))
+        XCTAssertEqual(summary.conflicted, 1)
+        XCTAssertEqual(manager.conflictedCount, 1)
+        XCTAssertTrue(manager.needsAttention)
+    }
+
+    func testClearSyncedRemovesOnlySyncedItems() async {
+        let manager = makeManager()
+        manager.enqueue(entityType: "transaction", entityId: "ok", summary: "Coffee")
+        manager.enqueue(entityType: "transaction", entityId: "bad", summary: "Hostel")
+
+        _ = await manager.processQueue(
+            isConnected: true,
+            using: ByEntityUploader(outcomes: ["ok": .success, "bad": .failure("nope")])
+        )
+        XCTAssertEqual(manager.syncedCount, 1)
+        XCTAssertEqual(manager.failedCount, 1)
+
+        manager.clearSynced()
+        XCTAssertEqual(manager.syncedCount, 0)
+        XCTAssertEqual(manager.failedCount, 1, "Failed items stay until resolved")
+    }
+
+    func testOfflineHeadlineIsHonest() {
+        let summary = SyncRunSummary(reachedNetwork: false, uploaded: 0, failed: 0, conflicted: 0, stillPending: 3)
+        XCTAssertTrue(summary.headline.localizedCaseInsensitiveContains("offline"))
+    }
+}

--- a/apps/ios/Tests/TransactionTimestampTests.swift
+++ b/apps/ios/Tests/TransactionTimestampTests.swift
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionTimestampTests.swift
+// FinanceTests
+//
+// Tests that a purchase keeps its original local day and time after the device
+// crosses into another timezone (#2206).
+
+import XCTest
+@testable import FinanceApp
+
+final class TransactionTimestampTests: XCTestCase {
+
+    private let bangkok = TimeZone(identifier: "Asia/Bangkok")!
+    private let lisbon = TimeZone(identifier: "Europe/Lisbon")!
+
+    /// 2026-01-05 23:50 local Bangkok time as an absolute instant.
+    private func lateNightBangkokInstant() -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = bangkok
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 1
+        components.day = 5
+        components.hour = 23
+        components.minute = 50
+        return calendar.date(from: components)!
+    }
+
+    func testLocalDayAnchoredToCaptureZoneNotDeviceZone() {
+        let instant = lateNightBangkokInstant()
+
+        let bangkokStamp = TransactionTimestamp(instant: instant, timeZone: bangkok)
+        let lisbonStamp = TransactionTimestamp(instant: instant, timeZone: lisbon)
+
+        var bangkokCal = Calendar(identifier: .gregorian)
+        bangkokCal.timeZone = bangkok
+        let bangkokDayComponents = bangkokCal.dateComponents([.day], from: bangkokStamp.localDay)
+        XCTAssertEqual(bangkokDayComponents.day, 5, "Purchase stays on Jan 5 in Bangkok")
+
+        // In Lisbon the same instant is still the 5th's afternoon, so the two
+        // local days differ — proving day is anchored to the capture zone.
+        XCTAssertNotEqual(bangkokStamp.localDay, lisbonStamp.localDay)
+    }
+
+    func testResolveTimeZoneFallsBackToCurrentForInvalidIdentifier() {
+        let zone = TransactionTimestamp.resolveTimeZone("Not/AZone")
+        XCTAssertEqual(zone, .current)
+    }
+
+    func testResolveTimeZoneUsesValidIdentifier() {
+        let zone = TransactionTimestamp.resolveTimeZone("Asia/Bangkok")
+        XCTAssertEqual(zone.identifier, "Asia/Bangkok")
+    }
+
+    func testDiffersFromDeviceZoneDetectsBorderCrossing() {
+        let stamp = TransactionTimestamp(instant: lateNightBangkokInstant(), timeZone: bangkok)
+        XCTAssertTrue(stamp.differsFromDeviceZone(deviceZone: lisbon))
+        XCTAssertFalse(stamp.differsFromDeviceZone(deviceZone: bangkok))
+    }
+
+    func testInitFromIdentifierPreservesZone() {
+        let stamp = TransactionTimestamp(instant: lateNightBangkokInstant(), timeZoneIdentifier: "Asia/Bangkok")
+        XCTAssertEqual(stamp.timeZone.identifier, "Asia/Bangkok")
+    }
+}

--- a/apps/ios/Tests/TripBudgetCalculatorTests.swift
+++ b/apps/ios/Tests/TripBudgetCalculatorTests.swift
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TripBudgetCalculatorTests.swift
+// FinanceTests
+//
+// Tests trip/country budget membership and spend measurement, including
+// timezone-preserved day matching and multi-currency roll-up (#2205, #2203).
+
+import XCTest
+@testable import FinanceApp
+
+final class TripBudgetCalculatorTests: XCTestCase {
+
+    private func day(_ year: Int, _ month: Int, _ dayOfMonth: Int, zone: String = "Asia/Bangkok") -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: zone)!
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = dayOfMonth
+        components.hour = 12
+        return calendar.date(from: components)!
+    }
+
+    private func expense(
+        id: String = UUID().uuidString,
+        amount: Int64,
+        currency: String = "THB",
+        on date: Date,
+        zone: String = "Asia/Bangkok",
+        tags: [String] = []
+    ) -> TransactionItem {
+        TransactionItem(
+            id: id,
+            payee: "Merchant",
+            category: "Food",
+            amountMinorUnits: -amount,
+            currencyCode: currency,
+            date: date,
+            type: .expense,
+            tagNames: tags,
+            timestamp: date,
+            timeZoneIdentifier: zone
+        )
+    }
+
+    private func makeTrip(tag: String = "", currency: String = "THB", limit: Int64 = 100_000) -> TripBudget {
+        TripBudget(
+            id: "trip1",
+            name: "Bangkok Jan",
+            country: "Thailand",
+            currencyCode: currency,
+            limitMinorUnits: limit,
+            startDate: day(2026, 1, 1),
+            endDate: day(2026, 1, 31),
+            matchTag: tag
+        )
+    }
+
+    func testMatchesByDateRange() {
+        let trip = makeTrip()
+        let inRange = expense(amount: 500, on: day(2026, 1, 15))
+        let outOfRange = expense(amount: 500, on: day(2026, 2, 15))
+        XCTAssertTrue(TripBudgetCalculator.matches(inRange, trip: trip))
+        XCTAssertFalse(TripBudgetCalculator.matches(outOfRange, trip: trip))
+    }
+
+    func testMatchesRequiresTagWhenSpecified() {
+        let trip = makeTrip(tag: "thailand")
+        let tagged = expense(amount: 500, on: day(2026, 1, 10), tags: ["Thailand"])
+        let untagged = expense(amount: 500, on: day(2026, 1, 10))
+        XCTAssertTrue(TripBudgetCalculator.matches(tagged, trip: trip), "Tag match is case-insensitive")
+        XCTAssertFalse(TripBudgetCalculator.matches(untagged, trip: trip))
+    }
+
+    func testProgressSumsExpensesInTripCurrency() {
+        let trip = makeTrip(limit: 10_000)
+        let transactions = [
+            expense(amount: 3000, on: day(2026, 1, 5)),
+            expense(amount: 2000, on: day(2026, 1, 6)),
+            expense(amount: 9999, on: day(2026, 2, 6)), // out of range
+        ]
+        let progress = TripBudgetCalculator.progress(for: trip, in: transactions)
+        XCTAssertEqual(progress.spentMinorUnits, 5000)
+        XCTAssertEqual(progress.transactionCount, 2)
+        XCTAssertFalse(progress.isOverBudget)
+        XCTAssertEqual(progress.remainingMinorUnits, 5000)
+    }
+
+    func testProgressConvertsForeignSpendWithConverter() {
+        let trip = makeTrip(currency: "THB", limit: 100_000)
+        let now = Date()
+        let converter = CurrencyConverter(
+            displayCurrencyCode: "THB",
+            rates: [ExchangeRate(currencyCode: "USD", rateToDisplay: 33.0, asOf: now)]
+        )
+        let transactions = [
+            expense(amount: 1000, currency: "THB", on: day(2026, 1, 5)),
+            expense(amount: 100, currency: "USD", on: day(2026, 1, 6)),
+        ]
+        let progress = TripBudgetCalculator.progress(for: trip, in: transactions, converter: converter, now: now)
+        XCTAssertEqual(progress.spentMinorUnits, 1000 + 3300)
+        XCTAssertTrue(progress.containsConversions)
+        XCTAssertFalse(progress.usedStaleRate)
+    }
+
+    func testProgressWithoutConverterFlagsMixedCurrency() {
+        let trip = makeTrip(currency: "THB")
+        let transactions = [
+            expense(amount: 1000, currency: "THB", on: day(2026, 1, 5)),
+            expense(amount: 100, currency: "USD", on: day(2026, 1, 6)),
+        ]
+        let progress = TripBudgetCalculator.progress(for: trip, in: transactions)
+        XCTAssertTrue(progress.containsConversions, "Mixed currency without converter must be disclosed")
+        XCTAssertTrue(progress.usedStaleRate)
+    }
+}

--- a/apps/ios/Tests/WalletCaptureViewModelTests.swift
+++ b/apps/ios/Tests/WalletCaptureViewModelTests.swift
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// WalletCaptureViewModelTests.swift
+// FinanceTests
+//
+// Tests the Wallet capture review inbox: activity loads, duplicates are
+// flagged against existing history, and one-tap import persists a transaction
+// and queues it for sync (#2171, #2204).
+
+import XCTest
+@testable import FinanceApp
+
+final class WalletCaptureViewModelTests: XCTestCase {
+
+    private func makeSyncQueue() -> SyncQueueManager {
+        let suite = "wallet-vm-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return SyncQueueManager(defaults: defaults, key: "queue")
+    }
+
+    @MainActor
+    func testLoadPopulatesCandidates() async {
+        let repo = StubTransactionRepository()
+        let vm = WalletCaptureViewModel(
+            provider: SimulatedWalletActivityProvider(),
+            transactionRepository: repo,
+            syncQueue: makeSyncQueue()
+        )
+
+        await vm.load()
+
+        XCTAssertFalse(vm.isEmpty)
+        XCTAssertGreaterThan(vm.candidates.count, 0)
+    }
+
+    @MainActor
+    func testImportPersistsTransactionAndQueuesSync() async {
+        let repo = StubTransactionRepository()
+        let queue = makeSyncQueue()
+        let vm = WalletCaptureViewModel(
+            provider: SimulatedWalletActivityProvider(),
+            transactionRepository: repo,
+            syncQueue: queue
+        )
+        await vm.load()
+        let target = vm.candidates.first!
+
+        let ok = await vm.importCandidate(target)
+
+        XCTAssertTrue(ok)
+        XCTAssertEqual(repo.createdTransactions.count, 1)
+        let created = repo.createdTransactions[0]
+        XCTAssertLessThan(created.amountMinorUnits, 0, "Imported purchases are expenses")
+        XCTAssertEqual(created.type, .expense)
+        XCTAssertTrue(created.hasPreservedTimeZone, "Import preserves instant + timezone")
+        XCTAssertTrue(created.tagNames.contains("apple-pay"))
+        XCTAssertEqual(queue.items.count, 1)
+        XCTAssertFalse(vm.candidates.contains { $0.id == target.id }, "Imported candidate leaves the inbox")
+        XCTAssertEqual(vm.importedCount, 1)
+    }
+
+    @MainActor
+    func testDismissRemovesWithoutImporting() async {
+        let repo = StubTransactionRepository()
+        let vm = WalletCaptureViewModel(
+            provider: SimulatedWalletActivityProvider(),
+            transactionRepository: repo,
+            syncQueue: makeSyncQueue()
+        )
+        await vm.load()
+        let target = vm.candidates.first!
+
+        vm.dismiss(target)
+
+        XCTAssertFalse(vm.candidates.contains { $0.id == target.id })
+        XCTAssertEqual(repo.createdTransactions.count, 0)
+    }
+
+    @MainActor
+    func testDuplicatesFlaggedAgainstExistingHistory() async {
+        let now = Date()
+        let repo = StubTransactionRepository()
+        // Seed history that duplicates one simulated candidate: Uber trip 1830.
+        repo.transactionsToReturn = [
+            TransactionItem(
+                id: "seed",
+                payee: "Uber Trip",
+                category: "Transport",
+                amountMinorUnits: -1830,
+                currencyCode: CurrencyPreferences.displayCurrencyCode(),
+                date: now,
+                type: .expense
+            )
+        ]
+        let vm = WalletCaptureViewModel(
+            provider: SimulatedWalletActivityProvider(now: now),
+            transactionRepository: repo,
+            syncQueue: makeSyncQueue()
+        )
+
+        await vm.load()
+
+        XCTAssertGreaterThan(vm.duplicateCount, 0, "The matching Uber trip should be flagged as duplicate")
+        XCTAssertLessThan(vm.nonDuplicateCandidates.count, vm.candidates.count)
+    }
+}

--- a/apps/ios/Tests/WalletDuplicateDetectorTests.swift
+++ b/apps/ios/Tests/WalletDuplicateDetectorTests.swift
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// WalletDuplicateDetectorTests.swift
+// FinanceTests
+//
+// Tests that imported Apple Pay activity is flagged when it duplicates an
+// existing transaction, so tapped purchases are not double-counted (#2171).
+
+import XCTest
+@testable import FinanceApp
+
+final class WalletDuplicateDetectorTests: XCTestCase {
+
+    private func existing(
+        payee: String,
+        amount: Int64,
+        currency: String = "USD",
+        date: Date
+    ) -> TransactionItem {
+        TransactionItem(
+            id: "existing-\(payee)",
+            payee: payee,
+            category: "Food",
+            amountMinorUnits: -amount,
+            currencyCode: currency,
+            date: date,
+            type: .expense
+        )
+    }
+
+    private func candidate(
+        merchant: String,
+        amount: Int64,
+        currency: String = "USD",
+        date: Date
+    ) -> WalletTransactionCandidate {
+        WalletTransactionCandidate(
+            id: "cand",
+            rawDescriptor: merchant,
+            merchant: merchant,
+            amountMinorUnits: amount,
+            currencyCode: currency,
+            date: date,
+            cardLast4: "4242",
+            suggestedCategory: nil,
+            confidence: .high,
+            duplicateOfId: nil
+        )
+    }
+
+    func testFlagsDuplicateWithMatchingAmountMerchantAndDate() {
+        let now = Date()
+        let existingTx = existing(payee: "Blue Bottle Coffee", amount: 540, date: now)
+        let cand = candidate(merchant: "Blue Bottle Coffee", amount: 540, date: now.addingTimeInterval(3600))
+
+        let match = WalletDuplicateDetector.findDuplicate(for: cand, in: [existingTx])
+        XCTAssertEqual(match?.id, existingTx.id)
+    }
+
+    func testDifferentAmountIsNotDuplicate() {
+        let now = Date()
+        let existingTx = existing(payee: "Blue Bottle Coffee", amount: 540, date: now)
+        let cand = candidate(merchant: "Blue Bottle Coffee", amount: 999, date: now)
+        XCTAssertNil(WalletDuplicateDetector.findDuplicate(for: cand, in: [existingTx]))
+    }
+
+    func testDifferentCurrencyIsNotDuplicate() {
+        let now = Date()
+        let existingTx = existing(payee: "Blue Bottle Coffee", amount: 540, currency: "USD", date: now)
+        let cand = candidate(merchant: "Blue Bottle Coffee", amount: 540, currency: "EUR", date: now)
+        XCTAssertNil(WalletDuplicateDetector.findDuplicate(for: cand, in: [existingTx]))
+    }
+
+    func testOutsideWindowIsNotDuplicate() {
+        let now = Date()
+        let existingTx = existing(payee: "Blue Bottle Coffee", amount: 540, date: now)
+        let cand = candidate(merchant: "Blue Bottle Coffee", amount: 540, date: now.addingTimeInterval(10 * 24 * 3600))
+        XCTAssertNil(WalletDuplicateDetector.findDuplicate(for: cand, in: [existingTx]))
+    }
+
+    func testDifferentMerchantIsNotDuplicate() {
+        let now = Date()
+        let existingTx = existing(payee: "Starbucks", amount: 540, date: now)
+        let cand = candidate(merchant: "Blue Bottle Coffee", amount: 540, date: now)
+        // "Coffee" is a shared-ish word but tokens here don't overlap enough:
+        // Starbucks vs Blue Bottle Coffee share no meaningful token.
+        XCTAssertNil(WalletDuplicateDetector.findDuplicate(for: cand, in: [existingTx]))
+    }
+
+    func testAnnotateSetsDuplicateId() {
+        let now = Date()
+        let existingTx = existing(payee: "Blue Bottle Coffee", amount: 540, date: now)
+        let candidates = [
+            candidate(merchant: "Blue Bottle Coffee", amount: 540, date: now),
+            candidate(merchant: "Airbnb", amount: 21_500, date: now),
+        ]
+        let annotated = WalletDuplicateDetector.annotate(candidates: candidates, existing: [existingTx])
+        XCTAssertTrue(annotated[0].isLikelyDuplicate)
+        XCTAssertFalse(annotated[1].isLikelyDuplicate)
+    }
+}


### PR DESCRIPTION
## Batch 10 — iOS digital-nomad travel finance + Apple Pay / Wallet capture

Implements a batch of five closely-related digital-nomad iOS issues in `apps/ios` (SwiftUI). Shared/KMP packages were treated as read-only; all persistence uses the existing iOS JSON `Codable` / `UserDefaults` patterns so nothing outside `apps/ios` changed.

Closes #2206
Closes #2205
Closes #2204
Closes #2203
Closes #2171

### #2203 — Display currency drives dashboard & budget totals
- `CurrencyPreferences` (single source of truth for the display currency, `finance_currency`) and a pure, testable `CurrencyConverter` producing a `CurrencyRollup` that discloses when a total is **converted** and when it relied on a **stale/offline** rate.
- `DashboardViewModel` and the budgets screens now read the display currency and surface multi-currency roll-up disclosure instead of assuming USD.

### #2206 — Preserve per-transaction timezone + local timestamp across borders
- `TransactionItem` gains a `timestamp` + `timeZoneIdentifier` (backward-compatible `decodeIfPresent` in `PersistentDataStore`), plus a `TransactionTimestamp` value type that anchors the **local day** to the capture timezone — an 11:50 PM Bangkok purchase no longer rolls into the next day when reviewed from Lisbon.
- Transaction create/edit capture and preserve the instant + timezone; detail view shows the original local time.

### #2205 — Trip / country budgets alongside global category budgets
- `TripBudget` model + `TripBudgetStore` (UserDefaults JSON) + pure `TripBudgetCalculator` (date-range + optional tag membership, multi-currency spend via the converter, using the preserved local day).
- `TripBudgetsView` / create flow, reachable from the Budgets screen. Trips can be archived when they end without losing historical reporting.

### #2204 — Trustworthy queued-sync feedback in offline mode
- Replaces the simulated `syncNow()` delay with a persisted `SyncQueueManager` state machine: `savedLocally → queued → uploading → synced / failed / conflicted`.
- New transactions enqueue on save; the Settings sync section shows an offline banner, per-state counts, an honest run summary, a retry action, and a per-change `SyncQueueDetailView`. Last-synced only advances when the server is actually reached.

### #2171 — Wallet-aware (Apple Pay) transaction capture
- A **"From Apple Pay" review inbox** (`WalletCaptureView`) that surfaces recent card activity as import candidates with automatic merchant recognition (`MerchantRecognizer`, reusing the shared `MerchantTokenizer`), category suggestions, a confidence level, and duplicate detection (`WalletDuplicateDetector`) against existing transactions. One-tap import instead of full manual re-entry; imports preserve instant + timezone and queue for sync.
- The activity source is abstracted behind `WalletActivityProviding` so a real PassKit/issuer integration can replace the deterministic simulated provider once the entitlement is provisioned.

### Tests
Added deterministic XCTest coverage: `CurrencyConverterTests`, `TransactionTimestampTests`, `TripBudgetCalculatorTests`, `SyncQueueManagerTests`, `MerchantRecognizerTests`, `WalletDuplicateDetectorTests`, `WalletCaptureViewModelTests`. Existing `SettingsViewModelTests` invariants preserved (connected `syncNow` uploads all pending → `pendingChangesCount == 0`).

## Needs Human Action
- **Apple Pay transaction-history entitlement / PassKit provisioning.** Apple does not expose Wallet / Apple Pay purchase history to third-party apps through any public API; full history requires the private, Apple-approved "Apple Pay transaction history" entitlement granted to issuing banks, plus signing/provisioning that cannot be performed from this environment. The code path is complete behind `WalletActivityProviding`; a human must (1) request/enable the entitlement in the Apple Developer portal, (2) add it to the app's provisioning profile & entitlements file, and (3) implement a real `WalletActivityProviding` conformance backed by the issuer/PassKit data, replacing `SimulatedWalletActivityProvider`.
- **Local iOS build/test.** This change was authored on Windows where the Swift/iOS toolchain is unavailable, so the iOS module could not be compiled/tested locally. JS/TS formatting + lint (`npm run format:check`, `npx eslint . --max-warnings 0`) pass; Swift is prettier-ignored. Please rely on the macOS CI job for the Swift build/test signal.
