### PR TITLE
fix(web): make onboarding consent recording resilient in non-secure contexts (#3898)

### DIFF
--- a/apps/web/src/lib/consent-history.test.ts
+++ b/apps/web/src/lib/consent-history.test.ts
@@ -6,7 +6,7 @@
  * References: issue #1641
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   loadConsentHistory,
   recordConsentChange,
@@ -88,6 +88,49 @@ describe('consent-history', () => {
       );
 
       expect(events[0].timestamp).toBe(events[1].timestamp);
+    });
+
+    // Regression: onboarding privacy buttons were dead in non-secure contexts
+    // (plain HTTP on a non-localhost host) because crypto.randomUUID is
+    // undefined there and threw, aborting the click handler. Recording consent
+    // must never throw so onboarding navigation is never blocked (#3898).
+    describe('non-secure context (crypto.randomUUID unavailable)', () => {
+      let originalRandomUUID: typeof crypto.randomUUID;
+
+      beforeEach(() => {
+        originalRandomUUID = crypto.randomUUID;
+        // Simulate a non-secure context where the API is absent.
+        (crypto as { randomUUID?: unknown }).randomUUID = undefined;
+      });
+
+      afterEach(() => {
+        (crypto as { randomUUID?: unknown }).randomUUID = originalRandomUUID;
+      });
+
+      it('records bulk changes without throwing and assigns unique ids', () => {
+        expect(() =>
+          recordBulkConsentChanges(
+            [
+              { category: 'analytics', granted: false },
+              { category: 'error_reporting', granted: false },
+              { category: 'sync', granted: false },
+              { category: 'marketing', granted: false },
+            ],
+            'first_run',
+            '1.0.0',
+          ),
+        ).not.toThrow();
+
+        const history = loadConsentHistory();
+        expect(history).toHaveLength(4);
+        const ids = new Set(history.map((event) => event.id));
+        expect(ids.size).toBe(4);
+      });
+
+      it('records a single change without throwing', () => {
+        expect(() => recordConsentChange('analytics', true, 'settings', '1.0.0')).not.toThrow();
+        expect(loadConsentHistory()).toHaveLength(1);
+      });
     });
   });
 

--- a/apps/web/src/lib/consent-history.ts
+++ b/apps/web/src/lib/consent-history.ts
@@ -13,6 +13,7 @@
  */
 
 import type { ConsentCategory } from './consent-storage';
