### PR TITLE
fix(web): respect top safe-area inset on mobile app header (#3904)

### DIFF
--- a/apps/web/src/styles/app-header-safe-area.test.ts
+++ b/apps/web/src/styles/app-header-safe-area.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression guard for #3904: the mobile top header (`.app-header`) must respect
+ * the top safe-area inset so it does not underlap the iOS status bar / notch on
+ * installed PWAs, mirroring how `.bottom-nav` / `.app-main` handle
+ * `safe-area-inset-bottom`. These assertions read the compiled CSS source so the
+ * inset can't silently regress if the rule is refactored.
+ */
+describe('app-header safe-area inset (responsive.css)', () => {
+  const css = readFileSync(join(process.cwd(), 'src/styles/responsive.css'), 'utf8');
+
+  const headerRule = css.slice(css.indexOf('.app-header {'), css.indexOf('.app-header__title'));
+
+  it('pads the header top by the safe-area inset so content clears the notch', () => {
+    expect(headerRule).toMatch(/padding:[^;]*env\(safe-area-inset-top/);
+  });
+
+  it('grows the header height by the safe-area inset so the box fills the notch strip', () => {
+    expect(headerRule).toMatch(/height:\s*calc\([^;]*env\(safe-area-inset-top[^;]*\)/);
+  });
+});

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -130,8 +130,16 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: var(--layout-header-height);
-  padding: 0 var(--layout-content-padding);
+  /* Grow the sticky header by the top safe-area inset so its background fills
+     the notch/status-bar strip and its content is pushed clear of it on
+     notched phones / installed PWAs. Under the global `box-sizing: border-box`
+     reset, `padding-top` sits inside `height`, so the height must include the
+     inset too — otherwise the content row would shrink instead of clearing the
+     notch. Mirrors how `.bottom-nav`/`.app-main` handle safe-area-inset-bottom
+     (needs viewport-fit=cover, which index.html sets). Resolves to 0px on
+     non-notched devices, so nothing changes there. */
+  height: calc(var(--layout-header-height) + env(safe-area-inset-top, 0px));
+  padding: env(safe-area-inset-top, 0px) var(--layout-content-padding) 0;
   background: var(--navigation-background);
   border-bottom: 1px solid var(--navigation-border);
 }


### PR DESCRIPTION
## Summary

On a notched iPhone running the app as an installed/standalone PWA, the mobile top header (`.app-header` — page title "Dashboard", breadcrumb, and the eye/bell/help/⌘K/settings icons) rendered **underneath the iOS status bar / notch on load**, with no scrolling required. The header did not respect the top safe-area inset, while the bottom tab bar and `.app-main` already handle their bottom/side insets.

## Changes

- `apps/web/src/styles/responsive.css` — `.app-header` now grows its box by the top safe-area inset and pads its content clear of the notch:
  - `padding-top: env(safe-area-inset-top, 0px)` pushes content below the status bar.
  - `height: calc(var(--layout-header-height) + env(safe-area-inset-top, 0px))` so, under the global `box-sizing: border-box` reset, the visible content row stays 56px and the sticky header background fills the notch strip (no transparent gap; sticky/z-index unchanged).
  - Resolves to `0px` on non-notched devices; desktop (`>=768px`) is unaffected because `.app-header` is `display: none` there.
- `apps/web/src/styles/app-header-safe-area.test.ts` — new regression guard asserting the `.app-header` rule keeps both the top-inset padding and the inset-inclusive height, so this can't silently regress.

`viewport-fit=cover` is already set in `apps/web/index.html`, so `env(safe-area-inset-*)` resolves to non-zero on notched devices — the fix is CSS-only.

## Issues

Closes #3904

## Testing

- [x] New guard test passes (`src/styles/app-header-safe-area.test.ts`, 2/2)
- [x] `AppLayout.test.tsx` stays green (22/22)
- [x] `npm run format:check` clean
- [x] `npx eslint . --max-warnings 0` clean
