### PR TITLE
feat(web): register concrete aggregator providers (Plaid/MX/TrueLayer/Finicity)

### DIFF
--- a/apps/web/src/lib/banking/__tests__/aggregator-providers.test.ts
+++ b/apps/web/src/lib/banking/__tests__/aggregator-providers.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createAggregatorProviders,
+  FinicityProvider,
+  MxProvider,
+  PlaidProvider,
+  TrueLayerProvider,
+} from '../aggregator-providers';
+import type { EdgeTransport } from '../base-aggregator-provider';
+
+/** Build a fake transport capturing the composed request URL + headers. */
+function fakeTransport(response: unknown): {
+  transport: EdgeTransport;
+  fetch: ReturnType<typeof vi.fn>;
+} {
+  const fetch = vi.fn(async () => new Response(JSON.stringify(response), { status: 200 }));
+  const transport: EdgeTransport = {
+    baseUrl: 'https://proj.supabase.co/functions/v1',
+    fetch: fetch as unknown as EdgeTransport['fetch'],
+    getAuthToken: async () => 'jwt-token',
+  };
+  return { transport, fetch };
+}
+
+describe('concrete aggregator providers', () => {
+  const { transport } = fakeTransport({});
+
+  it('PlaidProvider mirrors the seeded directory identity', () => {
+    const plaid = new PlaidProvider(transport);
+    expect(plaid.id).toBe('plaid');
+    expect(plaid.name).toBe('Plaid');
+    expect(plaid.supportedCountries).toEqual(['US', 'CA', 'GB', 'IE', 'FR', 'ES', 'NL']);
+    expect(plaid.features.internationalBanks).toBe(true);
+    expect(plaid.features.investmentAccounts).toBe(true);
+  });
+
+  it('MxProvider is a US/CA aggregator', () => {
+    const mx = new MxProvider(transport);
+    expect(mx.id).toBe('mx');
+    expect(mx.supportedCountries).toEqual(['US', 'CA']);
+    expect(mx.features.internationalBanks).toBe(false);
+  });
+
+  it('TrueLayerProvider is European open-banking (no investments/loans)', () => {
+    const tl = new TrueLayerProvider(transport);
+    expect(tl.id).toBe('truelayer');
+    expect(tl.supportedCountries).toContain('GB');
+    expect(tl.features.investmentAccounts).toBe(false);
+    expect(tl.features.loans).toBe(false);
+    expect(tl.features.internationalBanks).toBe(true);
+  });
+
+  it('FinicityProvider is a US/CA aggregator', () => {
+    const fin = new FinicityProvider(transport);
+    expect(fin.id).toBe('finicity');
+    expect(fin.supportedCountries).toEqual(['US', 'CA']);
+  });
+});
+
+describe('createAggregatorProviders', () => {
+  it('returns all four providers in directory-priority order', () => {
+    const { transport } = fakeTransport({});
+    const providers = createAggregatorProviders(transport);
+    expect(providers.map((p) => p.id)).toEqual(['plaid', 'mx', 'truelayer', 'finicity']);
+  });
+
+  it('drives edge requests through the injected transport with auth headers', async () => {
+    const { transport, fetch } = fakeTransport({
+      link_token: 'link-sandbox-123',
+      expiration: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const plaid = new PlaidProvider(transport);
+
+    const session = await plaid.initializeConnection({
+      countryCode: 'US',
+      metadata: { household_id: 'hh-1' },
+    });
+
+    expect(session.sessionId).toBe('link-sandbox-123');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = fetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      'https://proj.supabase.co/functions/v1/bank-connection?action=create_link_token',
+    );
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer jwt-token');
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init.body as string)).toMatchObject({ provider: 'plaid' });
+  });
+});

