### PR TITLE
fix(tools): detect canon files present on disk but absent from the lock (#4183)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -361,6 +361,7 @@ function validateSyncLock() {
   }
 
   findings.push(...verifyManagedContent(lock));
+  findings.push(...verifyLockCoverage(lock));
   return findings;
 }
 
@@ -398,13 +399,69 @@ function managedDigest(text) {
   return crypto.createHash('sha256').update(payload).digest('hex');
 }
 
-// Absence is tolerated only for the vendored token outputs still awaiting the repo-root
-// Absence is tolerated only for the vendored token outputs still awaiting the repo-root
-// sync (see #4169). Deriving the tolerance from that path rather than pinning a count
-// means it shrinks to zero on its own when the sync lands, and any other missing managed
-// target -- a deleted skill, prompt, instruction, or root doc -- is reported rather than
-// silently skipped. Counts alone cannot catch this: they count lock entries, not files.
+// Absence is tolerated only under the vendored-token base. The repo-root sync itself has
+// already run (the lock's generatedAt is that run's output); these paths are absent because
+// the frozen copies were deliberately deleted in #4066/#4076 so the next run repopulates
+// them. Absence is the one state the engine's local-modification guard does not block --
+// copier.mjs:248 plans `add` unconditionally for a missing path -- so the tolerance
+// self-discharges on the next successful run. Deriving it from the path rather than pinning
+// a count is what makes that automatic, and any other missing managed target -- a deleted
+// skill, prompt, instruction, or root doc -- is reported rather than silently skipped.
+// Counts alone cannot catch this: they count lock entries, not files.
 const PENDING_SYNC = /(^|\/)vendor\/@jrm\/tokens\//;
