### PR TITLE
fix(git): restore .bat/.cmd and binary carve-outs below canon region (#4067)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,22 @@
 # This prevents `core.autocrlf` from converting LF → CRLF on Windows,
 # keeping Prettier (`endOfLine: "lf"`) and EditorConfig (`end_of_line = lf`)
 # happy on all platforms.
+#
+# The general LF rule is owned by the studio:base managed region below.
+# Member-specific exceptions MUST stay after that region: .gitattributes is
+# last-match-wins, so any carve-out placed above it is silently overridden.
 
+# studio:base:start
+# synced from jrmoulckers/.github — canonical source; do not edit here
+# Normalize every detected text file to LF in the index and working tree.
+# Git's automatic text detection leaves binary files byte-for-byte unchanged.
 * text=auto eol=lf
+# studio:base:end
 
-# Windows batch files must keep CRLF
+# --- Member-owned exceptions (must remain below the managed region) ---
+
+# Windows batch files must keep CRLF — cmd.exe is unreliable with LF-only
+# scripts, and gradlew.bat is tracked with CRLF.
 *.bat text eol=crlf
 *.cmd text eol=crlf
 
@@ -20,10 +32,3 @@
 *.apk binary
 *.aab binary
 *.keystore binary
-
-# studio:base:start
-# synced from jrmoulckers/.github — canonical source; do not edit here
-# Normalize every detected text file to LF in the index and working tree.
-# Git's automatic text detection leaves binary files byte-for-byte unchanged.
-* text=auto eol=lf
-# studio:base:end


### PR DESCRIPTION
## Summary

The `studio:base` managed region added to `.gitattributes` by #4062 was appended **after** the pre-existing member-authored carve-outs. `.gitattributes` is **last-match-wins**, so canon's `* text=auto eol=lf` silently overrode every exception above it.

This is an ordering collision, not a defect in canon's content.

## Verified regression

`git check-attr`, measured at `a450c472^` (pre-merge) vs `main`:

| Path | Before | After #4062 |
| --- | --- | --- |
| `gradlew.bat` | `eol: crlf` | **`eol: lf`** |
| `*.cmd` | `eol: crlf` | **`eol: lf`** |
| `*.png` | `text: unset` (`-text`) | **`text: auto`** |
| `*.jar` / `*.keystore` | `text: unset` (`-text`) | **`text: auto`** |

**`gradlew.bat` is the live case** — it is the only tracked `.bat` file and is stored in the index with **91 CRLF pairs**. A fresh clone or `git add --renormalize` would rewrite it to LF. Windows is a first-class build target here, and `cmd.exe` is unreliable with LF-only batch scripts.

The binary carve-outs are a lost safety net rather than guaranteed corruption — Git's content detection still usually spots binaries via NUL bytes — but `-text` on keystores and APKs is a protection the repo wrote deliberately and shouldn't lose silently.

## Fix

Moved the member-owned exceptions **below** the managed region, restoring general-rule-then-exceptions ordering, and added a comment explaining why they must stay there.

Verified after the change:

```
marker pairs:                            1 1
managed region byte-identical to main:   true
gradlew.bat  -> eol: crlf      (restored)
*.cmd        -> eol: crlf      (restored)
*.png        -> text: unset    (restored)
src/main.ts  -> text: auto, eol: lf   (canon's rule still governs text)
```

The managed region is untouched, so this introduces **no drift** and nothing will be skipped on the next sync.

## Pre-existing, NOT fixed here

`git add --renormalize .` also flags three iOS files stored with CRLF in the index — `BudgetStatusView.swift` (48), `ComplicationProvider.swift` (64), `WatchDataSenderTests.swift` (66). They are unaffected by this change (no Swift carve-out exists before or after) and normalizing them is a separate, larger commit that would touch iOS source. Reported rather than bundled.

## Upstream note

finance's `.gitattributes` was previously **wholly member-authored with no managed region**, and already implemented canon's LF behavior by independent authorship. #4062 adopted a managed region into it. Any member with pre-existing carve-outs will hit this same collision when canon's block lands last — worth feeding back to `jrmoulckers/.github`.

Closes #4067
