### PR TITLE
test(web): e2e scaffolding for the aggregator bank-connections path (#3861)

### DIFF
--- a/apps/web/e2e-live/bank-connections-live.spec.ts
+++ b/apps/web/e2e-live/bank-connections-live.spec.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Live full-stack (edge) skeleton for the aggregator Bank Connections path.
+ *
+ * This is the opt-in, live counterpart to the stubbed
+ * e2e/bank-connections.spec.ts. It is intended to exercise the genuinely-wired
+ * consolidated-aggregator read path (epic #3846):
+ *
+ *   /bank-connections
+ *     -> useBankConnections reads the PowerSync-synced mirror tables
+ *        (bank_connection, bank_connection_health, aggregator_provider)
+ *     -> "View History" calls the real `aggregator-health` edge function
+ *        (GET ?action=health_history) through the Vite functions proxy
+ *     -> connection-health / provider-status render live data
+ *
+ * WHY IT IS SKIPPED BY DEFAULT
+ * ----------------------------
+ * The aggregator edge functions (`aggregator-health`, `bank-connection`) are
+ * NOT yet wired into the local Supabase stack, and there is no seed path that
+ * populates the synced bank-connection mirror tables for a freshly-signed-up
+ * user. Running the assertions below today would fail on an empty dashboard,
+ * which is noise rather than signal. The whole describe block is therefore
+ * gated behind the LIVE_AGGREGATOR env flag and skipped unless it is set.
+ *
+ * ENABLING (once the aggregator stack + seed land — tracked follow-up):
+ *   1. Wire aggregator-health + bank-connection into services/api local stack.
+ *   2. Seed at least one bank_connection + aggregator_provider row for the
+ *      test household (or drive a sandbox Plaid link).
+ *   3. Run:  LIVE_AGGREGATOR=1 npm run test:e2e:live -w apps/web
+ *
+ * Runs under playwright.live.config.ts (testDir ./e2e-live) against a REAL
+ * local edge backend — see docs/guides/full-stack-local.md and
+ * e2e-live/full-stack-smoke.spec.ts for the real-signup pattern this mirrors.
+ *
+ * References: #3861, #3846, #3852, #1577
+ */
+
+import { expect, test } from '@playwright/test';
+
+// Gate: only run when the aggregator stack + seed are explicitly available.
+// Default (unset) => the entire block is skipped, so the live smoke stays green
+// without the aggregator backend.
+const LIVE_AGGREGATOR_ENABLED = Boolean(process.env.LIVE_AGGREGATOR);
+
+// Comfortably above the client-side 12-character minimum, with mixed character
+// classes so it also clears any server-side strength policy (mirrors
+// full-stack-smoke.spec.ts).
+const PASSWORD = 'LocalEdgeE2e!2026';
+
+test.describe('Live aggregator Bank Connections', () => {
+  test.skip(
+    !LIVE_AGGREGATOR_ENABLED,
+    'Set LIVE_AGGREGATOR=1 after wiring the aggregator edge functions + seed ' +
+      'into the local stack (see file header). Skipped by default so the live ' +
+      'smoke passes without the aggregator backend.',
+  );
+
+  test('reaches the aggregator health dashboard through the real edge path', async ({ page }) => {
+    // Real signup (no __PLAYWRIGHT_E2E__ flag, no mocked network) — same
+    // real-edge auth bootstrap as full-stack-smoke.spec.ts. We only pre-seed
+    // the first-run consent + onboarding keys so the GDPR overlay does not
+    // intercept clicks.
+    const email = `e2e-bank+${Date.now()}@local.test`;
+
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'finance-gdpr-consent',
+        JSON.stringify({
+          categories: {
+            essential: true,
+            analytics: false,
+            error_reporting: false,
+            sync: false,
+            marketing: false,
+          },
+          timestamp: new Date().toISOString(),
+          policyVersion: '1.0.0',
+          method: 'first_run',
+          hasCompletedFirstRun: true,
+        }),
+      );
+      localStorage.setItem('finance-onboarding-complete', 'true');
+    });
+
+    await page.goto('/signup');
+
+    // Proof the app is wired to a real backend, not demo mode.
+    await expect(
+      page.getByText(/Demo Mode/i),
+      'App is in demo mode. Start the local stack and write apps/web/.env.local ' +
+        '(npm --prefix services/api run setup:windows) before running the live e2e.',
+    ).toHaveCount(0);
+
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password', { exact: true }).fill(PASSWORD);
+    await page.getByLabel('Confirm Password').fill(PASSWORD);
+
+    const signupResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/auth/signup') && response.request().method() === 'POST',
+      { timeout: 60_000 },
+    );
+    await page.getByRole('button', { name: 'Sign up' }).click();
+
+    const signup = await signupResponse;
+    expect(
+      signup.ok(),
+      `Edge signup did not succeed: ${signup.status()} ${signup.statusText()}`,
+    ).toBeTruthy();
+
+    // Leave the auth wall (household provisioning may route to /onboarding).
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: 60_000 })
+      .not.toMatch(/\/(login|signup)$/);
+
+    // Navigate to the Bank Connections dashboard.
+    await page.goto('/bank-connections');
+    await expect(page.getByRole('heading', { name: /bank connections/i, level: 1 })).toBeVisible();
+
+    // Arm a waiter for the real aggregator-health round-trip. "View History"
+    // on a connection card calls GET /functions/v1/aggregator-health
+    // ?action=health_history through the Vite functions proxy.
+    const healthResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('aggregator-health') &&
+        response.url().includes('action=health_history'),
+      { timeout: 60_000 },
+    );
+
+    // A seeded connection renders a card with a "History" action.
+    const historyButton = page.getByRole('button', { name: /view health history/i }).first();
+    await expect(
+      historyButton,
+      'No seeded bank connection found. Seed a bank_connection + aggregator_provider ' +
+        'row for the test household before enabling LIVE_AGGREGATOR (see file header).',
+    ).toBeVisible();
+    await historyButton.click();
+
+    const health = await healthResponse;
+    expect(
+      health.ok(),
+      `aggregator-health did not succeed: ${health.status()} ${health.statusText()}`,
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/e2e/bank-connections.spec.ts
+++ b/apps/web/e2e/bank-connections.spec.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * E2E tests for the Bank Connections Health Center (/bank-connections).
+ *
+ * This is the web surface of the consolidated live-data aggregator path
+ * (epic #3846). It runs against the STUBBED suite (mocked auth + in-memory
+ * stub DB), so no live backend is required. The E2E stub DB has no
+ * `bank_connection` / `aggregator_provider` tables, so reads resolve to empty
+ * and the page renders its empty state — this test locks the always-present
+ * page structure (heading, summary strip, tab pattern, empty state) so a
+ * regression in the connection-health dashboard is caught in CI.
+ *
+ * The genuinely-wired aggregator round-trip (real edge `aggregator-health`
+ * function) is covered separately by the opt-in live skeleton at
+ * e2e-live/bank-connections-live.spec.ts.
+ *
+ * References: #3861, #3846, #1575, #1577
+ */
+
+import { test, expect } from './fixtures';
+
+const TAB_LABELS = ['Connection Health', 'Providers', 'Wallets & Exchanges', 'Safety Center'];
+
+test.describe('Bank Connections page', () => {
+  test('loads and shows the Bank Connections heading', async ({ authenticatedPage: page }) => {
+    await page.goto('/bank-connections');
+
+    const heading = page.getByRole('heading', { name: /bank connections/i, level: 1 });
+    await expect(heading).toBeVisible();
+  });
+
+  test('shows the connection health summary strip', async ({ authenticatedPage: page }) => {
+    await page.goto('/bank-connections');
+
+    // The summary strip is always rendered (role="status") regardless of how
+    // many connections exist, and reports the total connection count.
+    const summary = page.getByRole('status', { name: /connection health summary/i });
+    await expect(summary).toBeVisible();
+    await expect(summary).toContainText(/connections/i);
+  });
+
+  test('renders all four section tabs', async ({ authenticatedPage: page }) => {
+    await page.goto('/bank-connections');
+
+    for (const label of TAB_LABELS) {
+      await expect(page.getByRole('tab', { name: label })).toBeVisible();
+    }
+
+    // The Connection Health tab is selected by default.
+    await expect(page.getByRole('tab', { name: 'Connection Health' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  test('switching to the Providers tab updates the active tab', async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto('/bank-connections');
+
+    const providersTab = page.getByRole('tab', { name: 'Providers' });
+    await providersTab.click();
+
+    await expect(providersTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByRole('tab', { name: 'Connection Health' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+
+  test('health tab shows connection cards or the empty state', async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto('/bank-connections');
+
+    // The health section heading always renders once the tab is active.
+    await expect(page.getByRole('heading', { name: /connection health/i, level: 2 })).toBeVisible();
+
+    // With no synced connections (stub DB), the empty state appears. If seed
+    // data is ever present, a connection card (an <article> labelled
+    // "… connection health") appears instead — tolerate both.
+    const emptyState = page.getByRole('heading', { name: /no bank connections/i, level: 3 });
+    const connectionCard = page.locator('article.connection-health-card').first();
+    await expect(emptyState.or(connectionCard)).toBeVisible();
+  });
+
+  test('switching to the Safety Center tab updates the active tab', async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto('/bank-connections');
+
+    const safetyTab = page.getByRole('tab', { name: 'Safety Center' });
+    await safetyTab.click();
+
+    await expect(safetyTab).toHaveAttribute('aria-selected', 'true');
+  });
+});


### PR DESCRIPTION
## Summary

Adds end-to-end test scaffolding for the **Bank Connections Health Center** (`/bank-connections`) — the web surface of the consolidated live-data aggregator path (epic #3846). This surface previously had **no e2e coverage**. Part of the Phase 6 review of the new live-data path.

## Changes

- **`apps/web/e2e/bank-connections.spec.ts`** (stubbed suite — runs in CI): 6 tests covering authenticated navigation to `/bank-connections` and the always-present page structure:
  - h1 heading, the connection-health summary strip (`role=status`), and the four-tab pattern (Connection Health / Providers / Wallets & Exchanges / Safety Center) with `aria-selected` state.
  - Tab switching (Providers, Safety Center) updates the active tab.
  - The health tab renders either connection cards or the empty state. The E2E stub DB has no `bank_connection` / `aggregator_provider` tables, so reads resolve empty and the empty state renders **deterministically**.
- **`apps/web/e2e-live/bank-connections-live.spec.ts`** (opt-in live skeleton): drives the real edge `aggregator-health` round-trip through a genuine signup (mirrors `full-stack-smoke.spec.ts`). **Gated behind `LIVE_AGGREGATOR` and skipped by default** because the aggregator edge functions + a synced-connection seed are not yet wired into the local Supabase stack — so the live smoke stays green today. The file header documents the exact steps to enable it once that backend lands.

## Why the live spec is skipped, not wired

There is no seed path that populates the synced bank-connection mirror tables for a freshly-signed-up user, and the `aggregator-health` function is not in the local stack yet. Running the live assertions today would fail on an empty dashboard (noise, not signal). The skeleton captures the intended assertions and enablement steps so it is ready the moment the aggregator backend + seed are available (tracked follow-up).

## Testing

- `npx prettier --check` — clean on both files.
- `npx eslint --max-warnings 0` — clean on both files.
- The stubbed suite is validated by CI (`vite preview` on the pre-built `dist/`). Note: the stubbed e2e suite does **not** run under local `vite` dev mode — the shared `authenticatedPage` fixture only reaches the authenticated shell under the CI preview build. Verified that the pre-existing `accounts.spec.ts` fails locally with the **identical** fixture error, confirming this is environmental and not specific to the new spec. The new spec mirrors the existing stubbed-suite conventions exactly.
- The live skeleton is skipped by default (`LIVE_AGGREGATOR` unset), so it does not affect the live smoke.

## Issues

Closes #3861
Refs #3846