### PR TITLE
feat(web): wire bank-connection UI to live PowerSync data + router metadata (#3852)

### DIFF
--- a/apps/web/src/db/repositories/bank-connections.test.ts
+++ b/apps/web/src/db/repositories/bank-connections.test.ts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Row, SqliteDb } from '../sqlite-wasm';
+
+vi.mock('../sqlite-wasm', () => ({
+  query: vi.fn(),
+  queryOne: vi.fn(),
+  execute: vi.fn(),
+}));
+
+import { query } from '../sqlite-wasm';
+import {
+  listAggregatorProviders,
+  listBankConnectionHealth,
+  listHealthHistory,
+} from './bank-connections';
+
+const mockQuery = vi.mocked(query);
+const mockDb = {} as SqliteDb;
+
+function result(rows: Row[]) {
+  return { columns: rows.length > 0 ? Object.keys(rows[0]) : [], rows };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listBankConnectionHealth', () => {
+  it('maps a joined connection + latest health row', () => {
+    mockQuery.mockReturnValueOnce(
+      result([
+        {
+          id: 'conn-1',
+          provider: 'plaid',
+          institution_name: 'Acme Bank',
+          connection_status: 'active',
+          connection_last_synced_at: '2026-04-01T00:00:00Z',
+          error_code: null,
+          health_status: 'stale',
+          error_category: 'provider',
+          staleness_minutes: 120,
+          last_successful_sync: '2026-04-02T00:00:00Z',
+          provider_type: 'aggregator',
+        },
+      ]),
+    );
+
+    const [connection] = listBankConnectionHealth(mockDb);
+
+    expect(connection).toEqual({
+      id: 'conn-1',
+      provider: 'plaid',
+      institutionName: 'Acme Bank',
+      connectionStatus: 'active',
+      healthStatus: 'stale',
+      stalenessMinutes: 120,
+      errorCategory: 'provider',
+      errorCode: null,
+      lastSyncedAt: '2026-04-02T00:00:00Z',
+      permissionLevel: 'read_only',
+      connectionType: 'aggregator',
+      needsReauth: false,
+    });
+  });
+
+  it('derives health status from connection status when no health row exists', () => {
+    mockQuery.mockReturnValueOnce(
+      result([
+        {
+          id: 'conn-2',
+          provider: 'mx',
+          institution_name: 'Beta CU',
+          connection_status: 'needs_reauth',
+          connection_last_synced_at: '2026-03-01T00:00:00Z',
+          error_code: 'ITEM_LOGIN_REQUIRED',
+          health_status: null,
+          error_category: null,
+          staleness_minutes: null,
+          last_successful_sync: null,
+          provider_type: null,
+        },
+      ]),
+    );
+
+    const [connection] = listBankConnectionHealth(mockDb);
+
+    expect(connection.healthStatus).toBe('auth_expired');
+    expect(connection.needsReauth).toBe(true);
+    expect(connection.stalenessMinutes).toBeNull();
+    expect(connection.connectionType).toBe('aggregator');
+    expect(connection.lastSyncedAt).toBe('2026-03-01T00:00:00Z');
+  });
+
+  it('ignores unknown health/category values', () => {
+    mockQuery.mockReturnValueOnce(
+      result([
+        {
+          id: 'conn-3',
+          provider: 'plaid',
+          institution_name: 'Gamma Bank',
+          connection_status: 'active',
+          connection_last_synced_at: null,
+          error_code: null,
+          health_status: 'not_a_real_status',
+          error_category: 'bogus',
+          staleness_minutes: 5,
+          last_successful_sync: null,
+          provider_type: 'open_banking',
+        },
+      ]),
+    );
+
+    const [connection] = listBankConnectionHealth(mockDb);
+
+    expect(connection.healthStatus).toBe('healthy');
+    expect(connection.errorCategory).toBeNull();
+    expect(connection.connectionType).toBe('open_banking');
+  });
+});
+
+describe('listAggregatorProviders', () => {
+  it('parses JSON regions/capabilities and coerces booleans', () => {
+    mockQuery.mockReturnValueOnce(
+      result([
+        {
+          id: 'prov-1',
+          name: 'plaid',
+          display_name: 'Plaid',
+          provider_type: 'aggregator',
+          status: 'active',
+          health_score: 98,
+          priority: 0,
+          is_enabled: 1,
+          supported_regions: '["US","CA"]',
+          capabilities: '{"transactions":true,"identity":false}',
+        },
+      ]),
+    );
+
+    const [provider] = listAggregatorProviders(mockDb);
+
+    expect(provider).toEqual({
+      id: 'prov-1',
+      name: 'plaid',
+      displayName: 'Plaid',
+      providerType: 'aggregator',
+      status: 'active',
+      healthScore: 98,
+      priority: 0,
+      isEnabled: true,
+      supportedRegions: ['US', 'CA'],
+      capabilities: { transactions: true, identity: false },
+    });
+  });
+
+  it('tolerates malformed JSON', () => {
+    mockQuery.mockReturnValueOnce(
+      result([
+        {
+          id: 'prov-2',
+          name: 'mx',
+          display_name: 'MX',
+          provider_type: 'aggregator',
+          status: 'degraded',
+          health_score: 70,
+          priority: 1,
+          is_enabled: 0,
+          supported_regions: 'not-json',
+          capabilities: null,
+        },
+      ]),
+    );
+
+    const [provider] = listAggregatorProviders(mockDb);
+
+    expect(provider.supportedRegions).toEqual([]);
+    expect(provider.capabilities).toEqual({});
+    expect(provider.isEnabled).toBe(false);
+  });
+});
+
+describe('listHealthHistory', () => {
+  it('maps history rows and passes the connection id + limit', () => {
+    mockQuery.mockReturnValueOnce(
+      result([
+        {
+          id: 'h-1',
+          status: 'stale',
+          error_category: 'provider',
+          error_detail: 'slow',
+          staleness_minutes: 60,
+          resolved_at: null,
+          resolution_action: null,
+          created_at: '2026-04-03T00:00:00Z',
+        },
+      ]),
+    );
+
+    const events = listHealthHistory(mockDb, 'conn-1');
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      id: 'h-1',
+      status: 'stale',
+      errorCategory: 'provider',
+      errorDetail: 'slow',
+      stalenessMinutes: 60,
+      resolvedAt: null,
+      resolutionAction: null,
+      createdAt: '2026-04-03T00:00:00Z',
+    });
+
+    const params = mockQuery.mock.calls[0][2];
+    expect(params).toEqual(['conn-1', 100]);
+  });
+
+  it('honours a custom limit', () => {
+    mockQuery.mockReturnValueOnce(result([]));
+
+    listHealthHistory(mockDb, 'conn-9', 25);
+
+    expect(mockQuery.mock.calls[0][2]).toEqual(['conn-9', 25]);
+  });
+});

