### PR TITLE
ci(config): enforce vendored-config drift in CI and refresh to v0.15.7

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -113,6 +113,9 @@ jobs:
       - name: ESLint
         run: npx eslint . --max-warnings 0 --cache --cache-location .eslintcache
 
+      - name: Vendored engineering configs match lock
+        run: node scripts/vendor-configs.mjs --check
+
       - name: Prettier
         run: npx prettier --check .
 

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -150,6 +150,55 @@ prompts,skills}` wholesale. The glob form would silently stop formatting finance
 `npm run format:check` (`npx prettier --check .`, whole tree) — **exit 0, all matched files use
 Prettier code style**, with the vendored config resolving and `.prettierrc.json` deleted.
 
+### Refreshed to `v0.15.7`, and drift is now enforced in CI
+
+`node scripts/vendor-configs.mjs --check` verifies the vendored tree against
+`engineering-configs.lock.json` and **fails on drift**, so an edit to a vendored file can no longer
+pass review as a local change. It runs in `ci-lint.yml`, immediately before the Prettier step it
+protects. A newer upstream release is reported as a **notice at exit 0**, deliberately: an upstream
+tag must never redden an unrelated PR.
+
+Two things worth knowing before relying on it:
+
+- **The staleness notice makes an unauthenticated call to `api.github.com`** on every lint run. It
+  fails open — non-200, rate limit, or offline all return "fine" rather than a false signal — so it
+  is safe, but it is outbound egress on a hot path, and belongs in the same ledger as the registry
+  routing in [`docs/security/supply-chain.md`](../security/supply-chain.md).
+- **Drift detection and staleness are different checks.** The first is a hash comparison and is
+  authoritative offline; the second is advisory and silently degrades to "no answer". A green
+  `--check` means _matches the lock_, not _up to date_.
+
+The refresh `v0.15.1` → `v0.15.7` changed **0 files of content** — the shared Prettier config has
+been byte-stable across six releases. The lock proves that rather than requiring the claim be
+taken on trust, which is the whole point of recording a SHA-256 per file.
+
+### Gap 12 is still open at `v0.15.7`
+
+The refresh was also the cheapest possible test of whether the missing `"type": "module"` marker
+had been fixed upstream. It has not: `v0.15.7` still vendors two source files and no module-type
+declaration, so finance's local workaround file stays. Re-test on each refresh — it is one command
+and removes the need to guess.
+
+### Resolve the ref; do not copy a version literal
+
+Upstream's guidance, and finance follows it — with the observation that it applies to upstream's
+own announcements too. The release notice that introduced `--check` named `v0.15.3`; the newest tag
+at the time of reading was **`v0.15.7`**, four releases further on. Pinning the literal from the
+message would have been stale on arrival.
+
+```powershell
+$tag = gh api repos/jrmoulckers/engineering/releases/latest --jq .tag_name
+node scripts/vendor-configs.mjs $tag --set prettier --dest config/engineering
+```
+
+`releases/latest` was verified to agree with a version-sorted tag listing (39 tags, newest
+`v0.15.7`). **Do not substitute a lexical sort** — `Sort-Object` without a version cast returns
+`v0.9.0` as the newest of these tags, which is the failure upstream's `sort -V` note warns about,
+reproduced here on PowerShell.
+
+A recorded ref inside this document is a **historical fact** — what was vendored, when — and stays
+literal. Only the instructions use the resolver.
+
 ### The one thing this change broke, and what it exposes
 
 Adding `scripts/vendor-configs.mjs` failed `npx eslint . --max-warnings 0` with **8 `no-undef`
@@ -883,19 +932,45 @@ desktop|Kotlin|Swift|multiplatform` returns a single incidental match. finance s
     finance carries a local workaround file that is deliberately outside the lock and therefore
     not hash-checked — which is exactly why it should not be the permanent answer.
 
-13. **The vendored/registry split needs a stated rule for _when_ to vendor.** ADR-0001 explains
-    why each package landed where it did, but not what a consumer should do with a vendored
+13. **The vendored/registry split needs a stated rule for _when_ to vendor.** ADR-0001 explains why each package landed where it did, but not what a consumer should do with a vendored
     config it is not yet ready to adopt. finance deferred `@jrmoulckers/tsconfig` on evidence
     (2,691 diagnostics) and therefore did **not** vendor it, on the reasoning that an
     unreferenced copy of another authority's config extends nothing, fails no gate, and drifts
     invisibly. Worth stating that vendoring should happen in the same change that adopts, since
     the obvious reading of "vendor the half that needs no token" is to fetch both sets at once.
 
