### PR TITLE
ci: one-time workflow to align auth.users JWT audience

### DIFF
--- a/.github/workflows/maintenance-align-jwt-aud.yml
+++ b/.github/workflows/maintenance-align-jwt-aud.yml
@@ -1,0 +1,94 @@
+# =============================================================================
+# Maintenance — Align auth.users JWT audience (one-time)
+# =============================================================================
+#
+# Sets `auth.users.aud = 'authenticated'` for any rows created while GoTrue ran
+# without `GOTRUE_JWT_AUD`. GoTrue stamps a token's `aud` from this column and
+# looks users up by (email, aud) at login, so until existing rows are aligned,
+# issued tokens carry `aud=""` — which the PowerSync sync service (Supabase auth
+# mode) rejects with PSYNC_S2105, and fresh sign-ins fail.
+#
+# The statement is fixed (not an input) and idempotent, so re-runs are safe
+# no-ops. Runs against the production server over the same SSH path the deploy
+# uses (DEPLOY_HOST / DEPLOY_SSH_KEY / DEPLOY_USER, gated by the `production`
+# environment). Trigger from the Actions tab → "Run workflow" → confirm: yes.
+# =============================================================================
+
+name: Maintenance — Align JWT audience
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "yes" to run the one-time auth.users aud alignment against production'
+        required: true
+        default: 'no'
+        type: choice
+        options:
+          - 'no'
+          - 'yes'
+
+concurrency:
+  group: maintenance-align-jwt-aud
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  align-jwt-aud:
+    name: Align auth.users aud on production
+    if: ${{ inputs.confirm == 'yes' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: production
+    steps:
+      - name: Align auth.users aud over SSH
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '~/finance' }}
+        run: |
+          if [ -z "$DEPLOY_HOST" ]; then
+            echo '::error::DEPLOY_HOST not configured — cannot reach the production server.'
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          # Pass DEPLOY_PATH via the command line and keep the remote body in a
+          # quoted heredoc so nothing expands on the runner (mirrors deploy-production.yml).
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+            "DEPLOY_PATH='$DEPLOY_PATH' bash -s" <<'REMOTE'
+            set -eu
+            # Expand a leading ~ that a non-interactive shell leaves literal.
+            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#"~"}" ;; esac
+            cd "$DEPLOY_PATH"
+
+            DC="docker compose -f deploy/docker-compose.yml"
+            PSQL="$DC exec -T db psql -U supabase_admin -d postgres -v ON_ERROR_STOP=1"
+
+            echo "aud distribution BEFORE:"
+            $PSQL -tAc "SELECT COALESCE(NULLIF(aud,''),'(empty)') AS aud, count(*) FROM auth.users GROUP BY 1 ORDER BY 1"
+
+            $PSQL -c "UPDATE auth.users SET aud = 'authenticated' WHERE COALESCE(aud, '') <> 'authenticated'"
+
+            echo "aud distribution AFTER:"
+            $PSQL -tAc "SELECT COALESCE(NULLIF(aud,''),'(empty)') AS aud, count(*) FROM auth.users GROUP BY 1 ORDER BY 1"
+          REMOTE
+
+          {
+            echo '### ✅ auth.users aud aligned to `authenticated`'
+            echo ''
+            echo 'PowerSync will now accept issued tokens and fresh sign-ins resolve.'
+            echo 'Hard-refresh finance.jrmoulckers.com to mint a corrected token.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Clean up SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key


### PR DESCRIPTION
## Why

Completes the **data half** of the `GOTRUE_JWT_AUD` fix (#3986). Setting the config makes GoTrue *issue* `aud="authenticated"` for **new** tokens, but GoTrue stamps a token's `aud` from each user's `auth.users.aud` column and matches users by `(email, aud)` at login. Rows created before the config was set still have `aud=''`, so:

- issued/refreshed tokens still carry `aud=""` → PowerSync rejects them (`PSYNC_S2105`) → "Sync Failed" → bank-connection 403;
- brand-new sign-ins fail the `(email, 'authenticated')` lookup.

A one-time alignment of existing rows fixes both. This repo applies DB changes manually on the VM, so this wires that one command into a **guarded, no-SSH-needed** workflow instead.

## What

- `.github/workflows/maintenance-align-jwt-aud.yml` — `workflow_dispatch` with a `confirm: yes` guard, `environment: production` (so the `DEPLOY_*` secrets resolve and the run is gated), reusing the deploy's SSH path.
- Runs a **fixed, idempotent** statement (not an input): `UPDATE auth.users SET aud='authenticated' WHERE COALESCE(aud,'') <> 'authenticated';` and prints the aud distribution before/after. Re-runs are safe no-ops.

## After merge

Actions → *Maintenance — Align JWT audience* → Run workflow → confirm **yes** → approve the production gate. Then hard-refresh the site: sync connects, membership syncs, the 403 clears.
