### PR TITLE
ci(deploy): reset production deploy onto a fresh concurrency lane (#3955)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -91,11 +91,18 @@ concurrency:
   # run blocked the whole lane, so automated promotions queued behind it hung
   # `pending` for hours with zero jobs started (#3086, #3186).
   #
-  # Fix: let a newer automated promotion (workflow_run -> workflow_call) or a
-  # manual `workflow_dispatch` cancel the older, superseded run (newest-wins) so
-  # the lane is freed instead of stranded. Tag pushes are distinct, immutable
+  # Newest-wins: let a newer automated promotion (workflow_run -> workflow_call)
+  # or a manual `workflow_dispatch` cancel the older, superseded run (newest-wins)
+  # so the lane is freed instead of stranded. Tag pushes are distinct, immutable
   # releases, so they keep the non-cancelling behaviour.
-  group: deploy-production
+  #
+  # Lane reset (#3955): cancelling runs while they were still `pending` (before
+  # any job had started) left the previous `deploy-production` lane in a stuck
+  # state where GitHub kept every subsequent run `pending` with ZERO jobs
+  # scheduled - with no incident, no billing issue, and no other run holding the
+  # lane. Renaming the group moves production deploys onto a fresh lane and
+  # clears the wedge, while preserving the same serialize-on-one-host guarantee.
+  group: deploy-production-v2
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 permissions:


### PR DESCRIPTION
﻿## Summary

Production deploys have been hanging in `pending` with **zero jobs scheduled** - never allocating a runner, no logs, no `startup_failure`. Three consecutive `Deploy - Production` runs wedged this way over 2026-07-28/29 (30378381639, 30483888254, 30490537706).

## Root cause

`deploy-production.yml` serializes all production deploys onto one constant concurrency lane (`group: deploy-production`). The identical config scheduled jobs normally on 2026-07-08 (run 28964869728 reached `failure`, i.e. jobs ran). Since then several runs were cancelled **while still `pending`** (before any job started). Cancelling `pending` runs in a `cancel-in-progress` group is a known GitHub Actions pathology that leaves the lane stuck - every subsequent run enters `pending` and is never scheduled.

Ruled out: GitHub incident (Actions operational), billing (scheduled Housekeeping runs succeed), disabled/invalid workflow (active, compiles standalone), and lane contention (no other run holds the lane; only this workflow uses the group). The lane itself is poisoned.

## Changes

- Rename the concurrency group `deploy-production` -> `deploy-production-v2`, moving production deploys onto a fresh lane and clearing the wedge.
- Preserve the same serialize-on-one-host guarantee and newest-wins (`cancel-in-progress`) semantics.
- Document the recovery inline for future readers.

## Testing

- `actionlint` clean; `prettier --check` passes.
- Validated by dispatching this branch ref and confirming the run leaves `pending` and schedules jobs on the fresh lane.

## Issues

Closes #3955
