### PR TITLE
fix(tools): account for recorded sources the check cannot evaluate (#4197)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -365,9 +365,15 @@ function validateSyncLock() {
   const source = verifySourceReproduction(lock);
   findings.push(...source.findings);
   const total = source.reproduced + source.unreproduced.length;
+  // The unobserved count is printed rather than subtracted away. Reporting only "N of M"
+  // over the evaluable population lets the ratio read as coverage of everything recorded,
+  // when a recorded-but-absent target was never attempted at all (#4197).
+  const unobserved = source.unobserved.length;
   process.stdout.write(
     `  [source] ${source.reproduced} of ${total} managed targets unstamp to their ` +
-      `recorded canon source\n`,
+      `recorded canon source` +
+      (unobserved ? `; ${unobserved} recorded targets not evaluable and unobserved` : '') +
+      `\n`,
   );
   // States only what was computed. The earlier wording asserted "cause unknown", which was
   // false once the engine documented this entry (copier.mjs:494-499) and would be unfounded
@@ -553,10 +559,19 @@ function unstampSource(entryPath, text) {
 // construction. This proves delivery fidelity, NOT currency -- it shows canon said this at
 // sync time, never that canon still says it.
 //
-// Unreproduced entries are disclosed by path rather than raised as findings. One exists
-// today (#4190) and its cause is unknown; asserting corruption on evidence that does not
-// establish it would make the check red on a file that must not be deleted. Listing each
-// path means the set cannot grow unnoticed, which is the property a bare count lacks.
+// Unreproduced entries are disclosed by path rather than raised as findings. Asserting
+// corruption on evidence that does not establish it would make the check red on a file
+// that must not be deleted. Listing each path means the set cannot grow unnoticed, which
+// is the property a bare count lacks.
+//
+// Absent targets are counted, not dropped. A recorded target that is not on disk cannot be
+// evaluated, but excluding it silently shrinks the denominator and lets the ratio read as
+// broader coverage than was actually attempted (#4197). It matters here rather than in the
+// abstract: nine of the thirteen absent entries share the exact `syncedAt` of the sole
+// residue, so that residue is plausibly one visible member of a ten-entry cohort rather
+// than an isolated anomaly. The conservation assertion in the suite -- reproduced plus
+// unreproduced plus unobserved equals every entry carrying a `sourceSha256` -- is what
+// keeps a future exclusion from reappearing as a quietly smaller number.
 //
 // For `vendor/@jrm/tokens/css/default/tokens.css` specifically, the engine documents the
 // cause at `copier.mjs:494-499`: an overlapping run reverted that entry to the hash and
@@ -567,15 +582,25 @@ function unstampSource(entryPath, text) {
 function verifySourceReproduction(lock) {
   const findings = [];
   const unreproduced = [];
+  const unobserved = [];
   let reproduced = 0;
   for (const [entry, metadata] of Object.entries(lock.entries || {})) {
     if (!metadata || !metadata.sourceSha256) continue;
     const absolute = path.join(ROOT, entry);
-    if (!fs.existsSync(absolute)) continue;
+    if (!fs.existsSync(absolute)) {
+      unobserved.push(entry);
+      continue;
+    }
     const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
-    if (managedRegion(text) !== null) continue;
+    if (managedRegion(text) !== null) {
+      unobserved.push(entry);
+      continue;
+    }
     const source = unstampSource(entry, text);
-    if (source.status === 'no-stamp') continue;
+    if (source.status === 'no-stamp') {
+      unobserved.push(entry);
+      continue;
+    }
     if (source.status === 'unknown') {
       unreproduced.push(entry);
       continue;
@@ -589,7 +614,7 @@ function verifySourceReproduction(lock) {
   if (reproduced === 0) {
     findings.push('no lock entry unstamped to its canon source — check is not observing');
   }
-  return { findings, reproduced, unreproduced };
+  return { findings, reproduced, unreproduced, unobserved };
 }
 
 function verifyManagedContent(lock) {

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -20,6 +20,7 @@ const {
   verifyLockCoverage,
   unstampSource,
   commentFamily,
+  verifySourceReproduction,
 } = require('./check-ai-manifest.js');
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -181,4 +182,22 @@ test('managed targets unstamp to their recorded canon source', () => {
   assert.equal(corruptedReproduced, 0, 'a corrupted body must not reproduce');
   // Breadth guard: a corpus exercising one family would certify the switch on a third of it.
   assert.ok(families.size >= 2, `switch exercised on only ${families.size} comment family`);
+});
+
+test('every recorded source is accounted for, not silently excluded', () => {
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  const recorded = Object.values(lock.entries || {}).filter((m) => m && m.sourceSha256).length;
+  const result = verifySourceReproduction(lock);
+  const accounted = result.reproduced + result.unreproduced.length + result.unobserved.length;
+  // Conservation law rather than a scan for today's instance. The defect it pins (#4197) was
+  // an early `continue` that dropped absent targets, which shrank the denominator with
+  // nothing in the output saying so -- the printed ratio then read as coverage of everything
+  // recorded. Any future exclusion, on any axis, breaks this equality instead of quietly
+  // producing a smaller and more flattering number.
+  assert.equal(
+    accounted,
+    recorded,
+    `${recorded - accounted} recorded sources fell out of the accounting`,
+  );
+  assert.ok(recorded > 0, 'lock records no source hashes; conservation would be vacuous');
 });


### PR DESCRIPTION
## Summary

`verifySourceReproduction` dropped any recorded target it could not evaluate with an early `continue`. The printed ratio then described the **evaluable** population while reading as coverage of everything recorded — the same "domain narrower than its printed count implies" defect this tool has already corrected on two other axes.

```
before   [source] 64 of 65 managed targets unstamp to their recorded canon source
after    [source] 64 of 65 ...; 16 recorded targets not evaluable and unobserved
```

65 + 16 = 81, every entry in the lock. Nothing changed about which entries pass.

## Why it is not cosmetic

The check's sole residue is `vendor/@jrm/tokens/css/default/tokens.css` (#4190). Measured against the raw lock text:

```
entries with syncedAt 2026-08-07T15:35:03.6xxZ : 10   (all under vendor/@jrm/tokens/)
  present on disk : 1   <- tokens.css, the residue
  absent          : 9   <- excluded by the early continue, never evaluated
```

The residue is not distinguished by being stale. It is distinguished by being **the only member of that cohort still on disk** — its apparent solitude was an artifact of the population filter. So the failure is plausibly 1 of 10 with 9 unobservable, and if those files return at the next sync the count can move with no prior warning.

The date is genuine and should not be read as corruption: `2026-08-07T15:35:03.616Z` lands **48.6 s** into sync run #7 (`2026-08-07T15:34:15Z`, `success`).

Reading the lock through `ConvertFrom-Json` is what hid this — it coerces the timestamps to local `DateTime`, dropping milliseconds and shifting the zone, which collapses distinct cohorts and made the count look like one. The measurement above is taken off raw text.

## Conservation, not a scan for the instance

The new test asserts `reproduced + unreproduced + unobserved === entries carrying a sourceSha256`. That is deliberately a law rather than an assertion about today's 16 — an instance test would self-liquidate the moment a sync restores those files, which is exactly when the guard is needed. Any future exclusion, on any axis, breaks the equality instead of quietly producing a smaller and more flattering number.

## Third fix: a stale sentence in the docblock

The `verifySourceReproduction` docblock still read *"One exists today (#4190) and its cause is unknown"* directly above the paragraph that states the cause. The output line was corrected in #4194; the comment two paragraphs up was not — a sentence asserting more than is known, inside the comment explaining why the check refuses to assert more than is known. Deleted.

## Validation

```
node --test tools/check-ai-manifest.test.mjs     11 pass  0 fail   (was 10)
node tools/check-ai-manifest.js --strict         exit 0
npx eslint <both files> --max-warnings 0         exit 0
npx prettier --check <both files>                clean
```

Mutation controls — each applied to the shipped source, suite re-run, source restored:

| mutation | result |
| --- | --- |
| absent target → silent `continue` (**the exact #4197 defect**) | **10 pass / 1 fail** |
| marker-managed → silent `continue` | **10 pass / 1 fail** |
| `unobserved` always reported empty | **10 pass / 1 fail** |

All three killed; baseline restored to 11/11 with `git diff --stat` clean on the tool.

Repo-wide `format:check` is not run here — it hangs monorepo-wide on a known pre-existing line-ending artifact. Both touched files are verified clean individually.

## Issues

Closes #4197

## Testing

- [x] `node --test tools/check-ai-manifest.test.mjs` — 11/11
- [x] `node tools/check-ai-manifest.js --strict` — exit 0, pass/fail set unchanged
- [x] eslint + prettier clean on both touched files
- [x] three mutation controls, all killed