### PR TITLE
ci(security): put the ENG citation gate behind the required check

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -525,6 +525,33 @@ jobs:
       - name: ESLint
         run: npx eslint . --max-warnings 0
 
+      # Always-on ENG-* citation gate. The ng-citations job in ci-lint.yml
+      # runs this too, but that job is not a required context, so a red result
+      # there does not block a merge. Running it here puts it behind the one
+      # check branch protection requires.
+      #
+      # Exit 1 and exit 2 are deliberately treated differently. Exit 1 is a
+      # local defect -- a citation naming an ENG-* ID that does not exist, or
+      # restating a principle's title wrongly -- and must block. Exit 2 means
+      # the upstream index could not be fetched, which is an outage in another
+      # repository; failing on it would let an upstream incident block every
+      # merge in finance. Verified 2026-08-12: a bogus ID exits 1, an
+      # unreachable index exits 2.
+      - name: ENG citation check (blocking on citation defects only)
+        run: |
+          set +e
+          npm run eng:citations
+          status=$?
+          set -e
+          if [ "$status" = "0" ]; then
+            echo "✅ Citations verified."
+          elif [ "$status" = "2" ]; then
+            echo "::warning::Upstream principles index unreachable; citation content was not verified. Not blocking."
+          else
+            echo "::error::ENG-* citation check failed (exit $status)."
+            exit 1
+          fi
+
       # Always-on text-encoding gate (#4090). U+FFFD in a committed file means a
       # character was already lost before the bytes arrived; mojibake is valid
       # UTF-8, so only a byte-level scan detects it.

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -525,32 +525,16 @@ jobs:
       - name: ESLint
         run: npx eslint . --max-warnings 0
 
-      # Always-on ENG-* citation gate. The ng-citations job in ci-lint.yml
+      # Always-on ENG-* citation gate. The eng-citations job in ci-lint.yml
       # runs this too, but that job is not a required context, so a red result
-      # there does not block a merge. Running it here puts it behind the one
+      # there cannot block a merge. Running it here puts it behind the single
       # check branch protection requires.
       #
-      # Exit 1 and exit 2 are deliberately treated differently. Exit 1 is a
-      # local defect -- a citation naming an ENG-* ID that does not exist, or
-      # restating a principle's title wrongly -- and must block. Exit 2 means
-      # the upstream index could not be fetched, which is an outage in another
-      # repository; failing on it would let an upstream incident block every
-      # merge in finance. Verified 2026-08-12: a bogus ID exits 1, an
-      # unreachable index exits 2.
-      - name: ENG citation check (blocking on citation defects only)
-        run: |
-          set +e
-          npm run eng:citations
-          status=$?
-          set -e
-          if [ "$status" = "0" ]; then
-            echo "✅ Citations verified."
-          elif [ "$status" = "2" ]; then
-            echo "::warning::Upstream principles index unreachable; citation content was not verified. Not blocking."
-          else
-            echo "::error::ENG-* citation check failed (exit $status)."
-            exit 1
-          fi
+      # The wrapper blocks on a citation defect (exit 1) but only warns when
+      # the upstream index is unreachable (exit 2), so an outage in another
+      # repository cannot block every merge in finance.
+      - name: ENG citation check
+        run: node scripts/eng-citations-gate.mjs
 
       # Always-on text-encoding gate (#4090). U+FFFD in a committed file means a
       # character was already lost before the bytes arrived; mojibake is valid

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -2614,20 +2614,78 @@ The checker already draws the distinction needed to avoid that, and it is measur
 So the step blocks on 1 and warns on 2. A local defect is finance's problem and must stop the
 merge; an upstream incident is not, and must not.
 
-Three assumptions in that step were load-bearing, so all three were tested rather than reasoned
-about:
+The policy lives in `scripts/eng-citations-gate.mjs` rather than inline shell, so the three cases can
+be executed locally instead of argued about. All three were:
 
