### PR TITLE
feat(bank): auto-provision a default household so first bank connect just works (PR3)

### DIFF
--- a/apps/web/src/components/bank/ConnectBankButton.test.tsx
+++ b/apps/web/src/components/bank/ConnectBankButton.test.tsx
@@ -18,6 +18,7 @@ import { expectNoAxeViolations } from '../../test-utils/axe';
 const mocks = vi.hoisted(() => ({
   readHouseholdValue: vi.fn(),
   ensureSyncedHouseholdMembership: vi.fn(),
+  ensureDefaultHousehold: vi.fn(),
   ensureAggregatorProvidersRegistered: vi.fn(),
   createConnection: vi.fn(),
   completeConnection: vi.fn(),
@@ -35,6 +36,7 @@ vi.mock('../../db/DatabaseProvider', () => ({
 
 vi.mock('../../db/repositories/household', () => ({
   ensureSyncedHouseholdMembership: mocks.ensureSyncedHouseholdMembership,
+  ensureDefaultHousehold: mocks.ensureDefaultHousehold,
 }));
 
 vi.mock('../../db/repositories/householdData', () => ({
@@ -73,6 +75,7 @@ describe('ConnectBankButton', () => {
     mocks.authUser = null;
     mocks.readHouseholdValue.mockResolvedValue({ id: 'hh-1' });
     mocks.ensureSyncedHouseholdMembership.mockResolvedValue(undefined);
+    mocks.ensureDefaultHousehold.mockResolvedValue('hh-new');
     mocks.ensureAggregatorProvidersRegistered.mockResolvedValue(undefined);
     mocks.createConnection.mockResolvedValue({ sessionId: 'link-token-1' });
     mocks.completeConnection.mockResolvedValue({ id: 'conn-1' });
@@ -139,6 +142,57 @@ describe('ConnectBankButton', () => {
         { householdId: 'hh-1', name: 'Test Household', userId: 'user-1' },
       ),
     );
+    // An existing household is left untouched — no default is provisioned.
+    expect(mocks.ensureDefaultHousehold).not.toHaveBeenCalled();
+  });
+
+  it('auto-provisions a default household on mount for a signed-in user with none', async () => {
+    mocks.authUser = { id: 'user-1', name: 'Alex Rivera', email: 'alex@example.com' };
+    mocks.readHouseholdValue.mockResolvedValue(null);
+
+    render(<ConnectBankButton />);
+
+    await waitFor(() =>
+      expect(mocks.ensureDefaultHousehold).toHaveBeenCalledWith(
+        { __fakeDb: true },
+        { id: 'user-1', name: 'Alex Rivera', email: 'alex@example.com' },
+      ),
+    );
+    // Provisioning owns the synced backfill; the mount effect must not also call
+    // it directly for a household that did not exist yet.
+    expect(mocks.ensureSyncedHouseholdMembership).not.toHaveBeenCalled();
+  });
+
+  it('connects using the auto-provisioned household without showing the wall', async () => {
+    mocks.authUser = { id: 'user-1' };
+    mocks.readHouseholdValue.mockResolvedValue(null);
+    mocks.ensureDefaultHousehold.mockResolvedValue('hh-fresh');
+    mocks.openPlaidLink.mockImplementation(
+      async (opts: {
+        token: string;
+        onSuccess: (publicToken: string, metadata: typeof PLAID_METADATA) => void;
+      }) => {
+        opts.onSuccess('public-token-xyz', PLAID_METADATA);
+        return { open: vi.fn(), exit: vi.fn(), destroy: vi.fn() };
+      },
+    );
+
+    render(<ConnectBankButton />);
+    await waitFor(() => expect(mocks.ensureDefaultHousehold).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Connect a bank' }));
+
+    await waitFor(() =>
+      expect(mocks.createConnection).toHaveBeenCalledWith('plaid', {
+        metadata: { household_id: 'hh-fresh' },
+      }),
+    );
+    expect(mocks.completeConnection).toHaveBeenCalledWith(
+      'plaid',
+      'link-token-1',
+      expect.objectContaining({ household_id: 'hh-fresh' }),
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('does not backfill membership when no user is signed in', async () => {
@@ -146,9 +200,10 @@ describe('ConnectBankButton', () => {
     await waitFor(() => expect(mocks.readHouseholdValue).toHaveBeenCalled());
 
     expect(mocks.ensureSyncedHouseholdMembership).not.toHaveBeenCalled();
+    expect(mocks.ensureDefaultHousehold).not.toHaveBeenCalled();
   });
 
-  it('shows an error and does not start linking when there is no household', async () => {
+  it('shows an error and does not start linking when there is no household and no user', async () => {
     mocks.readHouseholdValue.mockResolvedValue(null);
 
     render(<ConnectBankButton />);
@@ -157,6 +212,7 @@ describe('ConnectBankButton', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Connect a bank' }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(/create a household/i);
+    expect(mocks.ensureDefaultHousehold).not.toHaveBeenCalled();
     expect(mocks.ensureAggregatorProvidersRegistered).not.toHaveBeenCalled();
     expect(mocks.createConnection).not.toHaveBeenCalled();
   });

--- a/apps/web/src/components/bank/ConnectBankButton.tsx
+++ b/apps/web/src/components/bank/ConnectBankButton.tsx
@@ -23,7 +23,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAuth } from '../../auth/auth-context';
 import { useDatabase } from '../../db/DatabaseProvider';
-import { ensureSyncedHouseholdMembership } from '../../db/repositories/household';
+import {
+  ensureDefaultHousehold,
+  ensureSyncedHouseholdMembership,
+} from '../../db/repositories/household';
 import { HOUSEHOLD_SINGLETON_KEY, readHouseholdValue } from '../../db/repositories/householdData';
 
 /** Props for {@link ConnectBankButton}. */
@@ -68,58 +71,72 @@ export function ConnectBankButton({ onConnected }: ConnectBankButtonProps) {
   const busyRef = useRef(false);
 
   useEffect(() => {
-    let active = true;
-    resolveHouseholdId(db)
-      .then((id) => {
-        if (active) setHouseholdId(id);
-      })
-      .catch(() => {
-        if (active) setHouseholdId(null);
-      });
-    return () => {
-      active = false;
-    };
-  }, [db]);
-
-  // Backfill the synced `households` + owner `household_members` rows for the
-  // signed-in user. The app's household lives only in the local-only
-  // `hh_household` document store, but the bank-connection edge function
-  // authorizes `create_link_token` via a server-side membership row — without it
-  // the call 403s. Running this on mount (rather than at click time) gives
-  // PowerSync time to upload the rows before the user connects. Best-effort.
-  useEffect(() => {
     const userId = authUser?.id?.trim();
-    if (!userId) return;
     let active = true;
     void (async () => {
       try {
+        // Read the app's household from the same `hh_household` store the rest
+        // of the app persists to (via the `useHousehold` hook / Household page).
         const household = await readHouseholdValue<{ id?: unknown; name?: unknown } | null>(
           db,
           HOUSEHOLD_SINGLETON_KEY,
           null,
         );
-        if (!active || !household || typeof household.id !== 'string' || !household.id) return;
-        await ensureSyncedHouseholdMembership(db, {
-          householdId: household.id,
-          name: typeof household.name === 'string' ? household.name : 'Household',
-          userId,
-        });
+        let id =
+          household && typeof household.id === 'string' && household.id.length > 0
+            ? household.id
+            : null;
+
+        if (userId) {
+          if (id) {
+            // Existing household: backfill the synced `households` + owner
+            // `household_members` rows so the bank-connection edge function can
+            // authorize `create_link_token` (the `hh_*` doc store never reaches
+            // the server). Running on mount gives PowerSync time to upload the
+            // rows before the user connects. Best-effort.
+            const name = typeof household?.name === 'string' ? household.name : 'Household';
+            await ensureSyncedHouseholdMembership(db, { householdId: id, name, userId });
+          } else {
+            // Fresh account with no household yet: provision a default one so
+            // the user never hits the "create a household first" wall before
+            // their very first bank connection. `ensureDefaultHousehold` also
+            // writes the synced membership rows.
+            id = await ensureDefaultHousehold(db, {
+              id: userId,
+              name: authUser?.name ?? null,
+              email: authUser?.email ?? null,
+            });
+          }
+        }
+
+        if (active) setHouseholdId(id);
       } catch {
-        // Non-fatal: create_link_token will surface any genuine membership issue.
+        // Non-fatal: create_link_token will surface any genuine membership
+        // issue, and the click handler re-attempts provisioning.
+        if (active) setHouseholdId(null);
       }
     })();
     return () => {
       active = false;
     };
-  }, [db, authUser?.id]);
+  }, [db, authUser?.id, authUser?.name, authUser?.email]);
 
   const handleClick = useCallback(async () => {
     if (busyRef.current) return;
     // Re-resolve on click so a household created *after* this component mounted
-    // is picked up without a page refresh (the mount effect only runs once).
+    // is picked up without a page refresh (the mount effect only runs once). For
+    // a signed-in user with no household yet, provision a default one here too
+    // so the connect flow just works instead of dead-ending on the wall.
     let activeHouseholdId = householdId;
     if (!activeHouseholdId) {
-      activeHouseholdId = await resolveHouseholdId(db).catch(() => null);
+      const userId = authUser?.id?.trim();
+      activeHouseholdId = userId
+        ? await ensureDefaultHousehold(db, {
+            id: userId,
+            name: authUser?.name ?? null,
+            email: authUser?.email ?? null,
+          }).catch(() => null)
+        : await resolveHouseholdId(db).catch(() => null);
       if (activeHouseholdId) setHouseholdId(activeHouseholdId);
     }
     if (!activeHouseholdId) {
@@ -190,7 +207,7 @@ export function ConnectBankButton({ onConnected }: ConnectBankButtonProps) {
       setError(e instanceof Error ? e.message : 'We could not start the bank connection.');
       setPhase('error');
     }
-  }, [db, householdId, onConnected]);
+  }, [db, householdId, authUser?.id, authUser?.name, authUser?.email, onConnected]);
 
   const busy = phase === 'starting' || phase === 'finishing';
   const label =

--- a/apps/web/src/db/repositories/household.test.ts
+++ b/apps/web/src/db/repositories/household.test.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for {@link ensureDefaultHousehold} — the fresh-start auto-provision that
+ * removes the "create a household before connecting a bank" wall (PR3).
+ *
+ * `../async-db` and `./householdData` are mocked so the test asserts the
+ * orchestration (read → write local docs → mirror synced rows) without a real
+ * SQLite backend.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AsyncDb } from '../async-db';
+
+const mocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+  query: vi.fn(),
+  queryOne: vi.fn(),
+  readHouseholdValue: vi.fn(),
+  writeHouseholdValue: vi.fn(),
+}));
+
+vi.mock('../async-db', () => ({
+  execute: mocks.execute,
+  query: mocks.query,
+  queryOne: mocks.queryOne,
+}));
+
+vi.mock('./householdData', () => ({
+  HOUSEHOLD_SINGLETON_KEY: 'finance-household',
+  HOUSEHOLD_MEMBERS_KEY: 'finance-household-members',
+  readHouseholdValue: mocks.readHouseholdValue,
+  writeHouseholdValue: mocks.writeHouseholdValue,
+}));
+
+import { ensureDefaultHousehold } from './household';
+
+const db = { __fakeDb: true } as unknown as AsyncDb;
+
+function membersWriteCall() {
+  return mocks.writeHouseholdValue.mock.calls.find((c) => c[1] === 'finance-household-members');
+}
+
+describe('ensureDefaultHousehold', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readHouseholdValue.mockResolvedValue(null);
+    mocks.writeHouseholdValue.mockResolvedValue(undefined);
+    // No pre-existing synced household / member rows.
+    mocks.queryOne.mockResolvedValue(null);
+    mocks.execute.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null and writes nothing without an authenticated user id', async () => {
+    const id = await ensureDefaultHousehold(db, { id: '   ' });
+
+    expect(id).toBeNull();
+    expect(mocks.readHouseholdValue).not.toHaveBeenCalled();
+    expect(mocks.writeHouseholdValue).not.toHaveBeenCalled();
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing household id untouched (idempotent)', async () => {
+    mocks.readHouseholdValue.mockResolvedValue({ id: 'existing-hh' });
+
+    const id = await ensureDefaultHousehold(db, { id: 'user-1' });
+
+    expect(id).toBe('existing-hh');
+    expect(mocks.writeHouseholdValue).not.toHaveBeenCalled();
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it('provisions a default household + owner member and mirrors the synced rows', async () => {
+    const id = await ensureDefaultHousehold(db, { id: 'user-1', name: 'Alex Rivera' });
+
+    expect(typeof id).toBe('string');
+    expect(id).toHaveLength(36); // uuid v4
+
+    // Local doc store: household is written BEFORE members so the members write
+    // can resolve the owning household id for its promoted column.
+    expect(mocks.writeHouseholdValue).toHaveBeenNthCalledWith(
+      1,
+      db,
+      'finance-household',
+      expect.objectContaining({ id, name: 'My Household', ownerId: 'user-1', isSynced: false }),
+    );
+    const membersCall = membersWriteCall();
+    expect(membersCall?.[2]).toEqual([
+      expect.objectContaining({
+        householdId: id,
+        userId: 'user-1',
+        role: 'OWNER',
+        displayName: 'Alex Rivera',
+      }),
+    ]);
+
+    // Synced mirror: inserts households + household_members for this owner.
+    const sqls = mocks.execute.mock.calls.map((c) => String(c[1]));
+    expect(sqls.some((sql) => /INSERT INTO households/.test(sql))).toBe(true);
+    expect(sqls.some((sql) => /INSERT INTO household_members/.test(sql))).toBe(true);
+    const householdsInsert = mocks.execute.mock.calls.find((c) =>
+      /INSERT INTO households/.test(String(c[1])),
+    );
+    expect(householdsInsert?.[2]).toEqual([id, 'My Household', 'user-1']);
+  });
+
+  it('falls back to the email as the owner label when no name is present', async () => {
+    await ensureDefaultHousehold(db, { id: 'user-1', email: 'alex@example.com' });
+
+    expect(membersWriteCall()?.[2]).toEqual([
+      expect.objectContaining({ displayName: 'alex@example.com' }),
+    ]);
+  });
+});

--- a/apps/web/src/db/repositories/household.ts
+++ b/apps/web/src/db/repositories/household.ts
@@ -34,6 +34,12 @@ import type {
 import { ROLE_PERMISSIONS, cents } from '../../kmp/bridge';
 import { execute, query, queryOne, type AsyncDb, type Row } from '../async-db';
 import {
+  HOUSEHOLD_MEMBERS_KEY,
+  HOUSEHOLD_SINGLETON_KEY,
+  readHouseholdValue,
+  writeHouseholdValue,
+} from './householdData';
+import {
   SQLITE_NOW_EXPRESSION,
   mapSyncMetadata,
   optionalString,
@@ -376,6 +382,103 @@ export async function ensureSyncedHouseholdMembership(
       [crypto.randomUUID(), householdId, userId],
     );
   }
+}
+
+/** Minimal authenticated-user shape needed to seed a default household. */
+export interface DefaultHouseholdAuthUser {
+  /** The authenticated Supabase user id (`auth.uid()`). */
+  id: SyncId;
+  /** OAuth display name, used for the owner member's label when present. */
+  name?: string | null;
+  /** Account email, used as a fallback owner label. */
+  email?: string | null;
+}
+
+/** Name given to the household provisioned for a brand-new account. */
+export const DEFAULT_HOUSEHOLD_NAME = 'My Household';
+
+/**
+ * Ensure the signed-in user has a household, provisioning a sensible default
+ * when they have none. Idempotent: when an `hh_household` already exists its id
+ * is returned untouched, so this is safe to call on every mount/click.
+ *
+ * Bank data is household-scoped — the `by_household` sync bucket and the
+ * `create_link_token` owner check both require a household + owner membership —
+ * so a household must exist before the first bank connection. Rather than making
+ * a fresh user hand-create one (the "create a household before connecting a
+ * bank" wall), we seed a default they can rename later.
+ *
+ * Writes BOTH the local-only `hh_household` + `hh_member` document store (the
+ * app's UI source of truth, shared with `useHousehold`) AND, via
+ * {@link ensureSyncedHouseholdMembership}, the synced `households` /
+ * `household_members` rows (server authorization + PowerSync). This keeps the
+ * two stores in step exactly like `useHousehold.createHousehold`.
+ *
+ * Returns the resolved household id, or `null` when no authenticated user id is
+ * available (a synced household cannot be owned without `auth.uid()`).
+ */
+export async function ensureDefaultHousehold(
+  db: AsyncDb,
+  authUser: DefaultHouseholdAuthUser,
+): Promise<string | null> {
+  const userId = authUser.id?.trim();
+  if (!userId) return null;
+
+  const existing = await readHouseholdValue<{ id?: unknown } | null>(
+    db,
+    HOUSEHOLD_SINGLETON_KEY,
+    null,
+  );
+  if (existing && typeof existing.id === 'string' && existing.id.length > 0) {
+    return existing.id;
+  }
+
+  const now = new Date().toISOString();
+  const householdId = crypto.randomUUID();
+  // Prefer the OAuth name, then email — never expose a raw UUID as the label.
+  const displayName =
+    (authUser.name && authUser.name.trim().length > 0 ? authUser.name.trim() : null) ??
+    (authUser.email && authUser.email.trim().length > 0 ? authUser.email.trim() : null);
+
+  const household: Household = {
+    id: householdId,
+    name: DEFAULT_HOUSEHOLD_NAME,
+    ownerId: userId,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: false,
+  };
+
+  const ownerMember: HouseholdMember = {
+    id: crypto.randomUUID(),
+    householdId,
+    userId,
+    displayName,
+    role: 'OWNER',
+    joinedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: false,
+  };
+
+  // Local doc store first: household before members so the members write can
+  // resolve the owning household id for its promoted `household_id` column.
+  await writeHouseholdValue(db, HOUSEHOLD_SINGLETON_KEY, household);
+  await writeHouseholdValue(db, HOUSEHOLD_MEMBERS_KEY, [ownerMember]);
+
+  // Mirror into the synced tables so `create_link_token` authorizes this owner
+  // and the `by_household` bucket starts publishing their bank data.
+  await ensureSyncedHouseholdMembership(db, {
+    householdId,
+    name: household.name,
+    userId,
+  });
+
+  return householdId;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/db/repositories/householdData.ts
+++ b/apps/web/src/db/repositories/householdData.ts
@@ -46,6 +46,9 @@ import {
 /** Storage key for the single household record (stored as one row). */
 export const HOUSEHOLD_SINGLETON_KEY = 'finance-household';
 
+/** Storage key for the household member collection. */
+export const HOUSEHOLD_MEMBERS_KEY = 'finance-household-members';
+
 /**
  * Maps each household storage key to its backing `hh_` table. Keys mirror the
  * legacy `localStorage` keys exactly so the hook can swap backends transparently.


### PR DESCRIPTION
## PR3 of 3 — fresh-start live bank data

Stacked on #3980 (PR2 client cutover). Base retargets to `main` once PR2 merges.

### Why
A brand-new signed-in account has **no household**, but bank data is household-scoped — the PowerSync `by_household` bucket and the `create_link_token` owner check both require a household + owner membership. So the very first "Connect a bank" click dead-ended on **"Create a household before connecting a bank."** This removes that friction.

### What
- **`ensureDefaultHousehold(db, authUser)`** (household repo) — idempotent. Returns any existing `hh_household` id untouched; otherwise seeds:
  - the local-only `hh_household` + `hh_member` doc store (the app's UI source of truth, shared with `useHousehold`), and
  - the synced `households` / `household_members` rows (via `ensureSyncedHouseholdMembership`) so PowerSync uploads them and the edge function authorizes the owner. The `by_household` bucket then publishes the connected bank's accounts + transactions.
- **`ConnectBankButton`** provisions on mount (signed-in user, no household) and again on click as a fallback. The wall now only applies to an unauthenticated visitor.
- Exported `HOUSEHOLD_MEMBERS_KEY` from `householdData` so helper + hook share one storage key.

The default household is named **"My Household"** and can be renamed on the Household page. Existing households are never touched.

### Tests
- New `household.test.ts`: no user → null + no writes; idempotent return; provision writes local docs (household before members) + synced inserts; email fallback as the owner label.
- `ConnectBankButton.test.tsx`: auto-provision on mount; connect using the provisioned household with no wall; existing household left untouched; wall only for the no-user case.
- `tsc -b` clean · targeted vitest 20/20 · full web suite 10290/10292 (the 2 failures are pre-existing `requestAnimationFrame` animation flakes that pass in isolation) · eslint 0 · prettier clean.

### Rollout
Merge PR2 (#3980) → merge this → deploy → sign in → **Connect a bank** (Plaid sandbox: `user_good` / `pass_good`) → sandbox accounts + transactions stream in live via the `by_household` bucket. Sandbox creds return fake data (First Platypus).
