### PR TITLE
feat(api): real Plaid integration + webhook ingestion + provider seed (#3848)

### DIFF
--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -62,11 +62,22 @@ POWERSYNC_PUBLIC_KEY=YOUR_POWERSYNC_PUBLIC_KEY_HERE
 
 # ---------------------------------------------------------------------------
 # Bank Connection API (Plaid / MX)
+#
+# Plaid is the reference aggregator implementation (#3848). PLAID_ENVIRONMENT
+# selects the API host: sandbox | development | production. PLAID_WEBHOOK_URL
+# is the public URL Plaid posts async updates to (the bank-webhook function).
+# BANK_ENCRYPTION_KEY must be a 64-char hex string (32 bytes) used for
+# AES-256-GCM encryption of stored access tokens.
+#
+# NOTE: Plaid webhooks are verified via the signed JWT (JWS) in the
+# Plaid-Verification header using PLAID_CLIENT_ID/PLAID_SECRET — there is no
+# separate Plaid webhook shared secret. MX_WEBHOOK_SECRET is the HMAC secret
+# for MX webhook verification.
 # ---------------------------------------------------------------------------
 PLAID_CLIENT_ID=YOUR_PLAID_CLIENT_ID_HERE
 PLAID_SECRET=YOUR_PLAID_SECRET_HERE
 PLAID_ENVIRONMENT=sandbox
-PLAID_WEBHOOK_SECRET=YOUR_PLAID_WEBHOOK_SECRET_HERE
+PLAID_WEBHOOK_URL=https://YOUR_PROJECT_REF.functions.supabase.co/bank-webhook?provider=plaid
 MX_CLIENT_ID=YOUR_MX_CLIENT_ID_HERE
 MX_API_KEY=YOUR_MX_API_KEY_HERE
 MX_WEBHOOK_SECRET=YOUR_MX_WEBHOOK_SECRET_HERE

--- a/services/api/supabase/functions/_shared/bank-crypto.test.ts
+++ b/services/api/supabase/functions/_shared/bank-crypto.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for bank access-token encryption (#3848).
+ *
+ * Verifies AES-256-GCM round-trips, that ciphertext never leaks the
+ * plaintext, and that decryption fails with the wrong key.
+ */
+
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+  assertStringIncludes,
+} from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+
+import { decryptToken, encryptToken, TOKEN_ENVELOPE_PREFIX } from './bank-crypto.ts';
+
+const HEX_KEY = '0'.repeat(63) + '1'; // 64 hex chars = 32 bytes
+const PASSPHRASE_KEY = 'a-non-hex-passphrase-key-material';
+
+Deno.test('encrypt then decrypt returns the original token (hex key)', async () => {
+  const token = 'access-sandbox-1234567890';
+  const envelope = await encryptToken(token, HEX_KEY);
+  const decrypted = await decryptToken(envelope, HEX_KEY);
+  assertEquals(decrypted, token);
+});
+
+Deno.test('encrypt then decrypt returns the original token (passphrase key)', async () => {
+  const token = 'access-development-abcdef';
+  const envelope = await encryptToken(token, PASSPHRASE_KEY);
+  assertEquals(await decryptToken(envelope, PASSPHRASE_KEY), token);
+});
+
+Deno.test('ciphertext uses the versioned envelope format', async () => {
+  const envelope = await encryptToken('secret-value', HEX_KEY);
+  const parts = envelope.split(':');
+  assertEquals(parts.length, 3);
+  assertEquals(parts[0], TOKEN_ENVELOPE_PREFIX);
+});
+
+Deno.test('ciphertext never contains the plaintext token', async () => {
+  const token = 'super-sensitive-access-token';
+  const envelope = await encryptToken(token, HEX_KEY);
+  assertEquals(envelope.includes(token), false);
+});
+
+Deno.test('a fresh IV is used for every encryption', async () => {
+  const token = 'repeatable-input';
+  const a = await encryptToken(token, HEX_KEY);
+  const b = await encryptToken(token, HEX_KEY);
+  assertNotEquals(a, b);
+});
+
+Deno.test('decryption fails with the wrong key', async () => {
+  const envelope = await encryptToken('token', HEX_KEY);
+  await assertRejects(() => decryptToken(envelope, 'f'.repeat(64)));
+});
+
+Deno.test('decryption rejects a malformed envelope', async () => {
+  await assertRejects(() => decryptToken('not-an-envelope', HEX_KEY));
+});
+
+Deno.test('empty key material is rejected', async () => {
+  await assertRejects(() => encryptToken('token', ''), Error, 'Encryption key not configured');
+});
+
+Deno.test('tampered ciphertext fails authentication', async () => {
+  const envelope = await encryptToken('token', HEX_KEY);
+  const parts = envelope.split(':');
+  // Flip a character in the ciphertext segment.
+  const tamperedCt = parts[2].startsWith('A') ? 'B' + parts[2].slice(1) : 'A' + parts[2].slice(1);
+  const tampered = `${parts[0]}:${parts[1]}:${tamperedCt}`;
+  await assertRejects(() => decryptToken(tampered, HEX_KEY));
+});
+
+Deno.test('envelope prefix documents the algorithm', () => {
+  assertStringIncludes(TOKEN_ENVELOPE_PREFIX, 'aes256gcm');
+  assert(TOKEN_ENVELOPE_PREFIX.length > 0);
+});

--- a/services/api/supabase/functions/_shared/bank-crypto.ts
+++ b/services/api/supabase/functions/_shared/bank-crypto.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Bank access-token encryption helpers (#3848).
+ *
+ * Provides authenticated encryption (AES-256-GCM) for aggregator access
+ * tokens (Plaid/MX) before they are written to `bank_connections`. Uses the
+ * Web Crypto API (crypto.subtle) available in the Deno runtime — NOT Node's
+ * `crypto` module.
+ *
+ * Security:
+ *   - AES-256-GCM provides confidentiality AND integrity (auth tag).
+ *   - A fresh random 96-bit IV is generated for every encryption.
+ *   - The key is derived from BANK_ENCRYPTION_KEY: a 64-char hex string is
+ *     decoded to 32 raw bytes; any other value is hashed with SHA-256 to
+ *     produce a stable 32-byte key.
+ *   - NEVER log the plaintext token, the ciphertext, or the key material.
+ *
+ * Serialized format:  `aes256gcm:<base64url(iv)>:<base64url(ciphertext+tag)>`
+ */
+
+/** Prefix identifying the ciphertext envelope version/algorithm. */
+export const TOKEN_ENVELOPE_PREFIX = 'aes256gcm';
+
+/** Length of the AES-GCM initialization vector in bytes (96 bits). */
+const IV_LENGTH = 12;
+
+// ---------------------------------------------------------------------------
+// base64url helpers (no padding)
+// ---------------------------------------------------------------------------
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// ---------------------------------------------------------------------------
+// Key derivation
+// ---------------------------------------------------------------------------
+
+const HEX_64_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Derive a 32-byte AES-256 key from the configured key material.
+ *
+ * Accepts either a 64-character hex string (decoded directly to 32 bytes)
+ * or any other string (hashed with SHA-256 to a deterministic 32 bytes).
+ */
+async function deriveKeyBytes(keyMaterial: string): Promise<Uint8Array> {
+  if (HEX_64_PATTERN.test(keyMaterial)) {
+    return hexToBytes(keyMaterial);
+  }
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(keyMaterial));
+  return new Uint8Array(digest);
+}
+
+async function importAesKey(keyMaterial: string, usage: KeyUsage): Promise<CryptoKey> {
+  const keyBytes = await deriveKeyBytes(keyMaterial);
+  return crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM' }, false, [usage]);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Encrypt a plaintext access token for storage.
+ *
+ * @param plaintext The raw provider access token. NEVER logged.
+ * @param keyMaterial The BANK_ENCRYPTION_KEY value.
+ * @returns The serialized ciphertext envelope (safe to persist).
+ */
+export async function encryptToken(plaintext: string, keyMaterial: string): Promise<string> {
+  if (!keyMaterial) {
+    throw new Error('Encryption key not configured');
+  }
+  const key = await importAesKey(keyMaterial, 'encrypt');
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  const data = new TextEncoder().encode(plaintext);
+
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+
+  return [
+    TOKEN_ENVELOPE_PREFIX,
+    bytesToBase64Url(iv),
+    bytesToBase64Url(new Uint8Array(ciphertext)),
+  ].join(':');
+}
+
+/**
+ * Decrypt a serialized ciphertext envelope back to the plaintext token.
+ *
+ * @param envelope The serialized value produced by {@link encryptToken}.
+ * @param keyMaterial The BANK_ENCRYPTION_KEY value.
+ * @returns The plaintext token. NEVER logged.
+ */
+export async function decryptToken(envelope: string, keyMaterial: string): Promise<string> {
+  if (!keyMaterial) {
+    throw new Error('Encryption key not configured');
+  }
+  const parts = envelope.split(':');
+  if (parts.length !== 3 || parts[0] !== TOKEN_ENVELOPE_PREFIX) {
+    throw new Error('Malformed ciphertext envelope');
+  }
+
+  const key = await importAesKey(keyMaterial, 'decrypt');
+  const iv = base64UrlToBytes(parts[1]);
+  const ciphertext = base64UrlToBytes(parts[2]);
+
+  const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+  return new TextDecoder().decode(plaintext);
+}

--- a/services/api/supabase/functions/_shared/env.ts
+++ b/services/api/supabase/functions/_shared/env.ts
@@ -86,7 +86,9 @@ const FUNCTION_ENV_VARS: Record<string, readonly EnvVarSpec[]> = {
   'aggregator-health': [{ name: 'ALLOWED_ORIGINS', type: 'csv' }],
   'connector-permissions': [{ name: 'ALLOWED_ORIGINS', type: 'csv' }],
   'bank-webhook': [
-    { name: 'PLAID_WEBHOOK_SECRET', type: 'string' },
+    { name: 'PLAID_CLIENT_ID', type: 'string' },
+    { name: 'PLAID_SECRET', type: 'string' },
+    { name: 'BANK_ENCRYPTION_KEY', type: 'string' },
     { name: 'MX_WEBHOOK_SECRET', type: 'string' },
   ],
   'anomaly-detection': [{ name: 'ALLOWED_ORIGINS', type: 'csv' }],

--- a/services/api/supabase/functions/_shared/plaid-webhook.test.ts
+++ b/services/api/supabase/functions/_shared/plaid-webhook.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for Plaid webhook JWS verification (#3848).
+ *
+ * Generates an ephemeral ES256 key pair, signs a Plaid-style verification
+ * JWT, and asserts the verifier accepts valid webhooks and rejects tampered
+ * bodies, stale timestamps, wrong algorithms, and wrong keys.
+ */
+
+import { assertEquals } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+
+import { sha256Hex, verifyPlaidWebhook } from './plaid-webhook.ts';
+import type { PlaidVerificationKey } from './plaid.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function jsonToBase64Url(value: unknown): string {
+  return bytesToBase64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+async function generateKeyPair(): Promise<{ pair: CryptoKeyPair; jwk: PlaidVerificationKey }> {
+  const pair = (await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+  const exported = (await crypto.subtle.exportKey('jwk', pair.publicKey)) as JsonWebKey;
+  const jwk: PlaidVerificationKey = {
+    kty: exported.kty!,
+    crv: exported.crv!,
+    x: exported.x!,
+    y: exported.y!,
+    kid: 'test-key-1',
+    alg: 'ES256',
+  };
+  return { pair, jwk };
+}
+
+async function signJwt(
+  privateKey: CryptoKey,
+  header: Record<string, unknown>,
+  claims: Record<string, unknown>,
+): Promise<string> {
+  const headerB64 = jsonToBase64Url(header);
+  const payloadB64 = jsonToBase64Url(claims);
+  const signingInput = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+  const signature = await crypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    privateKey,
+    signingInput,
+  );
+  return `${headerB64}.${payloadB64}.${bytesToBase64Url(new Uint8Array(signature))}`;
+}
+
+async function buildWebhook(
+  privateKey: CryptoKey,
+  body: string,
+  opts: { alg?: string; kid?: string; iat?: number } = {},
+): Promise<string> {
+  const header = { alg: opts.alg ?? 'ES256', kid: opts.kid ?? 'test-key-1', typ: 'JWT' };
+  const claims = {
+    iat: opts.iat ?? Math.floor(Date.now() / 1000),
+    request_body_sha256: await sha256Hex(body),
+  };
+  return signJwt(privateKey, header, claims);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+Deno.test('accepts a correctly signed webhook with a matching body hash', async () => {
+  const { pair, jwk } = await generateKeyPair();
+  const body = JSON.stringify({ webhook_type: 'TRANSACTIONS', webhook_code: 'DEFAULT_UPDATE' });
+  const header = await buildWebhook(pair.privateKey, body);
+
+  const result = await verifyPlaidWebhook(body, header, { fetchKey: () => Promise.resolve(jwk) });
+  assertEquals(result, true);
+});
+
+Deno.test('rejects when the body does not match the signed hash', async () => {
+  const { pair, jwk } = await generateKeyPair();
+  const body = JSON.stringify({ webhook_type: 'TRANSACTIONS' });
+  const header = await buildWebhook(pair.privateKey, body);
+
+  // Deliver a different body than the one that was signed.
+  const tamperedBody = JSON.stringify({ webhook_type: 'ITEM' });
+  const result = await verifyPlaidWebhook(tamperedBody, header, {
+    fetchKey: () => Promise.resolve(jwk),
+  });
+  assertEquals(result, false);
+});
+
+Deno.test('rejects a stale webhook (iat outside the replay window)', async () => {
+  const { pair, jwk } = await generateKeyPair();
+  const body = '{}';
+  const header = await buildWebhook(pair.privateKey, body, {
+    iat: Math.floor(Date.now() / 1000) - 3600,
+  });
+
+  const result = await verifyPlaidWebhook(body, header, { fetchKey: () => Promise.resolve(jwk) });
+  assertEquals(result, false);
+});
+
+Deno.test('rejects a non-ES256 algorithm (defense against alg confusion)', async () => {
+  const { pair, jwk } = await generateKeyPair();
+  const body = '{}';
+  const header = await buildWebhook(pair.privateKey, body, { alg: 'none' });
+
+  const result = await verifyPlaidWebhook(body, header, { fetchKey: () => Promise.resolve(jwk) });
+  assertEquals(result, false);
+});
+
+Deno.test('rejects when signed by a different key', async () => {
+  const signer = await generateKeyPair();
+  const other = await generateKeyPair();
+  const body = '{}';
+  const header = await buildWebhook(signer.pair.privateKey, body);
+
+  // Verifier is handed the WRONG public key.
+  const result = await verifyPlaidWebhook(body, header, {
+    fetchKey: () => Promise.resolve(other.jwk),
+  });
+  assertEquals(result, false);
+});
+
+Deno.test('rejects a missing verification header', async () => {
+  const { jwk } = await generateKeyPair();
+  const result = await verifyPlaidWebhook('{}', null, { fetchKey: () => Promise.resolve(jwk) });
+  assertEquals(result, false);
+});
+
+Deno.test('rejects when the key cannot be resolved', async () => {
+  const { pair } = await generateKeyPair();
+  const body = '{}';
+  const header = await buildWebhook(pair.privateKey, body);
+  const result = await verifyPlaidWebhook(body, header, { fetchKey: () => Promise.resolve(null) });
+  assertEquals(result, false);
+});
+
+Deno.test('rejects a malformed (non-three-part) header', async () => {
+  const { jwk } = await generateKeyPair();
+  const result = await verifyPlaidWebhook('{}', 'not.a.valid.jwt.token', {
+    fetchKey: () => Promise.resolve(jwk),
+  });
+  assertEquals(result, false);
+});
+
+Deno.test('sha256Hex produces a stable lowercase hex digest', async () => {
+  const digest = await sha256Hex('hello');
+  assertEquals(digest, '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');
+});

--- a/services/api/supabase/functions/_shared/plaid-webhook.ts
+++ b/services/api/supabase/functions/_shared/plaid-webhook.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Plaid webhook signature verification (#3848).
+ *
+ * Plaid signs each webhook with a JWT (JWS, ES256) delivered in the
+ * `Plaid-Verification` header. Verification follows Plaid's documented flow:
+ *
+ *   1. Decode the JWT header; require alg === 'ES256' and read `kid`.
+ *   2. Fetch the public verification key for that `kid`
+ *      (POST /webhook_verification_key/get) — injected here as `fetchKey`.
+ *   3. Verify the JWT signature (ECDSA P-256 / SHA-256) over `header.payload`.
+ *   4. Reject tokens whose `iat` is older than the replay window (5 min).
+ *   5. Compute SHA-256 of the RAW request body and compare (timing-safe) to
+ *      the `request_body_sha256` claim.
+ *
+ * Security:
+ *   - Uses only Web Crypto (crypto.subtle) — no Node APIs.
+ *   - Fails closed on any malformed input.
+ *   - NEVER logs the body, the JWT, or key material.
+ */
+
+import type { PlaidVerificationKey } from './plaid.ts';
+
+/** Maximum accepted age of a webhook JWT (seconds) — replay protection. */
+const MAX_WEBHOOK_AGE_SECONDS = 300;
+
+/** Options for {@link verifyPlaidWebhook}. */
+export interface VerifyPlaidWebhookOptions {
+  /** Resolves the public verification key for a given `kid`. */
+  fetchKey: (keyId: string) => Promise<PlaidVerificationKey | null>;
+  /** Current time in ms (injectable for tests). Defaults to Date.now(). */
+  now?: () => number;
+}
+
+// ---------------------------------------------------------------------------
+// base64url helpers
+// ---------------------------------------------------------------------------
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function base64UrlToJson<T>(value: string): T {
+  return JSON.parse(new TextDecoder().decode(base64UrlToBytes(value))) as T;
+}
+
+// ---------------------------------------------------------------------------
+// SHA-256 body hashing
+// ---------------------------------------------------------------------------
+
+/** Compute the lowercase hex SHA-256 digest of a UTF-8 string. */
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Constant-time comparison of two equal-length hex strings. */
+function timingSafeHexEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+// ---------------------------------------------------------------------------
+// JWS verification
+// ---------------------------------------------------------------------------
+
+interface JwtHeader {
+  alg: string;
+  kid?: string;
+  typ?: string;
+}
+
+interface PlaidJwtClaims {
+  iat: number;
+  request_body_sha256: string;
+}
+
+async function importVerifyKey(key: PlaidVerificationKey): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'jwk',
+    { kty: key.kty, crv: key.crv, x: key.x, y: key.y, ext: true },
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    false,
+    ['verify'],
+  );
+}
+
+/**
+ * Verify a Plaid webhook.
+ *
+ * @param rawBody The exact raw request body string (unparsed).
+ * @param verificationHeader The `Plaid-Verification` header value (a JWT).
+ * @param options Key fetcher and optional clock.
+ * @returns true only if every check passes.
+ */
+export async function verifyPlaidWebhook(
+  rawBody: string,
+  verificationHeader: string | null,
+  options: VerifyPlaidWebhookOptions,
+): Promise<boolean> {
+  if (!verificationHeader) return false;
+
+  const parts = verificationHeader.split('.');
+  if (parts.length !== 3) return false;
+
+  const [headerB64, payloadB64, signatureB64] = parts;
+
+  let header: JwtHeader;
+  try {
+    header = base64UrlToJson<JwtHeader>(headerB64);
+  } catch {
+    return false;
+  }
+
+  // Plaid only signs webhooks with ES256; reject anything else (incl. "none").
+  if (header.alg !== 'ES256' || !header.kid) return false;
+
+  const key = await options.fetchKey(header.kid);
+  if (!key) return false;
+
+  let cryptoKey: CryptoKey;
+  try {
+    cryptoKey = await importVerifyKey(key);
+  } catch {
+    return false;
+  }
+
+  let signatureValid: boolean;
+  try {
+    const signature = base64UrlToBytes(signatureB64);
+    const signedData = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+    signatureValid = await crypto.subtle.verify(
+      { name: 'ECDSA', hash: 'SHA-256' },
+      cryptoKey,
+      signature,
+      signedData,
+    );
+  } catch {
+    return false;
+  }
+  if (!signatureValid) return false;
+
+  let claims: PlaidJwtClaims;
+  try {
+    claims = base64UrlToJson<PlaidJwtClaims>(payloadB64);
+  } catch {
+    return false;
+  }
+
+  // Replay protection: reject stale tokens.
+  const nowSeconds = Math.floor((options.now?.() ?? Date.now()) / 1000);
+  if (
+    typeof claims.iat !== 'number' ||
+    Math.abs(nowSeconds - claims.iat) > MAX_WEBHOOK_AGE_SECONDS
+  ) {
+    return false;
+  }
+
+  // Bind the signed claim to the actual delivered body.
+  if (typeof claims.request_body_sha256 !== 'string') return false;
+  const actualHash = await sha256Hex(rawBody);
+  return timingSafeHexEqual(actualHash, claims.request_body_sha256);
+}

--- a/services/api/supabase/functions/_shared/plaid.test.ts
+++ b/services/api/supabase/functions/_shared/plaid.test.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the Plaid REST client helpers (#3848).
+ *
+ * Covers pure logic: base URL resolution, link-token request building, and
+ * the Plaid-amount -> internal-cents provenance mapping. Network calls are
+ * exercised indirectly via the webhook/ingestion tests.
+ */
+
+import { assertEquals } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+
+import {
+  buildLinkTokenRequest,
+  plaidAmountToCents,
+  plaidBaseUrl,
+  plaidTransactionToRecord,
+  type PlaidTransaction,
+} from './plaid.ts';
+
+Deno.test('plaidBaseUrl maps known environments', () => {
+  assertEquals(plaidBaseUrl('sandbox'), 'https://sandbox.plaid.com');
+  assertEquals(plaidBaseUrl('development'), 'https://development.plaid.com');
+  assertEquals(plaidBaseUrl('production'), 'https://production.plaid.com');
+});
+
+Deno.test('plaidBaseUrl falls back to sandbox for unknown values', () => {
+  assertEquals(plaidBaseUrl('staging'), 'https://sandbox.plaid.com');
+  assertEquals(plaidBaseUrl(''), 'https://sandbox.plaid.com');
+});
+
+Deno.test('buildLinkTokenRequest sets required fields', () => {
+  const req = buildLinkTokenRequest('user-123');
+  assertEquals((req.user as { client_user_id: string }).client_user_id, 'user-123');
+  assertEquals(req.products, ['transactions']);
+  assertEquals(req.country_codes, ['US']);
+  assertEquals('webhook' in req, false);
+});
+
+Deno.test('buildLinkTokenRequest includes webhook when provided', () => {
+  const req = buildLinkTokenRequest('user-123', 'https://example.com/hook');
+  assertEquals(req.webhook, 'https://example.com/hook');
+});
+
+Deno.test('plaidAmountToCents treats outflow as a negative expense', () => {
+  // Plaid: positive amount = money leaving the account (a debit/expense).
+  const { amountCents, type } = plaidAmountToCents(12.34);
+  assertEquals(amountCents, -1234);
+  assertEquals(type, 'expense');
+});
+
+Deno.test('plaidAmountToCents treats inflow as a positive income', () => {
+  const { amountCents, type } = plaidAmountToCents(-56.78);
+  assertEquals(amountCents, 5678);
+  assertEquals(type, 'income');
+});
+
+Deno.test('plaidAmountToCents rounds to whole cents', () => {
+  assertEquals(plaidAmountToCents(12.344).amountCents, -1234);
+  assertEquals(plaidAmountToCents(12.346).amountCents, -1235);
+  assertEquals(plaidAmountToCents(0).amountCents, 0);
+});
+
+function sampleTransaction(overrides: Partial<PlaidTransaction> = {}): PlaidTransaction {
+  return {
+    transaction_id: 'txn_1',
+    account_id: 'acct_ext_1',
+    amount: 42.5,
+    iso_currency_code: 'USD',
+    unofficial_currency_code: null,
+    date: '2026-04-01',
+    authorized_date: '2026-03-31',
+    name: 'Coffee Shop',
+    merchant_name: 'Blue Bottle',
+    pending: false,
+    ...overrides,
+  };
+}
+
+Deno.test('plaidTransactionToRecord tags provenance and maps amount', () => {
+  const record = plaidTransactionToRecord(sampleTransaction(), {
+    householdId: 'hh-1',
+    accountId: 'acct-int-1',
+    currencyFallback: 'USD',
+  });
+  assertEquals(record.source, 'aggregator');
+  assertEquals(record.provider_transaction_id, 'txn_1');
+  assertEquals(record.household_id, 'hh-1');
+  assertEquals(record.account_id, 'acct-int-1');
+  assertEquals(record.amount_cents, -4250);
+  assertEquals(record.type, 'expense');
+  assertEquals(record.payee, 'Blue Bottle');
+  assertEquals(record.authorized_date, '2026-03-31');
+  assertEquals(record.posted_date, '2026-04-01');
+  assertEquals(record.status, 'CLEARED');
+});
+
+Deno.test('plaidTransactionToRecord marks pending transactions', () => {
+  const record = plaidTransactionToRecord(sampleTransaction({ pending: true }), {
+    householdId: 'hh-1',
+    accountId: 'acct-int-1',
+    currencyFallback: 'USD',
+  });
+  assertEquals(record.status, 'PENDING');
+  assertEquals(record.posted_date, null);
+});
+
+Deno.test('plaidTransactionToRecord falls back to name then currency fallback', () => {
+  const record = plaidTransactionToRecord(
+    sampleTransaction({
+      merchant_name: null,
+      iso_currency_code: null,
+      unofficial_currency_code: null,
+    }),
+    { householdId: 'hh-1', accountId: 'acct-int-1', currencyFallback: 'EUR' },
+  );
+  assertEquals(record.payee, 'Coffee Shop');
+  assertEquals(record.currency_code, 'EUR');
+});

--- a/services/api/supabase/functions/_shared/plaid.ts
+++ b/services/api/supabase/functions/_shared/plaid.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Plaid REST client for the Deno Edge runtime (#3848).
+ *
+ * Calls the Plaid API directly over `fetch` — the Plaid Node SDK is NOT used
+ * because it is not compatible with the Deno runtime that Supabase Edge
+ * Functions execute in.
+ *
+ * Security:
+ *   - Client credentials (PLAID_CLIENT_ID / PLAID_SECRET) are read from the
+ *     environment by the caller and passed in — NEVER hard-coded.
+ *   - NEVER log access tokens, public tokens, or client secrets.
+ *   - Errors surface Plaid's `error_code` only (safe) — never the raw body.
+ *
+ * Environment mapping (PLAID_ENVIRONMENT):
+ *   sandbox      -> https://sandbox.plaid.com
+ *   development  -> https://development.plaid.com
+ *   production   -> https://production.plaid.com
+ */
+
+/** Supported Plaid environments. */
+export type PlaidEnvironment = 'sandbox' | 'development' | 'production';
+
+/** Credentials + environment needed for every Plaid call. */
+export interface PlaidConfig {
+  clientId: string;
+  secret: string;
+  environment: string;
+  /** Optional webhook URL registered with Plaid for async updates. */
+  webhookUrl?: string;
+}
+
+/** A single transaction returned by /transactions/sync. */
+export interface PlaidTransaction {
+  transaction_id: string;
+  account_id: string;
+  amount: number;
+  iso_currency_code: string | null;
+  unofficial_currency_code: string | null;
+  date: string;
+  authorized_date: string | null;
+  name: string | null;
+  merchant_name: string | null;
+  pending: boolean;
+}
+
+/** Result of a /transactions/sync page. */
+export interface PlaidSyncResult {
+  added: PlaidTransaction[];
+  modified: PlaidTransaction[];
+  removed: Array<{ transaction_id: string }>;
+  next_cursor: string;
+  has_more: boolean;
+}
+
+/** A JSON Web Key returned by /webhook_verification_key/get. */
+export interface PlaidVerificationKey {
+  kty: string;
+  crv: string;
+  x: string;
+  y: string;
+  kid?: string;
+  use?: string;
+  alg?: string;
+  expired_at?: number | null;
+}
+
+/**
+ * An error raised by a Plaid API call. Carries only the safe `error_code`
+ * (never the raw body, which may echo sensitive request fields).
+ */
+export class PlaidApiError extends Error {
+  readonly status: number;
+  readonly errorCode: string;
+
+  constructor(status: number, errorCode: string) {
+    super(`Plaid API error (${status}): ${errorCode}`);
+    this.name = 'PlaidApiError';
+    this.status = status;
+    this.errorCode = errorCode;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Base URL resolution
+// ---------------------------------------------------------------------------
+
+const PLAID_BASE_URLS: Record<PlaidEnvironment, string> = {
+  sandbox: 'https://sandbox.plaid.com',
+  development: 'https://development.plaid.com',
+  production: 'https://production.plaid.com',
+};
+
+/**
+ * Resolve the Plaid base URL for a given environment string. Falls back to
+ * sandbox for unknown values so misconfiguration never targets production.
+ */
+export function plaidBaseUrl(environment: string): string {
+  return PLAID_BASE_URLS[environment as PlaidEnvironment] ?? PLAID_BASE_URLS.sandbox;
+}
+
+// ---------------------------------------------------------------------------
+// Low-level request helper
+// ---------------------------------------------------------------------------
+
+async function plaidPost<T>(
+  config: PlaidConfig,
+  path: string,
+  payload: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch(`${plaidBaseUrl(config.environment)}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: config.clientId,
+      secret: config.secret,
+      ...payload,
+    }),
+  });
+
+  const body = (await response.json()) as Record<string, unknown>;
+
+  if (!response.ok) {
+    const errorCode =
+      typeof body.error_code === 'string' ? body.error_code : `HTTP_${response.status}`;
+    throw new PlaidApiError(response.status, errorCode);
+  }
+
+  return body as T;
+}
+
+// ---------------------------------------------------------------------------
+// Request builders (pure — unit testable without network)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the request body for /link/token/create.
+ *
+ * @param userId The internal user id — used as Plaid's client_user_id.
+ * @param webhookUrl Optional webhook URL for async updates.
+ */
+export function buildLinkTokenRequest(
+  userId: string,
+  webhookUrl?: string,
+): Record<string, unknown> {
+  const request: Record<string, unknown> = {
+    client_name: 'Finance',
+    user: { client_user_id: userId },
+    products: ['transactions'],
+    country_codes: ['US'],
+    language: 'en',
+  };
+  if (webhookUrl) {
+    request.webhook = webhookUrl;
+  }
+  return request;
+}
+
+// ---------------------------------------------------------------------------
+// API operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a Plaid Link token. The client uses it to launch Plaid Link.
+ */
+export async function createLinkToken(
+  config: PlaidConfig,
+  userId: string,
+): Promise<{ link_token: string; expiration: string }> {
+  return plaidPost(config, '/link/token/create', buildLinkTokenRequest(userId, config.webhookUrl));
+}
+
+/**
+ * Exchange a Plaid public token for a long-lived access token + item id.
+ *
+ * SECURITY: the returned access_token is a bearer credential — NEVER log it,
+ * and encrypt it (AES-256-GCM) before persistence.
+ */
+export async function exchangePublicToken(
+  config: PlaidConfig,
+  publicToken: string,
+): Promise<{ access_token: string; item_id: string }> {
+  return plaidPost(config, '/item/public_token/exchange', { public_token: publicToken });
+}
+
+/**
+ * Fetch incremental transaction updates for an item via /transactions/sync.
+ *
+ * @param cursor The last cursor persisted for the item (empty for first sync).
+ */
+export async function transactionsSync(
+  config: PlaidConfig,
+  accessToken: string,
+  cursor: string | null,
+): Promise<PlaidSyncResult> {
+  return plaidPost<PlaidSyncResult>(config, '/transactions/sync', {
+    access_token: accessToken,
+    cursor: cursor ?? undefined,
+    count: 250,
+  });
+}
+
+/**
+ * Fetch the public verification key used to validate Plaid webhook JWTs.
+ *
+ * @param keyId The `kid` from the webhook JWT header.
+ */
+export async function getWebhookVerificationKey(
+  config: PlaidConfig,
+  keyId: string,
+): Promise<PlaidVerificationKey | null> {
+  const result = await plaidPost<{ key: PlaidVerificationKey | null }>(
+    config,
+    '/webhook_verification_key/get',
+    { key_id: keyId },
+  );
+  return result.key ?? null;
+}
+
+/**
+ * Convert a Plaid transaction amount (major units, positive = outflow) to the
+ * app's signed integer-cents convention (positive = income, negative =
+ * expense) plus the matching transaction `type`.
+ *
+ * This mirrors the CSV import default in `import-data` where a positive net
+ * amount is treated as income and a negative net amount as an expense.
+ */
+export function plaidAmountToCents(plaidAmount: number): {
+  amountCents: number;
+  type: 'income' | 'expense';
+} {
+  const amountCents = -Math.round(plaidAmount * 100);
+  return { amountCents, type: amountCents >= 0 ? 'income' : 'expense' };
+}
+
+/** Target internal account for an ingested transaction. */
+export interface IngestTarget {
+  householdId: string;
+  accountId: string;
+  currencyFallback: string;
+}
+
+/** A provenance-tagged transaction row ready to persist. */
+export interface TransactionRecord {
+  household_id: string;
+  account_id: string;
+  amount_cents: number;
+  currency_code: string;
+  type: 'income' | 'expense';
+  payee: string | null;
+  date: string;
+  authorized_date: string | null;
+  posted_date: string | null;
+  status: 'PENDING' | 'CLEARED';
+  source: 'aggregator';
+  provider_transaction_id: string;
+}
+
+/**
+ * Map a Plaid transaction to an internal `transactions` row with provenance
+ * columns populated. Pure function — no I/O — so it is unit-testable.
+ *
+ * NEVER logs the returned record (it describes a financial transaction).
+ */
+export function plaidTransactionToRecord(
+  txn: PlaidTransaction,
+  target: IngestTarget,
+): TransactionRecord {
+  const { amountCents, type } = plaidAmountToCents(txn.amount);
+  const currency = txn.iso_currency_code ?? txn.unofficial_currency_code ?? target.currencyFallback;
+  return {
+    household_id: target.householdId,
+    account_id: target.accountId,
+    amount_cents: amountCents,
+    currency_code: currency,
+    type,
+    payee: txn.merchant_name ?? txn.name ?? null,
+    date: txn.date,
+    authorized_date: txn.authorized_date,
+    posted_date: txn.pending ? null : txn.date,
+    status: txn.pending ? 'PENDING' : 'CLEARED',
+    source: 'aggregator',
+    provider_transaction_id: txn.transaction_id,
+  };
+}

--- a/services/api/supabase/functions/bank-connection/index.test.ts
+++ b/services/api/supabase/functions/bank-connection/index.test.ts
@@ -13,6 +13,8 @@ import {
   assertNotEquals,
 } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
 
+import { decryptToken, encryptToken } from '../_shared/bank-crypto.ts';
+
 // ---------------------------------------------------------------------------
 // Provider validation tests
 // ---------------------------------------------------------------------------
@@ -55,8 +57,8 @@ Deno.test('exchange_token action is parsed from URL', () => {
 
 Deno.test('create_link_token requires provider', () => {
   const body = { household_id: 'test-id' };
-  const hasProvider = 'provider' in body && body.provider;
-  assertEquals(hasProvider, undefined);
+  const hasProvider = 'provider' in body;
+  assertEquals(hasProvider, false);
 });
 
 Deno.test('exchange_token requires all fields', () => {
@@ -190,4 +192,39 @@ Deno.test('sync log types are valid', () => {
   for (const t of validTypes) {
     assertEquals(validTypes.includes(t), true);
   }
+});
+
+// ---------------------------------------------------------------------------
+// Access-token encryption at rest (real crypto, #3848)
+// ---------------------------------------------------------------------------
+
+const TEST_ENCRYPTION_KEY = '0'.repeat(64);
+
+Deno.test('exchanged access token is encrypted before storage', async () => {
+  const rawAccessToken = 'access-sandbox-plaid-secret-token';
+  const encrypted = await encryptToken(rawAccessToken, TEST_ENCRYPTION_KEY);
+
+  // What gets persisted must not be the raw token in any recoverable-by-eye form.
+  assertEquals(encrypted.startsWith('aes256gcm:'), true);
+  assertEquals(encrypted.includes(rawAccessToken), false);
+  assertNotEquals(encrypted, rawAccessToken);
+
+  // The service can still recover it for downstream Plaid calls.
+  assertEquals(await decryptToken(encrypted, TEST_ENCRYPTION_KEY), rawAccessToken);
+});
+
+Deno.test('persisted connection row never leaks the raw token', async () => {
+  const rawAccessToken = 'access-production-abcdef123456';
+  const encrypted = await encryptToken(rawAccessToken, TEST_ENCRYPTION_KEY);
+
+  // Simulate the row written to bank_connections.
+  const row = {
+    id: 'conn-9',
+    provider: 'plaid',
+    encrypted_access_token: encrypted,
+    metadata: { item_id: 'item-9' },
+    status: 'active',
+  };
+
+  assertEquals(JSON.stringify(row).includes(rawAccessToken), false);
 });

--- a/services/api/supabase/functions/bank-connection/index.ts
+++ b/services/api/supabase/functions/bank-connection/index.ts
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-// TODO(alpha): SPECULATIVE — Not wired to any client. Has tests but depends
-// on Plaid/MX provider integration (PLAID_CLIENT_ID, PLAID_SECRET, etc.)
-// that is not configured. Post-alpha feature. Exclude from alpha
-// deployment. (#1390)
-
 /**
- * Bank Connection API Edge Function (#265)
+ * Bank Connection API Edge Function (#265, #3848)
  *
  * Manages bank connections via Plaid and MX aggregators. Provides
  * link token creation, access token exchange, and connection management.
+ *
+ * Plaid is the reference implementation (real REST calls via fetch). MX
+ * remains a documented stub behind the same interface until its credentials
+ * and endpoints are provisioned.
  *
  * Endpoints:
  *   POST ?action=create_link_token  — Generate a link token for Plaid/MX
@@ -44,6 +43,13 @@ import { handleCorsPreflightRequest } from '../_shared/cors.ts';
 import { validateEnv } from '../_shared/env.ts';
 import { createLogger } from '../_shared/logger.ts';
 import { checkRateLimit, rateLimitResponse, RATE_LIMITS } from '../_shared/rate-limit.ts';
+import { encryptToken } from '../_shared/bank-crypto.ts';
+import {
+  createLinkToken as plaidCreateLinkToken,
+  exchangePublicToken as plaidExchangePublicToken,
+  PlaidApiError,
+  type PlaidConfig,
+} from '../_shared/plaid.ts';
 import {
   createdResponse,
   errorResponse,
@@ -74,100 +80,70 @@ interface ExchangeTokenRequest {
 }
 
 // ---------------------------------------------------------------------------
-// Encryption stub
+// Encryption
 // ---------------------------------------------------------------------------
 
 /**
- * Encrypt an access token for storage. Uses AES-256-GCM via Web Crypto API.
+ * Encrypt a provider access token for storage using AES-256-GCM.
  *
- * In production, BANK_ENCRYPTION_KEY provides the key material.
- * This is a stub — the actual implementation will use crypto.subtle.
- *
- * NEVER log the plaintext token or the encryption key.
+ * Key material comes from BANK_ENCRYPTION_KEY. NEVER log the plaintext token
+ * or the key.
  */
 async function encryptAccessToken(plaintext: string): Promise<string> {
   const key = Deno.env.get('BANK_ENCRYPTION_KEY');
   if (!key) {
     throw new Error('BANK_ENCRYPTION_KEY not configured');
   }
-
-  // Stub: In production, use AES-256-GCM with crypto.subtle
-  // For now, encode as base64 with a prefix to indicate encryption
-  const encoder = new TextEncoder();
-  const data = encoder.encode(plaintext);
-  const iv = crypto.getRandomValues(new Uint8Array(12));
-
-  const cryptoKey = await crypto.subtle.importKey(
-    'raw',
-    encoder.encode(key.padEnd(32, '0').slice(0, 32)),
-    { name: 'AES-GCM' },
-    false,
-    ['encrypt'],
-  );
-
-  const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, cryptoKey, data);
-
-  // Format: base64(iv):base64(ciphertext)
-  const ivB64 = btoa(String.fromCharCode(...iv));
-  const ctB64 = btoa(String.fromCharCode(...new Uint8Array(encrypted)));
-
-  return `aes256gcm:${ivB64}:${ctB64}`;
+  return encryptToken(plaintext, key);
 }
 
 // ---------------------------------------------------------------------------
-// Provider API stubs
+// Provider integrations
 // ---------------------------------------------------------------------------
+
+/** Read Plaid credentials from the environment. Throws if unset. */
+function plaidConfigFromEnv(): PlaidConfig {
+  const clientId = Deno.env.get('PLAID_CLIENT_ID');
+  const secret = Deno.env.get('PLAID_SECRET');
+  if (!clientId || !secret) {
+    throw new Error('Plaid credentials not configured');
+  }
+  return {
+    clientId,
+    secret,
+    environment: Deno.env.get('PLAID_ENVIRONMENT') ?? 'sandbox',
+    webhookUrl: Deno.env.get('PLAID_WEBHOOK_URL') ?? undefined,
+  };
+}
 
 /**
  * Create a link token via the provider's API.
  *
- * STUB: In production, this calls the Plaid or MX API.
- * Returns a link_token that the client uses to launch the
- * provider's connection UI.
+ * Plaid: real POST /link/token/create. MX: documented stub pending
+ * credential provisioning.
  */
 async function createProviderLinkToken(
   provider: Provider,
-  _userId: string,
+  userId: string,
 ): Promise<{ link_token: string; expiration: string }> {
-  // Plaid: POST /link/token/create
-  // MX: POST /users/{user_guid}/connect_widget_url
   if (provider === 'plaid') {
-    const clientId = Deno.env.get('PLAID_CLIENT_ID');
-    const secret = Deno.env.get('PLAID_SECRET');
-    const environment = Deno.env.get('PLAID_ENVIRONMENT') ?? 'sandbox';
-
-    if (!clientId || !secret) {
-      throw new Error('Plaid credentials not configured');
-    }
-
-    // STUB: Would call Plaid API here
-    // const response = await fetch(`https://${environment}.plaid.com/link/token/create`, { ... });
-    void environment;
-    return {
-      link_token: `link-${provider}-${crypto.randomUUID()}`,
-      expiration: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
-    };
-  } else {
-    const clientId = Deno.env.get('MX_CLIENT_ID');
-    const apiKey = Deno.env.get('MX_API_KEY');
-
-    if (!clientId || !apiKey) {
-      throw new Error('MX credentials not configured');
-    }
-
-    // STUB: Would call MX API here
-    return {
-      link_token: `link-${provider}-${crypto.randomUUID()}`,
-      expiration: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
-    };
+    return plaidCreateLinkToken(plaidConfigFromEnv(), userId);
   }
+
+  // MX stub — kept behind the same interface until MX is provisioned.
+  const clientId = Deno.env.get('MX_CLIENT_ID');
+  const apiKey = Deno.env.get('MX_API_KEY');
+  if (!clientId || !apiKey) {
+    throw new Error('MX credentials not configured');
+  }
+  return {
+    link_token: `link-${provider}-${crypto.randomUUID()}`,
+    expiration: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+  };
 }
 
 /**
  * Exchange a public token for an access token via the provider's API.
- *
- * STUB: In production, this calls Plaid's /item/public_token/exchange
- * or the MX equivalent.
  *
  * NEVER log the returned access token.
  */
@@ -175,21 +151,20 @@ async function exchangeProviderToken(
   provider: Provider,
   publicToken: string,
 ): Promise<{ access_token: string; item_id: string }> {
-  void publicToken;
-
   if (provider === 'plaid') {
-    // STUB: Would call POST /item/public_token/exchange
-    return {
-      access_token: `access-${provider}-${crypto.randomUUID()}`,
-      item_id: `item-${crypto.randomUUID()}`,
-    };
-  } else {
-    // STUB: Would call MX API
-    return {
-      access_token: `access-${provider}-${crypto.randomUUID()}`,
-      item_id: `member-${crypto.randomUUID()}`,
-    };
+    return plaidExchangePublicToken(plaidConfigFromEnv(), publicToken);
   }
+
+  // MX stub — kept behind the same interface until MX is provisioned.
+  const clientId = Deno.env.get('MX_CLIENT_ID');
+  const apiKey = Deno.env.get('MX_API_KEY');
+  if (!clientId || !apiKey) {
+    throw new Error('MX credentials not configured');
+  }
+  return {
+    access_token: `access-${provider}-${crypto.randomUUID()}`,
+    item_id: `member-${crypto.randomUUID()}`,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -259,7 +234,22 @@ serve(async (req: Request): Promise<Response> => {
         );
       }
 
-      const linkResult = await createProviderLinkToken(body.provider, user.id);
+      const linkResult = await createProviderLinkToken(body.provider, user.id).catch(
+        (err: unknown) => {
+          if (err instanceof PlaidApiError) {
+            logger.warn('Provider link token failed', {
+              provider: body.provider,
+              errorCode: err.errorCode,
+            });
+            return null;
+          }
+          throw err;
+        },
+      );
+
+      if (!linkResult) {
+        return errorResponse(req, 'Provider link token request failed', 502);
+      }
 
       logger.info('Link token created', {
         provider: body.provider,
@@ -305,7 +295,22 @@ serve(async (req: Request): Promise<Response> => {
       }
 
       // Exchange public token for access token — NEVER log the access token
-      const exchangeResult = await exchangeProviderToken(body.provider, body.public_token);
+      const exchangeResult = await exchangeProviderToken(body.provider, body.public_token).catch(
+        (err: unknown) => {
+          if (err instanceof PlaidApiError) {
+            logger.warn('Provider token exchange failed', {
+              provider: body.provider,
+              errorCode: err.errorCode,
+            });
+            return null;
+          }
+          throw err;
+        },
+      );
+
+      if (!exchangeResult) {
+        return errorResponse(req, 'Provider token exchange failed', 502);
+      }
 
       // Encrypt access token before storage
       const encryptedToken = await encryptAccessToken(exchangeResult.access_token);

--- a/services/api/supabase/functions/bank-webhook/index.test.ts
+++ b/services/api/supabase/functions/bank-webhook/index.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the Bank Webhook Handler (#3848).
+ *
+ * The handler module calls serve() at import time, so these tests exercise
+ * the pure ingestion + verification helpers it composes (imported directly
+ * from `_shared/`) rather than importing index.ts. This validates the
+ * security-relevant invariants: provenance tagging, no raw-token leakage,
+ * signature verification, and webhook routing.
+ */
+
+import { assertEquals, assertExists } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+
+import { plaidTransactionToRecord, type PlaidTransaction } from '../_shared/plaid.ts';
+import { sha256Hex, verifyPlaidWebhook } from '../_shared/plaid-webhook.ts';
+import type { PlaidVerificationKey } from '../_shared/plaid.ts';
+
+// ---------------------------------------------------------------------------
+// Provider routing validation (mirrors handler guard)
+// ---------------------------------------------------------------------------
+
+const SUPPORTED_PROVIDERS = ['plaid', 'mx'];
+
+Deno.test('webhook provider must be plaid or mx', () => {
+  assertEquals(SUPPORTED_PROVIDERS.includes('plaid'), true);
+  assertEquals(SUPPORTED_PROVIDERS.includes('mx'), true);
+  assertEquals(SUPPORTED_PROVIDERS.includes('yodlee'), false);
+  assertEquals(SUPPORTED_PROVIDERS.includes(''), false);
+});
+
+// ---------------------------------------------------------------------------
+// Ingestion mapping — provenance + no token leakage
+// ---------------------------------------------------------------------------
+
+function sampleTransaction(overrides: Partial<PlaidTransaction> = {}): PlaidTransaction {
+  return {
+    transaction_id: 'txn_ingest_1',
+    account_id: 'ext_acct_1',
+    amount: 19.99,
+    iso_currency_code: 'USD',
+    unofficial_currency_code: null,
+    date: '2026-04-02',
+    authorized_date: '2026-04-01',
+    name: 'Grocery Store',
+    merchant_name: 'Whole Foods',
+    pending: false,
+    ...overrides,
+  };
+}
+
+Deno.test('ingested transaction is tagged with aggregator provenance', () => {
+  const record = plaidTransactionToRecord(sampleTransaction(), {
+    householdId: 'hh-77',
+    accountId: 'acct-int-77',
+    currencyFallback: 'USD',
+  });
+
+  assertEquals(record.source, 'aggregator');
+  assertEquals(record.provider_transaction_id, 'txn_ingest_1');
+  assertExists(record.authorized_date);
+  assertEquals(record.household_id, 'hh-77');
+  assertEquals(record.account_id, 'acct-int-77');
+});
+
+Deno.test('ingested transaction record never carries an access token', () => {
+  const record = plaidTransactionToRecord(sampleTransaction(), {
+    householdId: 'hh-77',
+    accountId: 'acct-int-77',
+    currencyFallback: 'USD',
+  });
+
+  const serialized = JSON.stringify(record).toLowerCase();
+  assertEquals(serialized.includes('access_token'), false);
+  assertEquals(serialized.includes('access-sandbox'), false);
+  assertEquals(serialized.includes('secret'), false);
+});
+
+Deno.test('expense outflow maps to a negative amount', () => {
+  const record = plaidTransactionToRecord(sampleTransaction({ amount: 19.99 }), {
+    householdId: 'hh-77',
+    accountId: 'acct-int-77',
+    currencyFallback: 'USD',
+  });
+  assertEquals(record.amount_cents, -1999);
+  assertEquals(record.type, 'expense');
+});
+
+// ---------------------------------------------------------------------------
+// Webhook verification gate — an unsigned/forged webhook is rejected
+// ---------------------------------------------------------------------------
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function jsonToBase64Url(value: unknown): string {
+  return bytesToBase64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+Deno.test('a forged webhook (unsigned) is rejected before ingestion', async () => {
+  const body = JSON.stringify({ webhook_type: 'TRANSACTIONS', webhook_code: 'DEFAULT_UPDATE' });
+  // Attacker crafts a header with an ES256 alg but no valid signature.
+  const forgedHeader = `${jsonToBase64Url({ alg: 'ES256', kid: 'x' })}.${jsonToBase64Url({
+    iat: Math.floor(Date.now() / 1000),
+    request_body_sha256: await sha256Hex(body),
+  })}.${bytesToBase64Url(new Uint8Array(64))}`;
+
+  const key: PlaidVerificationKey = {
+    kty: 'EC',
+    crv: 'P-256',
+    x: 'f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU',
+    y: 'x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0',
+    kid: 'x',
+    alg: 'ES256',
+  };
+
+  const result = await verifyPlaidWebhook(body, forgedHeader, {
+    fetchKey: () => Promise.resolve(key),
+  });
+  assertEquals(result, false);
+});

--- a/services/api/supabase/functions/bank-webhook/index.ts
+++ b/services/api/supabase/functions/bank-webhook/index.ts
@@ -1,31 +1,37 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-// TODO(alpha): SPECULATIVE — Not wired to any client. No tests. Webhook
-// signature verification is stubbed (Plaid JWT, MX HMAC). Depends on
-// bank-connection being active. Exclude from alpha deployment. (#1390)
-
 /**
- * Bank Webhook Handler Edge Function (#265)
+ * Bank Webhook Handler Edge Function (#265, #3848)
  *
- * Receives webhook events from Plaid and MX when bank data changes.
- * Verifies webhook signatures, processes events, and triggers syncs.
+ * Receives webhook events from Plaid and MX when bank data changes,
+ * verifies their signatures, ingests transaction/balance updates into the
+ * `transactions` table (respecting provenance columns), and records a
+ * `bank_connection_health` event.
  *
  * Supported webhook types:
- *   Plaid: TRANSACTIONS (DEFAULT_UPDATE, INITIAL_UPDATE, HISTORICAL_UPDATE, REMOVED)
- *          ITEM (ERROR, PENDING_EXPIRATION, USER_PERMISSION_REVOKED)
+ *   Plaid: TRANSACTIONS (SYNC_UPDATES_AVAILABLE, DEFAULT_UPDATE,
+ *          INITIAL_UPDATE, HISTORICAL_UPDATE), ITEM (ERROR,
+ *          PENDING_EXPIRATION, USER_PERMISSION_REVOKED)
  *   MX:    member_connected, member_status_changed, transactions_added
  *
  * Security:
- *   - Verifies webhook signatures (Plaid: JWT, MX: HMAC-SHA256)
- *   - No user authentication — webhook endpoints are public but verified
- *   - NEVER logs raw financial data from webhook payloads
- *   - Rate limited by IP
+ *   - Plaid webhooks are verified via the signed JWT in the
+ *     `Plaid-Verification` header (ES256 JWS + request-body SHA-256).
+ *   - MX webhooks are verified via HMAC-SHA256 of the raw body.
+ *   - No user authentication — endpoints are public but cryptographically
+ *     verified. Rate limited by IP.
+ *   - Access tokens are decrypted only in memory for provider sync and are
+ *     NEVER logged or returned.
+ *   - NEVER logs raw financial data from webhook payloads.
  *
  * Environment Variables:
  *   SUPABASE_URL              — Project URL
  *   SUPABASE_SERVICE_ROLE_KEY — Service role key
- *   PLAID_WEBHOOK_SECRET      — Plaid webhook verification secret
- *   MX_WEBHOOK_SECRET         — MX webhook verification secret
+ *   PLAID_CLIENT_ID           — Plaid client id (webhook key fetch + sync)
+ *   PLAID_SECRET              — Plaid secret (webhook key fetch + sync)
+ *   PLAID_ENVIRONMENT         — Plaid environment (sandbox/development/production)
+ *   BANK_ENCRYPTION_KEY       — AES-256 key for decrypting stored access tokens
+ *   MX_WEBHOOK_SECRET         — MX HMAC verification secret
  */
 
 import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
@@ -45,45 +51,64 @@ import {
   jsonResponse,
   methodNotAllowedResponse,
 } from '../_shared/response.ts';
+import { decryptToken } from '../_shared/bank-crypto.ts';
+import { verifyWebhookSignature } from '../_shared/webhook-verify.ts';
+import { verifyPlaidWebhook } from '../_shared/plaid-webhook.ts';
+import {
+  getWebhookVerificationKey,
+  plaidTransactionToRecord,
+  transactionsSync,
+  type PlaidConfig,
+  type PlaidTransaction,
+} from '../_shared/plaid.ts';
 
 // ---------------------------------------------------------------------------
-// Webhook verification stubs
+// Config helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Verify a Plaid webhook signature.
- *
- * STUB: In production, verifies the JWS signature using Plaid's
- * public key endpoint. Returns true if signature is valid.
- */
-async function verifyPlaidWebhook(_body: string, _headers: Headers): Promise<boolean> {
-  const secret = Deno.env.get('PLAID_WEBHOOK_SECRET');
-  if (!secret) return false;
-
-  // STUB: Would verify Plaid JWS signature here
-  // 1. Extract the signed JWT from Plaid-Verification header
-  // 2. Fetch Plaid's public key from /webhook_verification_key/get
-  // 3. Verify the JWT signature against the public key
-  // 4. Compare the body hash against the signed claim
-  return true;
-}
-
-/**
- * Verify an MX webhook HMAC signature.
- *
- * STUB: In production, computes HMAC-SHA256 of the body and
- * compares against the signature header.
- */
-async function verifyMxWebhook(_body: string, _headers: Headers): Promise<boolean> {
-  const secret = Deno.env.get('MX_WEBHOOK_SECRET');
-  if (!secret) return false;
-
-  // STUB: Would verify MX HMAC-SHA256 signature here
-  return true;
+/** Read Plaid credentials from the environment. */
+function plaidConfigFromEnv(): PlaidConfig {
+  return {
+    clientId: Deno.env.get('PLAID_CLIENT_ID') ?? '',
+    secret: Deno.env.get('PLAID_SECRET') ?? '',
+    environment: Deno.env.get('PLAID_ENVIRONMENT') ?? 'sandbox',
+  };
 }
 
 // ---------------------------------------------------------------------------
-// Event processors
+// Webhook verification
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify a Plaid webhook using the signed JWT in the `Plaid-Verification`
+ * header. The verification key is fetched from Plaid for the JWT's `kid`.
+ */
+async function verifyPlaid(body: string, headers: Headers): Promise<boolean> {
+  const config = plaidConfigFromEnv();
+  if (!config.clientId || !config.secret) return false;
+
+  const verificationHeader = headers.get('plaid-verification');
+  return verifyPlaidWebhook(body, verificationHeader, {
+    fetchKey: (keyId) => getWebhookVerificationKey(config, keyId),
+  });
+}
+
+/**
+ * Verify an MX webhook via HMAC-SHA256 of the raw body. MX sends the
+ * signature in the `mx-signature` header as `sha256=<hex>`.
+ */
+async function verifyMx(body: string, headers: Headers): Promise<boolean> {
+  const mxSecret = Deno.env.get('MX_WEBHOOK_SECRET');
+  if (!mxSecret) return false;
+
+  const signature = headers.get('mx-signature');
+  if (!signature) return false;
+
+  return verifyWebhookSignature(body, signature, mxSecret);
+}
+
+// ---------------------------------------------------------------------------
+// Types
 // ---------------------------------------------------------------------------
 
 interface PlaidWebhookEvent {
@@ -101,16 +126,216 @@ interface MxWebhookEvent {
   user_guid: string;
 }
 
+interface BankConnectionRow {
+  id: string;
+  household_id: string;
+  encrypted_access_token: string;
+  metadata: Record<string, unknown> | null;
+}
+
+interface LinkedAccount {
+  account_id: string;
+  household_id: string;
+  currency_code: string;
+}
+
+/** Summary of an ingestion run (counts only — never transaction contents). */
+interface IngestionSummary {
+  added: number;
+  modified: number;
+  removed: number;
+}
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+type FunctionLogger = ReturnType<typeof createLogger>;
+
+// ---------------------------------------------------------------------------
+// Health event recording
+// ---------------------------------------------------------------------------
+
 /**
- * Process a Plaid webhook event.
+ * Record a `bank_connection_health` event for a connection. Best-effort —
+ * failures are logged but do not abort webhook processing.
+ */
+async function recordHealthEvent(
+  supabase: AdminClient,
+  connection: { id: string; household_id: string },
+  status: string,
+  logger: FunctionLogger,
+  detail?: { errorCategory?: string | null; errorDetail?: string | null },
+): Promise<void> {
+  const { error } = await supabase.from('bank_connection_health').insert({
+    bank_connection_id: connection.id,
+    household_id: connection.household_id,
+    status,
+    error_category: detail?.errorCategory ?? null,
+    error_detail: detail?.errorDetail ?? null,
+    last_successful_sync: status === 'healthy' ? new Date().toISOString() : null,
+  });
+
+  if (error) {
+    logger.warn('Failed to record health event', { errorMessage: error.message });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transaction ingestion (Plaid)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a map of Plaid external account id -> internal linked account.
+ * Only accounts that are linked to an internal Finance account participate.
+ */
+async function loadLinkedAccounts(
+  supabase: AdminClient,
+  connectionId: string,
+): Promise<Map<string, LinkedAccount>> {
+  const { data } = await supabase
+    .from('bank_connection_accounts')
+    .select('external_account_id, account_id, household_id, currency_code, is_linked')
+    .eq('bank_connection_id', connectionId)
+    .eq('is_linked', true)
+    .is('deleted_at', null);
+
+  const map = new Map<string, LinkedAccount>();
+  for (const row of data ?? []) {
+    if (row.account_id) {
+      map.set(row.external_account_id, {
+        account_id: row.account_id,
+        household_id: row.household_id,
+        currency_code: row.currency_code ?? 'USD',
+      });
+    }
+  }
+  return map;
+}
+
+/**
+ * Upsert a single Plaid transaction into `transactions` with provenance.
+ * Returns true if a new row was inserted.
  *
- * Handles transaction updates, item errors, and connection status changes.
- * NEVER logs raw transaction data — only event metadata.
+ * NEVER logs the transaction contents.
+ */
+async function upsertPlaidTransaction(
+  supabase: AdminClient,
+  txn: PlaidTransaction,
+  account: LinkedAccount,
+): Promise<boolean> {
+  // Deduplicate on the provider transaction id — provider webhooks may retry.
+  const { data: existing } = await supabase
+    .from('transactions')
+    .select('id')
+    .eq('provider_transaction_id', txn.transaction_id)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  const record = {
+    ...plaidTransactionToRecord(txn, {
+      householdId: account.household_id,
+      accountId: account.account_id,
+      currencyFallback: account.currency_code,
+    }),
+    imported_at: new Date().toISOString(),
+  };
+
+  if (existing) {
+    await supabase.from('transactions').update(record).eq('id', existing.id);
+    return false;
+  }
+
+  await supabase.from('transactions').insert(record);
+  return true;
+}
+
+/**
+ * Ingest incremental transaction updates for a Plaid connection via
+ * /transactions/sync, honoring the stored cursor and persisting the new one.
+ */
+async function ingestPlaidTransactions(
+  supabase: AdminClient,
+  connection: BankConnectionRow,
+  logger: FunctionLogger,
+): Promise<IngestionSummary> {
+  const summary: IngestionSummary = { added: 0, modified: 0, removed: 0 };
+
+  const config = plaidConfigFromEnv();
+  const encryptionKey = Deno.env.get('BANK_ENCRYPTION_KEY');
+  if (!config.clientId || !config.secret || !encryptionKey) {
+    logger.warn('Skipping ingestion — provider config incomplete');
+    return summary;
+  }
+
+  const accessToken = await decryptToken(connection.encrypted_access_token, encryptionKey);
+  const linkedAccounts = await loadLinkedAccounts(supabase, connection.id);
+
+  let cursor = (connection.metadata?.['cursor'] as string | undefined) ?? null;
+  let hasMore = true;
+  let pages = 0;
+  const MAX_PAGES = 20; // Guard against runaway pagination.
+
+  while (hasMore && pages < MAX_PAGES) {
+    pages++;
+    const page = await transactionsSync(config, accessToken, cursor);
+
+    for (const txn of page.added) {
+      const account = linkedAccounts.get(txn.account_id);
+      if (!account) continue;
+      const inserted = await upsertPlaidTransaction(supabase, txn, account);
+      if (inserted) summary.added++;
+      else summary.modified++;
+    }
+
+    for (const txn of page.modified) {
+      const account = linkedAccounts.get(txn.account_id);
+      if (!account) continue;
+      await upsertPlaidTransaction(supabase, txn, account);
+      summary.modified++;
+    }
+
+    for (const removed of page.removed) {
+      const { data: rows } = await supabase
+        .from('transactions')
+        .update({ deleted_at: new Date().toISOString() })
+        .eq('provider_transaction_id', removed.transaction_id)
+        .is('deleted_at', null)
+        .select('id');
+      summary.removed += rows?.length ?? 0;
+    }
+
+    cursor = page.next_cursor;
+    hasMore = page.has_more;
+  }
+
+  // Persist the advanced cursor for the next sync (merge into metadata).
+  const mergedMetadata = { ...(connection.metadata ?? {}), cursor };
+  await supabase
+    .from('bank_connections')
+    .update({ metadata: mergedMetadata, last_synced_at: new Date().toISOString() })
+    .eq('id', connection.id);
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// Event processors
+// ---------------------------------------------------------------------------
+
+const PLAID_TRANSACTION_CODES = new Set([
+  'SYNC_UPDATES_AVAILABLE',
+  'INITIAL_UPDATE',
+  'HISTORICAL_UPDATE',
+  'DEFAULT_UPDATE',
+  'TRANSACTIONS_REMOVED',
+]);
+
+/**
+ * Process a Plaid webhook event. NEVER logs raw transaction data — only
+ * event metadata and aggregate counts.
  */
 async function processPlaidEvent(
-  supabase: ReturnType<typeof createAdminClient>,
+  supabase: AdminClient,
   event: PlaidWebhookEvent,
-  logger: ReturnType<typeof createLogger>,
+  logger: FunctionLogger,
 ): Promise<void> {
   const { webhook_type, webhook_code, item_id } = event;
 
@@ -120,10 +345,9 @@ async function processPlaidEvent(
     hasError: !!event.error,
   });
 
-  // Find the connection by item_id in metadata
   const { data: connection } = await supabase
     .from('bank_connections')
-    .select('id, household_id')
+    .select('id, household_id, encrypted_access_token, metadata')
     .eq('provider', 'plaid')
     .contains('metadata', { item_id })
     .is('deleted_at', null)
@@ -134,6 +358,8 @@ async function processPlaidEvent(
     return;
   }
 
+  const conn = connection as BankConnectionRow;
+
   if (webhook_type === 'ITEM') {
     if (webhook_code === 'ERROR' || webhook_code === 'PENDING_EXPIRATION') {
       await supabase
@@ -143,17 +369,22 @@ async function processPlaidEvent(
           error_code: event.error?.error_code ?? webhook_code,
           error_message: event.error?.error_message ?? 'Reconnection required',
         })
-        .eq('id', connection.id);
+        .eq('id', conn.id);
+      await recordHealthEvent(supabase, conn, 'auth_expired', logger, {
+        errorCategory: 'auth',
+        errorDetail: event.error?.error_code ?? webhook_code,
+      });
     } else if (webhook_code === 'USER_PERMISSION_REVOKED') {
-      await supabase
-        .from('bank_connections')
-        .update({ status: 'disconnected' })
-        .eq('id', connection.id);
+      await supabase.from('bank_connections').update({ status: 'disconnected' }).eq('id', conn.id);
+      await recordHealthEvent(supabase, conn, 'auth_expired', logger, {
+        errorCategory: 'auth',
+        errorDetail: webhook_code,
+      });
     }
+    return;
   }
 
-  if (webhook_type === 'TRANSACTIONS') {
-    // Log sync operation
+  if (webhook_type === 'TRANSACTIONS' && PLAID_TRANSACTION_CODES.has(webhook_code)) {
     const syncType =
       webhook_code === 'INITIAL_UPDATE'
         ? 'initial'
@@ -161,31 +392,50 @@ async function processPlaidEvent(
           ? 'historical'
           : 'webhook';
 
+    let summary: IngestionSummary = { added: 0, modified: 0, removed: 0 };
+    let syncStatus = 'completed';
+    try {
+      summary = await ingestPlaidTransactions(supabase, conn, logger);
+    } catch (err) {
+      syncStatus = 'failed';
+      logger.error('Plaid ingestion failed', { errorMessage: (err as Error).message });
+    }
+
     await supabase.from('bank_sync_log').insert({
-      bank_connection_id: connection.id,
-      household_id: connection.household_id,
+      bank_connection_id: conn.id,
+      household_id: conn.household_id,
       sync_type: syncType,
-      status: 'pending',
-      transactions_added: event.new_transactions ?? 0,
+      status: syncStatus,
+      transactions_added: summary.added,
+      transactions_updated: summary.modified,
+      completed_at: new Date().toISOString(),
     });
 
-    // Update last_synced_at
-    await supabase
-      .from('bank_connections')
-      .update({ last_synced_at: new Date().toISOString() })
-      .eq('id', connection.id);
+    await recordHealthEvent(
+      supabase,
+      conn,
+      syncStatus === 'failed' ? 'provider_down' : 'healthy',
+      logger,
+    );
+
+    logger.info('Plaid transactions processed', {
+      added: summary.added,
+      modified: summary.modified,
+      removed: summary.removed,
+      syncStatus,
+    });
   }
 }
 
 /**
- * Process an MX webhook event.
- *
- * NEVER logs raw financial data — only event metadata.
+ * Process an MX webhook event. MX transaction contents are not delivered in
+ * the webhook payload, so we record intent and health (full MX pull is a
+ * documented follow-up). NEVER logs raw financial data.
  */
 async function processMxEvent(
-  supabase: ReturnType<typeof createAdminClient>,
+  supabase: AdminClient,
   event: MxWebhookEvent,
-  logger: ReturnType<typeof createLogger>,
+  logger: FunctionLogger,
 ): Promise<void> {
   logger.info('Processing MX event', { eventType: event.event_type });
 
@@ -207,6 +457,11 @@ async function processMxEvent(
       .from('bank_connections')
       .update({ status: 'needs_reauth' })
       .eq('id', connection.id);
+    await recordHealthEvent(supabase, connection, 'auth_expired', logger, {
+      errorCategory: 'auth',
+      errorDetail: event.event_type,
+    });
+    return;
   }
 
   if (event.event_type === 'transactions_added' || event.event_type === 'member_connected') {
@@ -216,11 +471,11 @@ async function processMxEvent(
       sync_type: 'webhook',
       status: 'pending',
     });
-
     await supabase
       .from('bank_connections')
       .update({ last_synced_at: new Date().toISOString() })
       .eq('id', connection.id);
+    await recordHealthEvent(supabase, connection, 'healthy', logger);
   }
 }
 
@@ -244,7 +499,6 @@ serve(async (req: Request): Promise<Response> => {
   if (envError) return envError;
 
   try {
-    // Rate limit by IP
     const supabase = createAdminClient();
     const clientIp = getClientIp(req) ?? 'unknown';
     const rateLimitResult = await checkRateLimit(supabase, clientIp, RATE_LIMITS['bank-webhook']);
@@ -261,20 +515,17 @@ serve(async (req: Request): Promise<Response> => {
       return errorResponse(req, 'provider query parameter must be plaid or mx', 400);
     }
 
-    // Verify webhook signature
-    let verified = false;
-    if (provider === 'plaid') {
-      verified = await verifyPlaidWebhook(body, req.headers);
-    } else {
-      verified = await verifyMxWebhook(body, req.headers);
-    }
+    // Verify webhook signature BEFORE parsing/processing.
+    const verified =
+      provider === 'plaid'
+        ? await verifyPlaid(body, req.headers)
+        : await verifyMx(body, req.headers);
 
     if (!verified) {
       logger.warn('Webhook signature verification failed', { provider });
       return errorResponse(req, 'Invalid webhook signature', 401);
     }
 
-    // Process the event
     const event = JSON.parse(body);
 
     if (provider === 'plaid') {

--- a/services/api/supabase/functions/deno.json
+++ b/services/api/supabase/functions/deno.json
@@ -19,6 +19,7 @@
       "launch-readiness/**/*.test.ts",
       "spending-forecast/**/*.test.ts",
       "bank-connection/**/*.test.ts",
+      "bank-webhook/**/*.test.ts",
       "anomaly-detection/**/*.test.ts",
       "investment-sync/**/*.test.ts",
       "detect-bills/**/*.test.ts",

--- a/services/api/supabase/migrations/20260401000003_seed_aggregator_providers_phase3.sql
+++ b/services/api/supabase/migrations/20260401000003_seed_aggregator_providers_phase3.sql
@@ -1,0 +1,52 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260401000003_seed_aggregator_providers_phase3
+-- Description: Phase 3 aggregator provider registry alignment (#3848, epic #3846).
+--   Establishes Plaid as the primary, enabled aggregator (priority 0) and MX
+--   as the secondary enabled aggregator (priority 1). Adds TrueLayer and
+--   (re)registers Finicity as DISABLED placeholders for future work.
+--
+--   The aggregator-health function orders providers by `priority ASC`, so
+--   priority 0 makes Plaid the default/first-choice provider and priority 1
+--   makes MX the first failover target.
+--
+-- Idempotency:
+--   Uses INSERT ... ON CONFLICT (name) DO UPDATE so re-running (or running
+--   after the 20260331000001 foundation seed) converges to the intended
+--   priorities and enabled flags without duplicating rows.
+--
+-- Security:
+--   - Reference data only (no user/financial data).
+--   - RLS on aggregator_providers already restricts writes to service_role.
+--   - No secrets stored here — provider credentials live in env vars only.
+--
+-- DOWN migration: services/api/supabase/migrations/down/20260401000003_seed_aggregator_providers_phase3.down.sql
+
+-- =============================================================================
+-- Upsert Phase 3 provider registry
+-- =============================================================================
+
+INSERT INTO aggregator_providers
+    (name, display_name, provider_type, priority, is_enabled, status, supported_regions, capabilities)
+VALUES
+    ('plaid', 'Plaid', 'aggregator', 0, true, 'active',
+     '["US", "CA", "GB", "IE", "FR", "ES", "NL"]'::jsonb,
+     '{"transactions": true, "balances": true, "identity": true, "investments": true}'::jsonb),
+    ('mx', 'MX', 'aggregator', 1, true, 'active',
+     '["US", "CA"]'::jsonb,
+     '{"transactions": true, "balances": true, "identity": true}'::jsonb),
+    ('truelayer', 'TrueLayer', 'open_banking', 12, false, 'maintenance',
+     '["GB", "IE", "FR", "ES", "IT", "DE", "PT", "NL", "LT"]'::jsonb,
+     '{"transactions": true, "balances": true, "identity": false}'::jsonb),
+    ('finicity', 'Finicity (Mastercard)', 'aggregator', 13, false, 'maintenance',
+     '["US", "CA"]'::jsonb,
+     '{"transactions": true, "balances": true, "identity": true}'::jsonb)
+ON CONFLICT (name) DO UPDATE SET
+    display_name      = EXCLUDED.display_name,
+    provider_type     = EXCLUDED.provider_type,
+    priority          = EXCLUDED.priority,
+    is_enabled        = EXCLUDED.is_enabled,
+    status            = EXCLUDED.status,
+    supported_regions = EXCLUDED.supported_regions,
+    capabilities      = EXCLUDED.capabilities,
+    updated_at        = now();

--- a/services/api/supabase/migrations/down/20260401000003_seed_aggregator_providers_phase3.down.sql
+++ b/services/api/supabase/migrations/down/20260401000003_seed_aggregator_providers_phase3.down.sql
@@ -1,0 +1,28 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- DOWN Migration: 20260401000003_seed_aggregator_providers_phase3
+-- Reverts: Phase 3 aggregator provider registry alignment (#3848)
+--
+-- Restores the priorities/enabled flags seeded by 20260331000001 for the
+-- providers that existed there (plaid -> 1, mx -> 2, finicity -> 4, both
+-- enabled/active) and removes the net-new TrueLayer placeholder row.
+--
+-- NOTE: Provider rows are reference data. This down migration is safe to run
+-- because aggregator_providers.name is UNIQUE and TrueLayer is only ever
+-- introduced by the paired up migration.
+
+-- Remove the net-new TrueLayer placeholder.
+DELETE FROM aggregator_providers WHERE name = 'truelayer';
+
+-- Restore prior priorities / enabled flags for pre-existing providers.
+UPDATE aggregator_providers
+    SET priority = 1, is_enabled = true, status = 'active', updated_at = now()
+    WHERE name = 'plaid';
+
+UPDATE aggregator_providers
+    SET priority = 2, is_enabled = true, status = 'active', updated_at = now()
+    WHERE name = 'mx';
+
+UPDATE aggregator_providers
+    SET priority = 4, is_enabled = true, status = 'active', updated_at = now()
+    WHERE name = 'finicity';


### PR DESCRIPTION
﻿## Summary

Phase 3 of epic #3846: replaces the speculative Plaid/MX stubs in the Supabase backend with a **real Plaid REST integration** on the Deno Edge runtime (Plaid Node SDK is not Deno-compatible, so all calls go through `fetch`). MX is kept behind the same interface as a stub; Plaid is the reference implementation.

## Changes

### `bank-connection` (link + exchange)
- `create_link_token` -> `POST /link/token/create`
- `exchange_token` -> `POST /item/public_token/exchange`; the returned access token is **encrypted with AES-256-GCM** (`BANK_ENCRYPTION_KEY`) before being written to `bank_connections`. The raw token is **never returned or logged**.
- Base URL resolved from `PLAID_ENVIRONMENT` (sandbox/development/production), defaulting to sandbox on misconfiguration.
- `PlaidApiError` surfaces only Plaid's `error_code` (never the raw body) and maps to `502`.

### `bank-webhook` (verify + ingest)
- **Plaid webhook verification**: validates the signed JWT (JWS, ES256) in the `Plaid-Verification` header — decodes the header (requires `alg=ES256` + `kid`), fetches the verification key via `/webhook_verification_key/get`, verifies the ECDSA P-256 signature, enforces a 5-minute `iat` replay window, and timing-safe-compares the request-body SHA-256 to the signed `request_body_sha256` claim. Verification happens **before** parsing/processing.
- **MX webhook verification**: HMAC-SHA256 of the raw body (existing `_shared/webhook-verify.ts`).
- **Transaction ingestion**: `/transactions/sync` with cursor persistence in `bank_connections.metadata`; rows written to `transactions` with provenance columns (`source='aggregator'`, `provider_transaction_id`, `authorized_date`, `posted_date`). Dedupe on `provider_transaction_id`. `bank_connection_health` events recorded per run.

### New shared modules (+ Deno tests)
- `_shared/bank-crypto.ts` — AES-256-GCM `encryptToken`/`decryptToken` (Web Crypto).
- `_shared/plaid.ts` — Plaid REST client + pure helpers (`plaidTransactionToRecord`, `plaidAmountToCents`).
- `_shared/plaid-webhook.ts` — `verifyPlaidWebhook` (injectable `fetchKey` for network-free tests).

### Migration
- `20260401000003_seed_aggregator_providers_phase3.sql` — upserts plaid (priority 0, enabled), mx (priority 1, enabled), truelayer + finicity (disabled placeholders) via `ON CONFLICT (name) DO UPDATE`.
- Matching down migration under `migrations/down/`.

### Config
- `.env.example` — **placeholders only** (`PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENVIRONMENT`, `PLAID_WEBHOOK_URL`, `MX_*`, `BANK_ENCRYPTION_KEY`).
- Removed the `SPECULATIVE`/`Post-alpha` TODO banners.

## Security decisions
- **Encryption at rest**: access tokens stored as `aes256gcm:<b64url(iv)>:<b64url(ct+tag)>`; fresh 96-bit IV per encryption; GCM auth tag gives integrity. Tokens never appear in responses or logs (verified by tests + the sensitive-logging backstop).
- **Webhook auth**: Plaid JWS (ES256) with replay + body-binding checks; fails closed on any malformed input. MX HMAC.
- Provider credentials come from env only; parameterized Supabase queries throughout.

## Testing
- 50 Deno tests pass (`deno test --allow-env --allow-net=none --no-check`) covering encryption round-trip (asserting the raw token is never persisted/returned), link-token/amount/provenance mapping, and webhook verification (valid, tampered body, stale `iat`, alg-confusion, wrong key, missing header).
- `prettier --check` and `eslint --max-warnings 0` clean on `services`.

## Human-gated follow-ups (do NOT merge until reviewed)
- [ ] Set real secrets in the deployment environment: `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENVIRONMENT`, `BANK_ENCRYPTION_KEY` (64-char hex), `MX_WEBHOOK_SECRET`, `PLAID_WEBHOOK_URL`.
- [ ] Run migration `20260401000003_seed_aggregator_providers_phase3.sql` against the database (human-gated; not run here).
- [ ] Register the `bank-webhook` URL with Plaid.
- [ ] Full MX transaction pull (webhook records intent only; documented as follow-up).

Closes #3848
