### PR TITLE
fix(tools): match manifest claims on logical lines, not wrap positions (#4153)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -93,13 +93,60 @@ const METRICS = [
   },
 ];
 
+// A prose paragraph is the only construct markdown formatters re-wrap, so it is the only
+// construct whose line breaks may not be assumed. Blocks holding a fence, list marker, table
+// row, blockquote, heading, or indented code are left exactly as written.
+const STRUCTURED_LINE = /^(\s*([-*+]|\d+\.)\s|\s*[|>#]|\s*```|\s{4,}\S)/;
+
+/**
+ * Split text into logical lines, joining wrapped prose paragraphs back into one entry.
+ *
+ * Pinned phrases and `<number> <noun>` metric claims are asserted against text that no
+ * formatter promises to leave hard-wrapped where it is today. Matching physical lines makes
+ * every such assertion depend on wrap position: a re-wrap silently drops metric matches and
+ * splits the roster statement, which reports as missing content rather than as a format change.
+ * Whitespace is never the content being asserted, so collapsing it inside a paragraph weakens
+ * nothing — a genuinely absent phrase or wrong number still fails.
+ *
+ * @param {string} text Raw document or section text.
+ * @returns {{ text: string, line: number }[]} Logical lines with their 1-based start line.
+ */
+function logicalLines(text) {
+  const physical = text.split(/\r?\n/);
+  const out = [];
+  let block = [];
+  let blockStart = 0;
+
+  const flush = () => {
+    if (!block.length) return;
+    if (block.some((line) => STRUCTURED_LINE.test(line))) {
+      block.forEach((line, offset) => out.push({ text: line, line: blockStart + offset + 1 }));
+    } else {
+      out.push({ text: block.map((line) => line.trim()).join(' '), line: blockStart + 1 });
+    }
+    block = [];
+  };
+
+  physical.forEach((line, index) => {
+    if (line.trim() === '') {
+      flush();
+      return;
+    }
+    if (!block.length) blockStart = index;
+    block.push(line);
+  });
+  flush();
+  return out;
+}
+
 function scanDoc(relPath, counts) {
   const abs = path.join(ROOT, relPath);
   if (!fs.existsSync(abs)) return { missing: true, findings: [] };
 
-  const lines = fs.readFileSync(abs, 'utf8').split(/\r?\n/);
+  const lines = logicalLines(fs.readFileSync(abs, 'utf8'));
   const findings = [];
-  lines.forEach((line, index) => {
+  lines.forEach((entry) => {
+    const line = entry.text;
     const normalized = line.replace(/[*`_]+/g, ' ');
     for (const metric of METRICS) {
       metric.regex.lastIndex = 0;
@@ -109,7 +156,7 @@ function scanDoc(relPath, counts) {
         const actual = counts[metric.key];
         findings.push({
           file: relPath,
-          line: index + 1,
+          line: entry.line,
           metric: metric.label,
           claimed,
           actual,
@@ -186,9 +233,11 @@ function validateActivationDoc() {
     return [`${ACTIVATION_DOC} is missing the bounded canonical runtime roster section`];
   }
 
-  const section = content.slice(start, end);
+  const section = logicalLines(content.slice(start, end))
+    .map((entry) => entry.text)
+    .join('\n');
   const rosterLine = section
-    .split(/\r?\n/)
+    .split('\n')
     .find((line) => line.startsWith('The generated canonical roster is:'));
   const documented = rosterLine
     ? [...rosterLine.matchAll(/`([^`]+)`/g)].map((match) => match[1]).sort()


### PR DESCRIPTION
## Summary

`tools/check-ai-manifest.js` asserted pinned phrases and `<number> <noun>` count claims against **physical lines**, making every assertion depend on where the document happens to be hard-wrapped. Both scanning functions now work on **logical lines**, with wrapped prose paragraphs joined.

Fixes #4153, and extends it to the second site described below.

## Two failure directions, one cause

| Site | On re-wrap | Severity |
| --- | --- | --- |
| `validateActivationDoc` | `startsWith` still matches the **first physical line** of the wrapped paragraph, now carrying a fraction of the 22 code spans | reports a confident roster regression that never happened |
| `scanDoc` | a wrap between a number and its noun means `(\d+)\s+agents` never matches | **silently** stops checking a claim, so a stale count passes |

The first is noisy and the second is quiet, which is the worse of the two. Fixing only the site in the issue would have left the silent one — the per-instance fix.

## What changed

`logicalLines(text)` joins blank-line-separated prose paragraphs into one entry, preserving the 1-based start line for reporting. Blocks holding a fence, list marker, table row, blockquote, heading, or indented code are returned line-by-line, exactly as written.

Whitespace is never the content being asserted, so collapsing it inside a paragraph weakens nothing: a genuinely absent phrase or a wrong number still fails.

## Verification

End-to-end, reflowing all three scanned documents at **44 columns** — deliberately *not* a replay of Prettier's `proseWrap`, so the guard is not pinned to the formatter setting that discovered the defect:

```
                                  exit   result
baseline, docs as written          0     unchanged
reflowed 44 cols, unfixed          1     24 false findings
reflowed 44 cols, fixed            0     clean
restored, docs dirty               no
```

Unfixed run reports `documented generated roster has 0 roles; expected 22`, names all 22 as missing, and calls the count statement missing. At Prettier's own width it reports 3 of 22 — the aggressive width surfaces strictly more, which is the point of not reusing the discovering tool's setting.

No detections lost on unmodified documents:

```
claims detected   original 5   fixed 5
output diff       0 lines (byte-identical)
```

Documents were restored with `git checkout --`, not a read/modify/write round-trip, and confirmed clean.

## Validation

- `npx prettier --check tools/check-ai-manifest.js` — clean
- `npx eslint tools/check-ai-manifest.js --max-warnings 0` — exit 0
- `node tools/check-ai-manifest.js --strict` — exit 0, no drift

Repo-wide `format:check` not run; it is unrelated to this change and hangs monorepo-wide here.

## Scope

One file. No predicate, threshold, or count value changed — `MANAGED_COUNTS` is untouched. No document was edited.

Closes #4153