### PR TITLE
feat(web): enable live PowerSync sync on the deployed sites (#3945)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -67,6 +67,9 @@ jobs:
           VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL || 'https://placeholder.supabase.co' }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
           VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
+          # Enable the live PowerSync client only when a real backend URL is
+          # configured; otherwise keep it off so @powersync/web is tree-shaken.
+          VITE_POWERSYNC_ENABLED: ${{ secrets.POWERSYNC_URL != '' && 'true' || 'false' }}
         run: npm run build -w apps/web
 
       - name: SPA fallback + Pages hygiene

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -345,6 +345,9 @@ jobs:
           VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
+          # Enable the live PowerSync client only when a real backend URL is
+          # configured; otherwise keep it off so @powersync/web is tree-shaken.
+          VITE_POWERSYNC_ENABLED: ${{ secrets.POWERSYNC_URL != '' && 'true' || 'false' }}
         run: npm run build -w apps/web
 
       - name: Verify web build env
@@ -444,6 +447,7 @@ jobs:
             export VITE_SUPABASE_URL="$(printf '%s' "$SUPABASE_URL_B64" | base64 -d)"
             export VITE_SUPABASE_ANON_KEY="$(printf '%s' "$SUPABASE_ANON_KEY_B64" | base64 -d)"
             export VITE_POWERSYNC_URL="$(printf '%s' "$POWERSYNC_URL_B64" | base64 -d)"
+            export VITE_POWERSYNC_ENABLED="$( [ -n "$VITE_POWERSYNC_URL" ] && echo true || echo false )"
             export VITE_SENTRY_DSN="$(printf '%s' "$SENTRY_DSN_B64" | base64 -d)"
             export VITE_ENVIRONMENT=production
             export VITE_APP_VERSION="$SHA_SHORT"
@@ -762,6 +766,7 @@ jobs:
               export VITE_SUPABASE_URL="$(printf '%s' "$SUPABASE_URL_B64" | base64 -d)"
               export VITE_SUPABASE_ANON_KEY="$(printf '%s' "$SUPABASE_ANON_KEY_B64" | base64 -d)"
               export VITE_POWERSYNC_URL="$(printf '%s' "$POWERSYNC_URL_B64" | base64 -d)"
+              export VITE_POWERSYNC_ENABLED="$( [ -n "$VITE_POWERSYNC_URL" ] && echo true || echo false )"
               export VITE_SENTRY_DSN="$(printf '%s' "$SENTRY_DSN_B64" | base64 -d)"
               export VITE_ENVIRONMENT=production
               export VITE_APP_VERSION="$ROLLBACK_TAG"

--- a/.github/workflows/deploy-progressive.yml
+++ b/.github/workflows/deploy-progressive.yml
@@ -171,6 +171,9 @@ jobs:
           VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
+          # Enable the live PowerSync client only when a real backend URL is
+          # configured; otherwise keep it off so @powersync/web is tree-shaken.
+          VITE_POWERSYNC_ENABLED: ${{ secrets.POWERSYNC_URL != '' && 'true' || 'false' }}
         run: |
           npm run build -w packages/design-tokens
           npm run build -w apps/web

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -303,6 +303,7 @@ jobs:
             export VITE_SUPABASE_URL="$(printf '%s' "$SUPABASE_URL_B64" | base64 -d)"
             export VITE_SUPABASE_ANON_KEY="$(printf '%s' "$SUPABASE_ANON_KEY_B64" | base64 -d)"
             export VITE_POWERSYNC_URL="$(printf '%s' "$POWERSYNC_URL_B64" | base64 -d)"
+            export VITE_POWERSYNC_ENABLED="$( [ -n "$VITE_POWERSYNC_URL" ] && echo true || echo false )"
             export VITE_BETA_ALLOWED_EMAILS="$(printf '%s' "$BETA_ALLOWED_EMAILS_B64" | base64 -d)"
             export VITE_SENTRY_DSN="$(printf '%s' "$SENTRY_DSN_B64" | base64 -d)"
             export VITE_ENVIRONMENT=staging

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -30,6 +30,10 @@ VITE_POWERSYNC_URL=https://your-powersync-instance.powersync.com
 # tree-shaken out of the build). Set to "true" — together with VITE_POWERSYNC_URL,
 # VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY — to connect the app to live,
 # syncing data from the backend instead of local file imports.