+14. **The "no version literals" rule needs a carve-out for evidence.** Replacing every literal with
+    a placeholder is right for _instructions_, where a stale pin propagates reversed guidance. It
+    is wrong for _measurements_: "verified with the checker at `v0.2.11`" is a claim about a
+    specific tool version, and a resolver silently re-points it at a different one on every read,
+    turning a reproducible result into an unfalsifiable one. **Instructions resolve; evidence
+    pins.** Worth stating, because the audit that produced this rule flagged one of finance's
+    evidence pins as an error.
+
+    That same audit reported `v0.2.11` as **"a tag that never existed"**. It exists —
+    `git ls-remote --tags` returns 39 version tags including `v0.2.11`, contiguous with `v0.2.10`
+    and `v0.2.12`. Worth re-checking how the audit decided a tag was missing, since the same method
+    presumably ran against six other repositories.
+
+15. **The staleness notice performs unauthenticated network I/O inside a lint gate.** `--check`
+    calls `api.github.com/repos/.../releases/latest` on every run. The implementation is careful —
+    it fails open, so rate limiting or an offline runner yields no signal rather than a false
+    one — but the behaviour is undocumented at the call site, and consumers with egress review
+    (finance keeps a supply-chain ledger) need to declare it. Either document it or add a
+    `--no-remote` flag for gate use, where only the hash comparison is wanted.
+
 ## Citation audit
 
 Verified with `scripts/check-citations.mjs --review` at `v0.2.11`, run over all 804 markdown
 files: **every ID valid, and every principle's true title matching the claim made about it.** The
 wrong-meaning defect reported elsewhere in the org did not reach finance.
+
+> **`v0.2.11` is a real tag.** An upstream audit reported this citation as pointing at "a tag that
+> never existed". It does exist: `git ls-remote --tags` returns **39 version tags**, `v0.2.11`
+> among them, contiguous with `v0.2.10` and `v0.2.12`. Left as a literal deliberately — it records
+> which version of the checker produced the result below, and a resolver would silently re-point
+> that claim at a different tool on every read. **Instructions should resolve; evidence should
+> pin.**
 
 Two notes, because the exit code is not the result:
 

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -45,6 +45,25 @@ The exposure is therefore narrower than "private package names leak", but it is 
 
 This is inherent `npm audit` behaviour, not something the shared toolchain introduces. No financial or user data is involved — the payload is dependency metadata only — so it is recorded rather than mitigated. Suppress it with `npm audit --offline` or omit the audit step where that egress is unacceptable.
 
+## Vendored-config staleness check
+
+`node scripts/vendor-configs.mjs --check` runs in `ci-lint.yml` and does two separable things:
+
+| Step                                                           | Network                                                                            | Failure mode                 |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ---------------------------- |
+| Hash the vendored tree against `engineering-configs.lock.json` | none                                                                               | **fails the build on drift** |
+| Report a newer upstream release                                | unauthenticated `GET api.github.com/repos/jrmoulckers/engineering/releases/latest` | notice only, exit 0          |
+
+The second is the one with an egress footprint. It transmits nothing about this repository — no
+dependency set, no package names, no request body — so unlike the audit egress above there is no
+disclosure to weigh; it is a plain public read. It **fails open** by design: non-200, rate limit,
+or an offline runner all yield "no answer", which is treated as fine rather than as a stale
+signal.
+
+Recorded because the call is invisible at the call site and sits inside a required gate. It is
+also why the two halves must not be conflated: **a green `--check` means the tree matches the
+lock, not that the pin is current.** Only the first half is authoritative offline.
+
 ## Policy
 
 Any release marked `production` must have a green provenance attestation for every shipped artifact. Release CI must fail if provenance generation fails; dry-run or non-publishing runs may skip attestation because no production artifact is shipped.

