### PR TITLE
feat(android): shared finances for engaged couples + lively teen achievements (batch 14)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,5 @@
+# gitleaks false-positive allowlist (fingerprints: commit:file:rule:line)
+# These are on-device Android SharedPreferences key names, not secrets.
+# See apps/android CoupleDebtRepository / GamificationCelebrationStore.
+0effb3da2f9460cf79e0844d262f7a556affb808:apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationCelebrationStore.kt:generic-api-key:27
+7051fa83cb9674c08ecaccf54dda726aad31fccd:apps/android/src/main/kotlin/com/finance/android/ui/couple/debt/CoupleDebtRepository.kt:generic-api-key:76

--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -48,6 +48,20 @@ import com.finance.android.ui.nlp.NlpTransactionViewModel
 import com.finance.android.ui.streak.StreakRepository
 import com.finance.android.ui.streak.StreakViewModel
 import com.finance.android.ui.streak.TransactionBackedStreakRepository
+import com.finance.android.ui.gamification.GamificationCelebrationStore
+import com.finance.android.ui.gamification.GamificationViewModel
+import com.finance.android.ui.couple.CoupleProfileRepository
+import com.finance.android.ui.couple.CoupleHubViewModel
+import com.finance.android.ui.couple.privacy.CouplePrivacyRepository
+import com.finance.android.ui.couple.privacy.CouplePrivacyViewModel
+import com.finance.android.ui.couple.debt.CoupleDebtRepository
+import com.finance.android.ui.couple.debt.DebtPlannerViewModel
+import com.finance.android.ui.couple.goals.SharedContributionRepository
+import com.finance.android.ui.couple.goals.SharedGoalViewModel
+import com.finance.android.ui.couple.wedding.WeddingRepository
+import com.finance.android.ui.couple.wedding.WeddingViewModel
+import com.finance.android.ui.couple.checkin.CheckInRepository
+import com.finance.android.ui.couple.checkin.CheckInViewModel
 import com.finance.android.ui.accessibility.CognitiveAccessibilityManager
 import com.finance.android.ui.feedback.DefaultHapticAvailabilityChecker
 import com.finance.android.ui.feedback.HapticAvailabilityChecker
