### PR TITLE
feat(api): revoke and purge aggregator tokens on disconnect and deletion (#3867, #3869)

### DIFF
--- a/services/api/supabase/functions/_shared/bank-revocation.test.ts
+++ b/services/api/supabase/functions/_shared/bank-revocation.test.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the best-effort aggregator token revocation helper (#3867/#3869).
+ *
+ * Verifies the outcome matrix (revoked / skipped / failed), that the helper
+ * NEVER throws into the caller, and that it never surfaces the plaintext token.
+ * All external dependencies (env, decrypt, Plaid) are injected so no network
+ * or real credentials are needed.
+ */
+
+import { assertEquals } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+import {
+  revokeProviderToken,
+  revokeProviderTokens,
+  type RevokeProviderTokenDeps,
+} from './bank-revocation.ts';
+import { PlaidApiError, type PlaidConfig } from './plaid.ts';
+
+const FULL_ENV: Record<string, string> = {
+  PLAID_CLIENT_ID: 'client',
+  PLAID_SECRET: 'secret',
+  BANK_ENCRYPTION_KEY: 'key-material',
+  PLAID_ENVIRONMENT: 'sandbox',
+};
+
+function depsWith(
+  env: Record<string, string>,
+  overrides: Partial<RevokeProviderTokenDeps> = {},
+): RevokeProviderTokenDeps {
+  return {
+    getEnv: (k: string) => env[k],
+    decrypt: () => Promise.resolve('decrypted-token'),
+    revokePlaid: () => Promise.resolve({ request_id: 'req-1' }),
+    ...overrides,
+  };
+}
+
+Deno.test('revokeProviderToken — skipped when no stored token', async () => {
+  const result = await revokeProviderToken(
+    { provider: 'plaid', encryptedAccessToken: null },
+    depsWith(FULL_ENV),
+  );
+  assertEquals(result.outcome, 'skipped');
+  assertEquals(result.detail, 'no stored token');
+});
+
+Deno.test('revokeProviderToken — skipped for non-Plaid providers (stub)', async () => {
+  for (const provider of ['mx', 'truelayer', 'finicity']) {
+    const result = await revokeProviderToken(
+      { provider, encryptedAccessToken: 'aes256gcm:iv:ct' },
+      depsWith(FULL_ENV),
+    );
+    assertEquals(result.outcome, 'skipped');
+    assertEquals(result.detail, 'provider revocation not implemented');
+  }
+});
+
+Deno.test('revokeProviderToken — skipped when Plaid credentials missing', async () => {
+  const result = await revokeProviderToken(
+    { provider: 'plaid', encryptedAccessToken: 'aes256gcm:iv:ct' },
+    depsWith({ BANK_ENCRYPTION_KEY: 'key-material' }),
+  );
+  assertEquals(result.outcome, 'skipped');
+  assertEquals(result.detail, 'provider credentials not configured');
+});
+
+Deno.test('revokeProviderToken — failed when encryption key missing', async () => {
+  const result = await revokeProviderToken(
+    { provider: 'plaid', encryptedAccessToken: 'aes256gcm:iv:ct' },
+    depsWith({ PLAID_CLIENT_ID: 'client', PLAID_SECRET: 'secret' }),
+  );
+  assertEquals(result.outcome, 'failed');
+  assertEquals(result.detail, 'encryption key not configured');
+});
+
+Deno.test('revokeProviderToken — failed when decryption throws', async () => {
+  const result = await revokeProviderToken(
+    { provider: 'plaid', encryptedAccessToken: 'aes256gcm:iv:ct' },
+    depsWith(FULL_ENV, {
+      decrypt: () => Promise.reject(new Error('bad ciphertext')),
+    }),
+  );
+  assertEquals(result.outcome, 'failed');
+  assertEquals(result.detail, 'token decryption failed');
+});
+
+Deno.test('revokeProviderToken — revoked on success with decrypted token', async () => {
+  let revokedWith: { config: PlaidConfig; token: string } | null = null;
+  const result = await revokeProviderToken(
+    { provider: 'plaid', encryptedAccessToken: 'aes256gcm:iv:ct' },
+    depsWith(FULL_ENV, {
+      decrypt: () => Promise.resolve('plaintext-access-token'),
+      revokePlaid: (config: PlaidConfig, token: string) => {
+        revokedWith = { config, token };
+        return Promise.resolve({ request_id: 'req-1' });
+      },
+    }),
+  );
+  assertEquals(result.outcome, 'revoked');
+  assertEquals(revokedWith!.token, 'plaintext-access-token');
+  assertEquals(revokedWith!.config.clientId, 'client');
+  assertEquals(revokedWith!.config.environment, 'sandbox');
+});
+
+Deno.test('revokeProviderToken — treats already-invalid item as revoked', async () => {
+  const result = await revokeProviderToken(
+    { provider: 'plaid', encryptedAccessToken: 'aes256gcm:iv:ct' },
+    depsWith(FULL_ENV, {
+      revokePlaid: () => Promise.reject(new PlaidApiError(400, 'ITEM_NOT_FOUND')),
+    }),
+  );
+  assertEquals(result.outcome, 'revoked');
+  assertEquals(result.detail, 'already invalid at provider');
+});
+
+Deno.test('revokeProviderToken — failed carries the safe Plaid error code', async () => {
+  const result = await revokeProviderToken(
+    { provider: 'plaid', encryptedAccessToken: 'aes256gcm:iv:ct' },
+    depsWith(FULL_ENV, {
+      revokePlaid: () => Promise.reject(new PlaidApiError(500, 'INTERNAL_SERVER_ERROR')),
+    }),
+  );
+  assertEquals(result.outcome, 'failed');
+  assertEquals(result.detail, 'INTERNAL_SERVER_ERROR');
+});
+
+Deno.test('revokeProviderToken — failed generically on a non-Plaid error', async () => {
+  const result = await revokeProviderToken(
+    { provider: 'plaid', encryptedAccessToken: 'aes256gcm:iv:ct' },
+    depsWith(FULL_ENV, {
+      revokePlaid: () => Promise.reject(new Error('network down')),
+    }),
+  );
+  assertEquals(result.outcome, 'failed');
+  assertEquals(result.detail, 'revocation request failed');
+});
+
+Deno.test('revokeProviderToken — never throws even if getEnv throws', async () => {
+  const result = await revokeProviderToken(
+    { provider: 'plaid', encryptedAccessToken: 'aes256gcm:iv:ct' },
+    {
+      getEnv: () => {
+        throw new Error('env exploded');
+      },
+    },
+  );
+  assertEquals(result.outcome, 'failed');
+  assertEquals(result.detail, 'unexpected error');
+});
+
+Deno.test('revokeProviderTokens — processes a batch of connections', async () => {
+  const results = await revokeProviderTokens(
+    [
+      { provider: 'plaid', encryptedAccessToken: 'aes256gcm:iv:ct' },
+      { provider: 'mx', encryptedAccessToken: 'aes256gcm:iv:ct' },
+      { provider: 'plaid', encryptedAccessToken: null },
+    ],
+    depsWith(FULL_ENV),
+  );
+  assertEquals(results.length, 3);
+  assertEquals(results[0].outcome, 'revoked');
+  assertEquals(results[1].outcome, 'skipped');
+  assertEquals(results[2].outcome, 'skipped');
+});

--- a/services/api/supabase/functions/_shared/bank-revocation.ts
+++ b/services/api/supabase/functions/_shared/bank-revocation.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Best-effort aggregator token revocation (#3867 / #3869).
+ *
+ * When a user disconnects a bank connection or deletes their account, the
+ * access token we hold on their behalf must be revoked at the aggregator so
+ * the processor no longer retains access to their financial data (GDPR
+ * Art. 17 erasure + processor deletion propagation).
+ *
+ * Design constraints:
+ *   - MUST be best-effort: revocation NEVER throws into the caller's
+ *     disconnect / delete flow. A processor outage or missing credential
+ *     must not block a user from disconnecting or deleting their account.
+ *   - MUST NOT log or return the plaintext access token or key material.
+ *   - Only Plaid has a real revocation path today (POST /item/remove). MX,
+ *     TrueLayer, and Finicity are stubs and record a `skipped` outcome so the
+ *     audit trail still shows revocation was attempted.
+ *
+ * The result is returned to the caller so it can be written to an audit log
+ * without exposing any secret.
+ */
+
+import { decryptToken } from './bank-crypto.ts';
+import { removeItem, PlaidApiError, type PlaidConfig } from './plaid.ts';
+
+/** Outcome of a best-effort revocation attempt. */
+export type TokenRevocationOutcome = 'revoked' | 'skipped' | 'failed';
+
+/** Result of a revocation attempt — safe to persist in an audit log. */
+export interface TokenRevocationResult {
+  /** The aggregator provider the token belonged to. */
+  provider: string;
+  /** Whether the token was revoked, skipped, or the attempt failed. */
+  outcome: TokenRevocationOutcome;
+  /**
+   * Safe, non-sensitive detail for skipped/failed outcomes (e.g. a Plaid
+   * error_code or a configuration note). NEVER contains a token.
+   */
+  detail?: string;
+}
+
+/** Inputs for a single connection's revocation. */
+export interface RevokeProviderTokenParams {
+  /** Aggregator provider (`plaid`, `mx`, `truelayer`, `finicity`). */
+  provider: string;
+  /** The stored AES-256-GCM token envelope, or null if none is stored. */
+  encryptedAccessToken: string | null | undefined;
+}
+
+/** Injectable dependencies (for tests — production uses the real ones). */
+export interface RevokeProviderTokenDeps {
+  getEnv?: (key: string) => string | undefined;
+  decrypt?: (envelope: string, keyMaterial: string) => Promise<string>;
+  revokePlaid?: (config: PlaidConfig, accessToken: string) => Promise<unknown>;
+}
+
+/**
+ * Plaid error codes that mean the Item is already gone at the provider. These
+ * are treated as a successful revocation — there is nothing left to revoke.
+ */
+const ALREADY_INVALID_PLAID_CODES = new Set([
+  'ITEM_NOT_FOUND',
+  'INVALID_ACCESS_TOKEN',
+  'ITEM_NO_LONGER_SUPPORTED',
+]);
+
+function defaultGetEnv(key: string): string | undefined {
+  // Deno is the Edge runtime; guard so the module can be imported under other
+  // runtimes (e.g. tooling) without a ReferenceError.
+  return typeof Deno !== 'undefined' ? Deno.env.get(key) : undefined;
+}
+
+/**
+ * Best-effort revoke a single connection's access token at its aggregator.
+ *
+ * Always resolves (never rejects). Returns a {@link TokenRevocationResult}
+ * describing what happened so the caller can audit it.
+ */
+export async function revokeProviderToken(
+  params: RevokeProviderTokenParams,
+  deps: RevokeProviderTokenDeps = {},
+): Promise<TokenRevocationResult> {
+  const provider = params.provider;
+  const getEnv = deps.getEnv ?? defaultGetEnv;
+  const decrypt = deps.decrypt ?? decryptToken;
+  const revokePlaid = deps.revokePlaid ?? removeItem;
+
+  try {
+    if (!params.encryptedAccessToken) {
+      return { provider, outcome: 'skipped', detail: 'no stored token' };
+    }
+
+    // Only Plaid supports revocation today. Other providers are stubs.
+    if (provider !== 'plaid') {
+      return { provider, outcome: 'skipped', detail: 'provider revocation not implemented' };
+    }
+
+    const clientId = getEnv('PLAID_CLIENT_ID');
+    const secret = getEnv('PLAID_SECRET');
+    if (!clientId || !secret) {
+      return { provider, outcome: 'skipped', detail: 'provider credentials not configured' };
+    }
+
+    const key = getEnv('BANK_ENCRYPTION_KEY');
+    if (!key) {
+      return { provider, outcome: 'failed', detail: 'encryption key not configured' };
+    }
+
+    let accessToken: string;
+    try {
+      accessToken = await decrypt(params.encryptedAccessToken, key);
+    } catch {
+      // Do not surface the crypto error detail — it could echo ciphertext.
+      return { provider, outcome: 'failed', detail: 'token decryption failed' };
+    }
+
+    const config: PlaidConfig = {
+      clientId,
+      secret,
+      environment: getEnv('PLAID_ENVIRONMENT') ?? 'sandbox',
+    };
+
+    try {
+      await revokePlaid(config, accessToken);
+      return { provider, outcome: 'revoked' };
+    } catch (err) {
+      if (err instanceof PlaidApiError && ALREADY_INVALID_PLAID_CODES.has(err.errorCode)) {
+        return { provider, outcome: 'revoked', detail: 'already invalid at provider' };
+      }
+      // PlaidApiError only carries a safe error_code; never the raw body.
+      const detail = err instanceof PlaidApiError ? err.errorCode : 'revocation request failed';
+      return { provider, outcome: 'failed', detail };
+    }
+  } catch {
+    // Absolute backstop: revocation must never throw into disconnect/delete.
+    return { provider, outcome: 'failed', detail: 'unexpected error' };
+  }
+}
+
+/**
+ * Best-effort revoke a batch of connections. Resolves after attempting every
+ * one; individual failures are captured in the returned results, never thrown.
+ */
+export async function revokeProviderTokens(
+  connections: ReadonlyArray<RevokeProviderTokenParams>,
+  deps: RevokeProviderTokenDeps = {},
+): Promise<TokenRevocationResult[]> {
+  const results: TokenRevocationResult[] = [];
+  for (const connection of connections) {
+    results.push(await revokeProviderToken(connection, deps));
+  }
+  return results;
+}

--- a/services/api/supabase/functions/_shared/plaid.test.ts
+++ b/services/api/supabase/functions/_shared/plaid.test.ts
@@ -15,6 +15,7 @@ import {
   plaidAmountToCents,
   plaidBaseUrl,
   plaidTransactionToRecord,
+  removeItem,
   type PlaidTransaction,
 } from './plaid.ts';
 
@@ -116,4 +117,29 @@ Deno.test('plaidTransactionToRecord falls back to name then currency fallback', 
   );
   assertEquals(record.payee, 'Coffee Shop');
   assertEquals(record.currency_code, 'EUR');
+});
+
+Deno.test('removeItem posts the access token to /item/remove', async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = '';
+  let capturedBody: Record<string, unknown> = {};
+  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+    capturedUrl = String(input);
+    capturedBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+    return Promise.resolve(new Response(JSON.stringify({ request_id: 'req-1' }), { status: 200 }));
+  }) as typeof fetch;
+
+  try {
+    const result = await removeItem(
+      { clientId: 'client', secret: 'secret', environment: 'sandbox' },
+      'access-token-xyz',
+    );
+    assertEquals(result.request_id, 'req-1');
+    assertEquals(capturedUrl, 'https://sandbox.plaid.com/item/remove');
+    assertEquals(capturedBody.access_token, 'access-token-xyz');
+    assertEquals(capturedBody.client_id, 'client');
+    assertEquals(capturedBody.secret, 'secret');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/services/api/supabase/functions/_shared/plaid.ts
+++ b/services/api/supabase/functions/_shared/plaid.ts
@@ -185,6 +185,25 @@ export async function exchangePublicToken(
 }
 
 /**
+ * Permanently invalidate an Item's access token via /item/remove.
+ *
+ * After this call Plaid stops billing for the Item and the access token can no
+ * longer be used. Call this when a user disconnects a connection or deletes
+ * their account so the aggregator no longer retains access on their behalf
+ * (GDPR Art. 17 / processor deletion propagation — #3867/#3869).
+ *
+ * SECURITY: NEVER log the access token.
+ */
+export async function removeItem(
+  config: PlaidConfig,
+  accessToken: string,
+): Promise<{ request_id: string }> {
+  return plaidPost<{ request_id: string }>(config, '/item/remove', {
+    access_token: accessToken,
+  });
+}
+
+/**
  * Fetch incremental transaction updates for an item via /transactions/sync.
  *
  * @param cursor The last cursor persisted for the item (empty for first sync).

--- a/services/api/supabase/functions/account-delete/index.ts
+++ b/services/api/supabase/functions/account-delete/index.ts
@@ -18,6 +18,7 @@ import {
 } from '../_shared/cookie.ts';
 import { refreshGrant } from '../_shared/supabase-auth.ts';
 import { type AuthenticatedUser, createAdminClient } from '../_shared/auth.ts';
+import { revokeProviderTokens } from '../_shared/bank-revocation.ts';
 
 const NO_STORE_JSON_HEADERS = {
   'Content-Type': 'application/json',
@@ -263,6 +264,9 @@ async function deleteAccountData(
   }
 
   if (soleHouseholdIds.length > 0) {
+    // Revoke aggregator tokens BEFORE their bank_connections rows are deleted
+    // so the processor stops retaining access on the user's behalf (#3869).
+    await revokeConnectionTokens(supabase, 'household_id', soleHouseholdIds);
     await deleteByIn(supabase, 'encryption_keys', 'household_id', soleHouseholdIds);
     for (const table of HOUSEHOLD_CHILD_TABLES) {
       await deleteByIn(supabase, table, 'household_id', soleHouseholdIds);
@@ -301,6 +305,9 @@ async function deleteAccountData(
   // Step 6: delete every user-owned row. For shared households this is
   // how the user's contributed data (transactions, budgets, etc.) is
   // removed — they all carry `owner_id = user.id`.
+  // First revoke any aggregator tokens the user still owns in SHARED
+  // households (sole-household connections were already revoked in step 3).
+  await revokeConnectionTokens(supabase, 'owner_id', user.id);
   for (const [table, column] of USER_OWNED_TABLES) {
     await deleteByEq(supabase, table, column, user.id);
   }
@@ -429,6 +436,40 @@ async function deleteByIn(
   if (values.length === 0) return;
   const { error } = await supabase.from(table).delete().in(column, values);
   if (error) throw error;
+}
+
+/**
+ * Best-effort revoke aggregator access tokens for the bank_connections that
+ * are about to be deleted (#3869). Fetches the stored encrypted tokens for the
+ * matching connections and asks each provider to revoke them so the processor
+ * no longer retains access on the user's behalf (GDPR Art. 17 propagation).
+ *
+ * NEVER throws — account deletion must proceed even if revocation fails, and
+ * NEVER logs a token.
+ */
+async function revokeConnectionTokens(
+  supabase: SupabaseAdminClient,
+  column: 'household_id' | 'owner_id',
+  values: readonly string[] | string,
+): Promise<void> {
+  try {
+    if (Array.isArray(values) && values.length === 0) return;
+    const base = supabase.from('bank_connections').select('provider, encrypted_access_token');
+    const query = Array.isArray(values)
+      ? base.in(column, values as string[])
+      : base.eq(column, values as string);
+    const { data, error } = await query;
+    if (error || !data) return;
+    const rows = data as Array<{ provider: string; encrypted_access_token: string | null }>;
+    await revokeProviderTokens(
+      rows.map((row) => ({
+        provider: row.provider,
+        encryptedAccessToken: row.encrypted_access_token,
+      })),
+    );
+  } catch {
+    // Best-effort — never block account deletion on revocation.
+  }
 }
 
 async function updateRows(

--- a/services/api/supabase/functions/bank-connection/index.ts
+++ b/services/api/supabase/functions/bank-connection/index.ts
@@ -50,6 +50,7 @@ import {
   PlaidApiError,
   type PlaidConfig,
 } from '../_shared/plaid.ts';
+import { revokeProviderToken } from '../_shared/bank-revocation.ts';
 import {
   createdResponse,
   errorResponse,
@@ -394,7 +395,7 @@ serve(async (req: Request): Promise<Response> => {
     }
 
     // -----------------------------------------------------------------------
-    // DELETE — Soft-delete
+    // DELETE — Disconnect: revoke the provider token, purge it, soft-delete.
     // -----------------------------------------------------------------------
     if (req.method === 'DELETE') {
       const connectionId = url.searchParams.get('id');
@@ -404,7 +405,7 @@ serve(async (req: Request): Promise<Response> => {
 
       const { data: existing, error: fetchError } = await supabase
         .from('bank_connections')
-        .select('id, household_id')
+        .select('id, household_id, provider, encrypted_access_token')
         .eq('id', connectionId)
         .is('deleted_at', null)
         .single();
@@ -430,9 +431,23 @@ serve(async (req: Request): Promise<Response> => {
         );
       }
 
+      // Best-effort revoke the token at the aggregator so the processor no
+      // longer retains access on the user's behalf (#3867). NEVER throws —
+      // a processor outage must not block the user's disconnect.
+      const revocation = await revokeProviderToken({
+        provider: existing.provider,
+        encryptedAccessToken: existing.encrypted_access_token,
+      });
+
+      // Soft-delete AND purge the stored credential — even if revocation was
+      // skipped/failed at the provider, we must not keep the token at rest.
       const { error: deleteError } = await supabase
         .from('bank_connections')
-        .update({ deleted_at: new Date().toISOString(), status: 'disconnected' })
+        .update({
+          deleted_at: new Date().toISOString(),
+          status: 'disconnected',
+          encrypted_access_token: null,
+        })
         .eq('id', connectionId);
 
       if (deleteError) {
@@ -442,7 +457,32 @@ serve(async (req: Request): Promise<Response> => {
         return internalErrorResponse(req);
       }
 
-      logger.info('Bank connection soft-deleted', { connectionId, httpStatus: 204 });
+      // Audit the revocation attempt (best-effort — never block the response).
+      const auditStatus =
+        revocation.outcome === 'revoked'
+          ? 'success'
+          : revocation.outcome === 'skipped'
+            ? 'partial'
+            : 'failure';
+      const { error: auditError } = await supabase.from('connector_access_log').insert({
+        bank_connection_id: connectionId,
+        household_id: existing.household_id,
+        access_type: 'revoke_access',
+        provider_name: existing.provider,
+        status: auditStatus,
+        error_message: revocation.detail ?? null,
+      });
+      if (auditError) {
+        logger.warn('Failed to write revocation audit log', {
+          errorMessage: auditError.message,
+        });
+      }
+
+      logger.info('Bank connection disconnected', {
+        connectionId,
+        revocationOutcome: revocation.outcome,
+        httpStatus: 204,
+      });
       return noContentResponse(req);
     }
 


### PR DESCRIPTION
## Summary

Two P1 compliance gaps from the Phase 6 review (#3866): disconnecting a bank
connection or deleting an account never revoked the aggregator access token or
propagated the deletion to the processor, and the stored (encrypted) credential
was retained after a soft-delete. This adds best-effort provider token
revocation and purges the credential, satisfying GDPR Art. 17 erasure and
processor deletion propagation.

## Changes

- **`_shared/plaid.ts`** — add `removeItem()` (`POST /item/remove`) to
  permanently invalidate a Plaid Item's access token.
- **`_shared/bank-revocation.ts`** (new) — best-effort revocation helper.
  Decrypts the stored token, calls the provider revoke (Plaid is real;
  MX/TrueLayer/Finicity are stubs and record `skipped`), **never throws** into
  the caller's disconnect/delete flow, and **never logs the token**. Returns an
  auditable `revoked`/`skipped`/`failed` outcome. Already-invalid Plaid
  items are treated as revoked.
- **`bank-connection` DELETE (#3867)** — revoke at the provider, null out
  `encrypted_access_token` on the soft-delete, and write a `revoke_access`
  entry to `connector_access_log`.
- **`account-delete` (#3869)** — revoke tokens **before** deleting
  `bank_connections` rows in both the sole-household and user-owned deletion
  paths.
- Tests for `removeItem` and the full revocation outcome matrix
  (`_shared/bank-revocation.test.ts`, `_shared/plaid.test.ts`).

## Security

- Revocation is best-effort: a processor outage or missing credential never
  blocks a user from disconnecting or deleting their account.
- The plaintext access token and key material are never logged or returned;
  audit details carry only safe Plaid `error_code` values.

## Issues

Closes #3867
Closes #3869
Refs #3846

## Testing

- [x] `npx prettier --write` clean on changed files
- [x] `npx eslint` clean (max-warnings 0) on changed files
- [ ] Deno tests run in CI (no local Deno runtime)