### PR TITLE
feat(web): provider-agnostic aggregator routing core (Phase 1)

### DIFF
--- a/apps/web/src/lib/banking/__tests__/aggregator-metadata.test.ts
+++ b/apps/web/src/lib/banking/__tests__/aggregator-metadata.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import type { BankConnectionProvider, ProviderFeatures } from '../types';
+import {
+  defaultMetaForProvider,
+  isStatusRoutable,
+  type AggregatorStatus,
+} from '../aggregator-metadata';
+
+const NO_FEATURES: ProviderFeatures = {
+  realTimeBalance: false,
+  transactionWebhooks: false,
+  investmentAccounts: false,
+  creditCards: false,
+  loans: false,
+  bnpl: false,
+  crypto: false,
+  internationalBanks: false,
+};
+
+function stubProvider(id: string, countries: readonly string[] = ['US']): BankConnectionProvider {
+  return {
+    id,
+    name: id,
+    supportedCountries: countries,
+    features: NO_FEATURES,
+    initializeConnection: vi.fn(),
+    completeConnection: vi.fn(),
+    refreshConnection: vi.fn(),
+    removeConnection: vi.fn(),
+    getAccounts: vi.fn(),
+    getTransactions: vi.fn(),
+    getBalances: vi.fn(),
+    getConnectionStatus: vi.fn(),
+    getProviderHealth: vi.fn(),
+  } as BankConnectionProvider;
+}
+
+describe('defaultMetaForProvider', () => {
+  it('derives enabled, healthy, lowest-precedence metadata', () => {
+    const provider = stubProvider('plaid', ['US', 'CA']);
+    const m = defaultMetaForProvider(provider);
+    expect(m).toEqual({
+      providerId: 'plaid',
+      status: 'active',
+      healthScore: 100,
+      priority: Number.MAX_SAFE_INTEGER,
+      isEnabled: true,
+      supportedRegions: ['US', 'CA'],
+    });
+  });
+});
+
+describe('isStatusRoutable', () => {
+  const cases: [AggregatorStatus, boolean, boolean][] = [
+    ['active', true, true],
+    ['degraded', true, true],
+    ['degraded', false, false],
+    ['down', true, false],
+    ['maintenance', true, false],
+  ];
+
+  it.each(cases)('status=%s includeDegraded=%s -> %s', (status, includeDegraded, expected) => {
+    expect(isStatusRoutable(status, includeDegraded)).toBe(expected);
+  });
+
+  it('includes degraded by default', () => {
+    expect(isStatusRoutable('degraded')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/banking/__tests__/bootstrap.test.ts
+++ b/apps/web/src/lib/banking/__tests__/bootstrap.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { bootstrapBanking, getProviderRouter, resetBankingBootstrapForTests } from '../bootstrap';
+import { defaultRegistry } from '../provider-registry';
+import type { RoutableProviderMeta } from '../aggregator-metadata';
+
+describe('bootstrapBanking', () => {
+  beforeEach(() => {
+    resetBankingBootstrapForTests();
+    defaultRegistry.clear();
+  });
+
+  it('registers the default providers into the shared registry', () => {
+    const { registry } = bootstrapBanking();
+    const ids = registry.getAllProviders().map((p) => p.id);
+    expect(ids).toContain('manual');
+    expect(ids.length).toBeGreaterThan(0);
+  });
+
+  it('builds a router that routes against the registered providers', () => {
+    const { router, registry } = bootstrapBanking();
+    const ids = registry.getAllProviders().map((p) => p.id);
+    const primaryId = router.selectPrimary()?.id;
+    expect(primaryId).toBeDefined();
+    expect(ids).toContain(primaryId);
+  });
+
+  it('is idempotent — repeated calls do not double-register', () => {
+    const first = bootstrapBanking();
+    const countAfterFirst = first.registry.getAllProviders().length;
+    const second = bootstrapBanking();
+    expect(second.registry.getAllProviders().length).toBe(countAfterFirst);
+    expect(second.router).toBe(first.router);
+  });
+
+  it('attaches a metadata source on first bootstrap', () => {
+    const metas: RoutableProviderMeta[] = [
+      {
+        providerId: 'manual',
+        status: 'active',
+        healthScore: 100,
+        priority: 0,
+        isEnabled: true,
+        supportedRegions: [],
+      },
+    ];
+    const { router } = bootstrapBanking(() => metas);
+    expect(router.selectPrimary({ preferredProviderId: 'manual' })?.id).toBe('manual');
+  });
+
+  it('updates the metadata source on a later call once bootstrapped', () => {
+    bootstrapBanking();
+    const router = getProviderRouter();
+    router.setMetaSource(() => []);
+    // Re-bootstrapping with a new source should update the existing router.
+    bootstrapBanking(() => [
+      {
+        providerId: 'manual',
+        status: 'down',
+        healthScore: 0,
+        priority: 0,
+        isEnabled: true,
+        supportedRegions: [],
+      },
+    ]);
+    // manual is now marked down, so it must not be selected.
+    expect(router.selectPrimary({ preferredProviderId: 'manual' })?.id).not.toBe('manual');
+  });
+
+  it('getProviderRouter bootstraps lazily when called first', () => {
+    const router = getProviderRouter();
+    expect(router).toBeDefined();
+    expect(defaultRegistry.getAllProviders().length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/lib/banking/__tests__/provider-router.test.ts
+++ b/apps/web/src/lib/banking/__tests__/provider-router.test.ts
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import type { BankConnectionProvider, ProviderFeatures } from '../types';
+import { ProviderRegistry } from '../provider-registry';
+import { resolveRoute, ProviderRouter } from '../provider-router';
+import type { RoutableProviderMeta } from '../aggregator-metadata';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NO_FEATURES: ProviderFeatures = {
+  realTimeBalance: false,
+  transactionWebhooks: false,
+  investmentAccounts: false,
+  creditCards: false,
+  loans: false,
+  bnpl: false,
+  crypto: false,
+  internationalBanks: false,
+};
+
+function stubProvider(
+  id: string,
+  opts: {
+    supportedCountries?: readonly string[];
+    features?: Partial<ProviderFeatures>;
+  } = {},
+): BankConnectionProvider {
+  return {
+    id,
+    name: id,
+    supportedCountries: opts.supportedCountries ?? [],
+    features: { ...NO_FEATURES, ...opts.features },
+    initializeConnection: vi.fn(),
+    completeConnection: vi.fn(),
+    refreshConnection: vi.fn(),
+    removeConnection: vi.fn(),
+    getAccounts: vi.fn(),
+    getTransactions: vi.fn(),
+    getBalances: vi.fn(),
+    getConnectionStatus: vi.fn(),
+    getProviderHealth: vi.fn(),
+  } as BankConnectionProvider;
+}
+
+function meta(
+  providerId: string,
+  overrides: Partial<RoutableProviderMeta> = {},
+): RoutableProviderMeta {
+  return {
+    providerId,
+    status: 'active',
+    healthScore: 100,
+    priority: 0,
+    isEnabled: true,
+    supportedRegions: [],
+    ...overrides,
+  };
+}
+
+function metaMap(...metas: RoutableProviderMeta[]): Map<string, RoutableProviderMeta> {
+  return new Map(metas.map((m) => [m.providerId, m]));
+}
+
+// ---------------------------------------------------------------------------
+// resolveRoute — ranking
+// ---------------------------------------------------------------------------
+
+describe('resolveRoute — ranking', () => {
+  it('orders by priority ascending (lower is preferred)', () => {
+    const plaid = stubProvider('plaid');
+    const mx = stubProvider('mx');
+    const decision = resolveRoute(
+      [mx, plaid],
+      metaMap(meta('plaid', { priority: 0 }), meta('mx', { priority: 1 })),
+    );
+    expect(decision.reason).toBe('routed');
+    expect(decision.primary?.id).toBe('plaid');
+    expect(decision.chain.map((p) => p.id)).toEqual(['plaid', 'mx']);
+    expect(decision.fallbacks.map((p) => p.id)).toEqual(['mx']);
+  });
+
+  it('breaks priority ties by health score descending', () => {
+    const a = stubProvider('a');
+    const b = stubProvider('b');
+    const decision = resolveRoute(
+      [a, b],
+      metaMap(
+        meta('a', { priority: 0, healthScore: 70 }),
+        meta('b', { priority: 0, healthScore: 95 }),
+      ),
+    );
+    expect(decision.chain.map((p) => p.id)).toEqual(['b', 'a']);
+  });
+
+  it('breaks priority + health ties by active-before-degraded', () => {
+    const a = stubProvider('a');
+    const b = stubProvider('b');
+    const decision = resolveRoute(
+      [a, b],
+      metaMap(meta('a', { status: 'degraded' }), meta('b', { status: 'active' })),
+    );
+    expect(decision.primary?.id).toBe('b');
+  });
+
+  it('is deterministic on full ties via provider id', () => {
+    const zed = stubProvider('zed');
+    const abe = stubProvider('abe');
+    const decision = resolveRoute([zed, abe], metaMap(meta('zed'), meta('abe')));
+    expect(decision.chain.map((p) => p.id)).toEqual(['abe', 'zed']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRoute — filtering
+// ---------------------------------------------------------------------------
+
+describe('resolveRoute — filtering', () => {
+  it('excludes disabled providers', () => {
+    const on = stubProvider('on');
+    const off = stubProvider('off');
+    const decision = resolveRoute(
+      [off, on],
+      metaMap(meta('off', { isEnabled: false, priority: 0 }), meta('on', { priority: 1 })),
+    );
+    expect(decision.chain.map((p) => p.id)).toEqual(['on']);
+  });
+
+  it('excludes down and maintenance providers', () => {
+    const up = stubProvider('up');
+    const down = stubProvider('down');
+    const maint = stubProvider('maint');
+    const decision = resolveRoute(
+      [down, maint, up],
+      metaMap(
+        meta('down', { status: 'down', priority: 0 }),
+        meta('maint', { status: 'maintenance', priority: 0 }),
+        meta('up', { priority: 5 }),
+      ),
+    );
+    expect(decision.chain.map((p) => p.id)).toEqual(['up']);
+  });
+
+  it('includes degraded providers by default but excludes when opted out', () => {
+    const good = stubProvider('good');
+    const degraded = stubProvider('degraded');
+    const metas = metaMap(
+      meta('good', { priority: 1 }),
+      meta('degraded', { status: 'degraded', priority: 0 }),
+    );
+
+    const withDegraded = resolveRoute([good, degraded], metas);
+    expect(withDegraded.chain.map((p) => p.id)).toEqual(['degraded', 'good']);
+
+    const withoutDegraded = resolveRoute([good, degraded], metas, { includeDegraded: false });
+    expect(withoutDegraded.chain.map((p) => p.id)).toEqual(['good']);
+  });
+
+  it('filters by required capabilities (must support every feature)', () => {
+    const invest = stubProvider('invest', { features: { investmentAccounts: true } });
+    const basic = stubProvider('basic');
+    const decision = resolveRoute([invest, basic], metaMap(meta('invest'), meta('basic')), {
+      requiredFeatures: ['investmentAccounts'],
+    });
+    expect(decision.chain.map((p) => p.id)).toEqual(['invest']);
+  });
+
+  it('filters by region using provider or metadata region lists (case-insensitive)', () => {
+    const us = stubProvider('us', { supportedCountries: ['US'] });
+    const gb = stubProvider('gb');
+    const decision = resolveRoute(
+      [us, gb],
+      metaMap(meta('us'), meta('gb', { supportedRegions: ['GB'] })),
+      { countryCode: 'gb' },
+    );
+    expect(decision.chain.map((p) => p.id)).toEqual(['gb']);
+  });
+
+  it('treats empty region lists as global (serves every country)', () => {
+    const global = stubProvider('global');
+    const decision = resolveRoute([global], metaMap(meta('global')), { countryCode: 'JP' });
+    expect(decision.primary?.id).toBe('global');
+  });
+
+  it('skips region filtering when no countryCode is supplied', () => {
+    const us = stubProvider('us', { supportedCountries: ['US'] });
+    const decision = resolveRoute([us], metaMap(meta('us')));
+    expect(decision.primary?.id).toBe('us');
+  });
+
+  it('returns reason "none" with an empty chain when nothing qualifies', () => {
+    const us = stubProvider('us', { supportedCountries: ['US'] });
+    const decision = resolveRoute([us], metaMap(meta('us')), { countryCode: 'FR' });
+    expect(decision.reason).toBe('none');
+    expect(decision.primary).toBeNull();
+    expect(decision.chain).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRoute — default metadata fallback
+// ---------------------------------------------------------------------------
+
+describe('resolveRoute — default metadata', () => {
+  it('routes providers with no metadata but ranks them last', () => {
+    const configured = stubProvider('configured');
+    const bare = stubProvider('bare');
+    const decision = resolveRoute(
+      [bare, configured],
+      metaMap(meta('configured', { priority: 10 })),
+    );
+    // `bare` gets MAX_SAFE_INTEGER priority, so `configured` wins.
+    expect(decision.chain.map((p) => p.id)).toEqual(['configured', 'bare']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRoute — override
+// ---------------------------------------------------------------------------
+
+describe('resolveRoute — override', () => {
+  it('promotes an eligible preferred provider to the front', () => {
+    const plaid = stubProvider('plaid');
+    const mx = stubProvider('mx');
+    const decision = resolveRoute(
+      [plaid, mx],
+      metaMap(meta('plaid', { priority: 0 }), meta('mx', { priority: 1 })),
+      { preferredProviderId: 'mx' },
+    );
+    expect(decision.reason).toBe('override');
+    expect(decision.primary?.id).toBe('mx');
+    expect(decision.chain.map((p) => p.id)).toEqual(['mx', 'plaid']);
+  });
+
+  it('reports "override" when the preferred provider is already primary', () => {
+    const plaid = stubProvider('plaid');
+    const decision = resolveRoute([plaid], metaMap(meta('plaid')), {
+      preferredProviderId: 'plaid',
+    });
+    expect(decision.reason).toBe('override');
+    expect(decision.primary?.id).toBe('plaid');
+  });
+
+  it('ignores an override that is not routable and falls back to routed', () => {
+    const plaid = stubProvider('plaid');
+    const mx = stubProvider('mx');
+    const decision = resolveRoute(
+      [plaid, mx],
+      metaMap(meta('plaid', { priority: 0 }), meta('mx', { status: 'down', priority: 1 })),
+      { preferredProviderId: 'mx' },
+    );
+    expect(decision.reason).toBe('routed');
+    expect(decision.primary?.id).toBe('plaid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProviderRouter
+// ---------------------------------------------------------------------------
+
+describe('ProviderRouter', () => {
+  it('routes against the current registry contents and metadata source', () => {
+    const registry = new ProviderRegistry();
+    registry.registerProvider(stubProvider('plaid'));
+    registry.registerProvider(stubProvider('mx'));
+
+    const router = new ProviderRouter(registry, () => [
+      meta('plaid', { priority: 5 }),
+      meta('mx', { priority: 0 }),
+    ]);
+
+    expect(router.selectPrimary()?.id).toBe('mx');
+  });
+
+  it('uses neutral defaults when no metadata source is provided', () => {
+    const registry = new ProviderRegistry();
+    registry.registerProvider(stubProvider('only'));
+    const router = new ProviderRouter(registry);
+    expect(router.selectPrimary()?.id).toBe('only');
+  });
+
+  it('reflects a swapped metadata source', () => {
+    const registry = new ProviderRegistry();
+    registry.registerProvider(stubProvider('a'));
+    registry.registerProvider(stubProvider('b'));
+    const router = new ProviderRouter(registry, () => [
+      meta('a', { priority: 0 }),
+      meta('b', { priority: 1 }),
+    ]);
+    expect(router.selectPrimary()?.id).toBe('a');
+
+    router.setMetaSource(() => [meta('a', { priority: 1 }), meta('b', { priority: 0 })]);
+    expect(router.selectPrimary()?.id).toBe('b');
+  });
+});

--- a/apps/web/src/lib/banking/aggregator-metadata.ts
+++ b/apps/web/src/lib/banking/aggregator-metadata.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Aggregator provider metadata — the runtime health/priority/region data used
+ * to route between interchangeable banking providers.
+ *
+ * A registered {@link BankConnectionProvider} describes *what it can do*
+ * (its `id`, `supportedCountries`, and capability `features`). This module adds
+ * the *operational* dimension the router needs to choose between several
+ * capable providers: whether the provider is enabled, its current health, and
+ * its failover priority.
+ *
+ * This metadata mirrors the backend `aggregator_providers` table
+ * (`services/api/.../20260331000001_bank_connectivity_foundation.sql`) so the
+ * client can make the same routing decisions the server would. In production it
+ * arrives via PowerSync-synced rows; in tests and bootstrap it can be supplied
+ * from static defaults.
+ *
+ * @module banking/aggregator-metadata
+ */
+
+import type { BankConnectionProvider } from './types';
+
+// ---------------------------------------------------------------------------
+// Provider operational status
+// ---------------------------------------------------------------------------
+
+/**
+ * Operational status of an aggregator provider.
+ *
+ * Mirrors the backend `aggregator_providers.status` CHECK constraint.
+ *
+ * - `active` — healthy and fully available.
+ * - `degraded` — reachable but impaired (elevated latency/errors); still usable.
+ * - `down` — unavailable; excluded from routing until recovered.
+ * - `maintenance` — intentionally offline; excluded from routing.
+ */
+export type AggregatorStatus = 'active' | 'degraded' | 'down' | 'maintenance';
+
+/**
+ * Runtime metadata for a single aggregator provider, keyed by `providerId`.
+ *
+ * `providerId` must match a {@link BankConnectionProvider.id} registered in the
+ * {@link ProviderRegistry} for the provider to be routable.
+ */
+export interface RoutableProviderMeta {
+  /** Provider identifier — matches {@link BankConnectionProvider.id}. */
+  providerId: string;
+  /** Current operational status. */
+  status: AggregatorStatus;
+  /** Provider health score in the range [0, 100] (higher is healthier). */
+  healthScore: number;
+  /**
+   * Failover priority. **Lower numbers are preferred** — this matches the
+   * backend `ORDER BY priority ASC` used by the aggregator-health function, so
+   * priority `0` outranks priority `1`.
+   */
+  priority: number;
+  /** Whether the provider is enabled for routing. Disabled providers are skipped. */
+  isEnabled: boolean;
+  /**
+   * ISO 3166-1 alpha-2 country codes this provider serves. An **empty array
+   * means the provider is treated as global** (serves every region).
+   */
+  supportedRegions: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+/**
+ * Default metadata applied to a registered provider that has no explicit
+ * operational metadata (e.g. a code-registered provider that is not present in
+ * the synced `aggregator_providers` table).
+ *
+ * Such providers are treated as enabled and healthy but ranked **last**
+ * (maximum priority value) so that any explicitly-configured aggregator always
+ * takes precedence.
+ *
+ * @param provider - The registered provider to derive defaults from.
+ * @returns Neutral, lowest-precedence metadata for the provider.
+ */
+export function defaultMetaForProvider(provider: BankConnectionProvider): RoutableProviderMeta {
+  return {
+    providerId: provider.id,
+    status: 'active',
+    healthScore: 100,
+    priority: Number.MAX_SAFE_INTEGER,
+    isEnabled: true,
+    supportedRegions: provider.supportedCountries,
+  };
+}
+
+/**
+ * Whether a provider's status permits it to be selected by the router.
+ *
+ * `down` and `maintenance` providers are never routable. `degraded` providers
+ * are routable unless the caller opts out.
+ *
+ * @param status - The provider's operational status.
+ * @param includeDegraded - Whether `degraded` providers are eligible. @default true
+ * @returns `true` if the status permits routing.
+ */
+export function isStatusRoutable(status: AggregatorStatus, includeDegraded = true): boolean {
+  if (status === 'down' || status === 'maintenance') return false;
+  if (status === 'degraded') return includeDegraded;
+  return true;
+}

--- a/apps/web/src/lib/banking/bootstrap.ts
+++ b/apps/web/src/lib/banking/bootstrap.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Banking bootstrap — one-time startup wiring for the banking layer.
+ *
+ * Historically {@link registerDefaultProviders} was only ever invoked from
+ * tests, so at runtime the {@link defaultRegistry} was empty and no provider
+ * routing could occur. This module is the single startup entry point that:
+ *
+ * 1. Registers the built-in providers into the shared {@link defaultRegistry}.
+ * 2. Constructs the shared {@link ProviderRouter} used for app-routed provider
+ *    selection.
+ *
+ * It is idempotent — safe to call across hot reloads and repeated imports — and
+ * returns the shared singletons so callers can wire the router's metadata source
+ * once the PowerSync-backed `aggregator_providers` query is available.
+ *
+ * @module banking/bootstrap
+ */
+
+import { defaultRegistry, type ProviderRegistry } from './provider-registry';
+import { ProviderRouter, type ProviderMetaSource } from './provider-router';
+import { registerDefaultProviders } from './register-default-providers';
+
+/** The shared, lazily-constructed router singleton. */
+let sharedRouter: ProviderRouter | undefined;
+let bootstrapped = false;
+
+/**
+ * The result of {@link bootstrapBanking}: the shared registry and router.
+ */
+export interface BankingBootstrap {
+  /** The registry the default providers were registered into. */
+  registry: ProviderRegistry;
+  /** The shared router for app-routed provider selection. */
+  router: ProviderRouter;
+}
+
+/**
+ * Register the default providers and build the shared router.
+ *
+ * Idempotent: subsequent calls return the same singletons without
+ * re-registering providers.
+ *
+ * @param metaSource - Optional operational-metadata source for the router. When
+ *   omitted, providers route with neutral defaults until
+ *   {@link ProviderRouter.setMetaSource} is called (e.g. after PowerSync is ready).
+ * @returns The shared {@link BankingBootstrap} singletons.
+ */
+export function bootstrapBanking(metaSource?: ProviderMetaSource): BankingBootstrap {
+  if (!bootstrapped) {
+    registerDefaultProviders(defaultRegistry);
+    sharedRouter = new ProviderRouter(defaultRegistry, metaSource);
+    bootstrapped = true;
+  } else if (metaSource && sharedRouter) {
+    sharedRouter.setMetaSource(metaSource);
+  }
+
+  return { registry: defaultRegistry, router: sharedRouter as ProviderRouter };
+}
+
+/**
+ * Return the shared {@link ProviderRouter}, bootstrapping if necessary.
+ *
+ * @returns The shared router.
+ */
+export function getProviderRouter(): ProviderRouter {
+  if (!sharedRouter) {
+    return bootstrapBanking().router;
+  }
+  return sharedRouter;
+}
+
+/**
+ * Reset bootstrap state. **Test-only** — lets suites re-bootstrap a clean
+ * registry/router without cross-test leakage.
+ *
+ * @internal
+ */
+export function resetBankingBootstrapForTests(): void {
+  sharedRouter = undefined;
+  bootstrapped = false;
+}

--- a/apps/web/src/lib/banking/index.ts
+++ b/apps/web/src/lib/banking/index.ts
@@ -33,6 +33,23 @@ export type {
 // Provider registry
 export { ProviderRegistry, defaultRegistry } from './provider-registry';
 
+// Aggregator metadata (routing inputs)
+export { defaultMetaForProvider, isStatusRoutable } from './aggregator-metadata';
+export type { AggregatorStatus, RoutableProviderMeta } from './aggregator-metadata';
+
+// Provider router (app-routed selection + failover + override)
+export { ProviderRouter, resolveRoute } from './provider-router';
+export type {
+  ProviderMetaSource,
+  RoutingDecision,
+  RoutingReason,
+  RoutingRequest,
+} from './provider-router';
+
+// Bootstrap (startup wiring)
+export { bootstrapBanking, getProviderRouter, resetBankingBootstrapForTests } from './bootstrap';
+export type { BankingBootstrap } from './bootstrap';
+
 // Connection manager
 export { ConnectionManager, categorizeError } from './connection-manager';
 export type { RetryConfig } from './connection-manager';

--- a/apps/web/src/lib/banking/provider-router.ts
+++ b/apps/web/src/lib/banking/provider-router.ts
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Provider router — chooses which banking aggregator serves a connection.
+ *
+ * This is the core of the app's **"app-routed by default, optional override"**
+ * provider-selection model. Given the user's region and the capabilities a
+ * connection needs, the router produces an ordered **failover chain** of
+ * interchangeable {@link BankConnectionProvider}s:
+ *
+ * 1. **Filter** to providers that are registered, enabled, capable of the
+ *    required features, and serve the requested region.
+ * 2. **Rank** the survivors by failover priority (ascending — lower is better,
+ *    matching the backend `ORDER BY priority ASC`), breaking ties by health
+ *    score (descending), then status (`active` before `degraded`), then
+ *    provider id for deterministic ordering.
+ * 3. **Override** — if the caller supplies a `preferredProviderId` that is
+ *    itself routable, it is promoted to the front of the chain. This is the
+ *    seam behind the optional advanced "choose your connection method" UX.
+ *
+ * The head of the chain is the primary provider; the remainder are ordered
+ * fallbacks the {@link ConnectionManager} can escalate to when the primary is
+ * unavailable.
+ *
+ * @module banking/provider-router
+ */
+
+import {
+  defaultMetaForProvider,
+  isStatusRoutable,
+  type RoutableProviderMeta,
+} from './aggregator-metadata';
+import type { ProviderRegistry } from './provider-registry';
+import type { BankConnectionProvider, ProviderFeatures } from './types';
+
+// ---------------------------------------------------------------------------
+// Request / result types
+// ---------------------------------------------------------------------------
+
+/**
+ * Parameters describing the connection the caller wants to route.
+ */
+export interface RoutingRequest {
+  /**
+   * ISO 3166-1 alpha-2 country code the connection targets. When omitted, the
+   * region filter is skipped and all providers are considered region-eligible.
+   */
+  countryCode?: string;
+  /**
+   * Capability flags the connection requires. Only providers whose
+   * {@link ProviderFeatures} are truthy for **every** listed feature qualify.
+   */
+  requiredFeatures?: readonly (keyof ProviderFeatures)[];
+  /**
+   * Advanced override: force this provider to the front of the chain when it is
+   * routable. Ignored if the provider is unregistered, disabled, unhealthy, or
+   * fails the region/capability filter.
+   */
+  preferredProviderId?: string;
+  /**
+   * Whether `degraded` providers are eligible. @default true
+   */
+  includeDegraded?: boolean;
+}
+
+/** Why the router produced the chain it did. */
+export type RoutingReason =
+  /** No eligible provider was found for the request. */
+  | 'none'
+  /** The chain head came from a valid {@link RoutingRequest.preferredProviderId}. */
+  | 'override'
+  /** The chain head was selected automatically by priority/health. */
+  | 'routed';
+
+/**
+ * The router's decision for a {@link RoutingRequest}.
+ */
+export interface RoutingDecision {
+  /** The selected primary provider, or `null` when nothing is eligible. */
+  primary: BankConnectionProvider | null;
+  /** Ordered fallback providers to escalate to after the primary. */
+  fallbacks: BankConnectionProvider[];
+  /** The full ordered chain: `[primary, ...fallbacks]` (empty when none). */
+  chain: BankConnectionProvider[];
+  /** How the primary was chosen. */
+  reason: RoutingReason;
+}
+
+// ---------------------------------------------------------------------------
+// Pure resolution
+// ---------------------------------------------------------------------------
+
+/** @internal A provider paired with its resolved operational metadata. */
+interface Candidate {
+  provider: BankConnectionProvider;
+  meta: RoutableProviderMeta;
+}
+
+/**
+ * Does `provider` support every feature in `required`?
+ *
+ * @internal
+ */
+function hasAllFeatures(
+  provider: BankConnectionProvider,
+  required: readonly (keyof ProviderFeatures)[] | undefined,
+): boolean {
+  if (!required || required.length === 0) return true;
+  return required.every((feature) => provider.features[feature]);
+}
+
+/**
+ * Does `provider` (with `meta`) serve `countryCode`?
+ *
+ * A provider serves a region when either its registered `supportedCountries`
+ * or its metadata `supportedRegions` list the country (case-insensitive), or
+ * when both region lists are empty (global provider). When no `countryCode` is
+ * requested, every provider is considered eligible.
+ *
+ * @internal
+ */
+function servesRegion(
+  provider: BankConnectionProvider,
+  meta: RoutableProviderMeta,
+  countryCode: string | undefined,
+): boolean {
+  if (!countryCode) return true;
+  const target = countryCode.toUpperCase();
+  const regions = [...provider.supportedCountries, ...meta.supportedRegions];
+  if (regions.length === 0) return true; // global provider
+  return regions.some((c) => c.toUpperCase() === target);
+}
+
+/**
+ * Rank comparator for eligible candidates.
+ *
+ * Ordering (best first): priority ascending, then health score descending,
+ * then `active` before `degraded`, then provider id ascending for stability.
+ *
+ * @internal
+ */
+function compareCandidates(a: Candidate, b: Candidate): number {
+  if (a.meta.priority !== b.meta.priority) return a.meta.priority - b.meta.priority;
+  if (a.meta.healthScore !== b.meta.healthScore) return b.meta.healthScore - a.meta.healthScore;
+  const statusRank = (s: RoutableProviderMeta['status']): number => (s === 'active' ? 0 : 1);
+  const statusDelta = statusRank(a.meta.status) - statusRank(b.meta.status);
+  if (statusDelta !== 0) return statusDelta;
+  return a.provider.id.localeCompare(b.provider.id);
+}
+
+/**
+ * Resolve a routing decision from an explicit provider + metadata list.
+ *
+ * This is the pure core of the router, exported for unit testing and reuse.
+ * The {@link ProviderRouter} class wraps it with a registry and a metadata
+ * source.
+ *
+ * @param providers - Candidate provider implementations.
+ * @param metaById - Operational metadata keyed by provider id. Providers absent
+ *   from this map fall back to {@link defaultMetaForProvider} (enabled, healthy,
+ *   lowest precedence).
+ * @param request - The routing request.
+ * @returns The ordered {@link RoutingDecision}.
+ */
+export function resolveRoute(
+  providers: readonly BankConnectionProvider[],
+  metaById: ReadonlyMap<string, RoutableProviderMeta>,
+  request: RoutingRequest = {},
+): RoutingDecision {
+  const includeDegraded = request.includeDegraded ?? true;
+
+  const eligible: Candidate[] = providers
+    .map((provider) => ({
+      provider,
+      meta: metaById.get(provider.id) ?? defaultMetaForProvider(provider),
+    }))
+    .filter(({ provider, meta }) => {
+      if (!meta.isEnabled) return false;
+      if (!isStatusRoutable(meta.status, includeDegraded)) return false;
+      if (!hasAllFeatures(provider, request.requiredFeatures)) return false;
+      if (!servesRegion(provider, meta, request.countryCode)) return false;
+      return true;
+    })
+    .sort(compareCandidates);
+
+  if (eligible.length === 0) {
+    return { primary: null, fallbacks: [], chain: [], reason: 'none' };
+  }
+
+  // Advanced override: promote the preferred provider iff it is eligible.
+  let reason: RoutingReason = 'routed';
+  const preferredId = request.preferredProviderId;
+  if (preferredId) {
+    const idx = eligible.findIndex((c) => c.provider.id === preferredId);
+    if (idx > 0) {
+      const [preferred] = eligible.splice(idx, 1);
+      eligible.unshift(preferred);
+      reason = 'override';
+    } else if (idx === 0) {
+      reason = 'override';
+    }
+  }
+
+  const chain = eligible.map((c) => c.provider);
+  return { primary: chain[0], fallbacks: chain.slice(1), chain, reason };
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/**
+ * A source of live provider metadata. In production this reads PowerSync-synced
+ * `aggregator_providers` rows; in tests/bootstrap it returns static values.
+ */
+export type ProviderMetaSource = () => readonly RoutableProviderMeta[];
+
+/**
+ * Stateful router bound to a {@link ProviderRegistry} and a metadata source.
+ *
+ * Prefer this over the bare {@link resolveRoute} function in application code —
+ * it always routes against the currently-registered providers and the latest
+ * metadata each time {@link ProviderRouter.route} is called.
+ */
+export class ProviderRouter {
+  private readonly registry: ProviderRegistry;
+  private metaSource: ProviderMetaSource;
+
+  /**
+   * @param registry - Registry supplying available provider implementations.
+   * @param metaSource - Supplies current operational metadata. Defaults to an
+   *   empty list, in which case every provider uses {@link defaultMetaForProvider}.
+   */
+  constructor(registry: ProviderRegistry, metaSource: ProviderMetaSource = () => []) {
+    this.registry = registry;
+    this.metaSource = metaSource;
+  }
+
+  /**
+   * Replace the metadata source (e.g. once the PowerSync query is available).
+   *
+   * @param metaSource - The new metadata source.
+   */
+  setMetaSource(metaSource: ProviderMetaSource): void {
+    this.metaSource = metaSource;
+  }
+
+  /**
+   * Route a request to an ordered failover chain of providers.
+   *
+   * @param request - The routing request.
+   * @returns The {@link RoutingDecision}.
+   */
+  route(request: RoutingRequest = {}): RoutingDecision {
+    const metaById = new Map<string, RoutableProviderMeta>();
+    for (const meta of this.metaSource()) {
+      metaById.set(meta.providerId, meta);
+    }
+    return resolveRoute(this.registry.getAllProviders(), metaById, request);
+  }
+
+  /**
+   * Convenience: return only the primary provider for a request, or `null`.
+   *
+   * @param request - The routing request.
+   * @returns The primary provider, or `null` when none is eligible.
+   */
+  selectPrimary(request: RoutingRequest = {}): BankConnectionProvider | null {
+    return this.route(request).primary;
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -18,6 +18,7 @@ import { applyStoredDisplayDensityPreference, applyStoredThemePreference } from 
 import { MoneyDisplayProvider } from './lib/display-settings';
 import { applyStoredSimplifiedModePreference } from './lib/accessibility-preferences';
 import { migrateLegacyDisplayCurrencyPreference } from './lib/display-currency';
+import { bootstrapBanking } from './lib/banking';
 import { initMonitoring } from './lib/monitoring';
 import {
   isViteDevServer,
@@ -129,6 +130,14 @@ if (
 }
 
 initMonitoring();
+
+// Register the built-in banking providers into the shared registry and build
+// the provider router used for app-routed aggregator selection. Without this
+// the registry stayed empty at runtime (registration previously happened only
+// in tests), so no provider could ever be selected. The router's operational
+// metadata source is attached later, once the PowerSync `aggregator_providers`
+// query is available (#3846).
+bootstrapBanking();
 
 // ---------------------------------------------------------------------------
 // Service worker registration


### PR DESCRIPTION
## Summary

Phase 1 of wiring the web app to live data via a **consolidated, provider-agnostic aggregator layer** (#3846). This lands the **app-routed provider-selection core** that lets the app switch interchangeably between banking aggregators (Plaid, MX, TrueLayer, Finicity) — the foundation every subsequent provider plugs into.

Selection model (confirmed with product): **app-routed by default** (region + capability + health/priority + automatic failover), with an **optional advanced override** so power users can force a specific provider. Users pick their *bank*; the app picks the *aggregator*.

## Changes

- **`provider-router.ts`** — the heart of selection. `resolveRoute()` (pure, testable) + `ProviderRouter` (registry + metadata-source bound) produce an ordered **failover chain**:
  1. Filter to registered, enabled, capable, region-eligible providers.
  2. Rank by failover **priority ascending** (matches the backend `aggregator-health` `ORDER BY priority ASC`), tie-broken by health score, then `active`-before-`degraded`, then provider id for determinism.
  3. Promote a valid `preferredProviderId` to the front (the override seam).
- **`aggregator-metadata.ts`** — `RoutableProviderMeta` (mirrors the `aggregator_providers` table) + `defaultMetaForProvider` / `isStatusRoutable` helpers. `down`/`maintenance` are excluded; `degraded` is included by default.
- **`bootstrap.ts`** — `bootstrapBanking()` registers the default providers into the shared registry and builds the shared router. **Now called from `main.tsx`.** Previously `registerDefaultProviders()` ran only in tests, so the runtime registry was empty and no provider could ever be selected — this fixes that gap.
- **`index.ts`** — barrel exports for the new modules.
- **Tests** — full unit coverage for ranking, filtering, capability/region, override promotion + rejection, default-metadata fallback, and idempotent bootstrap. **121 banking tests pass.**

## Not in this PR (tracked in #3846)

- `BaseAggregatorProvider` (edge-backed generic base) — Plaid phase.
- Backend Plaid SDK integration + secrets placeholders + seed `aggregator_providers` rows.
- PowerSync read wiring (replace `useBankConnections` stubs) — the router's metadata source attaches there.
- MX, TrueLayer, Finicity provider implementations.

## Testing

- [x] `npx vitest run src/lib/banking` — 121 passed
- [x] `npm run format:check` — clean
- [x] `npx eslint apps/web/src/lib/banking apps/web/src/main.tsx --max-warnings 0` — clean
- [x] `npx tsc --noEmit` (web) — no errors

## Notes

- No new dependencies.
- Secrets remain human-gated; this PR touches no credentials.
- Pre-existing `responsive.css` design-hook findings are unrelated to this change (TS-only) and left untouched.

Refs #3846