### PR TITLE
fix(ci): upload iOS build logs that are dotfiles

### DIFF
--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -176,7 +176,12 @@ jobs:
           path: |
             apps/ios/.build-xcodebuild.log
             apps/ios/.build-xcodebuild-test.log
-          if-no-files-found: ignore
+          # `.build-xcodebuild*.log` are dotfiles, and upload-artifact defaults to
+          # `include-hidden-files: false`, so without this the upload silently
+          # matches nothing. `warn` rather than `ignore` for the same reason: an
+          # absent log should announce itself, not disappear quietly (#4122).
+          if-no-files-found: warn
+          include-hidden-files: true
           retention-days: 14
 
       - name: Generate coverage report


### PR DESCRIPTION
## Summary

The iOS build-log upload added in #4123 never uploaded anything. Follow-up to #4122.

## Evidence

Run [`31550758677`](https://github.com/jrmoulckers/finance/actions/runs/31550758677) produced these artifacts:

```
ios-test-results   17019 bytes
ios-coverage         142 bytes
```

`ios-build-logs` is absent.

## Cause

Both paths are dotfiles:

```
apps/ios/.build-xcodebuild.log
apps/ios/.build-xcodebuild-test.log
```

`actions/upload-artifact` defaults to `include-hidden-files: false`, so the glob matched nothing. `if-no-files-found: ignore` then discarded that outcome without a warning, and the step reported success.

This is worth naming plainly: **it is the same failure mode #4123 was fixing** — a CI step that reports success while doing nothing — reintroduced by the fix itself. I asserted in the #4123 body and in [#4122](https://github.com/jrmoulckers/finance/issues/4122#issuecomment-5260725680) that "both logs are uploaded as artifacts for 14 days." That was false when written; it is true after this PR.

## Fix

```yaml
if-no-files-found: warn
include-hidden-files: true
```

`warn` rather than `ignore` for the same reason the rest of this work exists: an absent log should announce itself rather than vanish.

## Testing

- [x] `node tools/check-workflow-security.mjs` — exit 0 (action still SHA-pinned; the reviewed-reusable baseline is unaffected, this is `ci-ios.yml`)
- [x] `npm run format:check` — exit 0
- [x] `npx eslint . --max-warnings 0` — exit 0
- [x] `node tools/check-text-encoding.mjs` — exit 0, 5463 text / 57 binary
- [x] Parsed the workflow and asserted the resolved step config:
      `{"if-no-files-found":"warn","include-hidden-files":true,"retention-days":14}`
- [ ] Confirmed by the presence of `ios-build-logs` in this PR's own run

## Note

Does not close #4122 — that issue is already satisfied by #4123 and is awaiting human closure, since its auto-close reference was written inside a code span and did not fire. The remaining iOS compile work is #4125.
