### PR TITLE
fix(tools): assert sync-lock kind buckets exhaustively partition the lock (#4164)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -54,6 +54,7 @@ const MANAGED_COUNTS = {
   instructions: 5,
   tokens: 23,
   base: 2,
+  rootDocs: 2,
   total: 81,
 };
 
@@ -302,23 +303,41 @@ function validateSyncLock() {
   }
 
   const entries = Object.keys(lock.entries || {});
-  const count = (predicate) => entries.filter(predicate).length;
-  const counts = {
-    agents: count((entry) => entry.startsWith('.github/agents/')),
-    skills: count((entry) => entry.startsWith('.github/skills/')),
-    prompts: count((entry) => entry.startsWith('.github/prompts/')),
-    instructions: count((entry) => entry.startsWith('.github/instructions/')),
+  // Counts and the exhaustiveness assertion below are both derived from this one table,
+  // so a kind can never be counted by one and missed by the other.
+  const KIND_PREDICATES = {
+    agents: (entry) => entry.startsWith('.github/agents/'),
+    skills: (entry) => entry.startsWith('.github/skills/'),
+    prompts: (entry) => entry.startsWith('.github/prompts/'),
+    instructions: (entry) => entry.startsWith('.github/instructions/'),
     // Tolerates the pre- and post-migration vendored token roots
     // (apps/web/vendor/@jrm/tokens/ vs. vendor/@jrm/tokens/) so the check stays
     // green until the sync engine regenerates the lock at the new target path.
-    tokens: count((entry) => /(^|\/)vendor\/@jrm\/tokens\//.test(entry)),
-    base: count((entry) => entry === 'AGENTS.md' || entry === 'agency.toml'),
-    total: entries.length,
+    tokens: (entry) => /(^|\/)vendor\/@jrm\/tokens\//.test(entry),
+    base: (entry) => entry === 'AGENTS.md' || entry === 'agency.toml',
+    rootDocs: (entry) => entry === '.gitattributes' || entry === '.github/copilot-instructions.md',
   };
+  const counts = { total: entries.length };
+  for (const [kind, predicate] of Object.entries(KIND_PREDICATES)) {
+    counts[kind] = entries.filter(predicate).length;
+  }
   for (const [kind, expected] of Object.entries(MANAGED_COUNTS)) {
     if (counts[kind] !== expected) {
       findings.push(`sync lock has ${counts[kind]} managed ${kind}; expected ${expected}`);
     }
+  }
+
+  // The kind buckets must exhaustively partition the lock. `total` is a cardinality,
+  // so it only catches entries being added or dropped -- an entry that is *substituted*
+  // inside a region no bucket matches keeps every count correct and passes silently.
+  // Asserting exhaustiveness fails on a future managed asset landing in an unmatched
+  // path, rather than only on the two entries that exposed the gap.
+  const predicates = Object.values(KIND_PREDICATES);
+  const unclassified = entries.filter((entry) => !predicates.some((match) => match(entry)));
+  if (unclassified.length) {
+    findings.push(
+      `sync lock has ${unclassified.length} entries in no counted kind: ${unclassified.join(', ')}`,
+    );
   }
 
   for (const role of GENERATED_AGENTS) {


### PR DESCRIPTION
## Summary

`validateSyncLock()` counted managed lock entries into six kind buckets, but the buckets did not partition the lock — they summed to 79 against a `total` of 81. `.gitattributes` and `.github/copilot-instructions.md` fell in no bucket and were constrained only by cardinality.

## Measurement

```
entries covered by no kind: 2  (.gitattributes, .github/copilot-instructions.md)
sum of kind buckets: 79   total: 81
```

Because `total` is a length, any cardinality-preserving change in the uncovered region passed silently — the quiet failure sign, not a false finding.

## Changes

- Added `rootDocs` coverage for the two root-level managed documents.
- Derived the counts **and** the exhaustiveness assertion from a single `KIND_PREDICATES` table, so a kind cannot be counted by one and missed by the other.
- Added an exhaustiveness assertion naming any unclassified entry.

## Testing

Controls, both directions, lock and tool restored in a `finally` with `git status` asserted clean:

```
unmodified                                   SILENT (exit 0)
.gitattributes -> .github/JUNK.md            CAUGHT  rootDocs 1 vs 2
copilot-instructions.md -> docs/RANDOM.md    CAUGHT  rootDocs 1 vs 2
FUTURE: new entry in unmatched path          CAUGHT  total 82 vs 81
```

The third fires on `total`, so it does not exercise the new assertion. Tested in isolation by neutering only the `rootDocs` coverage and leaving the assertion in place:

```
shipped (rootDocs present)                   exit 0, assertion silent
rootDocs coverage removed, assertion kept    FIRES: 2 entries in no counted kind
```

- [x] `node tools/check-ai-manifest.js --strict` exit 0
- [x] `npx eslint tools/check-ai-manifest.js --max-warnings 0` clean
- [x] `npx prettier --check` clean

## Issues

Closes #4164