### PR TITLE
fix(security): bump fast-uri>=3.1.5 and undici 7.29.0 to clear high advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6624,9 +6624,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -9950,9 +9950,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -90,9 +90,9 @@
     "esbuild": "0.28.1",
     "js-yaml": "^4.3.0",
     "read-yaml-file": "^2.1.0",
-    "fast-uri": ">=3.1.4 <4.0.0",
+    "fast-uri": ">=3.1.5 <4.0.0",
     "jsdom": {
-      "undici": "7.28.0"
+      "undici": "7.29.0"
     },
     "simple-websocket": {
       "ws": "7.5.11"


### PR DESCRIPTION
## Why

Two newly-published high-severity advisories fail `npm audit --audit-level=high`, which feeds the repo-wide **Required Checks Gatekeeper** and transitively blocks every merge:

- **fast-uri** — GHSA-7p8r-x3mc-p8w7 (installed `3.1.4`, patched `3.1.5` on the 3.x line)
- **undici** — GHSA-4cwx-7wf7-3272 and related (installed `7.28.0`, patched `7.29.0` on the 7.x line)

## What changed

- `package.json` overrides:
  - `fast-uri`: `>=3.1.4 <4.0.0` → `>=3.1.5 <4.0.0` (respects the `<4` major pin)
  - jsdom-scoped `undici`: `7.28.0` → `7.29.0` (jsdom is the sole consumer; test-only)
- `package-lock.json`: regenerated with **npm@10.9.3** (CI parity). Surgical diff — only the two entries change (correct `version`/`resolved`/`integrity`).

## Validation

- `npx npm@10.9.3 ci` → clean install, integrity verified (added 737 packages)
- `npx npm@10.9.3 audit --audit-level=high` → **0 vulnerabilities**
- `prettier --check package.json` → clean

Unblocks PR #3989 (maintenance-align-jwt-aud workflow), which is currently red only on this audit check.
