### PR TITLE
fix(bank): Connect button reads household from hh_household store (fixes false 'create a household' error)

### DIFF
--- a/apps/web/src/components/bank/ConnectBankButton.test.tsx
+++ b/apps/web/src/components/bank/ConnectBankButton.test.tsx
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { expectNoAxeViolations } from '../../test-utils/axe';
 
 const mocks = vi.hoisted(() => ({
-  getPrimaryHouseholdId: vi.fn(),
+  readHouseholdValue: vi.fn(),
   ensureAggregatorProvidersRegistered: vi.fn(),
   createConnection: vi.fn(),
   completeConnection: vi.fn(),
@@ -27,8 +27,9 @@ vi.mock('../../db/DatabaseProvider', () => ({
   useDatabase: () => ({ __fakeDb: true }),
 }));
 
-vi.mock('../../db/repositories/household', () => ({
-  getPrimaryHouseholdId: mocks.getPrimaryHouseholdId,
+vi.mock('../../db/repositories/householdData', () => ({
+  HOUSEHOLD_SINGLETON_KEY: 'finance-household',
+  readHouseholdValue: mocks.readHouseholdValue,
 }));
 
 vi.mock('../../lib/banking/connection-manager', () => ({
@@ -59,7 +60,7 @@ const PLAID_METADATA = {
 describe('ConnectBankButton', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getPrimaryHouseholdId.mockResolvedValue('hh-1');
+    mocks.readHouseholdValue.mockResolvedValue({ id: 'hh-1' });
     mocks.ensureAggregatorProvidersRegistered.mockResolvedValue(undefined);
     mocks.createConnection.mockResolvedValue({ sessionId: 'link-token-1' });
     mocks.completeConnection.mockResolvedValue({ id: 'conn-1' });
@@ -74,7 +75,7 @@ describe('ConnectBankButton', () => {
     const { container } = render(<ConnectBankButton />);
 
     expect(screen.getByRole('button', { name: 'Connect a bank' })).toBeInTheDocument();
-    await waitFor(() => expect(mocks.getPrimaryHouseholdId).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.readHouseholdValue).toHaveBeenCalled());
     await expectNoAxeViolations(container);
   });
 
@@ -92,7 +93,7 @@ describe('ConnectBankButton', () => {
 
     const onConnected = vi.fn();
     render(<ConnectBankButton onConnected={onConnected} />);
-    await waitFor(() => expect(mocks.getPrimaryHouseholdId).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.readHouseholdValue).toHaveBeenCalled());
 
     await userEvent.click(screen.getByRole('button', { name: 'Connect a bank' }));
 
@@ -115,10 +116,10 @@ describe('ConnectBankButton', () => {
   });
 
   it('shows an error and does not start linking when there is no household', async () => {
-    mocks.getPrimaryHouseholdId.mockResolvedValue(null);
+    mocks.readHouseholdValue.mockResolvedValue(null);
 
     render(<ConnectBankButton />);
-    await waitFor(() => expect(mocks.getPrimaryHouseholdId).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.readHouseholdValue).toHaveBeenCalled());
 
     await userEvent.click(screen.getByRole('button', { name: 'Connect a bank' }));
 
@@ -136,7 +137,7 @@ describe('ConnectBankButton', () => {
     );
 
     render(<ConnectBankButton />);
-    await waitFor(() => expect(mocks.getPrimaryHouseholdId).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.readHouseholdValue).toHaveBeenCalled());
 
     await userEvent.click(screen.getByRole('button', { name: 'Connect a bank' }));
 

--- a/apps/web/src/components/bank/ConnectBankButton.tsx
+++ b/apps/web/src/components/bank/ConnectBankButton.tsx
@@ -22,7 +22,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useDatabase } from '../../db/DatabaseProvider';
-import { getPrimaryHouseholdId } from '../../db/repositories/household';
+import { HOUSEHOLD_SINGLETON_KEY, readHouseholdValue } from '../../db/repositories/householdData';
 
 /** Props for {@link ConnectBankButton}. */
 export interface ConnectBankButtonProps {
@@ -33,6 +33,26 @@ export interface ConnectBankButtonProps {
 type Phase = 'idle' | 'starting' | 'finishing' | 'error';
 
 const PROVIDER_ID = 'plaid';
+
+/**
+ * Resolve the active household id from the SAME `hh_household` store the rest of
+ * the app persists to (via the `useHousehold` hook / Household page).
+ *
+ * The first cut read the legacy relational `household` table, but the in-app
+ * "create a household" flow writes to `hh_household`. That table stays empty for
+ * real users, so the guard below wrongly fired even after a household existed
+ * (only sample/seed data ever populated the legacy table).
+ */
+async function resolveHouseholdId(db: ReturnType<typeof useDatabase>): Promise<string | null> {
+  const household = await readHouseholdValue<{ id?: unknown } | null>(
+    db,
+    HOUSEHOLD_SINGLETON_KEY,
+    null,
+  );
+  return household && typeof household.id === 'string' && household.id.length > 0
+    ? household.id
+    : null;
+}
 
 /**
  * A button that runs the end-to-end "connect a bank" handshake via Plaid Link.
@@ -46,7 +66,7 @@ export function ConnectBankButton({ onConnected }: ConnectBankButtonProps) {
 
   useEffect(() => {
     let active = true;
-    getPrimaryHouseholdId(db)
+    resolveHouseholdId(db)
       .then((id) => {
         if (active) setHouseholdId(id);
       })
@@ -60,7 +80,14 @@ export function ConnectBankButton({ onConnected }: ConnectBankButtonProps) {
 
   const handleClick = useCallback(async () => {
     if (busyRef.current) return;
-    if (!householdId) {
+    // Re-resolve on click so a household created *after* this component mounted
+    // is picked up without a page refresh (the mount effect only runs once).
+    let activeHouseholdId = householdId;
+    if (!activeHouseholdId) {
+      activeHouseholdId = await resolveHouseholdId(db).catch(() => null);
+      if (activeHouseholdId) setHouseholdId(activeHouseholdId);
+    }
+    if (!activeHouseholdId) {
       setError('Create a household before connecting a bank.');
       setPhase('error');
       return;
@@ -86,7 +113,7 @@ export function ConnectBankButton({ onConnected }: ConnectBankButtonProps) {
       const manager = new ConnectionManager(defaultRegistry);
 
       const session = await manager.createConnection(PROVIDER_ID, {
-        metadata: { household_id: householdId },
+        metadata: { household_id: activeHouseholdId },
       });
 
       await openPlaidLink({
@@ -108,7 +135,7 @@ export function ConnectBankButton({ onConnected }: ConnectBankButtonProps) {
                 public_token: publicToken,
                 institutionId: metadata.institution?.institution_id ?? undefined,
                 institutionName: metadata.institution?.name ?? undefined,
-                household_id: householdId,
+                household_id: activeHouseholdId,
               });
               setPhase('idle');
               onConnected?.();
@@ -128,7 +155,7 @@ export function ConnectBankButton({ onConnected }: ConnectBankButtonProps) {
       setError(e instanceof Error ? e.message : 'We could not start the bank connection.');
       setPhase('error');
     }
-  }, [householdId, onConnected]);
+  }, [db, householdId, onConnected]);
 
   const busy = phase === 'starting' || phase === 'finishing';
   const label =


### PR DESCRIPTION
## What & why

The in-app **"Connect a bank"** button showed **"Create a household before connecting a bank."** even for users who *had* created a household — hard-blocking the Plaid connect flow shipped in #3975.

### Root cause
`ConnectBankButton` resolved the active household via `getPrimaryHouseholdId(db)`, which runs `SELECT id FROM household …` against the **relational `household` table**. But the app's real household is created through the **Household page → `useHousehold` hook**, which persists to the **`hh_household` document store** (`saveToStorage` → `writeHouseholdValue`, key `finance-household` → table `hh_household`).

Those are two different tables. The relational `household` table is only ever populated by **sample/seed data**, so for a real user it's empty → `getPrimaryHouseholdId` returns `null` → the guard fires despite a household existing.

### Fix
- Resolve the household id from the **same `hh_household` singleton** the rest of the app reads/writes, via the exported `readHouseholdValue(db, HOUSEHOLD_SINGLETON_KEY, null)`.
- **Re-resolve on click** as well, so a household created *after* the component mounted is picked up without a page refresh (the mount effect only runs once).
- No change to the household requirement itself — bank connections/transactions are scoped to a `household_id` (ownership/tenancy boundary); we just check the correct store.

## Validation
- `ConnectBankButton.test.tsx` updated to mock the household-store read — **4/4 pass**.
- `tsc --noEmit` = 0, `eslint --max-warnings 0` = clean, `prettier --check` = clean.

## Scope
Web-only, 2 files (`ConnectBankButton.tsx` + its test). Platform jobs skip via path filters.
