### PR TITLE
fix(a11y): implement WAI-ARIA Tabs pattern on bank-connections tabs (#3862)

### DIFF
--- a/apps/web/src/components/bank/bank-connections.css
+++ b/apps/web/src/components/bank/bank-connections.css
@@ -497,9 +497,16 @@
   color: var(--semantic-text-primary, #111827);
 }
 
-.tab-nav__tab--active {
+/* Selected tab — keyed on the ARIA state as well as the state class so the
+   visible indicator can never drift from the value exposed to assistive tech
+   (#3862). The active cue is an underline bar plus a heavier weight, never
+   colour alone (WCAG 1.4.1). Tokens are theme-aware, so the accent stays
+   visible in both light and dark themes. */
+.tab-nav__tab--active,
+.tab-nav__tab[aria-selected='true'] {
   color: var(--semantic-interactive-default, #2563eb);
   border-bottom-color: var(--semantic-interactive-default, #2563eb);
+  font-weight: var(--font-weight-semibold, 600);
 }
 
 .tab-nav__tab:focus-visible {
@@ -576,6 +583,11 @@
   .provider-status-list__health-fill {
     transition: none;
   }
+
+  /* Honour reduced-motion for the tab selection indicator (#3862). */
+  .tab-nav__tab {
+    transition: none;
+  }
 }
 
 /* =========================================================================
@@ -592,6 +604,13 @@
   .health-badge,
   .provider-status-list__badge {
     border: 1px solid currentColor;
+  }
+
+  /* Thicken the selected-tab underline so the state survives high-contrast
+     palettes where the accent colour may be flattened (#3862). */
+  .tab-nav__tab--active,
+  .tab-nav__tab[aria-selected='true'] {
+    border-bottom-width: 3px;
   }
 }
 

--- a/apps/web/src/pages/BankConnectionsPage.test.tsx
+++ b/apps/web/src/pages/BankConnectionsPage.test.tsx
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Accessibility regression tests for the Bank Connections dashboard tabs
+ * (#3862). These lock in the WAI-ARIA Tabs pattern: a labelled tablist, each
+ * tab wired to the shared panel, a roving tabindex (single tab stop), automatic
+ * activation on Arrow/Home/End, and zero axe-core violations.
+ */
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useBankConnections } from '../hooks/useBankConnections';
+import { useConnectorPermissions } from '../hooks/useConnectorPermissions';
+import { expectNoAxeViolations } from '../test-utils/axe';
+import { BankConnectionsPage } from './BankConnectionsPage';
+
+vi.mock('../hooks/useBankConnections', () => ({
+  useBankConnections: vi.fn(),
+}));
+
+vi.mock('../hooks/useConnectorPermissions', () => ({
+  useConnectorPermissions: vi.fn(),
+}));
+
+const mockedUseBankConnections = vi.mocked(useBankConnections);
+const mockedUseConnectorPermissions = vi.mocked(useConnectorPermissions);
+
+/** Tab accessible names in DOM order. */
+const TAB_NAMES = [
+  'Connection Health',
+  'Providers',
+  'Wallets & Exchanges',
+  'Safety Center',
+] as const;
+
+function setupHooks(): void {
+  mockedUseBankConnections.mockReturnValue({
+    connections: [],
+    providers: [],
+    healthHistory: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    loadHealthHistory: vi.fn(),
+  });
+  mockedUseConnectorPermissions.mockReturnValue({
+    permissions: [],
+    accessLog: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    loadAccessLog: vi.fn(),
+  });
+}
+
+/**
+ * Renders the page inside a `<main>` landmark, mirroring the app shell so the
+ * page-level axe run isn't tripped by best-practice landmark rules.
+ */
+function renderPage(): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter>
+      <main>
+        <BankConnectionsPage />
+      </main>
+    </MemoryRouter>,
+  );
+}
+
+const getTab = (name: string): HTMLElement => screen.getByRole('tab', { name });
+
+describe('BankConnectionsPage — WAI-ARIA Tabs (#3862)', () => {
+  beforeEach(() => {
+    setupHooks();
+  });
+
+  it('renders a labelled tablist containing the four section tabs', () => {
+    renderPage();
+
+    const tablist = screen.getByRole('tablist', { name: 'Bank connections sections' });
+    const tabs = within(tablist).getAllByRole('tab');
+
+    expect(tabs).toHaveLength(TAB_NAMES.length);
+    tabs.forEach((tab, index) => {
+      expect(tab).toHaveTextContent(TAB_NAMES[index]);
+    });
+  });
+
+  it('associates every tab with the shared panel via aria-controls', () => {
+    renderPage();
+
+    const panel = screen.getByRole('tabpanel');
+    const panelId = panel.getAttribute('id');
+    expect(panelId).toBeTruthy();
+
+    for (const name of TAB_NAMES) {
+      const tab = getTab(name);
+      expect(tab).toHaveAttribute('id');
+      expect(tab).toHaveAttribute('aria-controls', panelId);
+    }
+  });
+
+  it('labels the panel with the active tab and keeps it focusable', () => {
+    renderPage();
+
+    const panel = screen.getByRole('tabpanel');
+    const activeTab = getTab('Connection Health');
+
+    expect(panel).toHaveAttribute('aria-labelledby', activeTab.getAttribute('id'));
+    expect(panel).toHaveAttribute('tabindex', '0');
+  });
+
+  it('uses a roving tabindex so only the selected tab is a tab stop', () => {
+    renderPage();
+
+    const selected = getTab('Connection Health');
+    expect(selected).toHaveAttribute('aria-selected', 'true');
+    expect(selected).toHaveAttribute('tabindex', '0');
+
+    for (const name of TAB_NAMES.slice(1)) {
+      const tab = getTab(name);
+      expect(tab).toHaveAttribute('aria-selected', 'false');
+      expect(tab).toHaveAttribute('tabindex', '-1');
+    }
+  });
+
+  it('activates a tab on click and repoints the panel label', () => {
+    renderPage();
+
+    const providers = getTab('Providers');
+    fireEvent.click(providers);
+
+    expect(providers).toHaveAttribute('aria-selected', 'true');
+    expect(providers).toHaveAttribute('tabindex', '0');
+    expect(getTab('Connection Health')).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('tabpanel')).toHaveAttribute(
+      'aria-labelledby',
+      providers.getAttribute('id'),
+    );
+  });
+
+  it('moves to the next tab with ArrowRight (automatic activation + focus)', () => {
+    renderPage();
+
+    const health = getTab('Connection Health');
+    health.focus();
+    fireEvent.keyDown(health, { key: 'ArrowRight' });
+
+    const providers = getTab('Providers');
+    expect(providers).toHaveAttribute('aria-selected', 'true');
+    expect(providers).toHaveAttribute('tabindex', '0');
+    expect(providers).toHaveFocus();
+  });
+
+  it('wraps to the last tab with ArrowLeft from the first tab', () => {
+    renderPage();
+
+    const health = getTab('Connection Health');
+    health.focus();
+    fireEvent.keyDown(health, { key: 'ArrowLeft' });
+
+    const safety = getTab('Safety Center');
+    expect(safety).toHaveAttribute('aria-selected', 'true');
+    expect(safety).toHaveFocus();
+  });
+
+  it('jumps to the first and last tabs with Home and End', () => {
+    renderPage();
+
+    fireEvent.click(getTab('Providers'));
+
+    fireEvent.keyDown(getTab('Providers'), { key: 'End' });
+    const safety = getTab('Safety Center');
+    expect(safety).toHaveAttribute('aria-selected', 'true');
+    expect(safety).toHaveFocus();
+
+    fireEvent.keyDown(safety, { key: 'Home' });
+    const health = getTab('Connection Health');
+    expect(health).toHaveAttribute('aria-selected', 'true');
+    expect(health).toHaveFocus();
+  });
+
+  it('has no axe-core accessibility violations', async () => {
+    const { container } = renderPage();
+    await expectNoAxeViolations(container);
+  });
+});

