### PR TITLE
fix(bank): provision missing server household on connect

### DIFF
--- a/services/api/supabase/functions/_shared/bank-authorization.test.ts
+++ b/services/api/supabase/functions/_shared/bank-authorization.test.ts
@@ -3,66 +3,150 @@
 import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
 import { assertEquals, assertRejects } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
 
-import { canManageHousehold } from './bank-authorization.ts';
+import { ensureCanManageHousehold } from './bank-authorization.ts';
 
 interface QueryResult {
-  data: { id: string } | null;
+  data: Record<string, string> | null;
   error: Error | null;
 }
 
-function clientWithResults(results: Record<string, QueryResult>): SupabaseClient {
-  return {
+interface UpsertRecord {
+  table: string;
+  value: Record<string, string>;
+  options: { onConflict: string; ignoreDuplicates: boolean };
+}
+
+function clientWithResults(
+  results: Record<string, QueryResult | QueryResult[]>,
+  upsertError: Error | null = null,
+): { client: SupabaseClient; upserts: UpsertRecord[] } {
+  const upserts: UpsertRecord[] = [];
+  const client = {
     from(table: string) {
       const query = {
         select: () => query,
         eq: () => query,
         is: () => query,
         in: () => query,
-        maybeSingle: () => Promise.resolve(results[table]),
+        maybeSingle: () => {
+          const result = results[table];
+          return Promise.resolve(Array.isArray(result) ? result.shift() : result);
+        },
+        upsert: (
+          value: Record<string, string>,
+          options: { onConflict: string; ignoreDuplicates: boolean },
+        ) => {
+          upserts.push({ table, value, options });
+          return Promise.resolve({ error: upsertError });
+        },
       };
       return query;
     },
   } as unknown as SupabaseClient;
+  return { client, upserts };
 }
 
-Deno.test('bank management allows an owner/admin membership', async () => {
-  const client = clientWithResults({
+Deno.test('bank management allows an owner/admin membership without writes', async () => {
+  const { client, upserts } = clientWithResults({
     household_members: { data: { id: 'member-1' }, error: null },
   });
 
-  assertEquals(await canManageHousehold(client, 'household-1', 'user-1'), true);
+  assertEquals(await ensureCanManageHousehold(client, 'household-1', 'user-1'), true);
+  assertEquals(upserts, []);
 });
 
 Deno.test(
-  'bank management allows the household creator while membership upload is pending',
+  'bank management allows the household creator without synthesizing membership',
   async () => {
-    const client = clientWithResults({
+    const { client, upserts } = clientWithResults({
       household_members: { data: null, error: null },
-      households: { data: { id: 'household-1' }, error: null },
+      households: { data: { id: 'household-1', created_by: 'user-1' }, error: null },
     });
 
-    assertEquals(await canManageHousehold(client, 'household-1', 'user-1'), true);
+    assertEquals(await ensureCanManageHousehold(client, 'household-1', 'user-1'), true);
+    assertEquals(upserts, []);
   },
 );
 
-Deno.test('bank management denies a user with neither membership nor ownership', async () => {
-  const client = clientWithResults({
+Deno.test(
+  'link-token creation provisions the authenticated user missing server household',
+  async () => {
+    const { client, upserts } = clientWithResults({
+      household_members: { data: null, error: null },
+      households: [
+        { data: null, error: null },
+        { data: { id: 'household-1', created_by: 'user-1' }, error: null },
+      ],
+    });
+
+    assertEquals(
+      await ensureCanManageHousehold(client, 'household-1', 'user-1', {
+        provisionIfMissing: true,
+      }),
+      true,
+    );
+    assertEquals(upserts, [
+      {
+        table: 'households',
+        value: { id: 'household-1', name: 'My Household', created_by: 'user-1' },
+        options: { onConflict: 'id', ignoreDuplicates: true },
+      },
+    ]);
+  },
+);
+
+Deno.test('bank management does not provision a missing household by default', async () => {
+  const { client, upserts } = clientWithResults({
     household_members: { data: null, error: null },
     households: { data: null, error: null },
   });
 
-  assertEquals(await canManageHousehold(client, 'household-1', 'user-2'), false);
+  assertEquals(await ensureCanManageHousehold(client, 'household-1', 'user-1'), false);
+  assertEquals(upserts, []);
+});
+
+Deno.test('bank management denies and does not modify another user household', async () => {
+  const { client, upserts } = clientWithResults({
+    household_members: { data: null, error: null },
+    households: { data: { id: 'household-1', created_by: 'user-1' }, error: null },
+  });
+
+  assertEquals(
+    await ensureCanManageHousehold(client, 'household-1', 'user-2', {
+      provisionIfMissing: true,
+    }),
+    false,
+  );
+  assertEquals(upserts, []);
+});
+
+Deno.test('bank management denies when another user wins the provisioning race', async () => {
+  const { client, upserts } = clientWithResults({
+    household_members: { data: null, error: null },
+    households: [
+      { data: null, error: null },
+      { data: { id: 'household-1', created_by: 'user-2' }, error: null },
+    ],
+  });
+
+  assertEquals(
+    await ensureCanManageHousehold(client, 'household-1', 'user-1', {
+      provisionIfMissing: true,
+    }),
+    false,
+  );
+  assertEquals(upserts.length, 1);
 });
 
 Deno.test(
   'bank management propagates database errors instead of mislabeling them 403',
   async () => {
-    const client = clientWithResults({
+    const { client } = clientWithResults({
       household_members: { data: null, error: new Error('database unavailable') },
     });
 
     await assertRejects(
-      () => canManageHousehold(client, 'household-1', 'user-1'),
+      () => ensureCanManageHousehold(client, 'household-1', 'user-1'),
       Error,
       'database unavailable',
     );

--- a/services/api/supabase/functions/_shared/bank-authorization.ts
+++ b/services/api/supabase/functions/_shared/bank-authorization.ts
@@ -3,18 +3,21 @@
 import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
 
 /**
- * Check whether a user can manage a household's bank connections.
+ * Ensure a user can manage a household's bank connections.
  *
  * Membership is the normal authorization path. The `created_by` fallback
- * preserves owner access while a newly-created local household membership is
- * still waiting for PowerSync to upload. It cannot grant access to another
- * user's household because both the household id and authenticated user id must
- * match the server row.
+ * preserves owner access while PowerSync is still uploading the membership.
+ * Link-token creation may also provision a missing server household that
+ * already exists in the authenticated user's local database. The membership is
+ * deliberately left to PowerSync because its local row has a client-generated
+ * id; synthesizing a second server row would violate the unique active-member
+ * constraint when the queued row uploads.
  */
-export async function canManageHousehold(
+export async function ensureCanManageHousehold(
   supabase: SupabaseClient,
   householdId: string,
   userId: string,
+  options: { provisionIfMissing?: boolean } = {},
 ): Promise<boolean> {
   const { data: membership, error: membershipError } = await supabase
     .from('household_members')
@@ -28,14 +31,36 @@ export async function canManageHousehold(
   if (membershipError) throw membershipError;
   if (membership) return true;
 
-  const { data: ownedHousehold, error: householdError } = await supabase
+  const { data: household, error: householdError } = await supabase
     .from('households')
-    .select('id')
+    .select('id, created_by')
     .eq('id', householdId)
-    .eq('created_by', userId)
     .is('deleted_at', null)
     .maybeSingle();
 
   if (householdError) throw householdError;
-  return ownedHousehold !== null;
+  if (household && household.created_by !== userId) return false;
+
+  if (household) return true;
+  if (!options.provisionIfMissing) return false;
+
+  const { error: createError } = await supabase
+    .from('households')
+    .upsert(
+      { id: householdId, name: 'My Household', created_by: userId },
+      { onConflict: 'id', ignoreDuplicates: true },
+    );
+  if (createError) throw createError;
+
+  // Re-read after the conflict-safe insert. If PowerSync or another request won
+  // the race, authorize only when that existing row belongs to this user.
+  const { data: provisionedHousehold, error: provisionError } = await supabase
+    .from('households')
+    .select('id, created_by')
+    .eq('id', householdId)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (provisionError) throw provisionError;
+  return provisionedHousehold?.created_by === userId;
 }

--- a/services/api/supabase/functions/bank-connection/index.ts
+++ b/services/api/supabase/functions/bank-connection/index.ts
@@ -44,7 +44,7 @@ import { validateEnv } from '../_shared/env.ts';
 import { createLogger } from '../_shared/logger.ts';
 import { checkRateLimit, rateLimitResponse, RATE_LIMITS } from '../_shared/rate-limit.ts';
 import { encryptToken } from '../_shared/bank-crypto.ts';
-import { canManageHousehold } from '../_shared/bank-authorization.ts';
+import { ensureCanManageHousehold } from '../_shared/bank-authorization.ts';
 import {
   createLinkToken as plaidCreateLinkToken,
   exchangePublicToken as plaidExchangePublicToken,
@@ -352,7 +352,11 @@ serve(async (req: Request): Promise<Response> => {
         return errorResponse(req, 'household_id is required');
       }
 
-      if (!(await canManageHousehold(supabase, body.household_id, user.id))) {
+      if (
+        !(await ensureCanManageHousehold(supabase, body.household_id, user.id, {
+          provisionIfMissing: true,
+        }))
+      ) {
         return errorResponse(
           req,
           'Only household owners and admins can manage bank connections',
@@ -402,7 +406,7 @@ serve(async (req: Request): Promise<Response> => {
       if (!body.institution_id) return errorResponse(req, 'institution_id is required');
       if (!body.institution_name) return errorResponse(req, 'institution_name is required');
 
-      if (!(await canManageHousehold(supabase, body.household_id, user.id))) {
+      if (!(await ensureCanManageHousehold(supabase, body.household_id, user.id))) {
         return errorResponse(
           req,
           'Only household owners and admins can manage bank connections',
@@ -575,7 +579,7 @@ serve(async (req: Request): Promise<Response> => {
         return errorResponse(req, 'Bank connection not found', 404);
       }
 
-      if (!(await canManageHousehold(supabase, existing.household_id, user.id))) {
+      if (!(await ensureCanManageHousehold(supabase, existing.household_id, user.id))) {
         return errorResponse(
           req,
           'Only household owners and admins can manage bank connections',


### PR DESCRIPTION
## Problem

After #4002 deployed, a fresh production attempt still returned 403. The enhanced diagnostics showed the request reached the correct ank-connection function, while the secure creator fallback also failed. Therefore **neither** the local household nor membership had reached Postgres; there was no server row on which to prove ownership.

## Fix

For **create_link_token only**, when no active owner/admin membership and no household row exists:

1. Conflict-safely upsert the requested household ID with created_by = auth.uid() and ignoreDuplicates: true.
2. Re-read the row and authorize only if its server-side created_by matches the authenticated user.
3. Do **not** synthesize membership: PowerSync owns that queued row and its client-generated UUID. A second server membership would collide with the unique active (household_id,user_id) constraint.

Existing households owned by another user are never updated or authorized. Exchange and disconnect cannot provision; they still require existing authorization.

## Concurrency

If PowerSync creates the household between lookup and upsert, ignoreDuplicates avoids a false 500. The mandatory re-read ensures a concurrent row is trusted only when its owner is the authenticated user.

## Validation

- 23 focused Deno tests passed
- 7 authorization tests cover membership, creator fallback, missing provisioning, default deny, other-owner denial, concurrent race loser, and DB errors
- Prettier and diff checks clean
- Independent final code review: no findings