### PR TITLE
fix(web): enable touch reorder and tame tap styles in CustomizePanel (#3902)

### DIFF
--- a/apps/web/src/components/dashboard/CustomizePanel.test.tsx
+++ b/apps/web/src/components/dashboard/CustomizePanel.test.tsx
@@ -36,6 +36,15 @@ function mockDataTransfer() {
   };
 }
 
+/** jsdom lacks pointer-capture APIs; stub them so pointer handlers don't throw. */
+function stubPointerCapture(el: Element) {
+  Object.assign(el, {
+    setPointerCapture: vi.fn(),
+    releasePointerCapture: vi.fn(),
+    hasPointerCapture: vi.fn(() => true),
+  });
+}
+
 describe('CustomizePanel', () => {
   it('renders nothing when isOpen is false', () => {
     const { container } = render(
@@ -182,6 +191,122 @@ describe('CustomizePanel', () => {
     expect(items[0]).toHaveClass('customize-panel__item--dragging');
 
     fireEvent.dragEnd(items[0], { dataTransfer });
+    expect(items[0]).not.toHaveClass('customize-panel__item--dragging');
+  });
+
+  it('exposes data-widget-id on each item for pointer hit-testing', () => {
+    const { container } = renderPanel();
+    const items = container.querySelectorAll('li.customize-panel__item');
+    for (const item of items) {
+      expect(item).toHaveAttribute('data-widget-id');
+    }
+  });
+
+  it('reorders via a touch pointer drag on the handle', () => {
+    const { props, container } = renderPanel();
+    const handles = container.querySelectorAll<HTMLElement>('.customize-panel__drag-handle');
+    const items = container.querySelectorAll<HTMLElement>('li.customize-panel__item');
+    const sourceHandle = handles[0];
+    stubPointerCapture(sourceHandle);
+
+    const fromPoint = vi.fn().mockReturnValue(items[2]);
+    document.elementFromPoint = fromPoint;
+
+    fireEvent.pointerDown(sourceHandle, {
+      pointerId: 1,
+      pointerType: 'touch',
+      clientX: 0,
+      clientY: 0,
+    });
+    expect(items[0]).toHaveClass('customize-panel__item--dragging');
+
+    fireEvent.pointerMove(sourceHandle, {
+      pointerId: 1,
+      pointerType: 'touch',
+      clientX: 0,
+      clientY: 200,
+    });
+    expect(items[2]).toHaveClass('customize-panel__item--drag-over');
+
+    fireEvent.pointerUp(sourceHandle, {
+      pointerId: 1,
+      pointerType: 'touch',
+      clientX: 0,
+      clientY: 200,
+    });
+
+    expect(props.onReorder).toHaveBeenCalledOnce();
+    expect(props.onReorder).toHaveBeenCalledWith(expect.any(String), 2);
+    expect(items[0]).not.toHaveClass('customize-panel__item--dragging');
+  });
+
+  it('announces a touch pointer reorder via the live status region', () => {
+    const { container } = renderPanel();
+    const handles = container.querySelectorAll<HTMLElement>('.customize-panel__drag-handle');
+    const items = container.querySelectorAll<HTMLElement>('li.customize-panel__item');
+    const sourceHandle = handles[0];
+    stubPointerCapture(sourceHandle);
+
+    const fromPoint = vi.fn().mockReturnValue(items[2]);
+    document.elementFromPoint = fromPoint;
+
+    fireEvent.pointerDown(sourceHandle, {
+      pointerId: 1,
+      pointerType: 'touch',
+      clientX: 0,
+      clientY: 0,
+    });
+    fireEvent.pointerUp(sourceHandle, {
+      pointerId: 1,
+      pointerType: 'touch',
+      clientX: 0,
+      clientY: 200,
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent(/moved to position 3 of/i);
+  });
+
+  it('ignores mouse pointerdown on the handle so native drag-and-drop stays in charge', () => {
+    const { props, container } = renderPanel();
+    const handles = container.querySelectorAll<HTMLElement>('.customize-panel__drag-handle');
+    const items = container.querySelectorAll<HTMLElement>('li.customize-panel__item');
+    const sourceHandle = handles[0];
+    stubPointerCapture(sourceHandle);
+
+    fireEvent.pointerDown(sourceHandle, {
+      pointerId: 1,
+      pointerType: 'mouse',
+      clientX: 0,
+      clientY: 0,
+    });
+
+    expect(items[0]).not.toHaveClass('customize-panel__item--dragging');
+    expect(props.onReorder).not.toHaveBeenCalled();
+  });
+
+  it('does not reorder when a touch pointer drag is cancelled', () => {
+    const { props, container } = renderPanel();
+    const handles = container.querySelectorAll<HTMLElement>('.customize-panel__drag-handle');
+    const items = container.querySelectorAll<HTMLElement>('li.customize-panel__item');
+    const sourceHandle = handles[0];
+    stubPointerCapture(sourceHandle);
+
+    fireEvent.pointerDown(sourceHandle, {
+      pointerId: 1,
+      pointerType: 'touch',
+      clientX: 0,
+      clientY: 0,
+    });
+    expect(items[0]).toHaveClass('customize-panel__item--dragging');
+
+    fireEvent.pointerCancel(sourceHandle, {
+      pointerId: 1,
+      pointerType: 'touch',
+      clientX: 0,
+      clientY: 0,
+    });
+
+    expect(props.onReorder).not.toHaveBeenCalled();
     expect(items[0]).not.toHaveClass('customize-panel__item--dragging');
   });
 

--- a/apps/web/src/components/dashboard/CustomizePanel.tsx
+++ b/apps/web/src/components/dashboard/CustomizePanel.tsx
@@ -10,7 +10,15 @@
  * @module components/dashboard/CustomizePanel
  */
 
-import { useCallback, useRef, useState, type DragEvent, type FC, type KeyboardEvent } from 'react';
+import {
+  useCallback,
+  useRef,
+  useState,
+  type DragEvent,
+  type FC,
+  type KeyboardEvent,
+  type PointerEvent,
+} from 'react';
 
 import { useFocusTrap } from '../../accessibility/aria';
 import { Checkbox } from '../common/Checkbox';
@@ -111,6 +119,84 @@ export const CustomizePanel: FC<CustomizePanelProps> = ({
     setDragOverId(null);
   }, []);
 
+  // ---------------------------------------------------------------------------
+  // Pointer-based drag fallback (touch / pen)
+  //
+  // Native HTML5 drag-and-drop does not fire on touch devices (iOS Safari,
+  // Android Chrome), so the drag handles are dead there. Pointer Events work
+  // across mouse, touch, and pen, so we add a touch/pen fallback on the handle
+  // while leaving native DnD to drive mouse dragging (and the existing tests).
+  // The arrow buttons + keyboard remain the accessible primary reorder path;
+  // dragging is only ever an enhancement.
+  // ---------------------------------------------------------------------------
+
+  const pointerDragId = useRef<WidgetId | null>(null);
+
+  const widgetIdAtPoint = useCallback((x: number, y: number): WidgetId | null => {
+    const element = document.elementFromPoint(x, y);
+    const item = element?.closest<HTMLElement>('[data-widget-id]');
+    return (item?.dataset.widgetId as WidgetId | undefined) ?? null;
+  }, []);
+
+  const handleHandlePointerDown = useCallback((e: PointerEvent<HTMLSpanElement>, id: WidgetId) => {
+    // Let mouse users keep the richer native HTML5 drag-and-drop path.
+    if (e.pointerType === 'mouse') return;
+    e.preventDefault();
+    pointerDragId.current = id;
+    setDraggingId(id);
+    // Route subsequent pointer events to the handle even if the finger
+    // drifts off it, so we can track which row it is over.
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }, []);
+
+  const handleHandlePointerMove = useCallback(
+    (e: PointerEvent<HTMLSpanElement>) => {
+      const draggedId = pointerDragId.current;
+      if (draggedId === null) return;
+      const overId = widgetIdAtPoint(e.clientX, e.clientY);
+      setDragOverId(overId !== null && overId !== draggedId ? overId : null);
+    },
+    [widgetIdAtPoint],
+  );
+
+  const finishPointerDrag = useCallback(
+    (e: PointerEvent<HTMLSpanElement>, commit: boolean) => {
+      const draggedId = pointerDragId.current;
+      if (draggedId === null) return;
+      pointerDragId.current = null;
+
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      }
+
+      if (commit) {
+        const overId = widgetIdAtPoint(e.clientX, e.clientY);
+        if (overId !== null && overId !== draggedId) {
+          const targetIndex = widgets.findIndex((w) => w.id === overId);
+          if (targetIndex !== -1) {
+            onReorder(draggedId, targetIndex);
+            const def = WIDGET_DEFINITION_MAP.get(draggedId);
+            announceReorder(def?.label ?? 'Widget', targetIndex + 1, widgets.length);
+          }
+        }
+      }
+
+      setDraggingId(null);
+      setDragOverId(null);
+    },
+    [widgetIdAtPoint, widgets, onReorder, announceReorder],
+  );
+
+  const handleHandlePointerUp = useCallback(
+    (e: PointerEvent<HTMLSpanElement>) => finishPointerDrag(e, true),
+    [finishPointerDrag],
+  );
+
+  const handleHandlePointerCancel = useCallback(
+    (e: PointerEvent<HTMLSpanElement>) => finishPointerDrag(e, false),
+    [finishPointerDrag],
+  );
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -160,6 +246,7 @@ export const CustomizePanel: FC<CustomizePanelProps> = ({
                 key={widget.id}
                 className={itemClass}
                 role="listitem"
+                data-widget-id={widget.id}
                 draggable
                 onDragStart={(e) => handleDragStart(e, widget.id)}
                 onDragEnter={() => handleDragEnter(widget.id)}
@@ -171,6 +258,10 @@ export const CustomizePanel: FC<CustomizePanelProps> = ({
                   className="customize-panel__drag-handle"
                   aria-hidden="true"
                   title="Drag to reorder"
+                  onPointerDown={(e) => handleHandlePointerDown(e, widget.id)}
+                  onPointerMove={handleHandlePointerMove}
+                  onPointerUp={handleHandlePointerUp}
+                  onPointerCancel={handleHandlePointerCancel}
                 >
                   ⠿
                 </span>

--- a/apps/web/src/components/dashboard/dashboard.css
+++ b/apps/web/src/components/dashboard/dashboard.css
@@ -311,6 +311,13 @@
   border: 1px solid var(--semantic-border-default);
   border-radius: var(--border-radius-md);
   background: var(--semantic-background-primary);
+  /* Suppress the iOS long-press text-selection callout and the saturated
+     tap highlight so pointer-dragging a row stays readable on touch. The
+     arrow buttons and checkbox remain fully operable as interactive children. */
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
   transition:
     border-color var(--duration-fast, 100ms) ease,
     box-shadow var(--duration-fast, 100ms) ease,
@@ -407,9 +414,20 @@
   font-family: inherit;
   cursor: pointer;
   line-height: 1;
+  /* Remove the saturated lavender flash on tap; the :active rule below
+     provides a subtle, readable pressed state instead. */
+  -webkit-tap-highlight-color: transparent;
 }
 
-.customize-panel__move-btn:hover:not(:disabled) {
+/* Only apply hover feedback on devices with a real hovering pointer so
+   touch devices don't get stuck in a "hovered" state after a tap. */
+@media (hover: hover) {
+  .customize-panel__move-btn:hover:not(:disabled) {
+    background: var(--semantic-background-secondary);
+  }
+}
+
+.customize-panel__move-btn:active:not(:disabled) {
   background: var(--semantic-background-secondary);
 }
 


### PR DESCRIPTION
## Summary

Fixes three related touch defects in the Dashboard **Customize Dashboard** panel (`CustomizePanel`), reproduced on iPhone Safari (mobile viewport). All three are the same user-reported bug and are fixed as one cohesive change.

## Changes

- **Touch reorder now works.** Added a Pointer Events touch/pen drag fallback on the drag handle. Native HTML5 drag-and-drop never fires on iOS Safari / Android Chrome, so the handles were completely dead on touch. Mouse users keep the existing native HTML5 DnD path; the pointer fallback only activates for `touch`/`pen`. `document.elementFromPoint` hit-tests the row under the finger (rows carry a new `data-widget-id`), and pointer capture keeps tracking even if the finger drifts off the handle.
- **Kept the accessible primary path intact.** The up/down arrow buttons and keyboard reorder, plus the `aria-live` position announcements, remain fully functional. Dragging is strictly an enhancement — never the only way to reorder (WCAG 2.2 AA).
- **Killed the iOS long-press text-selection callout.** `.customize-panel__item` now sets `user-select: none`, `-webkit-user-select: none`, `-webkit-touch-callout: none`, and `-webkit-tap-highlight-color: transparent`, so long-pressing a row no longer paints a saturated selection block over the widget name/description. The checkbox and arrow buttons remain fully operable.
- **Toned down the over-saturated tap colors.** `.customize-panel__move-btn` gets `-webkit-tap-highlight-color: transparent` (removing the heavy lavender flash) plus a subtle readable `:active` state, and `:hover` is now guarded behind `@media (hover: hover)` so touch devices don't get stuck in a hovered state — matching the existing iOS sticky-hover / tap-highlight fixes elsewhere in the app.

## Files

- `apps/web/src/components/dashboard/CustomizePanel.tsx`
- `apps/web/src/components/dashboard/dashboard.css`
- `apps/web/src/components/dashboard/CustomizePanel.test.tsx`

## Issues

Closes #3902

## Testing

- [x] `npm --prefix apps/web run test -- --run CustomizePanel` — 26 passed (added 5: touch pointer reorder, live-region announcement, mouse-pointer ignored so native DnD stays in charge, pointer-cancel does not reorder, `data-widget-id` present)
- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean
- [x] Existing native-DnD and arrow-button/keyboard tests remain green
- No contrast regressions: colors use existing semantic tokens; the `:active`/`:hover` state reuses `--semantic-background-secondary` (already used for hover), safe in light, dark, and high-contrast modes.

## Cross-Platform

Web-only (`apps/web`). Native platforms use their own list-reorder controls; the root cause is web HTML5-DnD + webkit touch CSS, so no shared `packages/` change is required.
