### PR TITLE
chore(config): verify vendored ESM files declare their module type

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -5245,6 +5245,109 @@ exactly where the other applies. They are not redundant, and they are not indepe
 they partition. That is a third relation worth distinguishing from both, and the coverage table is
 the only thing that shows which one you have.
 
+## The marker is load-bearing, and no gate in this repo would notice its removal
+
+Upstream reported the `"type": "module"` gap fixed in `vendor-configs.mjs` and told finance it could
+drop its workaround file. Both halves needed checking, and checking them corrected one of my own
+claims mid-investigation.
+
+### First, a correction to something I asserted this turn
+
+I searched for the workaround with `git ls-files | Select-String 'vendor.*package\.json'` and
+reported that finance had none. That pattern requires the literal string `vendor` in the path. The
+file is at `config/engineering/prettier/package.json`. **The search returned clean because it was
+looking in the wrong place**, which is the exact failure mode recorded earlier in this guide about
+remedies phrased as "look in your config" — and I produced it while responding to that very item.
+
+The marker is tracked, and `git log` names the commit: `3a423b13`, PR **#4077**, "adopt vendored
+@jrmoulckers/prettier-config at v0.15.1". I added it myself, and it is **not** in the lock's file
+list — the lock records 3 files and the marker is not one of them.
+
+### The instruction to drop it is wrong for finance, measured
+
+The first measurement said it was safe to drop. On Node 24.3.0, with and without the marker, the
+config resolves identically (`printWidth: 96`, `proseWrap: preserve` for `.md`) and `import()`
+succeeds. That measurement was sound and the conclusion did not follow, because **the runtime I
+measured on is not the runtime the repo declares**:
+
+| Source         | Node         |
+| -------------- | ------------ |
+| My shell       | 24.3.0       |
+| `.nvmrc`       | 22           |
+| `engines.node` | **>=22.0.0** |
+| CI (36 refs)   | 22           |
+
+Node enabled module syntax detection by default in **22.7.0**. `engines` permits 22.0–22.6, and
+`.nvmrc: 22` can resolve there. Re-measured with `--no-experimental-detect-module` to simulate that
+window:
+
+| State          | `import()` of the vendored config     |
+| -------------- | ------------------------------------- |
+| With marker    | ok, `printWidth = 100`                |
+| Without marker | **FAILED `ERR_REQUIRE_CYCLE_MODULE`** |
+
+**The marker is load-bearing inside the range this repository's own manifest permits.** My first
+test could not have found that, because it ran above the floor. A compatibility hedge tested on one
+runtime tells you nothing about the floor it hedges.
+
+### The part that makes it worth a gate
+
+With the marker removed _and_ detection disabled, `npx prettier --check` still **passes, exit 0**.
+Prettier loads its config through its own resolver, so `format:check` is not a proxy for
+loadability. Deleting the marker would have produced a fully green repository containing a config
+that Node cannot import at the declared engines floor.
+
+That is upstream's own point about hashes — every byte matching the lock, every file individually
+correct, the directory still not a loadable package — with one addition: **the marker was outside
+the lock entirely**, so `--check` was not silent about it by accident, it had nothing to say.
+
+### The fix
+
+`scripts/vendor-configs.mjs --check` now also verifies module markers. For each vendored `.js`
+using ESM syntax, a sibling `package.json` must declare `"type": "module"`. `.mjs` is skipped — its
+extension already declares the module system.
+
+Verified in three directions:
+
+| State                               | Result                                |
+| ----------------------------------- | ------------------------------------- |
+| As-is                               | 3 files match, **exit 0**             |
+| Marker deleted                      | **exit 1**, both ESM files named      |
+| Marker present, declares `commonjs` | **exit 1**, reports the declared type |
+
+The third case matters because upstream is right that a marker stating the wrong type is worse than
+none: it _overrides_ detection, converting a runtime that would have coped into one that cannot.
+Checking only for presence would have passed it.
+
+This runs in CI already — `ci-lint.yml` invokes it at L117 and L288 — so no new wiring was needed.
+
+### Do not re-pin yet, and why the re-pin was tested rather than reasoned about
+
+Upstream reports `v0.116.0` merged as #217. It does not exist:
+`git/refs/tags/v0.116.0` → **404**, and `releases/latest` → **`v0.115.0`**. Upstream's own advice in
+the same message — _re-resolve rather than copying the literal out of this message_ — is what
+caught it. A version number stated before it is published is the same class as `versions.json`
+recording registry state and being unable to lead a publish.
+
+Vendoring at the real latest was then run rather than argued about, and produced a result no
+reasoning would have predicted:
+
+```
+Vendored 9 file(s) from jrmoulckers/engineering@v0.115.0
+Ref moved v0.86.0 -> v0.115.0; 6 file(s) changed content.
+```
+
+`git diff --stat` showed **only the lock file changed** — because the six were _untracked_, and
+`git diff` does not show untracked files. The set had silently grown from 3 to 9, adding six
+`config/engineering/tsconfig/*.json` files that finance deliberately defers (2,691 diagnostics, and
+0 of 6 manifests declare `@types/node`). By upstream's own §4 — _vendor in the change that adopts_ —
+vendoring configs nothing extends is the anti-pattern, and re-pinning would have committed exactly
+that.
+
+Reverted. finance stays at `v0.86.0`: the three vendored files are byte-identical at `v0.115.0`,
+the `v0.112.0` declaration floor concerns `index.d.ts`, which finance does not vendor, and the
+marker fix that would justify moving is not released.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/scripts/vendor-configs.mjs
+++ b/scripts/vendor-configs.mjs
@@ -168,6 +168,19 @@ async function check() {
 
   process.stdout.write(`${entries.length} vendored file(s) match ${LOCK} at ${lock.ref}.\n`);
 
+  const unloadable = await missingModuleMarkers(
+    await Promise.all(
+      entries.map(async ([dest]) => [dest, await readFile(dest, 'utf8').catch(() => '')]),
+    ),
+  );
+  if (unloadable.length > 0) {
+    fail(
+      `${unloadable.length} vendored ESM file(s) lack a "type": "module" marker:\n  ${unloadable.join('\n  ')}`,
+      'Add a package.json containing {"type":"module"} beside each. Without it, ' +
+        'Node below 22.7 cannot import the file, and no other gate detects this.',
+    );
+  }
+
   const latest = await latestRef();
   if (latest && latest !== lock.ref) {
     // A newer tag is not the same claim as newer content, and conflating the two
@@ -201,6 +214,47 @@ async function check() {
       );
     }
   }
