### PR TITLE
ci(workflows): fail on event guards no declared trigger can satisfy

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -5047,6 +5047,107 @@ they put it, and the reason is that a fabricated column inherits the shape of th
 than the shape of the data. A genuine enumeration of a file across 153 tags produces collisions,
 because content repeats; only a fabricated one is perfectly distinct.
 
+## A dead guard is a permanently green security check, and it is one deletion away
+
+Upstream retracted a figure it had published for finance — `(7,1)` — on the grounds that it was
+never measured here but borrowed from an undercount of mine and reformatted into upstream's own
+notation. That retraction is correct and the general form is worth more than the correction:
+
+> A borrowed value laundered through someone else's notation reads as independent confirmation.
+
+It collided with a real defect on this side. My probe returned `(7,1)` because its normaliser
+stripped trailing parentheticals and collapsed `CodeQL (javascript-typescript)` and
+`CodeQL (java-kotlin)` onto one identity. Agreement between the two figures was therefore not
+evidence: one was my undercount, and the other was my undercount wearing different units. The
+true pair is `(7,4)`, caught only because three earlier sections of this guide record 4 ran /
+3 skipped on docs-only PRs — a contradiction with observed run counts, not a better probe.
+
+Worth recording that the instrument survived the error inside it. `(7,1)` and `(7,4)` are both
+non-vacuous, so the ranking against a repo with `(0,—)` never depended on which was right. The
+predicate it replaced — _is any required context unconditional?_ — would have returned `true` for
+both and hidden that one of us was wrong by a factor of four.
+
+### Tautology is a property of the guard against its trigger set
+
+Upstream's sharpening is right and it is the actionable part: an `if:` cannot be classified by
+reading it. `github.event_name == 'push'` is live, dead, or tautological depending entirely on the
+`on:` block — a different part of the file, which never mentions the job, and which changes
+independently.
+
+Classified every guard in the 31 workflows on that basis. 81 jobs carry an `if:`; 33 reference
+`github.event_name`. Of the guards decidable from the trigger set alone:
+
+| Workflow / job                           | Guard covers | Declared triggers | State     | Margin to DEAD |
+| ---------------------------------------- | ------------ | ----------------- | --------- | -------------- |
+| `ci-security.yml` / `codeql-java-kotlin` | 4 of 4       | 4                 | TAUTOLOGY | 4              |
+| `housekeeping.yml` / `add-to-project`    | 2 of 4       | 4                 | LIVE      | 2              |
+| `ci-web.yml` / `e2e-pr-smoke`            | 1 of 2       | 2                 | LIVE      | **1**          |
+| `ci-security.yml` / `dependency-review`  | 1 of 4       | 4                 | LIVE      | **1**          |
+
+**0 DEAD guards exist today.** That zero is what makes the next part a ratchet rather than a
+migration.
+
+### The loop closes on the gatekeeper
+
+`ci-security.yml`'s `Required Checks Gatekeeper` was built to defeat skip-satisfies-required at
+the branch-protection level: it runs `if: always()`, takes 8 security jobs as `needs:`, and fails
+if any of them failed or was cancelled. That aggregation is correct.
+
+But at L603–606 it accepts `skipped` as passing, and the comment at L597–599 says why:
+`dependency-review` only runs on pull requests, so on every push it is legitimately skipped.
+Making `skipped` fail would break every push. **The skip tolerance is forced.**
+
+So delete `pull_request:` from that `on:` block — one line, in a block that never names
+`dependency-review` — and the job is skipped on every event forever. The gatekeeper reports
+success, correctly by its own rules, and nothing in the repository can tell the difference between
+a job that is correctly skipped and one that can never run again.
+
+This is the same shape recorded earlier in this guide one level down. A `paths:`-filtered
+`pull_request` trigger makes a required check _never report_, which blocks the PR forever; the
+only remedy is trigger-always/skip-inside, which yields `SKIPPED`, which satisfies the
+requirement. The mandatory remedy for one trap manufactures the exact condition of the other — and
+the mechanism built to contain the consequence reproduces it at the level above.
+
+### The ratchet
+
+`tools/check-workflow-security.mjs` now exports `findDeadEventGuards`, wired into
+`scanWorkflowSecurity`, so the gatekeeper's own security check fails any workflow carrying a guard
+no declared trigger can satisfy.
+
+Three design constraints, each from a failure this guide already records:
+
+**It decides only what it can decide.** `pureEventDisjunction` returns the accepted events only
+for a plain `||` chain of `github.event_name == '<event>'`, and `null` for anything containing
+`&&`, `!`, or parentheses. 29 of the 33 event-referencing guards mix in `needs.*` outputs,
+`always()`, or `github.ref`, and their reachability is not a function of the trigger list. A
+checker that guessed at those would report violations against correct workflows.
+
+**Reusable workflows are exempt.** Inside a `workflow_call` target, `github.event_name` is the
+_caller's_ event, so the callee's own trigger list says nothing about which values are reachable.
+This is not hypothetical: `reusable-detect-changes.yml` declares `on: workflow_call:` and nothing
+else, and carries `if: github.event_name == 'pull_request'` at L65. The first draft flagged it.
+The file is correct; the checker was wrong. 3 workflows declare `workflow_call`.
+
+**It uses the real parser.** The file previously imported only node builtins, and matching that
+would have meant hand-rolling a folded-scalar parser — 22 of the guards are written as `if: >-`
+or `if: |`, including the tautological one. A bespoke parser would have silently skipped exactly
+the cases with the most room to hide. `js-yaml` is already a direct dependency at `^4.3.1`.
+
+Verified both directions. Against the 31 workflows as they stand: **0 violations, exit 0**.
+Against `ci-security.yml` with `pull_request:` removed from the trigger block and nothing else
+changed:
+
+```
+job 'codeql-java-kotlin' step 2 is guarded on 'pull_request', which no declared
+  trigger (push, schedule, workflow_dispatch) can satisfy — it can never run
+job 'dependency-review' is guarded on 'pull_request', which no declared
+  trigger (push, schedule, workflow_dispatch) can satisfy — it can never run
+```
+
+11/11 unit tests pass, including the reusable-workflow exemption and the case where a disjunction
+names one undeclared event alongside a declared one — that guard is live, and a checker requiring
+every term to be reachable would have been wrong about it.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-workflow-security.mjs
+++ b/tools/check-workflow-security.mjs
@@ -13,6 +13,8 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { load as loadYaml } from 'js-yaml';
+
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowDirectory = join(repositoryRoot, '.github', 'workflows');
 const canonicalWorkflowSha = '97ff60ec21321563fa0fc7ba80015261e7dcd6fa';
