### PR TITLE
fix(web): suppress touch tap-highlight flash on interactive elements (#3890)

### DIFF
--- a/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
+++ b/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
@@ -89,6 +89,23 @@ describe('Accessibility CSS', () => {
     });
   });
 
+  describe('Touch Tap-Highlight Suppression (#3890)', () => {
+    it('should suppress the default touch tap-highlight on interactive elements', () => {
+      expect(css).toContain('-webkit-tap-highlight-color: transparent');
+    });
+
+    it('should suppress the tap-highlight on label rows (composite tap targets)', () => {
+      const block = css.slice(0, css.indexOf('-webkit-tap-highlight-color: transparent'));
+      expect(block).toContain('label');
+    });
+
+    it('should not weaken keyboard focus outlines', () => {
+      // Focus rings remain intact — tap-highlight suppression is independent.
+      expect(css).toContain(':focus-visible');
+      expect(css).toContain('--focus-ring-color');
+    });
+  });
+
   describe('Reduced Motion (WCAG 2.3.3)', () => {
     it('should include prefers-reduced-motion media query', () => {
       expect(css).toContain('prefers-reduced-motion: reduce');

--- a/apps/web/src/styles/accessibility.css
+++ b/apps/web/src/styles/accessibility.css
@@ -183,6 +183,41 @@ textarea {
 }
 
 /* -------------------------------------------------------------------
+ * 2a. Touch Tap-Highlight Suppression
+ *
+ * On touch devices, mobile browsers (WebKit/Blink) paint a translucent
+ * grey box over the entire tappable element when it is pressed. For
+ * composite tap targets — e.g. a <label> row wrapping a visually-hidden
+ * checkbox (see the onboarding "Reduce Motion" toggle) — this flashes the
+ * whole row grey and reads as a rendering glitch rather than intentional
+ * feedback.
+ *
+ * We suppress the default tap-highlight globally on interactive elements.
+ * This is purely a touch-paint reset: keyboard :focus-visible outlines and
+ * the --focus-ring-* tokens are unaffected (see section 1), and intentional
+ * pressed/:active affordances remain available per component. Scoped to
+ * interactive selectors (not a blanket `*`) to keep the reset predictable.
+ *
+ * Refs: issue #3890
+ * ------------------------------------------------------------------- */
+
+a,
+button,
+label,
+input,
+select,
+textarea,
+summary,
+[role='button'],
+[role='link'],
+[role='tab'],
+[role='menuitem'],
+[role='switch'],
+[role='checkbox'] {
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* -------------------------------------------------------------------
  * Native form-control chrome normalization (centralized)
  *
  * The browser's stock number spinner arrows and native date/time


### PR DESCRIPTION
## Summary

On touch devices, tapping a toggle, button, or tappable `<label>` row flashed the entire element with an opaque grey overlay — the browser's default `-webkit-tap-highlight-color`. It read as a rendering glitch and affected controls app-wide (e.g. the onboarding Comfort step `Reduce Motion` toggle).

## Root cause

No `-webkit-tap-highlight-color` was declared anywhere in `apps/web/src`. Interactive elements fell back to the mobile browser default translucent/opaque grey box on tap.

## Changes

- Add a **global** tap-highlight reset in `apps/web/src/styles/accessibility.css` (imported in `main.tsx`), scoped to interactive selectors (`a, button, label, input, select, textarea, summary, [role=button|link|tab|menuitem|switch|checkbox]`) — not a blanket `*` — setting `-webkit-tap-highlight-color: transparent`.
- Keyboard `:focus-visible` outlines and `--focus-ring-*` tokens are **untouched** — tap-highlight suppression is independent of focus.
- Add regression tests to `wcag-audit.test.ts` asserting the reset exists, covers `label` rows, and does not weaken focus outlines.

## Verification

- Playwright iPhone 13 emulation: interactive `label` computes `rgba(0,0,0,0)` (transparent); a plain `div` retains the browser default, confirming the reset is precisely scoped.
- `npm run format:check` ✅ · `npx eslint . --max-warnings 0` ✅ · `wcag-audit.test.ts` 49/49 ✅

## Notes

- Did **not** touch `apps/web/src/pages/OnboardingPage.css` (in-flight PR #3885) or `vite.config.ts`.

## Issues

Closes #3890