### PR TITLE
feat(web): add BaseAggregatorProvider edge-backed base (#3849)

### DIFF
--- a/apps/web/src/lib/banking/__tests__/base-aggregator-provider.test.ts
+++ b/apps/web/src/lib/banking/__tests__/base-aggregator-provider.test.ts
@@ -1,0 +1,573 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  BaseAggregatorProvider,
+  BankingProviderError,
+  type AggregatorProviderConfig,
+  type EdgeTransport,
+  type SyncedBankDataSource,
+} from '../base-aggregator-provider';
+import type { ProviderFeatures } from '../types';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const FEATURES: ProviderFeatures = {
+  realTimeBalance: true,
+  transactionWebhooks: true,
+  investmentAccounts: true,
+  creditCards: true,
+  loans: true,
+  bnpl: false,
+  crypto: false,
+  internationalBanks: true,
+};
+
+/** A recorded fetch call for assertions. */
+interface RecordedCall {
+  url: string;
+  init?: RequestInit;
+}
+
+/**
+ * Build a mock {@link EdgeTransport} whose `fetch` returns a queued sequence of
+ * responses (or throws a queued error). Records every call for assertions.
+ */
+function makeTransport(responses: Array<Response | Error>): {
+  transport: EdgeTransport;
+  calls: RecordedCall[];
+  getAuthToken: ReturnType<typeof vi.fn>;
+} {
+  const calls: RecordedCall[] = [];
+  const queue = [...responses];
+  const getAuthToken = vi.fn(async () => 'test-token-not-real');
+
+  const transport: EdgeTransport = {
+    baseUrl: 'https://edge.example.test/functions/v1/',
+    getAuthToken,
+    fetch: vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      const next = queue.shift();
+      if (next === undefined) throw new Error('unexpected extra fetch call');
+      if (next instanceof Error) throw next;
+      return next;
+    }),
+  };
+
+  return { transport, calls, getAuthToken };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeProvider(
+  responses: Array<Response | Error> = [],
+  overrides: Partial<AggregatorProviderConfig> = {},
+): {
+  provider: BaseAggregatorProvider;
+  calls: RecordedCall[];
+  getAuthToken: ReturnType<typeof vi.fn>;
+} {
+  const { transport, calls, getAuthToken } = makeTransport(responses);
+  const provider = new BaseAggregatorProvider({
+    id: 'plaid',
+    name: 'Plaid',
+    supportedCountries: ['US', 'CA', 'GB'],
+    features: FEATURES,
+    transport,
+    resolveHouseholdId: async () => 'household-123',
+    ...overrides,
+  });
+  return { provider, calls, getAuthToken };
+}
+
+/** Convenience to construct a provider with a scripted response queue. */
+function withResponses(
+  responses: Array<Response | Error>,
+  overrides: Partial<AggregatorProviderConfig> = {},
+) {
+  return makeProvider(responses, overrides);
+}
+
+// ---------------------------------------------------------------------------
+// Identity & config
+// ---------------------------------------------------------------------------
+
+describe('BaseAggregatorProvider — identity', () => {
+  it('exposes config-driven identity and features', () => {
+    const { provider } = makeProvider();
+    expect(provider.id).toBe('plaid');
+    expect(provider.name).toBe('Plaid');
+    expect(provider.supportedCountries).toEqual(['US', 'CA', 'GB']);
+    expect(provider.features.creditCards).toBe(true);
+    expect(provider.features.bnpl).toBe(false);
+  });
+
+  it('supports thin subclassing', () => {
+    class MxProvider extends BaseAggregatorProvider {
+      constructor(transport: EdgeTransport) {
+        super({
+          id: 'mx',
+          name: 'MX',
+          supportedCountries: ['US'],
+          features: FEATURES,
+          transport,
+        });
+      }
+    }
+    const { transport } = makeTransport([]);
+    const mx = new MxProvider(transport);
+    expect(mx).toBeInstanceOf(BaseAggregatorProvider);
+    expect(mx.id).toBe('mx');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initializeConnection
+// ---------------------------------------------------------------------------
+
+describe('BaseAggregatorProvider — initializeConnection', () => {
+  it('maps a link-token response to a ConnectionSession', async () => {
+    const expiration = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    const { provider, calls, getAuthToken } = withResponses([
+      json({ link_token: 'link-plaid-abc', expiration }),
+    ]);
+
+    const session = await provider.initializeConnection({ metadata: { household_id: 'h-9' } });
+
+    expect(session.sessionId).toBe('link-plaid-abc');
+    expect(session.expiresInSeconds).toBeGreaterThan(0);
+    expect(session.metadata?.linkToken).toBe('link-plaid-abc');
+
+    // Correct endpoint, method, auth header and provider/household body.
+    expect(getAuthToken).toHaveBeenCalledOnce();
+    expect(calls[0].url).toBe(
+      'https://edge.example.test/functions/v1/bank-connection?action=create_link_token',
+    );
+    expect(calls[0].init?.method).toBe('POST');
+    const headers = calls[0].init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-token-not-real');
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({
+      provider: 'plaid',
+      household_id: 'h-9',
+    });
+  });
+
+  it('resolves household id from the configured resolver when absent in metadata', async () => {
+    const { provider, calls } = withResponses([
+      json({ link_token: 'lt', expiration: new Date().toISOString() }),
+    ]);
+    await provider.initializeConnection({});
+    expect(JSON.parse(String(calls[0].init?.body)).household_id).toBe('household-123');
+  });
+
+  it('throws a categorized error when the household id cannot be resolved', async () => {
+    const { provider } = withResponses([], { resolveHouseholdId: undefined });
+    await expect(provider.initializeConnection({})).rejects.toBeInstanceOf(BankingProviderError);
+  });
+
+  it('categorizes a 401 as AUTHENTICATION_EXPIRED', async () => {
+    const { provider } = withResponses([json({ error: 'bad token' }, 401)]);
+    try {
+      await provider.initializeConnection({ metadata: { household_id: 'h' } });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BankingProviderError);
+      expect((err as BankingProviderError).code).toBe('AUTHENTICATION_EXPIRED');
+      expect((err as BankingProviderError).retryable).toBe(false);
+    }
+  });
+
+  it('categorizes a 429 as retryable RATE_LIMITED', async () => {
+    const { provider } = withResponses([json({ error: 'slow down' }, 429)]);
+    try {
+      await provider.initializeConnection({ metadata: { household_id: 'h' } });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BankingProviderError);
+      expect((err as BankingProviderError).code).toBe('RATE_LIMITED');
+      expect((err as BankingProviderError).retryable).toBe(true);
+    }
+  });
+
+  it('categorizes a 500 as retryable PROVIDER_DOWN', async () => {
+    const { provider } = withResponses([json({ error: 'boom' }, 500)]);
+    try {
+      await provider.initializeConnection({ metadata: { household_id: 'h' } });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as BankingProviderError).code).toBe('PROVIDER_DOWN');
+      expect((err as BankingProviderError).retryable).toBe(true);
+    }
+  });
+
+  it('categorizes a thrown transport/network error', async () => {
+    const { provider } = withResponses([new Error('network timeout')]);
+    try {
+      await provider.initializeConnection({ metadata: { household_id: 'h' } });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BankingProviderError);
+      expect((err as BankingProviderError).code).toBe('PROVIDER_DOWN');
+    }
+  });
+
+  it('throws UNKNOWN when the link response is malformed', async () => {
+    const { provider } = withResponses([json({ nope: true })]);
+    try {
+      await provider.initializeConnection({ metadata: { household_id: 'h' } });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as BankingProviderError).code).toBe('UNKNOWN');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeConnection
+// ---------------------------------------------------------------------------
+
+describe('BaseAggregatorProvider — completeConnection', () => {
+  const goodMeta = {
+    household_id: 'h-1',
+    public_token: 'public-abc',
+    institution_id: 'ins_1',
+    institution_name: 'Test Bank',
+  };
+
+  it('exchanges the token and maps to a BankConnection', async () => {
+    const created = '2026-01-01T00:00:00.000Z';
+    const { provider, calls } = withResponses([
+      json(
+        {
+          id: 'conn-1',
+          provider: 'plaid',
+          institution_name: 'Test Bank',
+          status: 'active',
+          created_at: created,
+        },
+        201,
+      ),
+    ]);
+
+    const conn = await provider.completeConnection('session-x', goodMeta);
+
+    expect(conn).toMatchObject({
+      id: 'conn-1',
+      providerId: 'plaid',
+      providerConnectionId: 'conn-1',
+      institutionName: 'Test Bank',
+      status: 'active',
+      createdAt: created,
+    });
+
+    expect(calls[0].url).toBe(
+      'https://edge.example.test/functions/v1/bank-connection?action=exchange_token',
+    );
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({
+      provider: 'plaid',
+      household_id: 'h-1',
+      public_token: 'public-abc',
+      institution_id: 'ins_1',
+      institution_name: 'Test Bank',
+    });
+  });
+
+  it('throws UNKNOWN when institution metadata is missing', async () => {
+    const { provider } = withResponses([]);
+    try {
+      await provider.completeConnection('s', { household_id: 'h', public_token: 'p' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BankingProviderError);
+      expect((err as BankingProviderError).code).toBe('UNKNOWN');
+    }
+  });
+
+  it('categorizes a 403 exchange failure as INVALID_CREDENTIALS', async () => {
+    const { provider } = withResponses([json({ error: 'forbidden' }, 403)]);
+    try {
+      await provider.completeConnection('s', goodMeta);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as BankingProviderError).code).toBe('INVALID_CREDENTIALS');
+    }
+  });
+
+  it('throws UNKNOWN when the exchange response has no id', async () => {
+    const { provider } = withResponses([json({ status: 'active' }, 201)]);
+    try {
+      await provider.completeConnection('s', goodMeta);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as BankingProviderError).code).toBe('UNKNOWN');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshConnection
+// ---------------------------------------------------------------------------
+
+describe('BaseAggregatorProvider — refreshConnection', () => {
+  it('maps a healthy check_health response to success', async () => {
+    const { provider, calls } = withResponses([json({ health_status: 'healthy' })]);
+    const result = await provider.refreshConnection('conn-1');
+    expect(result).toEqual({ connectionId: 'conn-1', success: true });
+    expect(calls[0].url).toBe(
+      'https://edge.example.test/functions/v1/aggregator-health?action=check_health',
+    );
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({
+      connection_id: 'conn-1',
+      provider: 'plaid',
+    });
+  });
+
+  it('reports failure when the health status is an error state', async () => {
+    const { provider } = withResponses([json({ health_status: 'unknown_error' })]);
+    const result = await provider.refreshConnection('conn-1');
+    expect(result.success).toBe(false);
+  });
+
+  it('throws a categorized error on a non-2xx response', async () => {
+    const { provider } = withResponses([json({ error: 'nope' }, 500)]);
+    try {
+      await provider.refreshConnection('conn-1');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as BankingProviderError).code).toBe('PROVIDER_DOWN');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeConnection
+// ---------------------------------------------------------------------------
+
+describe('BaseAggregatorProvider — removeConnection', () => {
+  it('issues a DELETE with the connection id and tolerates an empty 204 body', async () => {
+    const { provider, calls } = withResponses([new Response(null, { status: 204 })]);
+    await expect(provider.removeConnection('conn-9')).resolves.toBeUndefined();
+    expect(calls[0].url).toBe('https://edge.example.test/functions/v1/bank-connection?id=conn-9');
+    expect(calls[0].init?.method).toBe('DELETE');
+  });
+
+  it('categorizes a 404 removal failure', async () => {
+    const { provider } = withResponses([json({ error: 'not found' }, 404)]);
+    try {
+      await provider.removeConnection('conn-9');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BankingProviderError);
+      expect((err as BankingProviderError).code).toBe('UNKNOWN');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getConnectionStatus
+// ---------------------------------------------------------------------------
+
+describe('BaseAggregatorProvider — getConnectionStatus', () => {
+  it('maps a matching health record to ConnectionStatus', async () => {
+    const { provider, calls } = withResponses([
+      json({
+        connections: [
+          {
+            id: 'conn-1',
+            connection_status: 'active',
+            health_status: 'healthy',
+            last_synced_at: '2026-01-02T00:00:00.000Z',
+          },
+        ],
+      }),
+    ]);
+
+    const status = await provider.getConnectionStatus('conn-1');
+    expect(status.status).toBe('active');
+    expect(status.lastSuccessfulSync).toBe('2026-01-02T00:00:00.000Z');
+    expect(calls[0].url).toBe(
+      'https://edge.example.test/functions/v1/aggregator-health?action=health&household_id=household-123',
+    );
+    expect(calls[0].init?.method).toBe('GET');
+  });
+
+  it('maps an auth-expired health record to an error status with a code', async () => {
+    const { provider } = withResponses([
+      json({ connections: [{ id: 'conn-1', health_status: 'auth_expired' }] }),
+    ]);
+    const status = await provider.getConnectionStatus('conn-1');
+    expect(status.status).toBe('error');
+    expect(status.errorCode).toBe('AUTHENTICATION_EXPIRED');
+  });
+
+  it('throws UNKNOWN when the connection is not in the health list', async () => {
+    const { provider } = withResponses([json({ connections: [] })]);
+    try {
+      await provider.getConnectionStatus('conn-missing');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as BankingProviderError).code).toBe('UNKNOWN');
+    }
+  });
+
+  it('categorizes a 403 health failure', async () => {
+    const { provider } = withResponses([json({ error: 'denied' }, 403)]);
+    try {
+      await provider.getConnectionStatus('conn-1');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as BankingProviderError).code).toBe('INVALID_CREDENTIALS');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getProviderHealth
+// ---------------------------------------------------------------------------
+
+describe('BaseAggregatorProvider — getProviderHealth', () => {
+  it('maps the matching provider directory entry to ProviderHealth', async () => {
+    const { provider } = withResponses([
+      json({
+        providers: [
+          {
+            name: 'plaid',
+            display_name: 'Plaid',
+            status: 'healthy',
+            health_score: 98,
+            is_enabled: true,
+            last_health_check: '2026-01-03T00:00:00.000Z',
+          },
+          { name: 'mx', status: 'down', is_enabled: true },
+        ],
+      }),
+    ]);
+
+    const health = await provider.getProviderHealth();
+    expect(health.isHealthy).toBe(true);
+    expect(health.message).toBe('Plaid');
+    expect(health.checkedAt).toBe('2026-01-03T00:00:00.000Z');
+  });
+
+  it('reports unhealthy when the provider is disabled', async () => {
+    const { provider } = withResponses([
+      json({ providers: [{ name: 'plaid', status: 'healthy', is_enabled: false }] }),
+    ]);
+    const health = await provider.getProviderHealth();
+    expect(health.isHealthy).toBe(false);
+  });
+
+  it('reports unhealthy when the provider is not listed', async () => {
+    const { provider } = withResponses([json({ providers: [] })]);
+    const health = await provider.getProviderHealth();
+    expect(health.isHealthy).toBe(false);
+    expect(health.message).toContain('not listed');
+  });
+
+  it('categorizes a 500 provider-health failure', async () => {
+    const { provider } = withResponses([json({ error: 'boom' }, 500)]);
+    try {
+      await provider.getProviderHealth();
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as BankingProviderError).code).toBe('PROVIDER_DOWN');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Data-read seam
+// ---------------------------------------------------------------------------
+
+describe('BaseAggregatorProvider — data reads', () => {
+  const range = { from: '2026-01-01', to: '2026-01-31' };
+
+  it('throws a categorized error for reads when no data-source is injected', async () => {
+    const { provider } = makeProvider();
+
+    for (const call of [
+      () => provider.getAccounts('conn-1'),
+      () => provider.getTransactions('conn-1', range),
+      () => provider.getBalances('conn-1'),
+    ]) {
+      try {
+        await call();
+        throw new Error('expected throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(BankingProviderError);
+        expect((err as BankingProviderError).code).toBe('UNKNOWN');
+        expect((err as BankingProviderError).message).toMatch(/synced local repositories/i);
+      }
+    }
+  });
+
+  it('delegates reads to the injected synced data-source without any fetch', async () => {
+    const dataSource: SyncedBankDataSource = {
+      getAccounts: vi.fn(async () => [
+        {
+          id: 'a1',
+          providerAccountId: 'pa1',
+          name: 'Checking',
+          type: 'checking' as const,
+          currency: 'USD',
+          institution: 'Test Bank',
+        },
+      ]),
+      getTransactions: vi.fn(async () => []),
+      getBalances: vi.fn(async () => [
+        { accountId: 'a1', currentCents: 12345, currency: 'USD', asOf: '2026-01-01T00:00:00Z' },
+      ]),
+    };
+
+    const { transport, calls } = makeTransport([]);
+    const provider = new BaseAggregatorProvider({
+      id: 'plaid',
+      name: 'Plaid',
+      supportedCountries: ['US'],
+      features: FEATURES,
+      transport,
+      dataSource,
+    });
+
+    const accounts = await provider.getAccounts('conn-1');
+    const txs = await provider.getTransactions('conn-1', range);
+    const balances = await provider.getBalances('conn-1');
+
+    expect(accounts).toHaveLength(1);
+    expect(txs).toEqual([]);
+    expect(balances[0].currentCents).toBe(12345);
+
+    expect(dataSource.getTransactions).toHaveBeenCalledWith('conn-1', range);
+    // No edge/network calls were made for reads.
+    expect(calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BankingProviderError re-categorization compatibility
+// ---------------------------------------------------------------------------
+
+describe('BankingProviderError', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is a real Error whose message survives for upstream re-categorization', async () => {
+    const { provider } = withResponses([json({ error: 'token has expired' }, 401)]);
+    try {
+      await provider.initializeConnection({ metadata: { household_id: 'h' } });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(BankingProviderError);
+      expect((err as Error).message.toLowerCase()).toContain('authentication');
+    }
+  });
+});

--- a/apps/web/src/lib/banking/base-aggregator-provider.ts
+++ b/apps/web/src/lib/banking/base-aggregator-provider.ts
@@ -1,0 +1,603 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Reusable base implementation for edge-backed banking aggregators.
+ *
+ * Real aggregators (Plaid, MX, TrueLayer, Finicity, …) become **thin
+ * subclasses** of {@link BaseAggregatorProvider}: they supply their identity,
+ * supported countries, and capability flags via config, and inherit the entire
+ * connection lifecycle. All privileged provider I/O is routed through the
+ * project's Supabase Edge Functions (`bank-connection`, `aggregator-health`)
+ * so that provider API keys and access tokens **never** touch the client.
+ *
+ * Two seams are dependency-injected to keep this class fully unit-testable and
+ * free of hidden globals:
+ *
+ * 1. {@link EdgeTransport} — a `fetch` implementation, an async auth-token
+ *    getter, and the edge base URL. There is **no** hardcoded global `fetch`.
+ * 2. {@link SyncedBankDataSource} — the local, PowerSync-synced read path for
+ *    accounts / transactions / balances. In this app those reads come from
+ *    synced SQLite repositories, **not** from per-provider network fetches, so
+ *    the read methods deliberately throw a categorized error when no
+ *    data-source is injected instead of faking a network call.
+ *
+ * @module banking/base-aggregator-provider
+ */
+
+import { categorizeError } from './connection-manager';
+import type {
+  AccountBalance,
+  BankAccount,
+  BankConnection,
+  BankConnectionProvider,
+  BankTransaction,
+  ConnectionConfig,
+  ConnectionError,
+  ConnectionErrorCode,
+  ConnectionSession,
+  ConnectionStatus,
+  ConnectionStatusType,
+  DateRange,
+  ProviderFeatures,
+  ProviderHealth,
+  RefreshResult,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Injected dependencies
+// ---------------------------------------------------------------------------
+
+/**
+ * Transport seam for reaching the Supabase Edge Functions.
+ *
+ * Injecting the `fetch` implementation and auth-token getter keeps the base
+ * provider free of hidden global state and trivially mockable in unit tests.
+ */
+export interface EdgeTransport {
+  /** Base URL for the edge functions (e.g. `https://<ref>.functions.supabase.co`). */
+  readonly baseUrl: string;
+  /** `fetch`-compatible implementation used for every edge request. */
+  fetch: (input: string, init?: RequestInit) => Promise<Response>;
+  /** Resolve the current user's bearer token for the `Authorization` header. */
+  getAuthToken: () => Promise<string>;
+}
+
+/**
+ * Local read path for normalized banking data.
+ *
+ * In this app, accounts / transactions / balances are served from
+ * PowerSync-synced local SQLite repositories rather than per-provider network
+ * calls. A concrete implementation is injected via config; when absent, the
+ * base provider's read methods throw a clear categorized error.
+ */
+export interface SyncedBankDataSource {
+  /** Read all accounts for a connection from the synced local store. */
+  getAccounts(connectionId: string): Promise<BankAccount[]>;
+  /** Read transactions for a connection within a date range from the synced local store. */
+  getTransactions(connectionId: string, dateRange: DateRange): Promise<BankTransaction[]>;
+  /** Read current balances for a connection from the synced local store. */
+  getBalances(connectionId: string): Promise<AccountBalance[]>;
+}
+
+/**
+ * Configuration for a {@link BaseAggregatorProvider} instance.
+ *
+ * The identity/capability fields drive the provider contract, while the
+ * injected `transport`, optional `dataSource`, and optional
+ * `resolveHouseholdId` supply the runtime seams.
+ */
+export interface AggregatorProviderConfig {
+  /** Unique provider identifier sent as `provider` to the edge functions. */
+  id: string;
+  /** Human-readable display name. */
+  name: string;
+  /** ISO 3166-1 alpha-2 country codes this provider supports. */
+  supportedCountries: readonly string[];
+  /** Capability flags for this provider. */
+  features: ProviderFeatures;
+  /** Transport used to reach the edge functions. */
+  transport: EdgeTransport;
+  /** Optional synced local read path for accounts/transactions/balances. */
+  dataSource?: SyncedBankDataSource;
+  /**
+   * Optional resolver for the household id used to scope edge requests when it
+   * is not supplied inline via connection metadata.
+   */
+  resolveHouseholdId?: () => Promise<string> | string;
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/**
+ * Error thrown by {@link BaseAggregatorProvider} that carries a structured,
+ * categorized {@link ConnectionError} alongside a standard `Error` message.
+ *
+ * Being a real `Error` preserves the message for any upstream re-categorization
+ * (e.g. {@link ConnectionManager}), while `connectionError` exposes the
+ * programmatic {@link ConnectionErrorCode} and retryability.
+ */
+export class BankingProviderError extends Error {
+  /** The structured, categorized error details. */
+  readonly connectionError: ConnectionError;
+
+  /**
+   * @param connectionError - The categorized error to wrap.
+   */
+  constructor(connectionError: ConnectionError) {
+    super(connectionError.message);
+    this.name = 'BankingProviderError';
+    this.connectionError = connectionError;
+  }
+
+  /** The categorized error code. */
+  get code(): ConnectionErrorCode {
+    return this.connectionError.code;
+  }
+
+  /** Whether the failed operation may be retried. */
+  get retryable(): boolean {
+    return this.connectionError.retryable;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small typed helpers (avoid `any`)
+// ---------------------------------------------------------------------------
+
+/** Narrow an unknown value to a plain record, or an empty record. @internal */
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+/** Return the value if it is a string, else `undefined`. @internal */
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/** Return the value if it is a finite number, else `undefined`. @internal */
+function num(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Produce a message keyword for an HTTP status so {@link categorizeError} can
+ * map it onto a {@link ConnectionErrorCode} using the shared heuristic.
+ * @internal
+ */
+function statusKeyword(status: number): string {
+  if (status === 401) return 'authentication expired';
+  if (status === 403) return 'invalid credentials';
+  if (status === 429) return 'rate limit exceeded';
+  if (status >= 500) return 'provider unavailable';
+  return 'request failed';
+}
+
+/** Map an edge connection-status string onto the normalized status type. @internal */
+function mapConnectionStatus(raw: string | undefined): ConnectionStatusType {
+  switch (raw) {
+    case 'active':
+    case 'healthy':
+      return 'active';
+    case 'disconnected':
+      return 'disconnected';
+    case 'error':
+      return 'error';
+    case 'pending':
+      return 'pending';
+    case 'needs_reauth':
+    case 'stale':
+    case 'degraded':
+      return 'degraded';
+    default:
+      return 'pending';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// BaseAggregatorProvider
+// ---------------------------------------------------------------------------
+
+/**
+ * Config-driven, edge-backed base class implementing
+ * {@link BankConnectionProvider}.
+ *
+ * ```ts
+ * class PlaidProvider extends BaseAggregatorProvider {
+ *   constructor(transport: EdgeTransport, dataSource: SyncedBankDataSource) {
+ *     super({
+ *       id: 'plaid',
+ *       name: 'Plaid',
+ *       supportedCountries: ['US', 'CA', 'GB'],
+ *       features: { ...  },
+ *       transport,
+ *       dataSource,
+ *     });
+ *   }
+ * }
+ * ```
+ */
+export class BaseAggregatorProvider implements BankConnectionProvider {
+  readonly id: string;
+  readonly name: string;
+  readonly supportedCountries: readonly string[];
+  readonly features: ProviderFeatures;
+
+  /** @internal */
+  protected readonly config: AggregatorProviderConfig;
+
+  /**
+   * @param config - Identity/capability fields plus the injected transport,
+   *   optional synced data-source, and optional household-id resolver.
+   */
+  constructor(config: AggregatorProviderConfig) {
+    this.config = config;
+    this.id = config.id;
+    this.name = config.name;
+    this.supportedCountries = config.supportedCountries;
+    this.features = config.features;
+  }
+
+  // -- Connection lifecycle --------------------------------------------------
+
+  /**
+   * Begin a new connection by requesting a link token from the
+   * `bank-connection?action=create_link_token` edge endpoint.
+   */
+  async initializeConnection(config: ConnectionConfig): Promise<ConnectionSession> {
+    const householdId = await this.householdIdFrom(config?.metadata);
+
+    const body = await this.request('bank-connection?action=create_link_token', {
+      method: 'POST',
+      body: JSON.stringify({ provider: this.id, household_id: householdId }),
+    });
+
+    const rec = asRecord(body);
+    const linkToken = str(rec.link_token);
+    if (!linkToken) {
+      throw new BankingProviderError({
+        code: 'UNKNOWN',
+        message: 'The link-creation response was malformed (no link identifier was returned).',
+        retryable: false,
+        providerError: body,
+      });
+    }
+
+    const expiration = str(rec.expiration);
+    const expiresAt = expiration ? Date.parse(expiration) : NaN;
+    const expiresInSeconds = Number.isNaN(expiresAt)
+      ? undefined
+      : Math.max(0, Math.floor((expiresAt - Date.now()) / 1000));
+
+    return {
+      sessionId: linkToken,
+      expiresInSeconds,
+      metadata: { linkToken, expiration },
+    };
+  }
+
+  /**
+   * Finalize a connection by exchanging the public token via
+   * `bank-connection?action=exchange_token`.
+   *
+   * `metadata` must carry the provider `publicToken`/`public_token` (from the
+   * client link SDK) plus the `institutionId`/`institutionName`. The household
+   * id may be supplied in metadata or resolved via `resolveHouseholdId`.
+   */
+  async completeConnection(
+    sessionId: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<BankConnection> {
+    const meta = asRecord(metadata);
+    const householdId = await this.householdIdFrom(metadata);
+    const publicToken = str(meta.publicToken) ?? str(meta.public_token) ?? sessionId;
+    const institutionId = str(meta.institutionId) ?? str(meta.institution_id);
+    const institutionName = str(meta.institutionName) ?? str(meta.institution_name);
+
+    if (!institutionId || !institutionName) {
+      throw new BankingProviderError({
+        code: 'UNKNOWN',
+        message:
+          'completeConnection requires institutionId and institutionName in metadata to finalize the link.',
+        retryable: false,
+      });
+    }
+
+    const body = await this.request('bank-connection?action=exchange_token', {
+      method: 'POST',
+      body: JSON.stringify({
+        provider: this.id,
+        household_id: householdId,
+        public_token: publicToken,
+        institution_id: institutionId,
+        institution_name: institutionName,
+      }),
+    });
+
+    const rec = asRecord(body);
+    const id = str(rec.id);
+    if (!id) {
+      throw new BankingProviderError({
+        code: 'UNKNOWN',
+        message: 'The token-exchange response was malformed (no connection id was returned).',
+        retryable: false,
+        providerError: body,
+      });
+    }
+
+    return {
+      id,
+      providerId: this.id,
+      providerConnectionId: id,
+      institutionName: str(rec.institution_name) ?? institutionName,
+      status: mapConnectionStatus(str(rec.status)),
+      createdAt: str(rec.created_at) ?? new Date().toISOString(),
+      metadata: { ...meta },
+    };
+  }
+
+  /**
+   * Trigger a server-side health check / re-sync for a connection via
+   * `aggregator-health?action=check_health`.
+   *
+   * Because transaction data flows to the client through PowerSync rather than
+   * a per-provider fetch, "refresh" here nudges the backend to re-evaluate the
+   * connection's health; `newTransactions` is intentionally omitted since new
+   * rows arrive via sync. Throws a {@link BankingProviderError} on failure so
+   * the {@link ConnectionManager} retry policy can act on it.
+   */
+  async refreshConnection(connectionId: string): Promise<RefreshResult> {
+    const body = await this.request('aggregator-health?action=check_health', {
+      method: 'POST',
+      body: JSON.stringify({ connection_id: connectionId, provider: this.id }),
+    });
+
+    const rec = asRecord(body);
+    const health = str(rec.health_status);
+    const success = health !== 'unknown_error' && health !== 'auth_expired';
+
+    return { connectionId, success };
+  }
+
+  /**
+   * Permanently remove a connection via `DELETE bank-connection?id=…`, which
+   * revokes provider-side access and soft-deletes the record server-side.
+   */
+  async removeConnection(connectionId: string): Promise<void> {
+    await this.request(`bank-connection?id=${encodeURIComponent(connectionId)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  // -- Data access (synced local read path) ----------------------------------
+
+  /** Read accounts from the injected synced data-source (never a network fetch). */
+  async getAccounts(connectionId: string): Promise<BankAccount[]> {
+    return this.readFromDataSource('getAccounts', (ds) => ds.getAccounts(connectionId));
+  }
+
+  /** Read transactions from the injected synced data-source (never a network fetch). */
+  async getTransactions(connectionId: string, dateRange: DateRange): Promise<BankTransaction[]> {
+    return this.readFromDataSource('getTransactions', (ds) =>
+      ds.getTransactions(connectionId, dateRange),
+    );
+  }
+
+  /** Read balances from the injected synced data-source (never a network fetch). */
+  async getBalances(connectionId: string): Promise<AccountBalance[]> {
+    return this.readFromDataSource('getBalances', (ds) => ds.getBalances(connectionId));
+  }
+
+  // -- Status ----------------------------------------------------------------
+
+  /**
+   * Fetch a single connection's health from
+   * `aggregator-health?action=health` and map it onto {@link ConnectionStatus}.
+   */
+  async getConnectionStatus(connectionId: string): Promise<ConnectionStatus> {
+    const householdId = await this.householdIdFrom();
+
+    const body = await this.request(
+      `aggregator-health?action=health&household_id=${encodeURIComponent(householdId)}`,
+      { method: 'GET' },
+    );
+
+    const list = asRecord(body).connections;
+    const connections = Array.isArray(list) ? list : [];
+    const match = connections.map(asRecord).find((c) => str(c.id) === connectionId);
+
+    if (!match) {
+      throw new BankingProviderError({
+        code: 'UNKNOWN',
+        message: `No health record was found for connection ${connectionId}.`,
+        retryable: false,
+      });
+    }
+
+    const health = str(match.health_status);
+    const lastSuccessfulSync = str(match.last_synced_at);
+
+    let status: ConnectionStatusType;
+    let errorCode: ConnectionErrorCode | undefined;
+    let message: string | undefined = str(match.error_code);
+
+    switch (health) {
+      case 'healthy':
+        status = 'active';
+        break;
+      case 'stale':
+        status = 'degraded';
+        break;
+      case 'auth_expired':
+        status = 'error';
+        errorCode = 'AUTHENTICATION_EXPIRED';
+        break;
+      case 'unknown_error':
+        status = 'error';
+        errorCode = 'UNKNOWN';
+        break;
+      default:
+        status = mapConnectionStatus(str(match.connection_status));
+    }
+
+    if (!message) {
+      message = `Connection health: ${health ?? str(match.connection_status) ?? 'unknown'}.`;
+    }
+
+    return { status, message, lastSuccessfulSync, errorCode };
+  }
+
+  /**
+   * Fetch this provider's health from `aggregator-health?action=providers` and
+   * map the matching directory entry onto {@link ProviderHealth}.
+   */
+  async getProviderHealth(): Promise<ProviderHealth> {
+    const body = await this.request('aggregator-health?action=providers', { method: 'GET' });
+
+    const list = asRecord(body).providers;
+    const providers = Array.isArray(list) ? list : [];
+    const match = providers.map(asRecord).find((p) => str(p.name) === this.id);
+
+    const checkedAt = new Date().toISOString();
+    if (!match) {
+      return {
+        isHealthy: false,
+        message: `Provider ${this.name} is not listed in the aggregator directory.`,
+        checkedAt,
+      };
+    }
+
+    const status = str(match.status);
+    const score = num(match.health_score);
+    const enabled = match.is_enabled !== false;
+    const isHealthy =
+      enabled && (status === 'healthy' || status === 'operational' || (score ?? 0) >= 50);
+
+    return {
+      isHealthy,
+      latencyMs: num(match.latency_ms),
+      message: str(match.display_name) ?? status,
+      checkedAt: str(match.last_health_check) ?? checkedAt,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Perform an authenticated edge request and return the parsed JSON body.
+   *
+   * On a thrown transport error or any non-2xx response, a categorized
+   * {@link BankingProviderError} is raised (reusing {@link categorizeError}).
+   * @internal
+   */
+  private async request(functionPath: string, init: RequestInit): Promise<unknown> {
+    const { transport } = this.config;
+
+    let response: Response;
+    try {
+      const token = await transport.getAuthToken();
+      const base = transport.baseUrl.replace(/\/+$/, '');
+      const url = `${base}/${functionPath}`;
+      response = await transport.fetch(url, {
+        ...init,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+          ...(init.headers ?? {}),
+        },
+      });
+    } catch (err) {
+      throw new BankingProviderError(categorizeError(err));
+    }
+
+    if (!response.ok) {
+      const errorBody = await this.safeParse(response);
+      throw new BankingProviderError(this.categorizeStatus(response.status, errorBody));
+    }
+
+    return this.safeParse(response);
+  }
+
+  /**
+   * Categorize an HTTP error status into a {@link ConnectionError}, reusing the
+   * shared {@link categorizeError} keyword heuristic.
+   * @internal
+   */
+  private categorizeStatus(status: number, body: unknown): ConnectionError {
+    const rec = asRecord(body);
+    const serverMessage =
+      str(rec.error) ?? str(rec.message) ?? (typeof body === 'string' ? body : undefined);
+    const keyword = statusKeyword(status);
+    const composed = `${keyword} (HTTP ${status})${serverMessage ? `: ${serverMessage}` : ''}`;
+    const categorized = categorizeError(new Error(composed));
+    return { ...categorized, providerError: body };
+  }
+
+  /**
+   * Read the response body once and parse it as JSON, falling back to the raw
+   * text (or `undefined` for empty bodies, e.g. a 204).
+   * @internal
+   */
+  private async safeParse(response: Response): Promise<unknown> {
+    try {
+      const text = await response.text();
+      if (!text) return undefined;
+      try {
+        return JSON.parse(text);
+      } catch {
+        return text;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Read from the injected {@link SyncedBankDataSource}, or throw a clear
+   * categorized error explaining that reads flow through synced repositories.
+   * @internal
+   */
+  private async readFromDataSource<T>(
+    op: string,
+    read: (dataSource: SyncedBankDataSource) => Promise<T>,
+  ): Promise<T> {
+    const { dataSource } = this.config;
+    if (!dataSource) {
+      throw new BankingProviderError({
+        code: 'UNKNOWN',
+        message:
+          `${op} is not served by the aggregator API: accounts, transactions, and ` +
+          'balances are read from PowerSync-synced local repositories. Inject a dataSource ' +
+          'to enable local reads.',
+        retryable: false,
+      });
+    }
+    return read(dataSource);
+  }
+
+  /**
+   * Resolve the household id from inline metadata or the configured resolver.
+   * @internal
+   */
+  private async householdIdFrom(metadata?: Record<string, unknown>): Promise<string> {
+    const rec = asRecord(metadata);
+    const inline = str(rec.householdId) ?? str(rec.household_id);
+    if (inline) return inline;
+
+    if (this.config.resolveHouseholdId) {
+      const resolved = await this.config.resolveHouseholdId();
+      if (resolved) return resolved;
+    }
+
+    throw new BankingProviderError({
+      code: 'UNKNOWN',
+      message:
+        'A household id is required to manage this bank connection, but none was supplied in ' +
+        'metadata or resolvable via resolveHouseholdId.',
+      retryable: false,
+    });
+  }
+}

--- a/apps/web/src/lib/banking/index.ts
+++ b/apps/web/src/lib/banking/index.ts
@@ -80,3 +80,11 @@ export { registerDefaultProviders } from './register-default-providers';
 // Mock provider
 export { MockProvider } from './mock-provider';
 export type { MockProviderConfig } from './mock-provider';
+
+// Base aggregator provider (edge-backed base for real aggregators — #3849)
+export { BaseAggregatorProvider, BankingProviderError } from './base-aggregator-provider';
+export type {
+  AggregatorProviderConfig,
+  EdgeTransport,
+  SyncedBankDataSource,
+} from './base-aggregator-provider';


### PR DESCRIPTION
## Summary

Phase 2 of epic #3846: add a reusable, config-driven BaseAggregatorProvider in `apps/web/src/lib/banking/` so real aggregators (Plaid / MX / TrueLayer / Finicity) become **thin subclasses**. No concrete provider is implemented yet — that follows once the backend lands.

## Changes

- **`base-aggregator-provider.ts`** — `BaseAggregatorProvider` implementing the `BankConnectionProvider` contract:
  - Config-driven `id` / `name` / `supportedCountries` / `features`.
  - Dependency-injected `EdgeTransport` (`fetch` impl + async auth-token getter + edge base URL). **No hardcoded global fetch** — fully unit-testable with a mock transport.
  - Generic connection lifecycle over the edge functions with `provider: this.id`:
    - `initializeConnection` → `bank-connection?action=create_link_token`
    - `completeConnection` → `bank-connection?action=exchange_token`
    - `removeConnection` → `DELETE bank-connection?id=…`
    - `refreshConnection` → `aggregator-health?action=check_health`
    - `getConnectionStatus` / `getProviderHealth` → `aggregator-health`
  - Responses mapped to the normalized types in `types.ts`. Any non-2xx or thrown error becomes a categorized `ConnectionError` (via `BankingProviderError`, reusing `categorizeError` from `connection-manager.ts`; HTTP status → code mapping for 401/403/429/5xx).
  - **Data reads seam**: `getAccounts` / `getTransactions` / `getBalances` come from PowerSync-synced local SQLite, not per-provider fetch. Modeled explicitly via an optional injected `SyncedBankDataSource`; if none is provided these methods throw a clear categorized error instead of faking network fetches.
- **`index.ts`** — barrel exports for `BaseAggregatorProvider`, `BankingProviderError`, and the `AggregatorProviderConfig` / `EdgeTransport` / `SyncedBankDataSource` types.
- **`__tests__/base-aggregator-provider.test.ts`** — 30 vitest cases with a mock `EdgeTransport` covering success mapping and error categorization for every lifecycle method, plus the data-read seam throw and subclassing.

Edge request/response shapes were matched against `services/api/supabase/functions/bank-connection/index.ts` and `aggregator-health/index.ts`.

## Issues

Closes #3849

## Testing

- [x] `npx vitest run src/lib/banking` — 151 passed (30 new)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npx eslint apps/web/src/lib/banking --max-warnings 0` — clean

## Notes

- No concrete `PlaidProvider` yet (follows once the backend lands).
- No secrets touched; provider keys/tokens stay server-side behind the edge functions.