### PR TITLE
fix(bank): preserve creator access during membership sync

### DIFF
--- a/.github/workflows/ops-prod-db-recovery.yml
+++ b/.github/workflows/ops-prod-db-recovery.yml
@@ -106,6 +106,17 @@ jobs:
                   echo "=== kernel OOM / killed (last 20) ==="; sudo dmesg </dev/null 2>&1 | grep -iE "oom|killed process|out of memory" | tail -20 || echo "(none)"
                 fi
                 echo "=== db logs (timeout 25, tail 120) ==="; timeout 25 $DC logs db --tail=120 --no-color </dev/null 2>&1 || echo "(db logs timed out/failed)"
+                echo "=== edge-functions bank env presence (values redacted) ==="
+                timeout 20 $DC exec -T edge-functions sh -c '
+                  for key in PLAID_CLIENT_ID PLAID_SECRET PLAID_ENVIRONMENT PLAID_WEBHOOK_URL BANK_ENCRYPTION_KEY MX_WEBHOOK_SECRET; do
+                    eval "value=\${$key:-}"
+                    if [ -n "$value" ]; then echo "$key=<set>"; else echo "$key=<missing>"; fi
+                  done
+                ' </dev/null 2>&1 || echo "(edge-functions env probe timed out/failed)"
+                echo "=== edge-functions logs (timeout 25, tail 160) ==="
+                timeout 25 $DC logs edge-functions --tail=160 --no-color </dev/null 2>&1 \
+                  | sed -E 's/(access_token|public_token|client_id|secret|authorization)(["=: ]+)[^", }]+/\1\2<redacted>/Ig' \
+                  || echo "(edge-functions logs timed out/failed)"
                 ;;
               up)
                 echo "=== docker compose up -d (timeout 180) ==="; timeout 180 $DC up -d </dev/null 2>&1 || echo "(up timed out/failed)"

--- a/services/api/supabase/functions/_shared/bank-authorization.test.ts
+++ b/services/api/supabase/functions/_shared/bank-authorization.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
+import { assertEquals, assertRejects } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+
+import { canManageHousehold } from './bank-authorization.ts';
+
+interface QueryResult {
+  data: { id: string } | null;
+  error: Error | null;
+}
+
+function clientWithResults(results: Record<string, QueryResult>): SupabaseClient {
+  return {
+    from(table: string) {
+      const query = {
+        select: () => query,
+        eq: () => query,
+        is: () => query,
+        in: () => query,
+        maybeSingle: () => Promise.resolve(results[table]),
+      };
+      return query;
+    },
+  } as unknown as SupabaseClient;
+}
+
+Deno.test('bank management allows an owner/admin membership', async () => {
+  const client = clientWithResults({
+    household_members: { data: { id: 'member-1' }, error: null },
+  });
+
+  assertEquals(await canManageHousehold(client, 'household-1', 'user-1'), true);
+});
+
+Deno.test(
+  'bank management allows the household creator while membership upload is pending',
+  async () => {
+    const client = clientWithResults({
+      household_members: { data: null, error: null },
+      households: { data: { id: 'household-1' }, error: null },
+    });
+
+    assertEquals(await canManageHousehold(client, 'household-1', 'user-1'), true);
+  },
+);
+
+Deno.test('bank management denies a user with neither membership nor ownership', async () => {
+  const client = clientWithResults({
+    household_members: { data: null, error: null },
+    households: { data: null, error: null },
+  });
+
+  assertEquals(await canManageHousehold(client, 'household-1', 'user-2'), false);
+});
+
+Deno.test(
+  'bank management propagates database errors instead of mislabeling them 403',
+  async () => {
+    const client = clientWithResults({
+      household_members: { data: null, error: new Error('database unavailable') },
+    });
+
+    await assertRejects(
+      () => canManageHousehold(client, 'household-1', 'user-1'),
+      Error,
+      'database unavailable',
+    );
+  },
+);

--- a/services/api/supabase/functions/_shared/bank-authorization.ts
+++ b/services/api/supabase/functions/_shared/bank-authorization.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
+
+/**
+ * Check whether a user can manage a household's bank connections.
+ *
+ * Membership is the normal authorization path. The `created_by` fallback
+ * preserves owner access while a newly-created local household membership is
+ * still waiting for PowerSync to upload. It cannot grant access to another
+ * user's household because both the household id and authenticated user id must
+ * match the server row.
+ */
+export async function canManageHousehold(
+  supabase: SupabaseClient,
+  householdId: string,
+  userId: string,
+): Promise<boolean> {
+  const { data: membership, error: membershipError } = await supabase
+    .from('household_members')
+    .select('id')
+    .eq('household_id', householdId)
+    .eq('user_id', userId)
+    .is('deleted_at', null)
+    .in('role', ['owner', 'admin'])
+    .maybeSingle();
+
+  if (membershipError) throw membershipError;
+  if (membership) return true;
+
+  const { data: ownedHousehold, error: householdError } = await supabase
+    .from('households')
+    .select('id')
+    .eq('id', householdId)
+    .eq('created_by', userId)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (householdError) throw householdError;
+  return ownedHousehold !== null;
+}

