### PR TITLE
docs(ops): record Resend + mail.jrmoulckers.com sending domain (#3973)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -77,16 +77,19 @@ VITE_BETA_ALLOWED_EMAILS=
 # SMTP — REQUIRED for all auth email (signup confirmation, magic links,
 # password reset). If these are left as placeholders/empty, GoTrue silently
 # fails to send: the UI still says the reset link "would have been sent"
-# (#3107) but the email never arrives. Use a transactional provider
-# (Resend / Postmark / Amazon SES / Mailgun / Brevo) and verify the sender
-# domain with SPF + DKIM + DMARC DNS records. SMTP_ADMIN_EMAIL must be on the
-# verified domain. Full setup + troubleshooting: docs/ops/password-reset-email.md.
+# (#3107) but the email never arrives. This deployment uses Resend
+# (SMTP_HOST=smtp.resend.com, SMTP_USER=resend, SMTP_PASS=<Resend API key>);
+# any transactional provider (Resend / Postmark / Amazon SES / Mailgun / Brevo)
+# works. Verify a dedicated `mail.` sending subdomain with SPF + DKIM + DMARC
+# DNS records. SMTP_ADMIN_EMAIL must be on that verified sending subdomain
+# (e.g. finance@mail.YOUR_DOMAIN_HERE) — NOT the app domain. Full setup +
+# troubleshooting: docs/ops/password-reset-email.md.
 # ---------------------------------------------------------------------------
 SMTP_HOST=YOUR_SMTP_HOST_HERE
 SMTP_PORT=587
 SMTP_USER=YOUR_SMTP_USER_HERE
 SMTP_PASS=YOUR_SMTP_PASSWORD_HERE
-SMTP_ADMIN_EMAIL=noreply@YOUR_DOMAIN_HERE
+SMTP_ADMIN_EMAIL=finance@mail.YOUR_DOMAIN_HERE
 SMTP_SENDER_NAME=Finance App
 
 # ---------------------------------------------------------------------------

--- a/docs/ops/infrastructure-standards.md
+++ b/docs/ops/infrastructure-standards.md
@@ -427,13 +427,16 @@ DNS names are the most visible identifier of the project. They appear in TLS cer
 
 The alpha deployment uses a subdomain of the owner's personal domain. A dedicated product domain will be registered before public launch.
 
-| Level           | Pattern                         | Alpha Value                       |
-| --------------- | ------------------------------- | --------------------------------- |
-| **Production**  | `finance.{base-domain}`         | `finance.jrmoulckers.com`         |
-| **Staging**     | `finance-staging.{base-domain}` | `finance-staging.jrmoulckers.com` |
-| **Base domain** | (owner's domain)                | `jrmoulckers.com` (Namecheap)     |
+| Level               | Pattern                         | Alpha Value                       |
+| ------------------- | ------------------------------- | --------------------------------- |
+| **Production**      | `finance.{base-domain}`         | `finance.jrmoulckers.com`         |
+| **Staging**         | `finance-staging.{base-domain}` | `finance-staging.jrmoulckers.com` |
+| **Transact. email** | `mail.{base-domain}`            | `mail.jrmoulckers.com`            |
+| **Base domain**     | (owner's domain)                | `jrmoulckers.com` (Namecheap)     |
 
 > **Note:** All configurations use the `DOMAIN` environment variable, so migrating to a dedicated domain (e.g., `financetrackerapp.com`) later requires updating only `.env` — no code changes.
+
+> **Transactional email** is sent via **Resend** from a dedicated `mail.{base-domain}` subdomain (`mail.jrmoulckers.com`), verified with SPF/DKIM/DMARC. The from-address is `finance@mail.jrmoulckers.com` (`SMTP_ADMIN_EMAIL`). Keeping the sending domain separate from the app domain (`finance.jrmoulckers.com`) isolates email authentication from the app's own DNS. See [password-reset-email.md](password-reset-email.md).
 
 ### Path-Based Routing (Current Architecture)
 

--- a/docs/ops/password-reset-email.md
+++ b/docs/ops/password-reset-email.md
@@ -111,14 +111,21 @@ will land in spam or be blocked. Use a transactional provider, for example:
 | Mailgun            | Mature; flexible domains                           |
 | Brevo (Sendinblue) | EU-friendly                                        |
 
+> **This deployment uses Resend.** Its SMTP relay is `smtp.resend.com:587`, the
+> SMTP **username is the literal string `resend`**, and the SMTP **password is a
+> Resend API key**. Generate the API key in the Resend dashboard.
+
 Create an account and generate **SMTP credentials** (host, port, username,
 password / API key).
 
 ### 2. Verify the sender domain (SPF / DKIM / DMARC)
 
-In the provider, add and **verify the sending domain** you control (the same
-domain used in `SMTP_ADMIN_EMAIL`, e.g. `noreply@yourdomain.com`). Add the DNS
-records the provider gives you:
+In the provider, add and **verify the sending domain** you control. Use a
+**dedicated `mail.` subdomain** (e.g. `mail.yourdomain.com`) rather than the app
+domain, so email authentication is isolated from the app's own DNS. This
+deployment sends from **`mail.jrmoulckers.com`** with the from-address
+**`finance@mail.jrmoulckers.com`** (`SMTP_ADMIN_EMAIL`). Add the DNS records the
+provider gives you:
 
 - **SPF** — a `TXT` record authorizing the provider to send for your domain.
 - **DKIM** — the `CNAME`/`TXT` record(s) the provider supplies for signing.
@@ -126,7 +133,10 @@ records the provider gives you:
   `p=none` for monitoring, tighten later).
 
 Unverified domains are the most common reason a message "sends" but lands in spam
-or is rejected outright.
+or is rejected outright. The `From` address **must** be on the verified sending
+subdomain (`mail.jrmoulckers.com`), **not** the app domain
+(`finance.jrmoulckers.com`) — Resend rejects mail whose `From` is off the
+authenticated domain.
 
 ### 3. Set the SMTP environment variables
 
@@ -134,12 +144,12 @@ Set these in the **production** `deploy/.env` (never commit real values — see
 [Secrets Inventory](secrets.md)). Variable **names** only:
 
 ```bash
-SMTP_HOST=          # provider SMTP host
-SMTP_PORT=          # 587 (STARTTLS) or 465 (TLS)
-SMTP_USER=          # provider SMTP username
-SMTP_PASS=          # provider SMTP password / API key
-SMTP_ADMIN_EMAIL=   # from-address on the verified domain, e.g. noreply@yourdomain.com
-SMTP_SENDER_NAME=   # display name, e.g. "Finance App"
+SMTP_HOST=smtp.resend.com   # Resend SMTP relay
+SMTP_PORT=587               # 587 (STARTTLS) or 465 (TLS)
+SMTP_USER=resend            # literal string "resend" for Resend
+SMTP_PASS=                  # Resend API key
+SMTP_ADMIN_EMAIL=finance@mail.jrmoulckers.com  # from-address on the verified mail. subdomain
+SMTP_SENDER_NAME=Finance    # display name, e.g. "Finance"
 ```
 
 These map 1:1 to the GoTrue settings in


### PR DESCRIPTION
## Summary

Records the now-decided transactional-email setup in the ops docs and deploy
template: **Resend** as the provider, a dedicated **`mail.jrmoulckers.com`**
sending subdomain, and **`finance@mail.jrmoulckers.com`** as the from-address
(`SMTP_ADMIN_EMAIL`).

Previously the docs listed several candidate providers with generic
`noreply@yourdomain.com` placeholders. That left room for an operator to set the
`From` on the app domain (`finance.jrmoulckers.com`), which is not the
authenticated sending domain — Resend would reject or spam-file that mail.

## Changes

- `docs/ops/password-reset-email.md` — note Resend as the selected provider
  (`smtp.resend.com`, user `resend`, pass = API key), the dedicated `mail.`
  sending subdomain, the `finance@mail.jrmoulckers.com` from-address, and an
  explicit warning that `From` must be on `mail.jrmoulckers.com`, not the app
  domain.
- `docs/ops/infrastructure-standards.md` — add `mail.{base-domain}` to the DNS
  domain-structure table plus a note on the Resend / `mail.` sending convention.
- `deploy/.env.example` — clarify `SMTP_ADMIN_EMAIL` belongs on a dedicated
  `mail.` sending subdomain (`finance@mail.YOUR_DOMAIN_HERE`), not the app domain,
  and reference the Resend host/user.

No secrets, API keys, or DNS records are committed — those remain human-only.
This is documentation and template alignment only.

## Issues

Closes #3973

## Testing

- [x] Prettier passes on the changed markdown (`.env.example` is prettier-ignored)
