### PR TITLE
fix(ci): guard find|head pipelines against pipefail; compare artifacts not refs (#4029)

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -284,7 +284,10 @@ jobs:
           echo "| Compile duration | ${{ steps.compile.outputs.duration || 'N/A' }}s |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Unit test duration | ${{ steps.unit-tests.outputs.duration || 'N/A' }}s |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Gradle cache | ${{ github.ref == 'refs/heads/main' && 'read-write' || 'read-only' }} |" >> "$GITHUB_STEP_SUMMARY"
-          APK=$(find apps/android/build/outputs/apk/debug -name '*.apk' 2>/dev/null | head -1)
+          # `|| true`: find exits 1 when the output dir is absent, head still exits 0.
+          # Harmless under the default shell, fatal under `shell: bash` (-eo pipefail),
+          # and this step runs with `if: always()` — i.e. exactly when the dir is missing.
+          APK=$(find apps/android/build/outputs/apk/debug -name '*.apk' 2>/dev/null | head -1 || true)
           if [ -n "$APK" ]; then
             SIZE=$(du -sh "$APK" | cut -f1)
             echo "| Debug APK size | $SIZE |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -210,8 +210,10 @@ jobs:
           fi
 
           # ── LCOV for third-party tooling ─────────────────────────
-          PROFDATA="$(find "$XCRESULT" -name '*.profdata' -type f 2>/dev/null | head -1)"
-          BINARY="$(find "$XCRESULT" -name '*.xctest' -type d 2>/dev/null | head -1)"
+          # `|| true` on both: find exits 1 if $XCRESULT is absent while head exits 0,
+          # so the pipeline only looks safe under the default shell. See ci-windows.yml.
+          PROFDATA="$(find "$XCRESULT" -name '*.profdata' -type f 2>/dev/null | head -1 || true)"
+          BINARY="$(find "$XCRESULT" -name '*.xctest' -type d 2>/dev/null | head -1 || true)"
           if [ -n "$PROFDATA" ] && [ -n "$BINARY" ]; then
             xcrun llvm-cov export -format=lcov \
               -instr-profile "$PROFDATA" \

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -111,7 +111,16 @@ jobs:
           echo "| Build duration | ${{ steps.build.outputs.duration || 'N/A' }}s |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Package duration | ${{ steps.package.outputs.duration || 'N/A' }}s |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Gradle cache | ${{ github.ref == 'refs/heads/main' && 'read-write' || 'read-only' }} |" >> "$GITHUB_STEP_SUMMARY"
-          MSI=$(find apps/windows/build/compose/binaries -name '*.msi' 2>/dev/null | head -1)
+          # `|| true` is load-bearing here, not defensive noise. This step declares
+          # `shell: bash`, which GitHub expands to `bash --noprofile --norc -eo pipefail`.
+          # `find` exits 1 when the build produced no output directory; `head` still
+          # exits 0, so pipefail propagates the 1 and `-e` aborts the step at this
+          # assignment. The step is `if: always()`, so it runs *because* the build
+          # failed — the guard is absent exactly on the runs the summary exists for.
+          # Measured: dir absent, pipefail -> step exit 1 and nothing after this line
+          # runs; with `|| true` -> exit 0, MSI empty. With a real MSI present the
+          # guard changes nothing.
+          MSI=$(find apps/windows/build/compose/binaries -name '*.msi' 2>/dev/null | head -1 || true)
           if [ -n "$MSI" ]; then
             SIZE=$(du -sh "$MSI" | cut -f1)
             echo "| MSI size | $SIZE |" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -573,9 +573,17 @@ than the registry, and `tsconfig` is deferred on its own evidence, not on access
 
    | Package                        | Range             | Note                                                    |
    | ------------------------------ | ----------------- | ------------------------------------------------------- |
-   | `@jrmoulckers/eslint-config`   | `>=0.12.0 <1.0.0` | plus three plugins in `devDependencies`, see below      |
+   | `@jrmoulckers/eslint-config`   | `>=0.13.0 <1.0.0` | plus three plugins in `devDependencies`, see below      |
    | `@jrmoulckers/tsconfig`        | `>=0.4.0 <1.0.0`  | registry channel; not installed here — deferred on cost |
    | `@jrmoulckers/prettier-config` | `>=0.3.0 <1.0.0`  | registry channel; vendored here by ref + lock instead   |
+
+   Re-read 2026-08-12: `eslint-config` had moved to **`0.13.0`** while this table still said
+   `0.12.0`. Worth being precise about the severity, because it is not the caret failure upstream
+   warns about. `>=0.12.0 <1.0.0` **already resolved `0.13.0`** — a correct lower-bound range
+   degrades gracefully and keeps installing new releases, where `^0.12.0` would have silently
+   excluded them. What went stale was the printed floor, which claims a currency it no longer has,
+   not the dependency itself. The two failure modes deserve different urgency and the caret warning
+   should not be read as covering both.
 
    The React preset and `vite-react.json` first shipped in `0.2.0`, as did `prettier-config`'s
    reversal to `proseWrap: 'preserve'`; `eslint-config@0.4.0` is the first release installable on
@@ -2071,6 +2079,20 @@ assertion that neither was published. Nothing evaluated the pair.
 
 Finance-invented, generic, and absent from the shared layers:
 
+- **A currency check must compare the artifact, not the version label.** `vendor-configs.mjs`
+  reported "pinned at `v0.15.7`; newest release is `v0.77.0`" — 62 releases, which reads as
+  seriously stale. Both vendored files are **byte-identical at both refs**, and identical at every
+  ref from `v0.5.0` through `main`; the last real change was the `proseWrap` reversal finance itself
+  argued for. Ref distance is not artifact distance whenever the vendored subset changes less often
+  than the repository is tagged, which is the normal case for a config package. The notice now
+  compares the SHA-256 the lock already records and distinguishes "newer tag, no diff" from "newer
+  tag, these N files differ". This matters for the same asymmetry reason as an un-failable
+  guardrail: a notice that is a false alarm 62 times trains the reader to skip the one time it is
+  real, so a signal nobody reads and one that never fires fail identically. Both directions are
+  controlled — `v0.2.0` reports both files as differing, `v0.5.0`/`v0.77.0`/`main` report identical.
+
+  Generic to any vendor-by-ref scheme, so it belongs in `jrmoulckers/.github` rather than here.
+
 - **The skip-with-success required-check pattern** — a path-filtered required check never
   reports status, leaving PRs permanently `BLOCKED`; gate inside the workflow instead. Generic
   Actions knowledge, so it belongs in `jrmoulckers/.github`.
@@ -2263,3 +2285,40 @@ find package 'prettier'` — resolution, not assertion — and the worktree had 
   variable empty by accident, whereas `|| echo ""` makes the empty result the explicit value being
   assigned. Same green build, but the second states the intent that a clean repository is a valid
   outcome rather than a suppressed error.
+
+  **Correction, measured.** The clause "under `pipefail`" above was wrong about the mechanism, and
+  the conclusion survives it. A `grep` whose no-match is the **last** command in the pipeline fails
+  under plain `-e` too, because the assignment takes the exit status of the last command in the
+  substitution — `pipefail` is not what catches that case. Measured, all four combinations:
+
+  | Pipeline shape                                       | `bash -e` | `bash -eo pipefail` |
+  | ---------------------------------------------------- | --------- | ------------------- |
+  | last command fails (`… \| grep -v`, no match)        | 1         | 1                   |
+  | **early fails, last always succeeds** (`… \| wc -l`) | **0**     | **1**               |
+  | finance's `echo "$HITS" \| wc -l`                    | 0         | 0                   |
+  | the shipped `\|\| echo ""` guard                     | 0         | 0                   |
+
+  So the hazard is a pipeline **ending in a command that always succeeds** — `wc -l`, `head`,
+  `sort`, `tee`. Those report success under GitHub's default shell and start failing the moment
+  someone adds `shell: bash`, which GitHub expands to `bash --noprofile --norc -eo pipefail`.
+  Adding that line looks like a formatting preference and is a semantic change to error handling.
+
+  finance's own `COUNT=$(echo "$HITS" | wc -l)` is that exact shape and is safe **only** because
+  `echo` cannot fail. It is one substituted command away from the failing form.
+
+- **A live instance of it, found by applying the corrected rule.** `ci-windows.yml` declares
+  `shell: bash` and ran `MSI=$(find … -name '*.msi' 2>/dev/null | head -1)`. `find` exits 1 when
+  the build produced no output directory; `head` still exits 0; `pipefail` propagates the 1 and
+  `-e` aborts the step at the assignment. The step is `if: always()` — so it runs **because** the
+  build failed, which is precisely when the directory is absent. Reproduced: dir absent under
+  pipefail, step exits 1 and nothing after that line executes; under the default shell, exit 0.
+  With `|| true`, exit 0 and `MSI` empty; with a real MSI present the guard changes nothing.
+
+  Fixed, plus three latent instances of the same shape that are safe today only because their
+  steps do not declare `shell: bash` — `ci-android.yml` (`find … .apk | head -1`) and two in
+  `ci-ios.yml` (`.profdata`, `.xctest`). Guarding them now means adding `shell: bash` later cannot
+  quietly convert them into the live case.
+
+  The generalisable part is the same asymmetry as the required-check finding, one layer down: the
+  guard is missing **exactly on the runs the step exists for**. A summary step that reports build
+  failures had a failure mode reachable only on failed builds, so every green run confirmed it.

--- a/scripts/vendor-configs.mjs
+++ b/scripts/vendor-configs.mjs
@@ -160,12 +160,57 @@ async function check() {
 
   const latest = await latestRef();
   if (latest && latest !== lock.ref) {
-    process.stdout.write(
-      `\nNotice: pinned at ${lock.ref}; newest release is ${latest}.\n` +
-        `This is not a failure. Update deliberately when you choose to:\n` +
-        `  node scripts/vendor-configs.mjs ${latest}\n`,
-    );
+    // A newer tag is not the same claim as newer content, and conflating the two
+    // makes this notice a false alarm most of the time. Measured on 2026-08-12:
+    // pinned v0.15.7 vs newest v0.77.0 — 62 releases apart, and both vendored
+    // files byte-identical. Ref distance is not artifact distance, because these
+    // two files change far less often than the repository is tagged. A notice
+    // that cries wolf 62 times trains the reader to skip the one time it matters,
+    // which is the same asymmetry that makes a guardrail unable to go red: a
+    // signal nobody reads is indistinguishable from one that never fires. So
+    // compare the bytes the lock already records, and say which case this is.
+    const drifted = await changedFilesAt(latest, lock);
+    if (drifted === null) {
+      process.stdout.write(
+        `\nNotice: pinned at ${lock.ref}; newest release is ${latest}.\n` +
+          `Could not compare content at ${latest}; treating as no signal.\n`,
+      );
+    } else if (drifted.length === 0) {
+      process.stdout.write(
+        `\nNotice: pinned at ${lock.ref}; newest release is ${latest}, ` +
+          `but all ${entries.length} vendored file(s) are byte-identical there.\n` +
+          `No action needed — refreshing the ref would produce no diff.\n`,
+      );
+    } else {
+      process.stdout.write(
+        `\nNotice: pinned at ${lock.ref}; newest release is ${latest}, ` +
+          `and ${drifted.length} vendored file(s) differ there:\n` +
+          drifted.map((f) => `  ${f}\n`).join('') +
+          `This is not a failure. Update deliberately when you choose to:\n` +
+          `  node scripts/vendor-configs.mjs ${latest}\n`,
+      );
+    }
   }
+}
+
+/**
+ * Which vendored files actually differ at `ref`, by the same SHA-256 the lock
+ * records. Returns null if any fetch fails, so an offline runner reports "no
+ * signal" rather than a wrong answer in either direction.
+ */
+async function changedFilesAt(ref, lock) {
+  const changed = [];
+  for (const [dest, entry] of Object.entries(lock.files)) {
+    let text;
+    try {
+      text = await fetchFile(ref, entry.source);
+    } catch {
+      return null;
+    }
+    if (text === null || text === undefined) return null;
+    if (sha256(text) !== entry.sha256) changed.push(dest);
+  }
+  return changed;
 }
 
 /**


### PR DESCRIPTION
## Summary

Upstream (`jrmoulckers/engineering` v0.59.0) corrected the mechanism finance had recorded behind its
`|| echo ""` guard. Their correction is right, it was verified rather than accepted, and applying
the corrected rule uncovered a **live defect** in `ci-windows.yml`.

## The corrected mechanism, measured

finance had written that the guard matters "under `pipefail` where a later `grep -v` matching
nothing also fails". That case fails under plain `-e` too — the assignment takes the exit status of
the last command in the substitution.

| Pipeline shape                                     | `bash -e` | `bash -eo pipefail` |
| -------------------------------------------------- | --------- | ------------------- |
| last command fails (`… \| grep -v`, no match)      | 1         | 1                   |
| **early fails, last always succeeds** (`… \| wc -l`) | **0**   | **1**               |
| finance's `echo "$HITS" \| wc -l`                  | 0         | 0                   |
| the shipped `\|\| echo ""` guard                   | 0         | 0                   |

The hazard is a pipeline **ending in a command that always succeeds** (`wc -l`, `head`, `sort`),
which reports success under GitHub's default shell and fails once a step declares `shell: bash`
(expanded to `bash --noprofile --norc -eo pipefail`).

## The live defect

`ci-windows.yml` declares `shell: bash` and assigned from `find … -name '*.msi' | head -1`. `find`
exits 1 when the build produced no output directory, `head` exits 0, pipefail propagates, `-e`
aborts the step.

The step is `if: always()` — it runs **because** the build failed, which is exactly when the
directory is absent. **The guard was missing precisely on the runs the step exists for**, so every
green run confirmed it. Same asymmetry as the path-filter/required-check finding, one layer down.

Reproduced and controlled:

- dir absent + pipefail → step exit 1, nothing after the line runs
- dir absent + default shell → exit 0
- dir absent + `|| true` → exit 0, `MSI` empty
- MSI present + `|| true` → unchanged behaviour

Fixed, plus three latent instances safe today only because they use the default shell:
`ci-android.yml` (`.apk`) and two in `ci-ios.yml` (`.profdata`, `.xctest`).

## Drift notice compared labels, not artifacts

`vendor-configs.mjs` reported *"pinned at `v0.15.7`; newest release is `v0.77.0`"* — 62 releases,
which reads as badly stale. Both vendored files are **byte-identical at both refs**, and at every
ref from `v0.5.0` through `main`. It compared version labels while the lock records content hashes.

It now compares the SHA-256 it already stores. Both directions controlled: `v0.2.0` → both files
differ; `v0.5.0`/`v0.77.0`/`main` → identical.

Rationale: a notice that is a false alarm 62 times trains the reader to skip the real one — a signal
nobody reads fails the same way as one that never fires.

## Version floor

`eslint-config` is at `0.13.0`; the table said `0.12.0`. Note this is **not** the caret failure —
`>=0.12.0 <1.0.0` already resolved `0.13.0`. Only the printed floor was stale.

## Changes

- `.github/workflows/ci-windows.yml`, `ci-android.yml`, `ci-ios.yml` — guard four pipelines
- `scripts/vendor-configs.mjs` — content-based drift comparison
- `docs/guides/engineering-practice-adoption.md` — corrected mechanism, live defect, floor, hoist

## Issues

Refs #4029

## Testing

- [x] `npx prettier --check` on both changed text files — exit 0
- [x] `npx eslint scripts/vendor-configs.mjs --max-warnings 0` — exit 0
- [x] YAML parse of all three modified workflows — OK
- [x] `node scripts/vendor-configs.mjs --check` — exit 0, reports "byte-identical, no action needed"
- [x] Drift comparison positive control at `v0.2.0` — reports both files differing
- [x] Citation checker v9 — exit 0; 126 citations / 39 principles / 441 files / 42 stated names
