### PR TITLE
ci(lint): document why the guardrail greps absorb exit 1 (#4029)

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -160,6 +160,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check for console logging in production code
+        # The `|| echo ""` below is load-bearing, not defensive noise: grep exits 1
+        # when it matches nothing, which here is the SUCCESS case. Without it the
+        # step goes red on a clean repository (and under `-o pipefail`, on any
+        # stage of the pipe matching nothing). Verified: clean=0, violation=1,
+        # `// SAFE:`=0, `.spec.`=0. Do not "simplify" it away.
         run: |
           CONSOLE_HITS=$(grep -rn 'console\.log\|console\.warn\|console\.error' \
             --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' \
@@ -185,6 +190,9 @@ jobs:
           fi
 
       - name: Check for sensitive data logging
+        # See the note on the previous step: the `|| echo ""` absorbs grep's
+        # exit 1 (no match), which is this check's success case. Removing it
+        # inverts the gate — it would fail on repositories with no violations.
         run: |
           SENSITIVE_PATTERNS=(
             'password'


### PR DESCRIPTION
## Summary

Comments only, no behaviour change — but they document a real bug found elsewhere and verified absent here.

The engineering repo generalised finance's `observability-guardrails` check into `practices/observability.md`, and the first transcription **failed on a clean repository**. Cause: `grep` exits `1` when it matches nothing, which for these guardrails is the *success* case. Without a guard, that non-zero becomes the step's exit status — so the gate goes red precisely on repos with no violations, and green logic is inverted.

Finance's version is correct, because both `run:` blocks wrap their pipelines in `$( ... || echo "" )`. That guard reads as redundant, which is exactly what puts it at risk from a future tidy-up. Hence the comments.

## Verified, not assumed

Both `run:` blocks were extracted verbatim and executed against fixture trees, under GitHub's default `bash -e` **and** the `shell: bash` form `bash -eo pipefail`:

| Case                | Expected | Actual |
| ------------------- | -------- | ------ |
| Clean tree          | 0        | **0**  |
| Planted violation   | 1        | **1**  |
| `// SAFE:` waiver   | 0        | **0**  |
| `.spec.ts` excluded | 0        | **0**  |
| Kotlin + `api_key`  | 1        | **1**  |

Both shell modes matter: the default for `run:` on Linux is `bash -e {0}`, but adding `shell: bash` switches to `bash --noprofile --norc -eo pipefail {0}`. Under `pipefail` a *later* stage matching nothing also fails the pipeline, so the guard has to wrap the whole thing rather than the first grep. It does.

The violation and waiver cases are the ones worth keeping: a guardrail that cannot fail is worse than one that fails wrongly, because nothing reports it.

## Issues

Refs #4029

## Testing

- [x] Both steps executed under `bash -e` and `bash -eo pipefail`, five paths each
- [x] Workflow YAML re-parsed; all four steps of `observability-guardrails` intact
- [x] `prettier --check .github/workflows/ci-lint.yml`
