### PR TITLE
fix(tools): refresh MANAGED_COUNTS for the repo-root token inventory (#4150)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -48,9 +48,9 @@ const MANAGED_COUNTS = {
   skills: 19,
   prompts: 8,
   instructions: 5,
-  tokens: 16,
+  tokens: 23,
   base: 2,
-  total: 72,
+  total: 81,
 };
 
 if (args.includes('--help') || args.includes('-h')) {
@@ -64,7 +64,7 @@ Usage:
 
 Validates filesystem counts, the exact 23-agent activated roster, generated
 provenance, the sole local finance-domain agent, retired-role absence, canonical
-runtime documentation, and the 72-entry Studio sync inventory.
+runtime documentation, and the 81-entry Studio sync inventory.
 `);
   process.exit(0);
 }


### PR DESCRIPTION
## Summary

`MANAGED_COUNTS` in `tools/check-ai-manifest.js` carried two stale values, so the check reported drift that did not exist on every run.

Before:

```
Canonical runtime activation:
  [DRIFT] sync lock has 23 managed tokens; expected 16
  [DRIFT] sync lock has 81 managed total; expected 72

⚠️ 0 drifted count claim(s), 2 canonical-activation finding(s) — informational only.
```

After:

```
Canonical runtime activation:
  [ok] 22 generated canonical agents + 1 local agent; 81 managed assets

✅ No drift detected.
```

Both findings were artifacts of the constant, not of the lock. The vendored `@jrm/tokens` distribution grew from 16 to 23 entries when it was repointed to the repo root, taking the managed total from 72 to 81. The lock was correct throughout.

## Changes

- `MANAGED_COUNTS.tokens` `16` → `23`
- `MANAGED_COUNTS.total` `72` → `81`
- `--help` text: "the 72-entry Studio sync inventory" → "the 81-entry Studio sync inventory"

Three numbers in one file. No predicate, grouping, or threshold changed.

## Deliberately not changed

**`MANAGED_COUNTS.instructions` stays at `5`.** The lock holds exactly five `.github/instructions/` entries and the value is correct today. It becomes `6` only after the next sync delivers `canon-formatting.instructions.md` — a file this repository selects but which has not yet been written to any member. Updating it now would swap a correct value for a wrong one.

## Verified counts against the current lock

| kind | predicate | lock | constant |
| --- | --- | --- | --- |
| agents | `.github/agents/` | 22 | 22 |
| skills | `.github/skills/` | 19 | 19 |
| prompts | `.github/prompts/` | 8 | 8 |
| instructions | `.github/instructions/` | 5 | 5 |
| tokens | `vendor/@jrm/tokens/` | 23 | 23 |
| base | `AGENTS.md`, `agency.toml` | 2 | 2 |
| total | all entries | 81 | 81 |

## Why fix a warning

The workflow pins `STRICT: '0'`, so nothing was failing. That is the reason to fix it rather than to leave it: a check that reports two known-false findings on every run teaches readers to skim its output, and the next finding — a real one — lands in the same block everyone has learned to ignore.

## Noted, out of scope

The named subgroups sum to 79. Two managed entries — `.gitattributes` and `.github/copilot-instructions.md` — belong to no subgroup and are counted only in `total`. That is a gap in the grouping rather than drift, and adding a subgroup would need its own expected value and its own change.

## Issues

Closes #4150

## Testing

- [x] `node tools/check-ai-manifest.js` — no drift detected
- [x] `node tools/check-ai-manifest.js --strict` — exit 0
- [x] `npx prettier --check tools/check-ai-manifest.js` — clean
- [x] `npx eslint tools/check-ai-manifest.js --max-warnings 0` — clean