### PR TITLE
fix(web): unify sync status source of truth so banner and settings agree (#3960)

### DIFF
--- a/apps/web/src/components/common/SyncStatusBar.tsx
+++ b/apps/web/src/components/common/SyncStatusBar.tsx
@@ -20,13 +20,13 @@
  * References: issue #416
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React from 'react';
 
-import { useSyncStatus } from '../../hooks/useSyncStatus';
-import { useLivePowerSyncStatus } from '../../hooks/useLivePowerSyncStatus';
-import { getUnresolvedConflicts } from '../../db/sync/sync-conflict';
-import { isPowerSyncEnabled } from '../../db/sync/powersync/database';
-import type { LivePowerSyncStatus } from '../../db/sync/powersync/live-status';
+import {
+  describeSyncVariant,
+  useSyncStatusVariant,
+  type SyncStatusVariant,
+} from '../../hooks/useSyncStatusVariant';
 
 import '../../styles/sync-status.css';
 
@@ -65,21 +65,6 @@ function formatRelativeTime(isoString: string | null): string {
 // Sync variant
 // ---------------------------------------------------------------------------
 
-type SyncVariant = 'synced' | 'pending' | 'syncing' | 'error' | 'offline' | 'conflict';
-
-/**
- * Derive the bar variant from the live `@powersync/web` runtime status.
- * Used only when the live PowerSync client is enabled; the real connection
- * state — not the local mutation queue — then drives the bar.
- */
-function deriveLiveVariant(live: LivePowerSyncStatus, isOffline: boolean): SyncVariant {
-  if (isOffline) return 'offline';
-  if (live.connecting || live.syncing) return 'syncing';
-  if (live.connected) return 'synced';
-  if (live.hasError) return 'error';
-  return 'offline';
-}
-
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -88,82 +73,15 @@ function deriveLiveVariant(live: LivePowerSyncStatus, isOffline: boolean): SyncV
  * Compact sync status indicator for the app layout.
  *
  * Renders a thin bar showing the current sync state with appropriate
- * semantic colours and screen reader announcements.
+ * semantic colours and screen reader announcements. The status is derived by
+ * the shared `useSyncStatusVariant` hook so this bar always agrees with the
+ * Settings → Sync & Devices status row.
  */
 export const SyncStatusBar: React.FC = () => {
-  const { isOnline, isOffline, pendingMutations, lastSyncTime, isSyncing, syncNow } =
-    useSyncStatus();
-  const live = useLivePowerSyncStatus();
-  const powerSyncActive = isPowerSyncEnabled();
+  const { variant, pendingMutations, conflictCount, lastSyncTime, syncNow, retry } =
+    useSyncStatusVariant();
 
-  const [conflictCount, setConflictCount] = useState(0);
-  const [lastSyncFailed, setLastSyncFailed] = useState(false);
-
-  // Track the previous syncing state to detect sync failures.
-  const prevSyncingRef = useRef(false);
-
-  useEffect(() => {
-    if (prevSyncingRef.current && !isSyncing && pendingMutations > 0 && isOnline) {
-      // Sync just finished but mutations remain → sync failed.
-      setLastSyncFailed(true);
-    } else if (isSyncing) {
-      setLastSyncFailed(false);
-    }
-    prevSyncingRef.current = isSyncing;
-  }, [isSyncing, pendingMutations, isOnline]);
-
-  // Poll unresolved conflicts whenever sync state changes.
-  useEffect(() => {
-    let cancelled = false;
-
-    async function checkConflicts(): Promise<void> {
-      try {
-        const conflicts = await getUnresolvedConflicts();
-        if (!cancelled) {
-          setConflictCount(conflicts.length);
-        }
-      } catch {
-        // IndexedDB may not be available in some contexts.
-      }
-    }
-
-    void checkConflicts();
-    return () => {
-      cancelled = true;
-    };
-  }, [isSyncing, pendingMutations]);
-
-  // Determine the visual variant.
-  let variant: SyncVariant;
-  if (isOffline) {
-    variant = 'offline';
-  } else if (isSyncing) {
-    variant = 'syncing';
-  } else if (conflictCount > 0) {
-    variant = 'conflict';
-  } else if (lastSyncFailed) {
-    variant = 'error';
-  } else if (pendingMutations > 0) {
-    variant = 'pending';
-  } else {
-    variant = 'synced';
-  }
-
-  // When the live PowerSync client is active, its real runtime status is the
-  // source of truth: the local mutation queue does not track the live
-  // connection. Flag off → variant is unchanged and behaviour is identical.
-  if (powerSyncActive) {
-    variant = deriveLiveVariant(live, isOffline);
-  }
-
-  const handleRetry = useCallback(() => {
-    setLastSyncFailed(false);
-    syncNow();
-  }, [syncNow]);
-
-  const relativeTime = powerSyncActive
-    ? formatRelativeTime(live.lastSyncedAt)
-    : formatRelativeTime(lastSyncTime);
+  const relativeTime = formatRelativeTime(lastSyncTime);
 
   return (
     <div
@@ -174,7 +92,7 @@ export const SyncStatusBar: React.FC = () => {
     >
       <SyncIcon variant={variant} />
       <span className="sync-status-bar__text">
-        {renderStatusText(variant, pendingMutations, conflictCount)}
+        {describeSyncVariant(variant, pendingMutations, conflictCount)}
       </span>
       {relativeTime && variant === 'synced' && (
         <span className="sync-status-bar__time" aria-label={`Last synced ${relativeTime}`}>
@@ -185,7 +103,7 @@ export const SyncStatusBar: React.FC = () => {
         <button
           type="button"
           className="sync-status-bar__action"
-          onClick={handleRetry}
+          onClick={syncNow}
           aria-label="Sync pending changes now"
         >
           Sync now
@@ -195,7 +113,7 @@ export const SyncStatusBar: React.FC = () => {
         <button
           type="button"
           className="sync-status-bar__action"
-          onClick={handleRetry}
+          onClick={retry}
           aria-label="Retry failed sync"
         >
           Retry
@@ -206,36 +124,11 @@ export const SyncStatusBar: React.FC = () => {
 };
 
 // ---------------------------------------------------------------------------
-// Status text
-// ---------------------------------------------------------------------------
-
-function renderStatusText(
-  variant: SyncVariant,
-  pendingMutations: number,
-  conflictCount: number,
-): string {
-  switch (variant) {
-    case 'synced':
-      return 'All synced';
-    case 'pending':
-      return `${pendingMutations} pending change${pendingMutations !== 1 ? 's' : ''}`;
-    case 'syncing':
-      return 'Syncing\u2026';
-    case 'error':
-      return 'Sync failed';
-    case 'offline':
-      return 'Offline. Changes saved locally';
-    case 'conflict':
-      return `${conflictCount} conflict${conflictCount !== 1 ? 's' : ''} need attention`;
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Icon
 // ---------------------------------------------------------------------------
 
 interface SyncIconProps {
-  variant: SyncVariant;
+  variant: SyncStatusVariant;
 }
 
 const SyncIcon: React.FC<SyncIconProps> = ({ variant }) => {

--- a/apps/web/src/hooks/__tests__/useSyncStatusVariant.test.ts
+++ b/apps/web/src/hooks/__tests__/useSyncStatusVariant.test.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Regression tests for the shared sync-status derivation.
+ *
+ * The original bug (#3960) was that the global banner and the Settings sync
+ * row derived "offline" from different sources, so the app could show
+ * "Offline. Changes saved locally" and "All synced" at the same time. These
+ * tests pin the single-source-of-truth behaviour so both surfaces agree.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const syncStatusMock = {
+  isOnline: true,
+  isOffline: false,
+  pendingMutations: 0,
+  lastSyncTime: null as string | null,
+  isSyncing: false,
+  syncNow: vi.fn(),
+  authError: false,
+  conflictCount: 0,
+};
+
+const liveStatusMock = {
+  connected: false,
+  connecting: false,
+  syncing: false,
+  hasSynced: false,
+  hasError: false,
+  lastSyncedAt: null as string | null,
+};
+
+const powerSyncEnabledMock = { value: false };
+
+vi.mock('../useSyncStatus', () => ({
+  useSyncStatus: () => syncStatusMock,
+}));
+
+vi.mock('../useLivePowerSyncStatus', () => ({
+  useLivePowerSyncStatus: () => liveStatusMock,
+}));
+
+vi.mock('../../db/sync/powersync/database', () => ({
+  isPowerSyncEnabled: () => powerSyncEnabledMock.value,
+}));
+
+vi.mock('../../db/sync/sync-conflict', () => ({
+  getUnresolvedConflicts: vi.fn().mockResolvedValue([]),
+}));
+
+import {
+  describeSyncVariant,
+  isDisconnectedVariant,
+  useSyncStatusVariant,
+} from '../useSyncStatusVariant';
+
+function resetMocks(): void {
+  syncStatusMock.isOnline = true;
+  syncStatusMock.isOffline = false;
+  syncStatusMock.pendingMutations = 0;
+  syncStatusMock.lastSyncTime = null;
+  syncStatusMock.isSyncing = false;
+  syncStatusMock.conflictCount = 0;
+
+  liveStatusMock.connected = false;
+  liveStatusMock.connecting = false;
+  liveStatusMock.syncing = false;
+  liveStatusMock.hasSynced = false;
+  liveStatusMock.hasError = false;
+  liveStatusMock.lastSyncedAt = null;
+
+  powerSyncEnabledMock.value = false;
+}
+
+describe('useSyncStatusVariant', () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  it('reports "synced" when online with no pending mutations (PowerSync off)', () => {
+    const { result } = renderHook(() => useSyncStatusVariant());
+
+    expect(result.current.variant).toBe('synced');
+    expect(result.current.isOffline).toBe(false);
+  });
+
+  it('reports "offline" when the browser is offline', () => {
+    syncStatusMock.isOffline = true;
+
+    const { result } = renderHook(() => useSyncStatusVariant());
+
+    expect(result.current.variant).toBe('offline');
+    expect(result.current.isOffline).toBe(true);
+  });
+
+  it('reports "pending" when mutations are queued (PowerSync off)', () => {
+    syncStatusMock.pendingMutations = 3;
+
+    const { result } = renderHook(() => useSyncStatusVariant());
+
+    expect(result.current.variant).toBe('pending');
+    expect(result.current.pendingMutations).toBe(3);
+  });
+
+  it('reports "offline" when PowerSync is enabled but the live client is not connected', () => {
+    // This is the exact #3960 scenario: browser is online but the live
+    // PowerSync connection has not been established. The single source of
+    // truth must report offline so the banner and Settings row agree.
+    powerSyncEnabledMock.value = true;
+    syncStatusMock.isOffline = false;
+
+    const { result } = renderHook(() => useSyncStatusVariant());
+
+    expect(result.current.variant).toBe('offline');
+    expect(result.current.isOffline).toBe(true);
+  });
+
+  it('reports "synced" when PowerSync is enabled and the live client is connected', () => {
+    powerSyncEnabledMock.value = true;
+    liveStatusMock.connected = true;
+    liveStatusMock.hasSynced = true;
+
+    const { result } = renderHook(() => useSyncStatusVariant());
+
+    expect(result.current.variant).toBe('synced');
+    expect(result.current.isOffline).toBe(false);
+  });
+
+  it('surfaces unresolved conflicts as the "conflict" variant', async () => {
+    const { getUnresolvedConflicts } = await import('../../db/sync/sync-conflict');
+    vi.mocked(getUnresolvedConflicts).mockResolvedValueOnce([{ id: 'c1' }, { id: 'c2' }] as never);
+
+    const { result } = renderHook(() => useSyncStatusVariant());
+
+    await waitFor(() => {
+      expect(result.current.variant).toBe('conflict');
+    });
+    expect(result.current.conflictCount).toBe(2);
+    expect(result.current.isOffline).toBe(true);
+  });
+});
+
+describe('describeSyncVariant', () => {
+  it('produces stable labels for every variant', () => {
+    expect(describeSyncVariant('synced', 0, 0)).toBe('All synced');
+    expect(describeSyncVariant('offline', 0, 0)).toBe('Offline. Changes saved locally');
+    expect(describeSyncVariant('syncing', 0, 0)).toBe('Syncing\u2026');
+    expect(describeSyncVariant('error', 0, 0)).toBe('Sync failed');
+    expect(describeSyncVariant('pending', 1, 0)).toBe('1 pending change');
+    expect(describeSyncVariant('pending', 3, 0)).toBe('3 pending changes');
+    expect(describeSyncVariant('conflict', 0, 1)).toBe('1 conflict need attention');
+    expect(describeSyncVariant('conflict', 0, 2)).toBe('2 conflicts need attention');
+  });
+});
+
+describe('isDisconnectedVariant', () => {
+  it('treats offline, error, and conflict as disconnected', () => {
+    expect(isDisconnectedVariant('offline')).toBe(true);
+    expect(isDisconnectedVariant('error')).toBe(true);
+    expect(isDisconnectedVariant('conflict')).toBe(true);
+    expect(isDisconnectedVariant('synced')).toBe(false);
+    expect(isDisconnectedVariant('pending')).toBe(false);
+    expect(isDisconnectedVariant('syncing')).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/useSyncStatusVariant.ts
+++ b/apps/web/src/hooks/useSyncStatusVariant.ts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Single source of truth for the app's displayed sync status.
+ *
+ * Both the global {@link SyncStatusBar} and the Settings → Sync & Devices
+ * status row consume this hook, so the two surfaces can never present
+ * contradictory states (for example one reading "Offline. Changes saved
+ * locally" while the other reads "All synced").
+ *
+ * The variant is derived from:
+ *   - the local mutation queue and `navigator.onLine` (via `useSyncStatus`),
+ *   - unresolved sync conflicts (via `getUnresolvedConflicts`),
+ *   - and, when the live `@powersync/web` client is enabled, its real runtime
+ *     connection state (via `useLivePowerSyncStatus`), which then overrides the
+ *     local-queue view.
+ *
+ * References: issues #416, #627, #3960
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useSyncStatus } from './useSyncStatus';
+import { useLivePowerSyncStatus } from './useLivePowerSyncStatus';
+import { getUnresolvedConflicts } from '../db/sync/sync-conflict';
+import { isPowerSyncEnabled } from '../db/sync/powersync/database';
+import type { LivePowerSyncStatus } from '../db/sync/powersync/live-status';
+
+export type SyncStatusVariant = 'synced' | 'pending' | 'syncing' | 'error' | 'offline' | 'conflict';
+
+export interface SyncStatusView {
+  /** The single derived status variant shared by every sync surface. */
+  variant: SyncStatusVariant;
+  /** Number of mutations waiting to be pushed to the server. */
+  pendingMutations: number;
+  /** Number of unresolved conflicts that need attention. */
+  conflictCount: number;
+  /** ISO-8601 timestamp of the last successful sync for the active source. */
+  lastSyncTime: string | null;
+  /** `true` when the derived variant represents a disconnected state. */
+  isOffline: boolean;
+  /** Manually trigger an immediate sync replay. */
+  syncNow: () => void;
+  /** Clear a failed-sync flag and retry syncing. */
+  retry: () => void;
+}
+
+/**
+ * Derive the variant from the live `@powersync/web` runtime status.
+ *
+ * Used only when the live PowerSync client is enabled; the real connection
+ * state — not the local mutation queue — then drives the status.
+ */
+export function deriveLiveVariant(
+  live: LivePowerSyncStatus,
+  isOffline: boolean,
+): SyncStatusVariant {
+  if (isOffline) return 'offline';
+  if (live.connecting || live.syncing) return 'syncing';
+  if (live.connected) return 'synced';
+  if (live.hasError) return 'error';
+  return 'offline';
+}
+
+/**
+ * Map a status variant to its human-readable label. Shared by every sync
+ * surface so the wording stays identical everywhere.
+ */
+export function describeSyncVariant(
+  variant: SyncStatusVariant,
+  pendingMutations: number,
+  conflictCount: number,
+): string {
+  switch (variant) {
+    case 'synced':
+      return 'All synced';
+    case 'pending':
+      return `${pendingMutations} pending change${pendingMutations !== 1 ? 's' : ''}`;
+    case 'syncing':
+      return 'Syncing\u2026';
+    case 'error':
+      return 'Sync failed';
+    case 'offline':
+      return 'Offline. Changes saved locally';
+    case 'conflict':
+      return `${conflictCount} conflict${conflictCount !== 1 ? 's' : ''} need attention`;
+  }
+}
+
+/**
+ * `true` when a variant represents a state where the app is not connected and
+ * successfully synced — used to drive offline indicators (dots, banners).
+ */
+export function isDisconnectedVariant(variant: SyncStatusVariant): boolean {
+  return variant === 'offline' || variant === 'error' || variant === 'conflict';
+}
+
+/**
+ * Compute the single, shared sync status view.
+ */
+export function useSyncStatusVariant(): SyncStatusView {
+  const { isOnline, isOffline, pendingMutations, lastSyncTime, isSyncing, syncNow } =
+    useSyncStatus();
+  const live = useLivePowerSyncStatus();
+  const powerSyncActive = isPowerSyncEnabled();
+
+  const [conflictCount, setConflictCount] = useState(0);
+  const [lastSyncFailed, setLastSyncFailed] = useState(false);
+
+  // Track the previous syncing state to detect sync failures.
+  const prevSyncingRef = useRef(false);
+
+  useEffect(() => {
+    if (prevSyncingRef.current && !isSyncing && pendingMutations > 0 && isOnline) {
+      // Sync just finished but mutations remain → sync failed.
+      setLastSyncFailed(true);
+    } else if (isSyncing) {
+      setLastSyncFailed(false);
+    }
+    prevSyncingRef.current = isSyncing;
+  }, [isSyncing, pendingMutations, isOnline]);
+
+  // Poll unresolved conflicts whenever sync state changes.
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkConflicts(): Promise<void> {
+      try {
+        const conflicts = await getUnresolvedConflicts();
+        if (!cancelled) {
+          setConflictCount(conflicts.length);
+        }
+      } catch {
+        // IndexedDB may not be available in some contexts.
+      }
+    }
+
+    void checkConflicts();
+    return () => {
+      cancelled = true;
+    };
+  }, [isSyncing, pendingMutations]);
+
+  // Determine the base variant from the local mutation queue.
+  let variant: SyncStatusVariant;
+  if (isOffline) {
+    variant = 'offline';
+  } else if (isSyncing) {
+    variant = 'syncing';
+  } else if (conflictCount > 0) {
+    variant = 'conflict';
+  } else if (lastSyncFailed) {
+    variant = 'error';
+  } else if (pendingMutations > 0) {
+    variant = 'pending';
+  } else {
+    variant = 'synced';
+  }
+
+  // When the live PowerSync client is active, its real runtime status is the
+  // source of truth: the local mutation queue does not track the live
+  // connection. Flag off → variant is unchanged and behaviour is identical.
+  if (powerSyncActive) {
+    variant = deriveLiveVariant(live, isOffline);
+  }
+
+  const retry = useCallback(() => {
+    setLastSyncFailed(false);
+    syncNow();
+  }, [syncNow]);
+
+  const activeLastSyncTime = powerSyncActive ? live.lastSyncedAt : lastSyncTime;
+
+  return {
+    variant,
+    pendingMutations,
+    conflictCount,
+    lastSyncTime: activeLastSyncTime,
+    isOffline: isDisconnectedVariant(variant),
+    syncNow,
+    retry,
+  };
+}

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -10,6 +10,15 @@ const offlineStatusMock = {
   isOffline: false,
   isOnline: true,
 };
+const syncStatusVariantMock = {
+  variant: 'synced' as 'synced' | 'pending' | 'syncing' | 'error' | 'offline' | 'conflict',
+  pendingMutations: 0,
+  conflictCount: 0,
+  lastSyncTime: null as string | null,
+  isOffline: false,
+  syncNow: vi.fn(),
+  retry: vi.fn(),
+};
 const { clearLocalAccountDataMock, householdImpactMock, wipeLocalDataMock } = vi.hoisted(() => ({
   clearLocalAccountDataMock: vi.fn<() => Promise<void>>(),
   householdImpactMock: vi.fn(() => ({
@@ -56,6 +65,14 @@ vi.mock('../auth/auth-context', () => ({
 vi.mock('../hooks/useOfflineStatus', () => ({
   useOfflineStatus: () => offlineStatusMock,
 }));
+
+vi.mock('../hooks/useSyncStatusVariant', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../hooks/useSyncStatusVariant')>();
+  return {
+    ...actual,
+    useSyncStatusVariant: () => syncStatusVariantMock,
+  };
+});
 
 vi.mock('../components/common', () => ({
   ErrorBanner: ({ message }: { message?: string }) => <div role="alert">{message}</div>,
@@ -259,6 +276,10 @@ describe('SettingsPage', () => {
     deleteAccountMock.mockResolvedValue(undefined);
     offlineStatusMock.isOffline = false;
     offlineStatusMock.isOnline = true;
+    syncStatusVariantMock.variant = 'synced';
+    syncStatusVariantMock.isOffline = false;
+    syncStatusVariantMock.pendingMutations = 0;
+    syncStatusVariantMock.conflictCount = 0;
 
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
@@ -577,8 +598,8 @@ describe('SettingsPage', () => {
     });
 
     it('shows offline sync messaging when the app is offline', () => {
-      offlineStatusMock.isOffline = true;
-      offlineStatusMock.isOnline = false;
+      syncStatusVariantMock.variant = 'offline';
+      syncStatusVariantMock.isOffline = true;
 
       renderSettingsAt('/settings/sync');
 

--- a/apps/web/src/pages/settings/SettingsSyncPage.tsx
+++ b/apps/web/src/pages/settings/SettingsSyncPage.tsx
@@ -9,7 +9,7 @@ import {
   type PreferredAuthMethod,
 } from '../../auth/preferred-auth-method';
 import { SettingInfoWidget } from '../../components/settings';
-import { useOfflineStatus } from '../../hooks/useOfflineStatus';
+import { describeSyncVariant, useSyncStatusVariant } from '../../hooks/useSyncStatusVariant';
 
 /**
  * Sync & Devices sub-page — sync status, passkey management,
@@ -23,7 +23,12 @@ export const SettingsSyncPage: React.FC = () => {
     webAuthnSupported,
     isDemoMode: demoModeActive,
   } = useAuth();
-  const { isOffline } = useOfflineStatus();
+  const {
+    variant: syncVariant,
+    pendingMutations,
+    conflictCount,
+    isOffline,
+  } = useSyncStatusVariant();
   const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
   const [passkeyMessage, setPasskeyMessage] = useState<string | null>(null);
   /**
@@ -90,7 +95,7 @@ export const SettingsSyncPage: React.FC = () => {
                   className={`settings-item__status-dot ${isOffline ? 'settings-item__status-dot--offline' : 'settings-item__status-dot--online'}`}
                 />
                 <span className="settings-item__value">
-                  {isOffline ? 'Offline. Changes saved locally' : 'All synced'}
+                  {describeSyncVariant(syncVariant, pendingMutations, conflictCount)}
                 </span>
               </span>
             </div>


### PR DESCRIPTION
## Summary

The web app could display two contradictory sync states at once: the global status banner read **"Offline. Changes saved locally"** while the Settings → Sync & Devices **Sync Status** row simultaneously showed a green dot and **"All synced"**.

## Root Cause

The two surfaces derived "offline" from different, unsynchronised sources:

- **Global banner** (`SyncStatusBar`) — when the live PowerSync client is enabled, used `deriveLiveVariant()`, whose fallback returns `offline` whenever the live client is enabled but not `connected`/`connecting`/`syncing`/`hasError`, even with `navigator.onLine === true`.
- **Settings Sync Status row** (`SettingsSyncPage`) — used `useOfflineStatus()` (`!navigator.onLine || hasReportedNetworkFailure`), so with the browser online it rendered "All synced".

With PowerSync enabled + browser online + live client not yet connected, the banner said Offline and Settings said All synced.

## Changes

- Add `apps/web/src/hooks/useSyncStatusVariant.ts` — a single source of truth deriving the sync variant (network state + PowerSync live override + conflicts + pending + last-sync-failed), plus shared `describeSyncVariant` / `isDisconnectedVariant` helpers.
- Refactor `SyncStatusBar` to consume the shared hook (behaviour unchanged).
- Update `SettingsSyncPage` Sync Status row to render from the same derived variant instead of its own `useOfflineStatus`-only logic — the two surfaces can no longer contradict.
- Add regression tests for the shared hook (including the exact #3960 scenario) and update `SettingsPage` tests.

## Issues

Closes #3960

## Testing

- [x] Affected Vitest suites pass (`useSyncStatusVariant`, `SyncStatusBar`, `SyncStatusBar.powersync`, `SettingsPage`) — 51 tests
- [x] `npm run format:check` clean
- [x] `npx eslint . --max-warnings 0` clean

## Cross-Platform

Web-only. The root cause is a mismatch between two React hooks in `apps/web`; iOS, Android, and Windows each derive sync state from their own single view model, so no platform duplicates are needed.
