### PR TITLE
fix(web): migrate react-router-dom 7 to react-router 8.3.0 to clear high-severity CVEs (#3949)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,7 +32,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "recharts": "^3.9.2",
     "sql.js": "^1.14.1",
     "tesseract.js": "^7.0.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { useCallback, useEffect, useRef, type FC } from 'react';
-import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate } from 'react-router';
 import { MilestoneToast } from './components/celebrations';
 import { ConsentDialog } from './components/gdpr';
 import { AppLayout } from './components/layout';

--- a/apps/web/src/AppBrowserRouter.test.tsx
+++ b/apps/web/src/AppBrowserRouter.test.tsx
@@ -23,7 +23,7 @@
 import { lazy, Suspense, type ComponentType, type ReactNode } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { Route, Routes, useLocation, useNavigate } from 'react-router';
 
 import { AppBrowserRouter } from './AppBrowserRouter';
 

--- a/apps/web/src/AppBrowserRouter.tsx
+++ b/apps/web/src/AppBrowserRouter.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { FC, ReactNode } from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 export interface AppBrowserRouterProps {
   /** Application routes / tree to render inside the router. */
@@ -19,7 +19,7 @@ export interface AppBrowserRouterProps {
  *
  * ## Why `useTransitions={false}` (#3551)
  *
- * `react-router-dom` v7's `<BrowserRouter>` wraps every location/router-state
+ * `react-router` v8's `<BrowserRouter>` wraps every location/router-state
  * update in `React.startTransition` by default (the library's own docs note the
  * default "can lead to buggy behaviors"). Every route in `routes.tsx` is a
  * `lazy()` page wrapped in a shared `RouteBoundary` → `<Suspense>` with the

--- a/apps/web/src/__tests__/auth-flows.test.tsx
+++ b/apps/web/src/__tests__/auth-flows.test.tsx
@@ -15,7 +15,7 @@
 
 import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
@@ -65,8 +65,8 @@ vi.mock('../auth/auth-context', () => ({
   },
 }));
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
   return { ...actual, useNavigate: () => navigateMock };
 });
 

