### PR TITLE
fix(tools): reproduce sourceSha256 member-side and drop the false impossibility claim (#4186)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -362,6 +362,11 @@ function validateSyncLock() {
 
   findings.push(...verifyManagedContent(lock));
   findings.push(...verifyLockCoverage(lock));
+  const source = verifySourceReproduction(lock);
+  findings.push(...source.findings);
+  process.stdout.write(
+    `  [source] ${source.reproduced} managed targets unstamp to their recorded canon source\n`,
+  );
   return findings;
 }
 
@@ -463,6 +468,66 @@ function walkFiles(dir) {
   });
 }
 
+// The exact text the engine injects. Kept separate from PROVENANCE_LINE (an anchored /m
+// test) because unstamping needs the literal to locate and splice, not merely detect.
+const PROVENANCE_STAMP =
+  '<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->';
+
+// Recovers canon's pre-stamp bytes from a delivered file, inverting provenance.mjs:
+//   :69-70  frontmatter present -> injectAfterFrontmatter -> splice(i+1, 0, stamp)  ONE line
+//   :72     no frontmatter      -> `${stamp}\n\n${content}`                          TWO lines
+// Position decides the shape, so a single rule is wrong in one direction or the other:
+// always-strip-one reproduces 50 of 54 and fails the no-frontmatter CHECKLIST.md files;
+// always-strip-two reproduces only those 4. Both controls are asserted to fail in
+// tools/check-ai-manifest.test.mjs so the split cannot be collapsed silently.
+function unstampProvenance(text) {
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
+  const index = lines.indexOf(PROVENANCE_STAMP);
+  if (index === -1) return null;
+  lines.splice(index, lines[0] === '---' ? 1 : 2);
+  return lines.join('\n');
+}
+
+// Verifies the lock's sourceSha256 against local bytes. The tool previously recorded this
+// field as unreachable member-side, on a measurement that hashed each delivered file as it
+// sits on disk and matched 0 of 56. That result was real and its reading was wrong:
+// sourceSha256 hashes canon BEFORE the stamp is injected, so the delivered form cannot
+// match it for any entry, ever -- the measurement could not have come out otherwise. Undo
+// the injection and the field reproduces exactly (54 of 54, byte-identical to canon's blob,
+// confirmed against `4950ca7e` for workflow.instructions.md). A false impossibility claim
+// stops the search, which is why this is a check and not just a corrected comment (#4186).
+//
+// Marker-managed files are excluded rather than failed: there sourceSha256 covers canon's
+// region source, not the whole file, so whole-file unstamping is inapplicable by
+// construction. This proves delivery fidelity, NOT currency -- it shows canon said this at
+// sync time, never that canon still says it.
+function verifySourceReproduction(lock) {
+  const findings = [];
+  let reproduced = 0;
+  for (const [entry, metadata] of Object.entries(lock.entries || {})) {
+    if (!metadata || !metadata.sourceSha256) continue;
+    const absolute = path.join(ROOT, entry);
+    if (!fs.existsSync(absolute)) continue;
+    const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
+    if (managedRegion(text) !== null) continue;
+    const source = unstampProvenance(text);
+    if (source === null) continue;
+    const digest = crypto.createHash('sha256').update(source).digest('hex');
+    if (digest === metadata.sourceSha256) reproduced += 1;
+    else
+      findings.push(
+        `does not unstamp to its recorded canon source: ${entry} ` +
+          `(sha256 ${digest.slice(0, 12)}, lock records ${metadata.sourceSha256.slice(0, 12)})`,
+      );
+  }
+  // Premise guard, for the same reason the claim this replaces was wrong: a population of
+  // zero would make this pass unconditionally and read as confirmation of delivery fidelity.
+  if (reproduced === 0) {
+    findings.push('no lock entry unstamped to its canon source — check is not observing');
+  }
+  return { findings, reproduced };
+}
+
 function verifyManagedContent(lock) {
   const findings = [];
   const pending = [];
@@ -495,9 +560,8 @@ function verifyManagedContent(lock) {
   //
   // The wording is deliberate: this asserts "unmodified since sync", NOT "current with
   // canon". targetSha256 records what was delivered; sourceSha256 records what canon
-  // looked like at sync time and is canon-side content -- measured unmatched by anything
-  // local for all 68 present entries. Canon can therefore move arbitrarily far ahead
-  // while every check here stays green, and a stale file defeats detection by existing.
+  // looked like at sync time. Canon can therefore move arbitrarily far ahead while every
+  // check here stays green, and a stale file defeats detection by existing.
   // Closing that requires comparing against the backbone at runtime, which is the open
   // owner-gated question in #4141. Until then this line must not imply currency.
   process.stdout.write(
@@ -625,4 +689,10 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { managedRegion, managedDigest, verifyLockCoverage };
+module.exports = {
+  managedRegion,
+  managedDigest,
+  verifyLockCoverage,
+  unstampProvenance,
+  verifySourceReproduction,
+};

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -14,7 +14,12 @@ import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { managedRegion, managedDigest, verifyLockCoverage } = require('./check-ai-manifest.js');
+const {
+  managedRegion,
+  managedDigest,
+  verifyLockCoverage,
+  unstampProvenance,
+} = require('./check-ai-manifest.js');
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 const sha = (text) => crypto.createHash('sha256').update(text).digest('hex');
@@ -99,4 +104,65 @@ test('every present managed target still verifies against the lock', () => {
   // real-corpus assertion vacuous while still reporting a pass.
   assert.ok(regions > 0, 'corpus contains no marker-managed entry to verify');
   assert.ok(whole > 0, 'corpus contains no whole-file entry to verify');
+});
+
+const STAMP = '<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->';
+
+// The two-shape split is load-bearing, not incidental. Either single rule reproduces one
+// group and corrupts the other, and the engine picks by position (provenance.mjs:69-72).
+test('unstampProvenance inverts both injection shapes', () => {
+  const withFm = `---\napplyTo: '**'\n---\n${STAMP}\nbody\n`;
+  const noFm = `${STAMP}\n\n# Title\nbody\n`;
+
+  assert.equal(unstampProvenance(withFm), "---\napplyTo: '**'\n---\nbody\n");
+  assert.equal(unstampProvenance(noFm), '# Title\nbody\n');
+
+  // Controls: each single rule must FAIL on the shape it does not serve. Without these the
+  // split could be collapsed to one branch and every assertion above would still pass on
+  // the majority shape -- which is exactly how the `.trim()` near-miss survived.
+  const stripFixed = (text, n) => {
+    const lines = text.split('\n');
+    lines.splice(lines.indexOf(STAMP), n);
+    return lines.join('\n');
+  };
+  assert.notEqual(
+    stripFixed(noFm, 1),
+    unstampProvenance(noFm),
+    'always-one must corrupt no-frontmatter',
+  );
+  assert.notEqual(
+    stripFixed(withFm, 2),
+    unstampProvenance(withFm),
+    'always-two must corrupt frontmatter',
+  );
+});
+
+test('unstampProvenance returns null when there is no stamp', () => {
+  assert.equal(unstampProvenance('# Local file\nnot synced\n'), null);
+});
+
+// Real-corpus sweep. This is the assertion the tool previously called impossible: the
+// original measurement hashed each delivered file AS DELIVERED and matched 0 of 56, which
+// could not have come out otherwise, since sourceSha256 hashes canon before the stamp
+// exists. The as-delivered control is kept below so that reading stays visible.
+test('every stamped whole-file entry unstamps to its recorded canon source', () => {
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  let reproduced = 0;
+  let asDelivered = 0;
+  for (const [entry, metadata] of Object.entries(lock.entries || {})) {
+    if (!metadata || !metadata.sourceSha256) continue;
+    const absolute = path.join(ROOT, entry);
+    if (!fs.existsSync(absolute)) continue;
+    const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
+    if (managedRegion(text) !== null) continue;
+    const source = unstampProvenance(text);
+    if (source === null) continue;
+    if (sha(text) === metadata.sourceSha256) asDelivered += 1;
+    assert.equal(sha(source), metadata.sourceSha256, `${entry} does not unstamp to canon source`);
+    reproduced += 1;
+  }
+  // Vacuity guard: zero entries would pass every assertion above by never running one.
+  assert.ok(reproduced > 0, 'corpus contains no stamped whole-file entry to verify');
+  // Pins the original error: the delivered form matches nothing, by construction.
+  assert.equal(asDelivered, 0, 'delivered form should never match a pre-stamp hash');
 });


### PR DESCRIPTION
## Summary

`tools/check-ai-manifest.js` shipped a false impossibility claim, and it was load-bearing — it was the stated reason an entire axis of verification was never attempted. This removes it and ships the check it said could not exist.

The claim (lines 497-500) rested on a real measurement: hashing each delivered file as it sits on disk matches `sourceSha256` **0 times out of 56**. But `sourceSha256` hashes canon *before* the engine injects its provenance line, so the delivered form cannot match it — for any entry, ever. The measurement could not have come out any other way, and it was read as evidence of unreachability rather than as a description of the stamp.

## The rule

Inverting `provenance.mjs:69-72`, where **position decides the shape**:

```
frontmatter present -> splice(i+1, 0, stamp)      -> strip ONE line
no frontmatter      -> `${stamp}\n\n${content}`   -> strip TWO lines
```

| rule | reproduced | failed |
| --- | --- | --- |
| derived (position decides) | **54** | 0 |
| control: always strip one | 50 | 4 |
| control: always strip two | 4 | 50 |
| control: as delivered (the original measurement) | 0 | 56 |

Both single-rule collapses fail, so the split is load-bearing rather than incidental. The 4 that defeat the one-line rule are the no-frontmatter `CHECKLIST.md`-style files.

Verified end-to-end on `.github/instructions/workflow.instructions.md`: unstamping yields bytes **byte-identical** (`Buffer.equals`) to canon's blob at `4950ca7e` — 23,183 bytes, hashing to the recorded `f832c6df…`.

## Changes

- Correct the comment: the field is reachable; what is unreachable is **currency**.
- Add `unstampProvenance()` and `verifySourceReproduction()`, reporting `[source] 54 managed targets unstamp to their recorded canon source`.
- Marker-managed entries are **excluded, not failed** — there `sourceSha256` covers canon's region source, so whole-file unstamping is inapplicable by construction.
- Vacuity guard: a population of zero is a finding, since it would otherwise pass unconditionally and read as confirmation of delivery fidelity — the same failure mode as the claim being removed.
- Three tests, including both single-rule controls asserted to **fail**, and the as-delivered control pinned at 0 so the original misreading stays visible.

## Mutation control

Collapsing the two-shape rule to either single branch is caught:

```
baseline                   pass 9  fail 0
mutant: always splice 1    pass 7  fail 2
mutant: always splice 2    pass 7  fail 2
restored                   pass 9  fail 0
```

## What this does not claim

Reproducing `sourceSha256` proves *canon said this at delivery*. It cannot prove *canon still says it*. The currency axis remains unreachable member-side and the success-line wording from #4181 is unchanged.

## Issues

Closes #4186

## Testing

- [x] `npm run ai:manifest:test` — 9 pass, 0 fail
- [x] `node tools/check-ai-manifest.js --strict` — exit 0
- [x] `npx eslint` on both touched files — exit 0
- [x] `npx prettier --check` on both touched files — clean
- [x] Mutation control above; probe files deleted, tree clean