### PR TITLE
fix(tools): replace the unstamp disjunction with the engine's comment-family rule (#4194)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -369,8 +369,12 @@ function validateSyncLock() {
     `  [source] ${source.reproduced} of ${total} managed targets unstamp to their ` +
       `recorded canon source\n`,
   );
+  // States only what was computed. The earlier wording asserted "cause unknown", which was
+  // false once the engine documented this entry (copier.mjs:494-499) and would be unfounded
+  // for any future path landing here -- the line cannot know the cause of an entry it has
+  // just met. Causes belong in the docblock and the issue, not in a per-entry verdict.
   for (const entry of source.unreproduced) {
-    process.stdout.write(`  [source] not reproducible, cause unknown: ${entry} (#4190)\n`);
+    process.stdout.write(`  [source] not reproducible from delivered bytes: ${entry} (#4190)\n`);
   }
   return findings;
 }
@@ -481,27 +485,58 @@ function walkFiles(dir) {
 const PROVENANCE_STAMP_LINE =
   /^(<!--|\/\*|#|\/\/)\s*(generated \+ )?synced from jrmoulckers\/(\.github|studio)\b/;
 
-// Returns the candidate pre-stamp bodies for a delivered file. At least two stampers exist
-// and they differ in shape: the canon-docs path (provenance.mjs:69-72) writes the stamp
-// alone after frontmatter but `${stamp}\n\n${content}` without it, while the studio token
-// path writes `${stamp}\n${content}` with no blank. Only the first has source I have read,
-// so rather than guess a per-asset-kind rule this returns both strips and the caller accepts
-// a hash match under either.
+// The engine injects its stamp with a shape chosen by the target's comment syntax, so the
+// inverse is a switch on file extension rather than a guess. Documented upstream in
+// `sync/README.md` and implemented at `provenance.mjs:57-73`:
 //
-// That is not a weakening. Reproducing a recorded sha256 under either strip is cryptographic
-// proof that the delivered bytes are canon's source plus a stamp; a wrong-strip false accept
-// needs a collision. The rules that WERE guessed here got measured first and refuted: a
-// unified "strip the blank line if present" reproduces 14 of 65, because content after
-// frontmatter legitimately begins with a blank line.
-function unstampCandidates(text) {
+//   hash   `# note\n`     + content -> strip 1   .toml .yml .sh .gitattributes
+//   block  `/* note */\n` + content -> strip 1   .css .js .ts .kt .swift
+//   html   `<!-- note -->\n\n` + content -> strip 2   .md .html
+//   html + frontmatter: spliced after the closing `---` -> strip 1
+//   none   content unchanged -> never stamped, so never reaches this
+//
+// Frontmatter is an exception *inside* the html family, not the top-level variable. This
+// tool previously inferred the latter and scored 55 of 65 -- right about `.md`, accidentally
+// right elsewhere -- then hedged with a disjunction that offered both strips and accepted a
+// match under either.
+//
+// The switch replaces that hedge and is a tightening, not a rename. Both score 64 of 65 on
+// the corpus (html+frontmatter 50/50, html+plain 5/5, hash 1/1, block 8/9), but a disjunction
+// also accepts a match under the WRONG strip: for an html file with no frontmatter whose body
+// legitimately begins blank, the one-line strip yields a body differing from canon only by a
+// leading blank, and nothing in the result distinguishes that from a correct recovery. The
+// switch fails closed instead (#4194).
+const HASH_EXTENSIONS = new Set(['.toml', '.yml', '.yaml', '.sh', '.gitattributes', '.gitignore']);
+const BLOCK_EXTENSIONS = new Set(['.css', '.js', '.mjs', '.cjs', '.ts', '.kt', '.kts', '.swift']);
+const HTML_EXTENSIONS = new Set(['.md', '.markdown', '.html']);
+
+function commentFamily(entryPath) {
+  const base = path.basename(entryPath);
+  // A dotfile with no further dot IS its own extension: path.extname('.gitattributes') is ''.
+  const extension =
+    base.startsWith('.') && !base.slice(1).includes('.') ? base : path.extname(base);
+  if (HASH_EXTENSIONS.has(extension)) return 'hash';
+  if (BLOCK_EXTENSIONS.has(extension)) return 'block';
+  if (HTML_EXTENSIONS.has(extension)) return 'html';
+  return null;
+}
+
+// Returns { status: 'no-stamp' } for a file the engine never stamped, { status: 'unknown' }
+// for a stamped file whose extension is unclassified, and { status: 'ok', body } otherwise.
+//
+// 'unknown' is a distinct status rather than a skip on purpose. Skipping a stamped entry
+// would shrink the denominator with nothing saying so, which is the silent-channel defect
+// this tool already corrected twice (#4190, #4191). The caller discloses it by path.
+function unstampSource(entryPath, text) {
   const lines = text.replace(/\r\n/g, '\n').split('\n');
   const index = lines.findIndex((line) => PROVENANCE_STAMP_LINE.test(line));
-  if (index === -1) return [];
-  return [1, 2].map((count) => {
-    const copy = lines.slice();
-    copy.splice(index, count);
-    return copy.join('\n');
-  });
+  if (index === -1) return { status: 'no-stamp' };
+  const family = commentFamily(entryPath);
+  if (family === null) return { status: 'unknown' };
+  const hasFrontmatter = lines[0].trim() === '---';
+  const copy = lines.slice();
+  copy.splice(index, family === 'html' && !hasFrontmatter ? 2 : 1);
+  return { status: 'ok', body: copy.join('\n') };
 }
 
 // Verifies the lock's sourceSha256 against local bytes. The tool previously recorded this
@@ -522,6 +557,13 @@ function unstampCandidates(text) {
 // today (#4190) and its cause is unknown; asserting corruption on evidence that does not
 // establish it would make the check red on a file that must not be deleted. Listing each
 // path means the set cannot grow unnoticed, which is the property a bare count lacks.
+//
+// For `vendor/@jrm/tokens/css/default/tokens.css` specifically, the engine documents the
+// cause at `copier.mjs:494-499`: an overlapping run reverted that entry to the hash and
+// timestamp of an older revision and the lock was later hand-repaired, so `targetSha256`
+// was corrected to match the bytes while `sourceSha256` and `syncedAt` stayed stale. That
+// makes it an internally inconsistent entry, not a stamping question -- the strip rule is
+// exact for its family, and the recorded source simply belongs to different bytes.
 function verifySourceReproduction(lock) {
   const findings = [];
   const unreproduced = [];
@@ -532,12 +574,14 @@ function verifySourceReproduction(lock) {
     if (!fs.existsSync(absolute)) continue;
     const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
     if (managedRegion(text) !== null) continue;
-    const candidates = unstampCandidates(text);
-    if (candidates.length === 0) continue;
-    const matched = candidates.some(
-      (body) => crypto.createHash('sha256').update(body).digest('hex') === metadata.sourceSha256,
-    );
-    if (matched) reproduced += 1;
+    const source = unstampSource(entry, text);
+    if (source.status === 'no-stamp') continue;
+    if (source.status === 'unknown') {
+      unreproduced.push(entry);
+      continue;
+    }
+    const digest = crypto.createHash('sha256').update(source.body).digest('hex');
+    if (digest === metadata.sourceSha256) reproduced += 1;
     else unreproduced.push(entry);
   }
   // Premise guard, for the same reason the claim this replaces was wrong: a population of
@@ -713,6 +757,7 @@ module.exports = {
   managedRegion,
   managedDigest,
   verifyLockCoverage,
-  unstampCandidates,
+  unstampSource,
+  commentFamily,
   verifySourceReproduction,
 };

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -18,7 +18,8 @@ const {
   managedRegion,
   managedDigest,
   verifyLockCoverage,
-  unstampCandidates,
+  unstampSource,
+  commentFamily,
 } = require('./check-ai-manifest.js');
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -111,26 +112,41 @@ const CANON_STAMP = '<!-- synced from jrmoulckers/.github — canonical source; 
 // Coverage regression guard. The first implementation matched one literal -- HTML comment,
 // canon message -- and silently skipped 11 present entries stamped `#`, `/* */`, or with the
 // studio "generated + synced" wording. It reported 54 and read as complete.
-test('unstampCandidates recognizes every comment syntax and both messages', () => {
+test('unstampSource recognizes every comment syntax and both messages', () => {
   const forms = [
-    CANON_STAMP,
-    '# synced from jrmoulckers/.github — canonical source; do not edit here',
-    '/* generated + synced from jrmoulckers/studio @jrm/tokens — do not edit here */',
-    '<!-- generated + synced from jrmoulckers/studio @jrm/tokens — do not edit here -->',
+    ['a.md', CANON_STAMP],
+    ['agency.toml', '# synced from jrmoulckers/.github — canonical source; do not edit here'],
+    ['t.css', '/* generated + synced from jrmoulckers/studio @jrm/tokens — do not edit here */'],
+    ['r.md', '<!-- generated + synced from jrmoulckers/studio @jrm/tokens — do not edit here -->'],
   ];
-  for (const stamp of forms) {
-    assert.equal(unstampCandidates(`${stamp}\nbody\n`).length, 2, `not recognized: ${stamp}`);
+  for (const [file, stamp] of forms) {
+    assert.equal(unstampSource(file, `${stamp}\nbody\n`).status, 'ok', `not recognized: ${stamp}`);
   }
-  assert.deepEqual(unstampCandidates('# Local file\nnot synced\n'), []);
+  assert.equal(unstampSource('a.md', '# Local file\nnot synced\n').status, 'no-stamp');
 });
 
-// The caller accepts a match under either strip, so both must be offered. A single-strip
-// implementation would reproduce one stamper's shape and silently drop the other's.
-test('unstampCandidates offers both the one-line and two-line strip', () => {
-  const noBlank = `${CANON_STAMP}\nbody\n`;
-  const blank = `${CANON_STAMP}\n\nbody\n`;
-  assert.deepEqual(unstampCandidates(noBlank), ['body\n', 'body\n'.replace('body\n', '')]);
-  assert.ok(unstampCandidates(blank).includes('body\n'));
+// The strip depth is decided by comment family, with frontmatter as an exception inside the
+// html family only. An earlier version keyed on frontmatter alone and scored 55 of 65 by
+// being right about `.md` and accidentally right elsewhere.
+test('unstampSource strips the depth the engine injected, per family', () => {
+  const cases = [
+    ['x.md', `${CANON_STAMP}\n\nbody\n`, 'body\n'],
+    ['x.md', `---\ntitle: t\n---\n${CANON_STAMP}\nbody\n`, '---\ntitle: t\n---\nbody\n'],
+    ['x.toml', '# synced from jrmoulckers/.github — x\nbody\n', 'body\n'],
+    ['x.css', '/* generated + synced from jrmoulckers/studio — x */\nbody\n', 'body\n'],
+  ];
+  for (const [file, delivered, expected] of cases) {
+    assert.equal(unstampSource(file, delivered).body, expected, `wrong strip for ${file}`);
+  }
+});
+
+// A stamped file whose extension is unclassified must be reported, never skipped. Skipping
+// shrinks the denominator with nothing saying so -- the silent-channel defect this tool has
+// already corrected twice.
+test('an unclassified stamped file is surfaced rather than skipped', () => {
+  assert.equal(unstampSource('weird.xyz', `${CANON_STAMP}\nbody\n`).status, 'unknown');
+  assert.equal(commentFamily('weird.xyz'), null);
+  assert.equal(commentFamily('.gitattributes'), 'hash', 'a dotfile is its own extension');
 });
 
 // The assertion the tool previously called impossible. The original measurement hashed each
@@ -141,22 +157,28 @@ test('managed targets unstamp to their recorded canon source', () => {
   let reproduced = 0;
   let asDelivered = 0;
   let corruptedReproduced = 0;
+  const families = new Set();
   for (const [entry, metadata] of Object.entries(lock.entries || {})) {
     if (!metadata || !metadata.sourceSha256) continue;
     const absolute = path.join(ROOT, entry);
     if (!fs.existsSync(absolute)) continue;
     const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
     if (managedRegion(text) !== null) continue;
-    const candidates = unstampCandidates(text);
-    if (candidates.length === 0) continue;
-    if (candidates.some((body) => sha(body) === metadata.sourceSha256)) reproduced += 1;
+    const source = unstampSource(entry, text);
+    if (source.status !== 'ok') continue;
+    families.add(commentFamily(entry));
+    if (sha(source.body) === metadata.sourceSha256) reproduced += 1;
     if (sha(text) === metadata.sourceSha256) asDelivered += 1;
-    // Corruption control: an edited body must reproduce under NEITHER candidate. Without
-    // this the disjunction could be accepting far more than it should and still count 64.
-    const corrupted = unstampCandidates(`${text}\n/* edited */\n`);
-    if (corrupted.some((body) => sha(body) === metadata.sourceSha256)) corruptedReproduced += 1;
+    // Corruption control: an edited body must not reproduce. Without this the strip could be
+    // accepting far more than it should and still count 64.
+    const corrupted = unstampSource(entry, `${text}\n/* edited */\n`);
+    if (corrupted.status === 'ok' && sha(corrupted.body) === metadata.sourceSha256) {
+      corruptedReproduced += 1;
+    }
   }
   assert.ok(reproduced > 0, 'corpus contains no stamped entry to verify');
   assert.equal(asDelivered, 0, 'delivered form should never match a pre-stamp hash');
-  assert.equal(corruptedReproduced, 0, 'a corrupted body must not reproduce under either strip');
+  assert.equal(corruptedReproduced, 0, 'a corrupted body must not reproduce');
+  // Breadth guard: a corpus exercising one family would certify the switch on a third of it.
+  assert.ok(families.size >= 2, `switch exercised on only ${families.size} comment family`);
 });


### PR DESCRIPTION
## Summary

Replaces the two-candidate unstamp disjunction with the engine's actual rule: a 4-way switch on the target's comment-syntax family (`provenance.mjs:57-73`), documented upstream in jrmoulckers/.github#689.

This tool had inferred that **frontmatter** was the variable. It is not — frontmatter is an exception *inside* the html family, which is why the earlier "frontmatter decides" measurement scored 55/65 by being right about `.md` and accidentally right elsewhere. Lacking the rule, the tool hedged: return both a one-line and a two-line strip and accept a hash match under either.

## Why this is a tightening, not a rename

Both rules score **64 of 65** on the corpus. The difference is what they accept:

```
html+frontmatter  drop 1   n=50  exact=50
html+plain        drop 2   n= 5  exact= 5
hash              drop 1   n= 1  exact= 1
block             drop 1   n= 9  exact= 8   residue: vendor/@jrm/tokens/css/default/tokens.css
TOTAL                      n=65  exact=64
```

A disjunction also accepts a match under the **wrong** strip. For an html file with no frontmatter whose body legitimately begins with a blank line, the one-line strip yields a body differing from canon only by a leading blank — and nothing in the result distinguishes that from a correct recovery. The switch fails closed.

All four branches are exercised by the corpus, so the switch is not certified on one family.

## Second fix: unknown family was a silent skip

`verifySourceReproduction` skipped any entry that produced no candidate body. Under the switch, a stamped entry with an unclassified extension would also produce none — and skipping it would shrink the denominator with nothing saying so. That is the silent-channel defect this tool already corrected in #4190/#4191. Such entries are now disclosed by path.

## Third fix: the residue line asserted a cause it cannot know

It printed `not reproducible, cause unknown`. That is now false for the one entry it names — the engine documents it at `copier.mjs:494-499` (an overlapping run reverted the entry to an older revision's hash **and timestamp**; the lock was later hand-repaired, correcting `targetSha256` to match the bytes while `sourceSha256` and `syncedAt` stayed stale). It would also be unfounded for any future path landing there. The line now states only what it computed; causes live in the docblock and the issue.

## Validation

```
node --test tools/check-ai-manifest.test.mjs     10 pass  0 fail   (was 9)
node tools/check-ai-manifest.js --strict         exit 0
  [content] 68 managed targets unmodified since sync; 13 awaiting the next sync run
  [source] 64 of 65 managed targets unstamp to their recorded canon source
npx eslint <both files> --max-warnings 0         exit 0
npx prettier --check <both files>                clean
```

Mutation controls — each applied to the shipped source, suite re-run, source restored:

| mutation | result |
| --- | --- |
| always strip 1 | **9 pass / 1 fail** |
| always strip 2 | **9 pass / 1 fail** |
| `unknown` returns `no-stamp` (silent skip) | **9 pass / 1 fail** |
| `hasFrontmatter` forced true | **9 pass / 1 fail** |

All four killed; baseline restored to 10/10 and `git diff --stat` clean.

Repo-wide `format:check` is not run here — it hangs monorepo-wide on a known pre-existing line-ending artifact. Both touched files are verified clean individually.

## Issues

Closes #4194

## Testing

- [x] `node --test tools/check-ai-manifest.test.mjs` — 10/10
- [x] `node tools/check-ai-manifest.js --strict` — exit 0, counts unchanged
- [x] eslint + prettier clean on both touched files
- [x] four mutation controls, all killed