### PR TITLE
fix(household): order doc-store reads by created_at, not rowid (fixes live-mode 'create a household' wall)

### DIFF
--- a/apps/web/src/db/repositories/householdData.test.ts
+++ b/apps/web/src/db/repositories/householdData.test.ts
@@ -2,6 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AsyncDb } from '../async-db';
+import { query, queryOne } from '../async-db';
 
 // Shared in-memory table store for the mocked sqlite primitives. `vi.hoisted`
 // keeps it available to both the (hoisted) mock factory and the test body.
@@ -198,5 +199,27 @@ describe('householdData repository', () => {
     await expect(writeHouseholdValue(db, 'finance-not-a-household-key', [])).rejects.toThrow(
       /Unknown household storage key/,
     );
+  });
+
+  it('orders reads by a PowerSync-view-safe column, never rowid', async () => {
+    // In live mode the backing store is PowerSync, which exposes every table as
+    // a SQLite *view* (no `rowid`). `ORDER BY rowid` therefore throws
+    // `no such column: rowid`, breaking every household read and dead-ending
+    // "Connect a bank" with the false "create a household first" wall. This
+    // guards the ordering because the mocked async-db ignores SQL semantics and
+    // cannot catch a view-incompatible clause behaviourally.
+    await writeHouseholdValue(db, MEMBERS_KEY, [makeMember()]);
+    await readHouseholdValue<FakeMember[]>(db, MEMBERS_KEY, []);
+    await readHouseholdValue<FakeMember | null>(db, HOUSEHOLD_SINGLETON_KEY, null);
+
+    const selects = [...vi.mocked(query).mock.calls, ...vi.mocked(queryOne).mock.calls].map(
+      ([, sql]) => String(sql),
+    );
+
+    expect(selects.length).toBeGreaterThan(0);
+    for (const sql of selects) {
+      expect(sql).not.toMatch(/rowid/i);
+      expect(sql).toMatch(/order by created_at/i);
+    }
   });
 });

--- a/apps/web/src/db/repositories/householdData.ts
+++ b/apps/web/src/db/repositories/householdData.ts
@@ -150,13 +150,23 @@ function parseRows<T>(rows: Row[]): T[] {
 // Reads
 // ---------------------------------------------------------------------------
 
+// Order by the promoted `created_at` (insertion timestamp) with `id` as a stable
+// tiebreaker rather than SQLite's implicit `rowid`. In live mode the database is
+// PowerSync, which exposes every table as a *view* over an internal
+// `ps_data_local__*` table — and SQLite views have no `rowid`, so
+// `ORDER BY rowid` throws `no such column: rowid`, breaking every household read
+// (and, via `ensureDefaultHousehold`, dead-ending "Connect a bank" with the
+// "create a household" wall). `created_at` + `id` are real columns on the view
+// in both the offline (sqlite-wasm) and live (PowerSync) backends.
+const DOCUMENT_ORDER = 'ORDER BY created_at ASC, id ASC';
+
 async function readCollection<T>(db: AsyncDb, table: string): Promise<T[]> {
-  const result = await query<Row>(db, `SELECT data FROM ${table} ORDER BY rowid ASC`);
+  const result = await query<Row>(db, `SELECT data FROM ${table} ${DOCUMENT_ORDER}`);
   return parseRows<T>(result.rows);
 }
 
 async function readSingleton<T>(db: AsyncDb, table: string): Promise<T | null> {
-  const row = await queryOne<Row>(db, `SELECT data FROM ${table} ORDER BY rowid ASC LIMIT 1`);
+  const row = await queryOne<Row>(db, `SELECT data FROM ${table} ${DOCUMENT_ORDER} LIMIT 1`);
   if (!row || typeof row.data !== 'string') {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes the false **"Create a household before connecting a bank."** wall that persists in production even after a household is created — the last blocker to the live sandbox bank-connect flow.

## Root cause

In **live mode the database is PowerSync**, which exposes every table as a SQLite **view** over an internal `ps_data_local__*` table. **SQLite views have no `rowid`**, so the household document-store reads:

```sql
SELECT data FROM hh_household ORDER BY rowid ASC LIMIT 1
```

threw `no such column: rowid` on **every** read. Writes (delete-then-insert, no `rowid`) still succeeded, so a freshly-created household was persisted but **never readable** — the app behaved as if no household existed.

This dead-ended "Connect a bank": `ensureDefaultHousehold` reads the `hh_household` singleton first → that read threw → `ConnectBankButton` caught it and fell back to `null` → the user hit the wall **right after creating a household**. It also silently broke the rest of the household feature (members, children, activity, reconciliation, …) whenever live sync was active.

### Why it wasn't caught earlier
- **Offline mode** uses real sqlite-wasm tables, which *do* have `rowid` → worked there.
- **Unit tests** mock `async-db` with an in-memory store that ignores SQL ordering → never exercised `rowid` against a view.
- `householdData.ts` is the **only** repository that ordered by `rowid`; every other repo already orders by a real column.

## Fix

Order the document-store reads by the promoted **`created_at`** column with **`id`** as a stable tiebreaker. Both are real columns on every `hh_*` table in **both** backends (offline sqlite-wasm *and* the live PowerSync view — confirmed in `powersync/schema.ts` `householdDocument()`), so reads resolve in either mode and stay deterministic.

With reads working, `ensureDefaultHousehold` correctly finds-or-creates and is properly idempotent in live mode → the wall clears and the first "Connect a bank" click provisions a default household.

## Changes
- `apps/web/src/db/repositories/householdData.ts` — replace `ORDER BY rowid` with `ORDER BY created_at ASC, id ASC` for both the singleton and collection reads; documented why.
- `apps/web/src/db/repositories/householdData.test.ts` — regression test asserting the generated read SQL never references `rowid` and always orders by `created_at` (the mock can't catch a view-incompatible clause behaviourally).

## Validation
- `tsc -b` → exit 0
- Targeted vitest: `householdData.test.ts` 9/9, `household.test.ts` + `ConnectBankButton.test.tsx` 12/12
- `eslint --max-warnings 0` clean · `prettier --check` clean

## Post-merge
Deploy web to production, then: sign in → Bank Connections → **Connect a bank** (no manual household step) → Plaid sandbox `user_good` / `pass_good` → First Platypus sandbox accounts + transactions stream in via the `by_household` bucket.
