### PR TITLE
ci(deploy): fix Promote to Production startup_failure (grant actions:read for reusable call)

### DIFF
--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -15,6 +15,10 @@ permissions:
   checks: read
   statuses: read
   deployments: write
+  # Required so the reusable deploy-production.yml call is not rejected at
+  # startup: its verify-ci-green job requests actions:read, and a called
+  # workflow cannot escalate a scope above the caller's grant.
+  actions: read
 
 jobs:
   promote:


### PR DESCRIPTION
## Summary

The **Promote to Production** workflow (`.github/workflows/promote-production.yml`) has failed with `startup_failure` on **every** run since it was created (PR #2105) — it has **never once succeeded**. As a result, automated promotion of a green staging commit to production has never actually invoked the production deploy pipeline.

## Root cause

`promote-production.yml` calls the reusable `deploy-production.yml` via a job-level `uses:`. That reusable workflow's `verify-ci-green` job declares a job-level `permissions:` block requesting `actions: read`. The caller, however, granted only four scopes — and because an explicit `permissions:` block implicitly sets every unlisted scope to `none`, the caller's `actions` scope was `none`:

```yaml
# before — caller
permissions:
  contents: write
  checks: read
  statuses: read
  deployments: write
  # actions unlisted => none
```

A **called reusable workflow cannot escalate a permission above the caller's grant**. GitHub validates this at **compile/startup time**, so the whole run is rejected before any job runs — producing the exact observed signature: `startup_failure` with **no jobs, no check-runs, and no logs**, attributed to the caller file.

### Why this went unnoticed

- `deploy-production.yml` run **standalone** via `workflow_dispatch` compiles and starts fine (only its runtime deploy steps fail) — so the callee YAML is valid; the failure is purely the caller's permission cap.
- `actions: read` is the **only** scope requested anywhere in the callee that the caller did not grant.
- `actionlint` passes both files — it does not cross-validate caller↔callee permission caps.

## Change

Add `actions: read` to the caller's `permissions:` block. Minimal, least-privilege (a single read scope actually required by the callee), and leaves the working `deploy-production.yml` untouched.

```diff
 permissions:
   contents: write
   checks: read
   statuses: read
   deployments: write
+  actions: read
```

## Testing

- [x] `actionlint` passes on both `promote-production.yml` and `deploy-production.yml` (exit 0)
- [x] `prettier --check` passes on the changed file
- [ ] End-to-end: the workflow only fires on a real staging deploy, so full validation happens on the next merge-to-`main` (the reusable pipeline should now start and reach the protected `production` environment gate instead of `startup_failure`)

## Notes

This fixes the workflow **definition** only. It does **not** trigger a production deploy — production promotion still respects the protected `production` environment (required reviewers + wait timer + branch policy), so human approval remains enforced at deploy time.

Closes #3953