### PR TITLE
fix(tools): show a pre-flight diff before overwriting branch protection

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -142,9 +142,16 @@ file-level changes effective.
 > **One-command option:** a maintainer with admin rights can apply all of the
 > settings in this section by running
 > [`tools/setup-branch-protection.sh`](../tools/setup-branch-protection.sh)
-> (`gh` must be authenticated with admin scope). It is idempotent and prompts for
-> confirmation. AI agents must **not** run it — repo-settings changes are
-> human-gated. The manual checklist below mirrors what the script applies.
+> (`gh` must be authenticated with admin scope). It prints a diff of the current
+> vs. proposed configuration and prompts for confirmation before writing.
+> It is **not** idempotent with respect to live state: the call fully replaces
+> the branch's protection config, so it reverts anything applied out-of-band and
+> applies this section's _entire_ pending policy (2 approvals, code-owner review,
+> "Include administrators") — not just the status-check list. Read the diff, and
+> note that the review/admin settings above currently conflict with the agent
+> self-merge autonomy described in `AGENTS.md` Category 2. AI agents must **not**
+> run it — repo-settings changes are human-gated. The manual checklist below
+> mirrors what the script applies.
 
 - [ ] **Add required status check:** `Required Checks Gatekeeper` (the single
       always-on gate). Optionally also add `ESLint & Prettier` and

--- a/tools/setup-branch-protection.sh
+++ b/tools/setup-branch-protection.sh
@@ -22,20 +22,17 @@
 # Defaults: repo = current `gh repo view`, branch = main
 #
 # Review the JSON below against .github/branch-protection.md before running.
-# Re-run safely; the PUT is idempotent (it replaces the protection config).
+#
+# NOT idempotent with respect to live state. The REST call is a *full
+# replacement* of the branch's protection config, so re-running reverts any
+# setting that was applied out-of-band (UI, another script) and is not restated
+# in the payload below. The pre-flight diff prints exactly what will change
+# before anything is written — read it rather than assuming a re-run is a no-op.
 
 set -euo pipefail
 
 REPO="${1:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
 BRANCH="${2:-main}"
-
-echo "About to apply branch protection to ${REPO}@${BRANCH}."
-echo "This OVERWRITES the existing protection config for that branch."
-read -r -p "Continue? [y/N] " confirm
-case "$confirm" in
-  [yY][eE][sS]|[yY]) ;;
-  *) echo "Aborted."; exit 1 ;;
-esac
 
 # Required status checks — must match the exact check names GitHub reports.
 # Keep this list in sync with .github/branch-protection.md "Recommended minimum
@@ -64,6 +61,124 @@ read -r -d '' PAYLOAD <<'JSON' || true
   "restrictions": null
 }
 JSON
