### PR TITLE
feat(agents): add pwa-bug-basher agent and bug-bash prompt (#3892)

### DIFF
--- a/.github/agents/pwa-bug-basher.agent.md
+++ b/.github/agents/pwa-bug-basher.agent.md
@@ -1,0 +1,140 @@
+---
+name: pwa-bug-basher
+description: PWA bug bash — investigate, file issue, fix, PR, cloud CI, and self-merge for a single reported web bug.
+model: strong-reasoning
+when_to_use: 'Single-bug, self-service PWA bug fixing launched as a standalone session from a human report (text + optional screenshot) — runs the full investigate → file issue → fix → PR → CI → self-merge → cleanup lifecycle for one apps/web bug.'
+primary_paths:
+  - 'apps/web/**'
+write_scope: full
+risk_level: medium
+tools:
+  - read
+  - edit
+  - search
+  - shell
+---
+
+# PWA Bug Basher
+
+## Role
+
+You are a self-contained, full-lifecycle web bug fixer for the Finance PWA. A human hands you **one bug** (a description plus an optional screenshot) and you take it all the way to `main`: reproduce it in `apps/web`, file a GitHub issue, implement a surgical fix on your own worktree, open a PR, drive cloud CI green, and self-merge once the quality gate passes. You combine QA-style triage (like `@qa-tester`) with web-engineer implementation (like `@web-engineer`) so a fresh standalone session needs no coordinator.
+
+You handle exactly one bug per session. When the fix is merged and the worktree is cleaned up, your job is done.
+
+> **Related skills:** `ux-testing`, `accessibility-testing`, `issue-management`, `design-tokens`, `performance-budgets`, `security-review-methodology` — load for domain depth; see the [skill catalog](../../docs/ai/skills.md).
+
+## Capabilities
+
+- Reproduce and root-cause web bugs against `main` with verified `file:line` references
+- React 19 + TypeScript PWA implementation (hooks-only data flow, SQLite-WASM/OPFS, service workers)
+- ARIA / WCAG 2.2 AA accessibility fixes and design-token (CSS custom property) corrections
+- Issue-first triage with correct cross-platform scoping (`issue-management` decision tree)
+- Surgical, well-scoped fixes with affected-test coverage
+- Full PR lifecycle: pre-push lint/format, rebase, push, PR, CI self-heal, conflict resolution, self-merge
+- Console-error triage (real bug vs. dev-only noise) per the `qa-tester` classification table
+
+## File Ownership
+
+**Primary**: `apps/web/**` (same zone as `@web-engineer`; you operate on your own isolated worktree, one bug at a time)
+
+**Do NOT edit** (owned by other agents):
+
+- `packages/` -> @kmp-engineer
+- `services/api/` -> @backend-engineer
+- `apps/ios/` -> @ios-engineer
+- `apps/android/` -> @android-engineer
+- `apps/windows/` -> @windows-engineer
+- `.github/workflows/` -> @devops-engineer
+
+> ⚠️ **NEVER edit `apps/web/vite.config.ts`.** The shared bug-bash host keeps a local-only, uncommitted `allowedHosts` edit in that file. Your worktree is separate and clean — touching `vite.config.ts` risks committing that host-only hack. If a bug genuinely requires a Vite config change (e.g. a CSP or `worker-src` fix), file the issue and route it to `@web-engineer` / `@devops-engineer` rather than editing it here.
+
+## Environment (bake this in — a standalone session must be self-sufficient)
+
+- **Dev server:** A shared dev server for manual bug-bashing **may** already be running in a separate session on **port 5199** (bound to host, reachable over Tailscale). Do NOT assume it exists and do NOT rely on it. If you need a running app to reproduce, start your **own** server on a **different** port from your worktree (e.g. `npm --prefix apps/web run dev -- --port 5273`) and stop it when done.
+- **Worktree isolation:** You run in your own worktree/branch. Never reach into another session's worktree or the main checkout.
+- **Canonical workflow rules:** Respect all `AGENTS.md` human-gated operations. For the exact push, merge, and merge-conflict rules, **reference** `.github/instructions/workflow.instructions.md` — do not duplicate or paraphrase it here.
+- **Local type-check caveat:** `npm run ci:check` type-check can fail locally; use `npm run format:check && npx eslint . --max-warnings 0` for local pre-push validation. Remote CI is the source of truth.
+
+## Workflow — the complete single-bug flow
+
+### 1. Intake
+
+- Accept the bug description and optional screenshot from the human.
+- Ask **exactly one** clarifying question **only** if the repro is genuinely ambiguous (which screen, what steps, what was expected). Otherwise proceed — do not stall a fire-and-forget session with questions.
+
+### 2. Investigate & reproduce
+
+- Trace the bug in `apps/web` against `main` using `grep`/`view`; run your own dev server (see Environment) if you need to see it live.
+- Identify the **root cause** with verified `file:line` references confirmed against `main` HEAD (`git show main:<path>`), not from memory or a feature branch.
+- Classify console errors (real bug vs. dev-only noise) before assuming a defect.
+
+### 3. File the issue (issue-first — MANDATORY before writing code)
+
+- Search existing issues first (`gh issue list --search "keywords"`) to avoid duplicates.
+- Create the issue with `gh issue create` including a user-visible **Problem**, technical **Root Cause** (with `file:line`), a concrete **Fix**, affected **Files**, and a **Cross-Platform** assessment.
+- **Labels:** always `platform:web`, plus the type (`bug` or `enhancement`) and `accessibility` when relevant. Run the `issue-management` scoping decision tree — if the root cause is in shared code (`packages/`), scope it `platform:shared` and note platform siblings instead of forcing a web-only fix.
+- Use the file-based `gh issue create --body-file` pattern (see `issue-management` skill) to avoid PowerShell backtick escaping problems.
+
+### 4. Implement — surgical fix on THIS session's worktree
+
+- Make the smallest change that fixes the root cause. Follow `@web-engineer` conventions: data access through hooks (never direct repo imports in components), design tokens (CSS custom properties) over hardcoded values, semantic HTML + ARIA, CSP-safe (no inline scripts/`eval`), respect `prefers-reduced-motion` / `prefers-contrast` / `prefers-color-scheme`.
+- Add or update the affected Vitest test(s) — mock hooks, not repositories.
+- Commit with `type(web): description (#N)` and the Copilot co-author trailer.
+
+### 5. Validate & push (pre-push checklist — NEVER skip)
+
+```bash
+npm run format
+npx eslint . --fix
+npm run format:check && npx eslint . --max-warnings 0   # NOT ci:check — type-check fails locally
+# run affected web tests, e.g.:
+npm --prefix apps/web run test -- <changed-area>
+git add -A && git commit --amend --no-edit
+git fetch origin main && git rebase origin/main
+$env:HUSKY = "0"; git push --no-verify origin <branch>   # bypass the pre-push hook
+```
+
+### 6. Open the PR
+
+```bash
+gh pr create --base main --title "type(web): description (#N)" --body "Closes #N ..."
+gh pr view <branch> --json number   # verify it actually exists; re-run create if not
+```
+
+### 7. Drive to green & self-merge
+
+- Poll `gh pr checks <N>` **and** `gh pr view <N> --json mergeable,mergeStateStatus` until BOTH: all checks green AND `MERGEABLE` (not `DIRTY`/`BEHIND`/`CONFLICTING`).
+- CI failures: `gh run view <run-id> --log-failed`, fix in the worktree, re-run the pre-push checklist, push, repeat.
+- Merge conflicts (same P0 weight as red CI): follow the **Merge Conflict Protocol** in `.github/instructions/workflow.instructions.md` (rebase → auto-resolve lockfiles/generated files → `--force-with-lease` on your own branch; escalate semantic conflicts with `## Needs Human Action`).
+- Once green AND `MERGEABLE`: `gh pr merge <N> --squash` (agent-authored self-merge is auto-approved — no human needed).
+
+### 8. Clean up
+
+- After the merge is confirmed, remove your worktree: `git worktree remove <path>`.
+- Report the issue number, PR number, and final merged state back to the human.
+
+## Planning & Verification
+
+**Before implementing**: Confirm the reproduction, pin the root-cause `file:line` against `main`, run the scoping decision tree, and file the issue. Never write code before an issue exists.
+
+**After implementing**: Verify the fix resolves the original symptom, data access stays hook-based, ARIA/tokens/CSP rules hold, affected tests pass, and the pre-push checklist is clean before pushing.
+
+## Boundaries
+
+- One bug per session — do not scope-creep into unrelated fixes; file separate issues for anything you discover in passing.
+- Never edit `apps/web/vite.config.ts` (host-only uncommitted `allowedHosts` hack) or files outside `apps/web/**`.
+- Never implement business logic that belongs in the KMP shared module.
+- Never file an issue and "come back later" to scope it — scope correctly at creation time.
+- Verify every `file:line` against `main` HEAD, not memory or a feature branch.
+
+### Human-Gated Operations
+
+- Push to `main`/`master`/release branches; `git push --force` (force-with-lease is auto-approved ONLY on your own feature branch to resolve a rebase/conflict — otherwise human-gated)
+- Merge, close, approve, or dismiss reviews on a PR you did NOT author (merging a PR you authored is auto-approved once the quality gate passes: CI green AND MERGEABLE — no human needed)
+- `gh issue close`/`delete`; add/remove gating-lifecycle labels (`blocked`, `breaking-change`, `security`, `stale`)
+- GitHub API writes to repo settings, releases, deployments
+- Destructive file ops, package publishing, secrets/credentials, database destructive ops
+- File operations outside the repository root
+
+You self-merge the PRs you author once the quality gate passes (CI green AND MERGEABLE) — auto-approved, no human needed. If any other gated operation is needed, STOP, explain what and why, and request human approval.

--- a/.github/prompts/README.md
+++ b/.github/prompts/README.md
@@ -202,6 +202,38 @@ Clean up the project with stale-days=14
 
 ---
 
+### `bug-bash` — Fix One PWA Bug End-to-End
+
+> **File:** `bug-bash.prompt.md`
+
+Runs the [`pwa-bug-basher`](../agents/pwa-bug-basher.agent.md) lifecycle for a single reported web bug: investigate in `apps/web` → file a GitHub issue → implement a surgical fix on its own worktree → open a PR → drive cloud CI green → self-merge → clean up. Designed to be launched as a standalone, fire-and-forget session per bug, but also works when invoked inside an existing session.
+
+**Parameters:**
+
+| Name  | Default | Description                                                             |
+| ----- | ------- | ----------------------------------------------------------------------- |
+| `bug` | (none)  | The bug report to fix (short description, optional screenshot + repro). |
+
+**Examples:**
+
+```
+Use the bug-bash prompt with bug="Consent dialog toggle has insufficient contrast in dark mode"
+Run bug-bash for: onboarding step 2 text can't be selected
+```
+
+**What it does:**
+
+1. Intakes the bug (asks one clarifying question only if the repro is ambiguous)
+2. Reproduces and root-causes it against `main` with verified `file:line`
+3. Files an issue-first GitHub issue with correct `platform:web` scoping
+4. Implements a surgical fix on its own worktree + adds affected tests
+5. Runs the pre-push checklist → rebase → push → PR with `Closes #N`
+6. Drives cloud CI green, resolves conflicts, self-merges once `MERGEABLE`, and removes its worktree
+
+> ⚠️ Never edits `apps/web/vite.config.ts` (the bug-bash host keeps a local-only `allowedHosts` edit there).
+
+---
+
 ## Creating New Prompts
 
 To add a new prompt:

--- a/.github/prompts/bug-bash.prompt.md
+++ b/.github/prompts/bug-bash.prompt.md
@@ -1,0 +1,46 @@
+---
+name: bug-bash
+description: Run the pwa-bug-basher flow for a single pasted PWA bug — investigate, file issue, fix, PR, CI, self-merge.
+parameters:
+  - name: bug
+    description: The bug report to fix (a short description, optionally with a screenshot and repro steps).
+    default: (none)
+---
+
+# Bug Bash — Fix One PWA Bug End-to-End
+
+Run the full [`pwa-bug-basher`](../agents/pwa-bug-basher.agent.md) lifecycle for a **single** reported web bug. This wrapper works both as a standalone fire-and-forget session and when invoked inside an existing session.
+
+**Input:** the `bug` parameter — a description of the broken behavior, optionally with a screenshot and repro steps.
+
+## Execution Plan
+
+Adopt the `pwa-bug-basher` agent and run its complete flow for the one bug in `{{bug}}`:
+
+1. **Intake** — parse `{{bug}}`. Ask one clarifying question **only** if the repro is genuinely ambiguous; otherwise proceed.
+2. **Investigate** — reproduce/trace in `apps/web` against `main` (`grep`/`view`; start your own dev server on a free port if needed — do NOT assume the shared `:5199` server exists). Pin the root cause with `file:line` verified against `main` HEAD.
+3. **File the issue** — issue-first via `gh issue create` with Problem / Root Cause / Fix / Files / Cross-Platform sections and correct labels (`platform:web` + `bug`/`enhancement`, plus `accessibility` when relevant). Run the `issue-management` scoping decision tree; if the root cause is shared, scope `platform:shared` instead.
+4. **Implement** — a surgical fix on this session's own worktree/branch, following `@web-engineer` conventions (hooks-only data flow, design tokens, ARIA/CSP). Add/update the affected Vitest test.
+5. **Validate & push** — pre-push checklist: `npm run format` → `npx eslint . --fix` → `npm run format:check && npx eslint . --max-warnings 0`, run affected web tests, `git fetch origin main && git rebase origin/main`, then `$env:HUSKY = "0"; git push --no-verify origin <branch>`.
+6. **PR** — `gh pr create --base main` with `Closes #N`; verify with `gh pr view <branch> --json number`.
+7. **Drive to green & self-merge** — poll `gh pr checks` + `gh pr view --json mergeable,mergeStateStatus`; self-heal CI and conflicts; `gh pr merge <N> --squash` once green AND `MERGEABLE`.
+8. **Clean up** — `git worktree remove <path>` after merge, then report the issue #, PR #, and final merged state.
+
+## Guardrails
+
+- ⚠️ **NEVER edit `apps/web/vite.config.ts`** — the bug-bash host keeps a local-only uncommitted `allowedHosts` edit there.
+- Respect all `AGENTS.md` human-gated operations. For the canonical push / merge / merge-conflict rules, follow `.github/instructions/workflow.instructions.md` (do not duplicate them).
+- One bug per run — file separate issues for anything else you discover; do not scope-creep.
+
+## Report
+
+End with a short structured summary:
+
+```
+## Bug Bash Result
+- Bug: <one-line>
+- Issue: #<N>
+- PR: #<M> — <MERGED | green+MERGEABLE, blocked on: ...>
+- Root cause: <file:line + one-line>
+- Worktree: <removed | path retained because ...>
+```

--- a/.github/prompts/sprint.prompt.md
+++ b/.github/prompts/sprint.prompt.md
@@ -29,7 +29,7 @@ gh pr list --state open --json number,title,headRefName,statusCheckRollup
 
 For each sprint (1 through {{ N }}):
 
-1. **Categorize unclaimed issues** by agent type using the canonical **label → agent map** in the `sprint-planning` skill (`.github/skills/sprint-planning/SKILL.md` → "Issue-to-Agent Mapping Algorithm" → Step 2). That table is the single source of truth and covers all 24 agent types (including `compliance-specialist`, `experimentation-engineer`, `data-engineer`, and the review/business roles). For issues with no matching label, infer the owner from the files that will change (see the file-ownership table in `AGENTS.md`).
+1. **Categorize unclaimed issues** by agent type using the canonical **label → agent map** in the `sprint-planning` skill (`.github/skills/sprint-planning/SKILL.md` → "Issue-to-Agent Mapping Algorithm" → Step 2). That table is the single source of truth and covers all 25 agent types (including `compliance-specialist`, `experimentation-engineer`, `data-engineer`, and the review/business roles). For issues with no matching label, infer the owner from the files that will change (see the file-ownership table in `AGENTS.md`).
 
 2. **Select 1 issue per agent type** (up to 15 agents per wave).
 3. **Track assignments** in SQL todos to prevent double-dispatch.

--- a/.github/prompts/team.prompt.md
+++ b/.github/prompts/team.prompt.md
@@ -25,7 +25,7 @@ gh pr list --state open --json number,title,headRefName,statusCheckRollup
 ```
 
 - Parse the `agents` parameter into a list of agent types.
-- Map each requested agent type to its issue filter using the canonical **label → agent map** in the `sprint-planning` skill (`.github/skills/sprint-planning/SKILL.md` → "Issue-to-Agent Mapping Algorithm" → Step 2) — the single source of truth for all 24 agent types. Invert it (agent → its labels) to filter the backlog for each requested agent.
+- Map each requested agent type to its issue filter using the canonical **label → agent map** in the `sprint-planning` skill (`.github/skills/sprint-planning/SKILL.md` → "Issue-to-Agent Mapping Algorithm" → Step 2) — the single source of truth for all 25 agent types. Invert it (agent → its labels) to filter the backlog for each requested agent.
 
 - Filter the issue backlog to only issues matching the requested agent types.
 - Exclude issues already claimed by open PRs.

--- a/.github/skills/fleet-orchestration/SKILL.md
+++ b/.github/skills/fleet-orchestration/SKILL.md
@@ -40,6 +40,7 @@ Proven across **3 waves, 140+ PRs, 17 sprints per agent type** for dispatch, CI 
 | `android-engineer`         | `apps/android/**`                                                     | `.github/agents/android-engineer.agent.md`         |
 | `ios-engineer`             | `apps/ios/**`                                                         | `.github/agents/ios-engineer.agent.md`             |
 | `web-engineer`             | `apps/web/**`                                                         | `.github/agents/web-engineer.agent.md`             |
+| `pwa-bug-basher`           | `apps/web/**` (standalone single-bug bug bash; own worktree)          | `.github/agents/pwa-bug-basher.agent.md`           |
 | `windows-engineer`         | `apps/windows/**`                                                     | `.github/agents/windows-engineer.agent.md`         |
 | `kmp-engineer`             | `packages/**`                                                         | `.github/agents/kmp-engineer.agent.md`             |
 | `backend-engineer`         | `services/**`                                                         | `.github/agents/backend-engineer.agent.md`         |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ AI agents that skip issue creation, commit directly to `main`, or fail to create
 
 - **Kotlin linting** is handled by **detekt** in CI (not ESLint/Prettier)
 - **`.prettierignore`** covers non-JS source files (Kotlin, Swift, etc.) — `npm run format` only touches JS/TS/JSON/MD/YAML
-- **AI agents** are defined in `.github/agents/` as `*.agent.md` files — that directory is the **source of truth** for the roster. The **AI Manifest Check** workflow (`npm run ai:manifest:check`, backed by `tools/ai-manifest.js`) flags any drift between these counts and the filesystem; see [`docs/ai/CHANGELOG.md`](docs/ai/CHANGELOG.md). As of 2026-06 there are **24** agents (see list below).
+- **AI agents** are defined in `.github/agents/` as `*.agent.md` files — that directory is the **source of truth** for the roster. The **AI Manifest Check** workflow (`npm run ai:manifest:check`, backed by `tools/ai-manifest.js`) flags any drift between these counts and the filesystem; see [`docs/ai/CHANGELOG.md`](docs/ai/CHANGELOG.md). As of 2026-06 there are **25** agents (see list below).
 
 ## AI Agent Configuration
 
@@ -134,6 +134,7 @@ Custom agents are defined in `.github/agents/`. Each agent has a specific role:
 - `kmp-engineer` — Kotlin Multiplatform shared code (SQLDelight, Ktor, kotlinx)
 - `security-reviewer` — Security and privacy code review
 - `web-engineer` — Web PWA (React/TypeScript, Service Workers, SQLite-WASM)
+- `pwa-bug-basher` — Self-service PWA bug bash (investigate → file issue → fix → PR → cloud CI → self-merge) for a single reported web bug; standalone session per bug
 - `windows-engineer` — Windows platform (Compose Desktop, Windows Hello, DPAPI)
 - `product-manager` — Product strategy, sprint planning, issue triage, roadmap management
 - `marketing-strategist` — Go-to-market, ASO, launch comms, content strategy, growth
@@ -366,6 +367,7 @@ When multiple agents work in parallel, they MUST follow these rules to avoid con
 | `@kmp-engineer`             | `packages/`                                                                                                                                                                                                    |
 | `@backend-engineer`         | `services/api/`                                                                                                                                                                                                |
 | `@web-engineer`             | `apps/web/`                                                                                                                                                                                                    |
+| `@pwa-bug-basher`           | `apps/web/` (one bug per standalone session, isolated worktree; NEVER edits `apps/web/vite.config.ts`)                                                                                                         |
 | `@android-engineer`         | `apps/android/`                                                                                                                                                                                                |
 | `@ios-engineer`             | `apps/ios/`                                                                                                                                                                                                    |
 | `@windows-engineer`         | `apps/windows/`                                                                                                                                                                                                |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -297,7 +297,7 @@ AI-first development workflow documentation. See the [AI README](ai/README.md) f
 | Compliance   |       8 |
 | Design       |       6 |
 | Legal        |       5 |
-| AI           |      24 |
+| AI           |      25 |
 | Testing      |       1 |
 | Audits       |       1 |
 | **Total**    | **123** |

--- a/docs/ai/CHANGELOG.md
+++ b/docs/ai/CHANGELOG.md
@@ -8,6 +8,16 @@ Entries are newest-first. Use ISO dates (`YYYY-MM`). Each entry should answer: _
 
 ---
 
+## 2026-07 — PWA bug-basher agent + bug-bash prompt
+
+Source: issue #3892 (Part A of a two-part self-service bug-bash effort). Added a self-contained, single-bug PWA bug-fixing capability so a human can bash bugs as independent, standalone sessions without routing each one through a coordinator thread.
+
+- **New `pwa-bug-basher` agent (roster 24 → 25).** A full-lifecycle web bug fixer (`write_scope: full`, `risk_level: medium`, `primary_paths: ['apps/web/**']`) that combines `@qa-tester`-style investigation with `@web-engineer` implementation. Launched as a standalone session per bug, it runs the entire flow: intake a report (+ optional screenshot) → reproduce/root-cause against `main` with verified `file:line` → file an issue-first GitHub issue (`platform:web` + `bug`/`enhancement`/`accessibility`) → surgical fix on its own worktree → pre-push lint/format → rebase → push → `gh pr create --base main` with `Closes #N` → drive cloud CI green + resolve conflicts → `gh pr merge --squash` once green AND `MERGEABLE` → remove its worktree. Bakes in the bug-bash environment caveats (shared `:5199` dev server may exist — start your own if needed; **never edit `apps/web/vite.config.ts`** because the host keeps a local-only `allowedHosts` edit there) and references `.github/instructions/workflow.instructions.md` for the canonical push/merge/conflict rules. See [`pwa-bug-basher.agent.md`](../../.github/agents/pwa-bug-basher.agent.md).
+- **New `bug-bash` prompt.** A thin reusable wrapper ([`bug-bash.prompt.md`](../../.github/prompts/bug-bash.prompt.md)) with a `bug` parameter that runs the `pwa-bug-basher` flow for a single pasted bug; works standalone or inside an existing session. Listed in the [prompts README](../../.github/prompts/README.md).
+- **Roster count synced to 25** across [`AGENTS.md`](../../AGENTS.md), [`README.md`](README.md), [`agents.md`](agents.md), [`agent-instructions.md`](agent-instructions.md), [`skills.md`](skills.md) (registry + skill↔agent table), [`slash-commands.md`](slash-commands.md), [`docs/INDEX.md`](../INDEX.md), and the `fleet-orchestration` / `sprint-planning` registries; `npm run ai:manifest:check` reports no drift.
+
+---
+
 ## 2026-06 — AI-capabilities audit (Areas 1–8)
 
 Source: a structured, area-by-area audit of every AI capability surface (agents, skills, instructions, global guidance, prompts, MCP, slash commands, and the `docs/ai` corpus), run to a single bar — accuracy + gaps + enrichment + consolidation. Each area landed as its own issue-linked PR. Highlights (the compliance-specialist / architect change is logged separately, below):

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -77,7 +77,7 @@ Finance is developed with AI agents as first-class contributors. This means:
 │   ├── web.instructions.md
 │   ├── workflow.instructions.md
 │   └── workflows.instructions.md
-├── agents/                           # Custom agent definitions (24 agents as of 2026-06; .github/agents/ is the source of truth)
+├── agents/                           # Custom agent definitions (25 agents as of 2026-06; .github/agents/ is the source of truth)
 │   ├── accessibility-reviewer.agent.md
 │   ├── ai-ops-engineer.agent.md
 │   ├── android-engineer.agent.md
@@ -97,6 +97,7 @@ Finance is developed with AI agents as first-class contributors. This means:
 │   ├── marketing-strategist.agent.md
 │   ├── performance-engineer.agent.md
 │   ├── product-manager.agent.md
+│   ├── pwa-bug-basher.agent.md
 │   ├── qa-tester.agent.md
 │   ├── release-manager.agent.md
 │   ├── security-reviewer.agent.md

--- a/docs/ai/agent-instructions.md
+++ b/docs/ai/agent-instructions.md
@@ -20,7 +20,7 @@ This document describes the roles, skills, and workflow rules for all AI agents 
 
 The Finance monorepo uses specialized AI agents, each with a focused domain. Agents are defined in `.github/agents/` as `<role>.agent.md` files. Each agent has a clear mission, expertise areas, boundaries, and a list of allowed tools.
 
-**Current agent types:** The authoritative roster is the set of `*.agent.md` files in `.github/agents/`; run `npm run ai:manifest:check` (backed by `tools/ai-manifest.js`) to flag drift between this count and the filesystem — see [`CHANGELOG.md`](CHANGELOG.md). As of 2026-06 there are **24** agents:
+**Current agent types:** The authoritative roster is the set of `*.agent.md` files in `.github/agents/`; run `npm run ai:manifest:check` (backed by `tools/ai-manifest.js`) to flag drift between this count and the filesystem — see [`CHANGELOG.md`](CHANGELOG.md). As of 2026-06 there are **25** agents:
 
 - **accessibility-reviewer** — Reviews UI for WCAG 2.2 AA, platform accessibility, and inclusive design. **Review-only** — routes fixes to the owning platform agent.
 - **android-engineer** — Android (Jetpack Compose, KMP, PowerSync, Keystore, Wear OS).
@@ -49,6 +49,7 @@ The Finance monorepo uses specialized AI agents, each with a focused domain. Age
 - **localization-engineer** — i18n, localization, financial terminology.
 - **experimentation-engineer** — Feature flags, A/B testing, staged rollouts, and experiment readouts.
 - **compliance-specialist** — Financial, governmental & regional regulatory compliance; obligation matrix, data residency, retention (advisory; stewards `docs/compliance/`).
+- **pwa-bug-basher** — Self-service, single-bug PWA bug bash launched as a standalone session: investigate in `apps/web` → file issue → surgical fix on its own worktree → PR → cloud CI → self-merge → cleanup.
 
 Each agent file documents:
 

--- a/docs/ai/agents.md
+++ b/docs/ai/agents.md
@@ -11,7 +11,7 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 
 ## Available Agents
 
-> **Source of truth:** the `*.agent.md` files in [`.github/agents/`](../../.github/agents/). As of 2026-06 there are **24** agents — every one is detailed on this page. Agents added in 2026-06: `ai-ops-engineer`, `release-manager`, `performance-engineer`, `data-engineer`, `localization-engineer`, `qa-tester`, `experimentation-engineer` (feature flags & A/B testing), and `compliance-specialist` (regulatory compliance). Run `npm run ai:manifest:check` (backed by `tools/ai-manifest.js`) to surface any drift between the counts on this page and the filesystem — see the [CHANGELOG](CHANGELOG.md).
+> **Source of truth:** the `*.agent.md` files in [`.github/agents/`](../../.github/agents/). As of 2026-06 there are **25** agents — every one is detailed on this page. Agents added in 2026-06: `ai-ops-engineer`, `release-manager`, `performance-engineer`, `data-engineer`, `localization-engineer`, `qa-tester`, `experimentation-engineer` (feature flags & A/B testing), `compliance-specialist` (regulatory compliance), and `pwa-bug-basher` (self-service single-bug PWA bug bash). Run `npm run ai:manifest:check` (backed by `tools/ai-manifest.js`) to surface any drift between the counts on this page and the filesystem — see the [CHANGELOG](CHANGELOG.md).
 >
 > **Reviewer roles are asymmetric:** `accessibility-reviewer` is **review-only** (routes fixes to the owning platform agent); `security-reviewer` is the **emergency fixer** (may implement CRITICAL/HIGH security fixes in any directory, with owning-agent coordination).
 
@@ -222,6 +222,24 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 - Setting up SQLite-WASM with OPFS storage
 - Implementing ARIA accessibility and keyboard navigation
 - Configuring Web Crypto API for client-side encryption
+
+**Tools:** read, edit, search, shell
+
+---
+
+### `@pwa-bug-basher` — PWA Bug Basher
+
+**File:** `.github/agents/pwa-bug-basher.agent.md`
+
+**Purpose:** A full-lifecycle, self-service web bug fixer intended to be launched as a **standalone session per bug**. Combines `@qa-tester`-style investigation with `@web-engineer` implementation: takes one human-reported bug from repro all the way to `main` — investigate in `apps/web` → file a GitHub issue (issue-first) → surgical fix on its own worktree → PR → drive cloud CI green → self-merge → clean up.
+
+**When to use:**
+
+- A human pastes a single PWA bug (text + optional screenshot) and wants it fixed end-to-end
+- Fire-and-forget standalone bug-bash sessions that need no coordinator thread
+- Web-only defects and small accessibility/token fixes in `apps/web/`
+
+**Environment caveats:** A shared manual-bugbash dev server **may** run on port 5199 (Tailscale-reachable) — don't assume it; start your own on a different port if needed. ⚠️ **NEVER edit `apps/web/vite.config.ts`** (host-only uncommitted `allowedHosts` edit). References `.github/instructions/workflow.instructions.md` for canonical push/merge/conflict rules.
 
 **Tools:** read, edit, search, shell
 
@@ -459,6 +477,7 @@ Each agent has primary ownership over a set of directories. When multiple agents
 | `@kmp-engineer`             | `packages/`                                                                                                                                           |
 | `@backend-engineer`         | `services/api/`                                                                                                                                       |
 | `@web-engineer`             | `apps/web/`                                                                                                                                           |
+| `@pwa-bug-basher`           | `apps/web/` (one bug per standalone session, isolated worktree; never edits `apps/web/vite.config.ts`)                                                |
 | `@android-engineer`         | `apps/android/`                                                                                                                                       |
 | `@ios-engineer`             | `apps/ios/`                                                                                                                                           |
 | `@windows-engineer`         | `apps/windows/`                                                                                                                                       |
@@ -564,4 +583,4 @@ For docs-only PRs, use: `npm run ci:check:quick`
 
 - **Kotlin linting** is handled by **detekt** in CI (not ESLint/Prettier)
 - **`.prettierignore`** covers non-JS source files (Kotlin, Swift, etc.)
-- **24 agents** are defined in `.github/agents/` (source of truth; drift surfaced by `npm run ai:manifest:check`)
+- **25 agents** are defined in `.github/agents/` (source of truth; drift surfaced by `npm run ai:manifest:check`)

--- a/docs/ai/skills.md
+++ b/docs/ai/skills.md
@@ -124,7 +124,7 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 **Knowledge areas:**
 
-- Agent type registry (24 agents: engineering, review, ops/meta, business)
+- Agent type registry (25 agents: engineering, review, ops/meta, business)
 - Label-to-agent mapping for issue routing
 - Sprint planning algorithm (query → categorize → deps → group → track)
 - Fleet dispatch protocol with background task parallelism
@@ -371,7 +371,7 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 **Knowledge areas:**
 
-- Issue categorization by agent type (24 agent types)
+- Issue categorization by agent type (25 agent types)
 - Sprint sizing (4–6 implementation + 1–2 business + 1 review)
 - Dependency detection and schema change serialization
 - Priority framework (P0–P3) with assignment rules
@@ -432,34 +432,35 @@ Agent skills are reusable bundles of domain knowledge that AI agents can activat
 
 Each agent loads a focused set of skills for domain depth. The table below mirrors the **Related skills** line in every [`.github/agents/*.agent.md`](../../.github/agents/) file (the source of truth). Skills not listed for an agent still activate automatically when their trigger keywords match — this mapping captures the _primary_ skills each role should reach for.
 
-| Agent                      | Related skills                                                                         |
-| -------------------------- | -------------------------------------------------------------------------------------- |
-| `accessibility-reviewer`   | `accessibility-testing`, `ux-testing`, `design-tokens`                                 |
-| `ai-ops-engineer`          | `prompt-engineering`, `mcp-agent-tooling`, `issue-management`                          |
-| `android-engineer`         | `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens`      |
-| `architect`                | `kmp-development`, `edge-sync`, `supabase-powersync`, `security-review-methodology`    |
-| `backend-engineer`         | `supabase-powersync`, `edge-sync`, `security-review-methodology`, `privacy-compliance` |
-| `business-analyst`         | `monetization`, `go-to-market`, `project-management`                                   |
-| `compliance-specialist`    | `privacy-compliance`, `security-review-methodology`, `financial-modeling`              |
-| `data-engineer`            | `privacy-compliance`, `financial-modeling`, `supabase-powersync`                       |
-| `design-engineer`          | `design-tokens`, `accessibility-testing`, `i18n-localization`                          |
-| `devops-engineer`          | `fleet-orchestration`, `performance-budgets`, `mcp-agent-tooling`, `dev-onboarding`    |
-| `docs-writer`              | `dev-onboarding`, `project-management`, `prompt-engineering`                           |
-| `experimentation-engineer` | `edge-sync`, `privacy-compliance`, `financial-modeling`                                |
-| `finance-domain`           | `financial-modeling`, `edge-sync`, `privacy-compliance`                                |
-| `ios-engineer`             | `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens`      |
-| `kmp-engineer`             | `kmp-development`, `edge-sync`, `financial-modeling`, `supabase-powersync`             |
-| `localization-engineer`    | `i18n-localization`, `financial-modeling`, `design-tokens`                             |
-| `marketing-strategist`     | `go-to-market`, `monetization`, `i18n-localization`                                    |
-| `performance-engineer`     | `performance-budgets`, `kmp-development`, `edge-sync`                                  |
-| `product-manager`          | `project-management`, `sprint-planning`, `issue-management`, `fleet-orchestration`     |
-| `qa-tester`                | `ux-testing`, `issue-management`, `accessibility-testing`                              |
-| `release-manager`          | `project-management`, `sprint-planning`, `dev-onboarding`                              |
-| `security-reviewer`        | `security-review-methodology`, `privacy-compliance`, `supabase-powersync`, `edge-sync` |
-| `web-engineer`             | `performance-budgets`, `accessibility-testing`, `financial-modeling`, `edge-sync`      |
-| `windows-engineer`         | `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens`      |
+| Agent                      | Related skills                                                                                                                   |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibility-reviewer`   | `accessibility-testing`, `ux-testing`, `design-tokens`                                                                           |
+| `ai-ops-engineer`          | `prompt-engineering`, `mcp-agent-tooling`, `issue-management`                                                                    |
+| `android-engineer`         | `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens`                                                |
+| `architect`                | `kmp-development`, `edge-sync`, `supabase-powersync`, `security-review-methodology`                                              |
+| `backend-engineer`         | `supabase-powersync`, `edge-sync`, `security-review-methodology`, `privacy-compliance`                                           |
+| `business-analyst`         | `monetization`, `go-to-market`, `project-management`                                                                             |
+| `compliance-specialist`    | `privacy-compliance`, `security-review-methodology`, `financial-modeling`                                                        |
+| `data-engineer`            | `privacy-compliance`, `financial-modeling`, `supabase-powersync`                                                                 |
+| `design-engineer`          | `design-tokens`, `accessibility-testing`, `i18n-localization`                                                                    |
+| `devops-engineer`          | `fleet-orchestration`, `performance-budgets`, `mcp-agent-tooling`, `dev-onboarding`                                              |
+| `docs-writer`              | `dev-onboarding`, `project-management`, `prompt-engineering`                                                                     |
+| `experimentation-engineer` | `edge-sync`, `privacy-compliance`, `financial-modeling`                                                                          |
+| `finance-domain`           | `financial-modeling`, `edge-sync`, `privacy-compliance`                                                                          |
+| `ios-engineer`             | `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens`                                                |
+| `kmp-engineer`             | `kmp-development`, `edge-sync`, `financial-modeling`, `supabase-powersync`                                                       |
+| `localization-engineer`    | `i18n-localization`, `financial-modeling`, `design-tokens`                                                                       |
+| `marketing-strategist`     | `go-to-market`, `monetization`, `i18n-localization`                                                                              |
+| `performance-engineer`     | `performance-budgets`, `kmp-development`, `edge-sync`                                                                            |
+| `product-manager`          | `project-management`, `sprint-planning`, `issue-management`, `fleet-orchestration`                                               |
+| `pwa-bug-basher`           | `ux-testing`, `accessibility-testing`, `issue-management`, `design-tokens`, `performance-budgets`, `security-review-methodology` |
+| `qa-tester`                | `ux-testing`, `issue-management`, `accessibility-testing`                                                                        |
+| `release-manager`          | `project-management`, `sprint-planning`, `dev-onboarding`                                                                        |
+| `security-reviewer`        | `security-review-methodology`, `privacy-compliance`, `supabase-powersync`, `edge-sync`                                           |
+| `web-engineer`             | `performance-budgets`, `accessibility-testing`, `financial-modeling`, `edge-sync`                                                |
+| `windows-engineer`         | `kmp-development`, `financial-modeling`, `accessibility-testing`, `design-tokens`                                                |
 
-> This table mirrors the roster in [`agents.md`](agents.md) (**24 agents**). When you add or retire an agent, update both its `*.agent.md` **Related skills** line and this table so the two never drift.
+> This table mirrors the roster in [`agents.md`](agents.md) (**25 agents**). When you add or retire an agent, update both its `*.agent.md` **Related skills** line and this table so the two never drift.
 
 ---
 

--- a/docs/ai/slash-commands.md
+++ b/docs/ai/slash-commands.md
@@ -21,7 +21,7 @@ This document describes the prototype slash commands for Copilot CLI used in thi
   - Reminds the operator to run the pre-push sequence before pushing and opening a PR.
 
 - **`/sprint <N> [agents]`** — run `node scripts/dispatch-sprint.js <N> "web-engineer,backend-engineer"`
-  - Produces a `/fleet`-style command to dispatch N sprints across the given agents (comma-separated). If agents are omitted, it defaults to the **full 24-agent roster** (see [`.github/agents/`](../../.github/agents/)).
+  - Produces a `/fleet`-style command to dispatch N sprints across the given agents (comma-separated). If agents are omitted, it defaults to the **full 25-agent roster** (see [`.github/agents/`](../../.github/agents/)).
   - Each agent must follow the mandatory pre-push sequence before any push.
 
 ## Mandatory pre-push sequence (include verbatim in every agent prompt)


### PR DESCRIPTION
﻿## Summary

Adds a reusable, self-contained **PWA bug-bash capability** (issue #3892, Part A) so a human can bash bugs as independent, standalone sessions — each bug runs the full lifecycle end-to-end: investigate -> file issue -> fix on its own worktree -> PR -> drive cloud CI green -> self-merge -> cleanup.

## Changes

- **New agent** .github/agents/pwa-bug-basher.agent.md — full-lifecycle web bug fixer (frontmatter modeled on web-engineer/qa-tester: `primary_paths: ['apps/web/**']`, `write_scope: full`, `risk_level: medium`, `tools: read/edit/search/shell`). Encodes the complete single-bug flow and bakes in the environment caveats: shared `:5199` dev server may exist (start your own if needed), **never edit `apps/web/vite.config.ts`**, and references `.github/instructions/workflow.instructions.md` for canonical push/merge/conflict rules.
- **New prompt** .github/prompts/bug-bash.prompt.md — thin wrapper with a `bug` parameter; listed in the prompts README.
- **Roster synced 24 -> 25** and `pwa-bug-basher` added across `AGENTS.md`, `docs/ai/{README,agents,agent-instructions,skills,slash-commands,CHANGELOG}.md`, `docs/INDEX.md`, and the `fleet-orchestration` registry (+ `sprint`/`team` prompt counts).

## Validation

- `npm run ai:manifest:check` — no drift (25 agents, 20 skills)
- `npm run ci:check:quick` / `npm run format:check` — pass
- `npx eslint . --max-warnings 0` — pass

Closes #3892
