### PR TITLE
docs: rejoin five silently-unverified citations and scope the atomicity claim (#4029)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,7 +1,6 @@
 # Architecture Decision Records
 
-Durable decision records for finance. The obligation to keep them is `ENG-ARCH-003`
-(Durable decisions) — see the
+Durable decision records for finance. The obligation to keep them is `ENG-ARCH-003` (Durable decisions) — see the
 [ratified principles](https://github.com/jrmoulckers/engineering/blob/main/principles/architecture/boundaries-and-contracts.md).
 This file is the index and the numbering convention; it does not restate the rule.
 

--- a/docs/architecture/security-architecture.md
+++ b/docs/architecture/security-architecture.md
@@ -6,8 +6,7 @@ This document provides a comprehensive review of the Finance application's secur
 
 The obligations it discharges are ratified in `jrmoulckers/engineering` and are cited, not
 restated: `ENG-SEC-001` (Secret lifecycle), `ENG-SEC-003` (Boundary threat models),
-`ENG-SEC-004` (Least authority), `ENG-SEC-005` (Trust-boundary validation), `ENG-SEC-007`
-(Secure failure), and `ENG-SEC-008` (Privacy-minimizing lifecycle evidence). The threat model,
+`ENG-SEC-004` (Least authority), `ENG-SEC-005` (Trust-boundary validation), `ENG-SEC-007` (Secure failure), and `ENG-SEC-008` (Privacy-minimizing lifecycle evidence). The threat model,
 MASVS mapping, and control implementations below are finance-specific.
 
 ---

--- a/docs/audits/accessibility-audit-wcag22.md
+++ b/docs/audits/accessibility-audit-wcag22.md
@@ -6,8 +6,7 @@
 > **Scope:** All 4 platforms (iOS, Android, Web, Windows)
 > **Standard:** WCAG 2.2 Level AA
 
-WCAG 2.2 AA is finance's own commitment; no ratified principle mandates it. `ENG-PERF-009`
-(Assurance precedence) applies _additively_: whatever this audit finds, it may not be traded away
+WCAG 2.2 AA is finance's own commitment; no ratified principle mandates it. `ENG-PERF-009` (Assurance precedence) applies _additively_: whatever this audit finds, it may not be traded away
 to meet a performance budget.
 
 ---

--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -7,8 +7,7 @@ This guide covers the accessibility features available in Finance and how to use
 WCAG 2.2 AA is a finance commitment, not a ratified obligation — no `ENG-*` principle covers
 accessibility. Two apply additively rather than as its source:
 `ENG-PERF-009` (Assurance precedence) forbids trading any of the below away to hit a performance
-budget, and `ENG-PERF-002`
-(Versioned performance budgets) is what it would be traded against.
+budget, and `ENG-PERF-002` (Versioned performance budgets) is what it would be traded against.
 
 ---
 

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -1347,6 +1347,56 @@ mode and `preserve` is the state in which the break is permanent. The exposure i
 the only automatic repair. The reflow measurement still justifies `preserve` on balance, but the
 remedy has to be the checker, because under `preserve` nothing else will ever catch this.
 
+### The atomicity result was scoped to linked citations, and most citations are not linked
+
+A sister repo pointed out that the paragraph above generalises a result obtained on **one** citation
+form. That is correct, and the correction matters more than the original finding.
+
+Two forms are in use. The **linked** form, `[`ID` (Title)](path)`, is what I tested — Prettier treats
+a Markdown link as an atomic inline node, so it cannot break inside it. The **bare** form,
+`` `ID` (Title) ``, is ordinary inline text with an ordinary break opportunity at every space, and it
+is the form the upstream practice PR uses and the form all five of finance's own split citations
+use. Prettier's atomicity protects the form almost nobody writes.
+
+Swept both forms across 41 margin positions (filler padding 0–80, step 2) at `printWidth: 96` under
+`--prose-wrap always`, with a deliberately wrong title in every fixture so that a check which _runs_
+must exit 1. Exit code is the discriminator, because the summary sentence differs between
+checked-and-failed and never-checked.
+
+| Citation form                | Wrong name caught | Silently missed |
+| ---------------------------- | ----------------- | --------------- |
+| Bare — `` `ID` (Title) ``    | 25 / 41           | **16 / 41**     |
+| Linked — `[`ID` (Title)](p)` | **41 / 41**       | 0 / 41          |
+
+Three things this establishes that neither repo had:
+
+1. **`always` does not merely fail to heal the bare form — it creates the defect.** On a correctly
+   authored single line, with no author involved, the formatter inserts the break. So `preserve` is
+   the safer setting for citation-bearing prose specifically, which is a second and independent
+   reason for it beyond the 592-file reflow measurement.
+2. **The misses are a contiguous band, not a scatter** — pads 30 through 60, and nothing outside it.
+   Below the band the whole line fits; above it the citation is pushed wholly onto the next line
+   intact. The hazard is precisely "the citation straddles the margin", which is why it feels random.
+3. **There are two break sites, not one.** After the ID, and _inside_ the title (`(Mandatory` ⏎
+   `coverage thresholds)`). A near-miss detector keyed only on ID-then-newline would miss the second,
+   which accounted for the lower half of the band.
+
+The linked form being 41/41 makes "prefer linked named citations" a **complete** mitigation under
+`always`, not a partial one — though it is worth being precise about its limit: it defends against
+the _formatter_, and under `preserve` a hand break inside a link is still unrecoverable. Links are
+not a substitute for the detector; they remove one of the two authors of the defect.
+
+### Five live instances in finance, and they were correct only by luck
+
+Searching finance's own corpus for the shape found **five**, in `docs/architecture/README.md`,
+`docs/architecture/security-architecture.md`, `docs/guides/accessibility.md`,
+`docs/audits/accessibility-audit-wcag22.md`, and this guide. Rejoining them onto one line moved the
+whole-tree verified count **36 → 41** — five name claims that every human reviewer reads as verified
+and the checker had never once checked. All five turned out to state the correct title, which is the
+point: they passed on their content being right, not on anything having confirmed it. Fixed by
+rejoining; Prettier reports the files unchanged afterwards, confirming `preserve` will not re-break
+them.
+
 Two mitigations, neither owned here: match across newlines in the pattern, or have `--review`
 report near-misses — an `ENG-*` ID followed by a parenthesised capitalised phrase that the strict
 pattern rejected. The second is cheap and turns a silent gap into a warning. Filed as **gap 18**.
@@ -1356,6 +1406,17 @@ observation (a split title, a dropped count) was real and reproducible, and the 
 attached to it was assumed rather than tested**. One `resolveConfig` call would have falsified it
 immediately. Prefer checking the mechanism you are about to name over the one that fits the
 narrative.
+
+**And the sweep above took two wrong detectors before it took a right one**, both of the same family
+this document has now named five times — an instrument that cannot distinguish the two states it is
+being used to tell apart. The first grepped the checker output for `stated name`, which also occurs
+in v9's _"checks run:"_ line, so every run looked like the name had been checked. The second grepped
+for `stated name(s) match`, which is absent both when the check is skipped **and** when it runs and
+fails — collapsing the good outcome into the bad one and reporting 0/41 for a form that actually
+scores 41/41. Only the exit code separates all three states. The lesson is not "grep more carefully":
+it is that a detector needs its own positive control, and the cheapest one is a fixture that _must_
+fail. Every number in the table above comes from a wrong-by-construction title for exactly that
+reason.
 
 **This is not wired into finance's CI**, deliberately. The checker resolves
 `principles/index.json` over the network by default, and gap 15 objects to exactly that — network
@@ -1388,8 +1449,7 @@ than omitted:
 - `docs/guides/accessibility.md` and `docs/audits/accessibility-audit-wcag22.md` note that
   `ENG-PERF-009` (Assurance precedence) forbids trading accessibility away for performance. It is
   not the source of the WCAG 2.2 AA commitment; it constrains what may be done to it.
-- Test colocation is named as a finance convention; the obligation it serves is `ENG-TEST-003`
-  (Regression boundaries).
+- Test colocation is named as a finance convention; the obligation it serves is `ENG-TEST-003` (Regression boundaries).
 
 The distinction is worth stating precisely, because the two readings differ in what they license.
 "Accessibility follows `ENG-PERF-009`" is false and would make the WCAG commitment look


### PR DESCRIPTION
Refs #4029.

## Summary

A sister repo pointed out that my Prettier-atomicity finding was scoped to **linked** citations
`[`ID` (Title)](path)`, while the form actually in use almost everywhere is **bare**
` `ID` (Title) `. That is correct, and testing it reversed part of the conclusion.

## Measurement

Both forms swept across 41 margin positions (padding 0-80, step 2) at `printWidth: 96` under
`--prose-wrap always`, every fixture carrying a **deliberately wrong** title so that a check which
actually runs must exit 1. Exit code is the discriminator.

| Citation form | Wrong name caught | Silently missed |
| --- | --- | --- |
| Bare | 25 / 41 | **16 / 41** |
| Linked | **41 / 41** | 0 / 41 |

- `always` does not merely fail to heal the bare form, it **creates** the break on a correctly
  authored line with no author involved.
- The misses are a **contiguous band** (pads 30-60) - the window where the citation straddles the
  margin - not a scatter.
- **Two break sites, not one**: after the ID, and inside the title. A detector keyed only on
  ID-then-newline would miss half the band.

## finance's own exposure

Five live instances found and fixed by rejoining. Whole-tree verified name count **36 -> 41**. All
five stated the correct title - they passed on being right, not on being checked. Prettier reports
the files unchanged afterwards, confirming `preserve` will not re-break them.

Also recorded: this sweep took **two wrong detectors** before a right one, both unable to
distinguish the two states they were being used to tell apart.

## Testing

- [x] `npx prettier --write` on all five files - unchanged after edit
- [x] Citation checker v9 whole-tree: 109 citations / 34 principles / 441 files, **41** stated names, exit 0