### PR TITLE
fix(docs,web): repair 7 lost characters and add a U+FFFD guard (#4090)

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -525,6 +525,12 @@ jobs:
       - name: ESLint
         run: npx eslint . --max-warnings 0
 
+      # Always-on text-encoding gate (#4090). U+FFFD in a committed file means a
+      # character was already lost before the bytes arrived; mojibake is valid
+      # UTF-8, so only a byte-level scan detects it.
+      - name: Text encoding check (U+FFFD)
+        run: npm run encoding:check
+
       # Always-on lightweight secret scan as a backstop to the dedicated jobs.
       - name: Secret backstop (tracked files)
         run: |

--- a/apps/web/src/lib/a11y.ts
+++ b/apps/web/src/lib/a11y.ts
@@ -354,7 +354,7 @@ export function relativeLuminance({ r, g, b }: { r: number; g: number; b: number
 }
 
 /**
- * WCAG contrast ratio (1�21) between two hex colors. Returns `null` if
+ * WCAG contrast ratio (1–21) between two hex colors. Returns `null` if
  * either color cannot be parsed.
  */
 export function contrastRatio(foreground: string, background: string): number | null {

--- a/docs/business/roadmap/go-live-assessment.md
+++ b/docs/business/roadmap/go-live-assessment.md
@@ -231,7 +231,7 @@ proceed.
 | App Review notes                   | 🟡     | Template exists; demo account not configured                    |
 | Export compliance                  | ✅     | `apps/ios/EXPORT_COMPLIANCE.md` — SQLCipher AES-256 documented  |
 | **Microsoft Store**                |        |                                                                 |
-| Name/description/screenshots       | ��     | `docs/guides/windows-store.md` guide exists                     |
+| Name/description/screenshots       | 🟡     | `docs/guides/windows-store.md` guide exists                     |
 | MSIX validation                    | 🟡     | MSIX packaging dir present; WACK not run                        |
 | Age rating questionnaire           | ❌     | Not completed                                                   |
 | **Web (PWA)**                      |        |                                                                 |

--- a/docs/business/sprints/alpha-household-constraints.md
+++ b/docs/business/sprints/alpha-household-constraints.md
@@ -87,7 +87,7 @@ needed to the signup backend — only the client onboarding flow is simplified
 | Shared account indicators      | 🔒 Hidden    | No sharing in alpha                            |
 | Household switching            | 🔒 Hidden    | Only one household; switcher is unnecessary    |
 | Transfer between households    | 🔒 Hidden    | Single household only                          |
-| Organization / advisor access  | �� Hidden    | Enterprise features not in alpha scope         |
+| Organization / advisor access  | 🔒 Hidden    | Enterprise features not in alpha scope         |
 
 **Implementation approach:** Use the existing feature-flag system (PostgreSQL +
 PowerSync sync rules) to gate multi-user features behind

--- a/docs/compliance/encryption-explainer.md
+++ b/docs/compliance/encryption-explainer.md
@@ -236,7 +236,7 @@ end
     end
 
     subgraph "Windows"
-        WK["�� KEK + SQLCipher key"]
+        WK["🔑 KEK + SQLCipher key"]
         WDP["DPAPI<br/>Per-user protection"]
         WK --> WDP
     end

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cleanup:worktrees": "node tools/cleanup-worktrees.js",
     "ai:manifest": "node tools/ai-manifest.js",
     "ai:manifest:check": "node tools/check-ai-manifest.js",
+    "encoding:check": "node tools/check-text-encoding.mjs",
     "workflow:security:check": "node tools/check-workflow-security.mjs",
     "workflow:security:test": "node --test tools/check-workflow-security.test.mjs",
     "agent:worktree": "node tools/agent-scripts/setup-worktree.js",

--- a/tools/check-text-encoding.mjs
+++ b/tools/check-text-encoding.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * Usage: npm run encoding:check
+ *        node tools/check-text-encoding.mjs --help
+ *
+ * Fails when a tracked text file contains U+FFFD (the Unicode replacement
+ * character, bytes EF BF BD). A U+FFFD in committed source means a character
+ * was already lost before the bytes reached the repository — the original is
+ * unrecoverable from the file itself.
+ *
+ * The scan is deliberately byte-level. Mojibake is *valid* UTF-8: EF BF BD is a
+ * well-formed encoding of a real code point, so a decoder validity check such as
+ * `new TextDecoder('utf-8', { fatal: true })` accepts it without complaint.
+ * Validity is the wrong predicate; the question is whether the text already lost
+ * characters before it arrived.
+ *
+ * Two byte patterns show up, and they come from different faults:
+ *   EF BF BD             a 3-byte character (en dash, arrow) collapsed to one
+ *                        replacement
+ *   EF BF BD EF BF BD    a 4-byte emoji whose UTF-16 surrogate pair was split
+ *                        and each half replaced independently
+ */
+
+import { spawnSync } from 'node:child_process';
+
+const REPLACEMENT = Buffer.from([0xef, 0xbf, 0xbd]);
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  console.log(
+    [
+      'Usage: node tools/check-text-encoding.mjs',
+      '',
+      'Scans every tracked file for U+FFFD (EF BF BD) and exits non-zero if any',
+      'is found. Files containing a NUL byte are treated as binary and skipped.',
+    ].join('\n'),
+  );
+  process.exit(0);
+}
+
+/**
+ * Lists every tracked path at HEAD.
+ *
+ * @returns {string[]} Repository-relative paths.
+ */
+function listTrackedFiles() {
+  const result = spawnSync('git', ['ls-files', '-z'], { maxBuffer: 1024 * 1024 * 256 });
+  if (result.status !== 0) {
+    console.error('Unable to list tracked files via `git ls-files`.');
+    process.exit(1);
+  }
+  return result.stdout.toString('utf8').split('\0').filter(Boolean);
+}
+
+/**
+ * Reads every tracked path's committed bytes in a single `git cat-file --batch`
+ * pass. Reading from the index rather than the working tree matters because a
+ * checkout filter can differ from what is committed; doing it in one process
+ * matters because spawning `git show` per file takes minutes on this repo.
+ *
+ * @param {string[]} paths Repository-relative paths.
+ * @returns {Map<string, Buffer>} Path to committed bytes.
+ */
+function readIndexBytes(paths) {
+  const result = spawnSync('git', ['cat-file', '--batch'], {
+    input: paths.map((path) => `:${path}`).join('\n') + '\n',
+    maxBuffer: 1024 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    console.error('Unable to read tracked files via `git cat-file --batch`.');
+    process.exit(1);
+  }
+
+  const contents = new Map();
+  const out = result.stdout;
+  let cursor = 0;
+  for (const path of paths) {
+    const newline = out.indexOf(0x0a, cursor);
+    if (newline === -1) break;
+    const header = out.slice(cursor, newline).toString('utf8');
+    if (header.endsWith('missing')) {
+      cursor = newline + 1;
+      continue;
+    }
+    const size = Number(header.slice(header.lastIndexOf(' ') + 1));
+    const start = newline + 1;
+    contents.set(path, out.slice(start, start + size));
+    cursor = start + size + 1;
+  }
+  return contents;
+}
+
+/**
+ * Reports every offset of the replacement character, collapsing a split
+ * surrogate pair into the single fault it represents.
+ *
+ * @param {Buffer} bytes File contents.
+ * @returns {{ offset: number, doubled: boolean }[]} One entry per lost character.
+ */
+function findReplacements(bytes) {
+  const found = [];
+  let index = bytes.indexOf(REPLACEMENT);
+  while (index !== -1) {
+    const doubled = bytes.slice(index + 3, index + 6).equals(REPLACEMENT);
+    found.push({ offset: index, doubled });
+    index = bytes.indexOf(REPLACEMENT, index + (doubled ? 6 : 3));
+  }
+  return found;
+}
+
+/**
+ * Converts a byte offset to a 1-based line number.
+ *
+ * @param {Buffer} bytes File contents.
+ * @param {number} offset Byte offset within the file.
+ * @returns {number} Line number containing the offset.
+ */
+function lineOf(bytes, offset) {
+  let line = 1;
+  for (let i = 0; i < offset; i += 1) {
+    if (bytes[i] === 0x0a) line += 1;
+  }
+  return line;
+}
+
+const failures = [];
+let scanned = 0;
+let skippedBinary = 0;
+
+const trackedFiles = listTrackedFiles();
+const contents = readIndexBytes(trackedFiles);
+
+for (const path of trackedFiles) {
+  const bytes = contents.get(path);
+  if (bytes === undefined) continue;
+  if (bytes.includes(0x00)) {
+    skippedBinary += 1;
+    continue;
+  }
+  scanned += 1;
+  for (const { offset, doubled } of findReplacements(bytes)) {
+    failures.push({ path, line: lineOf(bytes, offset), doubled });
+  }
+}
+
+if (failures.length > 0) {
+  for (const { path, line, doubled } of failures) {
+    const cause = doubled ? '4-byte character, surrogate pair split' : '3-byte character collapsed';
+    console.error(`::error file=${path},line=${line}::U+FFFD replacement character (${cause})`);
+  }
+  console.error(
+    `\n${failures.length} lost character(s) in ${new Set(failures.map((f) => f.path)).size} file(s).`,
+  );
+  console.error(
+    'A U+FFFD in a committed file means the original character is gone. Recover it from an\n' +
+      'uncorrupted revision if one exists; otherwise reconstruct it from context and say so.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `No U+FFFD found in ${scanned} tracked text file(s) (${skippedBinary} binary file(s) skipped).`,
+);


### PR DESCRIPTION
## Summary

Repairs seven U+FFFD replacement characters in four tracked files and adds a repo-level guard so they cannot come back.

Reported from outside the repo by a fleet-wide sweep run from `jrmoulckers/jrm-recipes`, then independently verified here by byte-level scan of the tree.

## The repairs are inferences, not restorations

The reporter cautioned that repairing by inference and reporting it as *restored* is worse than leaving it, because it closes the issue. That caution applies to **all four** files — I checked, and no clean revision exists for any of them:

| File | First corrupt at | Note |
| --- | --- | --- |
| `apps/web/src/lib/a11y.ts` | `f7f41ced` | the line was **introduced** corrupt; earlier revisions are clean only because the helper did not exist |
| `docs/business/roadmap/go-live-assessment.md` | `cfb73c6d` | corrupt in its first commit, at the pre-rename path |
| `docs/business/sprints/alpha-household-constraints.md` | `7eb6e7ae` | corrupt in its first commit, at the pre-rename path |
| `docs/compliance/encryption-explainer.md` | `11a01337` | corrupt in its first commit |

Two of those files were renamed, so `git log --follow` reports the pre-rename revisions as "absent"; I scanned the pre-rename paths separately. My first read of `a11y.ts` was that it had a clean parent — that was wrong, and re-checking is what caught it.

So every character below was **reconstructed from context**:

| File | Reconstructed | Ground | Confidence |
| --- | --- | --- | --- |
| `alpha-household-constraints.md` | `🔒` | **mechanical + unanimous.** The corrupted cell measured 14 UTF-16 units with 6 spaces — identical to the six contiguous sibling rows above it, which all read `🔒 Hidden`. Padding fixes the width class; the run fixes the identity | determined |
| `encryption-explainer.md` | `🔑` | **strongest of the four.** The full label string appears verbatim twice more in the same file — L227 `IK["🔑 KEK + SQLCipher key"]` and L233 `AK["🔑 KEK + SQLCipher key"]`, character-for-character identical to the repaired L239. The reconstruction copies an extant string rather than inferring a glyph | determined |
| `a11y.ts` | `–` | **weakest, but still constrained.** A single `EF BF BD` implies a 3-byte character, which excludes an ASCII hyphen. Of the two 3-byte dashes in the file, all four numeric ranges use the en dash (`0–100+` ×3, `90–99%`) and the em dash never separates numerals. No padding witness, since the site is prose | high |
| `go-live-assessment.md` | `🟡` | **strong, single-witness.** The mechanical constraints narrow only to `{🟡, 🔴, ⚠️}` — a doubled `EF BF BD` implies two UTF-16 code units, *not* a surrogate pair, so VS-16 clusters like `⚠️` survive both the encoding and the padding tests. Usage alone selects: `🔴` and `⚠️` are always label prefixes followed by text, never a bare Status cell | strong (usage only) |

Ranked by candidate-set size after the mechanical constraints, then by whether surviving context extends an extant string: **`🔒` > `🔑` > `🟡` > `–`**. **Population enumerated — one rule:** every pair of consecutive UTF-16 code units both ≥ U+0080, excluding pairs touching a U+FFFD. Its subcases — surrogate pair, VS16/ZWJ sequence, unrelated adjacency — are **mechanically indistinguishable to the fault**, which emits one `EF BF BD` per lost *code unit* and cannot see grapheme boundaries. (An earlier revision of this line said "clusters *and* adjacent pairs", describing one population as two; `⚠️` is itself two adjacent single-unit characters, so that distinction was cosmetic.) Measured at `662e862e`, the repair's parent: `🔒`'s file contains **6 genuine pairs, all one distinct sequence — `🔒` itself**, which is the strongest form of its 1-candidate basis. **None of this moves any repair from inference to recovery** — no clean revision exists for any of the four, and that is the only claim the repairs depend on.

## Two mechanisms, visible in the bytes

- `EF BF BD` — a 3-byte character (the en dash) collapsed to one replacement.
- `EF BF BD EF BF BD` — a 4-byte emoji whose UTF-16 surrogate pair was split and each half replaced independently.

## The durable fix

`tools/check-text-encoding.mjs`, wired into the always-on gatekeeper job in `ci-security.yml` beside the existing format/lint/secret backstops.

**The scan is deliberately byte-level.** Mojibake is *valid* UTF-8 — `EF BF BD` is a well-formed encoding of a real code point — so `new TextDecoder('utf-8', { fatal: true })` accepts it without complaint. Validity is the wrong predicate; the question is whether the text already lost characters before it arrived.

Studio `#105` added a U+FFFD guard but scopes it to the `dist/` surface, so it would not have caught these, which live in `apps/` and `docs/`.

**Verified in both directions**, since a check that has never returned a positive is not yet an instrument:

```
corrupted tree -> exit 1, all 4 faults reported with correct file, line, and mechanism
fixed tree     -> exit 0, "No U+FFFD found in 5462 tracked text file(s) (58 binary skipped)"
```

The 5462/58 split independently corroborates the reporter's 5,461/58 (the extra file is the new tool itself). Runtime is ~14s; it reads committed bytes via a single `git cat-file --batch` pass rather than spawning `git show` per file, which took minutes.

## Notes

- The two Paparazzi snapshot PNGs that match a naive text scan are binary and correctly skipped by the NUL check.
- The guard reads from the **index**, not the working tree, so a local checkout filter cannot mask a fault.

## Testing

- [x] `npx prettier --check` on all changed files — clean
- [x] `npx eslint --max-warnings 0` on the new tool and `a11y.ts` — clean
- [x] guard positive control (corrupted tree) — exits 1, 4 faults
- [x] guard negative control (fixed tree) — exits 0
- [x] re-ran the guard after rebasing onto the current `main`

Closes #4090






