### PR TITLE
feat(ios): single-parent budgeting workflows + smart notification timing

### DIFF
--- a/apps/ios/Finance/Components/AdaptiveLayout.swift
+++ b/apps/ios/Finance/Components/AdaptiveLayout.swift
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// AdaptiveLayout.swift
+// Finance
+//
+// Bridges the SwiftUI environment (horizontal size class + Dynamic Type) to the
+// pure `SizeClassInput` used by `CompactLayoutMetrics`, so compact-width devices
+// (iPhone SE) and accessibility text sizes get readable, non-crowded layouts.
+//
+// References: #2190
+
+import FinanceShared
+import SwiftUI
+
+extension SizeClassInput {
+    /// Maps the current SwiftUI environment into the pure layout input.
+    init(horizontalSizeClass: UserInterfaceSizeClass?, dynamicTypeSize: DynamicTypeSize) {
+        self.init(
+            isCompactWidth: horizontalSizeClass == .compact,
+            isAccessibilityTextSize: dynamicTypeSize.isAccessibilitySize
+        )
+    }
+}
+
+extension CompactLayoutMetrics {
+    /// Builds flexible `GridItem`s for the given column count.
+    static func gridItems(count: Int, spacing: CGFloat) -> [GridItem] {
+        Array(repeating: GridItem(.flexible(), spacing: spacing), count: max(count, 1))
+    }
+}

--- a/apps/ios/Finance/Repositories/Mocks/MockCategoryRepository.swift
+++ b/apps/ios/Finance/Repositories/Mocks/MockCategoryRepository.swift
@@ -22,6 +22,14 @@ struct MockCategoryRepository: CategoryRepository {
             CategoryItem(id: "c6", name: "Utilities", colorHex: "#D69E2E", icon: "bolt", sortOrder: 5),
             CategoryItem(id: "c7", name: "Health", colorHex: "#E53E3E", icon: "heart", sortOrder: 6),
             CategoryItem(id: "c8", name: "Housing", colorHex: "#5A67D8", icon: "house", sortOrder: 7),
+            // Kid-specific starter categories for single-parent / family setups (#2201).
+            // Kids create frequent, irregular spending that broad defaults miss.
+            CategoryItem(id: "kid-school", name: "School", colorHex: "#3182CE", icon: "graduationcap", sortOrder: 8),
+            CategoryItem(id: "kid-childcare", name: "Childcare", colorHex: "#805AD5", icon: "figure.and.child.holdinghands", sortOrder: 9),
+            CategoryItem(id: "kid-activities", name: "Activities & Sports", colorHex: "#38A169", icon: "figure.run", sortOrder: 10),
+            CategoryItem(id: "kid-birthdays", name: "Birthdays & Parties", colorHex: "#D53F8C", icon: "gift", sortOrder: 11),
+            CategoryItem(id: "kid-fieldtrips", name: "Field Trips", colorHex: "#DD6B20", icon: "bus", sortOrder: 12),
+            CategoryItem(id: "kid-clothing", name: "Kids' Clothing", colorHex: "#00B5D8", icon: "tshirt", sortOrder: 13),
         ]
     }
 