--- a/apps/web/src/lib/banking/__tests__/aggregator-transport.test.ts
+++ b/apps/web/src/lib/banking/__tests__/aggregator-transport.test.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSupabaseEdgeTransport, resolveEdgeFunctionsBaseUrl } from '../aggregator-transport';
+
+vi.mock('../../../auth/token-storage', () => ({
+  getAccessToken: vi.fn(async () => 'stored-token'),
+}));
+
+import { getAccessToken } from '../../../auth/token-storage';
+
+describe('resolveEdgeFunctionsBaseUrl', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('prefers an explicit functions URL and strips trailing slashes', () => {
+    vi.stubEnv('VITE_SUPABASE_FUNCTIONS_URL', 'https://fn.example.com/functions/v1/');
+    expect(resolveEdgeFunctionsBaseUrl()).toBe('https://fn.example.com/functions/v1');
+  });
+
+  it('derives the functions URL from the Supabase project URL', () => {
+    vi.stubEnv('VITE_SUPABASE_FUNCTIONS_URL', '');
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://proj.supabase.co/');
+    expect(resolveEdgeFunctionsBaseUrl()).toBe('https://proj.supabase.co/functions/v1');
+  });
+
+  it('returns an empty string when nothing is configured', () => {
+    vi.stubEnv('VITE_SUPABASE_FUNCTIONS_URL', '');
+    vi.stubEnv('VITE_SUPABASE_URL', '');
+    expect(resolveEdgeFunctionsBaseUrl()).toBe('');
+  });
+});
+
+describe('createSupabaseEdgeTransport', () => {
+  it('uses the resolved base URL by default', () => {
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://proj.supabase.co');
+    const transport = createSupabaseEdgeTransport();
+    expect(transport.baseUrl).toBe('https://proj.supabase.co/functions/v1');
+    vi.unstubAllEnvs();
+  });
+
+  it('resolves the bearer token from the shared token store', async () => {
+    const transport = createSupabaseEdgeTransport({ baseUrl: 'https://x/functions/v1' });
+    await expect(transport.getAuthToken()).resolves.toBe('stored-token');
+    expect(getAccessToken).toHaveBeenCalled();
+  });
+
+  it('returns an empty token when the store has none', async () => {
+    vi.mocked(getAccessToken).mockResolvedValueOnce(null);
+    const transport = createSupabaseEdgeTransport({ baseUrl: 'https://x/functions/v1' });
+    await expect(transport.getAuthToken()).resolves.toBe('');
+  });
+
+  it('honours explicit overrides for fetch and token', async () => {
+    const fetchSpy = vi.fn(async () => new Response('{}'));
+    const transport = createSupabaseEdgeTransport({
+      baseUrl: 'https://override/functions/v1',
+      fetch: fetchSpy,
+      getAuthToken: async () => 'explicit',
+    });
+    expect(transport.baseUrl).toBe('https://override/functions/v1');
+    await expect(transport.getAuthToken()).resolves.toBe('explicit');
+    await transport.fetch('https://override/functions/v1/ping');
+    expect(fetchSpy).toHaveBeenCalledWith('https://override/functions/v1/ping');
+  });
+});

--- a/apps/web/src/lib/banking/__tests__/bootstrap.test.ts
+++ b/apps/web/src/lib/banking/__tests__/bootstrap.test.ts
@@ -18,6 +18,12 @@ describe('bootstrapBanking', () => {
     expect(ids.length).toBeGreaterThan(0);
   });
 
