### PR TITLE
docs: audit ENG-* citations and expand ID ranges into verifiable lists

### DIFF
--- a/docs/architecture/0002-backend-sync-architecture.md
+++ b/docs/architecture/0002-backend-sync-architecture.md
@@ -4,7 +4,7 @@
 **Date:** 2025-07-17
 **Author:** Copilot (AI agent), based on backend/sync research
 **Reviewers:** Pending human review
-**Ratified obligations:** `ENG-LOCAL-001` (local durable ownership), `ENG-LOCAL-002` (optional sync seam), `ENG-LOCAL-004` (zero-config safe degradation), `ENG-DATA-001`–`ENG-DATA-003` — see [practices/local-first-sync.md](https://github.com/jrmoulckers/engineering/blob/main/practices/local-first-sync.md). This ADR records finance's implementation, not the rules.
+**Ratified obligations:** `ENG-LOCAL-001` (local durable ownership), `ENG-LOCAL-002` (optional sync seam), `ENG-LOCAL-004` (zero-config safe degradation), `ENG-DATA-001` (owned durable integrity), `ENG-DATA-002` (versioned bounded data contracts), `ENG-DATA-003` (minimized governed data) — see [practices/local-first-sync.md](https://github.com/jrmoulckers/engineering/blob/main/practices/local-first-sync.md). This ADR records finance's implementation, not the rules.
 
 ## Context
 

--- a/docs/architecture/0020-observability-architecture.md
+++ b/docs/architecture/0020-observability-architecture.md
@@ -6,7 +6,7 @@
 **Reviewers:** Pending human review
 **Sprint:** W2-S11
 **Extends:** [Monitoring Architecture](./monitoring.md) · [Monitoring Infrastructure](./monitoring-infrastructure.md) · [Alerting Rules](./alerting-rules.md)
-**Ratified obligations:** `ENG-OBS-001`–`ENG-OBS-007` (structured signals, live service identity, bounded dependency checks, end-to-end correlation, redacted evidence, SLO evidence, predictable degradation). This ADR records finance's implementation of them, not the rules themselves.
+**Ratified obligations:** `ENG-OBS-001` (structured operational signals), `ENG-OBS-002` (live service identity), `ENG-OBS-003` (bounded dependency checks), `ENG-OBS-004` (end-to-end correlation), `ENG-OBS-005` (redacted observable evidence), `ENG-OBS-006` (SLO evidence), `ENG-OBS-007` (predictable degradation). This ADR records finance's implementation of them, not the rules themselves.
 
 ## Context
 

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -243,6 +243,36 @@ desktop|Kotlin|Swift|multiplatform` returns a single incidental match. finance s
    profiling, the practice that would explain how is web-shaped, and there is no native area to
    host the obligation in the first place. Requesting an `ENG-NATIVE-*` (or `ENG-APP-*`) area.
 
+7. **`scripts/check-citations.mjs` does not expand ID ranges.** The checker resolves literal IDs
+   only, so a citation written as `` `ENG-OBS-001`–`ENG-OBS-007` `` is scanned as exactly two
+   citations and the five in between are never verified. That is precisely where a
+   wrong-meaning citation hides best: a range asserts something about every member while
+   showing the reader only the endpoints. In this repository the ranges concealed five IDs
+   (`ENG-OBS-002`–`006`, `ENG-DATA-002`) — all correct on manual check, but invisible to the
+   tool that exists to check them. Requesting that the checker either expand `NNN`–`NNN` ranges
+   within an area or warn that it cannot.
+
+## Citation audit
+
+Verified with `scripts/check-citations.mjs --review` at `v0.2.10`, run over all 804 markdown
+files: **42 literal citations across 27 distinct principles, every ID valid, and every
+principle's true title matching the claim made about it.** The wrong-meaning defect found
+elsewhere in the org did not reach finance.
+
+Two notes, because the exit code is not the result:
+
+- **`ENG-ARCH-003` is cited here correctly**, as the obligation to keep durable decision
+  records, in `docs/architecture/README.md`. It is one of the IDs miscited elsewhere, so it was
+  checked directly rather than assumed.
+- **Ranges were rewritten as explicit lists.** ADR-0002 and ADR-0020 previously cited
+  `ENG-DATA-001`–`003` and `ENG-OBS-001`–`007`. Both are now enumerated with each principle's
+  title inline, which brings five previously unverifiable IDs under the checker and removes the
+  blind spot described in gap 7. Prefer enumerated citations over ranges for this reason.
+
+Finance cites **nothing** for accessibility, test colocation, or service-tier structure — there
+is no ratified principle for any of them, and the prose covering them stays product-specific and
+uncited.
+
 ## Principles finance declines
 
 **None.** All 66 apply or are inapplicable-but-not-contradicted; none conflict with finance's


### PR DESCRIPTION
## Summary

Ran `scripts/check-citations.mjs --review` at `v0.2.10` over all 804 markdown files in the repository, including everything already merged.

**Result: clean.** 42 literal citations across 27 distinct principles. Every ID exists, and every principle's true title matches the claim made about it. The wrong-meaning citation defect found in libro did not spread here.

`ENG-ARCH-003` was checked directly rather than assumed, since it is one of the three IDs miscited elsewhere. Finance cites it in `docs/architecture/README.md` as the obligation to keep durable decision records — which is what it is.

Finance cites **nothing** for accessibility, test colocation, or service-tier structure. There is no ratified principle for any of them, so that prose stays product-specific and uncited.

## But the exit code is not the result — the checker has a blind spot

`check-citations.mjs` resolves **literal IDs only**. A citation written as:

```
`ENG-OBS-001`–`ENG-OBS-007` (structured signals, live service identity, ...)
```

is scanned as exactly **two** citations. The five in between are never verified.

That is precisely where a wrong-meaning citation hides best: a range asserts something about *every* member while showing the reader only the endpoints. Finance had two such ranges, concealing five IDs — `ENG-OBS-002`–`006` and `ENG-DATA-002`. All five turned out correct on manual check against `principles/index.json`, but they were invisible to the tool whose entire job is to check them.

Both are now enumerated with each principle's title inline, bringing them under the checker.

## Changes

- `docs/architecture/0002-backend-sync-architecture.md` — `ENG-DATA-001`–`003` expanded to three glossed citations
- `docs/architecture/0020-observability-architecture.md` — `ENG-OBS-001`–`007` expanded to seven glossed citations
- `docs/guides/engineering-practice-adoption.md` — new **Citation audit** section recording the result and method; new upstream gap 7 requesting the checker expand ranges or warn that it cannot

## Issues

Refs #4029

## Testing

- [x] `check-citations.mjs --review` over 804 files, before and after; exit 0 both times, all IDs resolve
- [x] Five range-hidden IDs resolved by hand against `principles/index.json` (66 principles)
- [x] `prettier --write` on all three files; no reformatting needed
