### PR TITLE
fix(tools): fail closed when the count-claim arm inspects nothing (#4212)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -202,6 +202,63 @@ function scanDoc(relPath, counts) {
   return { missing: false, findings };
 }
 
+// Scans the whole declared corpus and reports what it observed, not only what it objected to.
+//
+// The count arm is the first thing this tool advertises in `--help`, and its success line asserts
+// that counts are consistent. That line was gated on `driftedCounts.length === 0`, and zero
+// drifted claims is byte-identical to zero INSPECTED claims -- so rewriting `**23** agents` as
+// `twenty-three agents` retires the claim, matches no METRIC, and the tool certifies counts it
+// never read (#4212). The claims sit outside AGENTS.md's studio:base managed region, so
+// managedDigest is unchanged and verifyManagedContent raises nothing either.
+//
+// Zero matched claims is not a legitimate state: the corpus is repo-authored documentation that
+// exists to carry these claims, so an empty match set means the arm stopped observing rather than
+// that the repo is clean. It fails closed, the same way verifyLockCoverage's premise guard does
+// (#4204) -- that guard's vocabulary already existed in this file and this arm never got it.
+//
+// A document that is present but yields no claims is a different state and is NOT a finding:
+// docs/INDEX.md is in that state today. It is named in the report instead, because "3 documents
+// inspected" and "3 documents contributing claims" are different numbers and the gap is the
+// interesting one.
+function countCoverageFindings({ claimCount, missing }) {
+  const findings = [];
+  for (const doc of missing) {
+    // Previously printed as `not found (skipped)` with no finding. AGENTS.md is incidentally
+    // covered because it is a lock entry; docs/ai/README.md and docs/INDEX.md are not managed
+    // targets, so nothing at all observed their absence.
+    findings.push(`count-claim document is missing: ${doc}`);
+  }
+  if (claimCount === 0) {
+    findings.push(
+      'count-claim scan matched no claims in any document — the count check is not observing (#4212)',
+    );
+  }
+  return findings;
+}
+
+function scanDocs(counts, docs = DOC_FILES) {
+  const claims = [];
+  const missing = [];
+  const inert = [];
+  for (const doc of docs) {
+    const result = scanDoc(doc, counts);
+    if (result.missing) {
+      missing.push(doc);
+      continue;
+    }
+    if (!result.findings.length) inert.push(doc);
+    claims.push(...result.findings);
+  }
+  return {
+    findings: countCoverageFindings({ claimCount: claims.length, missing }),
+    claims,
+    missing,
+    inert,
+    inspected: docs.length - missing.length,
+    declared: docs.length,
+  };
+}
+
 function difference(left, right) {
   return left.filter((value) => !right.includes(value));
 }
@@ -835,18 +892,25 @@ function main() {
   );
   process.stdout.write(`Mode: ${STRICT ? 'STRICT (blocking)' : 'informational (warn-only)'}\n\n`);
 
-  let countFindings = [];
-  for (const doc of DOC_FILES) {
-    const { missing, findings } = scanDoc(doc, counts);
-    if (missing) process.stdout.write(`- ${doc}: not found (skipped)\n`);
-    countFindings = countFindings.concat(findings);
-  }
+  const scan = scanDocs(counts);
+  const countFindings = scan.claims;
   const driftedCounts = countFindings.filter((finding) => finding.drift);
   const activationFindings = [
+    ...scan.findings,
     ...validateAgentRoster(manifest.agents),
     ...validateActivationDoc(),
     ...validateSyncLock(),
   ];