+import { safeRandomUUID } from '../utils/uuid';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -88,7 +89,7 @@ export function recordConsentChange(
   policyVersion: string,
 ): ConsentEvent {
   const event: ConsentEvent = {
-    id: crypto.randomUUID(),
+    id: safeRandomUUID(),
     timestamp: new Date().toISOString(),
     category,
     granted,
@@ -117,7 +118,7 @@ export function recordBulkConsentChanges(
 ): ConsentEvent[] {
   const now = new Date().toISOString();
   const events: ConsentEvent[] = changes.map((change) => ({
-    id: crypto.randomUUID(),
+    id: safeRandomUUID(),
     timestamp: now,
     category: change.category,
     granted: change.granted,

--- a/apps/web/src/utils/uuid.test.ts
+++ b/apps/web/src/utils/uuid.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the secure-context-safe UUID helper.
+ *
+ * References: issue #3898
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { safeRandomUUID } from './uuid';
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('safeRandomUUID', () => {
+  const originalRandomUUID = crypto.randomUUID;
+  const originalGetRandomValues = crypto.getRandomValues;
+
+  afterEach(() => {
+    (crypto as { randomUUID?: unknown }).randomUUID = originalRandomUUID;
+    (crypto as { getRandomValues?: unknown }).getRandomValues = originalGetRandomValues;
+  });
+
+  it('uses the native crypto.randomUUID when available', () => {
+    expect(safeRandomUUID()).toMatch(UUID_V4);
+  });
+
+  it('falls back to getRandomValues when randomUUID is unavailable', () => {
+    (crypto as { randomUUID?: unknown }).randomUUID = undefined;
+
+    const id = safeRandomUUID();
+    expect(id).toMatch(UUID_V4);
+  });
+
+  it('falls back to Math.random when no crypto APIs are available', () => {
+    (crypto as { randomUUID?: unknown }).randomUUID = undefined;
+    (crypto as { getRandomValues?: unknown }).getRandomValues = undefined;
+
+    const id = safeRandomUUID();
+    expect(id).toMatch(UUID_V4);
+  });
+
+  it('produces unique values across calls', () => {
+    (crypto as { randomUUID?: unknown }).randomUUID = undefined;
+
+    const ids = new Set(Array.from({ length: 100 }, () => safeRandomUUID()));
+    expect(ids.size).toBe(100);
+  });
+});

--- a/apps/web/src/utils/uuid.ts
+++ b/apps/web/src/utils/uuid.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Secure-context-safe UUID generation.
+ *
+ * `crypto.randomUUID()` is only defined in a secure context (HTTPS or
+ * `localhost`). When the app is served over plain HTTP on a non-`localhost`
+ * host (a LAN IP or a Tailscale hostname used for on-device testing), the API
+ * is `undefined` and calling it throws `TypeError: crypto.randomUUID is not a
+ * function`. Any code path that relies on it unguarded then breaks — including
+ * privacy-consent recording during onboarding.
+ *
+ * This helper prefers the native API when available and otherwise falls back to
+ * a `crypto.getRandomValues`-based RFC-4122 v4 generator, with a final
+ * `Math.random` fallback so ID generation never throws.
+ *
+ * References: issue #3898 (onboarding privacy buttons dead in non-secure context)
+ */
+
+/** Generate an RFC-4122 v4 UUID that works in non-secure browsing contexts. */
+export function safeRandomUUID(): string {
+  const cryptoObj = globalThis.crypto;
+
+  if (typeof cryptoObj?.randomUUID === 'function') {
+    return cryptoObj.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  if (typeof cryptoObj?.getRandomValues === 'function') {
+    cryptoObj.getRandomValues(bytes);
+  } else {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Math.floor(Math.random() * 256);
+    }
+  }
+
+  // Set the version (4) and variant (RFC 4122) bits.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0'));
+  return (
+    hex.slice(0, 4).join('') +
+    '-' +
+    hex.slice(4, 6).join('') +
+    '-' +
+    hex.slice(6, 8).join('') +
+    '-' +
+    hex.slice(8, 10).join('') +
+    '-' +
+    hex.slice(10, 16).join('')
+  );
+}


### PR DESCRIPTION
﻿## Summary

Fixes a P0 onboarding dead-end: on the **Privacy Preferences** step, both "Essential Only" and "Help Improve Finance" buttons did nothing when clicked in a non-secure browsing context (plain HTTP on a non-`localhost` host, e.g. a LAN IP or Tailscale hostname used for device testing).

## Root Cause

Both handlers (`OnboardingPage.tsx:466-496`) call `recordBulkChanges` → `recordBulkConsentChanges` in `consent-history.ts`, which generated event IDs with **unguarded `crypto.randomUUID()`** (`consent-history.ts:91,120`). `crypto.randomUUID` is only defined in a secure context; over plain HTTP on a non-`localhost` host it is `undefined` and throws `TypeError`, aborting the click handler before `setStep(...)` ran. In local-only mode the step promises "your data never leaves this device", so consent recording must be resilient client-side and never block navigation.

## Changes

- Add `apps/web/src/utils/uuid.ts` — `safeRandomUUID()` prefers native `crypto.randomUUID`, falls back to a `crypto.getRandomValues`-based RFC-4122 v4 generator, then `Math.random`, so ID generation never throws.
- Use `safeRandomUUID()` in `consent-history.ts` (`recordConsentChange`, `recordBulkConsentChanges`).
- Add regression tests: `consent-history.test.ts` covers recording with `crypto.randomUUID` unavailable; new `uuid.test.ts` covers all fallback paths.

## Issues

Closes #3898

## Testing

- [x] Affected tests pass (`consent-history.test.ts`, `uuid.test.ts` — 14 tests)
- [x] `npm run format:check` clean
- [x] `npx eslint . --max-warnings 0` clean
