### PR TITLE
docs(tools): note the encoding guard's jointly load-bearing anchors (#4118)

### DIFF
--- a/tools/check-text-encoding.mjs
+++ b/tools/check-text-encoding.mjs
@@ -56,6 +56,19 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
  * is preferred because it makes every git call independent of the caller.
  * Both are applied, so neither is load-bearing alone: removing `cwd` leaves
  * the walk correct, and `--full-name` cannot be defeated by a caller's cwd.
+ *
+ * Since the read moved to object IDs, none of that governs *correctness* any
+ * more — an OID resolves the same from anywhere, so a mis-based path can no
+ * longer produce a wrong or failed read. What the anchors now govern is which
+ * files are selected at all, and there `:/` and `cwd` are jointly load-bearing:
+ * remove both and the walk narrows to the caller's subtree, reads it perfectly
+ * by OID, and reports success over a fraction of the repository. Nothing below
+ * can see it — every file listed was read, so conservation balances, the byte
+ * total is large, and only the count moves. No check reads the count.
+ *
+ * Remove at most one. This is the same trade the OID read bought: mis-anchoring
+ * used to fail loudly through unreadable paths, and now it cannot fail at all,
+ * so a narrowed walk is the only remaining way to be wrong and it is silent.
  */
 const repoRoot = (() => {
   const result = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' });
@@ -79,6 +92,9 @@ const repoRoot = (() => {
  * never the current subtree. It does not affect the *form* of the printed
  * paths — `--full-name` is what keeps those repository-relative, and does so
  * whatever directory the process was started from.
+ *
+ * Redundant with `cwd: repoRoot`, not with its absence: dropping both silently
+ * narrows the walk. See the `repoRoot` note above before removing either.
  *
  * @returns {{ mode: string, oid: string, path: string }[]} Tracked index entries.
  */


### PR DESCRIPTION
## Summary

Comment-only. Records that the encoding guard's three walk anchors are individually removable but **jointly load-bearing in one pair**, and that #4115's move to object-ID reads removed the loud signal for a mis-anchored walk.

## Measurement

Full mutation lattice, guard run from `apps/web`:

```
                  dea742fe (path reads)      fd44df32 (OID reads)
baseline          correct                    correct
-full-name        correct                    correct
-- :/             correct                    correct
-cwd              correct                    correct
-full-name -cwd   LOUD  (2517 unreadable)    correct
-:/ -cwd          SILENT (2514/5462)         SILENT (2514/5462)
ALL THREE         LOUD  (2517 unreadable)    SILENT (2514/5462)
```

Removing `:/` and `cwd: repoRoot` together narrows selection to the caller's subtree. Reads then succeed for every listed file, because an OID resolves identically from anywhere. Conservation balances, the byte total is large, `scanned` is far from zero, the self-test passes — **only the count moves, and no check reads the count.** The run reports success over 46% of the repository.

## Why the comment mattered

Two individually-true claims that are jointly false:

- "The `:/` pathspec is **redundant** with running from the repository root"
- "neither is load-bearing alone: **removing `cwd` leaves the walk correct**"

Both verify green in isolation. Removing one as documented-redundant, testing (green), then later removing the other as documented-removable, testing (green), lands in a guard silently checking 46% of the tree. No step in that sequence is careless and no step goes red.

## On #4115

Reading by OID is the right change and this does not argue against it — a mis-based path can no longer cause a wrong or failed read, which is strictly better. The side effect is that unreadable paths were the *only* loud signal for mis-anchoring, so two mutations that used to fail now pass. Silent multi-mutations went from 1 of 3 to 2 of 3. That trade is now stated at the call site rather than left to be rediscovered.

## Deliberately not done

No sixth runtime check. Detecting same-base truncation requires an external reference quantity, and any such quantity must track legitimate file growth — which makes it a check that eventually gets muted, per the reasoning recorded on #4100.

## Issues

Closes #4118

## Testing

- [x] `node tools/check-text-encoding.mjs` from repo root — 5,462 files, exit 0
- [x] same from `apps/web` — identical output, exit 0
- [x] `npx prettier --check tools/check-text-encoding.mjs` — clean
- [x] `npx eslint tools/check-text-encoding.mjs --max-warnings 0` — clean