--- a/apps/web/src/pages/BankConnectionsPage.tsx
+++ b/apps/web/src/pages/BankConnectionsPage.tsx
@@ -15,7 +15,7 @@
  * References: #1575, #1577, #1583
  */
 
-import React, { Suspense, lazy, useCallback, useState } from 'react';
+import React, { Suspense, lazy, useCallback, useRef, useState } from 'react';
 
 import { ConnectionHealthCard } from '../components/bank/ConnectionHealthCard';
 import { ProviderStatusList } from '../components/bank/ProviderStatusList';
@@ -34,6 +34,36 @@ const CryptoConnectionsPanel = lazy(() =>
     default: module.CryptoConnectionsPanel,
   })),
 );
+
+// ---------------------------------------------------------------------------
+// Tabs (WAI-ARIA Tabs pattern — #3862)
+// ---------------------------------------------------------------------------
+
+/** Identifiers for the four dashboard tabs, in display order. */
+type BankTabId = 'health' | 'providers' | 'crypto' | 'safety';
+
+/** A single tab's identity and visible label. */
+interface BankTabDef {
+  readonly id: BankTabId;
+  readonly label: string;
+}
+
+/**
+ * Ordered tab definitions that drive the tablist. Keeping them in one array
+ * lets the render, roving `tabIndex`, and keyboard handler stay in lockstep.
+ */
+const BANK_TABS: readonly BankTabDef[] = [
+  { id: 'health', label: 'Connection Health' },
+  { id: 'providers', label: 'Providers' },
+  { id: 'crypto', label: 'Wallets & Exchanges' },
+  { id: 'safety', label: 'Safety Center' },
+];
+
+/** Stable id of the shared tab panel; every tab's `aria-controls` points here. */
+const TAB_PANEL_ID = 'bank-connections-tabpanel';
+
+/** Builds the DOM id for a tab button so the panel can reference the active tab. */
+const tabButtonId = (id: BankTabId): string => `bank-tab-${id}`;
 
 // ---------------------------------------------------------------------------
 // Component
