### PR TITLE
fix(web): prevent text selection on onboarding Simple Mode card copy (#3885)

### DIFF
--- a/apps/web/src/pages/OnboardingPage.css
+++ b/apps/web/src/pages/OnboardingPage.css
@@ -165,6 +165,12 @@
 .onboarding__simple-mode-copy {
   display: grid;
   gap: var(--spacing-2);
+  /* Presentational chrome: prevent touch-and-drag text selection on iOS Safari
+     and remove the tap highlight. Interactive controls (the Use Simple Mode
+     button) are siblings, not children, so they stay fully operable. */
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .onboarding__simple-mode-kicker {


### PR DESCRIPTION
﻿## Summary

On iOS Safari (iPhone), touch-and-drag over the non-interactive text of the onboarding **Simple Mode** recommended-first-step card triggered native text selection, painting a dark selection highlight over the copy (e.g. the "Simplified screens with fewer distractions" bullet). That copy is presentational chrome and should not be user-selectable — it read as a rendering bug and was poor mobile UX.

## Changes

- Added `-webkit-user-select: none` / `user-select: none` and `-webkit-tap-highlight-color: transparent` to `.onboarding__simple-mode-copy` in `apps/web/src/pages/OnboardingPage.css`.
- The copy container wraps only the kicker, title, description, and bullet list. The `Use Simple Mode` button is a **sibling** of the copy container (not a child), so it and all other form controls (range, toggles) remain fully selectable/operable via pointer, keyboard, and assistive technology.

## Accessibility

- Change is scoped to presentational, non-editable UI chrome. No interactive/editable elements are affected, so keyboard and screen-reader operability is unchanged (per the accessibility-testing skill: `user-select: none` on non-editable chrome does not impede AT users, and removing the iOS tap highlight has no AT impact).

## Verification

- `npm run format:check` — passes.
- `npx eslint` on the changed component — no errors.
- Manual: at a mobile viewport with touch emulation, dragging over the card now scrolls instead of selecting; desktop selection of genuinely selectable content elsewhere is unaffected.

## Follow-up (out of scope for this PR)

Other presentational cards in the app likely share the same missing guard (any non-interactive card copy that a user might touch-drag over). A shared `non-selectable UI chrome` utility class (or a scoped global reset for known presentational containers) is worth considering as a follow-up. This PR is intentionally scoped to the onboarding Simple Mode card only.

Closes #3885