-- **`npm run` preserves the distinction.** Wrappers commonly normalise a child's status to 1, which
-  would have collapsed both cases into "blocking" and coupled finance's merge queue to upstream
-  availability. Measured: `npm run eng:citations` exits **2** on an unreachable index and **1** on a
-  bogus ID.
-- **The branch logic is right.** Executed under `bash` against statuses 0, 2, 1 and 3: pass, warn,
-  block, block. The last case matters — an exit code nobody anticipated falls through to blocking,
-  which is the safe direction for a gate.
+| Case                                              | Gate exit                   | Effect        |
+| ------------------------------------------------- | --------------------------- | ------------- |
+| Clean tree                                        | 0                           | merge allowed |
+| A tracked file citing an ID absent from the index | **1**                       | merge blocked |
+| Index URL 404s                                    | **0**, with a `::warning::` | merge allowed |
+
+Two assumptions underneath were also tested rather than reasoned about:
+
+- **The exit codes are distinguishable at all.** Wrappers commonly normalise a child's status to 1,
+  which would collapse both cases into "blocking" and couple finance's merge queue to upstream
+  availability. Measured: the checker exits **2** on an unreachable index and **1** on a bogus ID,
+  and `spawnSync` reports both faithfully. An unanticipated code falls through to blocking, which is
+  the safe direction for a gate.
 - **No credential is involved.** The existing job passes no token and the index resolves anonymously
   in CI, so the gatekeeper behaves identically. Had a token been required and absent, the step would
   have exited 2 and warned green forever — which is this document's recurring failure, and it would
   have been introduced by the commit that added the guard against it.
+
+### Three local validators passed a workflow file GitHub rejected
+
+The first attempt at the step above put the exit-code policy in an inline shell block. It was
+committed, pushed, and **broke `ci-security.yml` outright**: GitHub reported `Invalid workflow file
+... You have an error in your yaml syntax`, produced no jobs, and therefore never reported the
+required `Required Checks Gatekeeper` context. The PR sat at `BLOCKED` for forty minutes.
+
+The failure mode is worth recording because of how it presents. **A workflow that fails to parse
+does not show a red check — it shows a missing one.** `gh pr checks` listed no failures, because the
+jobs were never created. The run appears in `gh run list` identified by _path_ rather than by name,
+which is the visible tell:
+
+```
+CI — Lint                            completed  success
+.github/workflows/ci-security.yml    completed  failure
+```
+
+Diagnosing it needed the run page, because `gh api .../check-runs/<id>/annotations` returns 404 for
+a run with no jobs — the same shape as the private-repo billing-hold failures a peer repository
+reported, where logs and summaries are all empty.
+
+**Every local check passed on the broken file:**
+
+| Validator                                           | Verdict on the file GitHub rejected |
+| --------------------------------------------------- | ----------------------------------- |
+| `js-yaml` parse                                     | OK                                  |
+| `js-yaml` structural read (11 steps, correct order) | OK                                  |
+| `prettier --check .`                                | OK                                  |
+| `npm run workflow:security:check` / `:test`         | OK                                  |
+
+Byte-level checks were clean too: no BOM, no tabs, LF endings, no trailing space after `run: |`. I
+could not identify the offending token, and I want to state that plainly rather than invent a
+cause — **the honest finding is that finance has no local validator that agrees with GitHub's
+workflow parser**, and three that disagree with it silently.
+
+The fix does not depend on knowing the token. Moving the policy out of inline shell into
+`scripts/eng-citations-gate.mjs` reduced the workflow change to a single `run:` line, which is
+better independently: the exit-code policy is now executable locally, and its three cases are
+tested above rather than asserted. That is the right response to a construct you cannot validate —
+stop emitting the construct.
+
+Two smaller things the attempt exposed, both from writing YAML through PowerShell:
+
+- A double-quoted here-string ate a backtick-escaped word, turning `` `eng-citations` `` into
+  `ng-citations` in a comment. Prettier, ESLint and the YAML parsers were all happy with it. Line
+  arrays and `WriteAllLines` avoid the class entirely.
+- `npm run` scripts here reject `console.*` under `no-console`; the repo idiom is
+  `process.stdout.write` / `process.stderr.write`, as in `scripts/vendor-configs.mjs`. The gate
+  script was rewritten to match, and **its three cases were re-tested after that rewrite** rather
+  than assumed to have survived it, since the change touched the same statements that carry the exit
+  codes.
 
 ## Worth hoisting up
 

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -2559,6 +2559,76 @@ One thing deliberately not repeated: the peer also reported the adjacency check 
 `v0.66.0`. `adjacen` occurs 3 times in both versions and I did not verify what those occurrences do,
 so that half is unmeasured here and is not asserted.
 
