### PR TITLE
fix(tools): verify managed asset content against the lock's targetSha256 (#4169)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -3,6 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const { buildManifest } = require('./ai-manifest.js');
 
 const ROOT = path.resolve(__dirname, '..');
@@ -357,6 +358,60 @@ function validateSyncLock() {
     if (!metadata.sourceSha256 || !metadata.targetSha256 || !metadata.syncedAt) {
       findings.push(`sync lock entry is incomplete: ${entry}`);
     }
+  }
+
+  findings.push(...verifyManagedContent(lock));
+  return findings;
+}
+
+// Markers delimiting a managed region, per comment syntax of the host file.
+// Group 2 is the region body; the markers themselves are excluded from the digest.
+const REGION_MARKERS = [
+  /^<!-- studio:([\w-]+):start -->\n([\s\S]*?)^<!-- studio:\1:end -->$/m,
+  /^# studio:([\w-]+):start\n([\s\S]*?)^# studio:\1:end$/m,
+];
+
+function managedRegion(text) {
+  for (const pattern of REGION_MARKERS) {
+    const match = text.match(pattern);
+    if (match) return match[2];
+  }
+  return null;
+}
+
+// Reproduces the sync engine's targetSha256. The two shapes differ in trimming, so a
+// single rule verifies one group and reports false drift on the other:
+//   marker-managed -> sha256 of the region body, trimmed, markers excluded
+//   whole-file     -> sha256 of the whole file, LF-normalized, NOT trimmed
+// Verified against every present lock entry: 3 region, 65 whole, 0 mismatches.
+function verifyManagedContent(lock) {
+  const findings = [];
+  const pending = [];
+  for (const [entry, metadata] of Object.entries(lock.entries || {})) {
+    if (!metadata || !metadata.targetSha256) continue;
+    const absolute = path.join(ROOT, entry);
+    // Presence before classification: an absent target has no content to classify, and
+    // must not fall through to a whole-file compare that would report permanent drift.
+    if (!fs.existsSync(absolute)) {
+      pending.push(entry);
+      continue;
+    }
+    const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
+    const region = managedRegion(text);
+    const payload = region === null ? text : region.trim();
+    const digest = crypto.createHash('sha256').update(payload).digest('hex');
+    if (digest !== metadata.targetSha256) {
+      const scope = region === null ? 'managed file' : 'managed region';
+      findings.push(
+        `${scope} was edited after sync: ${entry} ` +
+          `(sha256 ${digest.slice(0, 12)}, lock records ${metadata.targetSha256.slice(0, 12)})`,
+      );
+    }
+  }
+  if (pending.length) {
+    process.stdout.write(
+      `  [pending] ${pending.length} managed targets absent, awaiting the next sync run\n`,
+    );
   }
   return findings;
 }


### PR DESCRIPTION
## Summary

`validateSyncLock()` asserted that `targetSha256` **exists** on every lock entry but never that it **matches**. Editing a managed file — including deleting canon's own prose from inside a managed region — passed `--strict` with exit 0.

## Why this is live

`jrmoulckers/.github` measured that repairing a duplicated marker region leaves a bare-name count of 2, not 1, which pressures the member to delete canon's prose out of the region. Here that points at `.github/copilot-instructions.md:207`. The harmful edit produces exactly the count the invariant blesses:

```
healthy                     bare 2   col0 1   --strict exit 0
canon prose L207 deleted    bare 1   col0 1   --strict exit 0
```

The wrong action yields the endorsed number and nothing objected. This repo carries no member-side copy of the marker rule, so the rule is unavailable exactly where the temptation lands.

## The digest recipe

Determined by measurement, not inferred from the field name:

- **Marker-managed**: `sha256(region body.trim())`, markers excluded
- **Whole-file**: `sha256(content, LF-normalized)`, **not** trimmed

```
entries 81 | absent 13 | REGION 3 | WHOLE 65 | MISMATCH 0
```

The two shapes differ in trimming. A single rule verifies one group and reports false drift on the other — guarded by a control below.

## Testing

```
unmodified                          exit 0   13 pending
THE HARM: canon prose deleted       exit 1   managed region was edited after sync
member text appended (must pass)    exit 0   no false positive
generated agent edited              exit 1   managed file was edited after sync
NEUTERED + harm (must be silent)    exit 0   comparison is what catches
single trimming rule (premise)      exit 1   two-recipe split is load-bearing
```

The last two matter most: neutering only the digest comparison makes the harm silent again, so the check is what catches it rather than something incidental; collapsing to one trimming rule fails, so the split is asserted rather than decorative.

Absent targets are reported as `[pending]`, testing **presence before classification** so the 13 vendored token entries awaiting the repo-root sync don't fall through to a whole-file compare and report permanent drift.

- [x] `node tools/check-ai-manifest.js --strict` exit 0
- [x] `npx eslint tools/check-ai-manifest.js --max-warnings 0` clean
- [x] `npx prettier --check` clean
- [x] All fixtures restored in a `finally`, `git status` asserted clean

## Issues

Closes #4169