### PR TITLE
fix(tools): match the provenance stamp as a delivered line, not a substring (#4162)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -9,7 +9,11 @@ const ROOT = path.resolve(__dirname, '..');
 const args = process.argv.slice(2);
 const STRICT = process.env.STRICT === '1' || args.includes('--strict');
 const ACTIVATION_DOC = 'docs/ai/README.md';
-const PROVENANCE = 'synced from jrmoulckers/.github — canonical source; do not edit here';
+// The stamp is delivered as a standalone comment on its own line. Matching it as a substring
+// cannot tell the delivered stamp from prose or a code span that quotes it — which the one
+// deliberately unstamped file is the most likely file to do — so match the delivered form.
+const PROVENANCE_LINE =
+  /^<!-- synced from jrmoulckers\/\.github — canonical source; do not edit here -->$/m;
 const GENERATED_AGENTS = [
   'accessibility-reviewer',
   'ai-ops-engineer',
@@ -216,7 +220,7 @@ function validateAgentRoster(runtimeAgents) {
     const relPath = `.github/agents/${role}.agent.md`;
     const abs = path.join(ROOT, relPath);
     if (!fs.existsSync(abs)) continue;
-    if (!fs.readFileSync(abs, 'utf8').includes(PROVENANCE)) {
+    if (!PROVENANCE_LINE.test(fs.readFileSync(abs, 'utf8'))) {
       findings.push(`${relPath} is missing canonical provenance`);
     }
   }
@@ -225,7 +229,7 @@ function validateAgentRoster(runtimeAgents) {
     const relPath = `.github/agents/${role}.agent.md`;
     const abs = path.join(ROOT, relPath);
     if (!fs.existsSync(abs)) continue;
-    if (fs.readFileSync(abs, 'utf8').includes(PROVENANCE)) {
+    if (PROVENANCE_LINE.test(fs.readFileSync(abs, 'utf8'))) {
       findings.push(`${relPath} must remain Finance-authored, not generated`);
     }
   }


### PR DESCRIPTION
## Summary

The canonical provenance stamp is delivered as a **standalone comment on its own line**:

```
.github/agents/architect.agent.md:16
<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
```

Both provenance assertions tested for it with `String.includes`. A substring test cannot distinguish the delivered stamp from prose or a code span that quotes it, so both were wrong in opposite directions.

## Two failure directions, both confirmed

```
fixture                                            before   after
A  local agent quotes the stamp in prose            FAIL     PASS
B  generated agent loses stamp, mentions the text   FAIL     PASS
```

- **A** produced a false positive: `finance-domain.agent.md must remain Finance-authored, not generated`, for a file that merely described the convention.
- **B** is the worse one and produced **no finding at all** — a generated agent with its real stamp removed passed the check on the strength of a prose mention. Silent, matching the `scanDoc` pattern from #4159.

## Why A is reachable rather than theoretical

`finance-domain.agent.md` is the one file in the repository whose defining property is *not* being generated. It is therefore the file most likely to explain the provenance convention, and explaining it means writing the stamp text. A file that must describe a marker necessarily contains strings satisfying a bare-name matcher for it.

Currently clean — the file mentions "provenance" once at L119, in an unrelated financial sense.

## Fix

```js
const PROVENANCE_LINE =
  /^<!-- synced from jrmoulckers\/\.github — canonical source; do not edit here -->$/m;
```

Anchored to a whole line with the multiline flag. This is the rule the backbone's marker convention already prescribes for its own delimiters — match the delimiter at column 0, never the bare name — applied to the stamp.

## Attribution

Found while verifying a correction from the backbone session. I had run a bare-name matcher against a marker convention that explicitly forbids it, reported a false positive, and was refuted. This is the same class in this repository, in shipped code rather than in an ad hoc probe.

## Validation

- `npx prettier --check tools/check-ai-manifest.js` — clean
- `npx eslint tools/check-ai-manifest.js --max-warnings 0` — exit 0
- `node tools/check-ai-manifest.js --strict` — exit 0, no drift
- Control run in both directions; fixtures restored in a `finally` block and confirmed clean

## Scope

One file, 7 insertions / 3 deletions. No agent file edited. No roster, count, or predicate changed.

Closes #4162