@@ -249,11 +251,106 @@ export function findInheritingJobs(workflow) {
   return { base: inlineBase || 'block', jobs: inheriting };
 }
 
+/**
+ * Returns the declared trigger names for a parsed workflow document, covering
+ * the three forms GitHub accepts: `on: push`, `on: [push, ...]`, and a mapping.
+ *
+ * YAML 1.1 resolves a bare `on` key to boolean true, so the `true` fallback is
+ * required for workflows that do not quote it.
+ */
+function declaredTriggers(document) {
+  const on = document?.on ?? document?.[true];
+  if (typeof on === 'string') return [on];
+  if (Array.isArray(on)) return on.filter((entry) => typeof entry === 'string');
+  if (on && typeof on === 'object') return Object.keys(on);
+  return [];
+}
+
+/**
+ * Returns the event names a guard accepts, but only when the guard is a plain
+ * disjunction of `github.event_name == '<event>'` terms.
+ *
+ * Returns null for every other shape. That is deliberate: a guard combining
+ * `&&`, negation, parentheses, `always()`, or job outputs cannot be decided
+ * from the trigger list alone, and a checker that guesses at those would report
+ * violations against correct workflows.
+ */
+export function pureEventDisjunction(expression) {
+  if (typeof expression !== 'string') return null;
+  const normalized = expression
+    .replace(/\$\{\{/g, ' ')
+    .replace(/\}\}/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!normalized || /[&!()]/.test(normalized)) return null;
+  const events = [];
+  for (const term of normalized.split('||')) {
+    const match = /^github\.event_name\s*==\s*'([a-z_]+)'$/.exec(term.trim());
+    if (!match) return null;
+    events.push(match[1]);
+  }
+  return events.length > 0 ? events : null;
+}
+
+/**
+ * Reports job and step guards that no declared trigger can satisfy.
+ *
+ * Such a guard is not merely conditional — it is permanently false, so the job
+ * reports `skipped` on every run forever. That matters here because the
+ * gatekeeper accepts `skipped` as passing (it must: `dependency-review` is
+ * legitimately skipped on push), so a guard that can never be true is a
+ * security job that is green forever with nothing to notice it.
+ *
+ * The dangerous edit is not to the guard. Deleting a trigger from the `on:`
+ * block — which never mentions the job — silently converts a live guard into a
+ * dead one, and `ci-security.yml`'s `dependency-review` is a single trigger
+ * deletion away from exactly that.
+ *
+ * Reusable workflows are exempt: inside a `workflow_call` target,
+ * `github.event_name` is the *caller's* event, so its own trigger list says
+ * nothing about which values are reachable.
+ */
+export function findDeadEventGuards(file, workflow) {
+  let document;
+  try {
+    document = loadYaml(workflow);
+  } catch {
+    return [];
+  }
+  if (!document || typeof document !== 'object') return [];
+
+  const triggers = declaredTriggers(document);
+  if (triggers.length === 0 || triggers.includes('workflow_call')) return [];
+
+  const violations = [];
+  const inspect = (where, expression) => {
+    const events = pureEventDisjunction(expression);
+    if (!events || events.some((event) => triggers.includes(event))) return;
+    violations.push(
+      `${where} is guarded on ${events.map((event) => `'${event}'`).join('/')}, ` +
+        `which no declared trigger (${triggers.join(', ')}) can satisfy — it can never run`,
+    );
+  };
+
+  for (const [jobId, job] of Object.entries(document.jobs ?? {})) {
+    if (!job || typeof job !== 'object') continue;
+    inspect(`job '${jobId}'`, job.if);
+    const steps = Array.isArray(job.steps) ? job.steps : [];
+    steps.forEach((step, index) => {
+      if (step && typeof step === 'object') {
+        inspect(`job '${jobId}' step ${index + 1}`, step.if);
+      }
+    });
+  }
+  return violations.map((violation) => `${file}: ${violation}`);
+}
+
 export function scanWorkflowSecurity(workflows, productionCompose = '') {
   const errors = [];
   const report = (file, message) => errors.push(`${file}: ${message}`);
 
   for (const [file, workflow] of Object.entries(workflows)) {
+    errors.push(...findDeadEventGuards(file, workflow));
     for (const violation of findMutableReferenceViolations(workflow)) {
       report(file, `line ${violation.line}: ${violation.reason}`);
     }

--- a/tools/check-workflow-security.test.mjs
+++ b/tools/check-workflow-security.test.mjs
@@ -3,11 +3,81 @@ import test from 'node:test';
 
 import {
   extractJob,
+  findDeadEventGuards,
   findInheritingJobs,
   findMutableReferenceViolations,
   findRunExpressionViolations,
+  pureEventDisjunction,
   scanWorkflowSecurity,
 } from './check-workflow-security.mjs';
+
+test('findDeadEventGuards flags a guard no declared trigger can satisfy', () => {
+  const workflow = `
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * *'
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    steps:
+      - run: echo hi
+`;
+
+  const violations = findDeadEventGuards('ci-security.yml', workflow);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /job 'dependency-review'/);
+  assert.match(violations[0], /can never run/);
+});
+
+test('findDeadEventGuards accepts a guard one declared trigger satisfies', () => {
+  const workflow = `
+on:
+  push:
+  pull_request:
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    steps:
+      - if: github.event_name == 'push' || github.event_name == 'schedule'
+        run: echo hi
+`;
+
+  // The job guard is live. The step guard names 'schedule', which is not
+  // declared, but 'push' is — a disjunction needs only one reachable term.
+  assert.deepEqual(findDeadEventGuards('ci.yml', workflow), []);
+});
+
+test('findDeadEventGuards exempts reusable workflows, where event_name is the caller\u2019s', () => {
+  const workflow = `
+on:
+  workflow_call:
+jobs:
+  detect:
+    steps:
+      - if: github.event_name == 'pull_request'
+        run: echo hi
+`;
+
+  assert.deepEqual(findDeadEventGuards('reusable-detect-changes.yml', workflow), []);
+});
+
+test('pureEventDisjunction decides only plain disjunctions', () => {
+  assert.deepEqual(pureEventDisjunction("github.event_name == 'push'"), ['push']);
+  assert.deepEqual(
+    pureEventDisjunction("${{ github.event_name == 'push' || github.event_name == 'schedule' }}"),
+    ['push', 'schedule'],
+  );
+  // Undecidable from the trigger list alone, so not decided at all.
+  assert.equal(
+    pureEventDisjunction("github.event_name == 'push' && needs.changes.outputs.web"),
+    null,
+  );
+  assert.equal(pureEventDisjunction("always() && github.event_name == 'push'"), null);
+  assert.equal(pureEventDisjunction("github.event_name != 'pull_request'"), null);
+  assert.equal(pureEventDisjunction(undefined), null);
+});
 
 test('findRunExpressionViolations finds direct input-to-shell interpolation', () => {
   const workflow = `


### PR DESCRIPTION
Upstream retracted a figure it had published for finance, `(7,1)`, on the grounds that it was
never measured here — it was borrowed from an undercount of mine and reformatted into upstream's
notation. The general form is worth more than the correction: **a borrowed value laundered through
someone else's notation reads as independent confirmation.** It collided with a real probe bug on
this side (a normaliser collapsed both CodeQL contexts onto one identity), so the agreement
between the two figures was my undercount agreeing with itself. The true pair is `(7,4)`.

Upstream's sharper point is the actionable one: **tautology is a property of the guard against its
trigger set.** An `if:` cannot be classified by reading it — the `on:` block decides, and it never
mentions the job.

## What that finds in finance

81 jobs carry an `if:`; 33 reference `github.event_name`. Of those decidable from triggers alone:

| Workflow / job | Covers | Triggers | State | Margin to DEAD |
| --- | --- | --- | --- | --- |
| `ci-security.yml` / `codeql-java-kotlin` | 4 of 4 | 4 | TAUTOLOGY | 4 |
| `housekeeping.yml` / `add-to-project` | 2 of 4 | 4 | LIVE | 2 |
| `ci-web.yml` / `e2e-pr-smoke` | 1 of 2 | 2 | LIVE | **1** |
| `ci-security.yml` / `dependency-review` | 1 of 4 | 4 | LIVE | **1** |

`Required Checks Gatekeeper` aggregates its 8 `needs:` correctly — but accepts `skipped` at
L603–606, and the comment at L597–599 says why: `dependency-review` only runs on PRs, so making
`skipped` fail would break every push. **The skip tolerance is forced.**

So deleting `pull_request:` from that `on:` block — one line, in a block that never names
`dependency-review` — makes the job skip forever and the gatekeeper report success, correctly by
its own rules. The mechanism built to defeat skip-satisfies-required at the branch-protection
level reproduces it at the aggregation level.

## The change

`tools/check-workflow-security.mjs` gains `findDeadEventGuards`, wired into `scanWorkflowSecurity`
and therefore into the gatekeeper. **0 violations today**, so it is a pure ratchet.

Three constraints, each from a failure already recorded in the guide:

- **Decides only what it can decide.** `pureEventDisjunction` returns `null` for anything with
  `&&`, `!`, or parens. 29 of 33 guards mix in `needs.*`/`always()`/`github.ref` and are not a
  function of the trigger list.
- **Reusable workflows are exempt** — inside a `workflow_call` target `github.event_name` is the
  *caller's* event. Not hypothetical: the first draft flagged `reusable-detect-changes.yml`, which
  is correct code. The checker was wrong.
- **Uses the real parser.** 22 guards are folded (`if: >-` / `if: |`), including the tautological
  one; a hand-rolled parser would have skipped exactly the cases with the most room to hide.
  `js-yaml` is already a direct dependency at `^4.3.1`.

## Verification

- `npm run workflow:security:test` — **11/11 pass**
- `npm run workflow:security:check` against the real 31 workflows — **0 violations, exit 0**
- With `pull_request:` removed from `ci-security.yml` and nothing else changed, it flags both
  `dependency-review` and the `codeql-java-kotlin` step
- `npx prettier --check .` clean; `eslint --max-warnings 0` on both changed files clean
- citations gate 141/40/806/44 exit 0; `vendor-configs.mjs --check` exit 0

Refs #4029