### PR TITLE
docs(ai): withdraw the false TypeScript 5.9.3 type-check exemption (#4029)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,8 +86,8 @@ See `docs/ai/worktrees.md` for the full worktree lifecycle guide.
 
 Tooling notes:
 
-- `npm run format:check && npx eslint . --max-warnings 0` — verify format + lint before every push (preferred over `npm run ci:check` — see Known Local Issues)
-- `npm run ci:check` — format:check + lint + type-check; use for full validation when TS is stable locally
+- `npm run ci:check` — format:check + lint + type-check; **type-check passes locally, so prefer this for full validation**
+- `npm run format:check && npx eslint . --max-warnings 0` — the fast format + lint subset, when you want a quicker loop than the full check
 - `npm run ci:check:quick` — lightweight check for docs-only or non-code changes
 - `npm run format` — auto-fix all Prettier issues; `npx eslint . --fix` — auto-fix ESLint issues
 - `npm run cleanup:worktrees` — clean up merged/stale worktrees

--- a/docs/ai/agent-cookbook.md
+++ b/docs/ai/agent-cookbook.md
@@ -40,7 +40,7 @@ git add -A && git commit --amend --no-edit
 $env:HUSKY = "0" ; git push --no-verify origin <branch-name>
 ```
 
-> **Remote CI is the source of truth** — not local `npm run ci:check`. Local type-check may fail on TS 5.9.3. See [CI Monitoring](ci-monitoring.md).
+> **Remote CI is the source of truth** for the platform jobs a local machine can't run. Local `npm run ci:check` — including type-check — is expected to pass; see [CI Monitoring](ci-monitoring.md#retracted-local-type-check-fails-on-ts-593).
 
 ---
 

--- a/docs/ai/ci-monitoring.md
+++ b/docs/ai/ci-monitoring.md
@@ -33,11 +33,21 @@ Fix locally, follow the [canonical pre-push workflow](workflow.md#️-mandatory-
 
 Local checks (`npm run ci:check`, `npm run format:check`, etc.) are useful for catching issues early, but **remote CI is the authoritative result**. A PR is not merge-ready until `gh pr checks` shows all green — regardless of what passes locally.
 
-### Known Issue: Local type-check on TS 5.9.3
+### Retracted: "Local type-check fails on TS 5.9.3"
 
-TypeScript 5.9.3 rejects the `ignoreDeprecations` compiler option locally, causing `npm run type-check` (and therefore `npm run ci:check`) to fail even on clean code. Remote CI uses a compatible configuration and is not affected.
+This repo previously documented a known issue stating that TypeScript 5.9.3 rejects the `ignoreDeprecations` compiler option locally, so `npm run type-check` (and therefore `npm run ci:check`) failed even on clean code, and that agents should skip type-check locally. **That claim is false and is withdrawn.**
 
-**Workaround:** The [canonical pre-push workflow](workflow.md#️-mandatory-pre-push-workflow-never-skip) intentionally checks only formatting and lint locally. Let remote CI handle the type-check.
+Measured on 2026-08-11:
+
+- The installed compiler is **TypeScript 6.0.3**, not 5.9.3 (`node -e "require('typescript/package.json').version"`).
+- `apps/web/tsconfig.json` carries `"ignoreDeprecations": "6.0"`, which 6.0.3 accepts.
+- `npm run type-check` exits **0** across the repo, and `tsc -p apps/web/tsconfig.json --noEmit` exits **0** with no output.
+
+A clean type-check is also the exact shape of an _aborted_ one — same exit code, same empty output — so the run was proved rather than assumed: planting `const planted: number = "definitely not a number";` in `apps/web/src` produced `TS2322` and exit **2**, then the probe was removed. The gate runs, and it is genuinely clean.
+
+**Run type-check locally.** `npm run ci:check` is the full gate and is expected to pass. Remote CI remains authoritative for the reasons in the section above — it runs the platform jobs a local machine does not — but not because local type-check is broken.
+
+> **Why this mattered enough to write down.** A wrong "known issue" is self-reinforcing: every agent that reads it skips the gate, and skipping the gate is what stops anyone discovering the claim is false. This one survived long enough to be copied into nine other documents, and the correction had reached only one of them. When retracting an exemption, grep for it — the claim spreads further than the fix does.
 
 ---
 

--- a/docs/ai/fleet-ci-analysis.md
+++ b/docs/ai/fleet-ci-analysis.md
@@ -239,7 +239,7 @@ Before EVERY push, you MUST complete ALL of these steps IN ORDER:
 ### Common Pitfalls
 - **Markdown files need Prettier too!** `npm run format` formats .md files
 - **ESLint warnings are errors in CI!** Remove unused imports, especially `vi` in test files
-- **Local type-check may fail on TS 5.9.3** — remote CI is the source of truth
+- **Local type-check passes** (TS 6.0.3) — the TS 5.9.3 exemption is [retracted](ci-monitoring.md#retracted-local-type-check-fails-on-ts-593); remote CI remains the source of truth for platform jobs
 - **Worktrees don't share node_modules** — always run `npm install` first
 - **Husky blocks non-interactive pushes** — always use `$env:HUSKY = "0"` with `--no-verify`
 ```

--- a/docs/ai/fleet-operations.md
+++ b/docs/ai/fleet-operations.md
@@ -436,7 +436,7 @@ Before EVERY push, you MUST complete ALL steps IN ORDER:
 ### Common Pitfalls
 - Markdown files need Prettier too! `npm run format` formats .md files
 - ESLint warnings are errors in CI! Remove unused imports, especially `vi` in test files
-- Local type-check may fail on TS 5.9.3 — remote CI is the source of truth
+- Local type-check passes (TS 6.0.3); the TS 5.9.3 exemption is [retracted](ci-monitoring.md#retracted-local-type-check-fails-on-ts-593) — remote CI remains the source of truth for platform jobs
 - Worktrees don't share node_modules — always run `npm install` first
 ```
 
@@ -485,7 +485,7 @@ git rebase origin/main
 $env:HUSKY = "0" ; git push --no-verify origin <branch-name>
 ```
 
-> **Remote CI is the source of truth** — not local `npm run ci:check` (which may fail on TS 5.9.3). This checklist is not optional. An agent that pushes without running these steps has not completed its pre-push workflow.
+> **Remote CI is the source of truth** for the platform jobs a local machine can't run. Local `npm run ci:check` — including type-check — is expected to pass; the TS 5.9.3 exemption is [retracted](ci-monitoring.md#retracted-local-type-check-fails-on-ts-593). This checklist is not optional. An agent that pushes without running these steps has not completed its pre-push workflow.
 
 ### PR creation
 

--- a/docs/ai/pain-points.md
+++ b/docs/ai/pain-points.md
@@ -159,28 +159,28 @@ Document that KMP/Swift agents should run platform-specific build commands local
 
 ---
 
-#### PP-0018: TS 5.9.3 rejects `ignoreDeprecations` locally
+#### PP-0018: TS 5.9.3 rejects `ignoreDeprecations` locally — **withdrawn, never reproducible**
 
-| Field          | Value            |
-| -------------- | ---------------- |
-| **ID**         | PP-0018          |
-| **Severity**   | 🟡 Medium        |
-| **Category**   | CI/CD, Tooling   |
-| **First seen** | 2025-07          |
-| **Status**     | Open             |
-| **Owner**      | @devops-engineer |
+| Field          | Value                  |
+| -------------- | ---------------------- |
+| **ID**         | PP-0018                |
+| **Severity**   | ⚪ None (invalid)      |
+| **Category**   | CI/CD, Tooling         |
+| **First seen** | 2025-07                |
+| **Status**     | Withdrawn (2026-08-11) |
+| **Owner**      | @devops-engineer       |
 
 **Description:**
-TypeScript 5.9.3 rejects the `ignoreDeprecations` compiler option in `tsconfig.json`, causing `npm run type-check` (and therefore `npm run ci:check`) to fail locally even on clean code. Remote CI uses a compatible configuration and is not affected.
+This entry claimed TypeScript 5.9.3 rejects the `ignoreDeprecations` compiler option in `tsconfig.json`, causing `npm run type-check` (and therefore `npm run ci:check`) to fail locally even on clean code. **The claim is false.** The installed compiler is TypeScript **6.0.3**, `apps/web/tsconfig.json` carries `"ignoreDeprecations": "6.0"` which 6.0.3 accepts, and `npm run type-check` exits 0. Verified to be a real run, not an aborted one, by planting a type error and confirming `TS2322` / exit 2. Full measurements in [CI Monitoring](ci-monitoring.md#retracted-local-type-check-fails-on-ts-593).
 
-**Impact:**
-Agents cannot use `npm run ci:check` as a reliable local gate. The canonical pre-push workflow now skips type-check locally and defers to remote CI.
+**Impact of the pain point as written:**
+It steered every agent away from a working gate for roughly a year, and was copied into nine other documents. Type failures were also excluded from the avoidable-CI-failure metric on its authority.
 
-**Current workaround:**
-The canonical pre-push workflow checks only format and lint locally. Remote CI handles type-check.
+**Resolution:**
+Withdrawn. `npm run ci:check` is a reliable local gate; run it. The nine downstream copies were corrected in the same change.
 
-**Suggested fix:**
-Pin TypeScript version or update `tsconfig.json` to remove `ignoreDeprecations` when all deprecated APIs have been migrated.
+**Lesson (kept deliberately):**
+A wrong "known issue" is self-reinforcing — each agent that obeys the exemption skips the very command that would falsify it, so the claim is never retested. Before recording an exemption, reproduce the failure; before trusting an old one, re-run it. And when retracting one, grep for it: the claim had spread to ten files while the correction had reached one.
 
 ---
 

--- a/docs/ai/troubleshooting.md
+++ b/docs/ai/troubleshooting.md
@@ -78,11 +78,11 @@ gh pr checks <number>
 - CI log shows TypeScript compilation errors
 - `npm run type-check` fails locally
 
-### Known Issue: TS 5.9.3
+### Retracted: "Known Issue: TS 5.9.3"
 
-TypeScript 5.9.3 rejects the `ignoreDeprecations` compiler option locally, causing `npm run type-check` (and `npm run ci:check`) to fail even on clean code. Remote CI uses a compatible configuration and is not affected.
+This section used to claim that TypeScript 5.9.3 rejects `ignoreDeprecations` locally, so a failing `npm run type-check` was "expected" and should be pushed past. **That was false** — the installed compiler is 6.0.3, the option is accepted, and the gate passes. See [CI Monitoring](ci-monitoring.md#retracted-local-type-check-fails-on-ts-593) for the measurements.
 
-**If the failure is the `ignoreDeprecations` error:** This is expected locally. Push your code (after passing format and lint checks) and let remote CI validate the type-check.
+**Treat every local type-check failure as a genuine type error.** There is no expected-failure case to wave through.
 
 ### Fix (for genuine type errors)
 

--- a/docs/ai/workflow-metrics.md
+++ b/docs/ai/workflow-metrics.md
@@ -100,7 +100,7 @@ Metrics are NOT used to evaluate individual agent "performance." They measure sy
 
 #### Q-1: Avoidable CI Failure Rate
 
-**Definition:** Percentage of CI runs that fail due to issues the pre-push checklist would have caught locally — formatting and lint (`npm run format:check && npx eslint . --max-warnings 0`). Type-check is excluded: it is unreliable locally on TS 5.9.3 (see [CI Monitoring](ci-monitoring.md)), so type failures are a remote-CI concern, not an avoidable local miss.
+**Definition:** Percentage of CI runs that fail due to issues the pre-push checklist would have caught locally — formatting and lint (`npm run format:check && npx eslint . --max-warnings 0`). Type-check was historically excluded on the grounds that it was unreliable locally; that claim has been [retracted](ci-monitoring.md#retracted-local-type-check-fails-on-ts-593) and type-check now passes locally, so type failures **do** count as avoidable local misses.
 
 **Measurement:** `avoidable_failures / total_ci_runs × 100`
 

--- a/docs/ai/workflow.md
+++ b/docs/ai/workflow.md
@@ -62,7 +62,7 @@ gh pr create --base main --title "type(scope): description (#N)" --body "Closes 
 gh pr checks <number>   # poll until all checks are green
 ```
 
-> **Why no local type-check?** TypeScript 5.9.3 rejects `ignoreDeprecations` locally (see [CI Monitoring](ci-monitoring.md)). The canonical workflow checks format and lint locally — which are reliable — and lets remote CI handle type-check. **Remote CI is the source of truth**, not local `npm run ci:check`.
+> **Why is type-check not in the fast loop?** Only because it is slower, not because it is broken. The earlier claim that TypeScript 5.9.3 rejects `ignoreDeprecations` locally has been [retracted](ci-monitoring.md#retracted-local-type-check-fails-on-ts-593) — the installed compiler is 6.0.3 and `npm run ci:check` passes. Run the full `ci:check` before pushing when you have the time; **remote CI is the source of truth** for the platform jobs a local machine can't run.
 
 > **Note:** `lint-staged` is configured in `.husky/pre-commit` and auto-formats staged files on commit. However, agents may bypass hooks or work in worktrees where hooks aren't active. **The explicit checklist above is mandatory regardless of hook status.**
 

--- a/docs/ai/worktrees.md
+++ b/docs/ai/worktrees.md
@@ -108,7 +108,7 @@ gh pr view <branch-name> --json number
 # If this errors with "no pull requests found" — re-run Step 7
 ```
 
-> **Remote CI is the source of truth.** Local type-check may fail on TS 5.9.3 — see [CI Monitoring](ci-monitoring.md). The workflow above checks format and lint locally (reliable), and defers type-check to remote CI.
+> **Remote CI is the source of truth** for the platform jobs a local machine can't run. The workflow above checks format and lint locally for speed; `npm run ci:check` adds type-check and is expected to pass — see [CI Monitoring](ci-monitoring.md#retracted-local-type-check-fails-on-ts-593).
 
 > **Note:** `lint-staged` is configured in `.husky/pre-commit` (`eslint --fix` + `prettier --write` for TS/JS files; `prettier --write` for JSON/YAML/MD/CSS). However, agents may bypass hooks or work in worktrees where hooks aren't active. **The explicit checklist above is mandatory regardless of hook status.**
 

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -1383,6 +1383,78 @@ the decision/observation test is worth auditing for drift **first**, before deci
 with it, because a corpus of observed facts filed as decisions decays silently and the decay is
 what actually hurts.
 
+## A false exemption survived in ten files while its retraction reached one
+
+Upstream's `v0.21.0` broadcast reported that a `copilot-instructions.md` claiming a TypeScript
+5.9.3 incompatibility had been steering every agent away from a working type-check gate. Most of
+that message described work finance never did — see the misattribution note below — but **this part
+was true here**, and checking it turned out to be worth more than the original claim.
+
+**The claim, measured.** finance's docs stated that TypeScript 5.9.3 rejects the
+`ignoreDeprecations` compiler option locally, so `npm run type-check` and `npm run ci:check` fail
+even on clean code, and agents should therefore check only format and lint before pushing. Every
+load-bearing element is false:
+
+| Claim                            | Measured                                                                      |
+| -------------------------------- | ----------------------------------------------------------------------------- |
+| Compiler is TypeScript 5.9.3     | **6.0.3**                                                                     |
+| `ignoreDeprecations` is rejected | `apps/web/tsconfig.json` sets `"ignoreDeprecations": "6.0"`; 6.0.3 accepts it |
+| `npm run type-check` fails       | exit **0** (turbo, 3 packages in scope, 1 task)                               |
+| `ci:check` unusable locally      | `tsc -p apps/web/tsconfig.json --noEmit` → exit **0**, no output              |
+
+**The clean result was proved, not assumed.** A healthy tree and a compiler that aborted before
+checking anything produce the same exit code and the same empty output, so a passing type-check is
+not by itself evidence the type-check ran. Planting
+`const planted: number = "definitely not a number";` under `apps/web/src` produced `TS2322` and
+exit **2**; removing it returned exit 0. The gate genuinely runs and is genuinely clean. This is
+the same discipline as the harness-versus-code distinction recorded elsewhere in this guide: a
+summary line is a claim about the harness until something makes it a claim about the code.
+
+**The part upstream did not have.** Their framing is that a wrong "known issue" is self-reinforcing
+— each agent that honours the exemption skips the command that would falsify it, so the claim is
+never retested. Correct, and finance is a worked example of a second-order version:
+
+> **A retraction does not propagate along the same paths the claim did.** The correction had
+> already landed in `.github/copilot-instructions.md`. Grepping for `5.9.3` found the claim alive
+> in **nine other files** — `ci-monitoring.md` (the hub every other doc linked to for it),
+> `workflow.md`, `agent-cookbook.md`, `troubleshooting.md`, `pain-points.md` (as open pain point
+> PP-0018), `fleet-operations.md` (twice), `fleet-ci-analysis.md`, `worktrees.md`, and
+> `workflow-metrics.md`. Fourteen occurrences in total. An agent reading any of the canonical
+> workflow docs would still have been told to skip the gate.
+
+Worse, the retraction had been applied to the _statement_ while leaving its _consequences_ in place
+two lines above it: `copilot-instructions.md` still listed the format+lint subset as "preferred over
+`npm run ci:check` — see Known Local Issues", pointing at the very section that now says the issue
+was never real. The exemption had also propagated into a **metric definition** —
+`workflow-metrics.md` excluded type failures from avoidable-CI-failure rate on its authority, so the
+false claim was quietly improving a number finance reports on itself.
+
+**What this changes for adoption.** `ENG-TEST-004` (Distinct static signals) requires format, lint
+and type-check to report independently. finance's `ci:check` satisfies the structure, but a
+documented exemption that stops anyone running one of the three signals defeats it just as
+thoroughly as merging them would. The exemption is withdrawn; PP-0018 is marked withdrawn rather
+than deleted, so the corpus keeps the lesson.
+
+**Generalisable, and offered upstream:** when retracting a documented exemption, grep the repo for
+the claim before considering it retracted, and check the guidance it _caused_ as well as the claim
+itself. Fixing the sentence is the cheap half. Recorded here because the ratio — one file corrected,
+nine still asserting it — is the useful number, not the retraction.
+
+### Misattribution in the same broadcast
+
+For the record, and so the right repo gets the credit and the re-check: the `v0.21.0` message
+attributes to finance a TypeScript 6.0.3 / `TS5101` / `baseUrl` false-clean report, a count of
+"838" in-bounds indexed reads, "your 2,691", and a `reactConfig()` diff of "266 findings". finance
+filed none of those. finance measured the published preset at **317** findings, not 266, and its
+`@jrmoulckers/tsconfig` blast radius at **2,691** was recorded here as a deferral, not as a bug
+report. The `baseUrl` finding in particular is someone else's — finance's `apps/web/tsconfig.json`
+carries `baseUrl` _and_ `ignoreDeprecations: "6.0"` together and type-checks cleanly on 6.0.3, so
+it cannot be the source of a report that the combination aborts.
+
+This is the fourth apparent mirror error across the seven-repo broadcast, and two earlier ones were
+confirmed as such. Flagged rather than corrected silently, because the reporting repo is the one
+that should be asked to re-check its own numbers.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:


### PR DESCRIPTION
## Summary

finance's agent documentation carried a "known issue" stating that **TypeScript 5.9.3 rejects the `ignoreDeprecations` compiler option locally**, so `npm run type-check` (and therefore `npm run ci:check`) fails even on clean code, and agents should push after checking only format and lint.

Every load-bearing element of that claim is false.

| Claim | Measured |
| --- | --- |
| Compiler is TypeScript 5.9.3 | **6.0.3** |
| `ignoreDeprecations` is rejected | `apps/web/tsconfig.json` sets `"ignoreDeprecations": "6.0"`; 6.0.3 accepts it |
| `npm run type-check` fails | exit **0** |
| `ci:check` unusable locally | `tsc -p apps/web/tsconfig.json --noEmit` → exit **0**, no output |

### The clean result was proved, not assumed

A healthy tree and a compiler that aborted before checking anything produce the **same exit code and the same empty output**, so a passing type-check is not by itself evidence the type-check ran. Planting `const planted: number = "definitely not a number";` under `apps/web/src` produced `TS2322` and exit **2**; removing it returned exit 0. The gate runs, and it is clean.

## The finding worth keeping

A wrong "known issue" is self-reinforcing — each agent that honours the exemption skips the very command that would falsify it, so the claim is never retested.

finance is a worked example of a **second-order** version of that:

> **A retraction does not propagate along the same paths the claim did.**

The correction had already landed in `.github/copilot-instructions.md`. Grepping for `5.9.3` found the claim still alive in **nine other files, 14 occurrences total** — including `ci-monitoring.md` (the hub every other doc linked to *for this issue*), `workflow.md`, `agent-cookbook.md`, `troubleshooting.md`, `pain-points.md` (as **open** pain point PP-0018), `fleet-operations.md` (×2), `fleet-ci-analysis.md`, `worktrees.md` and `workflow-metrics.md`. An agent reading any canonical workflow doc was still told to skip the gate.

Two compounding problems the sentence-level fix had missed:

- `copilot-instructions.md` still recommended the format+lint subset as *"preferred over `npm run ci:check` — see Known Local Issues"*, pointing at the section that now says the issue was never real. **The retraction landed on the claim but not on the guidance the claim caused.**
- `workflow-metrics.md` excluded type failures from avoidable-CI-failure rate on its authority — so the false claim was quietly improving a metric finance reports on itself.

## Relation to `ENG-TEST-004` (Distinct static signals)

finance's `ci:check` keeps format, lint and type-check reporting independently, which satisfies the structure. But a documented exemption that stops anyone *running* one of the three signals defeats the principle as thoroughly as merging them would.

## Changes

- `docs/ai/ci-monitoring.md` — the former hub section replaced with a full retraction carrying the measurements and the prove-it-ran evidence.
- Eight downstream docs repointed at that retraction.
- `docs/ai/pain-points.md` — **PP-0018 marked withdrawn rather than deleted**, so the corpus keeps the lesson.
- `docs/ai/workflow-metrics.md` — type failures now count as avoidable local misses.
- `.github/copilot-instructions.md` — tooling notes now recommend `ci:check`; edit is outside the `studio:base` markers (162–246), so it is member-owned and will not be detected as sync drift.
- `docs/guides/engineering-practice-adoption.md` — records the finding, plus a note that most of the upstream broadcast that prompted this check describes work finance never did (the `TS5101`/`baseUrl` report, "838", and "266 findings" — finance measured **317**). Flagged for the reporting repo to re-check rather than corrected silently.

## Issues

Refs #4029

## Testing

- [x] `npm run ci:check` — format:check + lint + type-check, **exit 0**
- [x] Type-check gate proved live via a planted `TS2322` (exit 2), then reverted
- [x] `prettier --write` on all 11 changed files
- [x] `grep 5.9.3` — every remaining occurrence is part of a retraction
