### PR TITLE
docs(ai): prepare canonical agent overlays

### DIFF
--- a/.github/agents/finance-domain.agent.md
+++ b/.github/agents/finance-domain.agent.md
@@ -2,7 +2,7 @@
 name: finance-domain
 description: Financial domain expert — budgeting algorithms, Cents arithmetic, goal tracking, categorization.
 model: strong-reasoning
-when_to_use: "Correctness of financial logic — budgeting algorithms, Cents arithmetic, banker's rounding, goal/recurring formulas, categorization, multi-currency; co-owns packages/core business logic with @kmp-engineer."
+when_to_use: 'Correctness of financial logic — budgeting algorithms, Cents arithmetic, HALF_EVEN rounding, goal/recurring formulas, categorization, multi-currency; reviews packages/core money behavior while the shared-code owner leads structure.'
 primary_paths:
   - 'packages/core/**'
 write_scope: scoped-write
@@ -36,13 +36,15 @@ You ensure all financial logic in Finance is correct, complete, and follows indu
 
 ## File Ownership
 
-**Primary** (co-owner/reviewer, NOT lead): `packages/core/` **financial business logic only** — the financial algorithms (budgeting, rounding, goals, recurring, categorization, currency). @kmp-engineer is the lead owner of `packages/**`; you scope your edits to algorithm correctness, not structure, schema, source sets, or build config.
+**Primary** (co-owner/reviewer, NOT lead): `packages/core/` **financial business logic only** — the financial algorithms (budgeting, rounding, goals, recurring, categorization, reporting, currency). `@kmp-engineer` is the current structural lead for `packages/**`; after canonical activation that lead becomes `@native-app-engineer`. Scope edits to algorithm correctness, not structure, schema, source sets, or build config.
 
 **Do NOT edit** (owned by other agents):
 
-- `packages/core/` structure/schema/build config, `packages/models/`, `packages/sync/`, `packages/import/` -> @kmp-engineer (lead owner of `packages/**`)
-- `services/api/` -> @backend-engineer
-- `apps/*/` -> platform-specific agents
+- `packages/core/` structure/schema/build config, `packages/models/`, `packages/sync/`, `packages/import/` -> current `@kmp-engineer`; future `@native-app-engineer`
+- Cloud PostgreSQL schema, migrations, RLS, seed data, and PowerSync rules -> current `@backend-engineer`; future `@database-engineer`
+- Edge Functions and API behavior -> @backend-engineer
+- `apps/android/`, `apps/ios/`, `apps/windows/` -> current platform agents; future `@native-app-engineer`
+- `apps/web/` -> @web-engineer
 - `.github/workflows/` -> @devops-engineer
 - `docs/architecture/` -> @architect
 
@@ -60,7 +62,7 @@ You ensure all financial logic in Finance is correct, complete, and follows indu
 
 **Before implementing**: List every calculation, identify edge cases (rounding at boundaries, currency conversion chains, overflow on large cent values), and define test scenarios covering boundary conditions.
 
-**After implementing**: Verify all calculations use Long cents (never Double), banker's rounding is applied consistently, currency codes accompany every monetary value, and tests cover zero, negative, max-value, and multi-currency scenarios.
+**After implementing**: Verify all calculations use checked `Long` minor-unit arithmetic (never `Double`/`Float`), `HALF_EVEN` rounding is applied exactly once at the defined boundary, currency code and minor-unit scale accompany every amount, and tests cover zero, negative, boundary, overflow, recurrence, and multi-currency scenarios.
 
 ## Technical Context
 
@@ -71,19 +73,19 @@ You ensure all financial logic in Finance is correct, complete, and follows indu
 @JvmInline value class Cents(val amount: Long)
 data class Money(val cents: Cents, val currency: CurrencyCode)
 
-// Addition/subtraction: same currency only
-fun Money.plus(other: Money): Money {
-    require(currency == other.currency) { "Currency mismatch" }
-    return Money(Cents(cents.amount + other.cents.amount), currency)
-}
-
 // NEVER: Floating point for money
 // val balance = 19.99  // FORBIDDEN
 ```
 
+- `Cents.amount` is the integer minor-unit quantity. Preserve the name for compatibility, but read the minor-unit scale from ISO 4217 metadata; zero- and three-decimal currencies are valid.
+- Addition and subtraction require matching currencies and checked overflow. Multiplication, division, percentages, and allocations use exact integer/rational operations and reconcile remainders deterministically.
+- Never convert through `Double` as a convenience path for money-affecting logic.
+
 ### Banker's Rounding
 
 Round half to even (IEEE 754): `0.5 -> 0`, `1.5 -> 2`, `2.5 -> 2`, `3.5 -> 4`. Use `RoundingMode.HALF_EVEN` in all financial calculations.
+
+Apply rounding at the explicit domain boundary, not at intermediate steps. Tests must cover positive and negative ties, scale changes, allocation remainders, and overflow-adjacent values.
 
 ### Budget Rollover Algorithm
 
@@ -95,20 +97,33 @@ if (is_rollover) {
 }
 ```
 
+Treat the pseudocode as a domain rule, not an arithmetic implementation: subtraction and addition must be checked for overflow, and the policy must define whether negative carry is clamped, carried, or rejected.
+
 ### Goal Tracking Formulas
 
-```
-progress_percent = (current_cents * 100) / target_cents
-days_remaining = target_date - today
-required_daily_savings = (target_cents - current_cents) / days_remaining
-projected_completion = today + ((target_cents - current_cents) / avg_daily_savings)
-```
+- Reject or explicitly model non-positive targets and invalid target dates; never divide by zero or a negative period.
+- Compute progress and savings rates with checked integer/rational operations, then apply the domain's `HALF_EVEN` rule at the declared output scale.
+- Clamp or represent overfunded progress intentionally; do not let integer truncation silently define the product behavior.
+- A non-positive savings rate produces an explicit unreachable/indeterminate projection, not a sentinel date derived from unchecked division.
 
 ### Financial Date Rules
 
 - Due dates, pay dates, statement dates are **calendar dates** (`LocalDate`), not timestamps
 - Always account for time zones when converting between dates and instants
 - Use `kotlinx-datetime` exclusively — never `java.time` in shared code
+
+### Currency and FX Rules
+
+- ISO 4217 code and minor-unit scale are part of the value contract; reject arithmetic across currencies unless an explicit conversion is requested.
+- Historical valuation uses the exchange rate effective at the transaction timestamp, not the latest rate.
+- Persist rate timestamp and provenance where conversion affects stored or reported values. Define behavior for missing/stale rates; never silently substitute a different currency or a `1:1` rate.
+
+### Recurrence Rules
+
+- Preserve the original calendar anchor across short months and leap years; do not drift a month-end series after clamping a single occurrence.
+- Support interval, count, end-date, skip-date, pause/resume, and positional-weekday semantics deterministically.
+- Generated occurrence identifiers must be stable and idempotent across retries, devices, and sync replay.
+- Test timezone transitions, February/leap years, month-end anchors, skipped dates, pause/resume, termination boundaries, and duplicate generation.
 
 ### Reference Files
 