+### Enforcement is a fourth link, and finance's was broken
+
+A peer repository found its citation gate correct in scope, correct in content, and **wired into no
+CI job at all** — defined, invoked by nothing. It proposed the chain: scope, binary version, and
+invocation are each silent on failure, and a green result is compatible with any link being broken.
+
+Turning that on finance found a fourth link the chain does not name.
+
+**Invocation here is sound, and I checked it by observation rather than by reading YAML.** On PR
+#4146 the job ran, in 14 seconds, and its log reports numbers identical to the local run:
+
+```
+132 citation(s) across 39 principle(s) in 806 file(s); all IDs exist, and 42 stated name(s) match.
+```
+
+That equality matters beyond invocation: a soft-failed index fetch would have exited 2, and a
+partial index would have changed the principle count. Matching numbers are evidence the fetch
+genuinely resolved.
+
+**Then the link that was broken.** `ENG Citations` is not in `main`'s required contexts:
+
+```
+ESLint & Prettier, Secret Detection, CodeQL Analysis (javascript-typescript),
+CodeQL Analysis (java-kotlin), Build, Build & Test, Required Checks Gatekeeper
+```
+
+Nor is it aggregated by `Required Checks Gatekeeper`, which lives in a different workflow file and
+so cannot reach it through `needs:`. **The gate ran, was correct, and could not block anything.**
+
+This is worth stating precisely, because it is close to something already claimed here and is not
+the same claim. When the gate shipped, this guide recorded that both its failure modes had been
+_proven to fail_. That was true. **Proving a check can fail is not proving a failure blocks** —
+they are different links, and the first is the one that feels like diligence.
+
+#### The fix, and why it is not simply "make it required"
+
+Adding a required context is a branch-protection change and human-gated. But finance already built
+the mechanism for exactly this problem: the gatekeeper is the one required check, and it
+independently re-runs lint and format precisely because the path-filtered workflow that owns them
+may be skipped. The citation check now runs there too — a workflow change, not a settings change.
+
+That introduces a hazard the existing gatekeeper steps do not have: every prior step is local, and
+this one fetches an index from another repository. Making a required check depend on an external
+fetch means an upstream outage blocks every merge in finance.
+
+The checker already draws the distinction needed to avoid that, and it is measured, not assumed:
+
+| Condition                                | Exit  |
+| ---------------------------------------- | ----- |
+| Citation names an ID that does not exist | **1** |
+| Upstream index unreachable               | **2** |
+
+So the step blocks on 1 and warns on 2. A local defect is finance's problem and must stop the
+merge; an upstream incident is not, and must not.
+
+Three assumptions in that step were load-bearing, so all three were tested rather than reasoned
+about:
+
+- **`npm run` preserves the distinction.** Wrappers commonly normalise a child's status to 1, which
+  would have collapsed both cases into "blocking" and coupled finance's merge queue to upstream
+  availability. Measured: `npm run eng:citations` exits **2** on an unreachable index and **1** on a
+  bogus ID.
+- **The branch logic is right.** Executed under `bash` against statuses 0, 2, 1 and 3: pass, warn,
+  block, block. The last case matters — an exit code nobody anticipated falls through to blocking,
+  which is the safe direction for a gate.
+- **No credential is involved.** The existing job passes no token and the index resolves anonymously
+  in CI, so the gatekeeper behaves identically. Had a token been required and absent, the step would
+  have exited 2 and warned green forever — which is this document's recurring failure, and it would
+  have been introduced by the commit that added the guard against it.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/scripts/eng-citations-gate.mjs
+++ b/scripts/eng-citations-gate.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Blocking wrapper around the ENG-* citation checker.
+ *
+ * The checker distinguishes two failures, and a required CI check must treat
+ * them differently:
+ *
+ *   exit 1  a citation names an ENG-* ID that does not exist, or restates a
+ *           principle's title wrongly. That is a defect in this repository and
+ *           must stop the merge.
+ *   exit 2  the upstream principles index could not be fetched. That is an
+ *           outage in another repository. Failing on it would let an upstream
+ *           incident block every merge in finance, so it warns instead.
+ *
+ * Collapsing the two is the easy mistake: a wrapper that treats "nonzero" as
+ * "broken" couples this repository's merge queue to another repository's
+ * availability, and a wrapper that treats exit 2 as success reports green
+ * while verifying nothing.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+const CHECKER = 'config/engineering/citations/check-citations.mjs';
+
+/**
+ * Run the citation checker and translate its exit code into a gate decision.
+ *
+ * @returns {number} process exit code: 0 to allow the merge, 1 to block it.
+ */
+function main() {
+  const result = spawnSync(process.execPath, [CHECKER, '.'], {
+    stdio: 'inherit',
+    shell: false,
+  });
+
+  if (result.error) {
+    process.stderr.write(`::error::Could not run ${CHECKER}: ${result.error.message}\n`);
+    return 1;
+  }
+
+  // A signal death has a null status and is not an upstream outage.
+  if (result.status === null) {
+    process.stderr.write(`::error::${CHECKER} terminated by signal ${result.signal}.\n`);
+    return 1;
+  }
+
+  if (result.status === 0) return 0;
+
+  if (result.status === 2) {
+    process.stderr.write(
+      '::warning::Upstream principles index unreachable; citation content was not verified. Not blocking.\n',
+    );
+    return 0;
+  }
+
+  process.stderr.write(`::error::ENG-* citation check failed (exit ${result.status}).\n`);
+  return 1;
+}
+
+process.exit(main());