--- a/services/api/supabase/functions/bank-connection/index.ts
+++ b/services/api/supabase/functions/bank-connection/index.ts
@@ -44,6 +44,7 @@ import { validateEnv } from '../_shared/env.ts';
 import { createLogger } from '../_shared/logger.ts';
 import { checkRateLimit, rateLimitResponse, RATE_LIMITS } from '../_shared/rate-limit.ts';
 import { encryptToken } from '../_shared/bank-crypto.ts';
+import { canManageHousehold } from '../_shared/bank-authorization.ts';
 import {
   createLinkToken as plaidCreateLinkToken,
   exchangePublicToken as plaidExchangePublicToken,
@@ -351,17 +352,7 @@ serve(async (req: Request): Promise<Response> => {
         return errorResponse(req, 'household_id is required');
       }
 
-      // Verify household membership
-      const { data: membership, error: memError } = await supabase
-        .from('household_members')
-        .select('id, role')
-        .eq('household_id', body.household_id)
-        .eq('user_id', user.id)
-        .is('deleted_at', null)
-        .in('role', ['owner', 'admin'])
-        .single();
-
-      if (memError || !membership) {
+      if (!(await canManageHousehold(supabase, body.household_id, user.id))) {
         return errorResponse(
           req,
           'Only household owners and admins can manage bank connections',
@@ -411,17 +402,7 @@ serve(async (req: Request): Promise<Response> => {
       if (!body.institution_id) return errorResponse(req, 'institution_id is required');
       if (!body.institution_name) return errorResponse(req, 'institution_name is required');
 
-      // Verify household membership
-      const { data: membership, error: memError } = await supabase
-        .from('household_members')
-        .select('id, role')
-        .eq('household_id', body.household_id)
-        .eq('user_id', user.id)
-        .is('deleted_at', null)
-        .in('role', ['owner', 'admin'])
-        .single();
-
-      if (memError || !membership) {
+      if (!(await canManageHousehold(supabase, body.household_id, user.id))) {
         return errorResponse(
           req,
           'Only household owners and admins can manage bank connections',
@@ -594,16 +575,7 @@ serve(async (req: Request): Promise<Response> => {
         return errorResponse(req, 'Bank connection not found', 404);
       }
 
-      const { data: membership, error: memError } = await supabase
-        .from('household_members')
-        .select('id, role')
-        .eq('household_id', existing.household_id)
-        .eq('user_id', user.id)
-        .is('deleted_at', null)
-        .in('role', ['owner', 'admin'])
-        .single();
-
-      if (memError || !membership) {
+      if (!(await canManageHousehold(supabase, existing.household_id, user.id))) {
         return errorResponse(
           req,
           'Only household owners and admins can manage bank connections',


### PR DESCRIPTION
## Problem

Production bank connection currently alternates between:

- **403** Only household owners and admins can manage bank connections
- **502** provider unavailable

The 403 is caused by a real consistency race: the UI creates/backfills households and household_members locally, then immediately calls the edge function while PowerSync uploads those rows asynchronously. Authorization only checked the membership row, so the authenticated household creator could be rejected until upload completed (or indefinitely while sync was degraded).

The 502 is a separate Plaid API failure. Production already forwards the provisioned Plaid variables into edge-runtime, and ank-connection logs Plaid's safe rror_code, but the production diagnostic only collected DB logs — so the actionable provider rejection was invisible.

## Fix

- Centralize bank management authorization in canManageHousehold.
- Keep explicit active owner/dmin membership as the primary path.
- If membership is not present yet, allow only when the server-side household row proves created_by = auth.uid().
- Propagate database errors so outages are not mislabeled as authorization failures.
- Reuse the helper for link-token creation, token exchange, and disconnect.
- Extend ops-prod-db-recovery diagnose output with:
  - required bank env **presence only** (<set>/<missing>; never values)
  - recent edge-function logs with defense-in-depth credential/token redaction

## Security

The fallback does not trust client claims: both household ID and authenticated user ID must match the existing server households.created_by row. It cannot authorize another user's household.

## Validation

- 20 focused Deno tests passed (existing bank-connection suite + 4 new authorization cases)
- New cases cover membership, creator fallback, unrelated-user denial, and DB-error propagation
- Prettier clean
- Workflow YAML parsed with repo's installed js-yaml
- Diff whitespace clean

## After merge

Run Ops — Production DB recovery with diagnose immediately to retrieve Plaid's safe error code for the remaining 502, then fix the provider configuration based on that exact result.