@@ -64,8 +94,47 @@ export const BankConnectionsPage: React.FC = () => {
     loadAccessLog,
   } = useConnectorPermissions();
 
-  const [activeTab, setActiveTab] = useState<'health' | 'providers' | 'crypto' | 'safety'>(
-    'health',
+  const [activeTab, setActiveTab] = useState<BankTabId>('health');
+
+  // Roving-tabindex focus management for the tablist (#3862). Each tab button
+  // registers its node so keyboard navigation can move DOM focus to the newly
+  // selected tab (this UI uses automatic activation).
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const activateTab = useCallback((index: number) => {
+    const tab = BANK_TABS[index];
+    if (!tab) return;
+    setActiveTab(tab.id);
+    tabRefs.current[index]?.focus();
+  }, []);
+
+  const handleTabListKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      const currentIndex = BANK_TABS.findIndex((tab) => tab.id === activeTab);
+      if (currentIndex === -1) return;
+
+      let nextIndex: number;
+      switch (event.key) {
+        case 'ArrowRight':
+          nextIndex = (currentIndex + 1) % BANK_TABS.length;
+          break;
+        case 'ArrowLeft':
+          nextIndex = (currentIndex - 1 + BANK_TABS.length) % BANK_TABS.length;
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = BANK_TABS.length - 1;
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      activateTab(nextIndex);
+    },
+    [activeTab, activateTab],
   );
 
   const handleViewHistory = useCallback(
@@ -131,48 +200,45 @@ export const BankConnectionsPage: React.FC = () => {
         )}
       </div>
 
