### PR TITLE
fix(tools): recognize every provenance stamp form and disclose the residue (#4190)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -364,9 +364,14 @@ function validateSyncLock() {
   findings.push(...verifyLockCoverage(lock));
   const source = verifySourceReproduction(lock);
   findings.push(...source.findings);
+  const total = source.reproduced + source.unreproduced.length;
   process.stdout.write(
-    `  [source] ${source.reproduced} managed targets unstamp to their recorded canon source\n`,
+    `  [source] ${source.reproduced} of ${total} managed targets unstamp to their ` +
+      `recorded canon source\n`,
   );
+  for (const entry of source.unreproduced) {
+    process.stdout.write(`  [source] not reproducible, cause unknown: ${entry} (#4190)\n`);
+  }
   return findings;
 }
 
@@ -468,24 +473,35 @@ function walkFiles(dir) {
   });
 }
 
-// The exact text the engine injects. Kept separate from PROVENANCE_LINE (an anchored /m
-// test) because unstamping needs the literal to locate and splice, not merely detect.
-const PROVENANCE_STAMP =
-  '<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->';
+// Matches the engine's stamp in any comment syntax it emits, for either message. The
+// previous literal recognized exactly one combination -- HTML comment, canon message -- and
+// silently skipped 11 present entries that carry the stamp in `#`, `/* */`, or the studio
+// "generated + synced" wording. A check that skips is worse than one that fails: the count
+// it printed read as complete.
+const PROVENANCE_STAMP_LINE =
+  /^(<!--|\/\*|#|\/\/)\s*(generated \+ )?synced from jrmoulckers\/(\.github|studio)\b/;
 
-// Recovers canon's pre-stamp bytes from a delivered file, inverting provenance.mjs:
-//   :69-70  frontmatter present -> injectAfterFrontmatter -> splice(i+1, 0, stamp)  ONE line
-//   :72     no frontmatter      -> `${stamp}\n\n${content}`                          TWO lines
-// Position decides the shape, so a single rule is wrong in one direction or the other:
-// always-strip-one reproduces 50 of 54 and fails the no-frontmatter CHECKLIST.md files;
-// always-strip-two reproduces only those 4. Both controls are asserted to fail in
-// tools/check-ai-manifest.test.mjs so the split cannot be collapsed silently.
-function unstampProvenance(text) {
+// Returns the candidate pre-stamp bodies for a delivered file. At least two stampers exist
+// and they differ in shape: the canon-docs path (provenance.mjs:69-72) writes the stamp
+// alone after frontmatter but `${stamp}\n\n${content}` without it, while the studio token
+// path writes `${stamp}\n${content}` with no blank. Only the first has source I have read,
+// so rather than guess a per-asset-kind rule this returns both strips and the caller accepts
+// a hash match under either.
+//
+// That is not a weakening. Reproducing a recorded sha256 under either strip is cryptographic
+// proof that the delivered bytes are canon's source plus a stamp; a wrong-strip false accept
+// needs a collision. The rules that WERE guessed here got measured first and refuted: a
+// unified "strip the blank line if present" reproduces 14 of 65, because content after
+// frontmatter legitimately begins with a blank line.
+function unstampCandidates(text) {
   const lines = text.replace(/\r\n/g, '\n').split('\n');
-  const index = lines.indexOf(PROVENANCE_STAMP);
-  if (index === -1) return null;
-  lines.splice(index, lines[0] === '---' ? 1 : 2);
-  return lines.join('\n');
+  const index = lines.findIndex((line) => PROVENANCE_STAMP_LINE.test(line));
+  if (index === -1) return [];
+  return [1, 2].map((count) => {
+    const copy = lines.slice();
+    copy.splice(index, count);
+    return copy.join('\n');
+  });
 }
 
 // Verifies the lock's sourceSha256 against local bytes. The tool previously recorded this
@@ -493,7 +509,7 @@ function unstampProvenance(text) {
 // sits on disk and matched 0 of 56. That result was real and its reading was wrong:
 // sourceSha256 hashes canon BEFORE the stamp is injected, so the delivered form cannot
 // match it for any entry, ever -- the measurement could not have come out otherwise. Undo
-// the injection and the field reproduces exactly (54 of 54, byte-identical to canon's blob,
+// the injection and the field reproduces (64 of 65, byte-identical to canon's blob,
 // confirmed against `4950ca7e` for workflow.instructions.md). A false impossibility claim
 // stops the search, which is why this is a check and not just a corrected comment (#4186).
 //
@@ -501,8 +517,14 @@ function unstampProvenance(text) {
 // region source, not the whole file, so whole-file unstamping is inapplicable by
 // construction. This proves delivery fidelity, NOT currency -- it shows canon said this at
 // sync time, never that canon still says it.
+//
+// Unreproduced entries are disclosed by path rather than raised as findings. One exists
+// today (#4190) and its cause is unknown; asserting corruption on evidence that does not
+// establish it would make the check red on a file that must not be deleted. Listing each
+// path means the set cannot grow unnoticed, which is the property a bare count lacks.
 function verifySourceReproduction(lock) {
   const findings = [];
+  const unreproduced = [];
   let reproduced = 0;
   for (const [entry, metadata] of Object.entries(lock.entries || {})) {
     if (!metadata || !metadata.sourceSha256) continue;
@@ -510,22 +532,20 @@ function verifySourceReproduction(lock) {
     if (!fs.existsSync(absolute)) continue;
     const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
     if (managedRegion(text) !== null) continue;
-    const source = unstampProvenance(text);
-    if (source === null) continue;
-    const digest = crypto.createHash('sha256').update(source).digest('hex');
-    if (digest === metadata.sourceSha256) reproduced += 1;
-    else
-      findings.push(
-        `does not unstamp to its recorded canon source: ${entry} ` +
-          `(sha256 ${digest.slice(0, 12)}, lock records ${metadata.sourceSha256.slice(0, 12)})`,
-      );
+    const candidates = unstampCandidates(text);
+    if (candidates.length === 0) continue;
+    const matched = candidates.some(
+      (body) => crypto.createHash('sha256').update(body).digest('hex') === metadata.sourceSha256,
+    );
+    if (matched) reproduced += 1;
+    else unreproduced.push(entry);
   }
   // Premise guard, for the same reason the claim this replaces was wrong: a population of
   // zero would make this pass unconditionally and read as confirmation of delivery fidelity.
   if (reproduced === 0) {
     findings.push('no lock entry unstamped to its canon source — check is not observing');
   }
-  return { findings, reproduced };
+  return { findings, reproduced, unreproduced };
 }
 
 function verifyManagedContent(lock) {
@@ -693,6 +713,6 @@ module.exports = {
   managedRegion,
   managedDigest,
   verifyLockCoverage,
-  unstampProvenance,
+  unstampCandidates,
   verifySourceReproduction,
 };

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -18,7 +18,7 @@ const {
   managedRegion,
   managedDigest,
   verifyLockCoverage,
-  unstampProvenance,
+  unstampCandidates,
 } = require('./check-ai-manifest.js');
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -106,63 +106,57 @@ test('every present managed target still verifies against the lock', () => {
   assert.ok(whole > 0, 'corpus contains no whole-file entry to verify');
 });
 
-const STAMP = '<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->';
+const CANON_STAMP = '<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->';
 
-// The two-shape split is load-bearing, not incidental. Either single rule reproduces one
-// group and corrupts the other, and the engine picks by position (provenance.mjs:69-72).
-test('unstampProvenance inverts both injection shapes', () => {
-  const withFm = `---\napplyTo: '**'\n---\n${STAMP}\nbody\n`;
-  const noFm = `${STAMP}\n\n# Title\nbody\n`;
-
-  assert.equal(unstampProvenance(withFm), "---\napplyTo: '**'\n---\nbody\n");
-  assert.equal(unstampProvenance(noFm), '# Title\nbody\n');
-
-  // Controls: each single rule must FAIL on the shape it does not serve. Without these the
-  // split could be collapsed to one branch and every assertion above would still pass on
-  // the majority shape -- which is exactly how the `.trim()` near-miss survived.
-  const stripFixed = (text, n) => {
-    const lines = text.split('\n');
-    lines.splice(lines.indexOf(STAMP), n);
-    return lines.join('\n');
-  };
-  assert.notEqual(
-    stripFixed(noFm, 1),
-    unstampProvenance(noFm),
-    'always-one must corrupt no-frontmatter',
-  );
-  assert.notEqual(
-    stripFixed(withFm, 2),
-    unstampProvenance(withFm),
-    'always-two must corrupt frontmatter',
-  );
+// Coverage regression guard. The first implementation matched one literal -- HTML comment,
+// canon message -- and silently skipped 11 present entries stamped `#`, `/* */`, or with the
+// studio "generated + synced" wording. It reported 54 and read as complete.
+test('unstampCandidates recognizes every comment syntax and both messages', () => {
+  const forms = [
+    CANON_STAMP,
+    '# synced from jrmoulckers/.github — canonical source; do not edit here',
+    '/* generated + synced from jrmoulckers/studio @jrm/tokens — do not edit here */',
+    '<!-- generated + synced from jrmoulckers/studio @jrm/tokens — do not edit here -->',
+  ];
+  for (const stamp of forms) {
+    assert.equal(unstampCandidates(`${stamp}\nbody\n`).length, 2, `not recognized: ${stamp}`);
+  }
+  assert.deepEqual(unstampCandidates('# Local file\nnot synced\n'), []);
 });
 
-test('unstampProvenance returns null when there is no stamp', () => {
-  assert.equal(unstampProvenance('# Local file\nnot synced\n'), null);
+// The caller accepts a match under either strip, so both must be offered. A single-strip
+// implementation would reproduce one stamper's shape and silently drop the other's.
+test('unstampCandidates offers both the one-line and two-line strip', () => {
+  const noBlank = `${CANON_STAMP}\nbody\n`;
+  const blank = `${CANON_STAMP}\n\nbody\n`;
+  assert.deepEqual(unstampCandidates(noBlank), ['body\n', 'body\n'.replace('body\n', '')]);
+  assert.ok(unstampCandidates(blank).includes('body\n'));
 });
 
-// Real-corpus sweep. This is the assertion the tool previously called impossible: the
-// original measurement hashed each delivered file AS DELIVERED and matched 0 of 56, which
-// could not have come out otherwise, since sourceSha256 hashes canon before the stamp
-// exists. The as-delivered control is kept below so that reading stays visible.
-test('every stamped whole-file entry unstamps to its recorded canon source', () => {
+// The assertion the tool previously called impossible. The original measurement hashed each
+// file AS DELIVERED and matched 0 of 65 -- which could not have come out otherwise, since
+// sourceSha256 hashes canon before the stamp exists. That control is pinned below.
+test('managed targets unstamp to their recorded canon source', () => {
   const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
   let reproduced = 0;
   let asDelivered = 0;
+  let corruptedReproduced = 0;
   for (const [entry, metadata] of Object.entries(lock.entries || {})) {
     if (!metadata || !metadata.sourceSha256) continue;
     const absolute = path.join(ROOT, entry);
     if (!fs.existsSync(absolute)) continue;
     const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
     if (managedRegion(text) !== null) continue;
-    const source = unstampProvenance(text);
-    if (source === null) continue;
+    const candidates = unstampCandidates(text);
+    if (candidates.length === 0) continue;
+    if (candidates.some((body) => sha(body) === metadata.sourceSha256)) reproduced += 1;
     if (sha(text) === metadata.sourceSha256) asDelivered += 1;
-    assert.equal(sha(source), metadata.sourceSha256, `${entry} does not unstamp to canon source`);
-    reproduced += 1;
+    // Corruption control: an edited body must reproduce under NEITHER candidate. Without
+    // this the disjunction could be accepting far more than it should and still count 64.
+    const corrupted = unstampCandidates(`${text}\n/* edited */\n`);
+    if (corrupted.some((body) => sha(body) === metadata.sourceSha256)) corruptedReproduced += 1;
   }
-  // Vacuity guard: zero entries would pass every assertion above by never running one.
-  assert.ok(reproduced > 0, 'corpus contains no stamped whole-file entry to verify');
-  // Pins the original error: the delivered form matches nothing, by construction.
+  assert.ok(reproduced > 0, 'corpus contains no stamped entry to verify');
   assert.equal(asDelivered, 0, 'delivered form should never match a pre-stamp hash');
+  assert.equal(corruptedReproduced, 0, 'a corrupted body must not reproduce under either strip');
 });


### PR DESCRIPTION
## Summary

The source-reproduction check shipped in #4188 matched a **single literal** — HTML comment, canon message — and silently skipped 11 present entries carrying the stamp in another form. It printed `54` and read as complete. Actual coverage was 54 of 65.

The skipped entries use comment syntaxes and a message the literal didn't cover:

```
# synced from jrmoulckers/.github …                          agency.toml
/* generated + synced from jrmoulckers/studio @jrm/tokens */  7 css, .kt, .swift
<!-- generated + synced from jrmoulckers/studio … -->         vendor README.md
```

This is the failure mode the check was written to remove, one layer down: not a wrong answer, a **narrower domain than the count implies**.

## Why a disjunction instead of a shape rule

At least two stampers exist and they disagree on shape. The canon-docs path (`provenance.mjs:69-72`) writes the stamp alone after frontmatter but `${stamp}\n\n${content}` without it; the studio token path writes `${stamp}\n${content}` with no blank line. `agency.toml` is canon-sourced yet follows the second shape, so "frontmatter decides" is not the general rule — and I have only read the source of the first stamper.

So the check offers both the one- and two-line strip and accepts a match under either. **This is not a weakening.** Reproducing a recorded sha256 under either strip is cryptographic proof the delivered bytes are canon's source plus a stamp; a false accept needs a collision. The corruption control below shows an edited body matches neither.

I measured a guessed unified rule before rejecting it, rather than reasoning about it:

| rule | reproduced |
| --- | --- |
| "strip the blank line if present" | **14** / 65 |
| frontmatter decides (previously shipped) | 55 / 65 |
| always strip one | 59 / 65 |
| always strip two | 5 / 65 |
| **disjunction (this PR)** | **64** / 65 |

The unified rule collapses because content after frontmatter legitimately begins with a blank line.

## The residue

One entry reproduces under nothing tried — `vendor/@jrm/tokens/css/default/tokens.css`, filed with full measurements as #4190. It is **disclosed by path on every run, not raised as a finding**:

```
[source] 64 of 65 managed targets unstamp to their recorded canon source
[source] not reproducible, cause unknown: vendor/@jrm/tokens/css/default/tokens.css (#4190)
```

Non-blocking is deliberate. Its `targetSha256` verifies, so it is unmodified since sync; what is unproven is that the delivered bytes are canon-plus-stamp. Asserting corruption on that evidence would turn CI red on the stylesheet the web app imports, whose likeliest "fix" is deletion. Listing paths rather than a bare count means the set cannot grow unnoticed.

I declined to exempt it by `syncedAt` even though it is the sole entry from the `2026-08-07` generation — with n=1 that is building the check from the one case it validates.

## Mutation control

```
baseline                              pass 9  fail 0
mutant: narrow matcher to HTML+canon  pass 8  fail 1
mutant: offer only the 1-line strip   pass 7  fail 2
mutant: offer only the 2-line strip   pass 7  fail 2
restored                              pass 9  fail 0
```

Row 1 is the regression this PR fixes: it is the code that shipped an hour ago, and the new tests catch it.

## Issues

Refs #4190, #4186

## Testing

- [x] `npm run ai:manifest:test` — 9 pass, 0 fail
- [x] `node tools/check-ai-manifest.js --strict` — exit 0, coverage 64/65
- [x] `npx eslint` / `npx prettier --check` on both touched files — clean
- [x] Mutation control above; corruption control asserts an edited body reproduces under neither strip; probes deleted, tree clean