@@ -124,9 +139,9 @@ projected_completion = today + ((target_cents - current_cents) / avg_daily_savin
 
 - Do NOT implement UI — focus on business logic and data models
 - Do NOT make security decisions — defer to @security-reviewer
-- Do NOT skip edge cases in financial calculations (rounding, overflow, currency conversion)
+- Do NOT skip edge cases in financial calculations (rounding, overflow, allocation remainder, currency conversion, recurrence boundaries)
 - Always flag calculations that could produce incorrect financial results
-- NEVER store monetary values as Double or Float — always Long cents
+- NEVER store monetary values as Double or Float — always checked `Long` minor units with currency metadata
 
 ### Human-Gated Operations
 

--- a/.github/instructions/agents.instructions.md
+++ b/.github/instructions/agents.instructions.md
@@ -6,9 +6,17 @@ applyTo: '.github/agents/**'
 
 You are working in `.github/agents/`, which defines Finance-specific custom agents and their operating boundaries.
 
+## Canonical Preparation State
+
+- The current 25 files remain authoritative until a later Studio sync atomically materializes the canonical roster. Preparation work must not delete, rename, or replace them.
+- The planned state is 22 Studio-generated canonical definitions plus the Finance-authored `finance-domain.agent.md`.
+- Product facts and path ownership belong in root `AGENTS.md` and scoped `.github/instructions/**`, not copied into generated role bodies.
+- After activation, do not hand-edit Studio-generated agent files. Change canonical behavior in the backbone or Finance behavior in local overlays, then rematerialize through the approved Studio workflow.
+- `bug-basher.agent.md` remains present only for runtime continuity before activation. Durable single-bug behavior belongs in `.github/prompts/bug-bash.prompt.md` and `.github/instructions/workflow.instructions.md`.
+
 ## Agent File Schema
 
-- Each file represents exactly one role and is named `<kebab-case-name>.agent.md`; the frontmatter `name` must match the filename stem.
+- Each Finance-authored local file represents exactly one role and is named `<kebab-case-name>.agent.md`; the frontmatter `name` must match the filename stem.
 - Frontmatter is YAML with **eight keys** (all agents in this repo use the full set):
 
   | Key             | Purpose                                                                                                                                                                                                                                                    |
@@ -22,7 +30,7 @@ You are working in `.github/agents/`, which defines Finance-specific custom agen
   | `risk_level`    | `low`, `medium`, or `high` — blast radius of the agent's writes.                                                                                                                                                                                           |
   | `tools`         | Minimal list from `read`, `edit`, `search`, `shell`. Grant `edit` only to agents that change code; grant `shell` only when the role needs command execution. A **review-only** agent may hold `shell` for read-only verification but MUST NOT hold `edit`. |
 
-- Use one clear role per file. Do not combine implementation, review, and product responsibilities in a single agent definition.
+- Use one clear role per Finance-authored file. Do not combine implementation, review, and product responsibilities in a single agent definition.
 - Keep `File Ownership` aligned with `AGENTS.md`; never claim paths owned by another agent without explicitly listing them under "Do NOT edit". Paths in `primary_paths` must exist, or be explicitly flagged as net-new in File Ownership.
 
 ## Content Expectations
@@ -31,3 +39,4 @@ You are working in `.github/agents/`, which defines Finance-specific custom agen
 - Reference the canonical workflow instructions instead of copying long global procedures that can drift.
 - Make capabilities repo-specific: cite Finance platforms, KMP/Supabase/PowerSync/Turborepo, accessibility, security, and privacy constraints when relevant.
 - Keep boundaries actionable and conservative for financial data, credentials, publishing, deployments, and destructive operations.
+- Canonical generation may use a different schema contract; validate generated files with Studio tooling rather than reshaping them to this local authoring template.

--- a/.github/instructions/apps.instructions.md
+++ b/.github/instructions/apps.instructions.md
@@ -8,7 +8,7 @@ You are working in the `apps/` directory, which contains platform-specific appli
 
 ## Platform Subdirectories
 
-- `apps/ios/` — iOS, iPadOS, macOS, watchOS — **SwiftUI**, KMP integration planned via Swift Export (currently pure Swift), Apple Keychain for secure storage, VoiceOver accessibility
+- `apps/ios/` — iOS, iPadOS, macOS, watchOS — **SwiftUI** with a staged Swift Export bridge (`Finance/KMP/`) while Swift-native repositories remain in use, Apple Keychain for secure storage, VoiceOver accessibility
 - `apps/android/` — Android phones, tablets, Wear OS — **Jetpack Compose**, KMP direct dependency, Material 3 design system, TalkBack accessibility
 - `apps/web/` — Progressive Web App — **TypeScript + React** (Kotlin/JS integration planned via `src/kmp/`), SQLite via wa-sqlite for local storage, ARIA attributes for accessibility, PWA with service worker
 - `apps/windows/` — Windows 11 native app — **Compose Desktop (JVM)**, Windows Hello for biometric auth, Narrator accessibility
@@ -24,6 +24,30 @@ You are working in the `apps/` directory, which contains platform-specific appli
 - Handle sync conflicts gracefully with clear user-facing resolution options
 - Local data is stored in SQLite and encrypted at rest — SQLCipher on iOS, Android, and Windows; the web PWA uses SQLite-WASM (OPFS) and relies on browser origin-storage isolation
 - Design tokens (DTCG JSON) drive visual consistency — consume generated platform-native constants (Swift, XML resources, CSS variables, XAML resources)
+
+## Prepared Native-Agent Overlay (Not Active)
+
+Until canonical activation, `@android-engineer`, `@ios-engineer`, `@windows-engineer`, and `@kmp-engineer` retain their current runtime ownership. After activation, `@native-app-engineer` leads the three native apps plus shared KMP packages; `@web-engineer` continues to lead the PWA.
+
+| Surface    | Concrete Finance rules                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Android    | Own `apps/android/src/**`, `build.gradle.kts`, and `fastlane/**`; use Compose + Material 3, Koin/ViewModels/repositories, Timber only in debug, WorkManager, SQLDelight + SQLCipher, and BiometricPrompt/Android Keystore. Keep minSdk 28 and compile/target SDK 35 aligned through the version catalog. Preserve TalkBack, font scaling, 48dp targets, Paparazzi snapshots, and Glance widgets.                                                                                       |
+| iOS        | Own `apps/ios/Finance/**`, `Shared/**`, `Tests/**`, `FinanceWatch/**`, `FinanceWidget/**`, `FinanceClip/**`, `Signing/**`, `fastlane/**`, and `Package.swift`; use SwiftUI, `@Observable`/`@MainActor`, complete strict concurrency, `os.Logger`, Keychain/biometrics, SQLCipher, VoiceOver, Dynamic Type, and 44pt targets. Preserve iOS 17, watchOS 10, and macOS 14 deployment targets and keep the live/stub Swift Export boundary explicit while native repositories still exist. |
+| Windows    | Own `apps/windows/src/**`, `build.gradle.kts`, and `packaging/**`; use Compose Desktop/JVM only (no Electron/web wrapper), Koin, ViewModels/repositories, DPAPI, Windows Hello, Narrator, full keyboard operation, and high contrast. MSI is the sideload package and MSIX is the Store package; never describe an unsigned MSIX as shippable.                                                                                                                                         |
+| Shared KMP | Do not duplicate financial or sync behavior in app code. Shared models, repositories, algorithms, SQLDelight, sync, and `expect`/`actual` boundaries live under `packages/` and follow `packages.instructions.md`; `@finance-domain` reviews money correctness without taking structural ownership.                                                                                                                                                                                    |
+
+### Native Release Preparation
+
+| Platform | Agent-prepared output                                                                                                                              | Human-gated final action                                                                                 |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Android  | Release AAB/APK, tests, mapping/metadata, and unsigned or CI-secret-backed signing configuration                                                   | Production keystore access, signing approval, and Google Play submission                                 |
+| iOS      | Swift package resolution, tests, archive/export metadata, widgets/watch/App Clip checks, and unsigned CI archive where credentials are unavailable | Distribution certificate/profile access, notarization where applicable, and App Store Connect submission |
+| Windows  | Compose distributable/MSI plus MSIX manifest/tooling checks and store metadata                                                                     | Certificate access, production signing, and Microsoft Store submission                                   |
+| Web      | Production PWA build, service-worker/offline checks, and deployment metadata                                                                       | Production deployment or release promotion                                                               |
+
+Never weaken signing checks, embed credentials, or convert a missing signing secret into a success-shaped published artifact.
+
+Before calling a release candidate ready, `@release-manager` coordinates: no unresolved P0/P1 defects; affected security review complete; the accessibility audit passes; platform-parity status recorded; Changesets/version/changelog and store metadata prepared; migration/rollback readiness reviewed; and a human-approved signed build exists for each shipping native platform. Agents prepare evidence and unsigned artifacts, but humans approve credentials and perform signing, publishing, deployment, and store submission. An unsigned artifact may pass CI but is never release-ready.
 
 ## Platform Dependency Injection & Logging
 
@@ -45,3 +69,4 @@ All platforms support three build variants with per-environment configuration:
 - **i18n** — Internationalization framework in `packages/core` provides multi-language financial terminology. Platform apps consume localized strings from the shared layer.
 - **`ownerId`** — All sync-enabled models include an `ownerId` field referencing the authenticated user. Platform apps must populate this on record creation.
 - **Feature flags** — Managed via PostgreSQL + PowerSync; flags sync to clients for runtime evaluation of feature availability.
+- **Accessibility routing** — `@accessibility-reviewer` remains review-only. Native findings route to the active platform owner now and `@native-app-engineer` after activation; web findings route to `@web-engineer`.

--- a/.github/instructions/config.instructions.md
+++ b/.github/instructions/config.instructions.md
@@ -14,7 +14,7 @@ You are working in `config/`, which holds versioned, cross-cutting configuration
 | ----------------------- | --------------------------- | --------------------------------------------------------------------------------------- |
 | `config/feature-flags/` | `@experimentation-engineer` | `flags.json` flag definitions + flag-schema `README.md`; rollout lifecycle              |
 | `config/detekt/`        | `@devops-engineer`          | `detekt.yml` — Kotlin static-analysis/lint rules run in CI                              |
-| `config/i18n/`          | `@localization-engineer`    | Locale catalogs and financial-terminology config (**net-new — may not exist yet**)      |
+| `config/i18n/`          | `@localization-engineer`    | Locale catalogs and financial-terminology config                                        |
 | `config/analytics/`     | `@data-engineer`            | Privacy-preserving event schemas / telemetry taxonomy (**net-new — may not exist yet**) |
 
 ## General Rules
@@ -27,11 +27,14 @@ You are working in `config/`, which holds versioned, cross-cutting configuration
 
 ## Feature Flags (`config/feature-flags/`)
 
-- `flags.json` is the source of truth for flag **content and lifecycle**. Each flag carries `description`, `enabled`, `owner` (the feature team building behind it), `platforms`, `rollout_percentage`, and `expires`.
+- `flags.json` is the source of truth for flag **content and lifecycle**. Each flag carries `description`, `enabled`, `owner` (the feature team building behind it), `platforms`, `rollout_percentage`, `expires`, and an explicit rollback/kill-switch plan.
 - Flags are also synced to clients at runtime via the PostgreSQL `feature_flags` table + PowerSync (see `services.instructions.md`); this directory governs the **definitions**, not the sync transport.
-- Experiments are privacy-first: never bucket users on PII or raw financial data. Set an `expires` date and remove stale flags to control flag debt.
+- Experiments are privacy-first: use stable random identifiers and deterministic bucketing, never PII or raw financial data. Set an `expires` date and remove stale flags to control flag debt.
+- Any flag that changes money calculations, allocation, rounding, recurrence, or financial recommendations requires `@finance-domain` review before rollout increases.
 
 ## Lint & Analytics Config
 
 - `config/detekt/detekt.yml` defines Kotlin code-quality rules enforced in CI — keep it aligned with the conventions in `build-logic/` and `packages.instructions.md`.
 - `config/analytics/` event schemas must follow data-minimization: collect only what a defined metric needs, document each event, and never capture account numbers, balances, or transaction detail.
+- Product telemetry is distinct from financial reporting. Telemetry schemas may describe user actions and operational outcomes with bounded cardinality; financial reports remain domain data and must not be repurposed as analytics events.
+- `config/i18n/` uses stable keys, CLDR formatting rules, ISO 4217 currency metadata, plural/placeholder validation, and RTL-safe catalogs. Platform integration routes to the native or web owner.

--- a/.github/instructions/packages.instructions.md
+++ b/.github/instructions/packages.instructions.md
@@ -24,6 +24,14 @@ You are working in the `packages/` directory, which contains shared libraries co
 - Financial calculations must use appropriate precision (avoid floating point for money)
 - All monetary values should use the smallest currency unit (cents, not dollars)
 
+## Prepared Shared-Code Ownership (Not Active)
+
+- Until canonical activation, `@kmp-engineer` leads shared package structure. After activation, `@native-app-engineer` leads `packages/core/`, `packages/models/`, `packages/sync/`, `packages/import/`, `gradle/libs.versions.toml`, and `settings.gradle.kts`.
+- `@finance-domain` remains the correctness lead for money algorithms only: integer minor units, rounding, budgets, goals, recurrence, categorization, reports, and currency behavior. It does not own source-set structure, schemas, repositories, or Gradle configuration.
+- `@data-engineer` co-reviews only product telemetry contracts in `AnalyticsEvent.kt`, `AnalyticsTracker.kt`, and `BufferedAnalyticsTracker.kt`. Financial reports, balances, transactions, and the domain event bus are not telemetry.
+- `packages/design-tokens/` remains owned by `@design-engineer` and follows `tokens.instructions.md`.
+- Client SQLDelight schemas and migrations remain shared/native code. Cloud PostgreSQL migrations, RLS, seed data, and PowerSync bucket rules belong to `@database-engineer` after activation; schema changes must be serialized across both owners.
+
 ## Monitoring Interfaces
 
 `packages/core/src/commonMain/kotlin/com/finance/core/monitoring/` contains cross-platform monitoring contracts:
@@ -51,6 +59,13 @@ These are `commonMain` interfaces — platform `actual` implementations live in 
 - All monetary values must be `Long` (cents) — enforce with Kotlin value classes (e.g., `@JvmInline value class Cents(val amount: Long)`)
 - Test with **kotlin.test** — all tests must pass on every target (`commonTest`, `iosTest`, `androidTest`, `jvmTest`, `jsTest`)
 - Kotlin lint: **detekt** runs in CI via GitHub Actions workflow. Follow detekt rules for code style and complexity.
+
+## Financial and Telemetry Boundaries
+
+- Treat `Cents(Long)` as integer currency minor units and carry the ISO 4217 currency/scale with every amount; never assume every currency has two decimal places.
+- Money-affecting multiplication, division, allocation, conversion, and percentages require exact integer/rational handling, checked overflow, and `HALF_EVEN` rounding.
+- Product telemetry must be consent-gated, bounded-cardinality, and free of PII, account identifiers, balances, transaction details, and raw financial amounts.
+- Monitoring contracts may report durations, counts, states, and error categories, but never financial payloads.
 
 ## Approved Model Additions
 

--- a/.github/instructions/services.instructions.md
+++ b/.github/instructions/services.instructions.md
@@ -10,6 +10,19 @@ You are working in the `services/` directory, which contains the consolidated ba
 
 - `services/api/` — The single backend API server for data synchronization
 
+## Prepared Backend Ownership Seams (Not Active)
+
+Current runtime ownership remains with `@backend-engineer` and `@devops-engineer` until canonical activation. The prepared post-activation split is:
+
+| Future owner         | Finance scope                                                                                                                                                                                                                                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@backend-engineer`  | `services/api/supabase/functions/**`, authentication and API behavior, shared Edge Function utilities, OpenAPI, request validation, CORS, rate limiting, and non-database service code; reviews Auth/Function sections of `services/api/supabase/config.toml`                                              |
+| `@database-engineer` | `services/api/supabase/migrations/**`, `services/api/supabase/seed.sql`, `services/api/supabase/tests/**`, `services/api/powersync/sync-rules.yaml`, and database backup/volume definitions under `deploy/backup/` and `deploy/volumes/db/`; leads `services/api/supabase/config.toml` with backend review |
+| `@sre-engineer`      | Reliability semantics for `services/api/monitoring/**`, `deploy/monitoring/**`, SLOs, alerts, incidents, rollback, capacity, disaster recovery, and backup/restore verification                                                                                                                            |
+| `@devops-engineer`   | CI/build/delivery automation and remaining deployment mechanics; does not redefine database correctness or reliability policy                                                                                                                                                                              |
+
+Backend code implements database and reliability contracts, but schema/RLS decisions require database review and SLO/alert/recovery decisions require SRE review.
+
 ## Guidelines
 
 - The backend exists primarily for data synchronization, NOT for business logic
@@ -31,6 +44,10 @@ You are working in the `services/` directory, which contains the consolidated ba
 - Never return raw financial data — always filter through RLS so users only see their own data
 - Edge Functions are written in **TypeScript** running on the **Deno** runtime
 - Database migrations must be versioned (sequential numbering) and reversible (include both `up` and `down` SQL)
+- Every forward migration under `migrations/` must have the matching `migrations/down/<timestamp>_<name>.down.sql`; never execute destructive migration operations against staging or production from an agent session
+- Store monetary amounts as `BIGINT` integer minor units with an explicit ISO 4217 currency code/scale; never use floating-point database types for money
+- Use `owner_id` for attribution and owner-protected operations; authorize shared household reads/writes through verified household membership and role. Test permitted owner and co-member paths plus outsider, cross-user, and cross-household denials for every RLS change
+- Use parameterized queries and validated identifiers at every SQL/API trust boundary
 
 ## Schema Alignment Decisions
 
@@ -48,12 +65,19 @@ Migration naming convention: `YYYYMMDDHHMMSS_<description>.sql` (e.g., `20260325
 - **PowerSync** sync rules define what data syncs to each client — configure in sync rules YAML
 - Sync is bidirectional: local SQLite ↔ PowerSync ↔ Supabase PostgreSQL
 - Conflict resolution uses last-write-wins (LWW) for simple fields with custom merge logic for complex data
+- Serialize each cloud schema or sync-rule change with the matching client SQLDelight/model change. After activation, `@database-engineer` leads the cloud side and `@native-app-engineer` leads the client side; `@finance-domain` reviews any money semantics
 
 ## Feature Flags
 
 - Feature flags are managed via a PostgreSQL `feature_flags` table synced to clients through PowerSync
 - Flags sync to client devices for runtime evaluation — no server round-trip needed for flag checks
 - Use feature flags for gradual rollouts, A/B testing, and platform-specific feature gating
+
+## Reliability and Data Protection Handoffs
+
+- API and sync health signals may contain status, latency, counts, and classified errors only; never include raw financial records, account identifiers, access tokens, or PII.
+- Backup work is incomplete without a restore-verification procedure. Production restore, deployment, and infrastructure mutation remain human-gated.
+- Compliance deletion and residency analysis must cover both on-device copies and synchronized Supabase/PowerSync copies.
 
 ## Environment Configurations
 

--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -324,6 +324,19 @@ Map issues to agents based on labels and file paths:
 - `documentation` → @docs-writer
 - `design-system` → @design-engineer
 
+#### Prepared Canonical Dispatch (Not Active)
+
+Continue using the current mappings above until Studio canonical materialization replaces the runtime definitions. After activation:
+
+- `platform:android`, `platform:ios`, `platform:windows`, `platform:shared`, `comp:sync`, and client SQLDelight work → `@native-app-engineer`
+- Supabase migrations, RLS, database tests, seed data, and PowerSync sync rules → `@database-engineer`
+- SLOs, monitoring semantics, incidents, rollback/recovery verification, and capacity → `@sre-engineer`
+- API/Auth/Edge Function behavior → `@backend-engineer`
+- A single reported bug → run `.github/prompts/bug-bash.prompt.md`; do not require a permanent bug-basher role
+- Money-affecting work → include `@finance-domain` for correctness review while the structural owner implements
+
+Do not dispatch the future-only slugs before their generated definitions are materialized.
+
 ### 3. Include Business Tasks
 
 Every sprint MUST include at least one business/management task:

--- a/.github/prompts/bug-bash.prompt.md
+++ b/.github/prompts/bug-bash.prompt.md
@@ -1,6 +1,6 @@
 ---
 name: bug-bash
-description: Run the bug-basher flow for a single pasted bug — infer the platform(s), investigate, file issue, fix (shared-once or widespread), PR, CI, self-merge.
+description: Fix one pasted bug end-to-end — infer the platform(s), investigate, file issue, fix (shared-once or widespread), PR, CI, self-merge.
 parameters:
   - name: bug
     description: The bug report to fix (a short description, optionally with a screenshot and repro steps).
@@ -12,13 +12,13 @@ parameters:
 
 # Bug Bash — Fix One Bug End-to-End (Any Platform)
 
-Run the full [`bug-basher`](../agents/bug-basher.agent.md) lifecycle for a **single** reported bug across any of Finance's four platforms (iOS, Android, Web, Windows) or its shared `packages/`. This wrapper works both as a standalone fire-and-forget session and when invoked inside an existing session.
+Run this prompt's complete lifecycle for a **single** reported bug across any of Finance's four platforms (iOS, Android, Web, Windows) or its shared `packages/`. This prompt is the durable task-mode definition and works both as a standalone fire-and-forget session and inside an existing session; it does not depend on a permanent bug-basher agent.
 
 **Input:** the `bug` parameter — a description of the broken behavior, optionally with a screenshot and repro steps — plus an optional `platform` parameter. When `platform` is omitted, infer the affected platform(s) from the report and screenshot; treat an undefined platform as "fix every affected platform (or the shared code once)", never web-only.
 
 ## Execution Plan
 
-Adopt the `bug-basher` agent and run its complete flow for the one bug in `{{bug}}` (target platform: `{{platform}}`):
+Run the complete flow below for the one bug in `{{bug}}` (target platform: `{{platform}}`):
 
 1. **Intake** — parse `{{bug}}` and `{{platform}}`. Ask one clarifying question **only** if the repro is genuinely ambiguous; otherwise proceed.
 2. **Infer platform(s)** — honor `{{platform}}` if given; otherwise infer from report + screenshot cues (iOS/SwiftUI, Android/Compose, Web/PWA, Windows/Compose-Desktop). If undefined or multi-platform, plan a shared or widespread fix.
@@ -26,16 +26,14 @@ Adopt the `bug-basher` agent and run its complete flow for the one bug in `{{bug
 4. **Decide scope** — root cause in shared code (`packages/`, `config/i18n`) → fix once (`platform:shared`); platform-specific + known platform → fix that platform natively; undefined/multi-platform → make the fix widespread across every affected platform (or file a cross-platform tracking issue with per-platform sub-issues). Never default to web-only. For large multi-native fixes you MAY dispatch platform sub-agents.
 5. **File the issue** — issue-first via `gh issue create` with Problem / Root Cause / Fix / Files / Cross-Platform sections and correct labels (the right `platform:*` — `platform:shared`, a single platform, or multiple — plus `bug`/`enhancement`, plus `accessibility` when relevant). Run the `issue-management` scoping decision tree.
 6. **Implement** — a surgical fix on this session's own worktree/branch, following the owning platform's conventions (web: hooks-only data flow, design tokens, ARIA/CSP; native: platform accessibility + conventions; shared: no platform leakage). Add/update the affected test.
-7. **Validate & push** — pre-push checklist: `npm run format` → `npx eslint . --fix` → `npm run format:check && npx eslint . --max-warnings 0`, run affected tests, `git fetch origin main && git rebase origin/main`, then `$env:HUSKY = "0"; git push --no-verify origin <branch>`.
-8. **PR** — `gh pr create --base main` with `Closes #N`; verify with `gh pr view <branch> --json number`.
-9. **Drive to green & self-merge** — poll `gh pr checks` + `gh pr view --json mergeable,mergeStateStatus`; self-heal CI and conflicts; `gh pr merge <N> --squash` once green AND `MERGEABLE`.
-10. **Clean up** — `git worktree remove <path>` after merge, then report the issue #, PR #, inferred platform(s), fix scope, and final merged state.
+7. **Validate & ship** — run the affected tests, then follow `.github/instructions/workflow.instructions.md` for the complete pre-push, rebase, push, PR verification, CI/conflict healing, and self-merge lifecycle.
+8. **Clean up** — remove the task worktree after merge, then report the issue #, PR #, inferred platform(s), fix scope, and final merged state.
 
 ## Guardrails
 
-- ⚠️ **NEVER edit `apps/web/vite.config.ts`** — the bug-bash host keeps a local-only uncommitted `allowedHosts` edit there.
 - Respect all `AGENTS.md` human-gated operations. For the canonical push / merge / merge-conflict rules, follow `.github/instructions/workflow.instructions.md` (do not duplicate them).
 - One bug per run — file separate issues for anything else you discover; do not scope-creep.
+- Prefer a shared fix when the root cause is shared; otherwise use the owning platform's native conventions. After canonical activation, native implementation routes to `@native-app-engineer`, while web remains `@web-engineer`.
 
 ## Report
 

--- a/.github/skills/financial-modeling/SKILL.md
+++ b/.github/skills/financial-modeling/SKILL.md
@@ -22,75 +22,27 @@ This skill covers **financial calculation and domain modeling** — money repres
 
 ## Money Representation — The Golden Rule
 
-**Never use floating-point for money.** All monetary values are `Long` cents.
+**Never use floating-point for money.** Finance stores integer currency minor units in `Long`/`BIGINT`. The existing `Cents` name is a compatibility type name; its value means the currency's minor-unit quantity, which is not always two decimal places.
 
 ```kotlin
-// KMP value class (packages/models)
-import kotlin.math.abs
-
 @JvmInline
-value class Cents(val amount: Long) {
-    operator fun plus(other: Cents) = Cents(amount + other.amount)
-    operator fun minus(other: Cents) = Cents(amount - other.amount)
-    fun toDollars(): String {
-        val sign = if (amount < 0) "-" else ""
-        return "$sign\$${abs(amount) / 100}.${(abs(amount) % 100).toString().padStart(2, '0')}"
-    }
+value class Cents(val amount: Long)
 
-    companion object {
-        fun fromDecimalString(input: String): Cents {
-            val trimmed = input.trim()
-            require(trimmed.isNotEmpty()) { "Amount is required" }
-            val negative = trimmed.startsWith("-")
-            val unsigned = trimmed.removePrefix("+").removePrefix("-")
-            val parts = unsigned.split('.', limit = 2)
-            val wholeDigits = parts[0].ifEmpty { "0" }
-            val fractionDigits = parts.getOrNull(1).orEmpty()
-            require(wholeDigits.all(Char::isDigit) && fractionDigits.all(Char::isDigit)) {
-                "Amount must be a decimal string"
-            }
-
-            val cents = wholeDigits.toLong() * 100 + fractionDigits.take(2).padEnd(2, '0').toLong()
-            val thirdDigit = fractionDigits.getOrNull(2)?.digitToIntOrNull() ?: 0
-            val hasNonZeroRemainder = fractionDigits.drop(3).any { it != '0' }
-            val shouldRoundUp =
-                thirdDigit > 5 || (thirdDigit == 5 && (hasNonZeroRemainder || cents % 2L == 1L))
-            val rounded = cents + if (shouldRoundUp) 1L else 0L
-            return Cents(if (negative) -rounded else rounded)
-        }
-
-        val ZERO = Cents(0L)
-    }
-}
-```
-
-```typescript
-// Web helper (apps/web): parse decimal strings with integer math and banker's rounding.
-export function centsFromDecimalString(input: string): number {
-  const match = input.trim().match(/^([+-])?(\d*)(?:\.(\d*))?$/);
-  if (!match || (!match[2] && !match[3])) throw new Error('Amount must be a decimal string');
-
-  const [, sign = '', wholeRaw = '0', fractionRaw = ''] = match;
-  const wholeCents = Number.parseInt(wholeRaw || '0', 10) * 100;
-  const centsDigits = (fractionRaw.slice(0, 2) || '0').padEnd(2, '0');
-  const baseCents = wholeCents + Number.parseInt(centsDigits, 10);
-  const thirdDigit = Number.parseInt(fractionRaw[2] ?? '0', 10);
-  const hasNonZeroRemainder = [...fractionRaw.slice(3)].some((digit) => digit !== '0');
-  const shouldRoundUp =
-    thirdDigit > 5 || (thirdDigit === 5 && (hasNonZeroRemainder || baseCents % 2 === 1));
-  const rounded = baseCents + (shouldRoundUp ? 1 : 0);
-
-  if (!Number.isSafeInteger(rounded)) throw new Error('Amount exceeds safe integer cents range');
-  return sign === '-' ? -rounded : rounded;
-}
+data class Money(
+    val cents: Cents,
+    val currency: CurrencyCode,
+)
 ```
 
 **Rules**:
 
-- Store as `INTEGER`/`BIGINT` (cents) in SQLite and PostgreSQL
-- Keep ISO 4217 currency code alongside every amount
-- Convert to display only at the UI rendering layer
-- Use `Cents` value class in KMP, `number` (cents) in TypeScript
+- Carry an ISO 4217 currency code and minor-unit scale with every amount; support zero- and three-decimal currencies.
+- Addition/subtraction require the same currency and checked overflow.
+- Multiplication, division, percentages, allocations, and decimal parsing use exact integer/rational operations with `HALF_EVEN` rounding at the declared boundary.
+- Reconcile allocation remainders deterministically so distributed parts equal the original total.
+- Store as `INTEGER`/`BIGINT` in SQLite/PostgreSQL and as `Long` in KMP. TypeScript may use integer `number` only while `Number.isSafeInteger` remains true.
+- Convert to localized decimal display only at the UI boundary using the currency scale; never hardcode division by 100.
+- Historical FX valuation uses the rate effective at the transaction timestamp and retains rate provenance. Missing/stale rates are explicit errors or domain states, never an implicit `1:1` conversion.
 
 ## AI-Powered Financial Engines
 
@@ -138,6 +90,8 @@ When `is_rollover = true` on a budget:
 3. Add carry-forward to new period's available amount
 4. Formula: `available = budget_cents + max(0, carry_forward) - current_spent`
 
+All subtraction/addition is checked for overflow. Rollover policy must explicitly define negative carry behavior instead of relying on arithmetic truncation.
+
 ### Budget Periods
 
 - `monthly`, `weekly`, `biweekly`, `yearly`
@@ -172,12 +126,17 @@ active → archived   (manual dismissal)
 
 ### Projection
 
-```kotlin
-// Time to goal at current savings rate
-val monthlyRate = recentContributions.sum() / months
-val remaining = goal.targetCents - goal.currentCents
-val monthsToGoal = if (monthlyRate > 0) remaining / monthlyRate else Long.MAX_VALUE
-```
+- Validate positive targets and periods before division.
+- Use checked integer/rational calculations and `HALF_EVEN` rounding at the output boundary.
+- Treat non-positive savings rates as unreachable/indeterminate; do not encode them as sentinel dates or `Long.MAX_VALUE`.
+- Define overfunded progress and negative contributions explicitly rather than inheriting integer truncation behavior.
+
+## Recurring Transactions
+
+- Use `LocalDate` for calendar anchors and preserve the original anchor across short months and leap years.
+- Support interval, count, end-date, skip-date, pause/resume, and positional-weekday semantics deterministically.
+- Generate stable occurrence IDs so retries, devices, and sync replay remain idempotent.
+- Test month-end anchors, February/leap years, timezone transitions, skipped dates, termination boundaries, and duplicate generation.
 
 ## Data Export Module
 
@@ -211,8 +170,11 @@ Located at `packages/core/src/commonMain/kotlin/com/finance/core/export/`:
 
 ## Testing Checklist
 
-- [ ] Rounding boundaries, including banker's rounding ties (e.g., `1.225` → `122` cents, `1.235` → `124` cents)
+- [ ] `HALF_EVEN` boundaries for positive/negative ties and zero-, two-, and three-decimal currencies
 - [ ] Negative amounts, zero values, high-value totals (`Long.MAX_VALUE` proximity)
+- [ ] Checked overflow and deterministic allocation remainders
+- [ ] Currency mismatch and historical FX-rate timestamp/provenance behavior
+- [ ] Recurrence anchors, leap years, skips, pauses, termination, and idempotent IDs
 - [ ] Serializer output: deterministic ordering, stable schemas
 - [ ] Checksum generation with known fixtures
 - [ ] Exported data never includes sync fields or raw user IDs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Finance is a multi-platform, native-first financial tracking application for per
 3. **Accessibility** — All UI code must meet WCAG 2.2 AA minimum. Use semantic elements, support screen readers, respect reduced motion and high contrast preferences.
 4. **Security** — Follow OWASP guidelines. Never hardcode secrets. Always validate and sanitize inputs. Use parameterized queries.
 5. **Transparency** — Document all significant decisions, trade-offs, and AI-generated code rationale in commit messages and PR descriptions.
+6. **No financial-data monetization** — Finance has no advertising business model. Never sell, share, target ads with, or derive advertising profiles from financial data; product telemetry is consent-gated and excludes raw financial values.
 
 ## ⚠️ MANDATORY: Pre-Push Lint & Format (NEVER skip)
 
@@ -148,6 +149,18 @@ Custom agents are defined in `.github/agents/`. Each agent has a specific role:
 - `experimentation-engineer` — Feature flags, A/B testing, staged rollouts, experiment readouts
 
 > **Reviewer roles are not symmetric.** `accessibility-reviewer` is **review-only** — it never edits production code and routes every fix to the owning platform agent. `security-reviewer` is the designated **emergency fixer** — it may implement CRITICAL/HIGH security fixes in any directory, coordinating with the owning agent, and is review-only for non-security code.
+
+### Canonical Agent Activation Preparation (Not Active)
+
+The 25 definitions above remain the authoritative runtime roster until Studio canonical materialization happens in a later, atomic change. Finance is prepared for a future runtime of **22 Studio-generated canonical agents plus the local `finance-domain` agent**. During that activation:
+
+- `android-engineer`, `ios-engineer`, `windows-engineer`, and `kmp-engineer` consolidate into `native-app-engineer`.
+- PostgreSQL schema, migration, RLS, seed, and PowerSync-rule ownership moves from the broad backend role to `database-engineer`.
+- SLOs, monitoring semantics, incident response, capacity, rollback, and recovery verification move from broad DevOps/backend ownership to `sre-engineer`.
+- Single-bug task mode comes from `.github/prompts/bug-bash.prompt.md` and workflow instructions, not a permanent `bug-basher` role.
+- `finance-domain` remains Finance-authored and leads financial correctness while the structural owner leads the surrounding package or platform.
+
+Do not delete, rename, or locally rewrite the 24 current definitions that will later be replaced or retired. Product-specific behavior belongs in this file and scoped `.github/instructions/**`; generated definitions remain generic. See [`docs/ai/README.md`](docs/ai/README.md#future-canonical-mapping-not-active) for the complete 25-role mapping.
 
 Agent skills are in `.github/skills/` (the source of truth) and provide reusable domain knowledge. As of 2026-06 there are **20** skills. The established set includes:
 
@@ -390,12 +403,25 @@ When multiple agents work in parallel, they MUST follow these rules to avoid con
 | `@localization-engineer`    | `config/i18n/`, `docs/i18n/` (net-new); locale catalogs, financial terminology                                                                                                                                   |
 | `@experimentation-engineer` | `config/feature-flags/`; A/B tests + staged rollouts (success metrics co-designed w/ `@data-engineer`, validation CI w/ `@devops-engineer`)                                                                      |
 
+**Prepared post-activation ownership (inactive until canonical materialization):**
+
+| Future owner               | Finance overlay scope and handoffs                                                                                                                                                                                                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@native-app-engineer`     | Leads `apps/android/`, `apps/ios/`, `apps/windows/`, `packages/` except `packages/design-tokens/`, and Gradle shared config. `@finance-domain` reviews money behavior; `@data-engineer` co-reviews only product-telemetry contracts.                                                       |
+| `@web-engineer`            | Continues to lead `apps/web/`; consumes shared KMP contracts through the current dual-path integration and does not duplicate shared business logic.                                                                                                                                       |
+| `@backend-engineer`        | Leads Edge Functions, authentication/API behavior, OpenAPI, validation, rate limiting, and non-database service implementation under `services/api/`.                                                                                                                                      |
+| `@database-engineer`       | Leads `services/api/supabase/migrations/`, `seed.sql`, database tests, `services/api/powersync/sync-rules.yaml`, and database backup/volume definitions. Coordinates each cloud schema change with client SQLDelight changes led by `@native-app-engineer`.                                |
+| `@sre-engineer`            | Leads reliability semantics and runbooks for `services/api/monitoring/`, `deploy/monitoring/`, uptime, incidents, rollback, backup/restore verification, disaster recovery, and capacity. Implementation changes still route to the owning backend, database, native, web, or DevOps role. |
+| `@devops-engineer`         | Retains CI/build/delivery mechanics in `.github/workflows/`, `build-logic/`, `tools/`, `scripts/`, Gradle wrapper, detekt config, and deployment automation that is not a database or reliability contract.                                                                                |
+| `@finance-domain`          | Remains the sole local agent and correctness authority for integer minor-unit arithmetic, `HALF_EVEN` rounding, budgets, goals, recurrence, categorization, reporting, and currency behavior in `packages/core/`; it does not take structural ownership from `@native-app-engineer`.       |
+| Review and advisory agents | Accessibility stays review-only; security may emergency-fix only CRITICAL/HIGH findings; compliance routes implementation; data owns product telemetry rather than financial reporting; experimentation requires `@finance-domain` review before changing money behavior.                  |
+
 **Coordination protocol:**
 
 1. **No two agents edit the same file in parallel.** If a task requires two agents to touch the same file, one agent leads and the other reviews.
-2. **Shared config files** (`gradle/libs.versions.toml`, `settings.gradle.kts`, `package.json`, `turbo.json`) must be edited by only one agent per fleet run — assign ownership to `@kmp-engineer` (Gradle) or `@devops-engineer` (Node/CI).
+2. **Shared config files** (`gradle/libs.versions.toml`, `settings.gradle.kts`, `package.json`, `turbo.json`) must be edited by only one agent per fleet run — assign Gradle ownership to the current `@kmp-engineer` or future `@native-app-engineer`, and Node/CI ownership to `@devops-engineer`.
 3. **Agents announce intent** — when starting a fleet task, the orchestrator should note which files each agent will touch in the issue or PR description.
-4. **Schema changes are serialized** — only `@backend-engineer` writes Supabase migrations; only `@kmp-engineer` writes SQLDelight `.sq` files. Both must be in sync (a single coordinated sprint task, not two independent ones).
+4. **Schema changes are serialized** — currently `@backend-engineer` writes Supabase migrations and `@kmp-engineer` writes SQLDelight `.sq` files; after activation those owners become `@database-engineer` and `@native-app-engineer`. Both sides stay in one coordinated task, never independent parallel PRs.
 5. **After parallel work, the last agent to commit runs** the pre-push checklist (`npm run format:check && npx eslint . --max-warnings 0`) **before pushing** to catch any integration issues.
 
 ### Fleet CI Monitoring & Self-Healing

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -3,6 +3,8 @@
 This directory contains comprehensive documentation for the AI-first development workflow used in the Finance monorepo. Every aspect of AI agent configuration, tooling, and usage is documented here for full transparency.
 
 > **New here (agent or human)?** Start with **[start-here.md](start-here.md)** — the canonical entry point that links the workflow, restrictions, agent roster, skills, and MCP setup in reading order.
+>
+> **Canonical activation preparation:** The 25 local definitions listed below are still active. A later atomic Studio materialization is planned to provide 22 generated canonical agents and retain `finance-domain` as Finance's sole local agent. No sync or runtime-file removal has happened yet.
 
 ## Why AI-First?
 
@@ -134,6 +136,42 @@ Finance is developed with AI agents as first-class contributors. This means:
 
 AGENTS.md                             # Root-level agent guidance (all AI tools)
 ```
+
+### Future Canonical Mapping (Not Active)
+
+This table records where each current authoritative role's Finance-specific behavior will live after activation. Same-slug entries become Studio-generated canonical definitions supplemented by local overlays.
+
+| Current role               | Future runtime target                                                                                       |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `accessibility-reviewer`   | Canonical `accessibility-reviewer`; four-platform checks and review-only routing stay in local instructions |
+| `ai-ops-engineer`          | Canonical `ai-ops-engineer`; Finance overlay and manifest conventions stay local                            |
+| `android-engineer`         | Canonical `native-app-engineer`                                                                             |
+| `architect`                | Canonical `architect`                                                                                       |
+| `backend-engineer`         | Canonical `backend-engineer`, with database and reliability seams routed separately                         |
+| `bug-basher`               | No permanent role; `.github/prompts/bug-bash.prompt.md` plus workflow instructions                          |
+| `business-analyst`         | Canonical `business-analyst`                                                                                |
+| `compliance-specialist`    | Canonical `compliance-specialist`                                                                           |
+| `data-engineer`            | Canonical `data-engineer`; product telemetry remains distinct from financial reporting                      |
+| `design-engineer`          | Canonical `design-engineer`                                                                                 |
+| `devops-engineer`          | Canonical `devops-engineer`; SLO/incident/recovery semantics route to `sre-engineer`                        |
+| `docs-writer`              | Canonical `docs-writer`                                                                                     |
+| `experimentation-engineer` | Canonical `experimentation-engineer`                                                                        |
+| `finance-domain`           | **Local `finance-domain` retained** as Finance's financial-correctness specialist                           |
+| `ios-engineer`             | Canonical `native-app-engineer`                                                                             |
+| `kmp-engineer`             | Canonical `native-app-engineer`                                                                             |
+| `localization-engineer`    | Canonical `localization-engineer`                                                                           |
+| `marketing-strategist`     | Canonical `marketing-strategist`                                                                            |
+| `performance-engineer`     | Canonical `performance-engineer`                                                                            |
+| `product-manager`          | Canonical `product-manager`                                                                                 |
+| `qa-tester`                | Canonical `qa-tester`                                                                                       |
+| `release-manager`          | Canonical `release-manager`                                                                                 |
+| `security-reviewer`        | Canonical `security-reviewer`                                                                               |
+| `web-engineer`             | Canonical `web-engineer`                                                                                    |
+| `windows-engineer`         | Canonical `native-app-engineer`                                                                             |
+
+The planned canonical roster is: `accessibility-reviewer`, `ai-ops-engineer`, `architect`, `backend-engineer`, `business-analyst`, `compliance-specialist`, `data-engineer`, `database-engineer`, `design-engineer`, `devops-engineer`, `docs-writer`, `experimentation-engineer`, `localization-engineer`, `marketing-strategist`, `native-app-engineer`, `performance-engineer`, `product-manager`, `qa-tester`, `release-manager`, `security-reviewer`, `sre-engineer`, and `web-engineer`.
+
+The future runtime therefore contains 23 physical agent files: 22 generated canonical files and one Finance-authored local file. Activation remains blocked until the backbone member configuration opts Finance into canonical agents, declares `finance-domain` as local, resolves canonical skill references, and confirms the database/SRE/DevOps ownership seams. Until then, counts and active dispatch continue to reflect the 25-file roster. `node tools/check-ai-manifest.js --strict` validates both current filesystem counts and this preparation mapping.
 
 ### Supported AI Tools
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -262,7 +262,7 @@ Scans `.github/agents/*.agent.md`, `.github/skills/*/SKILL.md`, `.github/instruc
 
 ### `check-ai-manifest.js` - AI manifest drift check
 
-Compares hardcoded counts in `docs/ai/README.md`, `docs/INDEX.md`, and `AGENTS.md` against the real filesystem counts (via `ai-manifest.js`). **Informational by default** (warns, exit 0) to avoid racing concurrent doc edits; set `STRICT=1` to make drift blocking (exit 1). Addresses issue #2863.
+Compares hardcoded counts in `docs/ai/README.md`, `docs/INDEX.md`, and `AGENTS.md` against the real filesystem counts (via `ai-manifest.js`). It also verifies that the pending canonical-activation section maps every current runtime role, names all 22 planned canonical roles, retains `finance-domain`, and retires `bug-basher` into task mode. **Informational by default** (warns, exit 0) to avoid racing concurrent doc edits; set `STRICT=1` or pass `--strict` to make drift blocking (exit 1). Addresses issues #2863 and #4009.
 
     node tools/check-ai-manifest.js                        # Warn-only (exit 0)
     STRICT=1 node tools/check-ai-manifest.js               # Blocking (exit 1 on drift)

--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -56,6 +56,43 @@ Set STRICT=1 (or pass --strict) to fail CI on drift.
 }
 
 const DOC_FILES = ['docs/ai/README.md', 'docs/INDEX.md', 'AGENTS.md'];
