### PR TITLE
fix(tools): implement the documented LF rule in managedDigest (#4201)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -385,6 +385,12 @@ function validateSyncLock() {
   return findings;
 }
 
+// The engine hashes LF-normalized text (`hashText`, lock.mjs:57). Naming it here rather
+// than spelling `.replace(/\r\n/g, '\n')` at each call site keeps one word for one rule:
+// three inline spellings is what made this normalization impossible to cite accurately,
+// and impossible to notice was untested (#4201).
+const toLF = (text) => text.replace(/\r\n/g, '\n');
+
 // Markers delimiting a managed region, per comment syntax of the host file.
 // Group 2 is the region body; the markers themselves are excluded from the digest.
 const REGION_MARKERS = [
@@ -413,9 +419,14 @@ function managedRegion(text) {
 // Leading whitespace inside a managed region is therefore significant and must be preserved.
 const stripTrailing = (text) => text.replace(/\s+$/, '');
 
+// `toLF` is applied here rather than assumed of the caller. Every current caller already
+// normalizes at the read, so this is idempotent today -- but this function is exported, the
+// precondition was unstated, and a caller that reads a file plainly is the obvious thing to
+// write. The rule stated three lines above now runs in full under it (#4201).
 function managedDigest(text) {
-  const region = managedRegion(text);
-  const payload = region === null ? text : stripTrailing(region);
+  const normalized = toLF(text);
+  const region = managedRegion(normalized);
+  const payload = region === null ? normalized : stripTrailing(region);
   return crypto.createHash('sha256').update(payload).digest('hex');
 }
 
@@ -534,7 +545,7 @@ function commentFamily(entryPath) {
 // would shrink the denominator with nothing saying so, which is the silent-channel defect
 // this tool already corrected twice (#4190, #4191). The caller discloses it by path.
 function unstampSource(entryPath, text) {
-  const lines = text.replace(/\r\n/g, '\n').split('\n');
+  const lines = toLF(text).split('\n');
   const index = lines.findIndex((line) => PROVENANCE_STAMP_LINE.test(line));
   if (index === -1) return { status: 'no-stamp' };
   const family = commentFamily(entryPath);
@@ -591,7 +602,7 @@ function verifySourceReproduction(lock) {
       unobserved.push(entry);
       continue;
     }
-    const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
+    const text = toLF(fs.readFileSync(absolute, 'utf8'));
     if (managedRegion(text) !== null) {
       unobserved.push(entry);
       continue;
@@ -631,7 +642,7 @@ function verifyManagedContent(lock) {
       else findings.push(`managed target is missing: ${entry}`);
       continue;
     }
-    const text = fs.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n');
+    const text = toLF(fs.readFileSync(absolute, 'utf8'));
     const digest = managedDigest(text);
     if (digest !== metadata.targetSha256) {
       const scope = managedRegion(text) === null ? 'managed file' : 'managed region';
@@ -779,6 +790,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  toLF,
   managedRegion,
   managedDigest,
   verifyLockCoverage,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -15,6 +15,7 @@ import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 const {
+  toLF,
   managedRegion,
   managedDigest,
   verifyLockCoverage,
@@ -47,6 +48,29 @@ test('the whole-file rule strips nothing', () => {
   assert.equal(managedRegion(text), null);
   assert.equal(managedDigest(text), sha(text));
   assert.notEqual(managedDigest(text), sha(text.trim()));
+});
+
+test('CRLF input digests identically to LF, for both shapes', () => {
+  // Every input this repo can read is already LF: `.gitattributes` sets `* text=auto eol=lf`
+  // and 0 of 61 managed files carry CRLF. So deleting the tool's normalization altogether
+  // left the whole suite green and `--strict` at exit 0 -- correct code, held up by a
+  // checkout setting rather than by anything that could fail (#4201). These assertions are
+  // the ones that notice. They construct CRLF rather than reading it, so they do not depend
+  // on the working tree's line endings and cannot decay if `.gitattributes` changes.
+  for (const lf of ['no markers here\n', wrap('canon line\n'), wrap('\nleading blank\n')]) {
+    const crlf = lf.replace(/\n/g, '\r\n');
+    assert.notEqual(crlf, lf, 'PREMISE: the two inputs must actually differ');
+    assert.equal(managedDigest(crlf), managedDigest(lf), 'digest must not depend on line endings');
+  }
+});
+
+test('toLF is idempotent and leaves a lone CR alone', () => {
+  // Idempotence is what lets the callers keep normalizing at the read without double-handling.
+  // The lone-CR case pins the boundary: the engine's rule is CRLF -> LF, not "delete every CR".
+  const mixed = 'a\r\nb\nc\r\n';
+  assert.equal(toLF(mixed), 'a\nb\nc\n');
+  assert.equal(toLF(toLF(mixed)), toLF(mixed));
+  assert.equal(toLF('old\rmac'), 'old\rmac');
 });
 
 test('lock coverage: baseline is zero, and a stamped unrecorded file is caught', () => {


### PR DESCRIPTION
Answers a question handed over by `jrmoulckers/.github`: is `managedDigest`'s input LF-normalized *by construction*, or by `* text=auto eol=lf`? The answer is one of each — correctness by construction, verification by `.gitattributes`.

## The measurement

Removing all three CRLF normalizations from the tool:

```
BASELINE   11 pass  0 fail   --strict exit 0
MUTANT     11 pass  0 fail   --strict exit 0
```

Nothing noticed, because nothing could:

```
.gitattributes   * text=auto eol=lf
managed files    0 CRLF-bearing / 61 LF-only
```

Every input the suite reads is already LF on disk. The normalization was correct code with no check behind it.

## The defect that was actually there

`managedDigest` is exported and its docblock states the engine's rule as `toLF(inner).replace(/\s+$/, '')`. It implemented the second half only and relied on an unstated precondition that callers pre-normalize. Every current caller does — so this was latent, not live, and it would have fired only on a checkout carrying CRLF, which this one cannot produce.

Same shape as the `cause unknown` sentence removed in #4197: a comment describing behaviour the code beneath it does not have.

## Changes

- Name the rule `toLF`, so the code, the docblock and the engine (`lock.mjs:57`) use one word for one concept. Three inline spellings of it is what made this rule impossible to cite accurately and impossible to notice was untested.
- Apply it inside `managedDigest`, so the exported function honours its own documented rule and carries no unstated precondition. Idempotent, so no call site changes behaviour.
- Keep caller-side normalization. It is cheap, and those call sites also feed `managedRegion` directly.
- Add two tests that **construct** CRLF rather than reading it, so they do not depend on the working tree and cannot decay if `.gitattributes` changes.

## Mutation controls

Baseline 13 pass / 0 fail.

| mutant | result | killed by |
| --- | --- | --- |
| `managedDigest` does not normalize | 12 pass / **1 fail** | `CRLF input digests identically to LF` |
| `toLF` is identity | 11 pass / **2 fail** | both new tests, by name |
| `toLF` strips every CR | 12 pass / **1 fail** | `toLF is idempotent and leaves a lone CR alone` |

The middle mutant is the one that scored 11/0 before this change. The third pins the boundary the rule actually has: CRLF → LF, not "delete every CR".

## Verification

```
node --test tools/check-ai-manifest.test.mjs   13 pass  0 fail
node tools/check-ai-manifest.js --strict       exit 0
npx prettier --check <both files>              clean
npx eslint <both files> --max-warnings 0       exit 0
```

`[source]` output unchanged: `64 of 65 ... ; 16 recorded targets not evaluable and unobserved`, with the #4190 residue still named.

## Scope

Tooling only. No change to `packages/design-tokens`, `.studio-sync.lock.json`, any vendored token file, or any workflow.

Closes #4201