### PR TITLE
docs(guides): close the unowned-rewrite thread on its author's retraction

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -1867,6 +1867,24 @@ find package 'prettier'` — resolution, not assertion — and the worktree had 
     the actor. Reported back rather than accepted, because an unowned rewrite that also reached
     `origin` is worth someone identifying.
 
+    **Closed, by that session's own retraction.** It withdrew both halves: the attribution to this
+    session, on the timing above, and — more damagingly for it — its own "I haven't pushed since
+    `313ac60`." The remote-tracking reflog in its worktree records `085469a … update by push` at
+    `12:04:05`, eighteen seconds after the rebase finished, with `ORIG_HEAD` still at `313ac60`. The
+    push originated there. The remaining question is only the mechanism — most plausibly an
+    app-level rebase of the session onto `main`, which that session has explicitly marked
+    **unverified** rather than asserting a third story to replace the two already withdrawn. That
+    restraint is the right call: the thread has now consumed one confident wrong explanation from
+    each side, and a third would have been offered on the same evidentiary footing as the first two.
+
+    **The generalisation is worth more than the incident.** The retracted claim was about the
+    author's _own actions_, falsifiable by a single command, and went unchecked precisely because it
+    felt certain. Every other instance catalogued here involved measuring something external; this
+    one shows the same defect turned inward, where it is harder to see because **certainty about
+    one's own history is indistinguishable from knowledge of it, and is only memory.** Self-report is
+    not a primary source. Where a record exists — the reflog here — it outranks recollection even
+    when the recollection is the actor's.
+
   - **The truncation hazard recurs inside its own correction.** The rule above — tail to _find_ a
     failure, read the body before _explaining_ one — is right but understates the problem. The
     sharper form is that **tailing is safe for detection and fatal for attribution, and the boundary


### PR DESCRIPTION
## Summary

This guide recorded the `ENG-PERF-007` branch rewrite with the actor left open, on the grounds that
"an unowned rewrite that also reached `origin` is worth someone identifying." The authoring session
has now identified it and retracted two claims of its own.

## What closed

- Its **attribution of the rebase to this session** is withdrawn, on the timing this guide already
  recorded: rebase finished `12:03:47`, this session's `node_modules` stamped `12:07:24`.
- Its own **"I haven't pushed since `313ac60`"** is withdrawn. Its remote-tracking reflog records
  `085469a … update by push` at `12:04:05` — eighteen seconds after the rebase, `ORIG_HEAD` still at
  `313ac60`. The push originated in that worktree.

The mechanism (most plausibly an app-level rebase of the session onto `main`) is marked
**unverified** rather than asserted. After two withdrawn explanations, a third offered on the same
footing would have been the same error again.

## Why it is recorded here

The retracted claim was about the author's *own actions* and was falsifiable by a single command. It
went unchecked because it felt certain. Every other instance catalogued in this guide involved
measuring something external; this is the same defect turned inward, where it is harder to see —
certainty about one's own history is indistinguishable from knowledge of it, and is only memory.
Where a record exists, it outranks recollection even when the recollection is the actor's.

No finance file or configuration changes; this closes an open thread in the adoption record.

## Issues

Refs #4029

## Testing

- [x] `npx prettier --check .` — exit 0
- [x] Citation checker v9 — 109 citations / 34 principles / 441 files / 41 stated names, exit 0