### PR TITLE
docs: cite ENG-PERF-009 additively over finance's accessibility commitment

### DIFF
--- a/docs/audits/accessibility-audit-wcag22.md
+++ b/docs/audits/accessibility-audit-wcag22.md
@@ -6,6 +6,10 @@
 > **Scope:** All 4 platforms (iOS, Android, Web, Windows)
 > **Standard:** WCAG 2.2 Level AA
 
+WCAG 2.2 AA is finance's own commitment; no ratified principle mandates it. `ENG-PERF-009`
+(assurance precedence) applies _additively_: whatever this audit finds, it may not be traded away
+to meet a performance budget.
+
 ---
 
 ## Executive Summary

--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -4,6 +4,11 @@ Finance is designed to be usable by everyone, regardless of ability. Accessibili
 
 This guide covers the accessibility features available in Finance and how to use them.
 
+WCAG 2.2 AA is a finance commitment, not a ratified obligation — no `ENG-*` principle covers
+accessibility. Two apply additively rather than as its source: `ENG-PERF-009` (assurance
+precedence) forbids trading any of the below away to hit a performance budget, and `ENG-PERF-002`
+(versioned performance budgets) is what it would be traded against.
+
 ---
 
 ## Table of Contents

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -254,10 +254,9 @@ desktop|Kotlin|Swift|multiplatform` returns a single incidental match. finance s
 
 ## Citation audit
 
-Verified with `scripts/check-citations.mjs --review` at `v0.2.10`, run over all 804 markdown
-files: **42 literal citations across 27 distinct principles, every ID valid, and every
-principle's true title matching the claim made about it.** The wrong-meaning defect found
-elsewhere in the org did not reach finance.
+Verified with `scripts/check-citations.mjs --review` at `v0.2.11`, run over all 804 markdown
+files: **every ID valid, and every principle's true title matching the claim made about it.** The
+wrong-meaning defect reported elsewhere in the org did not reach finance.
 
 Two notes, because the exit code is not the result:
 
@@ -269,9 +268,21 @@ Two notes, because the exit code is not the result:
   title inline, which brings five previously unverifiable IDs under the checker and removes the
   blind spot described in gap 7. Prefer enumerated citations over ranges for this reason.
 
-Finance cites **nothing** for accessibility, test colocation, or service-tier structure — there
-is no ratified principle for any of them, and the prose covering them stays product-specific and
-uncited.
+Finance cites **nothing as the source** of its accessibility, test-colocation, or service-tier
+requirements — there is no ratified principle for any of them. Those are finance commitments and
+say so. Where a ratified principle bears on them _additively_, that is now stated as such rather
+than omitted:
+
+- `docs/guides/accessibility.md` and `docs/audits/accessibility-audit-wcag22.md` note that
+  `ENG-PERF-009` (assurance precedence) forbids trading accessibility away for performance. It is
+  not the source of the WCAG 2.2 AA commitment; it constrains what may be done to it.
+- Test colocation is named as a finance convention; the obligation it serves is `ENG-TEST-003`
+  (regression boundaries).
+
+The distinction is worth stating precisely, because the two readings differ in what they license.
+"Accessibility follows `ENG-PERF-009`" is false and would make the WCAG commitment look
+negotiable by amending a principle finance does not own. "`ENG-PERF-009` additionally forbids
+trading it away" is true and adds a constraint without relocating authority.
 
 ## Principles finance declines
 


### PR DESCRIPTION
## Summary

Re-ran `scripts/check-citations.mjs --review` at `v0.2.11` over all 804 markdown files. **62 citations across 34 principles, every ID valid, every principle's title matching the claim made about it.** Clean, as at `v0.2.10`.

The `v0.2.11` context view — which shows surrounding lines and marks the citing line with `>` — did change the reading experience materially for this repository. Finance wraps markdown links heavily, so under `v0.2.10` a wrapped link left several citing lines showing only a bare URL with no visible claim.

## Applies the additive-citation model

Finance previously cited **nothing** over its accessibility docs, on the correct grounds that no ratified principle mandates accessibility. That stays true, but "cite nothing" lost a real constraint.

`ENG-PERF-009` (assurance precedence) is now cited in `docs/guides/accessibility.md` and `docs/audits/accessibility-audit-wcag22.md` for what it actually does — forbidding accessibility from being traded away to meet a performance budget. It is explicitly **not** named as the source of the WCAG 2.2 AA commitment, which remains finance's own.

The two readings are not interchangeable, and the difference is what each licenses:

- *"Accessibility follows `ENG-PERF-009`"* — **false.** It relocates authority for the WCAG commitment onto a principle finance does not own, making the commitment look amendable by editing that principle.
- *"`ENG-PERF-009` additionally forbids trading it away"* — **true.** Adds a constraint without moving authority.

## Changes

- `docs/guides/accessibility.md` — additive citation; WCAG 2.2 AA named as a finance commitment
- `docs/audits/accessibility-audit-wcag22.md` — same, scoped to the audit's findings
- `docs/guides/engineering-practice-adoption.md` — citation-audit section updated to `v0.2.11`; records the additive model and why the distinction matters

## Issues

Refs #4029

## Testing

- [x] `check-citations.mjs --review` at `v0.2.11`, before and after; exit 0, 62/34 all resolving
- [x] `prettier --write` on all three files; no reformatting needed
