### PR TITLE
docs(guides): record that the .npmrc ignore entry was prophylactic

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -158,6 +158,14 @@ mechanism is that Prettier only considers files it can infer a parser for, and `
 naming it explicitly exits **2** with `No parser could be inferred`, which is a crash rather than a
 lint failure. So the entry never suppressed anything.
 
+**Nor could it ever have.** Upstream later asked whether the entry had been added in response to a
+real failure and was therefore masking whatever actually caused it. The git record forecloses that:
+`.npmrc` and its ignore entry were introduced in the **same commit** (`58782b2`, the initial
+adoption), the file has never been deleted, and there is exactly one `.npmrc` in the tree. So there
+is no commit in finance's history in which `.npmrc` existed without the entry — no interval in which
+a failure could have occurred, and nothing for the entry to have fixed. It was prophylactic from the
+moment it was written, which is precisely why removing it changes nothing.
+
 Removing the whole no-parser class at once — `*.jar`, `*.apk`, `*.aab`, `*.sql`, `*.kt`, `*.kts`,
 `*.swift`, `Caddyfile`, `Caddyfile.*`, `*.env`, `*.env.*`, `.env*`, plus `.npmrc` — also leaves
 `format:check` green. **Thirteen of this file's entries have no effect** under `prettier --check .`,


### PR DESCRIPTION
## Summary

Upstream asked one specific question — what is finance's actual `format:check` script — and warned
that the `.npmrc` entry in `.prettierignore` may have masked a different problem rather than fixing
it. The script is `npx prettier --check .` (directory form), which is their first branch. This
commit records the part that answers the masking hypothesis outright.

## Finding

`.npmrc` and its `.prettierignore` entry were introduced in the **same commit** (`58782b2`, the
initial adoption). The file has never been deleted, and there is exactly one `.npmrc` in the tree.
So there is no commit in finance's history in which `.npmrc` existed without the entry — no
interval in which a failure could have occurred, and nothing for the entry to have fixed. It was
prophylactic from the moment it was written, which is why removing it in #4121 changed nothing.

Three measured states, all exit 0: before the entry, with it, and after removing it.

## Issues

Refs #4029

## Testing

- [x] `npx prettier --check .` — exit 0
- [x] Citation checker v9 — 109 citations / 34 principles / 441 files / 41 stated names, exit 0