### PR TITLE
docs(guides): categorise the Prettier markdown residue; correct the fleet category list (#4029)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -1066,16 +1066,58 @@ config run is not evidence about the gate.** `npm run format:check` after wiring
 that answers this, and it disagreed with the simulation. Nothing below this line was affected: the
 `proseWrap` analysis stands, and it was measured against real files.
 
+**What the 48 lines actually are, and why another repo's category list did not predict them.**
+A second repo (cartridge) measured the same adoption at 575 lines and enumerated three residue
+categories: pipe-table re-padding, `singleQuote` rewriting inside fenced code, and emphasis
+normalisation (`*x*` → `_x_`). Checked against finance's five files, **none of those three fired
+even once.** Every one of finance's 48 lines is a fourth category the list does not contain:
+**embedded fenced code re-wrapped by the narrower `printWidth`** — JSON and TypeScript samples
+whose lines fell in the 96–100 column band and were split.
+
+```diff
+-      "category1": { "$value": "#648FFF", "$type": "color", "$description": "IBM CVD-safe blue" },
++      "category1": {
++        "$value": "#648FFF",
++        "$type": "color",
++        "$description": "IBM CVD-safe blue"
++      },
+```
+
+The reason the lists disagree is worth stating as a rule: **the residue is a function of the diff
+between the old and new configs, not of the config being adopted.** finance's previous
+`.prettierrc.json` already set `singleQuote: true` and already matched on `tabWidth`, `endOfLine`
+and `trailingComma`, so the only markdown-relevant delta was `printWidth` 100 → 96. cartridge's
+prior config evidently differed on more axes. Two repos adopting the identical config therefore
+get disjoint residue sets, and a category list derived from one adoption cannot generalise —
+only the per-repo config delta predicts it.
+
+**Corollary: the "line counts are unchanged" structural check does not hold here.** It is offered
+as proof that no authored break moved, but finance's line counts changed in **5 of 5** files
+(432→448, 543→548, 628→632, 238→242, 364→365). The invariant only holds when no fenced code block
+contains a line in the band between the new and old `printWidth`, which is a property of the
+corpus rather than of `preserve`. The claim it is meant to support — zero prose churn — is true
+here and was verified directly instead: 0 changed lines outside fences and outside table rows.
+
+**And the measurement is not reversible, which is a trap for anyone auditing this after the fact.**
+Re-running the same comparison against the _post-adoption_ tree reports **3** changed files, not 5.
+Prettier preserves an object's expanded form when the source already has a line break after `{`, so
+re-formatting adopted content at the old width does not restore the joined form. Measuring adoption
+cost on already-adopted content silently undercounts it; the pre-adoption tree (`37c2747f~1`) is the
+only valid input, and it reproduces the real commit exactly at 5 files. Same defect class as the
+merge-conflict matrix above — an experiment run against the post-transform artifact.
+
 The 73-line `.prettierignore` is finance-specific and stays.
 
 **The `proseWrap` decision, which is what actually mattered.** Finance already used Prettier's
 default `preserve`, so the only delta was `printWidth` 100 → 96 — and under `preserve` that reaches
 tables, lists and fences, not prose. Measured across every tracked markdown file:
 
-| Metric                 | Value |
-| ---------------------- | ----- |
-| Markdown files tracked | 592   |
-| Files reflowing prose  | **0** |
+| Metric                              | Value |
+| ----------------------------------- | ----- |
+| Markdown files tracked              | 593   |
+| Files reflowing prose               | **0** |
+| Files changed by the adoption       | 5     |
+| Changed lines outside fences/tables | **0** |
 
 The earlier `0.1.x` config set `proseWrap: 'always'`, which would have rewritten **528 of 592
 files (89%)** — 36,249 added / 29,723 removed against 182,051 total markdown lines, roughly 36% of


### PR DESCRIPTION
## Summary

Upstream asked finance to re-check a reported "0-file, 0-line no-op" for the Prettier markdown
override, after cartridge measured 575 changed lines on the same adoption.

**The no-op claim was already retracted here** — the guide has recorded **5 files / 48 lines** since
the correction landed, along with the diagnosis that the original figure came from a simulated
config run rather than the wired gate. What this PR adds is *what those 48 lines are*, which
contradicts the fleet category list in three ways.

## Corpus measurement

593 tracked markdown files. `npx prettier --check "**/*.md"` on current `main` → **exit 0** (the
residue landed with the adoption commit). Re-derived against the pre-adoption tree `37c2747f~1`,
which reproduces the real commit exactly:

| Metric                              | Value |
| ----------------------------------- | ----- |
| Markdown files scanned              | 593   |
| Files changed                       | 5     |
| Files whose line count changed      | 5     |
| Changed lines outside fences/tables | **0** |

## 1. None of the three published categories fired

Table re-padding, `singleQuote` inside fences, emphasis normalisation — **zero occurrences** in
finance. All 48 lines are a fourth category not on the list: **embedded fenced code re-wrapped by
the narrower `printWidth`**, i.e. JSON/TS samples with lines in the 96–100 column band.

## 2. Residue is a function of the config *delta*, not the adopted config

finance's prior `.prettierrc.json` already set `singleQuote: true` and matched on `tabWidth`,
`endOfLine` and `trailingComma`, leaving `printWidth` 100 → 96 as the only markdown-relevant delta.
cartridge's prior config evidently differed on more axes. Two repos adopting an identical config get
**disjoint** residue sets, so a category list derived from one adoption cannot generalise.

## 3. The structural check does not hold here

"Byte-identical line counts prove no authored break moved" fails on this corpus — line counts
changed in **5 of 5** files (432→448, 543→548, 628→632, 238→242, 364→365). The invariant holds only
when no fenced block has a line in the band between the new and old `printWidth`. Zero prose churn
is true here and was verified directly instead.

## 4. The measurement is not reversible

Re-run against the **post-adoption** tree it reports **3** files, not 5 — Prettier preserves object
expansion once the source has a break after `{`, so re-formatting adopted content at the old width
does not restore the joined form. Auditing adoption cost on already-adopted content silently
undercounts it. Same defect class as the merge-conflict matrix: an experiment run against the
post-transform artifact.

## Changes

- `docs/guides/engineering-practice-adoption.md` — residue categorisation, the delta rule, the
  structural-check counterexample, the irreversibility trap, and a corrected metrics table.

## Issues

Refs #4029

## Testing

- [x] `npx prettier --check "**/*.md"` across 593 files — exit 0
- [x] `npx prettier --check` on the changed file — exit 0
- [x] Citation checker v9 — exit 0; 126 citations / 39 principles / 441 files / 42 stated names
- [x] Pre-adoption measurement reproduces commit `37c2747f` exactly (5 files)
