### PR TITLE
fix(tools): fail the encoding guard when the reader returns no bytes (#4100)

### DIFF
--- a/tools/check-text-encoding.mjs
+++ b/tools/check-text-encoding.mjs
@@ -190,6 +190,7 @@ const failures = [];
 let scanned = 0;
 let skippedBinary = 0;
 let unreadable = 0;
+let totalBytes = 0;
 
 selfTest();
 
@@ -207,6 +208,7 @@ for (const path of trackedFiles) {
     continue;
   }
   scanned += 1;
+  totalBytes += bytes.length;
   for (const { offset, doubled } of findReplacements(bytes)) {
     failures.push({ path, line: lineOf(bytes, offset), doubled });
   }
@@ -257,6 +259,22 @@ if (unreadable > 0) {
   process.exit(1);
 }
 
+// The three checks above all reason about file *counts*, so none of them can see a reader that
+// returns an empty buffer for every path: those buffers are defined and NUL-free, so each one
+// counts as scanned text, conservation balances exactly, and the detector correctly finds nothing
+// in zero bytes. selfTest() cannot see it either, because it feeds synthetic buffers straight to
+// the detector and never exercises the reader. Only the volume of data read distinguishes a
+// repository with no U+FFFD from a reader that returned nothing at all.
+if (totalBytes === 0) {
+  console.error(
+    `::error::encoding guard read 0 bytes across ${scanned} tracked text file(s). Tracked text\n` +
+      'files are never all empty, so the reader returned nothing and every file was reported\n' +
+      'clean without being examined.',
+  );
+  process.exit(1);
+}
+
 console.log(
-  `No U+FFFD found in ${scanned} tracked text file(s) (${skippedBinary} binary file(s) skipped).`,
+  `No U+FFFD found in ${scanned} tracked text file(s), ${totalBytes} byte(s) read ` +
+    `(${skippedBinary} binary file(s) skipped).`,
 );


### PR DESCRIPTION
## Summary

**Scope reduced after #4099 landed.** This PR originally closed two holes; #4099 independently
closed one of them (the uncounted `undefined` branch) with a conservation check and an `unreadable`
counter. That work is on `main` and this PR now rebases onto it and keeps **only** the check #4099
does not have.

Every existing guard reasons about file **counts**. None of them can see a reader that returns an
empty buffer for *every* path.

## The surviving hole, verified against `main` after #4099

An empty buffer is defined, so it passes the `undefined` check; NUL-free, so it classifies as text;
`scanned` increments; the detector correctly finds nothing in zero bytes. Running #4099's own guard
with the reader mutated to `out.slice(start, start)`:

```
No U+FFFD found in 5520 tracked text file(s) (0 binary file(s) skipped).
exit=0
```

An honest large number, a clean exit, and not one byte examined. Each existing layer is blind for
its own reason:

| Guard | Why it misses this |
| --- | --- |
| `scanned === 0` (#4095) | `scanned` is 5,520 |
| `selfTest()` (#4095) | feeds synthetic buffers straight to the detector; never runs the reader |
| conservation (#4099) | `5520 + 0 + 0 === 5520` balances exactly |
| `unreadable > 0` (#4099) | every path *is* in the map — the buffers are just empty |

The realistic route is the one #4099's commit message already implies: a desynchronised
`git cat-file --batch` cursor makes `Number(header.slice(...))` return `NaN`, so
`out.slice(start, start + NaN)` yields an empty buffer.

**Counts balance perfectly while contents are gone** — which is why a count-based invariant cannot
be the last line of defence.

## Change

One counter and one assertion (+19/−1):

```js
totalBytes += bytes.length;
...
if (totalBytes === 0) fail(...);
```

The success line now reports bytes read, so a collapsing reader is visible in the log before it is
ever a failure.

## Testing

Mutation matrix confirming all four layers fire independently and **none shadows another**:

| Mutation | Guard that fires |
| --- | --- |
| Reader returns empty buffers | `read 0 bytes across 5520 files` — **this PR** |
| Reader drops all but 40 files | `could not read 5480` — #4099 |
| Skip branch stops counting | `accounted for 5462 of 5520` — #4099 |
| Detector disabled | self-test `expected 1` — #4095 |
| Control (unmodified) | `5462 files, 41518536 bytes, 58 binary` — exit 0 |

- [x] `npx eslint tools/check-text-encoding.mjs --max-warnings 0` — clean
- [x] `npx prettier --check tools/check-text-encoding.mjs` — clean

## Issues

Closes #4100
