### PR TITLE
fix(security): bump brace-expansion override to >=5.0.9 (GHSA-rgw5-rvv9-x895)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5134,9 +5134,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "dompurify": ">=3.4.1",
     "fast-xml-parser": ">=5.7.0",
     "protobufjs": "7.6.3",
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.9",
     "postcss": ">=8.5.18",
     "styled-components": ">=6.4.1",
     "react": "19.2.7",


### PR DESCRIPTION
## Why

Repo-wide `npm audit --audit-level=high` began failing (blocking the **Required Checks Gatekeeper** on every PR) after a newly published high-severity advisory:

- **GHSA-rgw5-rvv9-x895** — *brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation.* The 5.x line is patched in **5.0.9**.

Our root override floor was `>=5.0.8`, which still resolves to the vulnerable **5.0.8**.

## What changed

- `package.json`: override `brace-expansion` `>=5.0.8` → `>=5.0.9`.
- `package-lock.json`: regenerated with **npm 10.9.3** (CI parity) — pins `brace-expansion@5.0.9`. Diff is 4 lines (version + resolved + integrity).

## Validation

- `npx npm@10.9.3 audit --audit-level=high` → **found 0 vulnerabilities**.
- Lockfile generated by npm 10.9.3 (the CI version) so `npm ci` stays in sync.

Minimal, dependency-only change (same pattern as #3950). Unblocks all open PRs.