### PR TITLE
docs(guides): record the 401-shaped hole in the auth-free version source (#4029)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -438,6 +438,49 @@ Granting access is human-gated and **owner-only**: either flip the three package
 grant this repository Read under each package's _Manage Actions access_. There is no API path for
 either action.
 
+#### The auth-free substitute is verified by a check that the same `401` switches off
+
+While blocked, finance reads peer ranges from `versions.json` in the engineering repo rather than
+from the registry, on the stated grounds that CI verifies that file against what is published.
+**It does — and the verification includes peer ranges, not just versions**, which was worth
+confirming rather than assuming, because finance's own TypeScript peer-disagreement finding rests
+entirely on that block. Read from `scripts/check-published-versions.mjs` on `main`:
+
+| Line | Behaviour                                                        |
+| ---- | ---------------------------------------------------------------- |
+| 48   | `diffPeers()` compares recorded against published peer ranges    |
+| 98   | reads `peerDependencies` from the packument's `dist-tags.latest` |
+| 165  | each differing peer becomes a `problem`                          |
+
+So the block is genuinely checked. The caveat is in how the check behaves when it cannot run:
+
+| Line   | Behaviour                                                             |
+| ------ | --------------------------------------------------------------------- |
+| 82–83  | HTTP **`401` or `403`** → `unreachable: true`                         |
+| 132–33 | `unreachable` → pushed to `unknown`, **not** to `problems`            |
+| 189–94 | `unknown` emits `console.warn`; the text says "this is not a failure" |
+| 186    | `process.exitCode = 1` only when `problems` is non-empty              |
+
+An authorization failure is therefore classified as an outage, and **the gate stays green with
+zero packages verified**. The console output is honest about it — `verified === 0` prints
+"versions.json was not confirmed against the registry on this run" rather than the usual "matches
+the registry for 3 of 3" — but that distinction lives only in log prose that nobody reads on a
+green run, which is the same shape as the "3 of 3" line that was quoted as proof of the opposite
+of what it said.
+
+**Why this is finance's problem specifically.** `401` on all three packages is not a hypothetical
+here — it is exactly what finance observes. The condition that blocks finance from the registry is
+the condition that silently stops the peer block being verified, and the repositories directed to
+trust that block as their auth-free substitute are precisely the ones without the access needed to
+notice it had lapsed. A credential regression is also durable rather than transient, so unlike a
+real outage it would not self-correct on the next run.
+
+**Proposed upstream, not worked around here** (finance cannot fix another authority's checker, and
+the file is still the best available source): treat `401`/`403` as a `problem` rather than as
+`unreachable`, or fail when `verified === 0` while a token was present. `404` should stay
+`unknown` — the existing comment gives a good reason for that one, and it is a different
+condition. finance continues to cite `versions.json`, now knowing which runs confirm it.
+
 ### Blocker 2 — the ESLint peer range excluded finance (**resolved upstream in 0.4.0**)
 
 `@jrmoulckers/eslint-config@0.3.0` declared `eslint: ^9.0.0` as a peer. Finance runs
@@ -513,6 +556,31 @@ the frame that threw, not the caller that caused it. The blast radius here — e
 plugin failing to load — made a config-level cause look like a package-level one, and the
 remedy that follows from the wrong diagnosis (drop the plugin) would have cost 18 working rules
 including `jsx-key`. Bisecting the config would have cost one more probe than accepting the trace.
+
+#### The version numeral is not a ref — the misattribution ran in reverse
+
+Upstream later reported this section as stale, on the diagnosis that finance had read the repo at
+tag **`v0.4.0`** and mistaken a nine-minor-old tree for current: "at `v0.4.0` (= `0.3.0`, what you
+read)". The correction was accompanied by a re-run of finance's own `./react` experiment, which
+reproduced finance's result.
+
+The diagnosis does not fit the record above. finance never read a tag. It read **published package
+tarballs** at three package versions — `0.3.0`, `0.4.0` and `0.8.0` (the `react.js` table) — and
+then re-measured the whole adoption against the real `0.6.0` artifact resolved from the registry.
+Two of those numerals are _higher_ than the tag finance is said to have been stuck at, which is
+available in the same section that was being corrected.
+
+The mechanism is the tag/package confusion that upstream itself documented, run in the opposite
+direction. Their rule is **never infer a package version from a tag**, because the two series
+numerically resemble each other. The inverse holds equally and is not yet stated: **never infer
+which ref someone read from a package version they quoted.** `0.4.0` appearing in a report is not
+evidence of tag `v0.4.0`; here it was the version in which the fix landed, named as the fix.
+
+Worth recording for the same reason the original wrong diagnosis was kept: it is cheap to check and
+expensive to skip. The check is to read what the report says it measured — the guide states the
+artifact and the resolved peer table on every claim — rather than pattern-matching a numeral. A
+correction issued against a misread of the evidence costs more than the error it targets, because
+it arrives with the authority of a re-run experiment attached, and the re-run agreed with finance.
 
 ### To unblock
 
