### PR TITLE
feat(web): real PowerSync client foundation (#3941)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -22,7 +22,15 @@
 # VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 
 # PowerSync Configuration (offline-first sync engine)
+# URL of the PowerSync sync service (self-hosted: https://finance.jrmoulckers.com/sync).
 VITE_POWERSYNC_URL=https://your-powersync-instance.powersync.com
+#
+# Live PowerSync client feature flag. Leave unset/false to keep the real
+# PowerSync client fully inert (the browser-only @powersync/web bundle is then
+# tree-shaken out of the build). Set to "true" — together with VITE_POWERSYNC_URL,
+# VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY — to connect the app to live,
+# syncing data from the backend instead of local file imports.
+# VITE_POWERSYNC_ENABLED=false
 
 # Auth Endpoints
 VITE_LOGIN_ENDPOINT=/api/auth/login

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,9 @@
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.331",
+    "@journeyapps/wa-sqlite": "^1.7.2",
+    "@powersync/common": "^2.0.0",
+    "@powersync/web": "^2.0.0",
     "@sentry/react": "^10.63.0",
     "d3": "^7.9.0",
     "lucide-react": "^1.23.0",

--- a/apps/web/src/db/sync/powersync/__tests__/config.test.ts
+++ b/apps/web/src/db/sync/powersync/__tests__/config.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  isPowerSyncClientConfigured,
+  postgrestBaseUrl,
+  resolvePowerSyncClientConfig,
+} from '../config';
+
+function stubEnv(values: Record<string, string>): void {
+  for (const [key, value] of Object.entries(values)) {
+    vi.stubEnv(key, value);
+  }
+}
+
+describe('powersync config', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('resolves all four backend coordinates from the environment', () => {
+    stubEnv({
+      VITE_POWERSYNC_URL: 'https://finance.jrmoulckers.com/sync',
+      VITE_SUPABASE_URL: 'https://finance.jrmoulckers.com',
+      VITE_SUPABASE_ANON_KEY: 'anon-key',
+      VITE_POWERSYNC_ENABLED: 'true',
+    });
+
+    const config = resolvePowerSyncClientConfig();
+
+    expect(config).toEqual({
+      powersyncUrl: 'https://finance.jrmoulckers.com/sync',
+      supabaseUrl: 'https://finance.jrmoulckers.com',
+      supabaseAnonKey: 'anon-key',
+      enabled: true,
+    });
+  });
+
+  it('treats a missing enabled flag as disabled', () => {
+    stubEnv({
+      VITE_POWERSYNC_URL: 'https://finance.jrmoulckers.com/sync',
+      VITE_SUPABASE_URL: 'https://finance.jrmoulckers.com',
+      VITE_SUPABASE_ANON_KEY: 'anon-key',
+    });
+
+    expect(resolvePowerSyncClientConfig().enabled).toBe(false);
+    expect(isPowerSyncClientConfigured()).toBe(false);
+  });
+
+  it('is configured only when enabled and all coordinates are present', () => {
+    const base = {
+      powersyncUrl: 'https://finance.jrmoulckers.com/sync',
+      supabaseUrl: 'https://finance.jrmoulckers.com',
+      supabaseAnonKey: 'anon-key',
+      enabled: true,
+    };
+
+    expect(isPowerSyncClientConfigured(base)).toBe(true);
+    expect(isPowerSyncClientConfigured({ ...base, enabled: false })).toBe(false);
+    expect(isPowerSyncClientConfigured({ ...base, powersyncUrl: '' })).toBe(false);
+    expect(isPowerSyncClientConfigured({ ...base, supabaseUrl: '' })).toBe(false);
+    expect(isPowerSyncClientConfigured({ ...base, supabaseAnonKey: '' })).toBe(false);
+  });
+
+  it('builds the PostgREST base URL, tolerating a trailing slash', () => {
+    expect(
+      postgrestBaseUrl({
+        powersyncUrl: '',
+        supabaseUrl: 'https://finance.jrmoulckers.com',
+        supabaseAnonKey: '',
+        enabled: true,
+      }),
+    ).toBe('https://finance.jrmoulckers.com/rest/v1');
+
+    expect(
+      postgrestBaseUrl({
+        powersyncUrl: '',
+        supabaseUrl: 'https://finance.jrmoulckers.com/',
+        supabaseAnonKey: '',
+        enabled: true,
+      }),
+    ).toBe('https://finance.jrmoulckers.com/rest/v1');
+  });
+});

