### PR TITLE
feat(web): granular even font-scale steps (#3886)

### DIFF
--- a/apps/web/src/hooks/useFontScale.test.ts
+++ b/apps/web/src/hooks/useFontScale.test.ts
@@ -23,8 +23,11 @@ const computedFontSizes: Record<string, string> = {
   '': '16px',
   '87.5%': '14px',
   '100%': '16px',
+  '112.5%': '18px',
   '125%': '20px',
+  '137.5%': '22px',
   '150%': '24px',
+  '175%': '28px',
   '200%': '32px',
 };
 
@@ -47,16 +50,29 @@ describe('useFontScale', () => {
     vi.restoreAllMocks();
   });
 
-  it('offers named steps through 200 percent text size', () => {
+  it('offers granular, evenly spaced steps through 200 percent text size', () => {
     expect(
       FONT_SCALE_OPTIONS.map((option) => [option.value, option.label, option.rootFontSize]),
     ).toEqual([
       ['small', 'Small', '87.5%'],
       ['default', 'Default', '100%'],
+      ['comfortable', 'Comfortable', '112.5%'],
       ['large', 'Large', '125%'],
+      ['larger', 'Larger', '137.5%'],
       ['extra-large', 'Extra Large', '150%'],
+      ['very-large', 'Very Large', '175%'],
       ['huge', 'Huge', '200%'],
     ]);
+  });
+
+  it('keeps neighboring steps within a 25 percentage-point jump', () => {
+    const percentages = FONT_SCALE_OPTIONS.map((option) => option.scale * 100);
+    for (let index = 1; index < percentages.length; index += 1) {
+      expect(percentages[index] - percentages[index - 1]).toBeLessThanOrEqual(25);
+    }
+    // 200% remains the maximum WCAG 2.2 SC 1.4.4 anchor.
+    expect(Math.max(...percentages)).toBe(200);
+    expect(Math.min(...percentages)).toBe(87.5);
   });
 
   it('persists and applies the Huge preference', () => {

--- a/apps/web/src/hooks/useFontScale.ts
+++ b/apps/web/src/hooks/useFontScale.ts
@@ -13,7 +13,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-export type FontScalePreference = 'small' | 'default' | 'large' | 'extra-large' | 'huge';
+export type FontScalePreference =
+  'small' | 'default' | 'comfortable' | 'large' | 'larger' | 'extra-large' | 'very-large' | 'huge';
 
 export interface FontScaleOption {
   value: FontScalePreference;
@@ -29,8 +30,17 @@ export const DEFAULT_FONT_SCALE_PREFERENCE: FontScalePreference = 'default';
 export const FONT_SCALE_OPTIONS: readonly FontScaleOption[] = [
   { value: 'small', label: 'Small', rootFontSize: '87.5%', scale: 0.875, basePixels: 14 },
   { value: 'default', label: 'Default', rootFontSize: '100%', scale: 1, basePixels: 16 },
+  {
+    value: 'comfortable',
+    label: 'Comfortable',
+    rootFontSize: '112.5%',
+    scale: 1.125,
+    basePixels: 18,
+  },
   { value: 'large', label: 'Large', rootFontSize: '125%', scale: 1.25, basePixels: 20 },
+  { value: 'larger', label: 'Larger', rootFontSize: '137.5%', scale: 1.375, basePixels: 22 },
   { value: 'extra-large', label: 'Extra Large', rootFontSize: '150%', scale: 1.5, basePixels: 24 },
+  { value: 'very-large', label: 'Very Large', rootFontSize: '175%', scale: 1.75, basePixels: 28 },
   { value: 'huge', label: 'Huge', rootFontSize: '200%', scale: 2, basePixels: 32 },
 ] as const;
 

--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -343,9 +343,9 @@ describe('OnboardingPage', () => {
     renderWithRouter(<OnboardingPage />);
 
     const textSizeSlider = screen.getByRole('slider', { name: /text size/i });
-    expect(textSizeSlider).toHaveAttribute('max', '4');
+    expect(textSizeSlider).toHaveAttribute('max', '7');
 
-    fireEvent.change(textSizeSlider, { target: { value: '4' } });
+    fireEvent.change(textSizeSlider, { target: { value: '7' } });
 
     expect(localStorage.getItem('finance-font-scale-preference')).toBe('huge');
     expect(document.documentElement.style.fontSize).toBe('200%');
@@ -408,7 +408,7 @@ describe('OnboardingPage', () => {
     renderWithRouter(<OnboardingPage />);
 
     fireEvent.change(screen.getByRole('slider', { name: /text size/i }), {
-      target: { value: '2' },
+      target: { value: '3' },
     });
     fireEvent.click(screen.getByRole('checkbox', { name: /reduce motion/i }));
     fireEvent.click(screen.getByRole('checkbox', { name: /simplified mode/i }));

--- a/apps/web/src/pages/onboarding/steps/ComfortStep.tsx
+++ b/apps/web/src/pages/onboarding/steps/ComfortStep.tsx
@@ -102,6 +102,11 @@ export const ComfortStep: React.FC<ComfortStepProps> = ({
               value={fontScaleValue}
               onChange={(event) => handleFontScaleChange(Number(event.target.value))}
               aria-label="Text Size"
+              aria-valuetext={
+                FONT_SCALE_OPTIONS[fontScaleValue]
+                  ? `${FONT_SCALE_OPTIONS[fontScaleValue].label} (${FONT_SCALE_OPTIONS[fontScaleValue].rootFontSize})`
+                  : undefined
+              }
             />
             <div className="onboarding__range-labels" aria-hidden="true">
               {FONT_SCALE_OPTIONS.map((option) => (

--- a/apps/web/src/styles/font-scaling.css
+++ b/apps/web/src/styles/font-scaling.css
@@ -168,6 +168,7 @@ html {
 
 /* Settings: large preference rows need one-column reflow before viewport breakpoints. */
 [data-font-scale='extra-large'] .settings-item,
+[data-font-scale='very-large'] .settings-item,
 [data-font-scale='huge'] .settings-item {
   grid-template-columns: minmax(0, 1fr);
   align-items: start;
@@ -179,6 +180,12 @@ html {
 [data-font-scale='extra-large'] .settings-item__select,
 [data-font-scale='extra-large'] .settings-item__input,
 [data-font-scale='extra-large'] .settings-item__checkbox,
+[data-font-scale='very-large'] .settings-item__value,
+[data-font-scale='very-large'] .settings-item__control,
+[data-font-scale='very-large'] .settings-item__status,
+[data-font-scale='very-large'] .settings-item__select,
+[data-font-scale='very-large'] .settings-item__input,
+[data-font-scale='very-large'] .settings-item__checkbox,
 [data-font-scale='huge'] .settings-item__value,
 [data-font-scale='huge'] .settings-item__control,
 [data-font-scale='huge'] .settings-item__status,
@@ -186,6 +193,7 @@ html {
 [data-font-scale='huge'] .settings-item__input,
 [data-font-scale='huge'] .settings-item__checkbox,
 [data-font-scale='extra-large'] .settings-item__checkbox-wrapper,
+[data-font-scale='very-large'] .settings-item__checkbox-wrapper,
 [data-font-scale='huge'] .settings-item__checkbox-wrapper {
   grid-column: 1;
   justify-self: stretch;
@@ -196,6 +204,8 @@ html {
 
 [data-font-scale='extra-large'] .settings-item__description,
 [data-font-scale='extra-large'] .settings-item__help,
+[data-font-scale='very-large'] .settings-item__description,
+[data-font-scale='very-large'] .settings-item__help,
 [data-font-scale='huge'] .settings-item__description,
 [data-font-scale='huge'] .settings-item__help {
   grid-column: 1;


### PR DESCRIPTION
﻿## Summary

The Text Size control (onboarding Comfort step + Settings > Preferences) previously offered only 5 named steps with large, uneven jumps — the `150% -> 200%` gap was especially jarring. This PR makes the font-scale progression **more granular and evenly spaced** while keeping **200% as the maximum** (WCAG 2.2 SC 1.4.4) and preserving full backward compatibility.

## Before / After

| Step | Before | After |
| ---- | ------ | ----- |
| 1 | Small — 87.5% | Small — 87.5% |
| 2 | Default — 100% | Default — 100% |
| 3 | Large — 125% | **Comfortable — 112.5%** (new) |
| 4 | Extra Large — 150% | Large — 125% |
| 5 | Huge — 200% | **Larger — 137.5%** (new) |
| 6 | — | Extra Large — 150% |
| 7 | — | **Very Large — 175%** (new) |
| 8 | — | Huge — 200% |

Neighbor increments shrink from up to **50pp** (150->200) to **12.5pp** across the lower/mid range and at most **25pp** at the very top — a much smoother ramp.

## Changes

- `useFontScale.ts`: expanded `FONT_SCALE_OPTIONS` and the `FontScalePreference` union with `comfortable` (112.5%), `larger` (137.5%), and `very-large` (175%).
- Kept every legacy token (`small`/`default`/`large`/`extra-large`/`huge`) at its **existing scale**, and left the `medium`->`default` / `x-large`->`extra-large` aliases in `normalizeFontScalePreference` untouched — already-persisted `finance-font-scale-preference` values still resolve.
- `ComfortStep.tsx`: added `aria-valuetext` to the onboarding slider so screen readers announce e.g. *"Large (125%)"* instead of a meaningless index.
- `font-scaling.css`: extended the stacked single-column `[data-font-scale]` settings overrides to the new `very-large` step (matching `extra-large`/`huge`).
- Updated unit tests for the new 8-option set.

## Accessibility reasoning

- **SC 1.4.4 Resize Text**: 200% remains the top anchor; the finer steps let users land closer to their comfortable size without overshooting, and the reflow overrides keep financial values from clipping at every large step.
- **Name/role/value**: the slider now exposes `aria-valuetext`, so the current size is spoken on change (the raw 0–7 index was previously announced). The Settings `<select>` already announces option labels.
- **Backward compatibility**: no stored value or legacy alias breaks; the max stays WCAG-compliant.

## Issues

Closes #3886

## Testing

- [x] `npx vitest run` — useFontScale, OnboardingPage, SettingsPreferencesPage (48 passed)
- [x] `prettier --check` on changed files
- [x] `eslint --max-warnings 0` on changed files
