### PR TITLE
docs(ai): record .vscode/mcp.json as an explicit local MCP overlay

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,5 +1,16 @@
 {
   // MCP server configuration for VS Code Copilot Agent Mode (JSONC — comments allowed).
+  //
+  // EXPLICIT LOCAL OVERLAY — NOT DRIFT. The canonical studio MCP policy is `agency.toml`
+  // (synced from jrmoulckers/.github). That canon enables only the intrinsically bounded
+  // servers by default and keeps `playwright` and `memory` as commented, pinned opt-ins
+  // pending verification of the host's tool-filter enforcement. This file deliberately
+  // declares a SUPERSET for the VS Code Agent Mode host: it adds `github`, `filesystem`
+  // and `supabase`, and enables `playwright` and `memory`. That divergence is intentional
+  // and member-owned — do not "reconcile" it against `agency.toml`, and do not treat it as
+  // sync drift. `agency.toml` remains the canonical policy; this is the local runtime
+  // opt-in recorded alongside it, per the note in that file. See docs/ai/mcp.md.
+  //
   // SECURITY HARDENING (audit #2856/#2857/#2858/#2878/#2879):
   //   * Every npx server is pinned to an EXACT version — no @latest, no floating tags.
   //   * No secret is ever passed as a --flag=value on argv; secrets flow via ${input:...} (env/header).


### PR DESCRIPTION
Comment-only. Records `.vscode/mcp.json` as a deliberate local overlay so nobody mistakes it for sync drift.

Refs #4056

## Why

The canonical MCP policy is `agency.toml`, synced from `jrmoulckers/.github`. It enables only the intrinsically bounded servers by default and keeps `playwright` and `memory` as **commented, pinned opt-ins**, pending verification that the consuming host actually enforces tool allowlists.

This repo's `.vscode/mcp.json` declares a **superset** for the VS Code Copilot Agent Mode host: it adds `github`, `filesystem` and `supabase`, and enables `playwright` and `memory`.

That divergence is intentional and member-owned — `agency.toml` itself anticipates it (''A local runtime may opt in only after proving that it exposes exactly the reviewed list and **recording that policy locally**''). But it was nowhere written down, so on inspection it read as unreconciled drift against canon.

This adds a header comment stating plainly that the file is an explicit local overlay, that `agency.toml` remains the canonical policy, and that the difference must not be ''reconciled'' away.

## Changes

`.vscode/mcp.json` — 11 added comment lines. No servers, versions, inputs, args or env changed. Zero behavior change.

## Context

Authored during the 2026-08-10 studio canon work; it originally rode on `studio-sync/2026-08-10` (PR #4045), which was closed as superseded. Re-landing standalone so it is not lost with that branch. It is member-owned content unrelated to canon and does not belong in a sync PR anyway.

## Not addressed here

- `Deploy Preview` fails on every PR in this repo with `VERCEL_TOKEN is required for trusted preview deployments`. Pre-existing and unrelated; reproduces on Dependabot and unrelated feature branches. Non-required, so it does not gate merge. Needs the repo secret configured.

## Testing

- [x] `npx prettier --check .vscode/mcp.json` — clean
- [x] Diff vs `main` is 11 comment lines in one file