+  for (const doc of scan.missing) process.stdout.write(`- ${doc}: not found\n`);
+  // Printed unconditionally, in both the passing and the failing branch. The old report emitted
+  // the "Detected count claims:" section only when the set was non-empty, so the sole trace of a
+  // zero was a section that did not appear -- and an absent section is not a report (#4212).
+  process.stdout.write(
+    `Count claims: ${countFindings.length} claim(s) across ` +
+      `${scan.inspected} of ${scan.declared} declared document(s)` +
+      (scan.inert.length ? `; no claims in ${scan.inert.join(', ')}` : '') +
+      '\n',
+  );
 
   process.stdout.write('Canonical runtime activation:\n');
   if (activationFindings.length === 0) {
@@ -944,6 +1008,11 @@ if (require.main === module) {
 module.exports = {
   toLF,
   PROVENANCE_LINE,
+  DOC_FILES,
+  METRICS,
+  scanDoc,
+  scanDocs,
+  countCoverageFindings,
   managedRegion,
   managedDigest,
   verifyLockCoverage,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -24,6 +24,10 @@ const {
   commentFamily,
   verifySourceReproduction,
   KNOWN_UNREPRODUCED,
+  DOC_FILES,
+  scanDoc,
+  scanDocs,
+  countCoverageFindings,
 } = require('./check-ai-manifest.js');
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -442,4 +446,88 @@ test('an entry stating no source hash is named rather than silently skipped', ()
     result.findings.every((f) => !f.includes('accounting lost')),
     'conservation must hold with the entry accounted for',
   );
+});
+
+// --- #4212: the count-claim arm must not certify a corpus it did not read ---------------------
+//
+// The success line asserts "counts ... are consistent". It was gated on zero DRIFTED claims, and
+// zero drifted is byte-identical to zero INSPECTED. Rewriting `**23** agents` as `twenty-three
+// agents` retires the claim, matches no METRIC, leaves AGENTS.md's managed region untouched, and
+// the tool exits 0 having read no claim at all. These pin the judgement rather than the printout.
+
+test('an empty claim set is a finding, not a clean result', () => {
+  const findings = countCoverageFindings({ claimCount: 0, missing: [] });
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /not observing/);
+});
+
+test('a missing declared document is a finding, not a printed skip', () => {
+  const findings = countCoverageFindings({ claimCount: 4, missing: ['docs/INDEX.md'] });
+  assert.deepEqual(findings, ['count-claim document is missing: docs/INDEX.md']);
+});
+
+test('every declared document missing reports absence AND non-observation', () => {
+  const findings = countCoverageFindings({ claimCount: 0, missing: [...DOC_FILES] });
+  // Both axes must be named: which documents vanished, and that nothing was measured. Reporting
+  // only the absences would leave the reader to infer the second, which is the inference this
+  // whole issue is about.
+  assert.equal(findings.length, DOC_FILES.length + 1);
+  assert.match(findings.at(-1), /not observing/);
+});
+
+test('claims present with nothing missing yields no finding', () => {
+  assert.deepEqual(countCoverageFindings({ claimCount: 1, missing: [] }), []);
+});
+
+test('a document present but contributing no claims is inert, not missing', () => {
+  // docs/INDEX.md is in this state today. It must not fail the build, and it must not be
+  // silently folded into the inspected count as though it had contributed something.
+  const scan = scanDocs({ agents: 0, skills: 0, instructions: 0, mcpServers: 0 }, [
+    'docs/INDEX.md',
+  ]);
+  assert.deepEqual(scan.missing, []);
+  assert.deepEqual(scan.inert, ['docs/INDEX.md']);
+  assert.equal(scan.inspected, 1);
+});
+
+test('the declared corpus is really observing right now', () => {
+  // The premise the guard rests on: this repo's documents do carry count claims. If this test
+  // ever fails, the guard above is the thing that stopped the tool certifying nothing.
+  const counts = { agents: 23, skills: 20, instructions: 14, mcpServers: 7 };
+  const scan = scanDocs(counts);
+  assert.deepEqual(scan.missing, []);
+  assert.ok(scan.claims.length > 0, 'declared corpus matched no count claims');
+  assert.deepEqual(scan.findings, []);
+});
+
+test('a retired claim is detected as non-observation, not as agreement', () => {
+  // The reproduction itself, at the seam: a document whose claims no longer match any METRIC
+  // yields the same empty set as a document with no drift. Only the guard separates them.
+  const real = scanDocs({ agents: 23, skills: 20, instructions: 14, mcpServers: 7 });
+  const retired = scanDocs({ agents: 23, skills: 20, instructions: 14, mcpServers: 7 }, [
+    'docs/INDEX.md',
+  ]);
+  assert.ok(real.claims.length > 0);
+  assert.equal(retired.claims.length, 0);
+  assert.deepEqual(real.findings, []);
+  assert.match(retired.findings.join('\n'), /not observing/);
+});
+
+test('scanDoc reports absence rather than throwing', () => {
+  const result = scanDoc('docs/does-not-exist-4212.md', { agents: 0 });
+  assert.equal(result.missing, true);
+  assert.deepEqual(result.findings, []);
+});
+test('inspected counts documents actually read, not documents declared', () => {
+  // Mutation D survived the first harness: `inspected` is printed in the passing summary and no
+  // test constrained it, so it could have reported the declared total while a document was
+  // absent -- a number in the report that nothing measures, which is the defect this issue is
+  // about, one level up in the fix for it.
+  const scan = scanDocs({ agents: 23, skills: 20, instructions: 14, mcpServers: 7 }, [
+    'docs/INDEX.md',
+    'docs/does-not-exist-4212.md',
+  ]);
+  assert.deepEqual(scan.missing, ['docs/does-not-exist-4212.md']);
+  assert.equal(scan.declared, 2);
+  assert.equal(scan.inspected, 1);
 });


