### PR TITLE
fix(web): honor local-only mode in ProtectedRoute and RootRedirect (#3916)

### DIFF
--- a/apps/web/src/auth/auth-context.test.tsx
+++ b/apps/web/src/auth/auth-context.test.tsx
@@ -13,10 +13,12 @@ import {
   isServiceUnavailableStatus,
   oauthProviderUnavailableMessage,
   parseBetaAllowedEmails,
+  ProtectedRoute,
   useAuth,
   type AuthProviderConfig,
 } from './auth-context';
 import { clearTokens } from './token-storage';
+import { setLocalOnlyMode } from '../lib/local-only-mode';
 
 const LAST_USER_STORAGE_KEY = 'finance.lastUser';
 
@@ -692,5 +694,64 @@ describe('loginWithOAuth keeps users in-app on a failed start (#3109)', () => {
     );
     expect(assignMock).not.toHaveBeenCalled();
     expect(screen.getByTestId('loading-state')).toHaveTextContent('ready');
+  });
+});
+
+describe('ProtectedRoute honors local-only mode (#3916)', () => {
+  const config: AuthProviderConfig = {
+    supabaseUrl: 'https://finance-test.supabase.co',
+    supabaseAnonKey: 'anon-key',
+    loginEndpoint: '/api/auth/login',
+    refreshEndpoint: '/api/auth/refresh',
+    logoutEndpoint: '/api/auth/logout',
+    signupEndpoint: '/api/auth/signup',
+  };
+
+  beforeEach(() => {
+    clearTokens();
+    localStorage.clear();
+    // No valid session — the AuthProvider settles as anonymous.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ error: 'no session' }, 401)));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearTokens();
+    localStorage.clear();
+  });
+
+  async function renderProtected(onUnauthenticated: () => void) {
+    render(
+      <AuthProvider config={config}>
+        <ProtectedRoute
+          fallback={<span data-testid="fallback">loading</span>}
+          onUnauthenticated={onUnauthenticated}
+        >
+          <span data-testid="protected">secret dashboard</span>
+        </ProtectedRoute>
+      </AuthProvider>,
+    );
+    // Wait for the provider to finish initializing (fallback disappears).
+    await waitFor(() => expect(screen.queryByTestId('fallback')).not.toBeInTheDocument());
+  }
+
+  it('renders children for an unauthenticated user when local-only mode is active', async () => {
+    setLocalOnlyMode(true);
+    const onUnauthenticated = vi.fn();
+
+    await renderProtected(onUnauthenticated);
+
+    expect(screen.getByTestId('protected')).toBeInTheDocument();
+    expect(onUnauthenticated).not.toHaveBeenCalled();
+  });
+
+  it('redirects an unauthenticated user to login when local-only mode is off', async () => {
+    setLocalOnlyMode(false);
+    const onUnauthenticated = vi.fn();
+
+    await renderProtected(onUnauthenticated);
+
+    expect(screen.queryByTestId('protected')).not.toBeInTheDocument();
+    await waitFor(() => expect(onUnauthenticated).toHaveBeenCalledOnce());
   });
 });

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -61,6 +61,7 @@ import { getPasskeyErrorMessage, PASSKEY_UNAVAILABLE_MESSAGE } from './passkey-e
 import { appendSecurityAuditEvent } from '../lib/security-audit-log';
 import { getStepUpStatus, markStepUpAuthenticated } from '../lib/session-security';
 import { isUnauthenticatedSafeRoute } from '../lib/auth/pre-auth-routes';
