### PR TITLE
ci(workflows): harden privileged trust boundaries (#4023)

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -13,15 +13,18 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   version:
     name: Version & Release
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment:
+      name: release
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -406,7 +406,7 @@ jobs:
 
       - name: Check npm license compliance
         run: |
-          npx license-checker --production --summary --out license-summary.txt 2>/dev/null || {
+          npx --yes license-checker@25.0.1 --production --summary --out license-summary.txt 2>/dev/null || {
             npm ls --all --json 2>/dev/null | node -e "
               const fs = require('fs');
               const data = JSON.parse(fs.readFileSync(0, 'utf8'));
@@ -511,6 +511,11 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Workflow security regression checks
+        run: |
+          npm run workflow:security:test
+          npm run workflow:security:check
 
       # Always-on lint + format gate (ci-lint.yml is path-filtered and may be
       # skipped, so we re-run the essentials here to guarantee coverage).

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -44,31 +44,22 @@ concurrency:
   group: preview-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pull-requests: write
-  deployments: write
-
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+permissions: {}
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Deploy: Build and deploy preview
+  # Build: Run PR-controlled code without secrets or write-capable permissions.
   # ---------------------------------------------------------------------------
-  deploy-preview:
-    name: Deploy Preview
-    if: github.event.action != 'closed'
+  build-preview:
+    name: Build Preview
+    if: >-
+      github.event.action != 'closed' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment:
-      name: preview
-      url: ${{ steps.deploy.outputs.url }}
-
-    outputs:
-      url: ${{ steps.deploy.outputs.url }}
-      deployment_id: ${{ steps.deploy.outputs.deployment_id }}
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -91,11 +82,51 @@ jobs:
           NODE_ENV: production
           VITE_APP_VERSION: pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}-${{ github.sha }}
           VITE_ENVIRONMENT: preview
-          VITE_BETA_ALLOWED_EMAILS: ${{ secrets.BETA_ALLOWED_EMAILS }}
         run: |
           BUILD_START=$SECONDS
           npm run build -w apps/web
           echo "build_duration=$(( SECONDS - BUILD_START ))" >> "$GITHUB_OUTPUT"
+
+      - name: Reject unsafe preview artifacts
+        run: |
+          set -euo pipefail
+          test -d apps/web/dist
+          if find apps/web/dist -type l -print -quit | grep -q .; then
+            echo "::error::Preview artifacts must not contain symbolic links"
+            exit 1
+          fi
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preview-dist
+          path: apps/web/dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Deploy: Consume inert build output; never check out or execute PR code here.
+  # ---------------------------------------------------------------------------
+  deploy-preview:
+    name: Deploy Preview
+    needs: build-preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      deployments: write
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.url }}
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
+      deployment_id: ${{ steps.deploy.outputs.deployment_id }}
+
+    steps:
+      - name: Download preview artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: preview-dist
+          path: apps/web/dist
 
       - name: Deploy to Vercel (preview)
         id: deploy
@@ -104,18 +135,28 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           HEAD_REF: ${{ github.head_ref }}
+          PR_NUM: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          SOURCE_SHA: ${{ github.sha }}
         run: |