--- a/apps/web/src/db/sync/powersync/__tests__/connector.test.ts
+++ b/apps/web/src/db/sync/powersync/__tests__/connector.test.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it, vi } from 'vitest';
+import { UpdateType, type CommonPowerSyncDatabase, type CrudEntry } from '@powersync/common';
+
+import { SupabaseConnector } from '../connector';
+import type { PowerSyncClientConfig } from '../config';
+
+const CONFIG: PowerSyncClientConfig = {
+  powersyncUrl: 'https://finance.jrmoulckers.com/sync',
+  supabaseUrl: 'https://finance.jrmoulckers.com',
+  supabaseAnonKey: 'anon-key',
+  enabled: true,
+};
+
+/** Build an OK fetch mock returning a minimal `Response`. */
+function okFetch() {
+  return vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(() =>
+    Promise.resolve({ ok: true, status: 200, text: async () => '' } as unknown as Response),
+  );
+}
+
+/** Wrap CRUD entries in a fake transaction with a spied `complete`. */
+function fakeDatabase(crud: CrudEntry[]) {
+  const complete = vi.fn(async () => {});
+  const database = {
+    getNextCrudTransaction: async () => (crud.length > 0 ? { crud, complete } : null),
+  } as unknown as CommonPowerSyncDatabase;
+  return { database, complete };
+}
+
+function entry(partial: Pick<CrudEntry, 'op' | 'id' | 'table'> & Partial<CrudEntry>): CrudEntry {
+  return partial as CrudEntry;
+}
+
+describe('SupabaseConnector', () => {
+  describe('fetchCredentials', () => {
+    it('returns the sync endpoint and the current access token', async () => {
+      const connector = new SupabaseConnector(CONFIG, { getToken: async () => 'jwt-token' });
+
+      await expect(connector.fetchCredentials()).resolves.toEqual({
+        endpoint: 'https://finance.jrmoulckers.com/sync',
+        token: 'jwt-token',
+      });
+    });
+
+    it('returns null when the user is not authenticated', async () => {
+      const connector = new SupabaseConnector(CONFIG, { getToken: async () => null });
+
+      await expect(connector.fetchCredentials()).resolves.toBeNull();
+    });
+  });
+
+  describe('uploadData', () => {
+    it('maps PUT/PATCH/DELETE ops to the correct PostgREST requests', async () => {
+      const fetchFn = okFetch();
+      const { database, complete } = fakeDatabase([
+        entry({ op: UpdateType.PUT, id: '1', table: 'accounts', opData: { name: 'Checking' } }),
+        entry({
+          op: UpdateType.PATCH,
+          id: '2',
+          table: 'transactions',
+          opData: { amount_cents: 500 },
+        }),
+        entry({ op: UpdateType.DELETE, id: '3', table: 'goals' }),
+      ]);
+      const connector = new SupabaseConnector(CONFIG, {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        getToken: async () => 'jwt-token',
+      });
+
+      await connector.uploadData(database);
+
+      expect(fetchFn).toHaveBeenCalledTimes(3);
+
+      const [putUrl, putInit] = fetchFn.mock.calls[0];
+      expect(putUrl).toBe('https://finance.jrmoulckers.com/rest/v1/accounts');
+      expect(putInit?.method).toBe('POST');
+      expect(putInit?.body).toBe(JSON.stringify({ id: '1', name: 'Checking' }));
+      const putHeaders = putInit?.headers as Record<string, string>;
+      expect(putHeaders.apikey).toBe('anon-key');
+      expect(putHeaders.Authorization).toBe('Bearer jwt-token');
+      expect(putHeaders.Prefer).toBe('resolution=merge-duplicates');
+
+      const [patchUrl, patchInit] = fetchFn.mock.calls[1];
+      expect(patchUrl).toBe('https://finance.jrmoulckers.com/rest/v1/transactions?id=eq.2');
+      expect(patchInit?.method).toBe('PATCH');
+      expect(patchInit?.body).toBe(JSON.stringify({ amount_cents: 500 }));
+
+      const [deleteUrl, deleteInit] = fetchFn.mock.calls[2];
+      expect(deleteUrl).toBe('https://finance.jrmoulckers.com/rest/v1/goals?id=eq.3');
+      expect(deleteInit?.method).toBe('DELETE');
+
+      expect(complete).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing when there is no queued transaction', async () => {
+      const fetchFn = okFetch();
+      const { database } = fakeDatabase([]);
+      const connector = new SupabaseConnector(CONFIG, {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        getToken: async () => 'jwt-token',
+      });
+
+      await connector.uploadData(database);
+
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it('throws without completing when no access token is available', async () => {
+      const fetchFn = okFetch();
+      const { database, complete } = fakeDatabase([
+        entry({ op: UpdateType.PUT, id: '1', table: 'accounts', opData: { name: 'Checking' } }),
+      ]);
+      const connector = new SupabaseConnector(CONFIG, {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        getToken: async () => null,
+      });
+
+      await expect(connector.uploadData(database)).rejects.toThrow(/no access token/i);
+      expect(fetchFn).not.toHaveBeenCalled();
+      expect(complete).not.toHaveBeenCalled();
+    });
+
+    it('throws (for retry) when PostgREST rejects the write', async () => {
+      const fetchFn = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+        () =>
+          Promise.resolve({
+            ok: false,
+            status: 409,
+            text: async () => 'conflict',
+          } as unknown as Response),
+      );
+      const { database, complete } = fakeDatabase([
+        entry({ op: UpdateType.PUT, id: '1', table: 'accounts', opData: { name: 'Checking' } }),
+      ]);
+      const connector = new SupabaseConnector(CONFIG, {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        getToken: async () => 'jwt-token',
+      });
+
+      await expect(connector.uploadData(database)).rejects.toThrow(/HTTP 409/);
+      expect(complete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/db/sync/powersync/__tests__/schema.test.ts
+++ b/apps/web/src/db/sync/powersync/__tests__/schema.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { AppSchema, SYNCED_TABLE_NAMES } from '../schema';
+
+/** Look up a resolved table by its synced name. */
+function table(name: string) {
+  const found = AppSchema.tables.find((candidate) => candidate.name === name);
+  if (!found) {
+    throw new Error(`table ${name} missing from AppSchema`);
+  }
+  return found;
+}
+
+/** Column type (TEXT/INTEGER/REAL) for a named column on a table. */
+function columnType(tableName: string, columnName: string): string | undefined {
+  return table(tableName).columns.find((column) => column.name === columnName)?.type;
+}
+
+describe('AppSchema', () => {
+  it('mirrors every table declared in the canonical sync rules', () => {
+    // Three buckets: by_household + user_profile + exchange_rates = 29 tables.
+    expect(SYNCED_TABLE_NAMES).toHaveLength(29);
+
+    for (const name of [
+      'accounts',
+      'transactions',
+      'categories',
+      'budgets',
+      'goals',
+      'households',
+      'household_members',
+      'recurring_transaction_templates',
+      'detected_bills',
+      'investment_holdings',
+      'users',
+      'passkey_credentials',
+      'exchange_rates',
+      'price_history',
+      'aggregator_providers',
+    ]) {
+      expect(SYNCED_TABLE_NAMES).toContain(name);
+    }
+  });
+
+  it('uses plural, canonical table names (not the divergent legacy singulars)', () => {
+    expect(SYNCED_TABLE_NAMES).toContain('accounts');
+    expect(SYNCED_TABLE_NAMES).not.toContain('account');
+    expect(SYNCED_TABLE_NAMES).not.toContain('transaction');
+  });
+
+  it('never declares an explicit id column (PowerSync manages the implicit PK)', () => {
+    for (const resolved of AppSchema.tables) {
+      expect(resolved.columns.some((column) => column.name === 'id')).toBe(false);
+    }
+  });
+
+  it('models monetary columns as integer cents', () => {
+    expect(columnType('accounts', 'balance_cents')).toBe('INTEGER');
+    expect(columnType('transactions', 'amount_cents')).toBe('INTEGER');
+    expect(columnType('budgets', 'amount_cents')).toBe('INTEGER');
+    expect(columnType('goals', 'target_cents')).toBe('INTEGER');
+    expect(columnType('goals', 'current_cents')).toBe('INTEGER');
+  });
+
+  it('models booleans as integers and free-form text as text', () => {
+    expect(columnType('accounts', 'is_active')).toBe('INTEGER');
+    expect(columnType('transactions', 'is_recurring')).toBe('INTEGER');
+    expect(columnType('accounts', 'currency_code')).toBe('TEXT');
+    expect(columnType('accounts', 'owner_id')).toBe('TEXT');
+    expect(columnType('transactions', 'household_id')).toBe('TEXT');
+  });
+
+  it('models genuinely fractional values as real', () => {
+    expect(columnType('detected_bills', 'confidence_score')).toBe('REAL');
+    expect(columnType('aggregator_providers', 'health_score')).toBe('REAL');
+  });
+
+  it('carries the schema-alignment columns added for canonical parity', () => {
+    expect(columnType('transactions', 'transfer_transaction_id')).toBe('TEXT');
+    expect(columnType('transactions', 'recurring_rule_id')).toBe('TEXT');
+    expect(columnType('budgets', 'is_rollover')).toBe('INTEGER');
+    expect(columnType('goals', 'account_id')).toBe('TEXT');
+    expect(columnType('goals', 'status')).toBe('TEXT');
+  });
+});

--- a/apps/web/src/db/sync/powersync/config.ts
+++ b/apps/web/src/db/sync/powersync/config.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Environment-derived configuration for the live PowerSync client.
+ *
+ * These values point the web client at the self-hosted Supabase + PowerSync
+ * backend (`finance.jrmoulckers.com`). They are injected at build time by Vite
+ * from `VITE_*` variables (see `.env.example` and the deploy workflows).
+ *
+ * The client stays completely inert unless `VITE_POWERSYNC_ENABLED === 'true'`.
+ * This lets the real sync path land behind a flag while the data layer is
+ * migrated onto it, without changing the behavior of the shipped app.
+ */
+
+/** Resolved PowerSync client configuration. */
+export interface PowerSyncClientConfig {
+  /** PowerSync sync-service URL, e.g. `https://finance.jrmoulckers.com/sync`. */
+  readonly powersyncUrl: string;
+  /** Supabase project URL, e.g. `https://finance.jrmoulckers.com`. */
+  readonly supabaseUrl: string;
+  /** Supabase anon/public key (used as the PostgREST `apikey`). */
+  readonly supabaseAnonKey: string;
+  /** Whether the live PowerSync client is enabled (feature flag). */
+  readonly enabled: boolean;
+}
+
+/** Read a trimmed Vite env var, returning an empty string when unset. */
+function readEnv(name: string): string {
+  const meta = import.meta as unknown as { env?: Record<string, string | undefined> };
+  return meta.env?.[name]?.trim() ?? '';
+}
+
+/** Resolve the PowerSync client configuration from the Vite environment. */
+export function resolvePowerSyncClientConfig(): PowerSyncClientConfig {
+  return {
+    powersyncUrl: readEnv('VITE_POWERSYNC_URL'),
+    supabaseUrl: readEnv('VITE_SUPABASE_URL'),
+    supabaseAnonKey: readEnv('VITE_SUPABASE_ANON_KEY'),
+    enabled: readEnv('VITE_POWERSYNC_ENABLED') === 'true',
+  };
+}
+
+/**
+ * Whether the client is both enabled and fully configured.
+ *
+ * Requires the feature flag plus all three backend coordinates. A missing URL
+ * or key means the client must not attempt to connect.
+ */
+export function isPowerSyncClientConfigured(
+  config: PowerSyncClientConfig = resolvePowerSyncClientConfig(),
+): boolean {
+  return (
+    config.enabled &&
+    config.powersyncUrl.length > 0 &&
+    config.supabaseUrl.length > 0 &&
+    config.supabaseAnonKey.length > 0
+  );
+}
+
+/** Build the Supabase PostgREST base URL (`<supabaseUrl>/rest/v1`). */
+export function postgrestBaseUrl(config: PowerSyncClientConfig): string {
+  return `${config.supabaseUrl.replace(/\/+$/, '')}/rest/v1`;
+}

--- a/apps/web/src/db/sync/powersync/connector.ts
+++ b/apps/web/src/db/sync/powersync/connector.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Supabase backend connector for the live PowerSync client.
+ *
+ * Bridges PowerSync to the self-hosted Supabase backend:
+ *
+ *   - `fetchCredentials()` returns the PowerSync sync-service endpoint plus the
+ *     current Supabase access token. The token is read from the in-memory
+ *     token store (`auth/token-storage.ts`) — the app authenticates against
+ *     GoTrue with a custom, cookie-backed flow rather than `@supabase/supabase-js`,
+ *     so there is no Supabase session object to read from.
+ *
+ *   - `uploadData()` drains PowerSync's local write queue one transaction at a
+ *     time and applies each change to Supabase PostgREST. Deletes in the app are
+ *     modelled as soft-deletes (`UPDATE ... SET deleted_at = ...`), which reach
+ *     PowerSync as PATCH ops; a genuine DELETE op is mapped to a PostgREST
+ *     row delete for completeness.
+ *
+ * References: sync-rules.yaml, issues #3941 / #3935.
+ */
+
+import {
+  UpdateType,
+  type CommonPowerSyncDatabase,
+  type CrudEntry,
+  type PowerSyncBackendConnector,
+  type PowerSyncCredentials,
+} from '@powersync/common';
+
+import { getAccessToken } from '../../../auth/token-storage';
+import { postgrestBaseUrl, type PowerSyncClientConfig } from './config';
+
+/** Injectable collaborators (overridable in tests). */
+export interface SupabaseConnectorOptions {
+  /** Fetch implementation (defaults to the global `fetch`). */
+  readonly fetchFn?: typeof fetch;
+  /** Access-token accessor (defaults to the auth token store). */
+  readonly getToken?: () => Promise<string | null>;
+}
+
+/** Best-effort read of a response body for error diagnostics. */
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 500);
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Connector that authenticates PowerSync with the Supabase JWT and writes local
+ * changes back through PostgREST.
+ */
+export class SupabaseConnector implements PowerSyncBackendConnector {
+  private readonly config: PowerSyncClientConfig;
+  private readonly fetchFn: typeof fetch;
+  private readonly getToken: () => Promise<string | null>;
+
+  constructor(config: PowerSyncClientConfig, options: SupabaseConnectorOptions = {}) {
+    this.config = config;
+    // Wrap rather than reference `fetch` directly so construction never throws
+    // in environments where the global is absent until call time.
+    this.fetchFn = options.fetchFn ?? ((input, init) => fetch(input, init));
+    this.getToken = options.getToken ?? getAccessToken;
+  }
+
+  /**
+   * Return fresh credentials for the PowerSync sync service, or `null` when the
+   * user is not authenticated (PowerSync then stays disconnected).
+   */
+  async fetchCredentials(): Promise<PowerSyncCredentials | null> {
+    const token = await this.getToken();
+    if (!token) {
+      return null;
+    }
+    return { endpoint: this.config.powersyncUrl, token };
+  }
+
+  /**
+   * Upload the next queued local transaction to Supabase. Throwing on failure
+   * leaves the batch queued so PowerSync retries after its backoff period.
+   */
+  async uploadData(database: CommonPowerSyncDatabase): Promise<void> {
+    const transaction = await database.getNextCrudTransaction();
+    if (!transaction) {
+      return;
+    }
+
+    const token = await this.getToken();
+    if (!token) {
+      // Leave the batch queued; a reconnect with a valid token will retry it.
+      throw new Error('PowerSync upload deferred: no access token available.');
+    }
+
+    for (const op of transaction.crud) {
+      await this.applyOp(op, token);
+    }
+
+    await transaction.complete();
+  }
+
+  /** Apply a single CRUD op to Supabase PostgREST. */
+  private async applyOp(op: CrudEntry, token: string): Promise<void> {
+    const base = postgrestBaseUrl(this.config);
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      apikey: this.config.supabaseAnonKey,
+      Authorization: `Bearer ${token}`,
+    };
+    const rowFilter = `${base}/${op.table}?id=eq.${encodeURIComponent(op.id)}`;
+
+    let response: Response;
+    switch (op.op) {
+      case UpdateType.PUT:
+        response = await this.fetchFn(`${base}/${op.table}`, {
+          method: 'POST',
+          headers: { ...headers, Prefer: 'resolution=merge-duplicates' },
+          body: JSON.stringify({ id: op.id, ...(op.opData ?? {}) }),
+        });
+        break;
+      case UpdateType.PATCH:
+        response = await this.fetchFn(rowFilter, {
+          method: 'PATCH',
+          headers,
+          body: JSON.stringify(op.opData ?? {}),
+        });
+        break;
+      case UpdateType.DELETE:
+        response = await this.fetchFn(rowFilter, { method: 'DELETE', headers });
+        break;
+      default:
+        return;
+    }
+
+    if (!response.ok) {
+      const detail = await safeReadText(response);
+      throw new Error(
+        `PowerSync upload failed (${op.op} ${op.table} ${op.id}): HTTP ${response.status} ${detail}`.trim(),
+      );
+    }
+  }
+}

--- a/apps/web/src/db/sync/powersync/database.ts
+++ b/apps/web/src/db/sync/powersync/database.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Lifecycle management for the live PowerSync database (browser-only).
+ *
+ * This is the ONLY module that touches the browser-only `@powersync/web`
+ * package, and it does so exclusively through a guarded dynamic `import()`.
+ * Each entry point begins with a literal
+ * `import.meta.env.VITE_POWERSYNC_ENABLED !== 'true'` guard so that, in the
+ * default build (the flag is unset in the deploy workflows), the guard folds to
+ * an unconditional early return and the bundler drops `@powersync/web`,
+ * `@powersync/common`, and the wa-sqlite WASM from the shipped bundle.
+ *
+ * When the flag is enabled at runtime the modules are loaded lazily on demand.
+ *
+ * References: sync-rules.yaml, issues #3941 / #3935.
+ */
+
+import type { AbstractPowerSyncDatabase } from '@powersync/common';
+
+import { isPowerSyncClientConfigured, resolvePowerSyncClientConfig } from './config';
+
+/** Local database filename for the PowerSync-managed SQLite store. */
+const DB_FILENAME = 'finance.db';
+
+/** Singleton instance, created lazily on first use. */
+let databasePromise: Promise<AbstractPowerSyncDatabase | null> | null = null;
+
+/** Runtime check for whether the live PowerSync client is enabled. */
+export function isPowerSyncEnabled(): boolean {
+  return import.meta.env.VITE_POWERSYNC_ENABLED === 'true';
+}
+
+/**
+ * Get (creating on first call) the live PowerSync database instance, or `null`
+ * when the client is disabled or not fully configured.
+ */
+export async function getPowerSyncDatabase(): Promise<AbstractPowerSyncDatabase | null> {
+  if (import.meta.env.VITE_POWERSYNC_ENABLED !== 'true') {
+    return null;
+  }
+  if (!isPowerSyncClientConfigured()) {
+    return null;
+  }
+  if (!databasePromise) {
+    databasePromise = (async () => {
+      const { PowerSyncDatabase } = await import('@powersync/web');
+      const { AppSchema } = await import('./schema');
+      return new PowerSyncDatabase({
+        schema: AppSchema,
+        database: { dbFilename: DB_FILENAME },
+      });
+    })();
+  }
+  return databasePromise;
+}
+
+/**
+ * Connect the live PowerSync database to the Supabase backend. Returns the
+ * connected database, or `null` when the client is disabled/unconfigured.
+ */
+export async function connectPowerSync(): Promise<AbstractPowerSyncDatabase | null> {
+  if (import.meta.env.VITE_POWERSYNC_ENABLED !== 'true') {
+    return null;
+  }
+  const database = await getPowerSyncDatabase();
+  if (!database) {
+    return null;
+  }
+  const config = resolvePowerSyncClientConfig();
+  const { SupabaseConnector } = await import('./connector');
+  await database.connect(new SupabaseConnector(config));
+  return database;
+}
+
+/** Disconnect the live PowerSync database if it exists (leaves data intact). */
+export async function disconnectPowerSync(): Promise<void> {
+  if (!databasePromise) {
+    return;
+  }
+  const database = await databasePromise;
+  await database?.disconnect();
+}
+
+/** Disconnect and dispose the live PowerSync database, clearing the singleton. */
+export async function closePowerSync(): Promise<void> {
+  if (!databasePromise) {
+    return;
+  }
+  const database = await databasePromise;
+  databasePromise = null;
+  await database?.close();
+}

--- a/apps/web/src/db/sync/powersync/index.ts
+++ b/apps/web/src/db/sync/powersync/index.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Public surface for the live PowerSync client.
+ *
+ * Only the config helpers and the browser-safe lifecycle functions are
+ * re-exported here. The schema and connector values are intentionally NOT
+ * re-exported so that importing this barrel does not eagerly pull
+ * `@powersync/common` into a consumer's bundle — those are loaded lazily by
+ * `database.ts` (or imported directly by tests).
+ *
+ * References: issues #3941 / #3935.
+ */
+
+export {
+  resolvePowerSyncClientConfig,
+  isPowerSyncClientConfigured,
+  postgrestBaseUrl,
+  type PowerSyncClientConfig,
+} from './config';
+
+export {
+  isPowerSyncEnabled,
+  getPowerSyncDatabase,
+  connectPowerSync,
+  disconnectPowerSync,
+  closePowerSync,
+} from './database';
+
+export type { SupabaseConnectorOptions } from './connector';

--- a/apps/web/src/db/sync/powersync/schema.ts
+++ b/apps/web/src/db/sync/powersync/schema.ts
@@ -1,0 +1,512 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Canonical PowerSync client schema for the Finance web app.
+ *
+ * This is the client-side mirror of `services/api/powersync/sync-rules.yaml`
+ * (the server-side source of truth). Every table below matches a synced table
+ * in the sync rules: plural table names, integer-cents money columns
+ * (`*_cents`), ISO-4217 `currency_code`, and soft-delete `deleted_at`.
+ *
+ * IMPORTANT invariants (keep in lock-step with the sync rules):
+ *   - PowerSync manages an implicit `id TEXT` primary key on every table, so it
+ *     is intentionally omitted from the column lists here.
+ *   - Monetary values are always integer cents (`column.integer`) — never
+ *     floating point. They pair with a `currency_code`.
+ *   - Booleans sync as 0/1 integers.
+ *   - Any column the server allowlists but the client omits here is silently
+ *     dropped on the client, so this list must stay complete.
+ *
+ * References: sync-rules.yaml, issues #3941 / #3935.
+ */
+
+import { Schema, Table, column } from '@powersync/common';
+
+const { text, integer, real } = column;
+
+// ---------------------------------------------------------------------------
+// by_household bucket — data scoped to the households the user belongs to.
+// ---------------------------------------------------------------------------
+
+const households = new Table({
+  name: text,
+  created_by: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const accounts = new Table(
+  {
+    household_id: text,
+    name: text,
+    type: text,
+    currency_code: text,
+    balance_cents: integer,
+    is_active: integer,
+    icon: text,
+    color: text,
+    sort_order: integer,
+    owner_id: text,
+    created_at: text,
+    updated_at: text,
+    deleted_at: text,
+  },
+  { indexes: { by_household: ['household_id'] } },
+);
+
+const transactions = new Table(
+  {
+    household_id: text,
+    account_id: text,
+    category_id: text,
+    amount_cents: integer,
+    currency_code: text,
+    type: text,
+    payee: text,
+    note: text,
+    date: text,
+    is_recurring: integer,
+    transfer_account_id: text,
+    status: text,
+    transfer_transaction_id: text,
+    recurring_rule_id: text,
+    tags: text,
+    is_biometric_protected: integer,
+    owner_id: text,
+    created_at: text,
+    updated_at: text,
+    deleted_at: text,
+  },
+  { indexes: { by_account: ['account_id'], by_date: ['date'] } },
+);
+
+const categories = new Table({
+  household_id: text,
+  name: text,
+  icon: text,
+  color: text,
+  parent_id: text,
+  is_income: integer,
+  is_system: integer,
+  sort_order: integer,
+  is_biometric_protected: integer,
+  owner_id: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const budgets = new Table({
+  household_id: text,
+  category_id: text,
+  name: text,
+  amount_cents: integer,
+  currency_code: text,
+  period: text,
+  start_date: text,
+  end_date: text,
+  is_rollover: integer,
+  owner_id: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const goals = new Table({
+  household_id: text,
+  name: text,
+  target_cents: integer,
+  current_cents: integer,
+  currency_code: text,
+  target_date: text,
+  icon: text,
+  color: text,
+  account_id: text,
+  status: text,
+  owner_id: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const household_members = new Table({
+  household_id: text,
+  user_id: text,
+  role: text,
+  joined_at: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const household_invitations = new Table({
+  household_id: text,
+  invited_by: text,
+  role: text,
+  expires_at: text,
+  accepted_at: text,
+  accepted_by: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const recurring_transaction_templates = new Table({
+  household_id: text,
+  account_id: text,
+  category_id: text,
+  amount_cents: integer,
+  currency_code: text,
+  type: text,
+  payee: text,
+  note: text,
+  frequency: text,
+  day_of_month: integer,
+  day_of_week: integer,
+  start_date: text,
+  end_date: text,
+  last_generated_date: text,
+  next_due_date: text,
+  is_active: integer,
+  owner_id: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const family_plan_subscriptions = new Table({
+  household_id: text,
+  billing_owner_id: text,
+  owner_id: text,
+  plan_type: text,
+  status: text,
+  price_cents: integer,
+  currency_code: text,
+  billing_cycle: text,
+  max_members: integer,
+  current_members: integer,
+  started_at: text,
+  current_period_end: text,
+  canceled_at: text,
+  expires_at: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const report_configs = new Table({
+  household_id: text,
+  owner_id: text,
+  name: text,
+  report_type: text,
+  config: text,
+  last_generated_at: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const detected_bills = new Table({
+  household_id: text,
+  owner_id: text,
+  merchant: text,
+  estimated_amount_cents: integer,
+  currency_code: text,
+  frequency: text,
+  confidence_score: real,
+  last_transaction_date: text,
+  next_expected_date: text,
+  transaction_count: integer,
+  avg_amount_cents: integer,
+  status: text,
+  category_id: text,
+  account_id: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const investment_portfolios = new Table({
+  household_id: text,
+  owner_id: text,
+  name: text,
+  description: text,
+  currency_code: text,
+  is_active: integer,
+  provider: text,
+  last_synced_at: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const investment_holdings = new Table({
+  portfolio_id: text,
+  household_id: text,
+  owner_id: text,
+  ticker_symbol: text,
+  name: text,
+  asset_type: text,
+  quantity_units: integer,
+  quantity_precision: integer,
+  cost_basis_cents: integer,
+  currency_code: text,
+  acquired_date: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const bill_reminders = new Table({
+  household_id: text,
+  owner_id: text,
+  detected_bill_id: text,
+  merchant: text,
+  amount_cents: integer,
+  currency_code: text,
+  frequency: text,
+  next_due_date: text,
+  is_auto_pay: integer,
+  is_active: integer,
+  reminder_days: integer,
+  account_id: text,
+  category_id: text,
+  note: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const report_templates = new Table({
+  household_id: text,
+  owner_id: text,
+  name: text,
+  description: text,
+  report_type: text,
+  template_config: text,
+  is_default: integer,
+  usage_count: integer,
+  last_used_at: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const import_jobs = new Table({
+  household_id: text,
+  owner_id: text,
+  account_id: text,
+  file_name: text,
+  format: text,
+  status: text,
+  total_rows: integer,
+  imported_rows: integer,
+  duplicate_rows: integer,
+  error_rows: integer,
+  source_type: text,
+  duplicate_strategy: text,
+  started_at: text,
+  completed_at: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const bank_connections = new Table({
+  household_id: text,
+  owner_id: text,
+  provider: text,
+  institution_id: text,
+  institution_name: text,
+  status: text,
+  last_synced_at: text,
+  error_code: text,
+  error_message: text,
+  metadata: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const bank_connection_health = new Table({
+  bank_connection_id: text,
+  household_id: text,
+  status: text,
+  error_category: text,
+  error_detail: text,
+  last_successful_sync: text,
+  staleness_minutes: integer,
+  resolved_at: text,
+  resolution_action: text,
+  created_at: text,
+});
+
+const connector_permissions = new Table({
+  bank_connection_id: text,
+  household_id: text,
+  owner_id: text,
+  permission_level: text,
+  granted_scopes: text,
+  scope_descriptions: text,
+  is_revoked: integer,
+  revoked_at: text,
+  token_status: text,
+  token_expires_at: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const connector_access_log = new Table({
+  bank_connection_id: text,
+  household_id: text,
+  access_type: text,
+  provider_name: text,
+  status: text,
+  record_count: integer,
+  duration_ms: integer,
+  created_at: text,
+});
+
+const open_banking_connections = new Table({
+  bank_connection_id: text,
+  household_id: text,
+  owner_id: text,
+  consent_id: text,
+  consent_status: text,
+  consent_expires_at: text,
+  regulation: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+// ---------------------------------------------------------------------------
+// user_profile bucket — per-user data that is not household-scoped.
+// ---------------------------------------------------------------------------
+
+const users = new Table({
+  email: text,
+  display_name: text,
+  avatar_url: text,
+  currency_code: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const passkey_credentials = new Table({
+  user_id: text,
+  credential_id: text,
+  device_type: text,
+  backed_up: integer,
+  transports: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const referrals = new Table({
+  referrer_id: text,
+  referee_id: text,
+  referral_code: text,
+  status: text,
+  reward_type: text,
+  accepted_at: text,
+  expires_at: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const user_consents = new Table({
+  user_id: text,
+  consent_type: text,
+  status: text,
+  policy_version: text,
+  created_at: text,
+});
+
+// ---------------------------------------------------------------------------
+// exchange_rates bucket — global, read-only reference data.
+// ---------------------------------------------------------------------------
+
+const exchange_rates = new Table({
+  base_currency: text,
+  target_currency: text,
+  rate_multiplied: integer,
+  rate_precision: integer,
+  source: text,
+  valid_date: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const price_history = new Table({
+  ticker_symbol: text,
+  close_price_cents: integer,
+  currency_code: text,
+  price_date: text,
+  source: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const aggregator_providers = new Table({
+  name: text,
+  display_name: text,
+  provider_type: text,
+  status: text,
+  health_score: real,
+  priority: integer,
+  is_enabled: integer,
+  supported_regions: text,
+  capabilities: text,
+  last_health_check: text,
+  incident_count: integer,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+/**
+ * The canonical app schema handed to `PowerSyncDatabase`. The object keys are
+ * the synced table names (must match the sync rules exactly).
+ */
+export const AppSchema = new Schema({
+  households,
+  accounts,
+  transactions,
+  categories,
+  budgets,
+  goals,
+  household_members,
+  household_invitations,
+  recurring_transaction_templates,
+  family_plan_subscriptions,
+  report_configs,
+  detected_bills,
+  investment_portfolios,
+  investment_holdings,
+  bill_reminders,
+  report_templates,
+  import_jobs,
+  bank_connections,
+  bank_connection_health,
+  connector_permissions,
+  connector_access_log,
+  open_banking_connections,
+  users,
+  passkey_credentials,
+  referrals,
+  user_consents,
+  exchange_rates,
+  price_history,
+  aggregator_providers,
+});
+
+/** Convenience list of all synced table names in the canonical schema. */
+export const SYNCED_TABLE_NAMES: readonly string[] = AppSchema.tables.map((table) => table.name);

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.331",
+        "@journeyapps/wa-sqlite": "^1.7.2",
+        "@powersync/common": "^2.0.0",
+        "@powersync/web": "^2.0.0",
         "@sentry/react": "^10.63.0",
         "d3": "^7.9.0",
         "lucide-react": "^1.23.0",
@@ -2654,6 +2657,12 @@
         }
       }
     },
+    "node_modules/@journeyapps/wa-sqlite": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@journeyapps/wa-sqlite/-/wa-sqlite-1.7.2.tgz",
+      "integrity": "sha512-EVRMzqHtHgJBFcTGOgQ5/YlxrYFSXLFFztC5yo6+jQx2mqFR+a1kkLV4IirquiBzIonjmYXfBtvZ26fmI8r9Nw==",
+      "hasInstallScript": true
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "dev": true,
@@ -3844,6 +3853,38 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@powersync/common": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@powersync/common/-/common-2.0.0.tgz",
+      "integrity": "sha512-GuWmk0w0Y6I1HDwX4uGFzzw1e4E4bkvDSSCpVikdTEIk1xcW5NNnqTX8xfDheZdoQZunm/XushrR/LsIp1Yc/g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@powersync/shared-internals": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@powersync/shared-internals/-/shared-internals-1.0.1.tgz",
+      "integrity": "sha512-0IIuZbDwLEIaSAzvp8z8+CrjKnjja6BPv9WMtF1eExQVTBVOx1TXK4E3iLrEdLceByRcSFlQ0TmPNkPRe5BDow==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@powersync/web": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@powersync/web/-/web-2.0.0.tgz",
+      "integrity": "sha512-tVtvr052kTv2dBm49YI1jMYZ/eHPLNmy9PyioRANq1DB4+EvRkodgSRu5gGt3GOerPWSCJsvoAmtdR/SUdKUTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@powersync/common": "2.0.0",
+        "@powersync/shared-internals": "1.0.1",
+        "comlink": "^4.4.2",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "powersync-web": "bin/powersync.cjs"
+      },
+      "peerDependencies": {
+        "@journeyapps/wa-sqlite": "^1.5.0",
+        "@powersync/common": "^2.0.0",
+        "@powersync/shared-internals": "^1.0.1"
+      }
     },
     "node_modules/@redocly/cli": {
       "version": "2.34.0",
@@ -5555,9 +5596,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
+    },
     "node_modules/commander": {
       "version": "12.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"


### PR DESCRIPTION
## Summary

Foundational, **flag-gated** client for **live PowerSync sync** against the self-hosted Supabase + PowerSync backend (`finance.jrmoulckers.com`). This is step 1 of moving the web app off manual file imports and onto real, syncing data. It is **purely additive**: no app code is wired to it yet, so shipped behavior is unchanged.

## Changes

- `config.ts` — resolves `VITE_POWERSYNC_URL` / `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` / `VITE_POWERSYNC_ENABLED` from the Vite env, with an `isPowerSyncClientConfigured()` gate.
- `schema.ts` — canonical client schema (`AppSchema`) mirroring `services/api/powersync/sync-rules.yaml` **exactly**: all 29 synced tables, plural names, integer-cents money columns, `currency_code`, soft-delete, `owner_id`/`household_id`. Money/counts/booleans → INTEGER, text/UUID/date/enum → TEXT, `confidence_score`/`health_score` → REAL. Implicit `id` PK intentionally omitted.
- `connector.ts` — `SupabaseConnector` implementing `PowerSyncBackendConnector`: `fetchCredentials()` reads the JWT from the in-memory auth token store (the app uses a custom cookie-backed GoTrue flow, not `@supabase/supabase-js`); `uploadData()` drains the local CRUD queue and maps PUT/PATCH/DELETE to Supabase PostgREST, throwing on failure so PowerSync retries.
- `database.ts` — browser-only lifecycle (`getPowerSyncDatabase` / `connectPowerSync` / `disconnect` / `close`) behind a **literal** `import.meta.env.VITE_POWERSYNC_ENABLED !== 'true'` guard, loading `@powersync/web` via a guarded dynamic `import()`. With the flag unset (the default in deploy workflows), the heavy `@powersync/web` + `wa-sqlite` WASM stay out of the shipped bundle.
- `index.ts` — barrel exporting config + lifecycle + types (not the eager schema/connector values).
- Co-located unit tests: `config` (env resolution), `schema` (table/column/type parity), `connector` (credentials + CRUD→PostgREST mapping). Documented the flag in `apps/web/.env.example`.

## Dependencies

- `@powersync/web` + `@powersync/common` — the PowerSync SDK (sync engine). `@journeyapps/wa-sqlite` — its WASM SQLite backend. All three are loaded lazily and excluded from the default build.

## Testing

- [x] New unit tests pass (`vitest run src/db/sync/powersync` — 3 files, 17 tests)
- [x] `tsc --noEmit` clean for the new modules
- [x] `prettier --check` + `eslint --max-warnings 0` clean
- [x] `vite build` succeeds; verified `dist` contains **no** `@powersync` / `PowerSyncDatabase` / `SupabaseConnector` — the client is fully tree-shaken while the flag is off

## Notes

- Follow-up PRs perform the actual cut-over: rewrite the ~20 synchronous repositories + hooks onto PowerSync's async DB, retire the custom sync stack, allowlist the `@journeyapps/wa-sqlite` postinstall, add the prod CSP `connect-src` entry, and flip `VITE_POWERSYNC_ENABLED` in the deploy workflows.
- CI note: the `NPM_AUDIT` job may report pre-existing advisories present on `main` (brace-expansion, PostCSS, etc.); this PR introduces no new named advisories.

Closes #3941
Refs #3935