### PR TITLE
docs(tokens): correct the false layer-ownership claim in theme/tokens.css

### DIFF
--- a/apps/web/src/theme/tokens.css
+++ b/apps/web/src/theme/tokens.css
@@ -1,24 +1,48 @@
 /**
  * Design token CSS imports.
  *
- * Finance renders from TWO layered token sources:
+ * Finance renders from TWO layered token sources. They are NOT split by
+ * concern — both carry a structural layer. They are split by NAMING, which is
+ * a transitional state, not a design (#4069).
  *
- *   1. @finance/design-tokens (base) — supplies the STRUCTURAL layer finance
- *      consumes pervasively and that the shared package does not own:
- *      numeric spacing (--spacing-4), type scale (--type-scale-*),
- *      radii (--border-radius-*), elevation (--elevation-*), motion
- *      (--duration-*, --easing-*, --animation-*), component tokens, and the
- *      primitive color ramps. It also seeds the semantic COLOR layer, which
- *      the shared layer below overrides.
+ *   1. @finance/design-tokens (base) — supplies the structural vocabulary that
+ *      finance's own components actually reference: numeric spacing
+ *      (--spacing-4), type scale (--type-scale-*), radii (--border-radius-*),
+ *      elevation (--elevation-*), motion (--duration-*, --easing-*,
+ *      --animation-*), component tokens, and the primitive color ramps. It also
+ *      seeds the semantic COLOR layer, which the shared layer below overrides.
  *
  *   2. @jrm/tokens (shared JRM Studio DNA, vendored under the repo-root
- *      vendor/ so all four platform apps share one copy) —
- *      overrides the shared --semantic-* COLOR layer (background/text/border/
- *      interactive/status/accent) and OWNS the mode variants
+ *      vendor/ so all four platform apps share one copy) — its index.css is an
+ *      aggregate BARREL, not a color-only sheet: its first import is
+ *      ./tokens.css, the structural sheet. So the shared layer DOES own and
+ *      DOES deliver spacing, radius, font, elevation, shadow, motion, layer,
+ *      and component tokens — finance loads all of them on every page.
+ *      It additionally overrides the --semantic-* COLOR layer (background/text/
+ *      border/interactive/status/accent) and OWNS the mode variants
  *      ([data-theme="dark|dark-oled|high-contrast"]), the prefers-color-scheme
  *      / prefers-contrast AUTO-SWITCHING, reduced-motion, and the cognitive
- *      [data-a11y-cognitive="true"] block. Imported AFTER the base so its
- *      brand colors win by cascade order.
+ *      [data-a11y-cognitive="true"] block. Imported AFTER the base so it wins
+ *      by cascade order.
+ *
+ * WHY BOTH STILL EXIST: the two layers mostly use DIFFERENT NAMES for the same
+ * concepts (--border-radius-* vs --radius-*, --type-scale-* vs --font-size-*),
+ * so they coexist instead of one replacing the other, and finance's components
+ * still point at the finance-named ones. Retiring @finance/design-tokens is
+ * therefore a RENAME MIGRATION, not a wiring fix — nothing here is
+ * mis-imported. Do NOT "fix" the imports; see #4069.
+ *
+ * WHERE THEY DO COLLIDE: 65 variable names are defined by both layers and the
+ * shared layer wins all of them; 33 resolve to a value finance did not intend.
+ * Most are the intended semantic color overrides, but some are not — notably
+ * --easing-standard, which finance defines as cubic-bezier(0.2, 0, 0, 1) and
+ * the shared layer redefines as the `ease` keyword. Tracked in #4069; do not
+ * assume a token named here resolves to the value defined in layer 1.
+ *
+ * CAUTION when migrating: map radii BY VALUE, never by name. finance's t-shirt
+ * radius names are shifted one step from the shared scale
+ * (--border-radius-sm is 4px; the shared --radius-sm is not), so a
+ * name-preserving rename silently changes corner radii and nothing fails.
  *
  * A thin finance-overlay.css then covers the finance-specific color delta the
  * shared layer does not own (e.g. --semantic-amount-*).
@@ -50,11 +74,13 @@
 /* High-contrast theme — explicit toggle via [data-theme="high-contrast"] */
 @import '../../../../packages/design-tokens/build/web/tokens-high-contrast.css';
 
-/* --- Layer 2: shared JRM Studio @jrm/tokens (semantic color DNA + modes) ----
- * Vendored, registry-free copy of the shared package. Its barrel emits the
- * light + [data-theme=*] mode blocks, prefers-color-scheme / prefers-contrast
- * auto-switching, reduced-motion, and the cognitive block, so finance defers
- * to it for all mode/auto-switch color behaviour (see below — finance's own
+/* --- Layer 2: shared JRM Studio @jrm/tokens (structure + semantic color DNA)
+ * Vendored, registry-free copy of the shared package. index.css is the
+ * aggregate barrel: it pulls in ./tokens.css (the STRUCTURAL sheet) plus the
+ * dark / dark-oled / high-contrast sheets, then emits the light +
+ * [data-theme=*] mode blocks, prefers-color-scheme / prefers-contrast
+ * auto-switching, reduced-motion, and the cognitive block. Finance defers to it
+ * for all mode/auto-switch color behaviour (see below — finance's own
  * hand-written auto-switch blocks were removed to avoid double-definition). */
 @import '../../../../vendor/@jrm/tokens/css/default/index.css';
 


