### PR TITLE
fix(tools): fail the encoding guard when it scans nothing or cannot detect

### DIFF
--- a/tools/check-text-encoding.mjs
+++ b/tools/check-text-encoding.mjs
@@ -122,9 +122,50 @@ function lineOf(bytes, offset) {
   return line;
 }
 
+/**
+ * Verifies the detector against synthetic input before it is trusted on real files.
+ *
+ * Without this, a broken detector and a clean repository produce the same exit code. The
+ * positive cases prove `findReplacements` still recognises both fault patterns; the negative
+ * case proves it is not simply reporting a hit for everything.
+ *
+ * @returns {void}
+ */
+function selfTest() {
+  const cases = [
+    {
+      name: 'single replacement',
+      bytes: Buffer.concat([Buffer.from('a'), REPLACEMENT]),
+      expected: 1,
+    },
+    {
+      name: 'split surrogate pair',
+      bytes: Buffer.concat([REPLACEMENT, REPLACEMENT]),
+      expected: 1,
+    },
+    {
+      name: 'clean text',
+      bytes: Buffer.from('en dash \u2013 and emoji \u{1f511}', 'utf8'),
+      expected: 0,
+    },
+  ];
+
+  for (const { name, bytes, expected } of cases) {
+    const actual = findReplacements(bytes).length;
+    if (actual !== expected) {
+      console.error(
+        `::error::encoding guard self-test failed: ${name} returned ${actual} result(s), expected ${expected}.`,
+      );
+      process.exit(1);
+    }
+  }
+}
+
 const failures = [];
 let scanned = 0;
 let skippedBinary = 0;
+
+selfTest();
 
 const trackedFiles = listTrackedFiles();
 const contents = readIndexBytes(trackedFiles);
@@ -153,6 +194,14 @@ if (failures.length > 0) {
   console.error(
     'A U+FFFD in a committed file means the original character is gone. Recover it from an\n' +
       'uncorrupted revision if one exists; otherwise reconstruct it from context and say so.',
+  );
+  process.exit(1);
+}
+
+if (scanned === 0) {
+  console.error(
+    '::error::encoding guard examined 0 tracked text files. This repository always has tracked\n' +
+      'text files, so an empty scan means the guard is broken, not that the tree is clean.',
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

`tools/check-text-encoding.mjs` (added in #4091) exited `0` when it examined no files.
A broken walk and a clean tree produced the same exit code, and a green check is exactly
when nobody reads the log.

## Verification, including the control that matters

Disabling `findReplacements` (early `return found;`) against the **pre-fix** script:

```
No U+FFFD found in 5462 tracked text file(s) (58 binary file(s) skipped).
exit=0
```

A completely disabled detector reported success over 5,462 files. Note this also shows a
`scanned > 0` assertion **alone would not have caught it** — the population was fine; the
detector was not. Both assertions are needed, and they fail independently:

| mutation | before | after |
| --- | --- | --- |
| detector disabled | `exit 0`, success message | `exit 1`, self-test failure |
| file list emptied | `exit 0`, `0 tracked text file(s)` | `exit 1`, empty-scan failure |
| unmodified | `exit 0`, 5,462 scanned | `exit 0`, 5,462 scanned |

## Changes

- `selfTest()` pushes synthetic `EF BF BD` and split-surrogate buffers through
  `findReplacements`, plus a clean control that must return zero, before any file is read
- fail when `scanned === 0`

No change to detection behaviour, output format, or the `ci-security.yml` wiring. The seven
characters repaired in #4091 are untouched.

## Issues

Closes #4094

## Testing

- [x] `node tools/check-text-encoding.mjs` — 5,462 scanned, 58 binary skipped, exit 0
- [x] two mutation controls above, both now exit 1
- [x] `npx prettier --check` and `npx eslint --max-warnings 0` on the touched file