### PR DESCRIPTION
## Summary

A peer repo found its citation gate correct in scope and content but **wired into no CI job at all**. Its chain — scope, binary version, invocation — each silent on failure. Turning that on finance found a **fourth link the chain doesn't name: enforcement.**

## Invocation is sound (checked by observation, not by reading YAML)

On PR #4146 the job ran in 14s, logging numbers identical to local:

```
132 citation(s) across 39 principle(s) in 806 file(s); all IDs exist, and 42 stated name(s) match.
```

That equality does double duty: a soft-failed index fetch exits 2, and a partial index would change the principle count. Matching numbers prove the fetch genuinely resolved.

## Enforcement was broken

`ENG Citations` is not in `main`'s required contexts:

```
ESLint & Prettier, Secret Detection, CodeQL (js-ts), CodeQL (java-kotlin),
Build, Build & Test, Required Checks Gatekeeper
```

Nor can `Required Checks Gatekeeper` reach it — different workflow file, so `needs:` can't span it. **The gate ran, was correct, and could block nothing.**

Precisely: this guide already recorded that both failure modes were *proven to fail*. That was true. **Proving a check can fail is not proving a failure blocks** — different links, and the first is the one that feels like diligence.

## The fix

Making it a required context is branch protection (human-gated). But finance already built the mechanism: the gatekeeper is the one required check and already re-runs lint/format *because their workflow is path-filtered and may skip*. Citations now run there too — workflow change, not settings change.

Hazard introduced: every other gatekeeper step is local; this one fetches from another repo. So it **blocks on exit 1** (local defect) and **warns on exit 2** (index unreachable) — an upstream outage must not block every merge in finance.

| Condition | Exit |
| --- | --- |
| Citation names a nonexistent ID | **1** |
| Upstream index unreachable | **2** |

Three load-bearing assumptions, all tested rather than reasoned about:

- **`npm run` preserves the distinction** — wrappers often normalise to 1, which would have collapsed both cases into blocking. Measured: **2** and **1**.
- **Branch logic** under `bash` for 0/2/1/3 → pass, warn, block, **block**. The unanticipated code falls through to blocking, the safe direction.
- **No credential involved** — the index resolves anonymously in CI. Had a token been needed and absent, the step would exit 2 and warn green forever: this document's recurring failure, introduced by the commit adding the guard against it.

## Issues

Refs #4029

## Testing

- [x] `npm run eng:citations` — 0
- [x] `npm run eng:vendor:check` — 0
- [x] `npx prettier --check .` — 0
- [x] `npx eslint . --max-warnings 0` — 0
- [x] `npm run workflow:security:check` — 0
- [x] `npm run workflow:security:test` — 0