### PR TITLE
fix(tools): read git's object format instead of assuming sha1

### DIFF
--- a/tools/check-text-encoding.mjs
+++ b/tools/check-text-encoding.mjs
@@ -80,6 +80,46 @@ const repoRoot = (() => {
 })();
 
 /**
+ * Git's hash algorithm for this repository, read from the repository itself.
+ *
+ * The `blob <len>\0<content>` construction in `blobOid` is identical under both
+ * formats — only the digest differs — so the identity check is portable and it
+ * is solely the algorithm that must not be assumed. Hardcoding `sha1` here
+ * would give a repository created with `--object-format=sha256` a **100%**
+ * false-positive rate: every tracked file would be reported as not hashing to
+ * its own entry, naming content when the fault is configuration.
+ *
+ * Read once, at startup, from the repository the walk actually covers, so the
+ * algorithm and the OIDs it is compared against always come from the same
+ * place. Older git predates `--show-object-format` and exits non-zero; sha1 is
+ * the correct fallback because it is the only format such a git can produce.
+ *
+ * @returns {{ algorithm: string, emptyBlob: string }} Digest name and the
+ *   published empty-blob OID for that format.
+ */
+const objectFormat = (() => {
+  const result = spawnSync('git', ['rev-parse', '--show-object-format'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  const name = result.status === 0 ? result.stdout.trim() : 'sha1';
+  const known = {
+    sha1: { algorithm: 'sha1', emptyBlob: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391' },
+    sha256: {
+      algorithm: 'sha256',
+      emptyBlob: '473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813',
+    },
+  };
+  if (!Object.hasOwn(known, name)) {
+    console.error(
+      `::error::encoding guard cannot verify object identity: unknown git object format ${name}.`,
+    );
+    process.exit(1);
+  }
+  return known[name];
+})();
+
+/**
  * Lists every tracked entry at HEAD as a `{ mode, oid, path }` triple.
  *
  * `-s` is what makes the read downstream safe. It emits the index entry's object
@@ -190,10 +230,13 @@ function readIndexBytes(entries) {
  * OID exactly when — and only when — the bytes are the ones that entry names.
  *
  * @param {Buffer} bytes File contents.
- * @returns {string} The 40-character blob OID.
+ * @returns {string} The blob OID: 40 hex characters under sha1, 64 under sha256.
  */
 function blobOid(bytes) {
-  return createHash('sha1').update(`blob ${bytes.length}\0`).update(bytes).digest('hex');
+  return createHash(objectFormat.algorithm)
+    .update(`blob ${bytes.length}\0`)
+    .update(bytes)
+    .digest('hex');
 }
 
 /**
@@ -267,15 +310,40 @@ function selfTest() {
     }
   }
 
-  // The identity check is only as good as the hash construction behind it. Git's
-  // empty blob is a fixed, published OID, so this pins the `blob <len>\0` prefix
-  // without shelling out. Get the prefix wrong and every file would mismatch —
-  // this names the cause instead of reporting 5,520 corrupt files.
-  const EMPTY_BLOB = 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391';
+  // The identity check is only as good as the hash construction behind it: both
+  // the `blob <len>\0` prefix and the digest algorithm must match what git used.
+  //
+  // The reference OID is asked of git rather than hardcoded, for the same reason
+  // the read moved to object IDs: a self-test whose expected value comes from
+  // the same table as the value under test moves in lockstep with it and cannot
+  // fail. A hardcoded sha1 empty blob compared against a hardcoded sha1
+  // algorithm passes happily in a sha256 repository, and every one of the
+  // thousands of files that follows is then reported as corrupt — which is the
+  // exact mass false positive this self-test exists to prevent.
+  const oracle = spawnSync('git', ['hash-object', '-t', 'blob', '--stdin'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    input: '',
+  });
+  if (oracle.status !== 0) {
+    console.error('::error::encoding guard self-test failed: `git hash-object` did not run.');
+    process.exit(1);
+  }
+  const expectedEmpty = oracle.stdout.trim();
   const actualEmpty = blobOid(Buffer.alloc(0));
-  if (actualEmpty !== EMPTY_BLOB) {
+  if (actualEmpty !== expectedEmpty) {
     console.error(
-      `::error::encoding guard self-test failed: empty blob hashed to ${actualEmpty}, expected ${EMPTY_BLOB}.`,
+      `::error::encoding guard self-test failed: empty blob hashed to ${actualEmpty}, but git ` +
+        `reports ${expectedEmpty} for object format ${objectFormat.algorithm}. Identity checks ` +
+        'are disabled rather than reporting every file as corrupt.',
+    );
+    process.exit(1);
+  }
+  // Belt and braces: the published constant for this format must agree with git.
+  if (expectedEmpty !== objectFormat.emptyBlob) {
+    console.error(
+      `::error::encoding guard self-test failed: git reports empty blob ${expectedEmpty}, which ` +
+        `does not match the published ${objectFormat.algorithm} constant ${objectFormat.emptyBlob}.`,
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

`blobOid()` hardcoded `sha1`, so the identity check added in #4115 fails for every tracked file in a repository created with `--object-format=sha256`.

Closes #4119

## Measured, not reasoned about

Built a real sha256 repository and ran both versions of the guard in it:

| scenario | pre-fix | fixed |
| --- | --- | --- |
| this repo (sha1) | exit 0, 5,463 files | exit 0, 5,463 files |
| sha256 repo | **exit 1 — every file "does not hash to this entry's object ID"** | exit 0 |
| sha256 repo, algorithm forced wrong | — | **exit 1, names the object-format mismatch** |

At this repository's size the middle row is 5,463 simultaneous false positives. Fail-closed is the right direction, but the message points at *content* when the fault is *configuration*.

## The design was already portable

The `blob <len>\0<content>` construction is byte-identical under both formats; only the digest changes. Confirmed against git's own output:

```
sha256("blob 5\0hello") == 8aec4e48…aeb60   git ls-files -s agrees
sha256("blob 0\0")      == 473a0f4c…21813   git's sha256 empty blob
```

So nothing about reading by OID needed to change. Only the algorithm selection was pinned, and it is now read once at startup from the repository the walk actually covers, via `git rev-parse --show-object-format`. Older gits predate the flag and exit non-zero; sha1 is the correct fallback, being the only format such a git can produce.

## The sharper half: the self-test was blind to exactly this

The self-test at the old L274 exists *specifically* to stop a broken hash construction from reporting thousands of corrupt files. It could not catch this, because it compared a hardcoded sha1 constant against a hardcoded sha1 implementation:

```js
const EMPTY_BLOB = 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391';
if (blobOid(Buffer.alloc(0)) !== EMPTY_BLOB) { … }
```

In a sha256 repository both sides are still sha1, so they agree, the self-test **passes**, and the mass false positive proceeds unannounced. A self-test whose expected value shares a source with the value under test cannot fail — the same defect as an instrument that consumes the output of the thing it is policing.

The reference is now asked of git itself (`git hash-object -t blob --stdin`), which is independent of our table, with the published constant cross-checked against it. Verified by sabotage: forcing sha1 selection inside the sha256 repo now produces

```
::error::encoding guard self-test failed: empty blob hashed to e69de29b…,
but git reports 473a0f4c… for object format sha1. Identity checks are
disabled rather than reporting every file as corrupt.
```

## Credit

Reported by the `jrm-recipes` session, which measured it in a real sha256 repository rather than inferring it from the source.

## Testing

- [x] `node tools/check-text-encoding.mjs` — exit 0, 5,463 text / 57 binary (unchanged)
- [x] Fixed guard in a real `--object-format=sha256` repo — exit 0
- [x] Pre-fix guard in the same repo — exit 1, 100% false positives (bug reproduced)
- [x] Sabotaged algorithm selection — self-test fires and names the cause
- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `node tools/check-workflow-security.mjs` — all exit 0

## Disclosure

Probe repositories were created under `%TEMP%` and left in place. Removing them requires a recursive directory delete, which is a human-gated operation for agents, so I did not run one. They are outside the repository and OS-managed: `sha256guard-*` and `oidprobe-*`.
