### PR TITLE
fix(tools): join wrapped list items into logical lines (#4159)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -93,20 +93,24 @@ const METRICS = [
   },
 ];
 
-// A prose paragraph is the only construct markdown formatters re-wrap, so it is the only
-// construct whose line breaks may not be assumed. Blocks holding a fence, list marker, table
-// row, blockquote, heading, or indented code are left exactly as written.
+// A wrapped prose paragraph and a wrapped list item are the constructs a markdown formatter
+// re-flows, so neither may be assumed to keep its line breaks. These markers begin a new
+// logical line; lines that follow without one are continuations of it.
 const STRUCTURED_LINE = /^(\s*([-*+]|\d+\.)\s|\s*[|>#]|\s*```|\s{4,}\S)/;
 
 /**
- * Split text into logical lines, joining wrapped prose paragraphs back into one entry.
+ * Split text into logical lines, joining wrapped prose and wrapped list items.
  *
  * Pinned phrases and `<number> <noun>` metric claims are asserted against text that no
  * formatter promises to leave hard-wrapped where it is today. Matching physical lines makes
  * every such assertion depend on wrap position: a re-wrap silently drops metric matches and
  * splits the roster statement, which reports as missing content rather than as a format change.
- * Whitespace is never the content being asserted, so collapsing it inside a paragraph weakens
- * nothing — a genuinely absent phrase or wrong number still fails.
+ * Whitespace is never the content being asserted, so collapsing it weakens nothing — a
+ * genuinely absent phrase or wrong number still fails.
+ *
+ * A new logical line begins at each structural marker, so continuation lines join the item
+ * they belong to and a number in one bullet can never pair with a noun in the next. Fenced
+ * code is emitted verbatim, including any blank lines inside it.
  *
  * @param {string} text Raw document or section text.
  * @returns {{ text: string, line: number }[]} Logical lines with their 1-based start line.
@@ -114,26 +118,39 @@ const STRUCTURED_LINE = /^(\s*([-*+]|\d+\.)\s|\s*[|>#]|\s*```|\s{4,}\S)/;
 function logicalLines(text) {
   const physical = text.split(/\r?\n/);
   const out = [];
-  let block = [];
-  let blockStart = 0;
+  let buffer = [];
+  let start = 0;
+  let fenced = false;
 
   const flush = () => {
-    if (!block.length) return;
-    if (block.some((line) => STRUCTURED_LINE.test(line))) {
-      block.forEach((line, offset) => out.push({ text: line, line: blockStart + offset + 1 }));
-    } else {
-      out.push({ text: block.map((line) => line.trim()).join(' '), line: blockStart + 1 });
-    }
-    block = [];
+    if (!buffer.length) return;
+    out.push({ text: buffer.map((line) => line.trim()).join(' '), line: start + 1 });
+    buffer = [];
   };
 
   physical.forEach((line, index) => {
+    if (/^\s*```/.test(line)) {
+      flush();
+      fenced = !fenced;
+      out.push({ text: line, line: index + 1 });
+      return;
+    }
+    if (fenced) {
+      out.push({ text: line, line: index + 1 });
+      return;
+    }
     if (line.trim() === '') {
       flush();
       return;
     }
-    if (!block.length) blockStart = index;
-    block.push(line);
+    if (STRUCTURED_LINE.test(line)) {
+      flush();
+      start = index;
+      buffer = [line];
+      return;
+    }
+    if (!buffer.length) start = index;
+    buffer.push(line);
   });
   flush();
   return out;


### PR DESCRIPTION
## Summary

#4156 fixed wrap-sensitivity for prose paragraphs and left it in place for **list items**. A claim inside a wrapped bullet still split and stopped being detected — silently, with the check continuing to exit 0.

The affected claim is the highest-value one in the file: `**23 agents**`, at the end of a long list item at `AGENTS.md:136`.

This is the quiet failure mode #4156 was written to catch, surviving inside the fix for it.

## Control, both directions

Reflowing prose **and list items** at 44 columns across all three scanned documents:

```
                exit   claims detected
before (#4156)    0        4 -> 3        silent loss
after             0        4 -> 4
```

The `before` row is the important one: exit code 0, no finding, one fewer claim checked. Nothing in the output indicates the check got weaker.

## Rule comparison, measured

`METRICS` extracted from the module rather than retyped:

```
AGENTS.md                    as-written   reflowed   matches absent from baseline
  raw physical lines             2            0                 0
  paragraph-join (#4156)         2            1                 0
  global collapse                2            2                 0
  item-aware join (this PR)      2            2                 0
```

`docs/ai/README.md` and `docs/INDEX.md` are unaffected under every rule — their claims sit in prose.

## The justification for the narrower rule did not hold

#4156 kept list blocks intact to prevent a number in one bullet pairing with a noun in the next. That risk was **asserted, not measured**. Measured now: global collapse produces **zero** matches absent from the baseline on all three documents. The harm the narrower rule was chosen to avoid does not occur here — and the rule was not free, costing one silently dropped claim.

This PR keeps the property anyway, by construction rather than by measurement: a new logical line begins at each structural marker, so continuation lines join the item they belong to and cross-bullet pairing remains impossible.

## Also fixed

Fenced code is now emitted verbatim. The previous implementation relied on the fence line matching the structural guard, so a blank line inside a fence split the block and un-guarded its interior. Latent, not currently reached by any scanned document.

## Validation

- `npx prettier --check tools/check-ai-manifest.js` — clean
- `npx eslint tools/check-ai-manifest.js --max-warnings 0` — exit 0
- `node tools/check-ai-manifest.js --strict` — exit 0, no drift
- Fixture documents restored with `git checkout --` and confirmed clean, not a read/modify/write round-trip

Repo-wide `format:check` not run; unrelated to this change and hangs monorepo-wide here.

## Scope

One file. No document edited. No count, predicate, or threshold changed.

Closes #4159