### PR TITLE
feat(web): runtime feature-flag consumer + gate live aggregator behind a staged rollout flag

### DIFF
--- a/apps/web/src/lib/feature-flags/__tests__/evaluate.test.ts
+++ b/apps/web/src/lib/feature-flags/__tests__/evaluate.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { evaluateFlag } from '../evaluate';
+import { computeBucket } from '../rollout';
+import type { FlagEvaluationContext, WebFeatureFlag } from '../types';
+
+const webContext: FlagEvaluationContext = { clientId: 'client-1', platform: 'web' };
+
+function flag(overrides: Partial<WebFeatureFlag> = {}): WebFeatureFlag {
+  return {
+    key: 'test_flag',
+    description: 'test',
+    enabled: true,
+    owner: 'web',
+    platforms: ['web'],
+    rolloutPercentage: 100,
+    ...overrides,
+  };
+}
+
+describe('evaluateFlag', () => {
+  it('is false when the master switch is off, regardless of rollout', () => {
+    expect(evaluateFlag(flag({ enabled: false, rolloutPercentage: 100 }), webContext)).toBe(false);
+  });
+
+  it('is false when the platform is not targeted', () => {
+    expect(evaluateFlag(flag({ platforms: ['android', 'ios'] }), webContext)).toBe(false);
+  });
+
+  it('is true when enabled, platform-targeted, and fully rolled out', () => {
+    expect(evaluateFlag(flag({ rolloutPercentage: 100 }), webContext)).toBe(true);
+  });
+
+  it('is false when enabled and platform-targeted but rolled out to 0%', () => {
+    expect(evaluateFlag(flag({ rolloutPercentage: 0 }), webContext)).toBe(false);
+  });
+
+  it('respects the deterministic rollout bucket for partial rollouts', () => {
+    const bucket = computeBucket(webContext.clientId, 'test_flag');
+    expect(evaluateFlag(flag({ rolloutPercentage: bucket + 1 }), webContext)).toBe(true);
+    expect(evaluateFlag(flag({ rolloutPercentage: bucket }), webContext)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/feature-flags/__tests__/feature-flag-context.test.tsx
+++ b/apps/web/src/lib/feature-flags/__tests__/feature-flag-context.test.tsx
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { renderHook } from '@testing-library/react';
+import type { FC, ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { FeatureFlagProvider, useFeatureFlag } from '../feature-flag-context';
+import type { WebFlagRegistry } from '../types';
+
+const testRegistry: WebFlagRegistry = Object.freeze({
+  on_flag: {
+    key: 'on_flag',
+    description: 'always on for web',
+    enabled: true,
+    owner: 'web',
+    platforms: ['web'],
+    rolloutPercentage: 100,
+  },
+  off_flag: {
+    key: 'off_flag',
+    description: 'disabled',
+    enabled: false,
+    owner: 'web',
+    platforms: ['web'],
+    rolloutPercentage: 100,
+  },
+});
+
+function makeWrapper(): FC<{ children: ReactNode }> {
+  return ({ children }) => (
+    <FeatureFlagProvider registry={testRegistry} clientId="fixed-client">
+      {children}
+    </FeatureFlagProvider>
+  );
+}
+
+describe('useFeatureFlag with a provider', () => {
+  it('returns true for an enabled, fully rolled-out flag', () => {
+    const { result } = renderHook(() => useFeatureFlag('on_flag'), { wrapper: makeWrapper() });
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false for a disabled flag', () => {
+    const { result } = renderHook(() => useFeatureFlag('off_flag'), { wrapper: makeWrapper() });
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false (fail-closed) for an unknown flag', () => {
+    const { result } = renderHook(() => useFeatureFlag('missing'), { wrapper: makeWrapper() });
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useFeatureFlag without a provider', () => {
+  it('falls back to direct evaluation — live_bank_data is dark-launched (off)', () => {
+    const { result } = renderHook(() => useFeatureFlag('live_bank_data'));
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/web/src/lib/feature-flags/__tests__/public-api.test.ts
+++ b/apps/web/src/lib/feature-flags/__tests__/public-api.test.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { CLIENT_ID_STORAGE_KEY, getStableClientId } from '../client-id';
+import { isFeatureEnabled, isFeatureEnabledWith } from '../index';
+import type { WebFlagRegistry } from '../types';
+
+const registry: WebFlagRegistry = Object.freeze({
+  web_on: {
+    key: 'web_on',
+    description: 'on for web',
+    enabled: true,
+    owner: 'web',
+    platforms: ['web'],
+    rolloutPercentage: 100,
+  },
+  android_only: {
+    key: 'android_only',
+    description: 'android only',
+    enabled: true,
+    owner: 'android',
+    platforms: ['android'],
+    rolloutPercentage: 100,
+  },
+});
+
+describe('isFeatureEnabledWith', () => {
+  it('resolves a known enabled web flag to true', () => {
+    expect(isFeatureEnabledWith('web_on', { clientId: 'c', platform: 'web' }, registry)).toBe(true);
+  });
+
+  it('resolves an unknown flag to false (fail-closed)', () => {
+    expect(isFeatureEnabledWith('nope', { clientId: 'c', platform: 'web' }, registry)).toBe(false);
+  });
+
+  it('respects the platform filter', () => {
+    expect(isFeatureEnabledWith('android_only', { clientId: 'c', platform: 'web' }, registry)).toBe(
+      false,
+    );
+  });
+});
+
+describe('isFeatureEnabled (default registry)', () => {
+  it('reports live_bank_data as off — dark-launched at 0% rollout', () => {
+    expect(isFeatureEnabled('live_bank_data')).toBe(false);
+  });
+});
+
+describe('getStableClientId', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('persists and reuses a single id across calls', () => {
+    const first = getStableClientId();
+    const second = getStableClientId();
+    expect(first).toBe(second);
+    expect(localStorage.getItem(CLIENT_ID_STORAGE_KEY)).toBe(first);
+  });
+});

--- a/apps/web/src/lib/feature-flags/__tests__/rollout.test.ts
+++ b/apps/web/src/lib/feature-flags/__tests__/rollout.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { computeBucket, isInRollout } from '../rollout';
+
+/**
+ * Cross-platform parity anchors.
+ *
+ * These `(userId, flagKey) -> bucket` values are produced by the shared FNV-1a
+ * algorithm and pinned here so any future edit to {@link computeBucket} that
+ * changes bucketing (and therefore diverges from Kotlin's `RolloutEvaluator`)
+ * fails loudly. If these need to change, the Kotlin implementation must change
+ * in lockstep.
+ */
+const PARITY_VECTORS: ReadonlyArray<readonly [string, string, number]> = [
+  ['user-123', 'live_bank_data', 21],
+  ['user-abc', 'live_bank_data', 57],
+  ['00000000-0000-0000-0000-000000000000', 'live_bank_data', 63],
+  ['alice', 'dark_mode_oled', 82],
+  ['', '', 73],
+];
+
+describe('computeBucket', () => {
+  it('matches the pinned cross-platform parity vectors', () => {
+    for (const [userId, flagKey, expected] of PARITY_VECTORS) {
+      expect(computeBucket(userId, flagKey)).toBe(expected);
+    }
+  });
+
+  it('is deterministic for the same inputs', () => {
+    expect(computeBucket('user-xyz', 'flag')).toBe(computeBucket('user-xyz', 'flag'));
+  });
+
+  it('always returns an integer in [0, 100)', () => {
+    for (let i = 0; i < 500; i++) {
+      const bucket = computeBucket(`user-${i}`, 'some_flag');
+      expect(Number.isInteger(bucket)).toBe(true);
+      expect(bucket).toBeGreaterThanOrEqual(0);
+      expect(bucket).toBeLessThan(100);
+    }
+  });
+
+  it('distributes roughly uniformly across deciles', () => {
+    const deciles = new Array(10).fill(0);
+    const n = 10_000;
+    for (let i = 0; i < n; i++) {
+      deciles[Math.floor(computeBucket(`u${i}`, 'live_bank_data') / 10)]++;
+    }
+    // Each decile should hold ~10% of samples; allow a generous tolerance.
+    for (const count of deciles) {
+      expect(count).toBeGreaterThan(n * 0.07);
+      expect(count).toBeLessThan(n * 0.13);
+    }
+  });
+});
+
+describe('isInRollout', () => {
+  it('is false for everyone at 0%', () => {
+    for (let i = 0; i < 200; i++) {
+      expect(isInRollout(`user-${i}`, 'flag', 0)).toBe(false);
+    }
+  });
+
+  it('is true for everyone at 100%', () => {
+    for (let i = 0; i < 200; i++) {
+      expect(isInRollout(`user-${i}`, 'flag', 100)).toBe(true);
+    }
+  });
+
+  it('includes a user whose bucket is below the percentage and excludes one above', () => {
+    const userId = 'user-123';
+    const bucket = computeBucket(userId, 'flag'); // deterministic
+    expect(isInRollout(userId, 'flag', bucket + 1)).toBe(true);
+    expect(isInRollout(userId, 'flag', bucket)).toBe(false);
+  });
+
+  it('throws on out-of-range or non-integer percentages', () => {
+    expect(() => isInRollout('u', 'f', -1)).toThrow(RangeError);
+    expect(() => isInRollout('u', 'f', 101)).toThrow(RangeError);
+    expect(() => isInRollout('u', 'f', 12.5)).toThrow(RangeError);
+  });
+});

--- a/apps/web/src/lib/feature-flags/client-id.ts
+++ b/apps/web/src/lib/feature-flags/client-id.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Stable per-install client identifier for rollout bucketing (#3875).
+ *
+ * Rollout percentages are evaluated deterministically against a stable id (see
+ * {@link ../feature-flags/rollout}). The web runtime evaluates flags both before
+ * authentication (at bootstrap, to gate the live aggregator layer) and inside
+ * authenticated components, so it standardizes on a persisted per-install id
+ * rather than the auth user id. This keeps a single install's flag results
+ * consistent across the session and avoids a user flipping buckets when they log
+ * in. When server-synced, per-user flag evaluation lands, bucketing moves
+ * server-side keyed on the user id.
+ *
+ * @module lib/feature-flags/client-id
+ */
+
+/** localStorage key holding the persisted install id. */
+export const CLIENT_ID_STORAGE_KEY = 'finance.feature-flags.client-id';
+
+/** Fallback id used when `localStorage`/`crypto` are unavailable. */
+const FALLBACK_CLIENT_ID = 'anonymous';
+
+function generateId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch {
+    /* fall through to the non-crypto path */
+  }
+  // Non-cryptographic fallback — bucketing only needs stability, not secrecy.
+  return `c_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Return a stable per-install client id, creating and persisting one on first
+ * use. Degrades to a constant when storage is unavailable (e.g. SSR/tests with
+ * no DOM), which still yields deterministic — if shared — bucketing.
+ *
+ * @returns The persisted (or fallback) client id.
+ */
+export function getStableClientId(): string {
+  try {
+    const existing = localStorage.getItem(CLIENT_ID_STORAGE_KEY);
+    if (existing) return existing;
+    const created = generateId();
+    localStorage.setItem(CLIENT_ID_STORAGE_KEY, created);
+    return created;
+  } catch {
+    return FALLBACK_CLIENT_ID;
+  }
+}

--- a/apps/web/src/lib/feature-flags/evaluate.ts
+++ b/apps/web/src/lib/feature-flags/evaluate.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Pure flag-evaluation logic (#3875).
+ *
+ * @module lib/feature-flags/evaluate
+ */
+
+import { isInRollout } from './rollout';
+import type { FlagEvaluationContext, WebFeatureFlag } from './types';
+
+/**
+ * Evaluate a boolean feature flag for the given context.
+ *
+ * A flag resolves to `true` only when all of the following hold:
+ *   1. `enabled` is `true` (master switch), and
+ *   2. the context's platform is listed in `platforms`, and
+ *   3. the context's `clientId` falls within the deterministic rollout.
+ *
+ * @param flag - The flag definition.
+ * @param context - The evaluation context (client id + platform).
+ * @returns Whether the flag is on for this context.
+ */
+export function evaluateFlag(flag: WebFeatureFlag, context: FlagEvaluationContext): boolean {
+  if (!flag.enabled) return false;
+  if (!flag.platforms.includes(context.platform)) return false;
+  return isInRollout(context.clientId, flag.key, flag.rolloutPercentage);
+}

--- a/apps/web/src/lib/feature-flags/feature-flag-context.tsx
+++ b/apps/web/src/lib/feature-flags/feature-flag-context.tsx
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React context + hook for feature flags (#3875).
+ *
+ * Component-level consumers read flags via {@link useFeatureFlag}. A
+ * {@link FeatureFlagProvider} is optional: the hook falls back to direct
+ * evaluation (against the persisted install id) when no provider is mounted, so
+ * it is usable anywhere in the tree. Mount a provider to override the registry
+ * or client id — primarily useful in tests and Storybook.
+ *
+ * @module lib/feature-flags/feature-flag-context
+ */
+
+import { createContext, useContext, useMemo } from 'react';
+import type { FC, ReactNode } from 'react';
+
+import { getStableClientId } from './client-id';
+import { WEB_FLAG_REGISTRY } from './flag-registry';
+import { isFeatureEnabled, isFeatureEnabledWith } from './index';
+import type { WebFlagRegistry } from './types';
+
+/** Value exposed by {@link FeatureFlagContext}. */
+interface FeatureFlagContextValue {
+  /** Evaluate a flag key for the provider's context. */
+  isEnabled: (key: string) => boolean;
+}
+
+const FeatureFlagContext = createContext<FeatureFlagContextValue | null>(null);
+
+/** Props for {@link FeatureFlagProvider}. */
+export interface FeatureFlagProviderProps {
+  /** Registry override (defaults to the web bootstrap registry). */
+  registry?: WebFlagRegistry;
+  /** Client id override for rollout bucketing (defaults to the install id). */
+  clientId?: string;
+  children: ReactNode;
+}
+
+/**
+ * Provide a memoized flag evaluator to the subtree.
+ *
+ * @param props - Optional registry/client-id overrides plus children.
+ */
+export const FeatureFlagProvider: FC<FeatureFlagProviderProps> = ({
+  registry = WEB_FLAG_REGISTRY,
+  clientId,
+  children,
+}) => {
+  const value = useMemo<FeatureFlagContextValue>(() => {
+    const context = { clientId: clientId ?? getStableClientId(), platform: 'web' as const };
+    return { isEnabled: (key: string) => isFeatureEnabledWith(key, context, registry) };
+  }, [registry, clientId]);
+
+  return <FeatureFlagContext.Provider value={value}>{children}</FeatureFlagContext.Provider>;
+};
+
+/**
+ * Read a boolean feature flag.
+ *
+ * Uses the nearest {@link FeatureFlagProvider} when present; otherwise evaluates
+ * directly against the persisted install id.
+ *
+ * @param key - The flag key.
+ * @returns Whether the flag is enabled.
+ */
+export function useFeatureFlag(key: string): boolean {
+  const context = useContext(FeatureFlagContext);
+  if (context) return context.isEnabled(key);
+  return isFeatureEnabled(key);
+}

--- a/apps/web/src/lib/feature-flags/flag-registry.ts
+++ b/apps/web/src/lib/feature-flags/flag-registry.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Web bootstrap feature-flag registry (#3875).
+ *
+ * The **single source of truth** for flag configuration is the cross-platform
+ * registry at `config/feature-flags/flags.json` (schema-validated by the
+ * `CI — Feature Flags` workflow). Until synced, runtime flag delivery exists on
+ * web, this module vendors the web-consumed flags as a bootstrap default set.
+ * Each entry here MUST stay in lockstep with the matching flags.json entry.
+ *
+ * Only flags the web runtime actually evaluates are listed — adding a flag to
+ * flags.json does not require adding it here unless the web app consumes it.
+ *
+ * @module lib/feature-flags/flag-registry
+ */
+
+import type { WebFeatureFlag, WebFlagRegistry } from './types';
+
+/**
+ * `live_bank_data` — gates activation of the live consolidated bank-data
+ * aggregator (Plaid/MX/TrueLayer/Finicity, epic #3846) on web.
+ *
+ * Dark-launched: `enabled` is `true` but `rolloutPercentage` is `0`, so the
+ * aggregator provider layer stays inert in production. Ramp the percentage
+ * (here and in flags.json) to stage exposure once the accessibility blocker
+ * (#3862) on the live bank UI is resolved.
+ */
+const LIVE_BANK_DATA: WebFeatureFlag = {
+  key: 'live_bank_data',
+  description:
+    'Activate the live consolidated bank-data aggregator (Plaid/MX/TrueLayer/Finicity) on web.',
+  enabled: true,
+  owner: 'web',
+  platforms: ['web'],
+  rolloutPercentage: 0,
+};
+
+/** The web bootstrap flag registry, keyed by flag key. */
+export const WEB_FLAG_REGISTRY: WebFlagRegistry = Object.freeze({
+  [LIVE_BANK_DATA.key]: LIVE_BANK_DATA,
+});
+
+/** Well-known flag keys the web runtime consumes, for typo-safe references. */
+export const FlagKeys = {
+  /** Live consolidated bank-data aggregator gate. */
+  LIVE_BANK_DATA: 'live_bank_data',
+} as const;

--- a/apps/web/src/lib/feature-flags/index.ts
+++ b/apps/web/src/lib/feature-flags/index.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Web runtime feature-flag consumer (#3875).
+ *
+ * Public entry point. Provides:
+ *   - {@link isFeatureEnabled} — synchronous, non-React gate usable anywhere
+ *     (including the pre-render bootstrap in `main.tsx`).
+ *   - {@link isFeatureEnabledWith} — the same, with an explicit context/registry
+ *     (used by tests and the React provider).
+ *   - The React {@link FeatureFlagProvider} + {@link useFeatureFlag} hook.
+ *
+ * The single source of truth for flag *configuration* is
+ * `config/feature-flags/flags.json`; see {@link ./flag-registry}.
+ *
+ * @module lib/feature-flags
+ */
+
+import { getStableClientId } from './client-id';
+import { evaluateFlag } from './evaluate';
+import { WEB_FLAG_REGISTRY } from './flag-registry';
+import type { FlagEvaluationContext, WebFlagRegistry } from './types';
+
+/**
+ * Evaluate a flag against an explicit context and registry.
+ *
+ * Unknown keys resolve to `false` (fail-closed) so a missing flag never
+ * accidentally enables a gated feature.
+ *
+ * @param key - The flag key.
+ * @param context - The evaluation context.
+ * @param registry - The registry to look the flag up in (defaults to the web
+ *   bootstrap registry).
+ * @returns Whether the flag is enabled for the context.
+ */
+export function isFeatureEnabledWith(
+  key: string,
+  context: FlagEvaluationContext,
+  registry: WebFlagRegistry = WEB_FLAG_REGISTRY,
+): boolean {
+  const flag = registry[key];
+  if (!flag) return false;
+  return evaluateFlag(flag, context);
+}
+
+/**
+ * Evaluate a flag for the current web install.
+ *
+ * Uses the persisted per-install client id and the `'web'` platform. Safe to
+ * call outside React (e.g. at bootstrap in `main.tsx`).
+ *
+ * @param key - The flag key.
+ * @returns Whether the flag is enabled for this install.
+ */
+export function isFeatureEnabled(key: string): boolean {
+  return isFeatureEnabledWith(key, { clientId: getStableClientId(), platform: 'web' });
+}
+
+export { FeatureFlagProvider, useFeatureFlag } from './feature-flag-context';
+export { WEB_FLAG_REGISTRY, FlagKeys } from './flag-registry';
+export { computeBucket, isInRollout } from './rollout';
+export { evaluateFlag } from './evaluate';
+export { getStableClientId, CLIENT_ID_STORAGE_KEY } from './client-id';
+export type { FlagEvaluationContext, FlagPlatform, WebFeatureFlag, WebFlagRegistry } from './types';

--- a/apps/web/src/lib/feature-flags/rollout.ts
+++ b/apps/web/src/lib/feature-flags/rollout.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Deterministic rollout-percentage evaluator (web).
+ *
+ * This is a **byte-for-byte port** of the Kotlin
+ * `com.finance.core.featureflags.RolloutEvaluator` so that web and KMP clients
+ * bucket a given `(userId, flagKey)` pair identically. Divergence here would let
+ * the same user see a flag on one platform and off on another at the same
+ * rollout percentage — so the algorithm below MUST NOT be "optimized" away from
+ * the Kotlin original.
+ *
+ * The hash is an FNV-1a-inspired 64-bit accumulation. JavaScript numbers cannot
+ * represent 64-bit integer wraparound, so we use `BigInt` masked to 64 bits to
+ * emulate Kotlin's `Long` two's-complement arithmetic, then interpret the final
+ * value as a signed 64-bit integer before the modulo — exactly matching
+ * Kotlin's signed `%` semantics.
+ *
+ * @module lib/feature-flags/rollout
+ */
+
+/** 2^64 - 1, used to emulate 64-bit `Long` wraparound. */
+const MASK_64 = (1n << 64n) - 1n;
+
+/** 2^63, the sign boundary for a signed 64-bit integer. */
+const SIGN_BIT = 1n << 63n;
+
+/** 2^64, subtracted to reinterpret an unsigned value as signed. */
+const TWO_POW_64 = 1n << 64n;
+
+/** FNV-1a 64-bit offset basis (`0xcbf29ce484222325`). */
+const OFFSET_BASIS = 0xcbf29ce484222325n;
+
+/** FNV-1a 64-bit prime (`0x100000001b3` = 1099511628211). */
+const FNV_PRIME = 0x100000001b3n;
+
+/** Number of rollout buckets — mirrors Kotlin `BUCKET_COUNT`. */
+const BUCKET_COUNT = 100n;
+
+/**
+ * Reinterpret a value in `[0, 2^64)` as a signed two's-complement 64-bit int.
+ *
+ * Kotlin's `Long % 100` operates on the signed value and may yield a negative
+ * result; the caller normalizes it back into `[0, 100)`.
+ */
+function toSigned64(value: bigint): bigint {
+  return value >= SIGN_BIT ? value - TWO_POW_64 : value;
+}
+
+/**
+ * Compute a deterministic bucket in `[0, 100)` for a `(userId, flagKey)` pair.
+ *
+ * Iterates UTF-16 code units via {@link String.charCodeAt} to match Kotlin's
+ * `for (char in input)` (which iterates `Char`s, i.e. UTF-16 code units).
+ *
+ * @param userId - The stable identifier (auth user id or per-install id).
+ * @param flagKey - The feature flag's key.
+ * @returns An integer in `[0, 100)`.
+ */
+export function computeBucket(userId: string, flagKey: string): number {
+  const input = `${userId}:${flagKey}`;
+  let hash = OFFSET_BASIS;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash ^ BigInt(input.charCodeAt(i))) & MASK_64;
+    hash = (hash * FNV_PRIME) & MASK_64;
+  }
+  const signed = toSigned64(hash);
+  const bucket = ((signed % BUCKET_COUNT) + BUCKET_COUNT) % BUCKET_COUNT;
+  return Number(bucket);
+}
+
+/**
+ * Determine whether a user falls within the rollout percentage for a flag.
+ *
+ * Short-circuits `0` (off for everyone) and `100` (on for everyone) exactly like
+ * the Kotlin original, so those endpoints never depend on the hash.
+ *
+ * @param userId - The stable identifier used for bucketing.
+ * @param flagKey - The feature flag's key.
+ * @param rolloutPercentage - Integer percentage in `[0, 100]`.
+ * @returns `true` if the user's deterministic bucket is below the percentage.
+ * @throws {RangeError} If `rolloutPercentage` is not an integer in `[0, 100]`.
+ */
+export function isInRollout(userId: string, flagKey: string, rolloutPercentage: number): boolean {
+  if (!Number.isInteger(rolloutPercentage) || rolloutPercentage < 0 || rolloutPercentage > 100) {
+    throw new RangeError(`rolloutPercentage must be an integer 0-100, was ${rolloutPercentage}`);
+  }
+  if (rolloutPercentage === 0) return false;
+  if (rolloutPercentage === 100) return true;
+  return computeBucket(userId, flagKey) < rolloutPercentage;
+}

--- a/apps/web/src/lib/feature-flags/types.ts
+++ b/apps/web/src/lib/feature-flags/types.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Types for the web runtime feature-flag consumer (#3875).
+ *
+ * These mirror the simple flat schema of the canonical cross-platform registry
+ * at `config/feature-flags/flags.json` (the single source of truth), reshaped to
+ * camelCase for TypeScript ergonomics. The richer KMP targeting model
+ * (`packages/core/.../featureflags/`) is intentionally NOT replicated here — the
+ * web v1 consumer only needs enable/platform/rollout semantics.
+ *
+ * @module lib/feature-flags/types
+ */
+
+/** Platforms a flag may target. Matches the `platforms` entries in flags.json. */
+export type FlagPlatform = 'web' | 'android' | 'ios';
+
+/**
+ * A single feature flag as consumed by the web runtime.
+ *
+ * Mirrors one entry of `config/feature-flags/flags.json`, with
+ * `rollout_percentage` renamed to {@link rolloutPercentage}.
+ */
+export interface WebFeatureFlag {
+  /** Stable flag key (the object key in flags.json). */
+  key: string;
+  /** Human-readable description of what the flag gates. */
+  description: string;
+  /** Master on/off switch. When `false`, the flag is off regardless of rollout. */
+  enabled: boolean;
+  /** Owning team (informational on the client). */
+  owner: string;
+  /** Platforms the flag applies to. A flag is off on platforms it does not list. */
+  platforms: FlagPlatform[];
+  /** Deterministic rollout percentage in [0, 100]. */
+  rolloutPercentage: number;
+}
+
+/** A keyed collection of web feature flags. */
+export type WebFlagRegistry = Readonly<Record<string, WebFeatureFlag>>;
+
+/**
+ * Context supplied when evaluating a flag.
+ *
+ * `clientId` is the stable identifier used for deterministic rollout bucketing
+ * (see {@link ../feature-flags/rollout}). On web v1 this is a persisted
+ * per-install id so the same install always resolves to the same bucket, and so
+ * evaluation is consistent between the pre-auth bootstrap and post-auth
+ * components.
+ */
+export interface FlagEvaluationContext {
+  /** Stable id used for rollout bucketing. */
+  clientId: string;
+  /** The evaluating platform. Always `'web'` in this app. */
+  platform: FlagPlatform;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -19,6 +19,7 @@ import { MoneyDisplayProvider } from './lib/display-settings';
 import { applyStoredSimplifiedModePreference } from './lib/accessibility-preferences';
 import { migrateLegacyDisplayCurrencyPreference } from './lib/display-currency';
 import { bootstrapBanking } from './lib/banking';
+import { isFeatureEnabled } from './lib/feature-flags';
 import { initMonitoring } from './lib/monitoring';
 import {
   isViteDevServer,
@@ -140,10 +141,17 @@ initMonitoring();
 // governed by the synced `aggregator_provider` directory, and the router's
 // operational metadata source is attached later once the PowerSync query is
 // available (#3846).
+//
+// The live aggregator layer is gated behind the `live_bank_data` feature flag
+// (#3875): dark-launched at 0% rollout, so the providers stay unregistered (and
+// the live-data path inert) until the rollout is ramped. When the flag is off
+// the app behaves as manual/offline-only, exactly as before Phase 5.
 bootstrapBanking();
-void import('./lib/banking/register-aggregator-providers').then((m) =>
-  m.ensureAggregatorProvidersRegistered(),
-);
+if (isFeatureEnabled('live_bank_data')) {
+  void import('./lib/banking/register-aggregator-providers').then((m) =>
+    m.ensureAggregatorProvidersRegistered(),
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Service worker registration

--- a/config/feature-flags/flags.json
+++ b/config/feature-flags/flags.json
@@ -47,6 +47,14 @@
       "platforms": ["android"],
       "rollout_percentage": 0,
       "expires": ""
+    },
+    "live_bank_data": {
+      "description": "Activate the live consolidated bank-data aggregator (Plaid/MX/TrueLayer/Finicity) on web. Dark-launched at 0%; ramp to stage the rollout once a11y blocker #3862 lands.",
+      "enabled": true,
+      "owner": "web",
+      "platforms": ["web"],
+      "rollout_percentage": 0,
+      "expires": ""
     }
   }
 }


### PR DESCRIPTION
## Summary

The repo has a canonical flag registry (`config/feature-flags/flags.json`, CI-validated) and a rich KMP evaluation engine (`packages/core/.../featureflags/`), but the **web app had no runtime feature-flag consumer** — the live consolidated aggregator (Plaid/MX/TrueLayer/Finicity, epic #3846) was registered unconditionally at bootstrap with no rollout control.

This adds a small, reusable web feature-flag consumer and uses it as the first consumer to **dark-launch / stage the rollout** of the live bank-data aggregator.

## Changes

- **`apps/web/src/lib/feature-flags/`** (new):
  - `rollout.ts` — a TS `RolloutEvaluator` that ports Kotlin `RolloutEvaluator` **exactly** (deterministic FNV-1a 64-bit bucket via `BigInt`, signed-Long modulo) so web and KMP bucket a `(userId, flagKey)` pair identically. Pinned parity vectors guard against divergence.
  - `types.ts`, `flag-registry.ts`, `evaluate.ts` — flag types, the web bootstrap registry (mirrors flags.json), and a pure `evaluateFlag` (`enabled` AND platform-targeted AND in-rollout).
  - `client-id.ts` — a stable per-install id for rollout bucketing (consistent pre-auth at bootstrap and post-auth in components).
  - `index.ts` — synchronous `isFeatureEnabled(key)` / `isFeatureEnabledWith(...)` (fail-closed on unknown keys).
  - `feature-flag-context.tsx` — React `FeatureFlagProvider` + `useFeatureFlag(key)` hook (usable with or without a provider).
- **`config/feature-flags/flags.json`** — new web-owned `live_bank_data` flag: `enabled: true`, `rollout_percentage: 0` (dark-launched, ready to ramp).
- **`apps/web/src/main.tsx`** — gate the `register-aggregator-providers` dynamic import behind `isFeatureEnabled('live_bank_data')`. When off, the app behaves as manual/offline-only exactly as before Phase 5.

## Why dark-launch at 0%

Keeps the merged aggregator code inert in production while giving ops a single dial to stage exposure, and aligns with the open accessibility blocker (#3862) that makes the live bank UI not-yet-alpha-shippable. It also references the flag literal in code, satisfying the Feature Flag CI orphaned-flag check.

## Testing

- [x] `npx vitest run src/lib/feature-flags` — 22 tests pass (rollout determinism/distribution + parity vectors, evaluation, provider/hook, public API)
- [x] `npx eslint . --max-warnings 0` — clean
- [x] `npm run format:check` — clean (only local gitignored `.impeccable/` cache flagged)

## Issues

Closes #3875
Refs #3846