-          PR_NUM="${{ github.event.pull_request.number || github.event.inputs.pr_number }}"
-
-          if [ -z "$VERCEL_TOKEN" ]; then
-            echo "::warning::VERCEL_TOKEN not configured — generating placeholder preview URL"
-            echo "url=https://finance-pr-${PR_NUM}.vercel.app" >> "$GITHUB_OUTPUT"
-            echo "deployment_id=dry-run" >> "$GITHUB_OUTPUT"
-            exit 0
+          set -euo pipefail
+          [[ "$PR_NUM" =~ ^[1-9][0-9]{0,9}$ ]] ||
+            { echo "::error::Invalid pull request number"; exit 1; }
+          [[ ${#HEAD_REF} -le 255 && "$HEAD_REF" != *$'\n'* && "$HEAD_REF" != *$'\r'* ]] ||
+            { echo "::error::Invalid head ref"; exit 1; }
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+            { echo "::error::Invalid source commit SHA"; exit 1; }
+          test -d apps/web/dist
+          if find apps/web/dist -type l -print -quit | grep -q .; then
+            echo "::error::Preview artifacts must not contain symbolic links"
+            exit 1
           fi
 
-          # Install Vercel CLI
-          npm i -g vercel@latest
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::error::VERCEL_TOKEN is required for trusted preview deployments"
+            exit 1
+          fi
+
+          npm install --global vercel@58.9.0
 
           # Deploy to preview with PR-specific alias. Use a tempfile so we
           # check the exit code separately from the URL parse — piping into
@@ -128,7 +169,7 @@ jobs:
             --yes \
             --archive=tgz \
             --meta pr="${PR_NUM}" \
-            --meta commit="${{ github.sha }}" \
+            --meta commit="$SOURCE_SHA" \
             --meta branch="$HEAD_REF" \
             apps/web/dist >"$DEPLOY_LOG" 2>&1; then
             echo "::error::Vercel preview deploy failed:"
@@ -136,6 +177,8 @@ jobs:
             exit 1
           fi
           DEPLOY_URL=$(tail -1 "$DEPLOY_LOG")
+          [[ "$DEPLOY_URL" =~ ^https://[A-Za-z0-9.-]+\.vercel\.app/?$ ]] ||
+            { echo "::error::Vercel returned an invalid deployment URL"; exit 1; }
 
           # Set alias for predictable URL
           ALIAS_URL="finance-pr-${PR_NUM}.vercel.app"
@@ -147,18 +190,6 @@ jobs:
           echo "url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
           echo "deployment_id=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
 
-      - name: Report bundle size
-        id: bundle
-        run: |
-          if [ -d "apps/web/dist" ]; then
-            TOTAL=$(du -sh apps/web/dist/ | cut -f1)
-            JS_SIZE=$(find apps/web/dist -name '*.js' -exec du -cb {} + 2>/dev/null | tail -1 | cut -f1 || echo "0")
-            CSS_SIZE=$(find apps/web/dist -name '*.css' -exec du -cb {} + 2>/dev/null | tail -1 | cut -f1 || echo "0")
-            echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
-            echo "js_kb=$(( JS_SIZE / 1024 ))" >> "$GITHUB_OUTPUT"
-            echo "css_kb=$(( CSS_SIZE / 1024 ))" >> "$GITHUB_OUTPUT"
-          fi
-
   # ---------------------------------------------------------------------------
   # Comment: Post preview URL to PR
   # ---------------------------------------------------------------------------
@@ -168,14 +199,22 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Find existing comment
         id: find-comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
         with:
           script: |
-            const prNumber = ${{ github.event.pull_request.number || github.event.inputs.pr_number }};
+            const prNumber = Number.parseInt(process.env.PR_NUMBER, 10);
+            if (!Number.isSafeInteger(prNumber) || prNumber < 1) {
+              core.setFailed('Invalid pull request number');
+              return;
+            }
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -193,11 +232,23 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           HEAD_REF: ${{ github.head_ref }}
+          PREVIEW_URL: ${{ needs.deploy-preview.outputs.url }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          SOURCE_SHA: ${{ github.sha }}
+          COMMENT_ID: ${{ steps.find-comment.outputs.comment_id }}
         with:
           script: |
-            const prNumber = ${{ github.event.pull_request.number || github.event.inputs.pr_number }};
-            const url = '${{ needs.deploy-preview.outputs.url }}';
-            const sha = '${{ github.sha }}'.slice(0, 7);
+            const prNumber = Number.parseInt(process.env.PR_NUMBER, 10);
+            const url = process.env.PREVIEW_URL;
+            const sha = process.env.SOURCE_SHA.slice(0, 7);
+            if (!Number.isSafeInteger(prNumber) || prNumber < 1) {
+              core.setFailed('Invalid pull request number');
+              return;
+            }
+            if (!/^https:\/\/[A-Za-z0-9.-]+\.vercel\.app\/?$/.test(url)) {
+              core.setFailed('Invalid preview URL');
+              return;
+            }
 
             const body = [
               '<!-- preview-deploy -->',
@@ -214,7 +265,7 @@ jobs:
               '*Updated on every push to this PR. Preview will be removed when the PR is closed.*',
             ].join('\n');
 
-            const commentId = '${{ steps.find-comment.outputs.comment_id }}';
+            const commentId = process.env.COMMENT_ID;
 
             if (commentId) {
               await github.rest.issues.updateComment({
@@ -243,6 +294,8 @@ jobs:
     if: github.event.action != 'closed' && needs.deploy-preview.outputs.url != ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     # Non-blocking: preview URL may not be immediately accessible
     continue-on-error: true
 
@@ -252,8 +305,13 @@ jobs:
 
       - name: Wait for deployment
         id: wait
+        env:
+          PREVIEW_URL: ${{ needs.deploy-preview.outputs.url }}
         run: |
-          URL="${{ needs.deploy-preview.outputs.url }}"
+          set -euo pipefail
+          URL="$PREVIEW_URL"
+          [[ "$URL" =~ ^https://[A-Za-z0-9.-]+\.vercel\.app/?$ ]] ||
+            { echo "::error::Invalid preview URL"; exit 1; }
           echo "Waiting for $URL to become accessible..."
 
           for i in $(seq 1 12); do
@@ -281,12 +339,15 @@ jobs:
 
       - name: Lighthouse Summary
         if: always()
+        env:
+          LIGHTHOUSE_OUTCOME: ${{ steps.lighthouse.outcome }}
+          PREVIEW_URL: ${{ needs.deploy-preview.outputs.url }}
         run: |
           echo "### 🔦 Lighthouse Audit (Preview)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Preview URL:** ${{ needs.deploy-preview.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Preview URL:** $PREVIEW_URL" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ steps.lighthouse.outcome }}" = "success" ]; then
+          if [ "$LIGHTHOUSE_OUTCOME" = "success" ]; then
             echo "✅ Lighthouse audit completed — check artifacts for full report." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "⚠️ Lighthouse audit could not complete (preview may not be accessible)." >> "$GITHUB_STEP_SUMMARY"
@@ -297,17 +358,27 @@ jobs:
   # ---------------------------------------------------------------------------
   cleanup:
     name: Cleanup Preview
-    if: github.event.action == 'closed'
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      deployments: write
+      pull-requests: write
+    environment:
+      name: preview
 
     steps:
       - name: Remove preview deployment
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          PR_NUM: ${{ github.event.pull_request.number }}
         run: |
-          PR_NUM="${{ github.event.pull_request.number }}"
+          set -euo pipefail
+          [[ "$PR_NUM" =~ ^[1-9][0-9]{0,9}$ ]] ||
+            { echo "::error::Invalid pull request number"; exit 1; }
           echo "### 🧹 Preview Cleanup" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
@@ -316,7 +387,7 @@ jobs:
             exit 0
           fi
 
-          npm i -g vercel@latest
+          npm install --global vercel@58.9.0
 
           # Remove the alias
           ALIAS_URL="finance-pr-${PR_NUM}.vercel.app"
@@ -329,9 +400,15 @@ jobs:
 
       - name: Update PR comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           script: |
-            const prNumber = ${{ github.event.pull_request.number }};
+            const prNumber = Number.parseInt(process.env.PR_NUMBER, 10);
+            if (!Number.isSafeInteger(prNumber) || prNumber < 1) {
+              core.setFailed('Invalid pull request number');
+              return;
+            }
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -51,6 +51,29 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      BANK_ENCRYPTION_KEY:
+        required: false
+      DEPLOY_HOST:
+        required: false
+      DEPLOY_SSH_KEY:
+        required: false
+      DEPLOY_USER:
+        required: false
+      MX_WEBHOOK_SECRET:
+        required: false
+      PLAID_CLIENT_ID:
+        required: false
+      PLAID_SECRET:
+        required: false
+      POWERSYNC_URL:
+        required: false
+      SENTRY_DSN:
+        required: false
+      SUPABASE_ANON_KEY:
+        required: false
+      SUPABASE_URL:
+        required: false
   workflow_dispatch:
     inputs:
       version:
@@ -107,11 +130,7 @@ concurrency:
   group: deploy-production-v3
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
-permissions:
-  contents: write
-  checks: read
-  statuses: read
-  deployments: write
+permissions: {}
 
 env:
   ENVIRONMENT: production
@@ -122,6 +141,8 @@ jobs:
     name: Prepare Deployment
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
       sha_short: ${{ steps.resolve.outputs.sha_short }}
@@ -330,6 +351,8 @@ jobs:
     if: needs.prepare.outputs.rollback != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout at deploy version
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -399,6 +422,9 @@ jobs:
       (needs.deploy-backend.result == 'success' || needs.deploy-backend.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      deployments: write
     environment:
       name: production
       url: ${{ steps.deploy.outputs.url }}
@@ -506,6 +532,9 @@ jobs:
       (needs.smoke-tests.result == 'success' || needs.smoke-tests.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      deployments: write
     environment:
       name: production
     steps:
@@ -639,6 +668,7 @@ jobs:
       (needs.deploy-backend.result == 'success' || needs.deploy-backend.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions: {}
     # NOTE: deliberately NOT scoped to `environment: production`. This job only
     # curls the already-public production URL to verify the deploy landed; it
     # performs no deployment and consumes no environment-scoped secrets. When it
@@ -729,6 +759,9 @@ jobs:
       needs.post-deploy-smoke.result == 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      deployments: write
     environment:
       name: production
     steps:
@@ -899,6 +932,10 @@ jobs:
       (needs.auto-rollback.result == 'skipped' || needs.auto-rollback.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment:
+      name: release
+    permissions:
+      contents: write
     steps:
       - name: Checkout deployed commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -990,6 +1027,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Deployment audit trail
         run: |

--- a/.github/workflows/deploy-progressive.yml
+++ b/.github/workflows/deploy-progressive.yml
@@ -81,21 +81,58 @@ concurrency:
   group: progressive-${{ github.event.inputs.mode }}-${{ github.event.inputs.version }}-${{ github.event.inputs.component || github.event.inputs.platform }}
   cancel-in-progress: false
 
-permissions:
-  contents: read
-  deployments: write
-  issues: read
+permissions: {}
 
 env:
   CRASH_FREE_THRESHOLD: '99.5'
   ERROR_RATE_THRESHOLD: '0.5'
 
 jobs:
+  validate-inputs:
+    name: Validate progressive deployment inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Validate inputs
+        env:
+          CANARY_PERCENTAGE: ${{ inputs.canary_percentage }}
+          COMPONENT: ${{ inputs.component }}
+          ERROR_THRESHOLD: ${{ inputs.error_threshold }}
+          MODE: ${{ inputs.mode }}
+          OBSERVATION_MINUTES: ${{ inputs.observation_minutes }}
+          PLATFORM: ${{ inputs.platform }}
+          TARGET_STAGE: ${{ inputs.target_stage }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          case "$MODE" in canary|rollout) ;; *) echo "::error::unsupported mode"; exit 1 ;; esac
+          case "$COMPONENT" in web|backend|all) ;; *) echo "::error::unsupported component"; exit 1 ;; esac
+          case "$PLATFORM" in android|ios|web|windows|all) ;; *) echo "::error::unsupported platform"; exit 1 ;; esac
+          case "$TARGET_STAGE" in '1 — 10%'|'2 — 25%'|'3 — 50%'|'4 — 100%') ;; *)
+            echo "::error::unsupported rollout stage"; exit 1 ;;
+          esac
+          [[ "$VERSION" =~ ^(v?[0-9]+[.][0-9]+[.][0-9]+([.-][0-9A-Za-z.-]+)?|[0-9a-f]{40})$ ]] ||
+            { echo "::error::version must be SemVer-compatible or a full commit SHA"; exit 1; }
+          [[ "$CANARY_PERCENTAGE" =~ ^[0-9]+$ ]] &&
+            (( CANARY_PERCENTAGE >= 1 && CANARY_PERCENTAGE <= 50 )) ||
+            { echo "::error::canary_percentage must be from 1 through 50"; exit 1; }
+          [[ "$OBSERVATION_MINUTES" =~ ^[0-9]+$ ]] &&
+            (( OBSERVATION_MINUTES >= 1 && OBSERVATION_MINUTES <= 60 )) ||
+            { echo "::error::observation_minutes must be from 1 through 60"; exit 1; }
+          [[ "$ERROR_THRESHOLD" =~ ^([0-9]+)([.][0-9]+)?$ ]] ||
+            { echo "::error::error_threshold must be numeric"; exit 1; }
+          node -e 'const n=Number(process.env.ERROR_THRESHOLD); if (!(n >= 0 && n <= 100)) process.exit(1)' ||
+            { echo "::error::error_threshold must be from 0 through 100"; exit 1; }
+
   prepare-canary:
     name: Prepare Canary Deployment
     if: inputs.mode == 'canary'
+    needs: validate-inputs
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
       sha_short: ${{ steps.resolve.outputs.sha_short }}
@@ -110,8 +147,10 @@ jobs:
 
       - name: Resolve version
         id: resolve
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          set -euo pipefail
           SHA=$(git rev-parse "$VERSION" 2>/dev/null || echo "")
           if [ -z "$SHA" ]; then
             echo "::error::Could not resolve '$VERSION' to a commit"
@@ -124,8 +163,9 @@ jobs:
 
       - name: Determine components
         id: components
+        env:
+          COMPONENT: ${{ inputs.component }}
         run: |
-          COMPONENT="${{ github.event.inputs.component || 'all' }}"
           echo "web=$( [ \"$COMPONENT\" = \"all\" ] || [ \"$COMPONENT\" = \"web\" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
           echo "backend=$( [ \"$COMPONENT\" = \"all\" ] || [ \"$COMPONENT\" = \"backend\" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
 
@@ -180,7 +220,7 @@ jobs:
 
       - name: Attest build provenance
         if: needs.prepare-canary.outputs.deploy_web == 'true'
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: apps/web/dist/**
 
@@ -194,13 +234,17 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           CANARY_PERCENTAGE: ${{ github.event.inputs.canary_percentage }}
+          DEPLOY_BACKEND: ${{ needs.prepare-canary.outputs.deploy_backend }}
+          DEPLOY_SHA: ${{ needs.prepare-canary.outputs.sha }}
+          DEPLOY_WEB: ${{ needs.prepare-canary.outputs.deploy_web }}
         run: |
+          set -euo pipefail
           DEPLOYED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
           echo "deployed_at=$DEPLOYED_AT" >> "$GITHUB_OUTPUT"
 
-          if [ "${{ needs.prepare-canary.outputs.deploy_web }}" = "true" ]; then
+          if [ "$DEPLOY_WEB" = "true" ]; then
             if [ -n "$VERCEL_TOKEN" ]; then
-              npm i -g vercel@latest
+              npm install --global vercel@58.9.0
               set -o pipefail
               CANARY_LOG="$RUNNER_TEMP/vercel-canary.log"
               if ! vercel deploy \
@@ -223,18 +267,13 @@ jobs:
             fi
           fi
 
-          if [ "${{ needs.prepare-canary.outputs.deploy_backend }}" = "true" ] && [ -n "$CANARY_HOST" ]; then
+          if [ "$DEPLOY_BACKEND" = "true" ] && [ -n "$CANARY_HOST" ]; then
             mkdir -p ~/.ssh
             echo "$CANARY_SSH_KEY" > ~/.ssh/deploy_key
             chmod 600 ~/.ssh/deploy_key
             ssh-keyscan -H "$CANARY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
-            ssh -i ~/.ssh/deploy_key "$CANARY_USER@$CANARY_HOST" << DEPLOY
-              cd /opt/finance-canary
-              git fetch origin
-              git checkout ${{ needs.prepare-canary.outputs.sha }}
-              docker compose -f deploy/docker-compose.yml pull
-              docker compose -f deploy/docker-compose.yml up -d --remove-orphans
-            DEPLOY
+            ssh -i ~/.ssh/deploy_key "$CANARY_USER@$CANARY_HOST" \
+              "cd /opt/finance-canary && git fetch origin && git checkout -- '$DEPLOY_SHA' && docker compose -f deploy/docker-compose.yml pull && docker compose -f deploy/docker-compose.yml up -d --remove-orphans"
             rm -f ~/.ssh/deploy_key
           fi
 
@@ -244,6 +283,7 @@ jobs:
     needs: [prepare-canary, deploy-canary]
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions: {}
     outputs:
       health_status: ${{ steps.monitor.outputs.health_status }}
       error_rate: ${{ steps.monitor.outputs.error_rate }}
@@ -294,11 +334,16 @@ jobs:
   promote-canary:
     name: Promote Canary to Production
     if: >-
+      always() &&
       inputs.mode == 'canary' &&
+      needs.deploy-canary.result == 'success' &&
       (needs.monitor-canary.outputs.recommendation == 'promote' || github.event.inputs.skip_monitoring == 'true')
     needs: [prepare-canary, deploy-canary, monitor-canary]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      deployments: write
     environment:
       name: production
     steps:
@@ -317,7 +362,7 @@ jobs:
             echo "::warning::VERCEL_TOKEN not configured — skipping web promotion"
             exit 0
           fi
-          npm i -g vercel@latest
+          npm install --global vercel@58.9.0
           npm ci
           npm run build -w packages/design-tokens
           npm run build -w apps/web
@@ -334,23 +379,22 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
-          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '~/finance' }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '/opt/finance' }}
+          DEPLOY_SHA: ${{ needs.prepare-canary.outputs.sha }}
         run: |
+          set -euo pipefail
           if [ -z "$DEPLOY_HOST" ]; then
             echo "::warning::DEPLOY_HOST not configured — skipping backend promotion"
             exit 0
           fi
+          [[ "$DEPLOY_PATH" =~ ^/[A-Za-z0-9._/-]+$ && "$DEPLOY_PATH" != *..* ]] ||
+            { echo "::error::DEPLOY_PATH must be an absolute safe path"; exit 1; }
           mkdir -p ~/.ssh
           echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
-          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" << DEPLOY
-            cd $DEPLOY_PATH
-            git fetch origin
-            git checkout ${{ needs.prepare-canary.outputs.sha }}
-            docker compose -f deploy/docker-compose.yml pull
-            docker compose -f deploy/docker-compose.yml up -d --remove-orphans
-          DEPLOY
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+            "cd '$DEPLOY_PATH' && git fetch origin && git checkout -- '$DEPLOY_SHA' && docker compose -f deploy/docker-compose.yml pull && docker compose -f deploy/docker-compose.yml up -d --remove-orphans"
           rm -f ~/.ssh/deploy_key
 
   rollback-canary:
@@ -359,6 +403,8 @@ jobs:
     needs: [prepare-canary, deploy-canary, monitor-canary]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      deployments: write
     steps:
       - name: Roll back canary traffic
         env:
@@ -388,6 +434,7 @@ jobs:
     if: always() && inputs.mode == 'canary'
     needs: [prepare-canary, deploy-canary, monitor-canary, promote-canary, rollback-canary]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Summary
         run: |
@@ -403,8 +450,11 @@ jobs:
   monitoring-gate:
     name: Rollout Monitoring Health Check
     if: inputs.mode == 'rollout' && inputs.skip_monitoring_check != true
+    needs: validate-inputs
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      issues: read
     outputs:
       healthy: ${{ steps.check.outputs.healthy }}
       crash_free_rate: ${{ steps.check.outputs.crash_free_rate }}
@@ -415,10 +465,10 @@ jobs:
         id: issues
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLATFORM: ${{ inputs.platform }}
+          VERSION: ${{ inputs.version }}
         run: |
-          VERSION="v${{ inputs.version }}"
-          PLATFORM="${{ inputs.platform || 'all' }}"
-          BLOCKING=$(gh issue list --label "priority:p0,priority:p1" --search "${VERSION} ${PLATFORM}" --state open --json number,title --jq 'length') || BLOCKING=0
+          BLOCKING=$(gh issue list --label "priority:p0,priority:p1" --search "v${VERSION} ${PLATFORM}" --state open --json number,title --jq 'length') || BLOCKING=0
           echo "blocking_issues=${BLOCKING}" >> "$GITHUB_OUTPUT"
 
       - name: Evaluate monitoring health
@@ -438,96 +488,122 @@ jobs:
 
   approval:
     name: Rollout Approval
-    if: inputs.mode == 'rollout'
-    needs: monitoring-gate
+    if: >-
+      always() &&
+      inputs.mode == 'rollout' &&
+      (inputs.skip_monitoring_check == true || needs.monitoring-gate.result == 'success')
+    needs: [validate-inputs, monitoring-gate]
     runs-on: ubuntu-latest
+    permissions: {}
     environment: ${{ contains(inputs.target_stage, '100%') && 'production' || 'staging' }}
     steps:
       - name: Approval checkpoint
+        env:
+          PLATFORM: ${{ inputs.platform }}
+          TARGET_STAGE: ${{ inputs.target_stage }}
+          VERSION: ${{ inputs.version }}
         run: |
           echo "### ✅ Rollout approved" >> "$GITHUB_STEP_SUMMARY"
-          echo "Version: v${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Platform: ${{ inputs.platform || 'all' }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Target stage: ${{ inputs.target_stage }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Version: v$VERSION" >> "$GITHUB_STEP_SUMMARY"
+          echo "Platform: $PLATFORM" >> "$GITHUB_STEP_SUMMARY"
+          echo "Target stage: $TARGET_STAGE" >> "$GITHUB_STEP_SUMMARY"
 
   android-rollout:
     name: Android Staged Rollout
     if: inputs.mode == 'rollout' && (inputs.platform == 'android' || inputs.platform == 'all')
     needs: approval
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - run: |
-          STAGE="${{ inputs.target_stage }}"
+      - env:
+          STAGE: ${{ inputs.target_stage }}
+          VERSION: ${{ inputs.version }}
+        run: |
           case "$STAGE" in
             *10%*)  PERCENT=10 ; TRACK='internal' ;;
             *25%*)  PERCENT=25 ; TRACK='alpha' ;;
             *50%*)  PERCENT=50 ; TRACK='beta' ;;
             *100%*) PERCENT=100 ; TRACK='production' ;;
           esac
-          echo "Android v${{ inputs.version }} → ${PERCENT}% (${TRACK})" >> "$GITHUB_STEP_SUMMARY"
+          echo "Android v$VERSION → ${PERCENT}% (${TRACK})" >> "$GITHUB_STEP_SUMMARY"
 
   ios-rollout:
     name: iOS Staged Rollout
     if: inputs.mode == 'rollout' && (inputs.platform == 'ios' || inputs.platform == 'all')
     needs: approval
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - run: |
-          STAGE="${{ inputs.target_stage }}"
+      - env:
+          STAGE: ${{ inputs.target_stage }}
+          VERSION: ${{ inputs.version }}
+        run: |
           case "$STAGE" in
             *10%*)  PERCENT=10 ;;
             *25%*)  PERCENT=25 ;;
             *50%*)  PERCENT=50 ;;
             *100%*) PERCENT=100 ;;
           esac
-          echo "iOS v${{ inputs.version }} → ${PERCENT}%" >> "$GITHUB_STEP_SUMMARY"
+          echo "iOS v$VERSION → ${PERCENT}%" >> "$GITHUB_STEP_SUMMARY"
 
   web-rollout:
     name: Web Staged Rollout
     if: inputs.mode == 'rollout' && (inputs.platform == 'web' || inputs.platform == 'all')
     needs: approval
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - run: |
-          STAGE="${{ inputs.target_stage }}"
+      - env:
+          STAGE: ${{ inputs.target_stage }}
+          VERSION: ${{ inputs.version }}
+        run: |
           case "$STAGE" in
             *10%*)  PERCENT=10 ;;
             *25%*)  PERCENT=25 ;;
             *50%*)  PERCENT=50 ;;
             *100%*) PERCENT=100 ;;
           esac
-          echo "Web v${{ inputs.version }} → ${PERCENT}%" >> "$GITHUB_STEP_SUMMARY"
+          echo "Web v$VERSION → ${PERCENT}%" >> "$GITHUB_STEP_SUMMARY"
 
   windows-rollout:
     name: Windows Staged Rollout
     if: inputs.mode == 'rollout' && (inputs.platform == 'windows' || inputs.platform == 'all')
     needs: approval
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - run: |
-          STAGE="${{ inputs.target_stage }}"
+      - env:
+          STAGE: ${{ inputs.target_stage }}
+          VERSION: ${{ inputs.version }}
+        run: |
           case "$STAGE" in
             *10%*)  PERCENT=10 ; RING='insiders' ;;
             *25%*)  PERCENT=25 ; RING='early-access' ;;
             *50%*)  PERCENT=50 ; RING='general' ;;
             *100%*) PERCENT=100 ; RING='all' ;;
           esac
-          echo "Windows v${{ inputs.version }} → ${PERCENT}% (${RING})" >> "$GITHUB_STEP_SUMMARY"
+          echo "Windows v$VERSION → ${PERCENT}% (${RING})" >> "$GITHUB_STEP_SUMMARY"
 
   rollout-summary:
     name: Rollout Summary
     if: always() && inputs.mode == 'rollout'
     needs: [monitoring-gate, approval, android-rollout, ios-rollout, web-rollout, windows-rollout]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Summary
+        env:
+          MONITORING: ${{ needs.monitoring-gate.outputs.healthy || 'skipped' }}
+          PLATFORM: ${{ inputs.platform }}
+          STAGE: ${{ inputs.target_stage }}
+          VERSION: ${{ inputs.version }}
         run: |
           echo "### 📊 Staged rollout summary" >> "$GITHUB_STEP_SUMMARY"
           echo "| Parameter | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-----------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Version | v${{ inputs.version }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Platform | ${{ inputs.platform || 'all' }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Stage | ${{ inputs.target_stage }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Monitoring | ${{ needs.monitoring-gate.outputs.healthy || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Version | v$VERSION |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Platform | $PLATFORM |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Stage | $STAGE |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Monitoring | $MONITORING |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "If monitoring degrades, trigger **Deploy — Rollback** for the affected platform before advancing the next stage." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-rollback.yml
+++ b/.github/workflows/deploy-rollback.yml
@@ -62,29 +62,63 @@ concurrency:
   group: rollback-${{ github.event.inputs.platform }}
   cancel-in-progress: false
 
-permissions:
-  contents: read
-  issues: write
-  deployments: write
+permissions: {}
 
 jobs:
+  validate:
+    name: Validate rollback inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Validate inputs
+        env:
+          CURRENT_VERSION: ${{ inputs.current_version }}
+          PLATFORM: ${{ inputs.platform }}
+          REASON: ${{ inputs.reason }}
+          ROLLBACK_VERSION: ${{ inputs.rollback_version }}
+          SEVERITY: ${{ inputs.severity }}
+        run: |
+          set -euo pipefail
+          case "$PLATFORM" in android|ios|web|windows|all) ;; *)
+            echo "::error::unsupported platform"; exit 1 ;;
+          esac
+          case "$SEVERITY" in
+            'P0 — Data loss/corruption'|'P1 — Crash on launch'|'P2 — Feature broken') ;;
+            *) echo "::error::unsupported severity"; exit 1 ;;
+          esac
+          for version in "$CURRENT_VERSION" "$ROLLBACK_VERSION"; do
+            [[ "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+([.-][0-9A-Za-z.-]+)?$ ]] ||
+              { echo "::error::versions must be SemVer-compatible"; exit 1; }
+          done
+          [[ -n "$REASON" && ${#REASON} -le 500 && "$REASON" != *$'\n'* && "$REASON" != *$'\r'* ]] ||
+            { echo "::error::reason must be a non-empty single-line value up to 500 characters"; exit 1; }
+
   # ── Approval Gate ────────────────────────────────────────────────
   approve:
     name: Rollback Approval
+    needs: validate
     runs-on: ubuntu-latest
     environment: production
+    permissions: {}
     steps:
       - name: Approval checkpoint
+        env:
+          CURRENT_VERSION: ${{ inputs.current_version }}
+          PLATFORM: ${{ inputs.platform }}
+          REASON: ${{ inputs.reason }}
+          ROLLBACK_VERSION: ${{ inputs.rollback_version }}
+          SEVERITY: ${{ inputs.severity }}
         run: |
           echo "### 🔙 Rollback Approved" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Parameter | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-----------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Platform | ${{ inputs.platform }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Rolling back FROM | v${{ inputs.current_version }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Rolling back TO | v${{ inputs.rollback_version }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Severity | ${{ inputs.severity }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Reason | ${{ inputs.reason }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Platform | $PLATFORM |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Rolling back FROM | v$CURRENT_VERSION |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Rolling back TO | v$ROLLBACK_VERSION |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Severity | $SEVERITY |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Reason | $REASON |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Approved by | @${{ github.actor }} |" >> "$GITHUB_STEP_SUMMARY"
 
   # ── Android Rollback ─────────────────────────────────────────────
@@ -94,38 +128,45 @@ jobs:
     if: inputs.platform == 'android' || inputs.platform == 'all'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Halt staged rollout
+        env:
+          CURRENT_VERSION: ${{ inputs.current_version }}
         run: |
-          echo "🛑 Halting staged rollout for Android v${{ inputs.current_version }}"
+          echo "🛑 Halting staged rollout for Android v$CURRENT_VERSION"
 
           # Production: use Fastlane or Google Play Developer API
           # fastlane supply \
           #   --track production \
           #   --rollout 0 \
-          #   --version_name "${{ inputs.current_version }}" \
+          #   --version_name "$CURRENT_VERSION" \
           #   --json_key "${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}"
 
           echo "✅ Staged rollout halted"
 
       - name: Promote previous version
+        env:
+          CURRENT_VERSION: ${{ inputs.current_version }}
+          ROLLBACK_VERSION: ${{ inputs.rollback_version }}
         run: |
-          echo "📱 Promoting Android v${{ inputs.rollback_version }} to production"
+          echo "📱 Promoting Android v$ROLLBACK_VERSION to production"
 
           # Production: promote previous version from the archive
           # fastlane supply \
           #   --track production \
           #   --rollout 1.0 \
-          #   --version_name "${{ inputs.rollback_version }}" \
+          #   --version_name "$ROLLBACK_VERSION" \
           #   --json_key "${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}"
 
           echo "### 🤖 Android Rollback Complete" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Halted rollout of v${{ inputs.current_version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Promoted v${{ inputs.rollback_version }} to production track" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Halted rollout of v$CURRENT_VERSION" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Promoted v$ROLLBACK_VERSION to production track" >> "$GITHUB_STEP_SUMMARY"
 
   # ── iOS Rollback ─────────────────────────────────────────────────
   ios-rollback:
@@ -134,17 +175,21 @@ jobs:
     if: inputs.platform == 'ios' || inputs.platform == 'all'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Pause phased release
+        env:
+          CURRENT_VERSION: ${{ inputs.current_version }}
         run: |
-          echo "🛑 Pausing phased release for iOS v${{ inputs.current_version }}"
+          echo "🛑 Pausing phased release for iOS v$CURRENT_VERSION"
 
           # Production: use App Store Connect API
           # fastlane deliver \
-          #   --app_version "${{ inputs.current_version }}" \
+          #   --app_version "$CURRENT_VERSION" \
           #   --phased_release_state "PAUSE" \
           #   --api_key_path "${{ secrets.APP_STORE_CONNECT_API_KEY }}"
 
@@ -152,8 +197,10 @@ jobs:
 
       - name: Remove from sale (if P0)
         if: contains(inputs.severity, 'P0')
+        env:
+          CURRENT_VERSION: ${{ inputs.current_version }}
         run: |
-          echo "🛑 Removing iOS v${{ inputs.current_version }} from sale (P0 severity)"
+          echo "🛑 Removing iOS v$CURRENT_VERSION from sale (P0 severity)"
 
           # Production: use App Store Connect API to remove from sale
           # This is the nuclear option — only for data loss/corruption
@@ -161,16 +208,20 @@ jobs:
           echo "⚠️ Version removed from sale. Expedited review needed for rollback build."
 
       - name: Summary
+        env:
+          CURRENT_VERSION: ${{ inputs.current_version }}
+          ROLLBACK_VERSION: ${{ inputs.rollback_version }}
+          SEVERITY: ${{ inputs.severity }}
         run: |
           echo "### 🍎 iOS Rollback" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Paused phased release of v${{ inputs.current_version }}" >> "$GITHUB_STEP_SUMMARY"
-          if [[ "${{ inputs.severity }}" == *"P0"* ]]; then
+          echo "- Paused phased release of v$CURRENT_VERSION" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$SEVERITY" == *"P0"* ]]; then
             echo "- ⚠️ Removed from sale (P0 severity)" >> "$GITHUB_STEP_SUMMARY"
           fi
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Manual steps required:**" >> "$GITHUB_STEP_SUMMARY"
-          echo "1. Submit v${{ inputs.rollback_version }} build for expedited review" >> "$GITHUB_STEP_SUMMARY"
+          echo "1. Submit v$ROLLBACK_VERSION build for expedited review" >> "$GITHUB_STEP_SUMMARY"
           echo "2. Apple review typically takes 24-48 hours (expedited: ~4 hours)" >> "$GITHUB_STEP_SUMMARY"
 
   # ── Web Rollback ─────────────────────────────────────────────────
@@ -180,13 +231,17 @@ jobs:
     if: inputs.platform == 'web' || inputs.platform == 'all'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Revert to previous deployment
+        env:
+          ROLLBACK_VERSION: ${{ inputs.rollback_version }}
         run: |
-          echo "🌐 Rolling back Web to v${{ inputs.rollback_version }}"
+          echo "🌐 Rolling back Web to v$ROLLBACK_VERSION"
 
           # Production: Vercel instant rollback
           # vercel rollback --token "${{ secrets.VERCEL_TOKEN }}" \
@@ -195,13 +250,13 @@ jobs:
           # Or promote specific deployment:
           # DEPLOY_URL=$(vercel ls --token "${{ secrets.VERCEL_TOKEN }}" \
           #   --scope "${{ secrets.VERCEL_ORG_ID }}" \
-          #   --meta version="${{ inputs.rollback_version }}" \
+          #   --meta version="$ROLLBACK_VERSION" \
           #   --json | jq -r '.[0].url')
           # vercel promote "$DEPLOY_URL" --token "${{ secrets.VERCEL_TOKEN }}"
 
           echo "### 🌐 Web Rollback Complete" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Reverted production to v${{ inputs.rollback_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Reverted production to v$ROLLBACK_VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Time to restore:** < 1 minute (instant Vercel revert)" >> "$GITHUB_STEP_SUMMARY"
 
   # ── Windows Rollback ─────────────────────────────────────────────
@@ -211,20 +266,24 @@ jobs:
     if: inputs.platform == 'windows' || inputs.platform == 'all'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Revert auto-update manifest
+        env:
+          ROLLBACK_VERSION: ${{ inputs.rollback_version }}
         run: |
-          echo "🪟 Rolling back Windows to v${{ inputs.rollback_version }}"
+          echo "🪟 Rolling back Windows to v$ROLLBACK_VERSION"
 
           # Production: Update auto-update endpoint to serve previous version
           # Or submit previous version to Microsoft Store
 
           echo "### 🪟 Windows Rollback" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Updated auto-update manifest to v${{ inputs.rollback_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Updated auto-update manifest to v$ROLLBACK_VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo "- Users with auto-update will receive the rollback on next check" >> "$GITHUB_STEP_SUMMARY"
 
   # ── Post-Rollback ───────────────────────────────────────────────
@@ -234,56 +293,72 @@ jobs:
     if: always() && needs.approve.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Create rollback tracking issue
         env:
+          ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_VERSION: ${{ inputs.current_version }}
+          PLATFORM: ${{ inputs.platform }}
+          REASON: ${{ inputs.reason }}
+          REPOSITORY: ${{ github.repository }}
+          ROLLBACK_VERSION: ${{ inputs.rollback_version }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+          SEVERITY: ${{ inputs.severity }}
         run: |
-          TITLE="[Rollback] ${{ inputs.platform }}: v${{ inputs.current_version }} → v${{ inputs.rollback_version }}"
-          BODY=$(cat << 'EOF'
-          ## Rollback Record
-
-          | Field | Value |
-          |-------|-------|
-          | **Platform** | ${{ inputs.platform }} |
-          | **Rolled back FROM** | v${{ inputs.current_version }} |
-          | **Rolled back TO** | v${{ inputs.rollback_version }} |
-          | **Severity** | ${{ inputs.severity }} |
-          | **Reason** | ${{ inputs.reason }} |
-          | **Initiated by** | @${{ github.actor }} |
-          | **Timestamp** | $(date -u +"%Y-%m-%dT%H:%M:%SZ") |
-          | **Workflow run** | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |
-
-          ## Post-Rollback Checklist
-
-          - [ ] Verify rollback is live and functioning
-          - [ ] Monitor crash-free rate for 1 hour
-          - [ ] Notify affected users (if applicable)
-          - [ ] Create post-mortem document
-          - [ ] Identify root cause of the issue
-          - [ ] Plan hotfix or corrected release
-          - [ ] Update release process if systemic issue
-
-          ## Related
-
-          - Rollback procedures: `docs/guides/rollback-procedures.md`
-          - Release process: `docs/guides/release-process.md`
-          EOF
-          )
-
-          echo "$BODY" > rollback-issue-body.md
+          TITLE="[Rollback] $PLATFORM: v$CURRENT_VERSION → v$ROLLBACK_VERSION"
+          node <<'NODE' > rollback-issue-body.md
+          const reason = process.env.REASON.replaceAll('|', '\\|');
+          const lines = [
+            '## Rollback Record',
+            '',
+            '| Field | Value |',
+            '|-------|-------|',
+            `| **Platform** | ${process.env.PLATFORM} |`,
+            `| **Rolled back FROM** | v${process.env.CURRENT_VERSION} |`,
+            `| **Rolled back TO** | v${process.env.ROLLBACK_VERSION} |`,
+            `| **Severity** | ${process.env.SEVERITY} |`,
+            `| **Reason** | ${reason} |`,
+            `| **Initiated by** | @${process.env.ACTOR} |`,
+            `| **Timestamp** | ${new Date().toISOString()} |`,
+            `| **Workflow run** | ${process.env.SERVER_URL}/${process.env.REPOSITORY}/actions/runs/${process.env.RUN_ID} |`,
+            '',
+            '## Post-Rollback Checklist',
+            '',
+            '- [ ] Verify rollback is live and functioning',
+            '- [ ] Monitor crash-free rate for 1 hour',
+            '- [ ] Notify affected users (if applicable)',
+            '- [ ] Create post-mortem document',
+            '- [ ] Identify root cause of the issue',
+            '- [ ] Plan hotfix or corrected release',
+            '- [ ] Update release process if systemic issue',
+            '',
+            '## Related',
+            '',
+            '- Rollback procedures: `docs/guides/rollback-procedures.md`',
+            '- Release process: `docs/guides/release-process.md`',
+          ];
+          process.stdout.write(`${lines.join('\n')}\n`);
+          NODE
 
           # Create the issue (the gh CLI will handle the body)
           gh issue create \
             --title "$TITLE" \
             --body-file rollback-issue-body.md \
-            --label "rollback,incident,${{ inputs.platform }}" \
-            || echo "::warning::Failed to create rollback tracking issue — create manually"
+            --label "rollback,incident,$PLATFORM"
 
       - name: Final summary
+        env:
+          CURRENT_VERSION: ${{ inputs.current_version }}
+          PLATFORM: ${{ inputs.platform }}
+          ROLLBACK_VERSION: ${{ inputs.rollback_version }}
         run: |
           echo "### 🔙 Rollback Complete" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -291,8 +366,8 @@ jobs:
           echo "|----------|------|----|--------|" >> "$GITHUB_STEP_SUMMARY"
 
           for P in android ios web windows; do
-            if [ "${{ inputs.platform }}" = "$P" ] || [ "${{ inputs.platform }}" = "all" ]; then
-              echo "| ${P} | v${{ inputs.current_version }} | v${{ inputs.rollback_version }} | ✅ Rolled back |" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$PLATFORM" = "$P" ] || [ "$PLATFORM" = "all" ]; then
+              echo "| ${P} | v$CURRENT_VERSION | v$ROLLBACK_VERSION | ✅ Rolled back |" >> "$GITHUB_STEP_SUMMARY"
             fi
           done
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,6 +70,7 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
   K6_VERSION: '0.54.0'
+  K6_LINUX_AMD64_SHA256: c7f03434854f837b6790ee81572e4b0f955241974c79a43cbb9f8d0fef069589
 
 jobs:
   web-build:
@@ -273,7 +274,7 @@ jobs:
           uploadArtifacts: true
           runs: 3
       - name: Lighthouse Budget Check
-        run: npx @lhci/cli assert --config=apps/web/lighthouserc-budget.json
+        run: npx --yes @lhci/cli@0.15.1 assert --config=apps/web/lighthouserc-budget.json
 
   web-nightly-issue:
     name: Open Web Nightly Issue
@@ -322,33 +323,63 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install k6
         run: |
-          curl -fsSL "https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-amd64.tar.gz" | tar xz --strip-components=1
-          sudo mv k6 /usr/local/bin/k6
+          set -euo pipefail
+          archive="$RUNNER_TEMP/k6-v${K6_VERSION}-linux-amd64.tar.gz"
+          curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+            --proto-redir '=https' \
+            "https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-amd64.tar.gz" \
+            --output "$archive"
+          printf '%s  %s\n' "$K6_LINUX_AMD64_SHA256" "$archive" | sha256sum --check --strict
+          install_dir="$RUNNER_TEMP/k6"
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" --strip-components=1 --directory "$install_dir"
+          sudo install -m 0755 "$install_dir/k6" /usr/local/bin/k6
       - name: Resolve target URL
         id: target
+        env:
+          DISPATCH_TARGET_URL: ${{ github.event.inputs.target_url }}
+          STAGING_URL: ${{ secrets.STAGING_URL }}
         run: |
-          URL="${{ github.event.inputs.target_url || secrets.STAGING_URL || '' }}"
+          set -euo pipefail
+          URL="${DISPATCH_TARGET_URL:-${STAGING_URL:-}}"
           if [ -z "$URL" ]; then
             echo "url=http://localhost:3000" >> "$GITHUB_OUTPUT"
             echo "has_real_target=false" >> "$GITHUB_OUTPUT"
           else
+            [[ "$URL" =~ ^https://[^[:space:]@/]+(:[0-9]+)?(/[^[:space:]]*)?$ ]] ||
+              { echo "::error::target_url must be credential-free HTTPS"; exit 1; }
             echo "url=$URL" >> "$GITHUB_OUTPUT"
             echo "has_real_target=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Create k6 scripts
+        env:
+          BASE_URL: ${{ steps.target.outputs.url }}
+          DURATION: ${{ github.event.inputs.duration || '2m' }}
+          VUS: ${{ github.event.inputs.vus || '50' }}
         run: |
+          set -euo pipefail
+          [[ "$VUS" =~ ^[0-9]+$ ]] && (( VUS >= 1 && VUS <= 500 )) ||
+            { echo "::error::vus must be an integer from 1 through 500"; exit 1; }
+          [[ "$DURATION" =~ ^[1-9][0-9]{0,2}[smh]$ ]] ||
+            { echo "::error::duration must be 1-999 followed by s, m, or h"; exit 1; }
           mkdir -p tools/load-tests
-          cat > tools/load-tests/api.js <<'SCRIPT'
-          import http from 'k6/http';
-          import { check, sleep } from 'k6';
-          const BASE_URL = '${{ steps.target.outputs.url }}';
-          export const options = { vus: Number('${{ github.event.inputs.vus || '50' }}'), duration: '${{ github.event.inputs.duration || '2m' }}' };
-          export default function () {
-            const res = http.get(`${BASE_URL}/api/health`);
-            check(res, { 'health ok': (r) => r.status < 500 });
-            sleep(1);
-          }
-          SCRIPT
+          node <<'NODE' > tools/load-tests/api.js
+          const baseUrl = JSON.stringify(process.env.BASE_URL);
+          const duration = JSON.stringify(process.env.DURATION);
+          const vus = Number(process.env.VUS);
+          process.stdout.write([
+            "import http from 'k6/http';",
+            "import { check, sleep } from 'k6';",
+            `const BASE_URL = ${baseUrl};`,
+            `export const options = { vus: ${vus}, duration: ${duration} };`,
+            'export default function () {',
+            '  const res = http.get(`${BASE_URL}/api/health`);',
+            "  check(res, { 'health ok': (r) => r.status < 500 });",
+            '  sleep(1);',
+            '}',
+            '',
+          ].join('\n'));
+          NODE
       - name: Run k6 load tests
         id: k6
         run: |

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -13,7 +13,6 @@ concurrency:
 permissions:
   contents: write
   checks: read
-  statuses: read
   deployments: write
   # Required so the reusable deploy-production.yml call is not rejected at
   # startup: its verify-ci-green job requests actions:read, and a called
@@ -38,4 +37,16 @@ jobs:
         ${{ github.event.workflow_run.head_sha }}
       create_release: true
       auto_rollback: true
-    secrets: inherit
+    # Explicit workflow_call contract: do not expose unrelated repository secrets.
+    secrets:
+      BANK_ENCRYPTION_KEY: ${{ secrets.BANK_ENCRYPTION_KEY }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      MX_WEBHOOK_SECRET: ${{ secrets.MX_WEBHOOK_SECRET }}
+      PLAID_CLIENT_ID: ${{ secrets.PLAID_CLIENT_ID }}
+      PLAID_SECRET: ${{ secrets.PLAID_SECRET }}
+      POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/.github/workflows/rc-branch-tag.yml
+++ b/.github/workflows/rc-branch-tag.yml
@@ -48,25 +48,65 @@ concurrency:
   group: rc-${{ github.event.inputs.version }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
+  validate:
+    name: Validate RC inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      base_ref: ${{ steps.validate.outputs.base_ref }}
+      rc_number: ${{ steps.validate.outputs.rc_number }}
+      version: ${{ steps.validate.outputs.version }}
+    steps:
+      - name: Validate inputs
+        id: validate
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+          RC_NUMBER: ${{ inputs.rc_number }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          [[ "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]] ||
+            { echo "::error::version must be MAJOR.MINOR.PATCH"; exit 1; }
+          [[ "$RC_NUMBER" =~ ^[0-9]+$ ]] && (( RC_NUMBER <= 9999 )) ||
+            { echo "::error::rc_number must be from 0 through 9999"; exit 1; }
+          [[ ${#BASE_REF} -le 128 && "$BASE_REF" != *..* && "$BASE_REF" != *'@{'* ]] ||
+            { echo "::error::unsafe base_ref"; exit 1; }
+          if [[ ! "$BASE_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            candidate="${BASE_REF#refs/heads/}"
+            candidate="${candidate#refs/tags/}"
+            git check-ref-format --branch "$candidate" >/dev/null ||
+              { echo "::error::base_ref is not a safe Git ref"; exit 1; }
+          fi
+          echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+          echo "rc_number=$RC_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
   # ── Gate ──────────────────────────────────────────────────────────
   approve:
     name: RC Approval Gate
+    needs: validate
     runs-on: ubuntu-latest
-    environment: staging
+    permissions: {}
     steps:
-      - run: echo "✅ RC creation approved for v${{ inputs.version }}"
+      - env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: echo "RC inputs validated for v$VERSION"
 
   # ── Create RC ────────────────────────────────────────────────────
   create-rc:
     name: Create Release Candidate
-    needs: approve
+    needs: [validate, approve]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment:
+      name: staging
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       rc_version: ${{ steps.rc.outputs.rc_version }}
       rc_tag: ${{ steps.rc.outputs.rc_tag }}
@@ -76,7 +116,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.base_ref }}
+          ref: ${{ needs.validate.outputs.base_ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -91,10 +131,12 @@ jobs:
 
       - name: Determine RC number
         id: rc
+        env:
+          BASE_REF: ${{ needs.validate.outputs.base_ref }}
+          RC_INPUT: ${{ needs.validate.outputs.rc_number }}
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
           BRANCH="release/v${VERSION}"
-          RC_INPUT=${{ inputs.rc_number }}
 
           if [ "$RC_INPUT" -gt 0 ] 2>/dev/null; then
             RC_NUM="$RC_INPUT"
@@ -123,7 +165,7 @@ jobs:
           echo "| Version | \`${RC_VERSION}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Tag | \`${RC_TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Branch | \`${BRANCH}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Base | \`${{ inputs.base_ref }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Base | \`$BASE_REF\` |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create or update release branch
         run: |
@@ -217,10 +259,14 @@ jobs:
     needs: create-rc
     if: inputs.skip_smoke_tests != true
     uses: ./.github/workflows/reusable-release-smoke-test.yml
+    permissions:
+      contents: read
     with:
       version: ${{ needs.create-rc.outputs.rc_version }}
       platforms: 'android,ios,web,windows'
-    secrets: inherit
+    secrets:
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
   # ── Summary ──────────────────────────────────────────────────────
   rc-summary:
@@ -229,6 +275,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Summary
         run: |

--- a/.github/workflows/release-platform.yml
+++ b/.github/workflows/release-platform.yml
@@ -90,8 +90,7 @@ concurrency:
   group: release-platform-${{ github.ref_name || github.run_id }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   prepare:
@@ -108,18 +107,77 @@ jobs:
       dry_run: ${{ steps.meta.outputs.dry_run }}
       publish_release: ${{ steps.meta.outputs.publish_release }}
       store_metadata: ${{ steps.meta.outputs.store_metadata }}
+      build_type: ${{ steps.meta.outputs.build_type }}
+      web_environment: ${{ steps.meta.outputs.web_environment }}
       matrix: ${{ steps.meta.outputs.matrix }}
+    permissions:
+      contents: read
     steps:
+      - name: Validate release inputs
+        id: validate
+        env:
+          BUILD_TYPE: ${{ github.event.inputs.build_type || 'release' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+          EVENT_NAME: ${{ github.event_name }}
+          GENERATE_STORE_METADATA: ${{ github.event.inputs.generate_store_metadata || 'true' }}
+          PLATFORM: ${{ github.event.inputs.platform || 'all' }}
+          RAW_VERSION: ${{ github.event.inputs.version }}
+          SOURCE_REF: ${{ github.event.inputs.source_ref || 'main' }}
+          WEB_ENVIRONMENT: ${{ github.event.inputs.web_environment || 'staging' }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            SOURCE_REF="$GITHUB_REF"
+          fi
+          if [[ -n "$RAW_VERSION" ]]; then
+            [[ "$RAW_VERSION" =~ ^v?[0-9]+[.][0-9]+[.][0-9]+([.-][0-9A-Za-z.-]+)?$ ]] ||
+              { echo "::error::version must be SemVer-compatible"; exit 1; }
+          fi
+          case "$PLATFORM" in all|web|android|ios|windows) ;; *)
+            echo "::error::unsupported platform"; exit 1 ;;
+          esac
+          case "$BUILD_TYPE" in release|debug) ;; *)
+            echo "::error::unsupported build type"; exit 1 ;;
+          esac
+          case "$WEB_ENVIRONMENT" in staging|production) ;; *)
+            echo "::error::unsupported web environment"; exit 1 ;;
+          esac
+          case "$DRY_RUN" in true|false) ;; *)
+            echo "::error::dry_run must be boolean"; exit 1 ;;
+          esac
+          case "$GENERATE_STORE_METADATA" in true|false) ;; *)
+            echo "::error::generate_store_metadata must be boolean"; exit 1 ;;
+          esac
+          [[ ${#SOURCE_REF} -le 128 && "$SOURCE_REF" != *..* && "$SOURCE_REF" != *'@{'* ]] ||
+            { echo "::error::unsafe source_ref"; exit 1; }
+          if [[ ! "$SOURCE_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            candidate="${SOURCE_REF#refs/heads/}"
+            candidate="${candidate#refs/tags/}"
+            git check-ref-format --branch "$candidate" >/dev/null ||
+              { echo "::error::source_ref is not a safe Git ref"; exit 1; }
+          fi
+          echo "source_ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.source_ref || github.ref }}
+          ref: ${{ steps.validate.outputs.source_ref }}
 
       - name: Extract version metadata
         id: meta
+        env:
+          BUILD_TYPE: ${{ github.event.inputs.build_type || 'release' }}
+          DISPATCH_DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+          DISPATCH_PLATFORM: ${{ github.event.inputs.platform || 'all' }}
+          DISPATCH_SOURCE_REF: ${{ steps.validate.outputs.source_ref }}
+          DISPATCH_STORE_METADATA: ${{ github.event.inputs.generate_store_metadata || 'true' }}
+          EVENT_NAME: ${{ github.event_name }}
+          RAW_VERSION: ${{ github.event.inputs.version }}
+          WEB_ENVIRONMENT: ${{ github.event.inputs.web_environment || 'staging' }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "push" ]; then
             TAG="${GITHUB_REF#refs/tags/}"
             VERSION="${TAG#v}"
             PLATFORM_FILTER="all"
@@ -128,18 +186,17 @@ jobs:
             PUBLISH_RELEASE=true
             STORE_METADATA=true
           else
-            RAW_VERSION="${{ github.event.inputs.version }}"
             if [ -n "$RAW_VERSION" ]; then
               VERSION="${RAW_VERSION#v}"
             else
               VERSION=$(node -e "console.log(require('./package.json').version)")
             fi
             TAG="v${VERSION}"
-            PLATFORM_FILTER="${{ github.event.inputs.platform || 'all' }}"
-            SOURCE_REF="${{ github.event.inputs.source_ref || 'main' }}"
-            DRY_RUN="${{ github.event.inputs.dry_run || 'true' }}"
+            PLATFORM_FILTER="$DISPATCH_PLATFORM"
+            SOURCE_REF="$DISPATCH_SOURCE_REF"
+            DRY_RUN="$DISPATCH_DRY_RUN"
             PUBLISH_RELEASE=false
-            STORE_METADATA="${{ github.event.inputs.generate_store_metadata || 'true' }}"
+            STORE_METADATA="$DISPATCH_STORE_METADATA"
           fi
 
           IFS='.-' read -r MAJOR MINOR PATCH _EXTRA <<< "$VERSION"
@@ -162,6 +219,8 @@ jobs:
           echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
           echo "publish_release=$PUBLISH_RELEASE" >> "$GITHUB_OUTPUT"
           echo "store_metadata=$STORE_METADATA" >> "$GITHUB_OUTPUT"
+          echo "build_type=$BUILD_TYPE" >> "$GITHUB_OUTPUT"
+          echo "web_environment=$WEB_ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
           # Build a dynamic job matrix filtered by the requested platform. The
           # build-platform job cannot reference the matrix context in its if:,
@@ -186,6 +245,8 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 50
+    environment:
+      name: release
     permissions:
       contents: read
       id-token: write
@@ -263,17 +324,19 @@ jobs:
         if: matrix.platform == 'android'
         shell: bash
         env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           ANDROID_KEYSTORE_FILE: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' && format('{0}/release-keystore.jks', github.workspace) || '' }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          BUILD_TYPE: ${{ needs.prepare.outputs.build_type }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          VERSION_CODE: ${{ needs.prepare.outputs.version_code }}
         run: |
-          if [ -n "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" ]; then
-            echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > "$GITHUB_WORKSPACE/release-keystore.jks"
+          set -euo pipefail
+          if [ -n "$ANDROID_KEYSTORE_BASE64" ]; then
+            printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$GITHUB_WORKSPACE/release-keystore.jks"
           fi
-          VERSION="${{ needs.prepare.outputs.version }}"
-          VERSION_CODE="${{ needs.prepare.outputs.version_code }}"
-          BUILD_TYPE="${{ github.event.inputs.build_type || 'release' }}"
           if [ "$BUILD_TYPE" = "release" ]; then
             ./gradlew :apps:android:bundleRelease :apps:android:assembleRelease :apps:android:testReleaseUnitTest \
               -PversionName="$VERSION" \
@@ -296,12 +359,14 @@ jobs:
       - name: Build iOS artifacts
         if: matrix.platform == 'ios'
         shell: bash
+        env:
+          XCODE_CONFIGURATION: ${{ needs.prepare.outputs.build_type == 'debug' && 'Debug' || 'Release' }}
         run: |
           cd apps/ios
           xcodebuild -resolvePackageDependencies -scheme FinanceApp -clonedSourcePackagesDirPath "${{ github.workspace }}/${{ env.SPM_CACHE_DIR }}" 2>&1 | tail -10
           xcodebuild build \
             -scheme FinanceApp \
-            -configuration "${{ github.event.inputs.build_type == 'debug' && 'Debug' || 'Release' }}" \
+            -configuration "$XCODE_CONFIGURATION" \
             -destination 'generic/platform=iOS' \
             -clonedSourcePackagesDirPath "${{ github.workspace }}/${{ env.SPM_CACHE_DIR }}" \
             -derivedDataPath "${{ github.workspace }}/${{ env.DERIVED_DATA_DIR }}" \
@@ -319,7 +384,7 @@ jobs:
             2>&1 | tail -30
           xcodebuild archive \
             -scheme FinanceApp \
-            -configuration "${{ github.event.inputs.build_type == 'debug' && 'Debug' || 'Release' }}" \
+            -configuration "$XCODE_CONFIGURATION" \
             -destination 'generic/platform=iOS' \
             -archivePath "${{ github.workspace }}/release-artifacts/Finance.xcarchive" \
             -clonedSourcePackagesDirPath "${{ github.workspace }}/${{ env.SPM_CACHE_DIR }}" \
@@ -351,7 +416,7 @@ jobs:
           npm test -w apps/web
           npx -w apps/web playwright install --with-deps chromium
           npx -w apps/web playwright test --project=chromium
-          npx @lhci/cli assert --config=apps/web/lighthouserc-budget.json || true
+          npx --yes @lhci/cli@0.15.1 assert --config=apps/web/lighthouserc-budget.json || true
           tar -czf "release-artifacts/finance-web-${{ needs.prepare.outputs.version }}.tar.gz" -C apps/web dist
           (cd apps/web && zip -r -q "${{ github.workspace }}/release-artifacts/finance-web-${{ needs.prepare.outputs.version }}.zip" dist)
           (cd release-artifacts && sha256sum * > checksums-web.sha256)
@@ -362,11 +427,17 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          WEB_ENVIRONMENT: ${{ needs.prepare.outputs.web_environment }}
         run: |
+          set -euo pipefail
           if [ -n "$VERCEL_TOKEN" ]; then
-            npm i -g vercel@latest
+            npm install --global vercel@58.9.0
             DEPLOY_LOG="$RUNNER_TEMP/vercel-release-platform.log"
-            vercel deploy --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID" ${{ github.event.inputs.web_environment == 'production' && '--prod' || '' }} --yes --archive=tgz apps/web/dist >"$DEPLOY_LOG" 2>&1 || {
+            PROD_ARGS=()
+            if [ "$WEB_ENVIRONMENT" = "production" ]; then
+              PROD_ARGS+=(--prod)
+            fi
+            vercel deploy --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID" "${PROD_ARGS[@]}" --yes --archive=tgz apps/web/dist >"$DEPLOY_LOG" 2>&1 || {
               cat "$DEPLOY_LOG"
               exit 1
             }
@@ -392,6 +463,9 @@ jobs:
       - name: Sign Windows MSI
         if: matrix.platform == 'windows' && env.HAS_WINDOWS_SIGNING_SECRETS == 'true'
         shell: pwsh
+        env:
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+          WINDOWS_SIGNING_CERT_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}
         run: |
           $sdkRoot = 'C:\Program Files (x86)\Windows Kits\10\bin'
           $signtool = Get-ChildItem -Path $sdkRoot -Directory |
@@ -401,12 +475,12 @@ jobs:
             Where-Object { Test-Path $_ } |
             Select-Object -First 1
           if (-not $signtool) { throw 'signtool.exe not found' }
-          $certBytes = [System.Convert]::FromBase64String("${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}")
+          $certBytes = [System.Convert]::FromBase64String($env:WINDOWS_SIGNING_CERT_BASE64)
           $certPath = Join-Path $env:RUNNER_TEMP 'signing-cert.pfx'
           [System.IO.File]::WriteAllBytes($certPath, $certBytes)
           try {
             Get-ChildItem -Path release-artifacts -Filter '*.msi' | ForEach-Object {
-              & $signtool sign /f $certPath /p "${{ secrets.WINDOWS_CERT_PASSWORD }}" /fd sha256 /tr http://timestamp.digicert.com /td sha256 $_.FullName
+              & $signtool sign /f $certPath /p $env:WINDOWS_CERT_PASSWORD /fd sha256 /tr http://timestamp.digicert.com /td sha256 $_.FullName
             }
           } finally {
             Remove-Item $certPath -Force -ErrorAction SilentlyContinue
@@ -414,7 +488,7 @@ jobs:
 
       - name: Attest build provenance
         if: needs.prepare.outputs.dry_run != 'true'
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: release-artifacts/*
 
@@ -437,6 +511,8 @@ jobs:
     if: needs.prepare.outputs.publish_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment:
+      name: release
     permissions:
       contents: write
       id-token: write
@@ -478,7 +554,7 @@ jobs:
           rm -f checksums-android.sha256 checksums-ios.sha256 checksums-web.sha256 checksums-windows.sha256
 
       - name: Attest release bundle
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: all-artifacts/*
 
@@ -499,6 +575,8 @@ jobs:
     if: needs.prepare.outputs.store_metadata == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -67,9 +67,7 @@ concurrency:
   group: release-train
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -79,6 +77,8 @@ jobs:
     name: Prepare Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     outputs:
       current_version: ${{ steps.version.outputs.current }}
       next_version: ${{ steps.version.outputs.next }}
@@ -88,6 +88,22 @@ jobs:
       is_dry_run: ${{ github.event.inputs.dry_run || 'false' }}
 
     steps:
+      - name: Validate release inputs
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          PRERELEASE_TAG: ${{ github.event.inputs.prerelease_tag || 'beta' }}
+          RELEASE_TYPE: ${{ github.event.inputs.release_type || 'patch' }}
+        run: |
+          set -euo pipefail
+          case "$RELEASE_TYPE" in patch|minor|major|prerelease) ;; *)
+            echo "::error::unsupported release type"; exit 1 ;;
+          esac
+          [[ "$PRERELEASE_TAG" =~ ^[0-9A-Za-z][0-9A-Za-z.-]{0,31}$ ]] ||
+            { echo "::error::invalid prerelease tag"; exit 1; }
+          case "$DRY_RUN" in true|false) ;; *)
+            echo "::error::dry_run must be boolean"; exit 1 ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -112,13 +128,14 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          PRERELEASE_TAG: ${{ github.event.inputs.prerelease_tag || 'beta' }}
+          RELEASE_TYPE: ${{ github.event.inputs.release_type || 'patch' }}
         run: |
           # Get current version from package.json
           CURRENT=$(node -e "console.log(require('./package.json').version)")
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
-
-          RELEASE_TYPE="${{ github.event.inputs.release_type || 'patch' }}"
-          PRERELEASE_TAG="${{ github.event.inputs.prerelease_tag || 'beta' }}"
 
           # Calculate next version
           IFS='.' read -r MAJOR MINOR PATCH <<< "${CURRENT%-*}"
@@ -159,7 +176,7 @@ jobs:
           echo "| Tag | \`$TAG\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Release type | $RELEASE_TYPE |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Changesets pending | ${{ steps.changesets.outputs.changeset_count }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Dry run | ${{ github.event.inputs.dry_run || 'false' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Dry run | $DRY_RUN |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate changelog
         id: changelog
@@ -212,6 +229,11 @@ jobs:
     if: needs.prepare.outputs.is_dry_run != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment:
+      name: release
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       pr_number: ${{ steps.pr.outputs.pr_number }}
       pr_url: ${{ steps.pr.outputs.pr_url }}
@@ -276,6 +298,8 @@ jobs:
           fi
 
       - name: Commit version bump
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release_type || 'patch' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -286,7 +310,7 @@ jobs:
           - Updated changelog
           - Applied changesets
 
-          Release-Type: ${{ github.event.inputs.release_type || 'patch' }}
+          Release-Type: $RELEASE_TYPE
           Triggered-By: @${{ github.actor }}"
 
       - name: Push release branch
@@ -349,6 +373,8 @@ jobs:
     if: github.event_name == 'push' && contains(github.event.head_commit.message, 'chore(release)')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     outputs:
       is_release: ${{ steps.check.outputs.is_release }}
       version: ${{ steps.check.outputs.version }}
@@ -380,6 +406,10 @@ jobs:
     if: needs.check-release-merge.outputs.is_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    environment:
+      name: release
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
@@ -424,10 +454,14 @@ jobs:
       github.event.inputs.skip_smoke_tests != 'true' &&
       github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-release-smoke-test.yml
+    permissions:
+      contents: read
     with:
       version: ${{ needs.prepare.outputs.next_version }}
       platforms: 'android,ios,web,windows'
-    secrets: inherit
+    secrets:
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
   # ---------------------------------------------------------------------------
   # Store Metadata: Generate store submission artifacts
@@ -441,6 +475,8 @@ jobs:
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -498,6 +534,7 @@ jobs:
     if: needs.prepare.outputs.is_dry_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
 
     steps:
       - name: Dry run report

--- a/.github/workflows/reusable-detect-changes.yml
+++ b/.github/workflows/reusable-detect-changes.yml
@@ -26,6 +26,12 @@
 # Never add `paths:` to a required-check workflow's `on:` — gate via this detector
 # instead. See docs/ops/ci-workflow.md and
 # .github/instructions/workflows.instructions.md.
+#
+# Canonical comparison: jrmoulckers/.github@97ff60ec21321563fa0fc7ba80015261e7dcd6fa
+# `reusable-change-detection.yml` accepts validated literal JSON prefixes and
+# exact SHAs. Finance intentionally keeps this dorny/paths-filter adapter because
+# required-check callers already pass glob-based YAML filters. Migration is not
+# parity-safe without changing every caller's filter contract.
 # =============================================================================
 name: Reusable - Detect Relevant Changes
 

--- a/.github/workflows/reusable-release-smoke-test.yml
+++ b/.github/workflows/reusable-release-smoke-test.yml
@@ -13,6 +13,10 @@
 # jrmoulckers/.github#60. Finance calls this file only via a relative
 # `uses: ./.github/workflows/...` path and does not consume the backbone
 # version under either name.
+# Canonical comparison: jrmoulckers/.github@97ff60ec21321563fa0fc7ba80015261e7dcd6fa
+# Finance delta: the canonical workflow is a single web smoke job; this workflow
+# validates four native-first platforms and therefore cannot migrate without
+# dropping Android, iOS, and Windows release coverage.
 #
 # Called by: rc-branch-tag.yml, release-train.yml
 #
@@ -38,17 +42,49 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      TURBO_TEAM:
+        required: false
+      TURBO_TOKEN:
+        required: false
     outputs:
       result:
         description: 'Overall smoke test result (pass/fail)'
         value: ${{ jobs.summary.outputs.result }}
 
+permissions: {}
+
 jobs:
+  validate:
+    name: Validate smoke inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Validate inputs
+        env:
+          ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
+          PLATFORMS: ${{ inputs.platforms }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          [[ "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+([.-][0-9A-Za-z.-]+)?$ ]] ||
+            { echo "::error::version must be SemVer-compatible"; exit 1; }
+          [[ "$PLATFORMS" =~ ^(android|ios|web|windows)(,(android|ios|web|windows))*$ ]] ||
+            { echo "::error::platforms must be a comma-separated supported platform list"; exit 1; }
+          if [[ -n "$ARTIFACT_RUN_ID" ]]; then
+            [[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]] ||
+              { echo "::error::artifact-run-id must be a positive integer"; exit 1; }
+          fi
+
   # ── Android Smoke Tests ──────────────────────────────────────────
   android:
     name: Android Smoke
     if: contains(inputs.platforms, 'android')
+    needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -95,8 +131,10 @@ jobs:
 
       - name: Smoke test summary
         if: always()
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          echo "### 🤖 Android Smoke Test — v${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### 🤖 Android Smoke Test — v$VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo "- Unit tests: ✅" >> "$GITHUB_STEP_SUMMARY"
           echo "- APK build: ✅" >> "$GITHUB_STEP_SUMMARY"
 
@@ -104,7 +142,10 @@ jobs:
   ios:
     name: iOS Smoke
     if: contains(inputs.platforms, 'ios')
+    needs: validate
     runs-on: macos-15
+    permissions:
+      contents: read
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -147,8 +188,10 @@ jobs:
 
       - name: Smoke test summary
         if: always()
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          echo "### 🍎 iOS Smoke Test — v${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### 🍎 iOS Smoke Test — v$VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo "- Build: ✅" >> "$GITHUB_STEP_SUMMARY"
           echo "- Tests: ✅" >> "$GITHUB_STEP_SUMMARY"
 
@@ -156,7 +199,10 @@ jobs:
   web:
     name: Web Smoke
     if: contains(inputs.platforms, 'web')
+    needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -196,8 +242,10 @@ jobs:
 
       - name: Smoke test summary
         if: always()
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          echo "### 🌐 Web Smoke Test — v${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### 🌐 Web Smoke Test — v$VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo "- Build: ✅" >> "$GITHUB_STEP_SUMMARY"
           echo "- Tests: ✅" >> "$GITHUB_STEP_SUMMARY"
 
@@ -205,7 +253,10 @@ jobs:
   windows:
     name: Windows Smoke
     if: contains(inputs.platforms, 'windows')
+    needs: validate
     runs-on: windows-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -231,35 +282,44 @@ jobs:
       - name: Smoke test summary
         if: always()
         shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          echo "### 🪟 Windows Smoke Test — v${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### 🪟 Windows Smoke Test — v$VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo "- Build: ✅" >> "$GITHUB_STEP_SUMMARY"
           echo "- Tests: ✅" >> "$GITHUB_STEP_SUMMARY"
 
   # ── Summary ──────────────────────────────────────────────────────
   summary:
     name: Smoke Test Summary
-    needs: [android, ios, web, windows]
+    needs: [validate, android, ios, web, windows]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
     outputs:
       result: ${{ steps.result.outputs.result }}
     steps:
       - name: Evaluate results
         id: result
+        env:
+          ANDROID: ${{ needs.android.result }}
+          IOS: ${{ needs.ios.result }}
+          VALIDATE: ${{ needs.validate.result }}
+          VERSION: ${{ inputs.version }}
+          WEB: ${{ needs.web.result }}
+          WINDOWS: ${{ needs.windows.result }}
         run: |
-          ANDROID="${{ needs.android.result }}"
-          IOS="${{ needs.ios.result }}"
-          WEB="${{ needs.web.result }}"
-          WINDOWS="${{ needs.windows.result }}"
-
-          echo "### 🧪 Smoke Test Results — v${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### 🧪 Smoke Test Results — v$VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Platform | Result |" >> "$GITHUB_STEP_SUMMARY"
           echo "|----------|--------|" >> "$GITHUB_STEP_SUMMARY"
 
           FAILED=false
+          if [ "$VALIDATE" != "success" ]; then
+            echo "::error::Smoke input validation did not pass"
+            FAILED=true
+          fi
           for PLATFORM in android ios web windows; do
             RESULT_VAR=$(echo "$PLATFORM" | tr '[:lower:]' '[:upper:]')
             RESULT="${!RESULT_VAR}"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -414,7 +414,8 @@ services:
   # Then update PS_PG_URI below to use that role instead of supabase_admin.
   # Migration: services/api/supabase/migrations/YYYYMMDDHHMMSS_powersync_role.sql
   powersync:
-    image: journeyapps/powersync-service:latest
+    # v1.23.3 multi-arch index, reviewed 2026-08-08.
+    image: journeyapps/powersync-service:1.23.3@sha256:b6b22fa7d0d862f04bdff62846e656756d17bcf3dd6eca399a0633671051438b
     restart: unless-stopped
     # Same incident took PowerSync down too; opt it into autoheal as well (#3074).
     labels:

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "cleanup:worktrees": "node tools/cleanup-worktrees.js",
     "ai:manifest": "node tools/ai-manifest.js",
     "ai:manifest:check": "node tools/check-ai-manifest.js",
+    "workflow:security:check": "node tools/check-workflow-security.mjs",
+    "workflow:security:test": "node --test tools/check-workflow-security.test.mjs",
     "agent:worktree": "node tools/agent-scripts/setup-worktree.js",
     "agent:check": "node tools/agent-scripts/pre-push-check.js",
     "agent:pr": "node tools/agent-scripts/create-pr.js",

--- a/tools/README.md
+++ b/tools/README.md
@@ -218,6 +218,19 @@ Detects hardcoded secrets, runs static code analysis patterns, and checks depend
     node tools/security-scan.js                            # Full scan
     node tools/security-scan.js --secrets-only             # Secret detection only
 
+### `check-workflow-security.mjs` - Privileged workflow regression gate
+
+Checks GitHub Actions workflows for full-SHA action pins, immutable external
+tooling, input-to-shell interpolation, inherited reusable secrets, protected
+release environments, least-privilege job permissions, verified k6 downloads,
+preview secret isolation, and reviewed Finance-local reusable workflow drift.
+
+```bash
+npm run workflow:security:test
+npm run workflow:security:check
+node tools/check-workflow-security.mjs --help
+```
+
 ### `ci-health-dashboard.js` - CI/CD health metrics
 
 Queries GitHub Actions via gh CLI for workflow success rates, build times, and flaky test detection.

--- a/tools/check-workflow-security.mjs
+++ b/tools/check-workflow-security.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+/**
+ * Usage: npm run workflow:security:check
+ *        node tools/check-workflow-security.mjs --help
+ *
+ * Fails when privileged GitHub Actions workflows regress on immutable
+ * dependencies, input-to-shell boundaries, secret isolation, integrity checks,
+ * least privilege, protected environments, or reviewed local reusable forks.
+ */
+
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const workflowDirectory = join(repositoryRoot, '.github', 'workflows');
+const canonicalWorkflowSha = '97ff60ec21321563fa0fc7ba80015261e7dcd6fa';
+const attestationActionSha = '4d101475d8b20a2381f78447822ac1eab6504dd8';
+const productionPowerSyncImage =
+  'journeyapps/powersync-service:1.23.3@sha256:b6b22fa7d0d862f04bdff62846e656756d17bcf3dd6eca399a0633671051438b';
+
+const privilegedWorkflows = new Set([
+  'changesets.yml',
+  'deploy-preview.yml',
+  'deploy-production.yml',
+  'deploy-progressive.yml',
+  'deploy-rollback.yml',
+  'nightly.yml',
+  'rc-branch-tag.yml',
+  'release-platform.yml',
+  'release-train.yml',
+  'reusable-release-smoke-test.yml',
+]);
+
+const localReusableBaselines = {
+  'reusable-detect-changes.yml': 'f67ce0e29f90d0d9a73e7db3155ba8ccec3525e2eb8a2730ed9337a3ef614ade',
+  'reusable-release-smoke-test.yml':
+    '6f63898e8b4306a4d87ba651557e23816674a746bfb3db72cb0a4adc2b69483e',
+};
+
+const requiredEnvironmentJobs = {
+  'changesets.yml': ['version'],
+  'deploy-production.yml': ['deploy-web', 'deploy-backend', 'auto-rollback', 'create-release'],
+  'deploy-rollback.yml': ['approve'],
+  'rc-branch-tag.yml': ['create-rc'],
+  'release-platform.yml': ['build-platform', 'publish-release'],
+  'release-train.yml': ['version-bump', 'create-tag'],
+};
+
+const leastPrivilegeWorkflows = [
+  'changesets.yml',
+  'deploy-preview.yml',
+  'deploy-production.yml',
+  'deploy-progressive.yml',
+  'deploy-rollback.yml',
+  'release-platform.yml',
+  'release-train.yml',
+  'reusable-release-smoke-test.yml',
+];
+
+function normalize(text) {
+  return text.replace(/\r\n/g, '\n');
+}
+
+function sha256(text) {
+  return createHash('sha256').update(normalize(text)).digest('hex');
+}
+
+export function extractJob(workflow, jobName) {
+  const lines = normalize(workflow).split('\n');
+  const start = lines.findIndex((line) => line === `  ${jobName}:`);
+  if (start === -1) return '';
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (/^ {2}[A-Za-z0-9_-]+:\s*$/.test(lines[index])) {
+      end = index;
+      break;
+    }
+  }
+  return lines.slice(start, end).join('\n');
+}
+
+export function findRunExpressionViolations(workflow) {
+  const lines = normalize(workflow).split('\n');
+  const violations = [];
+  let runIndent = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const indent = line.length - line.trimStart().length;
+    const runMatch = line.match(/^(\s*)(?:-\s*)?run:\s*(.*)$/);
+    if (runMatch) {
+      runIndent = runMatch[1].length;
+      if (/\$\{\{\s*(?:inputs|github\.event\.inputs)\./.test(runMatch[2])) {
+        violations.push(index + 1);
+      }
+      continue;
+    }
+
+    if (runIndent !== null && line.trim() && indent <= runIndent) {
+      runIndent = null;
+    }
+    if (runIndent !== null && /\$\{\{\s*(?:inputs|github\.event\.inputs)\./.test(line)) {
+      violations.push(index + 1);
+    }
+  }
+
+  return violations;
+}
+
+export function findMutableReferenceViolations(workflow) {
+  const violations = [];
+  const lines = normalize(workflow).split('\n');
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const uses = line.match(/^\s*(?:-\s*)?uses:\s*([^#\s]+)/);
+    if (uses && !uses[1].startsWith('./')) {
+      const separator = uses[1].lastIndexOf('@');
+      const reference = separator === -1 ? '' : uses[1].slice(separator + 1);
+      if (!/^[0-9a-f]{40}$/.test(reference)) {
+        violations.push({
+          line: index + 1,
+          reason: `action is not pinned by full SHA: ${uses[1]}`,
+        });
+      }
+    }
+
+    const mutableTool =
+      /\bvercel@(latest|next|beta)\b/.test(line) ||
+      /\bnpx(?:\s+--yes)?\s+@lhci\/cli(?:\s|$)/.test(line) ||
+      /\bnpx(?:\s+--yes)?\s+license-checker(?:\s|$)/.test(line) ||
+      /^\s*image:\s*\S+:(latest|main|master|stable)\b/.test(line) ||
+      /\bdocker\s+(?:pull|run)\s+\S+:(latest|main|master|stable)\b/.test(line);
+    if (mutableTool) {
+      violations.push({ line: index + 1, reason: 'mutable external tool or image reference' });
+    }
+    if (/\bcurl\b.*\|\s*tar\b/.test(line)) {
+      violations.push({
+        line: index + 1,
+        reason: 'archive is streamed from curl directly into tar',
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function scanWorkflowSecurity(workflows, productionCompose = '') {
+  const errors = [];
+  const report = (file, message) => errors.push(`${file}: ${message}`);
+
+  for (const [file, workflow] of Object.entries(workflows)) {
+    for (const violation of findMutableReferenceViolations(workflow)) {
+      report(file, `line ${violation.line}: ${violation.reason}`);
+    }
+    if (/^\s*secrets:\s*inherit\s*$/m.test(workflow)) {
+      report(
+        file,
+        'secrets: inherit is forbidden; declare the reusable secret contract explicitly',
+      );
+    }
+    if (privilegedWorkflows.has(file)) {
+      for (const line of findRunExpressionViolations(workflow)) {
+        report(file, `line ${line}: dispatch/workflow input is interpolated directly into shell`);
+      }
+    }
+  }
+
+  for (const file of leastPrivilegeWorkflows) {
+    if (!/^permissions:\s*\{\}\s*$/m.test(workflows[file] ?? '')) {
+      report(file, 'privileged workflow must default to permissions: {}');
+    }
+  }
+
+  for (const [file, jobs] of Object.entries(requiredEnvironmentJobs)) {
+    for (const jobName of jobs) {
+      const job = extractJob(workflows[file] ?? '', jobName);
+      if (!job) {
+        report(file, `required privileged job is missing: ${jobName}`);
+      } else {
+        if (
+          !/^\s{4}environment:\s*(?:\n\s{6}name:\s*)?(?:production|release|staging)\s*$/m.test(job)
+        ) {
+          report(
+            file,
+            `${jobName} must use a protected production, release, or staging environment`,
+          );
+        }
+        if (!/^\s{4}permissions:/m.test(job)) {
+          report(file, `${jobName} must declare job-level permissions`);
+        }
+      }
+    }
+  }
+
+  const preview = workflows['deploy-preview.yml'] ?? '';
+  const previewBuild = extractJob(preview, 'build-preview');
+  const previewDeploy = extractJob(preview, 'deploy-preview');
+  const previewCleanup = extractJob(preview, 'cleanup');
+  if (
+    !previewBuild.includes('github.event.pull_request.head.repo.full_name == github.repository')
+  ) {
+    report('deploy-preview.yml', 'preview build must fail closed for fork pull requests');
+  }
+  if (/\$\{\{\s*secrets\./.test(previewBuild)) {
+    report('deploy-preview.yml', 'PR-controlled build job must not receive secrets');
+  }
+  if (/actions\/checkout@|\bnpm\s+(?:ci|run)\b/.test(previewDeploy)) {
+    report('deploy-preview.yml', 'secret-bearing deploy job must not check out or execute PR code');
+  }
+  if (
+    !previewCleanup.includes('github.event.pull_request.head.repo.full_name == github.repository')
+  ) {
+    report('deploy-preview.yml', 'preview cleanup must fail closed for fork pull requests');
+  }
+
+  const nightly = workflows['nightly.yml'] ?? '';
+  if (
+    !nightly.includes(
+      'K6_LINUX_AMD64_SHA256: c7f03434854f837b6790ee81572e4b0f955241974c79a43cbb9f8d0fef069589',
+    ) ||
+    !nightly.includes('sha256sum --check --strict')
+  ) {
+    report('nightly.yml', 'k6 download must use the reviewed v0.54.0 SHA-256 checksum');
+  }
+
+  const attestPattern = new RegExp(
+    `actions/attest-build-provenance@${attestationActionSha}\\b`,
+    'g',
+  );
+  const attestationCount = Object.values(workflows).reduce(
+    (count, workflow) => count + [...workflow.matchAll(attestPattern)].length,
+    0,
+  );
+  if (attestationCount !== 3) {
+    report(
+      'workflows',
+      `expected 3 verified attest-build-provenance pins, found ${attestationCount}`,
+    );
+  }
+
+  if (!productionCompose.includes(`image: ${productionPowerSyncImage}`)) {
+    report(
+      'deploy/docker-compose.yml',
+      'production PowerSync image must retain its reviewed v1.23.3 multi-arch digest',
+    );
+  }
+  if (/^\s*image:\s*\S+:latest\s*$/m.test(productionCompose)) {
+    report('deploy/docker-compose.yml', 'production container images must not use latest tags');
+  }
+
+  for (const [file, expectedHash] of Object.entries(localReusableBaselines)) {
+    const workflow = workflows[file] ?? '';
+    if (!workflow.includes(`Canonical comparison: jrmoulckers/.github@${canonicalWorkflowSha}`)) {
+      report(file, `must document canonical comparison at ${canonicalWorkflowSha}`);
+    }
+    const actualHash = sha256(workflow);
+    if (actualHash !== expectedHash) {
+      report(
+        file,
+        `reviewed local reusable drifted (expected ${expectedHash}, found ${actualHash})`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+function loadWorkflows() {
+  return Object.fromEntries(
+    readdirSync(workflowDirectory)
+      .filter((file) => /\.ya?ml$/.test(file))
+      .sort()
+      .map((file) => [file, readFileSync(join(workflowDirectory, file), 'utf8')]),
+  );
+}
+
+function main() {
+  if (process.argv.includes('--help')) {
+    console.log('Usage: node tools/check-workflow-security.mjs');
+    console.log('Checks .github/workflows for privileged workflow security regressions.');
+    return;
+  }
+  if (process.argv.length > 2) {
+    console.error(`Unknown option: ${process.argv.slice(2).join(' ')}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const productionCompose = readFileSync(
+    join(repositoryRoot, 'deploy', 'docker-compose.yml'),
+    'utf8',
+  );
+  const errors = scanWorkflowSecurity(loadWorkflows(), productionCompose);
+  if (errors.length > 0) {
+    console.error('Workflow security regression check failed:');
+    for (const error of errors) console.error(`- ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `Workflow security regression check passed (${relative(repositoryRoot, workflowDirectory)}).`,
+  );
+}
+
+if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tools/check-workflow-security.test.mjs
+++ b/tools/check-workflow-security.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  extractJob,
+  findMutableReferenceViolations,
+  findRunExpressionViolations,
+} from './check-workflow-security.mjs';
+
+test('findRunExpressionViolations finds direct input-to-shell interpolation', () => {
+  const workflow = `
+jobs:
+  deploy:
+    steps:
+      - env:
+          VERSION: \${{ inputs.version }}
+        run: |
+          echo "$VERSION"
+      - run: echo "\${{ github.event.inputs.reason }}"
+`;
+
+  assert.deepEqual(findRunExpressionViolations(workflow), [9]);
+});
+
+test('findMutableReferenceViolations accepts SHAs and rejects mutable actions and tools', () => {
+  const workflow = `
+- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+- uses: actions/attest-build-provenance@v4
+- run: npm install --global vercel@latest
+`;
+
+  assert.equal(findMutableReferenceViolations(workflow).length, 2);
+});
+
+test('extractJob returns only the requested top-level job', () => {
+  const workflow = `
+jobs:
+  build:
+    permissions: {}
+  deploy:
+    environment: production
+`;
+
+  assert.match(extractJob(workflow, 'build'), /permissions/);
+  assert.doesNotMatch(extractJob(workflow, 'build'), /environment/);
+});


### PR DESCRIPTION
## Summary

Hardens Finance's privileged release, production, preview, rollback, and nightly workflows against supply-chain drift, input injection, over-broad authority, and secret exposure.

## Security boundaries

- Protects repository/environment secrets, OIDC attestation authority, release write tokens, production deploy credentials, and generated artifacts.
- Treats dispatch/reusable inputs, PR code/artifacts, external CLIs/archives/images, and local reusable-workflow drift as trust boundaries.
- Preview builds now execute PR-controlled code only in a secretless read-only job; the secret-bearing deploy job consumes a checked artifact without checking out or executing PR code and rejects forks.

## Changes

- Pins `actions/attest-build-provenance` to verified commit `4d101475d8b20a2381f78447822ac1eab6504dd8` and pins Vercel 58.9.0, LHCI 0.15.1, and license-checker 25.0.1.
- Downloads k6 0.54.0 over HTTPS, verifies the official SHA-256 checksum, then extracts it.
- Pins production PowerSync v1.23.3 to reviewed multi-arch digest `sha256:b6b22fa7d0d862f04bdff62846e656756d17bcf3dd6eca399a0633671051438b`.
- Moves dispatch/reusable inputs through environment boundaries with strict enum, range, SemVer, URL, and Git-ref validation.
- Defaults privileged workflows to `permissions: {}`, grants job-scoped permissions, and gates release/production-capable jobs through `staging`, `release`, or `production` environments.
- Replaces `secrets: inherit` with explicit `workflow_call` contracts for production deploy and multi-platform smoke workflows.
- Keeps Finance-local change detection and multi-platform smoke workflows after comparison with canonical SHA `97ff60ec21321563fa0fc7ba80015261e7dcd6fa`; comments document the non-parity deltas and static hashes detect unreviewed drift.
- Adds `tools/check-workflow-security.mjs`, unit tests, and a blocking Security CI invocation covering mutable actions/tools/images, input-to-shell interpolation, inherited secrets, gates/permissions, k6 integrity, preview isolation, and local reusable drift.

## Caller contract changes

- `deploy-production.yml` explicitly declares only the production secrets it consumes; `promote-production.yml` maps those names individually.
- `reusable-release-smoke-test.yml` explicitly declares optional `TURBO_TOKEN` and `TURBO_TEAM`; both callers map only those secrets.

## Follow-up

- #4024 tracks lower-risk non-privileged metrics interpolation and local-only mutable image references.

## Needs Human Action

Repository environment settings are outside this PR's authority. Confirm that `production`, `release`, and `staging` have required reviewers and appropriate branch/tag deployment restrictions, and that `preview` exposes preview-only credentials. No environment settings were changed by this PR.

## Validation

- `npm run format:check && npx eslint . --max-warnings 0`
- `npm run workflow:security:test && npm run workflow:security:check`
- `STRICT=1 npm run ai:manifest:check`
- `npm run ci:check:quick`
- `docker compose -f deploy/docker-compose.yml config --images`

## Issues

Closes #4023