### PR TITLE
ci(workflows): rename local reusable-smoke-test.yml to avoid canon name collision (jrmoulckers/.github#60)

### DIFF
--- a/.github/workflows/rc-branch-tag.yml
+++ b/.github/workflows/rc-branch-tag.yml
@@ -216,7 +216,7 @@ jobs:
     name: RC Smoke Tests
     needs: create-rc
     if: inputs.skip_smoke_tests != true
-    uses: ./.github/workflows/reusable-smoke-test.yml
+    uses: ./.github/workflows/reusable-release-smoke-test.yml
     with:
       version: ${{ needs.create-rc.outputs.rc_version }}
       platforms: 'android,ios,web,windows'

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -423,7 +423,7 @@ jobs:
       needs.prepare.outputs.is_dry_run != 'true' &&
       github.event.inputs.skip_smoke_tests != 'true' &&
       github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-smoke-test.yml
+    uses: ./.github/workflows/reusable-release-smoke-test.yml
     with:
       version: ${{ needs.prepare.outputs.next_version }}
       platforms: 'android,ios,web,windows'

--- a/.github/workflows/reusable-release-smoke-test.yml
+++ b/.github/workflows/reusable-release-smoke-test.yml
@@ -1,16 +1,25 @@
 # =============================================================================
-# Reusable Smoke Test — Pre-release validation for all platforms
+# Reusable Release Smoke Test — Pre-release validation for all platforms
 # =============================================================================
 #
 # Runs quick sanity checks against built artifacts to verify they are functional
 # before promoting to production or advancing a staged rollout.
 #
-# Called by: rc-branch-tag.yml, deploy-progressive.yml, release-train.yml
+# This is a Finance-local reusable workflow (multi-platform: android/ios/web/
+# windows) and is intentionally NOT the canon `reusable-smoke-test.yml` defined
+# in jrmoulckers/.github (a generic single-job web-only smoke test). It was
+# renamed from `reusable-smoke-test.yml` to `reusable-release-smoke-test.yml`
+# to remove an accidental filename collision with that canon workflow — see
+# jrmoulckers/.github#60. Finance calls this file only via a relative
+# `uses: ./.github/workflows/...` path and does not consume the backbone
+# version under either name.
 #
-# Issue: #1147
+# Called by: rc-branch-tag.yml, release-train.yml
+#
+# Issue: #1147, jrmoulckers/.github#60
 # =============================================================================
 
-name: Reusable Smoke Test
+name: Reusable Release Smoke Test
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary

Finance defined its own multi-platform `.github/workflows/reusable-smoke-test.yml` (275 lines: android/ios/web/windows release-artifact smoke tests) that collided in **filename only** with the backbone canon workflow of the same name in `jrmoulckers/.github` (154 lines: a generic single-job web-only smoke test with npm/pnpm support). The two files are unrelated in content; Finance's file is renamed here to remove the collision.

## Evidence

- **Provenance**: Finance's `reusable-smoke-test.yml` was authored from scratch in a single commit, `chore(devops): v2.0 release pipeline and artifact preparation (#1147)` (2e5bb5e9) - `275 insertions(+)`, no prior history, no sync/copy markers. It was never touched by any canon-sync tooling.
- **Content**: canon's version is a single `web` job (npm/pnpm install, build, test, optional HTTP health check) behind `permissions: contents: read`. Finance's version is four parallel platform jobs (Android Gradle unit/lint/APK, iOS xcodebuild, Web Vite build/test/bundle-size, Windows Gradle build/test) plus a results table - a shape canon's workflow cannot produce with any input combination. The only shared idiom is the generic "summary job reads needs.*.result" pattern, which is common CI boilerplate, not shared code.
- **Callers**: both Finance callers (`rc-branch-tag.yml`, `release-train.yml`) invoke it via a **relative** `uses: ./.github/workflows/reusable-smoke-test.yml` path. A repo-wide search confirms **zero** occurrences of `jrmoulckers/.github` anywhere under `.github/` in this repo - Finance does not call any backbone reusable workflow under any name today.

**Conclusion**: this is a genuinely independent, Finance-local workflow that happened to take a canon filename (issue resolution option 1), not a stale fork of canon (option 2).

## Changes

- Renamed `.github/workflows/reusable-smoke-test.yml` -> `.github/workflows/reusable-release-smoke-test.yml` (keeps the repo's `reusable-*.yml` naming convention while removing the collision) and documented the rationale + issue link in the file header.
- Updated the two relative callers, `rc-branch-tag.yml` and `release-train.yml`, to the new filename.

## Backbone follow-up (reported, not made here - out of scope for this repo)

`jrmoulckers/.github`'s `studio.config.json` registry lists, for `jrmoulckers/finance`:

```
"optIn": { ..., "workflows": ["reusable-ci-lint", "reusable-smoke-test"] }
```

Since Finance calls **no** backbone reusable workflow under either name (confirmed via the repo-wide search above), both entries are stale opt-ins with no effect. `reusable-smoke-test` in particular should be dropped from `jrmoulckers/finance`'s `optIn.workflows` list in `jrmoulckers/.github` to stop recording an opt-in to a workflow whose name Finance has independently taken for a different file. This requires an edit in `jrmoulckers/.github` and is reported here rather than made, per file-ownership boundaries.

## Testing

- [x] YAML parses (`npx js-yaml` on all 3 changed files)
- [x] `npx prettier --check` on all 3 changed files - pass
- [x] `npx eslint . --max-warnings 0` (full repo) - pass
- [x] `node tools/agent-scripts/pre-push-check.js` - pass (Prettier + ESLint)
- [x] Confirmed no remaining references to the old filename anywhere in the repo (`git grep -rn reusable-smoke-test`) outside a pre-existing, out-of-scope `docs/ops/secrets.md` mention (owned by @docs-writer; that doc is already stale against several other current workflow filenames and is not touched by this PR)

Resolves jrmoulckers/.github#60
