### PR TITLE
docs: adopt machine-verified citation names and record gap 18

### DIFF
--- a/docs/architecture/0002-backend-sync-architecture.md
+++ b/docs/architecture/0002-backend-sync-architecture.md
@@ -4,7 +4,7 @@
 **Date:** 2025-07-17
 **Author:** Copilot (AI agent), based on backend/sync research
 **Reviewers:** Pending human review
-**Ratified obligations:** `ENG-LOCAL-001` (local durable ownership), `ENG-LOCAL-002` (optional sync seam), `ENG-LOCAL-004` (zero-config safe degradation), `ENG-DATA-001` (owned durable integrity), `ENG-DATA-002` (versioned bounded data contracts), `ENG-DATA-003` (minimized governed data) — see [practices/local-first-sync.md](https://github.com/jrmoulckers/engineering/blob/main/practices/local-first-sync.md). This ADR records finance's implementation, not the rules.
+**Ratified obligations:** `ENG-LOCAL-001` (Local durable ownership), `ENG-LOCAL-002` (Optional sync seam), `ENG-LOCAL-004` (Zero-config safe degradation), `ENG-DATA-001` (Owned durable integrity), `ENG-DATA-002` (Versioned bounded data contracts), `ENG-DATA-003` (Minimized governed data) — see [practices/local-first-sync.md](https://github.com/jrmoulckers/engineering/blob/main/practices/local-first-sync.md). This ADR records finance's implementation, not the rules.
 
 ## Context
 

--- a/docs/architecture/0018-offline-conflict-resolution.md
+++ b/docs/architecture/0018-offline-conflict-resolution.md
@@ -5,7 +5,7 @@
 **Author:** System Architect (AI agent)
 **Reviewers:** Pending human review
 **Sprint:** W2-S7
-**Ratified obligation:** `ENG-LOCAL-003` (declared conflict model) — see [practices/local-first-sync.md](https://github.com/jrmoulckers/engineering/blob/main/practices/local-first-sync.md). Superseded in part by [ADR-0022](./0022-conflict-resolution-beyond-lww.md).
+**Ratified obligation:** `ENG-LOCAL-003` (Declared conflict model) — see [practices/local-first-sync.md](https://github.com/jrmoulckers/engineering/blob/main/practices/local-first-sync.md). Superseded in part by [ADR-0022](./0022-conflict-resolution-beyond-lww.md).
 
 ## Context
 

--- a/docs/architecture/0020-observability-architecture.md
+++ b/docs/architecture/0020-observability-architecture.md
@@ -6,7 +6,7 @@
 **Reviewers:** Pending human review
 **Sprint:** W2-S11
 **Extends:** [Monitoring Architecture](./monitoring.md) · [Monitoring Infrastructure](./monitoring-infrastructure.md) · [Alerting Rules](./alerting-rules.md)
-**Ratified obligations:** `ENG-OBS-001` (structured operational signals), `ENG-OBS-002` (live service identity), `ENG-OBS-003` (bounded dependency checks), `ENG-OBS-004` (end-to-end correlation), `ENG-OBS-005` (redacted observable evidence), `ENG-OBS-006` (SLO evidence), `ENG-OBS-007` (predictable degradation). This ADR records finance's implementation of them, not the rules themselves.
+**Ratified obligations:** `ENG-OBS-001` (Structured operational signals), `ENG-OBS-002` (Live service identity), `ENG-OBS-003` (Bounded dependency checks), `ENG-OBS-004` (End-to-end correlation), `ENG-OBS-005` (Redacted observable evidence), `ENG-OBS-006` (SLO evidence), `ENG-OBS-007` (Predictable degradation). This ADR records finance's implementation of them, not the rules themselves.
 
 ## Context
 

--- a/docs/architecture/0022-conflict-resolution-beyond-lww.md
+++ b/docs/architecture/0022-conflict-resolution-beyond-lww.md
@@ -1,6 +1,6 @@
 # ADR-0022: Conflict Resolution Beyond Last-Write-Wins
 
-> **Ratified obligation:** `ENG-LOCAL-003` (declared conflict model). The requirement to
+> **Ratified obligation:** `ENG-LOCAL-003` (Declared conflict model). The requirement to
 > declare a conflict model is ratified upstream; what follows is finance's declaration. See
 > [practices/local-first-sync.md](https://github.com/jrmoulckers/engineering/blob/main/practices/local-first-sync.md).
 

--- a/docs/architecture/0023-structured-error-handling.md
+++ b/docs/architecture/0023-structured-error-handling.md
@@ -1,6 +1,6 @@
 # ADR-0023: Standardized Structured Error Handling Across Clients
 
-> **Ratified obligations:** `ENG-INT-003` (typed retry-safe failures) and `ENG-SEC-007`
+> **Ratified obligations:** `ENG-INT-003` (Typed retry-safe failures) and `ENG-SEC-007`
 > (secure failure). This ADR records how finance satisfies them across four clients; it does
 > not restate them. See
 > [practices/resilience.md](https://github.com/jrmoulckers/engineering/blob/main/practices/resilience.md).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,7 +1,7 @@
 # Architecture Decision Records
 
 Durable decision records for finance. The obligation to keep them is `ENG-ARCH-003`
-(durable decisions) — see the
+(Durable decisions) — see the
 [ratified principles](https://github.com/jrmoulckers/engineering/blob/main/principles/architecture/boundaries-and-contracts.md).
 This file is the index and the numbering convention; it does not restate the rule.
 

--- a/docs/architecture/performance-budget-architecture.md
+++ b/docs/architecture/performance-budget-architecture.md
@@ -6,7 +6,7 @@
 **Reviewers:** Pending human review
 **Sprint:** W2-S8
 **Related:** [Performance Baselines](./performance-baselines.md) · [Monitoring Architecture](./monitoring.md) · [ADR-0001: Cross-Platform Framework](./0001-cross-platform-framework.md) · [ADR-0011: Scaling Architecture](./0011-scaling-architecture.md)
-**Ratified obligations:** `ENG-PERF-002` (versioned performance budgets), `ENG-WEB-003` (measured foreground performance), `ENG-TEST-004` (distinct static signals) — see [practices/performance-budgets.md](https://github.com/jrmoulckers/engineering/blob/main/practices/performance-budgets.md). The budget _values_ below are finance's.
+**Ratified obligations:** `ENG-PERF-002` (Versioned performance budgets), `ENG-WEB-003` (Measured foreground performance), `ENG-TEST-004` (Distinct static signals) — see [practices/performance-budgets.md](https://github.com/jrmoulckers/engineering/blob/main/practices/performance-budgets.md). The budget _values_ below are finance's.
 
 ---
 

--- a/docs/architecture/security-architecture.md
+++ b/docs/architecture/security-architecture.md
@@ -5,9 +5,9 @@ _Last updated: 2025-04-21_
 This document provides a comprehensive review of the Finance application's security architecture, covering encryption, authentication, session management, certificate pinning, biometric integration, threat modeling, and compliance mapping. It consolidates and extends the security decisions in [ADR-0004 (Auth & Security)](./0004-auth-security-architecture.md) with implementation-level detail.
 
 The obligations it discharges are ratified in `jrmoulckers/engineering` and are cited, not
-restated: `ENG-SEC-001` (secret lifecycle), `ENG-SEC-003` (boundary threat models),
-`ENG-SEC-004` (least authority), `ENG-SEC-005` (trust-boundary validation), `ENG-SEC-007`
-(secure failure), and `ENG-SEC-008` (privacy-minimizing lifecycle evidence). The threat model,
+restated: `ENG-SEC-001` (Secret lifecycle), `ENG-SEC-003` (Boundary threat models),
+`ENG-SEC-004` (Least authority), `ENG-SEC-005` (Trust-boundary validation), `ENG-SEC-007`
+(Secure failure), and `ENG-SEC-008` (Privacy-minimizing lifecycle evidence). The threat model,
 MASVS mapping, and control implementations below are finance-specific.
 
 ---

--- a/docs/audits/accessibility-audit-wcag22.md
+++ b/docs/audits/accessibility-audit-wcag22.md
@@ -7,7 +7,7 @@
 > **Standard:** WCAG 2.2 Level AA
 
 WCAG 2.2 AA is finance's own commitment; no ratified principle mandates it. `ENG-PERF-009`
-(assurance precedence) applies _additively_: whatever this audit finds, it may not be traded away
+(Assurance precedence) applies _additively_: whatever this audit finds, it may not be traded away
 to meet a performance budget.
 
 ---

--- a/docs/audits/security-checklist.md
+++ b/docs/audits/security-checklist.md
@@ -3,7 +3,7 @@
 **Last updated:** 2025-07-22
 **Standard:** [OWASP MASVS v2](https://mas.owasp.org/MASVS/) Level 1 (L1)
 **References:** [ADR-0004 Auth & Security](../architecture/0004-auth-security-architecture.md), [ADR-0003 Local Storage](../architecture/0003-local-storage-strategy.md)
-**Ratified obligation:** `ENG-SEC-006` (risk-focused security review). The MASVS controls and finance-specific verdicts below are this repository's evidence for it.
+**Ratified obligation:** `ENG-SEC-006` (Risk-focused security review). The MASVS controls and finance-specific verdicts below are this repository's evidence for it.
 
 > This checklist covers the Finance application security posture across all
 > four platforms (Android, iOS, Web, Windows). Items reference MASVS controls

--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -5,9 +5,10 @@ Finance is designed to be usable by everyone, regardless of ability. Accessibili
 This guide covers the accessibility features available in Finance and how to use them.
 
 WCAG 2.2 AA is a finance commitment, not a ratified obligation — no `ENG-*` principle covers
-accessibility. Two apply additively rather than as its source: `ENG-PERF-009` (assurance
-precedence) forbids trading any of the below away to hit a performance budget, and `ENG-PERF-002`
-(versioned performance budgets) is what it would be traded against.
+accessibility. Two apply additively rather than as its source:
+`ENG-PERF-009` (Assurance precedence) forbids trading any of the below away to hit a performance
+budget, and `ENG-PERF-002`
+(Versioned performance budgets) is what it would be traded against.
 
 ---
 

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -1160,11 +1160,77 @@ desktop|Kotlin|Swift|multiplatform` returns a single incidental match. finance s
     files are reported as changed. The practical effect is that the one signal telling a reader
     whether an upgrade is reviewable or a no-op is wrong precisely when previewing an upgrade.
 
+18. **A line-wrapped citation name stops being verified, silently, and the format pass is what
+    wraps it.** `v0.16.5`'s `TITLED` pattern is `[^)/#\n]{2,59}`, so a parenthesised title split
+    across a newline is not recognised as a claim. It does not fail — it is simply not checked, the
+    exit code stays 0, and the only visible symptom is the "stated name(s) match" count being one
+    lower than the number of names actually written. Reproduced in finance: the `ENG-PERF-009`
+    citation in `docs/guides/accessibility.md`, whose title `Assurance precedence` was wrapped
+    between the two words by Prettier at `printWidth: 96`. Unwrapping it moved the count 30 → 31.
+
+    The trigger is a formatter this guide recommends running, so the failure sequence is: write a
+    correct named citation, format, and lose the verification with no signal. Either match across
+    newlines, or have `--review` report near-misses — an `ENG-*` ID followed by a parenthesised
+    capitalised phrase that the strict pattern rejected. A near-miss warning is the cheaper fix and
+    converts a silent gap into a visible one, which is the same argument this document makes about
+    `rules-of-hooks`: **the dangerous lint result is the one that says nothing.**
+
+    **Corollary, found while writing the paragraph above.** Quoting the broken citation verbatim as
+    an example made this document fail the check with `claimed: Assurance\nprecedence`. The pattern
+    cannot distinguish a citation from a quotation of one, so **prose about miscitation is parsed as
+    miscitation** — the guide documenting the trap trips it. Worked around here by describing the
+    wrap instead of reproducing it, which is a worse document. A skip marker for fenced or inline
+    examples would fix it.
+
 ## Citation audit
 
 Verified with `scripts/check-citations.mjs --review` at `v0.2.11`, run over all 804 markdown
 files: **every ID valid, and every principle's true title matching the claim made about it.** The
 wrong-meaning defect reported elsewhere in the org did not reach finance.
+
+### Re-audited under machine-verified names (`v0.16.5`)
+
+`v0.16.5` makes a stated title checkable: a parenthesised phrase beginning with a capital after an
+`ENG-*` ID is read as a claim and diffed against `principles/index.json`. Finance had 35 such names
+already, written in lowercase and therefore invisible to the checker. All 35 were re-derived from
+the index before being capitalised, and **all 35 were already correct** — no wrong-meaning citation
+existed to find. They are now machine-verified rather than merely right:
+
+```powershell
+node scripts/check-citations.mjs docs --index <pinned-index> --review
+# 66 citation(s) across 34 principle(s) in 441 file(s); all IDs exist, and 31 stated name(s) match.
+```
+
+**31, not 35, because the count is of unique IDs.** Five names are cited in more than one file —
+`Versioned performance budgets` in three, `Assurance precedence` in three. Worth stating because a
+count that is lower than the number of names you just wrote reads exactly like five silent
+failures, and the exit code alone does not distinguish "deduplicated" from "rejected".
+
+Mutation-tested rather than assumed. Retitling `ENG-PERF-001` to another principle's real title
+fails with a `claimed:`/`actual:` diff and **exit 1**; restoring it returns **exit 0**. The guard
+is live.
+
+### One name was silently unverified, and the format pass caused it
+
+`docs/guides/accessibility.md` cited `ENG-PERF-009` with its title stated — and Prettier's reflow
+split that title between its two words at `printWidth: 96`. Upstream's pattern excludes newlines
+(`[^)/#\n]{2,59}`), so a wrapped name is **not read as a claim at all**. It does not fail; it
+stops being checked. Exit stays 0, and the "stated names match" count silently drops by one.
+
+This fails open, and the trigger is a formatter the adoption guide itself tells you to run. The
+sequence is: write a correct named citation → run the format pass → the citation is no longer
+verified, with no signal anywhere. Unwrapping that one line moved the verified count 30 → 31 and
+the "read as named but missed" count 1 → 0.
+
+Two mitigations, neither owned here: match across newlines in the pattern, or have `--review`
+report near-misses — an `ENG-*` ID followed by a parenthesised capitalised phrase that the strict
+pattern rejected. The second is cheap and turns a silent gap into a warning. Filed as **gap 18**.
+
+**This is not wired into finance's CI**, deliberately. The checker resolves
+`principles/index.json` over the network by default, and gap 15 objects to exactly that — network
+I/O inside a lint gate. Running it in CI would contradict a finding this document makes two
+sections earlier. It is run manually on any PR that touches citations, and the command is recorded
+above so the result is reproducible.
 
 > **`v0.2.11` is a real tag.** An upstream audit reported this citation as pointing at "a tag that
 > never existed". It does exist: `git ls-remote --tags` returns **39 version tags**, `v0.2.11`
@@ -1189,10 +1255,10 @@ say so. Where a ratified principle bears on them _additively_, that is now state
 than omitted:
 
 - `docs/guides/accessibility.md` and `docs/audits/accessibility-audit-wcag22.md` note that
-  `ENG-PERF-009` (assurance precedence) forbids trading accessibility away for performance. It is
+  `ENG-PERF-009` (Assurance precedence) forbids trading accessibility away for performance. It is
   not the source of the WCAG 2.2 AA commitment; it constrains what may be done to it.
 - Test colocation is named as a finance convention; the obligation it serves is `ENG-TEST-003`
-  (regression boundaries).
+  (Regression boundaries).
 
 The distinction is worth stating precisely, because the two readings differ in what they license.
 "Accessibility follows `ENG-PERF-009`" is false and would make the WCAG commitment look

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -3,8 +3,8 @@
 This guide defines performance targets, profiling techniques, and optimization best practices for the Finance app across all platforms.
 
 The obligations it satisfies are ratified elsewhere and are not restated here:
-`ENG-PERF-001` (reproducible measurements), `ENG-PERF-002` (versioned performance budgets),
-and `ENG-PERF-007` (platform-native profiling). See
+`ENG-PERF-001` (Reproducible measurements), `ENG-PERF-002` (Versioned performance budgets),
+and `ENG-PERF-007` (Platform-native profiling). See
 [practices/performance-budgets.md](https://github.com/jrmoulckers/engineering/blob/main/practices/performance-budgets.md).
 Everything below — the target values, the Gradle benchmark harness, and the per-platform
 profiling technique — is finance-specific.

--- a/docs/ops/workflow-reuse-assessment.md
+++ b/docs/ops/workflow-reuse-assessment.md
@@ -47,7 +47,7 @@ The backbone publishes 8 reusables. Seven finance workflows overlap one.
 title it adds: the skip-with-success `changes` detector that keeps a required check reporting on
 every PR; `.eslintcache` restore keys; financial-terminology glossary validation
 (`scripts/i18n/validate-glossary.js`); and an `observability-guardrails` job whose sensitive-data
-grep **fails the build** — the executable form of `ENG-OBS-005` (redacted observable evidence).
+grep **fails the build** — the executable form of `ENG-OBS-005` (Redacted observable evidence).
 The reusable has no equivalent for any of these. Swapping it in would delete a blocking privacy
 check.
 


### PR DESCRIPTION
## Summary

Adopts `v0.16.5` machine-verified citation names across finance's docs, and reports one gap found
by doing it.

## All 35 names were already correct

Finance had 35 parenthesised principle names, written in lowercase and therefore invisible to the
new check. Every one was re-derived from `principles/index.json` before capitalising — **all 35
already matched.** No wrong-meaning citation existed here. They are now machine-verified rather
than merely right.

**The tool reports 31, not 35, because it counts unique IDs** — five titles are cited in more than
one file. Worth flagging: a count lower than the number of names you just wrote reads exactly like
silent failures, and the exit code alone doesn't distinguish "deduplicated" from "rejected".

Mutation-tested rather than assumed — retitling `ENG-PERF-001` to another principle's real title
exits **1** with a `claimed:`/`actual:` diff; restoring exits **0**.

## Gap 18 — a wrapped title stops being verified, silently

`TITLED` is `[^)/#\n]{2,59}`, so a name split across a line break is **not read as a claim at
all**. It doesn't fail; it stops being checked. Exit stays 0 and the match count drops by one with
no other signal. Prettier at `printWidth: 96` wrapped one in `docs/guides/accessibility.md`.

The trigger is a formatter the adoption guide itself tells you to run, so the sequence is: write a
correct named citation → format → lose the verification. Unwrapping moved the count 30 → 31.

**Corollary, found while writing that paragraph:** quoting the broken citation verbatim as an
example made this document fail the check. The pattern can't distinguish a citation from a
quotation of one, so prose *about* miscitation is parsed *as* miscitation. Worked around by
describing the wrap instead of showing it — a worse document.

## Not wired into CI, deliberately

The checker resolves the index over the network by default. Gap 15 in this same guide objects to
network I/O inside a lint gate; running it in CI would contradict a finding two sections earlier.
It's run manually on PRs touching citations, with the command recorded.

## Issues

Refs #4029

## Testing

- [x] `check-citations.mjs docs --review` — exit 0, 31 names verified, 0 near-misses
- [x] Mutation test — exit 1 mutated, exit 0 restored
- [x] Re-ran the citation check **after** the format pass, given gap 18
- [x] `npm run format:check` — exit 0
- [x] `node scripts/vendor-configs.mjs --check` — exit 0
