### PR TITLE
fix(banking): restore Plaid refresh ingestion

### DIFF
--- a/apps/web/src/components/bank/bank-connections.css
+++ b/apps/web/src/components/bank/bank-connections.css
@@ -575,6 +575,46 @@
   color: var(--semantic-status-negative, #dc2626);
 }
 
+/* Connection health history */
+.connection-history {
+  margin-top: var(--spacing-5, 20px);
+  padding: var(--spacing-4, 16px);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-lg, 12px);
+  background: var(--semantic-background-elevated, #f9fafb);
+}
+
+.connection-history__header,
+.connection-history__event-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3, 12px);
+}
+
+.connection-history__header h3 {
+  margin: 0;
+}
+
+.connection-history__list {
+  display: grid;
+  gap: var(--spacing-3, 12px);
+  margin: var(--spacing-4, 16px) 0 0;
+  padding-left: var(--spacing-5, 20px);
+}
+
+.connection-history__event {
+  padding: var(--spacing-3, 12px);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-md, 8px);
+}
+
+.connection-history__event p,
+.connection-history__empty {
+  margin: var(--spacing-2, 8px) 0 0;
+  color: var(--semantic-text-secondary, #6b7280);
+}
+
 /* =========================================================================
    Connect a bank (Plaid Link launcher)
    ========================================================================= */

--- a/apps/web/src/hooks/useBankConnections.test.ts
+++ b/apps/web/src/hooks/useBankConnections.test.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  listAggregatorProviders,
+  listBankConnectionHealth,
+  listHealthHistory,
+} from '../db/repositories/bank-connections';
+import { defaultRegistry } from '../lib/banking';
+import { ensureAggregatorProvidersRegistered } from '../lib/banking/register-aggregator-providers';
+import { useBankConnections } from './useBankConnections';
+
+const mockDatabase = { __db: true };
+
+vi.mock('../db/DatabaseProvider', () => ({
+  useDatabase: () => mockDatabase,
+}));
+
+vi.mock('../db/repositories/bank-connections', () => ({
+  listAggregatorProviders: vi.fn(),
+  listBankConnectionHealth: vi.fn(),
+  listHealthHistory: vi.fn(),
+}));
+
+vi.mock('../lib/banking', () => ({
+  createDbProviderMetaSource: vi.fn(() => ({ __source: true })),
+  defaultRegistry: { getProvider: vi.fn() },
+  getProviderRouter: vi.fn(() => ({ setMetaSource: vi.fn() })),
+}));
+
+vi.mock('../lib/banking/register-aggregator-providers', () => ({
+  ensureAggregatorProvidersRegistered: vi.fn(),
+}));
+
+const activeConnection = {
+  id: 'conn-active',
+  provider: 'plaid',
+  institutionName: 'Example Bank',
+  connectionStatus: 'active',
+  healthStatus: 'healthy' as const,
+  stalenessMinutes: 0,
+  errorCategory: null,
+  errorCode: null,
+  lastSyncedAt: '2026-08-07T12:00:00.000Z',
+  permissionLevel: 'read_only',
+  connectionType: 'aggregator',
+  needsReauth: false,
+};
+
+const inactiveConnection = {
+  ...activeConnection,
+  id: 'conn-inactive',
+  provider: 'mx',
+  institutionName: 'Inactive Bank',
+  connectionStatus: 'disconnected',
+};
+
+describe('useBankConnections refresh', () => {
+  const refreshConnection = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listBankConnectionHealth).mockResolvedValue([activeConnection, inactiveConnection]);
+    vi.mocked(listAggregatorProviders).mockResolvedValue([]);
+    vi.mocked(listHealthHistory).mockResolvedValue([]);
+    vi.mocked(ensureAggregatorProvidersRegistered).mockResolvedValue(undefined);
+    vi.mocked(defaultRegistry.getProvider).mockReturnValue({
+      refreshConnection,
+    } as never);
+    refreshConnection.mockResolvedValue({
+      connectionId: activeConnection.id,
+      success: true,
+      newTransactions: 3,
+    });
+  });
+
+  it('refreshes every active displayed connection before reloading local data', async () => {
+    const { result } = renderHook(() => useBankConnections());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const initialLoadCount = vi.mocked(listBankConnectionHealth).mock.calls.length;
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(ensureAggregatorProvidersRegistered).toHaveBeenCalledOnce();
+    expect(defaultRegistry.getProvider).toHaveBeenCalledWith('plaid');
+    expect(defaultRegistry.getProvider).not.toHaveBeenCalledWith('mx');
+    expect(refreshConnection).toHaveBeenCalledWith('conn-active');
+    expect(listBankConnectionHealth).toHaveBeenCalledTimes(initialLoadCount + 1);
+  });
+
+  it('surfaces provider refresh failures and does not report silent success', async () => {
+    refreshConnection.mockRejectedValue(new Error('Provider refresh unavailable'));
+    const { result } = renderHook(() => useBankConnections());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const initialLoadCount = vi.mocked(listBankConnectionHealth).mock.calls.length;
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.error).toBe('Provider refresh unavailable');
+    expect(listBankConnectionHealth).toHaveBeenCalledTimes(initialLoadCount);
+  });
+
+  it('discards stale health history responses after a newer selection', async () => {
+    let resolveFirst: ((value: Awaited<ReturnType<typeof listHealthHistory>>) => void) | undefined;
+    vi.mocked(listHealthHistory)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce([
+        {
+          id: 'newer-event',
+          status: 'healthy',
+          errorCategory: null,
+          errorDetail: null,
+          stalenessMinutes: 0,
+          resolvedAt: null,
+          resolutionAction: null,
+          createdAt: '2026-08-07T13:00:00.000Z',
+        },
+      ]);
+    const { result } = renderHook(() => useBankConnections());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let firstRequest = Promise.resolve();
+    await act(async () => {
+      firstRequest = result.current.loadHealthHistory('conn-active');
+      await result.current.loadHealthHistory('conn-inactive');
+    });
+    await act(async () => {
+      resolveFirst?.([
+        {
+          id: 'stale-event',
+          status: 'provider_down',
+          errorCategory: 'provider',
+          errorDetail: 'STALE',
+          stalenessMinutes: null,
+          resolvedAt: null,
+          resolutionAction: null,
+          createdAt: '2026-08-07T12:00:00.000Z',
+        },
+      ]);
+      await firstRequest;
+    });
+
+    expect(result.current.healthHistory.map((event) => event.id)).toEqual(['newer-event']);
+  });
+});

