### PR TITLE
fix(web): stop household create from crashing the page (#3961)

### DIFF
--- a/apps/web/src/pages/HouseholdPage.test.tsx
+++ b/apps/web/src/pages/HouseholdPage.test.tsx
@@ -563,6 +563,33 @@ describe('HouseholdPage', () => {
     expect(screen.getByText(/privacy-by-default/i)).toBeInTheDocument();
   });
 
+  // Regression for the "Household couldn't load" crash on create (#3961). The
+  // create form renders while `household` is null; once creation succeeds
+  // `household` becomes non-null on the SAME mounted component. If any Hook is
+  // declared after the `!household` early return, React renders more Hooks than
+  // the previous pass and throws. This test drives that exact transition and
+  // asserts the management UI renders instead of crashing.
+  it('does not crash when a household is created on the mounted page (#3961)', () => {
+    mockedUseHousehold.mockReturnValue(mockHouseholdResult());
+
+    const { rerender } = render(<HouseholdPage />);
+    expect(screen.getByText('Create Your Household')).toBeInTheDocument();
+
+    // Simulate createHousehold() resolving: the hook now returns a household
+    // and its owner member for the already-mounted component.
+    mockedUseHousehold.mockReturnValue(
+      mockHouseholdResult({
+        household: makeHousehold(),
+        members: [makeOwnerMember()],
+      }),
+    );
+
+    expect(() => rerender(<HouseholdPage />)).not.toThrow();
+    expect(screen.queryByText('Create Your Household')).not.toBeInTheDocument();
+    expect(screen.getByText('Smith Family')).toBeInTheDocument();
+    expect(screen.getByText('Mid-Month Scorecard')).toBeInTheDocument();
+  });
+
   it('renders household management when household exists', () => {
     mockedUseHousehold.mockReturnValue(
       mockHouseholdResult({

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -1174,6 +1174,48 @@ export function HouseholdPage() {
     (option) => option.value === trustedHelperAccessMethod,
   );
 
+  // These memoized derivations MUST run on every render — before any early
+  // return below — so the Hooks call order stays stable. Creating a household
+  // flips `household` from null to set; if these lived after the early returns
+  // React would see more Hooks on the next render and crash the page
+  // ("Household couldn't load").
+  const scorecard = useMemo(
+    () =>
+      buildHouseholdScorecard({
+        members,
+        budgetSnapshots: getScorecardBudgetSnapshots(budgetData.budgets, household?.id ?? ''),
+        transactions: transactionData.transactions,
+        accountSharings,
+        resolveMemberName,
+        referenceDate: new Date(),
+      }),
+    [
+      accountSharings,
+      budgetData.budgets,
+      household?.id,
+      members,
+      resolveMemberName,
+      transactionData.transactions,
+    ],
+  );
+
+  const recurringBillReminders = useMemo(
+    () => buildRecurringBillReminders(recurringBills),
+    [recurringBills],
+  );
+  const goalPledgeProgress = useMemo(() => {
+    const pledgedGoalIds = Array.from(new Set(goalPledges.map((pledge) => pledge.goalId)));
+    return pledgedGoalIds.map((goalId) => calculateGoalPledgeProgress(goalPledges, goalId));
+  }, [goalPledges]);
+  const shoppingBudgetSummaries = useMemo(
+    () =>
+      shoppingBudgets.map((budget) => ({
+        budget,
+        summary: calculateShoppingBudgetSummary(budget),
+      })),
+    [shoppingBudgets],
+  );
+
   // -- Loading state -------------------------------------------------------
 
   if (loading) {
@@ -1234,42 +1276,6 @@ export function HouseholdPage() {
 
   // -- Filter pending invitations for display
   const pendingInvitations = invitations.filter((inv) => inv.status === 'PENDING');
-  const scorecard = useMemo(
-    () =>
-      buildHouseholdScorecard({
-        members,
-        budgetSnapshots: getScorecardBudgetSnapshots(budgetData.budgets, household.id),
-        transactions: transactionData.transactions,
-        accountSharings,
-        resolveMemberName,
-        referenceDate: new Date(),
-      }),
-    [
-      accountSharings,
-      budgetData.budgets,
-      household.id,
-      members,
-      resolveMemberName,
-      transactionData.transactions,
-    ],
-  );
-
-  const recurringBillReminders = useMemo(
-    () => buildRecurringBillReminders(recurringBills),
-    [recurringBills],
-  );
-  const goalPledgeProgress = useMemo(() => {
-    const pledgedGoalIds = Array.from(new Set(goalPledges.map((pledge) => pledge.goalId)));
-    return pledgedGoalIds.map((goalId) => calculateGoalPledgeProgress(goalPledges, goalId));
-  }, [goalPledges]);
-  const shoppingBudgetSummaries = useMemo(
-    () =>
-      shoppingBudgets.map((budget) => ({
-        budget,
-        summary: calculateShoppingBudgetSummary(budget),
-      })),
-    [shoppingBudgets],
-  );
   const activeReconciliationPlan = reconciliationPlans[0] ?? null;
   const activeReconciliationSummary = activeReconciliationPlan
     ? calculateReconciliationSummary(activeReconciliationPlan)


### PR DESCRIPTION
## Summary

Creating a household on the web app crashed the whole page — after entering a
name and pressing **Create Household**, the route error boundary took over with
**"Household couldn't load."** The household was never created from the user's
point of view.

## Root Cause

`HouseholdPage` violated the Rules of Hooks. Four `useMemo` hooks (`scorecard`,
`recurringBillReminders`, `goalPledgeProgress`, `shoppingBudgetSummaries`) were
declared **after** the `if (loading)` and `if (!household)` early returns. While
the create form is shown, `household` is `null` and the component returns early,
so those hooks never run. As soon as `createHousehold` succeeds, `household`
becomes non-null on the same mounted component, the early return is skipped, and
React renders **more hooks than the previous pass** — throwing
`Rendered more hooks than during the previous render.` `RouteErrorBoundary`
catches it and shows the generic "Household couldn't load" screen.

## Changes

- Move the four `useMemo` hooks above the early returns so the Hooks call order
  is stable on every render.
- Make the `scorecard` memo null-safe (`household?.id ?? ''`); its result is
  unused while `household` is null because the create-form early return fires
  first.
- Add a regression test that drives the create → loaded transition on a mounted
  page and asserts it renders the management UI instead of throwing. Verified the
  test fails with `Rendered more hooks than during the previous render.` before
  the fix and passes after.

## Issues

Closes #3961

## Testing

- [x] `npm --prefix apps/web run test -- HouseholdPage --run` — 30 passed
- [x] Regression test fails without the fix, passes with it
- [x] `prettier --write` + `eslint --max-warnings 0` clean on both changed files

## Cross-Platform

Web-only defect. iOS (SwiftUI), Android (Jetpack Compose), and Windows (Compose
Desktop) have no React Hooks ordering rule — N/A.
