### PR TITLE
docs: restore locally-authored method removed on false central-coverage claim

### DIFF
--- a/docs/business/growth/growth-metrics-framework.md
+++ b/docs/business/growth/growth-metrics-framework.md
@@ -44,6 +44,11 @@ Finance-specific commitments layered on top of the central obligations:
 2. **Platform parity in measurement.** The same metric definition and target apply
    to all four platforms; per-platform breakdowns exist for debugging, not for
    separate goals.
+3. **Leading indicators are prioritized over lagging ones.** Activation rate and
+   feature adoption predict future outcomes; total-user counts describe past ones.
+   Central authority requires each metric to state the decision it informs
+   (`PROD-MET-001`) but does not rank predictive against descriptive metrics —
+   this ordering is a Finance choice and is retained here deliberately.
 
 ---
 
@@ -234,13 +239,25 @@ that needs investigation.
 
 ## 4. NPS Measurement
 
-> NPS survey mechanics — question design, delivery cadence, sampling, and
-> non-incentivization — are generic method. Interpretation obligations are
-> `PROD-MET-003` (report uncertainty, limitations, and material segments before
-> deciding); collection is bounded by `PROD-MET-002`. Recorded below is only
-> Finance's instance: our targets by segment and the actions we bind to them.
+> Central authority governs how NPS results are **interpreted** (`PROD-MET-003` —
+> report uncertainty, limitations, guardrails, and material segments before
+> deciding) and how collection is **bounded** (`PROD-MET-002`). It does **not**
+> define survey-instrument design — question wording, follow-up branching,
+> delivery cadence, or sampling. That substance has no central home, so it is
+> retained here in full as Finance's own instrument.
 
-### 4.1 Survey Parameters
+### 4.1 Survey Design
+
+**Core Question:** "How likely are you to recommend Finance to a friend or
+colleague?" (0–10 scale)
+
+**Follow-up (conditional):**
+
+- Promoters (9–10): "What do you love most about Finance?"
+- Passives (7–8): "What would make Finance a 10 for you?"
+- Detractors (0–6): "What's the biggest issue holding you back?"
+
+### 4.2 Survey Parameters
 
 | Parameter          | Value                                       |
 | ------------------ | ------------------------------------------- |
@@ -252,7 +269,7 @@ that needs investigation.
 | Incentive          | None (to avoid bias)                        |
 | Sample target      | 10% of MAU per quarter                      |
 
-### 4.2 NPS Targets
+### 4.3 NPS Targets
 
 | Segment       | Target NPS | Good  | Alert |
 | ------------- | ---------- | ----- | ----- |
@@ -264,7 +281,7 @@ that needs investigation.
 | Web users     | 30+        | 20–40 | < 10  |
 | Windows users | 40+        | 30–50 | < 20  |
 
-### 4.3 NPS Action Protocol
+### 4.4 NPS Action Protocol
 
 | NPS Score | Action                                                      |
 | --------- | ----------------------------------------------------------- |
@@ -273,12 +290,14 @@ that needs investigation.
 | 10–29     | Concerning. Prioritize top detractor themes in next sprint. |
 | < 10      | Critical. Emergency product review. All hands on feedback.  |
 
-### 4.4 Qualitative Feedback Themes
+### 4.5 Qualitative Feedback Analysis
 
-Finance-specific theme categories tracked for trend: performance, features,
-pricing, privacy, UX. Top themes feed sprint planning as P1/P2 issues. Reporting
-them observes `PROD-MET-003` — themes are reported with sample size and
-limitations, not as standalone conclusions.
+Central authority does not define qualitative analysis method, so Finance's is
+retained: categorize open-ended responses into themes monthly, track the top five
+themes over time for trend, using the categories performance, features, pricing,
+privacy, and UX. Top themes feed sprint planning as P1/P2 issues. Reporting them
+observes `PROD-MET-003` — themes are reported with sample size and limitations,
+not as standalone conclusions.
 
 ---
 
@@ -312,11 +331,12 @@ limitations, not as standalone conclusions.
 | Conversion collapse | Trial-to-paid < 3% for 14 days     | Email         | 48 hours      |
 | Platform anomaly    | Any platform metric diverges 30%+  | Slack         | 24 hours      |
 
-### 5.3 Review Cadence
+### 5.3 Weekly Metrics Review Cadence
 
-Weekly and monthly review cadence is the local instance of `PROD-MET-003`
-(interpret honestly) and `PROD-PLAN-004` (groom on a declared cadence). Every
-readout carries definition version, window, sample and missingness, and guardrail
+Review cadence for **metrics** is not a central obligation — `PROD-PLAN-004`
+declares a cadence for backlog grooming, not for measurement review — so Finance's
+cadence is retained in full. `PROD-MET-003` governs the readout itself: every
+review carries definition version, window, sample and missingness, and guardrail
 context before a decision is drawn from it.
 
 | Day       | Activity                                            |
@@ -325,8 +345,19 @@ context before a decision is drawn from it.
 | Wednesday | Mid-week engagement check; A/B test progress review |
 | Friday    | Weekly metrics summary; publish to team             |
 
-Monthly business review covers growth, engagement, retention, revenue, quality,
-and per-platform health across the same catalog definitions.
+### 5.4 Monthly Business Review Metrics
+
+| Section         | Metrics Reviewed                                |
+| --------------- | ----------------------------------------------- |
+| Growth          | New users, growth rate, channel mix, CAC        |
+| Engagement      | DAU/MAU, session metrics, feature adoption      |
+| Retention       | D1/D7/D30 curves, cohort analysis, churn trends |
+| Revenue         | MRR, ARPU, LTV, conversion funnel, plan mix     |
+| Quality         | Crash rate, store rating, NPS, support tickets  |
+| Platform health | Per-platform breakdown of all above metrics     |
+
+All rows resolve against the catalog definitions
+([KPI Dashboard Spec](kpi-dashboard-spec.md) §2).
 
 ---
 

--- a/docs/business/growth/growth-metrics-framework.md
+++ b/docs/business/growth/growth-metrics-framework.md
@@ -13,51 +13,41 @@
 
 ---
 
