### PR TITLE
fix(sw): pass live backend endpoints through the service worker

### DIFF
--- a/apps/web/src/__tests__/service-worker-lifecycle.test.ts
+++ b/apps/web/src/__tests__/service-worker-lifecycle.test.ts
@@ -152,6 +152,16 @@ describe('Fetch strategy routing (#1330)', () => {
     const url = new URL('/assets/main.js', 'https://example.com');
     expect(STATIC_EXTENSIONS.test(url.pathname)).toBe(true);
   });
+
+  it('live backend endpoints (PowerSync + Supabase) bypass the SW via passthrough', () => {
+    // PowerSync sync service — the streaming POST that must never be cached.
+    expect(getFetchStrategyForPathname('/sync/stream')).toBe('passthrough');
+    expect(getFetchStrategyForPathname('/sync/probes/liveness')).toBe('passthrough');
+    // Supabase edge: PostgREST, GoTrue, and Edge Functions.
+    expect(getFetchStrategyForPathname('/rest/v1/accounts')).toBe('passthrough');
+    expect(getFetchStrategyForPathname('/auth/v1/token')).toBe('passthrough');
+    expect(getFetchStrategyForPathname('/functions/v1/bank-webhook')).toBe('passthrough');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/sw/__tests__/service-worker-wasm-cache-poisoning.test.ts
+++ b/apps/web/src/sw/__tests__/service-worker-wasm-cache-poisoning.test.ts
@@ -124,4 +124,19 @@ describe('cacheFirst (SQLite-WASM cache-poisoning guard, #3091)', () => {
     // A non-asset path is outside the guard, so normal caching still applies.
     expect(mockCache.put).toHaveBeenCalledTimes(1);
   });
+
+  it('bypasses the Cache API entirely for a non-GET request', async () => {
+    // The Cache API only supports GET; routing a non-GET (e.g. PowerSync's
+    // streaming POST /sync/stream) through the caching path would throw on
+    // cache.put() and be swallowed into a bogus "Offline" 503.
+    const netResponse = new Response('ok', { status: 200 });
+    globalThis.fetch = vi.fn().mockResolvedValue(netResponse);
+
+    const result = await cacheFirst(new Request(WASM_URL, { method: 'POST' }));
+
+    expect(result).toBe(netResponse);
+    expect(openMock).not.toHaveBeenCalled();
+    expect(mockCache.match).not.toHaveBeenCalled();
+    expect(mockCache.put).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/sw/service-worker.ts
+++ b/apps/web/src/sw/service-worker.ts
@@ -528,6 +528,12 @@ self.addEventListener('fetch', (event: FetchEvent) => {
     case 'navigation':
       event.respondWith(navigationHandler(request));
       return;
+    case 'passthrough':
+      // Deliberately do NOT call event.respondWith(): let the browser handle
+      // the request natively so streaming/authenticated backend responses
+      // (e.g. PowerSync's long-lived `POST /sync/stream`) are never buffered,
+      // cached, or wrapped by the service worker.
+      return;
   }
 });
 
@@ -662,6 +668,14 @@ function isHtmlForStaticAsset(request: Request, response: Response): boolean {
  * on read so the cache self-heals without a CACHE_VERSION bump.
  */
 export async function cacheFirst(request: Request, fallbackUrl?: string): Promise<Response> {
+  // The Cache API only supports GET; cache.match()/cache.put() throw on other
+  // methods. Never run the caching path for a non-GET request — otherwise a
+  // *successful* non-GET response is discarded by the catch below and surfaced
+  // as a bogus "Offline -- resource not cached" 503.
+  if (request.method !== 'GET') {
+    return fetch(request);
+  }
+
   const cache = await caches.open(STATIC_CACHE);
 
   const cached = await cache.match(request);
@@ -805,8 +819,35 @@ function isStaticAsset(pathname: string): boolean {
   return STATIC_EXTENSIONS.test(pathname);
 }
 
+/**
+ * Live backend endpoints that must bypass the service worker entirely.
+ *
+ * Covers the PowerSync sync service (`/sync/*` — notably the long-lived
+ * streaming `POST /sync/stream`) and the Supabase edge: PostgREST (`/rest/*`),
+ * GoTrue (`/auth/*`) and Edge Functions (`/functions/*`). These responses are
+ * authenticated, non-cacheable, and frequently non-GET/streaming. Routing them
+ * through any cache strategy calls `cache.put()`, which throws on a non-GET
+ * request; the error is swallowed and surfaced as a bogus
+ * "Offline -- resource not cached" 503, masking a *successful* response as an
+ * offline failure. They must hit the network natively instead.
+ */
+function isLiveBackendPath(pathname: string): boolean {
+  return (
+    pathname === '/sync' ||
+    pathname.startsWith('/sync/') ||
+    pathname.startsWith('/rest/') ||
+    pathname.startsWith('/auth/') ||
+    pathname.startsWith('/functions/')
+  );
+}
+
 export type FetchStrategy =
-  'receipt-cache-first' | 'network-first' | 'network-only-no-store' | 'cache-first' | 'navigation';
+  | 'receipt-cache-first'
+  | 'network-first'
+  | 'network-only-no-store'
+  | 'cache-first'
+  | 'navigation'
+  | 'passthrough';
 
 export function getFetchStrategyForPathname(
   pathname: string,
@@ -814,6 +855,12 @@ export function getFetchStrategyForPathname(
 ): FetchStrategy {
   if (isReceiptImagePath(pathname)) {
     return 'receipt-cache-first';
+  }
+
+  // Live backend endpoints (PowerSync + Supabase) must never be intercepted or
+  // cached — pass them straight to the network. See isLiveBackendPath.
+  if (isLiveBackendPath(pathname)) {
+    return 'passthrough';
   }
 
   if (pathname.startsWith('/api/sync/')) {


### PR DESCRIPTION
## Problem

After the JWT `aud` alignment let PowerSync return **200** instead of 401, sync still failed in the browser with a repeating console error:

```
[PowerSync]: Could not POST streaming to /sync/stream - 503 - Service Unavailable: Offline -- resource not cached
```

`Offline -- resource not cached` is **our service worker's** response, not PowerSync's. The server was healthy the whole time.

## Root cause

`getFetchStrategyForPathname()` only special-cases `/api/sync/*` (network-first) and `/api/*` (network-only-no-store). Everything else falls through to the default **`cache-first`**.

PowerSync posts to **`/sync/stream`** — no `/api` prefix — so it was routed to `cacheFirst()`. On a **successful** network response, `cacheFirst` runs `await cache.put(request, response.clone())`. The **Cache API rejects non-GET requests** (`cache.put` throws `Request method 'POST' is unsupported`), the bare `catch` swallows it, and returns a fabricated `503 Offline -- resource not cached`.

Before the `aud` fix, PowerSync returned 401 → `!response.ok` → `cache.put` was skipped → the real error passed through. Fixing `aud` (200 response) is what *revealed* this latent bug. The same trap affects every non-`/api` authenticated backend: `/rest/*` (PostgREST writes), `/auth/*` (GoTrue), `/functions/*` (edge functions) — their non-GET requests would also hit the throwing `cache.put` and could cache sensitive responses.

## Fix

- Add a **`passthrough`** `FetchStrategy`: in the fetch handler we simply `return` without calling `event.respondWith()`, so the browser handles the request natively. This is the correct pattern for long-lived streaming POSTs.
- Route live backend paths — `/sync`, `/sync/*`, `/rest/*`, `/auth/*`, `/functions/*` — to `passthrough` via `isLiveBackendPath()`. `/storage/*` is intentionally **excluded** so receipt-image caching is unaffected.
- Defensive guard at the top of `cacheFirst`: `if (request.method !== 'GET') return fetch(request);` — the Cache API only supports GET.

## Tests

- `service-worker-lifecycle.test.ts`: assert `/sync/stream`, `/sync/probes/liveness`, `/rest/v1/*`, `/auth/v1/token`, `/functions/v1/*` → `passthrough`. Existing `/api/*` and static-asset assertions unchanged.
- `service-worker-wasm-cache-poisoning.test.ts`: assert `cacheFirst` bypasses the Cache API entirely for a non-GET request (no `open`/`match`/`put`).

## Validation

- `npx vitest run` on both SW test files: **41 passed**
- `tsc -b`: exit 0 · `eslint --max-warnings 0`: clean · `prettier --check`: clean

## Deploy note

This is an `apps/web` change, so the production **web** deploy jobs will run (no path-filter skip). After merge + deploy, the updated service worker reaches the browser on next load (one extra reload or a "clear site data" may be needed once). Then `/sync/stream` connects with no 503 → the "must be household owner" 403 clears → Connect a bank (Plaid sandbox).