+import { isLocalOnlyMode } from '../lib/local-only-mode';
 import '../styles/auth.css';
 
 import {
@@ -1157,11 +1158,17 @@ interface ProtectedRouteProps {
 }
 
 /**
- * ProtectedRoute — renders children only when authenticated.
+ * ProtectedRoute — renders children only when authorized.
+ *
+ * A user is authorized when they are authenticated **or** when local-only
+ * mode is active. Local-only users intentionally have no account and never
+ * authenticate, yet the app promises them full access to the local
+ * experience (see `local-only-mode.ts`), so they must be treated as a
+ * first-class authorized state — not bounced to `/login`.
  *
  * While auth state is loading, renders the `fallback` (or nothing).
- * When the user is not authenticated, calls `onUnauthenticated` and
- * renders nothing.
+ * When the user is neither authenticated nor in local-only mode, calls
+ * `onUnauthenticated` and renders nothing.
  *
  * @example
  * ```tsx
@@ -1179,18 +1186,21 @@ export function ProtectedRoute({
   onUnauthenticated,
 }: ProtectedRouteProps) {
   const { isAuthenticated, isInitializing } = useAuth();
+  // Local-only users have no account by design but are fully authorized to
+  // use the local app, so they must not be redirected to `/login`.
+  const isAuthorized = isAuthenticated || isLocalOnlyMode();
 
   useEffect(() => {
-    if (!isInitializing && !isAuthenticated) {
+    if (!isInitializing && !isAuthorized) {
       onUnauthenticated?.();
     }
-  }, [isAuthenticated, isInitializing, onUnauthenticated]);
+  }, [isAuthorized, isInitializing, onUnauthenticated]);
 
   if (isInitializing) {
     return <>{fallback}</>;
   }
 
-  if (!isAuthenticated) {
+  if (!isAuthorized) {
     return null;
   }
 

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -6,6 +6,7 @@ import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 
 import { ProtectedRoute, useAuth } from './auth/auth-context';
 import { RouteErrorBoundary } from './components/common';
+import { isLocalOnlyMode } from './lib/local-only-mode';
 import './styles/route-loader.css';
 
 /*
@@ -146,7 +147,10 @@ const RootRedirect: FC = () => {
     return <PageLoader />;
   }
 
-  return <Navigate to={isAuthenticated ? '/dashboard' : '/login'} replace />;
+  // Local-only users are authorized for the app without an account, so send
+  // them into the app rather than to /login (mirrors ProtectedRoute).
+  const destination = isAuthenticated || isLocalOnlyMode() ? '/dashboard' : '/login';
+  return <Navigate to={destination} replace />;
 };
 
 /**


### PR DESCRIPTION
## Summary

Choosing **"Local Only"** during onboarding still forced the user into sign-in — after finishing the local-only path they were hard-redirected to `/login` and could not use the app without an account, directly contradicting the Choose step's promise ("No account needed. No data ever leaves your browser.").

The root cause: `/dashboard` and all app routes are gated by `ProtectedRoute`, which decided purely on `isAuthenticated` and had no awareness of local-only mode. A local-only user (intentionally no account, never authenticates) was treated as unauthenticated and bounced to `/login`. `RootRedirect` had the same gap.

## Changes

- `apps/web/src/auth/auth-context.tsx` — `ProtectedRoute` now treats `isAuthenticated || isLocalOnlyMode()` as authorized, rendering children instead of redirecting local-only users to `/login`. Imports the pure `isLocalOnlyMode()` from `lib/local-only-mode` (no provider coupling / circular deps).
- `apps/web/src/routes.tsx` — `RootRedirect` sends local-only + onboarding-complete users to `/dashboard` instead of `/login`, mirroring `ProtectedRoute`.
- `apps/web/src/auth/auth-context.test.tsx` — new `ProtectedRoute` coverage: unauthenticated + local-only renders children (no redirect); unauthenticated + non-local-only still redirects to `/login`.

## Behavior preserved

- Genuinely-unauthenticated, non-local-only users are **still** redirected to `/login`.
- Authenticated account users are unaffected.
- Account-only features (Cloud Sync, Household Sharing, Automatic Backups) remain gated per `FEATURE_AVAILABILITY` — this only lets local-only users reach and use the local app.
- The later "create an account" upgrade path (disableLocalOnly) is unaffected.

## Issues

Closes #3916

## Testing

- [x] `npm --prefix apps/web run test -- src/auth/auth-context.test.tsx --run` — 34 passed (incl. 2 new)
- [x] `npm --prefix apps/web run test -- src/pages/OnboardingPage.test.tsx src/AppBrowserRouter.test.tsx --run` — 40 passed
- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean
