### PR TITLE
fix(tools): anchor the encoding guard to the repository root (#4096)

### DIFF
--- a/tools/check-text-encoding.mjs
+++ b/tools/check-text-encoding.mjs
@@ -38,12 +38,36 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
 }
 
 /**
+ * Absolute path to the repository root.
+ *
+ * Every git invocation below runs here rather than in the caller's working
+ * directory. Both `git ls-files` and `git cat-file`'s `:<path>` syntax resolve
+ * relative to the current directory, so without this the guard silently
+ * examines whatever subtree it happens to be started from.
+ */
+const repoRoot = (() => {
+  const result = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    console.error('Unable to locate the repository root via `git rev-parse --show-toplevel`.');
+    process.exit(1);
+  }
+  return result.stdout.trim();
+})();
+
+/**
  * Lists every tracked path at HEAD.
+ *
+ * The `:/` pathspec is redundant with running from the repository root but
+ * states the intent at the call site: this walk covers the whole repository,
+ * never the current subtree.
  *
  * @returns {string[]} Repository-relative paths.
  */
 function listTrackedFiles() {
-  const result = spawnSync('git', ['ls-files', '-z'], { maxBuffer: 1024 * 1024 * 256 });
+  const result = spawnSync('git', ['ls-files', '-z', '--', ':/'], {
+    cwd: repoRoot,
+    maxBuffer: 1024 * 1024 * 256,
+  });
   if (result.status !== 0) {
     console.error('Unable to list tracked files via `git ls-files`.');
     process.exit(1);
@@ -62,6 +86,7 @@ function listTrackedFiles() {
  */
 function readIndexBytes(paths) {
   const result = spawnSync('git', ['cat-file', '--batch'], {
+    cwd: repoRoot,
     input: paths.map((path) => `:${path}`).join('\n') + '\n',
     maxBuffer: 1024 * 1024 * 1024,
   });
@@ -164,6 +189,7 @@ function selfTest() {
 const failures = [];
 let scanned = 0;
 let skippedBinary = 0;
+let unreadable = 0;
 
 selfTest();
 
@@ -172,7 +198,10 @@ const contents = readIndexBytes(trackedFiles);
 
 for (const path of trackedFiles) {
   const bytes = contents.get(path);
-  if (bytes === undefined) continue;
+  if (bytes === undefined) {
+    unreadable += 1;
+    continue;
+  }
   if (bytes.includes(0x00)) {
     skippedBinary += 1;
     continue;
@@ -202,6 +231,28 @@ if (scanned === 0) {
   console.error(
     '::error::encoding guard examined 0 tracked text files. This repository always has tracked\n' +
       'text files, so an empty scan means the guard is broken, not that the tree is clean.',
+  );
+  process.exit(1);
+}
+
+// Every tracked path must land in exactly one bucket. This catches a file that
+// silently disappears from the walk without being counted anywhere. It is a
+// weaker check than the floor above rather than a replacement for it: its
+// reference quantity is derived from the same walk it polices, so a narrowed
+// walk shrinks both sides together and passes. The floor's reference is the
+// constant 0, which nothing about the walk can move.
+if (scanned + skippedBinary + unreadable !== trackedFiles.length) {
+  console.error(
+    `::error::encoding guard accounted for ${scanned + skippedBinary + unreadable} of ` +
+      `${trackedFiles.length} tracked file(s). Files vanished from the walk without being\n` +
+      'counted, so the clean result covers an unknown subset of the repository.',
+  );
+  process.exit(1);
+}
+
+if (unreadable > 0) {
+  console.error(
+    `::error::encoding guard could not read ${unreadable} tracked file(s) from the index.`,
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

`tools/check-text-encoding.mjs` could report a clean, healthy-looking result while never opening the directory the corruptions were in.

> **Corrected 2026-08-11 (see #4103 / #4105).** The sentence below is wrong in its second clause and is retained rather than removed so the error stays greppable. **`git cat-file`'s `:<path>` is root-relative, not cwd-relative** — only `:./<path>` is cwd-relative. The cause is entirely `git ls-files`, which *selects* **and prints** relative to the cwd; bare names for files under the cwd are then looked up against the repository root and miss. Corrected wording is in the Changes section below.
>
> ~~Both git invocations resolve paths **relative to the current working directory**: `git ls-files` scopes its walk to the cwd, and `git cat-file`'s `:<path>` syntax resolves against it too.~~ Started from anywhere but the repository root, the guard silently narrowed its own corpus.

```
cwd          tracked files walked   exit
repo root                    5520      0
apps/                        3969      0
apps/web/                    2521      0
```

> **Corrected 2026-08-11 (second pass, see comment below).** Two figures in the sentence below are wrong; retained struck-through so they stay greppable. Running the pre-fix guard at `154d0b5a` from `apps/web` printed **`4`**, not ~2500 — and the four were the repository-root blobs sharing a name with an `apps/web` file (`.gitignore`, `README.md`, `package.json`, `performance.budget.json`). Also **three of four**, not all four, of #4091's repairs were under `docs/`; the fourth was `apps/web/src/lib/a11y.ts`, which was *also* dropped (`:src/lib/a11y.ts -> missing`). The conclusion holds and is stronger: the guard would have missed all four, including the one inside the directory it was run from.
>
> ~~From `apps/web` it printed *"No U+FFFD found in ~2500 tracked text file(s)"* and exited 0 — a plausible count — having never examined `docs/`. **All four corruptions repaired in #4091 were under `docs/`.**~~ The guard would have passed on the exact corpus it was written to catch. One `working-directory:` key in a workflow, or any local run from a subdirectory, triggers it.

## Changes

- Resolve the repository root once via `git rev-parse --show-toplevel` and run **every** git invocation with `cwd` set to it, so the caller's directory cannot influence the corpus. `git ls-files` scopes its walk to the cwd **and emits paths relative to it**, while `git cat-file`'s `:<path>` resolves against the repository root — so anchoring only the walk left every path *under* the cwd unreadable (**3969 of 5520 tracked** from `apps/` — equivalently **3913 of 5462 text**; not all of them, as the table above shows. An earlier revision of this note said *3969 of 5462*, which crosses two partitions of the same 5520: `3969` is by *location* and includes binaries, `5462` is by *type* and is repo-wide. **56 of the 58 binaries are under `apps/`**, so `3969` is not a subset of `5462`.), while paths above it still resolved via their `../` prefixes. `--full-name` on the walk is the one-flag minimal fix; `cwd: repoRoot` is preferred because it makes every git call independent of the caller. ~~anchoring only the walk left every path unreadable from a subdirectory~~ — corrected 2026-08-11, see #4103.
- Keep an explicit `:/` pathspec on `ls-files` to state the intent at the call site.
- Count files that drop out of the walk instead of skipping them uncounted. `if (bytes === undefined) continue;` incremented neither counter, so an unreadable file vanished from both totals.
- Add `scanned + skippedBinary + unreadable === trackedFiles.length` and fail if any file is unreadable.

## The floor from #4095 is kept, not replaced

My original issue text claimed the counting invariant was *"strictly stronger than `scanned === 0`"*. **That was wrong**, and I corrected #4096 in place and retracted the corresponding review comment on #4095 before it could be acted on. The invariant's reference quantity is derived from the same walk it polices, so both sides shrink together:

| check | narrowed walk | empty walk | uncounted drop |
| --- | --- | --- | --- |
| `cwd`-anchored git calls | **fixes the cause** | fixes cwd-caused case | — |
| `scanned === 0` (#4095) | passes, blind | **catches** | passes, blind |
| `scanned + skipped + unreadable === len` | passes, blind | passes trivially (`0 === 0`) | **catches** |

The floor's reference is the constant `0`, which nothing about the walk can move; `trackedFiles.length` is not independent of the failure. Three orthogonal checks, none subsuming another — so #4095's floor stays exactly as merged.

## Testing

Verified from six working directories, including one containing no tracked files:

```
.                                exit=0  No U+FFFD found in 5462 tracked text file(s) (58 binary skipped)
apps                             exit=0  ... 5462 ... (58 binary skipped)
apps/web                         exit=0  ... 5462 ... (58 binary skipped)
docs                             exit=0  ... 5462 ... (58 binary skipped)
tools                            exit=0  ... 5462 ... (58 binary skipped)
node_modules/.cache-probe-empty  exit=0  ... 5462 ... (58 binary skipped)
```

Byte-identical output everywhere; `5462 + 58 = 5520`, the full corpus.

Detection regression — a staged file containing `EF BF BD` under `docs/`, with the guard run from `apps/web`:

```
exit=1  ::error file=docs/_probe-encoding-4096.md,line=1::U+FFFD replacement character (3-byte character collapsed)
```

That is precisely the case this issue was filed for: a corruption in `docs/` found from a cwd that previously could not see it. Probe file removed; `git status` clean.

- [x] `npm run format:check` — all matched files use Prettier code style
- [x] `npx eslint . --max-warnings 0` — exit 0

## Credit

The cwd-scoping defect was found and measured by the `jrmoulckers/jrm-recipes` session, which ran the guard from three directories rather than reading it. They also caught the "strictly stronger" error in the fix I proposed for it.

## Issues

Closes #4096



