### PR TITLE
fix(ci): block new jobs from inheriting workflow-level permissions

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -2727,6 +2727,82 @@ passed is compatible with a correct gate and with one that cannot fail, and no a
 distinguishes them. The honest statement is that the block path is verified on the developer
 machine and unverified in the environment that enforces it.
 
+### Half of finance's CI jobs took their privileges by inheritance
+
+The fleet's workflow-permissions discussion has been entirely about grants that are too _small_:
+a caller omits a scope its callee needs and the run dies as a `startup_failure`. That hazard
+announces itself. The mirror hazard does not.
+
+A job that omits `permissions:` inherits the workflow-level grant, and the workflow-level grant is
+necessarily the **union** of what the file's most-privileged job needs. So the least-privileged job
+in a file runs at the privilege of the most-privileged one, and nothing ever fails to say so.
+
+Measured across all 31 workflows and 120 jobs:
+
+| Convention                     | Files | Jobs | Inheriting | New job fails                 |
+| ------------------------------ | ----- | ---- | ---------- | ----------------------------- |
+| `permissions: {}` at top level | 9     | 58   | 0          | closed                        |
+| Scoped grant at top level      | 21    | 61   | 60         | open                          |
+| No top-level block             | 1     | 1    | 0          | closed (job declares its own) |
+
+**60 of 120 jobs — half the repository — receive their scopes implicitly.** The concrete cases are
+not theoretical: `nightly.yml` grants `issues:write`, `pull-requests:write` and
+`security-events:write` at file level, and its `load-test` and `zap-baseline` jobs inherit all
+three. `ci-security.yml` grants `security-events:write` to ten jobs including `summary` and
+`gatekeeper`. `ci-android.yml` hands `security-events:write` to `changes`, a path-filter job.
+
+This is `ENG-SEC-004` (Least authority) precisely, and the principle names the mechanism rather
+than just the outcome: _broad or **implicit** authority turns one compromised identity or component
+into unrelated access_. Inheritance is the implicit form. The nine `permissions: {}` files are
+`ENG-SEC-007` (Secure failure) working as intended — a job added there without a block gets
+metadata only and its checkout fails immediately, so the mistake surfaces on the first run.
+
+**`permissions: {}` is not deny-all**, and it is worth being accurate about this because the
+fail-closed property depends on what survives rather than on nothing surviving. `metadata: read`
+cannot be dropped. The value of the empty map is not that it grants nothing; it is that what it
+grants is insufficient to check out the repository.
+
+#### The existing check had the same defect as everything else this session
+
+finance already had a least-privilege check, and it had been passing for as long as it existed. It
+asserts that privileged workflows declare `permissions: {}` — against a **hardcoded list of eight
+filenames**. That is the scope link once more, expressed as a list rather than as a path: the other
+twenty-one files were not failing the check, they were not _in_ it.
+
+The list had also drifted from the one beside it. `privilegedWorkflows` names ten files;
+`leastPrivilegeWorkflows` named eight. `rc-branch-tag.yml` is privileged, already satisfies the
+requirement, and was not asserted to — so removing its `permissions: {}` would have been silent.
+Adding it costs nothing today and closes the gap. (`nightly.yml` is the other omission and is
+genuinely non-empty, so it stays out.)
+
+The new check derives its scope from the tree instead of from a list, and is a **ratchet**: the 60
+jobs that already inherit are recorded as a baseline, and the check fails only when a sixty-first
+appears. Rewriting 21 workflows to drop scopes that jobs may actually need would risk breaking CI
+to fix a latent issue; freezing the current state and blocking growth does not. Shrinking the
+baseline is always safe.
+
+#### Two implementations, because one implementation is an assertion
+
+The check is dependency-free line scanning, matching the surrounding tool. `js-yaml` is **not a
+declared dependency** of finance — it resolved in a scratch script only by hoisting, which is
+exactly the kind of accident that makes a tool work until it doesn't.
+
+So the numbers above were produced twice: once with a real YAML parser, once with the shipped
+line-scanner. They agree on **60 of 60 inheriting jobs with zero mismatched files**. A single
+implementation would have given a number with nothing to check it against, and the count is the
+entire basis for the baseline.
+
+Both directions of the gate are proven rather than argued: an unbaselined inheriting job produces
+the error, a job declaring its own `permissions:` does not, and an empty-map base reports nothing.
+Unit tests cover all three.
+
+#### Enforcement, for free
+
+`workflow:security:check` already runs inside the required `Gatekeeper` job. Extending that script
+rather than adding a new step means the fourth link is closed with **no workflow-file edit at all**
+— which, having previously broken `ci-security.yml` in a way no local validator detected, is worth
+more than the tidiness of a separate script.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-workflow-security.mjs
+++ b/tools/check-workflow-security.mjs
@@ -54,10 +54,80 @@ const leastPrivilegeWorkflows = [
   'deploy-production.yml',
   'deploy-progressive.yml',
   'deploy-rollback.yml',
+  'rc-branch-tag.yml',
   'release-platform.yml',
   'release-train.yml',
   'reusable-release-smoke-test.yml',
 ];
