### PR TITLE
feat(bank): auto-provision + link accounts and initial backfill on connect

### DIFF
--- a/services/api/supabase/functions/_shared/bank-ingest.ts
+++ b/services/api/supabase/functions/_shared/bank-ingest.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Shared bank transaction ingestion (#265, #3848).
+ *
+ * Extracted from `bank-webhook` so the exact same ingestion path can run in two
+ * places with identical semantics:
+ *   1. `bank-webhook`    — incremental sync when a provider webhook fires.
+ *   2. `bank-connection` — an initial backfill immediately after a bank is
+ *      linked, so the user sees transactions without waiting for a webhook.
+ *
+ * Ingestion only accepts transactions whose external Plaid account is mapped to
+ * an internal Finance account via `bank_connection_accounts` (is_linked=true).
+ * Callers MUST provision + link those rows BEFORE invoking this module, or every
+ * transaction is silently dropped.
+ *
+ * Security:
+ *   - Access tokens are decrypted only in memory for provider sync and are
+ *     NEVER logged or returned.
+ *   - NEVER logs raw financial data — only aggregate counts.
+ *
+ * @module _shared/bank-ingest
+ */
+
+import { createAdminClient } from './auth.ts';
+import { decryptToken } from './bank-crypto.ts';
+import { createLogger } from './logger.ts';
+import {
+  plaidTransactionToRecord,
+  transactionsSync,
+  type PlaidConfig,
+  type PlaidTransaction,
+} from './plaid.ts';
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+type FunctionLogger = ReturnType<typeof createLogger>;
+
+/** A `bank_connections` row with the fields ingestion needs. */
+export interface BankConnectionRow {
+  id: string;
+  household_id: string;
+  encrypted_access_token: string;
+  metadata: Record<string, unknown> | null;
+}
+
+/** An external Plaid account mapped to an internal Finance account. */
+export interface LinkedAccount {
+  account_id: string;
+  household_id: string;
+  currency_code: string;
+}
+
+/** Summary of an ingestion run (counts only — never transaction contents). */
+export interface IngestionSummary {
+  added: number;
+  modified: number;
+  removed: number;
+}
+
+/** Read Plaid credentials from the environment. */
+function plaidConfigFromEnv(): PlaidConfig {
+  return {
+    clientId: Deno.env.get('PLAID_CLIENT_ID') ?? '',
+    secret: Deno.env.get('PLAID_SECRET') ?? '',
+    environment: Deno.env.get('PLAID_ENVIRONMENT') ?? 'sandbox',
+  };
+}
+
+/**
+ * Build a map of Plaid external account id -> internal linked account.
+ * Only accounts that are linked to an internal Finance account participate.
+ */
+export async function loadLinkedAccounts(
+  supabase: AdminClient,
+  connectionId: string,
+): Promise<Map<string, LinkedAccount>> {
+  const { data } = await supabase
+    .from('bank_connection_accounts')
+    .select('external_account_id, account_id, household_id, currency_code, is_linked')
+    .eq('bank_connection_id', connectionId)
+    .eq('is_linked', true)
+    .is('deleted_at', null);
+
+  const map = new Map<string, LinkedAccount>();
+  for (const row of data ?? []) {
+    if (row.account_id) {
+      map.set(row.external_account_id, {
+        account_id: row.account_id,
+        household_id: row.household_id,
+        currency_code: row.currency_code ?? 'USD',
+      });
+    }
+  }
+  return map;
+}
+
+/**
+ * Upsert a single Plaid transaction into `transactions` with provenance.
+ * Returns true if a new row was inserted.
+ *
+ * NEVER logs the transaction contents.
+ */
+export async function upsertPlaidTransaction(
+  supabase: AdminClient,
+  txn: PlaidTransaction,
+  account: LinkedAccount,
+): Promise<boolean> {
+  // Deduplicate on the provider transaction id — provider webhooks may retry.
+  const { data: existing } = await supabase
+    .from('transactions')
+    .select('id')
+    .eq('provider_transaction_id', txn.transaction_id)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  const record = {
+    ...plaidTransactionToRecord(txn, {
+      householdId: account.household_id,
+      accountId: account.account_id,
+      currencyFallback: account.currency_code,
+    }),
+    imported_at: new Date().toISOString(),
+  };
+
+  if (existing) {
+    await supabase.from('transactions').update(record).eq('id', existing.id);
+    return false;
+  }
+
+  await supabase.from('transactions').insert(record);
+  return true;
+}
+
+/**
+ * Ingest incremental transaction updates for a Plaid connection via
+ * /transactions/sync, honoring the stored cursor and persisting the new one.
+ *
+ * Safe to call for the initial backfill (empty cursor) and for every subsequent
+ * webhook-driven delta. Returns aggregate counts only.
+ */
+export async function ingestPlaidTransactions(
+  supabase: AdminClient,
+  connection: BankConnectionRow,
+  logger: FunctionLogger,
+): Promise<IngestionSummary> {
+  const summary: IngestionSummary = { added: 0, modified: 0, removed: 0 };
+
+  const config = plaidConfigFromEnv();
+  const encryptionKey = Deno.env.get('BANK_ENCRYPTION_KEY');
+  if (!config.clientId || !config.secret || !encryptionKey) {
+    logger.warn('Skipping ingestion — provider config incomplete');
+    return summary;
+  }
+
+  const accessToken = await decryptToken(connection.encrypted_access_token, encryptionKey);
+  const linkedAccounts = await loadLinkedAccounts(supabase, connection.id);
+
+  let cursor = (connection.metadata?.['cursor'] as string | undefined) ?? null;
+  let hasMore = true;
+  let pages = 0;
+  const MAX_PAGES = 20; // Guard against runaway pagination.
+
+  while (hasMore && pages < MAX_PAGES) {
+    pages++;
+    const page = await transactionsSync(config, accessToken, cursor);
+
+    for (const txn of page.added) {
+      const account = linkedAccounts.get(txn.account_id);
+      if (!account) continue;
+      const inserted = await upsertPlaidTransaction(supabase, txn, account);
+      if (inserted) summary.added++;
+      else summary.modified++;
+    }
+
+    for (const txn of page.modified) {
+      const account = linkedAccounts.get(txn.account_id);
+      if (!account) continue;
+      await upsertPlaidTransaction(supabase, txn, account);
+      summary.modified++;
+    }
+
+    for (const removed of page.removed) {
+      const { data: rows } = await supabase
+        .from('transactions')
+        .update({ deleted_at: new Date().toISOString() })
+        .eq('provider_transaction_id', removed.transaction_id)
+        .is('deleted_at', null)
+        .select('id');
+      summary.removed += rows?.length ?? 0;
+    }
+
+    cursor = page.next_cursor;
+    hasMore = page.has_more;
+  }
+
+  // Persist the advanced cursor for the next sync (merge into metadata).
+  const mergedMetadata = { ...(connection.metadata ?? {}), cursor };
+  await supabase
+    .from('bank_connections')
+    .update({ metadata: mergedMetadata, last_synced_at: new Date().toISOString() })
+    .eq('id', connection.id);
+
+  return summary;
+}

--- a/services/api/supabase/functions/_shared/plaid.test.ts
+++ b/services/api/supabase/functions/_shared/plaid.test.ts
@@ -12,6 +12,8 @@ import { assertEquals } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
 
 import {
   buildLinkTokenRequest,
+  getAccounts,
+  plaidAccountTypeToInternal,
   plaidAmountToCents,
   plaidBaseUrl,
   plaidTransactionToRecord,
@@ -142,4 +144,69 @@ Deno.test('removeItem posts the access token to /item/remove', async () => {
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+Deno.test('getAccounts posts the access token to /accounts/get and returns accounts', async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = '';
+  let capturedBody: Record<string, unknown> = {};
+  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+    capturedUrl = String(input);
+    capturedBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          accounts: [
+            {
+              account_id: 'acc-1',
+              name: 'Plaid Checking',
+              official_name: 'Plaid Gold Standard 0% Interest Checking',
+              mask: '0000',
+              type: 'depository',
+              subtype: 'checking',
+              balances: {
+                available: 100,
+                current: 110,
+                limit: null,
+                iso_currency_code: 'USD',
+                unofficial_currency_code: null,
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+  }) as typeof fetch;
+
+  try {
+    const result = await getAccounts(
+      { clientId: 'client', secret: 'secret', environment: 'sandbox' },
+      'access-token-xyz',
+    );
+    assertEquals(capturedUrl, 'https://sandbox.plaid.com/accounts/get');
+    assertEquals(capturedBody.access_token, 'access-token-xyz');
+    assertEquals(capturedBody.client_id, 'client');
+    assertEquals(result.accounts.length, 1);
+    assertEquals(result.accounts[0].account_id, 'acc-1');
+    assertEquals(result.accounts[0].balances.iso_currency_code, 'USD');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test('plaidAccountTypeToInternal maps Plaid types to canonical account types', () => {
+  assertEquals(plaidAccountTypeToInternal('depository', 'checking'), 'CHECKING');
+  assertEquals(plaidAccountTypeToInternal('depository', 'savings'), 'SAVINGS');
+  assertEquals(plaidAccountTypeToInternal('depository', 'money market'), 'SAVINGS');
+  assertEquals(plaidAccountTypeToInternal('depository', 'hsa'), 'SAVINGS');
+  assertEquals(plaidAccountTypeToInternal('depository', 'cash management'), 'CASH');
+  assertEquals(plaidAccountTypeToInternal('depository', 'prepaid'), 'CASH');
+  assertEquals(plaidAccountTypeToInternal('depository', null), 'CHECKING');
+  assertEquals(plaidAccountTypeToInternal('credit', 'credit card'), 'CREDIT_CARD');
+  assertEquals(plaidAccountTypeToInternal('loan', 'student'), 'LOAN');
+  assertEquals(plaidAccountTypeToInternal('investment', 'brokerage'), 'INVESTMENT');
+  assertEquals(plaidAccountTypeToInternal('brokerage', null), 'INVESTMENT');
+  assertEquals(plaidAccountTypeToInternal('other', 'other'), 'OTHER');
+  assertEquals(plaidAccountTypeToInternal(null, null), 'OTHER');
 });

--- a/services/api/supabase/functions/_shared/plaid.ts
+++ b/services/api/supabase/functions/_shared/plaid.ts
@@ -54,6 +54,31 @@ export interface PlaidSyncResult {
   has_more: boolean;
 }
 
+/** Balance snapshot attached to a Plaid account. */
+export interface PlaidAccountBalances {
+  available: number | null;
+  current: number | null;
+  limit: number | null;
+  iso_currency_code: string | null;
+  unofficial_currency_code: string | null;
+}
+
+/** A single account returned by /accounts/get. */
+export interface PlaidAccount {
+  account_id: string;
+  name: string | null;
+  official_name: string | null;
+  mask: string | null;
+  type: string | null;
+  subtype: string | null;
+  balances: PlaidAccountBalances;
+}
+
+/** Result of an /accounts/get call. */
+export interface PlaidAccountsResult {
+  accounts: PlaidAccount[];
+}
+
 /** A JSON Web Key returned by /webhook_verification_key/get. */
 export interface PlaidVerificationKey {
   kty: string;
@@ -182,6 +207,55 @@ export async function exchangePublicToken(
   publicToken: string,
 ): Promise<{ access_token: string; item_id: string }> {
   return plaidPost(config, '/item/public_token/exchange', { public_token: publicToken });
+}
+
+/**
+ * List the accounts associated with an Item via /accounts/get.
+ *
+ * Called at connection time to discover which external accounts exist so they
+ * can be provisioned + linked to internal Finance accounts. Account linking is
+ * a hard prerequisite for transaction ingestion, which drops any transaction
+ * whose external account is not linked.
+ *
+ * SECURITY: NEVER log the access token.
+ */
+export async function getAccounts(
+  config: PlaidConfig,
+  accessToken: string,
+): Promise<PlaidAccountsResult> {
+  return plaidPost<PlaidAccountsResult>(config, '/accounts/get', {
+    access_token: accessToken,
+  });
+}
+
+/**
+ * The app's canonical internal account types, stored verbatim in
+ * `accounts.type`. Mirrors the web `AccountType` union.
+ */
+export type InternalAccountType =
+  'CHECKING' | 'SAVINGS' | 'CREDIT_CARD' | 'CASH' | 'INVESTMENT' | 'LOAN' | 'OTHER';
+
+/**
+ * Map a Plaid account `type`/`subtype` to the app's canonical internal account
+ * type. Pure — no I/O — so it is unit-testable. Falls back to 'OTHER'.
+ *
+ * @see https://plaid.com/docs/api/accounts/#account-type-schema
+ */
+export function plaidAccountTypeToInternal(
+  type: string | null,
+  subtype: string | null,
+): InternalAccountType {
+  const t = (type ?? '').toLowerCase();
+  const s = (subtype ?? '').toLowerCase();
+  if (t === 'credit') return 'CREDIT_CARD';
+  if (t === 'loan') return 'LOAN';
+  if (t === 'investment' || t === 'brokerage') return 'INVESTMENT';
+  if (t === 'depository') {
+    if (s === 'savings' || s === 'money market' || s === 'cd' || s === 'hsa') return 'SAVINGS';
+    if (s === 'cash management' || s === 'prepaid') return 'CASH';
+    return 'CHECKING';
+  }
+  return 'OTHER';
 }
 
 /**

--- a/services/api/supabase/functions/bank-connection/index.ts
+++ b/services/api/supabase/functions/bank-connection/index.ts
@@ -47,9 +47,17 @@ import { encryptToken } from '../_shared/bank-crypto.ts';
 import {
   createLinkToken as plaidCreateLinkToken,
   exchangePublicToken as plaidExchangePublicToken,
+  getAccounts as plaidGetAccounts,
+  plaidAccountTypeToInternal,
   PlaidApiError,
+  type PlaidAccount,
   type PlaidConfig,
 } from '../_shared/plaid.ts';
+import {
+  ingestPlaidTransactions,
+  type BankConnectionRow,
+  type IngestionSummary,
+} from '../_shared/bank-ingest.ts';
 import { revokeProviderToken } from '../_shared/bank-revocation.ts';
 import {
   createdResponse,
@@ -66,6 +74,9 @@ import {
 
 type Provider = 'plaid' | 'mx';
 const VALID_PROVIDERS: readonly Provider[] = ['plaid', 'mx'];
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+type FunctionLogger = ReturnType<typeof createLogger>;
 
 interface CreateLinkTokenRequest {
   provider: Provider;
@@ -166,6 +177,129 @@ async function exchangeProviderToken(
     access_token: `access-${provider}-${crypto.randomUUID()}`,
     item_id: `member-${crypto.randomUUID()}`,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Account discovery + linking
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover the external accounts for a connection via the provider's API.
+ *
+ * Plaid: real POST /accounts/get. MX: documented stub (returns none) until its
+ * backend adapter lands — mirrors the createLinkToken/exchangeToken dispatch.
+ */
+async function discoverProviderAccounts(
+  provider: Provider,
+  accessToken: string,
+): Promise<PlaidAccount[]> {
+  if (provider === 'plaid') {
+    const { accounts } = await plaidGetAccounts(plaidConfigFromEnv(), accessToken);
+    return accounts;
+  }
+  // MX stub — no account discovery until MX is provisioned.
+  return [];
+}
+
+/**
+ * Run the provider's initial transaction backfill for a freshly-linked
+ * connection so transactions appear immediately (webhooks only deliver deltas
+ * afterward). Provider-agnostic dispatch — mirrors the other provider helpers.
+ */
+async function runInitialProviderSync(
+  supabase: AdminClient,
+  provider: Provider,
+  connection: BankConnectionRow,
+  logger: FunctionLogger,
+): Promise<IngestionSummary> {
+  if (provider === 'plaid') {
+    return ingestPlaidTransactions(supabase, connection, logger);
+  }
+  // MX sync lands with its backend adapter; nothing to backfill yet.
+  return { added: 0, modified: 0, removed: 0 };
+}
+
+/**
+ * Discover a connection's external accounts, provision a matching internal
+ * `accounts` row for each, and insert the linked `bank_connection_accounts`
+ * mapping (is_linked=true).
+ *
+ * Account linking is the HARD PREREQUISITE for transaction ingestion: both the
+ * webhook and the initial sync DROP any transaction whose external account is
+ * not linked here. Best-effort per account — a single failure is logged and
+ * skipped so the remaining accounts still link.
+ *
+ * @returns The number of external accounts successfully linked.
+ */
+async function provisionAndLinkAccounts(
+  supabase: AdminClient,
+  params: {
+    provider: Provider;
+    accessToken: string;
+    connectionId: string;
+    householdId: string;
+  },
+  logger: FunctionLogger,
+): Promise<number> {
+  const externalAccounts = await discoverProviderAccounts(params.provider, params.accessToken);
+  let linked = 0;
+
+  for (const ext of externalAccounts) {
+    const currencyCode = ext.balances?.iso_currency_code ?? 'USD';
+    const displayName = ext.name ?? ext.official_name ?? 'Account';
+    const currentBalance = ext.balances?.current;
+    const balanceCents =
+      typeof currentBalance === 'number' && Number.isFinite(currentBalance)
+        ? Math.round(currentBalance * 100)
+        : 0;
+
+    // 1. Provision an internal Finance account for this external account.
+    const { data: account, error: accountError } = await supabase
+      .from('accounts')
+      .insert({
+        household_id: params.householdId,
+        name: displayName,
+        type: plaidAccountTypeToInternal(ext.type, ext.subtype),
+        currency_code: currencyCode,
+        balance_cents: balanceCents,
+        is_active: true,
+      })
+      .select('id')
+      .single();
+
+    if (accountError || !account) {
+      logger.warn('Failed to provision internal account', {
+        connectionId: params.connectionId,
+        errorMessage: accountError?.message,
+      });
+      continue;
+    }
+
+    // 2. Insert the linked mapping so ingestion accepts this account's txns.
+    const { error: linkError } = await supabase.from('bank_connection_accounts').insert({
+      bank_connection_id: params.connectionId,
+      household_id: params.householdId,
+      account_id: account.id,
+      external_account_id: ext.account_id,
+      external_name: displayName,
+      external_type: ext.type,
+      external_subtype: ext.subtype,
+      currency_code: currencyCode,
+      is_linked: true,
+    });
+
+    if (linkError) {
+      logger.warn('Failed to link external account', {
+        connectionId: params.connectionId,
+        errorMessage: linkError.message,
+      });
+      continue;
+    }
+
+    linked++;
+  }
+
+  return linked;
 }
 
 // ---------------------------------------------------------------------------
@@ -344,6 +478,52 @@ serve(async (req: Request): Promise<Response> => {
         provider: body.provider,
         httpStatus: 201,
       });
+
+      // Discover + link the institution's accounts, then run an initial
+      // backfill so transactions appear immediately (webhooks only deliver
+      // DELTAS after this point). Best-effort: a failure here must NOT fail the
+      // connection — the next webhook or a manual refresh will catch up.
+      try {
+        const linkedCount = await provisionAndLinkAccounts(
+          supabase,
+          {
+            provider: body.provider,
+            accessToken: exchangeResult.access_token,
+            connectionId: connection.id,
+            householdId: body.household_id,
+          },
+          logger,
+        );
+
+        if (linkedCount > 0) {
+          const initialSync = await runInitialProviderSync(
+            supabase,
+            body.provider,
+            {
+              id: connection.id,
+              household_id: body.household_id,
+              encrypted_access_token: encryptedToken,
+              metadata: { item_id: exchangeResult.item_id },
+            },
+            logger,
+          );
+          logger.info('Initial account link + sync complete', {
+            connectionId: connection.id,
+            linkedAccounts: linkedCount,
+            added: initialSync.added,
+            modified: initialSync.modified,
+          });
+        } else {
+          logger.warn('No external accounts linked for connection', {
+            connectionId: connection.id,
+          });
+        }
+      } catch (err) {
+        logger.error('Account linking / initial sync failed (connection retained)', {
+          connectionId: connection.id,
+          errorMessage: (err as Error).message,
+        });
+      }
 
       // NEVER return the access token
       return createdResponse(req, {

--- a/services/api/supabase/functions/bank-webhook/index.ts
+++ b/services/api/supabase/functions/bank-webhook/index.ts
@@ -51,16 +51,14 @@ import {
   jsonResponse,
   methodNotAllowedResponse,
 } from '../_shared/response.ts';
-import { decryptToken } from '../_shared/bank-crypto.ts';
 import { verifyWebhookSignature } from '../_shared/webhook-verify.ts';
 import { verifyPlaidWebhook } from '../_shared/plaid-webhook.ts';
+import { getWebhookVerificationKey, type PlaidConfig } from '../_shared/plaid.ts';
 import {
-  getWebhookVerificationKey,
-  plaidTransactionToRecord,
-  transactionsSync,
-  type PlaidConfig,
-  type PlaidTransaction,
-} from '../_shared/plaid.ts';
+  ingestPlaidTransactions,
+  type BankConnectionRow,
+  type IngestionSummary,
+} from '../_shared/bank-ingest.ts';
 
 // ---------------------------------------------------------------------------
 // Config helpers
@@ -126,26 +124,6 @@ interface MxWebhookEvent {
   user_guid: string;
 }
 
-interface BankConnectionRow {
-  id: string;
-  household_id: string;
-  encrypted_access_token: string;
-  metadata: Record<string, unknown> | null;
-}
-
-interface LinkedAccount {
-  account_id: string;
-  household_id: string;
-  currency_code: string;
-}
-
-/** Summary of an ingestion run (counts only — never transaction contents). */
-interface IngestionSummary {
-  added: number;
-  modified: number;
-  removed: number;
-}
-
 type AdminClient = ReturnType<typeof createAdminClient>;
 type FunctionLogger = ReturnType<typeof createLogger>;
 
@@ -176,144 +154,6 @@ async function recordHealthEvent(
   if (error) {
     logger.warn('Failed to record health event', { errorMessage: error.message });
   }
-}
-
-// ---------------------------------------------------------------------------
-// Transaction ingestion (Plaid)
-// ---------------------------------------------------------------------------
-
-/**
- * Build a map of Plaid external account id -> internal linked account.
- * Only accounts that are linked to an internal Finance account participate.
- */
-async function loadLinkedAccounts(
-  supabase: AdminClient,
-  connectionId: string,
-): Promise<Map<string, LinkedAccount>> {
-  const { data } = await supabase
-    .from('bank_connection_accounts')
-    .select('external_account_id, account_id, household_id, currency_code, is_linked')
-    .eq('bank_connection_id', connectionId)
-    .eq('is_linked', true)
-    .is('deleted_at', null);
-
-  const map = new Map<string, LinkedAccount>();
-  for (const row of data ?? []) {
-    if (row.account_id) {
-      map.set(row.external_account_id, {
-        account_id: row.account_id,
-        household_id: row.household_id,
-        currency_code: row.currency_code ?? 'USD',
-      });
-    }
-  }
-  return map;
-}
-
-/**
- * Upsert a single Plaid transaction into `transactions` with provenance.
- * Returns true if a new row was inserted.
- *
- * NEVER logs the transaction contents.
- */
-async function upsertPlaidTransaction(
-  supabase: AdminClient,
-  txn: PlaidTransaction,
-  account: LinkedAccount,
-): Promise<boolean> {
-  // Deduplicate on the provider transaction id — provider webhooks may retry.
-  const { data: existing } = await supabase
-    .from('transactions')
-    .select('id')
-    .eq('provider_transaction_id', txn.transaction_id)
-    .is('deleted_at', null)
-    .maybeSingle();
-
-  const record = {
-    ...plaidTransactionToRecord(txn, {
-      householdId: account.household_id,
-      accountId: account.account_id,
-      currencyFallback: account.currency_code,
-    }),
-    imported_at: new Date().toISOString(),
-  };
-
-  if (existing) {
-    await supabase.from('transactions').update(record).eq('id', existing.id);
-    return false;
-  }
-
-  await supabase.from('transactions').insert(record);
-  return true;
-}
-
-/**
- * Ingest incremental transaction updates for a Plaid connection via
- * /transactions/sync, honoring the stored cursor and persisting the new one.
- */
-async function ingestPlaidTransactions(
-  supabase: AdminClient,
-  connection: BankConnectionRow,
-  logger: FunctionLogger,
-): Promise<IngestionSummary> {
-  const summary: IngestionSummary = { added: 0, modified: 0, removed: 0 };
-
-  const config = plaidConfigFromEnv();
-  const encryptionKey = Deno.env.get('BANK_ENCRYPTION_KEY');
-  if (!config.clientId || !config.secret || !encryptionKey) {
-    logger.warn('Skipping ingestion — provider config incomplete');
-    return summary;
-  }
-
-  const accessToken = await decryptToken(connection.encrypted_access_token, encryptionKey);
-  const linkedAccounts = await loadLinkedAccounts(supabase, connection.id);
-
-  let cursor = (connection.metadata?.['cursor'] as string | undefined) ?? null;
-  let hasMore = true;
-  let pages = 0;
-  const MAX_PAGES = 20; // Guard against runaway pagination.
-
-  while (hasMore && pages < MAX_PAGES) {
-    pages++;
-    const page = await transactionsSync(config, accessToken, cursor);
-
-    for (const txn of page.added) {
-      const account = linkedAccounts.get(txn.account_id);
-      if (!account) continue;
-      const inserted = await upsertPlaidTransaction(supabase, txn, account);
-      if (inserted) summary.added++;
-      else summary.modified++;
-    }
-
-    for (const txn of page.modified) {
-      const account = linkedAccounts.get(txn.account_id);
-      if (!account) continue;
-      await upsertPlaidTransaction(supabase, txn, account);
-      summary.modified++;
-    }
-
-    for (const removed of page.removed) {
-      const { data: rows } = await supabase
-        .from('transactions')
-        .update({ deleted_at: new Date().toISOString() })
-        .eq('provider_transaction_id', removed.transaction_id)
-        .is('deleted_at', null)
-        .select('id');
-      summary.removed += rows?.length ?? 0;
-    }
-
-    cursor = page.next_cursor;
-    hasMore = page.has_more;
-  }
-
-  // Persist the advanced cursor for the next sync (merge into metadata).
-  const mergedMetadata = { ...(connection.metadata ?? {}), cursor };
-  await supabase
-    .from('bank_connections')
-    .update({ metadata: mergedMetadata, last_synced_at: new Date().toISOString() })
-    .eq('id', connection.id);
-
-  return summary;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Live bank transactions could never land. `bank-webhook` ingestion only upserts a
transaction whose Plaid `account_id` maps to a `bank_connection_accounts` row with
`is_linked = true` — but **nothing in the repo ever created those rows**.
`exchange_token` stored the connection and zero accounts, so every transaction was
dropped (`if (!account) continue;`).

## What

Build the missing account-discovery + linking step and an initial backfill, inside
the existing provider-agnostic architecture.

- **`_shared/plaid.ts`** — add `getAccounts()` (`POST /accounts/get`) + `PlaidAccount*`
  types, and a pure `plaidAccountTypeToInternal()` mapper (Plaid `type`/`subtype` →
  canonical `CHECKING|SAVINGS|CREDIT_CARD|CASH|INVESTMENT|LOAN|OTHER`).
- **`_shared/bank-ingest.ts`** (new) — extract the Plaid ingestion path
  (`loadLinkedAccounts`, `upsertPlaidTransaction`, `ingestPlaidTransactions`) out of
  `bank-webhook` so it can be reused at connection time. Behaviour-preserving.
- **`bank-webhook/index.ts`** — import ingestion from the shared module (no behaviour
  change).
- **`bank-connection/index.ts` `exchange_token`** — after storing the connection:
  discover the institution's accounts, provision a matching internal `accounts` row per
  external account, insert the linked `bank_connection_accounts` mapping
  (`is_linked = true`), then run an initial `/transactions/sync` backfill so transactions
  appear immediately instead of waiting for the first webhook delta. Provider-agnostic
  dispatch (`discoverProviderAccounts` / `runInitialProviderSync`); wrapped best-effort so
  a linking/sync failure never fails the connection.

## Testing

- 34 Deno tests pass (`deno test` — plaid + bank-connection + bank-webhook), including 2
  new ones (`getAccounts` fetch contract, `plaidAccountTypeToInternal` mapping).
- Type-checks clean for the changed files; Prettier-clean.

## Notes

- No behaviour change until a bank is connected; the webhook path is unchanged.
- Unblocks the sandbox end-to-end proof and the upcoming in-app Connect UI (separate PR).
