### PR TITLE
fix(tools): match the engine's managed-region digest rule (#4178)

### DIFF
--- a/.github/workflows/ai-manifest-check.yml
+++ b/.github/workflows/ai-manifest-check.yml
@@ -26,6 +26,7 @@ on:
       - 'AGENTS.md'
       - 'tools/ai-manifest.js'
       - 'tools/check-ai-manifest.js'
+      - 'tools/check-ai-manifest.test.mjs'
   workflow_dispatch:
 
 concurrency:
@@ -49,6 +50,12 @@ jobs:
 
       - name: Generate manifest
         run: node tools/ai-manifest.js --markdown
+
+      - name: Digest rule tests
+        # Blocking, unlike the drift check below. These pin the two targetSha256 rules against
+        # the sync engine; the live check cannot catch a wrong rule, because this repo's corpus
+        # contains no input that separates the correct rule from its near-miss (.github#659).
+        run: npm run ai:manifest:test
 
       - name: Check for drift (informational)
         # Default is warn-only (exit 0). Set STRICT=1 here to make drift blocking.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "cleanup:worktrees": "node tools/cleanup-worktrees.js",
     "ai:manifest": "node tools/ai-manifest.js",
     "ai:manifest:check": "node tools/check-ai-manifest.js",
+    "ai:manifest:test": "node --test tools/check-ai-manifest.test.mjs",
     "encoding:check": "node tools/check-text-encoding.mjs",
     "workflow:security:check": "node tools/check-workflow-security.mjs",
     "workflow:security:test": "node --test tools/check-workflow-security.test.mjs",