+  it('does not eagerly register the aggregator providers', () => {
+    const { registry } = bootstrapBanking();
+    const ids = registry.getAllProviders().map((p) => p.id);
+    expect(ids).not.toContain('plaid');
+  });
+
   it('builds a router that routes against the registered providers', () => {
     const { router, registry } = bootstrapBanking();
     const ids = registry.getAllProviders().map((p) => p.id);

--- a/apps/web/src/lib/banking/__tests__/register-aggregator-providers.test.ts
+++ b/apps/web/src/lib/banking/__tests__/register-aggregator-providers.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ProviderRegistry } from '../provider-registry';
+import {
+  ensureAggregatorProvidersRegistered,
+  resetAggregatorRegistrationForTests,
+} from '../register-aggregator-providers';
+
+vi.mock('../../../auth/token-storage', () => ({
+  getAccessToken: vi.fn(async () => 'token'),
+}));
+
+describe('ensureAggregatorProvidersRegistered', () => {
+  afterEach(() => {
+    resetAggregatorRegistrationForTests();
+  });
+
+  it('lazily registers the four aggregator providers', async () => {
+    const registry = new ProviderRegistry();
+    await ensureAggregatorProvidersRegistered({ registry });
+    for (const id of ['plaid', 'mx', 'truelayer', 'finicity']) {
+      expect(registry.getProvider(id)).toBeDefined();
+    }
+    resetAggregatorRegistrationForTests(registry);
+  });
+
+  it('is single-flighted — concurrent calls share one registration', async () => {
+    const registry = new ProviderRegistry();
+    const a = ensureAggregatorProvidersRegistered({ registry });
+    const b = ensureAggregatorProvidersRegistered({ registry });
+    expect(a).toBe(b);
+    await Promise.all([a, b]);
+    expect(registry.getAllProviders()).toHaveLength(4);
+    resetAggregatorRegistrationForTests(registry);
+  });
+
+  it('does not duplicate providers already present in the registry', async () => {
+    const registry = new ProviderRegistry();
+    await ensureAggregatorProvidersRegistered({ registry });
+    resetAggregatorRegistrationForTests(registry);
+    await ensureAggregatorProvidersRegistered({ registry });
+    expect(registry.getAllProviders()).toHaveLength(4);
+    resetAggregatorRegistrationForTests(registry);
+  });
+});

--- a/apps/web/src/lib/banking/__tests__/register-default-providers.test.ts
+++ b/apps/web/src/lib/banking/__tests__/register-default-providers.test.ts
@@ -13,6 +13,13 @@ describe('registerDefaultProviders', () => {
     expect(registry.getProvider('crypto')).toBeDefined();
   });
 
+  it('does not eagerly register the edge-backed aggregator providers', () => {
+    const registry = new ProviderRegistry();
+    registerDefaultProviders(registry);
+    expect(registry.getProvider('plaid')).toBeUndefined();
+    expect(registry.getProvider('mx')).toBeUndefined();
+  });
+
   it('exposes a crypto-capable provider via feature query', () => {
     const registry = new ProviderRegistry();
     registerDefaultProviders(registry);

--- a/apps/web/src/lib/banking/aggregator-providers.ts
+++ b/apps/web/src/lib/banking/aggregator-providers.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Concrete aggregator provider implementations (#3854).
+ *
+ * Each provider is a thin {@link BaseAggregatorProvider} subclass that supplies
+ * only its identity and capability surface — all connection-lifecycle behaviour
+ * is inherited from the edge-backed base. Provider `id`s intentionally match the
+ * `name` column of the synced `aggregator_provider` directory so the
+ * {@link ProviderRouter} can align each registered implementation with its live
+ * operational metadata (status/priority/enabled/regions).
+ *
+ * Routing eligibility is governed entirely by that synced directory: TrueLayer
+ * and Finicity ship as **disabled placeholders** (see the Phase 3 seed) and are
+ * therefore never selected until their backend adapters and credentials land —
+ * the same posture as the MX backend stub.
+ *
+ * @module lib/banking/aggregator-providers
+ */
+
+import {
+  BaseAggregatorProvider,
+  type EdgeTransport,
+  type SyncedBankDataSource,
+} from './base-aggregator-provider';
+import type { ProviderFeatures } from './types';
+
+/** Capability surface shared by the full-coverage US/CA aggregators. */
+const AGGREGATOR_FEATURES: ProviderFeatures = {
+  realTimeBalance: true,
+  transactionWebhooks: true,
+  investmentAccounts: true,
+  creditCards: true,
+  loans: true,
+  bnpl: false,
+  crypto: false,
+  internationalBanks: false,
+};
+
+/**
+ * Plaid — primary aggregator (broad North-American + European coverage,
+ * real backend implementation).
+ */
+export class PlaidProvider extends BaseAggregatorProvider {
+  /**
+   * @param transport - Edge transport for the banking functions.
+   * @param dataSource - Optional synced local read path for accounts/transactions.
+   */
+  constructor(transport: EdgeTransport, dataSource?: SyncedBankDataSource) {
+    super({
+      id: 'plaid',
+      name: 'Plaid',
+      supportedCountries: ['US', 'CA', 'GB', 'IE', 'FR', 'ES', 'NL'],
+      features: { ...AGGREGATOR_FEATURES, internationalBanks: true },
+      transport,
+      dataSource,
+    });
+  }
+}
+
+/** MX — secondary US/CA aggregator (backend stub until credentials land). */
+export class MxProvider extends BaseAggregatorProvider {
+  /**
+   * @param transport - Edge transport for the banking functions.
+   * @param dataSource - Optional synced local read path for accounts/transactions.
+   */
+  constructor(transport: EdgeTransport, dataSource?: SyncedBankDataSource) {
+    super({
+      id: 'mx',
+      name: 'MX',
+      supportedCountries: ['US', 'CA'],
+      features: { ...AGGREGATOR_FEATURES, investmentAccounts: true },
+      transport,
+      dataSource,
+    });
+  }
+}
+
+/** TrueLayer — European open-banking provider (disabled placeholder). */
+export class TrueLayerProvider extends BaseAggregatorProvider {
+  /**
+   * @param transport - Edge transport for the banking functions.
+   * @param dataSource - Optional synced local read path for accounts/transactions.
+   */
+  constructor(transport: EdgeTransport, dataSource?: SyncedBankDataSource) {
+    super({
+      id: 'truelayer',
+      name: 'TrueLayer',
+      supportedCountries: ['GB', 'IE', 'FR', 'ES', 'IT', 'DE', 'PT', 'NL', 'LT'],
+      features: {
+        ...AGGREGATOR_FEATURES,
+        investmentAccounts: false,
+        loans: false,
+        internationalBanks: true,
+      },
+      transport,
+      dataSource,
+    });
+  }
+}
+
+/** Finicity (Mastercard) — US/CA aggregator (disabled placeholder). */
+export class FinicityProvider extends BaseAggregatorProvider {
+  /**
+   * @param transport - Edge transport for the banking functions.
+   * @param dataSource - Optional synced local read path for accounts/transactions.
+   */
+  constructor(transport: EdgeTransport, dataSource?: SyncedBankDataSource) {
+    super({
+      id: 'finicity',
+      name: 'Finicity (Mastercard)',
+      supportedCountries: ['US', 'CA'],
+      features: AGGREGATOR_FEATURES,
+      transport,
+      dataSource,
+    });
+  }
+}
+
+/**
+ * Instantiate every concrete aggregator provider, in directory-priority order
+ * (Plaid, MX, TrueLayer, Finicity).
+ *
+ * @param transport - Edge transport shared by all providers.
+ * @param dataSource - Optional synced local read path injected into each provider.
+ * @returns The four aggregator provider instances.
+ */
+export function createAggregatorProviders(
+  transport: EdgeTransport,
+  dataSource?: SyncedBankDataSource,
+): BaseAggregatorProvider[] {
+  return [
+    new PlaidProvider(transport, dataSource),
+    new MxProvider(transport, dataSource),
+    new TrueLayerProvider(transport, dataSource),
+    new FinicityProvider(transport, dataSource),
+  ];
+}

--- a/apps/web/src/lib/banking/aggregator-transport.ts
+++ b/apps/web/src/lib/banking/aggregator-transport.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Supabase Edge Function transport for aggregator providers (#3854).
+ *
+ * Provides the concrete {@link EdgeTransport} that
+ * {@link BaseAggregatorProvider} uses to reach the banking edge functions
+ * (`bank-connection`, `aggregator-health`). It resolves the functions base URL
+ * from the Vite environment and the caller's bearer token from the shared auth
+ * token store — no secrets or provider credentials are ever handled client-side.
+ *
+ * @module lib/banking/aggregator-transport
+ */
+
+import { getAccessToken } from '../../auth/token-storage';
+import type { EdgeTransport } from './base-aggregator-provider';
+
+/** Read a Vite env var safely (works under Vite build + test/SSR). @internal */
+function readEnv(key: string): string | undefined {
+  try {
+    const meta = import.meta as unknown as { env?: Record<string, string> };
+    const value = meta.env?.[key];
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the Supabase Edge Functions base URL (`<project>/functions/v1`).
+ *
+ * Prefers an explicit `VITE_SUPABASE_FUNCTIONS_URL`; otherwise derives it from
+ * `VITE_SUPABASE_URL`. Returns an empty string when neither is configured (e.g.
+ * demo mode) — provider requests will then fail fast with a categorized error
+ * rather than hitting an unintended origin.
+ *
+ * @returns The trimmed functions base URL, or `''` when unconfigured.
+ */
+export function resolveEdgeFunctionsBaseUrl(): string {
+  const explicit = readEnv('VITE_SUPABASE_FUNCTIONS_URL');
+  if (explicit) return explicit.replace(/\/+$/, '');
+
+  const supabaseUrl = readEnv('VITE_SUPABASE_URL');
+  if (!supabaseUrl) return '';
+  return `${supabaseUrl.replace(/\/+$/, '')}/functions/v1`;
+}
+
+/**
+ * Build the concrete {@link EdgeTransport} for aggregator providers.
+ *
+ * The transport is stateless: it reads the current base URL once at
+ * construction and resolves a fresh bearer token on every request via
+ * {@link getAccessToken} (which transparently refreshes near-expiry tokens).
+ *
+ * @param overrides - Optional seams for tests (custom `fetch`/base URL/token).
+ * @returns An {@link EdgeTransport} bound to the Supabase Edge Functions.
+ */
+export function createSupabaseEdgeTransport(overrides?: {
+  baseUrl?: string;
+  fetch?: (input: string, init?: RequestInit) => Promise<Response>;
+  getAuthToken?: () => Promise<string>;
+}): EdgeTransport {
+  const baseUrl = overrides?.baseUrl ?? resolveEdgeFunctionsBaseUrl();
+  const fetchImpl = overrides?.fetch ?? ((input: string, init?: RequestInit) => fetch(input, init));
+
+  return {
+    baseUrl,
+    fetch: fetchImpl,
+    getAuthToken:
+      overrides?.getAuthToken ??
+      (async () => {
+        const token = await getAccessToken();
+        return token ?? '';
+      }),
+  };
+}

--- a/apps/web/src/lib/banking/bootstrap.ts
+++ b/apps/web/src/lib/banking/bootstrap.ts
@@ -39,6 +39,11 @@ export interface BankingBootstrap {
 /**
  * Register the default providers and build the shared router.
  *
+ * Registers only the offline built-ins (manual, crypto) synchronously so the
+ * banking layer is ready at first paint. The edge-backed aggregator providers
+ * are registered lazily via `ensureAggregatorProvidersRegistered` (a dynamic
+ * import) to keep their implementation out of the eager startup bundle.
+ *
  * Idempotent: subsequent calls return the same singletons without
  * re-registering providers.
  *

--- a/apps/web/src/lib/banking/index.ts
+++ b/apps/web/src/lib/banking/index.ts
@@ -80,12 +80,23 @@ export { CryptoBankProvider } from './crypto-provider';
 // Default provider bootstrap
 export { registerDefaultProviders } from './register-default-providers';
 
+// NOTE: the edge-backed aggregator layer (register-aggregator-providers, the
+// concrete provider classes, and the edge transport) is intentionally NOT
+// re-exported from this barrel. It is loaded exclusively through a dynamic
+// import (see main.tsx / register-aggregator-providers.ts) so its
+// implementation stays code-split into a lazy chunk and out of the eager
+// `vendor-app` bundle (#3854). Import those modules directly where needed.
+
 // Mock provider
 export { MockProvider } from './mock-provider';
 export type { MockProviderConfig } from './mock-provider';
 
-// Base aggregator provider (edge-backed base for real aggregators — #3849)
-export { BaseAggregatorProvider, BankingProviderError } from './base-aggregator-provider';
+// Base aggregator provider types (edge-backed base for real aggregators — #3849).
+// NOTE: the BaseAggregatorProvider class and BankingProviderError value are
+// intentionally NOT re-exported from this barrel — a static value re-export
+// would pull the (otherwise lazily-loaded) provider implementation into the
+// eager `vendor-app` chunk and breach the performance budget (#3854). Import
+// them directly from './base-aggregator-provider' where needed.
 export type {
   AggregatorProviderConfig,
   EdgeTransport,

--- a/apps/web/src/lib/banking/register-aggregator-providers.ts
+++ b/apps/web/src/lib/banking/register-aggregator-providers.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Lazy registration of the edge-backed aggregator providers (#3854).
+ *
+ * The concrete aggregator providers (Plaid/MX/TrueLayer/Finicity) and their
+ * {@link BaseAggregatorProvider} base class are only needed once a user
+ * interacts with live bank connections — never at first paint. This module
+ * pulls them in through a **dynamic `import()`** so their implementation code is
+ * code-split into a lazy chunk and kept out of the eager startup bundle (which
+ * otherwise breached the `vendor-app` performance budget).
+ *
+ * Registration is idempotent and single-flighted: concurrent callers share one
+ * in-flight promise, and providers already present in the registry are skipped.
+ *
+ * @module lib/banking/register-aggregator-providers
+ */
+
+import type { SyncedBankDataSource } from './base-aggregator-provider';
+import { defaultRegistry, type ProviderRegistry } from './provider-registry';
+
+/** Options for {@link ensureAggregatorProvidersRegistered}. */
+export interface EnsureAggregatorProvidersOptions {
+  /** Registry to register into (defaults to the shared {@link defaultRegistry}). */
+  registry?: ProviderRegistry;
+  /** Optional synced local read path injected into each aggregator provider. */
+  dataSource?: SyncedBankDataSource;
+}
+
+/** In-flight/settled registration promise, keyed by registry, for single-flight. */
+const inFlight = new WeakMap<ProviderRegistry, Promise<void>>();
+
+/**
+ * Lazily import and register the four concrete aggregator providers.
+ *
+ * Safe to call repeatedly (e.g. on every navigation to the banking area): the
+ * first call performs the dynamic import + registration, and subsequent calls
+ * reuse the same resolved promise. Routing eligibility remains governed by the
+ * synced `aggregator_provider` directory, so disabled placeholders
+ * (TrueLayer/Finicity) never get selected until their backends land.
+ *
+ * @param options - Optional registry/data-source overrides.
+ * @returns A promise that resolves once the aggregator providers are registered.
+ */
+export function ensureAggregatorProvidersRegistered(
+  options: EnsureAggregatorProvidersOptions = {},
+): Promise<void> {
+  const registry = options.registry ?? defaultRegistry;
+  const existing = inFlight.get(registry);
+  if (existing) return existing;
+
+  const task = (async () => {
+    const [{ createAggregatorProviders }, { createSupabaseEdgeTransport }] = await Promise.all([
+      import('./aggregator-providers'),
+      import('./aggregator-transport'),
+    ]);
+    const transport = createSupabaseEdgeTransport();
+    for (const provider of createAggregatorProviders(transport, options.dataSource)) {
+      if (registry.getProvider(provider.id)) continue;
+      registry.registerProvider(provider);
+    }
+  })();
+
+  inFlight.set(registry, task);
+  return task;
+}
+
+/**
+ * Clear the single-flight cache. **Test-only.**
+ *
+ * @param registry - Registry whose cached promise should be dropped
+ *   (defaults to the shared {@link defaultRegistry}).
+ * @internal
+ */
+export function resetAggregatorRegistrationForTests(
+  registry: ProviderRegistry = defaultRegistry,
+): void {
+  inFlight.delete(registry);
+}

--- a/apps/web/src/lib/banking/register-default-providers.ts
+++ b/apps/web/src/lib/banking/register-default-providers.ts
@@ -20,7 +20,12 @@ import { defaultRegistry, type ProviderRegistry } from './provider-registry';
 import type { BankConnectionProvider } from './types';
 
 /**
- * Register the built-in banking providers into [registry].
+ * Register the built-in offline banking providers into [registry].
+ *
+ * Registers only the providers that require no network transport (manual
+ * import, crypto). The edge-backed aggregator providers are registered
+ * separately and lazily via `ensureAggregatorProvidersRegistered` so their
+ * implementation code stays out of the eager startup bundle.
  *
  * @param registry - Target registry (defaults to the shared {@link defaultRegistry}).
  * @returns The providers that were newly registered by this call.

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -132,12 +132,18 @@ if (
 initMonitoring();
 
 // Register the built-in banking providers into the shared registry and build
-// the provider router used for app-routed aggregator selection. Without this
-// the registry stayed empty at runtime (registration previously happened only
-// in tests), so no provider could ever be selected. The router's operational
-// metadata source is attached later, once the PowerSync `aggregator_providers`
-// query is available (#3846).
+// the provider router used for app-routed aggregator selection. The offline
+// built-ins (manual, crypto) register synchronously here. The edge-backed
+// aggregator providers (Plaid/MX/TrueLayer/Finicity, #3854) are registered via
+// a fully dynamic import so neither their implementation nor the registration
+// module is pulled into the eager startup bundle. Routing eligibility is still
+// governed by the synced `aggregator_provider` directory, and the router's
+// operational metadata source is attached later once the PowerSync query is
+// available (#3846).
 bootstrapBanking();
+void import('./lib/banking/register-aggregator-providers').then((m) =>
+  m.ensureAggregatorProvidersRegistered(),
+);
 
 // ---------------------------------------------------------------------------
 // Service worker registration

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -364,12 +364,25 @@ export default defineConfig({
               priority: 60,
             },
             {
+              // Data-access repositories (one module per domain table) are the
+              // fastest-growing part of the shared data layer — every web
+              // feature batch adds another repository. Peel them into their own
+              // shared chunk so cumulative repository growth does not push the
+              // core shared-infra chunk (`vendor-app`) past the lazy-chunk
+              // budget, mirroring the `vendor-i18n` split (#3478). Higher
+              // priority than `vendor-app` so these paths are claimed here.
+              name: 'vendor-repositories',
+              test: /[\\/]src[\\/]db[\\/]repositories[\\/]/,
+              priority: 60,
+            },
+            {
               // Shared application infrastructure (SQLite-WASM data layer,
               // repositories, auth, React contexts) is imported by nearly every
               // route. Hoist it into one shared chunk instead of letting
               // rolldown host it inside `route-dashboard`, which chronically
               // inflated that chunk past the budget (#2983). Locale catalogs are
-              // split into `vendor-i18n` above (#3478).
+              // split into `vendor-i18n` above (#3478); data-access repositories
+              // are split into `vendor-repositories` above.
               name: 'vendor-app',
               test: /[\\/]src[\\/](db|auth|contexts)[\\/]/,
               priority: 50,


### PR DESCRIPTION
## Summary

Phase 5 of the consolidated live-banking epic (#3846). Registers the edge-backed aggregator providers into the shared web `ProviderRegistry` so the app-routed `ProviderRouter` can select real providers whose identities match the synced `aggregator_provider` directory.

Until now only `ManualImportProvider` + `CryptoBankProvider` were registered, and there was no concrete `EdgeTransport` — `BaseAggregatorProvider` existed but was never wired at runtime.

## Design — fully code-split (keeps the perf budget intact)

The aggregator layer (concrete providers + `BaseAggregatorProvider` + edge transport) is reachable **only via a dynamic `import()`**, so it never enters the eager `vendor-app` chunk. `main.tsx` runs synchronous `bootstrapBanking()` (manual + crypto + router) and then lazily calls `ensureAggregatorProvidersRegistered()`. The banking barrel (`index.ts`) intentionally does **not** statically re-export any aggregator code (type-only re-exports remain), which is what keeps the dynamic import effective. Verified by grepping the built `vendor-app` chunk: zero aggregator symbols.

## Changes

- **`aggregator-transport.ts`** (new) — `createSupabaseEdgeTransport()` + `resolveEdgeFunctionsBaseUrl()`. Resolves the Supabase Edge Functions base URL from `VITE_SUPABASE_FUNCTIONS_URL` / `VITE_SUPABASE_URL` and the bearer token from the shared `getAccessToken()` store. No secrets or provider credentials are handled client-side.
- **`aggregator-providers.ts`** (new) — thin `BaseAggregatorProvider` subclasses `PlaidProvider`, `MxProvider`, `TrueLayerProvider`, `FinicityProvider` + `createAggregatorProviders()`. Identity/capabilities/regions mirror the Phase 3 directory seed.
- **`register-aggregator-providers.ts`** (new) — `ensureAggregatorProvidersRegistered()`: the dynamic-import boundary, single-flighted via a `WeakMap<ProviderRegistry, Promise<void>>`, plus a test reset helper.
- **`bootstrap.ts` / `register-default-providers.ts`** — kept lean and synchronous (manual + crypto + router only); doc comments note that aggregators register separately and lazily.
- **`index.ts`** — barrel keeps aggregator code out of the static graph (comment blocks explain why).
- **`main.tsx`** — `bootstrapBanking()` then `void import('./lib/banking/register-aggregator-providers').then((m) => m.ensureAggregatorProvidersRegistered())`.
- Unit tests for the transport, the providers (identities/capabilities + a real edge request through a fake transport), and lazy/single-flight registration.

## Also fixes a pre-existing `main` CI failure (#3856)

`main` was already red on **Web CI → Build → Enforce bundle performance budgets** (`vendor-app` gzip 208 KiB > 204 KiB budget) — cumulative growth of the shared `src/(db|auth|contexts)` chunk, independent of this PR's bytes. Because the Build check is required, it blocked this PR too. This PR includes a self-contained `vite.config.ts` commit that peels `src/db/repositories/` into a dedicated `vendor-repositories` chunk (priority 60), mirroring the existing `vendor-i18n` split (#3478):

- `vendor-app`: 214.65 → **179.45 KiB** gzip (under budget)
- `vendor-repositories`: **36.75 KiB** gzip (new, under budget)
- `performance.budget.json` **unchanged**

## Routing safety

Routing eligibility is governed entirely by the PowerSync-synced directory (`isEnabled` + `status`). TrueLayer and Finicity ship as **disabled placeholders** (per the Phase 3 seed), so they are never selected until their backend adapters and credentials land — the same posture as the MX backend stub. Registering all four now is harmless and keeps the web side aligned with the directory.

## Validation

- `npx vitest run src/lib/banking` — 172 passed / 15 files
- `npx tsc --noEmit` — clean
- `npx vite build` — aggregator code in lazy chunks only; zero aggregator symbols in `vendor-app`
- `node tools/check-web-performance-budget.mjs` — passes
- `eslint … --max-warnings 0` + `prettier --check` — clean

## Out of scope (follow-ups)

- Backend `bank-connection` adapters for TrueLayer/Finicity (need SDKs + credentials — secret/human-gated) and enabling them in the directory.
- MX real backend integration (currently a stub).

Closes #3854
Closes #3856
Refs #3846