### PR TITLE
feat(api): include aggregator connection data in data export (#3868)

### DIFF
--- a/services/api/supabase/functions/data-export/index.test.ts
+++ b/services/api/supabase/functions/data-export/index.test.ts
@@ -37,7 +37,15 @@ interface MockExportDeps {
 const VALID_FORMATS = ['json', 'csv'] as const;
 type ExportFormat = (typeof VALID_FORMATS)[number];
 const RATE_LIMIT_MAX = 10;
-const REDACTED_COLUMNS = new Set(['public_key']);
+const REDACTED_COLUMNS = new Set([
+  'public_key',
+  'credential_id',
+  'transports',
+  'encrypted_access_token',
+  'encrypted_refresh_token',
+  'access_token',
+  'refresh_token',
+]);
 
 const testCorsHeaders: Record<string, string> = {
   'Access-Control-Allow-Origin': 'https://app.finance.example.com',
@@ -488,12 +496,85 @@ Deno.test('data-export — does not redact non-sensitive columns', async () => {
   assertEquals(body.data.accounts[0].balance_cents, 150000);
 });
 
+Deno.test('data-export — redacts aggregator access token (#3868)', async () => {
+  const req = createMockRequest({
+    method: 'GET',
+    url: 'https://test.supabase.co/functions/v1/data-export?format=json',
+  });
+  const res = await handleDataExport(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    exportData: {
+      bank_connections: [
+        {
+          id: 'conn-1',
+          household_id: 'hh-1',
+          provider: 'plaid',
+          institution_name: 'Test Bank',
+          status: 'connected',
+          encrypted_access_token: 'aes256gcm:secret-iv:secret-ct',
+        },
+      ],
+    },
+  });
+
+  assertStatus(res, 200);
+  const body = await res.json();
+  const conn = body.data.bank_connections[0];
+  assertEquals(conn.encrypted_access_token, '[REDACTED]');
+  // Non-sensitive fields are preserved for portability.
+  assertEquals(conn.institution_name, 'Test Bank');
+  assertEquals(conn.status, 'connected');
+});
+
+Deno.test('data-export — redacts open banking refresh token (#3868)', async () => {
+  const req = createMockRequest({
+    method: 'GET',
+    url: 'https://test.supabase.co/functions/v1/data-export?format=json',
+  });
+  const res = await handleDataExport(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    exportData: {
+      open_banking_connections: [
+        {
+          id: 'ob-1',
+          household_id: 'hh-1',
+          provider: 'truelayer',
+          encrypted_refresh_token: 'aes256gcm:iv:ct',
+          access_token: 'raw-token',
+        },
+      ],
+    },
+  });
+
+  const body = await res.json();
+  const conn = body.data.open_banking_connections[0];
+  assertEquals(conn.encrypted_refresh_token, '[REDACTED]');
+  assertEquals(conn.access_token, '[REDACTED]');
+});
+
 Deno.test('redactRecord — replaces public_key with [REDACTED]', () => {
   const record = { id: '123', public_key: 'secret-data', name: 'test' };
   const redacted = redactRecord(record);
   assertEquals(redacted.public_key, '[REDACTED]');
   assertEquals(redacted.name, 'test');
   assertEquals(redacted.id, '123');
+});
+
+Deno.test('redactRecord — redacts aggregator token columns (#3868)', () => {
+  const record = {
+    id: '123',
+    encrypted_access_token: 'aes256gcm:iv:ct',
+    encrypted_refresh_token: 'aes256gcm:iv:ct2',
+    access_token: 'raw',
+    refresh_token: 'raw2',
+    institution_name: 'Test Bank',
+  };
+  const redacted = redactRecord(record);
+  assertEquals(redacted.encrypted_access_token, '[REDACTED]');
+  assertEquals(redacted.encrypted_refresh_token, '[REDACTED]');
+  assertEquals(redacted.access_token, '[REDACTED]');
+  assertEquals(redacted.refresh_token, '[REDACTED]');
+  assertEquals(redacted.institution_name, 'Test Bank');
 });
 
 Deno.test('redactRecord — preserves record without sensitive columns', () => {

--- a/services/api/supabase/functions/data-export/index.ts
+++ b/services/api/supabase/functions/data-export/index.ts
@@ -16,6 +16,13 @@
  *   - notification_preferences, notification_log
  *   - passkey_credentials (with sensitive data redacted)
  *
+ * Enhancement (#3868): aggregator connection data is now included for GDPR
+ * Art. 15 (access) / Art. 20 (portability) completeness:
+ *   - bank_connections, bank_connection_health, bank_connection_accounts,
+ *     bank_sync_log, open_banking_connections
+ *   The encrypted access/refresh token columns are ALWAYS redacted — a
+ *   credential must never appear in an export.
+ *
  * Anonymization: Other household members' data is anonymized —
  * their user_id, email, and display_name are replaced with opaque
  * identifiers to protect their privacy while preserving relational
@@ -74,13 +81,34 @@ const EXPORTABLE_TABLES = [
   { name: 'budgets', filterBy: 'household_id', isHouseholdScoped: true },
   { name: 'goals', filterBy: 'household_id', isHouseholdScoped: true },
   { name: 'recurring_transaction_templates', filterBy: 'household_id', isHouseholdScoped: true },
+  // Aggregator connection data (#3868) — GDPR Art. 15/20 completeness. The
+  // encrypted access/refresh token columns are stripped by REDACTED_COLUMNS.
+  { name: 'bank_connections', filterBy: 'household_id', isHouseholdScoped: true },
+  { name: 'bank_connection_health', filterBy: 'household_id', isHouseholdScoped: true },
+  { name: 'bank_connection_accounts', filterBy: 'household_id', isHouseholdScoped: true },
+  { name: 'bank_sync_log', filterBy: 'household_id', isHouseholdScoped: true },
+  { name: 'open_banking_connections', filterBy: 'household_id', isHouseholdScoped: true },
   { name: 'notification_preferences', filterBy: 'user_id', isUserScoped: true },
   { name: 'notification_log', filterBy: 'user_id', isUserScoped: true },
   { name: 'passkey_credentials', filterBy: 'user_id', isUserScoped: true },
 ] as const;
 
-/** Sensitive columns to redact from export. */
-const REDACTED_COLUMNS = new Set(['public_key', 'credential_id', 'transports']);
+/**
+ * Sensitive columns to redact from export.
+ *
+ * Includes passkey material and — for aggregator connections (#3868) — the
+ * encrypted access/refresh tokens and any raw provider secret. These are
+ * credentials and MUST NEVER leave the server in an export.
+ */
+const REDACTED_COLUMNS = new Set([
+  'public_key',
+  'credential_id',
+  'transports',
+  'encrypted_access_token',
+  'encrypted_refresh_token',
+  'access_token',
+  'refresh_token',
+]);
 
 /** User PII columns to anonymize for non-self records. */
 const USER_PII_COLUMNS = new Set(['user_id', 'email', 'display_name', 'created_by', 'owner_id']);


### PR DESCRIPTION
## Summary

Aggregator (bank) connection data was absent from the GDPR data export, one of
the P1 compliance gaps found in the Phase 6 compliance review (#3866). This adds
those tables to the `data-export` edge function so a user's export is complete
under GDPR Art. 15 (access) and Art. 20 (portability).

## Changes

- Add `bank_connections`, `bank_connection_health`, `bank_connection_accounts`,
  `bank_sync_log`, and `open_banking_connections` to `EXPORTABLE_TABLES`
  (all household-scoped).
- Redact credential columns (`encrypted_access_token`, `encrypted_refresh_token`,
  `access_token`, `refresh_token`) via `REDACTED_COLUMNS` so a stored credential
  can never appear in an export. Non-sensitive fields (institution name, status,
  timestamps) are preserved for portability.
- Add Deno tests covering token redaction for `bank_connections` and
  `open_banking_connections` plus the `redactRecord` helper.

## Issues

Closes #3868
Refs #3846

## Testing

- [x] `npx prettier --write` clean on changed files
- [x] `npx eslint` clean (max-warnings 0) on changed files
- [ ] Deno tests run in CI (no local Deno runtime)