+}
+
+/**
+ * Vendored `.js` files that use ESM syntax but sit in a directory with no
+ * `{"type":"module"}` marker.
+ *
+ * This is deliberately outside the SHA-256 drift check, because it asks a
+ * question hashes cannot: every byte can match the lock, every file can be
+ * individually correct, and the directory still not be a loadable package.
+ *
+ * The window is real rather than theoretical. Node enabled module syntax
+ * detection by default in 22.7.0, but this repo declares
+ * `engines.node: ">=22.0.0"` and `.nvmrc: 22`, so 22.0–22.6 are permitted and
+ * `import()` fails outright there without the marker. Measured with
+ * `--no-experimental-detect-module`: import succeeds with the marker and fails
+ * with `ERR_REQUIRE_CYCLE_MODULE` without it.
+ *
+ * Nothing else in the repository would notice. Prettier loads its config
+ * through its own resolver, so `format:check` passes either way — the gate
+ * stays green while the file is unimportable.
+ *
+ * `.mjs` is skipped: its extension already declares the module system.
+ */
+async function missingModuleMarkers(files) {
+  const offenders = [];
+  for (const [dest, text] of files) {
+    if (!dest.endsWith('.js')) continue;
+    if (!/^\s*(export\s+(default|const|function|class|\{)|import\s)/m.test(text)) continue;
+    const marker = join(dirname(dest), 'package.json');
+    let declared;
+    try {
+      declared = JSON.parse(await readFile(marker, 'utf8')).type;
+    } catch {
+      offenders.push(`${dest}: no ${marker}`);
+      continue;
+    }
+    if (declared !== 'module') {
+      offenders.push(`${dest}: ${marker} declares type '${declared ?? 'commonjs'}', not 'module'`);
+    }
+  }
+  return offenders;
 }
 
 /**


### PR DESCRIPTION
Upstream reported the `"type": "module"` gap fixed and told finance it could drop its workaround
file. Checking both halves corrected one of my own claims mid-investigation.

## A correction to myself first

I searched with `git ls-files | Select-String 'vendor.*package\.json'` and reported finance had no
workaround file. That pattern requires the literal `vendor` in the path; the file is at
`config/engineering/prettier/package.json`. **The search returned clean because it looked in the
wrong place** — the exact failure this guide already records about remedies phrased as "look in
your config", produced while responding to that item.

It is tracked, added by me in `3a423b13` (PR #4077), and it is **not** in the lock's file list.

## Dropping it would break finance at its own engines floor

First measurement said it was safe: on Node 24.3.0, with and without the marker, config resolves
identically and `import()` succeeds. Sound measurement, wrong conclusion — **the runtime I measured
is not the runtime the repo declares.**

| Source | Node |
| --- | --- |
| My shell | 24.3.0 |
| `.nvmrc` | 22 |
| `engines.node` | **>=22.0.0** |
| CI (36 refs) | 22 |

Node enabled module syntax detection by default in **22.7.0**. Re-measured with
`--no-experimental-detect-module` to simulate the permitted 22.0–22.6 window:

| State | `import()` of the vendored config |
| --- | --- |
| With marker | ok, `printWidth = 100` |
| Without marker | **FAILED `ERR_REQUIRE_CYCLE_MODULE`** |

**And with the marker removed, `npx prettier --check` still passes, exit 0.** Prettier uses its own
resolver, so `format:check` is not a proxy for loadability. Deleting the marker yields a fully green
repo containing a config Node cannot import at the declared floor.

## The fix

`vendor-configs.mjs --check` now verifies module markers: any vendored `.js` using ESM syntax needs
a sibling `package.json` declaring `"type": "module"`. `.mjs` is skipped — its extension already
declares the module system.

| State | Result |
| --- | --- |
| As-is | 3 files match, **exit 0** |
| Marker deleted | **exit 1**, both ESM files named |
| Marker declares `commonjs` | **exit 1**, reports the declared type |

The third case matters because a wrong marker *overrides* detection — worse than none. A
presence-only check would have passed it. Already wired: `ci-lint.yml` L117 and L288.

## Not re-pinning, and the re-pin was tested rather than reasoned about

`v0.116.0` does not exist — `git/refs/tags/v0.116.0` **404**, `releases/latest` = **`v0.115.0`**.
Upstream's own advice in the same message (re-resolve, don't copy the literal) is what caught it.

Vendoring at the real latest produced a result no reasoning would have predicted:

```
Vendored 9 file(s) ... Ref moved v0.86.0 -> v0.115.0; 6 file(s) changed content.
```

`git diff --stat` showed **only the lock changed** — the six were *untracked*, and `git diff` does
not show untracked files. The set had silently grown 3 → 9, adding six
`config/engineering/tsconfig/*.json` that finance deliberately defers. By upstream's own "vendor in
the change that adopts", re-pinning would have committed the anti-pattern. Reverted.

Staying at `v0.86.0`: the three vendored files are byte-identical at `v0.115.0`, the `v0.112.0`
floor concerns `index.d.ts` which finance does not vendor, and the marker fix is unreleased.

## Verification

- `vendor-configs.mjs --check` exit 0; fails correctly in both mutation directions
- `npx prettier --check .` clean; `eslint --max-warnings 0` clean
- citations gate 141/40/806/44 exit 0; workflow security exit 0

Refs #4029