+const PREPARATION_DOC = 'docs/ai/README.md';
+const EXPECTED_CURRENT_ROLE_TARGETS = {
+  'accessibility-reviewer': 'canonical:accessibility-reviewer',
+  'ai-ops-engineer': 'canonical:ai-ops-engineer',
+  'android-engineer': 'canonical:native-app-engineer',
+  architect: 'canonical:architect',
+  'backend-engineer': 'canonical:backend-engineer',
+  'bug-basher': 'task:bug-bash',
+  'business-analyst': 'canonical:business-analyst',
+  'compliance-specialist': 'canonical:compliance-specialist',
+  'data-engineer': 'canonical:data-engineer',
+  'design-engineer': 'canonical:design-engineer',
+  'devops-engineer': 'canonical:devops-engineer',
+  'docs-writer': 'canonical:docs-writer',
+  'experimentation-engineer': 'canonical:experimentation-engineer',
+  'finance-domain': 'local:finance-domain',
+  'ios-engineer': 'canonical:native-app-engineer',
+  'kmp-engineer': 'canonical:native-app-engineer',
+  'localization-engineer': 'canonical:localization-engineer',
+  'marketing-strategist': 'canonical:marketing-strategist',
+  'performance-engineer': 'canonical:performance-engineer',
+  'product-manager': 'canonical:product-manager',
+  'qa-tester': 'canonical:qa-tester',
+  'release-manager': 'canonical:release-manager',
+  'security-reviewer': 'canonical:security-reviewer',
+  'web-engineer': 'canonical:web-engineer',
+  'windows-engineer': 'canonical:native-app-engineer',
+};
+const NEW_CANONICAL_AGENTS = ['database-engineer', 'sre-engineer'];
+const PLANNED_CANONICAL_AGENTS = [
+  ...new Set([
+    ...Object.values(EXPECTED_CURRENT_ROLE_TARGETS)
+      .filter((target) => target.startsWith('canonical:'))
+      .map((target) => target.slice('canonical:'.length)),
+    ...NEW_CANONICAL_AGENTS,
+  ]),
+].sort();
 
 // Each metric maps to: the manifest count key + a regex capturing a claimed
 // numeric count immediately preceding the keyword. Regexes are intentionally
