### PR TITLE
fix(web): define-or-fallback 7 dangling CSS custom properties (#4073)

### DIFF
--- a/apps/web/src/components/common/SyncIndicator.tsx
+++ b/apps/web/src/components/common/SyncIndicator.tsx
@@ -74,7 +74,7 @@ export const SyncIndicator: React.FC<SyncIndicatorProps> = ({ className = '' }) 
         borderRadius: '999px',
         border: `1px solid ${borderColor}`,
         background,
-        color: 'var(--color-text-primary)',
+        color: 'var(--semantic-text-primary)',
         fontSize: '0.75rem',
         fontWeight: 600,
         lineHeight: 1,

--- a/apps/web/src/components/estate/estate-inventory.css
+++ b/apps/web/src/components/estate/estate-inventory.css
@@ -406,7 +406,7 @@
   }
 
   .estate-checklist__item--complete {
-    border-left-color: var(--semantic-status-success);
+    border-left-color: var(--semantic-status-positive);
   }
 
   .estate-checklist__item--needs-work {

--- a/apps/web/src/components/forms/TransactionForm.tsx
+++ b/apps/web/src/components/forms/TransactionForm.tsx
@@ -1552,7 +1552,7 @@ export function TransactionForm({
                 style={{
                   color:
                     hasSplitRows && !splitValidation.isBalanced
-                      ? 'var(--semantic-text-danger)'
+                      ? 'var(--semantic-status-negative)'
                       : 'var(--semantic-text-secondary)',
                   marginBottom: 'var(--spacing-2)',
                 }}

--- a/apps/web/src/pages/FirePlannerPage.css
+++ b/apps/web/src/pages/FirePlannerPage.css
@@ -261,7 +261,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1);
-  font-size: var(--type-scale-body-small-font-size);
+  font-size: var(--type-scale-caption-font-size);
   color: var(--semantic-text-primary);
   cursor: pointer;
 }
@@ -300,14 +300,14 @@
 }
 
 .fire-scenario-btn__mult {
-  font-size: var(--type-scale-body-small-font-size);
+  font-size: var(--type-scale-caption-font-size);
   color: var(--semantic-text-secondary);
 }
 
 .fire-results__scenario-note {
   margin: 0 0 var(--spacing-4) 0;
   color: var(--semantic-text-secondary);
-  font-size: var(--type-scale-body-small-font-size);
+  font-size: var(--type-scale-caption-font-size);
 }
 
 /* FI progress bar + income replacement (#3320). */
@@ -353,7 +353,7 @@
 .fire-progress__replacement {
   margin: 0;
   color: var(--semantic-text-secondary);
-  font-size: var(--type-scale-body-small-font-size);
+  font-size: var(--type-scale-caption-font-size);
 }
 
 /* Comparison / sensitivity tables (#3317, #3319). */
@@ -372,13 +372,13 @@
 .fire-table__note {
   margin: 0 0 var(--spacing-2) 0;
   color: var(--semantic-text-secondary);
-  font-size: var(--type-scale-body-small-font-size);
+  font-size: var(--type-scale-caption-font-size);
 }
 
 .fire-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: var(--type-scale-body-small-font-size);
+  font-size: var(--type-scale-caption-font-size);
 }
 
 .fire-table th,

--- a/apps/web/src/pages/TransactionDetailPage.tsx
+++ b/apps/web/src/pages/TransactionDetailPage.tsx
@@ -469,8 +469,8 @@ export const TransactionDetailPage: React.FC = () => {
               border: 'none',
               cursor: 'pointer',
               padding: 'var(--spacing-2) 0',
-              fontSize: 'var(--type-scale-subheading-font-size)',
-              fontWeight: 'var(--type-scale-subheading-font-weight)',
+              fontSize: 'var(--type-scale-title-font-size)',
+              fontWeight: 'var(--type-scale-title-font-weight)',
               color: 'var(--semantic-text-primary)',
               textAlign: 'left',
             }}
