### PR TITLE
fix(security): bump js-yaml override to >=4.3.1 to clear high advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7472,9 +7472,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@redocly/cli": "2.34.0",
     "@babel/core": "7.29.6",
     "esbuild": "0.28.1",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "read-yaml-file": "^2.1.0",
     "fast-uri": ">=3.1.5 <4.0.0",
     "jsdom": {


### PR DESCRIPTION
## Problem

A newly-published high-severity advisory — **CVE-2026-59870** ([GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj)), *"Quadratic CPU consumption in !!omap resolution"* — flags **js-yaml >=4.0.0 <4.3.1**. Our root `overrides` pinned `js-yaml: ^4.3.0`, which resolves to the still-vulnerable **4.3.0**.

As a result `npm audit --audit-level=high` fails **repo-wide**, which aggregates into the `Required Checks Gatekeeper` and blocks **every open PR** from merging.

## Fix

Bump the override to `^4.3.1` — the first patched release (published as the `v4-legacy` dist-tag for exactly this back-port). Fully surgical: the lockfile changes **only** the js-yaml entry (`4.3.0` -> `4.3.1` + integrity). js-yaml is a dev/tooling dependency, so there is no runtime impact.

## Validation

- `npm audit --audit-level=high`: **0 vulnerabilities** (was 1 high)
- Lockfile regenerated with npm 10.9.3 (CI parity); diff is js-yaml-only

Standalone security unblock (same pattern as #3991); no app-code changes.