### PR TITLE
fix(tools): widen the lock-coverage walk to the non-Markdown corpus (#4204)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -530,17 +530,35 @@ function coverageRoots(recorded) {
   return [...roots];
 }
 
-// Reads a file only if it is plausibly a stamped text file. The stamp is always within the
-// first bytes, but the whole text is needed for the line-anchored match; the size cap keeps a
-// large generated artifact from being read on every run, and the try/catch drops anything that
-// is not decodable rather than letting the walk throw on a binary that lands under a root.
+// Reads a file only if it is plausibly a stamped text file. The size cap keeps a large
+// generated artifact from being read on every run, and anything undecodable or unreadable is
+// dropped rather than allowed to throw from inside the walk.
+//
+// Size and content are taken through ONE descriptor: `statSync` followed by `readFileSync`
+// checks one path and then reads it again, so the file can change between the two calls
+// (js/file-system-race, flagged by CodeQL on this function's first version). That is not
+// hypothetical here -- this walk runs over a tree the sync engine writes, so a run overlapping
+// a sync is exactly the case. `fstatSync` on an open descriptor measures the object already
+// held, and the subsequent reads come from the same object.
 const STAMP_READ_LIMIT = 512 * 1024;
 function readTextForStamp(file) {
+  let fd;
   try {
-    if (fs.statSync(file).size > STAMP_READ_LIMIT) return null;
-    return fs.readFileSync(file, 'utf8');
+    fd = fs.openSync(file, 'r');
+    const { size } = fs.fstatSync(fd);
+    if (size > STAMP_READ_LIMIT) return null;
+    const buffer = Buffer.allocUnsafe(size);
+    let offset = 0;
+    while (offset < size) {
+      const read = fs.readSync(fd, buffer, offset, size - offset, offset);
+      if (read === 0) break;
+      offset += read;
+    }
+    return buffer.subarray(0, offset).toString('utf8');
   } catch {
     return null;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
   }
 }
 

--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -13,8 +13,18 @@ const ACTIVATION_DOC = 'docs/ai/README.md';
 // The stamp is delivered as a standalone comment on its own line. Matching it as a substring
 // cannot tell the delivered stamp from prose or a code span that quotes it — which the one
 // deliberately unstamped file is the most likely file to do — so match the delivered form.
+// Matches the delivered provenance stamp for either origin, in either comment syntax the
+// engine emits for it. The previous form matched one origin in one syntax
+// (`<!-- synced from jrmoulckers/.github ... -->`), which was the third of three independent
+// filters hiding the entire vendored token corpus from the coverage walk (#4204). Tokens
+// arrive from a different repository AND in block-comment syntax:
+//   .github  <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
+//   tokens   /* generated + synced from jrmoulckers/studio @jrm/tokens — do not edit here */
+// Still line-anchored, for the original reason: matching as a substring cannot tell a
+// delivered stamp from prose or a code span quoting it, and the one deliberately unstamped
+// file is the likeliest to quote it.
 const PROVENANCE_LINE =
