### PR TITLE
docs(guides): correct a reported upstream test defect that was an uninstalled worktree

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -1327,6 +1327,30 @@ Finance-invented, generic, and absent from the shared layers:
   made. **Read the statement, not the title**, and treat a citation as a quotation rather than a
   label.
 
+  **A defect was reported against upstream from that same worktree, and there was no defect.** The
+  report was that `npm test` failed on five files in `packages/eslint-config` and
+  `packages/prettier-config`, that stashing the change and re-running on clean `main` reproduced it
+  identically, and that green CI was therefore hiding a real failure. Every part of that is
+  checkable and the conclusion is still wrong. The failures were all `ERR_MODULE_NOT_FOUND: Cannot
+find package 'prettier'` — resolution, not assertion — and the worktree had no `node_modules` at
+  all. Running `npm install` at its root took the suite to **154/154 passing**. The test count is
+  the tell: it went 79 → 154, so the original run was not five failures out of a complete suite, it
+  was a suite that could not load half its files.
+
+  Two method lessons, both cheap and both generic:
+
+  - **CI passing where a fresh worktree fails is evidence _for_ an uninstalled tree, not against
+    it.** CI runs `npm ci` first; the install is precisely the variable CI controls and a new
+    worktree does not. That observation was read as "CI is blind" when it was the diagnosis.
+  - **`git stash` controls for the patch, not for the environment.** A missing `node_modules` is
+    invariant under stashing, so re-running on clean `main` could only ever return "identical
+    failures". The control was real but orthogonal to the hypothesis it was taken to test.
+
+  Same shape as the probe-harness error recorded above: in both cases the summary line — an exit
+  code, a pass/fail count — was taken as the finding without reading the error underneath it.
+  **Read the failure text before attributing the failure.** Note also that `npm install` rewrote a
+  line of `package-lock.json`; that was reverted so it did not ride along in the upstream PR.
+
 - **`.gitattributes` line-ending carve-out for Windows batch files.** The shared Prettier config
   sets `endOfLine: 'lf'`, which requires a `.gitattributes` to avoid `format:check` passing in CI
   and failing on every Windows checkout. finance already has one, and it goes further than the


### PR DESCRIPTION
## Summary

A `npm test` failure in the `jrmoulckers/engineering` worktree was reported to this session as a
pre-existing defect on `main` that green CI was hiding, with a recommendation to file an upstream
issue. It was checked rather than relayed, and there is no defect.

## What was actually wrong

All five failures were `ERR_MODULE_NOT_FOUND: Cannot find package 'prettier'` — resolution, not
assertion. The worktree had no `node_modules` at all. The root `package.json` declares
`workspaces: ["packages/*"]` and holds `prettier`/`eslint` in root devDependencies, while
`packages/prettier-config` declares `prettier` only as a peer, so it can never resolve without a
root install.

After `npm install` at the worktree root:

```
tests 154   pass 154   fail 0   exit=0
```

The count is the tell: **79 -> 154**. The original run was not five failures out of a complete
suite, it was a suite that could not load half its files.

## Changes

- Records the correction and two generic method lessons in
  `docs/guides/engineering-practice-adoption.md`:
  - **CI passing where a fresh worktree fails is evidence _for_ an uninstalled tree, not against
    it.** CI runs `npm ci` first; the install is exactly the variable CI controls and a new
    worktree does not. That observation was the diagnosis, and it was read as "CI is blind".
  - **`git stash` controls for the patch, not for the environment.** A missing `node_modules` is
    invariant under stashing, so re-running on clean `main` could only ever return "identical
    failures" — a real control, orthogonal to the hypothesis it was taken to test.

Same shape as the probe-harness error already recorded in this guide: in both cases a summary line
(an exit code, a pass/fail count) was taken as the finding without reading the error underneath it.

## Side effects handled

`npm install` rewrote one line of `package-lock.json` in that worktree; it was reverted with
`git checkout --` so it did not ride along in `jrmoulckers/engineering#72`. That worktree is
clean and still at `085469a`; PR #72 remains green and `MERGEABLE`, unmerged by design.

## Issues

Refs #4029

## Testing

- [x] `prettier --write` on the changed file, clean
- [x] `check-citations.mjs`: exit 0 — 69 citations, all IDs exist, 31 stated names match
- [x] No upstream issue filed, since the finding it would have rested on is false
