### PR TITLE
fix(web): hide keyboard-only command palette on touch-primary mobile devices (#3903)

### DIFF
--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -25,6 +25,7 @@ vi.mock('../../auth/auth-context', () => ({
 vi.mock('../../hooks', () => ({
   useKeyboardShortcuts: vi.fn(),
   useBreakpoint: vi.fn(),
+  useCoarsePointer: vi.fn(),
   useNotifications: () => ({
     notifications: [],
     unreadCount: 0,
@@ -99,7 +100,7 @@ vi.mock('../../contexts/PrivacyModeContext', () => ({
   }),
 }));
 
-import { useBreakpoint, useKeyboardShortcuts } from '../../hooks';
+import { useBreakpoint, useCoarsePointer, useKeyboardShortcuts } from '../../hooks';
 import { AppLayout } from './AppLayout';
 
 const mockSetShowHelp = vi.fn();
@@ -125,6 +126,7 @@ describe('AppLayout', () => {
       singleKeyShortcutsEnabled: true,
     });
     mockBreakpoint('mobile');
+    vi.mocked(useCoarsePointer).mockReturnValue(false);
     mockSetShowHelp.mockClear();
   });
 
@@ -276,6 +278,31 @@ describe('AppLayout', () => {
     // The "⌘K" text glyph was replaced with a real SVG icon.
     expect(commandButton.querySelector('svg')).not.toBeNull();
     expect(commandButton.textContent).not.toContain('⌘K');
+  });
+
+  it('hides the keyboard-only Command palette trigger on touch-primary devices (#3903)', () => {
+    vi.mocked(useCoarsePointer).mockReturnValue(true);
+    renderLayout();
+
+    // No physical keyboard means the ⌘K affordance and its shortcut chips are
+    // meaningless; touch users navigate via the bottom tab bar instead.
+    expect(screen.queryByRole('button', { name: 'Command palette' })).not.toBeInTheDocument();
+  });
+
+  it('does not wire the command palette into keyboard shortcuts on touch-primary devices (#3903)', () => {
+    vi.mocked(useCoarsePointer).mockReturnValue(true);
+    renderLayout();
+
+    const options = vi.mocked(useKeyboardShortcuts).mock.calls.at(-1)?.[0];
+    expect(options?.onOpenCommandPalette).toBeUndefined();
+  });
+
+  it('keeps the command palette wired to keyboard shortcuts on fine-pointer devices (#3903)', () => {
+    vi.mocked(useCoarsePointer).mockReturnValue(false);
+    renderLayout();
+
+    const options = vi.mocked(useKeyboardShortcuts).mock.calls.at(-1)?.[0];
+    expect(typeof options?.onOpenCommandPalette).toBe('function');
   });
 
   it('opens keyboard shortcuts modal when the header button is clicked', () => {

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -9,7 +9,7 @@ import { KeyboardShortcutsModal, SyncStatusBar } from '../common';
 import { CommandPalette, type CommandPaletteAction } from '../common/CommandPalette';
 import { ConflictResolutionDialog } from '../common/ConflictResolutionDialog';
 import { NotificationCenter } from '../notifications';
-import { useBreakpoint, useKeyboardShortcuts } from '../../hooks';
+import { useBreakpoint, useCoarsePointer, useKeyboardShortcuts } from '../../hooks';
 import { useAccessibility } from '../../hooks/useAccessibility';
 import { useHiddenModules } from '../../hooks/useModuleVisibility';
 import { usePrivacyMode } from '../../contexts/PrivacyModeContext';
@@ -115,6 +115,14 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
   // rendered here only on mobile; the desktop sidebar hosts them instead. Gating
   // by breakpoint keeps exactly one instance of each control in the DOM (#3197).
   const { isMobile } = useBreakpoint();
+  // The command palette is a keyboard-first feature: it is described as running
+  // actions "from the keyboard" and every row surfaces a physical keyboard
+  // shortcut chip. On touch-primary devices there is no physical keyboard, so
+  // the ⌘K trigger and the palette itself are confusing and meaningless. Gate
+  // them behind a fine (mouse/keyboard) pointer; touch users navigate via the
+  // bottom tab bar instead (#3903).
+  const isCoarsePointer = useCoarsePointer();
+  const commandPaletteEnabled = !isCoarsePointer;
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [simpleModeEnabled, setSimpleModeEnabled] = useState(getStoredSimplifiedModePreference);
   const { isSimplified } = useAccessibility();
@@ -131,7 +139,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
   const { showHelp, setShowHelp, singleKeyShortcutsEnabled } = useKeyboardShortcuts({
     onNavigate,
     onNewTransaction: () => onNavigate('/transactions?new=transaction'),
-    onOpenCommandPalette: () => setShowCommandPalette(true),
+    onOpenCommandPalette: commandPaletteEnabled ? () => setShowCommandPalette(true) : undefined,
     onTogglePrivacyMode: togglePrivacyMode,
   });
   const { conflictCount } = useSyncStatus();
@@ -383,15 +391,17 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
                 <KeyboardIcon />
               </button>
             ) : null}
-            <button
-              type="button"
-              className="icon-button"
-              aria-label="Command palette"
-              aria-keyshortcuts="Control+K Meta+K /"
-              onClick={openCommandPalette}
-            >
-              <Icon name={IconToken.SEARCH} size={20} />
-            </button>
+            {commandPaletteEnabled ? (
+              <button
+                type="button"
+                className="icon-button"
+                aria-label="Command palette"
+                aria-keyshortcuts="Control+K Meta+K /"
+                onClick={openCommandPalette}
+              >
+                <Icon name={IconToken.SEARCH} size={20} />
+              </button>
+            ) : null}
             <button
               type="button"
               className={`icon-button${isSimplified ? ' icon-button--labeled' : ''}`}
@@ -452,7 +462,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
         <SampleDataBanner />
       </div>
       <CommandPalette
-        isOpen={showCommandPalette}
+        isOpen={commandPaletteEnabled && showCommandPalette}
         actions={commandPaletteActions}
         onClose={closeCommandPalette}
         currentPath={activePath}


### PR DESCRIPTION
## Summary

On an installed PWA on a touch-primary mobile device (e.g. iPhone), the Command Palette (⌘K) is a keyboard-first feature that makes no sense without a physical keyboard. Its copy reads "Search destinations and run common actions **from the keyboard**" and every row shows a physical shortcut chip (`G F`, `G N`, `N`, `?`, `Ctrl+Shift+P`, …). Exposing the ⌘K header trigger and the palette on touch devices is confusing and adds no capability — touch users already have full navigation via the bottom tab bar.

This PR gates the command palette behind a fine (mouse/keyboard) pointer using the existing `useCoarsePointer()` hook (`matchMedia('(pointer: coarse)')` / `(hover: none)` — no UA sniffing).

## Changes

- `apps/web/src/components/layout/AppLayout.tsx`
  - Compute `isCoarsePointer` via `useCoarsePointer()`; derive `commandPaletteEnabled = !isCoarsePointer`.
  - On coarse/touch devices: do not render the ⌘K header trigger, do not wire `onOpenCommandPalette` into `useKeyboardShortcuts`, and do not mount `<CommandPalette>`.
  - On fine-pointer (desktop/keyboard) devices: behavior is unchanged.
- `apps/web/src/components/layout/AppLayout.test.tsx`
  - Mock `useCoarsePointer` (defaults to `false`).
  - Add coverage: trigger hidden on touch devices, palette not wired into keyboard shortcuts on touch, and still wired on fine-pointer devices.

## Issues

Closes #3903

## Testing

- [x] Affected web tests pass (`AppLayout`, `CommandPalette`, `useCoarsePointer`, `useKeyboardShortcuts` — 67 tests)
- [x] `npm run format:check` clean
- [x] `npx eslint … --max-warnings 0` clean

## Accessibility

Keeps WCAG 2.2 AA intact: removes a confusing, keyboard-only affordance from touch devices while preserving an equivalent navigation path (bottom tab bar). No change to the fine-pointer experience.

## Cross-Platform

Web/PWA-only. iOS, Android, and Windows use native navigation and do not render this web command palette; no shared-code change required.
