### PR TITLE
fix(web): gate secondary button hover behind hover-capable pointers (#3901)

### DIFF
--- a/apps/web/src/components/auth/OAuthButtons.test.tsx
+++ b/apps/web/src/components/auth/OAuthButtons.test.tsx
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { OAuthButtons } from './OAuthButtons';
+
+const PROVIDER_NAMES = ['Google', 'GitHub', 'Microsoft', 'Apple'] as const;
+
+describe('OAuthButtons', () => {
+  it('renders all four providers with the same classes (no per-provider styling)', () => {
+    render(<OAuthButtons onSelect={vi.fn()} />);
+
+    const buttons = PROVIDER_NAMES.map((name) =>
+      screen.getByRole('button', { name: `Sign in with ${name}` }),
+    );
+
+    expect(buttons).toHaveLength(4);
+
+    // Every provider button must share the identical class list so the group
+    // is visually consistent at rest. The odd-one-out fill reported in #3901
+    // came from a sticky CSS :hover state, not from markup differences — this
+    // guards against a regression where per-provider styling creeps back in.
+    const classLists = buttons.map((button) => button.className);
+    for (const className of classLists) {
+      expect(className).toBe('form-button form-button--secondary auth-oauth-button');
+    }
+    expect(new Set(classLists).size).toBe(1);
+  });
+
+  it('exposes an accessible group and honors a custom verb', () => {
+    render(<OAuthButtons onSelect={vi.fn()} verb="Sign up" groupLabel="Sign-up options" />);
+
+    expect(screen.getByRole('group', { name: 'Sign-up options' })).toBeInTheDocument();
+    for (const name of PROVIDER_NAMES) {
+      expect(screen.getByRole('button', { name: `Sign up with ${name}` })).toBeInTheDocument();
+    }
+  });
+
+  it('invokes onSelect with the chosen provider id', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(<OAuthButtons onSelect={onSelect} />);
+
+    await user.click(screen.getByRole('button', { name: 'Sign in with Google' }));
+    expect(onSelect).toHaveBeenCalledWith('google');
+
+    await user.click(screen.getByRole('button', { name: 'Sign in with Microsoft' }));
+    expect(onSelect).toHaveBeenCalledWith('azure');
+  });
+
+  it('disables every provider button when disabled', () => {
+    render(<OAuthButtons onSelect={vi.fn()} disabled />);
+
+    for (const name of PROVIDER_NAMES) {
+      expect(screen.getByRole('button', { name: `Sign in with ${name}` })).toBeDisabled();
+    }
+  });
+});

--- a/apps/web/src/components/forms/forms.css
+++ b/apps/web/src/components/forms/forms.css
@@ -429,8 +429,17 @@
   border-color: var(--semantic-border-default);
 }
 
-.form-button--secondary:hover:not(:disabled) {
-  background: var(--semantic-background-secondary);
+/*
+ * Gate the hover fill behind `@media (hover: hover)` so touch devices (iOS
+ * Safari) never keep a stuck hover background after a tap. Without this, the
+ * last-tapped OAuth/secondary button renders an odd-one-out `background`
+ * (`--semantic-background-secondary`) fill while its siblings stay at rest —
+ * an inconsistent, low-contrast render in high-contrast mode (#3901).
+ */
+@media (hover: hover) {
+  .form-button--secondary:hover:not(:disabled) {
+    background: var(--semantic-background-secondary);
+  }
 }
 
 .form-button:disabled {

--- a/apps/web/src/styles/accessibility.css
+++ b/apps/web/src/styles/accessibility.css
@@ -654,6 +654,22 @@ body.accessibility-simplified svg {
   stroke-width: 2.4;
 }
 
+/*
+ * High-contrast genuine-hover affordance for secondary / OAuth buttons.
+ *
+ * Gated behind `@media (hover: hover)` so it only applies to true pointer
+ * devices (never a stuck touch hover — see forms.css and #3901). In
+ * high-contrast mode the subtle `--semantic-background-secondary` fill alone
+ * is a weak signal, so add an explicit border emphasis that keeps the hover
+ * state clearly visible without relying on a low-contrast fill.
+ */
+@media (hover: hover) {
+  body.accessibility-high-contrast .form-button--secondary:hover:not(:disabled) {
+    border-color: var(--semantic-border-focus);
+    box-shadow: inset 0 0 0 1px var(--semantic-border-focus);
+  }
+}
+
 body.accessibility-reduced-motion *,
 body.accessibility-reduced-motion *::before,
 body.accessibility-reduced-motion *::after {


### PR DESCRIPTION
## Summary

On the Sign in page's OAuth provider button group ("or continue with" → Google / GitHub / Microsoft / Apple), the last-tapped button rendered with a filled grey/lavender background while the other three stayed white/outlined. A tester flagged this on **iPhone (iOS Safari) in high-contrast mode** as an inconsistent, low-contrast render.

## Root Cause

All four buttons render with identical classes in `OAuthButtons.tsx`, so there is no per-provider styling. The odd-one-out fill was a **sticky `:hover` state**: `forms.css` set `.form-button--secondary:hover:not(:disabled) { background: var(--semantic-background-secondary); }`. On touch devices `:hover` sticks after a tap, so the last-tapped button kept the fill. In high-contrast mode `--semantic-background-secondary` resolves to `#f3f4f6`, the muddy lavender/grey the tester saw.

This is distinct from #3890 / #3893 (which fixed `-webkit-tap-highlight-color` — a different property). This change composes with that work; it does not revert it.

## Changes

- `apps/web/src/components/forms/forms.css` — gate `.form-button--secondary:hover` behind `@media (hover: hover)` so touch devices never get a stuck hover fill; genuine mouse hover keeps its feedback.
- `apps/web/src/styles/accessibility.css` — add a high-contrast genuine-hover border emphasis (also gated behind `@media (hover: hover)`) so pointer hover stays clearly visible without relying on the low-contrast fill.
- `apps/web/src/components/auth/OAuthButtons.test.tsx` (new) — assert all four provider buttons share identical classes (guards against per-provider styling regressions), expose an accessible group, honor a custom verb, fire `onSelect` with the right provider id, and disable together.

`:focus-visible` outlines are untouched, so keyboard focus is unaffected.

## Testing

- [x] `OAuthButtons.test.tsx` — 4 tests pass (`vitest run OAuthButtons`)
- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean
- [x] Manual reasoning: `@media (hover: hover)` behavior cannot be asserted in jsdom; verified by inspection that touch (no hover) will no longer apply the fill while pointer devices retain it.

## Issues

Closes #3901
