### PR TITLE
docs(architecture): scope ADR-0009 to its decision and fix the drift it hid

### DIFF
--- a/docs/architecture/0009-legal-monetization-analysis.md
+++ b/docs/architecture/0009-legal-monetization-analysis.md
@@ -22,6 +22,29 @@
 
 ---
 
+## Decision
+
+**Finance is licensed under BUSL-1.1 with a four-year Change Date to Apache-2.0.**
+
+That is the one durable architectural tradeoff this record carries, and `LICENSE` is its
+authority: `Change Date: 2030-03-08`, `Change License: Apache License, Version 2.0`. Where this
+document and `LICENSE` disagree, `LICENSE` wins.
+
+The alternative considered and rejected was AGPL-3.0 plus a CLA for dual-licensing (§2.6). It was
+rejected because it requires a CLA from every contributor before publication, which BSL does not.
+The consequence accepted in exchange is that BUSL-1.1 is **not** OSI-approved open source, so the
+README must not describe the project as open source without qualification.
+
+**Scope of the rest of this document.** §§3–8 are analysis of law and platform policy that finance
+does not control — trademark availability, export-control thresholds, patent subject matter, App
+Store terms. Per `ENG-ARCH-003` (Durable decisions), whose evidence clause records consequential
+_durable choices_ and explicitly excludes routine ones, that material is **context, not decision**.
+It is dated, it is not legal advice (see the disclaimer above), and it carries no authority to
+constrain future work. Only this section does. When one of those findings is acted on, the choice
+made under it belongs in its own ADR that cites this analysis as context.
+
+---
+
 ## Table of Contents
 
 1. [Executive Summary](#1-executive-summary)
@@ -138,6 +161,12 @@ This is not hypothetical. Amazon, Google, and other cloud providers have built c
 
 **Primary Recommendation: BSL 1.1 with a 3-year change date to Apache 2.0**
 
+> **Superseded on implementation:** the change date actually adopted is **four** years, not the
+> three recommended here — `LICENSE` records `Change Date: 2030-03-08`. The 2025 recommendation is
+> left as written because an ADR records the judgement that was made, not a tidied version of it;
+> the bullets below therefore still say "3 years" and are historical. For the constraint in force,
+> see the Decision section above.
+
 This is the strongest recommendation for a solo developer monetizing a financial app:
 
 - ✅ Source code is publicly visible (aligns with "open development" principle)
@@ -170,9 +199,9 @@ If changing from MIT:
 3. [x] Update `package.json` `"license"` field — **Done (`"BUSL-1.1"`)**
 4. [x] Update all `// SPDX-License-Identifier: MIT` headers in source files — **Done (`BUSL-1.1`)**
 5. [x] Update `README.md` license section — **Done**
-6. [ ] Update `build.gradle.kts` SPDX identifiers (in `packages/core/`, `packages/sync/`, `packages/models/`)
+6. [x] Update `build.gradle.kts` SPDX identifiers (in `packages/core/`, `packages/sync/`, `packages/models/`) — **Done; all three carry `// SPDX-License-Identifier: BUSL-1.1` (verified 2026-08-11)**
 7. [ ] Add a `LICENSING.md` file explaining the license choice and any commercial licensing options
-8. [x] If BSL: define the "Change Date" (e.g., 3 years from each release) and "Change License" (Apache 2.0) — **Change Date: 2030-03-08, Change License: Apache 2.0**
+8. [x] If BSL: define the "Change Date" (e.g., 3 years from each release) and "Change License" (Apache 2.0) — **Change Date: 2030-03-08 (four years), Change License: Apache 2.0**
 9. [ ] If AGPL: prepare a CLA (see §3) before accepting any external contributions
 10. [ ] Consult an attorney to review the license text and any modifications
 

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -1287,6 +1287,67 @@ Worth noting for the corpus: `ENG-LOCAL-001` being simultaneously the principle 
 outright and the principle another treats as foundational is a sign it is well-drawn, not
 ambiguous — it makes a real claim that a repository can fail.
 
+## ADR corpus audited against the decision/observation test
+
+Upstream drew a distinction worth testing: an ADR records a **tradeoff you chose**, whereas
+behaviour of a tool or platform you don't control is shared guidance, not a decision record. The
+stated test is whether you could have chosen otherwise. `ENG-ARCH-003` (Durable decisions)
+supports it — "Record consequential architectural tradeoffs as ADRs before treating them as durable
+constraints" — and its **evidence clause carries a second exclusion the framing omits**: "routine
+implementation choices do not create records". So there are two ways to file a non-decision, not
+one. External facts are the more seductive failure; routine choices are the more common one.
+
+Finance's 25 ADRs were measured against it rather than reasoned about. A cheap discriminator does
+most of the work: **an ADR recording a choice names what it rejected.** Checking every ADR for
+`Decision`, `Alternatives Considered`, and `Consequences` headings —
+
+| Result                     | Count  |
+| -------------------------- | ------ |
+| All three sections present | **24** |
+| None of the three          | **1**  |
+
+The single outlier is **ADR-0009**, and it is exactly the shape upstream describes: 811 lines
+titled "Legal, Licensing & Monetization **Analysis**", most of it an account of licence law,
+trademark availability, export-control thresholds and App Store policy — none of which finance
+chose or can change. One real decision (BUSL-1.1) sits inside it in a subsection called
+"Recommendation".
+
+**The predicted decay had already happened, and in both directions.** This is the part worth
+recording, because it converts the upstream argument from plausible to demonstrated:
+
+- The ADR's recommendation line specified a **3-year** change date. `LICENSE` says **four**
+  (`Change Date: 2030-03-08`). The document that is supposed to govern the artifact had drifted
+  from it, while still carrying `Status: Accepted`.
+- Checklist item 6, SPDX identifiers in the three `build.gradle.kts` files, was marked
+  **outstanding**. All three already carry `// SPDX-License-Identifier: BUSL-1.1`. Verified by
+  reading the files.
+
+Neither error is visible from inside the document; both are only visible by checking the ADR
+against the thing it describes. That is the cost upstream names — the facts go stale while keeping
+the authority of a decision nobody revisits — and it lands hardest on the ADR that is mostly facts,
+because there is so much more of it to go stale and no `Decision` heading to anchor what is
+actually binding.
+
+**Fixed, without rewriting history.** ADR-0009 now opens with a `## Decision` section stating the
+one durable choice, naming `LICENSE` as the authority where the two disagree, giving the rejected
+alternative (AGPL-3.0 + CLA) and the consequence accepted in exchange (not OSI-approved, so the
+README must not call the project open source unqualified). The 2025 recommendation text is left as
+written and marked superseded rather than corrected in place — an ADR records the judgement that
+was made, not a tidied version of it. §§3–8 are explicitly scoped as context with no authority to
+constrain future work, and each future action taken under them is directed to its own ADR citing
+this one.
+
+Two things this does **not** do. It does not delete the analysis: the material is useful and the
+fault was its status, not its content. And it does not renumber or split the record, because
+inbound links and the ADR index refer to 0009 and a split would trade a scoping problem for a
+provenance one.
+
+**The generalisable finding:** applying the test cost one grep across 25 files, and the value came
+from what the outlier revealed rather than from the classification itself. A document that fails
+the decision/observation test is worth auditing for drift **first**, before deciding what to do
+with it, because a corpus of observed facts filed as decisions decays silently and the decay is
+what actually hurts.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:


### PR DESCRIPTION
## Summary

Upstream (`jrmoulckers/engineering` v0.17.1) drew a line worth testing: an ADR records a
**tradeoff you chose**; behaviour of a tool or platform you don't control is shared guidance, not a
decision record. The test is whether you could have chosen otherwise.

I checked the principle behind it rather than the summary. `ENG-ARCH-003` (Durable decisions)
supports the framing — _"Record consequential architectural tradeoffs as ADRs before treating them
as durable constraints"_ — and its **evidence clause carries a second exclusion the framing omits**:
_"routine implementation choices do not create records."_ Two ways to file a non-decision, not one.

## What the audit found

A cheap discriminator does most of the work: an ADR recording a choice names what it rejected.
Grepping all 25 ADRs for `Decision` / `Alternatives Considered` / `Consequences`:

| Result | Count |
| --- | --- |
| All three sections present | **24** |
| None of the three | **1** |

The outlier is **ADR-0009**, exactly the predicted shape: 811 lines titled "Legal, Licensing &
Monetization **Analysis**", mostly an account of licence law, trademark availability,
export-control thresholds and App Store policy — none of which finance chose or can change. One
real decision (BUSL-1.1) sits inside it under a heading called "Recommendation".

**The predicted decay had already happened, in both directions.** This is what makes the upstream
argument demonstrated rather than plausible:

- The ADR specified a **3-year** change date. `LICENSE` says **four** (`Change Date: 2030-03-08`).
  The document meant to govern the artifact had drifted from it while still reading `Status: Accepted`.
- Checklist item 6 (SPDX in three `build.gradle.kts` files) was marked **outstanding**. All three
  already carry `// SPDX-License-Identifier: BUSL-1.1` — verified by reading them.

Neither is visible from inside the document. Both require checking the ADR against the thing it
describes, and both landed on the ADR that is mostly facts, because there is more to go stale and
no `Decision` heading to anchor what actually binds.

## Changes

- **`docs/architecture/0009-legal-monetization-analysis.md`**
  - Adds `## Decision`: BUSL-1.1 with a four-year Change Date to Apache-2.0, `LICENSE` named as
    the authority where the two disagree, the rejected alternative (AGPL-3.0 + CLA) and the
    consequence accepted (not OSI-approved, so the README must not say "open source" unqualified).
  - Marks the 2025 recommendation **superseded** rather than correcting it in place — an ADR records
    the judgement that was made, not a tidied version of it.
  - Scopes §§3–8 as context with no authority to constrain future work; future choices made under
    them get their own ADR citing this one.
  - Corrects the two drifted facts.
- **`docs/guides/engineering-practice-adoption.md`** — records the audit, the counts, the drift
  evidence, and the generalisable finding.

**Not done deliberately:** the analysis is not deleted (the fault was its status, not its content),
and 0009 is not split or renumbered (inbound links and the ADR index point at it; a split trades a
scoping problem for a provenance one).

## Issues

Refs #4029

## Testing

- [x] `prettier --write` on both files — clean, no reflow
- [x] `check-citations.mjs` → exit 0; **71 citations, all IDs exist, 33 stated names match** (up
      from 31 — both new `ENG-ARCH-003` citations use the parenthesised form so they are
      machine-verified, and both survive the format pass unwrapped, avoiding gap 18)
- [x] Drift claims verified against the artifacts: `LICENSE` change date, and SPDX headers in
      `packages/{core,sync,models}/build.gradle.kts`
