### PR TITLE
fix(web): prevent onboarding comparison table clipping on mobile (#3899)

### DIFF
--- a/apps/web/src/pages/OnboardingPage.css
+++ b/apps/web/src/pages/OnboardingPage.css
@@ -8,11 +8,19 @@
  * ------------------------------------------------------------------- */
 
 .onboarding {
+  /* Dynamic viewport height (with 100vh fallback) so the standalone onboarding
+   * view sizes to the *visible* viewport on mobile. Plain 100vh resolves to the
+   * larger toolbar-hidden viewport, which left the trailing feature-comparison
+   * table under the browser toolbar / home indicator with no room to scroll it
+   * fully into view (#3899). */
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   justify-content: center;
   align-items: flex-start;
   padding: var(--spacing-6) var(--spacing-4);
+  /* Keep the last section clear of the home indicator / dynamic toolbar. */
+  padding-bottom: calc(var(--spacing-6) + env(safe-area-inset-bottom, 0px));
   background-color: var(--semantic-background-primary);
 }
 
@@ -1070,6 +1078,7 @@
 @media (max-width: 480px) {
   .onboarding {
     padding: var(--spacing-4) var(--spacing-3);
+    padding-bottom: calc(var(--spacing-4) + env(safe-area-inset-bottom, 0px));
   }
 
   .onboarding__preferences-card,


### PR DESCRIPTION
## Summary

On the onboarding welcome flow (step 2 — "Welcome to Finance — Choose how you want to get started"), the **Feature Comparison** table at the bottom was **clipped on mobile**: the trailing rows (Cloud Sync, Household Sharing, Automatic Backups) ran flush to the screen bottom with no visible bottom border or padding, and the page could not scroll far enough to reveal the full table.

## Root Cause

The onboarding step renders as a standalone `<main className="onboarding">` (no app-shell), so the document/body is the scroll boundary. `.onboarding` used `min-height: 100vh`, which on mobile resolves to the **large** (toolbar-hidden) viewport. While the browser toolbar / home indicator is visible, the element's trailing padding and last section end up beneath that chrome with insufficient room to scroll into view. There was also no `env(safe-area-inset-bottom)` allowance, so on notched / home-indicator devices the final padding was obscured.

## Changes

- `apps/web/src/pages/OnboardingPage.css`:
  - `.onboarding` now uses `min-height: 100dvh` (with a `100vh` fallback) so the view sizes to the **visible** viewport on mobile.
  - Bottom padding is now safe-area-aware — `padding-bottom: calc(<base> + env(safe-area-inset-bottom, 0px))` — for both the base rule and the `max-width: 480px` mobile override, so the last section clears the toolbar / home indicator.

Both changes are no-ops on desktop (`dvh == vh`, insets are `0`), so the two-column desktop layout is unaffected.

## Issues

Closes #3899

## Testing

- [x] `npx vitest run src/pages/OnboardingPage.test.tsx` — 37 passed (includes "renders feature comparison table after the comfort step")
- [x] `npx prettier --check apps/web/src/pages/OnboardingPage.css` — clean
- [x] CSS-only change; jsdom cannot measure scroll/layout, so the fix is validated by code review + the existing render test. Manual verification: on a small mobile viewport the full comparison table (through "Automatic Backups") plus its bottom border and trailing padding are now scrollable into view.