+
+# ---------------------------------------------------------------------------
+# Pre-flight: show what this PUT will actually change.
+# ---------------------------------------------------------------------------
+# Read-only. The desired context list is derived from $PAYLOAD above rather than
+# restated here, so the diff can never disagree with what gets applied.
+
+desired_contexts="$(printf '%s\n' "$PAYLOAD" \
+  | grep -o '"context": *"[^"]*"' \
+  | sed 's/.*"context": *"\(.*\)"/\1/' \
+  | sort)"
+
+# Contexts the "Required Checks Gatekeeper" aggregates via its `needs:` list and
+# its "Aggregate required security checks" step (.github/workflows/ci-security.yml).
+# Only used to soften the removal warning below; if this list goes stale the
+# script warns about a context that is in fact covered, which is the safe
+# direction to be wrong in.
+gatekeeper_covered="CodeQL Analysis (java-kotlin)
+CodeQL Analysis (javascript-typescript)
+Dependency Review
+Gradle Dependency Check
+License Compliance
+Secret Detection
+Secret Scan (gitleaks)
+npm Audit"
+
+echo "Reading current protection for ${REPO}@${BRANCH} ..."
+# One read, emitted as 8 ordered lines. Contexts are joined on US (\037) because
+# check names contain spaces and '&'.
+# Branch the on gh's exit status, not on empty output: an unprotected branch
+# returns a 404 whose JSON body still satisfies every `//` default below, which
+# would otherwise render as a diff full of blank "current" values.
+protection_query='[
+      (.required_status_checks.contexts // [] | join("\u001f")),
+      (.required_status_checks.strict // false),
+      (.required_pull_request_reviews.required_approving_review_count // 0),
+      (.required_pull_request_reviews.require_code_owner_reviews // false),
+      (.required_pull_request_reviews.require_last_push_approval // false),
+      (.enforce_admins.enabled // false),
+      (.required_conversation_resolution.enabled // false),
+      (.required_linear_history.enabled // false)
+    ] | map(tostring) | join("\n")'
+
+if current="$(gh api "repos/${REPO}/branches/${BRANCH}/protection" \
+      -H "Accept: application/vnd.github+json" \
+      --jq "$protection_query" 2>/dev/null)"; then
+  :
+else
+  current=""
+fi
+
+# Desired scalars are read back out of $PAYLOAD so they are never stated twice.
+pv() {
+  printf '%s\n' "$PAYLOAD" \
+    | grep -o "\"$1\": *[^,}]*" \
+    | head -1 \
+    | sed 's/.*: *//' \
+    | tr -d ' "'
+}
+
+echo
+if [ -z "$current" ]; then
+  echo "Current state: branch is NOT protected, or protection is unreadable with"
+  echo "this token. Everything in the payload will be applied as new."
+else
+  cur_contexts="$(printf '%s\n' "$current" | sed -n '1p' | tr '\037' '\n' | sed '/^$/d' | sort)"
+
+  echo "Required status checks"
+  echo "----------------------"
+  added="$(comm -13 <(printf '%s\n' "$cur_contexts") <(printf '%s\n' "$desired_contexts"))"
+  removed="$(comm -23 <(printf '%s\n' "$cur_contexts") <(printf '%s\n' "$desired_contexts"))"
+
+  printf '%s\n' "$added" | while IFS= read -r c; do
+    [ -n "$c" ] && echo "  + will become required: $c"
+  done
+
+  printf '%s\n' "$removed" | while IFS= read -r c; do
+    [ -z "$c" ] && continue
+    if printf '%s\n' "$gatekeeper_covered" | grep -Fxq "$c"; then
+      echo "  - will stop being required: $c  (still enforced via Gatekeeper)"
+    else
+      echo "  ! will stop being required: $c  ** NOT aggregated by the Gatekeeper **"
+    fi
+  done
+
+  if [ -z "$added" ] && [ -z "$removed" ]; then
+    echo "  (no change)"
+  fi
+
+  echo
+  echo "Other settings (current -> desired)"
+  echo "-----------------------------------"
+  field() {
+    label="$1"; cur="$2"; desired="$3"
+    if [ "$cur" = "$desired" ]; then
+      echo "  = ${label}: ${cur}"
+    else
+      echo "  * ${label}: ${cur} -> ${desired}"
+    fi
+  }
+  field "strict (up to date)"        "$(printf '%s\n' "$current" | sed -n '2p')" "$(pv strict)"
+  field "required approving reviews" "$(printf '%s\n' "$current" | sed -n '3p')" "$(pv required_approving_review_count)"
+  field "require code owner reviews" "$(printf '%s\n' "$current" | sed -n '4p')" "$(pv require_code_owner_reviews)"
+  field "require last push approval" "$(printf '%s\n' "$current" | sed -n '5p')" "$(pv require_last_push_approval)"
+  field "enforce for administrators" "$(printf '%s\n' "$current" | sed -n '6p')" "$(pv enforce_admins)"
+  field "conversation resolution"    "$(printf '%s\n' "$current" | sed -n '7p')" "$(pv required_conversation_resolution)"
+  field "linear history"             "$(printf '%s\n' "$current" | sed -n '8p')" "$(pv required_linear_history)"
+fi
+
+echo
+echo "About to apply branch protection to ${REPO}@${BRANCH}."
+echo "This OVERWRITES the existing protection config for that branch."
+echo "Lines marked '!' or '*' above are changes you may not have intended."
+read -r -p "Continue? [y/N] " confirm
+case "$confirm" in
+  [yY][eE][sS]|[yY]) ;;
+  *) echo "Aborted."; exit 1 ;;
+esac
 
 echo "$PAYLOAD" | gh api \
   --method PUT \


### PR DESCRIPTION
## Summary

`tools/setup-branch-protection.sh` issues a **full-replacement** `PUT` on the branch protection
config but never showed the maintainer what it was replacing — while its header advertised
"Re-run safely; the PUT is idempotent" and `.github/branch-protection.md` offered it as a
"One-command option".

Live protection has drifted from the script's payload in **both** directions, so a re-run today
does two things nobody asked for. This adds a read-only pre-flight diff so both are visible
before anything is written.

Closes #4148

## What running it would silently do (measured, not assumed)

```
+ will become required: Semantic PR Title
! will stop being required: Build                                ** NOT aggregated by the Gatekeeper **
! will stop being required: Build & Test                         ** NOT aggregated by the Gatekeeper **
- will stop being required: CodeQL Analysis (java-kotlin)        (still enforced via Gatekeeper)
- will stop being required: CodeQL Analysis (javascript-typescript) (still enforced via Gatekeeper)
- will stop being required: Secret Detection                     (still enforced via Gatekeeper)

  * required approving reviews: 0 -> 2
  * require code owner reviews: false -> true
  * require last push approval: false -> true
  * enforce for administrators: false -> true
  * conversation resolution: false -> true
```

Two distinct hazards:

1. **The `Build` gates vanish with no backstop.** The script justifies its short context list with
   "the Gatekeeper transitively enforces the granular security jobs." I verified that claim and it
   is **true** — `gatekeeper` in `ci-security.yml` `needs:` all eight security jobs and its
   aggregate step exits 1 on any `needs.*.result` outside `success|skipped`. But its `needs:` list
   contains *only* those eight. `Build` and `Build & Test` are aggregated nowhere, so dropping them
   removes the compile/test gate outright.
2. **A contexts-only re-run also enacts merge policy.** The review/admin deltas are *not* accidental
   drift — `.github/branch-protection.md` lists them under "Needs Human Action" as deliberate,
   still-unchecked #2860/#2880 policy. The defect is purely **bundling**: refreshing status checks
   also flips merge policy in the same command, which as configured would conflict with the agent
   self-merge autonomy in `AGENTS.md` Category 2 and stall every open agent PR at once.

## Changes

- Read-only pre-flight that diffs current vs. proposed **before** the confirmation prompt.
- Removed contexts with no transitive backstop are flagged `!`; ones the Gatekeeper covers are
  softened to `-`.
- Corrected the "re-run safely / idempotent" wording in both the script header and
  `.github/branch-protection.md`, and noted the `AGENTS.md` Category 2 conflict at the point of use.

## Design notes

- **The `PUT` payload is byte-identical.** This changes nothing about what the script applies.
  Deciding *which* side of the divergence should win is human-gated and deliberately out of scope.
- The desired context list and every scalar are **derived from `$PAYLOAD`** rather than restated,
  so the diff cannot disagree with what actually gets written.
- Branching is on `gh`'s **exit status**, not on empty output. An unprotected branch returns a 404
  whose body still satisfies every `//` jq default, which rendered a diff full of blank "current"
  values. That bug existed in my first draft and was only caught by testing the second path.
- The Gatekeeper-covered list is a hardcoded warning aid. If it goes stale the script warns about a
  context that *is* covered — the fail-safe direction.

## Testing

Verified read-only against the live API on three branches — protected (`main`), unprotected, and
nonexistent — using a harness truncated immediately before the confirmation prompt, asserted to
contain **zero** `PUT` statements. Output reproduced an independently-taken API measurement exactly.

**The script itself was never executed and no repo setting was changed** — that is human-gated
(Category 3).

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean
- [x] `npm run encoding:check` — clean (5463 files)
- [x] `bash -n` syntax check

## Disclosure

I initially filed #4148 with the `security` label, which is a human-gated PR-gating label under
`AGENTS.md` Category 3. I removed it; the issue now carries only `bug` and `tooling`.

## Recorded null result

I suspected the `✅ Branch protection applied` echo could fire after a failed `PUT`. It cannot —
`set -euo pipefail` aborts first. Recording it so it isn't re-investigated.