### PR TITLE
docs(security): record measured npm audit egress and registry routing rules

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -55,6 +55,11 @@ unauthenticated: User cannot be authenticated with the token provided`, which po
   user-level `~/.npmrc`, and in CI in the file `actions/setup-node` generates from
   `registry-url` + `scope`.
 
+  It also routes **by scope only**. Replacing the default registry wholesale would break
+  `npm audit` with `ERR_PNPM_AUDIT_ENDPOINT_NOT_EXISTS`, and no token fixes that. The routing
+  rules and the measured audit egress are recorded in
+  [`docs/security/supply-chain.md`](../security/supply-chain.md).
+
 ## Blocked: the shared toolchain presets
 
 `@jrmoulckers/eslint-config`, `@jrmoulckers/prettier-config`, and `@jrmoulckers/tsconfig` are

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -18,6 +18,33 @@ Attestations are visible at <https://github.com/jrmoulckers/finance/attestations
 - Windows: signed MSI installer and standalone distributable output, plus packaged MSI/EXE/checksum files from `release-platform.yml`.
 - Release manifests: combined `CHECKSUMS.sha256` and all final GitHub Release assets assembled by `release-platform.yml`.
 
+## Registry routing
+
+`.npmrc` routes **by scope only**:
+
+```ini
+@jrmoulckers:registry=https://npm.pkg.github.com
+```
+
+Two rules follow from that line, and both are load-bearing:
+
+- **Never replace the default registry.** A bare `registry=https://npm.pkg.github.com/` breaks `npm audit` with `ERR_PNPM_AUDIT_ENDPOINT_NOT_EXISTS`, because GitHub Packages implements no advisory endpoint and `@npmcli/arborist` resolves it as `auditRegistry || registry` — it never consults the scoped registry. No token fixes this; it is a routing fault, not an auth fault.
+- **Never commit a credential.** `.npmrc` carries no `_authToken`. Tokens are set user-level, or supplied in CI by `actions/setup-node`. A committed project-level `.npmrc` also outranks the user-level file `setup-node` writes, so the routing line above must name the same host the CI token is bound to.
+
+## Audit data egress
+
+`npm audit` sends the resolved dependency set to `registry.npmjs.org` at `POST /-/npm/v1/security/advisories/bulk` (gzip-encoded). Measured against this repository:
+
+| Package class                                      | Transmitted? | Evidence                                                       |
+| -------------------------------------------------- | ------------ | -------------------------------------------------------------- |
+| Public dependencies                                | Yes          | 745 name/version pairs in one request                          |
+| This repo's own `private: true` workspace packages | **No**       | zero `@finance/*` entries in that same request                 |
+| Dependencies resolved from `npm.pkg.github.com`    | **Yes**      | isolated probe sent `{"@jrmoulckers/eslint-config":["0.2.1"]}` |
+
+The exposure is therefore narrower than "private package names leak", but it is real and it is the half that matters: scoping a dependency to a private registry does **not** keep its name and version out of the bulk advisory request. Once `@jrmoulckers/*` is a dependency here, those names and versions reach npmjs on every audit.
+
+This is inherent `npm audit` behaviour, not something the shared toolchain introduces. No financial or user data is involved — the payload is dependency metadata only — so it is recorded rather than mitigated. Suppress it with `npm audit --offline` or omit the audit step where that egress is unacceptable.
+
 ## Policy
 
 Any release marked `production` must have a green provenance attestation for every shipped artifact. Release CI must fail if provenance generation fails; dry-run or non-publishing runs may skip attestation because no production artifact is shipped.


### PR DESCRIPTION
## Summary

Records two supply-chain facts in `docs/security/supply-chain.md`, both measured against this repository rather than taken on description.

## Registry routing

`.npmrc` must route by scope only. A bare `registry=https://npm.pkg.github.com/` override breaks `npm audit` with `ERR_PNPM_AUDIT_ENDPOINT_NOT_EXISTS` — GitHub Packages implements no advisory endpoint, and `@npmcli/arborist` resolves it as `auditRegistry || registry`, so it never consults the scoped registry. **No token fixes it**; it is a routing fault that presents as an auth fault. finance's `.npmrc` was already scope-only, so this is a guardrail against regression, not a fix.

## Audit egress — the upstream claim is half right, and the half that is wrong matters

The claim reaching us was that `npm audit` transmits *private package names* to `registry.npmjs.org`. Intercepted and gunzipped the actual request:

| Package class | Transmitted? | Evidence |
| --- | --- | --- |
| Public dependencies | Yes | 745 name/version pairs in one request |
| This repo's own `private: true` workspace packages | **No** | zero `@finance/*` entries in that same request |
| Dependency resolved from `npm.pkg.github.com` | **Yes** | isolated probe sent `{"@jrmoulckers/eslint-config":["0.2.1"]}` |

So finance's five internal package names (`finance`, `finance-getting-started`, `@finance/web`, `@finance/design-tokens`, `@finance/api`) never leave — npm excludes private workspace roots. But scoping a *dependency* to a private registry does **not** keep it out of the bulk advisory request. Once `@jrmoulckers/*` is depended on here, those names and versions reach npmjs on every audit.

Recorded rather than mitigated: the payload is dependency metadata only, no financial or user data. Noted that `--offline` suppresses it where that egress is unacceptable.

## Issues

Refs #4029

## Testing

- [x] `prettier --write` on both files; second pass clean
- [x] Payload captured twice through a local interception listener, gzip-decoded
- [x] Probe project created inside the repo and fully removed; tree clean
