### PR TITLE
docs(tools): correct the inverted cause in the encoding guard comment (#4103)

### DIFF
--- a/tools/check-text-encoding.mjs
+++ b/tools/check-text-encoding.mjs
@@ -41,9 +41,18 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
  * Absolute path to the repository root.
  *
  * Every git invocation below runs here rather than in the caller's working
- * directory. Both `git ls-files` and `git cat-file`'s `:<path>` syntax resolve
- * relative to the current directory, so without this the guard silently
- * examines whatever subtree it happens to be started from.
+ * directory, so the guard always examines the whole repository rather than
+ * whatever subtree it happens to be started from.
+ *
+ * The cause is `git ls-files`, which both *selects* and *prints* relative to
+ * the current directory. `git cat-file`'s `:<path>` syntax, by contrast, is
+ * root-relative — only `:./<path>` is cwd-relative — so a bare `src/app.ts`
+ * printed by a walk rooted in `apps/web` is looked up at the repository root
+ * and silently misses. Anchoring `ls-files` alone is therefore not enough:
+ * `:/` widens the selection but leaves the printed paths cwd-relative.
+ *
+ * `--full-name` on the walk is the minimal alternative fix; `cwd: repoRoot`
+ * is preferred because it makes every git call independent of the caller.
  */
 const repoRoot = (() => {
   const result = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' });
@@ -59,7 +68,8 @@ const repoRoot = (() => {
  *
  * The `:/` pathspec is redundant with running from the repository root but
  * states the intent at the call site: this walk covers the whole repository,
- * never the current subtree.
+ * never the current subtree. It does not affect the *form* of the printed
+ * paths — `cwd: repoRoot` above is what keeps those repository-relative.
  *
  * @returns {string[]} Repository-relative paths.
  */


### PR DESCRIPTION
Corrects a **false mechanism** recorded in `tools/check-text-encoding.mjs` by #4099. Comment-only —
the `cwd: repoRoot` fix and the guard's behaviour are unchanged.

## What was wrong

The comment claimed:

> Both `git ls-files` and `git cat-file`'s `:<path>` syntax resolve relative to the current directory

The second half is false. **`:<path>` is root-relative**; only `:./<path>` is cwd-relative:

```
root      git cat-file -s ":package.json"          -> 4271   (root package.json)
apps/web  git cat-file -s ":package.json"          -> 4271   <- ROOT, not apps/web's
apps/web  git cat-file -s ":./package.json"        -> 2177   (apps/web's)
apps/web  git cat-file -s ":apps/web/package.json" -> 2177
```

The real cause is the **other** call: `git ls-files` prints paths relative to cwd, and `-- :/` widens
the _selection_ without changing the _output form_.

```
apps/web  git ls-files -- :/               total=5520  bare=2521  ../-prefixed=2999
apps/web  git ls-files --full-name -- :/   ../-prefixed=0
```

Bare names — files under the walk's directory — are then handed to a root-relative lookup and miss.
That is precisely why anchoring `ls-files` alone was insufficient and produced `3969` failures from
`apps/`, and it makes `--full-name` the minimal alternative fix. `cwd: repoRoot` is kept because it
makes _every_ git call independent of the caller rather than fixing one of them.

## Why this is worth a PR rather than a note

The rule was right and the reason was wrong, which is the failure mode that makes a comment worse
than none: it sends the next reader to the wrong call site. Same shape as a correct lint rule with a
fabricated rationale — it survives review precisely because the conclusion checks out.

## A correction to the correction

The reporting session argued the `3969` figure discriminates between the two mechanisms. **It does
not.** Fed cwd-relative input, both resolvers agree on the inside/outside split:

| path seen from `apps/` | root-relative (true)          | cwd-relative (false)               |
| ---------------------- | ----------------------------- | ---------------------------------- |
| `src/App.tsx`          | `src/App.tsx` — absent → fail | `apps/src/App.tsx` — absent → fail  |
| `../docs/x.md`         | `docs/x.md` → ok              | `apps/../docs/x.md` = `docs/x.md` → ok |

Both predict _bare fails, `../` succeeds_, so both predict `3969`. It is separately confounded:
`git ls-files` **without** `:/` from `apps/` also returns `3969`, because the narrowed set and the
inside-cwd set are the same population. The claim is established by the direct `:package.json`
probe, not by the split — verified here before accepting it.

## Testing

- [x] `node tools/check-text-encoding.mjs` from repo root, `apps/web/`, and `docs/` — byte-identical:
      `No U+FFFD found in 5462 tracked text file(s) (58 binary file(s) skipped).`, exit 0
- [x] `npm run format:check` → _All matched files use Prettier code style!_, exit 0
- [x] `npx eslint . --max-warnings 0` → exit 0
- [x] `bare 200/200` fail vs `../ 0/200` fail from `apps/` — reproduced the split both stories predict

## Notes

- Reported by the `jrmoulckers/jrm-recipes` session; independently verified here before landing.
- `.vscode/mcp.json` remains an undocumented local MCP overlay declaring more servers than the
  canonical `agency.toml`. Out of scope here, still tracked separately.

Closes #4103