--- a/engineering-configs.lock.json
+++ b/engineering-configs.lock.json
@@ -1,7 +1,7 @@
 {
   "repository": "jrmoulckers/engineering",
-  "ref": "v0.15.1",
-  "fetchedAt": "2026-08-11T15:02:43.890Z",
+  "ref": "v0.15.7",
+  "fetchedAt": "2026-08-11T15:52:47.244Z",
   "refresh": "node scripts/vendor-configs.mjs <newer-ref>",
   "files": {
     "config/engineering/prettier/index.js": {

--- a/scripts/vendor-configs.mjs
+++ b/scripts/vendor-configs.mjs
@@ -83,13 +83,89 @@ function parseArgs(argv) {
       if (!value || value.startsWith('--')) fail(`${arg} requires a value`);
       flags[arg.slice(2)] = value;
       i += 1;
+    } else if (arg === '--check') {
+      flags.check = true;
     } else if (arg.startsWith('--')) {
-      fail(`unknown option ${arg}`, 'Usage: vendor-configs.mjs <ref> [--dest <dir>] [--set a,b]');
+      fail(
+        `unknown option ${arg}`,
+        'Usage: vendor-configs.mjs <ref> [--dest <dir>] [--set a,b] | vendor-configs.mjs --check',
+      );
     } else {
       positional.push(arg);
     }
   }
   return { positional, flags };
+}
+
+/**
+ * Report whether a newer release exists. Never throws and never fails the
+ * caller: a tag pushed upstream must not turn an unrelated PR red. Returns null
+ * when the answer cannot be determined, which is treated the same as "fine" —
+ * an offline or rate-limited runner is not a staleness signal.
+ */
+async function latestRef() {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
+      headers: { accept: 'application/vnd.github+json' },
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return typeof body.tag_name === 'string' ? body.tag_name : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify the vendored tree still matches the lock, then report staleness.
+ *
+ * The split in severity is the whole point. Drift is a local integrity failure
+ * — someone edited a generated file, or a write was lost — so it exits non-zero.
+ * Staleness is an upstream event the consumer has not acted on yet, so it only
+ * warns. Failing on staleness would make pinning automatic in effect: a red
+ * build pressures the next person into bumping the ref without deciding to
+ * accept the change, which is the property pinning exists to protect.
+ */
+async function check() {
+  let lock;
+  try {
+    lock = JSON.parse(await readFile(LOCK, 'utf8'));
+  } catch {
+    fail(`no ${LOCK} found`, 'Run: node scripts/vendor-configs.mjs <ref>');
+  }
+
+  const entries = Object.entries(lock.files ?? {});
+  if (entries.length === 0) fail(`${LOCK} records no files`, 'Re-run the vendor step.');
+
+  const drifted = [];
+  for (const [dest, meta] of entries) {
+    let text;
+    try {
+      text = await readFile(dest, 'utf8');
+    } catch {
+      drifted.push(`${dest}: missing`);
+      continue;
+    }
+    if (sha256(text) !== meta.sha256) drifted.push(`${dest}: content differs from the lock`);
+  }
+
+  if (drifted.length > 0) {
+    fail(
+      `${drifted.length} vendored file(s) drifted from ${LOCK}:\n  ${drifted.join('\n  ')}`,
+      `These files are generated. Do not edit them — re-run: node scripts/vendor-configs.mjs ${lock.ref}`,
+    );
+  }
+
+  process.stdout.write(`${entries.length} vendored file(s) match ${LOCK} at ${lock.ref}.\n`);
+
+  const latest = await latestRef();
+  if (latest && latest !== lock.ref) {
+    process.stdout.write(
+      `\nNotice: pinned at ${lock.ref}; newest release is ${latest}.\n` +
+        `This is not a failure. Update deliberately when you choose to:\n` +
+        `  node scripts/vendor-configs.mjs ${latest}\n`,
+    );
+  }
 }
 
 /**
@@ -147,9 +223,16 @@ const sha256 = (text) => createHash('sha256').update(text, 'utf8').digest('hex')
 
 async function main() {
   const { positional, flags } = parseArgs(process.argv.slice(2));
+  if (flags.check) {
+    if (positional.length > 0) {
+      fail('--check takes no ref', 'It verifies the ref already recorded in the lock file.');
+    }
+    await check();
+    return;
+  }
   const ref = positional[0];
   if (!ref) {
-    fail('a ref is required', 'Pass a tag, not a branch: node scripts/vendor-configs.mjs v0.15.0');
+    fail('a ref is required', 'Pass a tag, not a branch: node scripts/vendor-configs.mjs v1.2.3');
   }
   const dest = flags.dest ?? 'config/engineering';
   const names = (flags.set ?? Object.keys(SETS).join(',')).split(',').map((s) => s.trim());


### PR DESCRIPTION
## Summary

Adopts `vendor-configs.mjs --check` (new upstream) and wires it into `ci-lint.yml`, refreshes the
vendored Prettier config `v0.15.1` → `v0.15.7`, and **corrects an upstream audit finding aimed at
this repository**.

## Drift is now enforced — and the guard was proven to fail

`--check` hashes the vendored tree against `engineering-configs.lock.json`, so an edit to a
vendored file can no longer pass review as a local change. It runs immediately before the Prettier
step it protects.

Mutation-tested rather than assumed — appending one comment line:

```
error: 1 vendored file(s) drifted from engineering-configs.lock.json:
  config/engineering/prettier/index.js: content differs from the lock
DRIFT_EXIT=1
```

Restoring the file returns exit 0. **A guard that has never been observed failing is not a guard.**

## Refreshed to v0.15.7 — and resolved the ref rather than copying it

The refresh changed **0 files of content**; the shared Prettier config has been byte-stable across
six releases. The lock proves that rather than requiring the claim be taken on trust.

Upstream's new "don't copy version literals" rule turns out to apply to upstream's own
announcements: the notice introducing `--check` named **`v0.15.3`**, while the newest tag was
**`v0.15.7`** — four releases on. Pinning the literal from the message would have been stale on
arrival.

```powershell
$tag = gh api repos/jrmoulckers/engineering/releases/latest --jq .tag_name
node scripts/vendor-configs.mjs $tag --set prettier --dest config/engineering
```

`releases/latest` was verified to agree with a version-sorted listing of all **39** tags. A lexical
sort returns `v0.9.0` as newest — upstream's `sort -V` warning, reproduced on PowerShell.

## Correcting the audit finding: `v0.2.11` exists

The upstream audit reported this repo's citation of `v0.2.11` as pointing at *"a tag that never
existed"*. It exists — `git ls-remote --tags` returns 39 version tags including `v0.2.11`,
contiguous with `v0.2.10` and `v0.2.12`.

It is kept as a literal **deliberately**, and gap 14 states the distinction the rule is missing:

> **Instructions should resolve; evidence should pin.**

"Verified with the checker at `v0.2.11`" is a claim about a specific tool version. A resolver
silently re-points it at a different tool on every read, turning a reproducible result into an
unfalsifiable one.

## Changes

- `ci-lint.yml`: new `Vendored engineering configs match lock` step before Prettier.
- `scripts/vendor-configs.mjs` + `engineering-configs.lock.json`: refreshed to `v0.15.7`.
- `docs/security/supply-chain.md`: records the new egress.
- `docs/guides/engineering-practice-adoption.md`: the above, plus gaps 14 and 15.

**Gap 12 re-tested on the refresh and still open** — `v0.15.7` still vendors two source files and
no `"type": "module"` marker, so the local workaround file stays. The refresh was the cheapest
possible test of that, so it is now a standing step rather than a guess.

## Two new upstream gaps

**14 — the no-literals rule needs an evidence carve-out** (above). Also worth re-checking *how* the
audit decided a tag was missing, since the same method presumably ran against six other
repositories.

**15 — `--check` performs unauthenticated network I/O inside a lint gate.** It calls
`api.github.com/.../releases/latest` on every run. The implementation is careful and **fails
open** — rate limit or offline yields no signal rather than a false one — but it is invisible at
the call site. Either document it, or add `--no-remote` for gate use where only the hash comparison
is wanted.

Recorded in the supply-chain ledger. It transmits nothing about this repository — a plain public
read, no request body — so unlike the `npm audit` entry there is no disclosure to weigh. The ledger
also now states why the halves must not be conflated: **a green `--check` means the tree matches
the lock, not that the pin is current.** Only the hash half is authoritative offline.

## Issues

Refs #4029

## Testing

- [x] `node scripts/vendor-configs.mjs --check` — exit 0
- [x] Drift mutation test — exit 1 naming the file; exit 0 after restore
- [x] `npx eslint . --max-warnings 0` — exit 0
- [x] `npm run format:check` — exit 0
- [x] `releases/latest` cross-checked against a version-sorted listing of all 39 tags
