### PR TITLE
ci(deploy): wire Plaid/bank env into edge-functions + provision from secrets

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -512,6 +512,66 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.sha }}
 
+      - name: Provision bank-connection env (Plaid) on server
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '~/finance' }}
+          PLAID_CLIENT_ID: ${{ secrets.PLAID_CLIENT_ID }}
+          PLAID_SECRET: ${{ secrets.PLAID_SECRET }}
+          PLAID_ENVIRONMENT: ${{ vars.PLAID_ENVIRONMENT || 'sandbox' }}
+          PLAID_WEBHOOK_URL: ${{ vars.PLAID_WEBHOOK_URL || 'https://finance.jrmoulckers.com/functions/v1/bank-webhook?provider=plaid' }}
+          BANK_ENCRYPTION_KEY: ${{ secrets.BANK_ENCRYPTION_KEY }}
+          MX_WEBHOOK_SECRET: ${{ secrets.MX_WEBHOOK_SECRET }}
+        run: |
+          if [ -z "$DEPLOY_HOST" ]; then
+            echo '::warning::DEPLOY_HOST not configured — skipping bank env provisioning'
+            exit 0
+          fi
+          if [ -z "$PLAID_CLIENT_ID" ] && [ -z "$MX_WEBHOOK_SECRET" ]; then
+            echo '::notice::No bank credentials configured — leaving bank features dark'
+            exit 0
+          fi
+
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          # Assemble the managed .env block on the runner and base64 it so secret
+          # values transit the SSH command line safely (mirrors the web-deploy job).
+          BLOCK=$(printf '%s\n' \
+            '# >>> plaid-managed (deploy-production.yml) >>>' \
+            "PLAID_CLIENT_ID=$PLAID_CLIENT_ID" \
+            "PLAID_SECRET=$PLAID_SECRET" \
+            "PLAID_ENVIRONMENT=$PLAID_ENVIRONMENT" \
+            "PLAID_WEBHOOK_URL=$PLAID_WEBHOOK_URL" \
+            "BANK_ENCRYPTION_KEY=$BANK_ENCRYPTION_KEY" \
+            "MX_WEBHOOK_SECRET=$MX_WEBHOOK_SECRET" \
+            '# <<< plaid-managed <<<')
+          BLOCK_B64=$(printf '%s' "$BLOCK" | base64 -w 0)
+
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+            "DEPLOY_PATH='$DEPLOY_PATH' BLOCK_B64='$BLOCK_B64' bash -s" <<'REMOTE'
+            set -eu
+            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#"~"}" ;; esac  # quote ~ for a literal strip (unquoted ~ corrupts the path)
+            ENV_FILE="$DEPLOY_PATH/deploy/.env"
+            mkdir -p "$DEPLOY_PATH/deploy"
+            touch "$ENV_FILE"
+            tmp=$(mktemp)
+            # Drop any prior managed block, then append the fresh one (idempotent).
+            sed '/# >>> plaid-managed (deploy-production.yml) >>>/,/# <<< plaid-managed <<</d' "$ENV_FILE" > "$tmp"
+            printf '%s' "$BLOCK_B64" | base64 -d >> "$tmp"
+            printf '\n' >> "$tmp"
+            mv "$tmp" "$ENV_FILE"
+            chmod 600 "$ENV_FILE"
+            echo "Bank env keys now present in deploy/.env:"
+            grep -E '^(PLAID_|MX_WEBHOOK_SECRET|BANK_ENCRYPTION_KEY)=' "$ENV_FILE" | sed -E 's/=.*/=<set>/' || true
+          REMOTE
+
+          echo '### 🔐 Bank env provisioned on server' >> "$GITHUB_STEP_SUMMARY"
+
       - name: Deploy to production server
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -159,6 +159,41 @@ EDGE_FUNCTIONS_PATH=../services/api/supabase/functions
 WEB_DIST_PATH=../apps/web/dist
 
 # ---------------------------------------------------------------------------
+# Bank Connection API (Plaid / MX) — #3848
+# ---------------------------------------------------------------------------
+# Enables live bank-transaction auto-import via the bank-connection and
+# bank-webhook edge functions. Leave the placeholders as-is to keep the bank
+# features dark (the functions return 503 until real values are set).
+#
+# Plaid is the reference aggregator. PLAID_ENVIRONMENT selects the API host:
+# sandbox | development | production. Get client_id + secret from the Plaid
+# dashboard (Team Settings → Keys); the sandbox secret works with test banks
+# (login user_good / pass_good), no Plaid approval required.
+#
+# PLAID_WEBHOOK_URL is the public URL Plaid POSTs async transaction updates to
+# — it must resolve to the bank-webhook function through Caddy:
+#   https://YOUR_DOMAIN_HERE/functions/v1/bank-webhook?provider=plaid
+#
+# BANK_ENCRYPTION_KEY must be a 64-char hex string (32 bytes) used for
+# AES-256-GCM encryption of stored access tokens. Generate with:
+#   openssl rand -hex 32
+# WARNING: do not change it after connections exist — stored tokens become
+# undecryptable.
+#
+# MX_WEBHOOK_SECRET is the HMAC secret for MX webhook verification. MX itself
+# is a documented stub, but bank-webhook's env validation REQUIRES this to be
+# non-empty even in Plaid-only mode, so set it (openssl rand -hex 32). The
+# other MX_* vars can stay empty until MX is provisioned.
+PLAID_CLIENT_ID=YOUR_PLAID_CLIENT_ID_HERE
+PLAID_SECRET=YOUR_PLAID_SECRET_HERE
+PLAID_ENVIRONMENT=sandbox
+PLAID_WEBHOOK_URL=https://YOUR_DOMAIN_HERE/functions/v1/bank-webhook?provider=plaid
+MX_CLIENT_ID=
+MX_API_KEY=
+MX_WEBHOOK_SECRET=YOUR_MX_WEBHOOK_SECRET_HERE
+BANK_ENCRYPTION_KEY=YOUR_32_BYTE_AES_KEY_HEX_HERE
+
+# ---------------------------------------------------------------------------
 # PowerSync (offline-first sync engine) — #881
 # ---------------------------------------------------------------------------
 POWERSYNC_URL=YOUR_POWERSYNC_URL_HERE

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -326,6 +326,23 @@ services:
       WEBAUTHN_RP_ID: ${WEBAUTHN_RP_ID}
       WEBAUTHN_ORIGIN: ${WEBAUTHN_ORIGIN}
       CRON_SECRET: ${CRON_SECRET}
