### PR TITLE
feat(schema): unify server model with rich offline schema (PR1: additive backend)

### DIFF
--- a/apps/web/src/db/sync/powersync/__tests__/schema.test.ts
+++ b/apps/web/src/db/sync/powersync/__tests__/schema.test.ts
@@ -20,8 +20,10 @@ function columnType(tableName: string, columnName: string): string | undefined {
 
 describe('AppSchema', () => {
   it('mirrors every table declared in the canonical sync rules', () => {
-    // Three buckets: by_household + user_profile + exchange_rates = 29 tables.
-    expect(SYNCED_TABLE_NAMES).toHaveLength(29);
+    // Three buckets: by_household + user_profile + exchange_rates. Includes the
+    // four schema-unification tables (goal_progress_contributions,
+    // account_reconciliations, invoices, remittances) = 33 tables.
+    expect(SYNCED_TABLE_NAMES).toHaveLength(33);
 
     for (const name of [
       'accounts',
@@ -39,6 +41,10 @@ describe('AppSchema', () => {
       'exchange_rates',
       'price_history',
       'aggregator_providers',
+      'goal_progress_contributions',
+      'account_reconciliations',
+      'invoices',
+      'remittances',
     ]) {
       expect(SYNCED_TABLE_NAMES).toContain(name);
     }
@@ -83,5 +89,33 @@ describe('AppSchema', () => {
     expect(columnType('budgets', 'is_rollover')).toBe('INTEGER');
     expect(columnType('goals', 'account_id')).toBe('TEXT');
     expect(columnType('goals', 'status')).toBe('TEXT');
+  });
+
+  it('carries the schema-unification superset columns on the core tables', () => {
+    // accounts: retirement/HSA + purpose metadata.
+    expect(columnType('accounts', 'purpose')).toBe('TEXT');
+    expect(columnType('accounts', 'retirement_account_type')).toBe('TEXT');
+    expect(columnType('accounts', 'hsa_coverage_level')).toBe('TEXT');
+    // transactions: enrichment + merchant + splits + retirement contribution.
+    expect(columnType('transactions', 'mood_tag')).toBe('TEXT');
+    expect(columnType('transactions', 'merchant_city')).toBe('TEXT');
+    expect(columnType('transactions', 'splits')).toBe('TEXT');
+    expect(columnType('transactions', 'counterparty_name')).toBe('TEXT');
+    expect(columnType('transactions', 'retirement_contribution_year')).toBe('INTEGER');
+    // budgets/goals: manual ordering + goal description.
+    expect(columnType('budgets', 'sort_order')).toBe('INTEGER');
+    expect(columnType('goals', 'description')).toBe('TEXT');
+    expect(columnType('goals', 'sort_order')).toBe('INTEGER');
+  });
+
+  it('adds the four previously web-only tables to the synced schema', () => {
+    expect(columnType('goal_progress_contributions', 'amount')).toBe('INTEGER');
+    expect(columnType('goal_progress_contributions', 'goal_id')).toBe('TEXT');
+    expect(columnType('account_reconciliations', 'statement_balance')).toBe('INTEGER');
+    expect(columnType('account_reconciliations', 'transaction_ids')).toBe('TEXT');
+    expect(columnType('invoices', 'amount_cents')).toBe('INTEGER');
+    expect(columnType('invoices', 'client_name')).toBe('TEXT');
+    expect(columnType('remittances', 'send_amount_minor')).toBe('INTEGER');
+    expect(columnType('remittances', 'fx_rate')).toBe('REAL');
   });
 });

--- a/apps/web/src/db/sync/powersync/schema.ts
+++ b/apps/web/src/db/sync/powersync/schema.ts
@@ -48,6 +48,10 @@ const accounts = new Table(
     color: text,
     sort_order: integer,
     owner_id: text,
+    purpose: text,
+    retirement_account_type: text,
+    retirement_tax_treatment: text,
+    hsa_coverage_level: text,
     created_at: text,
     updated_at: text,
     deleted_at: text,
@@ -74,6 +78,21 @@ const transactions = new Table(
     tags: text,
     is_biometric_protected: integer,
     owner_id: text,
+    mood_tag: text,
+    merchant_address: text,
+    merchant_city: text,
+    merchant_state: text,
+    merchant_zip: text,
+    merchant_country: text,
+    external_reference_id: text,
+    statement_description: text,
+    custom_fields: text,
+    extra_notes: text,
+    counterparty_name: text,
+    counterparty_account_id: text,
+    splits: text,
+    retirement_contribution_year: integer,
+    retirement_contribution_designation: text,
     created_at: text,
     updated_at: text,
     deleted_at: text,
@@ -107,6 +126,7 @@ const budgets = new Table({
   start_date: text,
   end_date: text,
   is_rollover: integer,
+  sort_order: integer,
   owner_id: text,
   created_at: text,
   updated_at: text,
@@ -125,6 +145,8 @@ const goals = new Table({
   account_id: text,
   status: text,
   owner_id: text,
+  description: text,
+  sort_order: integer,
   created_at: text,
   updated_at: text,
   deleted_at: text,
@@ -472,6 +494,80 @@ const aggregator_providers = new Table({
   deleted_at: text,
 });
 
+// ---------------------------------------------------------------------------
+// Schema-unification tables (household-scoped). Money columns are integer
+// cents / minor units; `id` is the implicit PowerSync primary key.
+// ---------------------------------------------------------------------------
+
+const goal_progress_contributions = new Table({
+  goal_id: text,
+  household_id: text,
+  owner_id: text,
+  amount: integer,
+  currency: text,
+  note: text,
+  contributed_at: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const account_reconciliations = new Table({
+  account_id: text,
+  household_id: text,
+  owner_id: text,
+  statement_date: text,
+  statement_balance: integer,
+  starting_balance: integer,
+  cleared_transaction_count: integer,
+  transaction_ids: text,
+  created_by: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const invoices = new Table({
+  household_id: text,
+  owner_id: text,
+  client_name: text,
+  amount_cents: integer,
+  currency: text,
+  issue_date: text,
+  payment_term: text,
+  status: text,
+  expected_pay_date: text,
+  last_contacted_date: text,
+  amount_paid_cents: integer,
+  paid_date: text,
+  payment_account_id: text,
+  payment_transaction_id: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
+const remittances = new Table({
+  household_id: text,
+  owner_id: text,
+  date: text,
+  source_currency: text,
+  dest_currency: text,
+  send_amount_minor: integer,
+  fee_minor: integer,
+  fx_rate: real,
+  fee_model: text,
+  reference_rate: real,
+  recipient_name: text,
+  recipient_country: text,
+  note: text,
+  recurrence_frequency: text,
+  recurrence_next_date: text,
+  created_at: text,
+  updated_at: text,
+  deleted_at: text,
+});
+
 /**
  * The canonical app schema handed to `PowerSyncDatabase`. The object keys are
  * the synced table names (must match the sync rules exactly).
@@ -499,6 +595,10 @@ export const AppSchema = new Schema({
   connector_permissions,
   connector_access_log,
   open_banking_connections,
+  goal_progress_contributions,
+  account_reconciliations,
+  invoices,
+  remittances,
   users,
   passkey_credentials,
   referrals,

--- a/services/api/powersync/sync-rules.yaml
+++ b/services/api/powersync/sync-rules.yaml
@@ -44,7 +44,8 @@ bucket_definitions:
       # Financial accounts (checking, savings, credit cards, etc.)
       - >
         SELECT id, household_id, name, type, currency_code, balance_cents,
-               is_active, icon, color, sort_order, owner_id,
+               is_active, icon, color, sort_order, owner_id, purpose,
+               retirement_account_type, retirement_tax_treatment, hsa_coverage_level,
                created_at, updated_at, deleted_at
         FROM accounts
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
@@ -66,7 +67,11 @@ bucket_definitions:
                currency_code, type, payee, note, date, is_recurring,
                transfer_account_id, status,
                transfer_transaction_id, recurring_rule_id, tags,
-               is_biometric_protected, owner_id,
+               is_biometric_protected, owner_id, mood_tag,
+               merchant_address, merchant_city, merchant_state, merchant_zip,
+               merchant_country, external_reference_id, statement_description,
+               custom_fields, extra_notes, counterparty_name, counterparty_account_id,
+               splits, retirement_contribution_year, retirement_contribution_designation,
                created_at, updated_at, deleted_at
         FROM transactions
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
@@ -94,7 +99,7 @@ bucket_definitions:
       #   clients need for display; was previously missing from allowlist).
       - >
         SELECT id, household_id, category_id, name, amount_cents, currency_code,
-               period, start_date, end_date, is_rollover, owner_id,
+               period, start_date, end_date, is_rollover, sort_order, owner_id,
                created_at, updated_at, deleted_at
         FROM budgets
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
@@ -103,7 +108,7 @@ bucket_definitions:
       - >
         SELECT id, household_id, name, target_cents, current_cents,
                currency_code, target_date, icon, color,
-               account_id, status, owner_id,
+               account_id, status, owner_id, description, sort_order,
                created_at, updated_at, deleted_at
         FROM goals
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
@@ -268,6 +273,45 @@ bucket_definitions:
         FROM open_banking_connections
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
 
+      # Goal progress contributions (schema unification) — individual deposits
+      # toward a savings goal. `amount` is in minor units (cents).
+      - >
+        SELECT id, goal_id, household_id, owner_id, amount, currency, note,
+               contributed_at, created_at, updated_at, deleted_at
+        FROM goal_progress_contributions
+        WHERE household_id = bucket.household_id AND deleted_at IS NULL
+
+      # Account reconciliation history (schema unification). Balances in cents.
+      - >
+        SELECT id, account_id, household_id, owner_id, statement_date,
+               statement_balance, starting_balance, cleared_transaction_count,
+               transaction_ids, created_by,
+               created_at, updated_at, deleted_at
+        FROM account_reconciliations
+        WHERE household_id = bucket.household_id AND deleted_at IS NULL
+
+      # Invoices (schema unification) — household-scoped rows. Personal
+      # (NULL-household) invoices sync via the user_profile bucket instead.
+      - >
+        SELECT id, household_id, owner_id, client_name, amount_cents, currency,
+               issue_date, payment_term, status, expected_pay_date,
+               last_contacted_date, amount_paid_cents, paid_date,
+               payment_account_id, payment_transaction_id,
+               created_at, updated_at, deleted_at
+        FROM invoices
+        WHERE household_id = bucket.household_id AND deleted_at IS NULL
+
+      # Remittances (schema unification) — household-scoped rows. Personal
+      # (NULL-household) remittances sync via the user_profile bucket instead.
+      - >
+        SELECT id, household_id, owner_id, date, source_currency, dest_currency,
+               send_amount_minor, fee_minor, fx_rate, fee_model, reference_rate,
+               recipient_name, recipient_country, note,
+               recurrence_frequency, recurrence_next_date,
+               created_at, updated_at, deleted_at
+        FROM remittances
+        WHERE household_id = bucket.household_id AND deleted_at IS NULL
+
   # ---------------------------------------------------------------------------
   # user_profile — per-user data that is NOT household-scoped.
   # Contains the user's own profile and their passkey credential metadata
@@ -345,11 +389,36 @@ bucket_definitions:
                currency_code, type, payee, note, date, is_recurring,
                transfer_account_id, status,
                transfer_transaction_id, recurring_rule_id, tags,
-               is_biometric_protected, owner_id,
+               is_biometric_protected, owner_id, mood_tag,
+               merchant_address, merchant_city, merchant_state, merchant_zip,
+               merchant_country, external_reference_id, statement_description,
+               custom_fields, extra_notes, counterparty_name, counterparty_account_id,
+               splits, retirement_contribution_year, retirement_contribution_designation,
                created_at, updated_at, deleted_at
         FROM transactions
         WHERE owner_id = bucket.user_id AND is_biometric_protected = true
               AND deleted_at IS NULL
+
+      # Personal invoices/remittances (schema unification) — rows created before a
+      # household exists (household_id IS NULL) sync to their owner only; household
+      # -scoped rows sync via by_household. Column lists match the by_household rules.
+      - >
+        SELECT id, household_id, owner_id, client_name, amount_cents, currency,
+               issue_date, payment_term, status, expected_pay_date,
+               last_contacted_date, amount_paid_cents, paid_date,
+               payment_account_id, payment_transaction_id,
+               created_at, updated_at, deleted_at
+        FROM invoices
+        WHERE owner_id = bucket.user_id AND household_id IS NULL AND deleted_at IS NULL
+
+      - >
+        SELECT id, household_id, owner_id, date, source_currency, dest_currency,
+               send_amount_minor, fee_minor, fx_rate, fee_model, reference_rate,
+               recipient_name, recipient_country, note,
+               recurrence_frequency, recurrence_next_date,
+               created_at, updated_at, deleted_at
+        FROM remittances
+        WHERE owner_id = bucket.user_id AND household_id IS NULL AND deleted_at IS NULL
 
   # ---------------------------------------------------------------------------
   # exchange_rates — global exchange rate data synced to all authenticated users.

--- a/services/api/supabase/migrations/20260402000001_schema_unification_superset.sql
+++ b/services/api/supabase/migrations/20260402000001_schema_unification_superset.sql
@@ -1,0 +1,214 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260402000001_schema_unification_superset
+-- Description: Full-stack schema unification (PR1 of 3, ADDITIVE / non-breaking).
+--   Brings the rich, offline-only client data model into the synced server model so
+--   every feature round-trips through PowerSync once the client cuts over to the
+--   unified (plural) schema. Two parts:
+--     (A) Add the offline-only "superset" columns to accounts/transactions/budgets/goals.
+--     (B) Create the four web-first tables that had no server home yet
+--         (goal_progress_contributions, account_reconciliations, invoices, remittances).
+--   This migration is purely additive: existing rows/queries/clients are unaffected, so
+--   it is safe to deploy BEFORE the client rewrite (PR2). New columns/tables only become
+--   visible to clients once published in sync-rules.yaml (done in this same PR).
+-- Issues: live-data schema unification; fulfills the @backend-engineer note in
+--   apps/web/src/db/sqlite-wasm.ts migration v14 (invoices/remittances) and v10/v7.
+-- DOWN migration: services/api/supabase/migrations/down/20260402000001_schema_unification_superset.down.sql
+
+-- =============================================================================
+-- UP
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- (A) Superset columns on existing core tables (all nullable / defaulted → safe).
+-- -----------------------------------------------------------------------------
+
+-- accounts: account purpose + retirement/HSA account metadata (offline v9, v12).
+ALTER TABLE accounts
+    ADD COLUMN IF NOT EXISTS purpose                  TEXT NOT NULL DEFAULT 'personal',
+    ADD COLUMN IF NOT EXISTS retirement_account_type  TEXT,
+    ADD COLUMN IF NOT EXISTS retirement_tax_treatment TEXT,
+    ADD COLUMN IF NOT EXISTS hsa_coverage_level       TEXT;
+
+COMMENT ON COLUMN accounts.purpose IS 'Account purpose classification (e.g. personal, business, retirement); offline-parity column.';
+
+-- transactions: merchant details, external references, free-form enrichment,
+-- counterparty, splits, and retirement-contribution metadata (offline v6, v11, v12).
+-- mood_tag already exists (20260331000002); tags/is_biometric_protected/owner_id/
+-- transfer_transaction_id/recurring_rule_id already exist from earlier migrations.
+ALTER TABLE transactions
+    ADD COLUMN IF NOT EXISTS merchant_address                    TEXT,
+    ADD COLUMN IF NOT EXISTS merchant_city                       TEXT,
+    ADD COLUMN IF NOT EXISTS merchant_state                      TEXT,
+    ADD COLUMN IF NOT EXISTS merchant_zip                        TEXT,
+    ADD COLUMN IF NOT EXISTS merchant_country                    TEXT,
+    ADD COLUMN IF NOT EXISTS external_reference_id               TEXT,
+    ADD COLUMN IF NOT EXISTS statement_description               TEXT,
+    ADD COLUMN IF NOT EXISTS custom_fields                       TEXT,
+    ADD COLUMN IF NOT EXISTS extra_notes                         TEXT,
+    ADD COLUMN IF NOT EXISTS counterparty_name                   TEXT,
+    ADD COLUMN IF NOT EXISTS counterparty_account_id             TEXT,
+    ADD COLUMN IF NOT EXISTS splits                              TEXT,
+    ADD COLUMN IF NOT EXISTS retirement_contribution_year        INTEGER,
+    ADD COLUMN IF NOT EXISTS retirement_contribution_designation TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_retirement_year
+    ON transactions (retirement_contribution_year)
+    WHERE retirement_contribution_year IS NOT NULL;
+
+-- budgets: manual sort ordering (offline v8).
+ALTER TABLE budgets
+    ADD COLUMN IF NOT EXISTS sort_order INTEGER NOT NULL DEFAULT 0;
+
+-- goals: description + manual sort ordering (offline v6/v8).
+ALTER TABLE goals
+    ADD COLUMN IF NOT EXISTS description TEXT,
+    ADD COLUMN IF NOT EXISTS sort_order  INTEGER NOT NULL DEFAULT 0;
+
+-- -----------------------------------------------------------------------------
+-- (B) New tables (previously web-first / localStorage-only). Column names match the
+--     offline store verbatim to minimise client churn (client change = pluralise the
+--     table name). All household-scoped with the standard owner_id-aware RLS.
+-- -----------------------------------------------------------------------------
+
+-- goal_progress_contributions (offline v7) — individual contributions toward a goal.
+CREATE TABLE IF NOT EXISTS goal_progress_contributions (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    goal_id         UUID        NOT NULL REFERENCES goals(id),
+    household_id    UUID        NOT NULL REFERENCES households(id),
+    owner_id        UUID        REFERENCES auth.users(id),
+    amount          BIGINT      NOT NULL,
+    currency        TEXT        NOT NULL DEFAULT 'USD',
+    note            TEXT,
+    contributed_at  TIMESTAMPTZ NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at      TIMESTAMPTZ,
+    sync_version    BIGINT      NOT NULL DEFAULT 0,
+    is_synced       BOOLEAN     NOT NULL DEFAULT false
+);
+CREATE INDEX IF NOT EXISTS idx_goal_progress_contributions_goal      ON goal_progress_contributions (goal_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_goal_progress_contributions_household ON goal_progress_contributions (household_id) WHERE deleted_at IS NULL;
+COMMENT ON TABLE goal_progress_contributions IS 'Individual contributions toward a savings goal; amount is in minor units (cents).';
+
+-- account_reconciliations (offline v10) — statement reconciliation history.
+CREATE TABLE IF NOT EXISTS account_reconciliations (
+    id                        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id                UUID        NOT NULL REFERENCES accounts(id),
+    household_id              UUID        NOT NULL REFERENCES households(id),
+    owner_id                  UUID        REFERENCES auth.users(id),
+    statement_date            DATE        NOT NULL,
+    statement_balance         BIGINT      NOT NULL,
+    starting_balance          BIGINT      NOT NULL,
+    cleared_transaction_count INTEGER     NOT NULL DEFAULT 0,
+    transaction_ids           TEXT        NOT NULL DEFAULT '[]',
+    created_by                UUID        NOT NULL REFERENCES auth.users(id),
+    created_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at                TIMESTAMPTZ,
+    sync_version              BIGINT      NOT NULL DEFAULT 0,
+    is_synced                 BOOLEAN     NOT NULL DEFAULT false
+);
+CREATE INDEX IF NOT EXISTS idx_account_reconciliations_account   ON account_reconciliations (account_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_account_reconciliations_household ON account_reconciliations (household_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_account_reconciliations_stmt_date ON account_reconciliations (statement_date) WHERE deleted_at IS NULL;
+COMMENT ON TABLE account_reconciliations IS 'Statement reconciliation snapshots; balances are in minor units (cents).';
+
+-- invoices (offline v14/v16) — freelancer invoice pipeline. household_id nullable so a
+-- record created before a household exists still persists; scoped to owner in that case.
+CREATE TABLE IF NOT EXISTS invoices (
+    id                     UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    household_id           UUID        REFERENCES households(id),
+    owner_id               UUID        NOT NULL REFERENCES auth.users(id),
+    client_name            TEXT        NOT NULL,
+    amount_cents           BIGINT      NOT NULL,
+    currency               TEXT        NOT NULL DEFAULT 'USD',
+    issue_date             TEXT        NOT NULL,
+    payment_term           TEXT        NOT NULL,
+    status                 TEXT        NOT NULL DEFAULT 'Sent',
+    expected_pay_date      TEXT        NOT NULL,
+    last_contacted_date    TEXT,
+    amount_paid_cents      BIGINT      NOT NULL DEFAULT 0,
+    paid_date              TEXT,
+    payment_account_id     UUID        REFERENCES accounts(id),
+    payment_transaction_id UUID        REFERENCES transactions(id),
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at             TIMESTAMPTZ,
+    sync_version           BIGINT      NOT NULL DEFAULT 0,
+    is_synced              BOOLEAN     NOT NULL DEFAULT false
+);
+CREATE INDEX IF NOT EXISTS idx_invoices_household ON invoices (household_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_invoices_owner     ON invoices (owner_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_invoices_status    ON invoices (status) WHERE deleted_at IS NULL;
+COMMENT ON TABLE invoices IS 'Freelancer invoice pipeline; amount_cents/amount_paid_cents are minor units.';
+
+-- remittances (offline v14/v16) — cross-border remittance history.
+CREATE TABLE IF NOT EXISTS remittances (
+    id                   UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    household_id         UUID        REFERENCES households(id),
+    owner_id             UUID        NOT NULL REFERENCES auth.users(id),
+    date                 TEXT        NOT NULL,
+    source_currency      TEXT        NOT NULL,
+    dest_currency        TEXT        NOT NULL,
+    send_amount_minor    BIGINT      NOT NULL,
+    fee_minor            BIGINT      NOT NULL,
+    fx_rate              DOUBLE PRECISION NOT NULL,
+    fee_model            TEXT        NOT NULL,
+    reference_rate       DOUBLE PRECISION,
+    recipient_name       TEXT        NOT NULL,
+    recipient_country    TEXT        NOT NULL,
+    note                 TEXT,
+    recurrence_frequency TEXT,
+    recurrence_next_date TEXT,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at           TIMESTAMPTZ,
+    sync_version         BIGINT      NOT NULL DEFAULT 0,
+    is_synced            BOOLEAN     NOT NULL DEFAULT false
+);
+CREATE INDEX IF NOT EXISTS idx_remittances_household ON remittances (household_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_remittances_owner     ON remittances (owner_id) WHERE deleted_at IS NULL;
+COMMENT ON TABLE remittances IS 'Cross-border remittance history; send_amount_minor/fee_minor are minor units.';
+
+-- -----------------------------------------------------------------------------
+-- updated_at triggers (reuse public.set_updated_at()).
+-- -----------------------------------------------------------------------------
+DROP TRIGGER IF EXISTS trg_goal_progress_contributions_updated_at ON goal_progress_contributions;
+CREATE TRIGGER trg_goal_progress_contributions_updated_at BEFORE UPDATE ON goal_progress_contributions FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+DROP TRIGGER IF EXISTS trg_account_reconciliations_updated_at ON account_reconciliations;
+CREATE TRIGGER trg_account_reconciliations_updated_at BEFORE UPDATE ON account_reconciliations FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+DROP TRIGGER IF EXISTS trg_invoices_updated_at ON invoices;
+CREATE TRIGGER trg_invoices_updated_at BEFORE UPDATE ON invoices FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+DROP TRIGGER IF EXISTS trg_remittances_updated_at ON remittances;
+CREATE TRIGGER trg_remittances_updated_at BEFORE UPDATE ON remittances FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- -----------------------------------------------------------------------------
+-- Row Level Security. Household-scoped, owner_id-aware on write (mirrors accounts).
+-- invoices/remittances additionally allow personal (NULL-household) rows scoped to
+-- their owner, preserving the offline "create before a household exists" behaviour.
+-- -----------------------------------------------------------------------------
+ALTER TABLE goal_progress_contributions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE account_reconciliations     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE invoices                    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE remittances                 ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY goal_progress_contributions_select ON goal_progress_contributions FOR SELECT USING (household_id = ANY(public.household_ids()));
+CREATE POLICY goal_progress_contributions_insert ON goal_progress_contributions FOR INSERT WITH CHECK (household_id = ANY(public.household_ids()) AND (owner_id IS NULL OR owner_id = auth.uid()));
+CREATE POLICY goal_progress_contributions_update ON goal_progress_contributions FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()) AND (owner_id IS NULL OR owner_id = auth.uid()));
+CREATE POLICY goal_progress_contributions_delete ON goal_progress_contributions FOR DELETE USING (household_id = ANY(public.household_ids()));
+
+CREATE POLICY account_reconciliations_select ON account_reconciliations FOR SELECT USING (household_id = ANY(public.household_ids()));
+CREATE POLICY account_reconciliations_insert ON account_reconciliations FOR INSERT WITH CHECK (household_id = ANY(public.household_ids()) AND (owner_id IS NULL OR owner_id = auth.uid()));
+CREATE POLICY account_reconciliations_update ON account_reconciliations FOR UPDATE USING (household_id = ANY(public.household_ids())) WITH CHECK (household_id = ANY(public.household_ids()) AND (owner_id IS NULL OR owner_id = auth.uid()));
+CREATE POLICY account_reconciliations_delete ON account_reconciliations FOR DELETE USING (household_id = ANY(public.household_ids()));
+
+CREATE POLICY invoices_select ON invoices FOR SELECT USING (household_id = ANY(public.household_ids()) OR (household_id IS NULL AND owner_id = auth.uid()));
+CREATE POLICY invoices_insert ON invoices FOR INSERT WITH CHECK (owner_id = auth.uid() AND (household_id IS NULL OR household_id = ANY(public.household_ids())));
+CREATE POLICY invoices_update ON invoices FOR UPDATE USING (household_id = ANY(public.household_ids()) OR (household_id IS NULL AND owner_id = auth.uid())) WITH CHECK (owner_id = auth.uid() AND (household_id IS NULL OR household_id = ANY(public.household_ids())));
+CREATE POLICY invoices_delete ON invoices FOR DELETE USING (household_id = ANY(public.household_ids()) OR (household_id IS NULL AND owner_id = auth.uid()));
+
+CREATE POLICY remittances_select ON remittances FOR SELECT USING (household_id = ANY(public.household_ids()) OR (household_id IS NULL AND owner_id = auth.uid()));
+CREATE POLICY remittances_insert ON remittances FOR INSERT WITH CHECK (owner_id = auth.uid() AND (household_id IS NULL OR household_id = ANY(public.household_ids())));
+CREATE POLICY remittances_update ON remittances FOR UPDATE USING (household_id = ANY(public.household_ids()) OR (household_id IS NULL AND owner_id = auth.uid())) WITH CHECK (owner_id = auth.uid() AND (household_id IS NULL OR household_id = ANY(public.household_ids())));
+CREATE POLICY remittances_delete ON remittances FOR DELETE USING (household_id = ANY(public.household_ids()) OR (household_id IS NULL AND owner_id = auth.uid()));

--- a/services/api/supabase/migrations/down/20260402000001_schema_unification_superset.down.sql
+++ b/services/api/supabase/migrations/down/20260402000001_schema_unification_superset.down.sql
@@ -1,0 +1,35 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- DOWN migration for 20260402000001_schema_unification_superset
+
+DROP TABLE IF EXISTS remittances;
+DROP TABLE IF EXISTS invoices;
+DROP TABLE IF EXISTS account_reconciliations;
+DROP TABLE IF EXISTS goal_progress_contributions;
+
+DROP INDEX IF EXISTS idx_transactions_retirement_year;
+
+ALTER TABLE goals DROP COLUMN IF EXISTS sort_order;
+ALTER TABLE goals DROP COLUMN IF EXISTS description;
+
+ALTER TABLE budgets DROP COLUMN IF EXISTS sort_order;
+
+ALTER TABLE transactions DROP COLUMN IF EXISTS retirement_contribution_designation;
+ALTER TABLE transactions DROP COLUMN IF EXISTS retirement_contribution_year;
+ALTER TABLE transactions DROP COLUMN IF EXISTS splits;
+ALTER TABLE transactions DROP COLUMN IF EXISTS counterparty_account_id;
+ALTER TABLE transactions DROP COLUMN IF EXISTS counterparty_name;
+ALTER TABLE transactions DROP COLUMN IF EXISTS extra_notes;
+ALTER TABLE transactions DROP COLUMN IF EXISTS custom_fields;
+ALTER TABLE transactions DROP COLUMN IF EXISTS statement_description;
+ALTER TABLE transactions DROP COLUMN IF EXISTS external_reference_id;
+ALTER TABLE transactions DROP COLUMN IF EXISTS merchant_country;
+ALTER TABLE transactions DROP COLUMN IF EXISTS merchant_zip;
+ALTER TABLE transactions DROP COLUMN IF EXISTS merchant_state;
+ALTER TABLE transactions DROP COLUMN IF EXISTS merchant_city;
+ALTER TABLE transactions DROP COLUMN IF EXISTS merchant_address;
+
+ALTER TABLE accounts DROP COLUMN IF EXISTS hsa_coverage_level;
+ALTER TABLE accounts DROP COLUMN IF EXISTS retirement_tax_treatment;
+ALTER TABLE accounts DROP COLUMN IF EXISTS retirement_account_type;
+ALTER TABLE accounts DROP COLUMN IF EXISTS purpose;


### PR DESCRIPTION
## Schema unification — PR1 of 3 (additive backend, non-breaking)

The app has two divergent data models: the rich **offline** store (`sqlite-wasm.ts`, singular tables, superset columns) and the **synced** server model (Postgres → `sync-rules.yaml` → PowerSync `schema.ts`, plural tables). When PowerSync goes live the client swaps to the plural DB and every offline-only column/table disappears — which is why live mode loses features (and why `bank_connection` etc. threw "no such table").

This is **phase 1 of 3**: extend the **server/synced** model to carry everything the offline model has, so the client can later cut over losslessly.

**This PR is purely additive** — new nullable columns + new tables only. Existing rows, queries, and deployed clients are unaffected, so it is safe to ship **before** the client rewrite (PR2).

### Postgres — `services/api/supabase/migrations/20260402000001_schema_unification_superset.sql` (+ down)
- **accounts:** `purpose`, `retirement_account_type`, `retirement_tax_treatment`, `hsa_coverage_level`
- **transactions:** `merchant_{address,city,state,zip,country}`, `external_reference_id`, `statement_description`, `custom_fields`, `extra_notes`, `counterparty_{name,account_id}`, `splits`, `retirement_contribution_{year,designation}`
- **budgets:** `sort_order` · **goals:** `description`, `sort_order`
- **new tables:** `goal_progress_contributions`, `account_reconciliations`, `invoices`, `remittances` — household-scoped, `owner_id`-aware RLS mirroring `accounts`; `invoices`/`remittances` also permit personal (NULL-household) rows scoped to their owner (preserves the offline "create before a household exists" behaviour). Indexes + `updated_at` triggers included.

### PowerSync — `services/api/powersync/sync-rules.yaml`
- Publishes the new columns on the accounts/transactions/budgets/goals projections and adds the four new tables (household rows via `by_household`; personal NULL-household `invoices`/`remittances` via `user_profile`, identical column lists as PowerSync requires).

### Client mirror — `apps/web/src/db/sync/powersync/schema.ts`
- Adds the matching columns + four new `Table` definitions and registers them in `AppSchema` (**33 synced tables**). `schema.test.ts` updated (table count + column parity).

### Invariants
- Money stays in **minor units (cents)** on both sides — no arithmetic conversion.
- `sync_version` / `is_synced` remain **server-side only** (excluded from every sync-rules projection).

### Validation
- `tsc -b` 0 · `eslint --max-warnings 0` 0 · `prettier --check` clean (TS + YAML)
- `schema.test.ts` 9/9 pass · `sync-contract.test.ts` passes by construction (new tables have RLS, soft-delete + bucket filters, exist in migrations)

Follow-ups: **PR2** rewrites the offline schema + 16 repositories to the unified plural model (the large phase); **PR3** migrates existing local data and verifies live end-to-end.