--- a/apps/ios/Finance/Screens/BillCalendarView.swift
+++ b/apps/ios/Finance/Screens/BillCalendarView.swift
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// BillCalendarView.swift
+// Finance
+//
+// Payday-aligned bill calendar (#2196). For a single parent, timing is the whole
+// game: this lines every bill and one-off kid expense up against real paycheck
+// dates, leads with "what hits before your next paycheck", and flags pay periods
+// where bills outrun the money coming in — all framed supportively.
+
+import FinanceShared
+import SwiftUI
+
+struct BillCalendarView: View {
+    @State private var paydayStore: PaydaySettingsStore
+    @State private var showingSetup = false
+
+    private let bills: [BillItem]
+    private let extraEvents: [BillCalendarEvent]
+    private let referenceDate: Date
+
+    init(
+        bills: [BillItem],
+        extraEvents: [BillCalendarEvent] = [],
+        paydayStore: PaydaySettingsStore = PaydaySettingsStore(),
+        referenceDate: Date = Date()
+    ) {
+        self.bills = bills
+        self.extraEvents = extraEvents
+        _paydayStore = State(initialValue: paydayStore)
+        self.referenceDate = referenceDate
+    }
+
+    private var currencyCode: String { bills.first?.currencyCode ?? "USD" }
+
+    private var events: [BillCalendarEvent] {
+        let billEvents = bills.map { bill in
+            BillCalendarEvent(
+                id: bill.id,
+                name: bill.name,
+                amountMinorUnits: bill.amountMinorUnits,
+                dueDate: bill.nextDueDate,
+                isOneOff: false
+            )
+        }
+        return billEvents + extraEvents
+    }
+
+    private var paydays: [Date] { paydayStore.upcomingPaydays(count: 6, from: referenceDate) }
+
+    private var days: [BillCalendarDay] {
+        BillCalendarCalculator.days(events: events, paydays: paydays, referenceDate: referenceDate)
+    }
+
+    private var dueBeforePayday: [BillCalendarEvent] {
+        BillCalendarCalculator.dueBeforeNextPayday(events: events, paydays: paydays, referenceDate: referenceDate)
+    }
+
+    private var totalDueBeforePayday: Int64 {
+        BillCalendarCalculator.totalDueBeforeNextPayday(events: events, paydays: paydays, referenceDate: referenceDate)
+    }
+
+    private var payPeriods: [PayPeriodSummary] {
+        BillCalendarCalculator.payPeriods(events: events, deposits: paydayStore.deposits(count: 6, from: referenceDate))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: FinanceSpacing.lg) {
+                beforePaydayCard
+                if payPeriods.contains(where: \.isHighRisk) {
+                    riskSection
+                }
+                timelineSection
+            }
+            .padding()
+            .padding(.bottom, FinanceSpacing.lg)
+        }
+        .navigationTitle(String(localized: "Bill Calendar"))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button { showingSetup = true } label: {
+                    Image(systemName: "calendar.badge.plus")
+                }
+                .accessibilityLabel(String(localized: "Set payday"))
+                .accessibilityHint(String(localized: "Set your payday date and cadence"))
+            }
+        }
+        .sheet(isPresented: $showingSetup) {
+            PaydaySetupSheet(paydayStore: paydayStore)
+        }
+    }
+
+    // MARK: - Before payday
+
+    private var beforePaydayCard: some View {
+        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
+            Text(String(localized: "Before your next paycheck"))
+                .font(.headline)
+
+            if let next = BillCalendarCalculator.nextPayday(after: referenceDate, paydays: paydays) {
+                Text(String(localized: "Next payday \(next.formatted(.dateTime.month().day()))"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack {
+                Text(String(localized: "Due before then"))
+                    .font(.subheadline)
+                Spacer()
+                CurrencyLabel(
+                    amountInMinorUnits: totalDueBeforePayday,
+                    currencyCode: currencyCode,
+                    showSign: false,
+                    font: .title3.bold()
+                )
+            }
+
+            if dueBeforePayday.isEmpty {
+                Text(String(localized: "Nothing lands before your next paycheck. Nice breathing room."))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(dueBeforePayday) { event in
+                    HStack {
+                        Text(event.name)
+                            .font(.subheadline)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(event.dueDate.formatted(.dateTime.month().day()))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        CurrencyLabel(
+                            amountInMinorUnits: event.amountMinorUnits,
+                            currencyCode: currencyCode,
+                            showSign: false,
+                            font: .subheadline
+                        )
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(String(localized: "Bills before your next paycheck"))
+        .accessibilityValue(String(localized: "\(CurrencyLabel.formatted(minorUnits: totalDueBeforePayday, currencyCode: currencyCode)) across \(dueBeforePayday.count) bills"))
+    }
+
+    // MARK: - Risk
+
+    private var riskSection: some View {
+        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
+            Label(String(localized: "Tight pay periods"), systemImage: "exclamationmark.triangle")
+                .font(.headline)
+                .foregroundStyle(FinanceColors.statusWarning)
+                .accessibilityAddTraits(.isHeader)
+
+            Text(String(localized: "In these windows, bills are more than the paycheck that opens them. Worth planning ahead — maybe shift a due date or set a little aside."))
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            ForEach(payPeriods.filter(\.isHighRisk)) { period in
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: FinanceSpacing.xxs) {
+                        Text(periodRangeText(period))
+                            .font(.subheadline.weight(.medium))
+                        Text(String(localized: "Bills \(CurrencyLabel.formatted(minorUnits: period.billsDueMinorUnits, currencyCode: currencyCode)) · Pay \(CurrencyLabel.formatted(minorUnits: period.expectedIncomeMinorUnits, currencyCode: currencyCode))"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Image(systemName: "arrow.down.right.circle")
+                        .foregroundStyle(FinanceColors.statusWarning)
+                        .accessibilityHidden(true)
+                }
+                .padding(.vertical, FinanceSpacing.xxs)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(periodRangeText(period))
+                .accessibilityValue(String(localized: "Bills \(CurrencyLabel.formatted(minorUnits: period.billsDueMinorUnits, currencyCode: currencyCode)), paycheck \(CurrencyLabel.formatted(minorUnits: period.expectedIncomeMinorUnits, currencyCode: currencyCode))"))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(FinanceColors.statusWarning.opacity(0.1), in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl))
+    }
+
+    private func periodRangeText(_ period: PayPeriodSummary) -> String {
+        let start = period.start.formatted(.dateTime.month().day())
+        let end = period.end.formatted(.dateTime.month().day())
+        return "\(start) – \(end)"
+    }
+
+    // MARK: - Timeline
+
+    @ViewBuilder
+    private var timelineSection: some View {
+        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
+            Text(String(localized: "Timeline"))
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            if days.isEmpty {
+                EmptyStateView(
+                    systemImage: "calendar",
+                    title: String(localized: "No upcoming bills"),
+                    message: String(localized: "Bills and one-off costs will line up here against your paydays.")
+                )
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(days) { day in
+                        dayRow(day)
+                        if day.id != days.last?.id {
+                            Divider().padding(.leading, FinanceSpacing.minTapTarget)
+                        }
+                    }
+                }
+                .padding()
+                .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
+            }
+        }
+    }
+
+    private func dayRow(_ day: BillCalendarDay) -> some View {
+        HStack(alignment: .top, spacing: FinanceSpacing.sm) {
+            VStack(spacing: 2) {
+                Text(day.date.formatted(.dateTime.day()))
+                    .font(.headline)
+                    .monospacedDigit()
+                Text(day.date.formatted(.dateTime.month(.abbreviated)))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: FinanceSpacing.minTapTarget)
+
+            VStack(alignment: .leading, spacing: FinanceSpacing.xxs) {
+                if day.isPayday {
+                    Label(String(localized: "Payday"), systemImage: "dollarsign.circle.fill")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(FinanceColors.statusPositive)
+                }
+                ForEach(day.events) { event in
+                    HStack {
+                        if event.isOneOff {
+                            Image(systemName: "star.fill")
+                                .font(.caption2)
+                                .foregroundStyle(FinanceColors.statusInfo)
+                                .accessibilityHidden(true)
+                        }
+                        Text(event.name)
+                            .font(.subheadline)
+                            .lineLimit(1)
+                        Spacer()
+                        CurrencyLabel(
+                            amountInMinorUnits: event.amountMinorUnits,
+                            currencyCode: currencyCode,
+                            showSign: false,
+                            font: .subheadline
+                        )
+                    }
+                }
+            }
+        }
+        .padding(.vertical, FinanceSpacing.xs)
+        .background(
+            day.isBeforeNextPayday
+                ? FinanceColors.statusInfo.opacity(0.06)
+                : Color.clear
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(dayAccessibilityLabel(day))
+    }
+
+    private func dayAccessibilityLabel(_ day: BillCalendarDay) -> String {
+        let date = day.date.formatted(.dateTime.month().day())
+        let total = CurrencyLabel.formatted(minorUnits: day.totalMinorUnits, currencyCode: currencyCode)
+        let names = day.events.map(\.name).joined(separator: ", ")
+        let payday = day.isPayday ? String(localized: "Payday. ") : ""
+        return String(localized: "\(payday)\(date). \(names). Total \(total).")
+    }
+}
+
+// MARK: - Payday Setup Sheet
+
+/// Sets the payday anchor, cadence, and typical paycheck for the calendar.
+struct PaydaySetupSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var paydayStore: PaydaySettingsStore
+
+    @State private var paycheckText: String = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    DatePicker(
+                        String(localized: "Next payday"),
+                        selection: $paydayStore.anchorDate,
+                        displayedComponents: .date
+                    )
+                    Picker(String(localized: "Pay frequency"), selection: $paydayStore.frequency) {
+                        ForEach(PayFrequency.allCases, id: \.self) { freq in
+                            Text(freq.displayName).tag(freq)
+                        }
+                    }
+                } header: {
+                    Text(String(localized: "When you get paid"))
+                }
+
+                Section {
+                    HStack {
+                        Text(String(localized: "Typical paycheck"))
+                        Spacer()
+                        TextField(String(localized: "0.00"), text: $paycheckText)
+                            .keyboardType(.decimalPad)
+                            .multilineTextAlignment(.trailing)
+                            .frame(maxWidth: 140)
+                            .accessibilityLabel(String(localized: "Typical paycheck amount"))
+                    }
+                } footer: {
+                    Text(String(localized: "Used to flag pay periods where bills outrun your paycheck."))
+                }
+            }
+            .navigationTitle(String(localized: "Payday"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "Save")) {
+                        paydayStore.typicalPaycheckMinorUnits = GroceryModeView.minorUnits(
+                            from: paycheckText,
+                            currencyCode: "USD"
+                        )
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Cancel")) { dismiss() }
+                }
+            }
+            .onAppear {
+                if paydayStore.typicalPaycheckMinorUnits > 0 {
+                    let value = NSDecimalNumber(value: paydayStore.typicalPaycheckMinorUnits)
+                        .dividing(by: NSDecimalNumber(value: 100))
+                    paycheckText = value.stringValue
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        BillCalendarView(bills: [])
+    }
+}

--- a/apps/ios/Finance/Screens/BillsListView.swift
+++ b/apps/ios/Finance/Screens/BillsListView.swift
@@ -10,6 +10,7 @@
 // References: #1121
 
 import SwiftUI
+import FinanceShared
 
 // MARK: - View
 
@@ -17,6 +18,8 @@ import SwiftUI
 /// for marking as paid and deleting.
 struct BillsListView: View {
     @State private var viewModel: BillsViewModel
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     init(viewModel: BillsViewModel = BillsViewModel(
         repository: RepositoryProvider.shared.bills
@@ -45,6 +48,16 @@ struct BillsListView: View {
             }
             .navigationTitle(String(localized: "Bills"))
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    NavigationLink {
+                        BillCalendarView(bills: viewModel.bills)
+                    } label: {
+                        Image(systemName: "calendar")
+                    }
+                    .accessibilityIdentifier("bill_calendar_button")
+                    .accessibilityLabel(String(localized: "Bill calendar"))
+                    .accessibilityHint(String(localized: "Lines your bills up with your paydays"))
+                }
                 ToolbarItem(placement: .primaryAction) {
                     Button { viewModel.showingCreateBill = true } label: {
                         Image(systemName: "plus")
@@ -109,41 +122,26 @@ struct BillsListView: View {
     // MARK: - Summary Card
 
     private var summaryCard: some View {
-        HStack(spacing: 24) {
-            VStack(spacing: 4) {
-                Text(String(localized: "Due"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                CurrencyLabel(
-                    amountInMinorUnits: viewModel.totalDueMinorUnits,
-                    currencyCode: "USD",
-                    showSign: false,
-                    font: .title3.bold()
-                )
-            }
-
-            Divider().frame(height: 40)
-
-            VStack(spacing: 4) {
-                Text(String(localized: "Monthly Total"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                CurrencyLabel(
-                    amountInMinorUnits: viewModel.totalMonthlyMinorUnits,
-                    currencyCode: "USD",
-                    showSign: false,
-                    font: .title3.bold()
-                )
-            }
-
-            Divider().frame(height: 40)
-
-            VStack(spacing: 4) {
-                Text(String(localized: "Bills"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text("\(viewModel.bills.count)")
-                    .font(.title3.bold())
+        let columns = CompactLayoutMetrics.billsSummaryColumns(
+            for: SizeClassInput(horizontalSizeClass: horizontalSizeClass, dynamicTypeSize: dynamicTypeSize)
+        )
+        return Group {
+            if columns == 1 {
+                VStack(spacing: FinanceSpacing.sm) {
+                    dueStat
+                    Divider()
+                    monthlyStat
+                    Divider()
+                    countStat
+                }
+            } else {
+                HStack(spacing: 24) {
+                    dueStat
+                    Divider().frame(height: 40)
+                    monthlyStat
+                    Divider().frame(height: 40)
+                    countStat
+                }
             }
         }
         .frame(maxWidth: .infinity)
@@ -152,6 +150,44 @@ struct BillsListView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(String(localized: "Bills summary"))
         .accessibilityValue(String(localized: "\(viewModel.bills.count) bills, \(viewModel.overdueBills.count) overdue"))
+    }
+
+    private var dueStat: some View {
+        VStack(spacing: 4) {
+            Text(String(localized: "Due"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            CurrencyLabel(
+                amountInMinorUnits: viewModel.totalDueMinorUnits,
+                currencyCode: "USD",
+                showSign: false,
+                font: .title3.bold()
+            )
+        }
+    }
+
+    private var monthlyStat: some View {
+        VStack(spacing: 4) {
+            Text(String(localized: "Monthly Total"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            CurrencyLabel(
+                amountInMinorUnits: viewModel.totalMonthlyMinorUnits,
+                currencyCode: "USD",
+                showSign: false,
+                font: .title3.bold()
+            )
+        }
+    }
+
+    private var countStat: some View {
+        VStack(spacing: 4) {
+            Text(String(localized: "Bills"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text("\(viewModel.bills.count)")
+                .font(.title3.bold())
+        }
     }
 
     // MARK: - Bill Section

--- a/apps/ios/Finance/Screens/DashboardView.swift
+++ b/apps/ios/Finance/Screens/DashboardView.swift
@@ -7,6 +7,7 @@
 // and recent transactions. Supports pull-to-refresh for data sync.
 
 import SwiftUI
+import FinanceShared
 
 // MARK: - View
 
@@ -15,6 +16,8 @@ struct DashboardView: View {
     @State private var showingAskFinance = false
     @State private var showingSettings = false
     @Environment(DeepLinkHandler.self) private var deepLinkHandler: DeepLinkHandler?
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     // Low-noise mode: quick-access cards the user can hide. (#2122)
     @AppStorage(FeatureVisibility.investmentsKey) private var showInvestments = true
@@ -240,18 +243,36 @@ struct DashboardView: View {
         }
     }
 
+    // MARK: - Adaptive Layout (#2190)
+
+    /// Current environment mapped to the pure layout metrics input.
+    private var layoutInput: SizeClassInput {
+        SizeClassInput(horizontalSizeClass: horizontalSizeClass, dynamicTypeSize: dynamicTypeSize)
+    }
+
     // MARK: - Spending Summary
 
     private var spendingSummaryCard: some View {
-        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
+        let columns = CompactLayoutMetrics.summaryColumns(for: layoutInput)
+        return VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
             Text(String(localized: "This Month"))
                 .font(.headline)
-            HStack(spacing: FinanceSpacing.md) {
-                summaryColumn(title: String(localized: "Income"), amount: viewModel.monthlyIncome)
-                Divider().frame(height: FinanceSpacing.minTapTarget)
-                summaryColumn(title: String(localized: "Expenses"), amount: viewModel.monthlyExpenses)
-                Divider().frame(height: FinanceSpacing.minTapTarget)
-                summaryColumn(title: String(localized: "Net"), amount: viewModel.monthlyIncome - viewModel.monthlyExpenses)
+            if columns == 1 {
+                VStack(spacing: FinanceSpacing.sm) {
+                    summaryColumn(title: String(localized: "Income"), amount: viewModel.monthlyIncome)
+                    Divider()
+                    summaryColumn(title: String(localized: "Expenses"), amount: viewModel.monthlyExpenses)
+                    Divider()
+                    summaryColumn(title: String(localized: "Net"), amount: viewModel.monthlyIncome - viewModel.monthlyExpenses)
+                }
+            } else {
+                HStack(spacing: FinanceSpacing.md) {
+                    summaryColumn(title: String(localized: "Income"), amount: viewModel.monthlyIncome)
+                    Divider().frame(height: FinanceSpacing.minTapTarget)
+                    summaryColumn(title: String(localized: "Expenses"), amount: viewModel.monthlyExpenses)
+                    Divider().frame(height: FinanceSpacing.minTapTarget)
+                    summaryColumn(title: String(localized: "Net"), amount: viewModel.monthlyIncome - viewModel.monthlyExpenses)
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -318,11 +339,9 @@ struct DashboardView: View {
 
     // MARK: - Quick Access
 
-    /// Whether any quick-access card is visible. When the user hides them all
-    /// in low-noise mode, the whole section (and its heading) disappears. (#2122)
-    private var hasVisibleQuickAccess: Bool {
-        showInvestments || showBills || showReports
-    }
+    /// The single-parent workflow tiles are always available, so the section
+    /// heading shows whenever they or any low-noise quick-access card is on.
+    private var hasVisibleQuickAccess: Bool { true }
 
     @ViewBuilder
     private var quickAccessSection: some View {
@@ -332,11 +351,37 @@ struct DashboardView: View {
                     .font(.headline)
                     .accessibilityAddTraits(.isHeader)
 
-                LazyVGrid(columns: [
-                    GridItem(.flexible()),
-                    GridItem(.flexible()),
-                    GridItem(.flexible()),
-                ], spacing: FinanceSpacing.sm) {
+                LazyVGrid(
+                    columns: CompactLayoutMetrics.gridItems(
+                        count: CompactLayoutMetrics.quickAccessColumns(for: layoutInput),
+                        spacing: FinanceSpacing.sm
+                    ),
+                    spacing: FinanceSpacing.sm
+                ) {
+                    NavigationLink {
+                        GroceryModeView()
+                    } label: {
+                        quickAccessCard(
+                            title: String(localized: "Safe to Spend"),
+                            iconToken: .categoryGroceries,
+                            color: .green
+                        )
+                    }
+                    .accessibilityLabel(String(localized: "Safe to spend"))
+                    .accessibilityHint(String(localized: "Check if you can afford a purchase before payday"))
+
+                    NavigationLink {
+                        ExpectedIncomeView()
+                    } label: {
+                        quickAccessCard(
+                            title: String(localized: "Expected Income"),
+                            iconToken: .income,
+                            color: .teal
+                        )
+                    }
+                    .accessibilityLabel(String(localized: "Expected income"))
+                    .accessibilityHint(String(localized: "Track money you're expecting but haven't received"))
+
                     if showInvestments {
                         NavigationLink {
                             InvestmentPortfolioView()

--- a/apps/ios/Finance/Screens/ExpectedIncomeView.swift
+++ b/apps/ios/Finance/Screens/ExpectedIncomeView.swift
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// ExpectedIncomeView.swift
+// Finance
+//
+// Expected-income tracking (#2193) for single parents relying on late or
+// unreliable child support (plus freelance, reimbursements, tips). Keeps
+// uncertain money out of "cleared" cash and shows an honest cleared / expected /
+// at-risk split so planning reflects reality, not wishful thinking.
+
+import FinanceShared
+import SwiftUI
+
+struct ExpectedIncomeView: View {
+    @State private var store: ExpectedIncomeStore
+    @State private var showingEditor = false
+    @State private var editingIncome: ExpectedIncome?
+
+    private let referenceDate: Date
+
+    init(store: ExpectedIncomeStore = ExpectedIncomeStore(), referenceDate: Date = Date()) {
+        _store = State(initialValue: store)
+        self.referenceDate = referenceDate
+    }
+
+    private var breakdown: CashBreakdown { store.breakdown(asOf: referenceDate) }
+    private var overdue: [ExpectedIncome] { store.overdue(asOf: referenceDate) }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: FinanceSpacing.lg) {
+                breakdownCard
+                if !overdue.isEmpty {
+                    overdueSection
+                }
+                incomeListSection
+            }
+            .padding()
+            .padding(.bottom, FinanceSpacing.lg)
+        }
+        .navigationTitle(String(localized: "Expected Income"))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    editingIncome = nil
+                    showingEditor = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .accessibilityLabel(String(localized: "Add expected income"))
+                .accessibilityHint(String(localized: "Track money you're expecting but haven't received"))
+            }
+        }
+        .sheet(isPresented: $showingEditor) {
+            ExpectedIncomeEditorSheet(
+                store: store,
+                existing: editingIncome,
+                referenceDate: referenceDate
+            )
+        }
+    }
+
+    // MARK: - Breakdown
+
+    private var breakdownCard: some View {
+        VStack(alignment: .leading, spacing: FinanceSpacing.md) {
+            Text(String(localized: "Your cash, honestly"))
+                .font(.headline)
+
+            bucketRow(
+                title: String(localized: "Cleared"),
+                subtitle: String(localized: "In your accounts now"),
+                amount: breakdown.clearedMinorUnits,
+                color: FinanceColors.statusPositive,
+                symbol: "checkmark.circle.fill"
+            )
+            bucketRow(
+                title: String(localized: "Expected"),
+                subtitle: String(localized: "Dependable, on the way"),
+                amount: breakdown.expectedMinorUnits,
+                color: FinanceColors.statusInfo,
+                symbol: "clock.fill"
+            )
+            bucketRow(
+                title: String(localized: "At risk"),
+                subtitle: String(localized: "Late or unreliable — don't count on it yet"),
+                amount: breakdown.atRiskMinorUnits,
+                color: FinanceColors.statusWarning,
+                symbol: "exclamationmark.circle.fill"
+            )
+
+            Divider()
+
+            HStack {
+                Text(String(localized: "Safe to plan on"))
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                CurrencyLabel(
+                    amountInMinorUnits: breakdown.plannableMinorUnits,
+                    currencyCode: store.currencyCode,
+                    showSign: false,
+                    font: .headline
+                )
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(String(localized: "Safe to plan on"))
+            .accessibilityValue(CurrencyLabel.formatted(minorUnits: breakdown.plannableMinorUnits, currencyCode: store.currencyCode))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
+    }
+
+    private func bucketRow(title: String, subtitle: String, amount: Int64, color: Color, symbol: String) -> some View {
+        HStack(spacing: FinanceSpacing.sm) {
+            Image(systemName: symbol)
+                .foregroundStyle(color)
+                .font(.title3)
+                .frame(width: 28)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title).font(.subheadline.weight(.medium))
+                Text(subtitle).font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+            CurrencyLabel(
+                amountInMinorUnits: amount,
+                currencyCode: store.currencyCode,
+                showSign: false,
+                font: .callout.bold()
+            )
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(title)
+        .accessibilityValue(String(localized: "\(CurrencyLabel.formatted(minorUnits: amount, currencyCode: store.currencyCode)). \(subtitle)"))
+    }
+
+    // MARK: - Overdue
+
+    private var overdueSection: some View {
+        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
+            Label(String(localized: "Running late"), systemImage: "bell.badge")
+                .font(.headline)
+                .foregroundStyle(FinanceColors.statusWarning)
+                .accessibilityAddTraits(.isHeader)
+
+            ForEach(overdue) { income in
+                Text(SupportiveCoaching.billDueSoon(name: income.source, whenText: relativeText(income.expectedDate)))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(FinanceColors.statusWarning.opacity(0.1), in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl))
+    }
+
+    // MARK: - List
+
+    @ViewBuilder
+    private var incomeListSection: some View {
+        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
+            Text(String(localized: "Tracked income"))
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            if store.items.isEmpty {
+                EmptyStateView(
+                    systemImage: "tray",
+                    title: String(localized: "Nothing tracked yet"),
+                    message: String(localized: "Add child support, a freelance invoice, or a reimbursement to see it here — without pretending it's already arrived."),
+                    actionLabel: String(localized: "Add expected income"),
+                    action: {
+                        editingIncome = nil
+                        showingEditor = true
+                    }
+                )
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(store.items) { income in
+                        incomeRow(income)
+                        if income.id != store.items.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+                .padding()
+                .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
+            }
+        }
+    }
+
+    private func incomeRow(_ income: ExpectedIncome) -> some View {
+        Button {
+            editingIncome = income
+            showingEditor = true
+        } label: {
+            HStack(spacing: FinanceSpacing.sm) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(income.source)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    HStack(spacing: FinanceSpacing.xs) {
+                        statusBadge(income)
+                        Text(income.expectedDate.formatted(.dateTime.month().day()))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    CurrencyLabel(
+                        amountInMinorUnits: income.amountMinorUnits,
+                        currencyCode: store.currencyCode,
+                        showSign: false,
+                        font: .callout.bold()
+                    )
+                    Text(reliabilityText(income.reliability))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.vertical, FinanceSpacing.xs)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(income.source)
+        .accessibilityValue(String(localized: "\(CurrencyLabel.formatted(minorUnits: income.amountMinorUnits, currencyCode: store.currencyCode)), \(statusText(income.status)), \(reliabilityText(income.reliability))"))
+        .accessibilityHint(String(localized: "Opens details to update status"))
+    }
+
+    private func statusBadge(_ income: ExpectedIncome) -> some View {
+        Text(statusText(income.status))
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(statusColor(income.status).opacity(0.15), in: Capsule())
+            .foregroundStyle(statusColor(income.status))
+    }
+
+    private func statusColor(_ status: ExpectedIncomeStatus) -> Color {
+        switch status {
+        case .received: return FinanceColors.statusPositive
+        case .expected: return FinanceColors.statusInfo
+        case .partial: return FinanceColors.statusInfo
+        case .late: return FinanceColors.statusWarning
+        case .missed: return FinanceColors.statusNegative
+        }
+    }
+
+    private func statusText(_ status: ExpectedIncomeStatus) -> String {
+        switch status {
+        case .expected: return String(localized: "Expected")
+        case .received: return String(localized: "Received")
+        case .late: return String(localized: "Late")
+        case .partial: return String(localized: "Partial")
+        case .missed: return String(localized: "Missed")
+        }
+    }
+
+    private func reliabilityText(_ reliability: IncomeReliability) -> String {
+        switch reliability {
+        case .reliable: return String(localized: "Reliable")
+        case .usuallyOnTime: return String(localized: "Usually on time")
+        case .unreliable: return String(localized: "Unreliable")
+        }
+    }
+
+    private func relativeText(_ date: Date) -> String {
+        date.formatted(.relative(presentation: .named))
+    }
+}
+
+// MARK: - Editor Sheet
+
+/// Add or edit a single expected deposit, including quick status updates.
+struct ExpectedIncomeEditorSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let store: ExpectedIncomeStore
+
+    let existing: ExpectedIncome?
+    let referenceDate: Date
+
+    @State private var source: String = ""
+    @State private var amountText: String = ""
+    @State private var receivedText: String = ""
+    @State private var expectedDate: Date = Date()
+    @State private var reliability: IncomeReliability = .usuallyOnTime
+    @State private var status: ExpectedIncomeStatus = .expected
+
+    init(store: ExpectedIncomeStore, existing: ExpectedIncome?, referenceDate: Date) {
+        self.store = store
+        self.existing = existing
+        self.referenceDate = referenceDate
+        _expectedDate = State(initialValue: existing?.expectedDate ?? referenceDate)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField(String(localized: "Source (e.g. Child support)"), text: $source)
+                        .accessibilityLabel(String(localized: "Income source"))
+                    amountField(label: String(localized: "Amount expected"), text: $amountText)
+                    DatePicker(
+                        String(localized: "Expected date"),
+                        selection: $expectedDate,
+                        displayedComponents: .date
+                    )
+                }
+
+                Section {
+                    Picker(String(localized: "How reliable?"), selection: $reliability) {
+                        ForEach(IncomeReliability.allCases, id: \.self) { level in
+                            Text(reliabilityText(level)).tag(level)
+                        }
+                    }
+                } footer: {
+                    Text(String(localized: "Unreliable income is kept out of what's safe to plan on until it clears."))
+                }
+
+                Section {
+                    Picker(String(localized: "Status"), selection: $status) {
+                        ForEach(ExpectedIncomeStatus.allCases, id: \.self) { value in
+                            Text(statusText(value)).tag(value)
+                        }
+                    }
+                    if status == .partial {
+                        amountField(label: String(localized: "Received so far"), text: $receivedText)
+                    }
+                }
+
+                if existing != nil {
+                    Section {
+                        Button(role: .destructive) {
+                            if let id = existing?.id { store.remove(id: id) }
+                            dismiss()
+                        } label: {
+                            Text(String(localized: "Remove"))
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                }
+            }
+            .navigationTitle(existing == nil
+                ? String(localized: "Add income")
+                : String(localized: "Edit income"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "Save")) {
+                        save()
+                        dismiss()
+                    }
+                    .disabled(source.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Cancel")) { dismiss() }
+                }
+            }
+            .onAppear(perform: load)
+        }
+    }
+
+    private func amountField(label: String, text: Binding<String>) -> some View {
+        HStack {
+            Text(label)
+            Spacer()
+            TextField(String(localized: "0.00"), text: text)
+                .keyboardType(.decimalPad)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: 140)
+                .accessibilityLabel(label)
+        }
+    }
+
+    private func load() {
+        guard let existing else { return }
+        source = existing.source
+        amountText = Self.majorString(existing.amountMinorUnits)
+        receivedText = Self.majorString(existing.receivedMinorUnits)
+        expectedDate = existing.expectedDate
+        reliability = existing.reliability
+        status = existing.status
+    }
+
+    private func save() {
+        let amount = GroceryModeView.minorUnits(from: amountText, currencyCode: store.currencyCode)
+        let received = status == .partial
+            ? GroceryModeView.minorUnits(from: receivedText, currencyCode: store.currencyCode)
+            : (status == .received ? amount : 0)
+        let income = ExpectedIncome(
+            id: existing?.id ?? UUID().uuidString,
+            source: source.trimmingCharacters(in: .whitespaces),
+            amountMinorUnits: amount,
+            receivedMinorUnits: received,
+            expectedDate: expectedDate,
+            reliability: reliability,
+            status: status
+        )
+        if existing == nil {
+            store.add(income)
+        } else {
+            store.update(income)
+        }
+    }
+
+    private func reliabilityText(_ reliability: IncomeReliability) -> String {
+        switch reliability {
+        case .reliable: return String(localized: "Reliable")
+        case .usuallyOnTime: return String(localized: "Usually on time")
+        case .unreliable: return String(localized: "Unreliable")
+        }
+    }
+
+    private func statusText(_ status: ExpectedIncomeStatus) -> String {
+        switch status {
+        case .expected: return String(localized: "Expected")
+        case .received: return String(localized: "Received")
+        case .late: return String(localized: "Late")
+        case .partial: return String(localized: "Partial")
+        case .missed: return String(localized: "Missed")
+        }
+    }
+
+    private static func majorString(_ minorUnits: Int64) -> String {
+        guard minorUnits > 0 else { return "" }
+        let value = NSDecimalNumber(value: minorUnits).dividing(by: NSDecimalNumber(value: 100))
+        return value.stringValue
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ExpectedIncomeView()
+    }
+}

--- a/apps/ios/Finance/Screens/FamilySetupView.swift
+++ b/apps/ios/Finance/Screens/FamilySetupView.swift
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FamilySetupView.swift
+// Finance
+//
+// Family / single-parent setup (#2201). Offers kid-aware starter templates so
+// the frequent, irregular costs of raising children — school, childcare,
+// activities, birthdays, field trips — are there from day one, wrapped in warm,
+// non-judgmental coaching copy.
+
+import FinanceShared
+import SwiftUI
+
+struct FamilySetupView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    /// Invoked with the chosen template so the caller can seed categories.
+    let onAdopt: (FamilyBudgetTemplate) -> Void
+
+    /// UserDefaults key recording the adopted template id.
+    static let adoptedTemplateKey = "familySetup.adoptedTemplateId"
+
+    @State private var selectedID: String
+
+    private let templates: [FamilyBudgetTemplate]
+
+    init(
+        templates: [FamilyBudgetTemplate] = FamilyBudgetTemplates.all,
+        onAdopt: @escaping (FamilyBudgetTemplate) -> Void = { _ in }
+    ) {
+        self.templates = templates
+        self.onAdopt = onAdopt
+        _selectedID = State(initialValue: templates.first?.id ?? "")
+    }
+
+    private var selectedTemplate: FamilyBudgetTemplate? {
+        templates.first { $0.id == selectedID }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: FinanceSpacing.lg) {
+                    welcomeCard
+                    ForEach(templates) { template in
+                        templateCard(template)
+                    }
+                }
+                .padding()
+                .padding(.bottom, FinanceSpacing.xxxl)
+            }
+            .safeAreaInset(edge: .bottom) { adoptBar }
+            .navigationTitle(String(localized: "Family Setup"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Not now")) { dismiss() }
+                        .accessibilityHint(String(localized: "Skips family setup"))
+                }
+            }
+        }
+    }
+
+    // MARK: - Welcome
+
+    private var welcomeCard: some View {
+        HStack(alignment: .top, spacing: FinanceSpacing.sm) {
+            Image(systemName: "heart.circle.fill")
+                .font(.title)
+                .foregroundStyle(.pink)
+                .accessibilityHidden(true)
+            Text(SupportiveCoaching.familySetupWelcome)
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(SupportiveCoaching.familySetupWelcome)
+    }
+
+    // MARK: - Template card
+
+    private func templateCard(_ template: FamilyBudgetTemplate) -> some View {
+        let isSelected = template.id == selectedID
+        return Button {
+            selectedID = template.id
+        } label: {
+            VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
+                HStack {
+                    Text(template.name)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                        .accessibilityHidden(true)
+                }
+
+                Text(template.summary)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+
+                if !template.kidCategories.isEmpty {
+                    Text(String(localized: "Kid categories"))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    FlowRow(spacing: FinanceSpacing.xs) {
+                        ForEach(template.kidCategories) { category in
+                            categoryChip(category)
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
+            .overlay(
+                RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl)
+                    .strokeBorder(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(template.name)
+        .accessibilityValue(template.summary)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .accessibilityHint(String(localized: "Selects this starter template"))
+    }
+
+    private func categoryChip(_ category: StarterCategory) -> some View {
+        let color = Color(hex: category.colorHex) ?? .accentColor
+        return HStack(spacing: FinanceSpacing.xxs) {
+            Image(systemName: category.icon)
+                .font(.caption2)
+                .accessibilityHidden(true)
+            Text(category.name)
+                .font(.caption)
+        }
+        .padding(.horizontal, FinanceSpacing.xs)
+        .padding(.vertical, FinanceSpacing.xxs)
+        .background(color.opacity(0.15), in: Capsule())
+        .foregroundStyle(color)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(category.name)
+    }
+
+    // MARK: - Adopt bar
+
+    @ViewBuilder
+    private var adoptBar: some View {
+        if let template = selectedTemplate {
+            Button {
+                adopt(template)
+            } label: {
+                Text(String(localized: "Use \(template.name)"))
+                    .font(.headline)
+                    .frame(maxWidth: .infinity, minHeight: FinanceSpacing.minTapTarget)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding()
+            .background(.thinMaterial)
+            .accessibilityLabel(String(localized: "Use \(template.name)"))
+            .accessibilityHint(String(localized: "Adds these categories and finishes setup"))
+        }
+    }
+
+    private func adopt(_ template: FamilyBudgetTemplate) {
+        UserDefaults.standard.set(template.id, forKey: Self.adoptedTemplateKey)
+        onAdopt(template)
+        dismiss()
+    }
+}
+
+// MARK: - Flow layout
+
+/// A simple wrapping row layout for the category chips, so they reflow at large
+/// Dynamic Type sizes and on compact-width screens instead of clipping.
+struct FlowRow: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var totalHeight: CGFloat = 0
+        var totalWidth: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if rowWidth + size.width > maxWidth, rowWidth > 0 {
+                totalHeight += rowHeight + spacing
+                totalWidth = max(totalWidth, rowWidth - spacing)
+                rowWidth = 0
+                rowHeight = 0
+            }
+            rowWidth += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+        totalHeight += rowHeight
+        totalWidth = max(totalWidth, rowWidth - spacing)
+        return CGSize(width: min(totalWidth, maxWidth), height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX, x > bounds.minX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
+
+#Preview {
+    FamilySetupView()
+}

--- a/apps/ios/Finance/Screens/GroceryModeView.swift
+++ b/apps/ios/Finance/Screens/GroceryModeView.swift
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// GroceryModeView.swift
+// Finance
+//
+// Grocery-store mode (#2199): a fast, supportive "can I afford this?" answer
+// before checkout. Type the cart total, get an instant comfortable / tight /
+// beyond verdict against the cash that's safe to spend before the next payday.
+// Framed calmly — never a red-alert — per the content-language guidelines.
+
+import FinanceShared
+import SwiftUI
+
+struct GroceryModeView: View {
+    @State private var store: GroceryModeStore
+    @State private var paydayStore: PaydaySettingsStore
+    @State private var purchaseText: String = ""
+    @State private var showingSetup = false
+    @FocusState private var amountFocused: Bool
+
+    private let referenceDate: Date
+
+    init(
+        store: GroceryModeStore = GroceryModeStore(),
+        paydayStore: PaydaySettingsStore = PaydaySettingsStore(),
+        referenceDate: Date = Date()
+    ) {
+        _store = State(initialValue: store)
+        _paydayStore = State(initialValue: paydayStore)
+        self.referenceDate = referenceDate
+    }
+
+    private var nextPayday: Date {
+        paydayStore.nextPayday(from: referenceDate)
+            ?? Calendar.current.date(byAdding: .day, value: 14, to: referenceDate) ?? referenceDate
+    }
+
+    private var result: SafeToSpendResult {
+        store.result(nextPayday: nextPayday, referenceDate: referenceDate)
+    }
+
+    private var purchaseMinorUnits: Int64 {
+        Self.minorUnits(from: purchaseText, currencyCode: store.currencyCode)
+    }
+
+    private var verdict: AffordabilityVerdict {
+        SafeToSpendCalculator.verdict(
+            purchaseMinorUnits: purchaseMinorUnits,
+            spendableMinorUnits: result.spendableForCheckMinorUnits
+        )
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: FinanceSpacing.lg) {
+                safeToSpendCard
+                purchaseEntryCard
+                if purchaseMinorUnits > 0 {
+                    verdictCard
+                }
+            }
+            .padding()
+            .padding(.bottom, FinanceSpacing.lg)
+        }
+        .navigationTitle(String(localized: "Can I afford this?"))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button { showingSetup = true } label: {
+                    Image(systemName: "slider.horizontal.3")
+                }
+                .accessibilityLabel(String(localized: "Adjust amounts"))
+                .accessibilityHint(String(localized: "Set your cash on hand and bills due before payday"))
+            }
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button(String(localized: "Done")) { amountFocused = false }
+            }
+        }
+        .sheet(isPresented: $showingSetup) {
+            GroceryModeSetupSheet(store: store, paydayStore: paydayStore)
+        }
+    }
+
+    // MARK: - Safe to spend
+
+    private var safeToSpendCard: some View {
+        VStack(spacing: FinanceSpacing.xs) {
+            Text(String(localized: "Safe to spend"))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            CurrencyLabel(
+                amountInMinorUnits: result.spendableForCheckMinorUnits,
+                currencyCode: store.currencyCode,
+                showSign: false,
+                font: .system(size: 44, weight: .bold, design: .rounded)
+            )
+            .monospacedDigit()
+            .minimumScaleFactor(0.5)
+            .lineLimit(1)
+
+            if let pinned = result.pinnedCategoryName {
+                Text(String(localized: "left in \(pinned) this period"))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else if result.daysUntilPayday > 0 {
+                Text(String(localized: "to last the \(result.daysUntilPayday) days until payday"))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            if result.reservedForBillsMinorUnits > 0 {
+                Text(String(localized: "\(CurrencyLabel.formatted(minorUnits: result.reservedForBillsMinorUnits, currencyCode: store.currencyCode)) is set aside for bills first"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, FinanceSpacing.xxs)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(localized: "Safe to spend"))
+        .accessibilityValue(safeToSpendAccessibilityValue)
+    }
+
+    private var safeToSpendAccessibilityValue: String {
+        let amount = CurrencyLabel.formatted(minorUnits: result.spendableForCheckMinorUnits, currencyCode: store.currencyCode)
+        if let pinned = result.pinnedCategoryName {
+            return String(localized: "\(amount) left in \(pinned) this period")
+        }
+        return String(localized: "\(amount), to last \(result.daysUntilPayday) days until payday")
+    }
+
+    // MARK: - Purchase entry
+
+    private var purchaseEntryCard: some View {
+        VStack(alignment: .leading, spacing: FinanceSpacing.sm) {
+            Text(String(localized: "What's in the cart?"))
+                .font(.headline)
+            HStack(spacing: FinanceSpacing.sm) {
+                Text(Self.currencySymbol(store.currencyCode))
+                    .font(.largeTitle.bold())
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+                TextField(String(localized: "0.00"), text: $purchaseText)
+                    .keyboardType(.decimalPad)
+                    .font(.system(size: 40, weight: .bold, design: .rounded))
+                    .focused($amountFocused)
+                    .accessibilityLabel(String(localized: "Purchase amount"))
+                    .accessibilityHint(String(localized: "Enter the total you're about to spend"))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .cardBackground(cornerRadius: FinanceSpacing.Radius.xl)
+    }
+
+    // MARK: - Verdict
+
+    private var verdictCard: some View {
+        let remaining = SafeToSpendCalculator.remainingAfter(
+            purchaseMinorUnits: purchaseMinorUnits,
+            spendableMinorUnits: result.spendableForCheckMinorUnits
+        )
+        return VStack(spacing: FinanceSpacing.sm) {
+            HStack(spacing: FinanceSpacing.sm) {
+                Image(systemName: verdictSymbol)
+                    .font(.title)
+                    .foregroundStyle(verdictColor)
+                    .accessibilityHidden(true)
+                Text(verdictTitle)
+                    .font(.title3.bold())
+                    .foregroundStyle(.primary)
+            }
+            Text(verdictBody)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            Divider()
+
+            HStack {
+                Text(remaining >= 0
+                    ? String(localized: "Left afterwards")
+                    : String(localized: "Over by"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                CurrencyLabel(
+                    amountInMinorUnits: abs(remaining),
+                    currencyCode: store.currencyCode,
+                    showSign: false,
+                    font: .headline
+                )
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(verdictColor.opacity(0.12), in: RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl))
+        .overlay(
+            RoundedRectangle(cornerRadius: FinanceSpacing.Radius.xl)
+                .strokeBorder(verdictColor.opacity(0.4), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(verdictTitle)
+        .accessibilityValue(verdictBody)
+    }
+
+    private var verdictSymbol: String {
+        switch verdict {
+        case .comfortable: return "checkmark.circle.fill"
+        case .tight: return "exclamationmark.circle.fill"
+        case .beyond: return "hand.raised.circle.fill"
+        }
+    }
+
+    private var verdictColor: Color {
+        switch verdict {
+        case .comfortable: return FinanceColors.statusPositive
+        case .tight: return FinanceColors.statusWarning
+        case .beyond: return FinanceColors.statusInfo
+        }
+    }
+
+    private var verdictTitle: String {
+        switch verdict {
+        case .comfortable: return String(localized: "Yes — you've got room")
+        case .tight: return String(localized: "You can, but it's tight")
+        case .beyond: return String(localized: "This goes past your cushion")
+        }
+    }
+
+    private var verdictBody: String {
+        switch verdict {
+        case .comfortable:
+            return String(localized: "This fits comfortably within what's safe to spend before payday.")
+        case .tight:
+            return String(localized: "This works, but it uses most of your cushion. Just something to keep in mind.")
+        case .beyond:
+            return String(localized: "This would spend past your cushion before payday. No judgment — maybe split it or wait if you can.")
+        }
+    }
+
+    // MARK: - Conversion helpers
+
+    /// Localized currency symbol for the amount-entry prefix.
+    static func currencySymbol(_ currencyCode: String) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        return formatter.currencySymbol ?? "$"
+    }
+
+    /// Parses user-entered decimal text into integer minor units.
+    static func minorUnits(from text: String, currencyCode: String) -> Int64 {
+        let normalized = text.replacingOccurrences(of: ",", with: ".")
+        guard let value = Decimal(string: normalized), value > 0 else { return 0 }
+        let places = CurrencyLabel.decimalPlaces(for: currencyCode)
+        let multiplier = NSDecimalNumber(decimal: pow(10, places))
+        let minor = NSDecimalNumber(decimal: value).multiplying(by: multiplier)
+        return Int64(truncating: minor.rounding(accordingToBehavior: nil))
+    }
+}
+
+// MARK: - Setup Sheet
+
+/// Lets the user set the numbers behind the safe-to-spend figure.
+struct GroceryModeSetupSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var store: GroceryModeStore
+    @Bindable var paydayStore: PaydaySettingsStore
+
+    @State private var cashText: String = ""
+    @State private var billsText: String = ""
+    @State private var pinnedName: String = ""
+    @State private var pinnedRemainingText: String = ""
+    @State private var usePinned = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    labelledAmountField(
+                        label: String(localized: "Cash on hand"),
+                        text: $cashText
+                    )
+                    labelledAmountField(
+                        label: String(localized: "Bills due before payday"),
+                        text: $billsText
+                    )
+                } header: {
+                    Text(String(localized: "Your cushion"))
+                } footer: {
+                    Text(String(localized: "We hold back bills due before payday, then show what's safe to spend."))
+                }
+
+                Section {
+                    DatePicker(
+                        String(localized: "Next payday"),
+                        selection: $paydayStore.anchorDate,
+                        displayedComponents: .date
+                    )
+                    Picker(String(localized: "Pay frequency"), selection: $paydayStore.frequency) {
+                        ForEach(PayFrequency.allCases, id: \.self) { freq in
+                            Text(freq.displayName).tag(freq)
+                        }
+                    }
+                } header: {
+                    Text(String(localized: "Payday"))
+                }
+
+                Section {
+                    Toggle(String(localized: "Check against one category"), isOn: $usePinned)
+                    if usePinned {
+                        TextField(String(localized: "Category (e.g. Groceries)"), text: $pinnedName)
+                        labelledAmountField(
+                            label: String(localized: "Left this period"),
+                            text: $pinnedRemainingText
+                        )
+                    }
+                } header: {
+                    Text(String(localized: "Pin a category"))
+                } footer: {
+                    Text(String(localized: "Optional: check purchases against a single budget like Groceries instead of your whole cushion."))
+                }
+            }
+            .navigationTitle(String(localized: "Adjust amounts"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "Save")) {
+                        save()
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Cancel")) { dismiss() }
+                }
+            }
+            .onAppear(perform: load)
+        }
+    }
+
+    private func labelledAmountField(label: String, text: Binding<String>) -> some View {
+        HStack {
+            Text(label)
+            Spacer()
+            TextField(String(localized: "0.00"), text: text)
+                .keyboardType(.decimalPad)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: 140)
+                .accessibilityLabel(label)
+        }
+    }
+
+    private func load() {
+        cashText = Self.majorString(store.clearedCashMinorUnits, currencyCode: store.currencyCode)
+        billsText = Self.majorString(store.billsBeforePaydayMinorUnits, currencyCode: store.currencyCode)
+        usePinned = store.pinnedCategoryName != nil
+        pinnedName = store.pinnedCategoryName ?? ""
+        pinnedRemainingText = Self.majorString(store.pinnedCategoryRemainingMinorUnits, currencyCode: store.currencyCode)
+    }
+
+    private func save() {
+        store.clearedCashMinorUnits = GroceryModeView.minorUnits(from: cashText, currencyCode: store.currencyCode)
+        store.billsBeforePaydayMinorUnits = GroceryModeView.minorUnits(from: billsText, currencyCode: store.currencyCode)
+        if usePinned, !pinnedName.trimmingCharacters(in: .whitespaces).isEmpty {
+            store.pinnedCategoryName = pinnedName
+            store.pinnedCategoryRemainingMinorUnits = GroceryModeView.minorUnits(from: pinnedRemainingText, currencyCode: store.currencyCode)
+        } else {
+            store.pinnedCategoryName = nil
+        }
+    }
+
+    private static func majorString(_ minorUnits: Int64, currencyCode: String) -> String {
+        guard minorUnits > 0 else { return "" }
+        let places = CurrencyLabel.decimalPlaces(for: currencyCode)
+        let divisor = NSDecimalNumber(decimal: pow(10, places))
+        let value = NSDecimalNumber(value: minorUnits).dividing(by: divisor)
+        return value.stringValue
+    }
+}
+
+#Preview {
+    NavigationStack {
+        GroceryModeView()
+    }
+}

--- a/apps/ios/Finance/Screens/NotificationSettingsView.swift
+++ b/apps/ios/Finance/Screens/NotificationSettingsView.swift
@@ -33,6 +33,7 @@ struct NotificationSettingsView: View {
             schedulesSection
             budgetThresholdSection
             quietHoursSection
+            smartTimingSection
             smartAlertsSection
         }
         .navigationTitle(String(localized: "Notifications"))
@@ -246,6 +247,55 @@ struct NotificationSettingsView: View {
             Text(viewModel.quietHoursEnabled
                 ? String(localized: "Alerts are silenced \(viewModel.quietHoursSummary).")
                 : String(localized: "Silence non-urgent alerts overnight."))
+        }
+    }
+
+    // MARK: - Smart Timing Section (#2391)
+
+    @ViewBuilder
+    private var smartTimingSection: some View {
+        Section {
+            Toggle(isOn: $viewModel.smartTimingEnabled) {
+                Label(String(localized: "Smart Timing"), systemImage: "wand.and.stars")
+            }
+            .accessibilityLabel(String(localized: "Smart notification timing"))
+            .accessibilityHint(String(localized: "Learns when you're most likely to act and delivers reminders then"))
+
+            if viewModel.smartTimingEnabled {
+                HStack {
+                    Text(String(localized: "Best time"))
+                    Spacer()
+                    Text(viewModel.recommendedHourLabel)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(String(localized: "Recommended delivery time"))
+                .accessibilityValue(viewModel.recommendedHourLabel)
+
+                Button(role: .destructive) {
+                    viewModel.resetSmartTiming()
+                } label: {
+                    Text(String(localized: "Reset learned timing"))
+                }
+                .disabled(viewModel.smartTimingHealth.totalDelivered == 0)
+                .accessibilityHint(String(localized: "Clears learned data and returns to the fixed time"))
+            } else {
+                Picker(
+                    String(localized: "Reminder time"),
+                    selection: $viewModel.smartTimingFallbackHour
+                ) {
+                    ForEach(0..<24, id: \.self) { hour in
+                        Text(NotificationSettingsViewModel.formatHour(hour)).tag(hour)
+                    }
+                }
+                .accessibilityLabel(String(localized: "Fixed reminder time"))
+            }
+        } header: {
+            Text(String(localized: "Smart Timing"))
+                .accessibilityAddTraits(.isHeader)
+        } footer: {
+            Text(viewModel.smartTimingStatus)
         }
     }
 

--- a/apps/ios/Finance/Screens/OnboardingView.swift
+++ b/apps/ios/Finance/Screens/OnboardingView.swift
@@ -24,6 +24,7 @@ import SwiftUI
 /// boolean) so the flow is never shown again after dismissal.
 struct OnboardingView: View {
     @State private var currentPage = 0
+    @State private var showingFamilySetup = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// Callback invoked when the user completes or skips onboarding.
@@ -112,6 +113,18 @@ struct OnboardingView: View {
                     .accessibilityIdentifier("onboarding_get_started")
                     .accessibilityLabel(String(localized: "Get Started"))
                     .accessibilityHint(String(localized: "Completes onboarding and enters the app"))
+
+                    Button {
+                        showingFamilySetup = true
+                    } label: {
+                        Text(String(localized: "Setting up for your family?"))
+                            .font(.callout)
+                            .frame(maxWidth: .infinity, minHeight: FinanceSpacing.minTapTarget)
+                    }
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("onboarding_family_setup")
+                    .accessibilityLabel(String(localized: "Set up for your family"))
+                    .accessibilityHint(String(localized: "Choose a kid-aware starter budget with categories for school, childcare, and activities"))
                 } else {
                     Button {
                         withAnimation(reduceMotion ? nil : .easeInOut) {
@@ -132,6 +145,9 @@ struct OnboardingView: View {
             .padding(.bottom, FinanceSpacing.xxl)
         }
         .background(FinanceColors.backgroundPrimary.ignoresSafeArea())
+        .sheet(isPresented: $showingFamilySetup) {
+            FamilySetupView()
+        }
         .accessibilityIdentifier("onboarding_view")
         .accessibilityLabel(String(localized: "Onboarding"))
     }

--- a/apps/ios/Finance/Screens/TransactionCreateView.swift
+++ b/apps/ios/Finance/Screens/TransactionCreateView.swift
@@ -6,11 +6,14 @@
 // Multi-step sheet for creating a new transaction.
 
 import SwiftUI
+import FinanceShared
 
 // MARK: - View
 
 struct TransactionCreateView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var viewModel: TransactionCreateViewModel
 
     init(viewModel: TransactionCreateViewModel = TransactionCreateViewModel(
@@ -56,7 +59,10 @@ struct TransactionCreateView: View {
     // MARK: - Step Indicator
 
     private var stepIndicator: some View {
-        HStack(spacing: 0) {
+        let shortLabels = CompactLayoutMetrics.stepperUsesShortLabels(
+            for: SizeClassInput(horizontalSizeClass: horizontalSizeClass, dynamicTypeSize: dynamicTypeSize)
+        )
+        return HStack(spacing: 0) {
             ForEach(TransactionCreateViewModel.Step.allCases, id: \.rawValue) { step in
                 VStack(spacing: 4) {
                     Circle()
@@ -68,8 +74,13 @@ struct TransactionCreateView: View {
                                     .font(.system(size: 7, weight: .bold)).foregroundStyle(.white)
                             }
                         }
-                    Text(step.title).font(.caption2)
-                        .foregroundStyle(step.rawValue <= viewModel.currentStep.rawValue ? .primary : .secondary)
+                    // On compact width / large text, only the current step keeps
+                    // its label so the row never crowds on an iPhone SE. (#2190)
+                    if !shortLabels || step == viewModel.currentStep {
+                        Text(step.title).font(.caption2)
+                            .foregroundStyle(step.rawValue <= viewModel.currentStep.rawValue ? .primary : .secondary)
+                            .lineLimit(1)
+                    }
                 }
                 .frame(maxWidth: .infinity)
                 .accessibilityElement(children: .combine)

--- a/apps/ios/Finance/Services/ExpectedIncomeStore.swift
+++ b/apps/ios/Finance/Services/ExpectedIncomeStore.swift
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// ExpectedIncomeStore.swift
+// Finance
+//
+// Persists expected (not-yet-cleared) income — child support, freelance
+// invoices, reimbursements — separately from cleared cash, so single parents
+// relying on late or unreliable deposits never plan against money that hasn't
+// arrived. All computation is delegated to `ExpectedIncomeCalculator`.
+//
+// References: #2193
+
+import FinanceShared
+import Foundation
+import os
+import Observation
+
+@Observable
+final class ExpectedIncomeStore {
+    private let defaults: UserDefaults
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "ExpectedIncomeStore"
+    )
+
+    private enum Key {
+        static let items = "expectedIncome.items"
+        static let clearedCash = "expectedIncome.clearedCashMinorUnits"
+        static let currency = "expectedIncome.currencyCode"
+    }
+
+    /// The tracked expected deposits, persisted as JSON.
+    var items: [ExpectedIncome] {
+        didSet { persistItems() }
+    }
+
+    /// Cash the household already has cleared, entered by the user, minor units.
+    var clearedCashMinorUnits: Int64 {
+        didSet { defaults.set(clearedCashMinorUnits, forKey: Key.clearedCash) }
+    }
+
+    /// ISO currency code for display.
+    var currencyCode: String {
+        didSet { defaults.set(currencyCode, forKey: Key.currency) }
+    }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.clearedCashMinorUnits = Int64(defaults.integer(forKey: Key.clearedCash))
+        self.currencyCode = defaults.string(forKey: Key.currency) ?? "USD"
+
+        if let data = defaults.data(forKey: Key.items),
+           let decoded = try? JSONDecoder().decode([ExpectedIncome].self, from: data) {
+            self.items = decoded.sorted { $0.expectedDate < $1.expectedDate }
+        } else {
+            self.items = []
+        }
+    }
+
+    // MARK: - Derived
+
+    /// The honest cleared / expected / at-risk cash split.
+    func breakdown(asOf now: Date = Date()) -> CashBreakdown {
+        ExpectedIncomeCalculator.breakdown(
+            clearedCashMinorUnits: clearedCashMinorUnits,
+            expectedIncomes: items,
+            currencyCode: currencyCode,
+            asOf: now
+        )
+    }
+
+    /// Overdue deposits that should surface a gentle nudge.
+    func overdue(asOf now: Date = Date()) -> [ExpectedIncome] {
+        ExpectedIncomeCalculator.overdue(items, asOf: now)
+    }
+
+    // MARK: - Mutations
+
+    func add(_ income: ExpectedIncome) {
+        items.append(income)
+        items.sort { $0.expectedDate < $1.expectedDate }
+    }
+
+    func update(_ income: ExpectedIncome) {
+        guard let index = items.firstIndex(where: { $0.id == income.id }) else { return }
+        items[index] = income
+        items.sort { $0.expectedDate < $1.expectedDate }
+    }
+
+    func remove(id: String) {
+        items.removeAll { $0.id == id }
+    }
+
+    /// Replaces an item with a copy carrying a new status (and optional receipt).
+    func setStatus(id: String, status: ExpectedIncomeStatus, receivedMinorUnits: Int64? = nil) {
+        guard let existing = items.first(where: { $0.id == id }) else { return }
+        let updated = ExpectedIncome(
+            id: existing.id,
+            source: existing.source,
+            amountMinorUnits: existing.amountMinorUnits,
+            receivedMinorUnits: receivedMinorUnits ?? existing.receivedMinorUnits,
+            expectedDate: existing.expectedDate,
+            reliability: existing.reliability,
+            status: status
+        )
+        update(updated)
+    }
+
+    private func persistItems() {
+        do {
+            let data = try JSONEncoder().encode(items)
+            defaults.set(data, forKey: Key.items)
+        } catch {
+            Self.logger.error("Failed to persist expected income: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/apps/ios/Finance/Services/FinancialTipService.swift
+++ b/apps/ios/Finance/Services/FinancialTipService.swift
@@ -7,7 +7,7 @@
 // the user's spending patterns, budget status, and goal progress.
 // Tip dismissals are persisted in UserDefaults (non-sensitive boolean flags).
 //
-// References: #320
+// References: #320, #2201
 
 import Foundation
 import os
@@ -252,29 +252,29 @@ final class FinancialTipService: FinancialTipProviding, @unchecked Sendable {
     ) -> [FinancialTip] {
         var tips: [FinancialTip] = []
 
-        // Over-budget warning tip
+        // Over-plan heads-up — factual, calm, next-step oriented (#2201).
         let overBudgetCategories = budgets.filter { $0.progress >= 1.0 }
         if !overBudgetCategories.isEmpty {
             let names = overBudgetCategories.map(\.name).joined(separator: ", ")
             tips.append(FinancialTip(
                 id: "tip_dynamic_over_budget",
-                title: String(localized: "Over Budget Alert"),
-                body: String(localized: "You've exceeded your budget in: \(names). Consider reducing discretionary spending for the rest of the month."),
+                title: String(localized: "Past your plan"),
+                body: String(localized: "You've gone a little past your plan in: \(names). Want to adjust one of these categories, or move a little from another?"),
                 category: .budgeting,
                 applicableContexts: [context, .budgets, .dashboard, .overspending],
-                systemImage: "exclamationmark.triangle",
+                systemImage: "slider.horizontal.3",
                 priority: 15
             ))
         }
 
-        // Near-budget warning (75%+)
+        // Near-plan heads-up (75%+) — supportive, not high-pressure (#2201).
         let nearBudgetCategories = budgets.filter { $0.progress >= 0.75 && $0.progress < 1.0 }
         if !nearBudgetCategories.isEmpty {
             let names = nearBudgetCategories.map(\.name).joined(separator: ", ")
             tips.append(FinancialTip(
                 id: "tip_dynamic_near_budget",
-                title: String(localized: "Approaching Budget Limit"),
-                body: String(localized: "You're nearing the limit in: \(names). Plan your remaining spending carefully this period."),
+                title: String(localized: "Getting close"),
+                body: String(localized: "You're nearing your plan in: \(names). You've still got room — just something to keep in mind."),
                 category: .budgeting,
                 applicableContexts: [context, .budgets, .dashboard],
                 systemImage: "gauge.with.dots.needle.67percent",

--- a/apps/ios/Finance/Services/GroceryModeStore.swift
+++ b/apps/ios/Finance/Services/GroceryModeStore.swift
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// GroceryModeStore.swift
+// Finance
+//
+// Persists the small set of inputs behind grocery-store "can I afford this?"
+// mode: cash on hand, bills reserved before payday, and an optional pinned
+// category budget. All affordability math is delegated to `SafeToSpendCalculator`.
+//
+// References: #2199
+
+import FinanceShared
+import Foundation
+import Observation
+
+@Observable
+final class GroceryModeStore {
+    private let defaults: UserDefaults
+
+    private enum Key {
+        static let cleared = "grocery.clearedCashMinorUnits"
+        static let reserved = "grocery.billsBeforePaydayMinorUnits"
+        static let pinnedName = "grocery.pinnedCategoryName"
+        static let pinnedRemaining = "grocery.pinnedCategoryRemainingMinorUnits"
+        static let hasPinned = "grocery.hasPinnedCategory"
+        static let currency = "grocery.currencyCode"
+    }
+
+    /// Cash available right now (entered by the user), minor units.
+    var clearedCashMinorUnits: Int64 {
+        didSet { defaults.set(clearedCashMinorUnits, forKey: Key.cleared) }
+    }
+
+    /// Critical bills landing before the next payday to hold back, minor units.
+    var billsBeforePaydayMinorUnits: Int64 {
+        didSet { defaults.set(billsBeforePaydayMinorUnits, forKey: Key.reserved) }
+    }
+
+    /// Optional pinned high-frequency category (e.g. Groceries).
+    var pinnedCategoryName: String? {
+        didSet {
+            defaults.set(pinnedCategoryName, forKey: Key.pinnedName)
+            defaults.set(pinnedCategoryName != nil, forKey: Key.hasPinned)
+        }
+    }
+
+    /// Remaining budget for the pinned category, minor units.
+    var pinnedCategoryRemainingMinorUnits: Int64 {
+        didSet { defaults.set(pinnedCategoryRemainingMinorUnits, forKey: Key.pinnedRemaining) }
+    }
+
+    var currencyCode: String {
+        didSet { defaults.set(currencyCode, forKey: Key.currency) }
+    }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.clearedCashMinorUnits = Int64(defaults.integer(forKey: Key.cleared))
+        self.billsBeforePaydayMinorUnits = Int64(defaults.integer(forKey: Key.reserved))
+        self.pinnedCategoryRemainingMinorUnits = Int64(defaults.integer(forKey: Key.pinnedRemaining))
+        self.currencyCode = defaults.string(forKey: Key.currency) ?? "USD"
+        self.pinnedCategoryName = defaults.bool(forKey: Key.hasPinned)
+            ? defaults.string(forKey: Key.pinnedName)
+            : nil
+    }
+
+    /// Computes the safe-to-spend summary for the given payday.
+    func result(nextPayday: Date, referenceDate: Date = Date()) -> SafeToSpendResult {
+        let obligations: [SafeToSpendObligation]
+        if billsBeforePaydayMinorUnits > 0 {
+            obligations = [
+                SafeToSpendObligation(
+                    amountMinorUnits: billsBeforePaydayMinorUnits,
+                    dueDate: nextPayday,
+                    isCritical: true
+                )
+            ]
+        } else {
+            obligations = []
+        }
+
+        let input = SafeToSpendInput(
+            clearedCashMinorUnits: clearedCashMinorUnits,
+            nextPaydayDate: nextPayday,
+            obligations: obligations,
+            pinnedCategoryRemainingMinorUnits: pinnedCategoryName == nil ? nil : pinnedCategoryRemainingMinorUnits,
+            pinnedCategoryName: pinnedCategoryName,
+            currencyCode: currencyCode,
+            referenceDate: referenceDate
+        )
+        return SafeToSpendCalculator.evaluate(input)
+    }
+}

--- a/apps/ios/Finance/Services/NotificationSchedulerService.swift
+++ b/apps/ios/Finance/Services/NotificationSchedulerService.swift
@@ -149,22 +149,22 @@ actor NotificationSchedulerService: NotificationSchedulerProtocol {
             if percent >= 100 {
                 return SmartAlert(
                     type: .budgetAlert,
-                    title: String(localized: "\(budget.name) Over Budget"),
-                    body: String(localized: "You've exceeded your \(budget.name) budget by \(String(format: "%.0f", percent - 100))%."),
-                    priority: .urgent
+                    title: String(localized: "\(budget.name): past your plan"),
+                    body: String(localized: "You've gone a little past your \(budget.name) plan. Want to adjust this category?"),
+                    priority: .high
                 )
             } else if percent >= 90 {
                 return SmartAlert(
                     type: .budgetAlert,
-                    title: String(localized: "\(budget.name) Almost Full"),
-                    body: String(localized: "You've used \(String(format: "%.0f", percent))% of your \(budget.name) budget."),
-                    priority: .high
+                    title: String(localized: "\(budget.name): getting close"),
+                    body: String(localized: "You've used \(String(format: "%.0f", percent))% of your \(budget.name) plan. Still some room left."),
+                    priority: .normal
                 )
             } else if percent >= 75 {
                 return SmartAlert(
                     type: .budgetAlert,
-                    title: String(localized: "\(budget.name) Budget Update"),
-                    body: String(localized: "\(String(format: "%.0f", percent))% of your \(budget.name) budget has been used."),
+                    title: String(localized: "\(budget.name) update"),
+                    body: String(localized: "\(String(format: "%.0f", percent))% of your \(budget.name) plan has been used so far."),
                     priority: .normal
                 )
             }

--- a/apps/ios/Finance/Services/PaydaySettingsStore.swift
+++ b/apps/ios/Finance/Services/PaydaySettingsStore.swift
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// PaydaySettingsStore.swift
+// Finance
+//
+// Persists the user's payday anchor + cadence so the bill calendar and grocery
+// mode can line bills up with real paycheck timing. Thin wrapper over
+// UserDefaults; all date math lives in `PaydaySchedule` (FinanceShared).
+//
+// References: #2196, #2199
+
+import FinanceShared
+import Foundation
+import Observation
+
+@Observable
+final class PaydaySettingsStore {
+    private let defaults: UserDefaults
+
+    private enum Key {
+        static let anchor = "payday.anchor.timeInterval"
+        static let frequency = "payday.frequency"
+        static let paycheck = "payday.typicalPaycheckMinorUnits"
+    }
+
+    /// The date a known paycheck lands; future paydays are generated from it.
+    var anchorDate: Date {
+        didSet { defaults.set(anchorDate.timeIntervalSince1970, forKey: Key.anchor) }
+    }
+
+    /// How often the paycheck recurs.
+    var frequency: PayFrequency {
+        didSet { defaults.set(frequency.rawValue, forKey: Key.frequency) }
+    }
+
+    /// A typical take-home paycheck amount, used to gauge pay-period risk.
+    var typicalPaycheckMinorUnits: Int64 {
+        didSet { defaults.set(typicalPaycheckMinorUnits, forKey: Key.paycheck) }
+    }
+
+    init(defaults: UserDefaults = .standard, referenceDate: Date = Date()) {
+        self.defaults = defaults
+        self.typicalPaycheckMinorUnits = Int64(defaults.integer(forKey: Key.paycheck))
+        if let stored = defaults.object(forKey: Key.anchor) as? Double {
+            self.anchorDate = Date(timeIntervalSince1970: stored)
+        } else {
+            // Default to two weeks out so the calendar has a sensible horizon.
+            self.anchorDate = Calendar.current.date(byAdding: .day, value: 14, to: referenceDate) ?? referenceDate
+        }
+        if let raw = defaults.string(forKey: Key.frequency),
+           let freq = PayFrequency(rawValue: raw) {
+            self.frequency = freq
+        } else {
+            self.frequency = .biweekly
+        }
+    }
+
+    /// The next `count` paydays on or after `referenceDate`.
+    func upcomingPaydays(count: Int = 6, from referenceDate: Date = Date()) -> [Date] {
+        PaydaySchedule.upcomingPaydays(
+            anchor: anchorDate,
+            frequency: frequency,
+            from: referenceDate,
+            count: count
+        )
+    }
+
+    /// The soonest upcoming payday, if any.
+    func nextPayday(from referenceDate: Date = Date()) -> Date? {
+        upcomingPaydays(count: 1, from: referenceDate).first
+    }
+
+    /// Upcoming paydays as deposits carrying the typical paycheck amount, for
+    /// pay-period risk analysis.
+    func deposits(count: Int = 6, from referenceDate: Date = Date()) -> [PaydayDeposit] {
+        upcomingPaydays(count: count, from: referenceDate).map {
+            PaydayDeposit(date: $0, amountMinorUnits: typicalPaycheckMinorUnits)
+        }
+    }
+}

--- a/apps/ios/Finance/ViewModels/NotificationSettingsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/NotificationSettingsViewModel.swift
@@ -8,6 +8,7 @@
 //
 // References: #305
 
+import FinanceShared
 import Observation
 import os
 import SwiftUI
@@ -44,6 +45,9 @@ final class NotificationSettingsViewModel {
         static let quietHoursEnabled = "notifications.quietHours.enabled"
         static let quietHoursStart = "notifications.quietHours.startHour"
         static let quietHoursEnd = "notifications.quietHours.endHour"
+        static let smartTimingEnabled = "notifications.smartTiming.enabled"
+        static let smartTimingFallbackHour = "notifications.smartTiming.fallbackHour"
+        static let smartTimingEngagement = "notifications.smartTiming.engagement"
     }
 
     /// Whether quiet hours suppress alerts overnight.
@@ -59,6 +63,23 @@ final class NotificationSettingsViewModel {
     /// Hour (0–23) quiet hours end.
     var quietHoursEndHour: Int {
         didSet { defaults.set(quietHoursEndHour, forKey: PrefKey.quietHoursEnd) }
+    }
+
+    // MARK: - Smart Timing (#2391)
+
+    /// Master switch for on-device smart notification timing.
+    var smartTimingEnabled: Bool {
+        didSet { defaults.set(smartTimingEnabled, forKey: PrefKey.smartTimingEnabled) }
+    }
+
+    /// The fixed hour used when there isn't enough data to personalize.
+    var smartTimingFallbackHour: Int {
+        didSet { defaults.set(smartTimingFallbackHour, forKey: PrefKey.smartTimingFallbackHour) }
+    }
+
+    /// Content-free, per-hour engagement aggregates driving the timing model.
+    private(set) var engagement: [HourEngagement] {
+        didSet { persistEngagement() }
     }
 
     /// Budget-alert threshold options offered in the UI.
@@ -92,6 +113,14 @@ final class NotificationSettingsViewModel {
         self.quietHoursEnabled = defaults.bool(forKey: PrefKey.quietHoursEnabled)
         self.quietHoursStartHour = defaults.object(forKey: PrefKey.quietHoursStart) as? Int ?? 22
         self.quietHoursEndHour = defaults.object(forKey: PrefKey.quietHoursEnd) as? Int ?? 7
+        self.smartTimingEnabled = defaults.object(forKey: PrefKey.smartTimingEnabled) as? Bool ?? true
+        self.smartTimingFallbackHour = defaults.object(forKey: PrefKey.smartTimingFallbackHour) as? Int ?? 9
+        if let data = defaults.data(forKey: PrefKey.smartTimingEngagement),
+           let decoded = try? JSONDecoder().decode([HourEngagement].self, from: data) {
+            self.engagement = decoded
+        } else {
+            self.engagement = []
+        }
     }
 
     // MARK: - Alert Center Summary (#2163)
@@ -136,6 +165,81 @@ final class NotificationSettingsViewModel {
         components.hour = clamped
         let date = Calendar.current.date(from: components) ?? Date()
         return date.formatted(.dateTime.hour())
+    }
+
+    // MARK: - Smart Timing (#2391)
+
+    /// The active quiet-hours window, or `nil` when quiet hours are off.
+    var smartTimingQuietHours: QuietHours? {
+        guard quietHoursEnabled else { return nil }
+        return QuietHours(startHour: quietHoursStartHour, endHour: quietHoursEndHour)
+    }
+
+    /// The hour smart timing would schedule the next reminder for.
+    var recommendedHour: Int {
+        SmartNotificationTiming.recommendedHour(
+            engagement: engagement,
+            quietHours: smartTimingQuietHours,
+            fallbackHour: smartTimingFallbackHour,
+            smartTimingEnabled: smartTimingEnabled
+        )
+    }
+
+    /// A localized label for the recommended delivery time.
+    var recommendedHourLabel: String { Self.formatHour(recommendedHour) }
+
+    /// Whether the model has enough on-device data to personalize timing.
+    var canPersonalizeTiming: Bool {
+        SmartNotificationTiming.canPersonalize(engagement: engagement)
+    }
+
+    /// Privacy-preserving aggregate health of smart-timing delivery.
+    var smartTimingHealth: SmartTimingHealth {
+        SmartNotificationTiming.health(engagement: engagement)
+    }
+
+    /// A one-line status describing whether timing is personalized or learning.
+    var smartTimingStatus: String {
+        guard smartTimingEnabled else {
+            return String(localized: "Reminders arrive at \(recommendedHourLabel).")
+        }
+        if canPersonalizeTiming {
+            return String(localized: "Learned your best time: \(recommendedHourLabel).")
+        }
+        let remaining = max(SmartNotificationTiming.minSignalsToPersonalize - smartTimingHealth.totalDelivered, 0)
+        return String(localized: "Still learning — \(remaining) more reminders until timing personalizes. Using \(recommendedHourLabel) for now.")
+    }
+
+    /// Records a content-free engagement signal for the given hour, merging into
+    /// the existing per-hour bucket. `acted` marks whether the user acted on it.
+    func recordEngagement(hour: Int, acted: Bool) {
+        let clamped = ((hour % 24) + 24) % 24
+        var buckets = engagement
+        if let index = buckets.firstIndex(where: { $0.hour == clamped }) {
+            let existing = buckets[index]
+            buckets[index] = HourEngagement(
+                hour: clamped,
+                deliveredCount: existing.deliveredCount + 1,
+                actedCount: existing.actedCount + (acted ? 1 : 0)
+            )
+        } else {
+            buckets.append(HourEngagement(
+                hour: clamped,
+                deliveredCount: 1,
+                actedCount: acted ? 1 : 0
+            ))
+        }
+        engagement = buckets.sorted { $0.hour < $1.hour }
+    }
+
+    /// Clears all learned timing data, returning to the fixed fallback time.
+    func resetSmartTiming() {
+        engagement = []
+    }
+
+    private func persistEngagement() {
+        guard let data = try? JSONEncoder().encode(engagement) else { return }
+        defaults.set(data, forKey: PrefKey.smartTimingEngagement)
     }
 
     /// Updates the budget-alert threshold and reschedules if enabled.

--- a/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
@@ -79,6 +79,13 @@ final class TransactionCreateViewModel {
         PickerOption(id: "c4", name: "Entertainment", icon: "film"),
         PickerOption(id: "c5", name: "Shopping", icon: "bag"),
         PickerOption(id: "c6", name: "Income", icon: "dollarsign.circle"),
+        // Kid-specific categories for family / single-parent households (#2201).
+        PickerOption(id: "kid-school", name: "School", icon: "graduationcap"),
+        PickerOption(id: "kid-childcare", name: "Childcare", icon: "figure.and.child.holdinghands"),
+        PickerOption(id: "kid-activities", name: "Activities & Sports", icon: "figure.run"),
+        PickerOption(id: "kid-birthdays", name: "Birthdays & Parties", icon: "gift"),
+        PickerOption(id: "kid-fieldtrips", name: "Field Trips", icon: "bus"),
+        PickerOption(id: "kid-clothing", name: "Kids' Clothing", icon: "tshirt"),
     ]
 
     var canAdvance: Bool {

--- a/apps/ios/Shared/CompactLayoutMetrics.swift
+++ b/apps/ios/Shared/CompactLayoutMetrics.swift
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// CompactLayoutMetrics.swift - FinanceShared - Refs #2190
+//
+// Pure, dependency-free layout decisions for compact-width devices (iPhone SE)
+// and large Dynamic Type. Kept free of SwiftUI so the column/stacking logic can
+// be unit-tested in isolation; the view layer maps `SizeClassInput` from the
+// SwiftUI environment and applies the result.
+//
+// The goal: keep the "one screen at a glance" feeling even on a small phone and
+// at accessibility text sizes — never a hard-coded 3-up row that crushes labels.
+
+import Foundation
+
+/// Environment inputs the layout metrics react to, decoupled from SwiftUI.
+public struct SizeClassInput: Sendable, Hashable {
+    /// `true` when the horizontal size class is compact (portrait iPhone).
+    public let isCompactWidth: Bool
+    /// `true` when Dynamic Type is at an accessibility size (xxxL and above).
+    public let isAccessibilityTextSize: Bool
+
+    public init(isCompactWidth: Bool, isAccessibilityTextSize: Bool) {
+        self.isCompactWidth = isCompactWidth
+        self.isAccessibilityTextSize = isAccessibilityTextSize
+    }
+}
+
+/// Pure layout heuristics for adaptive summary/quick-access rows.
+public enum CompactLayoutMetrics {
+
+    /// Columns for a 3-metric summary row (Income / Expenses / Net).
+    ///
+    /// - Accessibility text size → 1 column (fully stacked, always readable).
+    /// - Compact width → 1 column so three currency values never crowd.
+    /// - Otherwise → 3 columns (the roomy default).
+    public static func summaryColumns(for input: SizeClassInput) -> Int {
+        if input.isAccessibilityTextSize { return 1 }
+        if input.isCompactWidth { return 1 }
+        return 3
+    }
+
+    /// Columns for the quick-access / more grid.
+    ///
+    /// - Accessibility text size → 1 column.
+    /// - Compact width → 2 columns (still glanceable, tap targets stay large).
+    /// - Otherwise → 3 columns.
+    public static func quickAccessColumns(for input: SizeClassInput) -> Int {
+        if input.isAccessibilityTextSize { return 1 }
+        if input.isCompactWidth { return 2 }
+        return 3
+    }
+
+    /// Columns for the bills summary row (Due / Monthly / Count).
+    public static func billsSummaryColumns(for input: SizeClassInput) -> Int {
+        summaryColumns(for: input)
+    }
+
+    /// Whether the multi-step transaction stepper should use shortened labels
+    /// (e.g. show only the current step's title) to avoid crowding.
+    public static func stepperUsesShortLabels(for input: SizeClassInput) -> Bool {
+        input.isCompactWidth || input.isAccessibilityTextSize
+    }
+}

--- a/apps/ios/Shared/ExpectedIncomeModel.swift
+++ b/apps/ios/Shared/ExpectedIncomeModel.swift
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BUSL-1.1
+// ExpectedIncomeModel.swift - FinanceShared - Refs #2193
+//
+// A pure, dependency-free model for tracking *expected* income separately from
+// cleared income — built for single parents relying on late or unreliable child
+// support, plus freelancers, reimbursements, and tips. All money is in integer
+// minor units (cents). No UI/KMP/networking dependencies, fully unit-testable.
+//
+// The core idea: never pretend uncertain money has already arrived. We split the
+// cash picture into three honest buckets — cleared, expected, and at-risk — so
+// planning reflects reality instead of wishful thinking.
+
+import Foundation
+
+/// How dependable a recurring expected deposit has historically been.
+public enum IncomeReliability: String, Sendable, CaseIterable, Codable {
+    /// Arrives on time, essentially always.
+    case reliable
+    /// Usually arrives, occasionally late.
+    case usuallyOnTime
+    /// Frequently late, partial, or missed.
+    case unreliable
+
+    /// Weight (0...1) applied when estimating how much expected cash to trust.
+    public var confidence: Double {
+        switch self {
+        case .reliable: return 1.0
+        case .usuallyOnTime: return 0.7
+        case .unreliable: return 0.4
+        }
+    }
+}
+
+/// The lifecycle status of a single expected deposit.
+public enum ExpectedIncomeStatus: String, Sendable, CaseIterable, Codable {
+    /// Not yet due / not yet arrived.
+    case expected
+    /// Fully received on or around the expected date.
+    case received
+    /// Past the expected date with nothing received yet.
+    case late
+    /// Some — but not all — of the expected amount arrived.
+    case partial
+    /// Written off for this cycle.
+    case missed
+}
+
+/// A single expected (not-yet-cleared) deposit.
+public struct ExpectedIncome: Sendable, Hashable, Codable, Identifiable {
+    public let id: String
+    /// Human label, e.g. "Child support" or "Freelance invoice #12".
+    public let source: String
+    /// The full amount expected, in minor units.
+    public let amountMinorUnits: Int64
+    /// The amount actually received so far (for partial payments), minor units.
+    public let receivedMinorUnits: Int64
+    public let expectedDate: Date
+    public let reliability: IncomeReliability
+    public let status: ExpectedIncomeStatus
+
+    public init(
+        id: String = UUID().uuidString,
+        source: String,
+        amountMinorUnits: Int64,
+        receivedMinorUnits: Int64 = 0,
+        expectedDate: Date,
+        reliability: IncomeReliability = .usuallyOnTime,
+        status: ExpectedIncomeStatus = .expected
+    ) {
+        self.id = id
+        self.source = source
+        self.amountMinorUnits = amountMinorUnits
+        self.receivedMinorUnits = receivedMinorUnits
+        self.expectedDate = expectedDate
+        self.reliability = reliability
+        self.status = status
+    }
+
+    /// The outstanding amount still expected but not yet received, minor units.
+    public var outstandingMinorUnits: Int64 {
+        max(amountMinorUnits - receivedMinorUnits, 0)
+    }
+
+    /// Whether the deposit is overdue relative to `now` and not yet resolved.
+    public func isOverdue(asOf now: Date) -> Bool {
+        (status == .expected || status == .late) && expectedDate < now && outstandingMinorUnits > 0
+    }
+}
+
+/// An honest three-way split of the household's cash position.
+public struct CashBreakdown: Sendable, Hashable, Codable {
+    /// Money that has cleared and is available right now, minor units.
+    public let clearedMinorUnits: Int64
+    /// Money expected soon that is reasonably dependable, minor units.
+    public let expectedMinorUnits: Int64
+    /// Expected money that is late or unreliable — do not spend against it yet.
+    public let atRiskMinorUnits: Int64
+    public let currencyCode: String
+
+    public init(
+        clearedMinorUnits: Int64,
+        expectedMinorUnits: Int64,
+        atRiskMinorUnits: Int64,
+        currencyCode: String
+    ) {
+        self.clearedMinorUnits = clearedMinorUnits
+        self.expectedMinorUnits = expectedMinorUnits
+        self.atRiskMinorUnits = atRiskMinorUnits
+        self.currencyCode = currencyCode
+    }
+
+    /// Cash you can plan on today: cleared plus dependable expected money.
+    public var plannableMinorUnits: Int64 {
+        clearedMinorUnits + expectedMinorUnits
+    }
+}
+
+/// Pure, deterministic expected-income cash-planning logic.
+public enum ExpectedIncomeCalculator {
+
+    /// Expected deposits at or below this confidence are treated as *at-risk*
+    /// rather than dependable "expected" cash.
+    public static let atRiskConfidenceCeiling = IncomeReliability.unreliable.confidence
+
+    /// Splits the cash picture into cleared / expected / at-risk buckets.
+    ///
+    /// - An expected item that is overdue (late) is always at-risk.
+    /// - An `.unreliable` item is at-risk even before it is due.
+    /// - `.missed` items contribute nothing.
+    /// - `.received` items are assumed already reflected in `clearedCashMinorUnits`
+    ///   and are not double-counted here.
+    public static func breakdown(
+        clearedCashMinorUnits: Int64,
+        expectedIncomes: [ExpectedIncome],
+        currencyCode: String = "USD",
+        asOf now: Date = Date()
+    ) -> CashBreakdown {
+        var expected: Int64 = 0
+        var atRisk: Int64 = 0
+
+        for income in expectedIncomes {
+            switch income.status {
+            case .received, .missed:
+                continue
+            case .expected, .late, .partial:
+                let outstanding = income.outstandingMinorUnits
+                guard outstanding > 0 else { continue }
+                let isLate = income.isOverdue(asOf: now)
+                let isUnreliable = income.reliability.confidence <= atRiskConfidenceCeiling
+                if isLate || isUnreliable {
+                    atRisk += outstanding
+                } else {
+                    expected += outstanding
+                }
+            }
+        }
+
+        return CashBreakdown(
+            clearedMinorUnits: clearedCashMinorUnits,
+            expectedMinorUnits: expected,
+            atRiskMinorUnits: atRisk,
+            currencyCode: currencyCode
+        )
+    }
+
+    /// Expected deposits that are overdue and should surface a gentle reminder.
+    public static func overdue(
+        _ expectedIncomes: [ExpectedIncome],
+        asOf now: Date = Date()
+    ) -> [ExpectedIncome] {
+        expectedIncomes
+            .filter { $0.isOverdue(asOf: now) }
+            .sorted { $0.expectedDate < $1.expectedDate }
+    }
+}

--- a/apps/ios/Shared/FamilyBudgetTemplate.swift
+++ b/apps/ios/Shared/FamilyBudgetTemplate.swift
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// FamilyBudgetTemplate.swift - FinanceShared - Refs #2201
+//
+// Pure, dependency-free family/single-parent starter templates and supportive
+// coaching copy. Kids create frequent, irregular spending — school fees,
+// childcare, sports, birthday parties, field trips — that generic default
+// categories miss. This gives iOS onboarding a family-aware starting point and a
+// calm, non-judgmental coaching voice.
+//
+// Colours are CSS-style hex so the app layer can map them straight onto
+// CategoryItem without a shared SwiftUI dependency.
+
+import Foundation
+
+/// A single starter category proposed by a family template.
+public struct StarterCategory: Sendable, Hashable, Codable, Identifiable {
+    public let id: String
+    public let name: String
+    public let colorHex: String
+    /// SF Symbol name for the category icon.
+    public let icon: String
+    /// Whether this is a kid/caregiver-specific bucket (used for emphasis).
+    public let isKidRelated: Bool
+
+    public init(id: String, name: String, colorHex: String, icon: String, isKidRelated: Bool = false) {
+        self.id = id
+        self.name = name
+        self.colorHex = colorHex
+        self.icon = icon
+        self.isKidRelated = isKidRelated
+    }
+}
+
+/// A named starter template a user can adopt instead of building from scratch.
+public struct FamilyBudgetTemplate: Sendable, Hashable, Identifiable {
+    public let id: String
+    public let name: String
+    /// Warm, plain-language description of who the template is for.
+    public let summary: String
+    public let categories: [StarterCategory]
+
+    public init(id: String, name: String, summary: String, categories: [StarterCategory]) {
+        self.id = id
+        self.name = name
+        self.summary = summary
+        self.categories = categories
+    }
+
+    /// Kid-specific buckets within the template.
+    public var kidCategories: [StarterCategory] {
+        categories.filter(\.isKidRelated)
+    }
+}
+
+/// The catalog of family-aware starter templates for iOS setup.
+public enum FamilyBudgetTemplates {
+
+    /// Core kid-specific categories requested in #2201.
+    public static let kidCategories: [StarterCategory] = [
+        StarterCategory(id: "kid-school", name: "School", colorHex: "#3182CE", icon: "graduationcap", isKidRelated: true),
+        StarterCategory(id: "kid-childcare", name: "Childcare", colorHex: "#805AD5", icon: "figure.and.child.holdinghands", isKidRelated: true),
+        StarterCategory(id: "kid-activities", name: "Activities & Sports", colorHex: "#38A169", icon: "figure.run", isKidRelated: true),
+        StarterCategory(id: "kid-birthdays", name: "Birthdays & Parties", colorHex: "#D53F8C", icon: "gift", isKidRelated: true),
+        StarterCategory(id: "kid-fieldtrips", name: "Field Trips", colorHex: "#DD6B20", icon: "bus", isKidRelated: true),
+        StarterCategory(id: "kid-clothing", name: "Kids' Clothing", colorHex: "#00B5D8", icon: "tshirt", isKidRelated: true),
+    ]
+
+    /// Everyday essentials shared across the family templates.
+    private static let essentials: [StarterCategory] = [
+        StarterCategory(id: "cat-groceries", name: "Groceries", colorHex: "#38A169", icon: "cart"),
+        StarterCategory(id: "cat-housing", name: "Housing", colorHex: "#5A67D8", icon: "house"),
+        StarterCategory(id: "cat-utilities", name: "Utilities", colorHex: "#D69E2E", icon: "bolt"),
+        StarterCategory(id: "cat-transport", name: "Transport", colorHex: "#3182CE", icon: "car"),
+        StarterCategory(id: "cat-health", name: "Health", colorHex: "#E53E3E", icon: "cross.case"),
+    ]
+
+    /// A single-parent template: essentials plus the full kid bucket set.
+    public static let singleParent = FamilyBudgetTemplate(
+        id: "template-single-parent",
+        name: "Single-Parent Budget",
+        summary: "Built for one income and a busy household. Includes the everyday essentials plus the kid costs that don't fit a tidy monthly rhythm.",
+        categories: essentials + kidCategories
+    )
+
+    /// A broader family template (two caregivers) with the same kid buckets.
+    public static let family = FamilyBudgetTemplate(
+        id: "template-family",
+        name: "Family Budget",
+        summary: "A family-aware starting point that already knows about school, childcare, activities, and the occasional birthday party.",
+        categories: essentials + kidCategories
+    )
+
+    /// All templates offered in setup, in display order.
+    public static let all: [FamilyBudgetTemplate] = [singleParent, family]
+}
+
+/// Calm, factual, next-step-oriented coaching copy per the content-language
+/// guidelines — framing like "past plan" and "want to adjust this category?"
+/// instead of blame-heavy alerts. Centralised so the tone stays consistent.
+public enum SupportiveCoaching {
+
+    /// A gentle heading for a category that has passed its plan.
+    public static func overPlanTitle(category: String) -> String {
+        "\(category): past your plan"
+    }
+
+    /// Body copy for an over-plan category — no shame, one clear next step.
+    public static func overPlanBody(category: String) -> String {
+        "You've gone a little past your \(category) plan this period. Want to adjust this category, or move a little from another one?"
+    }
+
+    /// Heading when a category is getting close to its plan.
+    public static func nearPlanTitle(category: String) -> String {
+        "\(category): getting close"
+    }
+
+    /// Body copy when approaching a plan limit.
+    public static func nearPlanBody(category: String) -> String {
+        "You're near your \(category) plan for this period. You've still got room — just something to keep in mind."
+    }
+
+    /// A supportive bill-due-soon reminder (vs. high-pressure "Overdue").
+    public static func billDueSoon(name: String, whenText: String) -> String {
+        "\(name) is due \(whenText). No rush — just a heads-up so it doesn't sneak up on you."
+    }
+
+    /// A warm affirmation surfaced during family setup.
+    public static let familySetupWelcome =
+        "Money's tight for a lot of families, and that's okay. Let's set this up to reflect your real life — kids and all."
+}

--- a/apps/ios/Shared/PaydayBillCalendarModel.swift
+++ b/apps/ios/Shared/PaydayBillCalendarModel.swift
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: BUSL-1.1
+// PaydayBillCalendarModel.swift - FinanceShared - Refs #2196
+//
+// A pure, dependency-free model that lines bill due dates up with payday reality.
+// For a stressed caregiver, totals aren't enough — timing is the whole game. This
+// turns a flat list of bills and expected paydays into a calendar the app can
+// render, and answers the question that matters: "What hits before my next
+// paycheck, and which weeks are tight?"
+//
+// All money is in integer minor units (cents). No UI/KMP dependencies.
+
+import Foundation
+
+/// A single dated money event on the planning calendar.
+public struct BillCalendarEvent: Sendable, Hashable, Codable, Identifiable {
+    public let id: String
+    public let name: String
+    public let amountMinorUnits: Int64
+    public let dueDate: Date
+    /// One-off kid/life expenses (school fees, birthday parties, sports signups)
+    /// live in the same planning view as recurring bills.
+    public let isOneOff: Bool
+
+    public init(
+        id: String = UUID().uuidString,
+        name: String,
+        amountMinorUnits: Int64,
+        dueDate: Date,
+        isOneOff: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.amountMinorUnits = amountMinorUnits
+        self.dueDate = dueDate
+        self.isOneOff = isOneOff
+    }
+}
+
+/// A day on the calendar that has at least one money event.
+public struct BillCalendarDay: Sendable, Hashable, Identifiable {
+    /// Start-of-day date; also serves as a stable identifier.
+    public let date: Date
+    public let events: [BillCalendarEvent]
+    /// Whether a payday lands on this day.
+    public let isPayday: Bool
+    /// Whether this day falls on or before the next payday from the reference date.
+    public let isBeforeNextPayday: Bool
+
+    public var id: Date { date }
+
+    public var totalMinorUnits: Int64 {
+        events.reduce(Int64(0)) { $0 + $1.amountMinorUnits }
+    }
+
+    public init(date: Date, events: [BillCalendarEvent], isPayday: Bool, isBeforeNextPayday: Bool) {
+        self.date = date
+        self.events = events
+        self.isPayday = isPayday
+        self.isBeforeNextPayday = isBeforeNextPayday
+    }
+}
+
+/// A pay-period window (one payday to the next) with its cash-flow health.
+public struct PayPeriodSummary: Sendable, Hashable, Identifiable {
+    public let start: Date
+    public let end: Date
+    public let billsDueMinorUnits: Int64
+    public let expectedIncomeMinorUnits: Int64
+
+    public var id: Date { start }
+
+    /// A week/period is "high-risk" when bills due exceed the income expected to
+    /// cover them within the window.
+    public var isHighRisk: Bool {
+        billsDueMinorUnits > expectedIncomeMinorUnits
+    }
+
+    public init(start: Date, end: Date, billsDueMinorUnits: Int64, expectedIncomeMinorUnits: Int64) {
+        self.start = start
+        self.end = end
+        self.billsDueMinorUnits = billsDueMinorUnits
+        self.expectedIncomeMinorUnits = expectedIncomeMinorUnits
+    }
+}
+
+/// An expected income deposit used to gauge pay-period cash-flow health.
+public struct PaydayDeposit: Sendable, Hashable, Codable {
+    public let date: Date
+    public let amountMinorUnits: Int64
+
+    public init(date: Date, amountMinorUnits: Int64) {
+        self.date = date
+        self.amountMinorUnits = amountMinorUnits
+    }
+}
+
+/// How often a paycheck or reliable deposit lands.
+public enum PayFrequency: String, Sendable, CaseIterable, Codable {
+    case weekly, biweekly, semimonthly, monthly
+
+    public var displayName: String {
+        switch self {
+        case .weekly: return "Weekly"
+        case .biweekly: return "Every 2 weeks"
+        case .semimonthly: return "Twice a month"
+        case .monthly: return "Monthly"
+        }
+    }
+}
+
+/// Pure generator for upcoming payday dates from an anchor + frequency, so the
+/// bill calendar and grocery mode can align bills to real paycheck timing.
+public enum PaydaySchedule {
+
+    /// Generates the next `count` paydays on or after `referenceDate`.
+    ///
+    /// - Semimonthly pays on the anchor's day-of-month and the 15th/last-day
+    ///   partner, approximated here as the anchor day and 14 days later.
+    public static func upcomingPaydays(
+        anchor: Date,
+        frequency: PayFrequency,
+        from referenceDate: Date = Date(),
+        count: Int = 6,
+        calendar: Calendar = .current
+    ) -> [Date] {
+        guard count > 0 else { return [] }
+        let today = calendar.startOfDay(for: referenceDate)
+        var result: [Date] = []
+        var current = calendar.startOfDay(for: anchor)
+
+        // Wind forward to the first payday on/after today (bounded to avoid loops).
+        var guardCount = 0
+        while current < today && guardCount < 1_000 {
+            current = advance(current, frequency: frequency, calendar: calendar)
+            guardCount += 1
+        }
+
+        while result.count < count && guardCount < 2_000 {
+            if current >= today {
+                result.append(current)
+            }
+            current = advance(current, frequency: frequency, calendar: calendar)
+            guardCount += 1
+        }
+        return result
+    }
+
+    private static func advance(_ date: Date, frequency: PayFrequency, calendar: Calendar) -> Date {
+        switch frequency {
+        case .weekly:
+            return calendar.date(byAdding: .day, value: 7, to: date) ?? date
+        case .biweekly, .semimonthly:
+            return calendar.date(byAdding: .day, value: 14, to: date) ?? date
+        case .monthly:
+            return calendar.date(byAdding: .month, value: 1, to: date) ?? date
+        }
+    }
+}
+
+/// Pure, deterministic bill-calendar + payday-alignment logic.
+public enum BillCalendarCalculator {
+
+    /// Groups events into calendar days, marking paydays and the "before next
+    /// payday" window. Days with no events are omitted (the UI fills the grid).
+    ///
+    /// - Parameters:
+    ///   - events: All dated money events to place.
+    ///   - paydays: Expected income dates.
+    ///   - referenceDate: "Now" — used to find the next payday.
+    ///   - calendar: Calendar for day bucketing (injectable for tests).
+    public static func days(
+        events: [BillCalendarEvent],
+        paydays: [Date],
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [BillCalendarDay] {
+        let paydayDays = Set(paydays.map { calendar.startOfDay(for: $0) })
+        let nextPayday = self.nextPayday(after: referenceDate, paydays: paydays, calendar: calendar)
+        let today = calendar.startOfDay(for: referenceDate)
+
+        let grouped = Dictionary(grouping: events) { calendar.startOfDay(for: $0.dueDate) }
+
+        return grouped
+            .map { day, dayEvents -> BillCalendarDay in
+                let beforeNext: Bool
+                if let nextPayday {
+                    beforeNext = day >= today && day <= calendar.startOfDay(for: nextPayday)
+                } else {
+                    beforeNext = false
+                }
+                return BillCalendarDay(
+                    date: day,
+                    events: dayEvents.sorted { $0.amountMinorUnits > $1.amountMinorUnits },
+                    isPayday: paydayDays.contains(day),
+                    isBeforeNextPayday: beforeNext
+                )
+            }
+            .sorted { $0.date < $1.date }
+    }
+
+    /// The next payday strictly on or after `referenceDate`, or `nil` if none.
+    public static func nextPayday(
+        after referenceDate: Date,
+        paydays: [Date],
+        calendar: Calendar = .current
+    ) -> Date? {
+        let today = calendar.startOfDay(for: referenceDate)
+        return paydays
+            .map { calendar.startOfDay(for: $0) }
+            .filter { $0 >= today }
+            .min()
+    }
+
+    /// Events that fall between now and the next payday (inclusive) — the
+    /// "what hits before my paycheck?" answer.
+    public static func dueBeforeNextPayday(
+        events: [BillCalendarEvent],
+        paydays: [Date],
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [BillCalendarEvent] {
+        guard let nextPayday = nextPayday(after: referenceDate, paydays: paydays, calendar: calendar) else {
+            return []
+        }
+        let today = calendar.startOfDay(for: referenceDate)
+        let payDay = calendar.startOfDay(for: nextPayday)
+        return events
+            .filter {
+                let day = calendar.startOfDay(for: $0.dueDate)
+                return day >= today && day <= payDay
+            }
+            .sorted { $0.dueDate < $1.dueDate }
+    }
+
+    /// Total amount due before the next payday, in minor units.
+    public static func totalDueBeforeNextPayday(
+        events: [BillCalendarEvent],
+        paydays: [Date],
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Int64 {
+        dueBeforeNextPayday(
+            events: events,
+            paydays: paydays,
+            referenceDate: referenceDate,
+            calendar: calendar
+        ).reduce(Int64(0)) { $0 + $1.amountMinorUnits }
+    }
+
+    /// Builds pay-period summaries between consecutive paydays, attributing bills
+    /// and expected income to the window they fall in. The final open-ended
+    /// window (after the last payday) is included so upcoming risk is visible.
+    public static func payPeriods(
+        events: [BillCalendarEvent],
+        deposits: [PaydayDeposit],
+        calendar: Calendar = .current
+    ) -> [PayPeriodSummary] {
+        guard !deposits.isEmpty else { return [] }
+        let sortedDeposits = deposits.sorted { $0.date < $1.date }
+        let boundaries = sortedDeposits.map { calendar.startOfDay(for: $0.date) }
+
+        var summaries: [PayPeriodSummary] = []
+        for (index, start) in boundaries.enumerated() {
+            let end: Date
+            let isLast = index == boundaries.count - 1
+            if isLast {
+                end = calendar.date(byAdding: .day, value: 30, to: start) ?? start
+            } else {
+                // Period runs up to (but not including) the next payday.
+                end = calendar.date(byAdding: .day, value: -1, to: boundaries[index + 1]) ?? boundaries[index + 1]
+            }
+
+            let billsDue = events
+                .filter {
+                    let day = calendar.startOfDay(for: $0.dueDate)
+                    return day >= start && day <= end
+                }
+                .reduce(Int64(0)) { $0 + $1.amountMinorUnits }
+
+            // Income for the window is the deposit that opens it.
+            let income = sortedDeposits[index].amountMinorUnits
+
+            summaries.append(
+                PayPeriodSummary(
+                    start: start,
+                    end: end,
+                    billsDueMinorUnits: billsDue,
+                    expectedIncomeMinorUnits: income
+                )
+            )
+        }
+        return summaries
+    }
+}

--- a/apps/ios/Shared/SafeToSpendModel.swift
+++ b/apps/ios/Shared/SafeToSpendModel.swift
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SafeToSpendModel.swift - FinanceShared - Refs #2199
+//
+// A pure, dependency-free "can I afford this?" calculator for the grocery-aisle
+// decision moment. All money is expressed in integer minor units (cents) so the
+// math is exact and deterministic. No UI, KMP, or networking dependencies — this
+// type is fully unit-testable in isolation.
+//
+// The question this answers, in the store, in seconds: "How much can I safely
+// spend right now, before my next payday and the critical bills that land before
+// it?" — framed supportively, never as a red-alert.
+
+import Foundation
+
+/// A critical outflow (bill or one-off kid expense) that must be reserved from
+/// cleared cash before the next payday.
+public struct SafeToSpendObligation: Sendable, Hashable, Codable {
+    public let amountMinorUnits: Int64
+    public let dueDate: Date
+    /// Whether this obligation is essential (rent, utilities, childcare). Only
+    /// essential obligations are reserved from the "safe to spend" figure.
+    public let isCritical: Bool
+
+    public init(amountMinorUnits: Int64, dueDate: Date, isCritical: Bool) {
+        self.amountMinorUnits = amountMinorUnits
+        self.dueDate = dueDate
+        self.isCritical = isCritical
+    }
+}
+
+/// Inputs for the safe-to-spend computation.
+public struct SafeToSpendInput: Sendable {
+    /// Cash that has actually cleared and is available right now, in minor units.
+    public let clearedCashMinorUnits: Int64
+    /// The date the user's next reliable income lands (payday).
+    public let nextPaydayDate: Date
+    /// Critical obligations that could land between now and payday.
+    public let obligations: [SafeToSpendObligation]
+    /// Remaining budget for the pinned high-frequency category (e.g. Groceries),
+    /// in minor units, if the user has pinned one. `nil` when not configured.
+    public let pinnedCategoryRemainingMinorUnits: Int64?
+    public let pinnedCategoryName: String?
+    public let currencyCode: String
+    public let referenceDate: Date
+
+    public init(
+        clearedCashMinorUnits: Int64,
+        nextPaydayDate: Date,
+        obligations: [SafeToSpendObligation],
+        pinnedCategoryRemainingMinorUnits: Int64? = nil,
+        pinnedCategoryName: String? = nil,
+        currencyCode: String = "USD",
+        referenceDate: Date = Date()
+    ) {
+        self.clearedCashMinorUnits = clearedCashMinorUnits
+        self.nextPaydayDate = nextPaydayDate
+        self.obligations = obligations
+        self.pinnedCategoryRemainingMinorUnits = pinnedCategoryRemainingMinorUnits
+        self.pinnedCategoryName = pinnedCategoryName
+        self.currencyCode = currencyCode
+        self.referenceDate = referenceDate
+    }
+}
+
+/// The glanceable "safe to spend" answer.
+public struct SafeToSpendResult: Sendable, Hashable, Codable {
+    /// Cash safe to spend before the next payday after reserving critical bills.
+    public let safeToSpendMinorUnits: Int64
+    /// Sum of critical obligations reserved (positive magnitude), minor units.
+    public let reservedForBillsMinorUnits: Int64
+    /// Remaining amount for the pinned category, if any. `nil` when unset.
+    public let pinnedCategoryRemainingMinorUnits: Int64?
+    public let pinnedCategoryName: String?
+    /// Whole days until the next payday (never negative).
+    public let daysUntilPayday: Int
+    public let currencyCode: String
+
+    public init(
+        safeToSpendMinorUnits: Int64,
+        reservedForBillsMinorUnits: Int64,
+        pinnedCategoryRemainingMinorUnits: Int64?,
+        pinnedCategoryName: String?,
+        daysUntilPayday: Int,
+        currencyCode: String
+    ) {
+        self.safeToSpendMinorUnits = safeToSpendMinorUnits
+        self.reservedForBillsMinorUnits = reservedForBillsMinorUnits
+        self.pinnedCategoryRemainingMinorUnits = pinnedCategoryRemainingMinorUnits
+        self.pinnedCategoryName = pinnedCategoryName
+        self.daysUntilPayday = daysUntilPayday
+        self.currencyCode = currencyCode
+    }
+
+    /// The number to answer an affordability check against: the pinned category
+    /// remaining when configured, otherwise the general safe-to-spend figure.
+    public var spendableForCheckMinorUnits: Int64 {
+        pinnedCategoryRemainingMinorUnits ?? safeToSpendMinorUnits
+    }
+}
+
+/// The outcome of an in-aisle "can I afford this?" check.
+public enum AffordabilityVerdict: String, Sendable, Equatable {
+    /// Comfortably within the safe-to-spend cushion.
+    case comfortable
+    /// Possible, but it uses most of the cushion — a gentle heads-up.
+    case tight
+    /// Would spend past the cushion before payday.
+    case beyond
+}
+
+/// Pure, deterministic safe-to-spend + affordability logic.
+public enum SafeToSpendCalculator {
+
+    /// Fraction of the cushion above which a purchase is flagged as "tight".
+    public static let tightThreshold: Double = 0.8
+
+    /// Computes the safe-to-spend summary from the given input.
+    ///
+    /// Only *critical* obligations that fall on or before the next payday are
+    /// reserved. The safe-to-spend figure is clamped at zero — it never reports
+    /// a negative "you owe" number, keeping the framing calm and actionable.
+    public static func evaluate(_ input: SafeToSpendInput) -> SafeToSpendResult {
+        let reserved = input.obligations
+            .filter { $0.isCritical && $0.dueDate >= input.referenceDate && $0.dueDate <= input.nextPaydayDate }
+            .reduce(Int64(0)) { $0 + max($1.amountMinorUnits, 0) }
+
+        let safe = max(input.clearedCashMinorUnits - reserved, 0)
+
+        let calendar = Calendar.current
+        let days = calendar.dateComponents(
+            [.day],
+            from: calendar.startOfDay(for: input.referenceDate),
+            to: calendar.startOfDay(for: input.nextPaydayDate)
+        ).day ?? 0
+
+        return SafeToSpendResult(
+            safeToSpendMinorUnits: safe,
+            reservedForBillsMinorUnits: reserved,
+            pinnedCategoryRemainingMinorUnits: input.pinnedCategoryRemainingMinorUnits,
+            pinnedCategoryName: input.pinnedCategoryName,
+            daysUntilPayday: max(days, 0),
+            currencyCode: input.currencyCode
+        )
+    }
+
+    /// Evaluates whether a prospective purchase fits within the spendable cushion.
+    ///
+    /// - Parameters:
+    ///   - purchaseMinorUnits: The prospective spend (positive magnitude).
+    ///   - spendableMinorUnits: The cushion to check against.
+    /// - Returns: A supportive verdict — comfortable, tight, or beyond.
+    public static func verdict(
+        purchaseMinorUnits: Int64,
+        spendableMinorUnits: Int64
+    ) -> AffordabilityVerdict {
+        let purchase = max(purchaseMinorUnits, 0)
+        guard spendableMinorUnits > 0 else {
+            return purchase == 0 ? .comfortable : .beyond
+        }
+        if purchase > spendableMinorUnits { return .beyond }
+        let fraction = Double(purchase) / Double(spendableMinorUnits)
+        return fraction >= tightThreshold ? .tight : .comfortable
+    }
+
+    /// The cushion remaining *after* a prospective purchase (may be negative).
+    public static func remainingAfter(
+        purchaseMinorUnits: Int64,
+        spendableMinorUnits: Int64
+    ) -> Int64 {
+        spendableMinorUnits - max(purchaseMinorUnits, 0)
+    }
+}

--- a/apps/ios/Shared/SmartNotificationTiming.swift
+++ b/apps/ios/Shared/SmartNotificationTiming.swift
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SmartNotificationTiming.swift - FinanceShared - Refs #2391
+//
+// A pure, on-device notification-timing policy. Finance reminders sent at fixed
+// times are easy to ignore; this learns — from local behavioural signals only —
+// the hours a user is most likely to act, and recommends delivery times that
+// respect quiet hours and Focus. No notification-interaction history ever leaves
+// the device: this type takes already-aggregated, content-free counts and never
+// touches finance data. Fully unit-testable, no UI/KMP dependencies.
+
+import Foundation
+
+/// A content-free, per-hour aggregate of how a user has responded to reminders.
+///
+/// We deliberately store only counts keyed by hour-of-day — never the reminder
+/// content, the amount, the payee, or a timestamped history. This is the entire
+/// feature set the timing model is allowed to see.
+public struct HourEngagement: Sendable, Hashable, Codable {
+    /// Hour of day, 0...23.
+    public let hour: Int
+    /// How many reminders were delivered in this hour bucket.
+    public let deliveredCount: Int
+    /// How many of those were acted upon (opened / tapped through).
+    public let actedCount: Int
+
+    public init(hour: Int, deliveredCount: Int, actedCount: Int) {
+        self.hour = hour
+        self.deliveredCount = deliveredCount
+        self.actedCount = actedCount
+    }
+
+    /// Action rate for the hour (0...1). Zero when nothing was delivered.
+    public var actionRate: Double {
+        guard deliveredCount > 0 else { return 0 }
+        return Double(actedCount) / Double(deliveredCount)
+    }
+}
+
+/// A quiet-hours window during which reminders should never be delivered.
+///
+/// Windows may wrap past midnight (e.g. 22:00–07:00).
+public struct QuietHours: Sendable, Hashable, Codable {
+    public let startHour: Int
+    public let endHour: Int
+
+    public init(startHour: Int, endHour: Int) {
+        self.startHour = startHour
+        self.endHour = endHour
+    }
+
+    /// A sensible default overnight quiet window (10pm–7am).
+    public static let overnightDefault = QuietHours(startHour: 22, endHour: 7)
+
+    /// Whether the given hour is inside the quiet window.
+    public func contains(_ hour: Int) -> Bool {
+        let h = ((hour % 24) + 24) % 24
+        if startHour == endHour { return false }
+        if startHour < endHour {
+            return h >= startHour && h < endHour
+        }
+        // Wraps past midnight.
+        return h >= startHour || h < endHour
+    }
+}
+
+/// Aggregate, privacy-preserving health of smart-timing delivery. Contains no
+/// finance content — only counts — so it is safe to surface or log in aggregate.
+public struct SmartTimingHealth: Sendable, Hashable, Codable {
+    public let totalDelivered: Int
+    public let totalActed: Int
+
+    public init(totalDelivered: Int, totalActed: Int) {
+        self.totalDelivered = totalDelivered
+        self.totalActed = totalActed
+    }
+
+    /// Overall open/act rate (0...1).
+    public var openRate: Double {
+        guard totalDelivered > 0 else { return 0 }
+        return Double(totalActed) / Double(totalDelivered)
+    }
+}
+
+/// Pure, deterministic smart-timing policy.
+public enum SmartNotificationTiming {
+
+    /// Minimum deliveries required before the model trusts learned data over the
+    /// fallback time. Below this we schedule at the fallback hour.
+    public static let minSignalsToPersonalize = 5
+
+    /// Recommends a delivery hour (0...23) for the next reminder.
+    ///
+    /// The chosen hour maximises historical action rate, breaking ties toward
+    /// more total engagement, and is nudged out of any quiet-hours window. When
+    /// there is not enough on-device data yet, the caller's `fallbackHour` is
+    /// used (also quiet-hours-adjusted). When smart timing is disabled the
+    /// fallback is returned unchanged so behaviour is fully predictable.
+    ///
+    /// - Parameters:
+    ///   - engagement: Per-hour, content-free engagement aggregates.
+    ///   - quietHours: The window to avoid, if any.
+    ///   - fallbackHour: The user's configured fixed time (default 9am).
+    ///   - smartTimingEnabled: Master switch; `false` returns `fallbackHour`.
+    public static func recommendedHour(
+        engagement: [HourEngagement],
+        quietHours: QuietHours? = QuietHours.overnightDefault,
+        fallbackHour: Int = 9,
+        smartTimingEnabled: Bool = true
+    ) -> Int {
+        guard smartTimingEnabled else {
+            return adjustOutOfQuietHours(fallbackHour, quietHours: quietHours)
+        }
+
+        let totalDelivered = engagement.reduce(0) { $0 + $1.deliveredCount }
+        guard totalDelivered >= minSignalsToPersonalize else {
+            return adjustOutOfQuietHours(fallbackHour, quietHours: quietHours)
+        }
+
+        // Consider only hours outside quiet hours with at least one delivery.
+        let candidates = engagement.filter { entry in
+            entry.deliveredCount > 0 && !(quietHours?.contains(entry.hour) ?? false)
+        }
+        guard let best = candidates.max(by: { lhs, rhs in
+            if lhs.actionRate == rhs.actionRate {
+                return lhs.actedCount < rhs.actedCount
+            }
+            return lhs.actionRate < rhs.actionRate
+        }) else {
+            return adjustOutOfQuietHours(fallbackHour, quietHours: quietHours)
+        }
+
+        // Only personalize if the best hour actually shows engagement.
+        guard best.actedCount > 0 else {
+            return adjustOutOfQuietHours(fallbackHour, quietHours: quietHours)
+        }
+        return best.hour
+    }
+
+    /// Whether the model has enough data to personalize rather than fall back.
+    public static func canPersonalize(engagement: [HourEngagement]) -> Bool {
+        engagement.reduce(0) { $0 + $1.deliveredCount } >= minSignalsToPersonalize
+    }
+
+    /// Aggregates content-free health metrics across all hour buckets.
+    public static func health(engagement: [HourEngagement]) -> SmartTimingHealth {
+        SmartTimingHealth(
+            totalDelivered: engagement.reduce(0) { $0 + $1.deliveredCount },
+            totalActed: engagement.reduce(0) { $0 + $1.actedCount }
+        )
+    }
+
+    /// Nudges an hour to the first non-quiet hour at/after it (wrapping a day),
+    /// so a fallback time never lands inside the quiet window.
+    public static func adjustOutOfQuietHours(_ hour: Int, quietHours: QuietHours?) -> Int {
+        guard let quietHours else { return ((hour % 24) + 24) % 24 }
+        var candidate = ((hour % 24) + 24) % 24
+        var guardCount = 0
+        while quietHours.contains(candidate) && guardCount < 24 {
+            candidate = (candidate + 1) % 24
+            guardCount += 1
+        }
+        return candidate
+    }
+}

--- a/apps/ios/Tests/BillCalendarCalculatorTests.swift
+++ b/apps/ios/Tests/BillCalendarCalculatorTests.swift
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// BillCalendarCalculatorTests.swift — FinanceTests — Refs #2196
+
+import XCTest
+@testable import FinanceShared
+
+final class BillCalendarCalculatorTests: XCTestCase {
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+        return calendar
+    }()
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, hour: Int = 12) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        return calendar.date(from: components)!
+    }
+
+    func testNextPaydayPicksSoonestFuture() {
+        let paydays = [date(2026, 6, 1), date(2026, 6, 15), date(2026, 6, 30)]
+        let next = BillCalendarCalculator.nextPayday(after: date(2026, 6, 10), paydays: paydays, calendar: calendar)
+        XCTAssertEqual(next.map { calendar.startOfDay(for: $0) }, calendar.startOfDay(for: date(2026, 6, 15)))
+    }
+
+    func testDueBeforeNextPaydayFiltersWindow() {
+        let events = [
+            BillCalendarEvent(name: "Rent", amountMinorUnits: 120_000, dueDate: date(2026, 6, 12)),
+            BillCalendarEvent(name: "Field trip", amountMinorUnits: 4_000, dueDate: date(2026, 6, 14), isOneOff: true),
+            BillCalendarEvent(name: "Internet", amountMinorUnits: 6_000, dueDate: date(2026, 6, 18)), // after payday
+        ]
+        let paydays = [date(2026, 6, 15)]
+
+        let due = BillCalendarCalculator.dueBeforeNextPayday(
+            events: events,
+            paydays: paydays,
+            referenceDate: date(2026, 6, 10),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(due.map(\.name), ["Rent", "Field trip"])
+        let total = BillCalendarCalculator.totalDueBeforeNextPayday(
+            events: events,
+            paydays: paydays,
+            referenceDate: date(2026, 6, 10),
+            calendar: calendar
+        )
+        XCTAssertEqual(total, 124_000)
+    }
+
+    func testDaysGroupAndFlagPaydayAndWindow() {
+        let events = [
+            BillCalendarEvent(name: "Rent", amountMinorUnits: 120_000, dueDate: date(2026, 6, 12, hour: 9)),
+            BillCalendarEvent(name: "Water", amountMinorUnits: 3_000, dueDate: date(2026, 6, 12, hour: 18)),
+            BillCalendarEvent(name: "Sports", amountMinorUnits: 5_000, dueDate: date(2026, 6, 20), isOneOff: true),
+        ]
+        let paydays = [date(2026, 6, 15)]
+
+        let days = BillCalendarCalculator.days(
+            events: events,
+            paydays: paydays,
+            referenceDate: date(2026, 6, 10),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(days.count, 2)
+        let firstDay = days[0]
+        XCTAssertEqual(firstDay.events.count, 2)
+        XCTAssertEqual(firstDay.totalMinorUnits, 123_000)
+        XCTAssertTrue(firstDay.isBeforeNextPayday)
+        XCTAssertFalse(firstDay.isPayday)
+        // Highest amount sorts first within a day.
+        XCTAssertEqual(firstDay.events.first?.name, "Rent")
+
+        let secondDay = days[1]
+        XCTAssertFalse(secondDay.isBeforeNextPayday) // June 20 is after payday
+    }
+
+    func testPayPeriodsFlagHighRiskWeeks() {
+        let events = [
+            BillCalendarEvent(name: "Rent", amountMinorUnits: 120_000, dueDate: date(2026, 6, 3)),
+            BillCalendarEvent(name: "Camp", amountMinorUnits: 40_000, dueDate: date(2026, 6, 18), isOneOff: true),
+        ]
+        let deposits = [
+            PaydayDeposit(date: date(2026, 6, 1), amountMinorUnits: 130_000),
+            PaydayDeposit(date: date(2026, 6, 15), amountMinorUnits: 30_000),
+        ]
+
+        let periods = BillCalendarCalculator.payPeriods(events: events, deposits: deposits, calendar: calendar)
+
+        XCTAssertEqual(periods.count, 2)
+        // First period: 130k income vs 120k bills → not high risk.
+        XCTAssertFalse(periods[0].isHighRisk)
+        // Second period: 30k income vs 40k camp → high risk.
+        XCTAssertTrue(periods[1].isHighRisk)
+    }
+
+    func testNoPaydaysYieldsEmptyWindow() {
+        let events = [BillCalendarEvent(name: "Rent", amountMinorUnits: 120_000, dueDate: date(2026, 6, 12))]
+        let due = BillCalendarCalculator.dueBeforeNextPayday(events: events, paydays: [], referenceDate: date(2026, 6, 10), calendar: calendar)
+        XCTAssertTrue(due.isEmpty)
+    }
+
+    func testUpcomingPaydaysBiweeklyFromAnchor() {
+        let paydays = PaydaySchedule.upcomingPaydays(
+            anchor: date(2026, 6, 5),
+            frequency: .biweekly,
+            from: date(2026, 6, 10),
+            count: 3,
+            calendar: calendar
+        )
+        XCTAssertEqual(paydays.count, 3)
+        XCTAssertEqual(paydays.map { calendar.startOfDay(for: $0) }, [
+            calendar.startOfDay(for: date(2026, 6, 19)),
+            calendar.startOfDay(for: date(2026, 7, 3)),
+            calendar.startOfDay(for: date(2026, 7, 17)),
+        ])
+    }
+
+    func testUpcomingPaydaysMonthlyIncludesTodayAnchor() {
+        let paydays = PaydaySchedule.upcomingPaydays(
+            anchor: date(2026, 6, 1),
+            frequency: .monthly,
+            from: date(2026, 6, 1),
+            count: 2,
+            calendar: calendar
+        )
+        XCTAssertEqual(paydays.first.map { calendar.startOfDay(for: $0) }, calendar.startOfDay(for: date(2026, 6, 1)))
+        XCTAssertEqual(paydays.count, 2)
+    }
+}

--- a/apps/ios/Tests/CompactLayoutMetricsTests.swift
+++ b/apps/ios/Tests/CompactLayoutMetricsTests.swift
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// CompactLayoutMetricsTests.swift — FinanceTests — Refs #2190
+
+import XCTest
+@testable import FinanceShared
+
+final class CompactLayoutMetricsTests: XCTestCase {
+
+    func testRegularWidthUsesThreeUpSummary() {
+        let input = SizeClassInput(isCompactWidth: false, isAccessibilityTextSize: false)
+        XCTAssertEqual(CompactLayoutMetrics.summaryColumns(for: input), 3)
+        XCTAssertEqual(CompactLayoutMetrics.quickAccessColumns(for: input), 3)
+        XCTAssertEqual(CompactLayoutMetrics.billsSummaryColumns(for: input), 3)
+    }
+
+    func testCompactWidthStacksSummaryAndUsesTwoUpQuickAccess() {
+        let input = SizeClassInput(isCompactWidth: true, isAccessibilityTextSize: false)
+        XCTAssertEqual(CompactLayoutMetrics.summaryColumns(for: input), 1)
+        XCTAssertEqual(CompactLayoutMetrics.quickAccessColumns(for: input), 2)
+    }
+
+    func testAccessibilityTextForcesSingleColumn() {
+        let input = SizeClassInput(isCompactWidth: false, isAccessibilityTextSize: true)
+        XCTAssertEqual(CompactLayoutMetrics.summaryColumns(for: input), 1)
+        XCTAssertEqual(CompactLayoutMetrics.quickAccessColumns(for: input), 1)
+    }
+
+    func testStepperUsesShortLabelsWhenTight() {
+        XCTAssertTrue(CompactLayoutMetrics.stepperUsesShortLabels(for: SizeClassInput(isCompactWidth: true, isAccessibilityTextSize: false)))
+        XCTAssertTrue(CompactLayoutMetrics.stepperUsesShortLabels(for: SizeClassInput(isCompactWidth: false, isAccessibilityTextSize: true)))
+        XCTAssertFalse(CompactLayoutMetrics.stepperUsesShortLabels(for: SizeClassInput(isCompactWidth: false, isAccessibilityTextSize: false)))
+    }
+}

--- a/apps/ios/Tests/ExpectedIncomeCalculatorTests.swift
+++ b/apps/ios/Tests/ExpectedIncomeCalculatorTests.swift
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// ExpectedIncomeCalculatorTests.swift — FinanceTests — Refs #2193
+
+import XCTest
+@testable import FinanceShared
+
+final class ExpectedIncomeCalculatorTests: XCTestCase {
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+        return calendar
+    }()
+
+    private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = 12
+        return calendar.date(from: components)!
+    }
+
+    func testReliableFutureIncomeCountsAsExpected() {
+        let now = date(2026, 6, 10)
+        let incomes = [
+            ExpectedIncome(source: "Child support", amountMinorUnits: 80_000, expectedDate: date(2026, 6, 15), reliability: .reliable),
+        ]
+
+        let breakdown = ExpectedIncomeCalculator.breakdown(
+            clearedCashMinorUnits: 20_000,
+            expectedIncomes: incomes,
+            asOf: now
+        )
+
+        XCTAssertEqual(breakdown.clearedMinorUnits, 20_000)
+        XCTAssertEqual(breakdown.expectedMinorUnits, 80_000)
+        XCTAssertEqual(breakdown.atRiskMinorUnits, 0)
+        XCTAssertEqual(breakdown.plannableMinorUnits, 100_000)
+    }
+
+    func testUnreliableIncomeIsAtRiskEvenBeforeDue() {
+        let now = date(2026, 6, 10)
+        let incomes = [
+            ExpectedIncome(source: "Child support", amountMinorUnits: 80_000, expectedDate: date(2026, 6, 15), reliability: .unreliable),
+        ]
+
+        let breakdown = ExpectedIncomeCalculator.breakdown(
+            clearedCashMinorUnits: 0,
+            expectedIncomes: incomes,
+            asOf: now
+        )
+
+        XCTAssertEqual(breakdown.expectedMinorUnits, 0)
+        XCTAssertEqual(breakdown.atRiskMinorUnits, 80_000)
+        XCTAssertEqual(breakdown.plannableMinorUnits, 0)
+    }
+
+    func testOverdueReliableIncomeBecomesAtRisk() {
+        let now = date(2026, 6, 20)
+        let incomes = [
+            ExpectedIncome(source: "Child support", amountMinorUnits: 80_000, expectedDate: date(2026, 6, 15), reliability: .reliable, status: .late),
+        ]
+
+        let breakdown = ExpectedIncomeCalculator.breakdown(
+            clearedCashMinorUnits: 0,
+            expectedIncomes: incomes,
+            asOf: now
+        )
+
+        XCTAssertEqual(breakdown.atRiskMinorUnits, 80_000)
+        XCTAssertEqual(breakdown.expectedMinorUnits, 0)
+    }
+
+    func testPartialPaymentCountsOnlyOutstanding() {
+        let now = date(2026, 6, 10)
+        let incomes = [
+            ExpectedIncome(
+                source: "Child support",
+                amountMinorUnits: 80_000,
+                receivedMinorUnits: 50_000,
+                expectedDate: date(2026, 6, 15),
+                reliability: .reliable,
+                status: .partial
+            ),
+        ]
+
+        let breakdown = ExpectedIncomeCalculator.breakdown(
+            clearedCashMinorUnits: 0,
+            expectedIncomes: incomes,
+            asOf: now
+        )
+
+        XCTAssertEqual(breakdown.expectedMinorUnits, 30_000)
+    }
+
+    func testReceivedAndMissedAreExcluded() {
+        let now = date(2026, 6, 10)
+        let incomes = [
+            ExpectedIncome(source: "Received", amountMinorUnits: 40_000, expectedDate: date(2026, 6, 5), reliability: .reliable, status: .received),
+            ExpectedIncome(source: "Missed", amountMinorUnits: 40_000, expectedDate: date(2026, 6, 5), reliability: .reliable, status: .missed),
+        ]
+
+        let breakdown = ExpectedIncomeCalculator.breakdown(
+            clearedCashMinorUnits: 10_000,
+            expectedIncomes: incomes,
+            asOf: now
+        )
+
+        XCTAssertEqual(breakdown.expectedMinorUnits, 0)
+        XCTAssertEqual(breakdown.atRiskMinorUnits, 0)
+        XCTAssertEqual(breakdown.clearedMinorUnits, 10_000)
+    }
+
+    func testOverdueSurfacesForReminders() {
+        let now = date(2026, 6, 20)
+        let incomes = [
+            ExpectedIncome(source: "Late one", amountMinorUnits: 80_000, expectedDate: date(2026, 6, 15), reliability: .usuallyOnTime),
+            ExpectedIncome(source: "Future one", amountMinorUnits: 20_000, expectedDate: date(2026, 6, 25), reliability: .reliable),
+        ]
+
+        let overdue = ExpectedIncomeCalculator.overdue(incomes, asOf: now)
+
+        XCTAssertEqual(overdue.count, 1)
+        XCTAssertEqual(overdue.first?.source, "Late one")
+    }
+
+    func testReliabilityConfidenceOrdering() {
+        XCTAssertGreaterThan(IncomeReliability.reliable.confidence, IncomeReliability.usuallyOnTime.confidence)
+        XCTAssertGreaterThan(IncomeReliability.usuallyOnTime.confidence, IncomeReliability.unreliable.confidence)
+    }
+}

--- a/apps/ios/Tests/FamilyBudgetTemplateTests.swift
+++ b/apps/ios/Tests/FamilyBudgetTemplateTests.swift
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// FamilyBudgetTemplateTests.swift — FinanceTests — Refs #2201
+
+import XCTest
+@testable import FinanceShared
+
+final class FamilyBudgetTemplateTests: XCTestCase {
+
+    func testKidCategoriesCoverRequestedBuckets() {
+        let names = Set(FamilyBudgetTemplates.kidCategories.map(\.name))
+        XCTAssertTrue(names.contains("School"))
+        XCTAssertTrue(names.contains("Childcare"))
+        XCTAssertTrue(names.contains("Activities & Sports"))
+        XCTAssertTrue(names.contains("Birthdays & Parties"))
+        XCTAssertTrue(names.contains("Field Trips"))
+        XCTAssertTrue(names.contains("Kids' Clothing"))
+    }
+
+    func testAllKidCategoriesFlaggedKidRelated() {
+        XCTAssertTrue(FamilyBudgetTemplates.kidCategories.allSatisfy(\.isKidRelated))
+    }
+
+    func testSingleParentTemplateIncludesEssentialsAndKids() {
+        let template = FamilyBudgetTemplates.singleParent
+        XCTAssertFalse(template.kidCategories.isEmpty)
+        XCTAssertTrue(template.categories.contains { $0.name == "Groceries" })
+        XCTAssertTrue(template.categories.contains { $0.name == "Housing" })
+        // Kid categories should be a strict subset of all categories.
+        XCTAssertEqual(template.kidCategories.count, FamilyBudgetTemplates.kidCategories.count)
+    }
+
+    func testTemplateIdsAreUniqueAndCategoryIdsUniqueWithinTemplate() {
+        let ids = FamilyBudgetTemplates.all.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count)
+
+        for template in FamilyBudgetTemplates.all {
+            let categoryIds = template.categories.map(\.id)
+            XCTAssertEqual(Set(categoryIds).count, categoryIds.count, "Duplicate category id in \(template.name)")
+        }
+    }
+
+    func testAllTemplatesExposed() {
+        XCTAssertEqual(FamilyBudgetTemplates.all.count, 2)
+    }
+
+    func testSupportiveCoachingIsNonJudgmental() {
+        let overBody = SupportiveCoaching.overPlanBody(category: "Groceries")
+        XCTAssertTrue(overBody.contains("Groceries"))
+        // Tone check: avoids blame-heavy words.
+        let lowered = overBody.lowercased()
+        XCTAssertFalse(lowered.contains("exceeded"))
+        XCTAssertFalse(lowered.contains("over budget"))
+
+        XCTAssertTrue(SupportiveCoaching.overPlanTitle(category: "School").contains("School"))
+        XCTAssertTrue(SupportiveCoaching.billDueSoon(name: "Rent", whenText: "Friday").contains("Rent"))
+        XCTAssertFalse(SupportiveCoaching.familySetupWelcome.isEmpty)
+    }
+}

--- a/apps/ios/Tests/NotificationSettingsViewModelTests.swift
+++ b/apps/ios/Tests/NotificationSettingsViewModelTests.swift
@@ -297,6 +297,124 @@ final class NotificationSettingsViewModelTests: XCTestCase {
         let (vm, _) = makeViewModel()
         XCTAssertTrue(vm.stateSummary.contains("\(vm.enabledScheduleCount)"))
     }
+
+    // MARK: - Smart Timing (#2391)
+
+    @MainActor
+    func testSmartTimingDefaults() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "smart.defaults")
+        defer { defaults.removePersistentDomain(forName: "smart.defaults") }
+
+        XCTAssertTrue(vm.smartTimingEnabled)
+        XCTAssertEqual(vm.smartTimingFallbackHour, 9)
+        XCTAssertFalse(vm.canPersonalizeTiming)
+        // With no data it falls back to the fixed hour.
+        XCTAssertEqual(vm.recommendedHour, 9)
+    }
+
+    @MainActor
+    func testRecordEngagementMergesBuckets() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "smart.record")
+        defer { defaults.removePersistentDomain(forName: "smart.record") }
+
+        vm.recordEngagement(hour: 18, acted: true)
+        vm.recordEngagement(hour: 18, acted: false)
+        vm.recordEngagement(hour: 18, acted: true)
+
+        XCTAssertEqual(vm.smartTimingHealth.totalDelivered, 3)
+        XCTAssertEqual(vm.smartTimingHealth.totalActed, 2)
+    }
+
+    @MainActor
+    func testSmartTimingPersonalizesAfterEnoughSignals() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "smart.personalize")
+        defer { defaults.removePersistentDomain(forName: "smart.personalize") }
+
+        // Feed clear engagement at 6pm (outside the default quiet window).
+        for _ in 0..<6 { vm.recordEngagement(hour: 18, acted: true) }
+
+        XCTAssertTrue(vm.canPersonalizeTiming)
+        XCTAssertEqual(vm.recommendedHour, 18)
+        XCTAssertFalse(vm.recommendedHourLabel.isEmpty)
+    }
+
+    @MainActor
+    func testDisabledSmartTimingUsesFallback() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "smart.disabled")
+        defer { defaults.removePersistentDomain(forName: "smart.disabled") }
+
+        for _ in 0..<6 { vm.recordEngagement(hour: 18, acted: true) }
+        vm.smartTimingEnabled = false
+        vm.smartTimingFallbackHour = 8
+
+        XCTAssertEqual(vm.recommendedHour, 8)
+    }
+
+    @MainActor
+    func testResetSmartTimingClearsData() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "smart.reset")
+        defer { defaults.removePersistentDomain(forName: "smart.reset") }
+
+        for _ in 0..<6 { vm.recordEngagement(hour: 18, acted: true) }
+        XCTAssertTrue(vm.canPersonalizeTiming)
+
+        vm.resetSmartTiming()
+
+        XCTAssertFalse(vm.canPersonalizeTiming)
+        XCTAssertEqual(vm.smartTimingHealth.totalDelivered, 0)
+    }
+
+    @MainActor
+    func testSmartTimingRespectsQuietHours() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "smart.quiet")
+        defer { defaults.removePersistentDomain(forName: "smart.quiet") }
+
+        vm.quietHoursEnabled = true
+        vm.quietHoursStartHour = 22
+        vm.quietHoursEndHour = 7
+        // All engagement lands inside quiet hours → should not recommend those.
+        for _ in 0..<6 { vm.recordEngagement(hour: 2, acted: true) }
+
+        XCTAssertFalse(QuietHoursContains(vm.recommendedHour, start: 22, end: 7))
+    }
+
+    @MainActor
+    func testSmartTimingPersistsAcrossInstances() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "smart.persist")
+        defer { defaults.removePersistentDomain(forName: "smart.persist") }
+
+        for _ in 0..<6 { vm.recordEngagement(hour: 17, acted: true) }
+
+        let vm2 = NotificationSettingsViewModel(
+            scheduler: StubNotificationScheduler(),
+            budgetRepository: StubBudgetRepository(),
+            transactionRepository: StubTransactionRepository(),
+            goalRepository: StubGoalRepository(),
+            defaults: defaults
+        )
+        XCTAssertTrue(vm2.canPersonalizeTiming)
+        XCTAssertEqual(vm2.recommendedHour, 17)
+    }
+
+    @MainActor
+    func testSmartTimingStatusStrings() {
+        let (vm, defaults) = makeViewModelWithDefaults(suiteName: "smart.status")
+        defer { defaults.removePersistentDomain(forName: "smart.status") }
+
+        XCTAssertFalse(vm.smartTimingStatus.isEmpty)
+        for _ in 0..<6 { vm.recordEngagement(hour: 18, acted: true) }
+        XCTAssertFalse(vm.smartTimingStatus.isEmpty)
+        vm.smartTimingEnabled = false
+        XCTAssertFalse(vm.smartTimingStatus.isEmpty)
+    }
+}
+
+/// Local mirror of `QuietHours.contains` for wrap-around assertions in tests.
+private func QuietHoursContains(_ hour: Int, start: Int, end: Int) -> Bool {
+    let h = ((hour % 24) + 24) % 24
+    if start == end { return false }
+    if start < end { return h >= start && h < end }
+    return h >= start || h < end
 }
 
 // MARK: - Notification Model Tests

--- a/apps/ios/Tests/SafeToSpendCalculatorTests.swift
+++ b/apps/ios/Tests/SafeToSpendCalculatorTests.swift
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SafeToSpendCalculatorTests.swift — FinanceTests — Refs #2199
+
+import XCTest
+@testable import FinanceShared
+
+final class SafeToSpendCalculatorTests: XCTestCase {
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+        return calendar
+    }()
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, hour: Int = 12) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        return calendar.date(from: components)!
+    }
+
+    func testReservesOnlyCriticalBillsBeforePayday() {
+        let now = date(2026, 6, 10)
+        let input = SafeToSpendInput(
+            clearedCashMinorUnits: 50_000, // $500
+            nextPaydayDate: date(2026, 6, 15),
+            obligations: [
+                .init(amountMinorUnits: 30_000, dueDate: date(2026, 6, 12), isCritical: true), // rent
+                .init(amountMinorUnits: 5_000, dueDate: date(2026, 6, 13), isCritical: false), // non-critical, ignored
+                .init(amountMinorUnits: 9_999, dueDate: date(2026, 6, 20), isCritical: true), // after payday, ignored
+            ],
+            referenceDate: now
+        )
+
+        let result = SafeToSpendCalculator.evaluate(input)
+
+        XCTAssertEqual(result.reservedForBillsMinorUnits, 30_000)
+        XCTAssertEqual(result.safeToSpendMinorUnits, 20_000) // 500 - 300
+    }
+
+    func testSafeToSpendClampsAtZero() {
+        let now = date(2026, 6, 10)
+        let input = SafeToSpendInput(
+            clearedCashMinorUnits: 10_000,
+            nextPaydayDate: date(2026, 6, 15),
+            obligations: [
+                .init(amountMinorUnits: 40_000, dueDate: date(2026, 6, 12), isCritical: true),
+            ],
+            referenceDate: now
+        )
+
+        let result = SafeToSpendCalculator.evaluate(input)
+
+        XCTAssertEqual(result.safeToSpendMinorUnits, 0)
+    }
+
+    func testDaysUntilPaydayNeverNegative() {
+        let now = date(2026, 6, 20)
+        let input = SafeToSpendInput(
+            clearedCashMinorUnits: 10_000,
+            nextPaydayDate: date(2026, 6, 15), // already passed
+            obligations: [],
+            referenceDate: now
+        )
+
+        let result = SafeToSpendCalculator.evaluate(input)
+
+        XCTAssertEqual(result.daysUntilPayday, 0)
+    }
+
+    func testPinnedCategoryDrivesSpendableForCheck() {
+        let now = date(2026, 6, 10)
+        let input = SafeToSpendInput(
+            clearedCashMinorUnits: 50_000,
+            nextPaydayDate: date(2026, 6, 15),
+            obligations: [],
+            pinnedCategoryRemainingMinorUnits: 8_000,
+            pinnedCategoryName: "Groceries",
+            referenceDate: now
+        )
+
+        let result = SafeToSpendCalculator.evaluate(input)
+
+        XCTAssertEqual(result.spendableForCheckMinorUnits, 8_000)
+        XCTAssertEqual(result.pinnedCategoryName, "Groceries")
+    }
+
+    func testVerdictComfortableTightBeyond() {
+        XCTAssertEqual(SafeToSpendCalculator.verdict(purchaseMinorUnits: 2_000, spendableMinorUnits: 10_000), .comfortable)
+        XCTAssertEqual(SafeToSpendCalculator.verdict(purchaseMinorUnits: 8_500, spendableMinorUnits: 10_000), .tight)
+        XCTAssertEqual(SafeToSpendCalculator.verdict(purchaseMinorUnits: 12_000, spendableMinorUnits: 10_000), .beyond)
+    }
+
+    func testVerdictWithNoCushion() {
+        XCTAssertEqual(SafeToSpendCalculator.verdict(purchaseMinorUnits: 100, spendableMinorUnits: 0), .beyond)
+        XCTAssertEqual(SafeToSpendCalculator.verdict(purchaseMinorUnits: 0, spendableMinorUnits: 0), .comfortable)
+    }
+
+    func testRemainingAfterPurchase() {
+        XCTAssertEqual(SafeToSpendCalculator.remainingAfter(purchaseMinorUnits: 3_000, spendableMinorUnits: 10_000), 7_000)
+        XCTAssertEqual(SafeToSpendCalculator.remainingAfter(purchaseMinorUnits: 12_000, spendableMinorUnits: 10_000), -2_000)
+    }
+}

--- a/apps/ios/Tests/SingleParentViewsTests.swift
+++ b/apps/ios/Tests/SingleParentViewsTests.swift
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// SingleParentViewsTests.swift
+// FinanceTests
+//
+// Instantiation + body-render coverage for the single-parent workflow screens
+// and unit tests for their persistence stores. Views are exercised via `.body`
+// (mirroring IconViewTests) so the new SwiftUI surfaces contribute coverage.
+//
+// References: #2199, #2196, #2193, #2201, #2190
+
+import FinanceShared
+import SwiftUI
+import XCTest
+@testable import FinanceApp
+
+final class SingleParentViewsTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    private func sampleBill(id: String, name: String, amount: Int64, daysOut: Int) -> BillItem {
+        let due = Calendar.current.date(byAdding: .day, value: daysOut, to: Date()) ?? Date()
+        return BillItem(
+            id: id,
+            name: name,
+            payee: name,
+            amountMinorUnits: amount,
+            currencyCode: "USD",
+            frequency: .monthly,
+            dueDate: due,
+            nextDueDate: due,
+            categoryName: "Bills",
+            icon: "bolt",
+            isAutoPay: false,
+            notes: "",
+            status: .upcoming,
+            reminderDaysBefore: 3,
+            createdAt: Date()
+        )
+    }
+
+    // MARK: - GroceryModeView (#2199)
+
+    @MainActor
+    func testGroceryModeViewInstantiatesAndRenders() {
+        let defaults = makeDefaults("grocery.view")
+        defer { defaults.removePersistentDomain(forName: "grocery.view") }
+        let store = GroceryModeStore(defaults: defaults)
+        store.clearedCashMinorUnits = 40_000
+        store.billsBeforePaydayMinorUnits = 15_000
+        let payday = PaydaySettingsStore(defaults: defaults)
+
+        let view = GroceryModeView(store: store, paydayStore: payday)
+        _ = view.body
+    }
+
+    @MainActor
+    func testGroceryModeViewWithPinnedCategory() {
+        let defaults = makeDefaults("grocery.pinned")
+        defer { defaults.removePersistentDomain(forName: "grocery.pinned") }
+        let store = GroceryModeStore(defaults: defaults)
+        store.pinnedCategoryName = "Groceries"
+        store.pinnedCategoryRemainingMinorUnits = 12_000
+        _ = GroceryModeView(store: store, paydayStore: PaydaySettingsStore(defaults: defaults)).body
+    }
+
+    func testGroceryMinorUnitsParsing() {
+        XCTAssertEqual(GroceryModeView.minorUnits(from: "12.34", currencyCode: "USD"), 1234)
+        XCTAssertEqual(GroceryModeView.minorUnits(from: "12,34", currencyCode: "USD"), 1234)
+        XCTAssertEqual(GroceryModeView.minorUnits(from: "0", currencyCode: "USD"), 0)
+        XCTAssertEqual(GroceryModeView.minorUnits(from: "abc", currencyCode: "USD"), 0)
+        XCTAssertEqual(GroceryModeView.minorUnits(from: "1000", currencyCode: "JPY"), 1000)
+        XCTAssertFalse(GroceryModeView.currencySymbol("USD").isEmpty)
+    }
+
+    // MARK: - BillCalendarView (#2196)
+
+    @MainActor
+    func testBillCalendarViewRendersWithBills() {
+        let defaults = makeDefaults("billcal.view")
+        defer { defaults.removePersistentDomain(forName: "billcal.view") }
+        let payday = PaydaySettingsStore(defaults: defaults)
+        payday.typicalPaycheckMinorUnits = 200_000
+
+        let bills = [
+            sampleBill(id: "b1", name: "Rent", amount: 120_000, daysOut: 3),
+            sampleBill(id: "b2", name: "Electric", amount: 8_000, daysOut: 10),
+        ]
+        _ = BillCalendarView(bills: bills, paydayStore: payday).body
+    }
+
+    @MainActor
+    func testBillCalendarViewRendersEmpty() {
+        let defaults = makeDefaults("billcal.empty")
+        defer { defaults.removePersistentDomain(forName: "billcal.empty") }
+        _ = BillCalendarView(bills: [], paydayStore: PaydaySettingsStore(defaults: defaults)).body
+    }
+
+    // MARK: - ExpectedIncomeView (#2193)
+
+    @MainActor
+    func testExpectedIncomeViewRendersWithItems() {
+        let defaults = makeDefaults("income.view")
+        defer { defaults.removePersistentDomain(forName: "income.view") }
+        let store = ExpectedIncomeStore(defaults: defaults)
+        store.clearedCashMinorUnits = 25_000
+        store.add(ExpectedIncome(
+            source: "Child support",
+            amountMinorUnits: 60_000,
+            expectedDate: Calendar.current.date(byAdding: .day, value: -3, to: Date()) ?? Date(),
+            reliability: .unreliable,
+            status: .late
+        ))
+        _ = ExpectedIncomeView(store: store).body
+    }
+
+    @MainActor
+    func testExpectedIncomeViewRendersEmpty() {
+        let defaults = makeDefaults("income.empty")
+        defer { defaults.removePersistentDomain(forName: "income.empty") }
+        _ = ExpectedIncomeView(store: ExpectedIncomeStore(defaults: defaults)).body
+    }
+
+    // MARK: - FamilySetupView (#2201)
+
+    @MainActor
+    func testFamilySetupViewRenders() {
+        _ = FamilySetupView().body
+    }
+
+    // MARK: - Setup sheets (coverage for presented content)
+
+    @MainActor
+    func testGrocerySetupSheetRenders() {
+        let defaults = makeDefaults("grocery.sheet")
+        defer { defaults.removePersistentDomain(forName: "grocery.sheet") }
+        let store = GroceryModeStore(defaults: defaults)
+        store.clearedCashMinorUnits = 30_000
+        store.pinnedCategoryName = "Groceries"
+        store.pinnedCategoryRemainingMinorUnits = 5_000
+        _ = GroceryModeSetupSheet(store: store, paydayStore: PaydaySettingsStore(defaults: defaults)).body
+    }
+
+    @MainActor
+    func testPaydaySetupSheetRenders() {
+        let defaults = makeDefaults("payday.sheet")
+        defer { defaults.removePersistentDomain(forName: "payday.sheet") }
+        let payday = PaydaySettingsStore(defaults: defaults)
+        payday.typicalPaycheckMinorUnits = 180_000
+        _ = PaydaySetupSheet(paydayStore: payday).body
+    }
+
+    @MainActor
+    func testExpectedIncomeEditorSheetRenders() {
+        let defaults = makeDefaults("income.sheet")
+        defer { defaults.removePersistentDomain(forName: "income.sheet") }
+        let store = ExpectedIncomeStore(defaults: defaults)
+        // New-income editor.
+        _ = ExpectedIncomeEditorSheet(store: store, existing: nil, referenceDate: Date()).body
+        // Edit-existing editor (drives the delete section + load path).
+        let income = ExpectedIncome(
+            source: "Child support",
+            amountMinorUnits: 50_000,
+            expectedDate: Date(),
+            reliability: .unreliable,
+            status: .partial
+        )
+        store.add(income)
+        _ = ExpectedIncomeEditorSheet(store: store, existing: income, referenceDate: Date()).body
+    }
+
+    // MARK: - GroceryModeStore
+
+    func testGroceryModeStoreSafeToSpend() {
+        let defaults = makeDefaults("grocery.store")
+        defer { defaults.removePersistentDomain(forName: "grocery.store") }
+        let store = GroceryModeStore(defaults: defaults)
+        store.clearedCashMinorUnits = 50_000
+        store.billsBeforePaydayMinorUnits = 20_000
+
+        let payday = Calendar.current.date(byAdding: .day, value: 10, to: Date()) ?? Date()
+        let result = store.result(nextPayday: payday)
+
+        XCTAssertEqual(result.reservedForBillsMinorUnits, 20_000)
+        XCTAssertEqual(result.safeToSpendMinorUnits, 30_000)
+        XCTAssertEqual(result.spendableForCheckMinorUnits, 30_000)
+    }
+
+    func testGroceryModeStorePinnedPreferred() {
+        let defaults = makeDefaults("grocery.store.pin")
+        defer { defaults.removePersistentDomain(forName: "grocery.store.pin") }
+        let store = GroceryModeStore(defaults: defaults)
+        store.clearedCashMinorUnits = 50_000
+        store.pinnedCategoryName = "Groceries"
+        store.pinnedCategoryRemainingMinorUnits = 8_000
+
+        let payday = Calendar.current.date(byAdding: .day, value: 5, to: Date()) ?? Date()
+        XCTAssertEqual(store.result(nextPayday: payday).spendableForCheckMinorUnits, 8_000)
+    }
+
+    // MARK: - ExpectedIncomeStore
+
+    func testExpectedIncomeStorePersistsAndBreaksDown() {
+        let defaults = makeDefaults("income.store")
+        defer { defaults.removePersistentDomain(forName: "income.store") }
+        let store = ExpectedIncomeStore(defaults: defaults)
+        store.clearedCashMinorUnits = 10_000
+        store.add(ExpectedIncome(
+            source: "Reliable gig",
+            amountMinorUnits: 30_000,
+            expectedDate: Calendar.current.date(byAdding: .day, value: 5, to: Date()) ?? Date(),
+            reliability: .reliable,
+            status: .expected
+        ))
+        store.add(ExpectedIncome(
+            source: "Flaky support",
+            amountMinorUnits: 40_000,
+            expectedDate: Calendar.current.date(byAdding: .day, value: 5, to: Date()) ?? Date(),
+            reliability: .unreliable,
+            status: .expected
+        ))
+
+        let breakdown = store.breakdown()
+        XCTAssertEqual(breakdown.clearedMinorUnits, 10_000)
+        XCTAssertEqual(breakdown.expectedMinorUnits, 30_000)
+        XCTAssertEqual(breakdown.atRiskMinorUnits, 40_000)
+
+        // Round-trips through UserDefaults.
+        let reloaded = ExpectedIncomeStore(defaults: defaults)
+        XCTAssertEqual(reloaded.items.count, 2)
+    }
+
+    func testExpectedIncomeStoreStatusAndRemoval() {
+        let defaults = makeDefaults("income.store.mut")
+        defer { defaults.removePersistentDomain(forName: "income.store.mut") }
+        let store = ExpectedIncomeStore(defaults: defaults)
+        let income = ExpectedIncome(
+            source: "Invoice",
+            amountMinorUnits: 20_000,
+            expectedDate: Date(),
+            reliability: .usuallyOnTime,
+            status: .expected
+        )
+        store.add(income)
+        store.setStatus(id: income.id, status: .received, receivedMinorUnits: 20_000)
+        XCTAssertEqual(store.items.first?.status, .received)
+
+        store.remove(id: income.id)
+        XCTAssertTrue(store.items.isEmpty)
+    }
+
+    // MARK: - PaydaySettingsStore
+
+    func testPaydaySettingsStoreGeneratesPaydays() {
+        let defaults = makeDefaults("payday.store")
+        defer { defaults.removePersistentDomain(forName: "payday.store") }
+        let store = PaydaySettingsStore(defaults: defaults)
+        store.frequency = .biweekly
+        store.anchorDate = Calendar.current.date(byAdding: .day, value: 3, to: Date()) ?? Date()
+
+        let paydays = store.upcomingPaydays(count: 3)
+        XCTAssertEqual(paydays.count, 3)
+        XCTAssertNotNil(store.nextPayday())
+
+        store.typicalPaycheckMinorUnits = 150_000
+        let deposits = store.deposits(count: 3)
+        XCTAssertEqual(deposits.count, 3)
+        XCTAssertEqual(deposits.first?.amountMinorUnits, 150_000)
+    }
+}

--- a/apps/ios/Tests/SmartNotificationTimingTests.swift
+++ b/apps/ios/Tests/SmartNotificationTimingTests.swift
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SmartNotificationTimingTests.swift — FinanceTests — Refs #2391
+
+import XCTest
+@testable import FinanceShared
+
+final class SmartNotificationTimingTests: XCTestCase {
+
+    func testFallsBackWhenNotEnoughSignals() {
+        let engagement = [
+            HourEngagement(hour: 8, deliveredCount: 2, actedCount: 2),
+        ]
+        let hour = SmartNotificationTiming.recommendedHour(
+            engagement: engagement,
+            quietHours: .overnightDefault,
+            fallbackHour: 9
+        )
+        XCTAssertEqual(hour, 9)
+        XCTAssertFalse(SmartNotificationTiming.canPersonalize(engagement: engagement))
+    }
+
+    func testPersonalizesToHighestActionRate() {
+        let engagement = [
+            HourEngagement(hour: 8, deliveredCount: 10, actedCount: 2), // 20%
+            HourEngagement(hour: 18, deliveredCount: 10, actedCount: 8), // 80%
+            HourEngagement(hour: 12, deliveredCount: 5, actedCount: 2), // 40%
+        ]
+        let hour = SmartNotificationTiming.recommendedHour(engagement: engagement, quietHours: .overnightDefault, fallbackHour: 9)
+        XCTAssertEqual(hour, 18)
+        XCTAssertTrue(SmartNotificationTiming.canPersonalize(engagement: engagement))
+    }
+
+    func testNeverRecommendsQuietHours() {
+        let engagement = [
+            HourEngagement(hour: 23, deliveredCount: 10, actedCount: 9), // best, but quiet
+            HourEngagement(hour: 17, deliveredCount: 10, actedCount: 5),
+        ]
+        let hour = SmartNotificationTiming.recommendedHour(
+            engagement: engagement,
+            quietHours: .overnightDefault,
+            fallbackHour: 9
+        )
+        XCTAssertEqual(hour, 17)
+    }
+
+    func testDisabledReturnsFallback() {
+        let engagement = [
+            HourEngagement(hour: 18, deliveredCount: 20, actedCount: 18),
+        ]
+        let hour = SmartNotificationTiming.recommendedHour(
+            engagement: engagement,
+            quietHours: .overnightDefault,
+            fallbackHour: 9,
+            smartTimingEnabled: false
+        )
+        XCTAssertEqual(hour, 9)
+    }
+
+    func testFallbackNudgedOutOfQuietHours() {
+        // Fallback at 2am should be pushed to the quiet-window end (7am).
+        let hour = SmartNotificationTiming.recommendedHour(
+            engagement: [],
+            quietHours: .overnightDefault,
+            fallbackHour: 2
+        )
+        XCTAssertEqual(hour, 7)
+    }
+
+    func testQuietHoursWrapsMidnight() {
+        let quiet = QuietHours(startHour: 22, endHour: 7)
+        XCTAssertTrue(quiet.contains(23))
+        XCTAssertTrue(quiet.contains(2))
+        XCTAssertFalse(quiet.contains(7))
+        XCTAssertFalse(quiet.contains(12))
+    }
+
+    func testQuietHoursDaytimeWindow() {
+        let quiet = QuietHours(startHour: 9, endHour: 17)
+        XCTAssertTrue(quiet.contains(12))
+        XCTAssertFalse(quiet.contains(8))
+        XCTAssertFalse(quiet.contains(17))
+    }
+
+    func testHealthAggregatesCountsOnly() {
+        let engagement = [
+            HourEngagement(hour: 8, deliveredCount: 10, actedCount: 3),
+            HourEngagement(hour: 18, deliveredCount: 10, actedCount: 7),
+        ]
+        let health = SmartNotificationTiming.health(engagement: engagement)
+        XCTAssertEqual(health.totalDelivered, 20)
+        XCTAssertEqual(health.totalActed, 10)
+        XCTAssertEqual(health.openRate, 0.5, accuracy: 0.0001)
+    }
+
+    func testActionRateZeroWhenNothingDelivered() {
+        let entry = HourEngagement(hour: 8, deliveredCount: 0, actedCount: 0)
+        XCTAssertEqual(entry.actionRate, 0)
+    }
+}


### PR DESCRIPTION
﻿## Summary

A batch of closely-related iOS (SwiftUI) improvements for single-parent budgeting, plus smart notification timing. Everything lives in `apps/ios`; shared packages were treated as read-only. The bulk of the logic sits in the pure-Foundation `FinanceShared` package so it is fully unit-testable, with thin SwiftUI surfaces on top.

All new UI keeps WCAG 2.2 AA in mind: 44pt tap targets, combined/labelled VoiceOver elements, Dynamic Type (including accessibility sizes) and compact-width reflow, and calm, non-judgmental copy.

## What''s included

### Kid categories + supportive coaching for setup — Closes #2201
- Kid-aware starter templates (School, Childcare, Activities & Sports, Birthdays & Parties, Field Trips, Kids'' Clothing) via `FamilyBudgetTemplate`/`FamilyBudgetTemplates`.
- New `FamilySetupView` template picker, reachable from onboarding ("Setting up for your family?").
- Warm, non-judgmental coaching copy (`SupportiveCoaching`) applied across tips and reminders (past-plan / near-plan / due-soon framing instead of blame).
- Kid categories also available in transaction entry and the mock category repository.

### Grocery-store "can I afford this?" mode — Closes #2199
- `GroceryModeView`: enter the cart total, get an instant comfortable / tight / beyond verdict against cash that''s safe to spend before payday, optionally scoped to a pinned category (e.g. Groceries).
- Pure `SafeToSpendCalculator` (reserve critical bills before payday, clamp at zero, supportive verdict thresholds).

### Payday-aligned bill calendar — Closes #2196
- `BillCalendarView`: lines bills and one-off kid expenses up against real paycheck dates, leads with "what hits before your next paycheck", and flags tight pay periods where bills outrun income.
- Pure `BillCalendarCalculator` + `PaydaySchedule` upcoming-payday generator (weekly / biweekly / semimonthly / monthly).

### Expected-income tracking for late/unreliable child support — Closes #2193
- `ExpectedIncomeView`: honest cleared / expected / at-risk cash split so late or unreliable money is never treated as spendable; overdue nudges surfaced gently.
- Pure `ExpectedIncomeCalculator` with reliability-weighted at-risk logic.

### Compact-width (iPhone SE) layouts — Closes #2190
- `CompactLayoutMetrics` (pure) + `AdaptiveLayout` SwiftUI bridge drive adaptive column counts and stepper labels from horizontal size class + Dynamic Type.
- Applied to the dashboard summary/quick-access grids, bills summary, and the transaction stepper so figures/labels never crowd or clip.

### Smart push-notification timing — Closes #2391
- `SmartNotificationTiming` (pure): learns, from on-device, content-free per-hour engagement signals only, the hours a user is most likely to act, and recommends delivery times that respect quiet hours with a fixed-time fallback.
- New Smart Timing section in notification settings with a best-time display, reset, fixed-time fallback picker, and a privacy-preserving health/status summary.

## Testing

Local build/test of the iOS target isn''t feasible in this environment (no Swift/SwiftUI toolchain on Windows); correctness of the SwiftUI layer was verified by careful API pattern-matching against existing code, and the iOS CI job (macOS xcodebuild) is the source of truth for build + coverage.

- Added focused XCTest suites for every pure calculator/model (SafeToSpend, ExpectedIncome, BillCalendar/PaydaySchedule, SmartNotificationTiming, CompactLayoutMetrics, FamilyBudgetTemplate).
- Extended `NotificationSettingsViewModelTests` with smart-timing coverage (engagement merge, personalization threshold, quiet-hours, disable/fallback, reset, persistence, status strings).
- Added `SingleParentViewsTests` with body-render coverage for the four new screens and their setup sheets, plus store unit tests.
- Mandatory pre-push passed locally: `npm run format` + `npx eslint . --fix`, then `npm run format:check` (clean) and `npx eslint . --max-warnings 0` (0). Swift is prettier-ignored, so no non-iOS files were touched.

## Notes
- Money is Int64 minor units throughout; all new persistence is UserDefaults-backed @Observable stores.
- No new issues were created; this PR implements the six existing issues below.

Closes #2201
Closes #2199
Closes #2196
Closes #2193
Closes #2190
Closes #2391
