### PR TITLE
docs(guides): correct the hoist ledger — two of three dropped rows landed (#4029)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -1402,8 +1402,34 @@ duplication this adoption removes.
    verifiable. Re-proposed upstream rather than restated here, since a practice may not be copied
    into a product repo.
 
+   **Correction — two of those three have since landed, and this ledger went stale.** Re-checked
+   against the live files rather than against the report of them, because the row above was true
+   when written and quietly stopped being true:
+
+   | Drafted content            | Status                                                                            |
+   | -------------------------- | --------------------------------------------------------------------------------- |
+   | The sampling floor         | **Landed** — `performance-budgets.md`, `### Know the floor of your instrument`    |
+   | Thermal state, device tier | **Landed** — `native-profiling.md`, as device tier / thermal and power / emulator |
+   | `ENG-TEST-008` channel     | **Still absent** from both performance guides                                     |
+
+   The sampling floor landed in `performance-budgets.md` rather than `native-profiling.md`, on the
+   reasoning that `pprof` and `node --cpu-prof` are in that file's tool table and nothing about
+   sampling resolution is native-specific. That is the better home, and it means **a hoist can land
+   in a different file than the one it was proposed against** — so checking only the target file
+   reports a false negative. This ledger did exactly that.
+
+   The third row survives and is narrower than it looks. `testing.md` does carry
+   `## Prove the test can fail (ENG-TEST-008)`, so the general principle is covered; what is still
+   unlanded is the **field-channel** application — breaking the observability channel on purpose to
+   establish it would report a failure, which is a different claim from breaking a test.
+
    Note also that the finance-authored PR is **still open and unmerged** while its content ships
-   elsewhere; flagged upstream so it is closed rather than landing a second time.
+   elsewhere; flagged upstream so it is closed rather than landing a second time. Its author now
+   reports it as `CONFLICTING`, 48 commits behind, and recommends closing rather than rebasing —
+   which this check supports more strongly than their own estimate did. They named the KMP
+   `kotlinx-benchmark`/`jvmTest` row as the last content plausibly not upstream; it **is** upstream,
+   at `native-profiling.md` line 88 with a dedicated paragraph arguing the row carries more weight
+   than its size suggests. Both of the remainders they identified are already landed.
 
 6. **No native-platform principle area.** The 66 principles span 11 areas — API, ARCH, BUILD,
    DATA, INT, LOCAL, OBS, PERF, SEC, TEST, WEB. `WEB` covers browser frontends; **nothing covers


### PR DESCRIPTION
## Summary

The sibling session that authored engineering PR #72 reported it as `CONFLICTING`, 48 commits
behind, and superseded by `practices/native-profiling.md`. Checking that against the live practice
files found finance's own hoist ledger had gone stale in the same way.

## The correction

The ledger recorded three pieces of finance's native-profiling draft as having "not survived"
upstream. **Two of them have since landed.** Verified by fetching the files, not by reading a
report of them:

| Drafted content            | Ledger said | Actually                                                                  |
| -------------------------- | ----------- | -------------------------------------------------------------------------- |
| The sampling floor         | dropped     | **Landed** — `performance-budgets.md`, `### Know the floor of your instrument` |
| Thermal state, device tier | dropped     | **Landed** — `native-profiling.md`, as device tier / thermal and power / emulator |
| `ENG-TEST-008` channel     | dropped     | **Still absent** from both performance guides                              |

## Why it went stale, which is the transferable part

The sampling floor landed in `performance-budgets.md`, **not** in `native-profiling.md` — the file
it was proposed against — on the reasoning that `pprof` and `node --cpu-prof` sit in that file's
tool table and nothing about sampling resolution is native-specific. That is the better home.

It also means **a hoist can land in a different file than the one it was proposed against**, so
checking only the target file reports a false negative. That is precisely what this ledger did: it
was accurate when written, and the material moved.

## The third row survives, narrower than stated

`testing.md` does carry `## Prove the test can fail (ENG-TEST-008)`, so the general principle is
covered. What remains unlanded is the **field-channel** application — breaking the observability
channel on purpose to establish that it would report a failure. Breaking a test and breaking a
channel are different claims, and only the first is documented.

## Bearing on PR #72

The check supports the author's "close, don't rebase" recommendation **more strongly than their own
estimate did**. They named the KMP `kotlinx-benchmark`/`jvmTest` row as the last content plausibly
not upstream; it is upstream, at `native-profiling.md` line 88, with a dedicated paragraph arguing
that row carries more weight than its size suggests. Both remainders they identified are already
landed. Still not finance's PR to close.

## Changes

- `docs/guides/engineering-practice-adoption.md` — corrected hoist ledger with verified landing
  locations, the false-negative mechanism, and the narrowed third row.

## Issues

Refs #4029

## Testing

- [x] `npx prettier --check` on the changed file — exit 0
- [x] Citation checker v9 — exit 0; 128 citations / 39 principles / 441 files / 42 stated names
- [x] Landing locations read from the live `practices/` files over auth-free `raw.githubusercontent`
