### PR TITLE
fix(bank): configure aggregator health rate limit

### DIFF
--- a/services/api/supabase/functions/_shared/rate-limit.test.ts
+++ b/services/api/supabase/functions/_shared/rate-limit.test.ts
@@ -458,9 +458,24 @@ Deno.test('RATE_LIMITS — has entries for all expected functions', () => {
     'account-deletion',
     'sync-health-report',
     'process-recurring',
+    'process-scheduled-reports',
     'manage-webhooks',
     'admin-dashboard',
     'send-notification',
+    'launch-readiness',
+    'family-plan',
+    'referral',
+    'generate-report',
+    'exchange-rates',
+    'detect-bills',
+    'import-data',
+    'spending-forecast',
+    'bank-connection',
+    'aggregator-health',
+    'bank-webhook',
+    'anomaly-detection',
+    'consent-management',
+    'investment-sync',
   ];
 
   for (const fn of expectedFunctions) {
@@ -506,6 +521,14 @@ Deno.test('RATE_LIMITS — account-deletion has strict limit', () => {
 Deno.test('RATE_LIMITS — health-check has per-minute limit', () => {
   assertEquals(RATE_LIMITS['health-check'].windowSeconds, 60);
   assertEquals(RATE_LIMITS['health-check'].maxRequests, 60);
+});
+
+Deno.test('RATE_LIMITS — aggregator-health has a bounded namespaced limit', () => {
+  assertEquals(RATE_LIMITS['aggregator-health'], {
+    maxRequests: 30,
+    windowSeconds: 60,
+    keyPrefix: 'aggregator-health',
+  });
 });
 
 Deno.test('RATE_LIMITS — passkey-authenticate is per-minute (pre-auth)', () => {

--- a/services/api/supabase/functions/_shared/rate-limit.ts
+++ b/services/api/supabase/functions/_shared/rate-limit.ts
@@ -229,6 +229,11 @@ export const RATE_LIMITS: Record<string, RateLimitConfig> = {
   'import-data': { maxRequests: 5, windowSeconds: 60, keyPrefix: 'import-data' },
   'spending-forecast': { maxRequests: 30, windowSeconds: 60, keyPrefix: 'spending-forecast' },
   'bank-connection': { maxRequests: 30, windowSeconds: 60, keyPrefix: 'bank-connection' },
+  'aggregator-health': {
+    maxRequests: 30,
+    windowSeconds: 60,
+    keyPrefix: 'aggregator-health',
+  },
   'bank-webhook': { maxRequests: 120, windowSeconds: 60, keyPrefix: 'bank-webhook' },
   'anomaly-detection': { maxRequests: 30, windowSeconds: 60, keyPrefix: 'anomaly-detection' },
   'consent-management': { maxRequests: 30, windowSeconds: 60, keyPrefix: 'consent-management' },

--- a/services/api/supabase/functions/aggregator-health/index.ts
+++ b/services/api/supabase/functions/aggregator-health/index.ts
@@ -40,6 +40,8 @@ import {
   methodNotAllowedResponse,
 } from '../_shared/response.ts';
 
+const AGGREGATOR_HEALTH_RATE_LIMIT = RATE_LIMITS['aggregator-health'];
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -140,10 +142,10 @@ serve(async (req: Request): Promise<Response> => {
     const supabase = createAdminClient();
 
     // Rate limiting
-    const rateLimitResult = await checkRateLimit(supabase, user.id, RATE_LIMITS['default']);
+    const rateLimitResult = await checkRateLimit(supabase, user.id, AGGREGATOR_HEALTH_RATE_LIMIT);
     if (!rateLimitResult.allowed) {
       logger.warn('Rate limit exceeded', { httpStatus: 429 });
-      return rateLimitResponse(req, rateLimitResult, RATE_LIMITS['default']);
+      return rateLimitResponse(req, rateLimitResult, AGGREGATOR_HEALTH_RATE_LIMIT);
     }
 
     const url = new URL(req.url);


### PR DESCRIPTION
## Summary

Fixes the production Bank Connections Refresh HTTP 500 caused by `aggregator-health` passing an undefined `RATE_LIMITS['default']` configuration into the shared rate limiter.

## Changes

- add an explicit `aggregator-health` limit of 30 authenticated requests per minute with its own key namespace
- reuse one local configuration constant for both the rate-limit check and 429 response
- add a focused configuration regression test and bring the complete rate-limit inventory assertion up to date

## Security

The endpoint remains authenticated and user-keyed. The new bound matches the existing `bank-connection` policy while using a distinct key prefix so health refresh traffic cannot consume another endpoint's quota.

## Testing

- `deno test --no-lock --allow-env --allow-net services/api/supabase/functions/_shared/rate-limit.test.ts services/api/supabase/functions/aggregator-health/index.test.ts`
- `deno check --no-lock services/api/supabase/functions/_shared/rate-limit.ts`
- `npm run format:check && npx eslint . --max-warnings 0`

Closes #4017