+#
+# The deploy workflows (deploy-production / deploy-staging / deploy-progressive /
+# deploy-pages) set this automatically to "true" whenever the POWERSYNC_URL
+# secret is present, and "false" otherwise, so you only need it here for local runs.
 # VITE_POWERSYNC_ENABLED=false
 
 # Auth Endpoints

--- a/apps/web/src/components/common/SyncStatusBar.powersync.test.tsx
+++ b/apps/web/src/components/common/SyncStatusBar.powersync.test.tsx
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const liveStatusMock = {
+  connected: false,
+  connecting: false,
+  syncing: false,
+  hasSynced: false,
+  hasError: false,
+  lastSyncedAt: null as string | null,
+};
+
+const syncStatusMock = {
+  isOnline: true,
+  isOffline: false,
+  pendingMutations: 0,
+  lastSyncTime: null as string | null,
+  isSyncing: false,
+  syncNow: vi.fn(),
+  authError: false,
+  conflictCount: 0,
+};
+
+vi.mock('../../hooks/useSyncStatus', () => ({
+  useSyncStatus: () => syncStatusMock,
+}));
+
+vi.mock('../../hooks/useLivePowerSyncStatus', () => ({
+  useLivePowerSyncStatus: () => liveStatusMock,
+}));
+
+vi.mock('../../db/sync/powersync/database', () => ({
+  isPowerSyncEnabled: () => true,
+}));
+
+vi.mock('../../db/sync/sync-conflict', () => ({
+  getUnresolvedConflicts: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../styles/sync-status.css', () => ({}));
+
+import { SyncStatusBar } from './SyncStatusBar';
+
+function resetLive(): void {
+  liveStatusMock.connected = false;
+  liveStatusMock.connecting = false;
+  liveStatusMock.syncing = false;
+  liveStatusMock.hasSynced = false;
+  liveStatusMock.hasError = false;
+  liveStatusMock.lastSyncedAt = null;
+}
+
+describe('SyncStatusBar (live PowerSync active)', () => {
+  beforeEach(() => {
+    resetLive();
+    syncStatusMock.isOnline = true;
+    syncStatusMock.isOffline = false;
+    syncStatusMock.pendingMutations = 0;
+    syncStatusMock.isSyncing = false;
+  });
+
+  it('shows "All synced" when the live client is connected', () => {
+    liveStatusMock.connected = true;
+    liveStatusMock.hasSynced = true;
+
+    render(<SyncStatusBar />);
+
+    expect(screen.getByRole('status')).toHaveClass('sync-status-bar--synced');
+    expect(screen.getByText('All synced')).toBeInTheDocument();
+  });
+
+  it('shows "Syncing…" when the live client is downloading or uploading', () => {
+    liveStatusMock.syncing = true;
+
+    render(<SyncStatusBar />);
+
+    expect(screen.getByRole('status')).toHaveClass('sync-status-bar--syncing');
+    expect(screen.getByText('Syncing\u2026')).toBeInTheDocument();
+  });
+
+  it('shows "Syncing…" while the live client is connecting', () => {
+    liveStatusMock.connecting = true;
+
+    render(<SyncStatusBar />);
+
+    expect(screen.getByRole('status')).toHaveClass('sync-status-bar--syncing');
+  });
+
+  it('shows offline when the browser is offline, regardless of live status', () => {
+    syncStatusMock.isOffline = true;
+    liveStatusMock.connected = true;
+
+    render(<SyncStatusBar />);
+
+    expect(screen.getByRole('status')).toHaveClass('sync-status-bar--offline');
+  });
+
+  it('shows an error when the live client reports an error while disconnected', () => {
+    liveStatusMock.hasError = true;
+
+    render(<SyncStatusBar />);
+
+    expect(screen.getByRole('status')).toHaveClass('sync-status-bar--error');
+  });
+
+  it('lets live status override local pending mutations', () => {
+    syncStatusMock.pendingMutations = 5;
+    liveStatusMock.connected = true;
+    liveStatusMock.hasSynced = true;
+
+    render(<SyncStatusBar />);
+
+    expect(screen.queryByText('5 pending changes')).not.toBeInTheDocument();
+    expect(screen.getByText('All synced')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/common/SyncStatusBar.tsx
+++ b/apps/web/src/components/common/SyncStatusBar.tsx
@@ -23,7 +23,10 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useSyncStatus } from '../../hooks/useSyncStatus';
+import { useLivePowerSyncStatus } from '../../hooks/useLivePowerSyncStatus';
 import { getUnresolvedConflicts } from '../../db/sync/sync-conflict';
+import { isPowerSyncEnabled } from '../../db/sync/powersync/database';
+import type { LivePowerSyncStatus } from '../../db/sync/powersync/live-status';
 
 import '../../styles/sync-status.css';
 
@@ -64,6 +67,19 @@ function formatRelativeTime(isoString: string | null): string {
 
 type SyncVariant = 'synced' | 'pending' | 'syncing' | 'error' | 'offline' | 'conflict';
 
+/**
+ * Derive the bar variant from the live `@powersync/web` runtime status.
+ * Used only when the live PowerSync client is enabled; the real connection
+ * state — not the local mutation queue — then drives the bar.
+ */
+function deriveLiveVariant(live: LivePowerSyncStatus, isOffline: boolean): SyncVariant {
+  if (isOffline) return 'offline';
+  if (live.connecting || live.syncing) return 'syncing';
+  if (live.connected) return 'synced';
+  if (live.hasError) return 'error';
+  return 'offline';
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -77,6 +93,8 @@ type SyncVariant = 'synced' | 'pending' | 'syncing' | 'error' | 'offline' | 'con
 export const SyncStatusBar: React.FC = () => {
   const { isOnline, isOffline, pendingMutations, lastSyncTime, isSyncing, syncNow } =
     useSyncStatus();
+  const live = useLivePowerSyncStatus();
+  const powerSyncActive = isPowerSyncEnabled();
 
   const [conflictCount, setConflictCount] = useState(0);
   const [lastSyncFailed, setLastSyncFailed] = useState(false);
@@ -131,12 +149,21 @@ export const SyncStatusBar: React.FC = () => {
     variant = 'synced';
   }
 
+  // When the live PowerSync client is active, its real runtime status is the
+  // source of truth: the local mutation queue does not track the live
+  // connection. Flag off → variant is unchanged and behaviour is identical.
+  if (powerSyncActive) {
+    variant = deriveLiveVariant(live, isOffline);
+  }
+
   const handleRetry = useCallback(() => {
     setLastSyncFailed(false);
     syncNow();
   }, [syncNow]);
 
-  const relativeTime = formatRelativeTime(lastSyncTime);
+  const relativeTime = powerSyncActive
+    ? formatRelativeTime(live.lastSyncedAt)
+    : formatRelativeTime(lastSyncTime);
 
   return (
     <div

--- a/apps/web/src/db/sync/powersync/__tests__/database.test.ts
+++ b/apps/web/src/db/sync/powersync/__tests__/database.test.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SyncStatus } from '@powersync/common';
+
+import { getLivePowerSyncStatusSnapshot, resetLivePowerSyncStatus } from '../live-status';
+
+// A hoisted fake `@powersync/web` so the bridge can be exercised without the
+// real wa-sqlite worker. `vi.hoisted` keeps these definitions available to the
+// hoisted `vi.mock` factory below.
+const fake = vi.hoisted(() => {
+  const connect = vi.fn(async () => {});
+  const disconnect = vi.fn(async () => {});
+  const close = vi.fn(async () => {});
+  const dispose = vi.fn();
+  const state: {
+    statusChanged: ((status: SyncStatus) => void) | null;
+    currentStatus: SyncStatus | null;
+  } = { statusChanged: null, currentStatus: null };
+
+  class FakePowerSyncDatabase {
+    connect = connect;
+    disconnect = disconnect;
+    close = close;
+    registerListener(listener: { statusChanged?: (status: SyncStatus) => void }): () => void {
+      state.statusChanged = listener.statusChanged ?? null;
+      return dispose;
+    }
+    get currentStatus(): SyncStatus | null {
+      return state.currentStatus;
+    }
+  }
+
+  return { connect, disconnect, close, dispose, state, FakePowerSyncDatabase };
+});
+
+vi.mock('@powersync/web', () => ({ PowerSyncDatabase: fake.FakePowerSyncDatabase }));
+vi.mock('../connector', () => ({
+  SupabaseConnector: class {
+    constructor(_config: unknown) {}
+  },
+}));
+vi.mock('../schema', () => ({ AppSchema: { tables: [] } }));
+
+import { closePowerSync, connectPowerSync, disconnectPowerSync } from '../database';
+
+function syncStatus(overrides: Partial<Record<keyof SyncStatus, unknown>> = {}): SyncStatus {
+  return {
+    connected: false,
+    connecting: false,
+    downloading: false,
+    uploading: false,
+    downloadError: undefined,
+    uploadError: undefined,
+    hasSynced: false,
+    lastSyncedAt: undefined,
+    ...overrides,
+  } as unknown as SyncStatus;
+}
+
+describe('connectPowerSync live-status bridge', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_POWERSYNC_ENABLED', 'true');
+    vi.stubEnv('VITE_POWERSYNC_URL', 'https://finance.jrmoulckers.com/sync');
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://finance.jrmoulckers.com');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key');
+    fake.connect.mockClear();
+    fake.disconnect.mockClear();
+    fake.close.mockClear();
+    fake.dispose.mockClear();
+    fake.state.statusChanged = null;
+    fake.state.currentStatus = syncStatus();
+    resetLivePowerSyncStatus();
+  });
+
+  afterEach(async () => {
+    // Clear the module-level database singleton between tests.
+    await closePowerSync();
+    vi.unstubAllEnvs();
+    resetLivePowerSyncStatus();
+  });
+
+  it('seeds the live-status store from currentStatus on connect', async () => {
+    fake.state.currentStatus = syncStatus({
+      connected: true,
+      hasSynced: true,
+      lastSyncedAt: new Date('2026-02-02T03:04:05.000Z'),
+    });
+
+    await connectPowerSync();
+
+    expect(fake.connect).toHaveBeenCalledTimes(1);
+    expect(getLivePowerSyncStatusSnapshot()).toEqual({
+      connected: true,
+      connecting: false,
+      syncing: false,
+      hasSynced: true,
+      hasError: false,
+      lastSyncedAt: '2026-02-02T03:04:05.000Z',
+    });
+  });
+
+  it('updates the store when the runtime status changes', async () => {
+    await connectPowerSync();
+    expect(fake.state.statusChanged).toBeTypeOf('function');
+
+    fake.state.statusChanged?.(
+      syncStatus({ connected: true, downloading: true, hasSynced: false }),
+    );
+
+    expect(getLivePowerSyncStatusSnapshot()).toMatchObject({
+      connected: true,
+      syncing: true,
+      hasSynced: false,
+    });
+  });
+
+  it('maps upload/download errors to hasError', async () => {
+    await connectPowerSync();
+
+    fake.state.statusChanged?.(syncStatus({ connected: false, uploadError: new Error('boom') }));
+
+    expect(getLivePowerSyncStatusSnapshot().hasError).toBe(true);
+  });
+
+  it('disposes the listener and resets the store on disconnect', async () => {
+    fake.state.currentStatus = syncStatus({ connected: true, hasSynced: true });
+    await connectPowerSync();
+
+    await disconnectPowerSync();
+
+    expect(fake.disconnect).toHaveBeenCalledTimes(1);
+    expect(fake.dispose).toHaveBeenCalledTimes(1);
+    expect(getLivePowerSyncStatusSnapshot()).toEqual({
+      connected: false,
+      connecting: false,
+      syncing: false,
+      hasSynced: false,
+      hasError: false,
+      lastSyncedAt: null,
+    });
+  });
+
+  it('does nothing when the feature flag is disabled', async () => {
+    vi.stubEnv('VITE_POWERSYNC_ENABLED', 'false');
+
+    const result = await connectPowerSync();
+
+    expect(result).toBeNull();
+    expect(fake.connect).not.toHaveBeenCalled();
+    expect(getLivePowerSyncStatusSnapshot().connected).toBe(false);
+  });
+});

--- a/apps/web/src/db/sync/powersync/__tests__/live-status.test.ts
+++ b/apps/web/src/db/sync/powersync/__tests__/live-status.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getLivePowerSyncStatusSnapshot,
+  resetLivePowerSyncStatus,
+  setLivePowerSyncStatus,
+  subscribeLivePowerSyncStatus,
+  type LivePowerSyncStatus,
+} from '../live-status';
+
+const DISCONNECTED: LivePowerSyncStatus = {
+  connected: false,
+  connecting: false,
+  syncing: false,
+  hasSynced: false,
+  hasError: false,
+  lastSyncedAt: null,
+};
+
+const CONNECTED: LivePowerSyncStatus = {
+  connected: true,
+  connecting: false,
+  syncing: false,
+  hasSynced: true,
+  hasError: false,
+  lastSyncedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('live PowerSync status store', () => {
+  afterEach(() => {
+    resetLivePowerSyncStatus();
+  });
+
+  it('starts at the disconnected default', () => {
+    expect(getLivePowerSyncStatusSnapshot()).toEqual(DISCONNECTED);
+  });
+
+  it('publishes a new snapshot and notifies subscribers on change', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeLivePowerSyncStatus(listener);
+
+    setLivePowerSyncStatus(CONNECTED);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(getLivePowerSyncStatusSnapshot()).toEqual(CONNECTED);
+
+    unsubscribe();
+  });
+
+  it('keeps a stable snapshot reference and skips notifying when unchanged', () => {
+    setLivePowerSyncStatus(CONNECTED);
+    const first = getLivePowerSyncStatusSnapshot();
+
+    const listener = vi.fn();
+    const unsubscribe = subscribeLivePowerSyncStatus(listener);
+
+    // A value-equal update must not produce a new reference or a notification.
+    setLivePowerSyncStatus({ ...CONNECTED });
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(getLivePowerSyncStatusSnapshot()).toBe(first);
+
+    unsubscribe();
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeLivePowerSyncStatus(listener);
+    unsubscribe();
+
+    setLivePowerSyncStatus(CONNECTED);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('reset returns to the disconnected default', () => {
+    setLivePowerSyncStatus(CONNECTED);
+    resetLivePowerSyncStatus();
+
+    expect(getLivePowerSyncStatusSnapshot()).toEqual(DISCONNECTED);
+  });
+});

--- a/apps/web/src/db/sync/powersync/database.ts
+++ b/apps/web/src/db/sync/powersync/database.ts
@@ -16,15 +16,35 @@
  * References: sync-rules.yaml, issues #3941 / #3935.
  */
 
-import type { AbstractPowerSyncDatabase } from '@powersync/common';
+import type { AbstractPowerSyncDatabase, SyncStatus } from '@powersync/common';
 
 import { isPowerSyncClientConfigured, resolvePowerSyncClientConfig } from './config';
+import {
+  resetLivePowerSyncStatus,
+  setLivePowerSyncStatus,
+  type LivePowerSyncStatus,
+} from './live-status';
 
 /** Local database filename for the PowerSync-managed SQLite store. */
 const DB_FILENAME = 'finance.db';
 
 /** Singleton instance, created lazily on first use. */
 let databasePromise: Promise<AbstractPowerSyncDatabase | null> | null = null;
+
+/** Disposes the live status listener registered on connect, if any. */
+let disposeStatusListener: (() => void) | null = null;
+
+/** Map the PowerSync runtime `SyncStatus` into the UI-facing snapshot shape. */
+function mapSyncStatus(status: SyncStatus): LivePowerSyncStatus {
+  return {
+    connected: status.connected,
+    connecting: status.connecting,
+    syncing: status.downloading || status.uploading,
+    hasSynced: status.hasSynced ?? false,
+    hasError: Boolean(status.downloadError || status.uploadError),
+    lastSyncedAt: status.lastSyncedAt ? status.lastSyncedAt.toISOString() : null,
+  };
+}
 
 /** Runtime check for whether the live PowerSync client is enabled. */
 export function isPowerSyncEnabled(): boolean {
@@ -70,6 +90,19 @@ export async function connectPowerSync(): Promise<AbstractPowerSyncDatabase | nu
   const config = resolvePowerSyncClientConfig();
   const { SupabaseConnector } = await import('./connector');
   await database.connect(new SupabaseConnector(config));
+
+  // Bridge the real runtime status into the live-status store so the visible
+  // sync bar can reflect actual connection/sync state. Registered once per
+  // database instance; disposed on disconnect/close.
+  if (!disposeStatusListener) {
+    disposeStatusListener = database.registerListener({
+      statusChanged: (status: SyncStatus) => {
+        setLivePowerSyncStatus(mapSyncStatus(status));
+      },
+    });
+  }
+  setLivePowerSyncStatus(mapSyncStatus(database.currentStatus));
+
   return database;
 }
 
@@ -79,7 +112,10 @@ export async function disconnectPowerSync(): Promise<void> {
     return;
   }
   const database = await databasePromise;
+  disposeStatusListener?.();
+  disposeStatusListener = null;
   await database?.disconnect();
+  resetLivePowerSyncStatus();
 }
 
 /** Disconnect and dispose the live PowerSync database, clearing the singleton. */
@@ -89,5 +125,8 @@ export async function closePowerSync(): Promise<void> {
   }
   const database = await databasePromise;
   databasePromise = null;
+  disposeStatusListener?.();
+  disposeStatusListener = null;
   await database?.close();
+  resetLivePowerSyncStatus();
 }

--- a/apps/web/src/db/sync/powersync/live-status.ts
+++ b/apps/web/src/db/sync/powersync/live-status.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Live PowerSync runtime status store.
+ *
+ * A tiny framework-agnostic external store that mirrors the real
+ * `@powersync/web` runtime `SyncStatus` into a shape the UI can consume via
+ * `useSyncExternalStore`. The connect path in `./database.ts` is the only
+ * writer; components read through `../../hooks/useLivePowerSyncStatus`.
+ *
+ * This store is deliberately separate from the custom mutation-queue status
+ * (`hooks/useSyncStatus.ts`): that subsystem has a large blast radius and its
+ * semantics must not change. Keeping the real runtime status in its own store
+ * means the visible sync bar can reflect live connection/sync state only when
+ * the live client is actually enabled, with zero behaviour change otherwise.
+ *
+ * References: issues #3945 / #3935.
+ */
+
+/** Snapshot of the live PowerSync runtime status, in UI-friendly form. */
+export interface LivePowerSyncStatus {
+  /** Whether the client is connected to the PowerSync service. */
+  readonly connected: boolean;
+  /** Whether the client is establishing a connection. */
+  readonly connecting: boolean;
+  /** Whether data is currently being downloaded or uploaded. */
+  readonly syncing: boolean;
+  /** Whether at least one full sync has completed since initialization. */
+  readonly hasSynced: boolean;
+  /** Whether the last download or upload reported an error. */
+  readonly hasError: boolean;
+  /** ISO-8601 timestamp of the last completed sync, or `null`. */
+  readonly lastSyncedAt: string | null;
+}
+
+/** The disconnected default snapshot, shared as a stable reference. */
+const INITIAL_STATUS: LivePowerSyncStatus = Object.freeze({
+  connected: false,
+  connecting: false,
+  syncing: false,
+  hasSynced: false,
+  hasError: false,
+  lastSyncedAt: null,
+});
+
+let current: LivePowerSyncStatus = INITIAL_STATUS;
+
+const listeners = new Set<() => void>();
+
+/** Return the current live status snapshot (stable reference between changes). */
+export function getLivePowerSyncStatusSnapshot(): LivePowerSyncStatus {
+  return current;
+}
+
+/**
+ * Subscribe to live status changes. Returns an unsubscribe function.
+ * Compatible with `useSyncExternalStore`.
+ */
+export function subscribeLivePowerSyncStatus(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function isSameStatus(a: LivePowerSyncStatus, b: LivePowerSyncStatus): boolean {
+  return (
+    a.connected === b.connected &&
+    a.connecting === b.connecting &&
+    a.syncing === b.syncing &&
+    a.hasSynced === b.hasSynced &&
+    a.hasError === b.hasError &&
+    a.lastSyncedAt === b.lastSyncedAt
+  );
+}
+
+/**
+ * Replace the live status. Only publishes a new snapshot (and notifies
+ * subscribers) when a field actually changed, so `useSyncExternalStore`
+ * consumers keep a stable reference and do not re-render needlessly.
+ */
+export function setLivePowerSyncStatus(next: LivePowerSyncStatus): void {
+  if (isSameStatus(current, next)) {
+    return;
+  }
+  current = Object.freeze({ ...next });
+  notify();
+}
+
+/** Reset the live status back to the disconnected default and notify. */
+export function resetLivePowerSyncStatus(): void {
+  setLivePowerSyncStatus(INITIAL_STATUS);
+}

--- a/apps/web/src/hooks/useLivePowerSyncStatus.test.ts
+++ b/apps/web/src/hooks/useLivePowerSyncStatus.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useLivePowerSyncStatus } from './useLivePowerSyncStatus';
+import { resetLivePowerSyncStatus, setLivePowerSyncStatus } from '../db/sync/powersync/live-status';
+
+describe('useLivePowerSyncStatus', () => {
+  afterEach(() => {
+    resetLivePowerSyncStatus();
+  });
+
+  it('returns the disconnected default initially', () => {
+    const { result } = renderHook(() => useLivePowerSyncStatus());
+
+    expect(result.current.connected).toBe(false);
+    expect(result.current.syncing).toBe(false);
+    expect(result.current.lastSyncedAt).toBeNull();
+  });
+
+  it('re-renders when the live status changes', () => {
+    const { result } = renderHook(() => useLivePowerSyncStatus());
+
+    act(() => {
+      setLivePowerSyncStatus({
+        connected: true,
+        connecting: false,
+        syncing: false,
+        hasSynced: true,
+        hasError: false,
+        lastSyncedAt: '2026-01-01T00:00:00.000Z',
+      });
+    });
+
+    expect(result.current.connected).toBe(true);
+    expect(result.current.hasSynced).toBe(true);
+    expect(result.current.lastSyncedAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+});

--- a/apps/web/src/hooks/useLivePowerSyncStatus.ts
+++ b/apps/web/src/hooks/useLivePowerSyncStatus.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook exposing the live `@powersync/web` runtime status.
+ *
+ * Thin `useSyncExternalStore` wrapper over the live-status store in
+ * `../db/sync/powersync/live-status`. When the live PowerSync client is
+ * disabled (the default build), the store simply stays at its disconnected
+ * default, so consumers can call this unconditionally and branch on
+ * `isPowerSyncEnabled()`.
+ *
+ * References: issues #3945 / #3935.
+ */
+
+import { useSyncExternalStore } from 'react';
+
+import {
+  getLivePowerSyncStatusSnapshot,
+  subscribeLivePowerSyncStatus,
+  type LivePowerSyncStatus,
+} from '../db/sync/powersync/live-status';
+
+/** Subscribe to the live PowerSync runtime status. */
+export function useLivePowerSyncStatus(): LivePowerSyncStatus {
+  return useSyncExternalStore(
+    subscribeLivePowerSyncStatus,
+    getLivePowerSyncStatusSnapshot,
+    getLivePowerSyncStatusSnapshot,
+  );
+}

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -55,7 +55,11 @@
 		# instantiation (sqlite-wasm) via the dedicated `wasm-unsafe-eval`
 		# directive. `wasm-unsafe-eval` does NOT enable JS `eval()` — it is
 		# the least-privilege grant for WebAssembly instantiation.
-		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; worker-src 'self'"
+		# `worker-src 'self' blob:` lets the live PowerSync client (@powersync/web)
+		# spawn its wa-sqlite database worker, which is instantiated from a
+		# same-origin blob URL. The app and backend are same-origin here, so
+		# `connect-src 'self'` already covers /rest, /auth and the /sync socket.
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:"
 
 		# Remove server identification
 		-Server

--- a/deploy/Caddyfile.staging
+++ b/deploy/Caddyfile.staging
@@ -25,7 +25,7 @@
 		X-Frame-Options "DENY"
 		X-XSS-Protection "1; mode=block"
 		Referrer-Policy "strict-origin-when-cross-origin"
-		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; worker-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 		-Server
 	}
 


### PR DESCRIPTION
## Summary

PR3 of the epic #3935 live-data migration. This flips the **deployed** web app into real, live PowerSync sync, so it boots into syncing data from the backend instead of arduous manual file imports. PR2 (#3944) already made the data layer async and connect-capable behind a flag; this PR turns the flag on where it matters and makes the real sync state visible.

## Changes

- **Enable live sync on every deployed site** — set `VITE_POWERSYNC_ENABLED` in all four deploy workflows (`deploy-production`, `deploy-staging`, `deploy-progressive`, `deploy-pages`). It is **secret-gated**: `true` only when the `POWERSYNC_URL` secret is present, otherwise `false`. Forks without the secret keep the client fully inert and tree-shaken out of the bundle.
- **CSP hardening for the WASM worker** — `deploy/Caddyfile` and `deploy/Caddyfile.staging` gain `worker-src 'self' blob:` so the `@powersync/web` wa-sqlite database worker can load. The app and backend are same-origin, so `connect-src 'self'` already covers `/rest`, `/auth`, and the `/sync` socket.
- **Bridge real runtime status into the visible sync bar** — a small framework-agnostic `live-status` external store + a `useLivePowerSyncStatus` hook mirror the real `@powersync/web` `SyncStatus`. `SyncStatusBar` reads it **only when `isPowerSyncEnabled()`**; with the flag off the bar is byte-for-byte unchanged. The connect path registers a `statusChanged` listener and resets the store on disconnect/close.
- **Docs** — note the workflow auto-enable behaviour in `apps/web/.env.example`.

## Testing

- `npm run type-check` (apps/web) — clean
- `npm run format:check` + `npx eslint . --max-warnings 0` — clean
- `npm run build -w apps/web` — succeeds; no `@powersync/web` chunk emitted with the flag off (tree-shaking intact)
- New/updated Vitest suites (56 tests green): `live-status` store, `useLivePowerSyncStatus`, connect→status bridge (mapping + listener + reset), and a PowerSync-active `SyncStatusBar` suite. Existing CSP and `SyncStatusBar` tests remain green (flag-off path unchanged).

## Issues

Closes #3945
Refs #3935

## Notes

- The **npm Audit** CI check is expected to remain red: it reports 9 pre-existing Dependabot vulnerabilities on the default branch, unrelated to this PR (no dependency manifests changed here). If it is the only failing check, this PR is cleared to squash-merge.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