### PR DESCRIPTION
Closes #4212

## The defect

`tools/check-ai-manifest.js` advertises count validation first in `--help`, and its success line asserts it:

```
✅ No drift detected — counts, activation, and managed content are consistent with the last sync.
```

That line was gated on `driftedCounts.length === 0`. **Zero drifted claims is byte-identical to zero inspected claims**, so the check certified counts it had never read.

## Reproduction, measured

Against a copy of the tool's read surface, rewriting the four claims so no `METRICS` regex matches — `**23** agents` → `twenty-three agents`:

```
before   Detected count claims:  4 claims, all [ok]              exit 0
after    (section absent)                                        exit 0
         ✅ No drift detected — counts ... are consistent
```

The only trace of the zero was that the "Detected count claims:" section did not print, and an absent section is not a report.

**Reachable by ordinary editing.** The claims in `AGENTS.md` and `docs/ai/README.md` sit outside the `studio:base` managed region, so `managedDigest` is unchanged and `verifyManagedContent` raises nothing.

Same reproduction on this branch:

```
Count claims: 0 claim(s) across 3 of 3 declared document(s); no claims in ...
  [DRIFT] count-claim scan matched no claims in any document — the count check is not observing (#4212)
❌ 0 drifted count claim(s), 1 canonical-activation finding(s). Failing (STRICT=1).   exit 1
```

## Already partly inert

`docs/INDEX.md` contributes **0 of the 4** matched claims today. One third of the declared corpus contributes nothing and the tool did not say so. It is now named in the report — as an observation, not a finding, because it is a true current state.

A missing `DOC_FILE` printed `not found (skipped)` and produced no finding. `AGENTS.md` is incidentally covered by being a lock entry; `docs/ai/README.md` and `docs/INDEX.md` are not managed targets, so nothing observed their absence at all.

## Same defect twice in one file

#4204 gave `verifyLockCoverage` a two-sided premise guard for exactly this reason — its comment reads *"nothing observed means the walk stopped reaching managed files, and a clean result reports that as complete coverage."* The vocabulary existed. The arm named first in `--help` never got it.

## Controls

Baseline **31 pass / 0 fail**. Each kill verified by failing test **name**, not by the aggregate, and each mutant's application verified by source index rather than trusting the harness to have applied it.

| Mutant | Result |
| --- | --- |
| A — zero-claim guard disabled | 3 FAIL |
| B — missing doc raises no finding | 2 FAIL |
| C — inert doc counted as missing | 3 FAIL |
| D — `inspected` ignores missing | 1 FAIL |
| E — `declared` reports inspected | 1 FAIL |

**D initially SURVIVED.** `inspected` is printed in the passing summary and no test constrained it — an unmeasured number in the report, inside the fix for unmeasured numbers in the report. Disclosed rather than dropped, then pinned and re-killed.

## Scope

Deliberately **not** fixed here: the `[ok] 22 generated canonical agents + 1 local agent; 81 managed assets` line renders three module constants, not measurements. I could construct no state where it prints a false number — each is guarded by a real check elsewhere — so it is unfalsifiable rather than wrong. Recorded in #4212.

No workflow, `packages/design-tokens`, lockfile, or vendored token change.

## Validation

- `node --test tools/check-ai-manifest.test.mjs` — 31 pass, 0 fail
- `node tools/check-ai-manifest.js --strict` — exit 0
- `npx eslint tools/check-ai-manifest.js tools/check-ai-manifest.test.mjs --max-warnings 0` — exit 0
- `npx prettier --write` on both touched files

Class credit: `jrmoulckers/.github#721` — an absent measurement rendered in the schema of a present one.