### PR TITLE
ci(deploy): move production deploy onto a fresh concurrency lane (-v3)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -102,7 +102,11 @@ concurrency:
   # scheduled - with no incident, no billing issue, and no other run holding the
   # lane. Renaming the group moves production deploys onto a fresh lane and
   # clears the wedge, while preserving the same serialize-on-one-host guarantee.
-  group: deploy-production-v2
+  #
+  # The `-v2` lane re-wedged the same way (an abandoned promotion left `pending`
+  # for hours cancelled newer promotions instead of yielding the lane), so bump
+  # to `-v3` for another fresh lane.
+  group: deploy-production-v3
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 permissions:


### PR DESCRIPTION
## What & why

The `deploy-production-v2` concurrency lane re-wedged: an abandoned `Promote to Production` run sat `pending` for hours and, instead of yielding the single-lane group, **cancelled every newer promotion within ~3s** (at `Prepare Deployment`, before the approval gate). That silently blocked auto-promotion — matching the recurring "triggered but cancelled" symptom.

This is the same GitHub Actions pathology fixed once before (v1 -> v2): cancelling a run while it is still `pending` (zero jobs started) leaves the lane stuck. The proven recovery is to rename the concurrency group onto a fresh lane.

## Change
- `.github/workflows/deploy-production.yml` — bump the production concurrency group `deploy-production-v2` -> `deploy-production-v3` (+ comment documenting the recurrence). Same serialize-on-one-host guarantee, fresh un-wedged lane.

## Validation
- Empirically proven: a `workflow_dispatch` of this branch's workflow went `in_progress` immediately on the `-v3` lane and deployed `db8d97ea` to production end-to-end (backend + web + post-deploy smoke all green), whereas the `-v2` promote could only reach `cancelled`.
- `prettier@3.9.1 --check` clean.

## Note
Merging re-runs the (idempotent) auto-promote once on the `-v3` lane; it will pause at the `production` gate as usual.