--- a/apps/web/src/db/repositories/bank-connections.ts
+++ b/apps/web/src/db/repositories/bank-connections.ts
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Bank connectivity repository (#3852).
+ *
+ * Read-only access to the PowerSync-synced bank connectivity tables:
+ *   - `bank_connection`        — connection identity + display status (no token)
+ *   - `bank_connection_health` — health history log
+ *   - `aggregator_provider`    — global provider directory
+ *
+ * These tables are populated exclusively by the sync pull path; the client
+ * never writes to them, so this repository exposes reads only. All financial
+ * amounts are irrelevant here — this is connection metadata, not money.
+ *
+ * @module db/repositories/bank-connections
+ */
+
+import { query, type Row, type SqliteDb } from '../sqlite-wasm';
+import { optionalString, requireNumber, requireString, toBoolean } from './helpers';
+
+// ---------------------------------------------------------------------------
+// Public DTO types (re-exported by hooks/useBankConnections for consumers)
+// ---------------------------------------------------------------------------
+
+/** Computed health status of a bank connection. */
+export type ConnectionHealthStatus =
+  | 'healthy'
+  | 'stale'
+  | 'auth_expired'
+  | 'provider_down'
+  | 'rate_limited'
+  | 'institution_error'
+  | 'unknown_error';
+
+/** Error category for structured reporting. */
+export type ErrorCategory = 'auth' | 'provider' | 'institution' | 'network' | 'data' | 'rate_limit';
+
+/** A bank connection with its latest health snapshot. */
+export interface BankConnectionHealth {
+  /** Connection ID. */
+  id: string;
+  /** Provider name (plaid, mx, etc.). */
+  provider: string;
+  /** Institution display name. */
+  institutionName: string;
+  /** Current connection status (active, needs_reauth, disconnected, error). */
+  connectionStatus: string;
+  /** Computed health status from the latest health snapshot. */
+  healthStatus: ConnectionHealthStatus;
+  /** Minutes since last successful sync (from the latest health snapshot). */
+  stalenessMinutes: number | null;
+  /** Structured error category (if any). */
+  errorCategory: ErrorCategory | null;
+  /** Error code from the provider (if any). */
+  errorCode: string | null;
+  /** Last successful sync timestamp. */
+  lastSyncedAt: string | null;
+  /** Permission level (read_only by default). */
+  permissionLevel: string;
+  /** Connection type (aggregator, open_banking, direct). */
+  connectionType: string;
+  /** Whether re-authentication is needed. */
+  needsReauth: boolean;
+}
+
+/** A single health-history event for a connection. */
+export interface HealthHistoryEvent {
+  /** Event ID. */
+  id: string;
+  /** Health status at the time. */
+  status: ConnectionHealthStatus;
+  /** Error category at the time. */
+  errorCategory: ErrorCategory | null;
+  /** Error detail at the time. */
+  errorDetail: string | null;
+  /** Staleness in minutes at the time. */
+  stalenessMinutes: number | null;
+  /** When the issue was resolved (null if unresolved). */
+  resolvedAt: string | null;
+  /** How it was resolved. */
+  resolutionAction: string | null;
+  /** When this event was recorded. */
+  createdAt: string;
+}
+
+/** An aggregator provider from the synced directory. */
+export interface AggregatorProvider {
+  /** Provider ID (row id). */
+  id: string;
+  /** Short name (plaid, mx, etc.). */
+  name: string;
+  /** Display name. */
+  displayName: string;
+  /** Provider type (aggregator, open_banking, direct). */
+  providerType: string;
+  /** Current health status. */
+  status: string;
+  /** Health score (0–100). */
+  healthScore: number;
+  /** Priority for failover ordering (lower = preferred). */
+  priority: number;
+  /** Whether the provider is enabled. */
+  isEnabled: boolean;
+  /** Supported regions (ISO 3166-1 alpha-2). */
+  supportedRegions: string[];
+  /** Provider capabilities. */
+  capabilities: Record<string, boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const VALID_HEALTH_STATUSES: ReadonlySet<string> = new Set([
+  'healthy',
+  'stale',
+  'auth_expired',
+  'provider_down',
+  'rate_limited',
+  'institution_error',
+  'unknown_error',
+]);
+
+const VALID_ERROR_CATEGORIES: ReadonlySet<string> = new Set([
+  'auth',
+  'provider',
+  'institution',
+  'network',
+  'data',
+  'rate_limit',
+]);
+
+/** Read a nullable integer column. */
+function optionalNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'bigint') return Number(value);
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/** Narrow an arbitrary string to a known {@link ConnectionHealthStatus}. */
+function toHealthStatus(value: unknown): ConnectionHealthStatus | null {
+  return typeof value === 'string' && VALID_HEALTH_STATUSES.has(value)
+    ? (value as ConnectionHealthStatus)
+    : null;
+}
+
+/** Narrow an arbitrary string to a known {@link ErrorCategory}. */
+function toErrorCategory(value: unknown): ErrorCategory | null {
+  return typeof value === 'string' && VALID_ERROR_CATEGORIES.has(value)
+    ? (value as ErrorCategory)
+    : null;
+}
+
+/**
+ * Derive a health status when a connection has no health-history rows yet,
+ * mapping the connection's own status onto the closest health category.
+ */
+function fallbackHealthStatus(connectionStatus: string): ConnectionHealthStatus {
+  switch (connectionStatus) {
+    case 'active':
+      return 'healthy';
+    case 'needs_reauth':
+      return 'auth_expired';
+    case 'disconnected':
+      return 'provider_down';
+    default:
+      return 'unknown_error';
+  }
+}
+
+/** Parse a JSON array of region strings, tolerating malformed data. */
+function parseRegions(value: unknown): string[] {
+  if (typeof value !== 'string' || value.trim().length === 0) return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((r): r is string => typeof r === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Parse a JSON object of boolean capability flags, tolerating malformed data. */
+function parseCapabilities(value: unknown): Record<string, boolean> {
+  if (typeof value !== 'string' || value.trim().length === 0) return {};
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out: Record<string, boolean> = {};
+    for (const [key, val] of Object.entries(parsed as Record<string, unknown>)) {
+      out[key] = Boolean(val);
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row mappers
+// ---------------------------------------------------------------------------
+
+/**
+ * Join `bank_connection` with its latest `bank_connection_health` snapshot and
+ * its provider directory entry so a single row carries everything the health
+ * dashboard needs.
+ */
+const CONNECTION_HEALTH_QUERY = `
+  SELECT
+    c.id                    AS id,
+    c.provider              AS provider,
+    c.institution_name      AS institution_name,
+    c.status                AS connection_status,
+    c.last_synced_at        AS connection_last_synced_at,
+    c.error_code            AS error_code,
+    h.status                AS health_status,
+    h.error_category        AS error_category,
+    h.staleness_minutes     AS staleness_minutes,
+    h.last_successful_sync  AS last_successful_sync,
+    p.provider_type         AS provider_type
+  FROM bank_connection c
+  LEFT JOIN (
+    SELECT bh.bank_connection_id, bh.status, bh.error_category,
+           bh.staleness_minutes, bh.last_successful_sync
+    FROM bank_connection_health bh
+    JOIN (
+      SELECT bank_connection_id, MAX(created_at) AS max_created
+      FROM bank_connection_health
+      GROUP BY bank_connection_id
+    ) latest
+      ON latest.bank_connection_id = bh.bank_connection_id
+      AND latest.max_created = bh.created_at
+  ) h ON h.bank_connection_id = c.id
+  LEFT JOIN aggregator_provider p ON p.name = c.provider
+  WHERE c.deleted_at IS NULL
+  ORDER BY c.institution_name COLLATE NOCASE
+`;
+
+function mapConnectionHealth(row: Row): BankConnectionHealth {
+  const connectionStatus = requireString(row.connection_status, 'connection_status');
+  const healthStatus = toHealthStatus(row.health_status) ?? fallbackHealthStatus(connectionStatus);
+  const providerType = optionalString(row.provider_type) ?? 'aggregator';
+
+  return {
+    id: requireString(row.id, 'id'),
+    provider: requireString(row.provider, 'provider'),
+    institutionName: requireString(row.institution_name, 'institution_name'),
+    connectionStatus,
+    healthStatus,
+    stalenessMinutes: optionalNumber(row.staleness_minutes),
+    errorCategory: toErrorCategory(row.error_category),
+    errorCode: optionalString(row.error_code),
+    lastSyncedAt:
+      optionalString(row.last_successful_sync) ?? optionalString(row.connection_last_synced_at),
+    permissionLevel: 'read_only',
+    connectionType: providerType,
+    needsReauth: connectionStatus === 'needs_reauth' || healthStatus === 'auth_expired',
+  };
+}
+
+function mapHealthHistory(row: Row): HealthHistoryEvent {
+  return {
+    id: requireString(row.id, 'id'),
+    status: toHealthStatus(row.status) ?? 'unknown_error',
+    errorCategory: toErrorCategory(row.error_category),
+    errorDetail: optionalString(row.error_detail),
+    stalenessMinutes: optionalNumber(row.staleness_minutes),
+    resolvedAt: optionalString(row.resolved_at),
+    resolutionAction: optionalString(row.resolution_action),
+    createdAt: requireString(row.created_at, 'created_at'),
+  };
+}
+
+function mapAggregatorProvider(row: Row): AggregatorProvider {
+  return {
+    id: requireString(row.id, 'id'),
+    name: requireString(row.name, 'name'),
+    displayName: requireString(row.display_name, 'display_name'),
+    providerType: requireString(row.provider_type, 'provider_type'),
+    status: requireString(row.status, 'status'),
+    healthScore: requireNumber(row.health_score, 'health_score'),
+    priority: requireNumber(row.priority, 'priority'),
+    isEnabled: toBoolean(row.is_enabled),
+    supportedRegions: parseRegions(row.supported_regions),
+    capabilities: parseCapabilities(row.capabilities),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public read API
+// ---------------------------------------------------------------------------
+
+/**
+ * List all active bank connections with their latest health snapshot.
+ *
+ * @param db - The local SQLite database.
+ * @returns One {@link BankConnectionHealth} per non-deleted connection.
+ */
+export function listBankConnectionHealth(db: SqliteDb): BankConnectionHealth[] {
+  return query(db, CONNECTION_HEALTH_QUERY).rows.map(mapConnectionHealth);
+}
+
+/**
+ * List the aggregator provider directory, ordered by failover priority.
+ *
+ * @param db - The local SQLite database.
+ * @returns The enabled, non-deleted {@link AggregatorProvider} entries.
+ */
+export function listAggregatorProviders(db: SqliteDb): AggregatorProvider[] {
+  return query(
+    db,
+    `SELECT id, name, display_name, provider_type, status, health_score,
+            priority, is_enabled, supported_regions, capabilities
+     FROM aggregator_provider
+     WHERE deleted_at IS NULL
+     ORDER BY priority ASC, name ASC`,
+  ).rows.map(mapAggregatorProvider);
+}
+
+/**
+ * List the health history for a single connection, most recent first.
+ *
+ * @param db - The local SQLite database.
+ * @param connectionId - The `bank_connection.id` to fetch history for.
+ * @param limit - Maximum number of events to return. @default 100
+ * @returns The connection's {@link HealthHistoryEvent}s, newest first.
+ */
+export function listHealthHistory(
+  db: SqliteDb,
+  connectionId: string,
+  limit = 100,
+): HealthHistoryEvent[] {
+  return query(
+    db,
+    `SELECT id, status, error_category, error_detail, staleness_minutes,
+            resolved_at, resolution_action, created_at
+     FROM bank_connection_health
+     WHERE bank_connection_id = ?
+     ORDER BY created_at DESC
+     LIMIT ?`,
+    [connectionId, limit],
+  ).rows.map(mapHealthHistory);
+}

--- a/apps/web/src/db/repositories/index.ts
+++ b/apps/web/src/db/repositories/index.ts
@@ -13,3 +13,4 @@ export * from './household';
 export * from './invoices';
 export * from './remittances';
 export * from './householdData';
+export * from './bank-connections';

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -751,6 +751,78 @@ export const MIGRATIONS: Migration[] = [
          );`,
     ],
   },
+  {
+    version: 18,
+    label: 'add-bank-connectivity-mirror-tables',
+    up: [
+      // #3852 (Phase 4): read-only client mirrors of the server-owned bank
+      // connectivity tables. These are populated exclusively by the sync pull
+      // path — the client NEVER writes to them — so the connection-health
+      // dashboard and the provider router can read live data from local SQLite
+      // instead of hitting the network on every render.
+      //
+      // The columns mirror the PowerSync `sync-rules.yaml` projections exactly.
+      // SECURITY: bank_connection deliberately has NO token column — the
+      // encrypted access token is excluded from the sync projection and never
+      // reaches the client.
+      `CREATE TABLE IF NOT EXISTS bank_connection (
+         id                TEXT PRIMARY KEY NOT NULL,
+         household_id      TEXT NOT NULL,
+         owner_id          TEXT,
+         provider          TEXT NOT NULL,
+         institution_id    TEXT,
+         institution_name  TEXT NOT NULL,
+         status            TEXT NOT NULL,
+         last_synced_at    TEXT,
+         error_code        TEXT,
+         error_message     TEXT,
+         metadata          TEXT,
+         created_at        TEXT NOT NULL,
+         updated_at        TEXT NOT NULL,
+         deleted_at        TEXT
+       );`,
+      `CREATE INDEX IF NOT EXISTS idx_bank_connection_household ON bank_connection (household_id);`,
+      `CREATE INDEX IF NOT EXISTS idx_bank_connection_status    ON bank_connection (status);`,
+
+      // Health history log — one row per health snapshot per connection.
+      `CREATE TABLE IF NOT EXISTS bank_connection_health (
+         id                   TEXT PRIMARY KEY NOT NULL,
+         bank_connection_id   TEXT NOT NULL,
+         household_id         TEXT NOT NULL,
+         status               TEXT NOT NULL,
+         error_category       TEXT,
+         error_detail         TEXT,
+         last_successful_sync TEXT,
+         staleness_minutes    INTEGER,
+         resolved_at          TEXT,
+         resolution_action    TEXT,
+         created_at           TEXT NOT NULL
+       );`,
+      `CREATE INDEX IF NOT EXISTS idx_bank_connection_health_connection ON bank_connection_health (bank_connection_id, created_at);`,
+      `CREATE INDEX IF NOT EXISTS idx_bank_connection_health_household  ON bank_connection_health (household_id, created_at);`,
+
+      // Global aggregator provider directory (read-only reference data). Drives
+      // provider selection/failover in the router and provider health display.
+      `CREATE TABLE IF NOT EXISTS aggregator_provider (
+         id                TEXT PRIMARY KEY NOT NULL,
+         name              TEXT NOT NULL,
+         display_name      TEXT NOT NULL,
+         provider_type     TEXT NOT NULL,
+         status            TEXT NOT NULL,
+         health_score      INTEGER NOT NULL,
+         priority          INTEGER NOT NULL,
+         is_enabled        INTEGER NOT NULL,
+         supported_regions TEXT NOT NULL,
+         capabilities      TEXT NOT NULL,
+         last_health_check TEXT,
+         incident_count    INTEGER NOT NULL DEFAULT 0,
+         created_at        TEXT NOT NULL,
+         updated_at        TEXT NOT NULL,
+         deleted_at        TEXT
+       );`,
+      `CREATE INDEX IF NOT EXISTS idx_aggregator_provider_status ON aggregator_provider (status, priority);`,
+    ],
+  },
 ];
 // ---------------------------------------------------------------------------
 // OPFS / IndexedDB feature detection

--- a/apps/web/src/hooks/useBankConnections.ts
+++ b/apps/web/src/hooks/useBankConnections.ts
@@ -9,100 +9,42 @@
  * Data access follows the standard hook pattern:
  *   DatabaseProvider → Repository → Hook → Component
  *
+ * Reads come from the PowerSync-synced local SQLite mirror tables
+ * (`bank_connection`, `bank_connection_health`, `aggregator_provider`) — there
+ * are no direct server calls on the read path. As a side effect the hook wires
+ * the synced provider directory into the shared {@link ProviderRouter} so app
+ * routing reflects live provider health.
+ *
  * @module hooks/useBankConnections
- * References: #1575, #1577
+ * References: #1575, #1577, #3852
  */
 
 import { useCallback, useEffect, useState } from 'react';
 
+import { useDatabase } from '../db/DatabaseProvider';
+import {
+  listAggregatorProviders,
+  listBankConnectionHealth,
+  listHealthHistory,
+} from '../db/repositories/bank-connections';
+import type {
+  AggregatorProvider,
+  BankConnectionHealth,
+  HealthHistoryEvent,
+} from '../db/repositories/bank-connections';
+import { createDbProviderMetaSource, getProviderRouter } from '../lib/banking';
+
 // ---------------------------------------------------------------------------
-// Types
+// Types (owned by the repository; re-exported here for existing consumers)
 // ---------------------------------------------------------------------------
 
-/** Health status of a bank connection. */
-export type ConnectionHealthStatus =
-  | 'healthy'
-  | 'stale'
-  | 'auth_expired'
-  | 'provider_down'
-  | 'rate_limited'
-  | 'institution_error'
-  | 'unknown_error';
-
-/** Error category for structured reporting. */
-export type ErrorCategory = 'auth' | 'provider' | 'institution' | 'network' | 'data' | 'rate_limit';
-
-/** A bank connection with health information. */
-export interface BankConnectionHealth {
-  /** Connection ID. */
-  id: string;
-  /** Provider name (plaid, mx, etc.). */
-  provider: string;
-  /** Institution display name. */
-  institutionName: string;
-  /** Current connection status. */
-  connectionStatus: string;
-  /** Computed health status. */
-  healthStatus: ConnectionHealthStatus;
-  /** Minutes since last successful sync. */
-  stalenessMinutes: number | null;
-  /** Structured error category (if any). */
-  errorCategory: ErrorCategory | null;
-  /** Error code from provider. */
-  errorCode: string | null;
-  /** Last successful sync timestamp. */
-  lastSyncedAt: string | null;
-  /** Permission level (read_only, etc.). */
-  permissionLevel: string;
-  /** Connection type (aggregator, open_banking, direct). */
-  connectionType: string;
-  /** Whether re-authentication is needed. */
-  needsReauth: boolean;
-}
-
-/** A health history event. */
-export interface HealthHistoryEvent {
-  /** Event ID. */
-  id: string;
-  /** Health status at the time. */
-  status: ConnectionHealthStatus;
-  /** Error category. */
-  errorCategory: ErrorCategory | null;
-  /** Error detail. */
-  errorDetail: string | null;
-  /** Staleness in minutes at the time. */
-  stalenessMinutes: number | null;
-  /** When the issue was resolved (null if unresolved). */
-  resolvedAt: string | null;
-  /** How it was resolved. */
-  resolutionAction: string | null;
-  /** When this event was recorded. */
-  createdAt: string;
-}
-
-/** An aggregator provider from the registry. */
-export interface AggregatorProvider {
-  /** Provider ID. */
-  id: string;
-  /** Short name (plaid, mx, etc.). */
-  name: string;
-  /** Display name. */
-  displayName: string;
-  /** Provider type. */
-  providerType: string;
-  /** Current health status. */
-  status: string;
-  /** Health score (0–100). */
-  healthScore: number;
-  /** Priority for failover ordering. */
-  priority: number;
-  /** Whether the provider is enabled. */
-  isEnabled: boolean;
-  /** Supported regions (ISO 3166-1 alpha-2). */
-  supportedRegions: string[];
-  /** Provider capabilities. */
-  capabilities: Record<string, boolean>;
-}
+export type {
+  AggregatorProvider,
+  BankConnectionHealth,
+  ConnectionHealthStatus,
+  ErrorCategory,
+  HealthHistoryEvent,
+} from '../db/repositories/bank-connections';
 
 /** Return type for the useBankConnections hook. */
 export interface UseBankConnectionsResult {
@@ -136,6 +78,7 @@ export interface UseBankConnectionsResult {
  * @returns Connection health data and management functions.
  */
 export function useBankConnections(): UseBankConnectionsResult {
+  const db = useDatabase();
   const [connections, setConnections] = useState<BankConnectionHealth[]>([]);
   const [providers, setProviders] = useState<AggregatorProvider[]>([]);
   const [healthHistory, setHealthHistory] = useState<HealthHistoryEvent[]>([]);
@@ -148,31 +91,37 @@ export function useBankConnections(): UseBankConnectionsResult {
     setRefreshToken((t) => t + 1);
   }, []);
 
-  // Load connections — in production this reads from local SQLite
-  // via PowerSync sync. For now, initialise with empty state.
+  // Feed the synced provider directory into the shared router so app-routed
+  // provider selection reflects live health/priority. Re-attached whenever the
+  // database instance changes (e.g. after a reload).
+  useEffect(() => {
+    getProviderRouter().setMetaSource(createDbProviderMetaSource(db));
+  }, [db]);
+
+  // Load connections + providers from the local SQLite mirror.
   useEffect(() => {
     try {
-      // TODO: Wire to PowerSync local database query
-      // const db = useDatabase();
-      // const rows = query(db, 'SELECT ... FROM bank_connections WHERE deleted_at IS NULL');
-      setConnections([]);
-      setProviders([]);
+      setConnections(listBankConnectionHealth(db));
+      setProviders(listAggregatorProviders(db));
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load bank connections');
     } finally {
       setLoading(false);
     }
-  }, [refreshToken]);
+  }, [db, refreshToken]);
 
-  const loadHealthHistory = useCallback((_connectionId: string) => {
-    try {
-      // TODO: Wire to PowerSync local database query
-      setHealthHistory([]);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load health history');
-    }
-  }, []);
+  const loadHealthHistory = useCallback(
+    (connectionId: string) => {
+      try {
+        setHealthHistory(listHealthHistory(db, connectionId));
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load health history');
+      }
+    },
+    [db],
+  );
 
   return {
     connections,

--- a/apps/web/src/lib/banking/__tests__/provider-meta-source.test.ts
+++ b/apps/web/src/lib/banking/__tests__/provider-meta-source.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SqliteDb } from '../../../db/sqlite-wasm';
+import type { AggregatorProvider } from '../../../db/repositories/bank-connections';
+
+vi.mock('../../../db/repositories/bank-connections', () => ({
+  listAggregatorProviders: vi.fn(),
+}));
+
+import { listAggregatorProviders } from '../../../db/repositories/bank-connections';
+import { createDbProviderMetaSource } from '../provider-meta-source';
+
+const mockList = vi.mocked(listAggregatorProviders);
+const mockDb = {} as SqliteDb;
+
+function provider(overrides: Partial<AggregatorProvider> = {}): AggregatorProvider {
+  return {
+    id: 'prov-1',
+    name: 'plaid',
+    displayName: 'Plaid',
+    providerType: 'aggregator',
+    status: 'active',
+    healthScore: 95,
+    priority: 0,
+    isEnabled: true,
+    supportedRegions: ['US'],
+    capabilities: {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createDbProviderMetaSource', () => {
+  it('maps directory rows to routable metadata keyed by provider name', () => {
+    mockList.mockReturnValue([provider()]);
+
+    const meta = createDbProviderMetaSource(mockDb)();
+
+    expect(meta).toEqual([
+      {
+        providerId: 'plaid',
+        status: 'active',
+        healthScore: 95,
+        priority: 0,
+        isEnabled: true,
+        supportedRegions: ['US'],
+      },
+    ]);
+  });
+
+  it('treats unknown statuses as down so they are excluded from routing', () => {
+    mockList.mockReturnValue([provider({ status: 'weird' })]);
+
+    const [meta] = createDbProviderMetaSource(mockDb)();
+
+    expect(meta.status).toBe('down');
+  });
+
+  it('re-reads the directory on every invocation', () => {
+    mockList.mockReturnValueOnce([]).mockReturnValueOnce([provider()]);
+
+    const source = createDbProviderMetaSource(mockDb);
+
+    expect(source()).toHaveLength(0);
+    expect(source()).toHaveLength(1);
+    expect(mockList).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/lib/banking/index.ts
+++ b/apps/web/src/lib/banking/index.ts
@@ -50,6 +50,9 @@ export type {
 export { bootstrapBanking, getProviderRouter, resetBankingBootstrapForTests } from './bootstrap';
 export type { BankingBootstrap } from './bootstrap';
 
+// DB-backed provider metadata source (PowerSync-synced directory — #3852)
+export { createDbProviderMetaSource } from './provider-meta-source';
+
 // Connection manager
 export { ConnectionManager, categorizeError } from './connection-manager';
 export type { RetryConfig } from './connection-manager';

--- a/apps/web/src/lib/banking/provider-meta-source.ts
+++ b/apps/web/src/lib/banking/provider-meta-source.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * DB-backed provider metadata source (#3852).
+ *
+ * Bridges the PowerSync-synced `aggregator_provider` directory into the
+ * {@link ProviderRouter}. The router calls the returned function each time it
+ * routes, so metadata always reflects the latest synced state without any
+ * explicit refresh wiring.
+ *
+ * @module lib/banking/provider-meta-source
+ */
+
+import { listAggregatorProviders } from '../../db/repositories/bank-connections';
+import type { SqliteDb } from '../../db/sqlite-wasm';
+import type { AggregatorStatus, RoutableProviderMeta } from './aggregator-metadata';
+import type { ProviderMetaSource } from './provider-router';
+
+const VALID_STATUSES: ReadonlySet<string> = new Set(['active', 'degraded', 'down', 'maintenance']);
+
+/**
+ * Coerce a directory status string to a routable {@link AggregatorStatus}.
+ * Unknown values are treated as `down` so an unrecognised provider is never
+ * silently routed to.
+ */
+function toAggregatorStatus(value: string): AggregatorStatus {
+  return VALID_STATUSES.has(value) ? (value as AggregatorStatus) : 'down';
+}
+
+/**
+ * Build a {@link ProviderMetaSource} backed by the local SQLite provider
+ * directory.
+ *
+ * The `providerId` is taken from the directory `name` column (e.g. `plaid`),
+ * which matches the registered {@link BankConnectionProvider.id} — not the row
+ * UUID.
+ *
+ * @param db - The local SQLite database.
+ * @returns A metadata source the router can query on every route.
+ */
+export function createDbProviderMetaSource(db: SqliteDb): ProviderMetaSource {
+  return (): readonly RoutableProviderMeta[] =>
+    listAggregatorProviders(db).map((provider) => ({
+      providerId: provider.name,
+      status: toAggregatorStatus(provider.status),
+      healthScore: provider.healthScore,
+      priority: provider.priority,
+      isEnabled: provider.isEnabled,
+      supportedRegions: provider.supportedRegions,
+    }));
+}

--- a/services/api/powersync/sync-rules.yaml
+++ b/services/api/powersync/sync-rules.yaml
@@ -219,6 +219,17 @@ bucket_definitions:
         FROM import_jobs
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
 
+      # Bank connections — non-sensitive display projection (#3852)
+      # SECURITY: encrypted_access_token is DELIBERATELY EXCLUDED — clients only
+      # receive connection identity and display status, never token material.
+      - >
+        SELECT id, household_id, owner_id, provider,
+               institution_id, institution_name, status,
+               last_synced_at, error_code, error_message, metadata,
+               created_at, updated_at, deleted_at
+        FROM bank_connections
+        WHERE household_id = bucket.household_id AND deleted_at IS NULL
+
       # Bank connection health status (#1577)
       # SECURITY: error_detail may reference provider error codes — no PII.
       - >


### PR DESCRIPTION
## Summary

Phase 4 of the consolidated live-banking epic (#3846). Wires the bank connection
health dashboard and the provider router to **live, PowerSync-synced data** from
local SQLite, replacing the `useBankConnections` empty stubs.

## Changes

- **Client schema (v18 migration)** — adds read-only client mirror tables
  `bank_connection`, `bank_connection_health`, and `aggregator_provider`.
  Populated exclusively by the sync pull path; the client never writes to them.
  🔒 `bank_connection` has **no token column** — the encrypted access token is
  excluded from the sync projection and never reaches the client.
- **Sync rules** — adds a safe, non-sensitive `bank_connections` projection to
  the `by_household` bucket. `encrypted_access_token` is **deliberately excluded**.
- **Repository** — `db/repositories/bank-connections.ts`: joins each connection
  with its latest health snapshot + provider directory entry, lists the provider
  directory (priority-ordered), and reads per-connection health history.
- **Router metadata** — `lib/banking/provider-meta-source.ts`:
  `createDbProviderMetaSource(db)` bridges the synced provider directory into the
  shared `ProviderRouter`, so app-routed provider selection reflects live
  health/priority. Unknown statuses coerce to `down` (excluded from routing).
- **Hook** — `useBankConnections` now reads via `useDatabase()` + the repository
  and attaches the DB-backed meta source to the router. Public types are now
  owned by the repository and re-exported from the hook (no consumer changes).
- **Tests** — repository mapping/JSON-parsing/fallback tests and meta-source tests.

## Issues

Closes #3852
Refs #3846

## Testing

- [x] `npx vitest run src/db/repositories/bank-connections.test.ts src/lib/banking` — 161 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npx eslint <changed files> --max-warnings 0` — clean

## Needs Human Action

- **PowerSync deploy required.** The new `sync-rules.yaml` projection only takes
  effect after the PowerSync service is redeployed with the updated rules
  (infra-gated). Until then the mirror tables stay empty and the dashboard shows
  the same empty state as today — no regression, but no live data yet either.
