### PR TITLE
docs(tools): name the axis the manifest check measures (#4181)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -538,7 +538,17 @@ function main() {
   }
 
   if (driftedCounts.length === 0 && activationFindings.length === 0) {
-    process.stdout.write('✅ No drift detected.\n');
+    // Name the axis in the success line, not just in the detail lines above it.
+    // "No drift detected" is true and reads as "this repo is in good order" -- and nothing
+    // here can distinguish those. Every managed file can be provably unmodified since sync
+    // while being an arbitrarily stale copy of canon: `targetSha256` hashes member-local
+    // content and is self-contained, but currency needs canon's CURRENT hash, which no
+    // member-side run can obtain (#4174, and .github#582 for the fleet-wide measurement).
+    // The more accurate this check gets, the more confidently the wrong inference is drawn.
+    process.stdout.write(
+      '✅ No drift detected — counts, activation, and managed content are consistent ' +
+        'with the last sync. Currency against canon is out of scope here (#4174).\n',
+    );
     process.exit(0);
   }
   const result =


### PR DESCRIPTION
`✅ No drift detected.` is true, and its natural reading is false.

## The gap

The check verifies count claims, canonical-activation docs, and that every present managed target is byte-identical to what the last sync wrote (`targetSha256`). It cannot verify that what the last sync wrote is what canon says **now** — `targetSha256` hashes member-local content and is self-contained, while currency needs canon's *current* hash, which no member-side run can obtain.

Measured across finance's delivered instruction files (jrmoulckers/.github#582): `current 0 | stale 5`. The sharpest case is `.github/instructions/workflow.instructions.md` — 23,217 delivered bytes against 248,159 in canon, **9.4%**, with `targetSha256` verifying exactly. Provably unmodified, maximally stale, green.

## Why wording and not a feature

There is no member-side fix, and the engine rejects the obvious one. `sync/lib/provenance.mjs:28-31`: the provenance note is inside `targetSha256`, so stamping canon's revision there would rewrite every synced file on every run and destroy the reviewability of the sync PR. Lines 33-38 reject the per-file variant too — `attachCanonHistory` injects the current note into historical blobs, so any revision-valued note reports untouched files as member drift.

Closing the axis requires reaching the backbone at runtime, which is the open owner-gated question in #4141. Out of scope.

Same class as #4174, one level up: that fixed a detail line (`verified against the lock` → `unmodified since sync`); this fixes the summary line a human actually reads. The more accurate the check becomes, the more confidently the wrong inference gets drawn from it.

## Change

```
- ✅ No drift detected.
+ ✅ No drift detected — counts, activation, and managed content are consistent with the
+   last sync. Currency against canon is out of scope here (#4174).
```

Plus a comment recording why the line names its axis, so the next reader does not "simplify" it back.

## Validation

```
node tools/check-ai-manifest.js --strict     exit 0
npm run ai:manifest:test                     tests 4  pass 4  fail 0
npx eslint tools/check-ai-manifest.js --max-warnings 0   exit 0
npx prettier --check tools/check-ai-manifest.js          clean
```

Wording only — no behaviour, no exit codes, no sync interaction. `packages/design-tokens` untouched.

Closes #4181