### PR TITLE
fix(ci): wire GitHub Pages deploy to real backend secrets (#3936)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -13,9 +13,12 @@
 # Build env:
 #   - PUBLIC_BASE_PATH=/finance/  -> vite base + router basename for the
 #     project-pages subpath (https://<owner>.github.io/finance/).
-#   - VITE_SUPABASE_URL / _ANON_KEY: use repo secrets if present (backend-
-#     connected), otherwise a `placeholder` URL that activates local-first /
-#     demo mode so the app still works.
+#   - VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY: mapped from the SUPABASE_URL /
+#     SUPABASE_ANON_KEY repo secrets when present (backend-connected). When the
+#     secrets are absent (e.g. forks) a `placeholder` URL activates local-first /
+#     demo mode so the app still builds and works.
+#   - VITE_POWERSYNC_URL: mapped from the POWERSYNC_URL repo secret to enable
+#     live sync; unset -> local-first only.
 # =============================================================================
 
 name: Deploy — Web (Pages)
@@ -61,8 +64,9 @@ jobs:
       - name: Build web app (Pages subpath)
         env:
           PUBLIC_BASE_PATH: /finance/
-          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'https://placeholder.supabase.co' }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+          VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
         run: npm run build -w apps/web
 
       - name: SPA fallback + Pages hygiene


### PR DESCRIPTION
﻿## Summary

The public web app on GitHub Pages (`https://jrmoulckers.github.io/finance/`) was permanently stuck in **demo / local-first mode** because `deploy-pages.yml` referenced secrets that do not exist: `secrets.VITE_SUPABASE_URL` and `secrets.VITE_SUPABASE_ANON_KEY`. The real repo secrets are `SUPABASE_URL` / `SUPABASE_ANON_KEY` / `POWERSYNC_URL` (no `VITE_` prefix), and every other deploy workflow maps them correctly. With the wrong names, the build always fell back to the `placeholder` Supabase URL, so `isDemoMode()` stayed true and the PowerSync URL was never passed.

## Changes

- Map `secrets.SUPABASE_URL` -> `VITE_SUPABASE_URL` and `secrets.SUPABASE_ANON_KEY` -> `VITE_SUPABASE_ANON_KEY` in the Pages build step.
- Add `VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}` so the deployed app can connect to live sync.
- Retain the `placeholder` fallback so forks without secrets still build in demo mode.
- Update the workflow header comment to document the real secret names.

## Issues

Closes #3936
Refs #3935

## Testing

- [x] `npx prettier --check` on the workflow file — clean
- [x] `npm run format:check` (repo-wide) — clean
- [ ] Post-merge: confirm the Pages deploy embeds the real backend URL (app exits demo mode) once secrets resolve



---

### CI note — npm Audit (admin override)

The Required Checks Gatekeeper / Security Summary are red **solely** because of `npm Audit`, which fails **identically on `main`** — pre-existing high-severity transitive advisories in `@changesets/cli` deps (`brace-expansion`, `fast-uri`, `js-yaml`). This PR is a **YAML-only workflow change**: it adds no dependencies and does not touch `package-lock.json`. All other required security checks pass (CodeQL js + jvm, Dependency Review, TruffleHog, gitleaks, Gradle Dependency Check, License Compliance). Merging with `--admin` per the documented pre-existing-override policy. A dedicated `@devops` dependency-remediation PR (breaking `@changesets/cli` major bump) is tracked separately to make the gate legitimately green.
