### PR TITLE
fix(tools): make an unreproducible source a finding, and pin the one exemption (#4209)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -374,7 +374,7 @@ function validateSyncLock() {
   findings.push(...verifyLockCoverage(lock));
   const source = verifySourceReproduction(lock);
   findings.push(...source.findings);
-  const total = source.reproduced + source.unreproduced.length;
+  const total = source.reproduced + source.unreproduced.length + source.knownUnreproduced.length;
   // The unobserved count is printed rather than subtracted away. Reporting only "N of M"
   // over the evaluable population lets the ratio read as coverage of everything recorded,
   // when a recorded-but-absent target was never attempted at all (#4197).
@@ -383,14 +383,20 @@ function validateSyncLock() {
     `  [source] ${source.reproduced} of ${total} managed targets unstamp to their ` +
       `recorded canon source` +
       (unobserved ? `; ${unobserved} recorded targets not evaluable and unobserved` : '') +
+      (source.unstated.length
+        ? `; ${source.unstated.length} recorded targets state no source hash`
+        : '') +
       `\n`,
   );
-  // States only what was computed. The earlier wording asserted "cause unknown", which was
-  // false once the engine documented this entry (copier.mjs:494-499) and would be unfounded
-  // for any future path landing here -- the line cannot know the cause of an entry it has
-  // just met. Causes belong in the docblock and the issue, not in a per-entry verdict.
-  for (const entry of source.unreproduced) {
-    process.stdout.write(`  [source] not reproducible from delivered bytes: ${entry} (#4190)\n`);
+  // Only entries carrying a pinned exemption are reported here. Everything else that fails
+  // to reproduce is a finding, so it leaves through the verdict rather than through stdout.
+  // The old line labelled every unreproduced entry "(#4190)" unconditionally, which would
+  // have attributed the next, unrelated failure to an issue that had nothing to do with it.
+  for (const entry of source.knownUnreproduced) {
+    process.stdout.write(
+      `  [source] not reproducible from delivered bytes: ${entry} ` +
+        `(${KNOWN_UNREPRODUCED[entry].issue}, known and pinned)\n`,
+    );
   }
   return findings;
 }
@@ -666,13 +672,40 @@ function unstampSource(entryPath, text) {
 // was corrected to match the bytes while `sourceSha256` and `syncedAt` stayed stale. That
 // makes it an internally inconsistent entry, not a stamping question -- the strip rule is
 // exact for its family, and the recorded source simply belongs to different bytes.
+// The single entry the sync engine is known to have left internally inconsistent (#4190).
+// The #4062 run wrote a syncedAt OLDER than the one already recorded, rolling ten token
+// entries back to their 08-07 values while the delivered bytes stayed at the 08-09 render.
+// A consumer cannot repair it: the lock is engine-owned, and hand-repairing one field of
+// this entry is what turned a uniformly stale record into a mixed one in the first place.
+//
+// So it is tolerated -- but as this exact state, never as a class. Both hashes are pinned,
+// so a second corruption of the same file does not inherit the exemption, and no other
+// entry inherits it at all. And an exemption whose entry has started reproducing again is
+// itself a finding: a tolerance that outlives the defect it was written for is a permanent,
+// silent downgrade of the only check that would notice the next one.
+const KNOWN_UNREPRODUCED = {
+  'vendor/@jrm/tokens/css/default/tokens.css': {
+    recorded: '343e10b1ac7914f2a3d1255cfc6ffad1930ac1a17da9eb5aa5551e6e4f67062c',
+    reproduces: '658721d427c18960232d1ecb45dbed3e54fcccd7e6efdd088d6b5fd47f5401bb',
+    issue: '#4190',
+  },
+};
+
 function verifySourceReproduction(lock) {
   const findings = [];
   const unreproduced = [];
+  const knownUnreproduced = [];
   const unobserved = [];
-  let reproduced = 0;
+  // #4207: entries carrying no sourceSha256 were skipped by a bare `continue`, leaving them
+  // absent from every bucket. The population is 0 today, which is exactly why it is worth a
+  // name -- a vacuous exclusion is indistinguishable from a correct one until it isn't.
+  const unstated = [];
+  const reproducedEntries = new Set();
   for (const [entry, metadata] of Object.entries(lock.entries || {})) {
-    if (!metadata || !metadata.sourceSha256) continue;
+    if (!metadata || !metadata.sourceSha256) {
+      unstated.push(entry);
+      continue;
+    }
     const absolute = path.join(ROOT, entry);
     if (!fs.existsSync(absolute)) {
       unobserved.push(entry);
@@ -689,19 +722,62 @@ function verifySourceReproduction(lock) {
       continue;
     }
     if (source.status === 'unknown') {
-      unreproduced.push(entry);
+      unreproduced.push({ entry, recorded: metadata.sourceSha256, digest: null });
       continue;
     }
     const digest = crypto.createHash('sha256').update(source.body).digest('hex');
-    if (digest === metadata.sourceSha256) reproduced += 1;
-    else unreproduced.push(entry);
+    if (digest === metadata.sourceSha256) {
+      reproducedEntries.add(entry);
+      continue;
+    }
+    const known = KNOWN_UNREPRODUCED[entry];
+    if (known && known.recorded === metadata.sourceSha256 && known.reproduces === digest) {
+      knownUnreproduced.push(entry);
+      continue;
+    }
+    unreproduced.push({ entry, recorded: metadata.sourceSha256, digest });
+  }
+  // Lock keys are unique, so set size is the count; deriving it removes the possibility of
+  // a counter and a collection disagreeing about the same population.
+  const reproduced = reproducedEntries.size;
+  // An unreproduced entry is a delivery-integrity failure and must reach the verdict. It
+  // previously reached stdout only, so --strict passed a lock whose recorded source and
+  // delivered bytes disagreed -- and would have passed the next one identically (#4209).
+  for (const item of unreproduced) {
+    findings.push(
+      `delivered bytes do not reproduce the recorded canon source: ${item.entry} ` +
+        `(bytes unstamp to ${item.digest ? item.digest.slice(0, 12) : '<unstampable>'}, ` +
+        `lock records ${item.recorded.slice(0, 12)})`,
+    );
+  }
+  for (const [entry, known] of Object.entries(KNOWN_UNREPRODUCED)) {
+    if (!reproducedEntries.has(entry)) continue;
+    findings.push(
+      `stale reproduction exemption: ${entry} now reproduces its recorded source, so ` +
+        `${known.issue} appears repaired — delete the exemption rather than carrying it`,
+    );
+  }
+  // A conservation law rather than a pinned count: every recorded entry lands in exactly one
+  // bucket. Counts decay with the corpus; the partition does not.
+  const recorded = Object.keys(lock.entries || {}).length;
+  const partitioned =
+    reproduced +
+    unreproduced.length +
+    knownUnreproduced.length +
+    unobserved.length +
+    unstated.length;
+  if (partitioned !== recorded) {
+    findings.push(
+      `source reproduction accounting lost ${recorded - partitioned} of ${recorded} ` +
+        `recorded entries — a population was excluded without being named`,
+    );
   }
   // Premise guard, for the same reason the claim this replaces was wrong: a population of
   // zero would make this pass unconditionally and read as confirmation of delivery fidelity.
   if (reproduced === 0) {
     findings.push('no lock entry unstamped to its canon source — check is not observing');
   }
-  return { findings, reproduced, unreproduced, unobserved };
+  return { findings, reproduced, unreproduced, knownUnreproduced, unobserved, unstated };
 }
 
 function verifyManagedContent(lock) {
@@ -874,4 +950,5 @@ module.exports = {
   unstampSource,
   commentFamily,
   verifySourceReproduction,
+  KNOWN_UNREPRODUCED,
 };

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -23,6 +23,7 @@ const {
   unstampSource,
   commentFamily,
   verifySourceReproduction,
+  KNOWN_UNREPRODUCED,
 } = require('./check-ai-manifest.js');
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -319,9 +320,17 @@ test('managed targets unstamp to their recorded canon source', () => {
 
 test('every recorded source is accounted for, not silently excluded', () => {
   const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
-  const recorded = Object.values(lock.entries || {}).filter((m) => m && m.sourceSha256).length;
+  // The denominator is now every recorded entry, not just those carrying a sourceSha256.
+  // Filtering the denominator by the same predicate the function skips on made the law
+  // unable to see that skip at all -- it cancelled on both sides (#4207).
+  const recorded = Object.keys(lock.entries || {}).length;
   const result = verifySourceReproduction(lock);
-  const accounted = result.reproduced + result.unreproduced.length + result.unobserved.length;
+  const accounted =
+    result.reproduced +
+    result.unreproduced.length +
+    result.knownUnreproduced.length +
+    result.unobserved.length +
+    result.unstated.length;
   // Conservation law rather than a scan for today's instance. The defect it pins (#4197) was
   // an early `continue` that dropped absent targets, which shrank the denominator with
   // nothing in the output saying so -- the printed ratio then read as coverage of everything
@@ -333,4 +342,104 @@ test('every recorded source is accounted for, not silently excluded', () => {
     `${recorded - accounted} recorded sources fell out of the accounting`,
   );
   assert.ok(recorded > 0, 'lock records no source hashes; conservation would be vacuous');
+});
+
+// --- #4209: an unreproducible source must reach the verdict, and the one pinned exemption
+// must not generalise to a class, to a different corruption, or to its own obsolescence.
+
+const REAL_LOCK = () =>
+  JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+
+// A lock holding exactly one entry, over a file that really exists on disk, so the walk
+// reaches it and the digest is computed from delivered bytes rather than from a fixture.
+const lockOf = (entry, metadata) => ({ entries: { [entry]: metadata } });
+
+const KNOWN_ENTRY = Object.keys(KNOWN_UNREPRODUCED)[0];
+
+test('the known-unreproducible entry is tolerated, and is the only one', () => {
+  const result = verifySourceReproduction(REAL_LOCK());
+  assert.deepEqual(
+    result.knownUnreproduced,
+    [KNOWN_ENTRY],
+    'the pinned exemption should absorb exactly the entry it names',
+  );
+  assert.deepEqual(
+    result.unreproduced,
+    [],
+    'no other entry should be failing to reproduce right now',
+  );
+  assert.deepEqual(result.findings, [], 'a tolerated known entry must not fail --strict');
+  // Without this the test passes just as well on a walk that observed nothing at all.
+  assert.ok(result.reproduced > 0, 'nothing reproduced; the check is not observing');
+});
+
+test('an unreproducible entry that is not the pinned one is a blocking finding', () => {
+  // Take a healthy entry and corrupt only its recorded hash: the bytes are untouched and
+  // real, so this is precisely "delivered bytes disagree with the record" and nothing else.
+  const real = REAL_LOCK();
+  const healthy = Object.entries(real.entries).find(
+    ([entry, m]) =>
+      entry !== KNOWN_ENTRY &&
+      m &&
+      m.sourceSha256 &&
+      fs.existsSync(path.join(ROOT, entry)) &&
+      verifySourceReproduction(lockOf(entry, m)).reproduced === 1,
+  );
+  assert.ok(healthy, 'no reproducing entry available to corrupt; the premise is gone');
+  const [entry, metadata] = healthy;
+  const result = verifySourceReproduction(
+    lockOf(entry, { ...metadata, sourceSha256: 'f'.repeat(64) }),
+  );
+  assert.equal(result.unreproduced.length, 1);
+  assert.equal(result.knownUnreproduced.length, 0, 'the exemption must not generalise');
+  assert.ok(
+    result.findings.some((f) => f.includes(entry) && f.includes('do not reproduce')),
+    `expected a blocking finding for ${entry}, got ${JSON.stringify(result.findings)}`,
+  );
+});
+
+test('the exemption is pinned to both hashes, so a second corruption is not inherited', () => {
+  // Same path, same real bytes, but a recorded hash that is neither correct nor the one the
+  // exemption names. Path-only pinning would swallow this; that is the mutant it kills.
+  const result = verifySourceReproduction(
+    lockOf(KNOWN_ENTRY, {
+      ...REAL_LOCK().entries[KNOWN_ENTRY],
+      sourceSha256: 'a'.repeat(64),
+    }),
+  );
+  assert.equal(result.knownUnreproduced.length, 0, 'exemption matched a state it does not name');
+  assert.equal(result.unreproduced.length, 1);
+  assert.ok(result.findings.some((f) => f.includes('do not reproduce')));
+});
+
+test('the exemption self-liquidates: it is a finding once the entry reproduces again', () => {
+  // The repaired future. `reproduces` is what the delivered bytes actually unstamp to, so
+  // recording it is exactly what a sync run re-rendering this target would write.
+  const result = verifySourceReproduction(
+    lockOf(KNOWN_ENTRY, {
+      ...REAL_LOCK().entries[KNOWN_ENTRY],
+      sourceSha256: KNOWN_UNREPRODUCED[KNOWN_ENTRY].reproduces,
+    }),
+  );
+  assert.equal(result.reproduced, 1, 'the repaired state should reproduce');
+  assert.ok(
+    result.findings.some((f) => f.includes('stale reproduction exemption')),
+    `a tolerance outliving its defect must announce itself, got ${JSON.stringify(result.findings)}`,
+  );
+});
+
+test('an entry stating no source hash is named rather than silently skipped', () => {
+  // #4207. The population is 0 in the real lock, so this is the only place the bucket can
+  // be exercised non-vacuously -- and an unexercised partition proves nothing.
+  const result = verifySourceReproduction(lockOf('AGENTS.md', { targetSha256: 'x'.repeat(64) }));
+  assert.deepEqual(result.unstated, ['AGENTS.md']);
+  assert.equal(
+    result.reproduced + result.unreproduced.length + result.unobserved.length,
+    0,
+    'the entry must land in exactly one bucket',
+  );
+  assert.ok(
+    result.findings.every((f) => !f.includes('accounting lost')),
+    'conservation must hold with the entry accounted for',
+  );
 });


### PR DESCRIPTION
## Summary

`verifySourceReproduction` was **computing** the #4190 defect, **printing** it, and returning it — but never turning it into a finding, so `--strict` exited 0 on a lock whose recorded source and delivered bytes disagree.

The tolerance itself was correct and deliberate: #4190 is engine-owned and a consumer cannot repair it. What was wrong is that it was implemented as a **blanket downgrade of the entire class**.

## Changes

- **An unreproducible entry is now a blocking finding**, with both hashes in the message.
- **The one known exemption is pinned to the entry and to both hashes** — the wrong one it records (`343e10b1…`) and the one its bytes actually produce (`658721d4…`). A second, unrelated corruption of the same file does not inherit it, and no other entry inherits it at all.
- **The exemption self-liquidates.** An exemption whose entry has started reproducing again is itself a blocking finding saying to delete it. Without this, the tolerance outlives the defect and silently downgrades the check forever — the failure mode that gets worse with time and cannot announce itself.
- **The stdout line no longer labels every failure `(#4190)`.** It did so unconditionally, which would have attributed the next unrelated defect to an unrelated issue.
- **Closes #4207** — same function, same root cause (*the accounting does not reach the verdict*). Entries stating no `sourceSha256` went through a bare `continue` and landed in no bucket; they now land in `unstated`. That population is **0 of 81** today, which is the reason to name it, not the reason to ignore it.

The partition is a conservation law rather than any pinned count:

```
reproduced + unreproduced + knownUnreproduced + unobserved + unstated === recorded
```

## What the existing tests caught

The **pre-existing #4197 conservation test** — written weeks ago for a different defect — failed immediately as `80 != 81` the moment I added a bucket it didn't know about. That is the only kind of control worth having.

Its denominator was also widened as part of this. It had filtered to entries carrying a `sourceSha256`, which is *the same predicate the function skips on*, so the skip cancelled on both sides and the law could not see the very thing #4207 describes.

## Validation

```
node --test tools/check-ai-manifest.test.mjs      22 pass  0 fail
node tools/check-ai-manifest.js --strict          exit 0
npx eslint <both files> --max-warnings 0          exit 0
npx prettier --check <both files>                 clean
```

Mutation, each kill verified by **failing test name** rather than by the aggregate:

| mutant | result |
| --- | --- |
| unreproduced never becomes a finding | 20 pass **2 FAIL** |
| exemption pinned on path only | 21 pass **1 FAIL** |
| stale-exemption check removed | 21 pass **1 FAIL** |
| unstated bucket removed (bare `continue`) | 21 pass **1 FAIL** |
| conservation finding removed | 22 pass 0 fail — **SURVIVES** |

### The surviving mutant, disclosed

The conservation *finding* cannot be reached from outside: it fires only when the partition is already broken by a code defect, which no input can construct. It is kept anyway, because it and the test quantify over **different populations** — the test runs over this repo's lock at test time, the finding runs over whatever lock exists at check time in any consumer state.

This is the second guard in this file that is load-bearing in conjunction and inert in isolation. Reporting it rather than deleting it or claiming coverage it doesn't have.

## Not done here

**No lock edit.** The recoverable values for #4190 are known (`sourceSha256 = 658721d4…`, `syncedAt = 2026-08-09T22:23:34.202Z`, verbatim from the engine's own record at #4027, independently corroborated by `cartridge`). They are deliberately not hand-applied — hand-repairing *one* field of that entry is what turned a uniformly stale record into a mixed one. A sync run that re-renders the target resolves all three for free.

No workflow changes. No changes to `packages/design-tokens`.

## Issues

Closes #4209
Closes #4207