+
+// Bases whose contents the sync engine may own. Used only to bound the coverage walk below.
+const MANAGED_BASES = [
+  '.github/agents',
+  '.github/skills',
+  '.github/prompts',
+  '.github/instructions',
+];
+
+// The inverse of verifyManagedContent: that asks "entry present, is the file there?", this
+// asks "file present, is it recorded?". A lock-iterating check cannot reach a canon target
+// that never became an entry, and the engine can produce one -- copier.mjs:94 leaves the lock
+// untouched on drift, so a member file that already differed from canon at first sync is
+// never recorded and is thereafter invisible to every check either side runs.
+//
+// Only the STAMPED case is decidable here, and it is decidable exactly: the engine writes the
+// provenance line, so a stamped file with no entry means engine-written but unrecorded.
+// Baseline is 0 and there is no exemption list.
+//
+// The unstamped case is NOT decidable member-side and this check does not claim it. A canon
+// target that drifted before it was ever synced carries no stamp -- the engine never wrote it
+// -- so it is indistinguishable from a legitimately Finance-authored file without canon's
+// inventory, which the lock does not record (it stores only version/backbone/generatedAt/
+// entries). Two such files are known today, reported as .github#669; closing that axis needs
+// the backbone at runtime, the owner-gated question in #4141.
+function verifyLockCoverage(lock) {
+  const findings = [];
+  const recorded = new Set(Object.keys(lock.entries || {}));
+  let stampedRecorded = 0;
+  for (const base of MANAGED_BASES) {
+    for (const file of walkFiles(path.join(ROOT, base))) {
+      const relPath = path.relative(ROOT, file).split(path.sep).join('/');
+      if (!/\.mdx?$/.test(relPath)) continue;
+      if (!PROVENANCE_LINE.test(fs.readFileSync(file, 'utf8'))) continue;
+      if (recorded.has(relPath)) stampedRecorded += 1;
+      else findings.push(`carries canonical provenance but is not a lock entry: ${relPath}`);
+    }
+  }
+  // Premise guard: if nothing stamped is recorded, the walk is not reaching managed files and
+  // a clean result means the check stopped observing, not that coverage is complete.
+  if (stampedRecorded === 0) {
+    findings.push('lock-coverage walk found no recorded canonical file — check is not observing');
+  }
+  return findings;
+}
+
+function walkFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((item) => {
+    const full = path.join(dir, item.name);
+    return item.isDirectory() ? walkFiles(full) : [full];
+  });
+}
 
 function verifyManagedContent(lock) {
   const findings = [];
@@ -568,4 +625,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { managedRegion, managedDigest };
+module.exports = { managedRegion, managedDigest, verifyLockCoverage };

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -14,7 +14,7 @@ import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { managedRegion, managedDigest } = require('./check-ai-manifest.js');
+const { managedRegion, managedDigest, verifyLockCoverage } = require('./check-ai-manifest.js');
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 const sha = (text) => crypto.createHash('sha256').update(text).digest('hex');
@@ -40,6 +40,46 @@ test('the whole-file rule strips nothing', () => {
   assert.equal(managedRegion(text), null);
   assert.equal(managedDigest(text), sha(text));
   assert.notEqual(managedDigest(text), sha(text.trim()));
+});
+
+test('lock coverage: baseline is zero, and a stamped unrecorded file is caught', () => {
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+
+  // BASELINE, printed before the treatment is read: a control that cannot show its baseline
+  // cannot be distinguished from one that is not running.
+  const baseline = verifyLockCoverage(lock);
+  assert.deepEqual(baseline, [], `expected clean baseline, got ${JSON.stringify(baseline)}`);
+
+  const dir = path.join(ROOT, '.github/skills/__coverage_probe__');
+  const file = path.join(dir, 'SKILL.md');
+  const stamp = '<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->';
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+
+    // Treatment A: stamped and unrecorded -> engine-written but not in the lock. Must fire.
+    fs.writeFileSync(file, `${stamp}\n\n# probe\n`);
+    const stamped = verifyLockCoverage(lock);
+    assert.equal(stamped.length, 1, 'a stamped unrecorded file must be reported');
+    assert.match(stamped[0], /__coverage_probe__/);
+
+    // Treatment B: unrecorded but UNSTAMPED -> indistinguishable from a Finance-authored
+    // file without canon's inventory. Must NOT fire. This pins the documented limitation as
+    // a deliberate boundary rather than an accident, so narrowing it later is a visible change.
+    fs.writeFileSync(file, '# probe\n');
+    assert.deepEqual(verifyLockCoverage(lock), [], 'an unstamped file must not be reported');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+
+  assert.deepEqual(verifyLockCoverage(lock), [], 'fixture must be fully removed');
+});
+
+test('PREMISE: lock coverage fails loudly if it stops observing managed files', () => {
+  // Guards the vacuity of the test above: with an empty lock nothing is recorded, so every
+  // stamped file becomes a finding and the premise guard fires. A walk that silently reached
+  // no files would return [] here and read exactly like the healthy baseline.
+  const findings = verifyLockCoverage({ entries: {} });
+  assert.ok(findings.length > 0, 'an empty lock must not read as complete coverage');
 });
 
 test('every present managed target still verifies against the lock', () => {


### PR DESCRIPTION
Closes the decidable half of an inverse blind spot, and pins the other half as a deliberate boundary.

## The gap

`verifyManagedContent()` iterates lock entries and asks *is the file there?*. The mirror — *this file is here, is it recorded?* — had no check, and the engine can produce files in that state.

`sync/lib/copier.mjs:94` is `default: // drift — leave the lock entry untouched`. When there was no entry, "untouched" means none is ever created, so a target can only enter the lock by never having drifted. A member file that already differed from canon at first sync is never recorded and is thereafter invisible to every lock-iterating check on either side.

This is correct engine behaviour — `:84-89` adopts only files that already *match* canon, because adopting a drifted file's hash would record member bytes as the baseline and bless the divergence permanently. The cost lands member-side.

It also defeats the exhaustiveness assertion from #4164 in the one direction that assertion cannot look: it proves every *lock entry* falls in a counted kind, and says nothing about a canon target that never became an entry.

## Measured

21 files under managed bases are not lock entries. Exactly 2 are canon targets:

```
.github/skills/edge-sync/SKILL.md            in canon, present, NOT a lock entry
.github/skills/fleet-orchestration/SKILL.md  in canon, present, NOT a lock entry
```

The other 19 are legitimately Finance-authored, confirmed by diffing against canon's `skills/` and `instructions/` inventories rather than by assuming.

## Why the obvious fix does not work

Canon-written files carry the provenance line, so "stamped" ought to classify. Measured:

```
edge-sync/SKILL.md            stamp = false
fleet-orchestration/SKILL.md  stamp = false
```

Both unstamped **because of the same mechanism** — the engine never wrote them, so it never stamped them. The two files the check was meant to catch are precisely the two the classifier cannot see. The lock offers no fallback: its top-level keys are `version`, `backbone`, `generatedAt`, `entries`, with no record of which paths canon owns.

So the unstamped case is not decidable member-side. It needs canon's inventory at runtime — the owner-gated question in #4141.

## Changes

- `verifyLockCoverage()` — **stamped and unrecorded** is decidable exactly. Baseline 0, no exemption list.
- The unstamped case is **not claimed**, and a test asserts it does not fire, so the boundary is deliberate rather than accidental and narrowing it later is a visible change.
- Premise guard: if no stamped file is recorded, the walk is not observing, and that fails rather than reading as complete coverage.
- Corrects a stale premise in the same file. The comment said the token tolerance "shrinks to zero when the sync lands"; the repo-root sync already ran on 2026-08-11 — the lock's own `generatedAt` is that run's output — and the 13 paths are absent because the frozen copies were deliberately deleted in #4066/#4076. `copier.mjs:248` plans `add` unconditionally for a missing path, which is why the tolerance still self-discharges.
- Removes a duplicated comment line introduced by #4179.

## Controls

```
baseline                                 0 findings
plant stamped + unrecorded fixture       1 finding, names the path
plant UNstamped + unrecorded fixture     0 findings   <- documented limitation, pinned
empty lock (premise guard)               fires
fixture removed                          0 findings
```

Neutered control — `verifyLockCoverage` not wired into `main()`, same planted fixture:

```
neutered   ❌ 2 drifted count claim(s), 0 canonical-activation finding(s)   exit 1
wired      ❌ 2 drifted count claim(s), 1 canonical-activation finding(s)   exit 1
```

Both exit 1, because planting a skill file also moves the `AGENTS.md` skills count. **The exit code cannot distinguish them** — only the finding quantity (`0` vs `1`) and the named `[DRIFT]` line can. Recording that because a verdict-only control here would have read as "the new code does nothing".

## Known, not fixed here

Coverage findings are routed through the activation-findings bucket, so the GitHub annotation attributes them to `docs/ai/README.md` rather than the offending path. Pre-existing routing; out of scope for this change.

## Validation

```
npm run ai:manifest:test                     tests 6  pass 6  fail 0
node tools/check-ai-manifest.js --strict     exit 0
npx eslint <touched> --max-warnings 0        exit 0
npx prettier --check <touched>               clean
```

Reported by the backbone session as jrmoulckers/.github#669. Reconciling the two skills against canon is separate work. `packages/design-tokens` untouched.

Closes #4183