### PR TITLE
fix(tools): anchor the encoding guard's walk with --full-name

### DIFF
--- a/tools/check-text-encoding.mjs
+++ b/tools/check-text-encoding.mjs
@@ -53,6 +53,8 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
  *
  * `--full-name` on the walk is the minimal alternative fix; `cwd: repoRoot`
  * is preferred because it makes every git call independent of the caller.
+ * Both are applied, so neither is load-bearing alone: removing `cwd` leaves
+ * the walk correct, and `--full-name` cannot be defeated by a caller's cwd.
  */
 const repoRoot = (() => {
   const result = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' });
@@ -69,12 +71,13 @@ const repoRoot = (() => {
  * The `:/` pathspec is redundant with running from the repository root but
  * states the intent at the call site: this walk covers the whole repository,
  * never the current subtree. It does not affect the *form* of the printed
- * paths — `cwd: repoRoot` above is what keeps those repository-relative.
+ * paths — `--full-name` is what keeps those repository-relative, and does so
+ * whatever directory the process was started from.
  *
  * @returns {string[]} Repository-relative paths.
  */
 function listTrackedFiles() {
-  const result = spawnSync('git', ['ls-files', '-z', '--', ':/'], {
+  const result = spawnSync('git', ['ls-files', '-z', '--full-name', '--', ':/'], {
     cwd: repoRoot,
     maxBuffer: 1024 * 1024 * 256,
   });


### PR DESCRIPTION
## Summary

`-- :/` (added in #4099) anchors the **selection** but not the **output base**. Measured from `apps/web`:

```
git ls-files                       listed 2521   with ../ =    0
git ls-files -- :/                 listed 5520   with ../ = 2999
git ls-files --full-name -- :/     listed 5520   with ../ =    0
```

`--full-name` anchors the base, making the walk correct independent of the spawn's cwd.

## Why, given `cwd: repoRoot` already works

It does, and #4105 documents why it is preferred — it covers every git call, not just the walk. This PR does not change that; it adds the second half so **neither mechanism is load-bearing alone**.

The concrete motivation is a live failure elsewhere in the org: jrmoulckers/studio imported the `-- :/` fix, validated it by row count, got a plausible `208 tracked file(s)`, and shipped a guard that listed one namespace and read another (jrmoulckers/studio#106 → PR #107). Their walk had no `cwd` anchor. Ours does — but the guard's correctness should not depend on a spawn option in a different part of the call.

This is the **population** layer, which the five existing guards trust rather than check: they detect an *inconsistent* walk, not a *consistently wrong* one. Making the trusted layer self-contained is different in kind from adding another downstream check.

## Verification

Baseline unchanged from the repository root:

```
No U+FFFD found in 5462 tracked text file(s), 41529240 byte(s) read (58 binary file(s) skipped).
```

With `cwd: repoRoot` deleted — the refactor this guards against — all subdirectories now agree with the root, where before they failed:

| cwd | before this PR | after |
| --- | --- | --- |
| `apps/web` | `could not read 2517 tracked file(s)` exit 1 | 5462 / 41529240 exit 0 |
| `docs/testing` | `1 file, 16178 bytes` exit 0 (wrong file) | 5462 / 41529240 exit 0 |
| `deploy/volumes/mongo` | `2 files, 17685 bytes` exit 0 (wrong files) | 5462 / 41529240 exit 0 |

`docs/testing` and `deploy/volumes/mongo` are two of five directories where *every* enumerated name also exists at the root, so no read fails and no guard fires — 16178 is the **root** `README.md`, not the 3008-byte file it named.

All existing guards still fire independently:

```
empty reader   -> read 0 bytes across 5520 tracked text file(s)
dead detector  -> self-test failed: single replacement returned 0 result(s)
emptied list   -> examined 0 tracked text files
```

Lint and format clean on the touched file.

## Issues

Closes #4111