### PR TITLE
fix(ci): stop maintenance JWT-aud SSH job hanging on stdin

### DIFF
--- a/.github/workflows/maintenance-align-jwt-aud.yml
+++ b/.github/workflows/maintenance-align-jwt-aud.yml
@@ -63,23 +63,34 @@ jobs:
 
           # Pass DEPLOY_PATH via the command line and keep the remote body in a
           # quoted heredoc so nothing expands on the runner (mirrors deploy-production.yml).
-          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+          # Keepalives + ConnectTimeout stop a NAT/idle drop from wedging the session.
+          ssh -i ~/.ssh/deploy_key \
+            -o BatchMode=yes \
+            -o ConnectTimeout=20 \
+            -o ServerAliveInterval=15 \
+            -o ServerAliveCountMax=8 \
+            "$DEPLOY_USER@$DEPLOY_HOST" \
             "DEPLOY_PATH='$DEPLOY_PATH' bash -s" <<'REMOTE'
             set -eu
             # Expand a leading ~ that a non-interactive shell leaves literal.
             case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#"~"}" ;; esac
             cd "$DEPLOY_PATH"
+            echo "[remote] connected to $(hostname); DEPLOY_PATH=$DEPLOY_PATH"
 
             DC="docker compose -f deploy/docker-compose.yml"
+            # `</dev/null` on every psql call is REQUIRED: `docker compose exec -T`
+            # proxies its stdin to the container, so without it the exec swallows the
+            # rest of this heredoc and blocks on read forever (no output → the idle
+            # SSH session is dropped with a broken pipe). Redirecting stdin fixes it.
             PSQL="$DC exec -T db psql -U supabase_admin -d postgres -v ON_ERROR_STOP=1"
 
             echo "aud distribution BEFORE:"
-            $PSQL -tAc "SELECT COALESCE(NULLIF(aud,''),'(empty)') AS aud, count(*) FROM auth.users GROUP BY 1 ORDER BY 1"
+            $PSQL -tAc "SELECT COALESCE(NULLIF(aud,''),'(empty)') AS aud, count(*) FROM auth.users GROUP BY 1 ORDER BY 1" </dev/null
 
-            $PSQL -c "UPDATE auth.users SET aud = 'authenticated' WHERE COALESCE(aud, '') <> 'authenticated'"
+            $PSQL -c "UPDATE auth.users SET aud = 'authenticated' WHERE COALESCE(aud, '') <> 'authenticated'" </dev/null
 
             echo "aud distribution AFTER:"
-            $PSQL -tAc "SELECT COALESCE(NULLIF(aud,''),'(empty)') AS aud, count(*) FROM auth.users GROUP BY 1 ORDER BY 1"
+            $PSQL -tAc "SELECT COALESCE(NULLIF(aud,''),'(empty)') AS aud, count(*) FROM auth.users GROUP BY 1 ORDER BY 1" </dev/null
           REMOTE
 
           {


### PR DESCRIPTION
## Why

The first dispatch of **Maintenance — Align JWT audience** (run 31030391281) failed: the SSH session dropped with `client_loop: send disconnect: Broken pipe` after ~4.5 minutes with **zero remote output**, before the UPDATE ran.

**Root cause:** the remote body runs `docker compose exec -T db psql …` inside a `bash -s` heredoc. With `-T`, `docker compose exec` proxies its stdin to the container — so it kept **reading the rest of the heredoc** and blocked on `read` forever. No output was flushed, the session went idle, and the network path killed it.

## Fix

- Redirect every `psql` call's stdin from `</dev/null` so the exec can't swallow the script or block.
- Add SSH `BatchMode` + `ConnectTimeout=20` + `ServerAliveInterval=15` / `ServerAliveCountMax=8` so an idle path can't wedge the session.
- Emit an early `[remote] connected …` marker to confirm connectivity and flush output.

The SQL is **unchanged and idempotent** (`UPDATE auth.users SET aud='authenticated' WHERE COALESCE(aud,'') <> 'authenticated'`), so re-running is a safe no-op. This is the operative step that lets PowerSync accept issued tokens (clears `PSYNC_S2105`) and fresh sign-ins resolve.

## Validation

- `js-yaml` parse: OK
- `prettier --check`: clean