@@ -779,7 +847,7 @@ records about lint evidence, turned on its author: **a probe reports the exit co
 not of the thing under test.** Where an exit code is the finding, it has to be taken from the real
 tool.
 
-**What finance must do.** Pin `>=0.12.0 <1.0.0` and declare the plugins the React preset imports at
+**What finance must do.** Pin `>=0.13.0 <1.0.0` and declare the plugins the React preset imports at
 module scope in `devDependencies`. There are **three**, not two:
 
 ```jsonc
@@ -1476,7 +1544,7 @@ desktop|Kotlin|Swift|multiplatform` returns a single incidental match. finance s
     installs the three plugins it needs, the real figure is **75.0 → 71.7 MB, 4.4%**; and the
     broadcast named two React plugins where three are required, `eslint-plugin-jsx-a11y` being a
     static import at `react.js` line 3. The `docs/adopting.md` table is right; only the broadcast
-    was short. Finance pins `>=0.12.0 <1.0.0`.
+    was short. Finance pins `>=0.13.0 <1.0.0`.
 
 17. **`--dest` writes the lock to the repo root but keys it by the destination path, so a trial
     vendoring disarms the drift gate while reporting success.** Vendoring into a scratch directory


### PR DESCRIPTION
## Summary

Two corrections and a floor refresh, arising from an upstream message asking finance to close
Blocker 2 and re-pin.

**Blocker 2 was already closed here** — the guide has recorded it as "resolved upstream in `0.4.0`"
along with the retraction of finance's own `eslint-plugin-react` misdiagnosis. No change needed.
What is new is below.

## 1. The auth-free version source is verified by a check that `401` switches off

While blocked on registry access, finance reads peer ranges from the engineering repo's
`versions.json` instead of the registry. That leans on the file's claim to be CI-verified, and
finance's TypeScript peer-disagreement finding rests entirely on it — so it was worth reading the
checker rather than assuming.

**Good news first:** the verification really does cover peer ranges, not just versions
(`diffPeers()` at line 48; peers read from the packument at line 98; each difference becomes a
`problem` at line 165). A hypothesis that the peer block was an unchecked region inside a
credible-looking file turned out to be wrong.

**The caveat:** HTTP `401`/`403` is classified as `unreachable` (lines 82–83), `unreachable` goes to
`unknown` rather than `problems` (132–133), and `process.exitCode = 1` fires only on `problems`
(186). So an authorization failure is treated as an outage and **the gate stays green having
verified zero packages**. The console output is honest — `verified === 0` prints "was not confirmed
against the registry on this run" — but that lives in log prose on a green run.

This is finance's problem specifically: `401` on all three packages is exactly what finance
observes. The condition that blocks finance is the condition that silently stops the peer block
being verified, and the repos directed to trust that block are the ones without the access to
notice. A credential regression is also durable, so unlike an outage it would not self-correct.

Proposed upstream, not worked around here — treat `401`/`403` as a `problem`, or fail when
`verified === 0` while a token was present. `404` should stay `unknown`.

## 2. `0.4.0` in finance's report was a package version, not the tag `v0.4.0`

Upstream reported the section stale on the diagnosis that finance had read the repo at tag
`v0.4.0`. The record does not support it: finance read **published tarballs** at package `0.3.0`,
`0.4.0` and `0.8.0`, and re-measured the whole adoption against the real `0.6.0` artifact. Two of
those numerals are higher than the tag finance is said to have been pinned to.

This is upstream's own tag/package confusion running in reverse. Their rule is *never infer a
package version from a tag*; the inverse is **never infer which ref someone read from a package
version they quoted**.

## 3. Floors

Two prescriptive lines still said `>=0.12.0 <1.0.0`; both now `>=0.13.0 <1.0.0`, matching the
`range` recorded in `versions.json`. The main table was already correct. Note this is a stale
*printed floor*, not a caret — `>=0.12.0 <1.0.0` already resolved `0.13.0`.

## Changes

- `docs/guides/engineering-practice-adoption.md` — new subsection under Blocker 1; new subsection
  closing Blocker 2; two floor refreshes.

## Issues

Refs #4029, refs #4038

## Testing

- [x] `npx prettier --check` on the changed file — exit 0
- [x] Citation checker v9 — exit 0; 126 citations / 39 principles / 441 files / 42 stated names
- [x] Checker behaviour read from `check-published-versions.mjs` on `main`, line-cited
- [x] `versions.json` re-read via auth-free `curl` (no local ref)
