### PR TITLE
fix(web): inline VITE_ env via static import.meta.env (fixes 405 on bank connect + PowerSync offline)

### DIFF
--- a/apps/web/src/db/sync/powersync-client.ts
+++ b/apps/web/src/db/sync/powersync-client.ts
@@ -266,12 +266,13 @@ let _config: PowerSyncConfig | null = null;
  *   - VITE_POWERSYNC_ENABLED   — "true" to enable PowerSync
  */
 export function resolvePowerSyncConfig(): PowerSyncConfig {
-  const meta = import.meta as unknown as { env?: Record<string, string> };
+  // Static `import.meta.env.VITE_*` access so the production bundler inlines
+  // each literal — dynamic/aliased access resolves to undefined at runtime.
   return {
-    instanceUrl: meta.env?.VITE_POWERSYNC_URL ?? '',
-    supabaseUrl: meta.env?.VITE_SUPABASE_URL ?? '',
-    supabaseAnonKey: meta.env?.VITE_SUPABASE_ANON_KEY ?? '',
-    enabled: meta.env?.VITE_POWERSYNC_ENABLED === 'true',
+    instanceUrl: import.meta.env.VITE_POWERSYNC_URL ?? '',
+    supabaseUrl: import.meta.env.VITE_SUPABASE_URL ?? '',
+    supabaseAnonKey: import.meta.env.VITE_SUPABASE_ANON_KEY ?? '',
+    enabled: import.meta.env.VITE_POWERSYNC_ENABLED === 'true',
   };
 }
 

--- a/apps/web/src/db/sync/powersync/config.ts
+++ b/apps/web/src/db/sync/powersync/config.ts
@@ -24,19 +24,27 @@ export interface PowerSyncClientConfig {
   readonly enabled: boolean;
 }
 
