### PR TITLE
chore(sync): update studio canon (2026-08-07)

### DIFF
--- a/.studio-sync.lock.json
+++ b/.studio-sync.lock.json
@@ -1,0 +1,97 @@
+{
+  "version": 1,
+  "backbone": "jrmoulckers/.github",
+  "generatedAt": "2026-08-07T15:35:03.618Z",
+  "entries": {
+    "AGENTS.md": {
+      "sourceSha256": "8f7d2cf3091d62277cf98ce3e8f35f77a8bb192fb20486f74ed8e6b9b8be33d8",
+      "targetSha256": "e28382afae36f0057b936558fd5f25dc2e39ffd55c4ddb36a9cdd848a07872ec",
+      "syncedAt": "2026-08-07T15:35:03.614Z"
+    },
+    "agency.toml": {
+      "sourceSha256": "281f6b5cf11d21b51acd26d139cb10d6ca9526f4844e4bac8ce8b759d9a5049e",
+      "targetSha256": "c5dc520a8bd3a4414bff540c4c00796ad1dbe4c43422731845ec07881911ef35",
+      "syncedAt": "2026-08-07T15:35:03.615Z"
+    },
+    "apps/web/vendor/@jrm/tokens/css/default/index.css": {
+      "sourceSha256": "cf5214b93290c39c6a1e35dd2ac9b8df9dd6fe26e57c85c7c1d554888dc34c2f",
+      "targetSha256": "8de39ffd250fd85b444e75254d950385e9254d7839d894fe830c25132521404d",
+      "syncedAt": "2026-08-07T15:35:03.616Z"
+    },
+    "apps/web/vendor/@jrm/tokens/css/default/tokens-dark-oled.css": {
+      "sourceSha256": "2ff46d8fff8761e9d7feae98e927e36f71eab99b62129772e7eaf2359e9fbbcc",
+      "targetSha256": "5fb5c07f9438929ba128f2b4eaf7c4ab2168e89d2a56f987dcb24eec6b428c56",
+      "syncedAt": "2026-08-07T15:35:03.616Z"
+    },
+    "apps/web/vendor/@jrm/tokens/css/default/tokens-dark.css": {
+      "sourceSha256": "01af015752a5cef4e9571458abe589e7aac87a660d5e9234f5aad4f1dcef33ed",
+      "targetSha256": "53fbc9d8ced28dcac04708795736daacc3f925355c6747c0a5feaff93b19a3dc",
+      "syncedAt": "2026-08-07T15:35:03.616Z"
+    },
+    "apps/web/vendor/@jrm/tokens/css/default/tokens-high-contrast.css": {
+      "sourceSha256": "447878d48a6756cedf140ea4d88b85f3268ff8284ec7a02d5a37c55df0595c18",
+      "targetSha256": "12d22deb031e4d92a98599e628184688263a3ca0c3be24e3777d011e2febec5a",
+      "syncedAt": "2026-08-07T15:35:03.616Z"
+    },
+    "apps/web/vendor/@jrm/tokens/css/default/tokens.css": {
+      "sourceSha256": "343e10b1ac7914f2a3d1255cfc6ffad1930ac1a17da9eb5aa5551e6e4f67062c",
+      "targetSha256": "bb35859efbfb66ccb46c5bcc082d552e33ab1a53b0f61575d9b1932862886d87",
+      "syncedAt": "2026-08-07T15:35:03.616Z"
+    },
+    "apps/web/vendor/@jrm/tokens/js/default/tokens.dark-oled.d.ts": {
+      "sourceSha256": "7c664068a688ec61e1844ea98e60421c9621296709c0d87a9be8d9d58dc57cb4",
+      "targetSha256": "673eba7f5ba89bc68e1eca4e6defa3c84d6b9bd9b9c4d0477992378a92fd5a02",
+      "syncedAt": "2026-08-07T15:35:03.616Z"
+    },
+    "apps/web/vendor/@jrm/tokens/js/default/tokens.dark-oled.js": {
+      "sourceSha256": "5fb302cb1dee71b6649432ed4876a3af6dfbadcb26db80b590c40e0f079d83d5",
+      "targetSha256": "2a1cdb87edf51afb96ba02d37b9ab4c8e8c9c10a8a6991a3fd9495325fb08df8",
+      "syncedAt": "2026-08-07T15:35:03.616Z"
+    },
+    "apps/web/vendor/@jrm/tokens/js/default/tokens.dark.d.ts": {
+      "sourceSha256": "b5c69f8738fe2d2aa281e3c00719d54486a87b9ad638e8c4c72434ce8267636f",
+      "targetSha256": "47f4e9c0b15ad7ddd6cebfb66d1614ed0caf50b72ef9a5395a28c8952c7ccaa7",
+      "syncedAt": "2026-08-07T15:35:03.616Z"
+    },
+    "apps/web/vendor/@jrm/tokens/js/default/tokens.dark.js": {
+      "sourceSha256": "4c93c6e4a87fb014f75109b2cf237e7bad00de408cd91254d224cebff24ecbdb",
+      "targetSha256": "552fab49c3c45232492d9acaed3ba41df9060cb00548490d9359fa89cca5e6ed",
+      "syncedAt": "2026-08-07T15:35:03.616Z"
+    },
+    "apps/web/vendor/@jrm/tokens/js/default/tokens.high-contrast.d.ts": {
+      "sourceSha256": "edf1099006f2936abc79328ec1fe90dbde6b8f19d27e5b0f46884a34c7b97ed5",
+      "targetSha256": "432034685862716e39fee39db5ad8127bddec27c434cfbc9fed663f212e02934",
+      "syncedAt": "2026-08-07T15:35:03.616Z"
+    },
+    "apps/web/vendor/@jrm/tokens/js/default/tokens.high-contrast.js": {
+      "sourceSha256": "84926f6df84d4a261a43731c8396fc5a4392dbd7f5dd976356db37658dba1c5e",
+      "targetSha256": "d639bba1b5db52811db9fd59b4bdd1d216dddff9a536c6794b6f017a0e6809b3",
+      "syncedAt": "2026-08-07T15:35:03.617Z"
+    },
+    "apps/web/vendor/@jrm/tokens/js/default/tokens.light.d.ts": {
+      "sourceSha256": "083baa505afb21a328371317f592017c5169de739b1dba4b7cc74ad510089a92",
+      "targetSha256": "6c871828f9f6f915e9cf7c23ea5639e4dd67dcc7497a3e2f8e5f77c6594fe614",
+      "syncedAt": "2026-08-07T15:35:03.617Z"
+    },
+    "apps/web/vendor/@jrm/tokens/js/default/tokens.light.js": {
+      "sourceSha256": "2b99418dd6d78b494bdd365b70dba82dc87d3f0a4fbdb201f072b4c7cba5f132",
+      "targetSha256": "6c327ab3f2c99f361245c6273fc2192647a37c7dc8b26a5ed010f33d16f97f0f",
+      "syncedAt": "2026-08-07T15:35:03.617Z"
+    },
+    "apps/web/vendor/@jrm/tokens/js/index.d.ts": {
+      "sourceSha256": "852802c61e34befbe963e7c7e47abbfc3728b2687b9a73ff522177676aa8a165",
+      "targetSha256": "05b8872cee1709287265f680a1f66d1019fd97457f0809d3ad9ba704d8d9cd9f",
+      "syncedAt": "2026-08-07T15:35:03.617Z"
+    },
+    "apps/web/vendor/@jrm/tokens/js/index.js": {
+      "sourceSha256": "f0e8a8ffc74ecf3c3015c619dc8a1f6fb4067f9404392af96a0633e0a4d87f7c",
+      "targetSha256": "e6f65ac26d8aab9dc02c05acd2906971ca7a8df49785f5f8e885743996dac69d",
+      "syncedAt": "2026-08-07T15:35:03.617Z"
+    },
+    "apps/web/vendor/@jrm/tokens/tailwind/default.cjs": {
+      "sourceSha256": "6e7f6486dcdd44e7ce9c3d0cf60827cbae2d75dab216f774cb6e0d32b0a6a8a9",
+      "targetSha256": "708c645a8553135c9bcf76b525891fc9da25d1b35f5044e6dd73057699a1f184",
+      "syncedAt": "2026-08-07T15:35:03.617Z"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -475,3 +475,145 @@ These tasks create GitHub issues using the same issue-first workflow as engineer
 **Requirements:** Copilot CLI with Pro+ subscription. No special repo configuration needed.
 
 See `docs/ai/` for complete AI development documentation.
+
+<!-- studio:base:start -->
+<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
+
+# AGENTS.md — JRM Studio base operating guide
+
+This file tells an AI agent (GitHub Copilot, Codex, Claude, and others) how to work safely and
+effectively across **JRM Studio** repositories. It is the shared floor. **Each product repo
+extends it** with its own root `AGENTS.md` that adds product-specific stack, paths, and rules —
+product rules layer on top of, and may override, the defaults here.
+
+> This file lives in the canonical `jrmoulckers/.github` backbone repo. It is distributed to
+> product repos by the studio sync tool; edit the canonical copy here, not the copies.
+
+## What JRM Studio is
+
+A family of independent product repositories (`jrm-recipes`, `score-king`, `finance`, and more)
+that share DNA — work practice, AI agents/skills, community-health files, and reusable CI —
+through this backbone repo and `@jrm` npm packages. Products stay independent; the shared layer
+keeps them consistent.
+
+## Golden rules
+
+1. **Never commit secrets.** Real values live only in git-ignored files. In tracked files use
+   `${VARS}` or placeholders (`YOUR_API_KEY_HERE`) and ship a `.env.example`. If you find a
+   secret that would be committed, stop and flag it.
+2. **Issue-first, PR-always.** Every change references an issue and lands as a PR. A task that
+   ends at a local commit is **incomplete**.
+3. **Stay in scope.** Make surgical, intentional edits. Don't reformat or "clean up" unrelated
+   code. Don't work outside the repository root.
+4. **Document decisions.** Non-trivial structural or design choices get an ADR in
+   `docs/architecture/` (or the product's ADR location).
+5. **When unsure, ask.** Prefer a short clarifying question over a guess that touches
+   security, data, or infrastructure.
+
+## Core principles
+
+1. **Privacy first** — treat user data as confidential by default; never log or transmit it in
+   plain text.
+2. **Accessibility** — UI meets WCAG 2.2 AA minimum: semantic elements, screen-reader support,
+   reduced-motion and high-contrast preferences.
+3. **Security** — follow OWASP guidance; validate and sanitize inputs; never hardcode secrets.
+4. **Transparency** — capture significant trade-offs in commit messages and PR descriptions.
+5. **Conventional commits** — `type(scope): description (#N)` (`feat`, `fix`, `docs`, `style`,
+   `refactor`, `test`, `chore`, `ci`, `perf`).
+
+## Definition of Done — not complete until ALL gates pass
+
+| Gate | Verification |
+| --- | --- |
+| **Lint & format** | The repo's lint/format check passes with no errors. |
+| **Type-check** | Static type-check passes (where the stack has one). |
+| **Tests** | Affected unit/integration tests pass. |
+| **Build** | The affected app/package builds. |
+| **PR open & green** | A PR is open against the default branch with CI green. |
+| **No conflicts** | The PR is `MERGEABLE` (not `DIRTY`/`BEHIND`). |
+| **Merged** | The PR is merged once the quality gate passes (unless a documented blocker prevents it). |
+
+Run the repo's own pre-push checks before every push (each product repo documents the exact
+commands). Merge conflicts carry the same weight as red CI — resolve them before merging.
+
+## Issue-First Development
+
+1. Every change references a GitHub issue — create one first if none exists.
+2. Work on a feature branch (or worktree); never commit directly to the default branch.
+3. Commit messages include the issue reference: `type(scope): description (#N)`.
+4. Push your feature branch, then open a PR against the default branch with `Closes #N`.
+5. Verify the PR exists, then monitor CI until it is green **and** the PR is `MERGEABLE`.
+6. Land the work: self-merge your own PR once the quality gate passes. A change left only on a
+   side branch is not done. If a real blocker prevents merge, leave one green, `MERGEABLE` PR
+   with a `## Needs Human Action` note.
+
+## Coding standards
+
+- Write clear, self-documenting code; comment only when intent isn't obvious.
+- Prefer small, focused functions, modules, and PRs.
+- Write tests alongside new code (unit tests for logic; integration tests for I/O and APIs).
+- Use each language's conventional naming; document public APIs.
+
+## What NOT to do
+
+- Do NOT commit secrets, API keys, tokens, or credentials.
+- Do NOT add dependencies without documenting why.
+- Do NOT bypass linters, formatters, or CI checks.
+- Do NOT ship placeholder implementations without a clearly marked `// TODO:`.
+- Do NOT make changes outside the scope of the assigned task.
+
+## Tooling (MCP)
+
+Shared MCP servers are declared in `agency.toml`: `context7` (library docs),
+`playwright` (browser automation), `sequential-thinking`, and `memory`. Product repos may add
+their own.
+
+## Human-Gated Operations (MANDATORY)
+
+These apply to **all** AI tools in every studio repo. Pushing feature branches and creating PRs
+is **required and auto-approved** — stopping at a local commit to ask permission is a workflow
+violation. The operations below, however, require explicit human approval.
+
+**1 — Git remote.** Auto-approved: push/rebase your **own** feature branch, `fetch`,
+`force-with-lease` on your own branch to resolve a rebase/conflict, read-only git.
+Gated/forbidden: pushing to `main`/release branches, plain `git push --force`, force-with-lease
+on shared branches, remote/merge reconfiguration.
+
+**2 — Pull requests.** Auto-approved on **your own** PRs: create, review, request changes,
+merge once the quality gate passes (CI green AND `MERGEABLE`). Gated: merging, approving,
+closing, or dismissing reviews on a PR you did **not** author; merging while CI is red or the PR
+conflicts.
+
+**3 — Remote platform.** Auto-approved: routine triage labels. Gated: closing/reopening/deleting
+issues, changing gating labels (`blocked`, `security`, `breaking-change`), and any repo-settings,
+branch-protection, secrets, deployment, or `gh api` write.
+
+**4 — Outside project boundary.** Never read, write, or execute outside the repository root, and
+never modify system configuration or install global tools.
+
+**5 — Destructive file ops.** No recursive/bulk/wildcard deletion; name each file to remove and
+explain why. Never overwrite a file without reading it first.
+
+**6 — Publishing & distribution.** No `npm publish`, image pushes, store submission, or deploy
+scripts. Prepare the release and hand the final publish to a human.
+
+**7 — Secrets & credentials.** Never create/read real secret files, access OS keychains, generate
+real keys, or echo secret-bearing env vars. Use `.env.example` placeholders.
+
+**8 — Destructive database ops.** No `DROP`/`TRUNCATE`/unqualified `DELETE`/destructive `ALTER`,
+no restores, no pointing connection strings at production. Write reversible migrations for a human
+to review and run.
+
+If a task needs a gated operation: **stop, state what and why, and wait for approval.** Never work
+around these restrictions. If no human is available, complete everything that is auto-approved,
+then leave a clear `## Needs Human Action` note.
+
+## Nested guides
+
+Scope-specific rules live alongside the code — read the relevant one before working in that area:
+
+- Each product repo's root `AGENTS.md` — stack, paths, and product-specific rules.
+- `agents/*.agent.md` — role definitions and boundaries.
+- `skills/<name>/SKILL.md` — reusable task playbooks; read the relevant one before acting.
+- `instructions/*.instructions.md` — path-scoped coding standards.
+<!-- studio:base:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,6 +476,7 @@ These tasks create GitHub issues using the same issue-first workflow as engineer
 
 See `docs/ai/` for complete AI development documentation.
 
+<!-- prettier-ignore-start -->
 <!-- studio:base:start -->
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
 
@@ -617,3 +618,4 @@ Scope-specific rules live alongside the code — read the relevant one before wo
 - `skills/<name>/SKILL.md` — reusable task playbooks; read the relevant one before acting.
 - `instructions/*.instructions.md` — path-scoped coding standards.
 <!-- studio:base:end -->
+<!-- prettier-ignore-end -->

--- a/agency.toml
+++ b/agency.toml
@@ -1,3 +1,4 @@
+# synced from jrmoulckers/.github — canonical source; do not edit here
 [mcps.servers]
 context7 = { args = ["-y", "@upstash/context7-mcp@latest"], command = "npx", tools = ["*"], type = "stdio" }
 playwright = { args = ["-y", "@anthropic/mcp-server-playwright"], command = "npx", tools = ["*"], type = "stdio" }


### PR DESCRIPTION
## Studio canon sync — 2026-08-07

Synced from [`jrmoulckers/.github`](https://github.com/jrmoulckers/.github) by the studio sync tool.

### Added (1)

- `AGENTS.md`

### Updated (1)

- `agency.toml`

### Baselined in lockfile (16)

These files already existed and are byte-identical to canon. Nothing was written to them; they are now tracked in `.studio-sync.lock.json` so later canon changes reach them.

- `apps/web/vendor/@jrm/tokens/css/default/index.css`
- `apps/web/vendor/@jrm/tokens/css/default/tokens-dark-oled.css`
- `apps/web/vendor/@jrm/tokens/css/default/tokens-dark.css`
- `apps/web/vendor/@jrm/tokens/css/default/tokens-high-contrast.css`
- `apps/web/vendor/@jrm/tokens/css/default/tokens.css`
- `apps/web/vendor/@jrm/tokens/js/default/tokens.dark-oled.d.ts`
- `apps/web/vendor/@jrm/tokens/js/default/tokens.dark-oled.js`
- `apps/web/vendor/@jrm/tokens/js/default/tokens.dark.d.ts`
- `apps/web/vendor/@jrm/tokens/js/default/tokens.dark.js`
- `apps/web/vendor/@jrm/tokens/js/default/tokens.high-contrast.d.ts`
- `apps/web/vendor/@jrm/tokens/js/default/tokens.high-contrast.js`
- `apps/web/vendor/@jrm/tokens/js/default/tokens.light.d.ts`
- `apps/web/vendor/@jrm/tokens/js/default/tokens.light.js`
- `apps/web/vendor/@jrm/tokens/js/index.d.ts`
- `apps/web/vendor/@jrm/tokens/js/index.js`
- `apps/web/vendor/@jrm/tokens/tailwind/default.cjs`

---
<sub>Native assets are not copied: community-health files are inherited from the backbone `.github` repo, and reusable workflows are called via `uses: jrmoulckers/.github/.github/workflows/*@main`. Vendored `@jrm/tokens` files under `vendor/@jrm/tokens/` are generated in `jrmoulckers/studio` and carried here by the sync engine — do not hand-edit them.</sub>
