### PR TITLE
fix(backend): bump @simplewebauthn/server to 13.2.0 to fix passkey setup (#3964)

### DIFF
--- a/services/api/supabase/functions/deno.json
+++ b/services/api/supabase/functions/deno.json
@@ -48,6 +48,6 @@
   "imports": {
     "std/testing/": "https://deno.land/std@0.208.0/testing/",
     "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.39.0",
-    "@simplewebauthn/server": "https://esm.sh/@simplewebauthn/server@9.0.3"
+    "@simplewebauthn/server": "https://esm.sh/@simplewebauthn/server@13.2.0"
   }
 }

--- a/services/api/supabase/functions/passkey-authenticate/index.ts
+++ b/services/api/supabase/functions/passkey-authenticate/index.ts
@@ -25,7 +25,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
 import {
   generateAuthenticationOptions,
   verifyAuthenticationResponse,
-} from 'https://esm.sh/@simplewebauthn/server@9.0.3';
+} from 'https://esm.sh/@simplewebauthn/server@13.2.0';
 import { getCorsHeaders, handleCorsPreflightRequest } from '../_shared/cors.ts';
 import { createLogger } from '../_shared/logger.ts';
 import { errorResponse, internalErrorResponse, jsonResponse } from '../_shared/response.ts';
@@ -40,7 +40,7 @@ import { validateEnv, requireEnv } from '../_shared/env.ts';
 import type {
   AuthenticatorTransportFuture,
   VerifiedAuthenticationResponse,
-} from 'https://esm.sh/@simplewebauthn/server@9.0.3';
+} from 'https://esm.sh/@simplewebauthn/server@13.2.0';
 
 interface StoredCredential {
   id: string;

--- a/services/api/supabase/functions/passkey-register/index.ts
+++ b/services/api/supabase/functions/passkey-register/index.ts
@@ -21,7 +21,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
 import {
   generateRegistrationOptions,
   verifyRegistrationResponse,
-} from 'https://esm.sh/@simplewebauthn/server@9.0.3';
+} from 'https://esm.sh/@simplewebauthn/server@13.2.0';
 import { getCorsHeaders, handleCorsPreflightRequest } from '../_shared/cors.ts';
 import { createLogger } from '../_shared/logger.ts';
 import { checkRateLimit, rateLimitResponse, RATE_LIMITS } from '../_shared/rate-limit.ts';
@@ -29,7 +29,7 @@ import { validateEnv, requireEnv } from '../_shared/env.ts';
 import type {
   GenerateRegistrationOptionsOpts,
   VerifiedRegistrationResponse,
-} from 'https://esm.sh/@simplewebauthn/server@9.0.3';
+} from 'https://esm.sh/@simplewebauthn/server@13.2.0';
 
 /**
  * Extract and verify the authenticated user from the JWT.


### PR DESCRIPTION
## Summary

Fixes passkey setup, which failed immediately with **"e.replace is not a function"** in Settings → Passkeys.

The passkey Edge Functions were written for the `@simplewebauthn/server` **v13** API but the import was pinned to **v9.0.3**. This bumps the pin to `13.2.0` (no logic changes) so the library matches the code that already uses it.

## Root Cause

With `@simplewebauthn/server@9.0.3`:

1. **Registration options** — `passkey-register/index.ts` passes `userID: new TextEncoder().encode(user.id)` (a `Uint8Array`, the v13 signature). v9.0.3 returns `user.id` **verbatim** as that `Uint8Array`, which `JSON.stringify` serializes to an indexed object `{"0":..}`. The web client's `base64UrlToBuffer(options.user.id)` then calls `.replace` on that object → **`e.replace is not a function`** (minified). Setup never reaches the system passkey prompt.
2. **Registration verify** — the code reads `registrationInfo.credential.{id,publicKey,counter,transports}` (v13 shape); v9.0.3 has no nested `credential` object, so verify also crashes.
3. **Authenticate verify** — passes the v13 `credential:` param to `verifyAuthenticationResponse`; v9.0.3 expects the old `authenticator:` param.

All three usages match `13.2.0` exactly (verified against the v13.2.0 source: `userID: Uint8Array` required, `user.id`/`challenge` base64url-encoded, `registrationInfo.credential`, `verifyAuthenticationResponse({ credential })`, base64url `excludeCredentials`/`allowCredentials` ids).

## Changes

- Bump `@simplewebauthn/server` `9.0.3` → `13.2.0` in:
  - `services/api/supabase/functions/deno.json`
  - `services/api/supabase/functions/passkey-register/index.ts` (value + type imports)
  - `services/api/supabase/functions/passkey-authenticate/index.ts` (value + type imports)

## Cross-Platform

The fix is in the shared Supabase Edge Functions consumed by every client, so this single backend change restores passkey registration/authentication on all platforms. The web client already expected the v13 JSON format; no client code changes are required.

## Testing

- [x] Prettier clean on changed files (`npm run format:check`)
- [x] ESLint clean on changed files (`npx eslint … --max-warnings 0`)
- [x] All four imported v13 type names (`GenerateRegistrationOptionsOpts`, `VerifiedRegistrationResponse`, `VerifiedAuthenticationResponse`, `AuthenticatorTransportFuture`) confirmed exported in `13.2.0`
- [x] Edge-function Deno tests use mock handlers (no real-module network fetch), so unaffected by the version change; remote CI runs the Deno suite

## Issues

Closes #3964