-/** Read a trimmed Vite env var, returning an empty string when unset. */
-function readEnv(name: string): string {
-  const meta = import.meta as unknown as { env?: Record<string, string | undefined> };
-  return meta.env?.[name]?.trim() ?? '';
+/** Trim a raw Vite env value, returning an empty string when unset. @internal */
+function trimEnv(value: string | undefined): string {
+  return value?.trim() ?? '';
 }
 
-/** Resolve the PowerSync client configuration from the Vite environment. */
+/**
+ * Resolve the PowerSync client configuration from the Vite environment.
+ *
+ * Each var is read via **static** `import.meta.env.VITE_*` access so the
+ * production bundler (rolldown-vite) inlines the literal at build time. Dynamic
+ * access (`import.meta.env[key]`) is NOT inlined and resolves to `undefined` at
+ * runtime, which left every coordinate empty in production — so
+ * {@link isPowerSyncClientConfigured} returned `false` and the live client never
+ * connected (the app stayed "offline" on sample data).
+ */
 export function resolvePowerSyncClientConfig(): PowerSyncClientConfig {
   return {
-    powersyncUrl: readEnv('VITE_POWERSYNC_URL'),
-    supabaseUrl: readEnv('VITE_SUPABASE_URL'),
-    supabaseAnonKey: readEnv('VITE_SUPABASE_ANON_KEY'),
-    enabled: readEnv('VITE_POWERSYNC_ENABLED') === 'true',
+    powersyncUrl: trimEnv(import.meta.env.VITE_POWERSYNC_URL),
+    supabaseUrl: trimEnv(import.meta.env.VITE_SUPABASE_URL),
+    supabaseAnonKey: trimEnv(import.meta.env.VITE_SUPABASE_ANON_KEY),
+    enabled: trimEnv(import.meta.env.VITE_POWERSYNC_ENABLED) === 'true',
   };
 }
 

--- a/apps/web/src/db/sync/syncEndpoint.ts
+++ b/apps/web/src/db/sync/syncEndpoint.ts
@@ -19,16 +19,15 @@ import { configureSyncEndpoint, type SyncConfig } from './replayMutations';
 // Environment helpers
 // ---------------------------------------------------------------------------
 
-/** Read a Vite env variable, returning `undefined` when absent or empty. */
-function envOrUndefined(key: string): string | undefined {
-  try {
-    // Vite injects import.meta.env at build time.
-    const meta = import.meta as unknown as { env?: Record<string, string> };
-    const value = meta.env?.[key];
-    return typeof value === 'string' && value.length > 0 ? value : undefined;
-  } catch {
-    return undefined;
-  }
+/**
+ * Coerce a raw Vite env value to a non-empty string, or `undefined`.
+ *
+ * Callers read `import.meta.env.VITE_*` via **static** member access so the
+ * production bundler inlines each literal at build time; dynamic access
+ * (`import.meta.env[key]`) is not inlined and resolves to `undefined`. @internal
+ */
+function nonEmpty(value: string | undefined): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -58,18 +57,18 @@ export interface SyncEndpointConfig extends SyncConfig {
  */
 export function resolveSyncEndpointConfig(): SyncEndpointConfig {
   const baseUrl =
-    envOrUndefined('VITE_SYNC_BASE_URL') ??
-    envOrUndefined('VITE_API_BASE_URL') ??
+    nonEmpty(import.meta.env.VITE_SYNC_BASE_URL) ??
+    nonEmpty(import.meta.env.VITE_API_BASE_URL) ??
     (typeof self !== 'undefined' && self.location ? self.location.origin : '');
 
-  const apiKey = envOrUndefined('VITE_SUPABASE_ANON_KEY');
+  const apiKey = nonEmpty(import.meta.env.VITE_SUPABASE_ANON_KEY);
 
   return {
     baseUrl,
-    pushEndpoint: envOrUndefined('VITE_SYNC_PUSH_ENDPOINT') ?? DEFAULT_PUSH_ENDPOINT,
-    pullEndpoint: envOrUndefined('VITE_SYNC_PULL_ENDPOINT') ?? DEFAULT_PULL_ENDPOINT,
-    healthEndpoint: envOrUndefined('VITE_SYNC_HEALTH_ENDPOINT') ?? DEFAULT_HEALTH_ENDPOINT,
-    timeout: Number(envOrUndefined('VITE_SYNC_TIMEOUT_MS')) || DEFAULT_TIMEOUT_MS,
+    pushEndpoint: nonEmpty(import.meta.env.VITE_SYNC_PUSH_ENDPOINT) ?? DEFAULT_PUSH_ENDPOINT,
+    pullEndpoint: nonEmpty(import.meta.env.VITE_SYNC_PULL_ENDPOINT) ?? DEFAULT_PULL_ENDPOINT,
+    healthEndpoint: nonEmpty(import.meta.env.VITE_SYNC_HEALTH_ENDPOINT) ?? DEFAULT_HEALTH_ENDPOINT,
+    timeout: Number(nonEmpty(import.meta.env.VITE_SYNC_TIMEOUT_MS)) || DEFAULT_TIMEOUT_MS,
     apiKey,
   };
 }

--- a/apps/web/src/lib/banking/aggregator-transport.ts
+++ b/apps/web/src/lib/banking/aggregator-transport.ts
@@ -15,15 +15,17 @@
 import { getAccessToken } from '../../auth/token-storage';
 import type { EdgeTransport } from './base-aggregator-provider';
 
-/** Read a Vite env var safely (works under Vite build + test/SSR). @internal */
-function readEnv(key: string): string | undefined {
-  try {
-    const meta = import.meta as unknown as { env?: Record<string, string> };
-    const value = meta.env?.[key];
-    return typeof value === 'string' && value.length > 0 ? value : undefined;
-  } catch {
-    return undefined;
-  }
+/**
+ * Coerce a raw Vite env value to a non-empty string, or `undefined`.
+ *
+ * IMPORTANT: callers MUST read `import.meta.env.VITE_*` via **static** member
+ * access. Dynamic access (`import.meta.env[key]`) is not inlined by the
+ * production bundler (rolldown-vite) and resolves to `undefined` at runtime —
+ * which silently emptied this base URL and sent bank-connection requests to the
+ * SPA origin without the `/functions/v1` prefix (Caddy answered 405). @internal
+ */
+function nonEmpty(value: string | undefined): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 /**
@@ -37,10 +39,10 @@ function readEnv(key: string): string | undefined {
  * @returns The trimmed functions base URL, or `''` when unconfigured.
  */
 export function resolveEdgeFunctionsBaseUrl(): string {
-  const explicit = readEnv('VITE_SUPABASE_FUNCTIONS_URL');
+  const explicit = nonEmpty(import.meta.env.VITE_SUPABASE_FUNCTIONS_URL);
   if (explicit) return explicit.replace(/\/+$/, '');
 
-  const supabaseUrl = readEnv('VITE_SUPABASE_URL');
+  const supabaseUrl = nonEmpty(import.meta.env.VITE_SUPABASE_URL);
   if (!supabaseUrl) return '';
   return `${supabaseUrl.replace(/\/+$/, '')}/functions/v1`;
 }

--- a/apps/web/src/pages/BetaLanding.tsx
+++ b/apps/web/src/pages/BetaLanding.tsx
@@ -20,25 +20,21 @@ const DOWNLOAD_DEFINITIONS = [
     id: 'ios',
     title: 'iOS TestFlight',
     description: 'Join the iPhone and iPad beta through Apple TestFlight.',
-    envKey: 'VITE_NATIVE_IOS_URL',
   },
   {
     id: 'android',
     title: 'Android internal track',
     description: 'Install the Android beta from the Play Store internal test track.',
-    envKey: 'VITE_NATIVE_ANDROID_URL',
   },
   {
     id: 'windows',
     title: 'Windows MSI',
     description: 'Try the desktop beta on Windows with the MSI installer.',
-    envKey: 'VITE_NATIVE_WINDOWS_URL',
   },
   {
     id: 'macos',
     title: 'macOS DMG',
     description: 'Download the macOS beta build as a signed DMG.',
-    envKey: 'VITE_NATIVE_MACOS_URL',
   },
 ] as const;
 
@@ -72,9 +68,18 @@ function normalizeHealthStatus(payload: unknown, responseOk: boolean): SystemSta
 }
 
 function getDownloadCards(): DownloadCard[] {
-  return DOWNLOAD_DEFINITIONS.flatMap(({ envKey, ...card }) => {
-    const url = import.meta.env[envKey]?.trim();
-    return url ? [{ ...card, url }] : [];
+  // Static `import.meta.env.VITE_*` access so the production bundler inlines
+  // each literal — dynamic `import.meta.env[key]` resolves to undefined at
+  // runtime and hid every download card.
+  const urlById: Record<string, string | undefined> = {
+    ios: import.meta.env.VITE_NATIVE_IOS_URL,
+    android: import.meta.env.VITE_NATIVE_ANDROID_URL,
+    windows: import.meta.env.VITE_NATIVE_WINDOWS_URL,
+    macos: import.meta.env.VITE_NATIVE_MACOS_URL,
+  };
+  return DOWNLOAD_DEFINITIONS.flatMap(({ id, title, description }) => {
+    const url = urlById[id]?.trim();
+    return url ? [{ id, title, description, url }] : [];
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes the **405 on "Connect a bank"** and the persistent **"offline / sample data"** state — both caused by one production-bundler behavior.

## Root cause

rolldown-vite (this repo's production bundler) only inlines **static** `import.meta.env.VITE_*` member access. Several config resolvers read env **dynamically** (`import.meta.env[key]` / aliased `meta.env?.[key]`). rolldown does **not** inline those, so `import.meta.env` was emitted verbatim into the bundle and evaluated to `undefined` at runtime (a native ESM `import.meta` has no `.env`). Every dynamic read returned empty.

## Production impact

- **Bank Connect → 405:** `aggregator-transport` resolved an **empty** edge-functions base URL, so the `create_link_token` POST went to `https://finance.jrmoulckers.com/bank-connection?...` **without** the `/functions/v1` prefix and hit Caddy's static SPA handler → `405 Method Not Allowed`. (Verified against production: a POST to any non-`/functions/v1` path returns 405; the same POST *with* the prefix reaches the edge function → 401/200.)
- **"Offline / sample data":** `resolvePowerSyncClientConfig()` returned empty coordinates and `enabled=false` → `isPowerSyncClientConfigured()` was `false` → the live PowerSync client never connected.

## Fix

Read every `VITE_` var via **static** `import.meta.env.VITE_SPECIFIC_KEY` access so rolldown inlines the literal at build time — the same pattern `main.tsx` already uses (which is why its `supabaseUrl` baked correctly). Runtime semantics and the test seams (`vi.stubEnv` / the `syncEndpoint` `Proxy` mock) are unchanged.

| File | Why |
| --- | --- |
| `lib/banking/aggregator-transport.ts` | **405 root cause** |
| `db/sync/powersync/config.ts` | **PowerSync-offline root cause** |
| `db/sync/powersync-client.ts` | same latent bug |
| `db/sync/syncEndpoint.ts` | legacy sync path, same bug |
| `pages/BetaLanding.tsx` | beta download cards, same bug |

## Verification

- Production `vite build`: **zero** `import.meta.env` occurrences remain in `dist`. The transport chunk inlines `https://finance.jrmoulckers.com` → base `…/functions/v1`; PowerSync `/sync` URL + anon key inline as literals.
- **350 unit tests green** (targeted 5-file set + full `db/sync` + `lib/banking`), `tsc --noEmit` = 0, `eslint --max-warnings 0` = 0, prettier clean.

🤖 Generated with Copilot