--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -381,9 +381,24 @@ function managedRegion(text) {
 
 // Reproduces the sync engine's targetSha256. The two shapes differ in trimming, so a
 // single rule verifies one group and reports false drift on the other:
-//   marker-managed -> sha256 of the region body, trimmed, markers excluded
-//   whole-file     -> sha256 of the whole file, LF-normalized, NOT trimmed
-// Verified against every present lock entry: 3 region, 65 whole, 0 mismatches.
+//   marker-managed -> sha256 of the region body, TRAILING whitespace stripped, markers excluded
+//   whole-file     -> sha256 of the whole file, LF-normalized, not stripped
+// The engine is `toLF(inner).replace(/\s+$/, '')` (basemerge.mjs:165, canonicalizeInner).
+// `.trim()` is the natural external guess and is wrong: it strips the leading end too, so the
+// two rules agree on every region body that does not begin with whitespace and diverge on
+// every one that does. This repo's 68 present lock entries contain no instance of that input
+// class, so the sweep that derived `.trim()` returned 0 mismatches over a corpus incapable of
+// separating the rules -- a true measurement that could not have found this (.github#659).
+// Leading whitespace inside a managed region is therefore significant and must be preserved.
+const stripTrailing = (text) => text.replace(/\s+$/, '');
+
+function managedDigest(text) {
+  const region = managedRegion(text);
+  const payload = region === null ? text : stripTrailing(region);
+  return crypto.createHash('sha256').update(payload).digest('hex');
+}
+
+// Absence is tolerated only for the vendored token outputs still awaiting the repo-root
 // Absence is tolerated only for the vendored token outputs still awaiting the repo-root
 // sync (see #4169). Deriving the tolerance from that path rather than pinning a count
 // means it shrinks to zero on its own when the sync lands, and any other missing managed
@@ -406,11 +421,9 @@ function verifyManagedContent(lock) {
       continue;
     }
     const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
-    const region = managedRegion(text);
-    const payload = region === null ? text : region.trim();
-    const digest = crypto.createHash('sha256').update(payload).digest('hex');
+    const digest = managedDigest(text);
     if (digest !== metadata.targetSha256) {
-      const scope = region === null ? 'managed file' : 'managed region';
+      const scope = managedRegion(text) === null ? 'managed file' : 'managed region';
       findings.push(
         `${scope} was edited after sync: ${entry} ` +
           `(sha256 ${digest.slice(0, 12)}, lock records ${metadata.targetSha256.slice(0, 12)})`,
@@ -539,4 +552,10 @@ function main() {
   process.exit(0);
 }
 
-main();
+// Guarded so the digest rule can be exercised by tools/check-ai-manifest.test.mjs. `main()`
+// calls process.exit, so an unguarded call would terminate any importer.
+if (require.main === module) {
+  main();
+}
+
+module.exports = { managedRegion, managedDigest };

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -1,0 +1,62 @@
+// Pins the two digest rules in check-ai-manifest.js against the sync engine.
+//
+// A comment recording a rule is not a check that the rule holds. This file exists because the
+// managed-region rule was derived empirically from a corpus that could not separate it from a
+// near-miss: `.trim()` agrees with the engine on every region body that does not begin with
+// whitespace, and none of this repo's region entries begin with one. The sweep was honest and
+// returned zero mismatches over inputs incapable of falsifying it (.github#659).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { managedRegion, managedDigest } = require('./check-ai-manifest.js');
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const sha = (text) => crypto.createHash('sha256').update(text).digest('hex');
+const wrap = (body) => `<!-- studio:base:start -->\n${body}<!-- studio:base:end -->\n`;
+
+test('a managed region body beginning with whitespace is significant, and .trim() is the near-miss', () => {
+  for (const body of ['\ncanon line\n', '  indented\n', '\t tab\n']) {
+    const digest = managedDigest(wrap(body));
+    assert.equal(digest, sha(body.replace(/\s+$/, '')), 'must follow the engine rule');
+    assert.notEqual(digest, sha(body.trim()), 'must not collapse to .trim()');
+  }
+});
+
+test('PREMISE: the two rules agree on canon-shaped bodies, which is why the defect is latent', () => {
+  // If this fails, the divergence is no longer latent and the test above is no longer
+  // describing a near-miss -- rather than passing on a corpus that no longer contains the case.
+  const body = 'canon line\n';
+  assert.equal(managedDigest(wrap(body)), sha(body.trim()));
+});
+
+test('the whole-file rule strips nothing', () => {
+  const text = 'no markers here\n';
+  assert.equal(managedRegion(text), null);
+  assert.equal(managedDigest(text), sha(text));
+  assert.notEqual(managedDigest(text), sha(text.trim()));
+});
+
+test('every present managed target still verifies against the lock', () => {
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  let regions = 0;
+  let whole = 0;
+  for (const [entry, metadata] of Object.entries(lock.entries || {})) {
+    if (!metadata || !metadata.targetSha256) continue;
+    const absolute = path.join(ROOT, entry);
+    if (!fs.existsSync(absolute)) continue;
+    const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
+    assert.equal(managedDigest(text), metadata.targetSha256, `digest mismatch for ${entry}`);
+    if (managedRegion(text) === null) whole += 1;
+    else regions += 1;
+  }
+  // Guards the premise of the sweep itself: a corpus with no region entries would make the
+  // real-corpus assertion vacuous while still reporting a pass.
+  assert.ok(regions > 0, 'corpus contains no marker-managed entry to verify');
+  assert.ok(whole > 0, 'corpus contains no whole-file entry to verify');
+});


### PR DESCRIPTION
Fixes a digest rule in `tools/check-ai-manifest.js` that this repository's corpus cannot falsify.

## The defect

`verifyManagedContent()` hashed the managed region as `region.trim()`. The sync engine is:

```js
// jrmoulckers/.github sync/lib/basemerge.mjs:165 — canonicalizeInner
return toLF(inner).replace(/\s+$/, '');
```

No `m` flag, so it strips the **end of the string only**; `.trim()` strips both ends. Verified against engine source rather than a paraphrase of it.

```
inner="canon line\n"       engine 805d2855  .trim() 805d2855  AGREE
inner="\ncanon line\n"     engine 98bb05e0  .trim() 805d2855  DIVERGE
inner="  indented\n"       engine b0c5a6eb  .trim() a258f543  DIVERGE
```

## Why the original measurement missed it

The rule was derived empirically and swept against every present lock entry — 3 marker-managed, 65 whole-file, **0 mismatches**. That was true, and it could not have found this: all three region bodies start with a non-whitespace character, so the corpus holds no instance of the one input class that separates the rules.

A truth set answers *does my rule reproduce these values*, never *is my rule the engine's rule*. Those coincide only when the corpus spans the rule's input space.

## Changes

- `stripTrailing` applies the engine rule to the region body; whole-file entries remain unstripped. Extracted as `managedDigest()` so the rule is addressable.
- `main()` guarded by `require.main === module` and the two functions exported — `main()` calls `process.exit`, so the rule was previously impossible to test.
- `tools/check-ai-manifest.test.mjs` pins both rules, plus two premise guards: one asserting the rules *do* agree on canon-shaped bodies (so if the divergence stops being latent the suite says so rather than passing), and one failing if the corpus ever contains no region or no whole-file entry to verify.
- Blocking CI step in `ai-manifest-check.yml`. An unrun guard is not a guard.

## Control

Reverting `stripTrailing` to `.trim()`:

```
tests 4   pass 3   fail 1        <- only the synthetic test catches it
live --strict run                -> "68 managed targets unmodified since sync", exit 0
```

The live check cannot detect its own wrong rule, which is the reason this needed a test and not a comment.

## Validation

```
npm run ai:manifest:test                     tests 4  pass 4  fail 0
node tools/check-ai-manifest.js --strict     exit 0, 68 unmodified / 13 pending
npx eslint <touched> --max-warnings 0        exit 0
npx prettier --check <touched>               all matched files use Prettier code style
```

Reported by the backbone session as jrmoulckers/.github#659. No change to `packages/design-tokens`; no sync behaviour altered.

Closes #4178