### PR TITLE
fix(web): hydrate onboarding comfort toggles from persisted state (#3891)

### DIFF
--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -18,6 +18,7 @@ import { useAuth } from '../auth/auth-context';
 import { useBudgets } from '../hooks/useBudgets';
 import { useConsent } from '../hooks/useConsent';
 import { useConsentHistory } from '../hooks/useConsentHistory';
+import { FONT_SCALE_OPTIONS } from '../hooks/useFontScale';
 import { useLocalOnlyMode } from '../hooks/useLocalOnlyMode';
 import { useGoals } from '../hooks/useGoals';
 import { useDatabase } from '../db/DatabaseProvider';
@@ -427,6 +428,36 @@ describe('OnboardingPage', () => {
 
     expect(screen.getByRole('heading', { name: /local only/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /create account/i })).toBeInTheDocument();
+  });
+
+  it('hydrates comfort toggles from persisted preferences on mount (#3891)', () => {
+    // Persisted comfort settings are applied on boot but the onboarding controls
+    // previously ignored them, rendering OFF while the effect stayed applied.
+    localStorage.setItem('finance-theme-preference', 'high-contrast');
+    localStorage.setItem('finance-reduced-motion-preference', 'true');
+    localStorage.setItem('finance-simplified-mode', 'true');
+    localStorage.setItem('finance-font-scale-preference', 'large');
+
+    renderWithRouter(<OnboardingPage />);
+
+    expect(screen.getByRole('checkbox', { name: /high contrast/i })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /reduce motion/i })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /simplified mode/i })).toBeChecked();
+    // Derive the expected slider index dynamically so the assertion stays
+    // robust if the font-scale option set changes (#3886/#3891).
+    const largeIndex = String(FONT_SCALE_OPTIONS.findIndex((o) => o.value === 'large'));
+    expect(screen.getByRole('slider', { name: /text size/i })).toHaveValue(largeIndex);
+  });
+
+  it('leaves comfort toggles OFF when nothing is persisted (#3891)', () => {
+    renderWithRouter(<OnboardingPage />);
+
+    expect(screen.getByRole('checkbox', { name: /high contrast/i })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /reduce motion/i })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /simplified mode/i })).not.toBeChecked();
+    // Defaults to the stored/default preference index, derived dynamically.
+    const defaultIndex = String(FONT_SCALE_OPTIONS.findIndex((o) => o.value === 'default'));
+    expect(screen.getByRole('slider', { name: /text size/i })).toHaveValue(defaultIndex);
   });
 
   it('navigates to signup without completing onboarding when Create Account is clicked', () => {

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -26,8 +26,12 @@ import { getPrimaryHouseholdId } from '../db/repositories/household';
 import { useBudgets } from '../hooks/useBudgets';
 import { useConsent } from '../hooks/useConsent';
 import { useConsentHistory } from '../hooks/useConsentHistory';
+import { FONT_SCALE_OPTIONS, getStoredFontScalePreference } from '../hooks/useFontScale';
 import { useGoals } from '../hooks/useGoals';
 import { useLocalOnlyMode } from '../hooks/useLocalOnlyMode';
+import { getStoredReducedMotionPreference } from '../hooks/useReducedMotion';
+import { getStoredTheme } from '../hooks/useTheme';
+import { getStoredSimplifiedModePreference } from '../lib/accessibility-preferences';
 import { buildOnboardingProgressAnnouncement } from '../lib/a11y/onboarding-progress';
 import { getBudgetStarterTemplates } from '../lib/budgeting/starter-budget-templates';
 import {
@@ -115,10 +119,15 @@ const OnboardingPage: React.FC = () => {
     // education/setup sequence rather than repeating the welcome flow (#3089).
     isAuthenticated ? DEFERRED_SETUP_START_STEP : 'comfort',
   );
-  const [fontScaleValue, setFontScaleValue] = useState(DEFAULT_FONT_SCALE_INDEX);
-  const [reducedMotion, setReducedMotion] = useState(false);
-  const [simplifiedMode, setSimplifiedMode] = useState(false);
-  const [highContrast, setHighContrast] = useState(false);
+  const [fontScaleValue, setFontScaleValue] = useState(() => {
+    const storedIndex = FONT_SCALE_OPTIONS.findIndex(
+      (option) => option.value === getStoredFontScalePreference(),
+    );
+    return storedIndex >= 0 ? storedIndex : DEFAULT_FONT_SCALE_INDEX;
+  });
+  const [reducedMotion, setReducedMotion] = useState(() => getStoredReducedMotionPreference());
+  const [simplifiedMode, setSimplifiedMode] = useState(() => getStoredSimplifiedModePreference());
+  const [highContrast, setHighContrast] = useState(() => getStoredTheme() === 'high-contrast');
   const [templateError, setTemplateError] = useState<string | null>(null);
   const [isApplyingTemplate, setIsApplyingTemplate] = useState(false);
   const [starterBudgetCreated, setStarterBudgetCreated] = useState(false);


### PR DESCRIPTION
﻿## Summary

In onboarding's Comfort step, enabling a comfort setting (High Contrast, Text Size, Reduce Motion, Simplified Mode), closing the app, and reopening left the setting **applied** (correctly persisted/re-applied on boot) but the onboarding **toggle rendered OFF**. The controls kept duplicate local copies of settings whose source of truth is persisted elsewhere (`applyComfortPreferences` in `comfort.ts`, re-applied on boot in `main.tsx`), and initialized them to hardcoded defaults instead of reading persisted state.

## Root cause

`OnboardingPage.tsx` initialized the four comfort settings to hardcoded `useState` defaults, ignoring persisted values. Other onboarding state in the same file (life stages, lessons) already used lazy initializers reading storage — the comfort toggles were the inconsistency. Settings > Preferences hydrates correctly, which is why the setting itself was retained.

## Changes

- Replaced the four hardcoded `useState` defaults in `OnboardingPage.tsx` with lazy initializers reading the existing stored getters:
  - High contrast: `getStoredTheme() === 'high-contrast'`
  - Reduced motion: `getStoredReducedMotionPreference()`
  - Simplified mode: `getStoredSimplifiedModePreference()`
  - Font scale index: derived dynamically from `getStoredFontScalePreference()` via `FONT_SCALE_OPTIONS.findIndex(...)` with a safe fallback to `DEFAULT_FONT_SCALE_INDEX` (robust to font-scale option set changes — e.g. #3886's granular steps).
- Added regression tests in `OnboardingPage.test.tsx` seeding localStorage with each comfort preference enabled and asserting the corresponding control renders checked/at the right index on mount, plus an OFF-by-default case. Slider index expectations are derived dynamically from `FONT_SCALE_OPTIONS`.

## Audit for other unhydrated setting controls

Audited the rest of `apps/web` for setting controls keeping local `useState` copies without hydrating from their persisted source. **None found** — Settings pages hydrate via `getStored*` and other persisted hooks (`useWidgetLayout`, `useSpendingWatchlists`, `useNotificationPreferences`, `SettingsSyncPage`) hydrate via lazy initializers or a mount `useEffect`. The onboarding comfort toggles were the isolated defect, so no follow-up issues were filed.

## Known pre-existing quirk (out of scope, not fixed here)

Disabling high contrast maps the theme to `'system'` rather than the user's prior light/dark choice (in `comfort.ts`). This is pre-existing and orthogonal to the hydration fix; left untouched per scope.

## Testing

- [x] `npx vitest run src/pages/OnboardingPage.test.tsx` — 37 passed
- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean

Closes #3891
