### PR TITLE
fix(npmrc): drop the interpolated _authToken line

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 @jrmoulckers:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -25,9 +25,17 @@ Upstream: [`docs/adopting.md`](https://github.com/jrmoulckers/engineering/blob/m
 - **Workflow reuse assessed.** See
   [`docs/ops/workflow-reuse-assessment.md`](../ops/workflow-reuse-assessment.md). Action
   pinning already satisfies `GH-ACT-003` — 241/241 refs SHA-pinned.
-- **`.npmrc` committed**, mapping the `@jrmoulckers` scope to GitHub Packages. It is inert
-  until the scope is actually depended on; `npm ci` and `npm install` work normally with
-  `NODE_AUTH_TOKEN` unset (verified).
+- **`.npmrc` committed**, containing the `@jrmoulckers` scope-routing line and nothing else. It
+  is inert until the scope is actually depended on; `npm ci` and `npm install` work normally
+  with no token configured (verified).
+
+  It deliberately carries **no `_authToken` line**. Interpolating `${NODE_AUTH_TOKEN}` into a
+  tracked file puts a credential-shaped string in version control, and when the variable is
+  unset npm sends an _empty_ token rather than none — the registry then answers `401
+unauthenticated: User cannot be authenticated with the token provided`, which points at a bad
+  token when the real problem is a missing one. Credentials belong in the developer's
+  user-level `~/.npmrc`, and in CI in the file `actions/setup-node` generates from
+  `registry-url` + `scope`.
 
 ## Blocked: the shared toolchain presets
 
@@ -49,8 +57,15 @@ by CI on `main`.
 
 1. Grant this repository read access to the packages from the `jrmoulckers/engineering`
    package settings, **or** create a classic PAT with `read:packages` and store it as the
-   `PACKAGES_READ_TOKEN` repository secret.
-2. Developers export the same token locally: `$env:NODE_AUTH_TOKEN = "ghp_..."`.
+   `PACKAGES_READ_TOKEN` repository secret. GitHub Packages accepts **classic PATs only** — a
+   fine-grained token fails with the same `401` as no token at all, so this is worth getting
+   right before debugging.
+2. Developers put the token in their **user-level `~/.npmrc`**, never in the repository's:
+
+   ```text
+   //npm.pkg.github.com/:_authToken=<classic-pat-with-read-packages>
+   ```
+
 3. Add registry auth to every workflow that runs `npm ci`:
 
    ```yaml


### PR DESCRIPTION
## Summary

Removes the interpolated `_authToken` line from the committed `.npmrc`, leaving only the `@jrmoulckers` scope-routing line. Corrects the developer-setup guidance to match. Follows an upstream correction to `docs/adopting.md` in `jrmoulckers/engineering`, whose original guidance recommended the line that this PR removes.

## Why

The failure mode is worse than merely untidy, and I verified it:

```
$ npm view @jrmoulckers/eslint-config version   # NODE_AUTH_TOKEN unset
npm error 401 Unauthorized - unauthenticated: User cannot be authenticated with the token provided.
```

With the variable unset, npm sends an **empty** token rather than no token, so the registry reports a *bad credential* when the real problem is a *missing* one. That is a genuinely misleading error to hand a new developer on day one.

Two further reasons the line does not belong in a tracked file:

- It puts a credential-shaped string (`_authToken=`) in version control, which is a poor pattern to normalise in a financial repo and an invitation for someone to eventually paste a literal token there.
- It is redundant in CI: `actions/setup-node` generates its own `.npmrc` from `registry-url` + `scope`, so the project file only ever needed the routing line.

Credentials now live in the developer''s user-level `~/.npmrc`, and in CI in the setup-node-generated file.

## Also recorded

GitHub Packages accepts **classic PATs only** -- a fine-grained token returns an identical `401`. Worth knowing before anyone burns time debugging a correctly-scoped fine-grained token.

## Verification

- [x] `npm install --package-lock-only --dry-run` succeeds with no token configured -- `.npmrc` remains inert
- [x] `prettier --check` passes on the changed doc
- [x] `.npmrc` stays in `.prettierignore` (still has no inferable parser)

## Issues

Refs #4038
