### PR TITLE
fix(web): clear iOS home indicator on mobile bottom tab bar (#3912)

### DIFF
--- a/apps/web/src/styles/app-header-safe-area.test.ts
+++ b/apps/web/src/styles/app-header-safe-area.test.ts
@@ -5,16 +5,18 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 /**
- * Regression guard for #3904: the mobile top header (`.app-header`) must respect
- * the top safe-area inset so it does not underlap the iOS status bar / notch on
- * installed PWAs, mirroring how `.bottom-nav` / `.app-main` handle
- * `safe-area-inset-bottom`. These assertions read the compiled CSS source so the
- * inset can't silently regress if the rule is refactored.
+ * Regression guard for #3904: the mobile top header (`.app-header`) and bottom
+ * tab bar (`.bottom-nav`) must respect the device safe-area insets so their
+ * interactive content does not underlap the iOS status bar / notch (top) or the
+ * home indicator (bottom) on installed PWAs. These assertions read the compiled
+ * CSS source so the insets can't silently regress if the rules are refactored.
  */
-describe('app-header safe-area inset (responsive.css)', () => {
+describe('safe-area insets (responsive.css)', () => {
   const css = readFileSync(join(process.cwd(), 'src/styles/responsive.css'), 'utf8');
 
   const headerRule = css.slice(css.indexOf('.app-header {'), css.indexOf('.app-header__title'));
+
+  const bottomNavRule = css.slice(css.indexOf('.bottom-nav {'), css.indexOf('.nav-item {'));
 
   it('pads the header top by the safe-area inset so content clears the notch', () => {
     expect(headerRule).toMatch(/padding:[^;]*env\(safe-area-inset-top/);
@@ -22,5 +24,13 @@ describe('app-header safe-area inset (responsive.css)', () => {
 
   it('grows the header height by the safe-area inset so the box fills the notch strip', () => {
     expect(headerRule).toMatch(/height:\s*calc\([^;]*env\(safe-area-inset-top[^;]*\)/);
+  });
+
+  it('pads the bottom nav by the safe-area inset so tap targets clear the home indicator', () => {
+    expect(bottomNavRule).toMatch(/padding-bottom:\s*env\(safe-area-inset-bottom/);
+  });
+
+  it('grows the bottom nav height by the safe-area inset so the tap targets are not compressed', () => {
+    expect(bottomNavRule).toMatch(/height:\s*calc\([^;]*env\(safe-area-inset-bottom[^;]*\)/);
   });
 });

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -190,10 +190,19 @@
   display: flex;
   align-items: center;
   justify-content: space-around;
-  height: var(--layout-bottom-nav-height);
+  /* Grow the fixed bottom nav by the bottom safe-area inset so the tap targets
+     clear the iOS home indicator. Under the global `box-sizing: border-box`
+     reset, `padding-bottom` sits inside `height`, so a bare inset padding on a
+     fixed `height` would compress the nav-item content box and the icon+label
+     would overflow down into the home-indicator zone (mis-triggering taps).
+     Adding the inset to the height keeps the interactive row a full
+     `--layout-bottom-nav-height` and lifts the buttons above the indicator,
+     while the background still fills the inset strip. Mirrors the top
+     `.app-header` safe-area handling; resolves to 0px on non-notched devices. */
+  height: calc(var(--layout-bottom-nav-height) + env(safe-area-inset-bottom, 0px));
   background: var(--navigation-background);
   border-top: 1px solid var(--navigation-border);
-  padding-bottom: env(safe-area-inset-bottom, 0);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 .nav-item {
   display: flex;


### PR DESCRIPTION
## Summary

Follow-up to #3904 / PR #3911 (top-header notch fix) — the **mirror-image** problem at the bottom of the mobile PWA. On a notched iPhone running the app as an installed/standalone PWA, the bottom tab bar (Dashboard / Accounts / Transactions / Debt / More) overlapped the iOS **home indicator** ("siri bar"), so tab tap targets sat in the home-indicator zone and mis-triggered.

> Note: this ships as a separate PR because PR #3911 (the top-header half of this safe-area work) had already merged to `main` by the time the bottom-edge report arrived — it could no longer be folded into that PR. Both halves are the same safe-area family and share the same root cause and guard test.

## Root Cause

`.bottom-nav` is `position: fixed; bottom: 0` with a **fixed** `height: var(--layout-bottom-nav-height)` (56px) and `padding-bottom: env(safe-area-inset-bottom, 0)`. Under the global `box-sizing: border-box` reset, that padding sits **inside** the fixed height, so the bar never grows — the padding instead compresses the `.nav-item` content box. Each `.nav-item` is a `flex-direction: column` icon+label, so once squeezed to `56px − inset` the content overflows downward into the home-indicator strip. Same bug class as #3904: a fixed-height, border-box element can't clear a safe-area inset with padding alone — the height must grow by the inset too.

## Changes

- `apps/web/src/styles/responsive.css` — `.bottom-nav` now:
  - `height: calc(var(--layout-bottom-nav-height) + env(safe-area-inset-bottom, 0px))`
  - `padding-bottom: env(safe-area-inset-bottom, 0px)`
  - Keeps the interactive row a full `--layout-bottom-nav-height` and lifts the buttons above the home indicator; background still fills the inset strip. Resolves to `0px` on non-notched devices; desktop (`>=768px`) unaffected (`.bottom-nav` is `display: none`).
- `apps/web/src/styles/app-header-safe-area.test.ts` — extended the safe-area guard (renamed `describe` to cover both edges) with two new assertions for `.bottom-nav`'s inset padding + inset-inclusive height.

`viewport-fit=cover` is already set in `apps/web/index.html`, so `env(safe-area-inset-*)` resolves to non-zero — the fix is CSS-only.

## Issues

Closes #3912
Refs #3904

## Testing

- [x] Safe-area guard test 4/4 (2 header + 2 bottom nav) ✅
- [x] `Navigation.test.tsx` stays green (51/51) ✅
- [x] `npx eslint . --max-warnings 0` clean ✅
- [x] Changed files Prettier-clean ✅