-      {/* Tab navigation */}
-      <nav className="tab-nav" role="tablist" aria-label="Bank connections sections">
-        <button
-          type="button"
-          className={`tab-nav__tab ${activeTab === 'health' ? 'tab-nav__tab--active' : ''}`}
-          onClick={() => setActiveTab('health')}
-          aria-selected={activeTab === 'health'}
-          role="tab"
-        >
-          Connection Health
-        </button>
-        <button
-          type="button"
-          className={`tab-nav__tab ${activeTab === 'providers' ? 'tab-nav__tab--active' : ''}`}
-          onClick={() => setActiveTab('providers')}
-          aria-selected={activeTab === 'providers'}
-          role="tab"
-        >
-          Providers
-        </button>
-        <button
-          type="button"
-          className={`tab-nav__tab ${activeTab === 'crypto' ? 'tab-nav__tab--active' : ''}`}
-          onClick={() => setActiveTab('crypto')}
-          aria-selected={activeTab === 'crypto'}
-          role="tab"
-        >
-          Wallets &amp; Exchanges
-        </button>
-        <button
-          type="button"
-          className={`tab-nav__tab ${activeTab === 'safety' ? 'tab-nav__tab--active' : ''}`}
-          onClick={() => setActiveTab('safety')}
-          aria-selected={activeTab === 'safety'}
-          role="tab"
-        >
-          Safety Center
-        </button>
-      </nav>
+      {/* Tab navigation — WAI-ARIA Tabs pattern (#3862). Roving tabindex keeps a
+          single tab stop; Left/Right/Home/End move (and activate) tabs. */}
+      <div
+        className="tab-nav"
+        role="tablist"
+        aria-label="Bank connections sections"
+        onKeyDown={handleTabListKeyDown}
+      >
+        {BANK_TABS.map((tab, index) => {
+          const isActive = activeTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              id={tabButtonId(tab.id)}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              className={`tab-nav__tab ${isActive ? 'tab-nav__tab--active' : ''}`}
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={TAB_PANEL_ID}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => setActiveTab(tab.id)}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
 
       {/* Tab content */}
-      <div className="tab-content" role="tabpanel">
+      <div
+        className="tab-content"
+        role="tabpanel"
+        id={TAB_PANEL_ID}
+        aria-labelledby={tabButtonId(activeTab)}
+        tabIndex={0}
+      >
         {/* Health tab */}
         {activeTab === 'health' && (
           <section aria-label="Connection health">


### PR DESCRIPTION
## Summary

Completes the WAI-ARIA Tabs pattern on the Bank Connections dashboard (`apps/web/src/pages/BankConnectionsPage.tsx`), which previously exposed `role="tab"`/`role="tablist"` but never wired the tabs to their panel, had no keyboard model, and had no `[aria-selected]`-keyed selected style. This gates the `live_bank_data` feature rollout.

## Changes

**`BankConnectionsPage.tsx`**

- Config-driven tabs (`BANK_TABS`) so render, roving `tabIndex`, and the keyboard handler stay in lockstep.
- Each tab now has a unique `id`, `aria-controls` pointing at the shared panel, `aria-selected`, and a roving `tabIndex` (`0` for the selected tab, `-1` for the rest) — a single tab stop. (WCAG 1.3.1, 4.1.2, 2.1.1)
- The panel gets a stable `id`, `aria-labelledby` pointing at the active tab, and `tabIndex={0}` so keyboard users can reach panel content.
- Keyboard handler on the tablist: **ArrowLeft/ArrowRight** move between tabs (wrapping), **Home** → first, **End** → last. Moving focus also activates the tab (automatic activation) and moves DOM focus to the newly selected tab.
- The tab container is now `div[role="tablist"]` instead of `nav[role="tablist"]` (a tablist is a composite widget, not a navigation landmark), matching the sibling `PlanningPage` convention.

**`bank-connections.css`**

- Selected-state style keyed on both `.tab-nav__tab--active` **and** `.tab-nav__tab[aria-selected="true"]` so the visible indicator can't drift from the exposed ARIA state. The cue is an underline bar **plus** a heavier font weight — never colour alone. (WCAG 1.4.1)
- Uses theme-aware `--semantic-*` tokens, so the indicator is visible in both light and dark themes.
- `prefers-reduced-motion: reduce` disables the tab transition; `prefers-contrast: more` thickens the selected underline.

**`BankConnectionsPage.test.tsx`** (new)

- Asserts the labelled tablist, per-tab `aria-controls`/`id`, panel `aria-labelledby`/`tabIndex`, roving tabindex, click activation, and Arrow/Home/End navigation (selection + focus).
- Adds an `axe-core` no-violations assertion using the existing `test-utils/axe` harness.

## Design decisions (standard APG choices, noted per request)

- **Single shared panel** (not one panel per tab): every tab's `aria-controls` points at one stable panel id and the panel's `aria-labelledby` tracks the active tab. This matches the existing single swapping `.tab-content` region and avoids dangling `aria-controls` references.
- **Automatic activation**: focus movement selects the tab, consistent with the page's existing click-to-activate behavior and appropriate since panels are cheap to render.
- **Selected-state CSS lives in `bank-connections.css`** (co-located with the existing `.tab-nav` styles) rather than the global `styles/accessibility.css`, to avoid restyling every other `role="tab"` surface in the app.

## Out of scope

- A pre-existing design-hook finding on `.provider-status-list__health-fill` (animates `width`) is unrelated to this a11y change and left untouched.

## Issues

Closes #3862

## Testing

- [x] `npm run test -w apps/web -- BankConnectionsPage` → 9/9 passing (includes axe-core)
- [x] `npm run format:check` clean for changed files
- [x] `npx eslint . --max-warnings 0` → exit 0