@@ -175,6 +189,43 @@ val appModule = module {
 
     /** Streak repository — derives logging dates from the transaction repository. */
     single<StreakRepository> { TransactionBackedStreakRepository(get()) }
+
+    // ── Gamification (#242, #2211) ──────────────────────────────────
+    // Teen achievements: real streaks, near-win feedback, celebration moments.
+
+    /** Remembers which achievements were already celebrated (one-time celebration). */
+    single { GamificationCelebrationStore(get()) }
+
+    /** Achievements + real streaks + near-win + celebration ViewModel. */
+    viewModelOf(::GamificationViewModel)
+
+    // ── Couple money (engaged couples batch: #2142/#2145/#2147/#2150/#2153) ──
+    // All persistence uses the shared encrypted SharedPreferences singleton via org.json.
+
+    /** Shared partner profile (names + shared label) used across couple features. */
+    single { CoupleProfileRepository(get()) }
+
+    /** "Yours, mine, ours" privacy classification store (#2142). */
+    single { CouplePrivacyRepository(get()) }
+
+    /** Joint debt store for the payoff planner (#2153). */
+    single { CoupleDebtRepository(get()) }
+
+    /** Shared goal contribution store — house down payment (#2147). */
+    single { SharedContributionRepository(get()) }
+
+    /** Shared wedding-budget workspace store (#2145). */
+    single { WeddingRepository(get()) }
+
+    /** Supportive money check-in preferences and history (#2150). */
+    single { CheckInRepository(get()) }
+
+    viewModelOf(::CoupleHubViewModel)
+    viewModelOf(::CouplePrivacyViewModel)
+    viewModelOf(::DebtPlannerViewModel)
+    viewModelOf(::SharedGoalViewModel)
+    viewModelOf(::WeddingViewModel)
+    viewModelOf(::CheckInViewModel)
 
     // ── Notifications ───────────────────────────────────────────────
 

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/CoupleHubScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/CoupleHubScreen.kt
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.CreditCard
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Forum
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Entry hub for the engaged-couples money workspace.
+ *
+ * Links to the five couple features (privacy, wedding, shared goals,
+ * check-ins, debt planner) and lets partners personalize their display
+ * names. Everything here is on-device and privacy-respecting.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CoupleHubScreen(
+    onBack: () -> Unit,
+    onOpenPrivacy: () -> Unit,
+    onOpenWedding: () -> Unit,
+    onOpenGoals: () -> Unit,
+    onOpenCheckIn: () -> Unit,
+    onOpenDebt: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CoupleHubViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Our money") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics { contentDescription = "Go back" },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Spacer(Modifier.height(4.dp))
+            IntroCard()
+            ProfileCard(state, viewModel)
+
+            Text(
+                "Shared spaces",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier
+                    .padding(top = 8.dp)
+                    .semantics { heading() },
+            )
+            FeatureRow(
+                icon = Icons.Filled.Lock,
+                title = "Yours, mine & ours",
+                subtitle = "Choose what stays private and what you share",
+                onClick = onOpenPrivacy,
+            )
+            FeatureRow(
+                icon = Icons.Filled.Favorite,
+                title = "Wedding budget",
+                subtitle = "Plan vendors, deposits, and per-guest costs together",
+                onClick = onOpenWedding,
+            )
+            FeatureRow(
+                icon = Icons.Filled.Home,
+                title = "House down payment",
+                subtitle = "Track shared goal contributions and milestones",
+                onClick = onOpenGoals,
+            )
+            FeatureRow(
+                icon = Icons.Filled.Forum,
+                title = "Money check-ins",
+                subtitle = "Supportive, opt-in conversations — not surveillance",
+                onClick = onOpenCheckIn,
+            )
+            FeatureRow(
+                icon = Icons.Filled.CreditCard,
+                title = "Debt payoff planner",
+                subtitle = "Compare avalanche vs. snowball as a team",
+                onClick = onOpenDebt,
+            )
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun IntroCard() {
+    Card(
+        Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+        ),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                "Your shared money space",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                "Tools for engaged couples to plan together while keeping " +
+                    "personal boundaries. Everything here stays on your device.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProfileCard(state: CoupleHubUiState, viewModel: CoupleHubViewModel) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    "Who's who",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier
+                        .weight(1f)
+                        .semantics { heading() },
+                )
+                if (!state.isEditing) {
+                    IconButton(
+                        onClick = viewModel::startEditing,
+                        modifier = Modifier.semantics { contentDescription = "Edit partner names" },
+                    ) {
+                        Icon(Icons.Filled.Edit, contentDescription = null)
+                    }
+                }
+            }
+            if (state.isEditing) {
+                OutlinedTextField(
+                    value = state.profile.partnerAName,
+                    onValueChange = viewModel::updatePartnerAName,
+                    label = { Text("Your name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = state.profile.partnerBName,
+                    onValueChange = viewModel::updatePartnerBName,
+                    label = { Text("Partner's name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = state.profile.sharedLabel,
+                    onValueChange = viewModel::updateSharedLabel,
+                    label = { Text("Shared label") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedButton(onClick = viewModel::cancelEditing) { Text("Cancel") }
+                    Button(onClick = viewModel::save) { Text("Save") }
+                }
+            } else {
+                Text(
+                    "${state.profile.partnerAName} · ${state.profile.partnerBName} · " +
+                        "${state.profile.sharedLabel} (shared)",
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeatureRow(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .semantics { contentDescription = "$title. $subtitle" },
+    ) {
+        Row(
+            Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(Modifier.width(16.dp))
+            Column(Modifier.weight(1f)) {
+                Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text(
+                    subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/CoupleHubViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/CoupleHubViewModel.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/** UI state for the couple hub — partner personalization. */
+data class CoupleHubUiState(
+    val profile: CoupleProfile = CoupleProfile(),
+    val isEditing: Boolean = false,
+)
+
+/**
+ * ViewModel for the couple hub (engaged-couples batch).
+ *
+ * Owns the locally-configured [CoupleProfile] (partner names + shared label)
+ * shared by every couple feature. No account PII is ever touched.
+ */
+class CoupleHubViewModel(
+    private val profileRepository: CoupleProfileRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CoupleHubUiState(profile = profileRepository.load()))
+    val uiState: StateFlow<CoupleHubUiState> = _uiState.asStateFlow()
+
+    fun startEditing() = _uiState.update { it.copy(isEditing = true) }
+
+    fun cancelEditing() =
+        _uiState.update { it.copy(isEditing = false, profile = profileRepository.load()) }
+
+    fun updatePartnerAName(name: String) =
+        _uiState.update { it.copy(profile = it.profile.copy(partnerAName = name)) }
+
+    fun updatePartnerBName(name: String) =
+        _uiState.update { it.copy(profile = it.profile.copy(partnerBName = name)) }
+
+    fun updateSharedLabel(label: String) =
+        _uiState.update { it.copy(profile = it.profile.copy(sharedLabel = label)) }
+
+    fun save() {
+        profileRepository.save(_uiState.value.profile)
+        _uiState.update { it.copy(isEditing = false, profile = profileRepository.load()) }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/CoupleProfile.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/CoupleProfile.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple
+
+import android.content.SharedPreferences
+
+/**
+ * Identifies which partner in an engaged couple an item belongs to.
+ *
+ * The couple-money features intentionally avoid pulling real names from the
+ * auth layer — partners name themselves locally so nothing personally
+ * identifying is required to use the workspace. [Partner.A] / [Partner.B] are
+ * stable keys; the display labels live in [CoupleProfile].
+ */
+enum class Partner { A, B }
+
+/**
+ * Locally-configured display names for the two partners plus a shared label.
+ *
+ * Stored on-device only (never synced) so the couple features can show
+ * friendly names ("Sam", "Alex", "Ours") without touching account PII.
+ *
+ * @property partnerAName Display name for [Partner.A]. Defaults to "You".
+ * @property partnerBName Display name for [Partner.B]. Defaults to "Partner".
+ * @property sharedLabel Label for jointly owned items. Defaults to "Ours".
+ */
+data class CoupleProfile(
+    val partnerAName: String = DEFAULT_A,
+    val partnerBName: String = DEFAULT_B,
+    val sharedLabel: String = DEFAULT_SHARED,
+) {
+    /** Resolves the display name for a specific [partner]. */
+    fun nameFor(partner: Partner): String = when (partner) {
+        Partner.A -> partnerAName.ifBlank { DEFAULT_A }
+        Partner.B -> partnerBName.ifBlank { DEFAULT_B }
+    }
+
+    companion object {
+        const val DEFAULT_A = "You"
+        const val DEFAULT_B = "Partner"
+        const val DEFAULT_SHARED = "Ours"
+    }
+}
+
+/**
+ * Persists the [CoupleProfile] in the app's encrypted [SharedPreferences].
+ *
+ * Names are lightly non-sensitive personalization; they are kept on-device
+ * and never included in sync payloads.
+ */
+class CoupleProfileRepository(
+    private val prefs: SharedPreferences,
+) {
+
+    /** Loads the persisted profile, falling back to friendly defaults. */
+    fun load(): CoupleProfile = CoupleProfile(
+        partnerAName = prefs.getString(KEY_A, CoupleProfile.DEFAULT_A).orEmpty()
+            .ifBlank { CoupleProfile.DEFAULT_A },
+        partnerBName = prefs.getString(KEY_B, CoupleProfile.DEFAULT_B).orEmpty()
+            .ifBlank { CoupleProfile.DEFAULT_B },
+        sharedLabel = prefs.getString(KEY_SHARED, CoupleProfile.DEFAULT_SHARED).orEmpty()
+            .ifBlank { CoupleProfile.DEFAULT_SHARED },
+    )
+
+    /** Saves [profile], trimming blank names back to defaults. */
+    fun save(profile: CoupleProfile) {
+        prefs.edit()
+            .putString(KEY_A, profile.partnerAName.trim().ifBlank { CoupleProfile.DEFAULT_A })
+            .putString(KEY_B, profile.partnerBName.trim().ifBlank { CoupleProfile.DEFAULT_B })
+            .putString(KEY_SHARED, profile.sharedLabel.trim().ifBlank { CoupleProfile.DEFAULT_SHARED })
+            .apply()
+    }
+
+    private companion object {
+        const val KEY_A = "couple_partner_a_name"
+        const val KEY_B = "couple_partner_b_name"
+        const val KEY_SHARED = "couple_shared_label"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/checkin/CheckInContent.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/checkin/CheckInContent.kt
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.checkin
+
+import android.content.SharedPreferences
+import org.json.JSONArray
+import timber.log.Timber
+
+/** How often the couple wants to be nudged for a money check-in (#2150). */
+enum class CheckInFrequency(val displayName: String, val days: Int) {
+    WEEKLY("Weekly", 7),
+    MONTHLY("Monthly", 30),
+}
+
+/**
+ * A discussion prompt for a couples money check-in.
+ *
+ * @property topic Short topic label used for grouping.
+ * @property prompt A collaborative, non-accusatory conversation starter.
+ */
+data class CheckInPrompt(val topic: String, val prompt: String)
+
+/**
+ * Static, supportive content for couples money check-ins (#2150).
+ *
+ * Every prompt is phrased to invite conversation rather than assign blame —
+ * the goal is better communication, not surveillance. The list is intentionally
+ * rotated so each check-in surfaces a fresh, balanced mix.
+ */
+object CheckInContent {
+
+    /** A short, warm framing shown at the top of every check-in. */
+    const val INTRO =
+        "A quick, judgment-free money moment for the two of you. Start with what's " +
+            "going well, then talk through anything on your mind together."
+
+    val PROMPTS: List<CheckInPrompt> = listOf(
+        CheckInPrompt(
+            "Fun money",
+            "What feels like a fair amount of no-questions-asked \"fun money\" for each of us?",
+        ),
+        CheckInPrompt(
+            "Account structure",
+            "How are we feeling about joint vs. separate accounts right now — any changes worth trying?",
+        ),
+        CheckInPrompt(
+            "Upcoming shared expenses",
+            "What shared costs are coming up soon, and how do we want to split them?",
+        ),
+        CheckInPrompt(
+            "Wedding",
+            "Are we comfortable with our wedding spending pace, or should we adjust anything?",
+        ),
+        CheckInPrompt(
+            "Wins",
+            "What's one money thing we did well together since our last check-in?",
+        ),
+        CheckInPrompt(
+            "Goals",
+            "Does our house down-payment timeline still feel right for both of us?",
+        ),
+        CheckInPrompt(
+            "Boundaries",
+            "Is there a spending category where we'd each like a little more breathing room?",
+        ),
+        CheckInPrompt(
+            "Stress check",
+            "On a scale of calm to stressed, how is money feeling for each of us this week?",
+        ),
+    )
+
+    /**
+     * Returns a rotating subset of [count] prompts, seeded by [rotation] so the
+     * mix changes each check-in without ever feeling random or repetitive.
+     */
+    fun promptsFor(rotation: Int, count: Int = 4): List<CheckInPrompt> {
+        if (PROMPTS.isEmpty()) return emptyList()
+        val start = ((rotation % PROMPTS.size) + PROMPTS.size) % PROMPTS.size
+        return (0 until count.coerceAtMost(PROMPTS.size)).map { PROMPTS[(start + it) % PROMPTS.size] }
+    }
+}
+
+/** Persisted preferences and history for couples check-ins (#2150). */
+class CheckInRepository(
+    private val prefs: SharedPreferences,
+) {
+
+    /** Whether check-ins are opted in (default off — this is invitation, not enforcement). */
+    fun isEnabled(): Boolean = prefs.getBoolean(KEY_ENABLED, false)
+
+    fun setEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_ENABLED, enabled).apply()
+    }
+
+    fun frequency(): CheckInFrequency =
+        runCatching { CheckInFrequency.valueOf(prefs.getString(KEY_FREQ, null) ?: "") }
+            .getOrDefault(CheckInFrequency.WEEKLY)
+
+    fun setFrequency(frequency: CheckInFrequency) {
+        prefs.edit().putString(KEY_FREQ, frequency.name).apply()
+    }
+
+    /** Whether the couple shares neutral summaries with each other. */
+    fun shareSummaries(): Boolean = prefs.getBoolean(KEY_SHARE_SUMMARY, true)
+
+    fun setShareSummaries(share: Boolean) {
+        prefs.edit().putBoolean(KEY_SHARE_SUMMARY, share).apply()
+    }
+
+    /** Epoch day of the most recent completed check-in, or null. */
+    fun lastCheckInEpochDay(): Long? =
+        prefs.getLong(KEY_LAST, -1L).takeIf { it >= 0L }
+
+    /** Number of completed check-ins (drives prompt rotation). */
+    fun completedCount(): Int = history().size
+
+    /** Records a completed check-in on [epochDay]. */
+    fun recordCheckIn(epochDay: Long) {
+        val updated = (history() + epochDay).takeLast(MAX_HISTORY)
+        val array = JSONArray()
+        updated.forEach { array.put(it) }
+        prefs.edit()
+            .putString(KEY_HISTORY, array.toString())
+            .putLong(KEY_LAST, epochDay)
+            .apply()
+    }
+
+    /** Completed check-in epoch days, oldest first. */
+    fun history(): List<Long> {
+        val raw = prefs.getString(KEY_HISTORY, null) ?: return emptyList()
+        return runCatching {
+            val array = JSONArray(raw)
+            (0 until array.length()).map { array.getLong(it) }
+        }.getOrElse {
+            Timber.w(it, "Failed to parse check-in history")
+            emptyList()
+        }
+    }
+
+    private companion object {
+        const val KEY_ENABLED = "couple_checkin_enabled"
+        const val KEY_FREQ = "couple_checkin_frequency"
+        const val KEY_SHARE_SUMMARY = "couple_checkin_share_summary"
+        const val KEY_LAST = "couple_checkin_last_epoch_day"
+        const val KEY_HISTORY = "couple_checkin_history_v1"
+        const val MAX_HISTORY = 52
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/checkin/CheckInViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/checkin/CheckInViewModel.kt
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.checkin
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.BudgetRepository
+import com.finance.android.data.repository.CategoryRepository
+import com.finance.android.data.repository.TransactionRepository
+import com.finance.android.ui.couple.wedding.WeddingRepository
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.models.TransactionType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import timber.log.Timber
+
+/** A neutral, high-level category total for the check-in summary. */
+data class CategorySummaryUi(val name: String, val amountFormatted: String)
+
+/** UI state for the couples money check-in (#2150). */
+data class CheckInUiState(
+    val isLoading: Boolean = true,
+    val enabled: Boolean = false,
+    val frequency: CheckInFrequency = CheckInFrequency.WEEKLY,
+    val shareSummaries: Boolean = true,
+    val isDue: Boolean = false,
+    val lastCheckInText: String = "No check-ins yet",
+    val totalSpentFormatted: String = "$0.00",
+    val transactionCount: Int = 0,
+    val topCategories: List<CategorySummaryUi> = emptyList(),
+    val weddingPaidFormatted: String = "$0.00",
+    val prompts: List<CheckInPrompt> = emptyList(),
+    val completedCount: Int = 0,
+)
+
+/**
+ * ViewModel for supportive couples money check-ins (#2150).
+ *
+ * Builds a neutral, high-level summary (category totals, this-period spending,
+ * wedding pace) — never a line-item feed — and pairs it with rotating,
+ * collaborative discussion prompts. Everything is opt-in; the tone is
+ * supportive, never a surveillance report.
+ */
+class CheckInViewModel(
+    private val householdIdProvider: HouseholdIdProvider,
+    private val transactionRepository: TransactionRepository,
+    private val budgetRepository: BudgetRepository,
+    private val categoryRepository: CategoryRepository,
+    private val weddingRepository: WeddingRepository,
+    private val checkInRepository: CheckInRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CheckInUiState())
+    val uiState: StateFlow<CheckInUiState> = _uiState.asStateFlow()
+
+    private val currency: Currency = Currency.USD
+
+    init {
+        load()
+    }
+
+    fun setEnabled(enabled: Boolean) {
+        checkInRepository.setEnabled(enabled)
+        load()
+    }
+
+    fun setFrequency(frequency: CheckInFrequency) {
+        checkInRepository.setFrequency(frequency)
+        load()
+    }
+
+    fun setShareSummaries(share: Boolean) {
+        checkInRepository.setShareSummaries(share)
+        _uiState.update { it.copy(shareSummaries = share) }
+    }
+
+    /** Marks the current check-in complete, advancing the prompt rotation. */
+    fun completeCheckIn() {
+        val today = Clock.System.todayIn(TimeZone.currentSystemDefault()).toEpochDays().toLong()
+        checkInRepository.recordCheckIn(today)
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            val householdId = householdIdProvider.householdId.value ?: run {
+                Timber.w("No household ID — skipping check-in load")
+                _uiState.update { it.copy(isLoading = false) }
+                return@launch
+            }
+
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                val transactions = transactionRepository.observeAll(householdId).first()
+                val categories = categoryRepository.observeAll(householdId).first()
+                budgetRepository.observeAll(householdId).first() // touch to reflect budget context
+                val wedding = weddingRepository.load()
+
+                val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+                val periodStart = today.toEpochDays() - checkInRepository.frequency().days
+                val recentExpenses = transactions.filter {
+                    it.type == TransactionType.EXPENSE && it.date.toEpochDays() >= periodStart
+                }
+
+                val totalSpent = recentExpenses.fold(0L) { s, t -> s + t.amount.amount }
+                val categoryNames = categories.associate { it.id.value to it.name }
+                val topCategories = recentExpenses
+                    .groupBy { it.categoryId?.value }
+                    .map { (catId, txns) ->
+                        val name = catId?.let { categoryNames[it] } ?: "Uncategorized"
+                        name to txns.fold(0L) { s, t -> s + t.amount.amount }
+                    }
+                    .sortedByDescending { it.second }
+                    .take(TOP_CATEGORY_COUNT)
+                    .map { (name, amount) ->
+                        CategorySummaryUi(name, CurrencyFormatter.format(Cents(amount), currency))
+                    }
+
+                val weddingPaid = wedding.vendors.fold(0L) { s, v -> s + v.paid.amount }
+
+                val lastEpoch = checkInRepository.lastCheckInEpochDay()
+                val isDue = lastEpoch == null ||
+                    (today.toEpochDays() - lastEpoch) >= checkInRepository.frequency().days
+
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        enabled = checkInRepository.isEnabled(),
+                        frequency = checkInRepository.frequency(),
+                        shareSummaries = checkInRepository.shareSummaries(),
+                        isDue = isDue,
+                        lastCheckInText = lastEpoch?.let { d ->
+                            "Last check-in ${daysAgoText((today.toEpochDays() - d).toInt())}"
+                        } ?: "No check-ins yet",
+                        totalSpentFormatted = CurrencyFormatter.format(Cents(totalSpent), currency),
+                        transactionCount = recentExpenses.size,
+                        topCategories = topCategories,
+                        weddingPaidFormatted = CurrencyFormatter.format(Cents(weddingPaid), currency),
+                        prompts = CheckInContent.promptsFor(checkInRepository.completedCount()),
+                        completedCount = checkInRepository.completedCount(),
+                    )
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to load check-in")
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+    private fun daysAgoText(days: Int): String = when {
+        days <= 0 -> "today"
+        days == 1 -> "yesterday"
+        days < DAYS_IN_WEEK -> "$days days ago"
+        else -> "${days / DAYS_IN_WEEK} week(s) ago"
+    }
+
+    private companion object {
+        const val TOP_CATEGORY_COUNT = 4
+        const val DAYS_IN_WEEK = 7
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/checkin/MoneyCheckInScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/checkin/MoneyCheckInScreen.kt
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.checkin
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Supportive couples money check-in (#2150).
+ *
+ * Opt-in weekly/monthly ritual with neutral summaries (category totals, spend,
+ * wedding pace) and collaborative discussion prompts. Designed to feel like a
+ * conversation, not a surveillance report.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MoneyCheckInScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CheckInViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Money check-in") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics { contentDescription = "Go back" },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Spacer(Modifier.height(4.dp))
+            OptInCard(state, viewModel)
+
+            if (state.enabled) {
+                IntroCard(state)
+                SummaryCard(state)
+                PromptsCard(state)
+                Button(
+                    onClick = viewModel::completeCheckIn,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics { contentDescription = "Mark this check-in complete" },
+                ) {
+                    Icon(Icons.Filled.Check, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("We talked it through")
+                }
+                if (state.completedCount > 0) {
+                    Text(
+                        "You've completed ${state.completedCount} check-in(s) together. Nice teamwork.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun OptInCard(state: CheckInUiState, viewModel: CheckInViewModel) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        "Couples check-ins",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics { heading() },
+                    )
+                    Text(
+                        "A gentle, opt-in rhythm to talk about money together",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = state.enabled,
+                    onCheckedChange = viewModel::setEnabled,
+                    modifier = Modifier.semantics { contentDescription = "Enable couples check-ins" },
+                )
+            }
+            if (state.enabled) {
+                Text("How often?", style = MaterialTheme.typography.labelLarge)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    CheckInFrequency.entries.forEach { f ->
+                        FilterChip(
+                            selected = state.frequency == f,
+                            onClick = { viewModel.setFrequency(f) },
+                            label = { Text(f.displayName) },
+                        )
+                    }
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(Modifier.weight(1f)) {
+                        Text("Share summaries with each other", style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            "Category totals only — never individual transactions",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Switch(
+                        checked = state.shareSummaries,
+                        onCheckedChange = viewModel::setShareSummaries,
+                        modifier = Modifier.semantics { contentDescription = "Share summaries" },
+                    )
+                }
+                Text(
+                    state.lastCheckInText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun IntroCard(state: CheckInUiState) {
+    Card(
+        Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+        ),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                if (state.isDue) "Time for a check-in" else "You're up to date",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(CheckInContent.INTRO, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun SummaryCard(state: CheckInUiState) {
+    if (!state.shareSummaries) {
+        Card(Modifier.fillMaxWidth()) {
+            Text(
+                "Summaries are private right now. Turn on sharing above to review together.",
+                Modifier.padding(16.dp),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        return
+    }
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                "The big picture (${state.frequency.displayName.lowercase()})",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            Text(
+                "${state.totalSpentFormatted} across ${state.transactionCount} expenses",
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            if (state.topCategories.isNotEmpty()) {
+                HorizontalDivider()
+                state.topCategories.forEach { c ->
+                    Row {
+                        Text(c.name, Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+                        Text(c.amountFormatted, fontWeight = FontWeight.SemiBold)
+                    }
+                }
+            }
+            HorizontalDivider()
+            Text(
+                "Wedding paid so far: ${state.weddingPaidFormatted}",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                "Totals only — this is a conversation starter, not a ledger review.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PromptsCard(state: CheckInUiState) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text(
+                "Talk about",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            state.prompts.forEach { p ->
+                Column {
+                    Text(
+                        p.topic,
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(p.prompt, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+    }
+}
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true)
+@Composable
+@Suppress("UnusedPrivateMember")
+private fun MoneyCheckInScreenPreview() {
+    FinanceTheme(dynamicColor = false) {
+        // Live data comes from the ViewModel.
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/debt/CoupleDebtRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/debt/CoupleDebtRepository.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.debt
+
+import android.content.SharedPreferences
+import com.finance.android.ui.couple.Partner
+import com.finance.models.types.Cents
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
+
+/**
+ * On-device persistence for the couple's tracked debts (#2153).
+ *
+ * Debts are stored as a JSON array in encrypted [SharedPreferences]. This keeps
+ * the joint planner fully functional without requiring changes to the shared
+ * [com.finance.models] package (which is read-only for this work).
+ */
+class CoupleDebtRepository(
+    private val prefs: SharedPreferences,
+) {
+
+    /** Loads all tracked debts, or an empty list on first run / parse failure. */
+    fun load(): List<CoupleDebt> {
+        val raw = prefs.getString(KEY, null) ?: return emptyList()
+        return runCatching {
+            val array = JSONArray(raw)
+            (0 until array.length()).mapNotNull { i -> decode(array.getJSONObject(i)) }
+        }.getOrElse {
+            Timber.w(it, "Failed to parse couple debts; starting empty")
+            emptyList()
+        }
+    }
+
+    /** Adds or replaces a debt (matched by id) and persists. */
+    fun upsert(debt: CoupleDebt) {
+        val updated = load().filterNot { it.id == debt.id } + debt
+        save(updated)
+    }
+
+    /** Removes a debt by id. */
+    fun delete(id: String) {
+        save(load().filterNot { it.id == id })
+    }
+
+    private fun save(debts: List<CoupleDebt>) {
+        val array = JSONArray()
+        debts.forEach { array.put(encode(it)) }
+        prefs.edit().putString(KEY, array.toString()).apply()
+    }
+
+    private fun encode(debt: CoupleDebt): JSONObject = JSONObject().apply {
+        put("id", debt.id)
+        put("name", debt.name)
+        put("balance", debt.balance.amount)
+        put("apr", debt.aprBasisPoints)
+        put("min", debt.minimumPayment.amount)
+        put("ownership", debt.ownership.name)
+        put("owner", debt.owner?.name ?: JSONObject.NULL)
+    }
+
+    private fun decode(json: JSONObject): CoupleDebt? = runCatching {
+        CoupleDebt(
+            id = json.getString("id"),
+            name = json.getString("name"),
+            balance = Cents(json.getLong("balance")),
+            aprBasisPoints = json.getInt("apr"),
+            minimumPayment = Cents(json.getLong("min")),
+            ownership = DebtOwnership.valueOf(json.getString("ownership")),
+            owner = json.optString("owner", "").takeIf { it.isNotBlank() }
+                ?.let { runCatching { Partner.valueOf(it) }.getOrNull() },
+        )
+    }.getOrNull()
+
+    private companion object {
+        const val KEY = "couple_debts_v1"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/debt/CoupleDebtRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/debt/CoupleDebtRepository.kt
@@ -73,6 +73,6 @@ class CoupleDebtRepository(
     }.getOrNull()
 
     private companion object {
-        const val KEY = "couple_debts_v1"
+        const val KEY = "couple_debts_v1" // gitleaks:allow (prefs key)
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/debt/DebtPayoffPlanner.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/debt/DebtPayoffPlanner.kt
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.debt
+
+import com.finance.android.ui.couple.Partner
+import com.finance.models.types.Cents
+
+/** How a debt is owned within the couple (#2153). */
+enum class DebtOwnership { PERSONAL, SHARED, JOINTLY_FUNDED }
+
+/** The two payoff strategies the planner can compare. */
+enum class PayoffStrategy(val displayName: String, val rationale: String) {
+    AVALANCHE("Avalanche", "Pay highest interest first — saves the most money"),
+    SNOWBALL("Snowball", "Pay smallest balance first — quick wins for momentum"),
+}
+
+/**
+ * A single debt owned by one or both partners.
+ *
+ * @property id Stable identifier.
+ * @property name Display name (e.g. "Sam's student loan").
+ * @property balance Current outstanding balance.
+ * @property aprBasisPoints Annual percentage rate in basis points (e.g. 1999 = 19.99%).
+ * @property minimumPayment Required monthly minimum payment.
+ * @property ownership Personal / shared / jointly-funded classification.
+ * @property owner The owning partner when [ownership] is [DebtOwnership.PERSONAL]; else null.
+ */
+data class CoupleDebt(
+    val id: String,
+    val name: String,
+    val balance: Cents,
+    val aprBasisPoints: Int,
+    val minimumPayment: Cents,
+    val ownership: DebtOwnership,
+    val owner: Partner? = null,
+) {
+    init {
+        require(name.isNotBlank()) { "Debt name cannot be blank" }
+        require(balance.amount >= 0L) { "Debt balance cannot be negative" }
+        require(aprBasisPoints >= 0) { "APR cannot be negative" }
+        require(minimumPayment.amount >= 0L) { "Minimum payment cannot be negative" }
+    }
+}
+
+/** Per-debt result within a computed [PayoffPlan]. */
+data class DebtPayoffResult(
+    val debtId: String,
+    val name: String,
+    val payoffMonth: Int,
+    val interestPaid: Cents,
+)
+
+/**
+ * The outcome of simulating one [PayoffStrategy].
+ *
+ * @property strategy The strategy simulated.
+ * @property monthsToDebtFree Total months until every debt is cleared.
+ * @property totalInterest Total interest paid across all debts.
+ * @property totalPaid Principal + interest paid.
+ * @property order Debts in the order they are paid off.
+ * @property completed False when the plan could not clear debts within the horizon.
+ */
+data class PayoffPlan(
+    val strategy: PayoffStrategy,
+    val monthsToDebtFree: Int,
+    val totalInterest: Cents,
+    val totalPaid: Cents,
+    val order: List<DebtPayoffResult>,
+    val completed: Boolean,
+)
+
+/**
+ * A comparison of both strategies plus a couple-friendly recommendation (#2153).
+ */
+data class PayoffComparison(
+    val avalanche: PayoffPlan,
+    val snowball: PayoffPlan,
+    val recommended: PayoffStrategy,
+    val interestSavedWithAvalanche: Cents,
+    val monthsSavedWithAvalanche: Int,
+) {
+    /** Plain-language recommendation for the "simpler decision aid" mode. */
+    val recommendationSummary: String
+        get() = when (recommended) {
+            PayoffStrategy.AVALANCHE ->
+                "Avalanche clears your debt for the least money — a solid default " +
+                    "while you balance the wedding and house savings."
+            PayoffStrategy.SNOWBALL ->
+                "Snowball costs about the same here but pays off a debt sooner, " +
+                    "which can keep you both motivated."
+        }
+}
+
+/**
+ * Pure, deterministic joint debt payoff simulator (#2153).
+ *
+ * No Android or clock dependencies — every calculation uses [Cents] (Long) so
+ * there is no floating-point drift on money, and it is straightforward to unit
+ * test. Interest accrues monthly; extra payments cascade to the strategy's
+ * priority debt once every minimum is covered.
+ */
+object DebtPayoffPlanner {
+
+    /** Safety horizon so a mis-configured plan can't loop forever. */
+    const val MAX_MONTHS = 600
+
+    /**
+     * Simulates paying off [debts] with a fixed [extraMonthlyPayment] on top of
+     * all minimums, using the given [strategy].
+     */
+    fun simulate(
+        debts: List<CoupleDebt>,
+        extraMonthlyPayment: Cents,
+        strategy: PayoffStrategy,
+    ): PayoffPlan {
+        val active = debts.filter { it.balance.amount > 0L }
+        if (active.isEmpty()) {
+            return PayoffPlan(strategy, 0, Cents.ZERO, Cents.ZERO, emptyList(), completed = true)
+        }
+
+        // Mutable simulation state keyed by debt id.
+        val balances = active.associate { it.id to it.balance.amount }.toMutableMap()
+        val interestByDebt = active.associate { it.id to 0L }.toMutableMap()
+        val principalByDebt = active.associate { it.id to it.balance.amount }.toMutableMap()
+        val payoffMonth = mutableMapOf<String, Int>()
+
+        val priority = orderFor(active, strategy)
+        var month = 0
+
+        while (balances.values.any { it > 0L } && month < MAX_MONTHS) {
+            month++
+
+            // 1) Accrue interest on every outstanding debt.
+            for (debt in active) {
+                val bal = balances.getValue(debt.id)
+                if (bal <= 0L) continue
+                val interest = monthlyInterest(bal, debt.aprBasisPoints)
+                balances[debt.id] = bal + interest
+                interestByDebt[debt.id] = interestByDebt.getValue(debt.id) + interest
+            }
+
+            // 2) Budget = sum of minimums (for still-open debts) + extra.
+            var pool = extraMonthlyPayment.amount
+            for (debt in active) {
+                if (balances.getValue(debt.id) <= 0L) continue
+                val bal = balances.getValue(debt.id)
+                val pay = minOf(debt.minimumPayment.amount, bal)
+                balances[debt.id] = bal - pay
+                pool += debt.minimumPayment.amount - pay // return unused minimum to the pool
+                if (balances.getValue(debt.id) <= 0L) recordPayoff(payoffMonth, debt.id, month)
+            }
+
+            // 3) Cascade the remaining pool onto the priority debt(s).
+            for (debt in priority) {
+                if (pool <= 0L) break
+                val bal = balances.getValue(debt.id)
+                if (bal <= 0L) continue
+                val pay = minOf(pool, bal)
+                balances[debt.id] = bal - pay
+                pool -= pay
+                if (balances.getValue(debt.id) <= 0L) recordPayoff(payoffMonth, debt.id, month)
+            }
+        }
+
+        val completed = balances.values.all { it <= 0L }
+        val results = active
+            .map {
+                DebtPayoffResult(
+                    debtId = it.id,
+                    name = it.name,
+                    payoffMonth = payoffMonth[it.id] ?: month,
+                    interestPaid = Cents(interestByDebt.getValue(it.id)),
+                )
+            }
+            .sortedBy { it.payoffMonth }
+        val totalInterest = Cents(interestByDebt.values.sum())
+        val totalPrincipal = principalByDebt.values.sum()
+        return PayoffPlan(
+            strategy = strategy,
+            monthsToDebtFree = month,
+            totalInterest = totalInterest,
+            totalPaid = Cents(totalPrincipal + totalInterest.amount),
+            order = results,
+            completed = completed,
+        )
+    }
+
+    /** Runs both strategies and recommends the cheaper (ties favour momentum). */
+    fun compare(debts: List<CoupleDebt>, extraMonthlyPayment: Cents): PayoffComparison {
+        val avalanche = simulate(debts, extraMonthlyPayment, PayoffStrategy.AVALANCHE)
+        val snowball = simulate(debts, extraMonthlyPayment, PayoffStrategy.SNOWBALL)
+        val interestSaved = Cents(snowball.totalInterest.amount - avalanche.totalInterest.amount)
+        val monthsSaved = snowball.monthsToDebtFree - avalanche.monthsToDebtFree
+        // Recommend avalanche only when it meaningfully saves money (> $50), else snowball's momentum.
+        val recommended =
+            if (interestSaved.amount > MEANINGFUL_SAVING_CENTS) PayoffStrategy.AVALANCHE
+            else PayoffStrategy.SNOWBALL
+        return PayoffComparison(
+            avalanche = avalanche,
+            snowball = snowball,
+            recommended = recommended,
+            interestSavedWithAvalanche = interestSaved,
+            monthsSavedWithAvalanche = monthsSaved,
+        )
+    }
+
+    /**
+     * Estimates how much sooner the couple is debt-free if they redirect
+     * [reallocated] per month away from another goal (e.g. wedding) into debt.
+     * Returns months saved versus paying only minimums-plus-current-extra.
+     */
+    fun monthsSavedByAdding(
+        debts: List<CoupleDebt>,
+        currentExtra: Cents,
+        reallocated: Cents,
+        strategy: PayoffStrategy,
+    ): Int {
+        val base = simulate(debts, currentExtra, strategy)
+        val boosted = simulate(debts, Cents(currentExtra.amount + reallocated.amount), strategy)
+        return (base.monthsToDebtFree - boosted.monthsToDebtFree).coerceAtLeast(0)
+    }
+
+    private fun orderFor(debts: List<CoupleDebt>, strategy: PayoffStrategy): List<CoupleDebt> =
+        when (strategy) {
+            PayoffStrategy.AVALANCHE -> debts.sortedWith(
+                compareByDescending<CoupleDebt> { it.aprBasisPoints }.thenBy { it.balance.amount },
+            )
+            PayoffStrategy.SNOWBALL -> debts.sortedWith(
+                compareBy<CoupleDebt> { it.balance.amount }.thenByDescending { it.aprBasisPoints },
+            )
+        }
+
+    /** Monthly interest in cents, rounded to the nearest cent. */
+    private fun monthlyInterest(balanceCents: Long, aprBasisPoints: Int): Long {
+        if (aprBasisPoints == 0 || balanceCents <= 0L) return 0L
+        // balance * (aprBps / 10_000) / 12, rounded.
+        val numerator = balanceCents.toDouble() * aprBasisPoints
+        return Math.round(numerator / (BPS_DIVISOR * MONTHS_PER_YEAR))
+    }
+
+    private fun recordPayoff(map: MutableMap<String, Int>, id: String, month: Int) {
+        map.putIfAbsent(id, month)
+    }
+
+    private const val BPS_DIVISOR = 10_000.0
+    private const val MONTHS_PER_YEAR = 12.0
+    private const val MEANINGFUL_SAVING_CENTS = 5_000L // $50
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/debt/DebtPayoffPlannerScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/debt/DebtPayoffPlannerScreen.kt
@@ -1,0 +1,460 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.debt
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.couple.Partner
+import com.finance.android.ui.theme.FinanceTheme
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Joint debt payoff planner (#2153).
+ *
+ * Compares avalanche vs snowball across both partners' debts, supports personal
+ * / shared / jointly-funded ownership, shows the tradeoff against wedding and
+ * house savings, and offers a simpler recommendation mode.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DebtPayoffPlannerScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: DebtPlannerViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    var showAdd by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Debt payoff planner") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics { contentDescription = "Go back" },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { showAdd = true },
+                modifier = Modifier.semantics { contentDescription = "Add a debt" },
+            ) {
+                Icon(Icons.Filled.Add, contentDescription = null)
+            }
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { Spacer(Modifier.height(4.dp)) }
+            item { SimpleModeToggle(state, viewModel) }
+            item { ExtraPaymentCard(state, viewModel) }
+
+            if (state.avalanche != null && state.snowball != null) {
+                if (state.simpleMode) {
+                    item { RecommendationCard(state) }
+                } else {
+                    item { StrategyComparison(state) }
+                }
+                state.weddingTradeoffText?.let { text ->
+                    item { TradeoffCard(text) }
+                }
+            } else {
+                item {
+                    Text(
+                        state.recommendationSummary,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            item {
+                Text(
+                    "Your debts",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.semantics { heading() },
+                )
+            }
+            items(state.debts, key = { it.id }) { debt ->
+                DebtRow(debt, onDelete = { viewModel.deleteDebt(debt.id) })
+            }
+            item { Spacer(Modifier.height(80.dp)) }
+        }
+    }
+
+    if (showAdd) {
+        AddDebtDialog(
+            partnerAName = state.profile.partnerAName,
+            partnerBName = state.profile.partnerBName,
+            onDismiss = { showAdd = false },
+            onAdd = { name, bal, apr, min, ownership, owner ->
+                viewModel.addDebt(name, bal, apr, min, ownership, owner)
+                showAdd = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun SimpleModeToggle(state: DebtPlannerUiState, viewModel: DebtPlannerViewModel) {
+    Row(
+        Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text("Just tell us what to do", style = MaterialTheme.typography.bodyLarge)
+            Text(
+                "Show one clear recommendation instead of the full comparison",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = state.simpleMode,
+            onCheckedChange = viewModel::setSimpleMode,
+            modifier = Modifier.semantics { contentDescription = "Simple recommendation mode" },
+        )
+    }
+}
+
+@Composable
+private fun ExtraPaymentCard(state: DebtPlannerUiState, viewModel: DebtPlannerViewModel) {
+    var text by remember(state.extraMonthlyCents) {
+        mutableStateOf((state.extraMonthlyCents / 100.0).toString())
+    }
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                "Extra toward debt each month",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            OutlinedTextField(
+                value = text,
+                onValueChange = {
+                    text = it
+                    it.toDoubleOrNull()?.let { d -> viewModel.setExtraMonthly(d) }
+                },
+                label = { Text("Extra monthly payment ($)") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Extra monthly payment in dollars" },
+            )
+            Text(
+                "Applied on top of every minimum payment.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecommendationCard(state: DebtPlannerUiState) {
+    val plan = if (state.recommendedStrategy == PayoffStrategy.AVALANCHE) {
+        state.avalanche
+    } else {
+        state.snowball
+    } ?: return
+    Card(
+        Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+        ),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                "Recommended: ${state.recommendedStrategy.displayName}",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.semantics { heading() },
+            )
+            Text(state.recommendationSummary, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                "Debt-free in ${plan.debtFreeText} · ${plan.totalInterestFormatted} interest",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                "Order: ${plan.orderedNames.joinToString(" → ")}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StrategyComparison(state: DebtPlannerUiState) {
+    Row(
+        Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        state.avalanche?.let {
+            PlanCard(
+                plan = it,
+                recommended = state.recommendedStrategy == PayoffStrategy.AVALANCHE,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        state.snowball?.let {
+            PlanCard(
+                plan = it,
+                recommended = state.recommendedStrategy == PayoffStrategy.SNOWBALL,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlanCard(plan: StrategyPlanUi, recommended: Boolean, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = if (recommended) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant
+            },
+        ),
+    ) {
+        Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                plan.strategy.displayName,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            if (recommended) {
+                AssistChip(onClick = {}, label = { Text("Recommended") })
+            }
+            Text("Debt-free: ${plan.debtFreeText}", style = MaterialTheme.typography.bodyMedium)
+            Text(
+                "Interest: ${plan.totalInterestFormatted}",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                plan.strategy.rationale,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TradeoffCard(text: String) {
+    Card(
+        Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                "Wedding & house tradeoff",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(text, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun DebtRow(debt: DebtRowUi, onDelete: () -> Unit) {
+    Card(Modifier.fillMaxWidth()) {
+        Row(
+            Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(debt.name, style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    "${debt.balanceFormatted} · ${debt.aprFormatted} · ${debt.minPaymentFormatted}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    debt.ownershipLabel,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            IconButton(
+                onClick = onDelete,
+                modifier = Modifier.semantics { contentDescription = "Delete ${debt.name}" },
+            ) {
+                Icon(Icons.Filled.Delete, contentDescription = null)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddDebtDialog(
+    partnerAName: String,
+    partnerBName: String,
+    onDismiss: () -> Unit,
+    onAdd: (String, Double, Double, Double, DebtOwnership, Partner?) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var balance by remember { mutableStateOf("") }
+    var apr by remember { mutableStateOf("") }
+    var minPayment by remember { mutableStateOf("") }
+    var ownership by remember { mutableStateOf(DebtOwnership.PERSONAL) }
+    var owner by remember { mutableStateOf(Partner.A) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onAdd(
+                        name,
+                        balance.toDoubleOrNull() ?: 0.0,
+                        apr.toDoubleOrNull() ?: 0.0,
+                        minPayment.toDoubleOrNull() ?: 0.0,
+                        ownership,
+                        if (ownership == DebtOwnership.PERSONAL) owner else null,
+                    )
+                },
+                enabled = name.isNotBlank() && (balance.toDoubleOrNull() ?: 0.0) > 0,
+            ) { Text("Add") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        title = { Text("Add a debt") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = balance,
+                    onValueChange = { balance = it },
+                    label = { Text("Balance ($)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = apr,
+                    onValueChange = { apr = it },
+                    label = { Text("APR (%)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = minPayment,
+                    onValueChange = { minPayment = it },
+                    label = { Text("Minimum payment ($/mo)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                )
+                Text("Ownership", style = MaterialTheme.typography.labelLarge)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    DebtOwnership.entries.forEach { opt ->
+                        FilterChip(
+                            selected = ownership == opt,
+                            onClick = { ownership = opt },
+                            label = {
+                                Text(
+                                    opt.name.lowercase()
+                                        .replace('_', ' ')
+                                        .replaceFirstChar { it.uppercase() },
+                                )
+                            },
+                        )
+                    }
+                }
+                if (ownership == DebtOwnership.PERSONAL) {
+                    SingleChoiceSegmentedButtonRow {
+                        SegmentedButton(
+                            selected = owner == Partner.A,
+                            onClick = { owner = Partner.A },
+                            shape = SegmentedButtonDefaults.itemShape(0, 2),
+                        ) { Text(partnerAName) }
+                        SegmentedButton(
+                            selected = owner == Partner.B,
+                            onClick = { owner = Partner.B },
+                            shape = SegmentedButtonDefaults.itemShape(1, 2),
+                        ) { Text(partnerBName) }
+                    }
+                }
+            }
+        },
+    )
+}
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true)
+@Composable
+@Suppress("UnusedPrivateMember")
+private fun DebtPlannerScreenPreview() {
+    FinanceTheme(dynamicColor = false) {
+        // Live data comes from the ViewModel.
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/debt/DebtPlannerViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/debt/DebtPlannerViewModel.kt
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.debt
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.ui.couple.CoupleProfile
+import com.finance.android.ui.couple.CoupleProfileRepository
+import com.finance.android.ui.couple.Partner
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.math.roundToLong
+
+/** A debt row formatted for display. */
+data class DebtRowUi(
+    val id: String,
+    val name: String,
+    val balanceFormatted: String,
+    val aprFormatted: String,
+    val minPaymentFormatted: String,
+    val ownershipLabel: String,
+)
+
+/** A strategy plan formatted for display. */
+data class StrategyPlanUi(
+    val strategy: PayoffStrategy,
+    val monthsToDebtFree: Int,
+    val debtFreeText: String,
+    val totalInterestFormatted: String,
+    val orderedNames: List<String>,
+    val completed: Boolean,
+)
+
+/** UI state for the joint debt payoff planner (#2153). */
+data class DebtPlannerUiState(
+    val isLoading: Boolean = true,
+    val profile: CoupleProfile = CoupleProfile(),
+    val debts: List<DebtRowUi> = emptyList(),
+    val extraMonthlyFormatted: String = "$0.00",
+    val extraMonthlyCents: Long = 0L,
+    val selectedStrategy: PayoffStrategy = PayoffStrategy.AVALANCHE,
+    val simpleMode: Boolean = false,
+    val avalanche: StrategyPlanUi? = null,
+    val snowball: StrategyPlanUi? = null,
+    val recommendedStrategy: PayoffStrategy = PayoffStrategy.AVALANCHE,
+    val recommendationSummary: String = "",
+    val interestSavedFormatted: String = "$0.00",
+    val weddingTradeoffText: String? = null,
+)
+
+/**
+ * ViewModel for the joint debt payoff planner (#2153).
+ *
+ * Wraps the pure [DebtPayoffPlanner] with persistence and formatting, compares
+ * avalanche vs snowball across both partners' debts, and surfaces how extra
+ * payments trade off against other goals like the wedding and house.
+ */
+class DebtPlannerViewModel(
+    private val repository: CoupleDebtRepository,
+    private val profileRepository: CoupleProfileRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DebtPlannerUiState())
+    val uiState: StateFlow<DebtPlannerUiState> = _uiState.asStateFlow()
+
+    private val currency: Currency = Currency.USD
+    private var extraMonthly: Cents = Cents(DEFAULT_EXTRA_CENTS)
+
+    init {
+        recompute()
+    }
+
+    fun addDebt(
+        name: String,
+        balanceDollars: Double,
+        aprPercent: Double,
+        minPaymentDollars: Double,
+        ownership: DebtOwnership,
+        owner: Partner?,
+    ) {
+        if (name.isBlank() || balanceDollars <= 0) return
+        repository.upsert(
+            CoupleDebt(
+                id = "debt-${System.currentTimeMillis()}",
+                name = name.trim(),
+                balance = Cents.fromDollars(balanceDollars),
+                aprBasisPoints = (aprPercent * BPS_PER_PERCENT).roundToLong().toInt().coerceAtLeast(0),
+                minimumPayment = Cents.fromDollars(minPaymentDollars.coerceAtLeast(0.0)),
+                ownership = ownership,
+                owner = if (ownership == DebtOwnership.PERSONAL) owner ?: Partner.A else null,
+            ),
+        )
+        recompute()
+    }
+
+    fun deleteDebt(id: String) {
+        repository.delete(id)
+        recompute()
+    }
+
+    fun setExtraMonthly(dollars: Double) {
+        extraMonthly = Cents.fromDollars(dollars.coerceAtLeast(0.0))
+        recompute()
+    }
+
+    fun selectStrategy(strategy: PayoffStrategy) {
+        _uiState.update { it.copy(selectedStrategy = strategy) }
+    }
+
+    fun setSimpleMode(simple: Boolean) {
+        _uiState.update { it.copy(simpleMode = simple) }
+    }
+
+    private fun recompute() {
+        viewModelScope.launch {
+            val debts = repository.load()
+            val profile = profileRepository.load()
+            val rows = debts.map { it.toRowUi(profile) }
+
+            if (debts.none { it.balance.amount > 0L }) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        profile = profile,
+                        debts = rows,
+                        extraMonthlyCents = extraMonthly.amount,
+                        extraMonthlyFormatted = CurrencyFormatter.format(extraMonthly, currency),
+                        avalanche = null,
+                        snowball = null,
+                        recommendationSummary = "Add both partners' debts to see a payoff plan.",
+                        weddingTradeoffText = null,
+                    )
+                }
+                return@launch
+            }
+
+            val comparison = DebtPayoffPlanner.compare(debts, extraMonthly)
+            val tradeoff = weddingTradeoff(debts, comparison.recommended)
+
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    profile = profile,
+                    debts = rows,
+                    extraMonthlyCents = extraMonthly.amount,
+                    extraMonthlyFormatted = CurrencyFormatter.format(extraMonthly, currency),
+                    avalanche = comparison.avalanche.toUi(),
+                    snowball = comparison.snowball.toUi(),
+                    recommendedStrategy = comparison.recommended,
+                    recommendationSummary = comparison.recommendationSummary,
+                    interestSavedFormatted = CurrencyFormatter.format(
+                        comparison.interestSavedWithAvalanche.abs(), currency,
+                    ),
+                    weddingTradeoffText = tradeoff,
+                )
+            }
+        }
+    }
+
+    private fun weddingTradeoff(debts: List<CoupleDebt>, strategy: PayoffStrategy): String {
+        val reallocated = Cents(WEDDING_REALLOCATION_CENTS)
+        val monthsSaved = DebtPayoffPlanner.monthsSavedByAdding(
+            debts = debts,
+            currentExtra = extraMonthly,
+            reallocated = reallocated,
+            strategy = strategy,
+        )
+        val amount = CurrencyFormatter.format(reallocated, currency)
+        return if (monthsSaved > 0) {
+            "Redirecting $amount/mo from wedding or house savings would clear debt " +
+                "about $monthsSaved month(s) sooner — weigh that against your timeline."
+        } else {
+            "At this pace, adding $amount/mo wouldn't change your debt-free date much — " +
+                "keeping it for the wedding or house may be the better call."
+        }
+    }
+
+    private fun CoupleDebt.toRowUi(profile: CoupleProfile): DebtRowUi = DebtRowUi(
+        id = id,
+        name = name,
+        balanceFormatted = CurrencyFormatter.format(balance, currency),
+        aprFormatted = "${aprBasisPoints / BPS_PER_PERCENT}% APR",
+        minPaymentFormatted = "${CurrencyFormatter.format(minimumPayment, currency)}/mo min",
+        ownershipLabel = ownershipLabel(profile),
+    )
+
+    private fun CoupleDebt.ownershipLabel(profile: CoupleProfile): String = when (ownership) {
+        DebtOwnership.PERSONAL -> profile.nameFor(owner ?: Partner.A)
+        DebtOwnership.SHARED -> profile.sharedLabel
+        DebtOwnership.JOINTLY_FUNDED -> "${profile.sharedLabel} (jointly funded)"
+    }
+
+    private fun PayoffPlan.toUi(): StrategyPlanUi = StrategyPlanUi(
+        strategy = strategy,
+        monthsToDebtFree = monthsToDebtFree,
+        debtFreeText = monthsToText(monthsToDebtFree),
+        totalInterestFormatted = CurrencyFormatter.format(totalInterest, currency),
+        orderedNames = order.map { it.name },
+        completed = completed,
+    )
+
+    private fun monthsToText(months: Int): String {
+        if (months <= 0) return "Debt-free"
+        val years = months / MONTHS_PER_YEAR_INT
+        val rem = months % MONTHS_PER_YEAR_INT
+        return when {
+            years == 0 -> "$months mo"
+            rem == 0 -> "$years yr"
+            else -> "$years yr $rem mo"
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_EXTRA_CENTS = 20_000L // $200 default extra
+        const val WEDDING_REALLOCATION_CENTS = 15_000L // $150 illustrative reallocation
+        const val BPS_PER_PERCENT = 100.0
+        const val MONTHS_PER_YEAR_INT = 12
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/goals/SharedGoalContributionsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/goals/SharedGoalContributionsScreen.kt
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.goals
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.outlined.Circle
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.couple.Partner
+import com.finance.android.ui.theme.FinanceTheme
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Shared goal contributions for a house down payment (#2147).
+ *
+ * Shows combined household progress plus each partner's contribution effort,
+ * suggested monthly targets, home-purchase milestones, and a contribution
+ * history. Partners can choose whether contributions are shown in detail or
+ * summarized.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SharedGoalContributionsScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: SharedGoalViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    var showAdd by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Shared goal") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics { contentDescription = "Go back" },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            if (state.selectedGoalId != null) {
+                FloatingActionButton(
+                    onClick = { showAdd = true },
+                    modifier = Modifier.semantics { contentDescription = "Add a contribution" },
+                ) {
+                    Icon(Icons.Filled.Add, contentDescription = null)
+                }
+            }
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { Spacer(Modifier.height(4.dp)) }
+            item { GoalPicker(state, viewModel) }
+
+            if (state.selectedGoalId == null && !state.isLoading) {
+                item {
+                    Text(
+                        "Create a savings goal (e.g. \"House down payment\") to start " +
+                            "contributing together.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            if (state.selectedGoalId != null) {
+                item { TotalProgressCard(state) }
+                item { VisibilityToggle(state, viewModel) }
+                item {
+                    Text(
+                        "Each partner",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics { heading() },
+                    )
+                }
+                items(state.partnerProgress, key = { it.partner.name }) { p ->
+                    PartnerProgressCard(p, state.showContributionsVisibly)
+                }
+                item { MilestonesCard(state) }
+                if (state.showContributionsVisibly && state.history.isNotEmpty()) {
+                    item {
+                        Text(
+                            "Contribution history",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.semantics { heading() },
+                        )
+                    }
+                    items(state.history, key = { it.id }) { row ->
+                        ContributionRow(row, onDelete = { viewModel.deleteContribution(row.id) })
+                    }
+                }
+            }
+            item { Spacer(Modifier.height(80.dp)) }
+        }
+    }
+
+    if (showAdd) {
+        AddContributionDialog(
+            partnerAName = state.profile.partnerAName,
+            partnerBName = state.profile.partnerBName,
+            onDismiss = { showAdd = false },
+            onAdd = { partner, amount, note ->
+                viewModel.addContribution(partner, amount, note)
+                showAdd = false
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GoalPicker(state: SharedGoalUiState, viewModel: SharedGoalViewModel) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        OutlinedButton(
+            onClick = { expanded = true },
+            enabled = state.goals.isNotEmpty(),
+            modifier = Modifier.semantics { contentDescription = "Choose shared goal" },
+        ) {
+            Text(state.selectedGoalName.ifBlank { "Select a goal" })
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            state.goals.forEach { g ->
+                DropdownMenuItem(
+                    text = { Text(g.name) },
+                    onClick = {
+                        expanded = false
+                        viewModel.selectGoal(g.id)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TotalProgressCard(state: SharedGoalUiState) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                "Household total",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            Text(
+                "${state.totalSavedFormatted} of ${state.targetFormatted}",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            LinearProgressIndicator(
+                progress = { state.progressFraction },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(10.dp)
+                    .semantics {
+                        contentDescription =
+                            "Progress ${(state.progressFraction * 100).toInt()} percent"
+                    },
+            )
+            Text(
+                "${state.remainingFormatted} to go",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun VisibilityToggle(state: SharedGoalUiState, viewModel: SharedGoalViewModel) {
+    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Column(Modifier.weight(1f)) {
+            Text("Show contribution detail", style = MaterialTheme.typography.bodyLarge)
+            Text(
+                "Off shows each partner's share as a summary only",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = state.showContributionsVisibly,
+            onCheckedChange = viewModel::toggleVisibility,
+            modifier = Modifier.semantics { contentDescription = "Show contribution detail" },
+        )
+    }
+}
+
+@Composable
+private fun PartnerProgressCard(p: PartnerProgressUi, showDetail: Boolean) {
+    Card(
+        Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Row {
+                Text(p.name, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.weight(1f))
+                if (showDetail) {
+                    Text(p.contributedFormatted, fontWeight = FontWeight.SemiBold)
+                }
+            }
+            if (showDetail) {
+                LinearProgressIndicator(
+                    progress = { p.fractionOfRecorded },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(8.dp)
+                        .semantics {
+                            contentDescription =
+                                "${p.name} contributed ${(p.fractionOfRecorded * 100).toInt()} " +
+                                    "percent of recorded"
+                        },
+                )
+            }
+            Text(
+                "Suggested: ${p.suggestedMonthlyFormatted}/mo",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MilestonesCard(state: SharedGoalUiState) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                "Home milestones",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            state.milestones.forEach { m ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = if (m.reached) {
+                            Icons.Filled.CheckCircle
+                        } else {
+                            Icons.Outlined.Circle
+                        },
+                        contentDescription = if (m.reached) "Reached" else "Not yet reached",
+                        tint = if (m.reached) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(m.label, Modifier.weight(1f))
+                    Text(m.amountFormatted, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            Text(
+                "Plan for closing costs and an emergency buffer on top of the down payment.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ContributionRow(row: ContributionRowUi, onDelete: () -> Unit) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text("${row.partnerName} · ${row.amountFormatted}", style = MaterialTheme.typography.bodyMedium)
+            if (row.note.isNotBlank()) {
+                Text(
+                    row.note,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        TextButton(
+            onClick = onDelete,
+            modifier = Modifier.semantics { contentDescription = "Remove contribution" },
+        ) {
+            Text("Remove")
+        }
+    }
+}
+
+@Composable
+private fun AddContributionDialog(
+    partnerAName: String,
+    partnerBName: String,
+    onDismiss: () -> Unit,
+    onAdd: (Partner, Double, String) -> Unit,
+) {
+    var partner by remember { mutableStateOf(Partner.A) }
+    var amount by remember { mutableStateOf("") }
+    var note by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = { onAdd(partner, amount.toDoubleOrNull() ?: 0.0, note) },
+                enabled = (amount.toDoubleOrNull() ?: 0.0) > 0,
+            ) { Text("Add") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        title = { Text("Add contribution") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    FilterChip(
+                        selected = partner == Partner.A,
+                        onClick = { partner = Partner.A },
+                        label = { Text(partnerAName) },
+                    )
+                    FilterChip(
+                        selected = partner == Partner.B,
+                        onClick = { partner = Partner.B },
+                        label = { Text(partnerBName) },
+                    )
+                }
+                OutlinedTextField(
+                    value = amount,
+                    onValueChange = { amount = it },
+                    label = { Text("Amount ($)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = note,
+                    onValueChange = { note = it },
+                    label = { Text("Note (optional)") },
+                    singleLine = true,
+                )
+            }
+        },
+    )
+}
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true)
+@Composable
+@Suppress("UnusedPrivateMember")
+private fun SharedGoalScreenPreview() {
+    FinanceTheme(dynamicColor = false) {
+        // Live data comes from the ViewModel.
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/goals/SharedGoalModels.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/goals/SharedGoalModels.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.goals
+
+import android.content.SharedPreferences
+import com.finance.android.ui.couple.Partner
+import com.finance.models.types.Cents
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
+
+/**
+ * A single partner contribution toward a shared goal (#2147).
+ *
+ * @property id Stable identifier.
+ * @property goalId The goal this contribution counts toward (a real [com.finance.models.Goal] id).
+ * @property partner Which partner contributed.
+ * @property amount Amount contributed.
+ * @property epochDay Day of the contribution (epoch day) for ordering / history.
+ * @property note Optional freeform note.
+ */
+data class GoalContribution(
+    val id: String,
+    val goalId: String,
+    val partner: Partner,
+    val amount: Cents,
+    val epochDay: Long,
+    val note: String = "",
+) {
+    init {
+        require(amount.amount > 0L) { "Contribution amount must be positive" }
+    }
+}
+
+/** A home-purchase milestone within the down-payment plan. */
+data class HomeMilestone(
+    val label: String,
+    val target: Cents,
+) {
+    /** Whether [saved] has reached this milestone's [target]. */
+    fun isReached(saved: Cents): Boolean = saved.amount >= target.amount
+}
+
+/**
+ * On-device persistence for per-goal partner contributions (#2147).
+ *
+ * Contributions layer partner-specific effort on top of the shared
+ * [com.finance.models.Goal] without modifying the read-only model package.
+ */
+class SharedContributionRepository(
+    private val prefs: SharedPreferences,
+) {
+
+    /** All contributions across every goal. */
+    fun all(): List<GoalContribution> {
+        val raw = prefs.getString(KEY, null) ?: return emptyList()
+        return runCatching {
+            val array = JSONArray(raw)
+            (0 until array.length()).mapNotNull { decode(array.getJSONObject(it)) }
+        }.getOrElse {
+            Timber.w(it, "Failed to parse contributions; starting empty")
+            emptyList()
+        }
+    }
+
+    /** Contributions for a specific goal, newest first. */
+    fun forGoal(goalId: String): List<GoalContribution> =
+        all().filter { it.goalId == goalId }.sortedByDescending { it.epochDay }
+
+    /** Adds a contribution and persists. */
+    fun add(contribution: GoalContribution) {
+        save(all() + contribution)
+    }
+
+    /** Removes a contribution by id. */
+    fun delete(id: String) {
+        save(all().filterNot { it.id == id })
+    }
+
+    private fun save(contributions: List<GoalContribution>) {
+        val array = JSONArray()
+        contributions.forEach { array.put(encode(it)) }
+        prefs.edit().putString(KEY, array.toString()).apply()
+    }
+
+    private fun encode(c: GoalContribution): JSONObject = JSONObject().apply {
+        put("id", c.id)
+        put("goalId", c.goalId)
+        put("partner", c.partner.name)
+        put("amount", c.amount.amount)
+        put("epochDay", c.epochDay)
+        put("note", c.note)
+    }
+
+    private fun decode(json: JSONObject): GoalContribution? = runCatching {
+        GoalContribution(
+            id = json.getString("id"),
+            goalId = json.getString("goalId"),
+            partner = Partner.valueOf(json.getString("partner")),
+            amount = Cents(json.getLong("amount")),
+            epochDay = json.getLong("epochDay"),
+            note = json.optString("note", ""),
+        )
+    }.getOrNull()
+
+    private companion object {
+        const val KEY = "couple_goal_contributions_v1"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/goals/SharedGoalViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/goals/SharedGoalViewModel.kt
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.goals
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.GoalRepository
+import com.finance.android.ui.couple.CoupleProfile
+import com.finance.android.ui.couple.CoupleProfileRepository
+import com.finance.android.ui.couple.Partner
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.models.Goal
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import timber.log.Timber
+
+/** A selectable goal in the shared-contributions picker. */
+data class SelectableGoalUi(val id: String, val name: String)
+
+/** Per-partner contribution summary. */
+data class PartnerProgressUi(
+    val partner: Partner,
+    val name: String,
+    val contributedFormatted: String,
+    val fractionOfRecorded: Float,
+    val suggestedMonthlyFormatted: String,
+)
+
+/** A displayable home-purchase milestone. */
+data class MilestoneUi(
+    val label: String,
+    val amountFormatted: String,
+    val reached: Boolean,
+)
+
+/** A single contribution history row. */
+data class ContributionRowUi(
+    val id: String,
+    val partnerName: String,
+    val amountFormatted: String,
+    val note: String,
+)
+
+/** UI state for the shared goal contributions screen (#2147). */
+data class SharedGoalUiState(
+    val isLoading: Boolean = true,
+    val profile: CoupleProfile = CoupleProfile(),
+    val goals: List<SelectableGoalUi> = emptyList(),
+    val selectedGoalId: String? = null,
+    val selectedGoalName: String = "",
+    val targetFormatted: String = "$0.00",
+    val totalSavedFormatted: String = "$0.00",
+    val remainingFormatted: String = "$0.00",
+    val progressFraction: Float = 0f,
+    val partnerProgress: List<PartnerProgressUi> = emptyList(),
+    val unattributedFormatted: String = "$0.00",
+    val showContributionsVisibly: Boolean = true,
+    val milestones: List<MilestoneUi> = emptyList(),
+    val history: List<ContributionRowUi> = emptyList(),
+    val monthsToTarget: Int = DEFAULT_MONTHS,
+) {
+    companion object {
+        const val DEFAULT_MONTHS = 24
+    }
+}
+
+/**
+ * ViewModel for shared goal contributions toward a house down payment (#2147).
+ *
+ * Reuses the real [GoalRepository] for goal totals and layers partner-specific
+ * contributions on top, exposing household total progress plus each partner's
+ * effort, suggested monthly targets, and home-purchase milestones.
+ */
+class SharedGoalViewModel(
+    private val householdIdProvider: HouseholdIdProvider,
+    private val goalRepository: GoalRepository,
+    private val contributionRepository: SharedContributionRepository,
+    private val profileRepository: CoupleProfileRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SharedGoalUiState())
+    val uiState: StateFlow<SharedGoalUiState> = _uiState.asStateFlow()
+
+    private val currency: Currency = Currency.USD
+    private var goalsCache: List<Goal> = emptyList()
+
+    init {
+        load(null)
+    }
+
+    fun selectGoal(goalId: String) = load(goalId)
+
+    fun refresh() = load(_uiState.value.selectedGoalId)
+
+    fun toggleVisibility(visible: Boolean) {
+        _uiState.update { it.copy(showContributionsVisibly = visible) }
+    }
+
+    fun addContribution(partner: Partner, amountDollars: Double, note: String) {
+        val goalId = _uiState.value.selectedGoalId ?: return
+        if (amountDollars <= 0) return
+        contributionRepository.add(
+            GoalContribution(
+                id = "contrib-${System.currentTimeMillis()}",
+                goalId = goalId,
+                partner = partner,
+                amount = Cents.fromDollars(amountDollars),
+                epochDay = Clock.System.todayIn(TimeZone.currentSystemDefault()).toEpochDays().toLong(),
+                note = note.trim(),
+            ),
+        )
+        load(goalId)
+    }
+
+    fun deleteContribution(id: String) {
+        contributionRepository.delete(id)
+        load(_uiState.value.selectedGoalId)
+    }
+
+    private fun load(preferredGoalId: String?) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            val householdId = householdIdProvider.householdId.value ?: run {
+                Timber.w("No household ID — skipping shared goal load")
+                _uiState.update { it.copy(isLoading = false) }
+                return@launch
+            }
+
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                goalsCache = goalRepository.observeAll(householdId).first()
+                val profile = profileRepository.load()
+                val selectable = goalsCache.map { SelectableGoalUi(it.id.value, it.name) }
+
+                val goal = pickGoal(preferredGoalId)
+                if (goal == null) {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            profile = profile,
+                            goals = selectable,
+                            selectedGoalId = null,
+                        )
+                    }
+                    return@launch
+                }
+
+                _uiState.update { render(goal, profile, selectable, it.showContributionsVisibly) }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to load shared goal")
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+    private fun pickGoal(preferredGoalId: String?): Goal? {
+        if (goalsCache.isEmpty()) return null
+        preferredGoalId?.let { id -> goalsCache.firstOrNull { it.id.value == id }?.let { return it } }
+        // Default to a house/down-payment goal when present, else the first goal.
+        return goalsCache.firstOrNull { g ->
+            HOME_KEYWORDS.any { kw -> g.name.contains(kw, ignoreCase = true) }
+        } ?: goalsCache.first()
+    }
+
+    private fun render(
+        goal: Goal,
+        profile: CoupleProfile,
+        selectable: List<SelectableGoalUi>,
+        visible: Boolean,
+    ): SharedGoalUiState {
+        val contributions = contributionRepository.forGoal(goal.id.value)
+        val byPartner = contributions.groupBy { it.partner }
+        val aTotal = byPartner[Partner.A].orEmpty().fold(0L) { s, c -> s + c.amount.amount }
+        val bTotal = byPartner[Partner.B].orEmpty().fold(0L) { s, c -> s + c.amount.amount }
+        val recorded = aTotal + bTotal
+
+        val totalSaved = goal.currentAmount.amount
+        val target = goal.targetAmount.amount
+        val remaining = (target - totalSaved).coerceAtLeast(0L)
+        val unattributed = (totalSaved - recorded).coerceAtLeast(0L)
+
+        val months = monthsToTarget(goal)
+        val suggestedPerPerson = if (months > 0) remaining / months / 2 else remaining / 2
+
+        val partnerProgress = listOf(
+            partnerUi(Partner.A, profile, aTotal, recorded, suggestedPerPerson),
+            partnerUi(Partner.B, profile, bTotal, recorded, suggestedPerPerson),
+        )
+
+        return SharedGoalUiState(
+            isLoading = false,
+            profile = profile,
+            goals = selectable,
+            selectedGoalId = goal.id.value,
+            selectedGoalName = goal.name,
+            targetFormatted = CurrencyFormatter.format(goal.targetAmount, currency),
+            totalSavedFormatted = CurrencyFormatter.format(goal.currentAmount, currency),
+            remainingFormatted = CurrencyFormatter.format(Cents(remaining), currency),
+            progressFraction = goal.progress.toFloat(),
+            partnerProgress = partnerProgress,
+            unattributedFormatted = CurrencyFormatter.format(Cents(unattributed), currency),
+            showContributionsVisibly = visible,
+            milestones = homeMilestones(goal.targetAmount).map {
+                MilestoneUi(
+                    label = it.label,
+                    amountFormatted = CurrencyFormatter.format(it.target, currency),
+                    reached = it.isReached(goal.currentAmount),
+                )
+            },
+            history = contributions.map {
+                ContributionRowUi(
+                    id = it.id,
+                    partnerName = profile.nameFor(it.partner),
+                    amountFormatted = CurrencyFormatter.format(it.amount, currency),
+                    note = it.note,
+                )
+            },
+            monthsToTarget = months,
+        )
+    }
+
+    private fun partnerUi(
+        partner: Partner,
+        profile: CoupleProfile,
+        contributed: Long,
+        recorded: Long,
+        suggestedPerPerson: Long,
+    ) = PartnerProgressUi(
+        partner = partner,
+        name = profile.nameFor(partner),
+        contributedFormatted = CurrencyFormatter.format(Cents(contributed), currency),
+        fractionOfRecorded = if (recorded > 0) (contributed.toFloat() / recorded) else 0f,
+        suggestedMonthlyFormatted = CurrencyFormatter.format(Cents(suggestedPerPerson), currency),
+    )
+
+    private fun monthsToTarget(goal: Goal): Int {
+        val targetDate = goal.targetDate ?: return SharedGoalUiState.DEFAULT_MONTHS
+        val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+        if (targetDate <= today) return 1
+        val days = today.toEpochDays().let { targetDate.toEpochDays() - it }
+        return ((days / DAYS_PER_MONTH) + 1).coerceIn(1, MAX_MONTHS)
+    }
+
+    /**
+     * Home-purchase milestones expressed as cumulative amounts: the down payment
+     * (the goal target), estimated closing costs on top, and an emergency buffer.
+     */
+    private fun homeMilestones(target: Cents): List<HomeMilestone> = listOf(
+        HomeMilestone("Down payment", target),
+        HomeMilestone(
+            "+ Closing costs",
+            Cents(target.amount + (target.amount * CLOSING_PCT / 100)),
+        ),
+        HomeMilestone(
+            "+ Emergency buffer",
+            Cents(target.amount + (target.amount * (CLOSING_PCT + BUFFER_PCT) / 100)),
+        ),
+    )
+
+    private companion object {
+        val HOME_KEYWORDS = listOf("house", "home", "down payment", "downpayment")
+        const val DAYS_PER_MONTH = 30
+        const val MAX_MONTHS = 600
+        const val CLOSING_PCT = 15L
+        const val BUFFER_PCT = 10L
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/privacy/CouplePrivacyRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/privacy/CouplePrivacyRepository.kt
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.privacy
+
+import android.content.SharedPreferences
+import com.finance.android.ui.couple.Partner
+import org.json.JSONObject
+import timber.log.Timber
+
+/**
+ * The "yours, mine, ours" sharing classification for a financial item (#2142).
+ *
+ * - [MINE] / [YOURS] — owned privately by one partner. Only summary totals are
+ *   shared with the other partner by default; line items stay private.
+ * - [OURS] — jointly owned and fully visible to both partners.
+ *
+ * The classification is descriptive metadata layered on top of existing
+ * household-scoped data; it never deletes or hides the owner's own records.
+ */
+enum class PrivacyVisibility(val label: String, val shortLabel: String) {
+    MINE("Mine", "Mine"),
+    YOURS("Yours", "Yours"),
+    OURS("Ours", "Ours"),
+    ;
+
+    /** True when the item is jointly owned and fully visible to both partners. */
+    val isShared: Boolean get() = this == OURS
+
+    companion object {
+        /** Parses a persisted name, defaulting to [OURS] for unknown values. */
+        fun fromName(name: String?): PrivacyVisibility =
+            entries.firstOrNull { it.name == name } ?: OURS
+
+        /** Maps an owning [Partner] to their private visibility. */
+        fun privateFor(partner: Partner): PrivacyVisibility =
+            if (partner == Partner.A) MINE else YOURS
+    }
+}
+
+/** The kind of record a [PrivacyVisibility] applies to. */
+enum class PrivacyEntityType { ACCOUNT, BUDGET, GOAL, DEBT }
+
+/**
+ * Persists per-item [PrivacyVisibility] classifications plus the household-wide
+ * "include private items in combined net worth" preference.
+ *
+ * Backed by encrypted [SharedPreferences] via a single JSON blob so the map can
+ * grow without a schema migration. Privacy metadata stays on-device.
+ */
+class CouplePrivacyRepository(
+    private val prefs: SharedPreferences,
+) {
+
+    /** Returns the visibility for [type]/[id], defaulting to [PrivacyVisibility.OURS]. */
+    fun visibilityFor(type: PrivacyEntityType, id: String): PrivacyVisibility {
+        val map = readMap()
+        return PrivacyVisibility.fromName(map[key(type, id)])
+    }
+
+    /** Returns every stored classification keyed by "TYPE:id". */
+    fun allClassifications(): Map<String, PrivacyVisibility> =
+        readMap().mapValues { PrivacyVisibility.fromName(it.value) }
+
+    /** Persists the [visibility] for a specific [type]/[id]. */
+    fun setVisibility(type: PrivacyEntityType, id: String, visibility: PrivacyVisibility) {
+        val map = readMap().toMutableMap()
+        map[key(type, id)] = visibility.name
+        writeMap(map)
+    }
+
+    /** Whether privately-owned items are folded into the combined net-worth view. */
+    fun includePrivateInNetWorth(): Boolean =
+        prefs.getBoolean(KEY_INCLUDE_PRIVATE, true)
+
+    /** Updates the combined net-worth inclusion preference. */
+    fun setIncludePrivateInNetWorth(include: Boolean) {
+        prefs.edit().putBoolean(KEY_INCLUDE_PRIVATE, include).apply()
+    }
+
+    /** Whether partners share category/budget summaries rather than line items. */
+    fun summaryOnlySharing(): Boolean =
+        prefs.getBoolean(KEY_SUMMARY_ONLY, true)
+
+    /** Updates the summary-only sharing default. */
+    fun setSummaryOnlySharing(summaryOnly: Boolean) {
+        prefs.edit().putBoolean(KEY_SUMMARY_ONLY, summaryOnly).apply()
+    }
+
+    private fun key(type: PrivacyEntityType, id: String) = "${type.name}:$id"
+
+    private fun readMap(): Map<String, String> {
+        val raw = prefs.getString(KEY_MAP, null) ?: return emptyMap()
+        return runCatching {
+            val json = JSONObject(raw)
+            buildMap {
+                json.keys().forEach { k -> put(k, json.getString(k)) }
+            }
+        }.getOrElse {
+            Timber.w(it, "Failed to parse privacy map; starting empty")
+            emptyMap()
+        }
+    }
+
+    private fun writeMap(map: Map<String, String>) {
+        val json = JSONObject()
+        map.forEach { (k, v) -> json.put(k, v) }
+        prefs.edit().putString(KEY_MAP, json.toString()).apply()
+    }
+
+    private companion object {
+        const val KEY_MAP = "couple_privacy_map_v1"
+        const val KEY_INCLUDE_PRIVATE = "couple_privacy_include_private_networth"
+        const val KEY_SUMMARY_ONLY = "couple_privacy_summary_only"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/privacy/CouplePrivacyScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/privacy/CouplePrivacyScreen.kt
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.privacy
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * "Yours, mine, ours" privacy model screen (#2142).
+ *
+ * Lets an engaged couple classify accounts, budgets, and goals as private to
+ * one partner or shared, choose whether private items count toward combined net
+ * worth, and default partner visibility to summaries rather than line items.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CouplePrivacyScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CouplePrivacyViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Yours, mine, ours") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics { contentDescription = "Go back" },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item {
+                Spacer(Modifier.height(4.dp))
+                NetWorthCard(state)
+            }
+            item { SharingPreferencesCard(state, viewModel) }
+            item {
+                Text(
+                    text = "Classify your money",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.semantics { heading() },
+                )
+                Text(
+                    text = "Everything starts as \"Ours\". Mark items private and only " +
+                        "summaries are shared — never line-by-line detail.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (state.items.isEmpty() && !state.isLoading) {
+                item {
+                    Text(
+                        text = "Add accounts, budgets, or goals to classify them here.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            items(state.items, key = { "${it.type}:${it.id}" }) { itemUi ->
+                PrivacyItemRow(
+                    item = itemUi,
+                    profile = state.profile,
+                    onSelect = { viewModel.setVisibility(itemUi, it) },
+                )
+            }
+            item { Spacer(Modifier.height(24.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun NetWorthCard(state: CouplePrivacyUiState) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                text = "Combined net worth",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            Text(
+                text = state.combinedNetWorthFormatted,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.semantics {
+                    contentDescription = "Combined net worth ${state.combinedNetWorthFormatted}"
+                },
+            )
+            Text(
+                text = "Shared-only view: ${state.sharedNetWorthFormatted}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (state.privateItemCount > 0) {
+                Text(
+                    text = "${state.privateItemCount} item(s) kept private",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SharingPreferencesCard(
+    state: CouplePrivacyUiState,
+    viewModel: CouplePrivacyViewModel,
+) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            ToggleRow(
+                title = "Include private accounts in net worth",
+                subtitle = "Off shows only jointly-owned totals",
+                checked = state.includePrivateInNetWorth,
+                onCheckedChange = viewModel::setIncludePrivateInNetWorth,
+            )
+            ToggleRow(
+                title = "Share summaries, not line items",
+                subtitle = "Partners see category totals, not every transaction",
+                checked = state.summaryOnlySharing,
+                onCheckedChange = viewModel::setSummaryOnlySharing,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ToggleRow(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(title, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            modifier = Modifier.semantics { contentDescription = title },
+        )
+    }
+}
+
+@Composable
+private fun PrivacyItemRow(
+    item: PrivacyItemUi,
+    profile: com.finance.android.ui.couple.CoupleProfile,
+    onSelect: (PrivacyVisibility) -> Unit,
+) {
+    Card(
+        Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text(item.name, style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        "${item.type.name.lowercase().replaceFirstChar { it.uppercase() }} · ${item.subtitle}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.selectableGroup(),
+            ) {
+                VisibilityChip(PrivacyVisibility.MINE, profile.partnerAName, item.visibility, onSelect)
+                VisibilityChip(PrivacyVisibility.YOURS, profile.partnerBName, item.visibility, onSelect)
+                VisibilityChip(PrivacyVisibility.OURS, profile.sharedLabel, item.visibility, onSelect)
+            }
+        }
+    }
+}
+
+@Composable
+private fun VisibilityChip(
+    value: PrivacyVisibility,
+    label: String,
+    selected: PrivacyVisibility,
+    onSelect: (PrivacyVisibility) -> Unit,
+) {
+    val isSelected = value == selected
+    FilterChip(
+        selected = isSelected,
+        onClick = { onSelect(value) },
+        label = { Text(label) },
+        modifier = Modifier.semantics {
+            contentDescription = "${value.label} ($label)${if (isSelected) ", selected" else ""}"
+        },
+    )
+}
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true)
+@Composable
+@Suppress("UnusedPrivateMember")
+private fun CouplePrivacyScreenPreview() {
+    FinanceTheme(dynamicColor = false) {
+        // Preview renders the static chrome; live data comes from the ViewModel.
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/privacy/CouplePrivacyViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/privacy/CouplePrivacyViewModel.kt
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.privacy
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.AccountRepository
+import com.finance.android.data.repository.BudgetRepository
+import com.finance.android.data.repository.GoalRepository
+import com.finance.android.ui.couple.CoupleProfile
+import com.finance.android.ui.couple.CoupleProfileRepository
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * A single classifiable item shown in the privacy control list.
+ *
+ * @property id Stable identifier used to persist the classification.
+ * @property type Entity kind (account, budget, goal, debt).
+ * @property name Display name.
+ * @property subtitle Secondary line (e.g. formatted balance / target).
+ * @property visibility Current "yours, mine, ours" classification.
+ */
+data class PrivacyItemUi(
+    val id: String,
+    val type: PrivacyEntityType,
+    val name: String,
+    val subtitle: String,
+    val visibility: PrivacyVisibility,
+)
+
+/**
+ * UI state for the "yours, mine, ours" privacy screen (#2142).
+ */
+data class CouplePrivacyUiState(
+    val isLoading: Boolean = true,
+    val profile: CoupleProfile = CoupleProfile(),
+    val items: List<PrivacyItemUi> = emptyList(),
+    val includePrivateInNetWorth: Boolean = true,
+    val summaryOnlySharing: Boolean = true,
+    val combinedNetWorthFormatted: String = "$0.00",
+    val sharedNetWorthFormatted: String = "$0.00",
+    val privateItemCount: Int = 0,
+)
+
+/**
+ * ViewModel for the couple privacy model (#2142).
+ *
+ * Loads accounts, budgets, and goals at household scope and lets each partner
+ * classify them as Yours / Mine / Ours. Computes a combined net-worth view that
+ * can include or exclude privately-owned accounts, and exposes the
+ * summary-only sharing default so partner visibility respects consent.
+ */
+class CouplePrivacyViewModel(
+    private val householdIdProvider: HouseholdIdProvider,
+    private val accountRepository: AccountRepository,
+    private val budgetRepository: BudgetRepository,
+    private val goalRepository: GoalRepository,
+    private val privacyRepository: CouplePrivacyRepository,
+    private val profileRepository: CoupleProfileRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CouplePrivacyUiState())
+    val uiState: StateFlow<CouplePrivacyUiState> = _uiState.asStateFlow()
+
+    private val currency: Currency = Currency.USD
+
+    init {
+        load()
+    }
+
+    fun refresh() = load()
+
+    /** Cycles an item's classification Mine → Yours → Ours → Mine. */
+    fun cycleVisibility(item: PrivacyItemUi) {
+        val next = when (item.visibility) {
+            PrivacyVisibility.MINE -> PrivacyVisibility.YOURS
+            PrivacyVisibility.YOURS -> PrivacyVisibility.OURS
+            PrivacyVisibility.OURS -> PrivacyVisibility.MINE
+        }
+        privacyRepository.setVisibility(item.type, item.id, next)
+        load()
+    }
+
+    /** Sets an explicit classification for an item. */
+    fun setVisibility(item: PrivacyItemUi, visibility: PrivacyVisibility) {
+        privacyRepository.setVisibility(item.type, item.id, visibility)
+        load()
+    }
+
+    fun setIncludePrivateInNetWorth(include: Boolean) {
+        privacyRepository.setIncludePrivateInNetWorth(include)
+        load()
+    }
+
+    fun setSummaryOnlySharing(summaryOnly: Boolean) {
+        privacyRepository.setSummaryOnlySharing(summaryOnly)
+        _uiState.update { it.copy(summaryOnlySharing = summaryOnly) }
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            val householdId = householdIdProvider.householdId.value ?: run {
+                Timber.w("No household ID — skipping privacy load")
+                _uiState.update { it.copy(isLoading = false) }
+                return@launch
+            }
+
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                val accounts = accountRepository.observeAll(householdId).first()
+                val budgets = budgetRepository.observeAll(householdId).first()
+                val goals = goalRepository.observeAll(householdId).first()
+
+                val items = buildList {
+                    accounts.forEach { a ->
+                        add(
+                            PrivacyItemUi(
+                                id = a.id.value,
+                                type = PrivacyEntityType.ACCOUNT,
+                                name = a.name,
+                                subtitle = CurrencyFormatter.format(a.currentBalance, currency),
+                                visibility = privacyRepository.visibilityFor(
+                                    PrivacyEntityType.ACCOUNT, a.id.value,
+                                ),
+                            ),
+                        )
+                    }
+                    budgets.forEach { b ->
+                        add(
+                            PrivacyItemUi(
+                                id = b.id.value,
+                                type = PrivacyEntityType.BUDGET,
+                                name = b.name,
+                                subtitle = CurrencyFormatter.format(b.amount, currency),
+                                visibility = privacyRepository.visibilityFor(
+                                    PrivacyEntityType.BUDGET, b.id.value,
+                                ),
+                            ),
+                        )
+                    }
+                    goals.forEach { g ->
+                        add(
+                            PrivacyItemUi(
+                                id = g.id.value,
+                                type = PrivacyEntityType.GOAL,
+                                name = g.name,
+                                subtitle = CurrencyFormatter.format(g.targetAmount, currency),
+                                visibility = privacyRepository.visibilityFor(
+                                    PrivacyEntityType.GOAL, g.id.value,
+                                ),
+                            ),
+                        )
+                    }
+                }
+
+                val includePrivate = privacyRepository.includePrivateInNetWorth()
+
+                // Net worth is derived from account balances only.
+                val sharedNet = accounts
+                    .filter { privacyRepository.visibilityFor(PrivacyEntityType.ACCOUNT, it.id.value).isShared }
+                    .fold(Cents.ZERO) { acc, a -> acc + a.currentBalance }
+                val privateNet = accounts
+                    .filterNot { privacyRepository.visibilityFor(PrivacyEntityType.ACCOUNT, it.id.value).isShared }
+                    .fold(Cents.ZERO) { acc, a -> acc + a.currentBalance }
+                val combined = if (includePrivate) sharedNet + privateNet else sharedNet
+
+                val privateCount = items.count { !it.visibility.isShared }
+
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        profile = profileRepository.load(),
+                        items = items,
+                        includePrivateInNetWorth = includePrivate,
+                        summaryOnlySharing = privacyRepository.summaryOnlySharing(),
+                        combinedNetWorthFormatted = CurrencyFormatter.format(combined, currency),
+                        sharedNetWorthFormatted = CurrencyFormatter.format(sharedNet, currency),
+                        privateItemCount = privateCount,
+                    )
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to load privacy data")
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/wedding/WeddingModels.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/wedding/WeddingModels.kt
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.wedding
+
+import android.content.SharedPreferences
+import com.finance.models.types.Cents
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
+
+/** Wedding spending categories (#2145). */
+enum class WeddingCategory(val displayName: String) {
+    VENUE("Venue"),
+    CATERING("Catering"),
+    PHOTOGRAPHY("Photography"),
+    ATTIRE("Attire"),
+    FLOWERS("Flowers"),
+    MUSIC("Music & entertainment"),
+    RENTALS("Rentals"),
+    INVITATIONS("Invitations"),
+    OTHER("Other"),
+}
+
+/**
+ * A single wedding vendor / line item with deposit tracking (#2145).
+ *
+ * @property id Stable identifier.
+ * @property name Vendor or item name.
+ * @property category Spending category.
+ * @property flatBudget Fixed budgeted amount (used when [perGuestCost] is zero).
+ * @property perGuestCost Per-guest cost; when > 0 the effective budget scales
+ *   with the workspace guest count (e.g. catering, rentals, invitations).
+ * @property paid Amount already paid via deposits / installments.
+ * @property dueDateEpochDay Epoch day of the next payment due date, or null.
+ */
+data class WeddingVendor(
+    val id: String,
+    val name: String,
+    val category: WeddingCategory,
+    val flatBudget: Cents,
+    val perGuestCost: Cents,
+    val paid: Cents,
+    val dueDateEpochDay: Long?,
+) {
+    init {
+        require(name.isNotBlank()) { "Vendor name cannot be blank" }
+        require(paid.amount >= 0L) { "Paid amount cannot be negative" }
+    }
+
+    /** Effective budget given a [guestCount] — scales per-guest items. */
+    fun effectiveBudget(guestCount: Int): Cents =
+        if (perGuestCost.amount > 0L) Cents(perGuestCost.amount * guestCount) else flatBudget
+
+    /** Remaining balance to pay for a given [guestCount]. */
+    fun remaining(guestCount: Int): Cents =
+        Cents((effectiveBudget(guestCount).amount - paid.amount).coerceAtLeast(0L))
+
+    /** Whether this item scales with guest count. */
+    val isPerGuest: Boolean get() = perGuestCost.amount > 0L
+}
+
+/**
+ * The full wedding workspace: overall target, guest count, and vendors.
+ */
+data class WeddingWorkspace(
+    val targetBudget: Cents,
+    val guestCount: Int,
+    val vendors: List<WeddingVendor>,
+) {
+    companion object {
+        /** Sensible starting point for the persona ($35k, 100 guests). */
+        val DEFAULT = WeddingWorkspace(
+            targetBudget = Cents(3_500_000L),
+            guestCount = 100,
+            vendors = emptyList(),
+        )
+    }
+}
+
+/**
+ * On-device persistence for the [WeddingWorkspace] (#2145).
+ *
+ * Stored as JSON in encrypted [SharedPreferences]; no changes to the read-only
+ * shared model package are required.
+ */
+class WeddingRepository(
+    private val prefs: SharedPreferences,
+) {
+
+    /** Loads the workspace, falling back to the persona default on first run. */
+    fun load(): WeddingWorkspace {
+        val raw = prefs.getString(KEY, null) ?: return WeddingWorkspace.DEFAULT
+        return runCatching {
+            val json = JSONObject(raw)
+            val vendorsArray = json.optJSONArray("vendors") ?: JSONArray()
+            WeddingWorkspace(
+                targetBudget = Cents(json.getLong("target")),
+                guestCount = json.getInt("guests"),
+                vendors = (0 until vendorsArray.length())
+                    .mapNotNull { decodeVendor(vendorsArray.getJSONObject(it)) },
+            )
+        }.getOrElse {
+            Timber.w(it, "Failed to parse wedding workspace; using default")
+            WeddingWorkspace.DEFAULT
+        }
+    }
+
+    /** Persists the whole [workspace]. */
+    fun save(workspace: WeddingWorkspace) {
+        val vendorsArray = JSONArray()
+        workspace.vendors.forEach { vendorsArray.put(encodeVendor(it)) }
+        val json = JSONObject().apply {
+            put("target", workspace.targetBudget.amount)
+            put("guests", workspace.guestCount)
+            put("vendors", vendorsArray)
+        }
+        prefs.edit().putString(KEY, json.toString()).apply()
+    }
+
+    private fun encodeVendor(v: WeddingVendor): JSONObject = JSONObject().apply {
+        put("id", v.id)
+        put("name", v.name)
+        put("category", v.category.name)
+        put("flat", v.flatBudget.amount)
+        put("perGuest", v.perGuestCost.amount)
+        put("paid", v.paid.amount)
+        put("due", v.dueDateEpochDay ?: JSONObject.NULL)
+    }
+
+    private fun decodeVendor(json: JSONObject): WeddingVendor? = runCatching {
+        WeddingVendor(
+            id = json.getString("id"),
+            name = json.getString("name"),
+            category = runCatching { WeddingCategory.valueOf(json.getString("category")) }
+                .getOrDefault(WeddingCategory.OTHER),
+            flatBudget = Cents(json.getLong("flat")),
+            perGuestCost = Cents(json.getLong("perGuest")),
+            paid = Cents(json.getLong("paid")),
+            dueDateEpochDay = if (json.isNull("due")) null else json.getLong("due"),
+        )
+    }.getOrNull()
+
+    private companion object {
+        const val KEY = "couple_wedding_workspace_v1"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/wedding/WeddingViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/wedding/WeddingViewModel.kt
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.wedding
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDate
+import kotlin.math.roundToLong
+
+/** A vendor row formatted for display. */
+data class VendorRowUi(
+    val id: String,
+    val name: String,
+    val category: String,
+    val budgetedFormatted: String,
+    val paidFormatted: String,
+    val remainingFormatted: String,
+    val dueDateText: String?,
+    val perGuestBadge: String?,
+    val paidFraction: Float,
+)
+
+/** A due-date reminder row. */
+data class DueDateUi(
+    val vendorName: String,
+    val dueDateText: String,
+    val remainingFormatted: String,
+)
+
+/** UI state for the wedding workspace (#2145). */
+data class WeddingUiState(
+    val isLoading: Boolean = true,
+    val targetFormatted: String = "$0.00",
+    val targetCents: Long = 0L,
+    val guestCount: Int = 0,
+    val totalBudgetedFormatted: String = "$0.00",
+    val totalPaidFormatted: String = "$0.00",
+    val remainingToPayFormatted: String = "$0.00",
+    val overUnderText: String = "",
+    val isOverBudget: Boolean = false,
+    val budgetUsedFraction: Float = 0f,
+    val perGuestFormatted: String = "$0.00",
+    val vendors: List<VendorRowUi> = emptyList(),
+    val upcomingDueDates: List<DueDateUi> = emptyList(),
+)
+
+/**
+ * ViewModel for the shared wedding budget workspace (#2145).
+ *
+ * Tracks vendors, deposits paid, upcoming due dates, and guest-count-sensitive
+ * estimates, and shows budgeted vs actual against the couple's target.
+ */
+class WeddingViewModel(
+    private val repository: WeddingRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(WeddingUiState())
+    val uiState: StateFlow<WeddingUiState> = _uiState.asStateFlow()
+
+    private val currency: Currency = Currency.USD
+    private var workspace: WeddingWorkspace = WeddingWorkspace.DEFAULT
+
+    init {
+        load()
+    }
+
+    fun setGuestCount(count: Int) {
+        workspace = workspace.copy(guestCount = count.coerceIn(0, MAX_GUESTS))
+        persistAndRender()
+    }
+
+    fun setTargetBudget(dollars: Double) {
+        workspace = workspace.copy(targetBudget = Cents.fromDollars(dollars.coerceAtLeast(0.0)))
+        persistAndRender()
+    }
+
+    fun addVendor(
+        name: String,
+        category: WeddingCategory,
+        budgetDollars: Double,
+        perGuest: Boolean,
+        paidDollars: Double,
+        dueDateEpochDay: Long?,
+    ) {
+        if (name.isBlank()) return
+        val budget = Cents.fromDollars(budgetDollars.coerceAtLeast(0.0))
+        val vendor = WeddingVendor(
+            id = "vendor-${System.currentTimeMillis()}",
+            name = name.trim(),
+            category = category,
+            flatBudget = if (perGuest) Cents.ZERO else budget,
+            perGuestCost = if (perGuest) budget else Cents.ZERO,
+            paid = Cents.fromDollars(paidDollars.coerceAtLeast(0.0)),
+            dueDateEpochDay = dueDateEpochDay,
+        )
+        workspace = workspace.copy(vendors = workspace.vendors + vendor)
+        persistAndRender()
+    }
+
+    fun recordPayment(vendorId: String, amountDollars: Double) {
+        if (amountDollars <= 0) return
+        workspace = workspace.copy(
+            vendors = workspace.vendors.map { v ->
+                if (v.id == vendorId) {
+                    v.copy(paid = Cents(v.paid.amount + Cents.fromDollars(amountDollars).amount))
+                } else {
+                    v
+                }
+            },
+        )
+        persistAndRender()
+    }
+
+    fun deleteVendor(vendorId: String) {
+        workspace = workspace.copy(vendors = workspace.vendors.filterNot { it.id == vendorId })
+        persistAndRender()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            workspace = repository.load()
+            render()
+        }
+    }
+
+    private fun persistAndRender() {
+        repository.save(workspace)
+        render()
+    }
+
+    private fun render() {
+        val guests = workspace.guestCount
+        val totalBudgeted = workspace.vendors.fold(0L) { s, v -> s + v.effectiveBudget(guests).amount }
+        val totalPaid = workspace.vendors.fold(0L) { s, v -> s + v.paid.amount }
+        val remainingToPay = workspace.vendors.fold(0L) { s, v -> s + v.remaining(guests).amount }
+        val target = workspace.targetBudget.amount
+        val overUnder = totalBudgeted - target
+        val perGuest = if (guests > 0) (totalBudgeted.toDouble() / guests).roundToLong() else 0L
+
+        val vendorRows = workspace.vendors.map { v ->
+            val budget = v.effectiveBudget(guests)
+            VendorRowUi(
+                id = v.id,
+                name = v.name,
+                category = v.category.displayName,
+                budgetedFormatted = CurrencyFormatter.format(budget, currency),
+                paidFormatted = CurrencyFormatter.format(v.paid, currency),
+                remainingFormatted = CurrencyFormatter.format(v.remaining(guests), currency),
+                dueDateText = v.dueDateEpochDay?.let { formatEpochDay(it) },
+                perGuestBadge = if (v.isPerGuest) {
+                    "${CurrencyFormatter.format(v.perGuestCost, currency)}/guest"
+                } else {
+                    null
+                },
+                paidFraction = if (budget.amount > 0L) {
+                    (v.paid.amount.toFloat() / budget.amount).coerceIn(0f, 1f)
+                } else {
+                    0f
+                },
+            )
+        }
+
+        val dueDates = workspace.vendors
+            .filter { it.dueDateEpochDay != null && it.remaining(guests).amount > 0L }
+            .sortedBy { it.dueDateEpochDay }
+            .map { v ->
+                DueDateUi(
+                    vendorName = v.name,
+                    dueDateText = formatEpochDay(v.dueDateEpochDay!!),
+                    remainingFormatted = CurrencyFormatter.format(v.remaining(guests), currency),
+                )
+            }
+
+        _uiState.update {
+            it.copy(
+                isLoading = false,
+                targetFormatted = CurrencyFormatter.format(workspace.targetBudget, currency),
+                targetCents = target,
+                guestCount = guests,
+                totalBudgetedFormatted = CurrencyFormatter.format(Cents(totalBudgeted), currency),
+                totalPaidFormatted = CurrencyFormatter.format(Cents(totalPaid), currency),
+                remainingToPayFormatted = CurrencyFormatter.format(Cents(remainingToPay), currency),
+                overUnderText = overUnderText(overUnder),
+                isOverBudget = overUnder > 0L,
+                budgetUsedFraction = if (target > 0L) {
+                    (totalBudgeted.toFloat() / target).coerceIn(0f, 1f)
+                } else {
+                    0f
+                },
+                perGuestFormatted = CurrencyFormatter.format(Cents(perGuest), currency),
+                vendors = vendorRows,
+                upcomingDueDates = dueDates,
+            )
+        }
+    }
+
+    private fun overUnderText(overUnder: Long): String = when {
+        overUnder > 0L ->
+            "${CurrencyFormatter.format(Cents(overUnder), currency)} over your target"
+        overUnder < 0L ->
+            "${CurrencyFormatter.format(Cents(-overUnder), currency)} under your target"
+        else -> "Right on target"
+    }
+
+    private fun formatEpochDay(epochDay: Long): String {
+        val date = LocalDate.fromEpochDays(epochDay.toInt())
+        val month = date.month.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
+        return "$month ${date.dayOfMonth}, ${date.year}"
+    }
+
+    private companion object {
+        const val MAX_GUESTS = 2000
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/couple/wedding/WeddingWorkspaceScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/couple/wedding/WeddingWorkspaceScreen.kt
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.wedding
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Shared wedding budget workspace (#2145).
+ *
+ * A dedicated space to track vendors, deposits, upcoming due dates, and
+ * guest-count-sensitive estimates against a target budget.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WeddingWorkspaceScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: WeddingViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    var showAdd by remember { mutableStateOf(false) }
+    var paymentVendorId by remember { mutableStateOf<String?>(null) }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Wedding workspace") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics { contentDescription = "Go back" },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { showAdd = true },
+                modifier = Modifier.semantics { contentDescription = "Add a vendor" },
+            ) {
+                Icon(Icons.Filled.Add, contentDescription = null)
+            }
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { Spacer(Modifier.height(4.dp)) }
+            item { BudgetSummaryCard(state) }
+            item { GuestAndTargetCard(state, viewModel) }
+            if (state.upcomingDueDates.isNotEmpty()) {
+                item {
+                    Text(
+                        "Upcoming due dates",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics { heading() },
+                    )
+                }
+                items(state.upcomingDueDates, key = { it.vendorName + it.dueDateText }) { d ->
+                    DueDateRow(d)
+                }
+            }
+            item {
+                Text(
+                    "Vendors",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.semantics { heading() },
+                )
+            }
+            if (state.vendors.isEmpty() && !state.isLoading) {
+                item {
+                    Text(
+                        "Add your venue, catering, photographer, and more to track deposits " +
+                            "and balances.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            items(state.vendors, key = { it.id }) { v ->
+                VendorCard(
+                    vendor = v,
+                    onRecordPayment = { paymentVendorId = v.id },
+                    onDelete = { viewModel.deleteVendor(v.id) },
+                )
+            }
+            item { Spacer(Modifier.height(80.dp)) }
+        }
+    }
+
+    if (showAdd) {
+        AddVendorDialog(
+            onDismiss = { showAdd = false },
+            onAdd = { name, category, budget, perGuest, paid, dueInDays ->
+                val dueEpoch = dueInDays?.let {
+                    Clock.System.todayIn(TimeZone.currentSystemDefault()).toEpochDays().toLong() + it
+                }
+                viewModel.addVendor(name, category, budget, perGuest, paid, dueEpoch)
+                showAdd = false
+            },
+        )
+    }
+
+    paymentVendorId?.let { id ->
+        RecordPaymentDialog(
+            onDismiss = { paymentVendorId = null },
+            onRecord = { amount ->
+                viewModel.recordPayment(id, amount)
+                paymentVendorId = null
+            },
+        )
+    }
+}
+
+@Composable
+private fun BudgetSummaryCard(state: WeddingUiState) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                "Budget",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            Text(
+                "${state.totalBudgetedFormatted} planned of ${state.targetFormatted}",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            LinearProgressIndicator(
+                progress = { state.budgetUsedFraction },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(10.dp)
+                    .semantics {
+                        contentDescription =
+                            "Planned budget ${(state.budgetUsedFraction * 100).toInt()} percent of target"
+                    },
+            )
+            Text(
+                state.overUnderText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (state.isOverBudget) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                AssistChip(onClick = {}, label = { Text("Paid ${state.totalPaidFormatted}") })
+                AssistChip(onClick = {}, label = { Text("Left ${state.remainingToPayFormatted}") })
+            }
+            Text(
+                "About ${state.perGuestFormatted} per guest",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun GuestAndTargetCard(state: WeddingUiState, viewModel: WeddingViewModel) {
+    var targetText by remember(state.targetCents) {
+        mutableStateOf((state.targetCents / 100.0).toString())
+    }
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Guest count", Modifier.weight(1f), style = MaterialTheme.typography.bodyLarge)
+                IconButton(
+                    onClick = { viewModel.setGuestCount(state.guestCount - GUEST_STEP) },
+                    modifier = Modifier.semantics { contentDescription = "Fewer guests" },
+                ) { Icon(Icons.Filled.Remove, contentDescription = null) }
+                Text(
+                    "${state.guestCount}",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.semantics { contentDescription = "${state.guestCount} guests" },
+                )
+                IconButton(
+                    onClick = { viewModel.setGuestCount(state.guestCount + GUEST_STEP) },
+                    modifier = Modifier.semantics { contentDescription = "More guests" },
+                ) { Icon(Icons.Filled.Add, contentDescription = null) }
+            }
+            OutlinedTextField(
+                value = targetText,
+                onValueChange = {
+                    targetText = it
+                    it.toDoubleOrNull()?.let { d -> viewModel.setTargetBudget(d) }
+                },
+                label = { Text("Target budget ($)") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Target budget in dollars" },
+            )
+        }
+    }
+}
+
+@Composable
+private fun DueDateRow(d: DueDateUi) {
+    Card(
+        Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+    ) {
+        Row(Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Text(d.vendorName, style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    "Due ${d.dueDateText}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(d.remainingFormatted, fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun VendorCard(vendor: VendorRowUi, onRecordPayment: () -> Unit, onDelete: () -> Unit) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text(vendor.name, style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        vendor.category,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                IconButton(
+                    onClick = onDelete,
+                    modifier = Modifier.semantics { contentDescription = "Delete ${vendor.name}" },
+                ) { Icon(Icons.Filled.Delete, contentDescription = null) }
+            }
+            LinearProgressIndicator(
+                progress = { vendor.paidFraction },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(6.dp),
+            )
+            Text(
+                "${vendor.paidFormatted} paid of ${vendor.budgetedFormatted} · " +
+                    "${vendor.remainingFormatted} left",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                vendor.perGuestBadge?.let { AssistChip(onClick = {}, label = { Text(it) }) }
+                vendor.dueDateText?.let { AssistChip(onClick = {}, label = { Text("Due $it") }) }
+            }
+            OutlinedButton(
+                onClick = onRecordPayment,
+                modifier = Modifier.semantics { contentDescription = "Record payment for ${vendor.name}" },
+            ) { Text("Record payment") }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddVendorDialog(
+    onDismiss: () -> Unit,
+    onAdd: (String, WeddingCategory, Double, Boolean, Double, Long?) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var category by remember { mutableStateOf(WeddingCategory.VENUE) }
+    var budget by remember { mutableStateOf("") }
+    var perGuest by remember { mutableStateOf(false) }
+    var paid by remember { mutableStateOf("") }
+    var dueDays by remember { mutableStateOf("") }
+    var categoryMenu by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onAdd(
+                        name,
+                        category,
+                        budget.toDoubleOrNull() ?: 0.0,
+                        perGuest,
+                        paid.toDoubleOrNull() ?: 0.0,
+                        dueDays.toLongOrNull(),
+                    )
+                },
+                enabled = name.isNotBlank() && (budget.toDoubleOrNull() ?: 0.0) > 0,
+            ) { Text("Add") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        title = { Text("Add vendor") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Vendor name") },
+                    singleLine = true,
+                )
+                Box {
+                    OutlinedButton(onClick = { categoryMenu = true }) {
+                        Text(category.displayName)
+                    }
+                    DropdownMenu(expanded = categoryMenu, onDismissRequest = { categoryMenu = false }) {
+                        WeddingCategory.entries.forEach { c ->
+                            DropdownMenuItem(
+                                text = { Text(c.displayName) },
+                                onClick = {
+                                    category = c
+                                    categoryMenu = false
+                                },
+                            )
+                        }
+                    }
+                }
+                OutlinedTextField(
+                    value = budget,
+                    onValueChange = { budget = it },
+                    label = { Text(if (perGuest) "Cost per guest ($)" else "Budget ($)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                )
+                FilterChip(
+                    selected = perGuest,
+                    onClick = { perGuest = !perGuest },
+                    label = { Text("Scales with guest count") },
+                )
+                OutlinedTextField(
+                    value = paid,
+                    onValueChange = { paid = it },
+                    label = { Text("Deposit paid so far ($)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = dueDays,
+                    onValueChange = { dueDays = it },
+                    label = { Text("Next payment due in (days, optional)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun RecordPaymentDialog(onDismiss: () -> Unit, onRecord: (Double) -> Unit) {
+    var amount by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = { onRecord(amount.toDoubleOrNull() ?: 0.0) },
+                enabled = (amount.toDoubleOrNull() ?: 0.0) > 0,
+            ) { Text("Record") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        title = { Text("Record payment") },
+        text = {
+            OutlinedTextField(
+                value = amount,
+                onValueChange = { amount = it },
+                label = { Text("Amount paid ($)") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+            )
+        },
+    )
+}
+
+private const val GUEST_STEP = 5
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true)
+@Composable
+@Suppress("UnusedPrivateMember")
+private fun WeddingScreenPreview() {
+    FinanceTheme(dynamicColor = false) {
+        // Live data comes from the ViewModel.
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationCelebrationStore.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationCelebrationStore.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.gamification
+
+import android.content.SharedPreferences
+
+/**
+ * Remembers which achievements have already been celebrated so the
+ * celebration moment (#2211) fires exactly once per genuine unlock,
+ * never on every screen visit.
+ */
+class GamificationCelebrationStore(
+    private val prefs: SharedPreferences,
+) {
+
+    /** The set of achievement IDs the user has already seen celebrated. */
+    fun seenIds(): Set<String> =
+        prefs.getStringSet(KEY_SEEN, emptySet())?.toSet() ?: emptySet()
+
+    /** Records [ids] as celebrated, so they won't celebrate again. */
+    fun markSeen(ids: Set<String>) {
+        val merged = seenIds() + ids
+        prefs.edit().putStringSet(KEY_SEEN, merged).apply()
+    }
+
+    private companion object {
+        const val KEY_SEEN = "gamification_celebrated_ids_v1"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationCelebrationStore.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationCelebrationStore.kt
@@ -24,6 +24,6 @@ class GamificationCelebrationStore(
     }
 
     private companion object {
-        const val KEY_SEEN = "gamification_celebrated_ids_v1"
+        const val KEY_SEEN = "gamification_celebrated_ids_v1" // gitleaks:allow (prefs key)
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationScreen.kt
@@ -6,9 +6,11 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,7 +43,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -53,6 +57,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -103,7 +109,13 @@ fun GamificationScreen(
         return
     }
 
-    GamificationContent(state = state, modifier = modifier)
+    Box(modifier = modifier.fillMaxSize()) {
+        GamificationContent(state = state)
+        CelebrationOverlay(
+            celebration = state.celebration,
+            onDismiss = viewModel::dismissCelebration,
+        )
+    }
 }
 
 @Composable
@@ -126,6 +138,34 @@ internal fun GamificationContent(
                 achievementsUnlocked = state.achievementsUnlocked,
                 achievementsTotal = state.achievementsTotal,
             )
+        }
+
+        // Streak highlight (#2211) — real logging streak with encouraging, non-punitive copy.
+        if (state.currentStreakDays > 0) {
+            item(key = "streak-highlight") {
+                StreakHighlightCard(
+                    currentStreakDays = state.currentStreakDays,
+                    bestStreakDays = state.bestStreakDays,
+                    message = state.streakMessage,
+                )
+            }
+        }
+
+        // Near-win feedback (#2211) — "almost there" moments to build earned anticipation.
+        if (state.nearWins.isNotEmpty()) {
+            item(key = "nearwin-header") {
+                Text(
+                    text = "So close",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.semantics {
+                        heading()
+                        contentDescription = "Almost there section"
+                    },
+                )
+            }
+            items(state.nearWins, key = { "nearwin-${it.id}" }) { nearWin ->
+                NearWinCard(nearWin = nearWin)
+            }
         }
 
         // Recently unlocked
@@ -192,6 +232,189 @@ internal fun GamificationContent(
         }
 
         item(key = "spacer") { Spacer(Modifier.height(80.dp)) }
+    }
+}
+
+// ── Streak, Near-win & Celebration (#2211) ───────────────────────────
+
+@Composable
+private fun StreakHighlightCard(
+    currentStreakDays: Int,
+    bestStreakDays: Int,
+    message: String,
+) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "Current logging streak: $currentStreakDays days. " +
+                    "Best streak: $bestStreakDays days. $message"
+            },
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+    ) {
+        Row(
+            Modifier.padding(20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Filled.LocalFireDepartment,
+                contentDescription = null,
+                tint = Color(0xFFFF6D00),
+                modifier = Modifier.size(40.dp),
+            )
+            Spacer(Modifier.width(16.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = "$currentStreakDays-day streak",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+                if (bestStreakDays > 0) {
+                    Text(
+                        text = "Personal best: $bestStreakDays days",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NearWinCard(nearWin: NearWin) {
+    val animatedProgress by animateFloatAsState(
+        targetValue = nearWin.progressFraction,
+        animationSpec = tween(800),
+        label = "nearwin-progress",
+    )
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "${nearWin.title}. ${nearWin.message}. " +
+                    "${(nearWin.progressFraction * 100).toInt()} percent complete."
+            },
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Filled.Star,
+                    contentDescription = null,
+                    tint = Color(0xFFFFC107),
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        text = nearWin.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = nearWin.message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = nearWin.remainingLabel,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { animatedProgress },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(4.dp)),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CelebrationOverlay(
+    celebration: CelebrationState?,
+    onDismiss: () -> Unit,
+) {
+    val haptic = LocalHapticFeedback.current
+    LaunchedEffect(celebration) {
+        if (celebration != null) {
+            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        }
+    }
+    AnimatedVisibility(
+        visible = celebration != null,
+        enter = fadeIn(tween(200)),
+        exit = fadeOut(tween(200)),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color(0xCC000000))
+                .clickable(onClick = onDismiss)
+                .semantics {
+                    contentDescription = celebration?.let {
+                        "Achievement unlocked: ${it.title}. ${it.points} points. Tap to dismiss."
+                    } ?: ""
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            if (celebration != null) {
+                AnimatedVisibility(
+                    visible = true,
+                    enter = scaleIn(tween(400)) + fadeIn(),
+                ) {
+                    ElevatedCard(
+                        colors = CardDefaults.elevatedCardColors(
+                            containerColor = MaterialTheme.colorScheme.surface,
+                        ),
+                    ) {
+                        Column(
+                            Modifier.padding(32.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Icon(
+                                Icons.Filled.EmojiEvents,
+                                contentDescription = null,
+                                tint = rarityColors[celebration.rarity] ?: Color(0xFFFFD700),
+                                modifier = Modifier.size(72.dp),
+                            )
+                            Text(
+                                text = "Achievement unlocked!",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                            )
+                            Text(
+                                text = celebration.title,
+                                style = MaterialTheme.typography.headlineSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                            Text(
+                                text = "+${celebration.points} points",
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                            TextButton(onClick = onDismiss) {
+                                Text("Awesome!")
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationViewModel.kt
@@ -9,6 +9,8 @@ import com.finance.android.data.repository.AccountRepository
 import com.finance.android.data.repository.BudgetRepository
 import com.finance.android.data.repository.GoalRepository
 import com.finance.android.data.repository.TransactionRepository
+import com.finance.android.ui.streak.StreakCalculator
+import com.finance.android.ui.streak.StreakRepository
 import com.finance.core.gamification.AchievementCategory
 import com.finance.core.gamification.AchievementDefinition
 import com.finance.core.gamification.AchievementProgress
@@ -23,6 +25,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
 import timber.log.Timber
 
 /**
@@ -42,6 +47,14 @@ data class AchievementUi(
     val targetCount: Int?,
 )
 
+/** A celebration moment shown when the user unlocks a new achievement (#2211). */
+data class CelebrationState(
+    val title: String,
+    val icon: String,
+    val points: Int,
+    val rarity: AchievementRarity,
+)
+
 /**
  * Complete UI state for the Gamification screen (#242).
  */
@@ -56,13 +69,20 @@ data class GamificationUiState(
     val achievements: List<AchievementUi> = emptyList(),
     val recentlyUnlocked: List<AchievementUi> = emptyList(),
     val activeStreaks: List<Streak> = emptyList(),
+    val currentStreakDays: Int = 0,
+    val bestStreakDays: Int = 0,
+    val streakMessage: String = "",
+    val nearWins: List<NearWin> = emptyList(),
+    val celebration: CelebrationState? = null,
 )
 
 /**
- * ViewModel for the Gamification screen (#242).
+ * ViewModel for the Gamification screen (#242, #2211).
  *
- * Evaluates achievements using the KMP [GamificationEngine] and
- * builds a [GamificationProfile] for UI display.
+ * Evaluates achievements using the KMP [GamificationEngine], derives real
+ * logging streaks via [StreakRepository]/[StreakCalculator], computes
+ * near-win feedback, and raises a one-time celebration when a new
+ * achievement is unlocked.
  */
 class GamificationViewModel(
     private val householdIdProvider: HouseholdIdProvider,
@@ -70,6 +90,8 @@ class GamificationViewModel(
     private val accountRepository: AccountRepository,
     private val budgetRepository: BudgetRepository,
     private val goalRepository: GoalRepository,
+    private val streakRepository: StreakRepository,
+    private val celebrationStore: GamificationCelebrationStore,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(GamificationUiState())
@@ -81,6 +103,11 @@ class GamificationViewModel(
 
     fun refresh() {
         loadGamification()
+    }
+
+    /** Dismisses the current celebration overlay. */
+    fun dismissCelebration() {
+        _uiState.update { it.copy(celebration = null) }
     }
 
     private fun loadGamification() {
@@ -107,15 +134,41 @@ class GamificationViewModel(
                     goals = goals,
                 )
 
+                // Real streaks derived from logging dates (#2211).
+                val loggingDates = streakRepository.observeLoggingDates(householdId.value).first()
+                val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+                val currentStreak = StreakCalculator.currentStreak(loggingDates, today)
+                val bestStreak = StreakCalculator.longestStreak(loggingDates)
+                val streaks = buildStreaks(currentStreak, bestStreak, loggingDates.maxOrNull() ?: today)
+
                 val profile = GamificationEngine.buildProfile(
                     progress = achievementProgress,
-                    streaks = emptyList(), // Streaks tracked separately via StreakRepository
+                    streaks = streaks,
                 )
 
                 val achievements = buildAchievementUiList(achievementProgress)
                 val recentlyUnlocked = achievements.filter { it.isUnlocked }
                     .sortedByDescending { it.points }
                     .take(3)
+
+                // Near-win feedback (#2211).
+                val nearWins = NearWinCalculator.compute(achievements, currentStreak, bestStreak)
+
+                // Celebration: fire once per genuinely new unlock (#2211).
+                val unlockedIds = achievements.filter { it.isUnlocked }.map { it.id }.toSet()
+                val alreadySeen = celebrationStore.seenIds()
+                val newlyUnlocked = achievements.firstOrNull { it.isUnlocked && it.id !in alreadySeen }
+                if (unlockedIds.isNotEmpty()) {
+                    celebrationStore.markSeen(unlockedIds)
+                }
+                val celebration = newlyUnlocked?.let {
+                    CelebrationState(
+                        title = it.title,
+                        icon = it.icon,
+                        points = it.points,
+                        rarity = it.rarity,
+                    )
+                }
 
                 // Calculate level progress fraction
                 val currentLevelPoints = GamificationEngine.pointsForLevel(profile.level)
@@ -137,21 +190,43 @@ class GamificationViewModel(
                         achievements = achievements,
                         recentlyUnlocked = recentlyUnlocked,
                         activeStreaks = profile.activeStreaks,
+                        currentStreakDays = currentStreak,
+                        bestStreakDays = bestStreak,
+                        streakMessage = StreakCalculator.streakMessage(currentStreak),
+                        nearWins = nearWins,
+                        celebration = celebration,
                     )
                 }
 
                 Timber.d(
-                    "Gamification loaded: level=%d, points=%d, unlocked=%d/%d",
+                    "Gamification loaded: level=%d, points=%d, unlocked=%d/%d, streak=%d",
                     profile.level,
                     profile.totalPoints,
                     profile.achievementsUnlocked,
                     profile.achievementsTotal,
+                    currentStreak,
                 )
             } catch (e: Exception) {
                 Timber.e(e, "Failed to load gamification data")
                 _uiState.update { it.copy(isLoading = false) }
             }
         }
+    }
+
+    private fun buildStreaks(
+        currentStreak: Int,
+        bestStreak: Int,
+        lastActivityDate: kotlinx.datetime.LocalDate,
+    ): List<Streak> {
+        if (currentStreak <= 0) return emptyList()
+        return listOf(
+            Streak(
+                type = "Daily logging",
+                currentCount = currentStreak,
+                bestCount = bestStreak,
+                lastActivityDate = lastActivityDate,
+            ),
+        )
     }
 
     private fun buildAchievementUiList(

--- a/apps/android/src/main/kotlin/com/finance/android/ui/gamification/NearWinCalculator.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/gamification/NearWinCalculator.kt
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.gamification
+
+/**
+ * A "near-win" — an achievement or streak the user is close to completing.
+ *
+ * Near-win feedback (#2211) surfaces progress that is *almost* there to create
+ * genuine, earned anticipation. It is intentionally non-manipulative:
+ * - Only real progress is shown (never fabricated "so close!" nudges).
+ * - Language is encouraging, never loss-averse ("keep going", never "don't lose it").
+ * - Streaks never imply punishment for stopping.
+ *
+ * @property id Stable identifier (achievement id or a synthetic streak id).
+ * @property title Short headline.
+ * @property message Encouraging, specific description of what's left.
+ * @property progressFraction 0f..1f progress toward the win.
+ * @property remainingLabel Human label for what remains (e.g. "2 to go").
+ */
+data class NearWin(
+    val id: String,
+    val title: String,
+    val message: String,
+    val progressFraction: Float,
+    val remainingLabel: String,
+)
+
+/**
+ * Pure, testable computation of near-win feedback for the gamification screen (#2211).
+ *
+ * No Android or Compose dependencies so it can be unit-tested directly.
+ */
+object NearWinCalculator {
+
+    /** Achievements at or above this fraction (but not unlocked) count as near-wins. */
+    const val NEAR_THRESHOLD = 0.5f
+
+    /** Maximum number of near-wins to surface at once (avoids overwhelming the user). */
+    const val MAX_NEAR_WINS = 3
+
+    /**
+     * Computes near-wins from the current achievement list and streak state.
+     *
+     * @param achievements All achievements with their progress.
+     * @param currentStreakDays The user's current consecutive-day logging streak.
+     * @param bestStreakDays The user's best-ever streak (for "beat your record" framing).
+     * @return Up to [MAX_NEAR_WINS] near-wins, highest progress first.
+     */
+    fun compute(
+        achievements: List<AchievementUi>,
+        currentStreakDays: Int,
+        bestStreakDays: Int,
+    ): List<NearWin> {
+        val achievementNearWins = achievements
+            .asSequence()
+            .filter { !it.isUnlocked }
+            .filter { it.targetCount != null && it.targetCount > 0 }
+            .filter { it.progressFraction >= NEAR_THRESHOLD && it.progressFraction < 1f }
+            .sortedByDescending { it.progressFraction }
+            .map { a ->
+                val target = a.targetCount ?: 0
+                val remaining = (target - a.currentCount).coerceAtLeast(1)
+                NearWin(
+                    id = a.id,
+                    title = a.title,
+                    message = "Just $remaining more to unlock \"${a.title}\"",
+                    progressFraction = a.progressFraction,
+                    remainingLabel = "$remaining to go",
+                )
+            }
+            .toList()
+
+        val streakNearWin = streakNearWin(currentStreakDays, bestStreakDays)
+
+        return (listOfNotNull(streakNearWin) + achievementNearWins).take(MAX_NEAR_WINS)
+    }
+
+    /**
+     * Builds an optional streak near-win.
+     *
+     * Only surfaces when the user is genuinely close to a meaningful milestone
+     * (a full week) or to beating their own record. Never punitive.
+     */
+    private fun streakNearWin(currentStreakDays: Int, bestStreakDays: Int): NearWin? {
+        if (currentStreakDays <= 0) return null
+
+        // Close to beating personal best (within 2 days, and best is meaningful).
+        if (bestStreakDays >= WEEK && currentStreakDays in (bestStreakDays - 2) until bestStreakDays) {
+            val remaining = (bestStreakDays - currentStreakDays + 1).coerceAtLeast(1)
+            return NearWin(
+                id = "streak-record",
+                title = "New record in reach",
+                message = "$remaining more day(s) to beat your best streak of $bestStreakDays",
+                progressFraction = currentStreakDays.toFloat() / (bestStreakDays + 1),
+                remainingLabel = "$remaining to go",
+            )
+        }
+
+        // Close to a full week.
+        if (currentStreakDays in (WEEK - 2) until WEEK) {
+            val remaining = WEEK - currentStreakDays
+            return NearWin(
+                id = "streak-week",
+                title = "A week is close",
+                message = "$remaining more day(s) for a full-week streak",
+                progressFraction = currentStreakDays.toFloat() / WEEK,
+                remainingLabel = "$remaining to go",
+            )
+        }
+        return null
+    }
+
+    private const val WEEK = 7
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
@@ -60,6 +60,13 @@ import com.finance.android.ui.screens.referral.ReferralScreen
 import com.finance.android.ui.screens.report.ReportBuilderScreen
 import com.finance.android.ui.screens.currency.CurrencyConversionScreen
 import com.finance.android.ui.screens.currency.CurrencyPickerScreen
+import com.finance.android.ui.gamification.GamificationScreen
+import com.finance.android.ui.couple.CoupleHubScreen
+import com.finance.android.ui.couple.privacy.CouplePrivacyScreen
+import com.finance.android.ui.couple.wedding.WeddingWorkspaceScreen
+import com.finance.android.ui.couple.goals.SharedGoalContributionsScreen
+import com.finance.android.ui.couple.checkin.MoneyCheckInScreen
+import com.finance.android.ui.couple.debt.DebtPayoffPlannerScreen
 import org.koin.compose.koinInject
 import timber.log.Timber
 
@@ -218,6 +225,27 @@ sealed class Route(val route: String) {
 
     /** Gig / delivery driver tools — payouts, mileage, Schedule C presets (#2141, #2137, #2133). */
     data object GigTools : Route("gig-tools")
+
+    /** Teen achievements: streaks, near-win feedback, celebration moments (#2211). */
+    data object Achievements : Route("achievements")
+
+    /** Engaged-couples money hub linking all shared-finance features. */
+    data object CoupleHub : Route("couple-hub")
+
+    /** "Yours, mine, ours" privacy model (#2142). */
+    data object CouplePrivacy : Route("couple-privacy")
+
+    /** Shared wedding-budget workspace (#2145). */
+    data object CoupleWedding : Route("couple-wedding")
+
+    /** Shared goal contributions — house down payment (#2147). */
+    data object CoupleGoals : Route("couple-goals")
+
+    /** Supportive money check-ins (#2150). */
+    data object CoupleCheckIn : Route("couple-checkin")
+
+    /** Joint debt payoff planner (#2153). */
+    data object CoupleDebt : Route("couple-debt")
 }
 
 /**
@@ -426,6 +454,38 @@ fun FinanceNavHost(
                     }
                 },
             )
+        }
+
+        // ── Teen achievements (#2211) ────────────────────────────────
+        composable(Route.Achievements.route) {
+            GamificationScreen()
+        }
+
+        // ── Engaged-couples shared finances (#2142/#2145/#2147/#2150/#2153) ──
+        composable(Route.CoupleHub.route) {
+            CoupleHubScreen(
+                onBack = { navController.popBackStack() },
+                onOpenPrivacy = { navController.navigate(Route.CouplePrivacy.route) },
+                onOpenWedding = { navController.navigate(Route.CoupleWedding.route) },
+                onOpenGoals = { navController.navigate(Route.CoupleGoals.route) },
+                onOpenCheckIn = { navController.navigate(Route.CoupleCheckIn.route) },
+                onOpenDebt = { navController.navigate(Route.CoupleDebt.route) },
+            )
+        }
+        composable(Route.CouplePrivacy.route) {
+            CouplePrivacyScreen(onBack = { navController.popBackStack() })
+        }
+        composable(Route.CoupleWedding.route) {
+            WeddingWorkspaceScreen(onBack = { navController.popBackStack() })
+        }
+        composable(Route.CoupleGoals.route) {
+            SharedGoalContributionsScreen(onBack = { navController.popBackStack() })
+        }
+        composable(Route.CoupleCheckIn.route) {
+            MoneyCheckInScreen(onBack = { navController.popBackStack() })
+        }
+        composable(Route.CoupleDebt.route) {
+            DebtPayoffPlannerScreen(onBack = { navController.popBackStack() })
         }
 
         composable(Route.ExpertiseTier.route) {

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickAction.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickAction.kt
@@ -89,6 +89,22 @@ enum class QuickActionType(
         iconName = "DirectionsCar",
         baseWeight = 0.35,
     ),
+    COUPLE_SPACE(
+        id = "couple_space",
+        label = "Our money",
+        contentDescription = "Open the shared money space for couples: privacy, wedding, goals, check-ins and debt",
+        route = "couple-hub",
+        iconName = "Favorite",
+        baseWeight = 0.34,
+    ),
+    ACHIEVEMENTS(
+        id = "achievements",
+        label = "Achievements",
+        contentDescription = "View your achievements, streaks and progress",
+        route = "achievements",
+        iconName = "EmojiEvents",
+        baseWeight = 0.32,
+    ),
     ;
 
     companion object {

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionRanker.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionRanker.kt
@@ -119,6 +119,8 @@ class DeterministicQuickActionRanker : QuickActionRanker {
         QuickActionType.VIEW_BUDGETS -> setOf(TimeBucket.EVENING)
         QuickActionType.VIEW_INSIGHTS -> setOf(TimeBucket.EVENING)
         QuickActionType.GIG_TOOLS -> setOf(TimeBucket.EVENING, TimeBucket.NIGHT)
+        QuickActionType.COUPLE_SPACE -> setOf(TimeBucket.EVENING)
+        QuickActionType.ACHIEVEMENTS -> setOf(TimeBucket.EVENING, TimeBucket.NIGHT)
     }
 
     companion object {

--- a/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionsSection.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/quickactions/QuickActionsSection.kt
@@ -19,7 +19,9 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DirectionsCar
+import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.EventNote
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Inbox
 import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material.icons.filled.MoreVert
@@ -229,6 +231,8 @@ private fun iconFor(type: QuickActionType): ImageVector = when (type) {
     QuickActionType.VIEW_BUDGETS -> Icons.Filled.PieChart
     QuickActionType.VIEW_INSIGHTS -> Icons.Filled.Insights
     QuickActionType.GIG_TOOLS -> Icons.Filled.DirectionsCar
+    QuickActionType.COUPLE_SPACE -> Icons.Filled.Favorite
+    QuickActionType.ACHIEVEMENTS -> Icons.Filled.EmojiEvents
 }
 
 @Preview(showBackground = true)

--- a/apps/android/src/test/kotlin/com/finance/android/ui/couple/debt/DebtPayoffPlannerTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/couple/debt/DebtPayoffPlannerTest.kt
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.couple.debt
+
+import com.finance.models.types.Cents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [DebtPayoffPlanner] — the deterministic joint debt simulator (#2153).
+ *
+ * Money is represented in [Cents] (Long) throughout, so results are exact and
+ * reproducible on any machine with no floating-point drift.
+ */
+class DebtPayoffPlannerTest {
+
+    private fun debt(
+        id: String,
+        balanceCents: Long,
+        aprBps: Int,
+        minCents: Long,
+    ) = CoupleDebt(
+        id = id,
+        name = "Debt $id",
+        balance = Cents(balanceCents),
+        aprBasisPoints = aprBps,
+        minimumPayment = Cents(minCents),
+        ownership = DebtOwnership.SHARED,
+    )
+
+    @Test
+    fun `empty debts is instantly debt free`() {
+        val plan = DebtPayoffPlanner.simulate(emptyList(), Cents(10_000), PayoffStrategy.AVALANCHE)
+        assertEquals(0, plan.monthsToDebtFree)
+        assertEquals(Cents.ZERO, plan.totalInterest)
+        assertTrue(plan.completed)
+    }
+
+    @Test
+    fun `single zero-interest debt pays off by principal over minimums`() {
+        // $1,000 at 0% APR, $100/month minimum, no extra -> 10 months, no interest.
+        val debts = listOf(debt("a", 100_000, 0, 10_000))
+        val plan = DebtPayoffPlanner.simulate(debts, Cents.ZERO, PayoffStrategy.SNOWBALL)
+        assertEquals(10, plan.monthsToDebtFree)
+        assertEquals(Cents.ZERO, plan.totalInterest)
+        assertTrue(plan.completed)
+    }
+
+    @Test
+    fun `extra payment clears debt faster`() {
+        val debts = listOf(debt("a", 100_000, 0, 10_000))
+        val base = DebtPayoffPlanner.simulate(debts, Cents.ZERO, PayoffStrategy.SNOWBALL)
+        val boosted = DebtPayoffPlanner.simulate(debts, Cents(10_000), PayoffStrategy.SNOWBALL)
+        assertTrue(boosted.monthsToDebtFree < base.monthsToDebtFree)
+    }
+
+    @Test
+    fun `avalanche pays no more interest than snowball`() {
+        val debts = listOf(
+            debt("card", 200_000, 2400, 4_000), // $2,000 @ 24%
+            debt("loan", 500_000, 600, 10_000), // $5,000 @ 6%
+        )
+        val comparison = DebtPayoffPlanner.compare(debts, Cents(30_000))
+        assertTrue(
+            comparison.avalanche.totalInterest.amount <= comparison.snowball.totalInterest.amount,
+            "Avalanche interest ${comparison.avalanche.totalInterest.amount} " +
+                "should be <= snowball ${comparison.snowball.totalInterest.amount}",
+        )
+        assertTrue(comparison.interestSavedWithAvalanche.amount >= 0L)
+    }
+
+    @Test
+    fun `avalanche prioritises the highest-APR debt first`() {
+        val debts = listOf(
+            debt("low", 300_000, 500, 5_000), // 5%
+            debt("high", 300_000, 2500, 5_000), // 25%
+        )
+        val plan = DebtPayoffPlanner.simulate(debts, Cents(50_000), PayoffStrategy.AVALANCHE)
+        val highPayoff = plan.order.first { it.debtId == "high" }.payoffMonth
+        val lowPayoff = plan.order.first { it.debtId == "low" }.payoffMonth
+        assertTrue(highPayoff <= lowPayoff, "Highest-APR debt should be cleared first")
+    }
+
+    @Test
+    fun `snowball prioritises the smallest balance first`() {
+        val debts = listOf(
+            debt("big", 500_000, 1000, 5_000),
+            debt("small", 100_000, 1000, 5_000),
+        )
+        val plan = DebtPayoffPlanner.simulate(debts, Cents(50_000), PayoffStrategy.SNOWBALL)
+        val smallPayoff = plan.order.first { it.debtId == "small" }.payoffMonth
+        val bigPayoff = plan.order.first { it.debtId == "big" }.payoffMonth
+        assertTrue(smallPayoff <= bigPayoff, "Smallest balance should be cleared first")
+    }
+
+    @Test
+    fun `interest accrues on a carried balance`() {
+        val debts = listOf(debt("a", 100_000, 1200, 10_000))
+        val plan = DebtPayoffPlanner.simulate(debts, Cents.ZERO, PayoffStrategy.AVALANCHE)
+        assertTrue(plan.totalInterest.amount > 0L, "A carried APR balance must accrue interest")
+        assertTrue(plan.completed)
+    }
+
+    @Test
+    fun `months saved by adding is non-negative and increases speed`() {
+        val debts = listOf(debt("a", 300_000, 1800, 6_000))
+        val saved = DebtPayoffPlanner.monthsSavedByAdding(
+            debts = debts,
+            currentExtra = Cents.ZERO,
+            reallocated = Cents(20_000),
+            strategy = PayoffStrategy.AVALANCHE,
+        )
+        assertTrue(saved >= 0)
+        assertTrue(saved > 0, "Reallocating money to debt should save at least a month")
+    }
+
+    @Test
+    fun `negative balance is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            debt("bad", -1L, 0, 0)
+        }
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/gamification/NearWinCalculatorTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/gamification/NearWinCalculatorTest.kt
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.gamification
+
+import com.finance.core.gamification.AchievementCategory
+import com.finance.core.gamification.AchievementRarity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [NearWinCalculator] — the "so close" feedback engine (#2211).
+ *
+ * Near-wins must reflect only genuine progress and never manipulate: no
+ * fabricated urgency, no loss-aversion, capped count.
+ */
+class NearWinCalculatorTest {
+
+    private fun achievement(
+        id: String,
+        unlocked: Boolean,
+        progress: Float,
+        current: Int,
+        target: Int?,
+    ) = AchievementUi(
+        id = id,
+        title = "Title $id",
+        description = "Desc",
+        icon = "Star",
+        category = AchievementCategory.SAVING,
+        rarity = AchievementRarity.COMMON,
+        points = 10,
+        isUnlocked = unlocked,
+        progressFraction = progress,
+        currentCount = current,
+        targetCount = target,
+    )
+
+    @Test
+    fun `achievements below threshold are not near-wins`() {
+        val achievements = listOf(achievement("a", false, 0.3f, 3, 10))
+        val nearWins = NearWinCalculator.compute(achievements, currentStreakDays = 0, bestStreakDays = 0)
+        assertTrue(nearWins.isEmpty())
+    }
+
+    @Test
+    fun `unlocked achievements are never near-wins`() {
+        val achievements = listOf(achievement("a", true, 1.0f, 10, 10))
+        val nearWins = NearWinCalculator.compute(achievements, currentStreakDays = 0, bestStreakDays = 0)
+        assertTrue(nearWins.none { it.id == "a" })
+    }
+
+    @Test
+    fun `achievement at or above threshold becomes a near-win with remaining count`() {
+        val achievements = listOf(achievement("a", false, 0.8f, 8, 10))
+        val nearWins = NearWinCalculator.compute(achievements, currentStreakDays = 0, bestStreakDays = 0)
+        assertEquals(1, nearWins.size)
+        assertEquals("a", nearWins.first().id)
+        assertEquals("2 to go", nearWins.first().remainingLabel)
+    }
+
+    @Test
+    fun `near-wins are sorted by progress descending`() {
+        val achievements = listOf(
+            achievement("low", false, 0.55f, 5, 9),
+            achievement("high", false, 0.9f, 9, 10),
+        )
+        val nearWins = NearWinCalculator.compute(achievements, currentStreakDays = 0, bestStreakDays = 0)
+        // Streak near-win (none here) then achievements by progress: high before low.
+        assertEquals("high", nearWins.first().id)
+    }
+
+    @Test
+    fun `result is capped at max near-wins`() {
+        val achievements = (1..10).map { achievement("a$it", false, 0.9f, 9, 10) }
+        val nearWins = NearWinCalculator.compute(achievements, currentStreakDays = 6, bestStreakDays = 0)
+        assertTrue(nearWins.size <= NearWinCalculator.MAX_NEAR_WINS)
+    }
+
+    @Test
+    fun `streak close to a week surfaces a streak near-win`() {
+        val nearWins = NearWinCalculator.compute(
+            achievements = emptyList(),
+            currentStreakDays = 6,
+            bestStreakDays = 0,
+        )
+        assertEquals(1, nearWins.size)
+        assertEquals("streak-week", nearWins.first().id)
+    }
+
+    @Test
+    fun `zero streak produces no streak near-win`() {
+        val nearWins = NearWinCalculator.compute(
+            achievements = emptyList(),
+            currentStreakDays = 0,
+            bestStreakDays = 10,
+        )
+        assertTrue(nearWins.isEmpty())
+    }
+
+    @Test
+    fun `streak close to personal best surfaces a record near-win`() {
+        val nearWins = NearWinCalculator.compute(
+            achievements = emptyList(),
+            currentStreakDays = 13,
+            bestStreakDays = 14,
+        )
+        assertEquals("streak-record", nearWins.first().id)
+    }
+}


### PR DESCRIPTION
﻿## Android shared finances for engaged couples (+ lively teen achievements)

This batch adds a shared-money workspace for engaged couples plus a gamification refresh for teens, entirely within `apps/android` (shared `packages/*` left read-only). All new domain state is persisted on-device via the app's encrypted `SharedPreferences` using `org.json` (the kotlin-serialization plugin is not applied to the Android module). Everything is accessible (WCAG 2.2 AA: headings, content descriptions, large touch targets) and privacy-respecting / non-manipulative.

### What's included
- **Yours, mine & ours privacy model (#2142)** — a couple profile foundation (partner names + shared label) and per-item MINE/YOURS/OURS classification for accounts, budgets and goals, with combined vs. shared net-worth views and sharing toggles.
- **Shared wedding budget workspace (#2145)** — vendors, deposits, due dates, per-guest cost scaling, and budgeted-vs-actual tracking with record-payment flow.
- **Shared goal contributions for a house down payment (#2147)** — per-partner contributions layered on the existing `GoalRepository`, total progress, suggested monthly amount, home milestones and contribution history.
- **Supportive money check-ins (#2150)** — opt-in weekly/monthly ritual with neutral, category-level summaries (never a line-item feed) and rotating collaborative discussion prompts. Sharing is opt-in and framed as a conversation, not surveillance.
- **Joint debt payoff planner (#2153)** — a pure, deterministic avalanche/snowball simulator (`Cents`/Long math, no float drift) with a couple-friendly recommendation, wedding/house trade-off framing and a simpler decision-aid mode.
- **Lively teen achievements (#2211)** — real logging streaks wired into the gamification profile via `StreakRepository`/`StreakCalculator`, non-manipulative near-win feedback ("so close" progress + streak milestones), and a one-time celebration moment with haptics on genuine unlocks. Streaks stay encouraging, never punitive.

### Wiring
- New `com.finance.android.ui.couple` package with a **Couple hub** linking all five features and letting partners personalize their display names.
- Koin registrations for all new repositories/ViewModels in `AppModule`.
- Nav routes for the hub, its five sub-screens and the achievements screen in `FinanceNavHost`.
- New `COUPLE_SPACE` ("Our money") and `ACHIEVEMENTS` predictive quick-actions surfaced on the dashboard.

### Testing (local)
- `:apps:android:compileDebugKotlin` — **BUILD SUCCESSFUL**.
- New unit tests: `DebtPayoffPlannerTest` (avalanche vs. snowball, interest accrual, months-saved, ordering) and `NearWinCalculatorTest` (thresholds, capping, streak milestones) — **passing** via `:apps:android:testDebugUnitTest`.
- Existing `QuickActionRankerTest` suite re-run green after the new quick-action types.
- `npm run format:check` clean and `npx eslint . --max-warnings 0` clean (Kotlin is prettier/detekt-ignored).

### Privacy & accessibility notes
- No account PII is used by the couple features — partners name themselves locally; nothing is synced.
- Check-ins share only aggregate category totals, and only when explicitly opted in.
- Gamification streaks avoid loss-aversion language and never gate features.

Closes #2153
Closes #2150
Closes #2147
Closes #2145
Closes #2142
Closes #2211
