### PR TITLE
fix(tokens): restore regressed lock hash for vendored tokens.css (#4083)

### DIFF
--- a/.studio-sync.lock.json
+++ b/.studio-sync.lock.json
@@ -330,7 +330,7 @@
     },
     "vendor/@jrm/tokens/css/default/tokens.css": {
       "sourceSha256": "343e10b1ac7914f2a3d1255cfc6ffad1930ac1a17da9eb5aa5551e6e4f67062c",
-      "targetSha256": "bb35859efbfb66ccb46c5bcc082d552e33ab1a53b0f61575d9b1932862886d87",
+      "targetSha256": "9966d8a4156263ab62ca0434039309a9b8c40713dea1a53afb913c6467b05bb6",
       "syncedAt": "2026-08-07T15:35:03.616Z"
     },
     "vendor/@jrm/tokens/js/default/tokens.dark-oled.d.ts": {


### PR DESCRIPTION
## Summary

`vendor/@jrm/tokens/css/default/tokens.css` is the last frozen vendored token file — 21,016 bytes on disk against 46,623 bytes of upstream canon. It is skipped as `drift` on every sync run and can never update.

The cause is one stale field in `.studio-sync.lock.json`. Its recorded `targetSha256` describes 08-07 content while the file on disk holds 08-09 content, which is indistinguishable from a member hand-edit — so the engine correctly refuses to clobber it, permanently.

This restores the field to **the value the engine itself recorded for these exact bytes**, recovered from the commit that recorded it.

## Changes

- `.studio-sync.lock.json` — one line. `entries["vendor/@jrm/tokens/css/default/tokens.css"].targetSha256`:
  - `bb35859efbfb66cc…` (superseded 08-07 value)
  - → `9966d8a4156263ab…` (recorded at `7cfb0f04`, byte-identical to disk)

Nothing else. No token content, no source, no workflows, and explicitly no change to `packages/design-tokens/`.

## How the regression happened

| commit | key | `targetSha256` | `syncedAt` |
| --- | --- | --- | --- |
| `290c96c8` base move | old | `bb35859e…` | 08-07T15:35:03 |
| `7cfb0f04` 08-09 wave | old | **`9966d8a4…`** | 08-09T22:23:34 |
| `a450c472` 08-10 wave | old | `bb35859e…` | 08-07T15:35:03 |
| `234528e4` 08-11 wave | new | `bb35859e…` | 08-07T15:35:03 |

The 08-09 wave wrote the content **and** recorded it correctly. The 08-10 wave reinstated an older lock snapshot, discarding that record. The 08-11 rekey then carried the regressed value faithfully to the new target base — correct behaviour on wrong input.

Independently confirmed by the backbone as [`jrmoulckers/.github#379`](https://github.com/jrmoulckers/.github/issues/379), which reached the same mechanism by a different route and also measured "9 match, 1 drifts" across the 10 present token files.

## Why this and not the alternatives

- **`--force`** — would work, but is blocked by an account-wide Actions spending limit, and `.github#379` notes it fixes the instance without fixing the mechanism.
- **Delete the file and let sync repopulate it** — unsafe, and tested rather than assumed. `css/default/index.css` is in sync and survives deletion; its line 3 is `@import './tokens.css';`. Removing the target leaves a dangling import and `vite build` fails in ~15s with `[postcss] ENOENT`. `Build` and `Build & Test` are required checks, so this would block every open PR in the repo until the sync landed.
- **Wait for the structural fixes** (`.github#379`, `#393`) — both are real and worth landing for the fleet, since the regression mechanism is not finance-specific. But finance doesn't need them, and shouldn't be the repo that waits.

## Verification

```
recorded: 9966d8a4156263ab62ca0434039309a9b8c40713dea1a53afb913c6467b05bb6
on-disk : 9966d8a4156263ab62ca0434039309a9b8c40713dea1a53afb913c6467b05bb6
MATCH   : True

control (index.css, untouched, known in-sync)
MATCH   : True
```

The corrected entry now behaves exactly like every in-sync sibling. `planFile` will compute `currentHash === entry.targetSha256`, `isLocallyModified` returns false, and the file falls through to the ordinary canon comparison and plans a clean `update`.

Consistent with [`.github#393`](https://github.com/jrmoulckers/.github/issues/393): `targetSha256 = hashText(rendered)` while `sourceSha256 = hashText(raw)`. `9966d8a4…` is a rendered-form hash with the provenance header included — the correct shape for this field.

## Testing

- [x] `npx prettier --check .studio-sync.lock.json` — clean
- [x] JSON parses; all 81 entries intact; `git diff --stat` = **1 insertion, 1 deletion**
- [x] Recorded hash asserted equal to on-disk hash, with a passing control on an untouched entry
- [x] `wcag-audit.test.ts` + `ConsentDialog.contrast.test.tsx` — **58/58 pass** (the two suites that read the vendored token CSS directly)
- [x] No npm script or workflow validates this lockfile, so nothing else is affected

## Expected consequences when it unfreezes

Pre-registered so the eventual sync PR is reviewed as an expected diff rather than a surprise:

- `--radius-md` 14px → 16px, **79 sites**; `--radius-sm` 9px → 8px, **31 sites**
- 24 dangling refs begin resolving — `--radius-full` alone is **20 sites resolving to nothing in production today**
- `--easing-standard` `ease` → `cubic-bezier(0.2, 0, 0, 1)`, **19 sites** — a timing change, so it needs an interaction pass, not stills
- `--duration-reduced` 0ms → 1ms
- **~175 `--font-size-*` sites change rendered size**, as upstream Studio #89's rem ladder collides with `@finance/design-tokens`' px ladder on 8 of 9 names and canon wins on cascade order

All corrections rather than regressions — but worth a deliberate visual and interaction review.

## Caveat

`.github#379` documents a two-wave hazard that could in principle re-regress this field. Accepted: the corrected state is strictly better than the current one, and a re-regression would be evidence for prioritising the structural fix.

Closes #4083