--- a/apps/web/src/__tests__/dashboard-visualizations.test.tsx
+++ b/apps/web/src/__tests__/dashboard-visualizations.test.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import {
   useAccounts,
   useBills,

--- a/apps/web/src/components/coaching/CoachCard.tsx
+++ b/apps/web/src/components/coaching/CoachCard.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { FC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { AppIcon, type IconName } from '../icons';
 import type { CoachAlert, CoachSeverity } from '../../lib/coaching';
 import './coach.css';

--- a/apps/web/src/components/coaching/CoachPanel.tsx
+++ b/apps/web/src/components/coaching/CoachPanel.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { FC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { CurrencyDisplay } from '../common';
 import { AppIcon, type IconName } from '../icons';
 import type { CoachAnalysis, CoachSeverity, RecurrenceCadence } from '../../lib/coaching';

--- a/apps/web/src/components/common/Button.test.tsx
+++ b/apps/web/src/components/common/Button.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter, Link } from 'react-router-dom';
+import { MemoryRouter, Link } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 
 import { Button, buttonClassName } from './Button';

--- a/apps/web/src/components/common/ErrorBoundary.stories.tsx
+++ b/apps/web/src/components/common/ErrorBoundary.stories.tsx
@@ -2,7 +2,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { ErrorBoundary } from './ErrorBoundary';
 

--- a/apps/web/src/components/common/ErrorBoundary.test.tsx
+++ b/apps/web/src/components/common/ErrorBoundary.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ErrorBoundary } from './ErrorBoundary';
 

--- a/apps/web/src/components/dashboard/AccountSummaryCard.test.tsx
+++ b/apps/web/src/components/dashboard/AccountSummaryCard.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { AccountSummaryCard } from './AccountSummaryCard';
 import type { Account } from '../../kmp/bridge';

--- a/apps/web/src/components/dashboard/AccountSummaryCard.tsx
+++ b/apps/web/src/components/dashboard/AccountSummaryCard.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { CurrencyDisplay } from '../common';
 import type { Account } from '../../kmp/bridge';

--- a/apps/web/src/components/dashboard/DashboardTaxReserveSection.tsx
+++ b/apps/web/src/components/dashboard/DashboardTaxReserveSection.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { useMemo, type FC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTransactions } from '../../hooks';
 import { useTaxReserve } from '../../hooks/useTaxReserve';
 import type { Account, Transaction } from '../../kmp/bridge';

--- a/apps/web/src/components/dashboard/DashboardThingsToCheckSection.test.tsx
+++ b/apps/web/src/components/dashboard/DashboardThingsToCheckSection.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DashboardThingsToCheckSection from './DashboardThingsToCheckSection';

--- a/apps/web/src/components/dashboard/DashboardThingsToCheckSection.tsx
+++ b/apps/web/src/components/dashboard/DashboardThingsToCheckSection.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { useMemo, type FC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTransactions } from '../../hooks';
 import type { Account } from '../../kmp/bridge';
 import {

--- a/apps/web/src/components/dashboard/GoalsProgressCard.test.tsx
+++ b/apps/web/src/components/dashboard/GoalsProgressCard.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { GoalsProgressCard } from './GoalsProgressCard';
 import type { Goal } from '../../kmp/bridge';

--- a/apps/web/src/components/dashboard/GoalsProgressCard.tsx
+++ b/apps/web/src/components/dashboard/GoalsProgressCard.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { CurrencyDisplay } from '../common';
 import type { Goal } from '../../kmp/bridge';

--- a/apps/web/src/components/feature-gate/FeatureGate.test.tsx
+++ b/apps/web/src/components/feature-gate/FeatureGate.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { FeatureGateProvider, useFeatureGate } from './FeatureGateProvider';
 import { FeatureGate } from './FeatureGate';
 import { UpgradePrompt } from './UpgradePrompt';

--- a/apps/web/src/components/import/ImportComplete.tsx
+++ b/apps/web/src/components/import/ImportComplete.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { AppIcon } from '../icons';
 
 import type { ImportSummary } from '../../hooks/useImport';

--- a/apps/web/src/components/insights/InsightCard.tsx
+++ b/apps/web/src/components/insights/InsightCard.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { AppIcon } from '../icons';
 import type { GeneratedInsight } from '../../lib/insights';
 

--- a/apps/web/src/components/insights/WeeklyDigest.test.tsx
+++ b/apps/web/src/components/insights/WeeklyDigest.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import type { WealthDigest } from '../../lib/insights';
 import { WeeklyDigest } from './WeeklyDigest';

--- a/apps/web/src/components/investments/HoldingsTable.test.tsx
+++ b/apps/web/src/components/investments/HoldingsTable.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { HoldingsTable, VIRTUALIZE_THRESHOLD, type HoldingRow } from './HoldingsTable';
 

--- a/apps/web/src/components/investments/HoldingsTable.tsx
+++ b/apps/web/src/components/investments/HoldingsTable.tsx
@@ -13,7 +13,7 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { CurrencyDisplay } from '../common';
 import { AppIcon, type IconName } from '../icons';

--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 vi.mock('../../accessibility/CognitiveAccessibilityProvider', () => ({
   useCognitiveAccessibility: () => ({

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import type { AppNotification } from '../../lib/notifications';
 import FeedbackDialog from '../FeedbackDialog';

--- a/apps/web/src/components/layout/FocusManager.test.tsx
+++ b/apps/web/src/components/layout/FocusManager.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockPathname = { value: '/' };
 
-vi.mock('react-router-dom', () => ({
+vi.mock('react-router', () => ({
   useLocation: () => ({ pathname: mockPathname.value }),
 }));
 

--- a/apps/web/src/components/layout/FocusManager.tsx
+++ b/apps/web/src/components/layout/FocusManager.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { type FC, useEffect, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { announce, moveFocusTo } from '../../accessibility/aria';
 
 export interface FocusManagerProps {

--- a/apps/web/src/components/navigation/Breadcrumb.tsx
+++ b/apps/web/src/components/navigation/Breadcrumb.tsx
@@ -15,7 +15,7 @@
  */
 
 import type { FC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 export interface BreadcrumbSegment {
   /** Display label for the breadcrumb segment. */

--- a/apps/web/src/components/navigation/Breadcrumbs.test.tsx
+++ b/apps/web/src/components/navigation/Breadcrumbs.test.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-vi.mock('react-router-dom', () => ({
+vi.mock('react-router', () => ({
   Link: ({ to, children, ...props }: { to: string; children?: ReactNode }) => (
     <a href={to} {...props}>
       {children}

--- a/apps/web/src/components/navigation/Breadcrumbs.tsx
+++ b/apps/web/src/components/navigation/Breadcrumbs.tsx
@@ -18,7 +18,7 @@
  */
 
 import { useMemo, type FC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { buildBreadcrumbTrail } from '../../lib/navigation/breadcrumb-trail';
 import './breadcrumb.css';

--- a/apps/web/src/components/navigation/NavigationGuard.test.tsx
+++ b/apps/web/src/components/navigation/NavigationGuard.test.tsx
@@ -2,15 +2,15 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { NavigationGuard } from './NavigationGuard';
 
 const mockNavigate = vi.hoisted(() => vi.fn());
 const mockUseAuth = vi.hoisted(() => vi.fn());
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
   return { ...actual, useNavigate: () => mockNavigate };
 });
 

--- a/apps/web/src/components/navigation/NavigationGuard.tsx
+++ b/apps/web/src/components/navigation/NavigationGuard.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import { useAuth } from '../../auth/auth-context';
 import {

--- a/apps/web/src/components/navigation/ResponsiveNav.test.tsx
+++ b/apps/web/src/components/navigation/ResponsiveNav.test.tsx
@@ -6,10 +6,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { ResponsiveNav, type NavItem } from './ResponsiveNav';
 
 // ---------------------------------------------------------------------------
-// Mock react-router-dom Link to render a plain <a> in tests
+// Mock react-router Link to render a plain <a> in tests
 // ---------------------------------------------------------------------------
 
-vi.mock('react-router-dom', () => ({
+vi.mock('react-router', () => ({
   Link: ({
     to,
     children,

--- a/apps/web/src/components/navigation/ResponsiveNav.tsx
+++ b/apps/web/src/components/navigation/ResponsiveNav.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { useCallback, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 

--- a/apps/web/src/components/navigation/ScrollToTop.test.tsx
+++ b/apps/web/src/components/navigation/ScrollToTop.test.tsx
@@ -24,7 +24,7 @@ const routerState = vi.hoisted(() => ({
   navigationType: 'PUSH' as 'PUSH' | 'POP' | 'REPLACE',
 }));
 
-vi.mock('react-router-dom', () => ({
+vi.mock('react-router', () => ({
   useLocation: () => routerState.location,
   useNavigationType: () => routerState.navigationType,
 }));

--- a/apps/web/src/components/navigation/ScrollToTop.tsx
+++ b/apps/web/src/components/navigation/ScrollToTop.tsx
@@ -31,7 +31,7 @@
  */
 
 import { useEffect, useLayoutEffect, useRef } from 'react';
-import { useLocation, useNavigationType } from 'react-router-dom';
+import { useLocation, useNavigationType } from 'react-router';
 
 import { getScrollPosition, recordScrollPosition } from '../../lib/navigation/history';
 

--- a/apps/web/src/components/recommendations/RecommendationCard.tsx
+++ b/apps/web/src/components/recommendations/RecommendationCard.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { CurrencyDisplay } from '../common/CurrencyDisplay';
 import { AppIcon } from '../icons';
 import type { PersonalizedRecommendation } from '../../lib/recommendations';

--- a/apps/web/src/components/recommendations/RecommendationDetail.tsx
+++ b/apps/web/src/components/recommendations/RecommendationDetail.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { CurrencyDisplay } from '../common/CurrencyDisplay';
 import { ModalBackdrop } from '../common/ModalBackdrop';
 import { AppIcon } from '../icons';

--- a/apps/web/src/components/recommendations/RecommendationsFeed.test.tsx
+++ b/apps/web/src/components/recommendations/RecommendationsFeed.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { RecommendationsFeed } from './RecommendationsFeed';
 import type { PersonalizedRecommendation, RecommendationSummary } from '../../lib/recommendations';
 

--- a/apps/web/src/components/savings/SuggestedGoals.tsx
+++ b/apps/web/src/components/savings/SuggestedGoals.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { CurrencyDisplay } from '../common';
 import { AppIcon, type IconName } from '../icons';

--- a/apps/web/src/components/tips/ContextualTips.test.tsx
+++ b/apps/web/src/components/tips/ContextualTips.test.tsx
@@ -2,13 +2,13 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ContextualTips } from './ContextualTips';
 import type { FinancialTip } from './tips-engine';
 
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/apps/web/src/components/tips/ContextualTips.tsx
+++ b/apps/web/src/components/tips/ContextualTips.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { FinancialTip, TipSeverity } from './tips-engine';
 import './tips.css';
 import { AppIcon, type IconName } from '../icons';

--- a/apps/web/src/components/transactions/RecentTransactionsCard.test.tsx
+++ b/apps/web/src/components/transactions/RecentTransactionsCard.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Account, Category, Transaction } from '../../kmp/bridge';

--- a/apps/web/src/components/transactions/RecentTransactionsCard.tsx
+++ b/apps/web/src/components/transactions/RecentTransactionsCard.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useId, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { CurrencyDisplay, EmptyState, LoadingSpinner } from '../common';
 import { useTransactions } from '../../hooks';

--- a/apps/web/src/components/warranty/ExpiringWarranties.tsx
+++ b/apps/web/src/components/warranty/ExpiringWarranties.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { Transaction } from '../../kmp/bridge';
 import type { WarrantyDeadline } from '../../lib/warranty';
 import { EmptyState } from '../common';

--- a/apps/web/src/components/warranty/WarrantyDashboard.test.tsx
+++ b/apps/web/src/components/warranty/WarrantyDashboard.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { WarrantyDashboard } from './WarrantyDashboard';
 import { addDays, todayLocalDate } from '../../lib/warranty';
 import {

--- a/apps/web/src/components/warranty/WarrantyDashboard.tsx
+++ b/apps/web/src/components/warranty/WarrantyDashboard.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTransactions } from '../../hooks';
 import {
   filterWarrantyEntries,

--- a/apps/web/src/hooks/useDocumentTitle.test.tsx
+++ b/apps/web/src/hooks/useDocumentTitle.test.tsx
@@ -3,7 +3,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { FC } from 'react';
-import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { useDocumentTitle } from './useDocumentTitle';

--- a/apps/web/src/hooks/useDocumentTitle.ts
+++ b/apps/web/src/hooks/useDocumentTitle.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { resolveDocumentTitle } from '../lib/i18n/page-title';
 import { useLocalePreferences } from './useLocalePreferences';

--- a/apps/web/src/hooks/useEscapeBack.ts
+++ b/apps/web/src/hooks/useEscapeBack.ts
@@ -15,7 +15,7 @@
  */
 
 import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 /** Route patterns that indicate a detail/sub page (has an ID segment). */
 const DETAIL_ROUTE_PATTERN =

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,7 +3,7 @@
 import { StrictMode } from 'react';
 import type { FC, ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { App } from './App';
 import { AppBrowserRouter } from './AppBrowserRouter';
 import { AuthProvider } from './auth/auth-context';

--- a/apps/web/src/pages/AcceptInvitePage.test.tsx
+++ b/apps/web/src/pages/AcceptInvitePage.test.tsx
@@ -11,7 +11,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 import type { Household, HouseholdInvitation, HouseholdMember } from '../kmp/bridge';
 import { useHousehold } from '../hooks/useHousehold';

--- a/apps/web/src/pages/AcceptInvitePage.tsx
+++ b/apps/web/src/pages/AcceptInvitePage.tsx
@@ -18,7 +18,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FC, FormEvent, ReactNode } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 
 import { useHousehold } from '../hooks/useHousehold';
 import type { AcceptInvitationResult } from '../hooks/useHousehold';

--- a/apps/web/src/pages/AccountDetailPage.test.tsx
+++ b/apps/web/src/pages/AccountDetailPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 import { useAccountReconciliation, useAccounts, useTransactions } from '../hooks';
 import { calculateReconciliationDifference } from '../lib/reconciliation';

--- a/apps/web/src/pages/AccountDetailPage.tsx
+++ b/apps/web/src/pages/AccountDetailPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 import { AppIcon } from '../components/icons';
 import { pluralize } from '../lib/ui/pluralize';
 

--- a/apps/web/src/pages/AccountsPage.test.tsx
+++ b/apps/web/src/pages/AccountsPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { PrivacyModeProvider } from '../contexts/PrivacyModeContext';
 import { useAccounts } from '../hooks';
 import { evaluatePrivacyScreenCoverage } from '../lib/security/privacy-screen';

--- a/apps/web/src/pages/AccountsPage.tsx
+++ b/apps/web/src/pages/AccountsPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { AccountPurposeBadge } from '../components/accounts';
 import {
   AccountsSkeleton,

--- a/apps/web/src/pages/AchievementsPage.test.tsx
+++ b/apps/web/src/pages/AchievementsPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { AchievementsPage } from './AchievementsPage';
 import type { GamificationState } from '../components/gamification/achievements-engine';
 

--- a/apps/web/src/pages/BetaLanding.test.tsx
+++ b/apps/web/src/pages/BetaLanding.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppRoutes } from '../routes';

--- a/apps/web/src/pages/BetaLanding.tsx
+++ b/apps/web/src/pages/BetaLanding.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import type { FC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import './BetaLanding.css';
 

--- a/apps/web/src/pages/BillDetailPage.test.tsx
+++ b/apps/web/src/pages/BillDetailPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { useBills } from '../hooks';
 import { BillDetailPage } from './BillDetailPage';
 

--- a/apps/web/src/pages/BillDetailPage.tsx
+++ b/apps/web/src/pages/BillDetailPage.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { getCurrentLocale } from '../lib/i18n';
 import { useBills } from '../hooks';

--- a/apps/web/src/pages/BillsPage.test.tsx
+++ b/apps/web/src/pages/BillsPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { useBills } from '../hooks';

--- a/apps/web/src/pages/BillsPage.tsx
+++ b/apps/web/src/pages/BillsPage.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { getCurrentLocale } from '../lib/i18n';
 import { pluralize } from '../lib/ui/pluralize';
 import {

--- a/apps/web/src/pages/BrokerageImportPage.tsx
+++ b/apps/web/src/pages/BrokerageImportPage.tsx
@@ -13,7 +13,7 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 // Direct import keeps this heavy component code-split into the brokerage route chunk.
 import { BrokerageImportPanel } from '../components/import/BrokerageImportPanel';

--- a/apps/web/src/pages/BudgetDetailPage.test.tsx
+++ b/apps/web/src/pages/BudgetDetailPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 import { useBudgets } from '../hooks/useBudgets';
 import { useCategories } from '../hooks/useCategories';

--- a/apps/web/src/pages/BudgetDetailPage.tsx
+++ b/apps/web/src/pages/BudgetDetailPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 import { AppIcon, type IconName } from '../components/icons';
 
 import { ConfirmDialog } from '../components/common/ConfirmDialog';

--- a/apps/web/src/pages/BudgetsPage.test.tsx
+++ b/apps/web/src/pages/BudgetsPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { useBudgets } from '../hooks/useBudgets';
 import { useCategories } from '../hooks/useCategories';
 import { useSyncStatus } from '../hooks/useSyncStatus';

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { BudgetAnalytics } from '../components/budgets';
 import { ConfirmDialog } from '../components/common/ConfirmDialog';
 import { CurrencyDisplay } from '../components/common/CurrencyDisplay';

--- a/apps/web/src/pages/CreateBillPage.tsx
+++ b/apps/web/src/pages/CreateBillPage.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import { useDatabase } from '../db/DatabaseProvider';
 import type { Row } from '../db/sqlite-wasm';
 import { useBills } from '../hooks';

--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import {

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { Suspense, useCallback, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { TimePeriod, ViewType } from '../components/charts';
 import { ChartEmptyState } from '../components/charts/ChartEmptyState';
 import { groupTopNCategories } from '../components/charts/chart-palette';

--- a/apps/web/src/pages/EstimatedTaxPage.test.tsx
+++ b/apps/web/src/pages/EstimatedTaxPage.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EstimatedTaxPage } from './EstimatedTaxPage';

--- a/apps/web/src/pages/EstimatedTaxPage.tsx
+++ b/apps/web/src/pages/EstimatedTaxPage.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useMemo, type FC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { ErrorBanner, LoadingSpinner } from '../components/common';
 import DashboardTaxReserveSection from '../components/dashboard/DashboardTaxReserveSection';

--- a/apps/web/src/pages/ForgotPasswordPage.test.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ForgotPasswordPage } from './ForgotPasswordPage';
 

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { z } from 'zod';
 
 import { LoadingSpinner } from '../components/common/LoadingSpinner';

--- a/apps/web/src/pages/GoalDetailPage.test.tsx
+++ b/apps/web/src/pages/GoalDetailPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 import { useGoals, useAccounts } from '../hooks';
 import { GoalDetailPage } from './GoalDetailPage';

--- a/apps/web/src/pages/GoalDetailPage.tsx
+++ b/apps/web/src/pages/GoalDetailPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 import { AppIcon, type IconName } from '../components/icons';
 import { pluralize } from '../lib/ui/pluralize';
 

--- a/apps/web/src/pages/GoalsPage.test.tsx
+++ b/apps/web/src/pages/GoalsPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { useAccounts, useCategories, useGoals, useTransactions } from '../hooks';
 import { GoalsPage } from './GoalsPage';
 import { AccessibilityProvider } from '../contexts/AccessibilityContext';

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   ConfirmDialog,
   CurrencyDisplay,

--- a/apps/web/src/pages/ImportPage.test.tsx
+++ b/apps/web/src/pages/ImportPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { useAccounts } from '../hooks/useAccounts';
 import { useImport } from '../hooks/useImport';

--- a/apps/web/src/pages/ImportPage.tsx
+++ b/apps/web/src/pages/ImportPage.tsx
@@ -24,7 +24,7 @@
  */
 
 import React, { useId } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { AppIcon } from '../components/icons';
 
 import {

--- a/apps/web/src/pages/InsightsPage.test.tsx
+++ b/apps/web/src/pages/InsightsPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { InsightsPage } from './InsightsPage';
 import type { ReactNode } from 'react';
 import type { CategorySpending, UseInsightsResult } from '../hooks/useInsights';

--- a/apps/web/src/pages/InsightsPage.tsx
+++ b/apps/web/src/pages/InsightsPage.tsx
@@ -12,7 +12,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { WeeklyDigest } from '../components/insights';
 import { RecommendationsFeed } from '../components/recommendations';
 import { WellnessOverview } from '../components/wellness';

--- a/apps/web/src/pages/InvestmentDetailPage.test.tsx
+++ b/apps/web/src/pages/InvestmentDetailPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { useInvestments } from '../hooks';
 import { InvestmentDetailPage } from './InvestmentDetailPage';
 

--- a/apps/web/src/pages/InvestmentDetailPage.tsx
+++ b/apps/web/src/pages/InvestmentDetailPage.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { useInvestments } from '../hooks';
 import { formatGainLoss } from '../lib/currency';

--- a/apps/web/src/pages/InvestmentsPage.test.tsx
+++ b/apps/web/src/pages/InvestmentsPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { useInvestments, useAccounts } from '../hooks';
 import { InvestmentsPage } from './InvestmentsPage';
 import { AccessibilityProvider } from '../contexts/AccessibilityContext';

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LoginPage } from './LoginPage';
 
@@ -42,8 +42,8 @@ const preferredAuthMock = vi.hoisted(() => ({
 }));
 vi.mock('../auth/preferred-auth-method', () => preferredAuthMock);
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
   return { ...actual, useNavigate: () => navigateMock };
 });
 

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useEffect, useId, useRef, useState } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router';
 
 import { useAuth } from '../auth/auth-context';
 import { getPreferredAuthMethod, setPreferredAuthMethod } from '../auth/preferred-auth-method';

--- a/apps/web/src/pages/NotFoundPage.test.tsx
+++ b/apps/web/src/pages/NotFoundPage.test.tsx
@@ -2,15 +2,15 @@
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 import { NotFoundPage } from './NotFoundPage';
 import { trackNotFound } from '../lib/monitoring';
 
 const mockNavigate = vi.fn();
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
   return { ...actual, useNavigate: () => mockNavigate };
 });
 

--- a/apps/web/src/pages/NotFoundPage.tsx
+++ b/apps/web/src/pages/NotFoundPage.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router';
 
 import { trackNotFound } from '../lib/monitoring';
 import '../styles/not-found.css';

--- a/apps/web/src/pages/NotificationsPage.test.tsx
+++ b/apps/web/src/pages/NotificationsPage.test.tsx
@@ -13,7 +13,7 @@
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { AppNotification } from '../lib/notifications';
 import type { UseNotificationsResult } from '../hooks/useNotifications';
 

--- a/apps/web/src/pages/NotificationsPage.tsx
+++ b/apps/web/src/pages/NotificationsPage.tsx
@@ -14,7 +14,7 @@
  */
 
 import type { FC } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { NotificationHistory } from '../components/notifications';
 import { useNotificationCenter } from '../contexts/NotificationsContext';

--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -9,8 +9,8 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
-import type { NavigateOptions, To } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
+import type { NavigateOptions, To } from 'react-router';
 
 import { App, shouldAutoLaunchOnboarding } from '../App';
 import OnboardingPage from './OnboardingPage';
@@ -47,8 +47,8 @@ vi.stubGlobal('matchMedia', createMatchMedia());
 
 const mockNavigate = vi.hoisted(() => vi.fn());
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
   return {
     ...actual,
     useNavigate: () => {

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { useAuth } from '../auth/auth-context';
 import { useFocusTrap } from '../accessibility/aria';

--- a/apps/web/src/pages/P2PImportPage.tsx
+++ b/apps/web/src/pages/P2PImportPage.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 // Direct import keeps this heavy component code-split into the P2P route chunk.
 import { P2PImportPanel } from '../components/import/P2PImportPanel';

--- a/apps/web/src/pages/ResetPasswordPage.test.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.test.tsx
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ResetPasswordPage } from './ResetPasswordPage';
 
 const navigateMock = vi.hoisted(() => vi.fn());
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
   return { ...actual, useNavigate: () => navigateMock };
 });
 

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router';
 
 import { PasswordInput } from '../components/auth/PasswordInput';
 import { PasswordStrengthMeter } from '../components/auth/PasswordStrengthMeter';

--- a/apps/web/src/pages/SafetyPage.test.tsx
+++ b/apps/web/src/pages/SafetyPage.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Transaction } from '../kmp/bridge';
 import { useTransactions } from '../hooks';

--- a/apps/web/src/pages/SafetyPage.tsx
+++ b/apps/web/src/pages/SafetyPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { useTransactions } from '../hooks';
 import { detectScamAlerts } from '../lib/notifications';

--- a/apps/web/src/pages/SettingsPage.search.test.tsx
+++ b/apps/web/src/pages/SettingsPage.search.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Navigate, Route, Routes } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('../hooks/useAccessibility', () => ({

--- a/apps/web/src/pages/SettingsPage.security.test.tsx
+++ b/apps/web/src/pages/SettingsPage.security.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Navigate, Route, Routes } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('../hooks/useAccessibility', () => ({

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { MemoryRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Navigate, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const logoutMock = vi.fn<() => Promise<void>>();

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useMemo, useState } from 'react';
-import { NavLink, Outlet, useLocation } from 'react-router-dom';
+import { NavLink, Outlet, useLocation } from 'react-router';
 
 import { useAccessibility } from '../hooks/useAccessibility';
 import './settings/settings-shell.css';

--- a/apps/web/src/pages/SignupPage.test.tsx
+++ b/apps/web/src/pages/SignupPage.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SignupPage } from './SignupPage';
 
@@ -25,8 +25,8 @@ vi.mock('../auth/auth-context', () => ({
   useAuth: () => authState,
 }));
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
   return { ...actual, useNavigate: () => navigateMock };
 });
 

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -11,7 +11,7 @@
  */
 
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 
 import { useAuth } from '../auth/auth-context';
 import { OAuthButtons } from '../components/auth/OAuthButtons';

--- a/apps/web/src/pages/TaxCenterPage.test.tsx
+++ b/apps/web/src/pages/TaxCenterPage.test.tsx
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { TaxCenterPage } from './TaxCenterPage';
 

--- a/apps/web/src/pages/TaxCenterPage.tsx
+++ b/apps/web/src/pages/TaxCenterPage.tsx
@@ -3,7 +3,7 @@
 /** Tax Center page for lot-level P&L, estimated tax, and wash-sale guardrails. */
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   CurrencyDisplay,
   EmptyState,

--- a/apps/web/src/pages/TransactionDetailPage.test.tsx
+++ b/apps/web/src/pages/TransactionDetailPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 import { useAccounts, useCategories, useTransactions } from '../hooks';
 import { TransactionDetailPage } from './TransactionDetailPage';

--- a/apps/web/src/pages/TransactionDetailPage.tsx
+++ b/apps/web/src/pages/TransactionDetailPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 import { AppIcon } from '../components/icons';
 
 import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';

--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from 'react';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import type { Transaction } from '../kmp/bridge';
 import { useAccounts } from '../hooks/useAccounts';

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 import { getCurrentLocale } from '../lib/i18n';
 import { AppIcon } from '../components/icons';
 

--- a/apps/web/src/pages/legal/LegalPage.tsx
+++ b/apps/web/src/pages/legal/LegalPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { FC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import './legal.css';
 

--- a/apps/web/src/pages/legal/LegalRoutes.test.tsx
+++ b/apps/web/src/pages/legal/LegalRoutes.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { LegalLinks } from '../../components/legal/LegalLinks';

--- a/apps/web/src/pages/onboarding/steps/CompleteStep.tsx
+++ b/apps/web/src/pages/onboarding/steps/CompleteStep.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import type { NavigateFunction } from 'react-router-dom';
+import type { NavigateFunction } from 'react-router';
 
 import { AppIcon } from '../../../components/icons';
 

--- a/apps/web/src/pages/settings/SettingsAboutPage.test.tsx
+++ b/apps/web/src/pages/settings/SettingsAboutPage.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SettingsAboutPage } from './SettingsAboutPage';

--- a/apps/web/src/pages/settings/SettingsAboutPage.tsx
+++ b/apps/web/src/pages/settings/SettingsAboutPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import packageJson from '../../../package.json';
 

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -2,7 +2,7 @@
 
 import { lazy, Suspense, useCallback } from 'react';
 import type { FC, ReactNode } from 'react';
-import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useNavigate } from 'react-router';
 
 import { ProtectedRoute, useAuth } from './auth/auth-context';
 import { RouteErrorBoundary } from './components/common';

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -329,7 +329,7 @@ export default defineConfig({
           groups: [
             {
               name: 'vendor-react',
-              test: /node_modules[\\/](react|react-dom|react-router|react-router-dom|scheduler)[\\/]/,
+              test: /node_modules[\\/](react|react-dom|react-router|scheduler)[\\/]/,
               priority: 100,
             },
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6893,6 +6893,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "lucide-react": "^1.23.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "recharts": "^3.9.2",
         "sql.js": "^1.14.1",
         "tesseract.js": "^7.0.0",
@@ -75,236 +75,6 @@
         "vitest": "^4.1.10"
       }
     },
-    "apps/web/node_modules/@fluentui/react-icons": {
-      "version": "2.0.330",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.330.tgz",
-      "integrity": "sha512-IaJjO755FGlUR5Myy1IuhJKlqGPfET9JqGpotoanJm1W1sK2rELRv8L3i2UAiZ70TSvi6KAi5t4M0inqI/h9Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "@griffel/react": "^1.6.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0 <20.0.0"
-      }
-    },
-    "apps/web/node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.60.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/browser": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.59.0.tgz",
-      "integrity": "sha512-d0o0oc78KNWCZ6yq9gREf9BPXWza/Wj9W+nCm0CvPD5k2IbouD/eJsm2Mb+d53YfEm12L+SePfgOx01KbbVx4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser-utils": "10.59.0",
-        "@sentry/core": "10.59.0",
-        "@sentry/feedback": "10.59.0",
-        "@sentry/replay": "10.59.0",
-        "@sentry/replay-canvas": "10.59.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/core": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
-      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/react": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.59.0.tgz",
-      "integrity": "sha512-B3MmXooGLnTu0gyL8hxElCu1+WVEXjIGoDPvGqn5qMHZNSmB2oPTAt1/UutuxAc6EWu2UKIHnyPowNeY2MPH3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "10.59.0",
-        "@sentry/core": "10.59.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || 17.x || 18.x || 19.x"
-      }
-    },
-    "apps/web/node_modules/@storybook/addon-a11y": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.2.tgz",
-      "integrity": "sha512-9Bm41peswHVPXm8iDBEA/sCXx+MUQV8Q10yFgNC2zTbtxKamMDb8HZCPIRDxvjBQ5v13eaXA2yZGTwQ+D8S6+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "axe-core": "^4.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^10.4.2"
-      }
-    },
-    "apps/web/node_modules/@storybook/builder-vite": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.2.tgz",
-      "integrity": "sha512-d3+i9vbbUfV6hvT90qabmy1WmC4bEJ7iAYDm0217doeA+S6awF25GF0qOy9gN9waU4NMntHoVpdB1YQO2wUj/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/csf-plugin": "10.4.2",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^10.4.2",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "apps/web/node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.2.tgz",
-      "integrity": "sha512-GqX/2DeF3/jKs5D7gpDiuT9gd0c/f2TKcnQ5av4/s3YqeN+0nhm7btkCrDfgF16uzE1Zj3OrkxvB3AOkfxWgDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unplugin": "^2.3.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "esbuild": "*",
-        "rollup": "*",
-        "storybook": "^10.4.2",
-        "vite": "*",
-        "webpack": "*"
-      },
-      "peerDependenciesMeta": {
-        "esbuild": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@storybook/react": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.2.tgz",
-      "integrity": "sha512-NfEH3CrdCAgUV4Z7SPN3Iw6nofcueqtRj8iHuo77GNjz0qSfuVi9iS7a8o7x7QFSeIBZwS0Jv3CgmhN8qvoLjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "10.4.2",
-        "react-docgen": "^8.0.2",
-        "react-docgen-typescript": "^2.2.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.2",
-        "typescript": ">= 4.9.x"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@storybook/react-dom-shim": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.2.tgz",
-      "integrity": "sha512-Eng3Yt2NCjPX94QcfyLeUFhrMj0hec2yU9J/qafBVbfj9XrFI8o+0ZwYJ7uXb9ECbvPN4y06dgt/2W/LiR417w==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@storybook/react-vite": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.4.2.tgz",
-      "integrity": "sha512-nGrS74p0ujPSQ7qD5jKLLlao2igfTTb6Kf/uRhVV8XM0uM7WvxR9K20ddCM8jFmx1jY9fRm0UBGaeaXHDIh5SA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
-        "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "10.4.2",
-        "@storybook/react": "10.4.2",
-        "empathic": "^2.0.0",
-        "magic-string": "^0.30.0",
-        "react-docgen": "^8.0.0",
-        "resolve": "^1.22.8",
-        "tsconfig-paths": "^4.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.2",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
     "apps/web/node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -315,121 +85,6 @@
         "csstype": "^3.2.2"
       }
     },
-    "apps/web/node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.8",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.8",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/chai": {
-      "version": "6.2.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "apps/web/node_modules/immer": {
       "version": "11.1.11",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
@@ -438,96 +93,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
-      }
-    },
-    "apps/web/node_modules/lucide-react": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
-      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "apps/web/node_modules/nanoid": {
-      "version": "5.1.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.15.tgz",
-      "integrity": "sha512-kBg3RpGtIe+RpTbyXwoI6pk5yD7KUiI3sygUqgeBMRst42KmhB4RZC7eiO9Wa1HIpaCCtpE2DJ6OI4Wi5ebwFw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
-    },
-    "apps/web/node_modules/playwright": {
-      "version": "1.60.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.60.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "apps/web/node_modules/playwright-core": {
-      "version": "1.60.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/react-router": {
-      "version": "7.16.0",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.16.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "apps/web/node_modules/recharts": {
@@ -565,234 +130,6 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
       "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
-    },
-    "apps/web/node_modules/storybook": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.2.tgz",
-      "integrity": "sha512-5Ax5vbHxFgMBGGhQDm75Rrumm/HZC4ICFhMcJaM0UlqnC/4FKj/IaZtImZFupknyiiyUEcWHPQFA2kX3/VSv1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@storybook/icons": "^2.0.2",
-        "@testing-library/jest-dom": "^6.9.1",
-        "@testing-library/user-event": "^14.6.1",
-        "@vitest/expect": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@webcontainer/env": "^1.1.1",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
-        "open": "^10.2.0",
-        "oxc-parser": "^0.127.0",
-        "oxc-resolver": "^11.19.1",
-        "recast": "^0.23.5",
-        "semver": "^7.7.3",
-        "use-sync-external-store": "^1.5.0",
-        "ws": "^8.18.0"
-      },
-      "bin": {
-        "storybook": "dist/bin/dispatcher.js"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "prettier": "^2 || ^3",
-        "vite-plus": "^0.1.15"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "prettier": {
-          "optional": true
-        },
-        "vite-plus": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/storybook/node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "apps/web/node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "apps/web/node_modules/vitest": {
-      "version": "4.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -2521,6 +1858,19 @@
       "resolved": "apps/web",
       "link": true
     },
+    "node_modules/@fluentui/react-icons": {
+      "version": "2.0.334",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.334.tgz",
+      "integrity": "sha512-6A2boRTWkn7qOSX6kgLPVqCMZ9WQg6babIx14LKrwpsRGPOYx7QaqgGs+XE671wiJqNQX0JjuIGhvRRGL5zD+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.6.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <20.0.0"
+      }
+    },
     "node_modules/@griffel/core": {
       "version": "1.21.2",
       "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.21.2.tgz",
@@ -3854,6 +3204,22 @@
         "win32"
       ]
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@powersync/common": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@powersync/common/-/common-2.0.0.tgz",
@@ -4218,88 +3584,108 @@
         }
       }
     },
-    "node_modules/@sentry/browser-utils": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.59.0.tgz",
-      "integrity": "sha512-DpJIrNi0Hsj/YONTZ8km1wv7ue2NzrTmFKJ3lRW8Q2nS/mrMeP3LCvjreLtKheTouB4go58NxM68AEFbXk4rPg==",
+    "node_modules/@sentry/browser": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.68.0.tgz",
+      "integrity": "sha512-8xVgk7oG2lajXnbXF6a7H1xMZ/U6icqSldHGzQu1+bajfrK8Gan9ULG/Xsj1VM1LlNeK6/7znDJ3u1jgvIwznw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.59.0"
+        "@sentry/browser-utils": "10.68.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/feedback": "10.68.0",
+        "@sentry/replay": "10.68.0",
+        "@sentry/replay-canvas": "10.68.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/browser-utils/node_modules/@sentry/core": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
-      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.68.0.tgz",
+      "integrity": "sha512-be8VtdjCngKc77cstJeV+gO15iH+blyXpBDk8yOehmtX4BkFO33mfTMNCWVR2LA0oOxjIHWRAhf77fIUEhzxPg==",
       "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/feedback": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.59.0.tgz",
-      "integrity": "sha512-Sa/06LlG/mYR4z8/JlxOwvkcOHJnaMW6JyTMKNsgEoR1SHZULIpirjUuHIp4P+7R1mqX/KGTj8I7SQ3adA0TxQ==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.68.0.tgz",
+      "integrity": "sha512-XbdcXiBnpC3vgw46eHOPeD/ZQ+XzluP75ubdUcaPDW02hCh2nsdXiwjZ2DBImbpvIpTbJgjHf/sIlHWvcZJ2Mg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.59.0"
+        "@sentry/core": "10.68.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/feedback/node_modules/@sentry/core": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
-      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
+    "node_modules/@sentry/react": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.68.0.tgz",
+      "integrity": "sha512-rIq4QR4ScMHHx9JJZv7Jgw31bMdUVJMx+ykHIJb7htjY6mj78sjKs+KpCsMDnvJxDhSmvftGM1KfKD4BggL7OQ==",
       "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.68.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
+      },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.59.0.tgz",
-      "integrity": "sha512-fpHL25JErsSfTyusuyZ3Q5JmRZeWYWynJO3PNiQH6A/58EqaCp8U5y8LCJ+CSPaeuBMka3S3Qn6U4eXcvkDMRA==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.68.0.tgz",
+      "integrity": "sha512-ZoG2n16vbkx4GWSCnLIqUUN9xlUmccQFbQ2US2rhruQeHTUnHl/ukr8NHOQXZaEbwKyMkX9bEMwfmZHJm+wSTQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.59.0",
-        "@sentry/core": "10.59.0"
+        "@sentry/browser-utils": "10.68.0",
+        "@sentry/core": "10.68.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay-canvas": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.59.0.tgz",
-      "integrity": "sha512-bJkqvxQiat27P7+hUYC/m545Ct/uVxZCjh+PeCFdRcuHnZZ92e6Z7XPLf0LqAR6tR1U7wDUa4V5ugrMIEz+vpQ==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.68.0.tgz",
+      "integrity": "sha512-HusYcr+He+ohnUDHunYrc5St6vdDnBXpUAndnT5ReyUMVSCiWKfY3paXowU/0787HwYfxdcpZgwC5u79+XbEIg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.59.0",
-        "@sentry/replay": "10.59.0"
+        "@sentry/core": "10.68.0",
+        "@sentry/replay": "10.68.0"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/replay-canvas/node_modules/@sentry/core": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
-      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/replay/node_modules/@sentry/core": {
-      "version": "10.59.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
-      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -4354,6 +3740,78 @@
       "version": "0.3.0",
       "license": "MIT"
     },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.5.5.tgz",
+      "integrity": "sha512-nsMnSRe7pzepXIkUUqI/rL7sp8juXOluyypU4Dz0UuYHhw/cKaxfzuO+3WJN5EtEr/gcnKYb4awxH/duPGavUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.5"
+      }
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.5.tgz",
+      "integrity": "sha512-dQoJ7gUl8y0z5rV9cE0mz6qTBNmN9R4GOLIZk98rJ8CwduNJOb9eGZXusDzzvnYcp8TnNkqDtyx4tXQSUDInPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "10.5.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.5",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@storybook/csf-plugin": {
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.5.tgz",
+      "integrity": "sha512-/euibhRFqklYCZqUseokojmfYcQpXshVY2QmA1qCuxMz9SzVFD3iSTw+aFLTxpsJGGdcZJk8fnm/rEthLzZ9jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^2.3.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "esbuild": "*",
+        "rollup": "*",
+        "storybook": "^10.5.5",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@storybook/global": {
       "version": "5.0.0",
       "dev": true,
@@ -4366,6 +3824,102 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.5.5.tgz",
+      "integrity": "sha512-T2Xj0ey7a9RHU6coYLC0L5lhjcdyhLCs9wNv15FvHvgmrRobkynEV72kq5vGW8tFkahNWI1X9+GZPQ6r8Nm38w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "10.5.5",
+        "react-docgen": "^8.0.2",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.5",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.5.tgz",
+      "integrity": "sha512-PIk7N3LLrZIxfNxmkvmQN1d5UQ70XEedT8n0GhBiXnM6XL09xPGB8n8TZXeJBRYluKhDQcAyQeT0/OZmcDVQJg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.5"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite": {
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.5.5.tgz",
+      "integrity": "sha512-Uy7VV72kVSkw6aDTAPQupXUeZX5LF6e4zqNvTZ+36qxsXAkaFgw7HPEm7L1tsaRfiV+s9anU7UvX47tfJpYGuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "10.5.5",
+        "@storybook/react": "10.5.5",
+        "empathic": "^2.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^8.0.2",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.5",
+        "typescript": ">= 4.9.x",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4586,6 +4140,8 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4808,6 +4364,8 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5135,6 +4693,217 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webcontainer/env": {
       "version": "1.1.1",
       "dev": true,
@@ -5262,6 +5031,8 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5363,14 +5134,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5526,6 +5299,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "dev": true,
@@ -5549,6 +5339,8 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5668,16 +5460,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.2",
@@ -6190,6 +5977,8 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6835,9 +6624,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -7102,25 +6891,6 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/git-raw-commits/node_modules/meow": {
@@ -7683,9 +7453,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -7821,6 +7591,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -8271,6 +8048,8 @@
     },
     "node_modules/loupe": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8280,6 +8059,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.27.0.tgz",
+      "integrity": "sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -8444,6 +8232,25 @@
       "version": "2.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -8841,6 +8648,8 @@
     },
     "node_modules/pathval": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8863,6 +8672,38 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "dev": true,
@@ -8872,9 +8713,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -8892,7 +8733,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8901,9 +8742,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -9119,6 +8960,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=22.22.0"
+      },
+      "peerDependencies": {
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-yaml-file": {
@@ -9433,10 +9295,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "license": "MIT"
-    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "dev": true,
@@ -9618,6 +9476,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/storybook": {
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.5.tgz",
+      "integrity": "sha512-UscBIBJDloUeqntukHOhP1a5W/vouePDJbzPSxj466WK801FZtzQiMffMtkjzJiWSuj20wfaYlB2QQKh9aOYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^2.0.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/expect": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@webcontainer/env": "^1.1.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
+        "jsonc-parser": "^3.3.1",
+        "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "^11.19.1",
+        "recast": "^0.23.5",
+        "semver": "^7.7.3",
+        "use-sync-external-store": "^1.5.0",
+        "ws": "^8.21.1"
+      },
+      "bin": {
+        "storybook": "dist/bin/dispatcher.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/stream": {
       "version": "0.0.3",
       "dev": true,
@@ -9710,6 +9617,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-dictionary": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.5.0.tgz",
+      "integrity": "sha512-AGkOZtAc3OTz99wlzstrmj5OM5BWOW2IbmXD74sf0MXFPi271TGBdywokgd7bS3L0tKOk9M0FR+R9gnbXRSSfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bundled-es-modules/deepmerge": "^4.3.2",
+        "@bundled-es-modules/glob": "^13.0.6",
+        "@bundled-es-modules/memfs": "^4.17.0",
+        "@zip.js/zip.js": "^2.7.44",
+        "chalk": "^5.3.0",
+        "change-case": "^5.3.0",
+        "colorjs.io": "^0.5.2",
+        "commander": "^12.1.0",
+        "is-plain-obj": "^4.1.0",
+        "json5": "^2.2.2",
+        "path-unified": "^0.2.0",
+        "prettier": "^3.3.3",
+        "tinycolor2": "^1.6.0"
+      },
+      "bin": {
+        "style-dictionary": "bin/style-dictionary.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -9813,8 +9748,20 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tinyspy": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9892,7 +9839,9 @@
       }
     },
     "node_modules/ts-dedent": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10006,6 +9955,8 @@
     },
     "node_modules/unplugin": {
       "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10204,6 +10155,172 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "dev": true,
@@ -10228,6 +10345,8 @@
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10472,34 +10591,6 @@
       "version": "0.1.0",
       "devDependencies": {
         "style-dictionary": "^5.5.0"
-      }
-    },
-    "packages/design-tokens/node_modules/style-dictionary": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.4.4.tgz",
-      "integrity": "sha512-Sd7dkEOLn33EpvlMyS8ykUu0us2EIFUqsysf4DSwZQ46nqQkZ2Q9o5mozu8cSizj3t7E220HaPk7EV1O7LjvDQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bundled-es-modules/deepmerge": "^4.3.2",
-        "@bundled-es-modules/glob": "^13.0.6",
-        "@bundled-es-modules/memfs": "^4.17.0",
-        "@zip.js/zip.js": "^2.7.44",
-        "chalk": "^5.3.0",
-        "change-case": "^5.3.0",
-        "colorjs.io": "^0.5.2",
-        "commander": "^12.1.0",
-        "is-plain-obj": "^4.1.0",
-        "json5": "^2.2.2",
-        "path-unified": "^0.2.0",
-        "prettier": "^3.3.3",
-        "tinycolor2": "^1.6.0"
-      },
-      "bin": {
-        "style-dictionary": "bin/style-dictionary.js"
-      },
-      "engines": {
-        "node": ">=22.0.0"
       }
     },
     "services/api": {

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "dompurify": ">=3.4.1",
     "fast-xml-parser": ">=5.7.0",
     "protobufjs": "7.6.3",
-    "brace-expansion": ">=5.0.6||<5.0.0",
-    "postcss": ">=8.5.10",
+    "brace-expansion": ">=5.0.8",
+    "postcss": ">=8.5.18",
     "styled-components": ">=6.4.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
@@ -88,8 +88,9 @@
     "@redocly/cli": "2.34.0",
     "@babel/core": "7.29.6",
     "esbuild": "0.28.1",
-    "js-yaml": "4.2.0",
+    "js-yaml": "^4.3.0",
     "read-yaml-file": "^2.1.0",
+    "fast-uri": ">=3.1.4 <4.0.0",
     "jsdom": {
       "undici": "7.28.0"
     },


### PR DESCRIPTION
## Summary

Migrates `apps/web` from the **discontinued** `react-router-dom@7` to **`react-router@8.3.0`** and bumps four transitive dependency overrides to clear **all High-severity `npm audit` advisories**. These advisories were failing the repo-wide **Required Checks Gatekeeper** (`ci-security.yml` aggregates `npm-audit`), which transitively **blocks every PR merge**.

`npm audit --audit-level=high`: **19 high → 0 vulnerabilities**.

## Why react-router v8 (not react-router-dom@8)

React Router v8 **discontinued the `react-router-dom` package** — everything consolidated into core `react-router` (with `react-router/dom` reserved for framework/RSC APIs this app does not use). All **16** declarative/hooks APIs the web app uses — `Link`, `Route`, `Routes`, `useNavigate`, `useLocation`, `useParams`, `Navigate`, `MemoryRouter`, `BrowserRouter` (incl. `useTransitions`), `NavLink`, `Outlet`, `useSearchParams`, `useNavigationType`, and the `NavigateOptions`/`To`/`NavigateFunction` types — are exported from core `react-router`.

This is a **mechanical import swap**, not a framework migration:

- The app is a **declarative SPA** (`<BrowserRouter><Routes>`) with **no loaders/actions/RSC**, so v8's framework-mode breaking changes (meta `loaderData`, always-on middleware, RSC context) **do not apply**.
- Peers already satisfied: **React 19.2.7**, **Vite 8**, **Node 22** (CI), ESM (`"type": "module"`).
- `<BrowserRouter useTransitions={false}>` (the fix for #3551) — `useTransitions` remains a valid `BrowserRouterProps` prop in v8.3.0, unchanged.

## Changes

- **`apps/web/package.json`**: `react-router-dom@^7.18.1` → `react-router@^8.3.0`.
- **118 `.ts`/`.tsx` files** in `apps/web`: import specifier `react-router-dom` → `react-router` (142 replacements).
- **Root `package.json` `overrides`** (clears the remaining High advisories):
  - `postcss` `>=8.5.10` → `>=8.5.18` (GHSA-r28c-9q8g-f849)
  - `js-yaml` `4.2.0` → `^4.3.0` (GHSA-52cp-r559-cp3m — the override was pinned at the vulnerable version; this cleared the entire changesets/cosmiconfig/@manypkg cluster)
  - `brace-expansion` `>=5.0.6||<5.0.0` → `>=5.0.8` (dev-only, via eslint→minimatch)
  - added `fast-uri` `>=3.1.4 <4.0.0` (GHSA-v2hh-gcrm-f6hx)
- **`apps/web/vite.config.ts`**: `vendor-react` manualChunks regex — removed the now-dead `react-router-dom` alternative.
- Stale comments updated (`AppBrowserRouter.tsx`, `ResponsiveNav.test.tsx`).
- `package-lock.json` regenerated.

## Testing

- [x] `tsc -b && vite build` (`npm run build -w @finance/web`) — **green**, exit 0
- [x] Web unit tests — **10251 passed** (vitest). The 3 local "failures" are pre-existing and **environmental only**: they read `import.meta.env` populated by a local gitignored `.env.local` (live-Supabase config). Proven by moving `.env.local` aside → all 5 env-sensitive files pass 25/25. CI has no `.env.local`, so they pass remotely.
- [x] `npm audit --audit-level=high` → **0 vulnerabilities**
- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean

## Impact

Once merged, this clears the **npm-audit High advisories on `main`**, turning the **Required Checks Gatekeeper green repo-wide** and unblocking all queued PR merges.

## Issues

Closes #3949
