### PR TITLE
feat(web): in-app "Connect a bank" flow via Plaid Link (#3846)

### DIFF
--- a/apps/web/src/components/bank/ConnectBankButton.test.tsx
+++ b/apps/web/src/components/bank/ConnectBankButton.test.tsx
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for {@link ConnectBankButton} (#3846).
+ *
+ * The button orchestrates the whole "connect a bank" handshake, pulling the
+ * aggregator layer + Plaid Link loader in via dynamic `import()`. Those modules
+ * are mocked here so the test asserts the orchestration (create → open →
+ * complete → refresh) without a real backend or Plaid CDN.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { expectNoAxeViolations } from '../../test-utils/axe';
+
+const mocks = vi.hoisted(() => ({
+  getPrimaryHouseholdId: vi.fn(),
+  ensureAggregatorProvidersRegistered: vi.fn(),
+  createConnection: vi.fn(),
+  completeConnection: vi.fn(),
+  openPlaidLink: vi.fn(),
+}));
+
+vi.mock('../../db/DatabaseProvider', () => ({
+  useDatabase: () => ({ __fakeDb: true }),
+}));
+
+vi.mock('../../db/repositories/household', () => ({
+  getPrimaryHouseholdId: mocks.getPrimaryHouseholdId,
+}));
+
+vi.mock('../../lib/banking/connection-manager', () => ({
+  ConnectionManager: class {
+    createConnection = mocks.createConnection;
+    completeConnection = mocks.completeConnection;
+  },
+}));
+
+vi.mock('../../lib/banking/provider-registry', () => ({
+  defaultRegistry: { __registry: true },
+}));
+
+vi.mock('../../lib/banking/register-aggregator-providers', () => ({
+  ensureAggregatorProvidersRegistered: mocks.ensureAggregatorProvidersRegistered,
+}));
+
+vi.mock('../../lib/banking/plaid-link', () => ({
+  openPlaidLink: mocks.openPlaidLink,
+}));
+
+import { ConnectBankButton } from './ConnectBankButton';
+
+const PLAID_METADATA = {
+  institution: { name: 'First Platypus Bank', institution_id: 'ins_109508' },
+};
+
+describe('ConnectBankButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPrimaryHouseholdId.mockResolvedValue('hh-1');
+    mocks.ensureAggregatorProvidersRegistered.mockResolvedValue(undefined);
+    mocks.createConnection.mockResolvedValue({ sessionId: 'link-token-1' });
+    mocks.completeConnection.mockResolvedValue({ id: 'conn-1' });
+    mocks.openPlaidLink.mockResolvedValue({ open: vi.fn(), exit: vi.fn(), destroy: vi.fn() });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a "Connect a bank" button with no axe violations', async () => {
+    const { container } = render(<ConnectBankButton />);
+
+    expect(screen.getByRole('button', { name: 'Connect a bank' })).toBeInTheDocument();
+    await waitFor(() => expect(mocks.getPrimaryHouseholdId).toHaveBeenCalled());
+    await expectNoAxeViolations(container);
+  });
+
+  it('runs the full create → open → complete → refresh handshake', async () => {
+    // Plaid Link "succeeds": invoke the onSuccess callback the component passes.
+    mocks.openPlaidLink.mockImplementation(
+      async (opts: {
+        token: string;
+        onSuccess: (publicToken: string, metadata: typeof PLAID_METADATA) => void;
+      }) => {
+        opts.onSuccess('public-token-xyz', PLAID_METADATA);
+        return { open: vi.fn(), exit: vi.fn(), destroy: vi.fn() };
+      },
+    );
+
+    const onConnected = vi.fn();
+    render(<ConnectBankButton onConnected={onConnected} />);
+    await waitFor(() => expect(mocks.getPrimaryHouseholdId).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Connect a bank' }));
+
+    await waitFor(() => expect(mocks.completeConnection).toHaveBeenCalled());
+
+    expect(mocks.ensureAggregatorProvidersRegistered).toHaveBeenCalledTimes(1);
+    expect(mocks.createConnection).toHaveBeenCalledWith('plaid', {
+      metadata: { household_id: 'hh-1' },
+    });
+    expect(mocks.openPlaidLink).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'link-token-1' }),
+    );
+    expect(mocks.completeConnection).toHaveBeenCalledWith('plaid', 'link-token-1', {
+      public_token: 'public-token-xyz',
+      institutionId: 'ins_109508',
+      institutionName: 'First Platypus Bank',
+      household_id: 'hh-1',
+    });
+    await waitFor(() => expect(onConnected).toHaveBeenCalledTimes(1));
+  });
+
+  it('shows an error and does not start linking when there is no household', async () => {
+    mocks.getPrimaryHouseholdId.mockResolvedValue(null);
+
+    render(<ConnectBankButton />);
+    await waitFor(() => expect(mocks.getPrimaryHouseholdId).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Connect a bank' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/create a household/i);
+    expect(mocks.ensureAggregatorProvidersRegistered).not.toHaveBeenCalled();
+    expect(mocks.createConnection).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the Plaid display message when the user exits with an error', async () => {
+    mocks.openPlaidLink.mockImplementation(
+      async (opts: { onExit?: (error: { display_message: string } | null) => void }) => {
+        opts.onExit?.({ display_message: 'The bank declined the connection.' });
+        return { open: vi.fn(), exit: vi.fn(), destroy: vi.fn() };
+      },
+    );
+
+    render(<ConnectBankButton />);
+    await waitFor(() => expect(mocks.getPrimaryHouseholdId).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Connect a bank' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('The bank declined the connection.');
+    expect(mocks.completeConnection).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/bank/ConnectBankButton.tsx
+++ b/apps/web/src/components/bank/ConnectBankButton.tsx
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * ConnectBankButton — launches the Plaid Link flow to connect a bank (#3846).
+ *
+ * Flow:
+ *   1. Ask the edge backend for a `link_token` (`create_link_token`) through the
+ *      registered Plaid aggregator provider.
+ *   2. Open Plaid Link (loaded on demand from Plaid's CDN) with that token.
+ *   3. On success, exchange the returned `public_token` (`exchange_token`). The
+ *      backend then discovers + links the institution's accounts and runs an
+ *      initial transaction backfill, so transactions appear right away.
+ *   4. Refresh the connection list so the new connection surfaces.
+ *
+ * Rendered only when the `live_bank_data` flag is on (see `BankConnectionsPage`
+ * / `main.tsx`). The aggregator provider layer and Plaid loader are pulled in via
+ * dynamic `import()` so they stay code-split out of first paint.
+ *
+ * @module components/bank/ConnectBankButton
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useDatabase } from '../../db/DatabaseProvider';
+import { getPrimaryHouseholdId } from '../../db/repositories/household';
+
+/** Props for {@link ConnectBankButton}. */
+export interface ConnectBankButtonProps {
+  /** Called after a bank connection is successfully established. */
+  onConnected?: () => void;
+}
+
+type Phase = 'idle' | 'starting' | 'finishing' | 'error';
+
+const PROVIDER_ID = 'plaid';
+
+/**
+ * A button that runs the end-to-end "connect a bank" handshake via Plaid Link.
+ */
+export function ConnectBankButton({ onConnected }: ConnectBankButtonProps) {
+  const db = useDatabase();
+  const [householdId, setHouseholdId] = useState<string | null>(null);
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const busyRef = useRef(false);
+
+  useEffect(() => {
+    let active = true;
+    getPrimaryHouseholdId(db)
+      .then((id) => {
+        if (active) setHouseholdId(id);
+      })
+      .catch(() => {
+        if (active) setHouseholdId(null);
+      });
+    return () => {
+      active = false;
+    };
+  }, [db]);
+
+  const handleClick = useCallback(async () => {
+    if (busyRef.current) return;
+    if (!householdId) {
+      setError('Create a household before connecting a bank.');
+      setPhase('error');
+      return;
+    }
+    busyRef.current = true;
+    setError(null);
+    setPhase('starting');
+
+    try {
+      const [
+        { ConnectionManager },
+        { defaultRegistry },
+        { ensureAggregatorProvidersRegistered },
+        { openPlaidLink },
+      ] = await Promise.all([
+        import('../../lib/banking/connection-manager'),
+        import('../../lib/banking/provider-registry'),
+        import('../../lib/banking/register-aggregator-providers'),
+        import('../../lib/banking/plaid-link'),
+      ]);
+
+      await ensureAggregatorProvidersRegistered();
+      const manager = new ConnectionManager(defaultRegistry);
+
+      const session = await manager.createConnection(PROVIDER_ID, {
+        metadata: { household_id: householdId },
+      });
+
+      await openPlaidLink({
+        token: session.sessionId,
+        onExit: (err) => {
+          busyRef.current = false;
+          if (err) {
+            setError(err.display_message ?? 'Bank connection was cancelled.');
+            setPhase('error');
+          } else {
+            setPhase('idle');
+          }
+        },
+        onSuccess: (publicToken, metadata) => {
+          void (async () => {
+            setPhase('finishing');
+            try {
+              await manager.completeConnection(PROVIDER_ID, session.sessionId, {
+                public_token: publicToken,
+                institutionId: metadata.institution?.institution_id ?? undefined,
+                institutionName: metadata.institution?.name ?? undefined,
+                household_id: householdId,
+              });
+              setPhase('idle');
+              onConnected?.();
+            } catch (e) {
+              setError(
+                e instanceof Error ? e.message : 'We could not finish connecting your bank.',
+              );
+              setPhase('error');
+            } finally {
+              busyRef.current = false;
+            }
+          })();
+        },
+      });
+    } catch (e) {
+      busyRef.current = false;
+      setError(e instanceof Error ? e.message : 'We could not start the bank connection.');
+      setPhase('error');
+    }
+  }, [householdId, onConnected]);
+
+  const busy = phase === 'starting' || phase === 'finishing';
+  const label =
+    phase === 'starting' ? 'Connecting…' : phase === 'finishing' ? 'Finishing…' : 'Connect a bank';
+
+  return (
+    <div className="connect-bank">
+      <button
+        type="button"
+        className="connect-bank__button"
+        onClick={handleClick}
+        disabled={busy}
+        aria-busy={busy}
+      >
+        {label}
+      </button>
+      <span className="connect-bank__status" role="status" aria-live="polite">
+        {phase === 'finishing' ? 'Linking your accounts and importing transactions…' : ''}
+      </span>
+      {error ? (
+        <span className="connect-bank__error" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export default ConnectBankButton;

--- a/apps/web/src/components/bank/bank-connections.css
+++ b/apps/web/src/components/bank/bank-connections.css
@@ -529,6 +529,13 @@
   margin-bottom: var(--spacing-4, 16px);
 }
 
+.section-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2, 8px);
+  flex-wrap: wrap;
+}
+
 .section-title {
   font-size: var(--type-scale-title-font-size, 1.25rem);
   font-weight: var(--type-scale-title-font-weight, 600);
@@ -569,6 +576,64 @@
 }
 
 /* =========================================================================
+   Connect a bank (Plaid Link launcher)
+   ========================================================================= */
+
+.connect-bank {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-2, 8px);
+}
+
+.connect-bank__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2, 8px);
+  min-height: 40px;
+  padding: var(--spacing-2, 8px) var(--spacing-4, 16px);
+  border: 1px solid transparent;
+  border-radius: var(--border-radius-md, 8px);
+  background: var(--semantic-interactive-default, #2563eb);
+  color: var(--semantic-text-inverse, #ffffff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.connect-bank__button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--semantic-interactive-default, #2563eb) 88%, black);
+}
+
+.connect-bank__button:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #2563eb);
+  outline-offset: 2px;
+}
+
+.connect-bank__button:disabled {
+  opacity: 0.65;
+  cursor: progress;
+}
+
+.connect-bank__status {
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-secondary, #6c757d);
+}
+
+.connect-bank__status:empty {
+  display: none;
+}
+
+.connect-bank__error {
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-status-negative, #dc2626);
+}
+
+/* =========================================================================
    Dark mode
 
    Surfaces and borders use theme-aware --semantic-* tokens, so no per-theme
@@ -586,6 +651,10 @@
 
   /* Honour reduced-motion for the tab selection indicator (#3862). */
   .tab-nav__tab {
+    transition: none;
+  }
+
+  .connect-bank__button {
     transition: none;
   }
 }

--- a/apps/web/src/lib/banking/__tests__/plaid-link.test.ts
+++ b/apps/web/src/lib/banking/__tests__/plaid-link.test.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the dependency-free Plaid Link CDN loader (#3846).
+ *
+ * jsdom provides no real network, so we fake Plaid's CDN by intercepting the
+ * `<script>` append and dispatching `load`/`error` events, setting
+ * `window.Plaid` as the real CDN script would.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { loadPlaidLink, openPlaidLink, resetPlaidLinkForTests } from '../plaid-link';
+
+const SCRIPT_URL = 'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
+
+interface FakeHandler {
+  open: ReturnType<typeof vi.fn>;
+  exit: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeHandler(): FakeHandler {
+  return { open: vi.fn(), exit: vi.fn(), destroy: vi.fn() };
+}
+
+function makeFakePlaid(handler: FakeHandler) {
+  return { create: vi.fn(() => handler) };
+}
+
+/**
+ * Whenever the Plaid script is appended, run `onAppend` (e.g. set window.Plaid)
+ * and fire the given DOM event on the script on the next microtask.
+ */
+function fakeCdn(eventType: 'load' | 'error', onAppend: () => void = () => {}): void {
+  const realAppend = document.head.appendChild.bind(document.head);
+  vi.spyOn(document.head, 'appendChild').mockImplementation((node: unknown) => {
+    const result = realAppend(node as Node);
+    if (node instanceof HTMLScriptElement && node.src === SCRIPT_URL) {
+      queueMicrotask(() => {
+        onAppend();
+        node.dispatchEvent(new Event(eventType));
+      });
+    }
+    return result;
+  });
+}
+
+function removeInjectedScripts(): void {
+  document.querySelectorAll(`script[src="${SCRIPT_URL}"]`).forEach((node) => node.remove());
+}
+
+describe('plaid-link loader', () => {
+  beforeEach(() => {
+    resetPlaidLinkForTests();
+    delete (window as { Plaid?: unknown }).Plaid;
+    removeInjectedScripts();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetPlaidLinkForTests();
+    delete (window as { Plaid?: unknown }).Plaid;
+    removeInjectedScripts();
+  });
+
+  it('injects the Plaid CDN script and resolves with window.Plaid', async () => {
+    const fakePlaid = makeFakePlaid(makeFakeHandler());
+    fakeCdn('load', () => {
+      (window as { Plaid?: unknown }).Plaid = fakePlaid;
+    });
+
+    const plaid = await loadPlaidLink();
+
+    expect(plaid).toBe(fakePlaid);
+    expect(document.querySelectorAll(`script[src="${SCRIPT_URL}"]`).length).toBe(1);
+  });
+
+  it('is idempotent — concurrent and repeat loads inject a single script', async () => {
+    const fakePlaid = makeFakePlaid(makeFakeHandler());
+    fakeCdn('load', () => {
+      (window as { Plaid?: unknown }).Plaid = fakePlaid;
+    });
+
+    const [a, b] = await Promise.all([loadPlaidLink(), loadPlaidLink()]);
+    await loadPlaidLink();
+
+    expect(a).toBe(fakePlaid);
+    expect(b).toBe(fakePlaid);
+    expect(document.querySelectorAll(`script[src="${SCRIPT_URL}"]`).length).toBe(1);
+  });
+
+  it('returns the cached global without injecting when Plaid already exists', async () => {
+    const fakePlaid = makeFakePlaid(makeFakeHandler());
+    (window as { Plaid?: unknown }).Plaid = fakePlaid;
+    const appendSpy = vi.spyOn(document.head, 'appendChild');
+
+    const plaid = await loadPlaidLink();
+
+    expect(plaid).toBe(fakePlaid);
+    expect(appendSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects and clears the cache when the script fails to load', async () => {
+    fakeCdn('error');
+
+    await expect(loadPlaidLink()).rejects.toThrow(/Could not load Plaid/);
+
+    // Cache cleared: a subsequent successful load works from a clean slate.
+    vi.restoreAllMocks();
+    removeInjectedScripts();
+    const fakePlaid = makeFakePlaid(makeFakeHandler());
+    fakeCdn('load', () => {
+      (window as { Plaid?: unknown }).Plaid = fakePlaid;
+    });
+
+    await expect(loadPlaidLink()).resolves.toBe(fakePlaid);
+  });
+
+  it('openPlaidLink creates the handler with the link token and opens it', async () => {
+    const handler = makeFakeHandler();
+    const fakePlaid = makeFakePlaid(handler);
+    fakeCdn('load', () => {
+      (window as { Plaid?: unknown }).Plaid = fakePlaid;
+    });
+
+    const onSuccess = vi.fn();
+    const onExit = vi.fn();
+    const returned = await openPlaidLink({ token: 'link-token-123', onSuccess, onExit });
+
+    expect(fakePlaid.create).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'link-token-123', onSuccess, onExit }),
+    );
+    expect(handler.open).toHaveBeenCalledTimes(1);
+    expect(returned).toBe(handler);
+  });
+});

--- a/apps/web/src/lib/banking/plaid-link.ts
+++ b/apps/web/src/lib/banking/plaid-link.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Minimal, dependency-free Plaid Link (web) loader.
+ *
+ * Rather than add the `react-plaid-link` npm dependency — which would pull a new
+ * package through the repo's `npm audit` merge gate and into the `vendor-app`
+ * bundle budget — we load Plaid's official Link script from its CDN **on demand**
+ * and drive it through the documented `window.Plaid.create(...).open()` handler
+ * API.
+ *
+ * The Link script and its iframe are served from `https://cdn.plaid.com`; the
+ * production Content-Security-Policy is widened to allow exactly those origins
+ * (see `deploy/Caddyfile`). Nothing is fetched until the user actually starts a
+ * connection, so the CDN script never enters first paint.
+ *
+ * @module banking/plaid-link
+ */
+
+/** URL of Plaid's stable Link initializer. */
+const PLAID_LINK_SCRIPT_URL = 'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
+
+/** Institution metadata Plaid reports for a link. */
+export interface PlaidLinkInstitution {
+  name: string | null;
+  institution_id: string | null;
+}
+
+/** Metadata Plaid passes to `onSuccess`. */
+export interface PlaidLinkOnSuccessMetadata {
+  institution: PlaidLinkInstitution | null;
+}
+
+/** Metadata Plaid passes to `onExit`. */
+export interface PlaidLinkOnExitMetadata {
+  institution: PlaidLinkInstitution | null;
+  status: string | null;
+}
+
+/** A Plaid error surfaced through `onExit`. */
+export interface PlaidLinkError {
+  error_type: string;
+  error_code: string;
+  display_message: string | null;
+}
+
+/** Options for {@link openPlaidLink}. */
+export interface OpenPlaidLinkOptions {
+  /** The `link_token` minted by the backend `create_link_token` call. */
+  token: string;
+  /** Called with the `public_token` once the user finishes linking. */
+  onSuccess: (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => void;
+  /** Called when the user abandons the flow or Link errors. */
+  onExit?: (error: PlaidLinkError | null, metadata: PlaidLinkOnExitMetadata) => void;
+}
+
+/** The subset of the Plaid Link handler we use. */
+interface PlaidHandler {
+  open: () => void;
+  exit: (options?: { force?: boolean }) => void;
+  destroy: () => void;
+}
+
+/** The subset of the global `Plaid` object we use. */
+interface PlaidGlobal {
+  create: (config: {
+    token: string;
+    onSuccess: (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => void;
+    onExit?: (error: PlaidLinkError | null, metadata: PlaidLinkOnExitMetadata) => void;
+  }) => PlaidHandler;
+}
+
+declare global {
+  interface Window {
+    Plaid?: PlaidGlobal;
+  }
+}
+
+/** Cached in-flight/settled load so the script is only injected once. */
+let scriptPromise: Promise<PlaidGlobal> | null = null;
+
+/**
+ * Load Plaid's Link script (idempotent). Resolves with the global `Plaid`.
+ *
+ * @throws If run outside a browser, or if the script fails to load (e.g. offline
+ *   or blocked by the Content-Security-Policy).
+ */
+export function loadPlaidLink(): Promise<PlaidGlobal> {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return Promise.reject(new Error('Plaid Link is only available in the browser.'));
+  }
+  if (window.Plaid) return Promise.resolve(window.Plaid);
+  if (scriptPromise) return scriptPromise;
+
+  scriptPromise = new Promise<PlaidGlobal>((resolve, reject) => {
+    const fail = () => {
+      scriptPromise = null;
+      reject(new Error('Could not load Plaid. Check your connection and try again.'));
+    };
+    const settle = () => {
+      if (window.Plaid) resolve(window.Plaid);
+      else fail();
+    };
+
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${PLAID_LINK_SCRIPT_URL}"]`,
+    );
+    if (existing) {
+      existing.addEventListener('load', settle);
+      existing.addEventListener('error', fail);
+      if (window.Plaid) resolve(window.Plaid);
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = PLAID_LINK_SCRIPT_URL;
+    script.async = true;
+    script.addEventListener('load', settle);
+    script.addEventListener('error', fail);
+    document.head.appendChild(script);
+  });
+
+  return scriptPromise;
+}
+
+/**
+ * Load Plaid Link and open the widget for the given `link_token`.
+ *
+ * @returns The opened Plaid handler so the caller can `exit`/`destroy` it.
+ */
+export async function openPlaidLink(options: OpenPlaidLinkOptions): Promise<PlaidHandler> {
+  const Plaid = await loadPlaidLink();
+  const handler = Plaid.create({
+    token: options.token,
+    onSuccess: options.onSuccess,
+    onExit: options.onExit,
+  });
+  handler.open();
+  return handler;
+}
+
+/** Reset the cached loader. **Test-only.** @internal */
+export function resetPlaidLinkForTests(): void {
+  scriptPromise = null;
+}

--- a/apps/web/src/lib/feature-flags/__tests__/feature-flag-context.test.tsx
+++ b/apps/web/src/lib/feature-flags/__tests__/feature-flag-context.test.tsx
@@ -52,8 +52,8 @@ describe('useFeatureFlag with a provider', () => {
 });
 
 describe('useFeatureFlag without a provider', () => {
-  it('falls back to direct evaluation — live_bank_data is dark-launched (off)', () => {
+  it('falls back to direct evaluation — live_bank_data is ramped on (100%)', () => {
     const { result } = renderHook(() => useFeatureFlag('live_bank_data'));
-    expect(result.current).toBe(false);
+    expect(result.current).toBe(true);
   });
 });

--- a/apps/web/src/lib/feature-flags/__tests__/public-api.test.ts
+++ b/apps/web/src/lib/feature-flags/__tests__/public-api.test.ts
@@ -42,8 +42,8 @@ describe('isFeatureEnabledWith', () => {
 });
 
 describe('isFeatureEnabled (default registry)', () => {
-  it('reports live_bank_data as off — dark-launched at 0% rollout', () => {
-    expect(isFeatureEnabled('live_bank_data')).toBe(false);
+  it('reports live_bank_data as on — ramped to 100% rollout', () => {
+    expect(isFeatureEnabled('live_bank_data')).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/feature-flags/flag-registry.ts
+++ b/apps/web/src/lib/feature-flags/flag-registry.ts
@@ -21,10 +21,10 @@ import type { WebFeatureFlag, WebFlagRegistry } from './types';
  * `live_bank_data` — gates activation of the live consolidated bank-data
  * aggregator (Plaid/MX/TrueLayer/Finicity, epic #3846) on web.
  *
- * Dark-launched: `enabled` is `true` but `rolloutPercentage` is `0`, so the
- * aggregator provider layer stays inert in production. Ramp the percentage
- * (here and in flags.json) to stage exposure once the accessibility blocker
- * (#3862) on the live bank UI is resolved.
+ * Fully ramped: `enabled` is `true` and `rolloutPercentage` is `100`, so the
+ * aggregator provider layer registers and the in-app "Connect a bank" flow
+ * (Plaid Link) is available to everyone. Keep this value in lockstep with
+ * `config/feature-flags/flags.json`.
  */
 const LIVE_BANK_DATA: WebFeatureFlag = {
   key: 'live_bank_data',
@@ -33,7 +33,7 @@ const LIVE_BANK_DATA: WebFeatureFlag = {
   enabled: true,
   owner: 'web',
   platforms: ['web'],
-  rolloutPercentage: 0,
+  rolloutPercentage: 100,
 };
 
 /** The web bootstrap flag registry, keyed by flag key. */

--- a/apps/web/src/pages/BankConnectionsPage.tsx
+++ b/apps/web/src/pages/BankConnectionsPage.tsx
@@ -24,6 +24,18 @@ import { EmptyState } from '../components/common/EmptyState';
 import '../components/bank/bank-connections.css';
 import { useBankConnections } from '../hooks/useBankConnections';
 import { useConnectorPermissions } from '../hooks/useConnectorPermissions';
+import { useFeatureFlag, FlagKeys } from '../lib/feature-flags';
+
+/**
+ * "Connect a bank" launcher (#3846). Lazy-loaded and rendered only when the
+ * `live_bank_data` flag is on, so the aggregator/Plaid Link code stays out of
+ * the bundle until a user can actually connect a bank.
+ */
+const ConnectBankButton = lazy(() =>
+  import('../components/bank/ConnectBankButton').then((module) => ({
+    default: module.ConnectBankButton,
+  })),
+);
 
 /**
  * Crypto wallet & exchange panel (#2164). Lazy-loaded so the crypto engine only
@@ -93,6 +105,8 @@ export const BankConnectionsPage: React.FC = () => {
     error: permissionsError,
     loadAccessLog,
   } = useConnectorPermissions();
+
+  const liveBankData = useFeatureFlag(FlagKeys.LIVE_BANK_DATA);
 
   const [activeTab, setActiveTab] = useState<BankTabId>('health');
 
@@ -244,14 +258,21 @@ export const BankConnectionsPage: React.FC = () => {
           <section aria-label="Connection health">
             <div className="section-header">
               <h2 className="section-title">Connection Health</h2>
-              <button
-                type="button"
-                className="section-action"
-                onClick={refreshConnections}
-                aria-label="Refresh connection health"
-              >
-                Refresh
-              </button>
+              <div className="section-actions">
+                {liveBankData && (
+                  <Suspense fallback={null}>
+                    <ConnectBankButton onConnected={refreshConnections} />
+                  </Suspense>
+                )}
+                <button
+                  type="button"
+                  className="section-action"
+                  onClick={refreshConnections}
+                  aria-label="Refresh connection health"
+                >
+                  Refresh
+                </button>
+              </div>
             </div>
 
             {connectionsLoading && (

--- a/config/feature-flags/flags.json
+++ b/config/feature-flags/flags.json
@@ -49,11 +49,11 @@
       "expires": ""
     },
     "live_bank_data": {
-      "description": "Activate the live consolidated bank-data aggregator (Plaid/MX/TrueLayer/Finicity) on web. Dark-launched at 0%; ramp to stage the rollout once a11y blocker #3862 lands.",
+      "description": "Activate the live consolidated bank-data aggregator (Plaid/MX/TrueLayer/Finicity) on web. Enables the in-app Connect-a-bank flow (Plaid Link) and aggregator provider registration.",
       "enabled": true,
       "owner": "web",
       "platforms": ["web"],
-      "rollout_percentage": 0,
+      "rollout_percentage": 100,
       "expires": ""
     }
   }

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -59,7 +59,7 @@
 		# spawn its wa-sqlite database worker, which is instantiated from a
 		# same-origin blob URL. The app and backend are same-origin here, so
 		# `connect-src 'self'` already covers /rest, /auth and the /sync socket.
-		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:"
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://cdn.plaid.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://cdn.plaid.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://cdn.plaid.com https://production.plaid.com https://sandbox.plaid.com; frame-src 'self' https://cdn.plaid.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:"
 
 		# Remove server identification
 		-Server

--- a/deploy/Caddyfile.staging
+++ b/deploy/Caddyfile.staging
@@ -25,7 +25,7 @@
 		X-Frame-Options "DENY"
 		X-XSS-Protection "1; mode=block"
 		Referrer-Policy "strict-origin-when-cross-origin"
-		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://cdn.plaid.com; connect-src 'self' https://cdn.plaid.com https://production.plaid.com https://sandbox.plaid.com; img-src 'self' data: blob: https://cdn.plaid.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; worker-src 'self' blob:; frame-src 'self' https://cdn.plaid.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 		-Server
 	}
 


### PR DESCRIPTION
## In-app "Connect a bank" flow (Plaid Link) — frontend half of live bank data (#3846)

This is **PR 2 of 2** for auto-importing bank transactions. It adds the in-app Connect UI and turns the feature on. It pairs with **#3972** (the backend account-linking + initial-sync fix) — merge/deploy **#3972 first** so the `exchange_token` call this UI makes actually links accounts and backfills transactions.

### What this adds
- **`ConnectBankButton`** — a self-contained button that runs the full handshake: `createConnection` (mint `link_token`) → **Plaid Link** → `exchange_token` (`completeConnection`) → refresh the connection list. It resolves the household id with the lightweight `getPrimaryHouseholdId` query rather than the heavy `useHousehold` hook, and reports inline `role=status` / `role=alert` state.
- **`lib/banking/plaid-link.ts`** — a dependency-free loader for Plaid's official Link script from `cdn.plaid.com`, loaded **on demand**. No `react-plaid-link` dependency, so **no new `npm audit` surface and no `vendor-app` bundle growth**.
- **Page wiring** — the button is added to `BankConnectionsPage` (Connection Health tab), **lazy-loaded** and gated by `useFeatureFlag('live_bank_data')`, so the aggregator + Plaid code stays code-split out of first paint. Build confirms separate `ConnectBankButton`, `plaid-link`, and `aggregator-*` chunks.

### Security-sensitive changes (please review closely)
- **CSP** (`deploy/Caddyfile` + `deploy/Caddyfile.staging`): add Plaid origins only where required — `script-src`/`img-src`/`connect-src` gain `https://cdn.plaid.com` (+ `https://production.plaid.com https://sandbox.plaid.com` for `connect-src`), and a **new `frame-src 'self' https://cdn.plaid.com`** for the Link iframe (previously it fell back to `default-src 'self'` and would have blocked Link). `frame-ancestors 'none'` is unchanged.
- **Flag ramp**: `live_bank_data` `rollout_percentage`/`rolloutPercentage` **0 → 100** in `config/feature-flags/flags.json` and `apps/web/src/lib/feature-flags/flag-registry.ts` (kept in lockstep). The a11y gate (#3862 / PR #3969) is satisfied. This is a personal, self-hosted single-user app, so 100% == "on for me".

### Tests / validation
- New: `plaid-link.test.ts` (script injection, idempotency, load-error recovery, `openPlaidLink`) and `ConnectBankButton.test.tsx` (create→open→complete→refresh, no-household guard, Plaid-exit error, axe-clean).
- Flipped the two flag tests that asserted `live_bank_data` was off.
- **18 targeted tests pass**; `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check`, and `vite build` all green.

### Caveat
Sandbox Plaid credentials only ever return **sandbox** (First Platypus Bank) data. Seeing **real** bank transactions needs Plaid **Production/Trial** access (external Plaid signup + approval) and a credential swap — not a code change.