@@ -116,6 +153,113 @@ function scanDoc(relPath, counts) {
   return { missing: false, findings };
 }
 
+function validateCanonicalPreparation(runtimeAgents) {
+  const abs = path.join(ROOT, PREPARATION_DOC);
+  if (!fs.existsSync(abs)) return [`${PREPARATION_DOC} is missing`];
+
+  const content = fs.readFileSync(abs, 'utf-8');
+  const start = content.indexOf('### Future Canonical Mapping (Not Active)');
+  const end = content.indexOf('### Supported AI Tools', start);
+  if (start === -1 || end === -1) {
+    return [`${PREPARATION_DOC} is missing the bounded future canonical mapping section`];
+  }
+
+  const section = content.slice(start, end);
+  const mappedRows = [...section.matchAll(/^\|\s*`([^`]+)`\s*\|\s*(.*?)\s*\|$/gm)];
+  const mappedTargets = new Map(mappedRows.map((match) => [match[1], match[2]]));
+  const mappedCurrentRoles = mappedRows.map((match) => match[1]).sort();
+  const expectedCurrentRoles = Object.keys(EXPECTED_CURRENT_ROLE_TARGETS).sort();
+  const actualRuntimeRoles = [...runtimeAgents].sort();
+  const missingRuntimeRoles = expectedCurrentRoles.filter(
+    (role) => !actualRuntimeRoles.includes(role),
+  );
+  const extraRuntimeRoles = actualRuntimeRoles.filter(
+    (role) => !expectedCurrentRoles.includes(role),
+  );
+  const missingMappings = expectedCurrentRoles.filter((role) => !mappedTargets.has(role));
+  const extraMappings = mappedCurrentRoles.filter((role) => !expectedCurrentRoles.includes(role));
+  const findings = [];
+
+  if (missingRuntimeRoles.length) {
+    findings.push(`runtime roster misses preparation roles: ${missingRuntimeRoles.join(', ')}`);
+  }
+  if (extraRuntimeRoles.length) {
+    findings.push(`runtime roster has unplanned roles: ${extraRuntimeRoles.join(', ')}`);
+  }
+  if (mappedCurrentRoles.length !== expectedCurrentRoles.length) {
+    findings.push(
+      `future mapping has ${mappedCurrentRoles.length} current-role rows; expected ${expectedCurrentRoles.length}`,
+    );
+  }
+  if (missingMappings.length) findings.push(`future mapping misses: ${missingMappings.join(', ')}`);
+  if (extraMappings.length)
+    findings.push(`future mapping has unknown roles: ${extraMappings.join(', ')}`);
+
+  for (const [currentRole, expectedTarget] of Object.entries(EXPECTED_CURRENT_ROLE_TARGETS)) {
+    const documentedTarget = mappedTargets.get(currentRole);
+    if (!documentedTarget) continue;
+    const [kind, target] = expectedTarget.split(':');
+    const expectedText =
+      kind === 'canonical'
+        ? `Canonical \`${target}\``
+        : kind === 'local'
+          ? `Local \`${target}\` retained`
+          : 'No permanent role';
+    if (!documentedTarget.includes(expectedText)) {
+      findings.push(`${currentRole} maps to "${documentedTarget}", expected ${expectedTarget}`);
+    }
+  }
+
+  const rosterLine = section
+    .split(/\r?\n/)
+    .find((line) => line.startsWith('The planned canonical roster is:'));
+  const documentedCanonicalAgents = rosterLine
+    ? [...rosterLine.matchAll(/`([^`]+)`/g)].map((match) => match[1]).sort()
+    : [];
+  const missingCanonicalAgents = PLANNED_CANONICAL_AGENTS.filter(
+    (role) => !documentedCanonicalAgents.includes(role),
+  );
+  const extraCanonicalAgents = documentedCanonicalAgents.filter(
+    (role) => !PLANNED_CANONICAL_AGENTS.includes(role),
+  );
+  if (documentedCanonicalAgents.length !== PLANNED_CANONICAL_AGENTS.length) {
+    findings.push(
+      `planned canonical roster has ${documentedCanonicalAgents.length} roles; ` +
+        `expected ${PLANNED_CANONICAL_AGENTS.length}`,
+    );
+  }
+  if (missingCanonicalAgents.length) {
+    findings.push(`planned canonical roster misses: ${missingCanonicalAgents.join(', ')}`);
+  }
+  if (extraCanonicalAgents.length) {
+    findings.push(`planned canonical roster has unknown roles: ${extraCanonicalAgents.join(', ')}`);
+  }
+
+  const futureCountMatch = section.match(
+    /future runtime therefore contains (\d+) physical agent files: (\d+) generated canonical files and one Finance-authored local file/,
+  );
+  if (!futureCountMatch) {
+    findings.push('future runtime count statement is missing');
+  } else {
+    const physicalCount = Number.parseInt(futureCountMatch[1], 10);
+    const canonicalCount = Number.parseInt(futureCountMatch[2], 10);
+    if (canonicalCount !== PLANNED_CANONICAL_AGENTS.length) {
+      findings.push(
+        `future runtime claims ${canonicalCount} canonical files; ` +
+          `expected ${PLANNED_CANONICAL_AGENTS.length}`,
+      );
+    }
+    if (physicalCount !== canonicalCount + 1) {
+      findings.push(
+        `future runtime claims ${physicalCount} physical files; ` +
+          `expected ${canonicalCount + 1}`,
+      );
+    }
+  }
+
+  return findings;
+}
+
 function main() {
   const manifest = buildManifest();
   const counts = manifest.counts;
@@ -143,6 +287,18 @@ function main() {
   process.stdout.write('\n');
 
   const drifted = allFindings.filter((f) => f.drift);
+  const preparationFindings = validateCanonicalPreparation(manifest.agents);
+
+  process.stdout.write('Canonical activation preparation:\n');
+  if (preparationFindings.length === 0) {
+    process.stdout.write(
+      `  [ok] ${manifest.agents.length} current roles mapped; ` +
+        `${PLANNED_CANONICAL_AGENTS.length} canonical roles + finance-domain prepared\n\n`,
+    );
+  } else {
+    for (const finding of preparationFindings) process.stdout.write(`  [DRIFT] ${finding}\n`);
+    process.stdout.write('\n');
+  }
 
   if (allFindings.length) {
     process.stdout.write('Detected count claims:\n');
@@ -165,10 +321,13 @@ function main() {
       `**${counts.instructions}** instructions · **${counts.mcpServers}** MCP servers`,
   );
   summaryLines.push('');
-  if (drifted.length === 0) {
+  if (drifted.length === 0 && preparationFindings.length === 0) {
     summaryLines.push('✅ No drift between doc counts and the filesystem.');
   } else {
-    summaryLines.push(`⚠️ Found **${drifted.length}** drifted count claim(s):`);
+    summaryLines.push(
+      `⚠️ Found **${drifted.length}** drifted count claim(s) and ` +
+        `**${preparationFindings.length}** canonical-preparation finding(s).`,
+    );
     summaryLines.push('');
     summaryLines.push('| File | Line | Metric | Claimed | Actual |');
     summaryLines.push('| ---- | ---- | ------ | ------- | ------ |');
@@ -180,6 +339,13 @@ function main() {
           `claims ${f.claimed} ${f.metric} but filesystem has ${f.actual}\n`,
       );
     }
+    for (const finding of preparationFindings) {
+      summaryLines.push(`- Canonical preparation: ${finding}`);
+      process.stdout.write(
+        `::${STRICT ? 'error' : 'warning'} file=${PREPARATION_DOC}::` +
+          `Canonical preparation drift: ${finding}\n`,
+      );
+    }
   }
   if (process.env.GITHUB_STEP_SUMMARY) {
     try {
@@ -189,18 +355,22 @@ function main() {
     }
   }
 
-  if (drifted.length === 0) {
+  if (drifted.length === 0 && preparationFindings.length === 0) {
     process.stdout.write('✅ No drift detected.\n');
     process.exit(0);
   }
 
   if (STRICT) {
-    process.stdout.write(`❌ ${drifted.length} drifted count claim(s). Failing (STRICT=1).\n`);
+    process.stdout.write(
+      `❌ ${drifted.length} drifted count claim(s), ` +
+        `${preparationFindings.length} canonical-preparation finding(s). Failing (STRICT=1).\n`,
+    );
     process.exit(1);
   }
 
   process.stdout.write(
-    `⚠️ ${drifted.length} drifted count claim(s) — informational only. ` +
+    `⚠️ ${drifted.length} drifted count claim(s), ` +
+      `${preparationFindings.length} canonical-preparation finding(s) — informational only. ` +
       'Re-run with STRICT=1 to enforce. Exiting 0.\n',
   );
   process.exit(0);


### PR DESCRIPTION
## Summary

- preserve Finance-specific behavior from all 25 current agent definitions in root/scoped overlays without copying generic persona or workflow boilerplate
- prepare the future 22-canonical-plus-`finance-domain` roster, including native-app, database, and SRE ownership seams while keeping all current runtime files active
- make the bug-bash prompt the durable single-bug task mode and strengthen money, currency, recurrence, RLS, release, telemetry, and signing constraints
- extend the local manifest drift check to validate all 25 current role mappings, the exact 22-role canonical roster, the retained local role, and future file counts

## Preparation Boundaries

- no Studio sync was run
- no runtime agent file was deleted or renamed
- no canonical backbone or sync lock/config was changed

## Validation

- `npm run format`
- `npx eslint . --fix`
- `npm run format:check`
- `npx eslint . --max-warnings 0`
- `node tools/check-ai-manifest.js --strict`

## Issues

Closes #4009