### PR TITLE
docs(guides): record the reusable-workflow registry auth constraint

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -64,6 +64,16 @@ by CI on `main`.
        NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
    ```
 
+   This applies to finance's own workflows, which install dependencies themselves. The
+   **reusable** workflows in `jrmoulckers/.github` that run `npm ci` / `pnpm install` currently
+   set no `registry-url`, no `scope`, and no `NODE_AUTH_TOKEN`, and expose no input or secret to
+   supply one — so a caller cannot fix this from its own side. That is being addressed upstream.
+
+   Ordering consequence: **do not migrate a dependency-installing workflow onto a backbone
+   reusable until both that fix and the token have landed.** It does not affect the workflows
+   finance runs today, but it gates the `deploy-pages.yml` migration, which would otherwise
+   start failing the moment `@jrmoulckers/*` enters the manifest.
+
 ### Then, for ESLint
 
 Install the preset and reduce `eslint.config.mjs` to `base({ ignores, rules, extend })`.


### PR DESCRIPTION
## Summary

Records a sequencing constraint discovered upstream after the adoption PR (#4034) merged: the dependency-installing **reusable** workflows in `jrmoulckers/.github` (`reusable-ci-lint`, `reusable-ci-web`, `reusable-deploy-pages`, `reusable-deploy-preview`, `reusable-perf-budget`, `reusable-smoke-test`) run `npm ci` / `pnpm install` with no `registry-url`, no `scope`, and no `NODE_AUTH_TOKEN` -- and expose no input or secret for a caller to supply one.

## Why it matters here

This is a *latent* constraint, which is exactly why it is worth writing down. Nothing is failing today, and nothing finance currently runs is affected:

- `ci-lint.yml`, `ci-web.yml`, and `ci-security.yml` are local supersets rather than callers, so they install dependencies themselves and can be wired with `NODE_AUTH_TOKEN` independently. **Preset adoption (#4038) is gated only on the token, not on the upstream fix.**
- But migrating any dependency-installing workflow *onto* a backbone reusable would 401 the moment `@jrmoulckers/*` enters `package.json`. That gates #4037 (`deploy-pages.yml`), turning a currently-green deploy path into a broken one if done in the wrong order.

Correct order: upstream adds registry auth -> `read:packages` granted -> then the `deploy-pages.yml` migration.

## Changes

- `docs/guides/engineering-practice-adoption.md` -- distinguishes "wire auth into finance''s own workflows" (possible once the token exists) from "call a backbone reusable" (additionally gated upstream), and states the ordering consequence.

Both affected issues carry the same constraint as comments.

## Issues

Refs #4037
Refs #4038

## Testing

- [x] `prettier --check` passes on the changed file

Docs-only; no code paths touched.
