### PR TITLE
ci(deploy): robust required-check gate for production deploy (#3915)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -267,25 +267,53 @@ jobs:
   verify-ci-green:
     name: Verify CI green on SHA
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     needs: [prepare]
     if: needs.prepare.outputs.rollback != 'true'
+    permissions:
+      contents: read
+      checks: read
+      actions: read
     steps:
-      - name: Wait for CI workflows
-        uses: lewagon/wait-on-check-action@1d57e2c51a58d812d2765e036a028b6bdb5a6154 # v1.8.1
+      - name: Checkout tooling at deploy SHA
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.prepare.outputs.sha }}
-          running-workflow-name: 'Verify CI green on SHA'
-          check-regexp: '^Required Checks Gatekeeper$'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-          allowed-conclusions: success,skipped
-          # Wait up to 10 min for the gatekeeper check-run to be discovered. When a
-          # deploy is triggered right after a squash-merge, the push-triggered
-          # `ci-security.yml` gatekeeper may not register its check-run within the
-          # action's 60s default, which fails the gate on a commit whose CI actually
-          # passes moments later (#3533). 600s stays well inside this job's 30-min timeout.
-          checks-discovery-timeout: '600'
+          sparse-checkout: |
+            tools/verify-required-checks.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      # Robust required-check gate (#3915). The previous approach waited on the
+      # `Required Checks Gatekeeper` check-run via lewagon/wait-on-check-action,
+      # but that job `needs:` the ~20-30 min CodeQL/security jobs, so GitHub does
+      # not CREATE its check-run until those finish. A fast staging deploy then
+      # triggers promotion and the wait step looked for a check-run that did not
+      # exist yet, hard-failing with "The requested check was never run against
+      # this ref" even though CI ultimately passed. A fixed discovery timeout
+      # (even 600s) cannot reliably outlast CodeQL.
+      #
+      # This poller queries the check-runs API directly and fails closed:
+      #   - pass  → gatekeeper COMPLETED with success/skipped
+      #   - fail  → gatekeeper COMPLETED with a real failure (immediate)
+      #   - wait  → gatekeeper missing/queued/in_progress (it is created late)
+      #   - deadline with no pass → exit 1 (never deploy an ungated SHA)
+      # The 1500s budget stays comfortably inside this job's 40-min timeout.
+      - name: Wait for Required Checks Gatekeeper on SHA
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          node tools/verify-required-checks.mjs \
+            --sha "${{ needs.prepare.outputs.sha }}" \
+            --check-name "Required Checks Gatekeeper" \
+            --allowed-conclusions "success,skipped" \
+            --timeout 1500 \
+            --interval 20
 
   smoke-tests:
     name: Pre-deploy Smoke Tests

--- a/tools/README.md
+++ b/tools/README.md
@@ -303,6 +303,28 @@ branch-protection config documented in
       ./tools/setup-branch-protection.sh                     # current repo, main
       ./tools/setup-branch-protection.sh owner/repo main     # explicit target
 