-> **Satisfies:** `PROD-MET-001`, `PROD-MET-002`, `PROD-MET-003` — Product obligations are
-> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). The generic
-> measurement method this document used to define locally now lives centrally; what remains
-> here is the finance-specific instance — targets, thresholds, platform parity expectations,
-> and the rollout checklist.
+> **Satisfies:** `PROD-MET-001`, `PROD-MET-002`, `PROD-MET-003` — Product obligations
+> are defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). Those
+> obligations require that each metric have one versioned definition stating the
+> decision it informs, that collection be bounded by purpose and consent, and that
+> readouts state uncertainty and limitations. They do **not** define a metric
+> taxonomy, a survey instrument, or an indicator-preference heuristic — the method
+> below is Finance's own and is retained here in full. See also
+> [`templates/metric-definition.md`](https://github.com/jrmoulckers/product/blob/main/templates/metric-definition.md)
+> for the shape of an individual metric record.
 
 ## Executive Summary
 
-This document records the Finance-specific growth measurement instance across all
-four platforms (iOS, Android, Web, Windows): the metrics we track, the targets and
-alert thresholds we hold them to, expected platform variance, and the phased
-rollout of measurement itself.
+This document defines the comprehensive growth metrics framework for the Finance
+app across all four platforms (iOS, Android, Web, Windows). It covers core
+metric definitions, per-platform tracking plans, retention curve targets, NPS
+methodology, success criteria with alert thresholds, and privacy-compliant
+tracking architecture. This framework is the single source of truth for how we
+measure success.
 
-It does **not** define what a metric definition must contain, how measurement is
-bounded, or how results must be interpreted — those are central obligations
-(`PROD-MET-001`, `PROD-MET-002`, `PROD-MET-003`), and the reusable shape for a
-metric record is
-[`templates/metric-definition.md`](https://github.com/jrmoulckers/product/blob/main/templates/metric-definition.md).
-The local metric catalog — one versioned definition per metric, per `PROD-MET-001` —
-is [KPI Dashboard Spec](kpi-dashboard-spec.md) §2. Definitions are not restated here.
+### Metrics Philosophy
 
-### Measurement posture
-
-Finance-specific commitments layered on top of the central obligations:
-
-1. **No third-party data-selling SDKs.** Analytics use anonymous, aggregated data
-   and contain no raw financial values. Collection is consent-gated per
-   `PROD-MET-002` and `PROD-COMP-008`.
-2. **Platform parity in measurement.** The same metric definition and target apply
-   to all four platforms; per-platform breakdowns exist for debugging, not for
-   separate goals.
-3. **Leading indicators are prioritized over lagging ones.** Activation rate and
-   feature adoption predict future outcomes; total-user counts describe past ones.
-   Central authority requires each metric to state the decision it informs
-   (`PROD-MET-001`) but does not rank predictive against descriptive metrics —
-   this ordering is a Finance choice and is retained here deliberately.
+1. **Privacy-first measurement** — All metrics use anonymous, aggregated data.
+   No PII in analytics. No third-party SDKs that sell data.
+2. **Actionable over vanity** — Every metric must answer "what should we do?"
+   not just "how big are we?"
+3. **Platform parity** — Same metrics, same definitions, same targets across
+   all 4 platforms. Platform-specific breakdowns for debugging only.
+4. **Leading indicators** — Prioritize metrics that predict future outcomes
+   (activation rate, feature adoption) over lagging indicators (total users).
 
 ---
 
-## 1. Core Metrics and Targets
+## 1. Core Metrics Taxonomy
 
-> Metric definitions live in the catalog ([KPI Dashboard Spec](kpi-dashboard-spec.md) §2).
-> The tables below record Finance's targets, not definitions.
-
-### 1.1 Funnel Targets
+### 1.1 AARRR Framework (Pirate Metrics)
 
 | Stage       | Key Metric        | Definition                                      | Target       |
 | ----------- | ----------------- | ----------------------------------------------- | ------------ |
@@ -239,14 +229,7 @@ that needs investigation.
 
 ## 4. NPS Measurement
 
-> Central authority governs how NPS results are **interpreted** (`PROD-MET-003` —
-> report uncertainty, limitations, guardrails, and material segments before
-> deciding) and how collection is **bounded** (`PROD-MET-002`). It does **not**
-> define survey-instrument design — question wording, follow-up branching,
-> delivery cadence, or sampling. That substance has no central home, so it is
-> retained here in full as Finance's own instrument.
-
-### 4.1 Survey Design
+### 4.1 NPS Survey Design
 
 **Core Question:** "How likely are you to recommend Finance to a friend or
 colleague?" (0–10 scale)
@@ -257,7 +240,7 @@ colleague?" (0–10 scale)
 - Passives (7–8): "What would make Finance a 10 for you?"
 - Detractors (0–6): "What's the biggest issue holding you back?"
 
-### 4.2 Survey Parameters
+### 4.2 Survey Delivery
 
 | Parameter          | Value                                       |
 | ------------------ | ------------------------------------------- |
@@ -292,12 +275,10 @@ colleague?" (0–10 scale)
 
 ### 4.5 Qualitative Feedback Analysis
 
-Central authority does not define qualitative analysis method, so Finance's is
-retained: categorize open-ended responses into themes monthly, track the top five
-themes over time for trend, using the categories performance, features, pricing,
-privacy, and UX. Top themes feed sprint planning as P1/P2 issues. Reporting them
-observes `PROD-MET-003` — themes are reported with sample size and limitations,
-not as standalone conclusions.
+- Categorize open-ended responses into themes (monthly)
+- Top 5 themes tracked over time for trend analysis
+- Common theme categories: performance, features, pricing, privacy, UX
+- Feed top themes into sprint planning as P1/P2 issues
 
 ---
 
@@ -333,12 +314,6 @@ not as standalone conclusions.
 
 ### 5.3 Weekly Metrics Review Cadence
 
-Review cadence for **metrics** is not a central obligation — `PROD-PLAN-004`
-declares a cadence for backlog grooming, not for measurement review — so Finance's
-cadence is retained in full. `PROD-MET-003` governs the readout itself: every
-review carries definition version, window, sample and missingness, and guardrail
-context before a decision is drawn from it.
-
 | Day       | Activity                                            |
 | --------- | --------------------------------------------------- |
 | Monday    | Review weekend metrics; check for anomalies         |
@@ -355,9 +330,6 @@ context before a decision is drawn from it.
 | Revenue         | MRR, ARPU, LTV, conversion funnel, plan mix     |
 | Quality         | Crash rate, store rating, NPS, support tickets  |
 | Platform health | Per-platform breakdown of all above metrics     |
-
-All rows resolve against the catalog definitions
-([KPI Dashboard Spec](kpi-dashboard-spec.md) §2).
 
 ---
 

--- a/docs/business/growth/kpi-dashboard-spec.md
+++ b/docs/business/growth/kpi-dashboard-spec.md
@@ -10,38 +10,26 @@
 ---
 
 > **Satisfies:** `PROD-MET-001`, `PROD-MET-002` — Product obligations are defined in
-> [jrmoulckers/product](https://github.com/jrmoulckers/product). **§2 of this document is
-> Finance's metric catalog** — the one versioned definition per metric required by
-> `PROD-MET-001`. The reusable shape for a metric record is
-> [`templates/metric-definition.md`](https://github.com/jrmoulckers/product/blob/main/templates/metric-definition.md).
-> Sections 3 and 7 describe dashboard and analytics-stack mechanism, which is Engineering
-> authority rather than Product.
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). **Section 2 below is Finance's metric catalog** — the one
+> versioned definition per metric required by `PROD-MET-001`. The reusable shape for an
+> individual metric record is
+> [`templates/metric-definition.md`](https://github.com/jrmoulckers/product/blob/main/templates/metric-definition.md); the
+> taxonomy, thresholds, and baselines here are local. Sections 3 and 7 describe dashboard and
+> analytics-stack mechanism, which is Engineering authority rather than Product.
 
 ## Executive Summary
 
-This document is Finance's metric catalog and launch measurement baseline. §2
-carries the definitions — decision use, formula, population, window, and
-exclusions — that all downstream business analysis (cohort analysis, churn
-modeling, conversion tracking, revenue forecasting) resolves against. Other
-documents cite these definitions rather than restating them.
+This document defines the complete business intelligence infrastructure for the Finance app post-launch. It specifies every core KPI with precise definitions, data sources, calculation methodology, baseline targets, and alerting thresholds. This is the foundational measurement layer that gates all subsequent business analysis (cohort analysis, churn modeling, conversion tracking, revenue forecasting).
 
-**Key outcome:** a privacy-respecting metrics baseline that provides actionable
-business intelligence without compromising the "no tracking, no ads, no data
-selling" commitment.
+**Key outcome:** A privacy-respecting, real-time metrics dashboard that provides actionable business intelligence without compromising our "no tracking, no ads, no data selling" commitment.
 
 ---
 
-## 1. Collection Bounds
+## 1. KPI Framework
 
-> `PROD-MET-002` requires measurement to be bounded by purpose and consent before
-> it is approved, and `PROD-MET-001` requires each metric to carry one versioned
-> definition. Recorded below are the Finance-specific bounds every definition in §2
-> is subject to. The five lifecycle pillars (acquire, activate, engage, monetize,
-> retain) are simply how this catalog is organized.
+### 1.1 Metric Taxonomy
 
-> The five lifecycle pillars (acquire, activate, engage, monetize, retain) are how
-> this catalog is organized; central authority defines per-metric records but no
-> taxonomy, so the organizing map is retained below.
+All metrics are organized into five pillars aligned with the business lifecycle:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -58,13 +46,9 @@ selling" commitment.
 └───────────┴───────────┴───────────┴───────────┴─────────────────┘
 ```
 
-### 1.1 Privacy Constraints on Analytics
+### 1.2 Privacy Constraints on Analytics
 
-All metrics MUST comply with these non-negotiable privacy constraints. Consent
-evidence is
-[`docs/compliance/consent-management-audit.md`](../../compliance/consent-management-audit.md);
-minimization evidence is
-[`docs/compliance/data-minimization-audit.md`](../../compliance/data-minimization-audit.md).
+All metrics MUST comply with these non-negotiable privacy principles:
 
 | Constraint                                       | Implementation                                                                             |
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
@@ -75,13 +59,7 @@ minimization evidence is
 | **No fingerprinting**                            | No canvas fingerprinting, no device fingerprinting beyond anonymous ID                     |
 | **Data minimization**                            | Collect only what's needed for each metric — no "collect everything, analyze later"        |
 
-No raw financial value — balance, transaction amount, or category name — is ever
-collected as telemetry.
-
-### 1.2 Analytics Stack Options
-
-> Stack selection is Engineering mechanism, recorded here only because the choice
-> constrains what can be measured within the bounds above.
+**Recommended Analytics Stack:**
 
 | Component         | Option A (Self-hosted) | Option B (Privacy SaaS)  |
 | ----------------- | ---------------------- | ------------------------ |
@@ -93,12 +71,7 @@ collected as telemetry.
 
 ---
 
-## 2. Core KPI Definitions — Finance metric catalog
-
-> This section is the single local source for metric meaning, per `PROD-MET-001`.
-> Other documents in `docs/business/` cite these definitions; they do not restate
-> them. A breaking change to a definition requires a version bump and a migration
-> note here.
+## 2. Core KPI Definitions
 
 ### 2.1 Acquisition Metrics
 

--- a/docs/business/growth/kpi-dashboard-spec.md
+++ b/docs/business/growth/kpi-dashboard-spec.md
@@ -39,6 +39,25 @@ selling" commitment.
 > is subject to. The five lifecycle pillars (acquire, activate, engage, monetize,
 > retain) are simply how this catalog is organized.
 
+> The five lifecycle pillars (acquire, activate, engage, monetize, retain) are how
+> this catalog is organized; central authority defines per-metric records but no
+> taxonomy, so the organizing map is retained below.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    FINANCE APP KPI FRAMEWORK                    │
+├───────────┬───────────┬───────────┬───────────┬─────────────────┤
+│ ACQUIRE   │ ACTIVATE  │ ENGAGE    │ MONETIZE  │ RETAIN          │
+├───────────┼───────────┼───────────┼───────────┼─────────────────┤
+│ Downloads │ Reg. Rate │ DAU/MAU   │ MRR       │ D1/D7/D30 Ret.  │
+│ Installs  │ Onboarding│ Session   │ ARPU      │ Churn Rate      │
+│ Sources   │ Completion│ Frequency │ Conv Rate │ Reactivation    │
+│ CAC       │ 1st Txn   │ Features  │ LTV       │ NPS Proxy       │
+│ WoW Growth│ Time-to-  │ Per-User  │ Trial→    │ Cohort Curves   │
+│           │ Value     │ Actions   │ Paid %    │                 │
+└───────────┴───────────┴───────────┴───────────┴─────────────────┘
+```
+
 ### 1.1 Privacy Constraints on Analytics
 
 All metrics MUST comply with these non-negotiable privacy constraints. Consent

--- a/docs/business/growth/sprint-8-growth-metrics-review.md
+++ b/docs/business/growth/sprint-8-growth-metrics-review.md
@@ -10,30 +10,19 @@
 ---
 
 > **Satisfies:** `PROD-PLAN-004`, `PROD-MET-001` — Product obligations are defined in
-> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the dated
-> Sprint 8 scope-adjustment decision. It previously restated metric and cohort definitions,
-> creating a second local source of truth; `PROD-MET-001` requires **one** versioned
-> definition per metric and `PROD-CONTENT-001` forbids the duplicate. Definitions now live
-> solely in the metric catalog ([KPI Dashboard Spec](kpi-dashboard-spec.md) §2).
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the dated Sprint 8 scope-adjustment decision.
+> Where its metric and cohort definitions overlap the
+> [KPI Dashboard Spec](kpi-dashboard-spec.md) section 2 catalog, that catalog is the
+> authoritative local definition under `PROD-MET-001`; the text here is retained as the
+> record of what was believed at the time of the decision.
 
 ## Executive Summary
 
-This document records the Sprint 8 scope adjustment and the evidence behind it:
-which metrics were reviewed, what the competitive pricing observation showed, and
-how the engineering workload changed as a result. It is a dated planning decision,
-not a standing framework.
-
-Metric definitions are **not** defined here. The catalog is
-[KPI Dashboard Spec](kpi-dashboard-spec.md) §2; standing targets and platform
-parity expectations are in
-[Growth Metrics Framework](growth-metrics-framework.md).
+This document defines the growth metrics framework for the Finance app, establishes measurement baselines, defines the free-to-premium conversion funnel, and adjusts Sprint 8 scope based on data-driven analysis. It serves as the operating playbook for measuring and optimizing growth from Sprint 8 onward.
 
 ---
 
-## Metrics Reviewed for Sprint 8
-
-> Definitions resolve against the catalog ([KPI Dashboard Spec](kpi-dashboard-spec.md) §2).
-> The targets below are the Sprint 8 goals set against those definitions.
+## Growth Metrics Framework
 
 ### Core KPIs
 
@@ -206,13 +195,7 @@ Based on the stability review (#788) and release planning (#792), the following 
 
 ---
 
-## Cohort Segments Used in This Review
-
-> Cohort and segment boundaries below are the working slices for this dated
-> review. The underlying metric definitions (session, DAU/WAU/MAU, transaction)
-> resolve against the catalog ([KPI Dashboard Spec](kpi-dashboard-spec.md) §2);
-> the Sprint 6 cohort results are in
-> [Cohort Analysis Sprint 6](cohort-analysis-sprint6.md).
+## Cohort Analysis Framework
 
 ### User Cohorts to Track
 

--- a/docs/business/pricing/premium-strategy-conversion-funnel.md
+++ b/docs/business/pricing/premium-strategy-conversion-funnel.md
@@ -15,8 +15,11 @@
 ---
 
 > **Satisfies:** `PROD-BUS-001`, `PROD-DISC-002` — Product obligations are defined in
-> [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the local
-> instance and evidence; the obligation is central.
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). `PROD-DISC-002` requires that a decision rule, guardrails, and
+> kill conditions exist before exposure; it does **not** fix the thresholds, platform, or
+> rollout timing, so the test design below is Finance's own. Individual test decisions are
+> recorded using
+> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
 
 ## Executive Summary
 
@@ -307,34 +310,15 @@ industry benchmarks of 2–5% for users who encounter a gate).
 
 ---
 
-## 6. Planned Pricing Experiments
+## 6. A/B Testing Strategy
 
-> `PROD-DISC-002` governs how an experiment is designed and decided — hypothesis,
-> pre-declared decision rule, and a stop condition committed **before** exposure.
-> The reusable record shape is
-> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
-> Each test below opens its own decision record from that template; the generic
-> evaluation method that used to be restated here is not redefined locally.
+### 6.1 Testing Infrastructure
 
-### 6.1 Finance-specific test constraints
-
-Central authority requires a predeclared decision rule and guardrails
-(`PROD-DISC-002`) but sets no significance level, sample floor, or rollout
-commitment. These are Finance's and are retained:
-
-- **Platform:** PostHog feature flags (self-hosted) or Statsig (privacy mode).
-- **Assignment:** sticky per user — a user must never see the price change
-  underneath them mid-consideration.
-- **Minimum sample:** 500 users per variant, reflecting Finance's expected
-  paywall-view volume.
-- **Significance:** p < 0.05 with minimum 80% power.
-- **Maximum concurrent tests:** 2, to avoid interaction effects across the small
-  monetization surface.
-- **Guardrails that may never degrade:** retention and trust signals. A pricing
-  lift that costs trust is a loss for a privacy-positioned product.
-- **Rollout:** the winner is rolled out to 100% within one week of conclusion.
-- No experiment may vary privacy behavior or data collection — only presentation
-  and price.
+- **Platform:** PostHog feature flags (self-hosted) or Statsig (privacy mode)
+- **Assignment:** Random per user, sticky (same user always sees same variant)
+- **Minimum sample:** 500 users per variant per test
+- **Statistical significance:** p < 0.05, minimum 80% power
+- **Maximum concurrent tests:** 2 (to avoid interaction effects)
 
 ### 6.2 Test Roadmap (Priority Order)
 
@@ -345,6 +329,15 @@ commitment. These are Finance's and are retained:
 | 3        | Price point ($4.99 vs $5.99)    | $4.99 converts enough more to offset      | Week 7–12  |
 | 4        | Annual discount (20% vs 30%)    | 30% discount lifts annual adoption        | Week 9–14  |
 | 5        | Paywall layout (2-col vs stack) | Side-by-side plans convert better         | Week 11–16 |
+
+### 6.3 Test Evaluation Framework
+
+Each test must have:
+
+- **Primary metric:** The one metric that determines winner
+- **Guardrail metrics:** Metrics that must not degrade (retention, NPS)
+- **Decision criteria:** Minimum lift to ship, maximum acceptable degradation
+- **Rollout plan:** Winner rolled out to 100% within 1 week of conclusion
 
 ---
 

--- a/docs/business/pricing/premium-strategy-conversion-funnel.md
+++ b/docs/business/pricing/premium-strategy-conversion-funnel.md
@@ -318,14 +318,21 @@ industry benchmarks of 2–5% for users who encounter a gate).
 
 ### 6.1 Finance-specific test constraints
 
+Central authority requires a predeclared decision rule and guardrails
+(`PROD-DISC-002`) but sets no significance level, sample floor, or rollout
+commitment. These are Finance's and are retained:
+
+- **Platform:** PostHog feature flags (self-hosted) or Statsig (privacy mode).
 - **Assignment:** sticky per user — a user must never see the price change
   underneath them mid-consideration.
 - **Minimum sample:** 500 users per variant, reflecting Finance's expected
   paywall-view volume.
+- **Significance:** p < 0.05 with minimum 80% power.
 - **Maximum concurrent tests:** 2, to avoid interaction effects across the small
   monetization surface.
 - **Guardrails that may never degrade:** retention and trust signals. A pricing
   lift that costs trust is a loss for a privacy-positioned product.
+- **Rollout:** the winner is rolled out to 100% within one week of conclusion.
 - No experiment may vary privacy behavior or data collection — only presentation
   and price.
 

--- a/docs/business/pricing/pricing-validation-sprint7.md
+++ b/docs/business/pricing/pricing-validation-sprint7.md
@@ -160,12 +160,20 @@ Analysis plan:
   - Post-hoc: Tukey HSD for pairwise comparisons
   - Also run: Mann-Whitney U (non-parametric) as robustness check
   - Report: Point estimates, 95% CI, p-values, effect sizes (Cohen's d)
+
+Decision rule for this test (predeclared per PROD-DISC-002):
+  1. If one variant significantly outperforms others (p < 0.05 AND practical significance):
+     → Recommend winner (pending human sign-off)
+  2. If no significant difference:
+     → Maintain current pricing (Variant A); retest after feature additions
+  3. If results are directional but not significant:
+     → Extend test duration or increase traffic; do NOT make pricing changes
 ```
 
-The decision rule and stop condition are committed in the test's decision record
-before exposure, per `PROD-DISC-002`. `PROD-MET-003` additionally forbids reading
-a directional-but-inconclusive result as a win — an inconclusive test means
-pricing does not change.
+The rule above is Finance's own — central authority requires that a decision rule
+and stop condition exist and be committed before exposure, not what their content
+must be. `PROD-MET-003` additionally forbids reading a directional-but-inconclusive
+result as a win: an inconclusive test means pricing does not change.
 
 ### 2.5 Test Integrity Requirements
 

--- a/docs/business/pricing/pricing-validation-sprint7.md
+++ b/docs/business/pricing/pricing-validation-sprint7.md
@@ -10,29 +10,17 @@
 
 ---
 
-> **Satisfies:** `PROD-BUS-002`, `PROD-BUS-003`, `PROD-DISC-002` — Product obligations are
-> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is
-> the dated Sprint 7 pricing validation. The generic experiment-design and decision method it
-> used to define is central; the benchmarks, price points, and sensitivity analysis are local.
+> **Satisfies:** `PROD-BUS-002`, `PROD-BUS-003`, `PROD-DISC-002` — Product obligations
+> are defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the dated Sprint 7 pricing
+> validation. `PROD-DISC-002` obliges a pre-declared decision rule to exist; the specific
+> rule, benchmarks, price points, and sensitivity analysis below are local and are retained
+> in full.
 
 ## Executive Summary
 
-This document records Finance's Sprint 7 pricing validation: refreshed
-competitive benchmarks, the specific price variants under test, price-sensitivity
-and demand modelling, regional considerations, and the resulting recommendation.
+This document defines the pricing validation methodology for the Finance app's Premium tier. It includes competitive pricing benchmarks (refreshed from pre-launch), A/B test design with statistical rigor, price sensitivity analysis framework, and a decision matrix for recommending final pricing. All pricing decisions require human sign-off before implementation.
 
-Experiment design and decision discipline are not defined here — `PROD-DISC-002`
-requires a hypothesis, a pre-declared decision rule, and a stop condition
-committed before exposure, recorded using
-[`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
-`PROD-BUS-002` requires the value exchange to be legible and `PROD-BUS-003`
-requires pricing to be justified rather than assumed; this document is the
-evidence for both.
-
-**Key insight:** the optimal price maximizes _revenue per paywall view_ (RPV),
-not conversion rate. A higher price with lower conversion can yield more revenue
-than a lower price with higher conversion. All pricing decisions require human
-sign-off before implementation.
+**Key insight:** The optimal price maximizes _revenue per paywall view_ (RPV), not conversion rate. A higher price with lower conversion can yield more revenue than a lower price with higher conversion.
 
 ---
 
@@ -90,13 +78,7 @@ POSITIONING: Finance is the MOST AFFORDABLE premium option among
 
 ---
 
-## 2. Test Variants and Parameters
-
-> Experiment design discipline is central (`PROD-DISC-002`). This section records
-> the Finance-specific variants and the parameters chosen for this test; the
-> hypothesis, decision rule, and stop condition are committed in the test's own
-> decision record opened from
-> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
+## 2. A/B Test Design
 
 ### 2.1 Test Variants
 
@@ -130,7 +112,7 @@ Example calculations:
 | **Post-conversion D30 churn** | Do lower-price subscribers churn faster (less committed)?    |
 | **LTV at 6 months**           | True revenue impact (not just initial conversion)            |
 
-### 2.4 Sizing for This Test
+### 2.4 Statistical Methodology
 
 ```
 Test Parameters:
@@ -155,13 +137,13 @@ Sample Size Calculation:
 
   Practical adjustment: If traffic is low, extend test OR use Bayesian analysis
 
-Analysis plan:
+Statistical Test:
   - ANOVA for RPV comparison across 3 variants
   - Post-hoc: Tukey HSD for pairwise comparisons
   - Also run: Mann-Whitney U (non-parametric) as robustness check
   - Report: Point estimates, 95% CI, p-values, effect sizes (Cohen's d)
 
-Decision rule for this test (predeclared per PROD-DISC-002):
+Decision Rule:
   1. If one variant significantly outperforms others (p < 0.05 AND practical significance):
      → Recommend winner (pending human sign-off)
   2. If no significant difference:
@@ -169,11 +151,6 @@ Decision rule for this test (predeclared per PROD-DISC-002):
   3. If results are directional but not significant:
      → Extend test duration or increase traffic; do NOT make pricing changes
 ```
-
-The rule above is Finance's own — central authority requires that a decision rule
-and stop condition exist and be committed before exposure, not what their content
-must be. `PROD-MET-003` additionally forbids reading a directional-but-inconclusive
-result as a win: an inconclusive test means pricing does not change.
 
 ### 2.5 Test Integrity Requirements
 
@@ -306,16 +283,9 @@ Conclusion: Annual plan is better for LTV. Optimize for annual plan adoption.
 
 ---
 
-## 5. Pricing Decision Record for This Test
+## 5. Pricing Decision Framework
 
-> The obligation that a price change be justified by evidence and communicated
-> honestly is central (`PROD-BUS-002`, `PROD-BUS-003`, `PROD-BUS-001`), and the
-> generic experiment decision shape is
-> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
-> Recorded below is the Finance-specific mapping from each variant outcome to the
-> action this repository commits to.
-
-### 5.1 Variant Outcomes and Committed Actions
+### 5.1 Decision Matrix
 
 ```
 IF A/B test shows clear winner (p < 0.05):

--- a/docs/business/revenue/premium-conversion-tracking.md
+++ b/docs/business/revenue/premium-conversion-tracking.md
@@ -10,11 +10,11 @@
 
 ---
 
-> **Satisfies:** `PROD-MET-001`, `PROD-MET-002`, `PROD-DISC-002` — Product obligations are
-> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). Metric meaning
-> resolves against the catalog
-> ([KPI Dashboard Spec](../growth/kpi-dashboard-spec.md) §2); this document is the local
-> conversion-tracking instance and evidence.
+> **Satisfies:** `PROD-MET-001`, `PROD-MET-002`, `PROD-DISC-002` — Product obligations
+> are defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). Metric meaning resolves against the catalog
+> ([KPI Dashboard Spec](../growth/kpi-dashboard-spec.md) section 2); this document is the
+> local conversion-tracking instance and evidence, and its funnel, trigger inventory, and
+> test thresholds are local.
 
 ## Executive Summary
 
@@ -357,16 +357,7 @@ trial_expired:
 
 ---
 
-## 6. Paywall Experiment Candidates
-
-> Experiment design and decision discipline are central (`PROD-DISC-002`) and are
-> recorded per test using
-> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
-> Listed below are the Finance-specific paywall elements considered testable and
-> the sizing that follows from Finance's paywall traffic. `PROD-BUS-001` and
-> `PROD-STRAT-001` constrain the copy variants: no paywall variant may overstate a
-> privacy guarantee, and social-proof claims must be true and verifiable — a
-> monetization surface may not spend trust to buy a conversion.
+## 6. Paywall A/B Testing Framework
 
 ### 6.1 Testable Elements
 
@@ -380,7 +371,7 @@ trial_expired:
 | **Social proof**         | None                           | "Joined by X users this week"         | Social proof may increase trial starts         |
 | **Trigger timing**       | After 3rd gate hit             | After 5th gate hit                    | Later trigger = more invested user             |
 
-### 6.2 Sizing at Finance's Paywall Volume
+### 6.2 A/B Test Statistical Requirements
 
 ```
 Minimum Detectable Effect (MDE): 5 percentage points
@@ -396,16 +387,10 @@ Test duration: Until both variants reach 500+ paywall views
   At estimated 30 paywall views/day: ~17 days per test
   Run max 1 test at a time (avoid interaction effects)
 
-Analysis plan: Two-proportion z-test with α=0.05
+Statistical method: Two-proportion z-test with α=0.05
   Also report: 95% CI, effect size, p-value
-
-Decision rule (predeclared per PROD-DISC-002):
-  Implement winner only if p < 0.05 AND practical significance (MDE ≥ 3pp)
+  Decision rule: Implement winner only if p < 0.05 AND practical significance (MDE ≥ 3pp)
 ```
-
-The threshold above is Finance's own — central authority requires that a decision
-rule and stop condition be committed before exposure, not what they must contain.
-`PROD-MET-003` forbids treating an underpowered or inconclusive result as a win.
 
 ---
 

--- a/docs/business/revenue/premium-conversion-tracking.md
+++ b/docs/business/revenue/premium-conversion-tracking.md
@@ -398,11 +398,14 @@ Test duration: Until both variants reach 500+ paywall views
 
 Analysis plan: Two-proportion z-test with α=0.05
   Also report: 95% CI, effect size, p-value
+
+Decision rule (predeclared per PROD-DISC-002):
+  Implement winner only if p < 0.05 AND practical significance (MDE ≥ 3pp)
 ```
 
-The decision rule and stop condition are committed in each test's decision record
-before exposure, per `PROD-DISC-002`; `PROD-MET-003` forbids treating an
-underpowered or inconclusive result as a win.
+The threshold above is Finance's own — central authority requires that a decision
+rule and stop condition be committed before exposure, not what they must contain.
+`PROD-MET-003` forbids treating an underpowered or inconclusive result as a win.
 
 ---
 

--- a/docs/business/roadmap/launch-readiness-dashboard-and-platform-parity.md
+++ b/docs/business/roadmap/launch-readiness-dashboard-and-platform-parity.md
@@ -10,25 +10,19 @@
 ---
 
 > **Satisfies:** `PROD-REL-001`, `PROD-PLAN-003` — Product obligations are defined in
-> [jrmoulckers/product](https://github.com/jrmoulckers/product). `PROD-REL-001` requires
-> release readiness to be an explicit, evidenced decision rather than an inference from a
-> green build; the release decision itself is recorded using
-> [`templates/go-no-go-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/go-no-go-record.md).
-> Part 1 below is the Finance-specific instrumentation that supplies that evidence — it does
-> not restate the obligation or replace the decision record. Parts 2 and 3 are local
-> platform-parity assessment and implementation planning.
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). `PROD-REL-001` requires release readiness to be an explicit,
+> evidenced decision rather than an inference from a green build; the decision itself is
+> recorded using [`templates/go-no-go-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/go-no-go-record.md).
+> Central carries no readiness-_dashboard_ shape, so Part 1 below is retained in full as the
+> Finance-specific instrumentation that supplies that evidence.
 
-## Part 1: Launch Readiness Evidence Surface
+## Part 1: Launch Readiness Dashboard Requirements
 
 ### Overview
 
-The launch readiness dashboard is Finance's evidence surface for `PROD-REL-001`.
-It provides a single-page view answering "is it safe to launch?", consolidating
-backend health, platform readiness, key metrics, and blocking issues into an
-at-a-glance status page accessible to all stakeholders, so the go/no-go decision
-is made against observed state rather than assumption. The dashboard **informs**
-the decision; it does not constitute it, and a green dashboard is not by itself a
-go.
+The launch readiness dashboard provides a single-page view answering: Is it safe
+to launch? It consolidates backend health, platform readiness, key metrics, and
+blocking issues into an at-a-glance status page accessible to all stakeholders.
 
 Reference: docs/architecture/monitoring-infrastructure.md section 7
 

--- a/docs/business/roadmap/launch-readiness-dashboard-and-platform-parity.md
+++ b/docs/business/roadmap/launch-readiness-dashboard-and-platform-parity.md
@@ -23,10 +23,12 @@
 ### Overview
 
 The launch readiness dashboard is Finance's evidence surface for `PROD-REL-001`.
-It consolidates backend health, platform readiness, key metrics, and blocking
-issues into a single at-a-glance status page so the go/no-go decision is made
-against observed state rather than assumption. The dashboard **informs** the
-decision; it does not constitute it, and a green dashboard is not by itself a go.
+It provides a single-page view answering "is it safe to launch?", consolidating
+backend health, platform readiness, key metrics, and blocking issues into an
+at-a-glance status page accessible to all stakeholders, so the go/no-go decision
+is made against observed state rather than assumption. The dashboard **informs**
+the decision; it does not constitute it, and a green dashboard is not by itself a
+go.
 
 Reference: docs/architecture/monitoring-infrastructure.md section 7
 

--- a/docs/business/roadmap/v10-go-no-go-review.md
+++ b/docs/business/roadmap/v10-go-no-go-review.md
@@ -12,11 +12,12 @@
 
 > **Satisfies:** `PROD-PLAN-005`, `PROD-REL-001`, `PROD-REL-002` — Product obligations are
 > defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). The reusable
-> go/no-go _shape_ — what a decision record must name, how risk acceptance must expire, what
-> counts as deterministic no-go — is central, and the template is
+> go/no-go _shape_ — what a decision record must name and how risk acceptance must be owned
+> and expire — is central, and the template is
 > [`templates/go-no-go-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/go-no-go-record.md).
-> What remains here is the dated v1.0 record: the criteria actually applied, the launch-day
-> plan, and the rollback triggers.
+> Which specific conditions count as no-go for Finance is **not** central; those thresholds
+> are local and are retained below, along with the dated v1.0 record, the launch-day plan,
+> and the rollback triggers.
 
 ## Executive Summary
 

--- a/docs/business/roadmap/v10-go-no-go-review.md
+++ b/docs/business/roadmap/v10-go-no-go-review.md
@@ -10,37 +10,33 @@
 
 ---
 
-> **Satisfies:** `PROD-PLAN-005`, `PROD-REL-001`, `PROD-REL-002` — Product obligations are
-> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). The reusable
-> go/no-go _shape_ — what a decision record must name and how risk acceptance must be owned
-> and expire — is central, and the template is
-> [`templates/go-no-go-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/go-no-go-record.md).
-> Which specific conditions count as no-go for Finance is **not** central; those thresholds
-> are local and are retained below, along with the dated v1.0 record, the launch-day plan,
-> and the rollback triggers.
+> **Satisfies:** `PROD-PLAN-005`, `PROD-REL-001`, `PROD-REL-002` — Product obligations
+> are defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). What a release decision must name, and how risk
+> acceptance must be owned and expire, are central; the reusable record shape is
+> [`templates/go-no-go-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/go-no-go-record.md). Which
+> specific conditions count as no-go for Finance is **not** central — those thresholds, the
+> checklist, the sign-off roster, the dated v1.0 verdict, the launch-day plan, and the
+> rollback triggers are all local and retained below.
 
 ## Executive Summary
 
-This is the v1.0 production launch go/no-go record for Finance. It captures the
-readiness criteria applied across engineering, quality, security, infrastructure,
-store submission, documentation, and communications, together with the launch-day
-execution plan and rollback triggers.
+This document defines the formal go/no-go decision framework for the v1.0
+production launch of Finance. It provides a comprehensive checklist covering
+engineering readiness, quality gates, security posture, store submissions,
+marketing preparedness, and operational readiness. The go/no-go meeting is
+the final gate before public release.
 
-It is **not** the definition of how a go/no-go decision must be made. That is
-`PROD-REL-001` (readiness criteria across scope, security, privacy, compliance,
-accessibility, localization, content, rollback, and support), `PROD-REL-002` (risk
-acceptance must be explicit, owned, and expiring), and `PROD-PLAN-005` (the
-decision must be recorded before material exposure). New release decisions start
-from the central template, not from a copy of this file.
+### Decision Framework
+
+The launch decision uses a traffic-light system:
+
+- **🟢 GO:** All P0 criteria met, no unresolved blockers
+- **🟡 CONDITIONAL GO:** Minor gaps with documented workarounds and fix timelines
+- **🔴 NO-GO:** Any P0 criteria failed, unresolved security issues, or data loss risk
 
 ---
 
-## v1.0 Readiness Checklist
-
-> The criteria categories below are Finance's application of `PROD-REL-001`. The
-> traffic-light states used throughout are: 🟢 GO, 🟡 CONDITIONAL GO (a gap accepted
-> under `PROD-REL-002`, requiring an owner, a compensating action, and an expiry),
-> 🔴 NO-GO.
+## Go/No-Go Checklist
 
 ### 1. Engineering Readiness
 
@@ -178,14 +174,9 @@ from the central template, not from a copy of this file.
 
 ---
 
-## v1.0 Decision Thresholds
+## Go/No-Go Decision Matrix
 
-> `PROD-REL-002` requires unresolved P0 risk to be no-go and every accepted P1 or
-> material gap to carry an owner, compensating action, expiry, and remediation
-> trigger. The lists below are the Finance-specific instantiation of that
-> obligation for v1.0 — not a reusable definition of it.
-
-### Deterministic NO-GO conditions for v1.0
+### Automatic NO-GO (Any Single Item = Block Launch)
 
 - Any P0 bug unresolved
 - Security audit failure unaddressed
@@ -196,9 +187,7 @@ from the central template, not from a copy of this file.
 - No database backup mechanism
 - Store submissions rejected without resubmission plan
 
-### Gaps accepted for v1.0 under `PROD-REL-002`
-
-Each requires a named owner, a compensating action, and an expiry date:
+### Conditional GO (Acceptable with Documented Plan)
 
 - P1 bugs with workarounds and fix timeline (ship in v1.0.1 within 1 week)
 - Non-critical platform parity gaps (e.g., Windows data import can follow)
@@ -206,7 +195,7 @@ Each requires a named owner, a compensating action, and an expiry date:
 - Analytics not fully instrumented (manual tracking as interim)
 - Documentation gaps (ship and update within 1 week)
 
-### GO threshold for v1.0
+### GO Criteria
 
 - All P0 items green across all 7 sections
 - No more than 3 P1 items yellow with documented workarounds
@@ -299,30 +288,33 @@ Initiate rollback if any of the following occur within 48 hours of launch:
 
 ---
 
-## v1.0 Sign-Off
+## Stakeholder Sign-Off Template
 
-> The reusable sign-off _shape_ is central:
-> [`templates/go-no-go-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/go-no-go-record.md).
-> Do not copy the blank form that used to live here — start a new release decision
-> from the template so it stays current with `PROD-REL-001` and `PROD-REL-002`.
-> Recorded below is the v1.0 sign-off itself.
+### Go/No-Go Meeting Record
 
-**Decision date:** 2025-07-29
+**Date:** **\*\***\_\_\_**\*\***
+**Attendees:** **\*\***\_\_\_**\*\***
 
-| Role              | Decision   | Conditions/Notes |
-| ----------------- | ---------- | ---------------- |
-| Product Manager   | GO / NO-GO |                  |
-| Engineering Lead  | GO / NO-GO |                  |
-| Security Reviewer | GO / NO-GO |                  |
-| Marketing Lead    | GO / NO-GO |                  |
-| DevOps Lead       | GO / NO-GO |                  |
+| Role              | Name | Decision   | Conditions/Notes |
+| ----------------- | ---- | ---------- | ---------------- |
+| Product Manager   |      | GO / NO-GO |                  |
+| Engineering Lead  |      | GO / NO-GO |                  |
+| Security Reviewer |      | GO / NO-GO |                  |
+| Marketing Lead    |      | GO / NO-GO |                  |
+| DevOps Lead       |      | GO / NO-GO |                  |
 
 **Final Decision:** 🟢 GO / 🟡 CONDITIONAL GO / 🔴 NO-GO
 
-Any CONDITIONAL GO condition recorded above is an accepted risk under
-`PROD-REL-002` and must carry an accountable owner, a compensating action, and an
-expiry — an accepted gap without an end condition is not a valid acceptance. The
-v1.0.1 hotfix window was the declared remediation trigger.
+**Conditions (if CONDITIONAL GO):**
+
+1. ***
+2. ***
+3. ***
+
+**Fix Timeline (if CONDITIONAL GO):**
+
+- v1.0.1 hotfix target date: **\*\***\_\_\_**\*\***
+- Items to fix: **\*\***\_\_\_**\*\***
 
 ---
 

--- a/docs/business/roadmap/v2-feature-prioritization-matrix.md
+++ b/docs/business/roadmap/v2-feature-prioritization-matrix.md
@@ -9,51 +9,51 @@
 ---
 
 > **Satisfies:** `PROD-PLAN-002`, `PROD-PLAN-004` — Product obligations are defined in
-> [jrmoulckers/product](https://github.com/jrmoulckers/product). Making work decision-ready
-> before commitment and keeping the backlog intentional are central obligations. The generic
-> impact/effort scoring method this document used to define is one local technique for meeting
-> them, not a second definition of them.
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). Making work decision-ready before commitment and keeping the
+> backlog intentional are central obligations. Central prescribes no scoring method, so the
+> impact and effort rubrics below are Finance's own technique for meeting those obligations
+> and are retained as the audit trail for the scores.
 
 ## Executive Summary
 
-This document ranks the remaining open V2 issues (#293, #295, #299, #300, #301,
-#303, #304, #305) by business impact and implementation effort, producing a dated
-prioritized execution order for the v2.0 cycle. Two V2 issues (#294 Native
-Platform Integrations and #302 Offline-first Data Migration) were completed in
-earlier sprints and are excluded.
+This document ranks all remaining open V2 issues (#293, #295, #299, #300, #301,
+#303, #304, #305) by business impact and implementation effort, producing a
+prioritized execution order for the v2.0 development cycle. Two V2 issues (#294
+Native Platform Integrations and #302 Offline-first Data Migration) were
+completed in earlier sprints and are excluded.
 
-The ranking is the instance. The obligations it serves — every committed item has
-a priority, an accountable owner, bounded scope, testable acceptance, and stated
-non-goals (`PROD-PLAN-002`), and the backlog is groomed so retained items still
-carry current value and evidence (`PROD-PLAN-004`) — are central and are not
-redefined here.
+### Scoring Methodology
 
-### Scoring technique used for this ranking
-
-Each feature is scored on two dimensions and ranked by Impact / Effort. The
-rubrics below are the working technique for this dated exercise, recorded so the
-scores can be audited — they are not a standing method for the repository.
+Each feature is scored on two dimensions:
 
 - **Impact (1-5):** Composite of user value, revenue potential, retention
   effect, and competitive differentiation
 - **Effort (1-5):** Composite of engineering complexity, cross-platform scope,
   backend requirements, and dependency count
 
-| Impact | User Value       | Revenue Potential   | Retention Effect | Competitive Edge  |
-| ------ | ---------------- | ------------------- | ---------------- | ----------------- |
-| 5      | Core need, daily | Direct revenue gate | Churn prevention | No competitor has |
-| 4      | Frequent use     | Premium upsell      | Strong retention | Few competitors   |
-| 3      | Weekly use       | Indirect revenue    | Moderate         | Parity feature    |
-| 2      | Occasional use   | Minimal revenue     | Low retention    | Many have this    |
-| 1      | Nice-to-have     | No revenue impact   | Negligible       | Table stakes      |
+**Priority Score** = Impact / Effort (higher is better)
 
-| Effort | Engineering | Cross-Platform   | Backend          | Dependencies    |
-| ------ | ----------- | ---------------- | ---------------- | --------------- |
-| 5      | 12+ weeks   | All 4 platforms  | New infra needed | 3+ dependencies |
-| 4      | 8-12 weeks  | 3 platforms      | Significant API  | 2 dependencies  |
-| 3      | 4-8 weeks   | 2 platforms      | Moderate API     | 1 dependency    |
-| 2      | 2-4 weeks   | 1 platform + KMP | Minor API        | No dependencies |
-| 1      | < 2 weeks   | KMP only         | None             | No dependencies |
+---
+
+## Impact Scoring Criteria
+
+| Score | User Value       | Revenue Potential   | Retention Effect | Competitive Edge  |
+| ----- | ---------------- | ------------------- | ---------------- | ----------------- |
+| 5     | Core need, daily | Direct revenue gate | Churn prevention | No competitor has |
+| 4     | Frequent use     | Premium upsell      | Strong retention | Few competitors   |
+| 3     | Weekly use       | Indirect revenue    | Moderate         | Parity feature    |
+| 2     | Occasional use   | Minimal revenue     | Low retention    | Many have this    |
+| 1     | Nice-to-have     | No revenue impact   | Negligible       | Table stakes      |
+
+## Effort Scoring Criteria
+
+| Score | Engineering | Cross-Platform   | Backend          | Dependencies    |
+| ----- | ----------- | ---------------- | ---------------- | --------------- |
+| 5     | 12+ weeks   | All 4 platforms  | New infra needed | 3+ dependencies |
+| 4     | 8-12 weeks  | 3 platforms      | Significant API  | 2 dependencies  |
+| 3     | 4-8 weeks   | 2 platforms      | Moderate API     | 1 dependency    |
+| 2     | 2-4 weeks   | 1 platform + KMP | Minor API        | No dependencies |
+| 1     | < 2 weeks   | KMP only         | None             | No dependencies |
 
 ---
 

--- a/docs/business/sprints/alpha-testing-protocol.md
+++ b/docs/business/sprints/alpha-testing-protocol.md
@@ -35,6 +35,19 @@ often unrecoverable once compounded. So for this product the primary guardrail o
 exposure is not engagement or crash rate but **data integrity**: the checks in §3
 are the kill conditions required by `PROD-DISC-002`.
 
+### Local operating commitments
+
+Central authority requires staged exposure with a proven ability to stop
+(`PROD-DISC-003`) but sets no turnaround target and no automation expectation.
+These are Finance's own and are retained:
+
+1. **Fast feedback loop** — tester → bug report → triage → fix → deploy → verify,
+   targeting **under 48 hours for P0/P1** issues.
+2. **Hard phase gates** — no phase advances until its exit criteria are met. A gate
+   that is not met is not waived.
+3. **Automate what can be automated** — the §3 data-quality checks run
+   continuously, not only when someone remembers to check.
+
 ---
 
 ## 1. Alpha Cohorts and Gates

--- a/docs/business/sprints/alpha-testing-protocol.md
+++ b/docs/business/sprints/alpha-testing-protocol.md
@@ -8,52 +8,37 @@
 
 ---
 
-> **Satisfies:** `PROD-DISC-001`, `PROD-DISC-002`, `PROD-DISC-003` — Product obligations are
-> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). Staged exposure,
-> predeclared bounds, kill conditions, and honest conclusion are central obligations, and the
-> reusable shape for an exposure decision is
-> [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
-> What remains here is Finance's instance: the alpha cohort sizes and gates, and — most
-> importantly — the financial data-quality checks in §3, which have no generic equivalent.
+> **Satisfies:** `PROD-DISC-001`, `PROD-DISC-002`, `PROD-DISC-003` — Product
+> obligations are defined in
+> [jrmoulckers/product](https://github.com/jrmoulckers/product). Those obligations
+> require that exposure be staged with a proven stop and that a decision rule exist
+> before exposure begins. They do **not** set a feedback-loop target, a phase-gate
+> rule, or any expectation specific to financial data integrity — the protocol below
+> is Finance's own and is retained here in full, because it is deliberately stricter
+> than a general alpha.
 
 ## Executive Summary
 
-This document records Finance's alpha exposure instance: three cohorts
-(Internal → Friends & Family → Wider Alpha) with their sizes, gates, and exit
-criteria, and the automated financial data-quality checks that determine whether a
-gate is passed.
+This document defines the repeatable testing protocol for Finance's alpha
+launch. It covers three testing phases (Internal → Friends & Family → Wider
+Alpha), entry and exit criteria for each phase, automated data-quality checks,
+bug triage and escalation, feedback collection mechanisms, key metrics, and the
+rollback plan. The goal is to ship a high-quality alpha that surfaces real
+issues early while protecting tester data integrity.
 
-The obligation to stage exposure deliberately, to predeclare stop conditions, and
-to prove exposure can be halted is central (`PROD-DISC-003`); it is not restated
-here. Bug severity and triage workflow are Engineering mechanism, recorded here
-only as the local escalation agreement.
+### Core Objectives
 
-### Why data quality is the gate
-
-Financial data errors are uniquely harmful — they erode trust permanently and are
-often unrecoverable once compounded. So for this product the primary guardrail on
-exposure is not engagement or crash rate but **data integrity**: the checks in §3
-are the kill conditions required by `PROD-DISC-002`.
-
-### Local operating commitments
-
-Central authority requires staged exposure with a proven ability to stop
-(`PROD-DISC-003`) but sets no turnaround target and no automation expectation.
-These are Finance's own and are retained:
-
-1. **Fast feedback loop** — tester → bug report → triage → fix → deploy → verify,
-   targeting **under 48 hours for P0/P1** issues.
-2. **Hard phase gates** — no phase advances until its exit criteria are met. A gate
-   that is not met is not waived.
-3. **Automate what can be automated** — the §3 data-quality checks run
-   continuously, not only when someone remembers to check.
+1. **Catch data-integrity bugs before they compound** — financial data errors
+   are uniquely harmful because they erode trust permanently.
+2. **Establish a fast feedback loop** — tester → bug report → triage → fix →
+   deploy → verify, targeting < 48 hours for P0/P1 issues.
+3. **Define clear phase gates** — no phase advances until exit criteria are met.
+4. **Automate what can be automated** — data-quality checks run continuously,
+   not just when someone remembers to check.
 
 ---
 
-## 1. Alpha Cohorts and Gates
-
-> Cohort staging observes `PROD-DISC-003`. Recorded below are Finance's cohort
-> sizes, durations, and gate criteria — the instance, not the method.
+## 1. Testing Phases
 
 ### Phase Overview
 
@@ -175,12 +160,7 @@ beta.
 
 ---
 
-## 2. Bug Triage and Kill Conditions
-
-> Severity taxonomy and triage workflow are Engineering mechanism, not Product
-> method — recorded here as the local escalation agreement. The escalation table
-> in §2.3 doubles as the predeclared kill conditions required by `PROD-DISC-002`:
-> each row states a condition under which exposure stops.
+## 2. Bug Triage Process
 
 ### 2.1 Severity Levels
 
@@ -223,11 +203,6 @@ flowchart TD
 ---
 
 ## 3. Data Quality Checks
-
-> **Finance-specific.** These checks have no generic equivalent in central
-> authority — they encode this product's financial correctness invariants
-> (`PRODUCT.md` invariants 6 and 7). They are the primary guardrail on alpha
-> exposure per `PROD-DISC-002`.
 
 These checks validate the integrity of financial data. They run both as
 automated scheduled jobs and as on-demand verification tools.
@@ -424,11 +399,6 @@ CREATE TABLE data_quality_runs (
 
 ## 5. Feedback Collection
 
-> Feedback-collection method — in-app prompts, milestone surveys, crash reporting —
-> is generic. Collection is bounded by `PROD-MET-002` and, where consent-dependent,
-> `PROD-COMP-008`. Recorded below is Finance's instance and, in §5.3, the
-> product-specific rule that financial values never enter a crash payload.
-
 ### 5.1 In-App Feedback
 
 | Mechanism                | Trigger                                      | Data Collected                        |
@@ -537,13 +507,7 @@ Sent via email at key milestones:
 
 ## 8. Rollback Plan
 
-> `PROD-DISC-003` requires evidence that exposure can be halted, and `PROD-REL-003`
-> requires a release to name a supported rollback target. This section is that
-> evidence. The rollback _procedures_ in §8.2 are Engineering mechanism and are
-> owned by the platform and DevOps agents; the _trigger conditions_ in §8.1 are the
-> Product stop conditions.
-
-### 8.1 Stop Conditions
+### 8.1 When to Rollback
 
 A rollback is triggered if any of the following occur during alpha:
 
@@ -632,6 +596,3 @@ The following can be **triaged forward** (documented but not blocking):
 - [Security Posture Report](../../architecture/security/security-posture-report.md)
 - [Smart Features Beta Program](sprint-9-beta-program.md)
 - [Go-Live Assessment](../roadmap/go-live-assessment.md)
-- [Product definition](../../../PRODUCT.md) — invariants this protocol protects
-- [Product obligations](https://github.com/jrmoulckers/product) — `PROD-DISC-001`,
-  `PROD-DISC-002`, `PROD-DISC-003`, `PROD-DISC-004`

--- a/docs/business/sprints/sprint-9-beta-program.md
+++ b/docs/business/sprints/sprint-9-beta-program.md
@@ -9,26 +9,16 @@
 
 ---
 
-> **Satisfies:** `PROD-DISC-002`, `PROD-DISC-003`, `PROD-DISC-004` — Product obligations are
-> defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). Staged exposure
-> with a pre-declared decision rule (`PROD-DISC-002`), participant consent and honest framing
-> (`PROD-DISC-003`), and acting on what was learned (`PROD-DISC-004`) are central obligations.
-> This document is the Sprint 9 beta instance: the specific cohorts, gates, AI-accuracy
-> thresholds, and dates. Per-gate decisions are recorded using
+> **Satisfies:** `PROD-DISC-002`, `PROD-DISC-003`, `PROD-DISC-004` — Product obligations
+> are defined in [jrmoulckers/product](https://github.com/jrmoulckers/product). Staged exposure with a pre-declared decision rule,
+> honest participant framing, and acting on what was learned are central obligations; the
+> cohorts, gates, AI-accuracy thresholds, and dates below are the local Sprint 9 instance.
+> Per-gate decisions are recorded using
 > [`templates/experiment-decision-record.md`](https://github.com/jrmoulckers/product/blob/main/templates/experiment-decision-record.md).
 
 ## Executive Summary
 
-This document records Finance's Sprint 9 beta program for AI-powered features:
-who participates, in what order features are exposed, what accuracy is tracked,
-and the specific thresholds that gate Alpha → Beta → GA. The beta runs for four
-weeks before general availability.
-
-The generic method — how staged exposure, consent, and readout are supposed to
-work — is central and is cited above rather than restated here. What is local is
-the AI-accuracy tracking and the finance-specific success criteria: a
-miscategorized transaction or a wrong forecast is a correctness failure in a
-money product, not a tolerable UX rough edge.
+This document defines the beta program for AI-powered features in the Finance app. It covers participant recruitment, feature rollout strategy, structured feedback mechanisms, accuracy tracking methodology, success criteria, and the feedback-to-improvement pipeline. The beta program runs for 4 weeks before general availability.
 
 ---
 
@@ -87,10 +77,6 @@ Week 5+: General Availability (staged rollout)
 **Recruitment method:** In-app opt-in with beta badge. "Help shape Finance's AI features — join the beta."
 
 ### Participant Rights
-
-> Consent, honest framing, and the freedom to leave are required by
-> `PROD-DISC-003`, and `PROD-MET-002` bounds what may be collected. Listed below
-> is how Finance meets them for this program.
 
 - [ ] Clear explanation of what beta involves before opt-in
 - [ ] Ability to leave beta at any time (instant, no questions)
@@ -272,10 +258,6 @@ Settings → AI Features → Report an Issue
 ---
 
 ## Success Criteria
-
-> These gates are the decision rule for this program, declared before exposure per
-> `PROD-DISC-002`. A gate that is not met means the program does not advance —
-> `PROD-MET-003` forbids reinterpreting a missed threshold after the fact.
 
 ### Alpha → Beta Gate (End of Week 2)
 


### PR DESCRIPTION
## Summary

Restores every passage removed during the Product-authority consolidation (#4030) on the mistaken assumption that central authority carried it. Central does not. The citations added in #4030 are kept — they are correct and useful — but they are now placed **above** the content they attribute rather than in place of it.

The end state is a **purely additive** diff against the pre-consolidation base: `66 files changed, 660 insertions(+), 13 deletions(-)`, with all 13 deletions in the single sanctioned `docs/architecture/roadmap.md` product-identity extraction into `PRODUCT.md`. Zero deletions anywhere else.

## What was wrongly removed, and why it had no central home

Each item below was checked against the ratified body text of the cited principle, not its title.

| Restored content | Had been cited as | Central coverage |
| --- | --- | --- |
| AARRR taxonomy heading and framing | `PROD-MET-001` | None — MET-001 governs individual metric records, not a funnel taxonomy |
| NPS core question and all three conditional follow-ups | `PROD-MET-003` | None — MET-003 governs readout honesty. Exact wording must stay verbatim for cross-quarter comparability |
| "Actionable over vanity" heuristic | `PROD-MET-001` | None — no vanity-metric heuristic exists centrally |
| "Leading indicators" preference | `PROD-MET-001` | None — MET-001 requires a stated decision use; it does not rank metric kinds |
| Qualitative feedback theming method | `PROD-MET-003` | None |
| Weekly review cadence, monthly business review table | `PROD-PLAN-004` | None — PLAN-004 scopes cadence to backlog grooming |
| Financial-data-integrity rationale in the alpha protocol | `PROD-DISC-001` | None — and this was never generic; it is the argument for why the protocol is stricter than a normal alpha |
| < 48h P0/P1 feedback-loop target; "no phase advances until exit criteria are met" | `PROD-DISC-003` | None — DISC-003 requires a proven stop, sets no turnaround target or gate rule |
| Go/no-go checklist, decision matrix, sign-off roster, no-go thresholds | `PROD-REL-001` | Partial — the record *shape* is central; which conditions count as no-go for Finance is not |
| Launch readiness dashboard requirements (Part 1) | `PROD-REL-001` | None — central has a go/no-go record template but no readiness-dashboard shape |
| Impact and effort scoring rubrics, quadrant analysis | `PROD-PLAN-002` | None — central prescribes no scoring method; these are the audit trail for the scores |
| Experiment decision rules, significance thresholds, rollout commitments | `PROD-DISC-002` | Partial — DISC-002 requires *that* a rule exists, not its numeric content |
| KPI five-pillar taxonomy diagram | — | None |

## Corrected citation wording

Three citation blocks asserted that the local method "now lives centrally." That claim was false and load-bearing for the deletions beneath it. Reworded in `growth-metrics-framework.md`, `alpha-testing-protocol.md`, `v10-go-no-go-review.md`, `launch-readiness-dashboard-and-platform-parity.md`, `v2-feature-prioritization-matrix.md`, and `sprint-8-growth-metrics-review.md` to state precisely what central obliges and to say explicitly that the method below is Finance's own and retained in full.

## Root cause

The reductions were made against obligation **titles** rather than ratified **body text**. "Interpret metrics honestly" reads as though it covers survey design; its body is strictly about readout content. "Keep the backlog intentional" reads as general review cadence; its body scopes it to grooming. A citation attributes authority — it does not substitute for substance.

## Issues

Closes #4032

## Testing

- [x] `npm run format` and `npm run format:check` pass
- [x] `git diff --numstat` confirms zero deletions outside `docs/architecture/roadmap.md`
- [x] All five product differentiators and both audience statements verified present in `PRODUCT.md` before accepting the roadmap extraction
- [x] Documentation-only change set; ESLint config targets only `**/*.{ts,tsx,mjs,js}`
