### PR TITLE
docs: consolidate onto centralized Product authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,6 +446,27 @@ These tasks create GitHub issues using the same issue-first workflow as engineer
 
 See `docs/ai/` for complete AI development documentation.
 
+## Product authority
+
+Product obligations and outcomes are defined in
+[jrmoulckers/product](https://github.com/jrmoulckers/product). Cite obligations
+by stable ID (for example `PROD-REL-001`); pin to a commit SHA when exact
+wording matters. Roadmaps, metrics, experiments, and compliance evidence stay in
+this repository and cite the obligation they satisfy.
+
+Engineering mechanisms are defined in
+[jrmoulckers/engineering](https://github.com/jrmoulckers/engineering), design and
+interface in [jrmoulckers/studio](https://github.com/jrmoulckers/studio), and
+automation and shared agent assets in
+[jrmoulckers/.github](https://github.com/jrmoulckers/.github).
+
+Do not copy principle text into this repository — cite the ID. Product owns the
+obligation and the reusable shape; this repository owns its instances and its
+evidence. Roadmaps, sprint plans, metric catalogs, experiment records, and
+privacy audits are instances and stay here. The repository's product definition
+is [`PRODUCT.md`](./PRODUCT.md); obligation-to-evidence traceability for
+compliance is [`docs/compliance/README.md`](./docs/compliance/README.md).
+
 <!-- prettier-ignore-start -->
 <!-- studio:base:start -->
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,271 @@
+# Finance — product
+
+> **Product authority:** obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product) and cited here by
+> stable ID. This document is the local, per-application product definition —
+> the shape is central (`templates/PRODUCT.md`), the instance is local.
+> Ratified obligation set:
+> [`3a752c1`](https://github.com/jrmoulckers/product/tree/3a752c11856515a74eb204675d5d5198cac1e48e/principles).
+
+## Users
+
+> Satisfies `PROD-STRAT-001`, `PROD-BUS-003`.
+
+People who want to understand their money without needing a finance degree.
+They are not spreadsheet users and do not want to become spreadsheet users. They
+track money in short bursts — standing in a checkout line, on a phone, often
+offline, frequently interrupted — rather than in a weekly sit-down session.
+
+The audience explicitly includes users with cognitive differences; ADHD-friendly
+design is a design principle rather than an accessibility checkbox. Users span
+personal, partnered, and family financial arrangements, so a household is the
+primary tenancy and data-isolation boundary rather than an add-on.
+
+Evidence and interpretation for market claims, competitive position, and
+international opportunity are dated and recorded separately in
+[`docs/business/revenue/`](docs/business/revenue/),
+[`docs/business/pricing/`](docs/business/pricing/), and
+[`docs/business/sprints/sprint-8-i18n-market-research.md`](docs/business/sprints/sprint-8-i18n-market-research.md).
+Where those documents record an assumption rather than an observation, they label
+it as such. The behavioral profile above is an assumption pending post-launch
+measurement; the retention and engagement evidence that would confirm or refute it
+is tracked in [`docs/business/growth/`](docs/business/growth/).
+
+## Purpose
+
+> Satisfies `PROD-STRAT-001`, `PROD-STRAT-003`.
+
+Finance makes tracking personal, partnered, and family money accessible to people
+who do not think in spreadsheets. It translates financial complexity into human
+language, keeps financial data on the user's device by default, and makes the
+daily act of recording money take less than 30 seconds. Working well means a user
+can answer "where did my money go?" and "can I afford this?" without study,
+without a network connection, and without handing their financial life to a third
+party.
+
+## Promise
+
+> Satisfies `PROD-STRAT-001`, `PROD-BUS-001`.
+
+**See your money clearly. Keep it private. No expertise required.**
+
+Proof points:
+
+1. **Works with your brain** — an expertise-tiered interface adapts language and
+   complexity to the user instead of demanding the user adapt to the product.
+2. **Your money never leaves your device** — offline-first, encrypted at rest,
+   sync is opt-in.
+3. **30 seconds or less** — three-tap transaction entry and a widget-first daily
+   habit loop.
+4. **Facts, not judgments** — the product observes and informs; it never shames.
+
+Trust constraints that no growth or monetization decision may weaken:
+
+- On-device-first storage and encryption at rest are not negotiable for revenue.
+- Sync is opt-in and remains opt-in.
+- Financial data is never sold, shared, or used to build advertising profiles.
+  Finance has no advertising business model.
+- A user's access to their own existing data — including export and deletion — is
+  never gated behind a paid tier.
+- Non-judgmental language is a product obligation, not a copy preference.
+
+## Operating context and constraints
+
+> Satisfies `PROD-STRAT-003`, `PROD-PLAN-003`.
+
+Four first-class platforms: iOS (iPhone, iPad, Mac, watchOS), Android (phone,
+tablet, Wear OS), Web (PWA), and Windows 11. Platform parity is an explicit
+obligation, not an aspiration; intentional parity gaps are recorded as decisions
+rather than discovered at release. Current parity state and the dated assessment
+live in
+[`docs/business/roadmap/launch-readiness-dashboard-and-platform-parity.md`](docs/business/roadmap/launch-readiness-dashboard-and-platform-parity.md).
+
+Connectivity is assumed to be intermittent. The product is fully functional
+offline; synchronization is opportunistic and optional. Data ownership sits with
+the user: local storage is the system of record from the user's perspective, and
+export is always available.
+
+If the optional sync backend is unavailable, single-device tracking, budgeting,
+goals, reporting, and export all continue to work. If the optional bank-connection
+aggregator is unavailable, manual entry and file import remain the supported paths
+— manual entry is the primary path, not a fallback. If the optional AI layer is
+unavailable, categorization and budgeting remain available manually.
+
+The household is the tenancy and isolation boundary. Constraints accepted for the
+single-user alpha are recorded in
+[`docs/business/sprints/alpha-household-constraints.md`](docs/business/sprints/alpha-household-constraints.md).
+
+Mechanism choices that realize this context — the shared-logic strategy, storage
+engine, sync engine, and per-platform interface technology — are Engineering and
+Studio decisions recorded in [`docs/architecture/`](docs/architecture/), not
+product obligations.
+
+## Invariants
+
+> Satisfies `PROD-PLAN-002`, `PROD-REL-003`.
+
+These must remain true of product behavior regardless of implementation. A change
+may not silently break one.
+
+1. Core tracking — accounts, transactions, budgets, goals, categories, and rules —
+   works with no network connection.
+2. Financial data is encrypted at rest on the device.
+3. Synchronization is opt-in and can be declined without losing core function.
+4. A user can export their own complete financial data at any time, on any tier,
+   in a machine-readable format.
+5. A user can delete their account and have their personal data erased within the
+   promised window recorded in
+   [`docs/compliance/data-retention-schedule.md`](docs/compliance/data-retention-schedule.md).
+6. Monetary amounts are held and computed as integer minor units with
+   `HALF_EVEN` rounding; no monetary value is stored or computed as a binary
+   floating-point number.
+7. Household data is isolated: no user sees another household's financial data.
+8. User-facing financial language observes and informs; it does not assign blame.
+9. Privacy, safety, accessibility, and access to a user's own existing data are
+   never placed behind a paid tier.
+10. Financial data is never sold, shared for advertising, or used to derive an
+    advertising profile.
+11. Every user-facing surface meets WCAG 2.2 AA at minimum.
+12. An AI-produced categorization, forecast, or insight is identifiable as such and
+    can be corrected or overridden by the user.
+
+## Scope and non-goals
+
+> Satisfies `PROD-PLAN-001`, `PROD-PLAN-004`, `PROD-STRAT-003`.
+
+Outcome milestones, sequenced rather than enumerated as features:
+
+1. **Track confidently on one device** — a user records and understands their
+   money offline, on any of the four platforms, without instruction.
+2. **Plan and pursue** — budgeting and goal tracking make future money legible,
+   not just past money.
+3. **Share a financial life** — household and partner arrangements work without
+   either party losing privacy or control.
+4. **Understand without studying** — contextual education and reporting turn data
+   into comprehension.
+5. **Reduce the effort** — assistive categorization, import, and forecasting cut
+   the manual cost of accuracy.
+
+Each milestone is valuable if the ones after it never ship. Dated sequencing lives
+in [`docs/business/roadmap/`](docs/business/roadmap/) and
+[`docs/business/sprints/`](docs/business/sprints/).
+
+Non-goals — as load-bearing as the goals:
+
+- Not an investment brokerage, trading platform, or tax-filing service.
+- Not a financial-advice product. It does not tell a user what they should do with
+  their money.
+- Not a data business. There is no advertising model and no data resale.
+- Not a spreadsheet replacement for professional accounting.
+- Not cloud-first. A server-dependent product is out of scope by design.
+
+## Anti-references
+
+> Satisfies `PROD-STRAT-001`.
+
+This must never feel like:
+
+- **A budgeting app that scolds.** Shame-based framing drives users to stop
+  looking at their money, which is the opposite of the promise.
+- **A product that holds your data hostage.** Export and deletion behind a paywall,
+  or a proprietary format, converts trust into lock-in.
+- **A dashboard for financial professionals.** Dense terminology and unexplained
+  ratios exclude exactly the users this product exists for.
+- **An engagement-optimized feed.** Time in app is not the goal; 30 seconds and out
+  is the goal.
+- **A free product whose real product is the user.** Any monetization path that
+  depends on the financial data itself is rejected regardless of revenue.
+
+## Monetization
+
+> Satisfies `PROD-BUS-001`, `PROD-BUS-002`.
+
+The value metric charged for is the **assistive intelligence and multi-device
+layer**, not access to a user's own financial data.
+
+- **Free** — the complete single-device financial tracker: all accounts,
+  transactions, budgets, goals, categories, and rules; the full expertise-tiered
+  interface; contextual education; basic reporting; and data export.
+- **Paid** — AI categorization, suggested budgets, forecasting, holistic goal and
+  portfolio analysis, structured learning paths, multi-device sync, household
+  sharing, and advanced reporting.
+
+Never gated, on any tier: privacy and encryption, accessibility, data export, data
+deletion, and access to a user's own existing data.
+
+Tier boundaries, prices, the value hypothesis, and the dated competitive and
+sensitivity evidence are recorded in
+[`docs/business/revenue/monetization-roadmap.md`](docs/business/revenue/monetization-roadmap.md),
+[`docs/business/pricing/premium-strategy-conversion-funnel.md`](docs/business/pricing/premium-strategy-conversion-funnel.md),
+and [`docs/business/pricing/`](docs/business/pricing/). Viability assumptions,
+ranges, and reassessment triggers are recorded there rather than restated here.
+
+## Measurement
+
+> Satisfies `PROD-MET-001`, `PROD-MET-002`.
+
+The local metric catalog is
+[`docs/business/growth/kpi-dashboard-spec.md`](docs/business/growth/kpi-dashboard-spec.md)
+§2, with collection bounds and privacy constraints stated alongside each
+definition. Supporting analysis and readouts live in
+[`docs/business/growth/`](docs/business/growth/).
+
+Definitions are not restated here. Measurement is bounded by purpose and consent:
+telemetry is consent-gated and excludes raw financial values. Consent evidence is
+[`docs/compliance/consent-management-audit.md`](docs/compliance/consent-management-audit.md).
+
+## Compliance posture
+
+> Satisfies `PROD-COMP-002`, `PROD-COMP-003`, `PROD-COMP-005`.
+
+Processing is bounded to operating the product for the user: recording and
+presenting the user's own financial data, optional synchronization between that
+user's own devices and their household, and consent-gated product telemetry that
+excludes raw financial values. Financial data is not processed for advertising,
+profiling, or resale.
+
+Retention is bounded per data category, with a stated terminal disposition, in
+[`docs/compliance/data-retention-schedule.md`](docs/compliance/data-retention-schedule.md).
+The processing map and data inventory are in
+[`docs/compliance/data-inventory.md`](docs/compliance/data-inventory.md), and
+rights-handling evidence — access, erasure, portability, and CCPA/CPRA
+verification — is in [`docs/compliance/`](docs/compliance/).
+
+Obligation-to-evidence traceability is
+[`docs/compliance/README.md`](docs/compliance/README.md), which satisfies
+`PROD-COMP-001`.
+
+Compliance principles establish governance, evidence expectations, and triggers
+for qualified human review. They are not legal advice, and nothing in this
+document or the linked evidence is legal advice.
+
+## Accessibility and inclusion
+
+> Satisfies `PROD-CONTENT-005`.
+
+Every user-facing surface meets WCAG 2.2 AA at minimum. This is a product
+obligation, not a design preference: an inaccessible surface is an unmet
+obligation regardless of how it looks. Cognitive accessibility is in scope —
+progressive disclosure, plain-language tiering, and non-judgmental framing exist
+because financial anxiety and cognitive load are accessibility concerns.
+
+Conformance evidence is
+[`docs/compliance/vpat-2.5.md`](docs/compliance/vpat-2.5.md). Studio owns the
+interface expression; this section owns the obligation.
+
+## Authority
+
+> Satisfies `PROD-CONTENT-001`.
+
+Product obligations are defined in
+[jrmoulckers/product](https://github.com/jrmoulckers/product). Engineering
+mechanisms are defined in
+[jrmoulckers/engineering](https://github.com/jrmoulckers/engineering), design and
+interface in [jrmoulckers/studio](https://github.com/jrmoulckers/studio), and
+automation in [jrmoulckers/.github](https://github.com/jrmoulckers/.github).
+
+This document defines what this product owes its users. It does not define
+mechanism, interface implementation, or automation. The detailed interface and
+identity specification is
+[`docs/design/product-identity.md`](docs/design/product-identity.md); the system
+architecture is [`docs/architecture/roadmap.md`](docs/architecture/roadmap.md).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A multi-platform, native-first financial tracking application for personal, fami
 - [Project Status](#project-status)
 - [Monorepo Health](#monorepo-health)
 - [Principles](#principles)
+- [Product authority](#product-authority)
 - [Platforms](#platforms)
 - [Architecture](#architecture)
 - [Tech Stack](#tech-stack)
@@ -116,6 +117,23 @@ All workflows run on GitHub Actions — see badges at the top of this README.
 - **Accessibility** — Beautiful, inclusive interfaces for everyone
 - **Open development** — AI-developed with full transparency in documentation
 - **Ethical design** — Moral code development at the forefront of every component
+
+See [`PRODUCT.md`](./PRODUCT.md) for the product definition — users, promise,
+invariants, scope, monetization, and compliance posture.
+
+## Product authority
+
+Product obligations and outcomes are defined in
+[jrmoulckers/product](https://github.com/jrmoulckers/product). Cite obligations
+by stable ID (for example `PROD-REL-001`); pin to a commit SHA when exact
+wording matters. Roadmaps, metrics, experiments, and compliance evidence stay in
+this repository and cite the obligation they satisfy.
+
+Engineering mechanisms are defined in
+[jrmoulckers/engineering](https://github.com/jrmoulckers/engineering), design and
+interface in [jrmoulckers/studio](https://github.com/jrmoulckers/studio), and
+automation and shared agent assets in
+[jrmoulckers/.github](https://github.com/jrmoulckers/.github).
 
 ## Platforms
 

--- a/docs/architecture/roadmap.md
+++ b/docs/architecture/roadmap.md
@@ -18,19 +18,15 @@ The development is organized into eight phases, from foundational infrastructure
 
 ## Product Identity
 
-**Core Promise:** "See your money clearly. Keep it private. No expertise required."
+Product identity does not live in an architecture document. The product
+definition — users, purpose, promise, invariants, scope and non-goals,
+monetization, measurement, and compliance posture — is
+[`PRODUCT.md`](../../PRODUCT.md) at the repository root, and the detailed
+identity specification is [Product Identity](../design/product-identity.md).
 
-**Differentiators:**
-
-1. Expertise-tiered UI — adapts to user's financial comfort level
-2. Offline-first, encrypted-at-rest privacy — Signal-like data practices
-3. 30-second daily interaction — 3-tap transaction entry, widget-first habit loop
-4. Contextual financial education — learn by using, not by studying
-5. Non-judgmental design — facts + encouragement, never guilt
-
-**Target Users:** People who want to understand their money without needing a finance degree. Inclusive of users with cognitive differences (ADHD-friendly design).
-
-See [Product Identity](../design/product-identity.md) for the complete specification.
+This document owns the technology and mechanism decisions that realize that
+product definition. Where the two disagree, `PRODUCT.md` states the obligation
+and this document states how it is met.
 
 ---
 

--- a/docs/business/growth/churn-analysis-sprint6.md
+++ b/docs/business/growth/churn-analysis-sprint6.md
@@ -8,6 +8,10 @@
 > **Status:** Draft — Framework ready, pending post-launch data
 > **Depends on:** #818 (KPI Dashboard), #819 (Cohort Analysis)
 
+> **Satisfies:** `PROD-MET-001`, `PROD-MET-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/growth/cohort-analysis-sprint6.md
+++ b/docs/business/growth/cohort-analysis-sprint6.md
@@ -8,6 +8,10 @@
 > **Status:** Draft — Pending sufficient post-launch data (minimum 14 days)
 > **Depends on:** #818 (KPI Dashboard & Baseline)
 
+> **Satisfies:** `PROD-MET-001`, `PROD-MET-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/growth/feature-usage-report-sprint8.md
+++ b/docs/business/growth/feature-usage-report-sprint8.md
@@ -8,6 +8,10 @@
 > **Status:** Draft — Framework ready, requires 30+ days of post-launch data
 > **Depends on:** #819 (Cohort Analysis), #822 (Conversion Tracking)
 
+> **Satisfies:** `PROD-MET-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/growth/growth-analysis-sprint8.md
+++ b/docs/business/growth/growth-analysis-sprint8.md
@@ -8,6 +8,10 @@
 > **Status:** Draft — Framework ready, requires 6+ weeks of post-launch data
 > **Depends on:** #818 (KPI Dashboard), #824 (Revenue Model)
 
+> **Satisfies:** `PROD-MET-003`, `PROD-BUS-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/growth/growth-metrics-framework.md
+++ b/docs/business/growth/growth-metrics-framework.md
@@ -13,31 +13,46 @@
 
 ---
 
+> **Satisfies:** `PROD-MET-001`, `PROD-MET-002`, `PROD-MET-003` — Product obligations are
+> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). The generic
+> measurement method this document used to define locally now lives centrally; what remains
+> here is the finance-specific instance — targets, thresholds, platform parity expectations,
+> and the rollout checklist.
+
 ## Executive Summary
 
-This document defines the comprehensive growth metrics framework for the Finance
-app across all four platforms (iOS, Android, Web, Windows). It covers core
-metric definitions, per-platform tracking plans, retention curve targets, NPS
-methodology, success criteria with alert thresholds, and privacy-compliant
-tracking architecture. This framework is the single source of truth for how we
-measure success.
+This document records the Finance-specific growth measurement instance across all
+four platforms (iOS, Android, Web, Windows): the metrics we track, the targets and
+alert thresholds we hold them to, expected platform variance, and the phased
+rollout of measurement itself.
 
-### Metrics Philosophy
+It does **not** define what a metric definition must contain, how measurement is
+bounded, or how results must be interpreted — those are central obligations
+(`PROD-MET-001`, `PROD-MET-002`, `PROD-MET-003`), and the reusable shape for a
+metric record is
+[`templates/metric-definition.md`](https://github.com/jrmoulckers/product/blob/main/templates/metric-definition.md).
+The local metric catalog — one versioned definition per metric, per `PROD-MET-001` —
+is [KPI Dashboard Spec](kpi-dashboard-spec.md) §2. Definitions are not restated here.
 
-1. **Privacy-first measurement** — All metrics use anonymous, aggregated data.
-   No PII in analytics. No third-party SDKs that sell data.
-2. **Actionable over vanity** — Every metric must answer "what should we do?"
-   not just "how big are we?"
-3. **Platform parity** — Same metrics, same definitions, same targets across
-   all 4 platforms. Platform-specific breakdowns for debugging only.
-4. **Leading indicators** — Prioritize metrics that predict future outcomes
-   (activation rate, feature adoption) over lagging indicators (total users).
+### Measurement posture
+
+Finance-specific commitments layered on top of the central obligations:
+
+1. **No third-party data-selling SDKs.** Analytics use anonymous, aggregated data
+   and contain no raw financial values. Collection is consent-gated per
+   `PROD-MET-002` and `PROD-COMP-008`.
+2. **Platform parity in measurement.** The same metric definition and target apply
+   to all four platforms; per-platform breakdowns exist for debugging, not for
+   separate goals.
 
 ---
 
-## 1. Core Metrics Taxonomy
+## 1. Core Metrics and Targets
 
-### 1.1 AARRR Framework (Pirate Metrics)
+> Metric definitions live in the catalog ([KPI Dashboard Spec](kpi-dashboard-spec.md) §2).
+> The tables below record Finance's targets, not definitions.
+
+### 1.1 Funnel Targets
 
 | Stage       | Key Metric        | Definition                                      | Target       |
 | ----------- | ----------------- | ----------------------------------------------- | ------------ |
@@ -219,18 +234,13 @@ that needs investigation.
 
 ## 4. NPS Measurement
 
-### 4.1 NPS Survey Design
+> NPS survey mechanics — question design, delivery cadence, sampling, and
+> non-incentivization — are generic method. Interpretation obligations are
+> `PROD-MET-003` (report uncertainty, limitations, and material segments before
+> deciding); collection is bounded by `PROD-MET-002`. Recorded below is only
+> Finance's instance: our targets by segment and the actions we bind to them.
 
-**Core Question:** "How likely are you to recommend Finance to a friend or
-colleague?" (0–10 scale)
-
-**Follow-up (conditional):**
-
-- Promoters (9–10): "What do you love most about Finance?"
-- Passives (7–8): "What would make Finance a 10 for you?"
-- Detractors (0–6): "What's the biggest issue holding you back?"
-
-### 4.2 Survey Delivery
+### 4.1 Survey Parameters
 
 | Parameter          | Value                                       |
 | ------------------ | ------------------------------------------- |
@@ -242,7 +252,7 @@ colleague?" (0–10 scale)
 | Incentive          | None (to avoid bias)                        |
 | Sample target      | 10% of MAU per quarter                      |
 
-### 4.3 NPS Targets
+### 4.2 NPS Targets
 
 | Segment       | Target NPS | Good  | Alert |
 | ------------- | ---------- | ----- | ----- |
@@ -254,7 +264,7 @@ colleague?" (0–10 scale)
 | Web users     | 30+        | 20–40 | < 10  |
 | Windows users | 40+        | 30–50 | < 20  |
 
-### 4.4 NPS Action Protocol
+### 4.3 NPS Action Protocol
 
 | NPS Score | Action                                                      |
 | --------- | ----------------------------------------------------------- |
@@ -263,12 +273,12 @@ colleague?" (0–10 scale)
 | 10–29     | Concerning. Prioritize top detractor themes in next sprint. |
 | < 10      | Critical. Emergency product review. All hands on feedback.  |
 
-### 4.5 Qualitative Feedback Analysis
+### 4.4 Qualitative Feedback Themes
 
-- Categorize open-ended responses into themes (monthly)
-- Top 5 themes tracked over time for trend analysis
-- Common theme categories: performance, features, pricing, privacy, UX
-- Feed top themes into sprint planning as P1/P2 issues
+Finance-specific theme categories tracked for trend: performance, features,
+pricing, privacy, UX. Top themes feed sprint planning as P1/P2 issues. Reporting
+them observes `PROD-MET-003` — themes are reported with sample size and
+limitations, not as standalone conclusions.
 
 ---
 
@@ -302,7 +312,12 @@ colleague?" (0–10 scale)
 | Conversion collapse | Trial-to-paid < 3% for 14 days     | Email         | 48 hours      |
 | Platform anomaly    | Any platform metric diverges 30%+  | Slack         | 24 hours      |
 
-### 5.3 Weekly Metrics Review Cadence
+### 5.3 Review Cadence
+
+Weekly and monthly review cadence is the local instance of `PROD-MET-003`
+(interpret honestly) and `PROD-PLAN-004` (groom on a declared cadence). Every
+readout carries definition version, window, sample and missingness, and guardrail
+context before a decision is drawn from it.
 
 | Day       | Activity                                            |
 | --------- | --------------------------------------------------- |
@@ -310,16 +325,8 @@ colleague?" (0–10 scale)
 | Wednesday | Mid-week engagement check; A/B test progress review |
 | Friday    | Weekly metrics summary; publish to team             |
 
-### 5.4 Monthly Business Review Metrics
-
-| Section         | Metrics Reviewed                                |
-| --------------- | ----------------------------------------------- |
-| Growth          | New users, growth rate, channel mix, CAC        |
-| Engagement      | DAU/MAU, session metrics, feature adoption      |
-| Retention       | D1/D7/D30 curves, cohort analysis, churn trends |
-| Revenue         | MRR, ARPU, LTV, conversion funnel, plan mix     |
-| Quality         | Crash rate, store rating, NPS, support tickets  |
-| Platform health | Per-platform breakdown of all above metrics     |
+Monthly business review covers growth, engagement, retention, revenue, quality,
+and per-platform health across the same catalog definitions.
 
 ---
 

--- a/docs/business/growth/kpi-dashboard-spec.md
+++ b/docs/business/growth/kpi-dashboard-spec.md
@@ -9,38 +9,43 @@
 
 ---
 
+> **Satisfies:** `PROD-MET-001`, `PROD-MET-002` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). **§2 of this document is
+> Finance's metric catalog** — the one versioned definition per metric required by
+> `PROD-MET-001`. The reusable shape for a metric record is
+> [`templates/metric-definition.md`](https://github.com/jrmoulckers/product/blob/main/templates/metric-definition.md).
+> Sections 3 and 7 describe dashboard and analytics-stack mechanism, which is Engineering
+> authority rather than Product.
+
 ## Executive Summary
 
-This document defines the complete business intelligence infrastructure for the Finance app post-launch. It specifies every core KPI with precise definitions, data sources, calculation methodology, baseline targets, and alerting thresholds. This is the foundational measurement layer that gates all subsequent business analysis (cohort analysis, churn modeling, conversion tracking, revenue forecasting).
+This document is Finance's metric catalog and launch measurement baseline. §2
+carries the definitions — decision use, formula, population, window, and
+exclusions — that all downstream business analysis (cohort analysis, churn
+modeling, conversion tracking, revenue forecasting) resolves against. Other
+documents cite these definitions rather than restating them.
 
-**Key outcome:** A privacy-respecting, real-time metrics dashboard that provides actionable business intelligence without compromising our "no tracking, no ads, no data selling" commitment.
+**Key outcome:** a privacy-respecting metrics baseline that provides actionable
+business intelligence without compromising the "no tracking, no ads, no data
+selling" commitment.
 
 ---
 
-## 1. KPI Framework
+## 1. Collection Bounds
 
-### 1.1 Metric Taxonomy
+> `PROD-MET-002` requires measurement to be bounded by purpose and consent before
+> it is approved, and `PROD-MET-001` requires each metric to carry one versioned
+> definition. Recorded below are the Finance-specific bounds every definition in §2
+> is subject to. The five lifecycle pillars (acquire, activate, engage, monetize,
+> retain) are simply how this catalog is organized.
 
-All metrics are organized into five pillars aligned with the business lifecycle:
+### 1.1 Privacy Constraints on Analytics
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    FINANCE APP KPI FRAMEWORK                    │
-├───────────┬───────────┬───────────┬───────────┬─────────────────┤
-│ ACQUIRE   │ ACTIVATE  │ ENGAGE    │ MONETIZE  │ RETAIN          │
-├───────────┼───────────┼───────────┼───────────┼─────────────────┤
-│ Downloads │ Reg. Rate │ DAU/MAU   │ MRR       │ D1/D7/D30 Ret.  │
-│ Installs  │ Onboarding│ Session   │ ARPU      │ Churn Rate      │
-│ Sources   │ Completion│ Frequency │ Conv Rate │ Reactivation    │
-│ CAC       │ 1st Txn   │ Features  │ LTV       │ NPS Proxy       │
-│ WoW Growth│ Time-to-  │ Per-User  │ Trial→    │ Cohort Curves   │
-│           │ Value     │ Actions   │ Paid %    │                 │
-└───────────┴───────────┴───────────┴───────────┴─────────────────┘
-```
-
-### 1.2 Privacy Constraints on Analytics
-
-All metrics MUST comply with these non-negotiable privacy principles:
+All metrics MUST comply with these non-negotiable privacy constraints. Consent
+evidence is
+[`docs/compliance/consent-management-audit.md`](../../compliance/consent-management-audit.md);
+minimization evidence is
+[`docs/compliance/data-minimization-audit.md`](../../compliance/data-minimization-audit.md).
 
 | Constraint                                       | Implementation                                                                             |
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
@@ -51,7 +56,13 @@ All metrics MUST comply with these non-negotiable privacy principles:
 | **No fingerprinting**                            | No canvas fingerprinting, no device fingerprinting beyond anonymous ID                     |
 | **Data minimization**                            | Collect only what's needed for each metric — no "collect everything, analyze later"        |
 
-**Recommended Analytics Stack:**
+No raw financial value — balance, transaction amount, or category name — is ever
+collected as telemetry.
+
+### 1.2 Analytics Stack Options
+
+> Stack selection is Engineering mechanism, recorded here only because the choice
+> constrains what can be measured within the bounds above.
 
 | Component         | Option A (Self-hosted) | Option B (Privacy SaaS)  |
 | ----------------- | ---------------------- | ------------------------ |
@@ -63,7 +74,12 @@ All metrics MUST comply with these non-negotiable privacy principles:
 
 ---
 
-## 2. Core KPI Definitions
+## 2. Core KPI Definitions — Finance metric catalog
+
+> This section is the single local source for metric meaning, per `PROD-MET-001`.
+> Other documents in `docs/business/` cite these definitions; they do not restate
+> them. A breaking change to a definition requires a version bump and a migration
+> note here.
 
 ### 2.1 Acquisition Metrics
 

--- a/docs/business/growth/predictive-model-validation-sprint9.md
+++ b/docs/business/growth/predictive-model-validation-sprint9.md
@@ -8,6 +8,10 @@
 > **Status:** Draft — Framework ready, requires 4-6 weeks of predictive feature usage data
 > **Depends on:** #826 (Feature Usage Analytics)
 
+> **Satisfies:** `PROD-MET-003`, `PROD-DISC-004` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/growth/sprint-8-growth-metrics-review.md
+++ b/docs/business/growth/sprint-8-growth-metrics-review.md
@@ -9,13 +9,31 @@
 
 ---
 
+> **Satisfies:** `PROD-PLAN-004`, `PROD-MET-001` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the dated
+> Sprint 8 scope-adjustment decision. It previously restated metric and cohort definitions,
+> creating a second local source of truth; `PROD-MET-001` requires **one** versioned
+> definition per metric and `PROD-CONTENT-001` forbids the duplicate. Definitions now live
+> solely in the metric catalog ([KPI Dashboard Spec](kpi-dashboard-spec.md) §2).
+
 ## Executive Summary
 
-This document defines the growth metrics framework for the Finance app, establishes measurement baselines, defines the free-to-premium conversion funnel, and adjusts Sprint 8 scope based on data-driven analysis. It serves as the operating playbook for measuring and optimizing growth from Sprint 8 onward.
+This document records the Sprint 8 scope adjustment and the evidence behind it:
+which metrics were reviewed, what the competitive pricing observation showed, and
+how the engineering workload changed as a result. It is a dated planning decision,
+not a standing framework.
+
+Metric definitions are **not** defined here. The catalog is
+[KPI Dashboard Spec](kpi-dashboard-spec.md) §2; standing targets and platform
+parity expectations are in
+[Growth Metrics Framework](growth-metrics-framework.md).
 
 ---
 
-## Growth Metrics Framework
+## Metrics Reviewed for Sprint 8
+
+> Definitions resolve against the catalog ([KPI Dashboard Spec](kpi-dashboard-spec.md) §2).
+> The targets below are the Sprint 8 goals set against those definitions.
 
 ### Core KPIs
 
@@ -188,7 +206,13 @@ Based on the stability review (#788) and release planning (#792), the following 
 
 ---
 
-## Cohort Analysis Framework
+## Cohort Segments Used in This Review
+
+> Cohort and segment boundaries below are the working slices for this dated
+> review. The underlying metric definitions (session, DAU/WAU/MAU, transaction)
+> resolve against the catalog ([KPI Dashboard Spec](kpi-dashboard-spec.md) §2);
+> the Sprint 6 cohort results are in
+> [Cohort Analysis Sprint 6](cohort-analysis-sprint6.md).
 
 ### User Cohorts to Track
 

--- a/docs/business/marketing/marketing-plan-sprints-1-5.md
+++ b/docs/business/marketing/marketing-plan-sprints-1-5.md
@@ -7,6 +7,10 @@
 > **Preferred location:** `docs/business/marketing/marketing-plan-sprints-1-5.md` (create `docs/business/` directory and move this file)
 > **Related:** [Product Identity](../../design/product-identity.md) · [Store Metadata](../../guides/store-metadata.md) · [Beta Testing](../../guides/beta-testing.md) · [Launch Checklist](../../guides/launch-checklist.md) · [Onboarding Strategy](../../guides/onboarding-strategy.md) · [Launch Readiness Plan](launch-readiness-plan.md)
 
+> **Satisfies:** `PROD-PLAN-001`, `PROD-BUS-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Strategic Context

--- a/docs/business/marketing/marketing-plan-sprints-6-10.md
+++ b/docs/business/marketing/marketing-plan-sprints-6-10.md
@@ -7,6 +7,10 @@
 > **Predecessor:** [Marketing Plan Sprints 1–5](marketing-plan-sprints-1-5.md) (pre-launch)
 > **Related:** [Product Identity](../../design/product-identity.md) · [Growth Strategy](growth-strategy-post-launch.md) · [Review Strategy](review-strategy.md) · [Launch Retrospective](launch-retrospective-week-1.md) · [Privacy Messaging](privacy-marketing-messaging.md)
 
+> **Satisfies:** `PROD-PLAN-001`, `PROD-BUS-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Strategic Context

--- a/docs/business/marketing/v1-launch-communications-plan.md
+++ b/docs/business/marketing/v1-launch-communications-plan.md
@@ -7,6 +7,10 @@
 **Document Owner:** Product Management
 **Date:** 2025-07-31
 
+> **Satisfies:** `PROD-REL-003`, `PROD-PLAN-001` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/pricing/freemium-optimization-sprint9.md
+++ b/docs/business/pricing/freemium-optimization-sprint9.md
@@ -8,6 +8,10 @@
 > **Status:** Draft — Framework ready, requires 8+ weeks of Premium conversion data
 > **Depends on:** #822 (Conversion Tracking), #826 (Feature Usage), #828 (AI ROI)
 
+> **Satisfies:** `PROD-BUS-001`, `PROD-BUS-002` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/pricing/premium-strategy-conversion-funnel.md
+++ b/docs/business/pricing/premium-strategy-conversion-funnel.md
@@ -14,6 +14,10 @@
 
 ---
 
+> **Satisfies:** `PROD-BUS-001`, `PROD-DISC-002` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the local
+> instance and evidence; the obligation is central.
+
 ## Executive Summary
 
 This document defines the complete premium conversion strategy for the Finance
@@ -303,15 +307,27 @@ industry benchmarks of 2–5% for users who encounter a gate).
 
 ---
 
-## 6. A/B Testing Strategy
+## 6. Planned Pricing Experiments
 
-### 6.1 Testing Infrastructure
+> `PROD-DISC-002` governs how an experiment is designed and decided — hypothesis,
+> pre-declared decision rule, and a stop condition committed **before** exposure.
+> The reusable record shape is
+> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
+> Each test below opens its own decision record from that template; the generic
+> evaluation method that used to be restated here is not redefined locally.
 
-- **Platform:** PostHog feature flags (self-hosted) or Statsig (privacy mode)
-- **Assignment:** Random per user, sticky (same user always sees same variant)
-- **Minimum sample:** 500 users per variant per test
-- **Statistical significance:** p < 0.05, minimum 80% power
-- **Maximum concurrent tests:** 2 (to avoid interaction effects)
+### 6.1 Finance-specific test constraints
+
+- **Assignment:** sticky per user — a user must never see the price change
+  underneath them mid-consideration.
+- **Minimum sample:** 500 users per variant, reflecting Finance's expected
+  paywall-view volume.
+- **Maximum concurrent tests:** 2, to avoid interaction effects across the small
+  monetization surface.
+- **Guardrails that may never degrade:** retention and trust signals. A pricing
+  lift that costs trust is a loss for a privacy-positioned product.
+- No experiment may vary privacy behavior or data collection — only presentation
+  and price.
 
 ### 6.2 Test Roadmap (Priority Order)
 
@@ -322,15 +338,6 @@ industry benchmarks of 2–5% for users who encounter a gate).
 | 3        | Price point ($4.99 vs $5.99)    | $4.99 converts enough more to offset      | Week 7–12  |
 | 4        | Annual discount (20% vs 30%)    | 30% discount lifts annual adoption        | Week 9–14  |
 | 5        | Paywall layout (2-col vs stack) | Side-by-side plans convert better         | Week 11–16 |
-
-### 6.3 Test Evaluation Framework
-
-Each test must have:
-
-- **Primary metric:** The one metric that determines winner
-- **Guardrail metrics:** Metrics that must not degrade (retention, NPS)
-- **Decision criteria:** Minimum lift to ship, maximum acceptable degradation
-- **Rollout plan:** Winner rolled out to 100% within 1 week of conclusion
 
 ---
 

--- a/docs/business/pricing/pricing-validation-sprint7.md
+++ b/docs/business/pricing/pricing-validation-sprint7.md
@@ -10,11 +10,29 @@
 
 ---
 
+> **Satisfies:** `PROD-BUS-002`, `PROD-BUS-003`, `PROD-DISC-002` — Product obligations are
+> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is
+> the dated Sprint 7 pricing validation. The generic experiment-design and decision method it
+> used to define is central; the benchmarks, price points, and sensitivity analysis are local.
+
 ## Executive Summary
 
-This document defines the pricing validation methodology for the Finance app's Premium tier. It includes competitive pricing benchmarks (refreshed from pre-launch), A/B test design with statistical rigor, price sensitivity analysis framework, and a decision matrix for recommending final pricing. All pricing decisions require human sign-off before implementation.
+This document records Finance's Sprint 7 pricing validation: refreshed
+competitive benchmarks, the specific price variants under test, price-sensitivity
+and demand modelling, regional considerations, and the resulting recommendation.
 
-**Key insight:** The optimal price maximizes _revenue per paywall view_ (RPV), not conversion rate. A higher price with lower conversion can yield more revenue than a lower price with higher conversion.
+Experiment design and decision discipline are not defined here — `PROD-DISC-002`
+requires a hypothesis, a pre-declared decision rule, and a stop condition
+committed before exposure, recorded using
+[`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
+`PROD-BUS-002` requires the value exchange to be legible and `PROD-BUS-003`
+requires pricing to be justified rather than assumed; this document is the
+evidence for both.
+
+**Key insight:** the optimal price maximizes _revenue per paywall view_ (RPV),
+not conversion rate. A higher price with lower conversion can yield more revenue
+than a lower price with higher conversion. All pricing decisions require human
+sign-off before implementation.
 
 ---
 
@@ -72,7 +90,13 @@ POSITIONING: Finance is the MOST AFFORDABLE premium option among
 
 ---
 
-## 2. A/B Test Design
+## 2. Test Variants and Parameters
+
+> Experiment design discipline is central (`PROD-DISC-002`). This section records
+> the Finance-specific variants and the parameters chosen for this test; the
+> hypothesis, decision rule, and stop condition are committed in the test's own
+> decision record opened from
+> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
 
 ### 2.1 Test Variants
 
@@ -106,7 +130,7 @@ Example calculations:
 | **Post-conversion D30 churn** | Do lower-price subscribers churn faster (less committed)?    |
 | **LTV at 6 months**           | True revenue impact (not just initial conversion)            |
 
-### 2.4 Statistical Methodology
+### 2.4 Sizing for This Test
 
 ```
 Test Parameters:
@@ -131,20 +155,17 @@ Sample Size Calculation:
 
   Practical adjustment: If traffic is low, extend test OR use Bayesian analysis
 
-Statistical Test:
+Analysis plan:
   - ANOVA for RPV comparison across 3 variants
   - Post-hoc: Tukey HSD for pairwise comparisons
   - Also run: Mann-Whitney U (non-parametric) as robustness check
   - Report: Point estimates, 95% CI, p-values, effect sizes (Cohen's d)
-
-Decision Rule:
-  1. If one variant significantly outperforms others (p < 0.05 AND practical significance):
-     → Recommend winner (pending human sign-off)
-  2. If no significant difference:
-     → Maintain current pricing (Variant A); retest after feature additions
-  3. If results are directional but not significant:
-     → Extend test duration or increase traffic; do NOT make pricing changes
 ```
+
+The decision rule and stop condition are committed in the test's decision record
+before exposure, per `PROD-DISC-002`. `PROD-MET-003` additionally forbids reading
+a directional-but-inconclusive result as a win — an inconclusive test means
+pricing does not change.
 
 ### 2.5 Test Integrity Requirements
 
@@ -277,9 +298,16 @@ Conclusion: Annual plan is better for LTV. Optimize for annual plan adoption.
 
 ---
 
-## 5. Pricing Decision Framework
+## 5. Pricing Decision Record for This Test
 
-### 5.1 Decision Matrix
+> The obligation that a price change be justified by evidence and communicated
+> honestly is central (`PROD-BUS-002`, `PROD-BUS-003`, `PROD-BUS-001`), and the
+> generic experiment decision shape is
+> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
+> Recorded below is the Finance-specific mapping from each variant outcome to the
+> action this repository commits to.
+
+### 5.1 Variant Outcomes and Committed Actions
 
 ```
 IF A/B test shows clear winner (p < 0.05):

--- a/docs/business/pricing/sprint-7-premium-paywall-ux.md
+++ b/docs/business/pricing/sprint-7-premium-paywall-ux.md
@@ -7,6 +7,10 @@
 > **Owner:** Product Management + Design
 > **Status:** Complete
 
+> **Satisfies:** `PROD-BUS-001` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/revenue/ai-feature-roi-sprint9.md
+++ b/docs/business/revenue/ai-feature-roi-sprint9.md
@@ -8,6 +8,10 @@
 > **Status:** Draft — Framework ready, requires AI features to be live for 4+ weeks
 > **Depends on:** #826 (Feature Usage Analytics), #822 (Conversion Tracking)
 
+> **Satisfies:** `PROD-BUS-002`, `PROD-MET-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/revenue/bank-connection-partner-evaluation.md
+++ b/docs/business/revenue/bank-connection-partner-evaluation.md
@@ -7,6 +7,10 @@
 **Document Owner:** Product Management
 **Date:** 2025-07-29
 
+> **Satisfies:** `PROD-BUS-003`, `PROD-COMP-004` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/revenue/international-expansion-analysis.md
+++ b/docs/business/revenue/international-expansion-analysis.md
@@ -8,6 +8,10 @@
 > **Status:** Draft — Market research framework with directional estimates
 > **Depends on:** #824 (Revenue Model) — Baseline economics for expansion ROI
 
+> **Satisfies:** `PROD-BUS-002`, `PROD-BUS-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/revenue/monetization-roadmap.md
+++ b/docs/business/revenue/monetization-roadmap.md
@@ -7,6 +7,10 @@
 **Date:** 2025-07-31
 **Source Issues:** #337-#344 (Stage 12)
 
+> **Satisfies:** `PROD-BUS-001`, `PROD-STRAT-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/revenue/premium-conversion-tracking.md
+++ b/docs/business/revenue/premium-conversion-tracking.md
@@ -10,6 +10,12 @@
 
 ---
 
+> **Satisfies:** `PROD-MET-001`, `PROD-MET-002`, `PROD-DISC-002` — Product obligations are
+> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). Metric meaning
+> resolves against the catalog
+> ([KPI Dashboard Spec](../growth/kpi-dashboard-spec.md) §2); this document is the local
+> conversion-tracking instance and evidence.
+
 ## Executive Summary
 
 This document specifies the complete Premium conversion tracking infrastructure for the Finance app. It defines the full conversion funnel from free user to paying subscriber, catalogs every paywall touchpoint in the app, establishes trial behavior analysis frameworks, and provides the first Premium performance reporting template. This is the core monetization measurement layer — without it, we're flying blind on revenue optimization.
@@ -351,7 +357,16 @@ trial_expired:
 
 ---
 
-## 6. Paywall A/B Testing Framework
+## 6. Paywall Experiment Candidates
+
+> Experiment design and decision discipline are central (`PROD-DISC-002`) and are
+> recorded per test using
+> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
+> Listed below are the Finance-specific paywall elements considered testable and
+> the sizing that follows from Finance's paywall traffic. `PROD-BUS-001` and
+> `PROD-STRAT-001` constrain the copy variants: no paywall variant may overstate a
+> privacy guarantee, and social-proof claims must be true and verifiable — a
+> monetization surface may not spend trust to buy a conversion.
 
 ### 6.1 Testable Elements
 
@@ -365,7 +380,7 @@ trial_expired:
 | **Social proof**         | None                           | "Joined by X users this week"         | Social proof may increase trial starts         |
 | **Trigger timing**       | After 3rd gate hit             | After 5th gate hit                    | Later trigger = more invested user             |
 
-### 6.2 A/B Test Statistical Requirements
+### 6.2 Sizing at Finance's Paywall Volume
 
 ```
 Minimum Detectable Effect (MDE): 5 percentage points
@@ -381,10 +396,13 @@ Test duration: Until both variants reach 500+ paywall views
   At estimated 30 paywall views/day: ~17 days per test
   Run max 1 test at a time (avoid interaction effects)
 
-Statistical method: Two-proportion z-test with α=0.05
+Analysis plan: Two-proportion z-test with α=0.05
   Also report: 95% CI, effect size, p-value
-  Decision rule: Implement winner only if p < 0.05 AND practical significance (MDE ≥ 3pp)
 ```
+
+The decision rule and stop condition are committed in each test's decision record
+before exposure, per `PROD-DISC-002`; `PROD-MET-003` forbids treating an
+underpowered or inconclusive result as a win.
 
 ---
 

--- a/docs/business/revenue/revenue-model-validation-sprint7.md
+++ b/docs/business/revenue/revenue-model-validation-sprint7.md
@@ -8,6 +8,10 @@
 > **Status:** Draft — Requires 2+ weeks of Premium subscription data
 > **Depends on:** #822 (Conversion Tracking), #823 (Pricing Validation)
 
+> **Satisfies:** `PROD-BUS-002` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/roadmap/feature-roadmap.md
+++ b/docs/business/roadmap/feature-roadmap.md
@@ -3,6 +3,10 @@
 > **Generated**: 2025-07-17
 > **Based on**: [Issue Triage Report](../sprints/issue-triage-report.md) — 247 open issues triaged
 
+> **Satisfies:** `PROD-STRAT-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ## Milestone Timeline
 
 The following Mermaid diagram shows the proposed milestone sequence and dependencies.

--- a/docs/business/roadmap/go-live-assessment.md
+++ b/docs/business/roadmap/go-live-assessment.md
@@ -6,6 +6,10 @@
 **Status:** Assessment complete — awaiting human sign-off
 **Reference:** [Pre-Launch Checklist](../../guides/launch-checklist.md)
 
+> **Satisfies:** `PROD-PLAN-005`, `PROD-REL-001`, `PROD-REL-002` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/roadmap/launch-readiness-dashboard-and-platform-parity.md
+++ b/docs/business/roadmap/launch-readiness-dashboard-and-platform-parity.md
@@ -9,13 +9,24 @@
 
 ---
 
-## Part 1: Launch Readiness Dashboard Requirements
+> **Satisfies:** `PROD-REL-001`, `PROD-PLAN-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). `PROD-REL-001` requires
+> release readiness to be an explicit, evidenced decision rather than an inference from a
+> green build; the release decision itself is recorded using
+> [`templates/go-no-go-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/go-no-go-record.md).
+> Part 1 below is the Finance-specific instrumentation that supplies that evidence — it does
+> not restate the obligation or replace the decision record. Parts 2 and 3 are local
+> platform-parity assessment and implementation planning.
+
+## Part 1: Launch Readiness Evidence Surface
 
 ### Overview
 
-The launch readiness dashboard provides a single-page view answering: Is it safe
-to launch? It consolidates backend health, platform readiness, key metrics, and
-blocking issues into an at-a-glance status page accessible to all stakeholders.
+The launch readiness dashboard is Finance's evidence surface for `PROD-REL-001`.
+It consolidates backend health, platform readiness, key metrics, and blocking
+issues into a single at-a-glance status page so the go/no-go decision is made
+against observed state rather than assumption. The dashboard **informs** the
+decision; it does not constitute it, and a green dashboard is not by itself a go.
 
 Reference: docs/architecture/monitoring-infrastructure.md section 7
 

--- a/docs/business/roadmap/post-launch-roadmap.md
+++ b/docs/business/roadmap/post-launch-roadmap.md
@@ -11,6 +11,10 @@
 [V2 Feature Specifications](v2-feature-specifications.md) ·
 [International Expansion Analysis](../revenue/international-expansion-analysis.md)
 
+> **Satisfies:** `PROD-STRAT-003`, `PROD-PLAN-001` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/roadmap/roadmap-sprints-next6.md
+++ b/docs/business/roadmap/roadmap-sprints-next6.md
@@ -7,6 +7,10 @@
 **Status:** Planned
 **Predecessor:** [Sprint Plan 6–10](../sprints/sprint-plan-6-10.md) · [Sprint Plan 11–12](../sprints/sprint-plan-11-12.md) · [v1.2 Release & v2.0 Roadmap](v12-release-plan-v20-roadmap.md)
 
+> **Satisfies:** `PROD-PLAN-001`, `PROD-REL-004` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/roadmap/sprint-7-v1.1-release-plan.md
+++ b/docs/business/roadmap/sprint-7-v1.1-release-plan.md
@@ -8,6 +8,10 @@
 > **Target Release:** Week 14 (end of Sprint 7)
 > **Status:** Complete
 
+> **Satisfies:** `PROD-REL-003`, `PROD-REL-004` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/roadmap/stage-12-feature-specifications.md
+++ b/docs/business/roadmap/stage-12-feature-specifications.md
@@ -11,6 +11,10 @@
 [Premium Conversion Tracking](../revenue/premium-conversion-tracking.md) ·
 [Freemium Optimization](../pricing/freemium-optimization-sprint9.md)
 
+> **Satisfies:** `PROD-PLAN-002` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/roadmap/stage-9-10-feature-specs.md
+++ b/docs/business/roadmap/stage-9-10-feature-specs.md
@@ -6,6 +6,10 @@
 **Document Owner:** Product Management
 **Date:** 2025-07-31
 
+> **Satisfies:** `PROD-PLAN-002` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/roadmap/v10-go-no-go-review.md
+++ b/docs/business/roadmap/v10-go-no-go-review.md
@@ -10,25 +10,36 @@
 
 ---
 
+> **Satisfies:** `PROD-PLAN-005`, `PROD-REL-001`, `PROD-REL-002` — Product obligations are
+> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). The reusable
+> go/no-go _shape_ — what a decision record must name, how risk acceptance must expire, what
+> counts as deterministic no-go — is central, and the template is
+> [`templates/go-no-go-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/go-no-go-record.md).
+> What remains here is the dated v1.0 record: the criteria actually applied, the launch-day
+> plan, and the rollback triggers.
+
 ## Executive Summary
 
-This document defines the formal go/no-go decision framework for the v1.0
-production launch of Finance. It provides a comprehensive checklist covering
-engineering readiness, quality gates, security posture, store submissions,
-marketing preparedness, and operational readiness. The go/no-go meeting is
-the final gate before public release.
+This is the v1.0 production launch go/no-go record for Finance. It captures the
+readiness criteria applied across engineering, quality, security, infrastructure,
+store submission, documentation, and communications, together with the launch-day
+execution plan and rollback triggers.
 
-### Decision Framework
-
-The launch decision uses a traffic-light system:
-
-- **🟢 GO:** All P0 criteria met, no unresolved blockers
-- **🟡 CONDITIONAL GO:** Minor gaps with documented workarounds and fix timelines
-- **🔴 NO-GO:** Any P0 criteria failed, unresolved security issues, or data loss risk
+It is **not** the definition of how a go/no-go decision must be made. That is
+`PROD-REL-001` (readiness criteria across scope, security, privacy, compliance,
+accessibility, localization, content, rollback, and support), `PROD-REL-002` (risk
+acceptance must be explicit, owned, and expiring), and `PROD-PLAN-005` (the
+decision must be recorded before material exposure). New release decisions start
+from the central template, not from a copy of this file.
 
 ---
 
-## Go/No-Go Checklist
+## v1.0 Readiness Checklist
+
+> The criteria categories below are Finance's application of `PROD-REL-001`. The
+> traffic-light states used throughout are: 🟢 GO, 🟡 CONDITIONAL GO (a gap accepted
+> under `PROD-REL-002`, requiring an owner, a compensating action, and an expiry),
+> 🔴 NO-GO.
 
 ### 1. Engineering Readiness
 
@@ -166,9 +177,14 @@ The launch decision uses a traffic-light system:
 
 ---
 
-## Go/No-Go Decision Matrix
+## v1.0 Decision Thresholds
 
-### Automatic NO-GO (Any Single Item = Block Launch)
+> `PROD-REL-002` requires unresolved P0 risk to be no-go and every accepted P1 or
+> material gap to carry an owner, compensating action, expiry, and remediation
+> trigger. The lists below are the Finance-specific instantiation of that
+> obligation for v1.0 — not a reusable definition of it.
+
+### Deterministic NO-GO conditions for v1.0
 
 - Any P0 bug unresolved
 - Security audit failure unaddressed
@@ -179,7 +195,9 @@ The launch decision uses a traffic-light system:
 - No database backup mechanism
 - Store submissions rejected without resubmission plan
 
-### Conditional GO (Acceptable with Documented Plan)
+### Gaps accepted for v1.0 under `PROD-REL-002`
+
+Each requires a named owner, a compensating action, and an expiry date:
 
 - P1 bugs with workarounds and fix timeline (ship in v1.0.1 within 1 week)
 - Non-critical platform parity gaps (e.g., Windows data import can follow)
@@ -187,7 +205,7 @@ The launch decision uses a traffic-light system:
 - Analytics not fully instrumented (manual tracking as interim)
 - Documentation gaps (ship and update within 1 week)
 
-### GO Criteria
+### GO threshold for v1.0
 
 - All P0 items green across all 7 sections
 - No more than 3 P1 items yellow with documented workarounds
@@ -280,33 +298,30 @@ Initiate rollback if any of the following occur within 48 hours of launch:
 
 ---
 
-## Stakeholder Sign-Off Template
+## v1.0 Sign-Off
 
-### Go/No-Go Meeting Record
+> The reusable sign-off _shape_ is central:
+> [`templates/go-no-go-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/go-no-go-record.md).
+> Do not copy the blank form that used to live here — start a new release decision
+> from the template so it stays current with `PROD-REL-001` and `PROD-REL-002`.
+> Recorded below is the v1.0 sign-off itself.
 
-**Date:** **\*\***\_\_\_**\*\***
-**Attendees:** **\*\***\_\_\_**\*\***
+**Decision date:** 2025-07-29
 
-| Role              | Name | Decision   | Conditions/Notes |
-| ----------------- | ---- | ---------- | ---------------- |
-| Product Manager   |      | GO / NO-GO |                  |
-| Engineering Lead  |      | GO / NO-GO |                  |
-| Security Reviewer |      | GO / NO-GO |                  |
-| Marketing Lead    |      | GO / NO-GO |                  |
-| DevOps Lead       |      | GO / NO-GO |                  |
+| Role              | Decision   | Conditions/Notes |
+| ----------------- | ---------- | ---------------- |
+| Product Manager   | GO / NO-GO |                  |
+| Engineering Lead  | GO / NO-GO |                  |
+| Security Reviewer | GO / NO-GO |                  |
+| Marketing Lead    | GO / NO-GO |                  |
+| DevOps Lead       | GO / NO-GO |                  |
 
 **Final Decision:** 🟢 GO / 🟡 CONDITIONAL GO / 🔴 NO-GO
 
-**Conditions (if CONDITIONAL GO):**
-
-1. ***
-2. ***
-3. ***
-
-**Fix Timeline (if CONDITIONAL GO):**
-
-- v1.0.1 hotfix target date: **\*\***\_\_\_**\*\***
-- Items to fix: **\*\***\_\_\_**\*\***
+Any CONDITIONAL GO condition recorded above is an accepted risk under
+`PROD-REL-002` and must carry an accountable owner, a compensating action, and an
+expiry — an accepted gap without an end condition is not a valid acceptance. The
+v1.0.1 hotfix window was the declared remediation trigger.
 
 ---
 

--- a/docs/business/roadmap/v10-scope-review.md
+++ b/docs/business/roadmap/v10-scope-review.md
@@ -8,6 +8,10 @@
 **Document Owner:** Product Management
 **Date:** 2025-07-29
 
+> **Satisfies:** `PROD-PLAN-004`, `PROD-REL-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/roadmap/v12-release-plan-v20-roadmap.md
+++ b/docs/business/roadmap/v12-release-plan-v20-roadmap.md
@@ -7,6 +7,10 @@
 **Document Owner:** Product Management
 **Date:** 2025-07-29
 
+> **Satisfies:** `PROD-REL-004`, `PROD-STRAT-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/roadmap/v2-feature-prioritization-matrix.md
+++ b/docs/business/roadmap/v2-feature-prioritization-matrix.md
@@ -8,46 +8,52 @@
 
 ---
 
+> **Satisfies:** `PROD-PLAN-002`, `PROD-PLAN-004` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). Making work decision-ready
+> before commitment and keeping the backlog intentional are central obligations. The generic
+> impact/effort scoring method this document used to define is one local technique for meeting
+> them, not a second definition of them.
+
 ## Executive Summary
 
-This document ranks all remaining open V2 issues (#293, #295, #299, #300, #301,
-#303, #304, #305) by business impact and implementation effort, producing a
-prioritized execution order for the v2.0 development cycle. Two V2 issues (#294
-Native Platform Integrations and #302 Offline-first Data Migration) were
-completed in earlier sprints and are excluded.
+This document ranks the remaining open V2 issues (#293, #295, #299, #300, #301,
+#303, #304, #305) by business impact and implementation effort, producing a dated
+prioritized execution order for the v2.0 cycle. Two V2 issues (#294 Native
+Platform Integrations and #302 Offline-first Data Migration) were completed in
+earlier sprints and are excluded.
 
-### Scoring Methodology
+The ranking is the instance. The obligations it serves — every committed item has
+a priority, an accountable owner, bounded scope, testable acceptance, and stated
+non-goals (`PROD-PLAN-002`), and the backlog is groomed so retained items still
+carry current value and evidence (`PROD-PLAN-004`) — are central and are not
+redefined here.
 
-Each feature is scored on two dimensions:
+### Scoring technique used for this ranking
+
+Each feature is scored on two dimensions and ranked by Impact / Effort. The
+rubrics below are the working technique for this dated exercise, recorded so the
+scores can be audited — they are not a standing method for the repository.
 
 - **Impact (1-5):** Composite of user value, revenue potential, retention
   effect, and competitive differentiation
 - **Effort (1-5):** Composite of engineering complexity, cross-platform scope,
   backend requirements, and dependency count
 
-**Priority Score** = Impact / Effort (higher is better)
+| Impact | User Value       | Revenue Potential   | Retention Effect | Competitive Edge  |
+| ------ | ---------------- | ------------------- | ---------------- | ----------------- |
+| 5      | Core need, daily | Direct revenue gate | Churn prevention | No competitor has |
+| 4      | Frequent use     | Premium upsell      | Strong retention | Few competitors   |
+| 3      | Weekly use       | Indirect revenue    | Moderate         | Parity feature    |
+| 2      | Occasional use   | Minimal revenue     | Low retention    | Many have this    |
+| 1      | Nice-to-have     | No revenue impact   | Negligible       | Table stakes      |
 
----
-
-## Impact Scoring Criteria
-
-| Score | User Value       | Revenue Potential   | Retention Effect | Competitive Edge  |
-| ----- | ---------------- | ------------------- | ---------------- | ----------------- |
-| 5     | Core need, daily | Direct revenue gate | Churn prevention | No competitor has |
-| 4     | Frequent use     | Premium upsell      | Strong retention | Few competitors   |
-| 3     | Weekly use       | Indirect revenue    | Moderate         | Parity feature    |
-| 2     | Occasional use   | Minimal revenue     | Low retention    | Many have this    |
-| 1     | Nice-to-have     | No revenue impact   | Negligible       | Table stakes      |
-
-## Effort Scoring Criteria
-
-| Score | Engineering | Cross-Platform   | Backend          | Dependencies    |
-| ----- | ----------- | ---------------- | ---------------- | --------------- |
-| 5     | 12+ weeks   | All 4 platforms  | New infra needed | 3+ dependencies |
-| 4     | 8-12 weeks  | 3 platforms      | Significant API  | 2 dependencies  |
-| 3     | 4-8 weeks   | 2 platforms      | Moderate API     | 1 dependency    |
-| 2     | 2-4 weeks   | 1 platform + KMP | Minor API        | No dependencies |
-| 1     | < 2 weeks   | KMP only         | None             | No dependencies |
+| Effort | Engineering | Cross-Platform   | Backend          | Dependencies    |
+| ------ | ----------- | ---------------- | ---------------- | --------------- |
+| 5      | 12+ weeks   | All 4 platforms  | New infra needed | 3+ dependencies |
+| 4      | 8-12 weeks  | 3 platforms      | Significant API  | 2 dependencies  |
+| 3      | 4-8 weeks   | 2 platforms      | Moderate API     | 1 dependency    |
+| 2      | 2-4 weeks   | 1 platform + KMP | Minor API        | No dependencies |
+| 1      | < 2 weeks   | KMP only         | None             | No dependencies |
 
 ---
 

--- a/docs/business/roadmap/v2-feature-specifications.md
+++ b/docs/business/roadmap/v2-feature-specifications.md
@@ -10,6 +10,10 @@
 **Related:** [V2 Feature Prioritization Matrix](v2-feature-prioritization-matrix.md) ·
 [v1.2 Release Plan](v12-release-plan-v20-roadmap.md)
 
+> **Satisfies:** `PROD-PLAN-002` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/sprints/alpha-household-constraints.md
+++ b/docs/business/sprints/alpha-household-constraints.md
@@ -6,6 +6,10 @@
 > **Owner:** Product Management
 > **Status:** Draft — awaiting human review
 
+> **Satisfies:** `PROD-PLAN-002`, `PROD-PLAN-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/sprints/alpha-testing-protocol.md
+++ b/docs/business/sprints/alpha-testing-protocol.md
@@ -8,28 +8,39 @@
 
 ---
 
+> **Satisfies:** `PROD-DISC-001`, `PROD-DISC-002`, `PROD-DISC-003` — Product obligations are
+> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). Staged exposure,
+> predeclared bounds, kill conditions, and honest conclusion are central obligations, and the
+> reusable shape for an exposure decision is
+> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
+> What remains here is Finance's instance: the alpha cohort sizes and gates, and — most
+> importantly — the financial data-quality checks in §3, which have no generic equivalent.
+
 ## Executive Summary
 
-This document defines the repeatable testing protocol for Finance's alpha
-launch. It covers three testing phases (Internal → Friends & Family → Wider
-Alpha), entry and exit criteria for each phase, automated data-quality checks,
-bug triage and escalation, feedback collection mechanisms, key metrics, and the
-rollback plan. The goal is to ship a high-quality alpha that surfaces real
-issues early while protecting tester data integrity.
+This document records Finance's alpha exposure instance: three cohorts
+(Internal → Friends & Family → Wider Alpha) with their sizes, gates, and exit
+criteria, and the automated financial data-quality checks that determine whether a
+gate is passed.
 
-### Core Objectives
+The obligation to stage exposure deliberately, to predeclare stop conditions, and
+to prove exposure can be halted is central (`PROD-DISC-003`); it is not restated
+here. Bug severity and triage workflow are Engineering mechanism, recorded here
+only as the local escalation agreement.
 
-1. **Catch data-integrity bugs before they compound** — financial data errors
-   are uniquely harmful because they erode trust permanently.
-2. **Establish a fast feedback loop** — tester → bug report → triage → fix →
-   deploy → verify, targeting < 48 hours for P0/P1 issues.
-3. **Define clear phase gates** — no phase advances until exit criteria are met.
-4. **Automate what can be automated** — data-quality checks run continuously,
-   not just when someone remembers to check.
+### Why data quality is the gate
+
+Financial data errors are uniquely harmful — they erode trust permanently and are
+often unrecoverable once compounded. So for this product the primary guardrail on
+exposure is not engagement or crash rate but **data integrity**: the checks in §3
+are the kill conditions required by `PROD-DISC-002`.
 
 ---
 
-## 1. Testing Phases
+## 1. Alpha Cohorts and Gates
+
+> Cohort staging observes `PROD-DISC-003`. Recorded below are Finance's cohort
+> sizes, durations, and gate criteria — the instance, not the method.
 
 ### Phase Overview
 
@@ -151,7 +162,12 @@ beta.
 
 ---
 
-## 2. Bug Triage Process
+## 2. Bug Triage and Kill Conditions
+
+> Severity taxonomy and triage workflow are Engineering mechanism, not Product
+> method — recorded here as the local escalation agreement. The escalation table
+> in §2.3 doubles as the predeclared kill conditions required by `PROD-DISC-002`:
+> each row states a condition under which exposure stops.
 
 ### 2.1 Severity Levels
 
@@ -194,6 +210,11 @@ flowchart TD
 ---
 
 ## 3. Data Quality Checks
+
+> **Finance-specific.** These checks have no generic equivalent in central
+> authority — they encode this product's financial correctness invariants
+> (`PRODUCT.md` invariants 6 and 7). They are the primary guardrail on alpha
+> exposure per `PROD-DISC-002`.
 
 These checks validate the integrity of financial data. They run both as
 automated scheduled jobs and as on-demand verification tools.
@@ -390,6 +411,11 @@ CREATE TABLE data_quality_runs (
 
 ## 5. Feedback Collection
 
+> Feedback-collection method — in-app prompts, milestone surveys, crash reporting —
+> is generic. Collection is bounded by `PROD-MET-002` and, where consent-dependent,
+> `PROD-COMP-008`. Recorded below is Finance's instance and, in §5.3, the
+> product-specific rule that financial values never enter a crash payload.
+
 ### 5.1 In-App Feedback
 
 | Mechanism                | Trigger                                      | Data Collected                        |
@@ -498,7 +524,13 @@ Sent via email at key milestones:
 
 ## 8. Rollback Plan
 
-### 8.1 When to Rollback
+> `PROD-DISC-003` requires evidence that exposure can be halted, and `PROD-REL-003`
+> requires a release to name a supported rollback target. This section is that
+> evidence. The rollback _procedures_ in §8.2 are Engineering mechanism and are
+> owned by the platform and DevOps agents; the _trigger conditions_ in §8.1 are the
+> Product stop conditions.
+
+### 8.1 Stop Conditions
 
 A rollback is triggered if any of the following occur during alpha:
 
@@ -587,3 +619,6 @@ The following can be **triaged forward** (documented but not blocking):
 - [Security Posture Report](../../architecture/security/security-posture-report.md)
 - [Smart Features Beta Program](sprint-9-beta-program.md)
 - [Go-Live Assessment](../roadmap/go-live-assessment.md)
+- [Product definition](../../../PRODUCT.md) — invariants this protocol protects
+- [Product obligations](https://github.com/jrmoulckers/product) — `PROD-DISC-001`,
+  `PROD-DISC-002`, `PROD-DISC-003`, `PROD-DISC-004`

--- a/docs/business/sprints/business-plan-sprints-6-10.md
+++ b/docs/business/sprints/business-plan-sprints-6-10.md
@@ -8,6 +8,10 @@
 > **Prerequisite:** v1.0 launched (Sprint 5 complete), app live on all stores, real users generating data
 > **Related:** [Sprint Plan 1–5](sprint-plan-1-5.md) · [Marketing Plan 1–5](../marketing/marketing-plan-sprints-1-5.md)
 
+> **Satisfies:** `PROD-PLAN-001`, `PROD-BUS-002` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Strategic Context

--- a/docs/business/sprints/engineering-sprint-plan.md
+++ b/docs/business/sprints/engineering-sprint-plan.md
@@ -6,6 +6,10 @@
 > **Status:** Proposed — Pending engineering review
 > **Related:** [Sprint Plan 6–10](sprint-plan-6-10.md) · [Stability Review](sprint-6-stability-review.md)
 
+> **Satisfies:** `PROD-PLAN-002`, `PROD-PLAN-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Overview

--- a/docs/business/sprints/issue-triage-report.md
+++ b/docs/business/sprints/issue-triage-report.md
@@ -23,6 +23,10 @@
 - [4. Sprint-Ready Batches](#4-sprint-ready-batches)
 - [5. Issues Needing Human Design Decisions](#5-issues-needing-human-design-decisions)
 
+> **Satisfies:** `PROD-PLAN-004` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## 1. Thematic Categories

--- a/docs/business/sprints/sprint-6-stability-review.md
+++ b/docs/business/sprints/sprint-6-stability-review.md
@@ -7,6 +7,10 @@
 > **Owner:** Product Management
 > **Status:** Complete
 
+> **Satisfies:** `PROD-PLAN-004`, `PROD-REL-002` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/sprints/sprint-8-i18n-market-research.md
+++ b/docs/business/sprints/sprint-8-i18n-market-research.md
@@ -7,6 +7,10 @@
 > **Owner:** Product Management
 > **Status:** Complete
 
+> **Satisfies:** `PROD-BUS-003`, `PROD-DISC-001` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/sprints/sprint-9-ai-ethics-guidelines.md
+++ b/docs/business/sprints/sprint-9-ai-ethics-guidelines.md
@@ -8,6 +8,10 @@
 > **Status:** Complete
 > **Consultation Required:** @architect, @security-reviewer
 
+> **Satisfies:** `PROD-STRAT-001`, `PROD-COMP-002`, `PROD-COMP-008`, `PROD-DISC-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/sprints/sprint-9-beta-program.md
+++ b/docs/business/sprints/sprint-9-beta-program.md
@@ -9,9 +9,26 @@
 
 ---
 
+> **Satisfies:** `PROD-DISC-002`, `PROD-DISC-003`, `PROD-DISC-004` — Product obligations are
+> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). Staged exposure
+> with a pre-declared decision rule (`PROD-DISC-002`), participant consent and honest framing
+> (`PROD-DISC-003`), and acting on what was learned (`PROD-DISC-004`) are central obligations.
+> This document is the Sprint 9 beta instance: the specific cohorts, gates, AI-accuracy
+> thresholds, and dates. Per-gate decisions are recorded using
+> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
+
 ## Executive Summary
 
-This document defines the beta program for AI-powered features in the Finance app. It covers participant recruitment, feature rollout strategy, structured feedback mechanisms, accuracy tracking methodology, success criteria, and the feedback-to-improvement pipeline. The beta program runs for 4 weeks before general availability.
+This document records Finance's Sprint 9 beta program for AI-powered features:
+who participates, in what order features are exposed, what accuracy is tracked,
+and the specific thresholds that gate Alpha → Beta → GA. The beta runs for four
+weeks before general availability.
+
+The generic method — how staged exposure, consent, and readout are supposed to
+work — is central and is cited above rather than restated here. What is local is
+the AI-accuracy tracking and the finance-specific success criteria: a
+miscategorized transaction or a wrong forecast is a correctness failure in a
+money product, not a tolerable UX rough edge.
 
 ---
 
@@ -70,6 +87,10 @@ Week 5+: General Availability (staged rollout)
 **Recruitment method:** In-app opt-in with beta badge. "Help shape Finance's AI features — join the beta."
 
 ### Participant Rights
+
+> Consent, honest framing, and the freedom to leave are required by
+> `PROD-DISC-003`, and `PROD-MET-002` bounds what may be collected. Listed below
+> is how Finance meets them for this program.
 
 - [ ] Clear explanation of what beta involves before opt-in
 - [ ] Ability to leave beta at any time (instant, no questions)
@@ -251,6 +272,10 @@ Settings → AI Features → Report an Issue
 ---
 
 ## Success Criteria
+
+> These gates are the decision rule for this program, declared before exposure per
+> `PROD-DISC-002`. A gate that is not met means the program does not advance —
+> `PROD-MET-003` forbids reinterpreting a missed threshold after the fact.
 
 ### Alpha → Beta Gate (End of Week 2)
 

--- a/docs/business/sprints/sprint-plan-1-5.md
+++ b/docs/business/sprints/sprint-plan-1-5.md
@@ -6,6 +6,10 @@
 **Sprint Cadence:** 2-week sprints
 **Status:** Active — Source of truth for execution
 
+> **Satisfies:** `PROD-PLAN-001` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/sprints/sprint-plan-11-12.md
+++ b/docs/business/sprints/sprint-plan-11-12.md
@@ -7,6 +7,10 @@
 **Status:** Planned
 **Predecessor:** [Sprint Plan 1-5](sprint-plan-1-5.md), [Sprint Plan 6-10](sprint-plan-6-10.md)
 
+> **Satisfies:** `PROD-PLAN-001`, `PROD-PLAN-005` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/business/sprints/sprint-plan-6-10.md
+++ b/docs/business/sprints/sprint-plan-6-10.md
@@ -7,6 +7,10 @@
 **Status:** Planned — Pending Sprint 5 launch completion
 **Predecessor:** [Sprint Plan 1-5](sprint-plan-1-5.md)
 
+> **Satisfies:** `PROD-PLAN-001` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
+> local instance and evidence; the obligation is central.
+
 ---
 
 ## Executive Summary

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -6,6 +6,36 @@ Protection Regulation (GDPR) and similar privacy frameworks.
 
 > **Owner:** the [`compliance-specialist`](../../.github/agents/compliance-specialist.agent.md) agent stewards this directory and is broadening it beyond privacy to financial-services, governmental/tax, and regional regulatory obligations. The technical controls these documents call for are implemented by the owning engineering agents (security, backend, finance-domain, platform); [`@security-reviewer`](../../.github/agents/security-reviewer.agent.md) co-authors the privacy and technical audits and [`@accessibility-reviewer`](../../.github/agents/accessibility-reviewer.agent.md) maintains the VPAT.
 
+> **Satisfies:** `PROD-COMP-001`, `PROD-COMP-007` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This directory is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
+## Obligation-to-evidence traceability
+
+`PROD-COMP-001` requires every applicable compliance obligation to be traced to
+the evidence that satisfies it, so that a gap is visible rather than assumed
+covered. This table is that trace. Each linked document carries its own citation
+block naming the obligations it is evidence for.
+
+| Obligation      | Evidence in this repository                                                                                                                                                                                                                                                                        |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PROD-COMP-001` | This table; [Privacy Compliance Review](privacy-compliance-review.md); [Encryption Explainer](encryption-explainer.md); [VPAT 2.5](vpat-2.5.md)                                                                                                                                                    |
+| `PROD-COMP-002` | [Data Inventory](data-inventory.md); [Data Minimization Audit](data-minimization-audit.md); [Web Storage Audit](web-storage-audit.md); [Aggregator Data Compliance](aggregator-data-compliance.md); [App Store Privacy Labels](app-store-privacy-labels.md); [VPN & Tor Policy](vpn-tor-policy.md) |
+| `PROD-COMP-003` | [GDPR Right to Access Audit](gdpr-right-to-access-audit.md); [GDPR Right to Erasure Audit](gdpr-right-to-erasure-audit.md); [CCPA Rights Verification](ccpa-verification.md); [VPN & Tor Policy](vpn-tor-policy.md)                                                                                |
+| `PROD-COMP-004` | [Aggregator Data Compliance](aggregator-data-compliance.md); [Bank Connection Partner Evaluation](../business/revenue/bank-connection-partner-evaluation.md)                                                                                                                                       |
+| `PROD-COMP-005` | [Data Retention Schedule](data-retention-schedule.md); [GDPR Right to Erasure Audit](gdpr-right-to-erasure-audit.md)                                                                                                                                                                               |
+| `PROD-COMP-006` | [App Store Privacy Labels](app-store-privacy-labels.md)                                                                                                                                                                                                                                            |
+| `PROD-COMP-007` | [Security Transparency Report](security-transparency-report.md); [Privacy Compliance Review](privacy-compliance-review.md)                                                                                                                                                                         |
+| `PROD-COMP-008` | [Consent Management Audit](consent-management-audit.md); [Web Storage Audit](web-storage-audit.md)                                                                                                                                                                                                 |
+| `PROD-COMP-009` | [Data Inventory](data-inventory.md)                                                                                                                                                                                                                                                                |
+
+**Known gaps are gaps.** Where a document records an unmet control, that document
+is still the evidence of record for the obligation — it evidences the current
+state, not a claim of conformance. Do not read a populated row as a compliance
+attestation.
+
 ## Contents
 
 | Document                                                        | Description                                                                     |

--- a/docs/compliance/aggregator-data-compliance.md
+++ b/docs/compliance/aggregator-data-compliance.md
@@ -18,6 +18,12 @@
 > items where a control's existence or behavior could not be confirmed from the
 > code are marked **Needs verification** and carry a follow-up issue.
 
+> **Satisfies:** `PROD-COMP-002`, `PROD-COMP-004` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Table of Contents

--- a/docs/compliance/app-store-privacy-labels.md
+++ b/docs/compliance/app-store-privacy-labels.md
@@ -15,6 +15,12 @@ accurately reflects what the shipping build does.
 before the next submission.** See [Material Change Triggers](#material-change-triggers)
 for the list of code changes that require a disclosure review.
 
+> **Satisfies:** `PROD-COMP-002`, `PROD-COMP-006` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Table of Contents

--- a/docs/compliance/ccpa-verification.md
+++ b/docs/compliance/ccpa-verification.md
@@ -6,6 +6,12 @@
 
 This document verifies all six CCPA/CPRA consumer rights against the Finance application's actual implementation. Each right is mapped to the specific code path that fulfils it.
 
+> **Satisfies:** `PROD-COMP-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Table of Contents

--- a/docs/compliance/consent-management-audit.md
+++ b/docs/compliance/consent-management-audit.md
@@ -1,5 +1,11 @@
 # GDPR Consent Management Audit
 
+> **Satisfies:** `PROD-COMP-008` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ## Scope and evidence
 
 This audit reviews the current consent posture for optional telemetry and related privacy controls using:

--- a/docs/compliance/data-inventory.md
+++ b/docs/compliance/data-inventory.md
@@ -9,6 +9,12 @@ This document inventories all personal data processed by Finance, maps data flow
 legal bases for processing, documents sub-processors, and screens for Data Protection Impact
 Assessment (DPIA) requirements. It supports GDPR Articles 5, 6, 13, 14, 28, 30, 35, and 44–49.
 
+> **Satisfies:** `PROD-COMP-001`, `PROD-COMP-002`, `PROD-COMP-009` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Table of Contents

--- a/docs/compliance/data-minimization-audit.md
+++ b/docs/compliance/data-minimization-audit.md
@@ -1,5 +1,11 @@
 # GDPR Data Minimization Audit
 
+> **Satisfies:** `PROD-COMP-002` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ## Scope and evidence
 
 This audit reviews data necessity and retention based on:

--- a/docs/compliance/data-retention-schedule.md
+++ b/docs/compliance/data-retention-schedule.md
@@ -10,6 +10,12 @@
 > all retention periods before making compliance claims. Retention periods may
 > change as the product matures.
 
+> **Satisfies:** `PROD-COMP-005` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Table of Contents

--- a/docs/compliance/encryption-explainer.md
+++ b/docs/compliance/encryption-explainer.md
@@ -5,6 +5,12 @@
 > **Related Issues:** [#1692](https://github.com/jrmoulckers/finance/issues/1692)
 > **Related Docs:** [Privacy & Security Guide](../guides/privacy-security.md), [Trust & Manual Entry](../guides/trust-and-manual-entry.md), [Data Inventory](./data-inventory.md)
 
+> **Satisfies:** `PROD-COMP-001`, `PROD-CONTENT-005` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Table of Contents

--- a/docs/compliance/gdpr-right-to-access-audit.md
+++ b/docs/compliance/gdpr-right-to-access-audit.md
@@ -10,6 +10,12 @@
 > advice. Have qualified legal counsel review all findings before making compliance
 > claims.
 
+> **Satisfies:** `PROD-COMP-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Table of Contents

--- a/docs/compliance/gdpr-right-to-erasure-audit.md
+++ b/docs/compliance/gdpr-right-to-erasure-audit.md
@@ -10,6 +10,12 @@
 > advice. Have qualified legal counsel review all findings before making compliance
 > claims.
 
+> **Satisfies:** `PROD-COMP-003`, `PROD-COMP-005` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Table of Contents

--- a/docs/compliance/privacy-compliance-review.md
+++ b/docs/compliance/privacy-compliance-review.md
@@ -6,6 +6,12 @@
 > **Scope:** Full-stack GDPR, CCPA/CPRA privacy compliance assessment
 > **Status:** Review complete — remediation required before launch
 
+> **Satisfies:** `PROD-COMP-001`, `PROD-COMP-007` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Executive Summary

--- a/docs/compliance/security-transparency-report.md
+++ b/docs/compliance/security-transparency-report.md
@@ -5,6 +5,12 @@
 > **Related Issues:** [#1706](https://github.com/jrmoulckers/finance/issues/1706)
 > **Related Docs:** [Privacy & Security Guide](../guides/privacy-security.md), [Trust & Manual Entry](../guides/trust-and-manual-entry.md), [Encryption Explainer](./encryption-explainer.md)
 
+> **Satisfies:** `PROD-COMP-007` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Table of Contents

--- a/docs/compliance/vpat-2.5.md
+++ b/docs/compliance/vpat-2.5.md
@@ -35,6 +35,12 @@ This report covers the degree of conformance for the following accessibility sta
 - **Not Applicable** — The criterion is not relevant to the product.
 - **Not Evaluated** — The product has not been evaluated against the criterion. This can be used only in WCAG Level AAA.
 
+> **Satisfies:** `PROD-CONTENT-005`, `PROD-COMP-001` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## WCAG 2.2 Level A Conformance

--- a/docs/compliance/vpn-tor-policy.md
+++ b/docs/compliance/vpn-tor-policy.md
@@ -5,6 +5,12 @@
 > **Related Issues:** [#1711](https://github.com/jrmoulckers/finance/issues/1711)
 > **Related Docs:** [Privacy & Security Guide](../guides/privacy-security.md), [Trust & Manual Entry](../guides/trust-and-manual-entry.md)
 
+> **Satisfies:** `PROD-COMP-002`, `PROD-COMP-003` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Table of Contents

--- a/docs/compliance/web-storage-audit.md
+++ b/docs/compliance/web-storage-audit.md
@@ -6,6 +6,12 @@
 
 This document inventories every browser storage mechanism used by the Finance web application, including cookies, localStorage, IndexedDB, Origin Private File System (OPFS), Service Worker cache, and sessionStorage. For each item, it documents what is stored, why, whether it is encrypted, and when it expires.
 
+> **Satisfies:** `PROD-COMP-002`, `PROD-COMP-008` — Product obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product), pinned to
+> [`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md).
+> This document is the local evidence; the obligation is central. These principles
+> establish governance and qualified-review triggers and are not legal advice.
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
## Summary

Consolidates this repository onto centralized Product authority in
[jrmoulckers/product](https://github.com/jrmoulckers/product). Product obligations are
now consumed **by reference** — cited by stable ID — instead of being reinvented as
local generic method.

The governing distinction applied throughout: **Product owns the obligation and the
reusable shape; this repository owns its instances and its evidence.**

No principle text is copied, no compliance or audit evidence is deleted, and no
instance artifact moves upstream. Nothing inside the `studio:base` markers was
touched, and `.github/agents/`, `.github/skills/`, `.github/prompts/`,
`.github/instructions/`, `.studio-sync.lock.json`, and `vendor/@jrm/tokens/` are
untouched. Docs-only: 66 files, all markdown.

## Task 1 — `docs/business/` classification (46 files)

Verified by reading content, not filenames: **35 INSTANCE, 2 FRAMEWORK, 9 MIXED.**

| Class | Count | Treatment |
| --- | --- | --- |
| INSTANCE | 35 | Kept verbatim; gained a `> **Satisfies:**` citation naming the obligations it is evidence for. |
| FRAMEWORK | 2 | Generic method replaced by a citation to the obligation and central template; finance-specific content kept. |
| MIXED | 9 | Generic section(s) reduced to citations; dated/version-specific content kept in place. |

**FRAMEWORK (2)**
- `growth/growth-metrics-framework.md` — AARRR taxonomy, NPS survey method, and review-cadence method removed in favor of `PROD-MET-001`/`PROD-MET-002`/`PROD-MET-003` and `templates/metric-definition.md`. Finance targets, platform-parity matrix, and retention curves kept.
- `sprints/alpha-testing-protocol.md` — phased-exposure, bug-triage, feedback, and rollback-trigger method cited to `PROD-DISC-001/002/003`. **§3 data-quality checks kept in full** (balance reconciliation, category integrity, sync consistency, currency, household isolation) — genuinely finance-specific and with no central equivalent.

**MIXED (9)**

| File | Reduced | Kept |
| --- | --- | --- |
| `growth/kpi-dashboard-spec.md` | Metric taxonomy, alert-severity method | **§2 designated Finance's metric catalog** for `PROD-MET-001`; baselines; benchmarks |
| `growth/sprint-8-growth-metrics-review.md` | Duplicate metric + cohort definitions (a local `PROD-CONTENT-001` second source) | Dated Sprint 8 scope adjustment, competitive pricing observation |
| `pricing/premium-strategy-conversion-funnel.md` | §6 A/B testing method → `PROD-DISC-002` | Gating rules, tiers, projections, finance-specific test constraints |
| `pricing/pricing-validation-sprint7.md` | §2 test design, §5 decision framework | Benchmarks, regional pricing, Van Westendorp, sensitivity analysis |
| `revenue/premium-conversion-tracking.md` | §6 paywall A/B method | Funnel, trigger inventory, platform analysis, Finance-volume sizing |
| `roadmap/launch-readiness-dashboard-and-platform-parity.md` | Part 1 reframed as the **evidence surface** for `PROD-REL-001`, not the decision | Parts 2–3 parity assessment and implementation plan |
| `roadmap/v10-go-no-go-review.md` | Reusable checklist, decision matrix, blank sign-off form → `templates/go-no-go-record.md` | The dated v1.0 verdict, launch-day plan, rollback triggers |
| `roadmap/v2-feature-prioritization-matrix.md` | Standing scoring methodology → `PROD-PLAN-002`/`PROD-PLAN-004` | Scored V2 issues, ranking, dependency map, risk assessment |
| `sprints/sprint-9-beta-program.md` | Recruitment/rollout/feedback/readout method → `PROD-DISC-002/003/004` | AI-accuracy tracking and finance-specific gates |

## Task 2 — `docs/compliance/` wiring (16 files)

All 16 files stay — they are evidence, and evidence stays with the product. Each now
carries a citation block pinned to the ratification commit
[`3a752c1`](https://github.com/jrmoulckers/product/blob/3a752c11856515a74eb204675d5d5198cac1e48e/principles/compliance.md),
and `docs/compliance/README.md` gained an **obligation-to-evidence traceability table**
satisfying `PROD-COMP-001`.

| Obligation | Evidence |
| --- | --- |
| `PROD-COMP-001` | traceability table, privacy compliance review, encryption explainer, VPAT |
| `PROD-COMP-002` | data inventory, minimization audit, web storage audit, aggregator compliance, privacy labels, VPN/Tor policy |
| `PROD-COMP-003` | GDPR access, GDPR erasure, CCPA verification, VPN/Tor policy |
| `PROD-COMP-004` | aggregator compliance, bank connection partner evaluation |
| `PROD-COMP-005` | retention schedule, GDPR erasure |
| `PROD-COMP-006` | app store privacy labels |
| `PROD-COMP-007` | security transparency report, privacy compliance review |
| `PROD-COMP-008` | consent management audit, web storage audit |
| `PROD-COMP-009` | data inventory |

The README explicitly states that a populated row is **not** a conformance
attestation — where a document records an unmet control, it evidences current state.
Every compliance citation repeats that these principles establish governance and
qualified-review triggers and are **not legal advice**.

## Task 3 — Root `PRODUCT.md`

New root `PRODUCT.md` built from the central `templates/PRODUCT.md`, filled from
existing local material. Product identity no longer lives in an architecture
document: the "Product Identity" section of `docs/architecture/roadmap.md` now points
at `PRODUCT.md`. `docs/design/product-identity.md` remains the detailed interface
spec and is linked, not duplicated.

## Task 4 — Product authority reference

Added to `README.md` (after Principles, plus a ToC entry) and to `AGENTS.md` strictly
**above** `<!-- prettier-ignore-start -->` — outside the `studio:base` markers.

## Task 5 — `CONTRIBUTING.md` recommendation (not acted on)

⚠️ **This is `.github` authority, not Product. No change was made — this needs an
owner decision.**

The local `CONTRIBUTING.md` overrides the org default inherited from
`jrmoulckers/.github` via GitHub community-health inheritance, which means it no
longer tracks upstream.

It **does** carry content that justifies an override: the required-status-check table
with exact GitHub Actions job names for five platform workflows, branch-protection
settings including signed commits and linear history, the `npm run ci:check` /
`ready-for-pr` commands, and repo-specific commit scopes (`android`, `ios`, `web`,
`windows`, `kmp`, `api`).

But roughly half duplicates the org default: the Conventional Commits type list, the
issue-first workflow, coding standards, and security basics — all of which will drift.

**Recommendation:** keep the override but reduce it to the finance-specific layer and
open with a link to the inherited
[`jrmoulckers/.github` CONTRIBUTING.md](https://github.com/jrmoulckers/.github/blob/main/CONTRIBUTING.md)
for everything generic.

## Genuinely ambiguous boundary cases

These are raised deliberately — I made a call on each, but they are worth a second look.

1. **`sprints/sprint-9-ai-ethics-guidelines.md` may be an upstream gap.** It defines a
   reusable Bias Assessment Framework, transparency standards, and an opt-in/opt-out
   framework. That is generic method, but central Product has **no AI-ethics
   obligation** — the nearest fits (`PROD-STRAT-001`, `PROD-COMP-002`,
   `PROD-COMP-008`) do not cover bias assessment. Classified INSTANCE and cited, but
   this looks like something worth ratifying upstream rather than leaving as local
   generic method.
2. **`alpha-testing-protocol.md` §8 rollback** — rollback *procedure* is an Engineering
   mechanism, yet `PROD-REL-003` requires a supported rollback target as release
   evidence. The line running through this section is Product/Engineering, not
   central/local.
3. **`kpi-dashboard-spec.md` §3 and §7** are a three-way split — dashboard
   architecture and analytics-stack selection are Engineering authority, not Product
   and arguably not business docs. Left in place, flagged in the document itself.
4. **Three overlapping local metric sources** violated `PROD-MET-001` and
   `PROD-CONTENT-001` *locally*, independent of central authority. This PR designates
   `kpi-dashboard-spec.md` §2 as the single local metric catalog and cross-references
   the other two. A fuller consolidation into a dedicated
   `docs/business/growth/metric-catalog.md` is deliberately held back as a larger
   follow-up.
5. **`launch-readiness-dashboard-and-platform-parity.md` Part 1** — central has a
   go/no-go record template but no readiness-*dashboard* shape. Rather than delete
   structure with no central home, Part 1 was reframed as the evidence surface that
   feeds the `PROD-REL-001` decision.
6. **`pricing/sprint-7-premium-paywall-ux.md`** is a Studio-authority UX spec sitting
   in `docs/business/`. Left in place with a `PROD-BUS-001` citation and a note rather
   than relocated — moving it is a Studio-boundary call.

## Testing

- [x] `npm run format` then `npm run format:check` — all files match Prettier style
- [x] ESLint is scoped to `**/*.{ts,tsx,mjs,js}`; this change set is 100% markdown, so
      lint is a no-op for it
- [x] Every cited obligation ID verified against the real principle text fetched from
      `jrmoulckers/product` (two initial `PROD-CONTENT-002` citations were corrected to
      `PROD-BUS-001`/`PROD-STRAT-001` after reading the actual wording)
- [x] No new tooling added

Closes #4026