-  /^<!-- synced from jrmoulckers\/\.github — canonical source; do not edit here -->$/m;
+  /^(?:<!--|\/\*|#) (?:generated \+ )?synced from jrmoulckers\/[^\n]*?do not edit here(?: -->| \*\/)?$/m;
 const GENERATED_AGENTS = [
   'accessibility-reviewer',
   'ai-ops-engineer',
@@ -468,22 +478,70 @@ const MANAGED_BASES = [
 function verifyLockCoverage(lock) {
   const findings = [];
   const recorded = new Set(Object.keys(lock.entries || {}));
+  const seen = new Set();
   let stampedRecorded = 0;
-  for (const base of MANAGED_BASES) {
+  let stampedRecordedNonMarkdown = 0;
+  for (const base of coverageRoots(recorded)) {
     for (const file of walkFiles(path.join(ROOT, base))) {
       const relPath = path.relative(ROOT, file).split(path.sep).join('/');
-      if (!/\.mdx?$/.test(relPath)) continue;
-      if (!PROVENANCE_LINE.test(fs.readFileSync(file, 'utf8'))) continue;
-      if (recorded.has(relPath)) stampedRecorded += 1;
-      else findings.push(`carries canonical provenance but is not a lock entry: ${relPath}`);
+      // Roots may nest -- the lock contributes `.github`, which contains every MANAGED_BASES
+      // entry -- so a file is reachable by more than one root and would otherwise be counted
+      // and reported once per root. The suite's stamped-unrecorded control caught this
+      // immediately as `2 !== 1`, which is what that control is for.
+      if (seen.has(relPath)) continue;
+      seen.add(relPath);
+      const text = readTextForStamp(file);
+      if (text === null) continue;
+      if (!PROVENANCE_LINE.test(text)) continue;
+      if (recorded.has(relPath)) {
+        stampedRecorded += 1;
+        if (!/\.mdx?$/.test(relPath)) stampedRecordedNonMarkdown += 1;
+      } else {
+        findings.push(`carries canonical provenance but is not a lock entry: ${relPath}`);
+      }
     }
   }
-  // Premise guard: if nothing stamped is recorded, the walk is not reaching managed files and
-  // a clean result means the check stopped observing, not that coverage is complete.
+  // Premise guard, now two-sided. The first clause is the original: nothing observed means the
+  // walk stopped reaching managed files, and a clean result reports that as complete coverage.
+  // The second exists because this check spent its whole life blind to every non-Markdown
+  // entry -- 23 of 81, the vendored token corpus -- behind three filters that were each a
+  // provable no-op when removed alone (#4204). Only the conjunction was load-bearing, so no
+  // single-variable audit could find it. This clause fails if the walk regresses to Markdown.
   if (stampedRecorded === 0) {
     findings.push('lock-coverage walk found no recorded canonical file — check is not observing');
+  } else if (stampedRecordedNonMarkdown === 0) {
+    findings.push(
+      'lock-coverage walk observed only Markdown — the non-Markdown corpus is unobserved (#4204)',
+    );
   }
   return findings;
+}
+
+// Roots are derived from the lock rather than hand-listed, so the walk follows the engine when
+// it delivers somewhere new instead of silently declining to look. MANAGED_BASES stays in the
+// union: those directories must be walked even when nothing in them is recorded yet, which is
+// the only state in which an unrecorded stamped file is the interesting finding.
+function coverageRoots(recorded) {
+  const roots = new Set(MANAGED_BASES);
+  for (const entry of recorded) {
+    const top = entry.split('/')[0];
+    if (top && top !== entry) roots.add(top);
+  }
+  return [...roots];
+}
+
+// Reads a file only if it is plausibly a stamped text file. The stamp is always within the
+// first bytes, but the whole text is needed for the line-anchored match; the size cap keeps a
+// large generated artifact from being read on every run, and the try/catch drops anything that
+// is not decodable rather than letting the walk throw on a binary that lands under a root.
+const STAMP_READ_LIMIT = 512 * 1024;
+function readTextForStamp(file) {
+  try {
+    if (fs.statSync(file).size > STAMP_READ_LIMIT) return null;
+    return fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
 }
 
 function walkFiles(dir) {
@@ -791,6 +849,7 @@ if (require.main === module) {
 
 module.exports = {
   toLF,
+  PROVENANCE_LINE,
   managedRegion,
   managedDigest,
   verifyLockCoverage,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -16,6 +16,7 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const {
   toLF,
+  PROVENANCE_LINE,
   managedRegion,
   managedDigest,
   verifyLockCoverage,
@@ -48,6 +49,88 @@ test('the whole-file rule strips nothing', () => {
   assert.equal(managedRegion(text), null);
   assert.equal(managedDigest(text), sha(text));
   assert.notEqual(managedDigest(text), sha(text.trim()));
+});
+
+test('lock coverage observes the non-Markdown corpus, not just .github Markdown', () => {
+  // This check spent its whole life blind to 23 of 81 lock entries -- the vendored token tree
+  // -- behind three independent filters: a .github-only root list, a `.mdx?` extension filter,
+  // and a stamp regex matching one origin in one comment syntax. Measured as a 2^3 lattice,
+  // every single-filter removal was a provable no-op (54 observed in all four of the 000/100/
+  // 010/001 cells); only lifting all three moved it, to 64. So no single-variable audit could
+  // have found it, and the pair that surfaced one file invites an explanation rather than an
+  // audit (#4204). These assertions are over the delivered corpus, not a fixture.
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  const recorded = Object.keys(lock.entries || {});
+  const nonMarkdown = recorded.filter((entry) => !/\.mdx?$/.test(entry));
+
+  // PREMISE: if the lock ever holds only Markdown, this test proves nothing and should say so
+  // rather than pass. The engine delivers CSS, Kotlin, Swift and TypeScript to this repo.
+  assert.ok(nonMarkdown.length > 0, 'PREMISE: the lock must record non-Markdown targets');
+
+  const present = nonMarkdown.filter((entry) => fs.existsSync(path.join(ROOT, entry)));
+  assert.ok(present.length > 0, 'PREMISE: at least one non-Markdown target must be on disk');
+
+  // The stamp on those files is a different origin AND a different comment syntax than the
+  // canon stamp. Matching only the canon form is what made filter 3 load-bearing.
+  const stamped = present.filter((entry) =>
+    PROVENANCE_LINE.test(fs.readFileSync(path.join(ROOT, entry), 'utf8')),
+  );
+  assert.ok(
+    stamped.length > 0,
+    `no on-disk non-Markdown target matches PROVENANCE_LINE; the walk is blind again (${present.length} present)`,
+  );
+
+  // And the walk must actually reach them: a clean result from a walk that never entered
+  // vendor/ is the failure this issue was about.
+  assert.deepEqual(verifyLockCoverage(lock), [], 'baseline must stay clean over the wider walk');
+});
+
+test('lock coverage counts each file once when roots nest', () => {
+  // The lock contributes `.github` as a root, which contains all four MANAGED_BASES, so every
+  // managed file is reachable twice. Without dedupe the walk double-reports; the stamped-
+  // unrecorded control caught exactly that as `2 !== 1` while this change was being written.
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  const dir = path.join(ROOT, '.github/skills/__nesting_probe__');
+  const file = path.join(dir, 'SKILL.md');
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      file,
+      '<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->\n\n# probe\n',
+    );
+    const findings = verifyLockCoverage(lock);
+    assert.equal(findings.length, 1, `a file reachable by nested roots must report once`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  assert.deepEqual(verifyLockCoverage(lock), [], 'probe must leave no residue');
+});
+
+test('the two-sided premise guard fires when the walk observes only Markdown', () => {
+  // Disabling this guard alone leaves the suite green, because it never fires against the real
+  // corpus. It is nonetheless what kills the three filter mutants -- restoring any one of the
+  // original filters drops non-Markdown observation to zero and this clause turns that into a
+  // loud finding. So it is load-bearing in conjunction and invisible in isolation, which is
+  // the exact shape that let #4204 survive. This test exercises it directly, on a synthetic
+  // lock rather than by degrading the checker.
+  const real = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  const markdownOnly = Object.fromEntries(
+    Object.entries(real.entries).filter(([entry]) => /\.mdx?$/.test(entry)),
+  );
+
+  // PREMISE: the synthetic lock must still record Markdown, or the first clause fires instead
+  // and this test would pass for the wrong reason.
+  assert.ok(Object.keys(markdownOnly).length > 0, 'PREMISE: synthetic lock must record Markdown');
+
+  const findings = verifyLockCoverage({ entries: markdownOnly });
+  assert.ok(
+    findings.some((f) => f.includes('observed only Markdown')),
+    `the Markdown-only guard must fire; got ${JSON.stringify(findings.slice(0, 3))}`,
+  );
+  assert.ok(
+    !findings.some((f) => f.includes('check is not observing')),
+    'the zero-observation clause must NOT fire; Markdown was observed',
+  );
 });
 
 test('CRLF input digests identically to LF, for both shapes', () => {

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -133,6 +133,32 @@ test('the two-sided premise guard fires when the walk observes only Markdown', (
   );
 });
 
+test('the stamp reader skips files past the size cap', () => {
+  // The cap was inert when added: nothing in the corpus is near 512 KB, so disabling it left
+  // the suite green. A guard that cannot fire is indistinguishable from one that was deleted,
+  // so the condition is constructed here rather than waited for. The probe is stamped and
+  // unrecorded, which is the state that produces a finding -- so if the cap stops working the
+  // file is read, matched, and reported, and this test says so.
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  const dir = path.join(ROOT, '.github/skills/__size_probe__');
+  const file = path.join(dir, 'SKILL.md');
+  const stamp = '<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->';
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+
+    // PREMISE: at the small size it IS reported, so a clean result at the large size is the
+    // cap working rather than the walk failing to reach the directory at all.
+    fs.writeFileSync(file, `${stamp}\n\n# probe\n`);
+    assert.equal(verifyLockCoverage(lock).length, 1, 'PREMISE: small stamped probe is reported');
+
+    fs.writeFileSync(file, `${stamp}\n\n${'x'.repeat(600 * 1024)}\n`);
+    assert.deepEqual(verifyLockCoverage(lock), [], 'a file past the size cap must not be read');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  assert.deepEqual(verifyLockCoverage(lock), [], 'probe must leave no residue');
+});
+
 test('CRLF input digests identically to LF, for both shapes', () => {
   // Every input this repo can read is already LF: `.gitattributes` sets `* text=auto eol=lf`
   // and 0 of 61 managed files carry CRLF. So deleting the tool's normalization altogether


### PR DESCRIPTION
`verifyLockCoverage` is the only member-side guard against files the engine wrote but never recorded. It could not see any of the 23 vendored `@jrm/tokens` entries — 28% of the lock, and the corpus at the centre of #4190.

Found by applying a rule from `jrmoulckers/.github`: *before explaining why a datum is alone, enumerate what your walk excluded.* They had just found the same class in `enumerateTargets`, on the same corpus, from the other side. Both inventories were blind to the same population.

## Three filters, each individually a no-op

| # | filter | tokens excluded because |
| --- | --- | --- |
| 1 | `MANAGED_BASES` = four `.github/**` dirs | `vendor/` never walked |
| 2 | `if (!/\.mdx?$/.test(relPath)) continue;` | `.css .js .ts .cjs .kt .swift` |
| 3 | `PROVENANCE_LINE` = one origin, one syntax | token stamp differs in both |

```
.github  <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
tokens   /* generated + synced from jrmoulckers/studio @jrm/tokens — do not edit here */
```

## The 2³ lattice

Instrumented on the observation count. `findings` is the wrong readout — every on-disk token file *is* recorded, so it reads `0` in both the blind and the seeing state, which is a quantity that cannot distinguish the states it was chosen to distinguish.

```
vendor  noMd  stamp     observed
  0      0      0          54
  1      0      0          54      <- single fix: no effect
  0      1      0          54      <- single fix: no effect
  0      0      1          54      <- single fix: no effect
  1      1      0          54
  1      0      1          55      <- +1: vendor/README.md
  0      1      1          54
  1      1      1          64      <- +10, the whole on-disk token corpus
```

**No single-variable audit could find this.** Removing any one filter measures "no change" — true, and misleading. The `101` cell is worse than the zeros: it surfaces exactly one file, which invites the explanation *"just the vendor README"* and ends the audit.

The premise guard passed throughout, because 54 `.github` Markdown files were recorded. The check certified itself as observing while blind to 23 of 81 entries.

## Changes

- **Derive walk roots from the lock** (top-level segment of each entry) ∪ `MANAGED_BASES`, so the walk follows the engine instead of a hand-maintained list.
- **Drop the extension filter.** The stamp is the discriminator.
- **Match either origin across comment families**, still line-anchored — matching as a substring cannot tell a delivered stamp from prose quoting it, and the one deliberately unstamped file is the likeliest to quote it.
- **Dedupe by path.** The lock contributes `.github`, which contains every `MANAGED_BASES` entry, so files were reachable twice. The existing stamped-unrecorded control caught this as `2 !== 1` while the change was being written — that control doing exactly its job.
- **Two-sided premise guard.** Observing only Markdown is now a finding.

## Mutation controls

Baseline 16 pass / 0 fail.

| mutant | result |
| --- | --- |
| filter 1 restored (roots) | **3 FAIL** |
| filter 2 restored (`.mdx?`) | **3 FAIL** |
| filter 3 restored (stamp) | **3 FAIL** |
| dedupe removed | **2 FAIL** |
| two-sided guard disabled | **1 FAIL** |
| non-Markdown counter counts everything | **1 FAIL** |

The three filters are now each independently detectable — the conjunction that hid the defect is broken.

The guard needed its own test. Disabling it alone was **invisible** (16 pass / 0 fail) even though it is the mechanism that kills the other three: restoring any filter drops non-Markdown observation to zero, and the guard turns that into a loud finding. Load-bearing in conjunction, inert in isolation — the same shape as the defect itself, reproduced inside its fix. The direct test uses a synthetic Markdown-only lock rather than degrading the checker.

## Verification

```
node --test tools/check-ai-manifest.test.mjs   16 pass  0 fail
node tools/check-ai-manifest.js --strict       exit 0, findings []
npx prettier --check <both files>              unchanged
npx eslint <both files> --max-warnings 0       exit 0
```

## Scope

Tooling only. Changes what the checker looks at, not what is delivered. No change to `packages/design-tokens`, `.studio-sync.lock.json`, any vendored token file, or any workflow.

Closes #4204