### PR TITLE
ci(deploy): disable sample-data seeding in production web builds (#3957)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -355,6 +355,8 @@ jobs:
           # Enable the live PowerSync client only when a real backend URL is
           # configured; otherwise keep it off so @powersync/web is tree-shaken.
           VITE_POWERSYNC_ENABLED: ${{ secrets.POWERSYNC_URL != '' && 'true' || 'false' }}
+          # Production starts with an empty workspace — never seed sample data (#3957).
+          VITE_DISABLE_SAMPLE_DATA: 'true'
         run: npm run build -w apps/web
 
       - name: Verify web build env
@@ -457,6 +459,7 @@ jobs:
             export VITE_POWERSYNC_ENABLED="$( [ -n "$VITE_POWERSYNC_URL" ] && echo true || echo false )"
             export VITE_SENTRY_DSN="$(printf '%s' "$SENTRY_DSN_B64" | base64 -d)"
             export VITE_ENVIRONMENT=production
+            export VITE_DISABLE_SAMPLE_DATA=true  # production starts empty — no sample data (#3957)
             export VITE_APP_VERSION="$SHA_SHORT"
             export NODE_ENV=production
             export HUSKY=0  # husky is a devDep; skip its git-hook install on the production VM
@@ -776,6 +779,7 @@ jobs:
               export VITE_POWERSYNC_ENABLED="$( [ -n "$VITE_POWERSYNC_URL" ] && echo true || echo false )"
               export VITE_SENTRY_DSN="$(printf '%s' "$SENTRY_DSN_B64" | base64 -d)"
               export VITE_ENVIRONMENT=production
+              export VITE_DISABLE_SAMPLE_DATA=true  # production starts empty — no sample data (#3957)
               export VITE_APP_VERSION="$ROLLBACK_TAG"
               export NODE_ENV=production
               export HUSKY=0  # husky is a devDep; skip its git-hook install on the production VM


### PR DESCRIPTION
## Summary

Production first-run seeds sample data and shows the onboarding **"Sample data"** banner because the `deploy-production.yml` web builds never set `VITE_DISABLE_SAMPLE_DATA`. Per `apps/web/src/db/sampleData.ts`, production is meant to start with an **empty workspace** and set this flag.

This adds `VITE_DISABLE_SAMPLE_DATA=true` to all three production web-build steps so a fresh production browser no longer seeds placeholder sample data.

## Changes

- `.github/workflows/deploy-production.yml`:
  - **smoke-tests** `Build web (production config)` env block → `VITE_DISABLE_SAMPLE_DATA: 'true'`
  - **deploy-web-vm** SSH rebuild heredoc → `export VITE_DISABLE_SAMPLE_DATA=true`
  - **auto-rollback** SSH rebuild heredoc → `export VITE_DISABLE_SAMPLE_DATA=true`

## Context

This is one half of the live-data fix. The other half is a gated ops action (owner sets the `POWERSYNC_URL` production **environment** secret to `https://finance.jrmoulckers.com/sync`, replacing the leaked `YOUR_POWERSYNC_URL_HERE` placeholder). A single production web redeploy then picks up both.

Note: this only affects **fresh/empty** browsers. An already-seeded browser still shows the banner until the user clicks "Clear sample data & start fresh".

## Issues

Closes #3957

## Testing

- [x] `npx prettier --check .github/workflows/deploy-production.yml` — clean
- [x] YAML parses (Prettier validated); change is additive env vars only — no trigger, permissions, or required-check impact
