### PR TITLE
fix(deploy): set GOTRUE_JWT_AUD=authenticated so PowerSync accepts tokens (fixes Sync Failed + bank 403)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -354,6 +354,36 @@ docker compose exec db psql -U postgres -d postgres -c "
 "
 ```
 
+### Aligning the JWT audience (one-time)
+
+The base compose sets `GOTRUE_JWT_AUD: authenticated` so every access token carries
+`aud="authenticated"` — the value the PowerSync sync service (Supabase auth mode)
+requires. GoTrue reads the `aud` it stamps on a token from each user's
+`auth.users.aud` column, and it looks users up by **(email, aud)** at login, so the
+config and the existing rows must agree. Deployments that previously ran without
+`GOTRUE_JWT_AUD` have `auth.users.aud = ''`; align them once, right after the auth
+container picks up the new setting:
+
+```bash
+# 1. Recreate GoTrue with the corrected GOTRUE_JWT_AUD (from the deployed compose)
+docker compose up -d auth
+
+# 2. Point every existing user at the standard audience (idempotent)
+docker compose exec -T db psql -U supabase_admin -d postgres -c "
+  UPDATE auth.users SET aud = 'authenticated' WHERE COALESCE(aud, '') <> 'authenticated';
+"
+
+# 3. Confirm no empty-audience users remain (expect 0)
+docker compose exec -T db psql -U supabase_admin -d postgres -c "
+  SELECT count(*) AS empty_aud FROM auth.users WHERE COALESCE(aud, '') <> 'authenticated';
+"
+```
+
+Existing browser sessions keep working (refresh-token grants don't use the `aud`
+lookup); only a brand-new sign-in between steps 1 and 2 would be briefly rejected.
+After step 2, a hard refresh mints a token with `aud="authenticated"` and live sync
+connects.
+
 ---
 
 ## Backup Procedures

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -160,6 +160,15 @@ services:
       GOTRUE_JWT_SECRET: ${JWT_SECRET}
       GOTRUE_JWT_EXP: ${JWT_EXPIRY:-3600}
       GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+      # Audience claim baked into every issued access token. MUST be
+      # "authenticated" (the Supabase convention): the PowerSync sync service runs
+      # in Supabase auth mode, which hard-requires aud="authenticated" and rejects
+      # any other value with PSYNC_S2105 ("Unexpected aud claim value"). Leaving
+      # this unset makes GoTrue issue tokens with an empty aud, which breaks live
+      # sync (and therefore bank-connection household authorization). GoTrue also
+      # looks users up by (email, aud) at login, so existing auth.users rows must
+      # carry the same aud — see deploy/README.md "Aligning the JWT audience".
+      GOTRUE_JWT_AUD: authenticated
 
       # Session lifecycle
       GOTRUE_SESSION_TIMEBOX: ${SESSION_TIMEBOX:-24h}


### PR DESCRIPTION
## Why

Live sync has been failing in production with **`PSYNC_S2105: Unexpected "aud" claim value: ""`** on every `POST /sync/stream` (HTTP 401), surfaced in the app as **"Sync Failed"**. Downstream, "Connect a bank" returns **403 "Only household owners and admins can manage bank connections"** because the client's owner `household_members` row is provisioned locally but can never upload while sync is down, so the `bank-connection` edge function sees no membership.

### Root cause

The `auth` (GoTrue) service never set **`GOTRUE_JWT_AUD`**, so GoTrue issues access tokens with an **empty `aud` claim**. The self-hosted **PowerSync** service runs in Supabase auth mode (`client_auth.supabase: true`), whose key collector hard-codes `requiresAudience: ['authenticated']` and, per `KeyStore.verifyJwt`, **replaces** (not merges) any configured audience — so a PowerSync-side `audience` override cannot help. The token itself must carry `aud="authenticated"`.

Verified against `supabase/auth` v2.170.0:
- `generateAccessToken` stamps `Audience: jwt.ClaimStrings{user.Aud}` — the token `aud` comes from the user's `auth.users.aud` column.
- `ResourceOwnerPasswordGrant` looks users up via `FindUserByEmailAndAudience(email, aud)` where `aud` falls back to `config.JWT.Aud` (`GOTRUE_JWT_AUD`). Current logins succeed with empty tokens ⇒ both config and rows are currently `""` (internally consistent).

## What changed

- `deploy/docker-compose.yml`: add `GOTRUE_JWT_AUD: authenticated` to the `auth` service JWT block (the Supabase-standard value the official self-host compose always sets). Staging inherits it via the layered compose.
- `deploy/README.md`: new **"Aligning the JWT audience (one-time)"** section — because GoTrue looks users up by `(email, aud)`, existing `auth.users` rows created while `aud` was empty must be set to `authenticated` once, right after `auth` picks up the new setting.

## Operator step (one-time, after deploy)

```bash
docker compose up -d auth
docker compose exec -T db psql -U supabase_admin -d postgres -c \
  "UPDATE auth.users SET aud = 'authenticated' WHERE COALESCE(aud, '') <> 'authenticated';"
```

Existing browser sessions keep working (refresh-token grants don't use the `aud` lookup); only a brand-new sign-in between the two commands would be briefly rejected. After the update, a hard refresh mints a token with `aud="authenticated"`, PowerSync connects, the owner membership syncs, and the bank-connection 403 clears.

## Risk

Config-only + one idempotent data alignment. No app code, schema, or client changes. Reversible (unset the env / value is standard).