@@ -562,7 +562,7 @@ export const TransactionDetailPage: React.FC = () => {
                             style={{
                               textAlign: 'left',
                               padding: 'var(--spacing-1) var(--spacing-2)',
-                              borderBottom: '1px solid var(--semantic-border-primary)',
+                              borderBottom: '1px solid var(--semantic-border-default)',
                               fontWeight: 600,
                             }}
                           >
@@ -573,7 +573,7 @@ export const TransactionDetailPage: React.FC = () => {
                             style={{
                               textAlign: 'left',
                               padding: 'var(--spacing-1) var(--spacing-2)',
-                              borderBottom: '1px solid var(--semantic-border-primary)',
+                              borderBottom: '1px solid var(--semantic-border-default)',
                               fontWeight: 600,
                             }}
                           >
@@ -587,7 +587,7 @@ export const TransactionDetailPage: React.FC = () => {
                             <td
                               style={{
                                 padding: 'var(--spacing-1) var(--spacing-2)',
-                                borderBottom: '1px solid var(--semantic-border-primary)',
+                                borderBottom: '1px solid var(--semantic-border-default)',
                               }}
                             >
                               {key}
@@ -595,7 +595,7 @@ export const TransactionDetailPage: React.FC = () => {
                             <td
                               style={{
                                 padding: 'var(--spacing-1) var(--spacing-2)',
-                                borderBottom: '1px solid var(--semantic-border-primary)',
+                                borderBottom: '1px solid var(--semantic-border-default)',
                               }}
                             >
                               {value}


### PR DESCRIPTION
## Summary

Seven CSS custom properties were referenced in `apps/web/src` with **neither a definition anywhere nor a `var()` fallback**, across **15 call sites**. Each silently dropped its declaration at computed-value time — the element rendered with an inherited or initial value, nothing errored, and no test failed.

Closes #4073

## Changes

| Property | Refs | Replacement |
| --- | --- | --- |
| `--type-scale-body-small-font-size` | 6 | `--type-scale-caption-font-size` |
| `--semantic-border-primary` | 4 | `--semantic-border-default` |
| `--type-scale-subheading-font-size` | 1 | `--type-scale-title-font-size` |
| `--type-scale-subheading-font-weight` | 1 | `--type-scale-title-font-weight` |
| `--semantic-status-success` | 1 | `--semantic-status-positive` |
| `--semantic-text-danger` | 1 | `--semantic-status-negative` |
| `--color-text-primary` | 1 | `--semantic-text-primary` |

Each was mapped to the vocabulary already defined in its own namespace, not guessed. The strongest case is `--semantic-status-success`: the *same file* uses `--semantic-status-warning` (line 413) and `--semantic-status-negative` (line 289), and the defined set is `positive / negative / warning / info / neutral / pending` — `success` was never a member.

## Accessibility impact

Two are not cosmetic:

- **`TransactionForm.tsx:1555`** is an `aria-live="polite"` split-balance validation message. Its failure state was meant to render in the danger colour and instead inherited, conveying the error with less colour distinction than intended.
- **`estate-inventory.css:409`** is the `--complete` checklist state. Its sibling `--needs-work` resolved correctly, so complete and incomplete items were less distinguishable than designed.

## Deliberately unchanged

- `utils/browserCompat.ts:109` — `CSS.supports('color', 'var(--test)')` is a feature probe; `--test` is *supposed* to be undefined.
- `lib/a11y.test.ts:193` — asserts an unresolvable var returns `null`. Correct as written.
- `lib/display-settings.ts:73` — `var(--semantic-text-secondary, var(--color-text-secondary))`; the outer name is defined so the inner is unreachable. Harmless.

## Testing

Census was re-run after the change: **7 real defects → 0**, with only the 3 documented intentional cases remaining.

- [x] `npx prettier --check` on touched files — clean
- [x] `npx eslint` on touched `.ts`/`.tsx` — exit 0 (the 2 CSS "no matching configuration" warnings are an artifact of passing `.css` paths explicitly; ESLint has no CSS config here)
- [x] `npx tsc --noEmit` in `apps/web` — exit 0
- [x] `npx vitest run` — **141 tests / 8 files passed**, including the token-path a11y and GDPR contrast suites
- [x] `npx vite build` — succeeds

Repo-wide `npm run format:check` was not used: it hangs across this monorepo (>20 min). Touched files were verified individually and are clean.

## Notes

Found while auditing token usage ahead of the `@jrm/tokens` migration (`jrmoulckers/.github#109`, #4042, #4063, #4069). Independent of that work — touches no vendored file and no `packages/design-tokens`.

An initial raw census flagged 121 names; **that figure is misleading and shouldn't be quoted.** The large majority are `var(--x, fallback)` guarded or set dynamically via inline `style`/`setProperty`. Only these 7 are genuinely unguarded.
