### PR TITLE
fix(web): align Bank Connections page with standardized UI (#3962)

### DIFF
--- a/apps/web/src/components/bank/bank-connections.css
+++ b/apps/web/src/components/bank/bank-connections.css
@@ -11,8 +11,8 @@
 
 .connection-health-card {
   background: var(--semantic-background-secondary, #f8f9fa);
-  border: 1px solid var(--semantic-border-primary, #dee2e6);
-  border-radius: var(--radius-3, 12px);
+  border: 1px solid var(--semantic-border-default, #dee2e6);
+  border-radius: var(--border-radius-lg, 12px);
   padding: var(--spacing-4, 16px);
   margin-bottom: var(--spacing-3, 12px);
 }
@@ -41,7 +41,7 @@
 .health-badge {
   display: inline-block;
   padding: var(--spacing-1, 4px) var(--spacing-2, 8px);
-  border-radius: var(--radius-full, 9999px);
+  border-radius: var(--border-radius-full, 9999px);
   font-size: var(--font-size-xs, 0.75rem);
   font-weight: 600;
   text-transform: uppercase;
@@ -49,28 +49,24 @@
 }
 
 .health-badge--healthy {
-  background: var(--semantic-success-bg, #d4edda);
-  color: var(--semantic-success-text, #155724);
+  background: color-mix(in srgb, var(--semantic-status-positive, #16a34a) 15%, transparent);
+  color: var(--semantic-status-positive, #16a34a);
 }
 
-.health-badge--stale {
-  background: var(--semantic-warning-bg, #fff3cd);
-  color: var(--semantic-warning-text, #856404);
-}
-
+.health-badge--stale,
 .health-badge--warning {
-  background: var(--semantic-warning-bg, #fff3cd);
-  color: var(--semantic-warning-text, #856404);
+  background: color-mix(in srgb, var(--semantic-status-warning, #d97706) 15%, transparent);
+  color: var(--semantic-status-warning, #d97706);
 }
 
 .health-badge--error {
-  background: var(--semantic-error-bg, #f8d7da);
-  color: var(--semantic-error-text, #721c24);
+  background: color-mix(in srgb, var(--semantic-status-negative, #dc2626) 15%, transparent);
+  color: var(--semantic-status-negative, #dc2626);
 }
 
 .health-badge--unknown {
-  background: var(--semantic-neutral-bg, #e2e3e5);
-  color: var(--semantic-neutral-text, #383d41);
+  background: color-mix(in srgb, var(--semantic-text-secondary, #6b7280) 15%, transparent);
+  color: var(--semantic-text-secondary, #6b7280);
 }
 
 .connection-health-card__details {
@@ -99,7 +95,7 @@
 }
 
 .connection-health-card__value--error {
-  color: var(--semantic-error-text, #721c24);
+  color: var(--semantic-status-negative, #dc2626);
 }
 
 .connection-health-card__actions {
@@ -110,8 +106,8 @@
 
 .connection-health-card__action {
   padding: var(--spacing-1, 4px) var(--spacing-3, 12px);
-  border: 1px solid var(--semantic-border-primary, #dee2e6);
-  border-radius: var(--radius-2, 8px);
+  border: 1px solid var(--semantic-border-default, #dee2e6);
+  border-radius: var(--border-radius-md, 8px);
   background: transparent;
   color: var(--semantic-text-primary, #111);
   font-size: var(--font-size-sm, 0.875rem);
@@ -119,17 +115,17 @@
 }
 
 .connection-health-card__action:hover {
-  background: var(--semantic-background-hover, #e9ecef);
+  background: var(--semantic-background-secondary, #e9ecef);
 }
 
 .connection-health-card__action--primary {
-  background: var(--semantic-primary, #0d6efd);
+  background: var(--semantic-interactive-default, #0d6efd);
   color: white;
-  border-color: var(--semantic-primary, #0d6efd);
+  border-color: var(--semantic-interactive-default, #0d6efd);
 }
 
 .connection-health-card__action--primary:hover {
-  background: var(--semantic-primary-hover, #0b5ed7);
+  background: var(--semantic-interactive-hover, #0b5ed7);
 }
 
 /* =========================================================================
@@ -142,8 +138,8 @@
 
 .safety-center__summary {
   background: var(--semantic-background-secondary, #f8f9fa);
-  border: 1px solid var(--semantic-border-primary, #dee2e6);
-  border-radius: var(--radius-3, 12px);
+  border: 1px solid var(--semantic-border-default, #dee2e6);
+  border-radius: var(--border-radius-lg, 12px);
   padding: var(--spacing-4, 16px);
   margin-bottom: var(--spacing-4, 16px);
 }
@@ -163,10 +159,10 @@
 
 .safety-center__note {
   font-size: var(--font-size-sm, 0.875rem);
-  color: var(--semantic-success-text, #155724);
-  background: var(--semantic-success-bg, #d4edda);
+  color: var(--semantic-status-positive, #16a34a);
+  background: color-mix(in srgb, var(--semantic-status-positive, #16a34a) 15%, transparent);
   padding: var(--spacing-2, 8px) var(--spacing-3, 12px);
-  border-radius: var(--radius-2, 8px);
+  border-radius: var(--border-radius-md, 8px);
   margin: 0;
 }
 
@@ -187,8 +183,8 @@
 }
 
 .safety-center__item {
-  border: 1px solid var(--semantic-border-primary, #dee2e6);
-  border-radius: var(--radius-2, 8px);
+  border: 1px solid var(--semantic-border-default, #dee2e6);
+  border-radius: var(--border-radius-md, 8px);
   padding: var(--spacing-3, 12px);
   margin-bottom: var(--spacing-2, 8px);
 }
@@ -223,9 +219,9 @@
 .safety-center__permission-badge {
   font-size: var(--font-size-sm, 0.875rem);
   padding: var(--spacing-1, 4px) var(--spacing-2, 8px);
-  border-radius: var(--radius-full, 9999px);
-  background: var(--semantic-success-bg, #d4edda);
-  color: var(--semantic-success-text, #155724);
+  border-radius: var(--border-radius-full, 9999px);
+  background: color-mix(in srgb, var(--semantic-status-positive, #16a34a) 15%, transparent);
+  color: var(--semantic-status-positive, #16a34a);
 }
 
 .safety-center__token-status {
@@ -234,12 +230,12 @@
 }
 
 .safety-center__token-status--active {
-  color: var(--semantic-success-text, #155724);
+  color: var(--semantic-status-positive, #16a34a);
 }
 
 .safety-center__token-status--expired,
 .safety-center__token-status--revoked {
-  color: var(--semantic-error-text, #721c24);
+  color: var(--semantic-status-negative, #dc2626);
 }
 
 .safety-center__scopes {
@@ -254,8 +250,8 @@
 
 .safety-center__toggle {
   padding: var(--spacing-2, 8px) var(--spacing-3, 12px);
-  border: 1px solid var(--semantic-border-primary, #dee2e6);
-  border-radius: var(--radius-2, 8px);
+  border: 1px solid var(--semantic-border-default, #dee2e6);
+  border-radius: var(--border-radius-md, 8px);
   background: transparent;
   cursor: pointer;
   font-size: var(--font-size-sm, 0.875rem);
@@ -263,7 +259,7 @@
 }
 
 .safety-center__toggle:hover {
-  background: var(--semantic-background-hover, #e9ecef);
+  background: var(--semantic-background-secondary, #e9ecef);
 }
 
 .safety-center__log-table {
@@ -277,7 +273,7 @@
 .safety-center__log-table td {
   padding: var(--spacing-2, 8px);
   text-align: left;
-  border-bottom: 1px solid var(--semantic-border-primary, #dee2e6);
+  border-bottom: 1px solid var(--semantic-border-default, #dee2e6);
 }
 
 .safety-center__log-table th {
@@ -288,15 +284,15 @@
 }
 
 .safety-center__status--success {
-  color: var(--semantic-success-text, #155724);
+  color: var(--semantic-status-positive, #16a34a);
 }
 
 .safety-center__status--failure {
-  color: var(--semantic-error-text, #721c24);
+  color: var(--semantic-status-negative, #dc2626);
 }
 
 .safety-center__status--partial {
-  color: var(--semantic-warning-text, #856404);
+  color: var(--semantic-status-warning, #d97706);
 }
 
 .safety-center__empty {
@@ -305,7 +301,7 @@
 }
 
 .safety-center__error {
-  color: var(--semantic-error-text, #721c24);
+  color: var(--semantic-status-negative, #dc2626);
 }
 
 /* =========================================================================
@@ -327,8 +323,8 @@
 }
 
 .provider-status-list__item {
-  border: 1px solid var(--semantic-border-primary, #dee2e6);
-  border-radius: var(--radius-2, 8px);
+  border: 1px solid var(--semantic-border-default, #dee2e6);
+  border-radius: var(--border-radius-md, 8px);
   padding: var(--spacing-3, 12px);
 }
 
@@ -346,30 +342,30 @@
 
 .provider-status-list__badge {
   padding: var(--spacing-1, 4px) var(--spacing-2, 8px);
-  border-radius: var(--radius-full, 9999px);
+  border-radius: var(--border-radius-full, 9999px);
   font-size: var(--font-size-xs, 0.75rem);
   font-weight: 600;
   text-transform: uppercase;
 }
 
 .provider-status-list__badge--active {
-  background: var(--semantic-success-bg, #d4edda);
-  color: var(--semantic-success-text, #155724);
+  background: color-mix(in srgb, var(--semantic-status-positive, #16a34a) 15%, transparent);
+  color: var(--semantic-status-positive, #16a34a);
 }
 
 .provider-status-list__badge--degraded {
-  background: var(--semantic-warning-bg, #fff3cd);
-  color: var(--semantic-warning-text, #856404);
+  background: color-mix(in srgb, var(--semantic-status-warning, #d97706) 15%, transparent);
+  color: var(--semantic-status-warning, #d97706);
 }
 
 .provider-status-list__badge--down {
-  background: var(--semantic-error-bg, #f8d7da);
-  color: var(--semantic-error-text, #721c24);
+  background: color-mix(in srgb, var(--semantic-status-negative, #dc2626) 15%, transparent);
+  color: var(--semantic-status-negative, #dc2626);
 }
 
 .provider-status-list__badge--maintenance {
-  background: var(--semantic-neutral-bg, #e2e3e5);
-  color: var(--semantic-neutral-text, #383d41);
+  background: color-mix(in srgb, var(--semantic-text-secondary, #6b7280) 15%, transparent);
+  color: var(--semantic-text-secondary, #6b7280);
 }
 
 .provider-status-list__health {
@@ -382,15 +378,15 @@
 .provider-status-list__health-bar {
   flex: 1;
   height: 8px;
-  background: var(--semantic-background-tertiary, #e9ecef);
-  border-radius: var(--radius-full, 9999px);
+  background: var(--semantic-background-secondary, #e9ecef);
+  border-radius: var(--border-radius-full, 9999px);
   overflow: hidden;
 }
 
 .provider-status-list__health-fill {
   height: 100%;
-  background: var(--semantic-success, #28a745);
-  border-radius: var(--radius-full, 9999px);
+  background: var(--semantic-status-positive, #28a745);
+  border-radius: var(--border-radius-full, 9999px);
   transition: width 0.3s ease;
 }
 
@@ -421,31 +417,156 @@
 }
 
 /* =========================================================================
-   Dark mode
+   Page layout — header summary, tab bar, section headers
+
+   Uses the shared design-system vocabulary (page-heading / page-summary /
+   page-section come from styles) plus these page-scoped helpers, all built on
+   theme-aware --semantic-* tokens so the page matches the rest of the app.
    ========================================================================= */
 
-@media (prefers-color-scheme: dark) {
-  .connection-health-card {
-    background: var(--semantic-background-secondary, #1e1e1e);
-    border-color: var(--semantic-border-primary, #333);
-  }
-
-  .safety-center__summary {
-    background: var(--semantic-background-secondary, #1e1e1e);
-    border-color: var(--semantic-border-primary, #333);
-  }
-
-  .provider-status-list__item {
-    border-color: var(--semantic-border-primary, #333);
-  }
+.connection-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3, 12px);
+  margin-bottom: var(--spacing-5, 20px);
 }
 
-[data-theme='dark'] .connection-health-card,
-[data-theme='dark'] .safety-center__summary,
-[data-theme='dark'] .provider-status-list__item {
-  background: var(--semantic-background-secondary, #1e1e1e);
-  border-color: var(--semantic-border-primary, #333);
+.connection-summary__stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1, 4px);
+  min-width: 7rem;
+  padding: var(--spacing-3, 12px) var(--spacing-4, 16px);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-md, 12px);
+  background: var(--semantic-background-elevated, #f9fafb);
 }
+
+.connection-summary__count {
+  font-size: var(--type-scale-headline-font-size, 1.5rem);
+  font-weight: var(--type-scale-headline-font-weight, 700);
+  line-height: 1.1;
+  color: var(--semantic-text-primary, #111827);
+}
+
+.connection-summary__count--healthy {
+  color: var(--semantic-status-positive, #16a34a);
+}
+
+.connection-summary__count--issue {
+  color: var(--semantic-status-negative, #dc2626);
+}
+
+.connection-summary__count--reauth {
+  color: var(--semantic-status-warning, #d97706);
+}
+
+.connection-summary__label {
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--semantic-text-secondary, #6b7280);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Underline tab bar — mirrors the shared .planning-tab pattern. */
+.tab-nav {
+  display: flex;
+  gap: var(--spacing-2, 8px);
+  border-bottom: 1px solid var(--semantic-border-default, #e5e7eb);
+  margin-bottom: var(--spacing-5, 20px);
+  overflow-x: auto;
+}
+
+.tab-nav__tab {
+  padding: var(--spacing-3, 12px) var(--spacing-4, 16px);
+  border: none;
+  background: none;
+  color: var(--semantic-text-secondary, #6b7280);
+  font: inherit;
+  font-weight: var(--font-weight-medium, 500);
+  white-space: nowrap;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition:
+    color var(--duration-fast, 150ms) ease,
+    border-color var(--duration-fast, 150ms) ease;
+}
+
+.tab-nav__tab:hover {
+  color: var(--semantic-text-primary, #111827);
+}
+
+.tab-nav__tab--active {
+  color: var(--semantic-interactive-default, #2563eb);
+  border-bottom-color: var(--semantic-interactive-default, #2563eb);
+}
+
+.tab-nav__tab:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #2563eb);
+  outline-offset: -2px;
+  border-radius: var(--border-radius-sm, 4px);
+}
+
+.tab-content {
+  margin-top: var(--spacing-2, 8px);
+}
+
+/* Section header inside a tab panel — title + trailing action. */
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3, 12px);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-4, 16px);
+}
+
+.section-title {
+  font-size: var(--type-scale-title-font-size, 1.25rem);
+  font-weight: var(--type-scale-title-font-weight, 600);
+  color: var(--semantic-text-primary, #111827);
+  margin: 0;
+}
+
+.section-action {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2, 8px);
+  min-height: 40px;
+  padding: var(--spacing-2, 8px) var(--spacing-4, 16px);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-md, 8px);
+  background: var(--semantic-background-elevated, #f9fafb);
+  color: var(--semantic-text-primary, #111827);
+  font: inherit;
+  font-weight: var(--font-weight-medium, 500);
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast, 150ms) ease,
+    border-color var(--duration-fast, 150ms) ease;
+}
+
+.section-action:hover {
+  background: var(--semantic-background-secondary, #f3f4f6);
+  border-color: var(--semantic-interactive-default, #2563eb);
+}
+
+.section-action:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #2563eb);
+  outline-offset: 2px;
+}
+
+.error-message {
+  color: var(--semantic-status-negative, #dc2626);
+}
+
+/* =========================================================================
+   Dark mode
+
+   Surfaces and borders use theme-aware --semantic-* tokens, so no per-theme
+   colour overrides are needed here.
+   ========================================================================= */
 
 /* =========================================================================
    Reduced motion

--- a/apps/web/src/components/investments/crypto-connections.css
+++ b/apps/web/src/components/investments/crypto-connections.css
@@ -15,7 +15,7 @@
   border: 1px solid var(--semantic-border-default, #e5e7eb);
   border-radius: var(--border-radius-lg, 12px);
   padding: var(--spacing-5, 20px);
-  background: var(--semantic-surface, #fff);
+  background: var(--semantic-background-elevated, #fff);
 }
 
 .crypto-panel__header {
@@ -63,35 +63,35 @@
   align-items: center;
   gap: var(--spacing-1, 4px);
   padding: var(--spacing-1, 4px) var(--spacing-2, 8px);
-  border-radius: var(--radius-full, 999px);
+  border-radius: var(--border-radius-full, 999px);
   font-size: var(--type-scale-caption-font-size, 0.8125rem);
   font-weight: var(--font-weight-medium, 500);
   border: 1px solid transparent;
 }
 
 .crypto-badge--healthy {
-  background: var(--semantic-positive-subtle, #ecfdf5);
-  color: var(--semantic-positive-strong, #047857);
-  border-color: var(--semantic-positive, #059669);
+  background: color-mix(in srgb, var(--semantic-status-positive, #16a34a) 15%, transparent);
+  color: var(--semantic-status-positive, #047857);
+  border-color: var(--semantic-status-positive, #059669);
 }
 
 .crypto-badge--manual {
-  background: var(--semantic-info-subtle, #eff6ff);
-  color: var(--semantic-info-strong, #1d4ed8);
-  border-color: var(--semantic-info, #2563eb);
+  background: color-mix(in srgb, var(--semantic-status-info, #2563eb) 15%, transparent);
+  color: var(--semantic-status-info, #1d4ed8);
+  border-color: var(--semantic-status-info, #2563eb);
 }
 
 .crypto-badge--stale {
-  background: var(--semantic-warning-subtle, #fffbeb);
-  color: var(--semantic-warning-strong, #b45309);
-  border-color: var(--semantic-warning, #d97706);
+  background: color-mix(in srgb, var(--semantic-status-warning, #d97706) 15%, transparent);
+  color: var(--semantic-status-warning, #b45309);
+  border-color: var(--semantic-status-warning, #d97706);
 }
 
 .crypto-badge--needs-attention,
 .crypto-badge--failed {
-  background: var(--semantic-negative-subtle, #fef2f2);
-  color: var(--semantic-negative-strong, #b91c1c);
-  border-color: var(--semantic-negative, #dc2626);
+  background: color-mix(in srgb, var(--semantic-status-negative, #dc2626) 15%, transparent);
+  color: var(--semantic-status-negative, #b91c1c);
+  border-color: var(--semantic-status-negative, #dc2626);
 }
 
 .crypto-form {
@@ -129,10 +129,10 @@
 .crypto-field__select {
   padding: var(--spacing-2, 8px);
   border: 1px solid var(--semantic-border-default, #d1d5db);
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--border-radius-md, 8px);
   font: inherit;
   color: inherit;
-  background: var(--semantic-surface, #fff);
+  background: var(--semantic-background-elevated, #fff);
 }
 
 .crypto-field__input:focus-visible,
@@ -146,13 +146,13 @@
 .crypto-segmented {
   display: inline-flex;
   border: 1px solid var(--semantic-border-default, #d1d5db);
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--border-radius-md, 8px);
   overflow: hidden;
 }
 
 .crypto-segmented__option {
   padding: var(--spacing-2, 8px) var(--spacing-3, 12px);
-  background: var(--semantic-surface, #fff);
+  background: var(--semantic-background-elevated, #fff);
   border: none;
   font: inherit;
   color: inherit;
@@ -160,8 +160,8 @@
 }
 
 .crypto-segmented__option[aria-pressed='true'] {
-  background: var(--semantic-accent-subtle, #eff6ff);
-  color: var(--semantic-accent-strong, #1d4ed8);
+  background: color-mix(in srgb, var(--semantic-interactive-default, #2563eb) 12%, transparent);
+  color: var(--semantic-interactive-default, #1d4ed8);
   font-weight: var(--font-weight-semibold, 600);
 }
 
@@ -170,18 +170,18 @@
   align-items: center;
   gap: var(--spacing-1, 4px);
   padding: var(--spacing-2, 8px) var(--spacing-3, 12px);
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--border-radius-md, 8px);
   border: 1px solid var(--semantic-border-default, #d1d5db);
-  background: var(--semantic-surface, #fff);
+  background: var(--semantic-background-elevated, #fff);
   color: inherit;
   font: inherit;
   cursor: pointer;
 }
 
 .crypto-btn--primary {
-  background: var(--semantic-accent, #2563eb);
-  border-color: var(--semantic-accent, #2563eb);
-  color: var(--semantic-on-accent, #fff);
+  background: var(--semantic-interactive-default, #2563eb);
+  border-color: var(--semantic-interactive-default, #2563eb);
+  color: var(--semantic-text-inverse, #fff);
 }
 
 .crypto-btn--ghost {
@@ -199,11 +199,11 @@
 
 .crypto-validation--invalid,
 .crypto-validation--duplicate-risk {
-  color: var(--semantic-negative-strong, #b91c1c);
+  color: var(--semantic-status-negative, #b91c1c);
 }
 
 .crypto-validation--valid {
-  color: var(--semantic-positive-strong, #047857);
+  color: var(--semantic-status-positive, #047857);
 }
 
 .crypto-list {
@@ -222,7 +222,7 @@
   flex-wrap: wrap;
   padding: var(--spacing-3, 12px);
   border: 1px solid var(--semantic-border-default, #e5e7eb);
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--border-radius-md, 8px);
 }
 
 .crypto-source__meta {
@@ -267,8 +267,8 @@
 .crypto-chip {
   font-size: var(--type-scale-caption-font-size, 0.75rem);
   padding: 2px var(--spacing-2, 8px);
-  border-radius: var(--radius-full, 999px);
-  background: var(--semantic-surface-muted, #f3f4f6);
+  border-radius: var(--border-radius-full, 999px);
+  background: var(--semantic-background-secondary, #f3f4f6);
   color: var(--semantic-text-secondary, #4b5563);
 }
 
@@ -276,7 +276,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1, 4px);
-  color: var(--semantic-warning-strong, #b45309);
+  color: var(--semantic-status-warning, #b45309);
   font-size: var(--type-scale-caption-font-size, 0.8125rem);
 }
 

--- a/apps/web/src/pages/BankConnectionsPage.tsx
+++ b/apps/web/src/pages/BankConnectionsPage.tsx
@@ -20,6 +20,7 @@ import React, { Suspense, lazy, useCallback, useState } from 'react';
 import { ConnectionHealthCard } from '../components/bank/ConnectionHealthCard';
 import { ProviderStatusList } from '../components/bank/ProviderStatusList';
 import { SafetyCenter } from '../components/bank/SafetyCenter';
+import { EmptyState } from '../components/common/EmptyState';
 import '../components/bank/bank-connections.css';
 import { useBankConnections } from '../hooks/useBankConnections';
 import { useConnectorPermissions } from '../hooks/useConnectorPermissions';
@@ -85,10 +86,12 @@ export const BankConnectionsPage: React.FC = () => {
   const needsReauthCount = connections.filter((c) => c.needsReauth).length;
 
   return (
-    <div className="page-container">
-      <header className="page-header">
-        <h1 className="page-title">Bank Connections</h1>
-        <p className="page-subtitle">
+    <>
+      <header>
+        <div className="page-header">
+          <h1 className="page-heading">Bank Connections</h1>
+        </div>
+        <p className="page-summary">
           Monitor connection health, manage third-party access, and configure providers.
         </p>
       </header>
@@ -129,7 +132,7 @@ export const BankConnectionsPage: React.FC = () => {
       </div>
 
       {/* Tab navigation */}
-      <nav className="tab-nav" aria-label="Bank connections sections">
+      <nav className="tab-nav" role="tablist" aria-label="Bank connections sections">
         <button
           type="button"
           className={`tab-nav__tab ${activeTab === 'health' ? 'tab-nav__tab--active' : ''}`}
@@ -198,13 +201,11 @@ export const BankConnectionsPage: React.FC = () => {
             )}
 
             {!connectionsLoading && !connectionsError && connections.length === 0 && (
-              <div className="empty-state">
-                <h3 className="empty-state__title">No bank connections</h3>
-                <p className="empty-state__description">
-                  Connect your bank accounts to automatically import transactions and monitor
-                  account balances.
-                </p>
-              </div>
+              <EmptyState
+                title="No bank connections"
+                description="Connect your bank accounts to automatically import transactions and monitor account balances."
+                headingLevel={3}
+              />
             )}
 
             {connections.map((connection) => (
@@ -249,7 +250,7 @@ export const BankConnectionsPage: React.FC = () => {
           />
         )}
       </div>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

Aligns the **Bank Connections** page (`/bank-connections`) with the standardized UI used across the rest of the web app. Previously the page used a bespoke set of CSS class names that were **defined nowhere**, and two of its stylesheets referenced design tokens that don't exist — so in dark mode the header, summary strip, and tabs rendered unstyled and the **Wallets & Exchanges** panel showed up as a white card with washed-out, low-contrast text.

Before this change the page relied on `page-container`, `page-title`, `page-subtitle`, `tab-nav`, `section-header`, etc. (none of which had any CSS) and on tokens like `--semantic-surface` / `--semantic-accent` / `--semantic-*-subtle` / `--radius-*` (none of which are in the token vocabulary at `apps/web/vendor/@jrm/tokens/css/default/index.css`).

## Changes

- **`BankConnectionsPage.tsx`** — use the shared page vocabulary (`page-header` + `page-heading` + `page-summary`), drop the undefined `page-container` wrapper (the app shell provides layout), add `role="tablist"`, and render the empty state via the shared `EmptyState` component.
- **`bank-connections.css`** — migrate all colours to the canonical `--semantic-*` tokens (status badges now use the `color-mix` tint pattern used ~114× elsewhere), fix non-canonical radius tokens (`--radius-*` → `--border-radius-*`), drop the hand-rolled dark-mode overrides (canonical tokens are already theme-aware), and add token-driven layout CSS for the summary stat cards, the underline tab bar (mirrors the shared `.planning-tab` pattern), and the section header/action.
- **`crypto-connections.css`** — replace every non-existent token (`--semantic-surface` → `--semantic-background-elevated`, `--semantic-accent` → `--semantic-interactive-default`, `--semantic-on-accent` → `--semantic-text-inverse`, `--semantic-*-subtle/-strong` → status tokens + `color-mix`, `--radius-*` → `--border-radius-*`) so the panel adopts the elevated dark surface with readable text instead of a hardcoded `#fff` card.

## Screenshots (CSS harness, real tokens)

Dark and light both now match the app: stacked header, coloured stat cards, accent underline tabs, and a properly themed elevated crypto card with readable text (no more white-card-in-dark-mode).

## Issues

Closes #3962

## Testing

- [x] `npx prettier --check` on all three files — clean
- [x] `npx eslint` on the changed TS — clean
- [x] `vitest run` for `CryptoConnectionsPanel` — 8/8 pass
- [x] Visual verification of both dark and light themes via a static harness loading the real token + component CSS

## Cross-Platform

Web-only — presentation/CSS in `apps/web`. No shared (`packages/`) or native code involved.