+      # Bank Connection API (Plaid / MX) — #3848. The bank-connection and
+      # bank-webhook functions read these at runtime; without them they fail
+      # env validation and return 503. Compose only forwards the vars listed
+      # here, so a value present in the VM .env is invisible to the container
+      # unless it is also mapped below. Empty defaults keep the bank features
+      # gracefully dark until the operator populates deploy/.env. Note:
+      # bank-webhook's validateEnv requires MX_WEBHOOK_SECRET even in
+      # Plaid-only mode, so it must be set (any non-empty value) to enable
+      # webhook-driven transaction ingestion.
+      PLAID_CLIENT_ID: ${PLAID_CLIENT_ID:-}
+      PLAID_SECRET: ${PLAID_SECRET:-}
+      PLAID_ENVIRONMENT: ${PLAID_ENVIRONMENT:-sandbox}
+      PLAID_WEBHOOK_URL: ${PLAID_WEBHOOK_URL:-}
+      MX_CLIENT_ID: ${MX_CLIENT_ID:-}
+      MX_API_KEY: ${MX_API_KEY:-}
+      MX_WEBHOOK_SECRET: ${MX_WEBHOOK_SECRET:-}
+      BANK_ENCRYPTION_KEY: ${BANK_ENCRYPTION_KEY:-}
     volumes:
       - ${EDGE_FUNCTIONS_PATH:-../services/api/supabase/functions}:/home/deno/functions:ro
     healthcheck:


### PR DESCRIPTION
## What & why

Live bank-transaction auto-import (Plaid/MX, #3848) has a fully-built, deployed backend, but the `bank-connection` and `bank-webhook` edge functions return **503** in production because their required env vars never reach the container.

**Root cause (two gaps, both fixed here):**
1. **Compose allow-list** — the `edge-functions` service in `deploy/docker-compose.yml` forwards env via an explicit allow-list. The Plaid/MX/`BANK_ENCRYPTION_KEY` vars were never listed, so even a fully-populated VM `.env` is invisible to the Deno runtime and `validateEnv` fails early with a 503.
2. **No path to populate the VM `.env`** — that file is gitignored and hand-maintained, and the deploy workflow never templated it, so the credentials could previously only be placed by manual SSH to the VM.

## Changes
- **`deploy/docker-compose.yml`** — map the bank env vars into the `edge-functions` container: `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENVIRONMENT` (defaults to `sandbox`), `PLAID_WEBHOOK_URL`, `MX_CLIENT_ID`, `MX_API_KEY`, `MX_WEBHOOK_SECRET`, `BANK_ENCRYPTION_KEY`. Empty defaults keep the features gracefully dark until configured.
- **`deploy/.env.example`** — document the self-hosted bank vars, the Caddy webhook URL shape (`/functions/v1/bank-webhook?provider=plaid`), the 64-hex `BANK_ENCRYPTION_KEY`, and the gotcha that `bank-webhook`'s `validateEnv` requires `MX_WEBHOOK_SECRET` even in Plaid-only mode.
- **`.github/workflows/deploy-production.yml`** — new **"Provision bank-connection env (Plaid) on server"** step in the `deploy-backend` job. Using the existing `DEPLOY_SSH_KEY`, it writes a marker-delimited managed block into `$DEPLOY_PATH/deploy/.env` from GitHub **production environment secrets** before the container comes up. It skips cleanly when creds are unset, base64-encodes the block so values transit the SSH command line safely, is idempotent across re-deploys, and masks values in its confirmation output.

## Required-var mapping (from `services/api/supabase/functions/_shared/env.ts`)
- `bank-connection`: `ALLOWED_ORIGINS` (already mapped) + `BANK_ENCRYPTION_KEY`; the Plaid REST calls also need `PLAID_CLIENT_ID` / `PLAID_SECRET` / `PLAID_ENVIRONMENT` at runtime.
- `bank-webhook`: `PLAID_CLIENT_ID` + `PLAID_SECRET` + `BANK_ENCRYPTION_KEY` + `MX_WEBHOOK_SECRET`.

## Deploy / rollout
The 4 secrets (`PLAID_CLIENT_ID`, `PLAID_SECRET`, `BANK_ENCRYPTION_KEY`, `MX_WEBHOOK_SECRET`) are set as **production environment secrets**. After merge, the auto-promote pipeline (`component` defaults to `all`) runs the new provisioning step (writes `deploy/.env` from those secrets) then `git checkout <sha>` + `docker compose up -d`, recreating `edge-functions` with the vars present. `bank-connection` then returns non-503 and `bank-webhook` can ingest. Sandbox Plaid creds → low risk; swap to production creds later by updating the same secrets.

## Testing
- `prettier@3.9.1 --check` → clean on both `deploy/docker-compose.yml` and `.github/workflows/deploy-production.yml` (`.env.example` is prettier-ignored).
- `bash -n` on the runner-side and remote (heredoc) halves of the new step → both syntax-clean.
- Config/CI-only change; no application code or unit tests affected.

Refs #3848