### PR TITLE
fix(web): hide grouped skip links off-screen until focus (#3959)

### DIFF
--- a/apps/web/src/styles/accessibility.css
+++ b/apps/web/src/styles/accessibility.css
@@ -384,9 +384,14 @@ input[type='radio'] {
   z-index: 10000;
 }
 
+/* Hidden state: pull each grouped link off-screen with a fixed offset rather
+   than a percentage. `.skip-links` is absolutely positioned with all-absolute
+   children, so it collapses to zero height; a percentage `top` resolves against
+   that 0px height (`top: -100%` == `0px`), leaving the links visible in the
+   top-left corner. A fixed rem offset hides them reliably (#3959). */
 .skip-links .skip-link {
   position: absolute;
-  top: -100%;
+  top: -10rem;
   left: 0;
 }
 


### PR DESCRIPTION
## Summary

The two bypass-block skip links — "Skip to main content" and "Skip to navigation" — were permanently visible in the top-left corner of every route (including the dashboard) instead of appearing only on keyboard focus.

## Root Cause

`.skip-links` is an absolutely-positioned container whose children are all absolutely positioned, so it collapses to **zero height**. The hide rule used a percentage offset:

```css
.skip-links .skip-link { top: -100%; }
```

A percentage `top` on an absolutely-positioned child resolves against the containing block's height — which is `0px` here — so `top: -100%` evaluated to `0px`, pinning both links on-screen at the container origin (`top: 8px; left: 16px`). They never moved off-screen.

## Changes

- `apps/web/src/styles/accessibility.css`: replace the percentage `top: -100%` hide offset for grouped `.skip-links .skip-link` with a fixed `top: -10rem`, so the links stay off-screen regardless of the zero-height container and only appear via the existing `.skip-links:focus-within` rule.

## Issues

Closes #3959

## Testing

- [x] `npm run format:check` — passes
- [x] `apps/web` SkipLinks tests pass (`vitest run src/components/layout/SkipLinks.test.tsx` — 4/4)
- [x] Verified links now hide off-screen and reveal only on `:focus-within`

## Cross-Platform

Web-only. This is a CSS containing-block/percentage-height quirk specific to the web PWA skip-link markup; iOS/Android/Windows use native bypass affordances and are unaffected.
