### PR TITLE
fix(tools): report a missing managed target instead of skipping it (#4172)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -384,16 +384,25 @@ function managedRegion(text) {
 //   marker-managed -> sha256 of the region body, trimmed, markers excluded
 //   whole-file     -> sha256 of the whole file, LF-normalized, NOT trimmed
 // Verified against every present lock entry: 3 region, 65 whole, 0 mismatches.
+// Absence is tolerated only for the vendored token outputs still awaiting the repo-root
+// sync (see #4169). Deriving the tolerance from that path rather than pinning a count
+// means it shrinks to zero on its own when the sync lands, and any other missing managed
+// target -- a deleted skill, prompt, instruction, or root doc -- is reported rather than
+// silently skipped. Counts alone cannot catch this: they count lock entries, not files.
+const PENDING_SYNC = /(^|\/)vendor\/@jrm\/tokens\//;
+
 function verifyManagedContent(lock) {
   const findings = [];
   const pending = [];
+  let verified = 0;
   for (const [entry, metadata] of Object.entries(lock.entries || {})) {
     if (!metadata || !metadata.targetSha256) continue;
     const absolute = path.join(ROOT, entry);
     // Presence before classification: an absent target has no content to classify, and
     // must not fall through to a whole-file compare that would report permanent drift.
     if (!fs.existsSync(absolute)) {
-      pending.push(entry);
+      if (PENDING_SYNC.test(entry)) pending.push(entry);
+      else findings.push(`managed target is missing: ${entry}`);
       continue;
     }
     const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
@@ -406,13 +415,18 @@ function verifyManagedContent(lock) {
         `${scope} was edited after sync: ${entry} ` +
           `(sha256 ${digest.slice(0, 12)}, lock records ${metadata.targetSha256.slice(0, 12)})`,
       );
+    } else {
+      verified += 1;
     }
   }
-  if (pending.length) {
-    process.stdout.write(
-      `  [pending] ${pending.length} managed targets absent, awaiting the next sync run\n`,
-    );
-  }
+  // Report what was verified, not only what was skipped. A run that verifies nothing must
+  // be distinguishable at a glance from one that verifies everything -- otherwise the
+  // check can stop observing while still reading as success.
+  process.stdout.write(
+    `  [content] ${verified} managed targets verified against the lock` +
+      (pending.length ? `; ${pending.length} awaiting the next sync run` : '') +
+      '\n',
+  );
   return findings;
 }
 


### PR DESCRIPTION
## Summary

`verifyManagedContent()` (#4170) skipped absent targets and printed a `[pending]` count that nothing asserted. An entry could escape content verification entirely just by not existing:

```
baseline                                        exit 0  pending=13  contentDrift=0
present token entry -> absent path (count held) exit 0  pending=14  contentDrift=0
```

Kind counts count *lock entries*, not files on disk, so nothing objected. `13 -> 14` was printed and unchecked.

## Changes

- Absence is tolerated **only** under `vendor/@jrm/tokens/`, the one migration actually in flight. All 13 absent entries are vendored token outputs; all 58 non-token managed entries are present. Deriving the tolerance means it shrinks to zero when the sync lands, instead of pinning a `13` to maintain.
- Any other missing managed target — skill, prompt, instruction, root doc — is now a finding. Previously silent: `GENERATED_AGENTS` covers agent roles only.
- Reports the **verified** count, not only the skipped one.

## Testing

```
BASELINE (expect 68 verified, 13 pending)   exit 0  68 verified
token absent (tolerated migration)          exit 0  67 verified
managed skill absent (was silent)           exit 1  67 verified  managed target is missing: .github/skills/design-tokens/SKILL.md
managed instruction absent (was silent)     exit 1  67 verified  managed target is missing: .github/instructions/workflow.instructions.md
NEUTERED + missing skill (must be silent)   exit 0  67 verified
```

Neutering only the new `findings.push` restores the silence, so the new branch is what catches it.

### On the reporting change

An earlier run of this control targeted `.github/skills/kmp-development/SKILL.md`, which is a finance-**local** skill and not a lock entry — so the swap was a no-op and the row read `exit 0`, which looks exactly like "the gap is real and unfixed." It was caught because the row printed `68 verified`, **identical to the baseline**, when a real swap must show `67`.

That is the reason for printing the verified count, and the control now throws if it targets a path the lock doesn't contain rather than silently testing nothing.

- [x] `node tools/check-ai-manifest.js --strict` exit 0 (`68 managed targets verified against the lock; 13 awaiting the next sync run`)
- [x] `npx eslint tools/check-ai-manifest.js --max-warnings 0` clean
- [x] `npx prettier --check` clean
- [x] Lock restored in a `finally`, `git status` on the lock asserted empty

## Issues

Closes #4172