+### `verify-required-checks.mjs` - Robust deploy gate on a required check-run
+
+Gates a production deploy on a required aggregate check-run (default
+`Required Checks Gatekeeper`) for a specific commit SHA by polling the
+check-runs REST API directly. Replaces `lewagon/wait-on-check-action` in
+`deploy-production.yml` (#3915): the gatekeeper job `needs:` the ~20-30 min
+CodeQL/security jobs, so GitHub does not **create** its check-run until those
+finish. A fast staging deploy then triggered promotion and the old wait step
+looked for a check-run that did not exist yet, hard-failing with "The requested
+check was never run against this ref". This poller fails **closed**:
+
+- **pass** — gatekeeper completed with an allowed conclusion (`success`/`skipped`)
+- **fail** (immediate) — gatekeeper completed with a real failure
+- **wait** — gatekeeper missing/queued/in_progress (it is legitimately created late)
+- **deadline with no pass** — exit 1 (never deploys an ungated SHA)
+
+Reads a token from `GITHUB_TOKEN`/`GH_TOKEN` (needs `checks: read`). Unit tests
+in `verify-required-checks.test.mjs` (`node --test`); quick self-check via
+`node tools/verify-required-checks.mjs --self-test`.
+
+    node tools/verify-required-checks.mjs --sha <commit-sha> [--timeout 1500] [--interval 20]
+
 ## Suggested `package.json` scripts
 
 `package.json` is shared and is not edited by the DevOps agent. When a maintainer

--- a/tools/verify-required-checks.mjs
+++ b/tools/verify-required-checks.mjs
@@ -1,0 +1,385 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: BUSL-1.1
+//
+// verify-required-checks.mjs
+// -----------------------------------------------------------------------------
+// Robustly gate a production deploy on a required aggregate check-run (by
+// default the "Required Checks Gatekeeper" produced by ci-security.yml) for a
+// specific commit SHA, using the GitHub check-runs REST API directly.
+//
+// Why this exists (issue #3915):
+//   The gatekeeper job `needs:` the ~20-30 min CodeQL/security jobs, so GitHub
+//   does not CREATE its check-run until those upstream jobs finish. A staging
+//   deploy finishes quickly and triggers promotion, so the deploy's wait step
+//   used to look for a gatekeeper check-run that legitimately does not exist yet
+//   and hard-failed with "The requested check was never run against this ref".
+//   A fixed discovery timeout (even 600s) cannot reliably outlast CodeQL.
+//
+// Behaviour (fail-closed, security-preserving):
+//   - PASS  → the gatekeeper check-run COMPLETED with an allowed conclusion
+//             (default: success, skipped). Exit 0.
+//   - FAIL  → the gatekeeper check-run COMPLETED with a disallowed conclusion
+//             (failure, cancelled, timed_out, ...). Exit 1 immediately — do not
+//             keep waiting on a genuine failure.
+//   - WAIT  → the gatekeeper check-run is missing / queued / in_progress. Keep
+//             polling until the deadline, because it is created late by design.
+//   - At the deadline with no PASS → exit 1 (never deploy an ungated SHA),
+//             reporting whether the check-run was never seen vs. never completed.
+//
+// Usage:
+//   node tools/verify-required-checks.mjs --sha <commit-sha> [options]
+//
+// Options (env fallbacks in brackets):
+//   --sha <sha>                 Commit SHA to verify.            [VERIFY_SHA, GITHUB_SHA]
+//   --repo <owner/name>         Repository.                      [GITHUB_REPOSITORY]
+//   --check-name <name>         Required check-run name.
+//                               [VERIFY_CHECK_NAME] (default: "Required Checks Gatekeeper")
+//   --allowed-conclusions a,b   Comma-separated allowed conclusions.
+//                               [VERIFY_ALLOWED_CONCLUSIONS] (default: "success,skipped")
+//   --timeout <seconds>         Overall wait budget.             [VERIFY_TIMEOUT] (default: 1800)
+//   --interval <seconds>        Poll interval.                   [VERIFY_INTERVAL] (default: 20)
+//   --self-test                 Run the built-in assertions and exit.
+//   --help                      Show this help.
+//
+// Auth: reads a token from GITHUB_TOKEN (or GH_TOKEN). Needs `checks: read`.
+// -----------------------------------------------------------------------------
+
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_CHECK_NAME = 'Required Checks Gatekeeper';
+const DEFAULT_ALLOWED = ['success', 'skipped'];
+const DEFAULT_TIMEOUT_SECONDS = 1800;
+const DEFAULT_INTERVAL_SECONDS = 20;
+
+/**
+ * Pick the most recently started check-run matching `name`.
+ * The API can return several runs sharing a name across suites; the newest
+ * (by started_at, then id) is the authoritative one.
+ * @param {Array<object>} runs
+ * @param {string} name
+ * @returns {object | null}
+ */
+export function selectLatestCheckRun(runs, name) {
+  const matches = (runs ?? []).filter((run) => run && run.name === name);
+  if (matches.length === 0) return null;
+  return matches.reduce((latest, run) => {
+    const a = Date.parse(run.started_at ?? '') || 0;
+    const b = Date.parse(latest.started_at ?? '') || 0;
+    if (a !== b) return a > b ? run : latest;
+    return (run.id ?? 0) > (latest.id ?? 0) ? run : latest;
+  });
+}
+
+/**
+ * Classify a gatekeeper check-run into a deploy-gate decision.
+ * @param {object | null} run  The selected check-run, or null if absent.
+ * @param {string[]} allowedConclusions
+ * @returns {{ decision: 'missing' | 'pending' | 'pass' | 'fail', conclusion: string | null }}
+ */
+export function classifyGatekeeper(run, allowedConclusions = DEFAULT_ALLOWED) {
+  if (!run) return { decision: 'missing', conclusion: null };
+  if (run.status !== 'completed')
+    return { decision: 'pending', conclusion: run.conclusion ?? null };
+  const conclusion = run.conclusion ?? null;
+  if (conclusion && allowedConclusions.includes(conclusion)) {
+    return { decision: 'pass', conclusion };
+  }
+  return { decision: 'fail', conclusion };
+}
+
+function parseArgs(argv) {
+  const opts = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--help':
+        opts.help = true;
+        break;
+      case '--self-test':
+        opts.selfTest = true;
+        break;
+      case '--sha':
+        opts.sha = argv[++i];
+        break;
+      case '--repo':
+        opts.repo = argv[++i];
+        break;
+      case '--check-name':
+        opts.checkName = argv[++i];
+        break;
+      case '--allowed-conclusions':
+        opts.allowed = argv[++i];
+        break;
+      case '--timeout':
+        opts.timeout = argv[++i];
+        break;
+      case '--interval':
+        opts.interval = argv[++i];
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function resolveConfig(opts) {
+  const sha = opts.sha ?? process.env.VERIFY_SHA ?? process.env.GITHUB_SHA;
+  const repo = opts.repo ?? process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const checkName = opts.checkName ?? process.env.VERIFY_CHECK_NAME ?? DEFAULT_CHECK_NAME;
+  const allowed = (
+    opts.allowed ??
+    process.env.VERIFY_ALLOWED_CONCLUSIONS ??
+    DEFAULT_ALLOWED.join(',')
+  )
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const timeoutSeconds = Number(
+    opts.timeout ?? process.env.VERIFY_TIMEOUT ?? DEFAULT_TIMEOUT_SECONDS,
+  );
+  const intervalSeconds = Number(
+    opts.interval ?? process.env.VERIFY_INTERVAL ?? DEFAULT_INTERVAL_SECONDS,
+  );
+
+  const errors = [];
+  if (!sha) errors.push('A commit SHA is required (--sha or VERIFY_SHA/GITHUB_SHA).');
+  if (!repo) errors.push('A repository is required (--repo or GITHUB_REPOSITORY).');
+  if (!token) errors.push('A token is required (GITHUB_TOKEN or GH_TOKEN).');
+  if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0)
+    errors.push('--timeout must be a positive number.');
+  if (!Number.isFinite(intervalSeconds) || intervalSeconds <= 0)
+    errors.push('--interval must be a positive number.');
+  if (errors.length > 0) {
+    throw new Error(errors.join('\n'));
+  }
+  return { sha, repo, token, checkName, allowed, timeoutSeconds, intervalSeconds };
+}
+
+async function fetchCheckRuns({ repo, sha, token }) {
+  const runs = [];
+  let page = 1;
+  // Paginate defensively; a busy SHA can carry many check-runs.
+  for (;;) {
+    const url = `https://api.github.com/repos/${repo}/commits/${encodeURIComponent(sha)}/check-runs?per_page=100&page=${page}`;
+    const response = await globalThis.fetch(url, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'finance-verify-required-checks',
+      },
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(
+        `GitHub API ${response.status} ${response.statusText} while listing check-runs: ${body.slice(0, 300)}`,
+      );
+    }
+    const payload = await response.json();
+    const pageRuns = payload.check_runs ?? [];
+    runs.push(...pageRuns);
+    if (pageRuns.length < 100) break;
+    page += 1;
+  }
+  return runs;
+}
+
+const sleep = (seconds) => new Promise((done) => setTimeout(done, seconds * 1000));
+
+async function run() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    printHelp();
+    return 0;
+  }
+  if (opts.selfTest) {
+    return selfTest();
+  }
+
+  const config = resolveConfig(opts);
+  const deadline = Date.now() + config.timeoutSeconds * 1000;
+  const shaShort = config.sha.slice(0, 12);
+
+  console.log(`Verifying required check "${config.checkName}" on ${config.repo}@${shaShort}`);
+  console.log(`Allowed conclusions: ${config.allowed.join(', ')}`);
+  console.log(`Wait budget: ${config.timeoutSeconds}s, poll interval: ${config.intervalSeconds}s`);
+
+  let everSawGatekeeper = false;
+  let sawAnyCheckRuns = false;
+
+  for (;;) {
+    let allRuns;
+    try {
+      allRuns = await fetchCheckRuns(config);
+    } catch (error) {
+      // Transient API/network hiccups should not abort a 30-min gate; log and retry.
+      console.warn(`⚠️  ${error.message}`);
+      if (Date.now() >= deadline) break;
+      await sleep(config.intervalSeconds);
+      continue;
+    }
+
+    if (allRuns.length > 0) sawAnyCheckRuns = true;
+    const gatekeeper = selectLatestCheckRun(allRuns, config.checkName);
+    if (gatekeeper) everSawGatekeeper = true;
+    const { decision, conclusion } = classifyGatekeeper(gatekeeper, config.allowed);
+
+    if (decision === 'pass') {
+      console.log(
+        `✅ "${config.checkName}" completed with conclusion "${conclusion}" — gate passed.`,
+      );
+      return 0;
+    }
+    if (decision === 'fail') {
+      console.error(
+        `❌ "${config.checkName}" completed with disallowed conclusion "${conclusion}" — refusing to deploy ${shaShort}.`,
+      );
+      return 1;
+    }
+
+    if (Date.now() >= deadline) {
+      break;
+    }
+
+    const remaining = Math.round((deadline - Date.now()) / 1000);
+    if (decision === 'missing') {
+      const total = allRuns.length;
+      console.log(
+        `⏳ "${config.checkName}" check-run not created yet (it is produced after the security/CodeQL jobs). ` +
+          `${total} check-run(s) on SHA so far. Retrying in ${config.intervalSeconds}s (${remaining}s left).`,
+      );
+    } else {
+      console.log(
+        `⏳ "${config.checkName}" is ${gatekeeper.status}${conclusion ? ` (${conclusion})` : ''} — waiting for completion. ` +
+          `Retrying in ${config.intervalSeconds}s (${remaining}s left).`,
+      );
+    }
+    await sleep(config.intervalSeconds);
+  }
+
+  // Fail closed: never promote a SHA whose required gate did not demonstrably pass.
+  if (!everSawGatekeeper) {
+    console.error(
+      `❌ Timed out after ${config.timeoutSeconds}s: "${config.checkName}" check-run was never found on ${shaShort}. ` +
+        (sawAnyCheckRuns
+          ? 'Other checks ran but the required gatekeeper did not — did ci-security.yml execute for this commit?'
+          : 'No check-runs were found at all — CI may not have run for this commit.'),
+    );
+  } else {
+    console.error(
+      `❌ Timed out after ${config.timeoutSeconds}s: "${config.checkName}" was found but never completed on ${shaShort}. ` +
+        'Refusing to deploy an ungated commit.',
+    );
+  }
+  return 1;
+}
+
+function printHelp() {
+  const header = '\nverify-required-checks.mjs — gate a deploy on a required check-run for a SHA\n';
+  console.log(header);
+  console.log('Usage: node tools/verify-required-checks.mjs --sha <commit-sha> [options]\n');
+  console.log('Options:');
+  console.log('  --sha <sha>                 Commit SHA to verify (env: VERIFY_SHA / GITHUB_SHA)');
+  console.log('  --repo <owner/name>         Repository (env: GITHUB_REPOSITORY)');
+  console.log(
+    `  --check-name <name>         Required check-run name (default: "${DEFAULT_CHECK_NAME}")`,
+  );
+  console.log(
+    `  --allowed-conclusions a,b   Allowed conclusions (default: "${DEFAULT_ALLOWED.join(',')}")`,
+  );
+  console.log(
+    `  --timeout <seconds>         Overall wait budget (default: ${DEFAULT_TIMEOUT_SECONDS})`,
+  );
+  console.log(`  --interval <seconds>        Poll interval (default: ${DEFAULT_INTERVAL_SECONDS})`);
+  console.log('  --self-test                 Run built-in assertions and exit');
+  console.log('  --help                      Show this help\n');
+  console.log('Auth: GITHUB_TOKEN or GH_TOKEN (needs `checks: read`).');
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Self-test failed: ${message}`);
+}
+
+function selfTest() {
+  // selectLatestCheckRun picks the newest run by started_at.
+  const runs = [
+    {
+      id: 1,
+      name: 'Required Checks Gatekeeper',
+      status: 'completed',
+      conclusion: 'failure',
+      started_at: '2026-07-18T10:00:00Z',
+    },
+    {
+      id: 2,
+      name: 'Required Checks Gatekeeper',
+      status: 'completed',
+      conclusion: 'success',
+      started_at: '2026-07-18T11:00:00Z',
+    },
+    {
+      id: 3,
+      name: 'Other Check',
+      status: 'completed',
+      conclusion: 'failure',
+      started_at: '2026-07-18T12:00:00Z',
+    },
+  ];
+  assert(
+    selectLatestCheckRun(runs, 'Required Checks Gatekeeper').id === 2,
+    'should pick newest matching run',
+  );
+  assert(selectLatestCheckRun(runs, 'Nope') === null, 'should return null when nothing matches');
+
+  // classifyGatekeeper decisions.
+  assert(classifyGatekeeper(null).decision === 'missing', 'null run => missing');
+  assert(
+    classifyGatekeeper({ name: 'g', status: 'in_progress', conclusion: null }).decision ===
+      'pending',
+    'in_progress => pending',
+  );
+  assert(
+    classifyGatekeeper({ name: 'g', status: 'queued', conclusion: null }).decision === 'pending',
+    'queued => pending',
+  );
+  assert(
+    classifyGatekeeper({ name: 'g', status: 'completed', conclusion: 'success' }).decision ===
+      'pass',
+    'completed+success => pass',
+  );
+  assert(
+    classifyGatekeeper({ name: 'g', status: 'completed', conclusion: 'skipped' }).decision ===
+      'pass',
+    'completed+skipped => pass (allowed by default)',
+  );
+  assert(
+    classifyGatekeeper({ name: 'g', status: 'completed', conclusion: 'failure' }).decision ===
+      'fail',
+    'completed+failure => fail',
+  );
+  assert(
+    classifyGatekeeper({ name: 'g', status: 'completed', conclusion: 'cancelled' }).decision ===
+      'fail',
+    'completed+cancelled => fail',
+  );
+  assert(
+    classifyGatekeeper({ name: 'g', status: 'completed', conclusion: 'skipped' }, ['success'])
+      .decision === 'fail',
+    'skipped is fail when not in allowed list',
+  );
+
+  console.log('✅ verify-required-checks self-test passed.');
+  return 0;
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly || process.env.VERIFY_FORCE_RUN === '1') {
+  run()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error(`❌ ${error.message}`);
+      process.exit(1);
+    });
+}

--- a/tools/verify-required-checks.test.mjs
+++ b/tools/verify-required-checks.test.mjs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Unit tests for tools/verify-required-checks.mjs
+// Run with: node --test tools/verify-required-checks.test.mjs
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { classifyGatekeeper, selectLatestCheckRun } from './verify-required-checks.mjs';
+
+test('selectLatestCheckRun picks the newest matching run by started_at', () => {
+  const runs = [
+    {
+      id: 1,
+      name: 'Required Checks Gatekeeper',
+      status: 'completed',
+      conclusion: 'failure',
+      started_at: '2026-07-18T10:00:00Z',
+    },
+    {
+      id: 2,
+      name: 'Required Checks Gatekeeper',
+      status: 'completed',
+      conclusion: 'success',
+      started_at: '2026-07-18T11:00:00Z',
+    },
+    {
+      id: 3,
+      name: 'Other Check',
+      status: 'completed',
+      conclusion: 'failure',
+      started_at: '2026-07-18T12:00:00Z',
+    },
+  ];
+  assert.equal(selectLatestCheckRun(runs, 'Required Checks Gatekeeper').id, 2);
+});
+
+test('selectLatestCheckRun returns null when nothing matches', () => {
+  assert.equal(selectLatestCheckRun([{ id: 1, name: 'A' }], 'Missing'), null);
+  assert.equal(selectLatestCheckRun([], 'A'), null);
+  assert.equal(selectLatestCheckRun(undefined, 'A'), null);
+});
+
+test('classifyGatekeeper treats a missing run as missing (keep waiting)', () => {
+  assert.equal(classifyGatekeeper(null).decision, 'missing');
+});
+
+test('classifyGatekeeper treats queued/in_progress as pending (keep waiting)', () => {
+  assert.equal(classifyGatekeeper({ status: 'queued', conclusion: null }).decision, 'pending');
+  assert.equal(classifyGatekeeper({ status: 'in_progress', conclusion: null }).decision, 'pending');
+});
+
+test('classifyGatekeeper passes on completed + allowed conclusion', () => {
+  assert.equal(classifyGatekeeper({ status: 'completed', conclusion: 'success' }).decision, 'pass');
+  assert.equal(classifyGatekeeper({ status: 'completed', conclusion: 'skipped' }).decision, 'pass');
+});
+
+test('classifyGatekeeper fails on completed + disallowed conclusion', () => {
+  for (const conclusion of ['failure', 'cancelled', 'timed_out', 'action_required', 'neutral']) {
+    assert.equal(
+      classifyGatekeeper({ status: 'completed', conclusion }).decision,
+      'fail',
+      conclusion,
+    );
+  }
+});
+
+test('classifyGatekeeper honours a custom allow-list', () => {
+  assert.equal(
+    classifyGatekeeper({ status: 'completed', conclusion: 'skipped' }, ['success']).decision,
+    'fail',
+  );
+  assert.equal(
+    classifyGatekeeper({ status: 'completed', conclusion: 'success' }, ['success']).decision,
+    'pass',
+  );
+});


### PR DESCRIPTION
## Summary

Durably fixes the failing **Deploy — Production** pipeline. No production deploy has succeeded since 2026-07-08 because the `verify-ci-green` gate hard-fails on commits whose CI actually passed, leaving merged fixes stranded on staging.

## Root cause

`deploy-production.yml` job `verify-ci-green` (`Verify CI green on SHA`) used `lewagon/wait-on-check-action` to wait for the `Required Checks Gatekeeper` check-run on the deploy SHA, failing with `The requested check was never run against this ref, exiting...` (e.g. [run 28964869728](https://github.com/jrmoulckers/finance/actions/runs/28964869728)).

The gatekeeper job (in `ci-security.yml`) declares `needs: [codeql-java-kotlin, codeql-javascript, dependency-review, secret-scanning, gitleaks, npm-audit, gradle-dependency-check, license-check]`. **In GitHub Actions a job's check-run is not created until its `needs` complete**, so the gatekeeper check-run does not exist on the SHA for the ~20-30 min CodeQL/security jobs run. `Deploy — Staging` finishes quickly and triggers `Promote to Production` -> `deploy-production` -> `verify-ci-green`, which then looks for a check-run that legitimately will not exist for tens of minutes.

I confirmed against the pinned action source (`v1.8.1`) that `checks-discovery-timeout` **is** a supported input, but the `wait_for_check_discovery` loop only waits `discovery_timeout` seconds before raising `CheckNeverRunError`. Even 600s cannot outlast CodeQL, and the job's own `timeout-minutes: 30` bounded everything — so no fixed discovery window is a durable fix.

## Changes

- **New `tools/verify-required-checks.mjs`** — polls the check-runs REST API for the deploy SHA and fails **closed**:
  - **pass** — gatekeeper completed with an allowed conclusion (`success`/`skipped`)
  - **fail** (immediate) — gatekeeper completed with a real failure (`failure`/`cancelled`/`timed_out`/...)
  - **wait** — gatekeeper missing/queued/in_progress (it is created late by design) — keep polling
  - **deadline with no pass** — exit 1, never deploying an ungated SHA; distinguishes `never seen` vs `never completed`
- **`deploy-production.yml`** — `verify-ci-green` now sparse-checks-out the tool at the deploy SHA, sets up Node 22, and runs the poller (1500s budget). Job `timeout-minutes` raised 30 -> 40 so the poll window comfortably outlasts CodeQL; `actions: read` granted; least-privilege job `permissions` added.
- **Tests** — `tools/verify-required-checks.test.mjs` (`node --test`, 7 cases) plus a `--self-test` mode; `tools/README.md` documents the tool.

Security intent preserved: production still never deploys a SHA whose `Required Checks Gatekeeper` did not actually pass. The required check name is unchanged, so no branch-protection changes are needed.

## Testing

- `node tools/verify-required-checks.mjs --self-test` — passes
- `node --test tools/verify-required-checks.test.mjs` — 7/7 pass
- `npx eslint tools/verify-required-checks*.mjs --max-warnings 0` — clean
- `npx prettier --check` on all changed files — clean
- `deploy-production.yml` parses as valid YAML

## Issues

Closes #3915

## Needs Human Action

- The fix is validated by static review + unit tests only. **Deployment triggers are human-gated** (AGENTS.md Category 3), so I did not trigger a live production promotion. To fully confirm end-to-end, a human should run a `workflow_dispatch` of **Deploy — Production** (or let the next staging deploy auto-promote) and verify the `Verify CI green on SHA` job now passes.
- No branch-protection/settings change is required.