### PR TITLE
fix(ci): trigger web build on vendored token changes (#4079)

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -6,7 +6,7 @@ name: Web CI
 on:
   push:
     branches: [main]
-    paths: ['apps/web/**', 'packages/design-tokens/**']
+    paths: ['apps/web/**', 'packages/design-tokens/**', 'vendor/**']
   pull_request:
     branches: [main]
 
@@ -39,6 +39,10 @@ jobs:
         relevant:
           - 'apps/web/**'
           - 'packages/design-tokens/**'
+          # Vendored @jrm/tokens is imported by apps/web/src/theme/tokens.css and
+          # resolved by PostCSS at build time, so it must trigger the build even
+          # though it lives outside apps/web/.
+          - 'vendor/**'
           - '.github/workflows/ci-web.yml'
           - '.github/workflows/reusable-detect-changes.yml'
 


### PR DESCRIPTION
## Summary

A PR that changes only `vendor/@jrm/tokens/**` currently skips `Build`, `Build & Test`, `Unit Tests` and `Instrumented Tests (E2E)`, even though those files are a build-time input to the web app. This adds `vendor/**` to ci-web.yml's change detector so token changes are actually built and tested.

This regressed in #4044. The vendored package used to live at `apps/web/vendor/@jrm/tokens/**`, which matched the existing `apps/web/**` filter; moving it to the repo root removed it from the trigger. Nothing else about that move was wrong -- this side effect was simply missed.

## Evidence

PR #4076 touched **only** `vendor/` (13 files) and every build/test context reported `skipping`:

```
Build                     skipping
Build & Test              skipping   (x3)
Unit Tests (shard ...)    skipping
Instrumented Tests (E2E)  skipping
```

The dependency is real and resolves at build time:

```
apps/web/src/main.tsx:29                    import './theme/tokens.css';
apps/web/src/theme/tokens.css               @import '../../../../vendor/@jrm/tokens/css/default/index.css';
vendor/@jrm/tokens/css/default/index.css    @import './tokens.css';
```

Renaming the vendored directory away and running `vite build` fails with `[postcss] ENOENT`, so it is not an optional or runtime-only asset.

## Why now

The next `@jrm/tokens` sync PR changes exactly these files and is not a cosmetic update: Studio has begun emitting a primitive `--font-size-*` ladder that collides with eight names `@finance/design-tokens` already defines, and finance defines no `--radius-*` names at all. Without this fix that PR would merge with no build, no tests and no visual verification.

## Changes

- Add `vendor/**` to the `relevant` filter in the `changes` detector
- Add `vendor/**` to `on.push.paths`
- Comment explaining why a repo-root path feeds the web build

## Notes

Follows the skip-with-success pattern documented in `.github/instructions/workflows.instructions.md`: no trigger-level `paths:` was added to `on.pull_request`, so the required `Build` context still always reports. Workflow and job names are unchanged, since branch protection depends on them.

This PR self-validates -- `ci-web.yml` is itself in the filter, so `Build` should **run** here rather than skip.

## Issues

Closes #4079

## Testing

- [x] `yaml.parse` on the modified workflow succeeds; `on.push.paths` and the detector filter both contain `vendor/**`
- [x] `npx prettier --check .github/workflows/ci-web.yml` clean
- [x] `Build` runs on this PR instead of skipping