--- a/apps/web/src/hooks/useBankConnections.ts
+++ b/apps/web/src/hooks/useBankConnections.ts
@@ -19,7 +19,7 @@
  * References: #1575, #1577, #3852
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useDatabase } from '../db/DatabaseProvider';
 import {
@@ -32,7 +32,8 @@ import type {
   BankConnectionHealth,
   HealthHistoryEvent,
 } from '../db/repositories/bank-connections';
-import { createDbProviderMetaSource, getProviderRouter } from '../lib/banking';
+import { createDbProviderMetaSource, defaultRegistry, getProviderRouter } from '../lib/banking';
+import { ensureAggregatorProvidersRegistered } from '../lib/banking/register-aggregator-providers';
 
 // ---------------------------------------------------------------------------
 // Types (owned by the repository; re-exported here for existing consumers)
@@ -56,12 +57,16 @@ export interface UseBankConnectionsResult {
   healthHistory: HealthHistoryEvent[];
   /** Whether data is loading. */
   loading: boolean;
+  /** Whether health history is loading. */
+  historyLoading: boolean;
   /** Human-readable error message. */
   error: string | null;
   /** Refresh all connection data. */
-  refresh: () => void;
+  refresh: () => Promise<void>;
+  /** Reload local PowerSync-backed data without triggering a server refresh. */
+  reloadLocal: () => Promise<void>;
   /** Load health history for a specific connection. */
-  loadHealthHistory: (connectionId: string) => void;
+  loadHealthHistory: (connectionId: string) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -83,13 +88,46 @@ export function useBankConnections(): UseBankConnectionsResult {
   const [providers, setProviders] = useState<AggregatorProvider[]>([]);
   const [healthHistory, setHealthHistory] = useState<HealthHistoryEvent[]>([]);
   const [loading, setLoading] = useState(true);
+  const [historyLoading, setHistoryLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [refreshToken, setRefreshToken] = useState(0);
+  const historyRequestId = useRef(0);
 
-  const refresh = useCallback(() => {
+  const reloadLocal = useCallback(async () => {
     setLoading(true);
-    setRefreshToken((t) => t + 1);
-  }, []);
+    try {
+      setConnections(await listBankConnectionHealth(db));
+      setProviders(await listAggregatorProviders(db));
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load bank connections');
+    } finally {
+      setLoading(false);
+    }
+  }, [db]);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await ensureAggregatorProvidersRegistered();
+      for (const connection of connections.filter(
+        (candidate) => candidate.connectionStatus === 'active',
+      )) {
+        const provider = defaultRegistry.getProvider(connection.provider);
+        if (!provider) {
+          throw new Error(`No refresh provider is registered for ${connection.provider}.`);
+        }
+        const result = await provider.refreshConnection(connection.id);
+        if (!result.success) {
+          throw new Error(`Refresh failed for ${connection.institutionName}.`);
+        }
+      }
+      await reloadLocal();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to refresh bank connections');
+      setLoading(false);
+    }
+  }, [connections, reloadLocal]);
 
   // Feed the synced provider directory into the shared router so app-routed
   // provider selection reflects live health/priority. Re-attached whenever the
@@ -100,33 +138,29 @@ export function useBankConnections(): UseBankConnectionsResult {
 
   // Load connections + providers from the local SQLite mirror.
   useEffect(() => {
-    const load = async () => {
-      try {
-        setConnections(await listBankConnectionHealth(db));
-        setProviders(await listAggregatorProviders(db));
-        setError(null);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load bank connections');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    load();
-  }, [db, refreshToken]);
+    void reloadLocal();
+  }, [reloadLocal]);
 
   const loadHealthHistory = useCallback(
-    (connectionId: string) => {
-      const load = async () => {
-        try {
-          setHealthHistory(await listHealthHistory(db, connectionId));
+    async (connectionId: string) => {
+      const requestId = ++historyRequestId.current;
+      setHealthHistory([]);
+      setHistoryLoading(true);
+      try {
+        const history = await listHealthHistory(db, connectionId);
+        if (historyRequestId.current === requestId) {
+          setHealthHistory(history);
           setError(null);
-        } catch (err) {
+        }
+      } catch (err) {
+        if (historyRequestId.current === requestId) {
           setError(err instanceof Error ? err.message : 'Failed to load health history');
         }
-      };
-
-      load();
+      } finally {
+        if (historyRequestId.current === requestId) {
+          setHistoryLoading(false);
+        }
+      }
     },
     [db],
   );
@@ -136,8 +170,10 @@ export function useBankConnections(): UseBankConnectionsResult {
     providers,
     healthHistory,
     loading,
+    historyLoading,
     error,
     refresh,
+    reloadLocal,
     loadHealthHistory,
   };
 }

--- a/apps/web/src/lib/banking/__tests__/base-aggregator-provider.test.ts
+++ b/apps/web/src/lib/banking/__tests__/base-aggregator-provider.test.ts
@@ -317,9 +317,11 @@ describe('BaseAggregatorProvider — completeConnection', () => {
 
 describe('BaseAggregatorProvider — refreshConnection', () => {
   it('maps a healthy check_health response to success', async () => {
-    const { provider, calls } = withResponses([json({ health_status: 'healthy' })]);
+    const { provider, calls } = withResponses([
+      json({ health_status: 'healthy', new_transactions: 7 }),
+    ]);
     const result = await provider.refreshConnection('conn-1');
-    expect(result).toEqual({ connectionId: 'conn-1', success: true });
+    expect(result).toEqual({ connectionId: 'conn-1', success: true, newTransactions: 7 });
     expect(calls[0].url).toBe(
       'https://edge.example.test/functions/v1/aggregator-health?action=check_health',
     );
@@ -333,6 +335,14 @@ describe('BaseAggregatorProvider — refreshConnection', () => {
     const { provider } = withResponses([json({ health_status: 'unknown_error' })]);
     const result = await provider.refreshConnection('conn-1');
     expect(result.success).toBe(false);
+  });
+
+  it('omits a malformed new transaction count', async () => {
+    const { provider } = withResponses([
+      json({ health_status: 'healthy', new_transactions: 'not-a-number' }),
+    ]);
+    const result = await provider.refreshConnection('conn-1');
+    expect(result.newTransactions).toBeUndefined();
   });
 
   it('throws a categorized error on a non-2xx response', async () => {

--- a/apps/web/src/lib/banking/base-aggregator-provider.ts
+++ b/apps/web/src/lib/banking/base-aggregator-provider.ts
@@ -341,11 +341,8 @@ export class BaseAggregatorProvider implements BankConnectionProvider {
    * Trigger a server-side health check / re-sync for a connection via
    * `aggregator-health?action=check_health`.
    *
-   * Because transaction data flows to the client through PowerSync rather than
-   * a per-provider fetch, "refresh" here nudges the backend to re-evaluate the
-   * connection's health; `newTransactions` is intentionally omitted since new
-   * rows arrive via sync. Throws a {@link BankingProviderError} on failure so
-   * the {@link ConnectionManager} retry policy can act on it.
+   * Transaction rows still reach the client through PowerSync, while the
+   * aggregate count reports what the server-side refresh ingested.
    */
   async refreshConnection(connectionId: string): Promise<RefreshResult> {
     const body = await this.request('aggregator-health?action=check_health', {
@@ -356,8 +353,12 @@ export class BaseAggregatorProvider implements BankConnectionProvider {
     const rec = asRecord(body);
     const health = str(rec.health_status);
     const success = health !== 'unknown_error' && health !== 'auth_expired';
+    const newTransactions =
+      typeof rec.new_transactions === 'number' && Number.isFinite(rec.new_transactions)
+        ? rec.new_transactions
+        : undefined;
 
-    return { connectionId, success };
+    return { connectionId, success, newTransactions };
   }
 
   /**

--- a/apps/web/src/pages/BankConnectionsPage.test.tsx
+++ b/apps/web/src/pages/BankConnectionsPage.test.tsx
@@ -41,8 +41,10 @@ function setupHooks(): void {
     providers: [],
     healthHistory: [],
     loading: false,
+    historyLoading: false,
     error: null,
     refresh: vi.fn(),
+    reloadLocal: vi.fn(),
     loadHealthHistory: vi.fn(),
   });
   mockedUseConnectorPermissions.mockReturnValue({
@@ -185,5 +187,93 @@ describe('BankConnectionsPage — WAI-ARIA Tabs (#3862)', () => {
   it('has no axe-core accessibility violations', async () => {
     const { container } = renderPage();
     await expectNoAxeViolations(container);
+  });
+
+  it('opens a visible history panel with an empty state', () => {
+    const loadHealthHistory = vi.fn().mockResolvedValue(undefined);
+    mockedUseBankConnections.mockReturnValue({
+      connections: [
+        {
+          id: 'conn-1',
+          provider: 'plaid',
+          institutionName: 'Example Bank',
+          connectionStatus: 'active',
+          healthStatus: 'healthy',
+          stalenessMinutes: 0,
+          errorCategory: null,
+          errorCode: null,
+          lastSyncedAt: '2026-08-07T12:00:00.000Z',
+          permissionLevel: 'read_only',
+          connectionType: 'aggregator',
+          needsReauth: false,
+        },
+      ],
+      providers: [],
+      healthHistory: [],
+      loading: false,
+      historyLoading: false,
+      error: null,
+      refresh: vi.fn(),
+      reloadLocal: vi.fn(),
+      loadHealthHistory,
+    });
+
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /view health history/i }));
+
+    expect(loadHealthHistory).toHaveBeenCalledWith('conn-1');
+    expect(screen.getByRole('heading', { name: 'Health history for Example Bank' })).toBeVisible();
+    expect(
+      screen.getByText('No health events have been recorded for this connection.'),
+    ).toBeVisible();
+  });
+
+  it('renders health event status, timestamp, and resolution metadata', () => {
+    mockedUseBankConnections.mockReturnValue({
+      connections: [
+        {
+          id: 'conn-1',
+          provider: 'plaid',
+          institutionName: 'Example Bank',
+          connectionStatus: 'active',
+          healthStatus: 'provider_down',
+          stalenessMinutes: 10,
+          errorCategory: 'provider',
+          errorCode: 'PLAID_SYNC_FAILED',
+          lastSyncedAt: '2026-08-07T12:00:00.000Z',
+          permissionLevel: 'read_only',
+          connectionType: 'aggregator',
+          needsReauth: false,
+        },
+      ],
+      providers: [],
+      healthHistory: [
+        {
+          id: 'event-1',
+          status: 'provider_down',
+          errorCategory: 'provider',
+          errorDetail: 'PLAID_SYNC_FAILED',
+          stalenessMinutes: 10,
+          resolvedAt: '2026-08-07T13:00:00.000Z',
+          resolutionAction: 'manual_refresh',
+          createdAt: '2026-08-07T12:30:00.000Z',
+        },
+      ],
+      loading: false,
+      historyLoading: false,
+      error: null,
+      refresh: vi.fn(),
+      reloadLocal: vi.fn(),
+      loadHealthHistory: vi.fn().mockResolvedValue(undefined),
+    });
+
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /view health history/i }));
+
+    expect(screen.getByText('provider down')).toBeVisible();
+    expect(screen.getByText('Error category: provider')).toBeVisible();
+    expect(screen.getByText('Error detail: PLAID_SYNC_FAILED')).toBeVisible();
+    expect(screen.getByText(/via manual refresh/)).toBeVisible();
+    expect(document.querySelectorAll('time')).toHaveLength(2);
   });
 });

--- a/apps/web/src/pages/BankConnectionsPage.tsx
+++ b/apps/web/src/pages/BankConnectionsPage.tsx
@@ -25,6 +25,7 @@ import '../components/bank/bank-connections.css';
 import { useBankConnections } from '../hooks/useBankConnections';
 import { useConnectorPermissions } from '../hooks/useConnectorPermissions';
 import { useFeatureFlag, FlagKeys } from '../lib/feature-flags';
+import { formatDate } from '../utils/formatDate';
 
 /**
  * "Connect a bank" launcher (#3846). Lazy-loaded and rendered only when the
@@ -94,7 +95,10 @@ export const BankConnectionsPage: React.FC = () => {
     providers,
     loading: connectionsLoading,
     error: connectionsError,
+    healthHistory,
+    historyLoading,
     refresh: refreshConnections,
+    reloadLocal: reloadConnections,
     loadHealthHistory,
   } = useBankConnections();
 
@@ -109,6 +113,7 @@ export const BankConnectionsPage: React.FC = () => {
   const liveBankData = useFeatureFlag(FlagKeys.LIVE_BANK_DATA);
 
   const [activeTab, setActiveTab] = useState<BankTabId>('health');
+  const [historyConnectionId, setHistoryConnectionId] = useState<string | null>(null);
 
   // Roving-tabindex focus management for the tablist (#3862). Each tab button
   // registers its node so keyboard navigation can move DOM focus to the newly
@@ -153,10 +158,12 @@ export const BankConnectionsPage: React.FC = () => {
 
   const handleViewHistory = useCallback(
     (connectionId: string) => {
-      loadHealthHistory(connectionId);
+      setHistoryConnectionId(connectionId);
+      void loadHealthHistory(connectionId);
     },
     [loadHealthHistory],
   );
+  const historyConnection = connections.find((connection) => connection.id === historyConnectionId);
 
   const handleReauth = useCallback((_connectionId: string) => {
     // TODO: Trigger re-authentication flow via aggregator provider
@@ -261,13 +268,13 @@ export const BankConnectionsPage: React.FC = () => {
               <div className="section-actions">
                 {liveBankData && (
                   <Suspense fallback={null}>
-                    <ConnectBankButton onConnected={refreshConnections} />
+                    <ConnectBankButton onConnected={() => void reloadConnections()} />
                   </Suspense>
                 )}
                 <button
                   type="button"
                   className="section-action"
-                  onClick={refreshConnections}
+                  onClick={() => void refreshConnections()}
                   aria-label="Refresh connection health"
                 >
                   Refresh
@@ -303,6 +310,64 @@ export const BankConnectionsPage: React.FC = () => {
                 onReauth={handleReauth}
               />
             ))}
+
+            {historyConnectionId && (
+              <section className="connection-history" aria-labelledby="connection-history-title">
+                <div className="connection-history__header">
+                  <h3 id="connection-history-title">
+                    Health history
+                    {historyConnection ? ` for ${historyConnection.institutionName}` : ''}
+                  </h3>
+                  <button
+                    type="button"
+                    className="connection-health-card__action"
+                    onClick={() => setHistoryConnectionId(null)}
+                  >
+                    Close history
+                  </button>
+                </div>
+
+                {historyLoading ? (
+                  <p role="status">Loading health history…</p>
+                ) : healthHistory.length === 0 ? (
+                  <p className="connection-history__empty">
+                    No health events have been recorded for this connection.
+                  </p>
+                ) : (
+                  <ol className="connection-history__list">
+                    {healthHistory.map((event) => (
+                      <li key={event.id} className="connection-history__event">
+                        <div className="connection-history__event-header">
+                          <strong>{event.status.replaceAll('_', ' ')}</strong>
+                          <time dateTime={event.createdAt}>
+                            {formatDate(event.createdAt, {
+                              dateStyle: 'medium',
+                              timeStyle: 'short',
+                            })}
+                          </time>
+                        </div>
+                        {event.errorCategory && <p>Error category: {event.errorCategory}</p>}
+                        {event.errorDetail && <p>Error detail: {event.errorDetail}</p>}
+                        {event.resolvedAt && (
+                          <p>
+                            Resolved{' '}
+                            <time dateTime={event.resolvedAt}>
+                              {formatDate(event.resolvedAt, {
+                                dateStyle: 'medium',
+                                timeStyle: 'short',
+                              })}
+                            </time>
+                            {event.resolutionAction
+                              ? ` via ${event.resolutionAction.replaceAll('_', ' ')}`
+                              : ''}
+                          </p>
+                        )}
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </section>
+            )}
           </section>
         )}
 

--- a/services/api/supabase/functions/_shared/bank-ingest.test.ts
+++ b/services/api/supabase/functions/_shared/bank-ingest.test.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { assertEquals, assertRejects } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+
+import {
+  loadLinkedAccounts,
+  persistPlaidSyncMetadata,
+  removePlaidTransaction,
+  upsertPlaidTransaction,
+} from './bank-ingest.ts';
+import type { PlaidTransaction } from './plaid.ts';
+
+type LoadClient = Parameters<typeof loadLinkedAccounts>[0];
+type UpsertClient = Parameters<typeof upsertPlaidTransaction>[0];
+
+const transaction: PlaidTransaction = {
+  transaction_id: 'provider-transaction-id',
+  account_id: 'provider-account-id',
+  amount: 1,
+  iso_currency_code: 'USD',
+  unofficial_currency_code: null,
+  date: '2026-08-07',
+  authorized_date: null,
+  name: 'Test transaction',
+  merchant_name: null,
+  pending: false,
+};
+
+const linkedAccount = {
+  account_id: 'account-id',
+  household_id: 'household-id',
+  currency_code: 'USD',
+};
+
+Deno.test('loadLinkedAccounts propagates database failures', async () => {
+  const result = Promise.resolve({ data: null, error: { message: 'database unavailable' } });
+  const query = {
+    select: () => query,
+    eq: () => query,
+    is: () => result,
+  };
+  const client = { from: () => query } as unknown as LoadClient;
+
+  await assertRejects(
+    () => loadLinkedAccounts(client, 'connection-id'),
+    Error,
+    'Plaid ingestion failed while loading linked accounts',
+  );
+});
+
+Deno.test('upsertPlaidTransaction propagates existing-transaction lookup failures', async () => {
+  const query = {
+    select: () => query,
+    eq: () => query,
+    is: () => query,
+    maybeSingle: () => Promise.resolve({ data: null, error: { message: 'database unavailable' } }),
+  };
+  const client = { from: () => query } as unknown as UpsertClient;
+
+  await assertRejects(
+    () => upsertPlaidTransaction(client, transaction, linkedAccount),
+    Error,
+    'Plaid ingestion failed while checking for an existing transaction',
+  );
+});
+
+Deno.test(
+  'upsertPlaidTransaction increments eligibility only after a successful insert',
+  async () => {
+    const lookup = {
+      select: () => lookup,
+      eq: () => lookup,
+      is: () => lookup,
+      maybeSingle: () => Promise.resolve({ data: null, error: null }),
+    };
+    const client = {
+      from: () => ({
+        ...lookup,
+        insert: () => Promise.resolve({ error: null }),
+      }),
+    } as unknown as UpsertClient;
+
+    assertEquals(await upsertPlaidTransaction(client, transaction, linkedAccount), true);
+  },
+);
+
+Deno.test('upsertPlaidTransaction propagates insert failures', async () => {
+  const lookup = {
+    select: () => lookup,
+    eq: () => lookup,
+    is: () => lookup,
+    maybeSingle: () => Promise.resolve({ data: null, error: null }),
+  };
+  const client = {
+    from: () => ({
+      ...lookup,
+      insert: () => Promise.resolve({ error: { message: 'insert failed' } }),
+    }),
+  } as unknown as UpsertClient;
+
+  await assertRejects(
+    () => upsertPlaidTransaction(client, transaction, linkedAccount),
+    Error,
+    'Plaid ingestion failed while inserting a transaction',
+  );
+});
+
+Deno.test('upsertPlaidTransaction propagates update failures', async () => {
+  const lookup = {
+    select: () => lookup,
+    eq: () => lookup,
+    is: () => lookup,
+    maybeSingle: () => Promise.resolve({ data: { id: 'transaction-id' }, error: null }),
+  };
+  const updateQuery = {
+    update: () => updateQuery,
+    eq: () => Promise.resolve({ error: { message: 'update failed' } }),
+  };
+  const client = {
+    from: () => ({
+      ...lookup,
+      update: updateQuery.update,
+    }),
+  } as unknown as UpsertClient;
+
+  await assertRejects(
+    () => upsertPlaidTransaction(client, transaction, linkedAccount),
+    Error,
+    'Plaid ingestion failed while updating a transaction',
+  );
+});
+
+Deno.test('removePlaidTransaction propagates update failures', async () => {
+  const query = {
+    update: () => query,
+    eq: () => query,
+    is: () => query,
+    select: () => Promise.resolve({ data: null, error: { message: 'update failed' } }),
+  };
+  const client = { from: () => query } as unknown as Parameters<typeof removePlaidTransaction>[0];
+
+  await assertRejects(
+    () => removePlaidTransaction(client, 'provider-transaction-id'),
+    Error,
+    'Plaid ingestion failed while removing a transaction',
+  );
+});
+
+Deno.test('persistPlaidSyncMetadata propagates cursor persistence failures', async () => {
+  const query = {
+    update: () => query,
+    eq: () => Promise.resolve({ error: { message: 'update failed' } }),
+  };
+  const client = { from: () => query } as unknown as Parameters<typeof persistPlaidSyncMetadata>[0];
+
+  await assertRejects(
+    () =>
+      persistPlaidSyncMetadata(
+        client,
+        {
+          id: 'connection-id',
+          household_id: 'household-id',
+          encrypted_access_token: 'encrypted-test-token',
+          metadata: null,
+        },
+        'next-cursor',
+      ),
+    Error,
+    'Plaid ingestion failed while persisting the connection sync cursor',
+  );
+});

--- a/services/api/supabase/functions/_shared/bank-ingest.ts
+++ b/services/api/supabase/functions/_shared/bank-ingest.ts
@@ -57,6 +57,11 @@ export interface IngestionSummary {
   removed: number;
 }
 
+/** Create a stable, data-safe error for a failed ingestion database operation. */
+function ingestionDatabaseError(operation: string): Error {
+  return new Error(`Plaid ingestion failed while ${operation}`);
+}
+
 /** Read Plaid credentials from the environment. */
 function plaidConfigFromEnv(): PlaidConfig {
   return {
@@ -74,12 +79,16 @@ export async function loadLinkedAccounts(
   supabase: AdminClient,
   connectionId: string,
 ): Promise<Map<string, LinkedAccount>> {
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from('bank_connection_accounts')
     .select('external_account_id, account_id, household_id, currency_code, is_linked')
     .eq('bank_connection_id', connectionId)
     .eq('is_linked', true)
     .is('deleted_at', null);
+
+  if (error) {
+    throw ingestionDatabaseError('loading linked accounts');
+  }
 
   const map = new Map<string, LinkedAccount>();
   for (const row of data ?? []) {
@@ -106,12 +115,16 @@ export async function upsertPlaidTransaction(
   account: LinkedAccount,
 ): Promise<boolean> {
   // Deduplicate on the provider transaction id — provider webhooks may retry.
-  const { data: existing } = await supabase
+  const { data: existing, error: lookupError } = await supabase
     .from('transactions')
     .select('id')
     .eq('provider_transaction_id', txn.transaction_id)
     .is('deleted_at', null)
     .maybeSingle();
+
+  if (lookupError) {
+    throw ingestionDatabaseError('checking for an existing transaction');
+  }
 
   const record = {
     ...plaidTransactionToRecord(txn, {
@@ -123,12 +136,55 @@ export async function upsertPlaidTransaction(
   };
 
   if (existing) {
-    await supabase.from('transactions').update(record).eq('id', existing.id);
+    const { error } = await supabase.from('transactions').update(record).eq('id', existing.id);
+    if (error) {
+      throw ingestionDatabaseError('updating a transaction');
+    }
     return false;
   }
 
-  await supabase.from('transactions').insert(record);
+  const { error } = await supabase.from('transactions').insert(record);
+  if (error) {
+    throw ingestionDatabaseError('inserting a transaction');
+  }
   return true;
+}
+
+/**
+ * Soft-delete one removed Plaid transaction and return the number of rows changed.
+ */
+export async function removePlaidTransaction(
+  supabase: AdminClient,
+  providerTransactionId: string,
+): Promise<number> {
+  const { data: rows, error } = await supabase
+    .from('transactions')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('provider_transaction_id', providerTransactionId)
+    .is('deleted_at', null)
+    .select('id');
+
+  if (error) {
+    throw ingestionDatabaseError('removing a transaction');
+  }
+  return rows?.length ?? 0;
+}
+
+/** Persist the cursor and successful-sync timestamp for a completed ingestion run. */
+export async function persistPlaidSyncMetadata(
+  supabase: AdminClient,
+  connection: BankConnectionRow,
+  cursor: string | null,
+): Promise<void> {
+  const mergedMetadata = { ...(connection.metadata ?? {}), cursor };
+  const { error } = await supabase
+    .from('bank_connections')
+    .update({ metadata: mergedMetadata, last_synced_at: new Date().toISOString() })
+    .eq('id', connection.id);
+
+  if (error) {
+    throw ingestionDatabaseError('persisting the connection sync cursor');
+  }
 }
 
 /**
@@ -141,15 +197,14 @@ export async function upsertPlaidTransaction(
 export async function ingestPlaidTransactions(
   supabase: AdminClient,
   connection: BankConnectionRow,
-  logger: FunctionLogger,
+  _logger: FunctionLogger,
 ): Promise<IngestionSummary> {
   const summary: IngestionSummary = { added: 0, modified: 0, removed: 0 };
 
   const config = plaidConfigFromEnv();
   const encryptionKey = Deno.env.get('BANK_ENCRYPTION_KEY');
   if (!config.clientId || !config.secret || !encryptionKey) {
-    logger.warn('Skipping ingestion — provider config incomplete');
-    return summary;
+    throw new Error('Plaid ingestion cannot start because provider configuration is incomplete');
   }
 
   const accessToken = await decryptToken(connection.encrypted_access_token, encryptionKey);
@@ -175,18 +230,13 @@ export async function ingestPlaidTransactions(
     for (const txn of page.modified) {
       const account = linkedAccounts.get(txn.account_id);
       if (!account) continue;
-      await upsertPlaidTransaction(supabase, txn, account);
-      summary.modified++;
+      const inserted = await upsertPlaidTransaction(supabase, txn, account);
+      if (inserted) summary.added++;
+      else summary.modified++;
     }
 
     for (const removed of page.removed) {
-      const { data: rows } = await supabase
-        .from('transactions')
-        .update({ deleted_at: new Date().toISOString() })
-        .eq('provider_transaction_id', removed.transaction_id)
-        .is('deleted_at', null)
-        .select('id');
-      summary.removed += rows?.length ?? 0;
+      summary.removed += await removePlaidTransaction(supabase, removed.transaction_id);
     }
 
     cursor = page.next_cursor;
@@ -194,11 +244,7 @@ export async function ingestPlaidTransactions(
   }
 
   // Persist the advanced cursor for the next sync (merge into metadata).
-  const mergedMetadata = { ...(connection.metadata ?? {}), cursor };
-  await supabase
-    .from('bank_connections')
-    .update({ metadata: mergedMetadata, last_synced_at: new Date().toISOString() })
-    .eq('id', connection.id);
+  await persistPlaidSyncMetadata(supabase, connection, cursor);
 
   return summary;
 }

--- a/services/api/supabase/functions/aggregator-health/index.ts
+++ b/services/api/supabase/functions/aggregator-health/index.ts
@@ -28,6 +28,7 @@
 
 import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
 import { createAdminClient, requireAuth } from '../_shared/auth.ts';
+import { ingestPlaidTransactions, type IngestionSummary } from '../_shared/bank-ingest.ts';
 import { handleCorsPreflightRequest } from '../_shared/cors.ts';
 import { validateEnv } from '../_shared/env.ts';
 import { createLogger } from '../_shared/logger.ts';
@@ -303,18 +304,25 @@ serve(async (req: Request): Promise<Response> => {
         return errorResponse(req, 'connection_id is required');
       }
 
-      // Fetch connection (RLS ensures household scoping)
+      // Fetch only the connection fields needed for authorization, health, and
+      // the Plaid re-sync. The encrypted token is never logged or returned.
       const { data: connection, error: connError } = await supabase
         .from('bank_connections')
         .select(
           'id, household_id, provider, status, last_synced_at, ' +
-            'error_code, staleness_threshold_hours',
+            'error_code, staleness_threshold_hours, encrypted_access_token, metadata',
         )
         .eq('id', connectionId)
         .is('deleted_at', null)
-        .single();
+        .maybeSingle();
 
-      if (connError || !connection) {
+      if (connError) {
+        logger.error('Failed to fetch bank connection for health check', {
+          errorMessage: connError.message,
+        });
+        return internalErrorResponse(req);
+      }
+      if (!connection) {
         return errorResponse(req, 'Bank connection not found', 404);
       }
 
@@ -331,12 +339,46 @@ serve(async (req: Request): Promise<Response> => {
         return errorResponse(req, 'Household access denied', 403);
       }
 
-      // Calculate health status
+      let ingestionSummary: IngestionSummary = { added: 0, modified: 0, removed: 0 };
+      let effectiveLastSyncedAt = connection.last_synced_at;
+      let refreshedPlaid = false;
+
+      if (connection.provider === 'plaid' && connection.status === 'active') {
+        try {
+          ingestionSummary = await ingestPlaidTransactions(supabase, connection, logger);
+          effectiveLastSyncedAt = new Date().toISOString();
+          refreshedPlaid = true;
+        } catch {
+          logger.error('Plaid connection refresh failed', { connectionId });
+          const { error: failureEventError } = await supabase
+            .from('bank_connection_health')
+            .insert({
+              bank_connection_id: connectionId,
+              household_id: connection.household_id,
+              status: 'provider_down',
+              error_category: 'provider',
+              error_detail: 'PLAID_SYNC_FAILED',
+              last_successful_sync: connection.last_synced_at,
+              staleness_minutes: null,
+            });
+
+          if (failureEventError) {
+            logger.error('Failed to record Plaid refresh failure', {
+              errorMessage: failureEventError.message,
+            });
+            return internalErrorResponse(req);
+          }
+          return errorResponse(req, 'Bank connection refresh failed', 502);
+        }
+      }
+
+      // Calculate health status from the timestamp produced by a successful
+      // Plaid refresh. Providers without an adapter remain health-only checks.
       const staleness = categoriseStaleness(
-        connection.last_synced_at,
+        effectiveLastSyncedAt,
         connection.staleness_threshold_hours ?? 24,
       );
-      const errorCategory = categoriseError(connection.error_code);
+      const errorCategory = refreshedPlaid ? null : categoriseError(connection.error_code);
 
       // Record health event
       const healthStatus =
@@ -351,8 +393,8 @@ serve(async (req: Request): Promise<Response> => {
         household_id: connection.household_id,
         status: healthStatus,
         error_category: errorCategory,
-        error_detail: connection.error_code,
-        last_successful_sync: connection.last_synced_at,
+        error_detail: refreshedPlaid ? null : connection.error_code,
+        last_successful_sync: effectiveLastSyncedAt,
         staleness_minutes: staleness.stalenessMinutes,
       });
 
@@ -373,6 +415,7 @@ serve(async (req: Request): Promise<Response> => {
         staleness_minutes: staleness.stalenessMinutes,
         error_category: errorCategory,
         needs_reauth: connection.status === 'needs_reauth',
+        new_transactions: ingestionSummary.added,
       });
     }
 


### PR DESCRIPTION
## Summary

- fail Plaid ingestion on every linked-account, lookup, transaction write, removal, and cursor persistence database error
- make authenticated Bank Connections refresh run a real Plaid transaction sync for active tenant-authorized connections while MX remains health-only
- refresh active displayed connections through registered providers before local PowerSync reload and render accessible health history feedback

## Behavior

- transaction counts advance only after successful writes, including modified Plaid rows that must be inserted locally
- refresh failures record a safe non-success health event and return an explicit error without exposing tokens or financial data
- successful refreshes record fresh healthy history and return aggregate `new_transactions`
- post-link completion reloads local data without immediately triggering a duplicate server re-sync
- history actions always open a visible panel, including an explicit empty state

## Testing

- `deno test --allow-env --allow-net=none --no-check services/api/supabase/functions/_shared/bank-ingest.test.ts services/api/supabase/functions/aggregator-health/index.test.ts`
- `npm run test -w apps/web -- --run src/lib/banking/__tests__/base-aggregator-provider.test.ts src/hooks/useBankConnections.test.ts src/pages/BankConnectionsPage.test.tsx --reporter=dot`
- `npm run type-check -w apps/web`
- `npm run format:check`
- `npx eslint . --max-warnings 0`

## Deployment

This PR changes Edge Function and web application code only. Production deployment remains a separately approved operation and is not triggered by this PR.

Closes #4013