+
+// Jobs that omit `permissions:` inherit the workflow-level grant, which is necessarily the union
+// of what the file's most-privileged job needs. ENG-SEC-004 names *implicit* authority as the
+// hazard, so this is a ratchet rather than a rewrite: the jobs below are the ones that already
+// inherited when the check was introduced, and the check fails only when a new one appears.
+// Shrinking this list is always safe; adding to it requires a deliberate edit and review.
+const permissionInheritanceBaseline = {
+  'ai-eval.yml': ['evals'],
+  'ai-manifest-check.yml': ['manifest'],
+  'ai-metrics.yml': ['collect'],
+  'ci-android.yml': ['changes', 'detekt', 'build-and-test', 'instrumented-tests'],
+  'ci-feature-flags.yml': ['validate-flags'],
+  'ci-ios.yml': ['changes', 'build'],
+  'ci-lint.yml': [
+    'changes',
+    'eslint-prettier',
+    'pr-title',
+    'observability-guardrails',
+    'eng-citations',
+  ],
+  'ci-security.yml': [
+    'codeql-java-kotlin',
+    'codeql-javascript',
+    'dependency-review',
+    'secret-scanning',
+    'gitleaks',
+    'npm-audit',
+    'gradle-dependency-check',
+    'license-check',
+    'summary',
+    'gatekeeper',
+  ],
+  'ci-shared.yml': ['lint-and-test'],
+  'ci-web.yml': [
+    'changes',
+    'build',
+    'unit-tests',
+    'e2e-pr-smoke',
+    'e2e-pr-report',
+    'e2e-main-desktop',
+    'e2e-main-report',
+  ],
+  'ci-windows.yml': ['changes', 'build'],
+  'deploy-pages.yml': ['build', 'deploy'],
+  'deploy-staging.yml': [
+    'pre-deploy-checks',
+    'deploy-web-vm',
+    'deploy-backend',
+    'smoke-tests',
+    'notify',
+  ],
+  'housekeeping.yml': ['add-to-project', 'stale', 'uptime', 'prod-uptime'],
+  'maintenance-align-jwt-aud.yml': ['align-jwt-aud'],
+  'migration-reversal-check.yml': ['reversals'],
+  'nightly.yml': [
+    'web-build',
+    'web-e2e-tests',
+    'web-e2e-report',
+    'web-visual-regression',
+    'web-lighthouse',
+    'web-nightly-issue',
+    'load-test',
+    'zap-baseline',
+  ],
+  'ops-prod-db-recovery.yml': ['ops'],
+  'promote-production.yml': ['promote'],
+  'reusable-detect-changes.yml': ['detect'],
+  'update-visual-snapshots.yml': ['update'],
+};
 
 function normalize(text) {
   return text.replace(/\r\n/g, '\n');
@@ -147,6 +217,38 @@ export function findMutableReferenceViolations(workflow) {
   return violations;
 }
 
+export function findInheritingJobs(workflow) {
+  const lines = normalize(workflow).split('\n');
+  const topLevel = lines.findIndex((line) => /^permissions:/.test(line));
+  if (topLevel === -1) return { base: null, jobs: [] };
+
+  const inlineBase = lines[topLevel].slice('permissions:'.length).trim();
+  if (inlineBase === '{}') return { base: '{}', jobs: [] };
+
+  const jobsStart = lines.findIndex((line) => /^jobs:\s*$/.test(line));
+  if (jobsStart === -1) return { base: inlineBase || 'block', jobs: [] };
+
+  const inheriting = [];
+  for (let index = jobsStart + 1; index < lines.length; index += 1) {
+    const header = lines[index].match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+    if (!header) continue;
+    let end = lines.length;
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      if (/^ {2}[A-Za-z0-9_-]+:\s*$/.test(lines[cursor])) {
+        end = cursor;
+        break;
+      }
+    }
+    const declaresPermissions = lines
+      .slice(index + 1, end)
+      .some((line) => /^ {4}permissions:/.test(line));
+    if (!declaresPermissions) inheriting.push(header[1]);
+    index = end - 1;
+  }
+
+  return { base: inlineBase || 'block', jobs: inheriting };
+}
+
 export function scanWorkflowSecurity(workflows, productionCompose = '') {
   const errors = [];
   const report = (file, message) => errors.push(`${file}: ${message}`);
@@ -171,6 +273,17 @@ export function scanWorkflowSecurity(workflows, productionCompose = '') {
   for (const file of leastPrivilegeWorkflows) {
     if (!/^permissions:\s*\{\}\s*$/m.test(workflows[file] ?? '')) {
       report(file, 'privileged workflow must default to permissions: {}');
+    }
+  }
+
+  for (const [file, workflow] of Object.entries(workflows)) {
+    const allowed = new Set(permissionInheritanceBaseline[file] ?? []);
+    for (const jobName of findInheritingJobs(workflow).jobs) {
+      if (allowed.has(jobName)) continue;
+      report(
+        file,
+        `job ${jobName} omits permissions: and inherits the workflow-level grant; declare job-level permissions (ENG-SEC-004)`,
+      );
     }
   }
 

--- a/tools/check-workflow-security.test.mjs
+++ b/tools/check-workflow-security.test.mjs
@@ -3,8 +3,10 @@ import test from 'node:test';
 
 import {
   extractJob,
+  findInheritingJobs,
   findMutableReferenceViolations,
   findRunExpressionViolations,
+  scanWorkflowSecurity,
 } from './check-workflow-security.mjs';
 
 test('findRunExpressionViolations finds direct input-to-shell interpolation', () => {
@@ -43,4 +45,66 @@ jobs:
 
   assert.match(extractJob(workflow, 'build'), /permissions/);
   assert.doesNotMatch(extractJob(workflow, 'build'), /environment/);
+});
+
+test('findInheritingJobs reports only jobs that omit their own permissions', () => {
+  const workflow = [
+    'permissions:',
+    '  contents: read',
+    '  issues: write',
+    'jobs:',
+    '  declares:',
+    '    permissions:',
+    '      contents: read',
+    '    runs-on: ubuntu-latest',
+    '  inherits:',
+    '    runs-on: ubuntu-latest',
+    '',
+  ].join('\n');
+
+  assert.deepEqual(findInheritingJobs(workflow).jobs, ['inherits']);
+});
+
+test('findInheritingJobs treats an empty workflow-level grant as already fail-closed', () => {
+  const workflow = ['permissions: {}', 'jobs:', '  bare:', '    runs-on: ubuntu-latest', ''].join(
+    '\n',
+  );
+
+  const result = findInheritingJobs(workflow);
+  assert.equal(result.base, '{}');
+  assert.deepEqual(result.jobs, []);
+});
+
+test('scanWorkflowSecurity flags a new job that inherits a non-empty grant', () => {
+  const workflow = [
+    'permissions:',
+    '  contents: read',
+    'jobs:',
+    '  unbaselined:',
+    '    runs-on: ubuntu-latest',
+    '',
+  ].join('\n');
+
+  const errors = scanWorkflowSecurity({ 'zz-not-baselined.yml': workflow });
+  assert.equal(
+    errors.some((error) => /zz-not-baselined\.yml: job unbaselined omits permissions:/.test(error)),
+    true,
+  );
+});
+
+test('scanWorkflowSecurity does not flag jobs recorded in the inheritance baseline', () => {
+  const workflow = [
+    'permissions:',
+    '  contents: read',
+    'jobs:',
+    '  reversals:',
+    '    runs-on: ubuntu-latest',
+    '',
+  ].join('\n');
+
+  const errors = scanWorkflowSecurity({ 'migration-reversal-check.yml': workflow });
+  assert.equal(
+    errors.some((error) => /omits permissions:/.test(error)),
+    false,
+  );
 });


### PR DESCRIPTION
## Summary

Half of finance's CI jobs — **60 of 120** — omit `permissions:` and inherit the workflow-level
grant, which is necessarily the **union** of what the file's most-privileged job needs. So the
least-privileged job in each of 21 files runs at the privilege of the most-privileged one.

The fleet's workflow-permissions discussion has been entirely about grants that are too *small*,
which announce themselves as `startup_failure`. An excessive inherited grant never fails, and so is
never found.

This is `ENG-SEC-004` (Least authority), which names the mechanism rather than the outcome: *broad
or **implicit** authority turns one compromised identity or component into unrelated access.*

## Measurement

| Convention | Files | Jobs | Inheriting | New job fails |
| --- | --- | --- | --- | --- |
| `permissions: {}` at top level | 9 | 58 | 0 | closed |
| Scoped grant at top level | 21 | 61 | 60 | open |
| No top-level block | 1 | 1 | 0 | closed |

Concrete cases: `nightly.yml` gives `load-test` and `zap-baseline` inherited `issues:write`,
`pull-requests:write` and `security-events:write`; `ci-security.yml` gives `security-events:write`
to ten jobs including `summary`; `ci-android.yml` gives it to `changes`, a path-filter job.

## The existing check had the same defect

`leastPrivilegeWorkflows` asserted `permissions: {}` against a **hardcoded list of eight
filenames**. The other 21 workflows were not passing it — they were not in it. The list had also
drifted from `privilegedWorkflows` (ten files): `rc-branch-tag.yml` is privileged, already
satisfies the requirement, and was not asserted to, so removing its `{}` would have been silent.
Added. `nightly.yml` is the other omission and is genuinely non-empty, so it stays out.

## Approach: ratchet, not rewrite

The new check derives its scope from the tree. The 60 existing inheriting jobs are a baseline; only
a sixty-first fails. Rewriting 21 workflows to drop scopes jobs may actually need would risk
breaking CI to fix a latent issue. Shrinking the baseline is always safe.

## Verification

Counted **twice**, because one implementation is an assertion: a real YAML parser and the shipped
dependency-free line scanner agree on **60/60 inheriting jobs, zero mismatched files**. `js-yaml`
is **not a declared dependency** — it resolved in a scratch script only by hoisting — so the
shipped check does not use it.

Both directions proven, not argued: an unbaselined inheriting job errors, a job declaring its own
`permissions:` does not, an empty-map base reports nothing.

## Enforcement

`workflow:security:check` already runs in the required `Gatekeeper` job, so this closes the
enforcement link with **no workflow-file edit at all**.

## Issues

Refs #4029

## Testing

- [x] `npm run workflow:security:test` — 7/7 pass (4 new)
- [x] `npm run workflow:security:check` — clean tree passes
- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — exit 0
- [x] `npm run eng:citations` — 134 citations, 44 stated names, exit 0
- [x] `npm run eng:vendor:check` — 3/3 byte-identical
