### PR TITLE
docs(gitattributes): correct the false CRLF-tracking claim on gradlew.bat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,12 +16,24 @@
 
 # --- Member-owned exceptions (must remain below the managed region) ---
 
-# Windows batch files must keep CRLF — cmd.exe is unreliable with LF-only
-# scripts, and gradlew.bat is tracked with CRLF.
+# Windows batch files must be CRLF *in the working tree* — cmd.exe is unreliable
+# with LF-only scripts. `text` stays set, so the blob is still normalized to LF in
+# the index and `eol=crlf` converts on checkout. Measured on gradlew.bat:
+# index 2800 B / CR=0; working tree 2891 B / CR=91.
+#
+# Do NOT switch these to `binary` or `-text` in order to "preserve" CRLF: that
+# unsets `text`, which disables conversion in both directions and lets CRLF into
+# the index — the opposite of what this file exists to do.
 *.bat text eol=crlf
 *.cmd text eol=crlf
 
-# Binary files — do not touch
+# Binary files — do not touch.
+#
+# Verifying these with `git check-attr eol` is misleading: it reports `eol: lf`
+# even here, because the attribute is still assigned by the `* text=auto eol=lf`
+# rule above. It is inert — `eol` only takes effect when `text` is set, and the
+# `binary` macro (`-diff -merge -text`) unsets it. Check the committed bytes
+# (`git cat-file -s :<path>`), not the attribute readout.
 *.png binary
 *.jpg binary
 *.jpeg binary


### PR DESCRIPTION
## Summary

`.gitattributes` justified its `*.bat text eol=crlf` carve-out with a claim that is false, and false
in the direction that argues for a harmful change.

```
# Windows batch files must keep CRLF — cmd.exe is unreliable with LF-only
# scripts, and gradlew.bat is tracked with CRLF.
```

## Measurement

```
git check-attr text eol -- gradlew.bat
  text: set      eol: crlf

INDEX    gradlew.bat: 2800 B, CR=0,  LF=91, CRLF pairs=0
WORKTREE gradlew.bat: 2891 B, CR=91, LF=91          (2800 + 91 = 2891)
```

`text` is set, so the blob is normalized to LF in the index; `eol=crlf` converts on **checkout**.
"Tracked" means the index, and the index has zero CR. The rule is correct; the reason given for it
was not what happens.

The failure mode this invites is concrete: a reader wanting to preserve "the CRLF gradlew.bat is
tracked with" reaches for `binary` or `-text` on `*.bat`, which unsets `text`, disables conversion in
**both** directions, and admits CRLF to the index — exactly what this file exists to prevent.

## Also recorded: `git check-attr` is a misleading verifier here

```
git check-attr text eol binary -- <a .png>
  text: unset      eol: lf      binary: set
```

`eol: lf` is still displayed on a `binary`/`-text` path because `* text=auto eol=lf` assigns it — but
it is inert, since `eol` only takes effect when `text` is set. Checking the attribute readout instead
of the committed bytes reads as though the carve-out failed. Reported by the `jrmoulckers/jrm-recipes`
session against their own `.gitattributes`; reproduced here on git 2.53.0 via the `binary` macro
rather than an explicit `-text`.

## Changes

- Replace the false clause with the measured index/working-tree split
- Warn explicitly against the `binary`/`-text` "fix"
- Note the `check-attr` pitfall beside the binary block

## Scope

**Comment-only.** Verified before pushing:

```
changed lines that are not comments/blank : none
pattern lines                             : 13 before, 13 after, identical
studio:base managed region                : byte-identical
working tree after edit                   : 1 modified file, no renormalization
```

## Issues

Closes #4108

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — exit 0
- [x] `node tools/check-text-encoding.mjs` — 5462 text / 58 binary, exit 0
