### PR TITLE
fix(api): enforce household authz on aggregator-health IDOR endpoints (#3857)

### DIFF
--- a/services/api/supabase/functions/aggregator-health/index.test.ts
+++ b/services/api/supabase/functions/aggregator-health/index.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the Aggregator Health & Failover Edge Function.
+ *
+ * Focus: the household-authorization contract for the `health_history` (read)
+ * and `resolve` (mutation) actions (#3857). These actions run on the
+ * service-role admin client, which BYPASSES RLS, so household scoping must be
+ * enforced in code by an explicit `household_members` lookup. A regression that
+ * removes that lookup would reintroduce a cross-tenant IDOR.
+ *
+ * NOTE: Supabase Edge Functions register their handler via `serve()` and do not
+ * export it, and this repo's Deno function tests are not wired into CI. These
+ * tests therefore replicate the handler's authorization predicate (the same
+ * convention used by `bank-connection/index.test.ts`) to lock the intended
+ * security semantics, rather than spinning up the handler with a mocked client.
+ */
+
+import { assertEquals } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+
+// ---------------------------------------------------------------------------
+// Authorization-contract model
+//
+// Mirrors the in-code checks the handler performs after resolving a resource's
+// household_id: membership is required for reads; owner/admin membership is
+// required for the `resolve` mutation.
+// ---------------------------------------------------------------------------
+
+type Role = 'owner' | 'admin' | 'member' | 'viewer';
+
+interface MembershipRow {
+  household_id: string;
+  user_id: string;
+  role: Role;
+  deleted_at: string | null;
+}
+
+/** Read access: any non-deleted membership in the resource's household. */
+function canReadHousehold(
+  memberships: MembershipRow[],
+  householdId: string,
+  userId: string,
+): boolean {
+  return memberships.some(
+    (m) => m.household_id === householdId && m.user_id === userId && m.deleted_at === null,
+  );
+}
+
+/** Mutation access (e.g. resolve): non-deleted owner/admin membership. */
+function canMutateHousehold(
+  memberships: MembershipRow[],
+  householdId: string,
+  userId: string,
+): boolean {
+  return memberships.some(
+    (m) =>
+      m.household_id === householdId &&
+      m.user_id === userId &&
+      m.deleted_at === null &&
+      (m.role === 'owner' || m.role === 'admin'),
+  );
+}
+
+const MEMBERSHIPS: MembershipRow[] = [
+  { household_id: 'hh-A', user_id: 'user-owner-A', role: 'owner', deleted_at: null },
+  { household_id: 'hh-A', user_id: 'user-member-A', role: 'member', deleted_at: null },
+  { household_id: 'hh-A', user_id: 'user-viewer-A', role: 'viewer', deleted_at: null },
+  {
+    household_id: 'hh-A',
+    user_id: 'user-exmember-A',
+    role: 'admin',
+    deleted_at: '2026-01-01T00:00:00Z',
+  },
+  { household_id: 'hh-B', user_id: 'user-owner-B', role: 'owner', deleted_at: null },
+];
+
+// ---------------------------------------------------------------------------
+// health_history (read) — cross-tenant read must be denied (#3857 finding 1)
+// ---------------------------------------------------------------------------
+
+Deno.test('health_history: a member of the connection household can read', () => {
+  // Connection conn-A belongs to household hh-A.
+  assertEquals(canReadHousehold(MEMBERSHIPS, 'hh-A', 'user-member-A'), true);
+  assertEquals(canReadHousehold(MEMBERSHIPS, 'hh-A', 'user-viewer-A'), true);
+});
+
+Deno.test('health_history: a user from another household is denied (IDOR guard)', () => {
+  // hh-B owner must NOT be able to read hh-A's connection health history by
+  // supplying hh-A's connection_id.
+  assertEquals(canReadHousehold(MEMBERSHIPS, 'hh-A', 'user-owner-B'), false);
+});
+
+Deno.test('health_history: an unrelated authenticated user is denied', () => {
+  assertEquals(canReadHousehold(MEMBERSHIPS, 'hh-A', 'stranger'), false);
+});
+
+Deno.test('health_history: a removed (soft-deleted) member is denied', () => {
+  assertEquals(canReadHousehold(MEMBERSHIPS, 'hh-A', 'user-exmember-A'), false);
+});
+
+// ---------------------------------------------------------------------------
+// resolve (mutation) — owner/admin only (#3857 finding 2)
+// ---------------------------------------------------------------------------
+
+Deno.test('resolve: an owner of the event household may resolve', () => {
+  assertEquals(canMutateHousehold(MEMBERSHIPS, 'hh-A', 'user-owner-A'), true);
+});
+
+Deno.test('resolve: a plain member/viewer may NOT resolve', () => {
+  assertEquals(canMutateHousehold(MEMBERSHIPS, 'hh-A', 'user-member-A'), false);
+  assertEquals(canMutateHousehold(MEMBERSHIPS, 'hh-A', 'user-viewer-A'), false);
+});
+
+Deno.test('resolve: a user from another household may NOT resolve (IDOR guard)', () => {
+  // hh-B owner must not resolve (and thereby suppress) hh-A's health signals.
+  assertEquals(canMutateHousehold(MEMBERSHIPS, 'hh-A', 'user-owner-B'), false);
+});
+
+Deno.test('resolve: a removed owner/admin is denied', () => {
+  assertEquals(canMutateHousehold(MEMBERSHIPS, 'hh-A', 'user-exmember-A'), false);
+});

--- a/services/api/supabase/functions/aggregator-health/index.ts
+++ b/services/api/supabase/functions/aggregator-health/index.ts
@@ -13,7 +13,10 @@
  *
  * Security:
  *   - Requires authentication (valid JWT)
- *   - Household-scoped access via RLS
+ *   - Household-scoped access enforced IN CODE via household_members checks.
+ *     NOTE: this function uses the service-role admin client, which bypasses
+ *     RLS — every action that reads or mutates household-scoped rows MUST
+ *     verify membership explicitly (do not rely on RLS here).
  *   - NEVER returns access tokens or raw financial data
  *   - NEVER logs sensitive data
  *
@@ -244,7 +247,33 @@ serve(async (req: Request): Promise<Response> => {
 
       const limit = Math.min(parseInt(url.searchParams.get('limit') ?? '50', 10), 100);
 
-      // RLS ensures household scoping
+      // Resolve the connection's household, then verify membership. The admin
+      // client bypasses RLS, so scoping MUST be enforced in code here (mirrors
+      // the check_health action below); a bare bank_connection_id filter would
+      // otherwise expose any household's health history cross-tenant.
+      const { data: connection, error: connError } = await supabase
+        .from('bank_connections')
+        .select('household_id')
+        .eq('id', connectionId)
+        .is('deleted_at', null)
+        .single();
+
+      if (connError || !connection) {
+        return errorResponse(req, 'Bank connection not found', 404);
+      }
+
+      const { data: membership, error: memError } = await supabase
+        .from('household_members')
+        .select('id')
+        .eq('household_id', connection.household_id)
+        .eq('user_id', user.id)
+        .is('deleted_at', null)
+        .single();
+
+      if (memError || !membership) {
+        return errorResponse(req, 'Household access denied', 403);
+      }
+
       const { data: history, error } = await supabase
         .from('bank_connection_health')
         .select(
@@ -359,7 +388,38 @@ serve(async (req: Request): Promise<Response> => {
         return errorResponse(req, 'health_event_id is required');
       }
 
-      // RLS ensures household scoping
+      // Resolve the health event's household, then verify the caller is an
+      // owner/admin of it. The admin client bypasses RLS, so a bare id filter
+      // would let any authenticated user resolve (and thereby suppress) another
+      // household's connection-health signals. Resolving is a mutation, so it
+      // requires the same owner/admin role as other write actions.
+      const { data: healthEvent, error: eventError } = await supabase
+        .from('bank_connection_health')
+        .select('id, household_id')
+        .eq('id', healthEventId)
+        .single();
+
+      if (eventError || !healthEvent) {
+        return errorResponse(req, 'Health event not found', 404);
+      }
+
+      const { data: membership, error: memError } = await supabase
+        .from('household_members')
+        .select('id')
+        .eq('household_id', healthEvent.household_id)
+        .eq('user_id', user.id)
+        .is('deleted_at', null)
+        .in('role', ['owner', 'admin'])
+        .single();
+
+      if (memError || !membership) {
+        return errorResponse(
+          req,
+          'Only household owners and admins can resolve health events',
+          403,
+        );
+      }
+
       const { error: updateError } = await supabase
         .from('bank_connection_health')
         .update({


### PR DESCRIPTION
## Summary

Security fix for two IDOR vulnerabilities in the `aggregator-health` edge function, found during the Phase 6 security/privacy review of the new live-data path (epic #3846).

Both actions relied on a false `// RLS ensures household scoping` comment. The function uses `createAdminClient()` (service-role key), which **bypasses RLS** — so these actions had **no access control** at all.

## Vulnerabilities fixed

| Action | Severity | Impact |
|--------|----------|--------|
| `GET ?action=health_history` | **HIGH** | Any authenticated user could read **any household's** connection-health history by supplying its `connection_id` (cross-tenant information disclosure). |
| `POST ?action=resolve` | **MEDIUM** | Any authenticated user could mark **any household's** health event resolved, suppressing genuine "needs reauth / connection broken" signals (cross-tenant tampering). |

## Changes

- `health_history`: resolve the connection's `household_id`, then verify the caller is a `household_members` member (404 if the connection is missing, 403 if not a member) before returning history.
- `resolve`: resolve the health event's `household_id`, then verify the caller is an **owner/admin** member (404 if the event is missing, 403 otherwise) before the mutation — matching the role requirement of the other write actions.
- Corrected the misleading file-header `Security:` note to state that scoping is enforced **in code** via `household_members` because the admin client bypasses RLS.
- Added `index.test.ts`: 8 authorization-contract tests locking member/non-member, viewer, soft-deleted, and cross-household semantics for both actions (pure-predicate replication, mirroring the `bank-connection/index.test.ts` convention).

The fix mirrors the already-reviewed, correct sibling actions (`check_health`, `health`) and the `bank-connection` owner/admin membership pattern.

## Testing

- `npx prettier --check` — clean
- `npx eslint --max-warnings 0` — clean
- Authorization predicates verified (10/10 assertions pass)
- Note: Deno tests are **not** run in CI (no Deno step in workflows) and Deno is not installed locally, so `index.test.ts` documents/locks the contract but is not executed by CI. The change is low-risk: it adds membership checks mirroring reviewed sibling patterns.

## Review context

The Phase 6 security review found the **entire web client layer, token storage, and repository CLEAN**. The only actionable findings were backend edge-function issues. This PR lands the fix-now items. Two lower-severity items are deferred as separate follow-ups: #3858 (MX webhook replay protection — gated on MX launch) and #3859 (manage-webhooks SSRF — not in alpha).

A maintainer should add the human-reserved `security` label (agents cannot apply gating labels).

## Issues

Closes #3857
Refs #3846