### PR TITLE
fix(web): autocomplete=username on auth identifier fields for password-manager save/fill (#3900)

### DIFF
--- a/apps/web/src/__tests__/auth-flows.test.tsx
+++ b/apps/web/src/__tests__/auth-flows.test.tsx
@@ -128,12 +128,15 @@ describe('Login form validation (#1331)', () => {
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
   });
 
-  it('email field has type="email" and autocomplete="email"', () => {
+  it('email field has type="email" and autocomplete="username" for login-pair recognition', () => {
     renderLoginPage();
 
     const emailInput = screen.getByLabelText('Email');
     expect(emailInput).toHaveAttribute('type', 'email');
-    expect(emailInput).toHaveAttribute('autoComplete', 'email');
+    // The identifier half of a login pair must use autocomplete="username" so
+    // iOS Safari / iCloud Keychain and password managers offer save/fill.
+    // See issue #3900.
+    expect(emailInput).toHaveAttribute('autoComplete', 'username');
   });
 
   it('password field has type="password" and autocomplete="current-password"', () => {

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -95,7 +95,7 @@ export const ForgotPasswordPage: React.FC = () => {
               id={emailId}
               className="auth-field__input"
               type="email"
-              autoComplete="email"
+              autoComplete="username"
               autoCapitalize="none"
               autoCorrect="off"
               spellCheck={false}

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -149,6 +149,22 @@ describe('LoginPage', () => {
     expect(email).toHaveAttribute('inputmode', 'email');
   });
 
+  it('exposes login-pair autocomplete tokens for password-manager save/fill', () => {
+    // iOS Safari / iCloud Keychain and most password managers pair a credential
+    // using autocomplete="username" on the identifier + "current-password" on
+    // the password. Using autocomplete="email" alone suppresses the save/fill
+    // prompt. See issue #3900.
+    renderLoginPage();
+
+    const email = screen.getByLabelText('Email');
+    expect(email).toHaveAttribute('autocomplete', 'username');
+    expect(email).toHaveAttribute('type', 'email');
+
+    const password = screen.getByLabelText('Password');
+    expect(password).toHaveAttribute('autocomplete', 'current-password');
+    expect(password).toHaveAttribute('type', 'password');
+  });
+
   it('shows hosted legal links in the login footer', () => {
     renderLoginPage();
 

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -337,7 +337,7 @@ export const LoginPage: React.FC = () => {
                 name="email"
                 type="email"
                 required
-                autoComplete="email"
+                autoComplete="username"
                 autoCapitalize="none"
                 autoCorrect="off"
                 spellCheck={false}

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -322,7 +322,7 @@ export const SignupPage: React.FC = () => {
                 id={emailId}
                 className="auth-field__input"
                 type="email"
-                autoComplete="email"
+                autoComplete="username"
                 autoCapitalize="none"
                 autoCorrect="off"
                 spellCheck={false}


### PR DESCRIPTION
## Summary

On iOS Safari, the sign-in form's password manager / iCloud Keychain AutoFill did not offer to fill or save credentials. Root cause: the identifier (email) field used `autocomplete="email"`, which enables email autofill but is frequently **not** recognized as the username half of a login credential pair. iOS Safari / iCloud Keychain and most password managers pair a credential using `autocomplete="username"` on the identifier plus `current-password` on the password. Because the identifier never signalled `username`, the credential pair never formed and the save/fill prompt was suppressed.

The password fields were already correct (`current-password` on login, `new-password` on signup/reset), and the form structure was already sound (real `<form>`, named inputs, `PasswordInput` forwarding a real `<input>`). The only defect was the identifier token.

## Changes

- `LoginPage.tsx` — sign-in email: `autoComplete="email"` → `autoComplete="username"`
- `SignupPage.tsx` — signup email: `autoComplete="email"` → `autoComplete="username"` (pairs with `new-password` for credential save)
- `ForgotPasswordPage.tsx` — reset-request email: `autoComplete="email"` → `autoComplete="username"` (identifier consistency)
- `LoginPage.test.tsx` — added an RTL assertion that the email exposes `autocomplete="username"` + `type="email"` and the password exposes `autocomplete="current-password"` + `type="password"`
- `auth-flows.test.tsx` — updated the existing login-field test to assert the corrected `username` token

Left untouched (correct as-is): `AcceptInvitePage.tsx` invite-code input (`autocomplete="off"`, not a credential) and `HouseholdPage.tsx` invite-by-email field (`autocomplete="email"` is correct there — it's a contact email, not the account identifier).

## Reasoning (spec-backed)

Per the [HTML autofill spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) and Apple/WebKit guidance, the identifier of a login pair should carry the `username` token. `email` is an autofill *detail* token for email autofill, not the credential-identifier token, so browsers/keychains often decline to form the `username`+`password` pair required to prompt for save/fill.

## Environmental caveat (documented, not a phantom fix)

During the bug bash the tester reached the dev build over **http on a Tailscale/LAN dev host** that has no saved credentials for that origin, and http origins get degraded AutoFill. That alone can explain an absent popup regardless of markup. The markup change here is still spec-correct and improves password-manager recognition across all browsers and origins — but a fully reliable repro also needs an https origin with a saved credential.

## Testing

- [x] Affected web auth tests pass (`LoginPage.test.tsx`, `SignupPage.test.tsx`, `auth-flows.test.tsx` — 71/71)
- [x] `npm run format` + `npx eslint --max-warnings 0` clean on changed files
- [ ] Native OS AutoFill cannot be E2E-tested in CI — validated via attribute assertions + spec reasoning

## Cross-Platform

Web-only (`platform:web`). Root cause is HTML `autocomplete` markup, not a shared input primitive — `PasswordInput` correctly forwards whatever token the caller passes. iOS/Android/Windows native use their own content-type/autofill-hint APIs and are unaffected.

## Issues

Closes #3900