### PR DESCRIPTION
Corrects a false claim in the `apps/web/src/theme/tokens.css` header that was the stated justification for keeping `@finance/design-tokens` alive as a parallel structural layer.

**Comment-only. No token values, imports, selectors, or behaviour changed.** Verified: filtering the diff to non-comment lines yields nothing.

## The false claim

The header said `@finance/design-tokens` supplies the structural layer *"that the shared package does not own"*. It does own it. `vendor/@jrm/tokens/css/default/index.css` is an aggregate barrel, not a colour-only sheet — its first import is the structural sheet:

```css
@import './tokens.css';
@import './tokens-dark.css';
@import './tokens-dark-oled.css';
@import './tokens-high-contrast.css';
```

Finance already loads Studio's spacing, radius, font, elevation, shadow, motion, layer, and component tokens on every page. **There is no import bug** — the old comment invited a "fix the imports" reading that would be wrong, so the new text says so explicitly.

## What is actually true

Both layers carry structure. They are split by **naming**, not by concern:

| finance | Studio |
| --- | --- |
| `--border-radius-*` | `--radius-*` |
| `--type-scale-*` | `--font-size-*` (semantic roles) |

Because the names differ, the layers coexist rather than one replacing the other, and finance's components still point at the finance-named ones. Retiring the local package is therefore a **rename migration**, not a wiring fix.

## Measured collisions now recorded in the file

Parsed both built sheets. **65 names are defined by both layers**; since `index.css` is imported after the finance base, **Studio wins all 65**, and **33 resolve to a value finance did not intend**.

Most are the intended semantic colour overrides. These are not, and have live usage in `apps/web/src`:

| var | finance intends | actual (Studio wins) | usages |
| --- | --- | --- | --- |
| `--easing-standard` | `cubic-bezier(0.2, 0, 0, 1)` | `ease` | **19** |
| `--input-padding-y` | `var(--spacing-2)` -> 8px | `11px` | 6 |
| `--input-padding-x` | `var(--spacing-3)` -> 12px | `var(--spacing-md)` -> 14px | 6 |
| `--card-shadow` | `var(--elevation-low)` | `var(--shadow-lift)` | 10 |
| `--duration-reduced` | `1ms` | `0ms` | 0 |
| `--z-index-*` | 1100-1700 | 100-3000 | 0 |

`--easing-standard` is the sharpest: 19 call sites animate with the `ease` keyword rather than finance's tuned bezier.

Two mitigating details, both verified: z-index **relative order is preserved** (`sticky < overlay < modal < toast < tooltip` in both), so stacking is not broken — only absolute values differ. And `--card-padding` collides but both sides resolve to 16px, so it is benign.

**This PR does not change any of those values.** It records them so the next reader does not assume a token resolves to the value defined in layer 1.

## Also added

A `map radii BY VALUE, never by name` caution. finance's t-shirt radius names are shifted one step from the shared scale (`--border-radius-sm` is 4px; the shared `--radius-sm` is not), so a name-preserving rename would silently change corner radii with nothing failing.

## Validation

- `npx prettier --check apps/web/src/theme/tokens.css` -> **All matched files use Prettier code style!**
- `npx vitest run src/accessibility/__tests__/wcag-audit.test.ts src/components/gdpr/ConsentDialog.contrast.test.tsx` -> **2 files / 58 tests passed**. These parse and read this exact file plus the vendored token CSS, so they confirm the comment edit did not disturb the import chain.
- Non-comment diff lines: **none**.

## Scope

`packages/design-tokens` is **not** touched. Its retirement is separate work, and it remains blocked: finance's vendored `tokens.css` is 17,817 bytes / 331 vars — a much thinner structural head than the current Studio build (spacing 7 not 68, radius 4 not 42). The unambiguous numeric radius ladder a migration should target (`--radius-1` ... `--radius-8`) does not exist in the vendored copy, which has only `--radius-sm: 9px`, `--radius-md: 14px`, `--radius-chip: 10px`, `--radius-pill: 999px`. Studio's `dist/` is a gitignored build artifact, so the newer build has not reached finance via sync yet.

## Issues

Closes #4069

## Testing

- [x] `npx prettier --check` on the changed file
- [x] `npx vitest run` — 58 tests covering token CSS resolution
- [x] Confirmed diff is comment-only
