### PR TITLE
docs(tools): state what the content check asserts -- unmodified, not current (#4174)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -422,8 +422,16 @@ function verifyManagedContent(lock) {
   // Report what was verified, not only what was skipped. A run that verifies nothing must
   // be distinguishable at a glance from one that verifies everything -- otherwise the
   // check can stop observing while still reading as success.
+  //
+  // The wording is deliberate: this asserts "unmodified since sync", NOT "current with
+  // canon". targetSha256 records what was delivered; sourceSha256 records what canon
+  // looked like at sync time and is canon-side content -- measured unmatched by anything
+  // local for all 68 present entries. Canon can therefore move arbitrarily far ahead
+  // while every check here stays green, and a stale file defeats detection by existing.
+  // Closing that requires comparing against the backbone at runtime, which is the open
+  // owner-gated question in #4141. Until then this line must not imply currency.
   process.stdout.write(
-    `  [content] ${verified} managed targets verified against the lock` +
+    `  [content] ${verified} managed targets unmodified since sync` +
       (pending.length ? `; ${pending.length} awaiting the next sync run` : '') +
       '\n',
   );


### PR DESCRIPTION
## Summary

The content check printed `68 managed targets verified against the lock`. That reads as a currency claim it cannot support.

```
present entries         68
sourceSha256 == target   0
sourceSha256 == local    0
sourceSha256 unmatched  68   <- canon-side content, not reproducible locally
```

`sourceSha256` records canon at sync time. Nothing local can tell us canon has moved. The check asserts **unmodified since sync**, never **current with canon**.

## Why now

`jrmoulckers/.github` measured finance's delivered instruction files against canon at `c033f11` — 0 of 6 current, 5 stale, 1 missing. Confirmed locally: `.github/instructions/workflow.instructions.md` is 23,263 bytes / 384 lines against a canon source of 248,159 bytes / 2,872 lines, roughly **9%**.

That file is present, correctly stamped, plausibly sized, and passes every check in this repo. A missing file is caught by its absence; a stale file defeats detection by existing — and a green line reading "verified" is part of what makes it invisible.

## Changes

Wording only, plus a comment recording the boundary so the next reader doesn't re-derive it. No behaviour change.

```
- [content] 68 managed targets verified against the lock; 13 awaiting the next sync run
+ [content] 68 managed targets unmodified since sync; 13 awaiting the next sync run
```

## Explicitly out of scope

Detecting canon drift requires finance's checks to reach `jrmoulckers/.github` at runtime. That is the open **owner-gated** question in #4141 and is deliberately not actioned here. Sync recency is not the problem — oldest `syncedAt` is 4 days — the growth is canon-side.

## Testing

- [x] `node tools/check-ai-manifest.js --strict` exit 0, prints `68 managed targets unmodified since sync; 13 awaiting the next sync run`
- [x] `npx eslint tools/check-ai-manifest.js --max-warnings 0` clean
- [x] `npx prettier --check` clean

## Issues

Closes #4174